### PR TITLE
Add PLC OSS community template files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: File a bug report
+title: "[BUG]: "
+labels: ["bug", "? - Needs Triage"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of VSS are you running?
+      placeholder: "e.g. 3.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation method
+      options:
+        - Docker Compose
+        - Source build
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Deploy with '...'
+        2. Send request '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear description of what you expected to happen.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please paste any relevant log output.
+      render: shell
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment details
+      description: |
+        Include relevant details about your environment:
+        - OS and version
+        - GPU model and driver version
+        - Docker version
+        - Any relevant configuration
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/main/CODE_OF_CONDUCT.md)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+
+contact_links:
+  - name: Ask a Question
+    url: https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/discussions
+    about: Please ask any questions here.

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -1,0 +1,38 @@
+name: Documentation Request
+description: Report incorrect or missing documentation
+title: "[DOC]: "
+labels: ["documentation", "? - Needs Triage"]
+body:
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Is this a correction or a request for new documentation?
+      options:
+        - Correction / Update
+        - New Documentation
+    validations:
+      required: true
+  - type: input
+    id: doc-link
+    attributes:
+      label: Link to existing documentation (if applicable)
+      placeholder: "https://..."
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue or what documentation is needed
+      description: Provide details about what is incorrect, outdated, or missing.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed correction or content
+      description: If you have a suggestion for the correction or new content, describe it here.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/main/CODE_OF_CONDUCT.md)
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_form.yml
@@ -1,0 +1,56 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[FEA]: "
+labels: ["feature request", "? - Needs Triage"]
+body:
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Is this a new feature, an improvement, or a change to existing functionality?
+      options:
+        - New Feature
+        - Improvement
+        - Change
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: How would you describe the priority of this feature request?
+      options:
+        - Critical (currently preventing work)
+        - High
+        - Medium
+        - Low (nice-to-have)
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of the problem.
+      placeholder: "I'm frustrated when..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Any alternative solutions or features you've considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or examples.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/main/CODE_OF_CONDUCT.md)
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Description
+<!-- Provide a standalone description of changes in this PR. -->
+<!-- Reference any issues closed by this PR with "closes #1234". -->
+
+## Checklist
+- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
+- [ ] New or existing tests cover these changes.
+- [ ] The documentation is up to date with these changes.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ repos:
     hooks:
       - id: trufflehog
         name: TruffleHog secret scan
-        entry: trufflehog git file://. --since-commit HEAD --only-verified --fail
+        entry: trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail
         language: golang
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.94.2
+    hooks:
+      - id: trufflehog
+        name: TruffleHog secret scan
+        entry: trufflehog git file://. --since-commit HEAD --only-verified --fail
+        language: golang
+        stages: [pre-commit]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting GitHub_Conduct@nvidia.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and appropriate
+to the circumstances. The project team is obligated to maintain confidentiality with
+regard to the reporter of an incident. Further details of specific enforcement policies
+may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,41 @@ If you are interested in contributing to Video Search and Summarization (VSS), y
     - If you need more context on a particular issue, please ask and we shall
     provide.
 
+## Licensing
+
+This project uses a dual-license model:
+
+- **Apache-2.0** — applies to all code in the repository except the `ui/` directory.
+- **MIT** — applies to the original code under the `ui/` directory, which is derived from [NVIDIA NeMo Agent Toolkit UI](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/).
+
+**All contributions to this repository, regardless of which directory they target, are accepted under the Apache-2.0 license.** Even if you are contributing changes to the `ui/` directory, your contribution will be licensed under Apache-2.0. The original `ui/` code retains its MIT license, but any additions or modifications contributed through this repository are Apache-2.0.
+
+See the [LICENSE](LICENSE) file for the full license texts.
+
+### Developer Certificate of Origin (DCO)
+
+All contributions must include a DCO sign-off. By adding a `Signed-off-by` line to your commit messages, you certify that you wrote (or otherwise have the right to submit) the contribution, and that you are licensing it under the Apache-2.0 license.
+
+To sign off, add the `-s` flag when committing:
+
+```bash
+git commit -s -m "Your commit message"
+```
+
+This appends a line like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+If you have already made commits without a sign-off, you can amend the most recent one:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+**Pull requests with unsigned commits will not be merged.**
+
 ## Code contributions
 
 ### Your first issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Video Search and Summarization
+
+If you are interested in contributing to Video Search and Summarization (VSS), your contributions will fall into the following categories:
+
+1. You want to report a bug, feature request, or documentation issue
+    - File an [issue](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/issues/new/choose)
+    describing what you encountered or what you want to see changed.
+    - The team will evaluate the issues and triage them, scheduling
+    them for a release. If you believe the issue needs priority attention,
+    comment on the issue to notify the team.
+2. You want to propose a new feature and implement it
+    - Post about your intended feature, and we shall discuss the design and
+    implementation.
+    - Once we agree that the plan looks good, go ahead and implement it, using
+    the [code contributions](#code-contributions) guide below.
+3. You want to implement a feature or bug-fix for an outstanding issue
+    - Follow the [code contributions](#code-contributions) guide below.
+    - If you need more context on a particular issue, please ask and we shall
+    provide.
+
+## Code contributions
+
+### Your first issue
+
+1. Read the project's [README.md](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/main/README.md)
+    to learn how to set up the development environment.
+2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+    or [help wanted](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels.
+3. Comment on the issue saying you are going to work on it.
+4. Code! Make sure to update unit tests!
+5. When done, [create your pull request](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/compare).
+6. Verify that CI passes all [status checks](https://help.github.com/articles/about-status-checks/), or fix if needed.
+7. Wait for other developers to review your code and update code as needed.
+8. Once reviewed and approved, a maintainer will merge your pull request.
+
+Remember, if you are unsure about anything, don't hesitate to comment on issues and ask for clarifications!
+
+### Pull request guidelines
+
+- Provide a clear description of the changes in your PR.
+- Reference any issues closed by the PR with "closes #1234".
+- Ensure new or existing tests cover your changes.
+- Keep the documentation up to date with your changes.
+
+### Branch naming
+
+Branches used to create PRs should have a name of the form `<type>/<name>` which conforms to the following conventions:
+
+- Type:
+    - `feat` - For new features
+    - `fix` - For bug fixes
+    - `docs` - For documentation changes
+    - `refactor` - For code refactoring
+    - `test` - For adding or updating tests
+- Name:
+    - A name to convey what is being worked on
+    - Please use dashes between words as opposed to spaces.
+
+## Attribution
+
+Portions adopted from the [NVIDIA PLC-OSS-Template](https://github.com/NVIDIA-GitHub-Management/PLC-OSS-Template).


### PR DESCRIPTION
## Summary
- Add standard open-source community files adopted from the [NVIDIA PLC-OSS-Template](https://github.com/NVIDIA-GitHub-Management/PLC-OSS-Template)
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant v1.4) and `CONTRIBUTING.md` with contribution guidelines
- Add GitHub issue templates (bug report, feature request, documentation request) and PR template
- Add `.pre-commit-config.yaml` with TruffleHog secret scanning hook

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.