### PR TITLE
Fix #81: [DOC]: Local Gradio example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ The platform requirement can vary depending on the configuration and deployment 
 Follow the steps from the [documentation](https://docs.nvidia.com/vss/3.1.0/cloud-brev.html) and notebook in [scripts](scripts/) directory to complete all pre-requisites and deploy the blueprint using Brev Launchable in a 2xRTX PRO 6000 SE AWS instance.
 - [scripts/deploy_vss_launchable.ipynb](scripts/deploy_vss_launchable.ipynb): This notebook is tailored specifically for the AWS CSP which uses Ephemeral storage.
 
+### Local GPU Deployment (Docker Compose with Local Models)
+
+**Ideal for:** Running the full stack on your own GPU(s) without relying on remote API keys for inference.
+
+The Docker Compose deployment supports local NIM model hosting. Set the following variables in your `.env` file (e.g. `deployments/developer-workflow/dev-profile-base/.env`) before starting:
+
+```bash
+LLM_MODE=local_shared   # run LLM locally on GPU, sharing VRAM
+VLM_MODE=local_shared   # run VLM locally on GPU
+HARDWARE_PROFILE=H100   # match your GPU (H100, L40S, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER)
+```
+
+An NVIDIA AI Enterprise developer licence and NGC API key are still required to pull NIM containers. See [GPU requirements](https://docs.nvidia.com/vss/3.1.0/prerequisites.html#development-profile-gpu-requirements) for validated topologies and VRAM budgets, and [Local NIM deployment docs](https://docs.nvidia.com/vss/3.1.0/quickstart.html) for the full setup walkthrough.
+
 ### Docker Compose Deployment
 
 **Ideal for:** Deploying a VSS agent on your own hardware or bare metal cloud instance.


### PR DESCRIPTION
Closes #81

## Description
Adds a new **Local GPU Deployment** section to `README.md` (after the Brev Launchable section, before the existing Docker Compose section) documenting how to run the full VSS stack on-premises using local NIM containers instead of remote API keys.

Specifically documents the three `.env` variables users must set in `deployments/developer-workflow/dev-profile-base/.env`:
- `LLM_MODE=local_shared` — serves the LLM locally on GPU
- `VLM_MODE=local_shared` — serves the VLM locally on GPU
- `HARDWARE_PROFILE` — selects the validated GPU topology (H100, L40S, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER)

Also clarifies that an NVIDIA AI Enterprise developer licence and NGC API key are still required to pull NIM containers, with links to the GPU requirements and quickstart docs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*