### PR TITLE
fix: add optional confidence field to ReviewAlertEventInfo

### DIFF
--- a/src/vss-engine/src/vss_api_models.py
+++ b/src/vss-engine/src/vss_api_models.py
@@ -1658,6 +1658,13 @@ class ReviewAlertEventInfo(ViaBaseModel):
             "Vehicle detected in pedestrian zone",
         ],
     )
+    confidence: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Detection confidence score from the CV pipeline",
+        examples=[0.95, 0.87, 0.72],
+    )
 
 
 class ReviewAlertDebugInfo(ViaBaseModel):


### PR DESCRIPTION
## Summary

When using the Event Reviewer with the `cv-event-detector` example (e.g., GroundingDINO), the CV pipeline naturally includes a detection confidence score in the event payload. However, `ReviewAlertEventInfo` inherits from `ViaBaseModel` which sets `extra="forbid"`, causing a Pydantic validation error:

```
Extra inputs are not permitted [type=extra_forbidden, input_value=0.85, input_type=float]
```

This PR adds `confidence` as an `Optional[float]` field to `ReviewAlertEventInfo`, so CV pipelines can include detection confidence scores without triggering validation errors.

## Changes

- Added `confidence: Optional[float]` field to `ReviewAlertEventInfo` in `vss_api_models.py`
  - Default: `None` (fully backward-compatible)
  - Constraints: `ge=0.0, le=1.0`

## Reproduction

1. Deploy Event Reviewer on DGX Spark (`IS_SBSA=1`)
2. Send an alert with `event.confidence`:

```bash
curl -X POST http://localhost:9080/api/v1/alerts \
  -H "Content-Type: application/json" \
  -d '{
    "id": "550e8400-e29b-41d4-a716-446655440000",
    "version": "1.0",
    "@timestamp": "2026-03-08T10:00:00.000Z",
    "sensor_id": "warehouse-cam-1",
    "video_path": "/tmp/alert-media-dir/clip.mp4",
    "confidence": 0.92,
    "alert": {
      "type": "safety_violation",
      "description": "Person without hard hat",
      "severity": "HIGH",
      "status": "REVIEW_PENDING"
    },
    "event": {
      "type": "object_detection",
      "description": "Person detected without PPE",
      "confidence": 0.85
    },
    "vss_params": {
      "vlm_params": {
        "prompt": "Is the person wearing a hard hat? Answer Yes or No.",
        "max_tokens": 200,
        "temperature": 0.3
      }
    }
  }'
```

3. Without this fix, `event.confidence` triggers: `Extra inputs are not permitted`

## Environment

- VSS 2.4.1 (Event Reviewer deployment)
- DGX Spark (ARM64 SBSA), DGX OS 7.4.0
- CV pipeline: `examples/cv-event-detector` with GroundingDINO