### PR TITLE
agent: sync latest changes from internal develop (a23beae4)

### DIFF
--- a/agent/src/vss_agents/agents/report_agent.py
+++ b/agent/src/vss_agents/agents/report_agent.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 _ARTIFACT_DISPLAY_NOTE = (
     "Do not include or offer to provide report download links in your final response "
-    "since they are already displayed to the user automatically."
+    "since they will be automatically appended to your final response to the user."
 )
 
 
@@ -582,6 +582,9 @@ async def report_agent(config: ReportAgentConfig, builder: Builder) -> AsyncGene
         # Format output
         side_effects = {}
 
+        if hasattr(report_result, "lvs_fallback_warning") and report_result.lvs_fallback_warning:
+            side_effects["lvs_fallback_warning"] = report_result.lvs_fallback_warning
+
         # Format HITL prompts if available (from LVS) - used in both side_effects and messages
         hitl_text = None
         if hasattr(report_result, "hitl_prompts") and report_result.hitl_prompts:
@@ -593,8 +596,10 @@ async def report_agent(config: ReportAgentConfig, builder: Builder) -> AsyncGene
                 prompts_parts.append(f"- Events of interest: {', '.join(hitl['events'])}")
             if hitl.get("objects_of_interest"):
                 prompts_parts.append(f"- Objects of interest: {', '.join(hitl['objects_of_interest'])}")
-            hitl_text = "\n".join(prompts_parts) + "\n"
-            side_effects["hitl_prompts"] = hitl_text
+            # Only show Prompts section if there's actual content beyond the header
+            if len(prompts_parts) > 1:
+                hitl_text = "\n".join(prompts_parts) + "\n"
+                side_effects["hitl_prompts"] = hitl_text
 
         # Handle multi-video vs single-video downloads
         if hasattr(report_result, "all_reports") and report_result.all_reports:

--- a/agent/src/vss_agents/agents/top_agent.py
+++ b/agent/src/vss_agents/agents/top_agent.py
@@ -1418,8 +1418,6 @@ async def top_agent(config: TopAgentConfig, builder: Builder) -> AsyncGenerator[
             "Summarize and return the final answer to the user after all steps are completed.\n"
             "- Your final answer MUST answer ALL parts of the user's question (User's Question: {question}). "
             "If the user asked multiple things, you MUST answer each one. "
-            f"Refer to the tool results in '{_TOOL_RESULTS_DELIMITER}' as your "
-            "source of truth when answering the user's question.\n"
         )
         if tool_call_prompt:
             plan_exec_system += "\n\n## Tool call rules:\n " + tool_call_prompt
@@ -1430,7 +1428,7 @@ async def top_agent(config: TopAgentConfig, builder: Builder) -> AsyncGenerator[
         plan_exec_prompt = ChatPromptTemplate(
             [
                 ("system", plan_exec_system),
-                ("user", "User Question: {question}\n\nExecution Plan and Tool Results:\n{plan_section}\n\n"),
+                ("user", "User Question: {question}\n\nExecution Plan:\n{plan_section}\n\n"),
             ]
         )
 

--- a/agent/src/vss_agents/api/custom_fastapi_worker.py
+++ b/agent/src/vss_agents/api/custom_fastapi_worker.py
@@ -66,6 +66,7 @@ class CustomFastApiFrontEndWorker(FastApiFrontEndPluginWorker):
         """Register streaming ingest routes (video upload and RTSP streams) only when configured."""
         front_end_cfg = getattr(getattr(self.config, "general", None), "front_end", None)
         streaming_config = getattr(front_end_cfg, "streaming_ingest", None) if front_end_cfg else None
+        logger.info(f"Streaming config: {streaming_config}")
 
         # Register video upload streaming routes
         try:

--- a/agent/src/vss_agents/api/front_end_config.py
+++ b/agent/src/vss_agents/api/front_end_config.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Custom FastAPI front-end config that extends NAT's FastApiFrontEndConfig
+"""
+
+from collections.abc import AsyncGenerator
+
+from nat.cli.register_workflow import register_front_end
+from nat.data_models.config import Config
+from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfig
+from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+
+class StreamingIngestConfig(BaseModel):
+    """Configuration for the streaming video ingest and RTSP stream endpoints."""
+
+    model_config = ConfigDict(extra="allow")
+
+    vst_internal_url: str = Field(default="", description="Internal URL for VST service")
+    rtvi_embed_base_url: str = Field(default="", description="Base URL for RTVI embedding service")
+    rtvi_embed_model: str = Field(default="cosmos-embed1-448p", description="Embedding model name")
+    rtvi_embed_chunk_duration: int = Field(default=5, description="Chunk duration in seconds for embedding")
+    rtvi_cv_base_url: str = Field(default="", description="Base URL for RTVI CV service")
+    vlm_mode: str = Field(default="", description="VLM mode (remote/local/local_shared)")
+    internal_ip: str = Field(default="", description="Internal IP address of the host")
+    external_ip: str = Field(default="", description="External IP address for public-facing URLs")
+    elasticsearch_url: str = Field(default="", description="Elasticsearch endpoint URL")
+    rtvi_embed_es_index: str = Field(default="", description="Elasticsearch index for embeddings")
+    stream_mode: str = Field(default="search", description="'search' for search profile, 'other' for VST only")
+
+
+class VSSFastApiFrontEndConfig(FastApiFrontEndConfig, name="vss_fastapi"):  # type: ignore[call-arg]
+    """
+    Extends NAT's FastAPI front-end config with a streaming_ingest section
+    used by the custom video upload, RTSP stream, and video delete routes.
+    """
+
+    streaming_ingest: StreamingIngestConfig | None = Field(
+        default=None,
+        description="Configuration for streaming video ingest and RTSP stream management endpoints",
+    )
+
+
+@register_front_end(config_type=VSSFastApiFrontEndConfig)
+async def register_vss_fastapi_front_end(
+    _config: VSSFastApiFrontEndConfig, full_config: Config
+) -> AsyncGenerator[FastApiFrontEndPlugin]:
+    yield FastApiFrontEndPlugin(full_config=full_config)

--- a/agent/src/vss_agents/api/rtsp_stream_api.py
+++ b/agent/src/vss_agents/api/rtsp_stream_api.py
@@ -642,7 +642,7 @@ def register_rtsp_stream_api_routes(app: FastAPI, config: Any) -> None:
             default_stream_mode = str(
                 getattr(streaming_config, "stream_mode", None) or os.getenv("STREAM_MODE", "search")
             )
-            logger.info("Using streaming_ingest config from YAML")
+            logger.info("Using streaming_ingest config from YAML for RTSP stream routes")
         else:
             # Fallback to environment variables
             host_ip = os.getenv("HOST_IP")

--- a/agent/src/vss_agents/api/video_search_ingest.py
+++ b/agent/src/vss_agents/api/video_search_ingest.py
@@ -374,7 +374,7 @@ def register_streaming_routes(app: "FastAPI", config: "Any") -> None:
             rtvi_cv_base_url = getattr(streaming_config, "rtvi_cv_base_url", None) or ""
             rtvi_embed_model = getattr(streaming_config, "rtvi_embed_model", "cosmos-embed1-448p")
             rtvi_embed_chunk_duration = getattr(streaming_config, "rtvi_embed_chunk_duration", 5)
-            logger.info("Using streaming_ingest config from YAML")
+            logger.info("Using streaming_ingest config from YAML for search video ingest routes")
         else:
             # Fallback: streaming_ingest not found (NAT strips unknown fields)
             # Use environment variables

--- a/agent/src/vss_agents/embed/cosmos_embed.py
+++ b/agent/src/vss_agents/embed/cosmos_embed.py
@@ -19,10 +19,12 @@ import httpx
 from typing_extensions import override  # noqa: UP035  # mypy targets 3.11
 
 from vss_agents.embed.embed import EmbedClient
+from vss_agents.embed.embed import LRUEmbeddingCache
 
 logger = logging.getLogger(__name__)
 
 _EMBED_MODEL = os.getenv("RTVI_EMBED_MODEL", "cosmos-embed1-448p")
+_TEXT_EMBEDDING_CACHE_MAXSIZE = 1024
 
 
 class CosmosEmbedClient(EmbedClient):
@@ -32,6 +34,25 @@ class CosmosEmbedClient(EmbedClient):
         self.text_embeddings_url = f"{endpoint}/v1/generate_text_embeddings"
         self.image_embeddings_url = f"{endpoint}/v1/generate_image_embeddings"
         self.video_embeddings_url = f"{endpoint}/v1/generate_video_embeddings"
+        # Connection pooling: lazily created, reused across requests
+        self._client: httpx.AsyncClient | None = None
+        # Bounded LRU cache for text embeddings (with per-key async locks)
+        self._text_cache = LRUEmbeddingCache(maxsize=_TEXT_EMBEDDING_CACHE_MAXSIZE)
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Get or create the shared httpx client (lazy initialization for connection pooling)."""
+        if self._client is None:
+            timeout = httpx.Timeout(connect=30.0, read=120.0, write=120.0, pool=30.0)
+            self._client = httpx.AsyncClient(timeout=timeout)
+        return self._client
+
+    @override
+    async def aclose(self) -> None:
+        """Close the shared httpx client and clear caches."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+        self._text_cache.clear()
 
     @override
     async def get_image_embedding(self, image_url: str) -> list[float]:
@@ -51,11 +72,9 @@ class CosmosEmbedClient(EmbedClient):
             "model": self.model,
         }
         try:
-            timeout = httpx.Timeout(connect=30.0, read=120.0, write=120.0, pool=30.0)
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                response = await client.post(self.image_embeddings_url, json=payload)
-                response.raise_for_status()
-                result = response.json()
+            response = await self._get_client().post(self.image_embeddings_url, json=payload)
+            response.raise_for_status()
+            result = response.json()
             embedding: list[float] = result["data"][0]["embedding"]
             return embedding
         except httpx.HTTPError as e:
@@ -64,18 +83,40 @@ class CosmosEmbedClient(EmbedClient):
 
     @override
     async def get_text_embedding(self, text: str) -> list[float]:
-        """Generate embedding for text input"""
+        """Generate embedding for text input.
+
+        Results are cached (bounded LRU) so concurrent callers with the same
+        query share a single network round-trip and avoid redundant work.
+        """
+        cached = self._text_cache.get(text)
+        if cached is not None:
+            logger.debug(f"Text embedding cache hit for: {text[:80]}")
+            return cached
+
+        # Per-key lock so only one caller fetches a given text
+        lock = self._text_cache.get_lock(text)
+
+        async with lock:
+            # Double-check after acquiring lock
+            cached = self._text_cache.get(text)
+            if cached is not None:
+                return cached
+
+            embedding = await self._fetch_text_embedding(text)
+            self._text_cache.put(text, embedding)
+            return embedding
+
+    async def _fetch_text_embedding(self, text: str) -> list[float]:
+        """Fetch text embedding from Cosmos Embed API."""
         payload = {
             "text_input": [text],
             "model": self.model,
         }
 
         try:
-            timeout = httpx.Timeout(connect=30.0, read=120.0, write=120.0, pool=30.0)
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                response = await client.post(self.text_embeddings_url, json=payload)
-                response.raise_for_status()
-                result = response.json()
+            response = await self._get_client().post(self.text_embeddings_url, json=payload)
+            response.raise_for_status()
+            result = response.json()
             embeddings: list[float] = result["data"][0]["embeddings"]
             return embeddings
         except httpx.HTTPError as e:
@@ -102,11 +143,9 @@ class CosmosEmbedClient(EmbedClient):
         }
         logger.info(f"Payload: {payload}")
 
-        timeout = httpx.Timeout(connect=30.0, read=120.0, write=120.0, pool=30.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(self.video_embeddings_url, json=payload)
-            response.raise_for_status()
-            result = response.json()
+        response = await self._get_client().post(self.video_embeddings_url, json=payload)
+        response.raise_for_status()
+        result = response.json()
 
         # Extract embeddings from response
         embeddings = [item["embedding"] for item in result["data"]]

--- a/agent/src/vss_agents/embed/embed.py
+++ b/agent/src/vss_agents/embed/embed.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 from abc import ABC
 from abc import abstractmethod
+import asyncio
+from collections import OrderedDict
 
 
 class EmbedClient(ABC):
@@ -33,3 +35,55 @@ class EmbedClient(ABC):
     async def get_video_embedding(self, video_url: str) -> list[float]:
         """Generate embedding for video input."""
         pass
+
+    async def aclose(self) -> None:
+        """Release any resources held by this client.
+
+        Default implementation is a no-op. Subclasses with persistent HTTP clients
+        or caches should override to close/clear them.
+        """
+        return None
+
+
+class LRUEmbeddingCache:
+    """Bounded LRU cache for text embeddings with per-key async locks.
+
+    Both the cache and the lock dictionary are bounded by ``maxsize``. When full,
+    the oldest (least-recently-used) entry is evicted along with its matching lock.
+    """
+
+    def __init__(self, maxsize: int = 1024):
+        self._maxsize = maxsize
+        self._cache: OrderedDict[str, list[float]] = OrderedDict()
+        self._locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
+
+    def get(self, key: str) -> list[float] | None:
+        value = self._cache.get(key)
+        if value is not None:
+            self._cache.move_to_end(key)  # LRU bump
+        return value
+
+    def put(self, key: str, value: list[float]) -> None:
+        self._cache[key] = value
+        self._cache.move_to_end(key)
+        while len(self._cache) > self._maxsize:
+            evicted, _ = self._cache.popitem(last=False)
+            self._locks.pop(evicted, None)  # prune matching lock
+
+    def get_lock(self, key: str) -> asyncio.Lock:
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        self._locks.move_to_end(key)
+        # Bound locks dict independently; keys with cache entries will tend to stay
+        while len(self._locks) > self._maxsize:
+            self._locks.popitem(last=False)
+        return lock
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._locks.clear()
+
+    def __len__(self) -> int:
+        return len(self._cache)

--- a/agent/src/vss_agents/embed/rtvi_cv_embed.py
+++ b/agent/src/vss_agents/embed/rtvi_cv_embed.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncio
 import logging
 from typing import cast
 
@@ -20,8 +19,11 @@ import httpx
 from typing_extensions import override  # noqa: UP035  # mypy targets 3.11
 
 from vss_agents.embed.embed import EmbedClient
+from vss_agents.embed.embed import LRUEmbeddingCache
 
 logger = logging.getLogger(__name__)
+
+_TEXT_EMBEDDING_CACHE_MAXSIZE = 1024
 
 
 class RTVICVEmbedClient(EmbedClient):
@@ -36,30 +38,37 @@ class RTVICVEmbedClient(EmbedClient):
         """
         self.endpoint = endpoint.rstrip("/")
         self.text_embeddings_url = f"{self.endpoint}/api/v1/generate_text_embeddings"
-        self._text_embedding_cache: dict[str, list[float]] = {}
-        self._text_embedding_locks: dict[str, asyncio.Lock] = {}
+        # Bounded LRU cache for text embeddings (with per-key async locks)
+        self._text_cache = LRUEmbeddingCache(maxsize=_TEXT_EMBEDDING_CACHE_MAXSIZE)
+
+    @override
+    async def aclose(self) -> None:
+        """Clear cached embeddings and locks."""
+        self._text_cache.clear()
 
     @override
     async def get_text_embedding(self, text: str) -> list[float]:
         """Generate embedding for text input using RTVI CV API.
 
-        Results are cached by text input so that concurrent callers
-        with the same query share a single network round-trip.
+        Results are cached (bounded LRU) so concurrent callers with the same
+        query share a single network round-trip.
         """
-        if text in self._text_embedding_cache:
+        cached = self._text_cache.get(text)
+        if cached is not None:
             logger.debug(f"Text embedding cache hit for: {text[:80]}")
-            return self._text_embedding_cache[text]
+            return cached
 
         # Per-key lock so only one caller fetches a given text
-        lock = self._text_embedding_locks.setdefault(text, asyncio.Lock())
+        lock = self._text_cache.get_lock(text)
 
         async with lock:
             # Double-check after acquiring lock
-            if text in self._text_embedding_cache:
-                return self._text_embedding_cache[text]
+            cached = self._text_cache.get(text)
+            if cached is not None:
+                return cached
 
             embedding = await self._fetch_text_embedding(text)
-            self._text_embedding_cache[text] = embedding
+            self._text_cache.put(text, embedding)
             return embedding
 
     async def _fetch_text_embedding(self, text: str) -> list[float]:

--- a/agent/src/vss_agents/evaluators/customized_trajectory_evaluator/evaluate.py
+++ b/agent/src/vss_agents/evaluators/customized_trajectory_evaluator/evaluate.py
@@ -18,6 +18,7 @@
 
 import ast
 import contextlib
+import copy
 import json
 import logging
 from typing import Any
@@ -31,7 +32,9 @@ from nat.data_models.evaluator import EvalOutputItem
 from nat.plugins.eval.evaluator.base_evaluator import BaseEvaluator
 
 from vss_agents.evaluators.utils import ScoreOutputParser
+from vss_agents.evaluators.utils import extract_tool_results_from_trajectory
 from vss_agents.evaluators.utils import invoke_llm_with_retry
+from vss_agents.evaluators.utils import parse_tool_result
 from vss_agents.evaluators.utils import should_evaluate
 from vss_agents.evaluators.utils import strip_agent_think_tags
 
@@ -182,6 +185,88 @@ class CustomizedTrajectoryEvaluator(BaseEvaluator):
 
         return agent_selected_uuids
 
+    def _resolve_refs(
+        self,
+        ground_truth: list[dict[str, Any]],
+        tool_results: dict[str, list[Any]],
+        previous_turn_results: dict[str, dict[str, list[Any]]] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Resolve $ref references in ground truth params using actual tool results.
+
+        A $ref tells the evaluator: "don't compare against a hardcoded value. Instead,
+        look up the actual result from a previous tool call and compare against that."
+
+        $ref fields:
+            - tool (required): which tool's result to look up.
+            - path (required): keys/indices to navigate into the result.
+              Strings are dict keys, integers are list indices.
+              e.g. ["items", 0, "id"] means result["items"][0]["id"].
+            - index (optional, default 0): which occurrence of the tool to use,
+              if the same tool was called multiple times.
+            - turn (optional): reference a previous turn's tool result instead of
+              the current turn.
+
+        Examples:
+            {"$ref": {"tool": "tool_a", "path": ["items", 0, "id"]}}
+            {"$ref": {"tool": "tool_a", "index": 1, "path": ["items", 0]}}
+            {"$ref": {"turn": "turn_1", "tool": "tool_a", "path": ["items", 0]}}
+
+        Args:
+            ground_truth: The trajectory_ground_truth list from the dataset.
+            tool_results: Current turn's tool results, keyed by
+                tool_name -> [result_0, result_1, ...] (ordered by occurrence).
+            previous_turn_results: Previous turns' tool results, keyed by
+                turn_id -> {tool_name -> [result_0, ...]}. Extracted from
+                trajectories in evaluate_patch.
+
+        Returns:
+            A deep copy of ground_truth with all $ref values resolved to concrete values.
+            Unresolvable $ref values are left unchanged.
+        """
+        resolved = copy.deepcopy(ground_truth)
+        for entry in resolved:
+            if "params" not in entry:
+                continue
+            for param_key, param_value in entry["params"].items():
+                if not (isinstance(param_value, dict) and "$ref" in param_value):
+                    continue
+                ref = param_value["$ref"]
+                ref_tool = ref.get("tool")
+                ref_index = ref.get("index", 0)
+                ref_path = ref.get("path", [])
+                ref_turn = ref.get("turn")
+
+                if not ref_tool:
+                    logger.warning(f"$ref missing required 'tool' key: {ref}")
+                    continue
+
+                # Pick the source: previous turn or current turn
+                if ref_turn:
+                    source = (previous_turn_results or {}).get(ref_turn, {})
+                else:
+                    source = tool_results
+
+                # Look up the tool's result list, then pick by index
+                results_list = source.get(ref_tool, [])
+                if ref_index >= len(results_list):
+                    logger.warning(
+                        f"$ref resolution failed: tool '{ref_tool}' has {len(results_list)} results, "
+                        f"requested index {ref_index}"
+                    )
+                    continue
+
+                result = parse_tool_result(results_list[ref_index])
+
+                try:
+                    value = result
+                    for key in ref_path:
+                        value = value[key]
+                    entry["params"][param_key] = value
+                except (KeyError, IndexError, TypeError):
+                    logger.warning(f"$ref path resolution failed for {ref_path}")
+
+        return resolved
+
     async def evaluate_item(self, item: EvalInputItem) -> EvalOutputItem:
         """
         Evaluate a single EvalInputItem and return an EvalOutputItem.
@@ -244,7 +329,10 @@ class CustomizedTrajectoryEvaluator(BaseEvaluator):
 
         logger.info(f"After filtering LLM reasoning steps: {len(agent_trajectory)} steps remain")
 
-        # Extract tool calls with step numbers.
+        # Extract tool results for $ref resolution
+        tool_results = extract_tool_results_from_trajectory(trajectory)
+
+        # Extract tool calls with step numbers for the LLM judge.
         # Each LLM reasoning step (contains "Tool calls:") marks the start of a new step.
         # Tools following the same LLM step are parallel (same step number).
         structured_tool_calls = []
@@ -261,6 +349,12 @@ class CustomizedTrajectoryEvaluator(BaseEvaluator):
                     params = ast.literal_eval(params)
             structured_tool_calls.append({"step": step_number, "name": action.tool, "params": params})
 
+        # Get previous turns' tool results for cross-turn $ref resolution.
+        # These are extracted from the trajectory in evaluate_patch.py and indexed by tool name.
+        previous_turn_results: dict[str, dict[str, list[Any]]] | None = None
+        if hasattr(item, "full_dataset_entry") and item.full_dataset_entry:
+            previous_turn_results = item.full_dataset_entry.get("_all_turn_tool_results")
+
         # Get conversation history from previous turns (multi-turn only)
         conv_history = []
         if hasattr(item, "full_dataset_entry") and item.full_dataset_entry:
@@ -269,20 +363,23 @@ class CustomizedTrajectoryEvaluator(BaseEvaluator):
                 conv_history = []
 
         # Auto-detect: check if this item has trajectory_ground_truth
-        reference = None
+        reference: list[dict[str, Any]] | None = None
         if hasattr(item, "full_dataset_entry") and item.full_dataset_entry:
             reference = item.full_dataset_entry.get("trajectory_ground_truth")
 
         has_reference = reference is not None
 
-        if has_reference and self.prompt_with_reference:
+        if reference is not None and self.prompt_with_reference:
+            # Resolve $ref placeholders in ground truth using actual tool results
+            resolved_reference = self._resolve_refs(reference, tool_results, previous_turn_results)
+
             # Reference mode: compare structured tool calls against ground truth
             if structured_tool_calls:
                 actual_tool_calls_str = json.dumps(structured_tool_calls, indent=2)
             else:
                 actual_tool_calls_str = "(no tool calls)"
 
-            reference_str = json.dumps(reference, indent=2)
+            reference_str = json.dumps(resolved_reference, indent=2)
 
             prompt_text = self.prompt_with_reference.format(
                 question=question,
@@ -324,12 +421,15 @@ class CustomizedTrajectoryEvaluator(BaseEvaluator):
             )
 
         # Build reasoning closure to capture local variables
+        resolved_ref = resolved_reference if has_reference and self.prompt_with_reference else reference
+
         def build_reasoning(eval_result: dict) -> dict:
             return {
                 "reasoning": eval_result["reasoning"],
                 "query": question,
                 "actual_tool_calls": structured_tool_calls,
                 "expected_tool_calls": reference,
+                "resolved_expected_tool_calls": resolved_ref,
                 "final_answer": generated_answer,
                 "trajectory": [(action.model_dump(), output) for action, output in agent_trajectory],
                 "conversation_history": conv_history,

--- a/agent/src/vss_agents/evaluators/evaluate_patch.py
+++ b/agent/src/vss_agents/evaluators/evaluate_patch.py
@@ -68,6 +68,7 @@ from nat.data_models.evaluator import EvalInputItem
 from tqdm import tqdm
 
 from vss_agents.evaluators.utils import compute_item_latency
+from vss_agents.evaluators.utils import extract_tool_results_from_trajectory
 from vss_agents.evaluators.utils import strip_agent_think_tags
 
 logger = logging.getLogger(__name__)
@@ -302,11 +303,16 @@ def apply_patch() -> None:
             ContextState.get().conversation_id.set(conv_id)
             logger.info(f"[Multi-turn] Running conversation {conv_id} with {len(items)} turns sequentially")
             conversation_history: list[dict[str, str]] = []
+            all_turn_tool_results: dict[str, dict[str, Any]] = {}
 
             for item in items:
                 # Add previous turns so evaluators have conversation context
                 if conversation_history:
                     item.full_dataset_entry["_conversation_history"] = list(conversation_history)
+
+                # Pass previous turns' tool results for cross-turn $ref resolution
+                if all_turn_tool_results:
+                    item.full_dataset_entry["_all_turn_tool_results"] = dict(all_turn_tool_results)
 
                 # Re-set conversation_id before each turn
                 ContextState.get().conversation_id.set(conv_id)
@@ -316,13 +322,18 @@ def apply_patch() -> None:
                 await _original_run_workflow_local(self, session_manager)
                 pbar.update(1)
 
+                turn_id = item.full_dataset_entry.get("turn_id", f"turn_{len(conversation_history) + 1}")
                 conversation_history.append(
                     {
-                        "turn_id": item.full_dataset_entry.get("turn_id", f"turn_{len(conversation_history) + 1}"),
+                        "turn_id": turn_id,
                         "query": item.input_obj,
                         "answer": strip_agent_think_tags(item.output_obj),
                     }
                 )
+                # Extract tool results from trajectory for cross-turn $ref resolution
+                tool_results = extract_tool_results_from_trajectory(item.trajectory or [])
+                if tool_results:
+                    all_turn_tool_results[turn_id] = tool_results
 
         async def run_non_multi_turn() -> None:
             """Run non-multi-turn items."""

--- a/agent/src/vss_agents/evaluators/utils.py
+++ b/agent/src/vss_agents/evaluators/utils.py
@@ -15,7 +15,10 @@
 
 """Shared utilities for evaluators."""
 
+import ast
 from collections.abc import Callable
+import contextlib
+import json
 import logging
 import re
 from typing import Any
@@ -34,6 +37,47 @@ from vss_agents.utils.reasoning_utils import get_llm_reasoning_bind_kwargs
 from vss_agents.utils.reasoning_utils import get_thinking_tag
 
 logger = logging.getLogger(__name__)
+
+
+def parse_tool_result(output: Any) -> Any:
+    """Parse a tool output into a structured form for $ref resolution.
+
+    Handles dicts/lists (returned as-is), JSON strings, and Python repr strings.
+    """
+    if isinstance(output, (dict, list)):
+        return output
+    if isinstance(output, str):
+        with contextlib.suppress(Exception):
+            return json.loads(output)
+        with contextlib.suppress(Exception):
+            return ast.literal_eval(output)
+    return output
+
+
+def extract_tool_results_from_trajectory(trajectory: list) -> dict[str, list[Any]]:
+    """Extract top-level tool results from a trajectory, indexed by tool name.
+
+    Only includes TOOL_END events at the workflow level (not nested tool calls).
+    Results are collected as lists to handle multiple calls to the same tool.
+
+    Returns:
+        Mapping of tool_name -> [result_0, result_1, ...] in call order.
+    """
+    from nat.data_models.intermediate_step import IntermediateStepType
+
+    tool_results: dict[str, list[Any]] = {}
+    for step in trajectory:
+        if (
+            step.event_type == IntermediateStepType.TOOL_END
+            and step.function_ancestry
+            and step.function_ancestry.function_name == "<workflow>"
+            and step.name
+            and step.data
+        ):
+            output = getattr(step.data, "output", None)
+            if output is not None:
+                tool_results.setdefault(step.name, []).append(output)
+    return tool_results
 
 
 def compute_item_latency(item: EvalInputItem) -> float | None:

--- a/agent/src/vss_agents/tools/attribute_search.py
+++ b/agent/src/vss_agents/tools/attribute_search.py
@@ -37,6 +37,7 @@ from vss_agents.embed.embed import EmbedClient
 from vss_agents.embed.rtvi_cv_embed import RTVICVEmbedClient
 from vss_agents.tools.vst.snapshot import build_screenshot_url
 from vss_agents.utils.time_measure import TimeMeasure
+from vss_agents.utils.uuid_string import is_standard_uuid_string
 
 logger = logging.getLogger(__name__)
 
@@ -567,31 +568,38 @@ async def _search_behavior(
         if overlap_filter["bool"]["must"]:
             filter_clauses.append(overlap_filter)
 
-    # Add video_sources filter if provided (same logic as embed_search)
+    # Add video_sources filter if provided (same two-tier logic as embed_search)
+    # Resolved UUIDs get a single `terms` clause; unresolved names use wildcard/regexp fallback
     if video_sources:
-        should_clauses = []
-        for vname in video_sources:
-            escaped_vname = vname.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?")
-            # Check sensor.id (for RTSP streams and video files)
-            should_clauses.append({"term": {"sensor.id.keyword": vname}})
-            should_clauses.append({"wildcard": {"sensor.id.keyword": f"*{escaped_vname}*"}})
-            # Check sensor.info.url (for uploaded video files)
-            should_clauses.append({"wildcard": {"sensor.info.url.keyword": f"*{escaped_vname}"}})
-            should_clauses.append({"wildcard": {"sensor.info.url.keyword": f"*{escaped_vname}*"}})
-            # Check sensor.info.path (for RTSP streams - contains UUID)
-            should_clauses.append({"wildcard": {"sensor.info.path.keyword": f"*{escaped_vname}*"}})
-            regex_escaped = re.escape(vname)
-            should_clauses.append({"regexp": {"sensor.info.url": f".*{regex_escaped}"}})
-            should_clauses.append({"regexp": {"sensor.info.path": f".*{regex_escaped}"}})
+        uuid_sources = [v for v in video_sources if is_standard_uuid_string(v)]
+        non_uuid_sources = [v for v in video_sources if not is_standard_uuid_string(v)]
 
-        filter_clauses.append(
-            {
-                "bool": {
-                    "should": should_clauses,
-                    "minimum_should_match": 1,
+        if uuid_sources and not non_uuid_sources:
+            # All sources are UUIDs — single terms clause (fastest)
+            filter_clauses.append({"terms": {"sensor.id.keyword": uuid_sources}})
+        else:
+            # Mixed or all non-UUID — build should clauses
+            should_clauses: list[dict[str, Any]] = []
+            if uuid_sources:
+                should_clauses.append({"terms": {"sensor.id.keyword": uuid_sources}})
+            for vname in non_uuid_sources:
+                escaped_vname = vname.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?")
+                should_clauses.append({"term": {"sensor.id.keyword": vname}})
+                should_clauses.append({"wildcard": {"sensor.id.keyword": f"*{escaped_vname}*"}})
+                should_clauses.append({"wildcard": {"sensor.info.url.keyword": f"*{escaped_vname}"}})
+                should_clauses.append({"wildcard": {"sensor.info.url.keyword": f"*{escaped_vname}*"}})
+                should_clauses.append({"wildcard": {"sensor.info.path.keyword": f"*{escaped_vname}*"}})
+                regex_escaped = re.escape(vname)
+                should_clauses.append({"regexp": {"sensor.info.url": f".*{regex_escaped}"}})
+                should_clauses.append({"regexp": {"sensor.info.path": f".*{regex_escaped}"}})
+            filter_clauses.append(
+                {
+                    "bool": {
+                        "should": should_clauses,
+                        "minimum_should_match": 1,
+                    }
                 }
-            }
-        )
+            )
 
     # Build KNN query with filters INSIDE (so filters are applied during KNN search, not after)
     # Fetch more candidates to account for duplicates - we'll deduplicate and return top_k later
@@ -1415,9 +1423,20 @@ async def build_attribute_search(config: AttributeSearchConfig, _builder: Builde
             config.enable_frame_lookup,
         )
 
-    yield FunctionInfo.create(
-        single_fn=attribute_search_fn,
-        description="Search for objects by visual attributes",
-        input_schema=AttributeSearchInput,
-        # Note: single_output_schema removed to avoid Python 3.13 isinstance() issues with parameterized generics
-    )
+    try:
+        yield FunctionInfo.create(
+            single_fn=attribute_search_fn,
+            description="Search for objects by visual attributes",
+            input_schema=AttributeSearchInput,
+            # Note: single_output_schema removed to avoid Python 3.13 isinstance() issues with parameterized generics
+        )
+    finally:
+        # Release embedding cache + close ES client
+        try:
+            await embed_client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing embed client: {e}")
+        try:
+            await es_client.close()
+        except Exception as e:
+            logger.warning(f"Error closing ES client: {e}")

--- a/agent/src/vss_agents/tools/embed_search.py
+++ b/agent/src/vss_agents/tools/embed_search.py
@@ -39,6 +39,7 @@ from vss_agents.tools.vst.snapshot import build_screenshot_url
 from vss_agents.utils.time_convert import datetime_to_iso8601
 from vss_agents.utils.time_convert import iso8601_to_datetime
 from vss_agents.utils.time_measure import TimeMeasure
+from vss_agents.utils.uuid_string import is_standard_uuid_string
 
 if TYPE_CHECKING:
     from vss_agents.embed.embed import EmbedClient
@@ -277,30 +278,39 @@ def _build_es_query(query_input: QueryInput, query_embedding: list[float], confi
     filters: list[dict[str, Any]] = []
 
     # Add video_sources filter if provided
+    # Two-tier approach: resolved UUIDs get a single `terms` clause (O(1) hash lookup),
+    # unresolved names fall back to wildcard/regexp pattern (expensive scan).
+    # UUIDs are resolved upstream in execute_core_search() via VST streams_info mapping.
     if video_sources:
-        should_clauses = []
-        for vname in video_sources:
-            escaped_vname = vname.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?")
-            # Check sensor.id (for RTSP streams and video files)
-            should_clauses.append({"term": {"sensor.id.keyword": vname}})
-            should_clauses.append({"wildcard": {"sensor.id.keyword": f"*{escaped_vname}*"}})
-            # Check sensor.info.url (for uploaded video files)
-            should_clauses.append({"wildcard": {"sensor.info.url.keyword": f"*{escaped_vname}"}})
-            should_clauses.append({"wildcard": {"sensor.info.url.keyword": f"*{escaped_vname}*"}})
-            # Check sensor.info.path (for RTSP streams - contains UUID)
-            should_clauses.append({"wildcard": {"sensor.info.path.keyword": f"*{escaped_vname}*"}})
-            regex_escaped = re.escape(vname)
-            should_clauses.append({"regexp": {"sensor.info.url": f".*{regex_escaped}"}})
-            should_clauses.append({"regexp": {"sensor.info.path": f".*{regex_escaped}"}})
+        uuid_sources = [v for v in video_sources if is_standard_uuid_string(v)]
+        non_uuid_sources = [v for v in video_sources if not is_standard_uuid_string(v)]
 
-        filters.append(
-            {
-                "bool": {
-                    "should": should_clauses,
-                    "minimum_should_match": 1,
+        if uuid_sources and not non_uuid_sources:
+            # All sources are UUIDs — single terms clause (fastest)
+            filters.append({"terms": {"sensor.id.keyword": uuid_sources}})
+        else:
+            # Mixed or all non-UUID — build should clauses
+            should_clauses: list[dict[str, Any]] = []
+            if uuid_sources:
+                should_clauses.append({"terms": {"sensor.id.keyword": uuid_sources}})
+            for vname in non_uuid_sources:
+                escaped_vname = vname.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?")
+                should_clauses.append({"term": {"sensor.id.keyword": vname}})
+                should_clauses.append({"wildcard": {"sensor.id.keyword": f"*{escaped_vname}*"}})
+                should_clauses.append({"wildcard": {"sensor.info.url.keyword": f"*{escaped_vname}"}})
+                should_clauses.append({"wildcard": {"sensor.info.url.keyword": f"*{escaped_vname}*"}})
+                should_clauses.append({"wildcard": {"sensor.info.path.keyword": f"*{escaped_vname}*"}})
+                regex_escaped = re.escape(vname)
+                should_clauses.append({"regexp": {"sensor.info.url": f".*{regex_escaped}"}})
+                should_clauses.append({"regexp": {"sensor.info.path": f".*{regex_escaped}"}})
+            filters.append(
+                {
+                    "bool": {
+                        "should": should_clauses,
+                        "minimum_should_match": 1,
+                    }
                 }
-            }
-        )
+            )
 
     # Add description filter
     if description:
@@ -455,11 +465,9 @@ async def _process_search_hit(
 
         # Priority 1: Check sensor.stream_id field (if present, it's the UUID)
         sensor_stream_id = sensor_data.get("stream_id", "")
-        if sensor_stream_id:
-            is_uuid = len(sensor_stream_id) == 36 and sensor_stream_id.count("-") == 4
-            if is_uuid:
-                stream_id = sensor_stream_id
-                logger.debug(f"Found UUID in sensor.stream_id: {stream_id}")
+        if sensor_stream_id and is_standard_uuid_string(sensor_stream_id):
+            stream_id = sensor_stream_id
+            logger.debug(f"Found UUID in sensor.stream_id: {stream_id}")
 
         # Priority 2: Extract UUID from sensor.info.path (works for both RTSP and video files)
         if not stream_id and video_path:
@@ -471,8 +479,7 @@ async def _process_search_hit(
 
         # Priority 3: If no UUID in path, check if sensor.id is a UUID (video file case)
         if not stream_id:
-            is_uuid = len(sensor_id_raw) == 36 and sensor_id_raw.count("-") == 4
-            if is_uuid:
+            if is_standard_uuid_string(sensor_id_raw):
                 # Video file: sensor.id IS the UUID
                 stream_id = sensor_id_raw
                 logger.debug(f"Using sensor.id as UUID: {stream_id}")
@@ -508,8 +515,7 @@ async def _process_search_hit(
         # ============================================================================================
         video_name = response_data.get("video_name", "")
         if not video_name:
-            is_uuid = len(sensor_id_raw) == 36 and sensor_id_raw.count("-") == 4
-            if is_uuid:
+            if is_standard_uuid_string(sensor_id_raw):
                 # Video file: extract filename from path
                 if video_path:
                     video_name = video_path.split("/")[-1]  # e.g., "boxcart_1_20250101_000000_c9b20.mp4"
@@ -652,14 +658,25 @@ async def embed_search(config: EmbedSearchConfig, _builder: Builder) -> AsyncGen
 
         return EmbedSearchOutput(query_embedding=query_embedding, results=results)
 
-    yield FunctionInfo.create(
-        single_fn=_embed_search,
-        description=_embed_search.__doc__,
-        input_schema=QueryInput,
-        single_output_schema=EmbedSearchOutput,
-        converters=[
-            _str_input_converter,
-            _chat_request_input_converter,
-            _to_str_output,
-        ],
-    )
+    try:
+        yield FunctionInfo.create(
+            single_fn=_embed_search,
+            description=_embed_search.__doc__,
+            input_schema=QueryInput,
+            single_output_schema=EmbedSearchOutput,
+            converters=[
+                _str_input_converter,
+                _chat_request_input_converter,
+                _to_str_output,
+            ],
+        )
+    finally:
+        # Release persistent HTTP client + embedding cache, then close ES client
+        try:
+            await embed_client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing embed client: {e}")
+        try:
+            await es_client.close()
+        except Exception as e:
+            logger.warning(f"Error closing ES client: {e}")

--- a/agent/src/vss_agents/tools/lvs_video_understanding.py
+++ b/agent/src/vss_agents/tools/lvs_video_understanding.py
@@ -49,6 +49,7 @@ from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import field_validator
 
+from vss_agents.utils.hitl import format_hitl_popup_header
 from vss_agents.utils.url_translation import translate_url
 
 logger = logging.getLogger(__name__)
@@ -230,6 +231,16 @@ class LVSVideoUnderstandingInput(BaseModel):
         ...,
         description="The sensor ID(s) of the video(s) to understand. Can be a single sensor ID or a list for parallel processing.",
     )
+    request_total_videos: int | None = Field(
+        default=None,
+        description=(
+            "Internal field set by the dispatcher (e.g. video_report_gen's mixed-routing "
+            "path) to the total number of videos in the user's original request when this "
+            "tool is invoked with only a subset. When set and larger than the number of "
+            "sensor_ids, HITL popups render 'Setting prompt for X out of Y videos' instead "
+            "of 'Analyzing X video(s)'. Do not populate this field from LLM tool calls."
+        ),
+    )
 
     @field_validator("sensor_id")
     @classmethod
@@ -338,6 +349,7 @@ async def lvs_video_understanding(
         events: list[str],
         objects_of_interest: list[str],
         sensor_ids: list[str] | None = None,
+        total_videos: int | None = None,
     ) -> str:
         """
         Show all LVS configuration and get user confirmation.
@@ -347,16 +359,17 @@ async def lvs_video_understanding(
             events: List of events to detect
             objects_of_interest: List of objects to focus on
             sensor_ids: Optional list of video sensor IDs to show in the prompt context
+            total_videos: Optional total number of videos in the user's request. When
+                set and larger than ``len(sensor_ids)``, the header becomes
+                "Setting prompt for X out of Y videos" to signal the popup applies to
+                a subset (e.g. the LVS group in a mixed-routing batch).
 
         Returns:
             str: Normalized user choice ("/redo", "/cancel", or empty string for proceed)
         """
         config_summary = _format_lvs_config_summary(scenario, events, objects_of_interest)
 
-        video_context = ""
-        if sensor_ids:
-            video_list = ", ".join(f"`{sid}`" for sid in sensor_ids)
-            video_context = f"**Analyzing {len(sensor_ids)} video(s):** {video_list}\n\n"
+        video_context = format_hitl_popup_header(sensor_ids, total_videos)
 
         hitl_template = config.hitl_confirmation_template or DEFAULT_HITL_CONFIRMATION_TEMPLATE
         prompt_text = f"{video_context}{config_summary}\n\n{hitl_template}"
@@ -373,6 +386,7 @@ async def lvs_video_understanding(
     async def _collect_hitl_parameters(
         current_params: tuple[str, list[str], list[str]] | None = None,
         sensor_ids: list[str] | None = None,
+        total_videos: int | None = None,
     ) -> tuple[str, list[str], list[str]] | None:
         """
         Collect scenario, events, and objects_of_interest via HITL.
@@ -383,6 +397,10 @@ async def lvs_video_understanding(
         Args:
             current_params: Optional current parameters (scenario, events, objects_of_interest)
             sensor_ids: Optional list of video sensor IDs to show in the prompt context
+            total_videos: Optional total number of videos in the user's request. When
+                set and larger than ``len(sensor_ids)``, the header becomes
+                "Setting prompt for X out of Y videos" to signal the popup applies to
+                a subset (e.g. the LVS group in a mixed-routing batch).
 
         Returns:
             tuple: (scenario, events, objects_of_interest), or None if cancelled
@@ -393,10 +411,7 @@ async def lvs_video_understanding(
         cancel_info = "\n\n**Note:** Type `/cancel` at any time to abort the video analysis."
 
         # Build video context header if sensor_ids provided
-        video_context = ""
-        if sensor_ids:
-            video_list = ", ".join(f"`{sid}`" for sid in sensor_ids)
-            video_context = f"**Analyzing {len(sensor_ids)} video(s):** {video_list}\n\n"
+        video_context = format_hitl_popup_header(sensor_ids, total_videos)
 
         # Build prompt with current values if they exist
         if current_params:
@@ -651,6 +666,7 @@ async def lvs_video_understanding(
         # Normalize sensor_id to list for unified handling
         sensor_ids = [lvs_input.sensor_id] if isinstance(lvs_input.sensor_id, str) else lvs_input.sensor_id
         is_multi_video = len(sensor_ids) > 1
+        request_total_videos = lvs_input.request_total_videos
 
         # Get thread_id for state persistence
         thread_id = ContextState.get().conversation_id.get()
@@ -678,7 +694,9 @@ async def lvs_video_understanding(
         while True:
             # Step 1: Collect parameters via HITL
             logger.info("Running HITL workflow to collect/confirm parameters")
-            params_result = await _collect_hitl_parameters(current_params, sensor_ids=sensor_ids)
+            params_result = await _collect_hitl_parameters(
+                current_params, sensor_ids=sensor_ids, total_videos=request_total_videos
+            )
 
             # Handle cancellation
             if params_result is None:
@@ -695,7 +713,13 @@ async def lvs_video_understanding(
 
             # Step 2: Show all configs and get confirmation
             logger.info("Showing LVS configuration for user confirmation")
-            user_choice = await _confirm_lvs_request(scenario, events_list, objects_of_interest, sensor_ids=sensor_ids)
+            user_choice = await _confirm_lvs_request(
+                scenario,
+                events_list,
+                objects_of_interest,
+                sensor_ids=sensor_ids,
+                total_videos=request_total_videos,
+            )
 
             if user_choice == "/redo":
                 # User wants to modify parameters - loop back with current values

--- a/agent/src/vss_agents/tools/search.py
+++ b/agent/src/vss_agents/tools/search.py
@@ -833,12 +833,17 @@ async def execute_core_search(
             # Fetch sensor names from VST based on source_type
             video_file_names: list[str] = []
             video_stream_names: list[str] = []
+            name_to_uuid: dict[str, str] = {}
             try:
                 vst_url = getattr(config, "vst_internal_url", None)
                 if vst_url:
                     streams_info = await get_streams_info(vst_url)
                     source_type = getattr(search_input, "source_type", None)
-                    for _stream_id, stream_info in streams_info.items():
+                    # Classify streams by source_type AND build the name→UUID mapping
+                    # used for two-tier video source filtering. Only include names
+                    # matching the query's source_type so names that collide across
+                    # RTSP and video_file sources don't overwrite each other.
+                    for stream_id, stream_info in streams_info.items():
                         name = stream_info.get("name", "")
                         url = stream_info.get("url", "")
                         if not name:
@@ -846,9 +851,14 @@ async def execute_core_search(
                         is_rtsp = url and url.startswith("rtsp://")
                         if source_type == "rtsp" and is_rtsp:
                             video_stream_names.append(name)
+                            name_to_uuid[name] = stream_id
                         elif source_type == "video_file" and not is_rtsp:
                             video_file_names.append(name)
+                            name_to_uuid[name] = stream_id
                         elif source_type is None:
+                            # source_type unspecified — include all, matching existing
+                            # behavior for the name lists
+                            name_to_uuid[name] = stream_id
                             if is_rtsp:
                                 video_stream_names.append(name)
                             else:
@@ -876,6 +886,19 @@ async def execute_core_search(
                 search_input.query = decomposed.query
             if decomposed.video_sources:
                 search_input.video_sources = decomposed.video_sources
+            # Resolve video source names → UUIDs using the VST mapping (two-tier filtering)
+            # Resolved UUIDs get fast exact-match ES filters; unresolved names fall back to wildcards
+            if search_input.video_sources and name_to_uuid:
+                resolved_sources = []
+                for vname in search_input.video_sources:
+                    uuid = name_to_uuid.get(vname)
+                    if uuid:
+                        resolved_sources.append(uuid)
+                        logger.info(f"Resolved video source '{vname}' to UUID '{uuid}'")
+                    else:
+                        resolved_sources.append(vname)
+                        logger.info(f"Video source '{vname}' not resolved — will use wildcard filter")
+                search_input.video_sources = resolved_sources
             if decomposed.timestamp_start:
                 try:
                     search_input.timestamp_start = iso8601_to_datetime(decomposed.timestamp_start)

--- a/agent/src/vss_agents/tools/video_caption.py
+++ b/agent/src/vss_agents/tools/video_caption.py
@@ -339,8 +339,9 @@ async def video_caption(config: VideoCaptionConfig, builder: Builder) -> AsyncGe
 
                 step_size = 1 / video_caption_input.fps
                 with TimeMeasure(
-                    f"frame_select-{resolved_file_path}, {video_caption_input.start_timestamp}, "
-                    f"{video_caption_input.end_timestamp}, {video_caption_input.fps}"
+                    f"frame_select-{resolved_file_path}, {video_caption_input.start_timestamp}, {
+                        video_caption_input.end_timestamp
+                    }, {video_caption_input.fps}"
                 ):
                     base64_frames = await loop.run_in_executor(
                         None,

--- a/agent/src/vss_agents/tools/video_report_gen.py
+++ b/agent/src/vss_agents/tools/video_report_gen.py
@@ -62,6 +62,7 @@ from vss_agents.tools.lvs_video_understanding import LVSStatus
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import get_stream_id
 from vss_agents.tools.vst.video_clip import get_video_url
+from vss_agents.utils.hitl import format_hitl_popup_header
 from vss_agents.utils.reasoning_parsing import parse_reasoning_content
 from vss_agents.utils.time_convert import datetime_to_iso8601
 from vss_agents.utils.time_convert import iso8601_to_datetime
@@ -505,6 +506,10 @@ class VideoReportGenOutput(BaseModel):
     hitl_prompts: dict[str, Any] | None = Field(
         default=None,
         description="HITL prompts used for LVS analysis (scenario, events, objects_of_interest). Shared across all videos in multi-video processing.",
+    )
+    lvs_fallback_warning: str | None = Field(
+        default=None,
+        description="Warning message when LVS was not available and fell back to standard video understanding for a long video.",
     )
     # Multi-video specific fields
     all_reports: list[dict[str, Any]] | None = Field(
@@ -1420,6 +1425,7 @@ Enter your choice or press Submit to keep current value:"""
     async def _collect_hitl_vlm_prompt(
         current_prompt: str | None,
         sensor_ids: list[str] | None = None,
+        total_videos: int | None = None,
     ) -> str | None:
         """
         Collect/confirm VLM prompt via HITL with support for /generate and /refine commands.
@@ -1432,7 +1438,11 @@ Enter your choice or press Submit to keep current value:"""
 
         Args:
             current_prompt: Current prompt from state (if any)
-            sensor_ids: Optional list of video sensor IDs to show in the prompt context
+            sensor_ids: Optional list of video sensor IDs this prompt will apply to.
+            total_videos: Optional total number of videos in the user's request.
+                When larger than ``len(sensor_ids)``, the popup header switches to
+                "Setting prompt for X out of Y videos" so the user knows the prompt
+                only applies to a subset (e.g. the short-video batch in mixed routing).
 
         Returns:
             str: The confirmed or updated VLM prompt, or None if cancelled
@@ -1442,10 +1452,7 @@ Enter your choice or press Submit to keep current value:"""
         hitl_template = config.hitl_vlm_prompt_template or default_hitl_vlm_prompt_template
 
         # Build video context header if sensor_ids provided
-        video_context = ""
-        if sensor_ids:
-            video_list = ", ".join(f"`{sid}`" for sid in sensor_ids)
-            video_context = f"**Analyzing {len(sensor_ids)} video(s):** {video_list}\n\n"
+        video_context = format_hitl_popup_header(sensor_ids, total_videos)
 
         # Track the working prompt and its source
         working_prompt = current_prompt or config.vlm_prompt
@@ -1566,12 +1573,38 @@ Enter your choice or press Submit to keep current value:"""
 
         logger.info(f"Video routing: {len(lvs_sensor_ids)} LVS, {len(base_sensor_ids)} base VLM")
 
+        # When the request splits into both LVS and base VLM groups, each HITL popup
+        # only covers a subset of the user's videos. Pass the total count so popups
+        # render "Setting prompt for X out of Y videos" instead of "Analyzing X video(s)".
+        total_videos = len(sensor_ids)
+        request_total_videos: int | None = total_videos if (lvs_sensor_ids and base_sensor_ids) else None
+
+        # Build consolidated LVS fallback warning for long videos
+        fallback_videos = [(sid, dur) for sid, dur in durations if dur > config.lvs_video_length and not lvs_available]
+        if fallback_videos:
+            if len(fallback_videos) == 1:
+                sid, dur = fallback_videos[0]
+                video_summary = f"Input video {sid} is {dur:.1f}s long"
+            else:
+                video_list = ", ".join(f"{sid} ({dur:.1f}s)" for sid, dur in fallback_videos)
+                video_summary = f"Input videos {video_list} exceed the expected length"
+            multi_lvs_fallback_warning: str | None = (
+                f"⚠️ **Note:** {video_summary}. "
+                f"Please use 'Long Video Summarization' for videos longer than {config.lvs_video_length}s.\n\n"
+            )
+        else:
+            multi_lvs_fallback_warning = None
+
         # Step 2: Collect base VLM prompt upfront (if any base videos and HITL enabled)
         vlm_prompt_override: str | None = None
         if base_sensor_ids and config.hitl_enabled:
             thread_id = ContextState.get().conversation_id.get()
             current_prompt = _get_prompt(thread_id)
-            resolved_prompt = await _collect_hitl_vlm_prompt(current_prompt, sensor_ids=base_sensor_ids)
+            resolved_prompt = await _collect_hitl_vlm_prompt(
+                current_prompt,
+                sensor_ids=base_sensor_ids,
+                total_videos=request_total_videos,
+            )
             if resolved_prompt is None:
                 return VideoReportGenOutput(
                     summary="Report generation was cancelled by the user.",
@@ -1592,7 +1625,12 @@ Enter your choice or press Submit to keep current value:"""
                 user_query=report_input.user_query,
                 vlm_reasoning=report_input.vlm_reasoning,
             )
-            tasks.append((lvs_sensor_ids, _video_report_gen_single(lvs_input)))
+            tasks.append(
+                (
+                    lvs_sensor_ids,
+                    _video_report_gen_single(lvs_input, request_total_videos=request_total_videos),
+                )
+            )
 
         for sid in base_sensor_ids:
             base_input = VideoReportGenInput(
@@ -1684,6 +1722,7 @@ Enter your choice or press Submit to keep current value:"""
             pdf_file_size=total_pdf_file_size,
             all_reports=all_reports,
             hitl_prompts=shared_hitl_prompts,
+            lvs_fallback_warning=multi_lvs_fallback_warning,
         )
 
     async def _generate_single_report(
@@ -1768,6 +1807,7 @@ Enter your choice or press Submit to keep current value:"""
     async def _video_report_gen_single(
         report_input: VideoReportGenInput,
         vlm_prompt_override: str | None = None,
+        request_total_videos: int | None = None,
     ) -> VideoReportGenOutput:
         """
         Generate a video analysis report for one video (or a batch of LVS videos).
@@ -1776,6 +1816,10 @@ Enter your choice or press Submit to keep current value:"""
             report_input: Input with sensor_id (str or list[str] for LVS batch).
             vlm_prompt_override: Pre-collected free-text prompt for base VLM videos,
                 bypasses per-video HITL when provided.
+            request_total_videos: Total number of videos in the user's original request,
+                forwarded to the LVS tool so its HITL popups can show
+                "Setting prompt for X out of Y videos" when only a subset is dispatched
+                here. ``None`` when this call covers the whole request.
         """
         sensor_id = report_input.sensor_id if isinstance(report_input.sensor_id, str) else report_input.sensor_id[0]
         logger.info(f"Generating report for sensor '{sensor_id}'")
@@ -1805,8 +1849,8 @@ Enter your choice or press Submit to keep current value:"""
                     f"Falling back to standard video_understanding tool. for video duration {duration_seconds:.1f}s > {config.lvs_video_length}s"
                 )
                 lvs_fallback_warning = (
-                    f"⚠️ **Note:** Input video {sensor_id} is {duration_seconds:.1f}s long. \n"
-                    f"Please use Long video Summarization' for videos longer than {config.lvs_video_length}s.\n\n"
+                    f"⚠️ **Note:** Input video {sensor_id} is {duration_seconds:.1f}s long. "
+                    f"Please use 'Long Video Summarization' for videos longer than {config.lvs_video_length}s.\n\n"
                 )
         else:
             logger.info(
@@ -1822,6 +1866,8 @@ Enter your choice or press Submit to keep current value:"""
             vlm_input: dict[str, Any] = {
                 "sensor_id": report_input.sensor_id,
             }
+            if request_total_videos is not None:
+                vlm_input["request_total_videos"] = request_total_videos
 
             if report_input.vlm_reasoning is not None:
                 vlm_input["vlm_reasoning"] = report_input.vlm_reasoning
@@ -2054,10 +2100,8 @@ Enter your choice or press Submit to keep current value:"""
         )
 
         # Create summary
-        summary = ""
-        if lvs_fallback_warning:
-            summary += lvs_fallback_warning
-        summary += f"Report generated for '{sensor_id}'.\n\n"
+
+        summary = f"Report generated for '{sensor_id}'.\n\n"
 
         logger.info(f"report generation complete: {report_metadata['http_url']}")
 
@@ -2071,6 +2115,7 @@ Enter your choice or press Submit to keep current value:"""
             content=None,  # Not needed
             video_url=report_metadata["video_url"],
             hitl_prompts=hitl_prompts,
+            lvs_fallback_warning=lvs_fallback_warning or None,
         )
 
     async def _video_report_gen(report_input: VideoReportGenInput) -> VideoReportGenOutput:

--- a/agent/src/vss_agents/tools/vst/snapshot.py
+++ b/agent/src/vss_agents/tools/vst/snapshot.py
@@ -76,6 +76,11 @@ class VSTSnapshotConfig(FunctionBaseConfig, name="vst.snapshot"):
         False,
         description="Whether to enable overlay configuration for object detection bounding box overlays",
     )
+    timeout_seconds: float = Field(
+        10.0,
+        description="HTTP request timeout in seconds for snapshot URL requests. "
+        "Increase when multiple snapshots are requested concurrently (they queue on the stream processor).",
+    )
     time_format: Literal["offset", "iso"] = Field(
         "offset",
         description="Timestamp input format: 'iso' for ISO 8601 UTC strings (e.g. '2025-08-25T03:05:55Z'), "
@@ -141,6 +146,7 @@ async def get_snapshot_url(
     start_time: float | str,
     vst_internal_url: str,
     overlay_enabled: bool = False,
+    timeout_seconds: float = 10.0,
 ) -> str:
     """Get the snapshot URL for a given stream ID.
 
@@ -149,6 +155,7 @@ async def get_snapshot_url(
         start_time: Seconds offset (float) or ISO 8601 timestamp (str).
         vst_internal_url: Internal VST URL.
         overlay_enabled: Whether to add bounding box overlay.
+        timeout_seconds: HTTP request timeout in seconds.
 
     Returns:
         The snapshot image URL from VST.
@@ -172,7 +179,7 @@ async def get_snapshot_url(
     if overlay_param:
         url += f"&overlay={overlay_param}"
 
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout_seconds)) as session:
         async for attempt in create_retry_strategy(retries=3):
             with attempt:
                 async with session.get(url) as response:
@@ -201,6 +208,7 @@ async def vst_snapshot(config: VSTSnapshotConfig, _builder: Builder) -> AsyncGen
             vst_snapshot_input.start_time,
             config.vst_internal_url,
             overlay_enabled=config.overlay_config,
+            timeout_seconds=config.timeout_seconds,
         )
 
         # Replace internal URL with external URL for client access

--- a/agent/src/vss_agents/utils/hitl.py
+++ b/agent/src/vss_agents/utils/hitl.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for rendering Human-in-the-Loop (HITL) popup content."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def format_hitl_popup_header(sensor_ids: list[str] | None, total_videos: int | None) -> str:
+    """Build the "which videos does this HITL popup apply to" header.
+
+    Used by tools that collect HITL input for a subset of the user's requested videos
+    (e.g. the LVS / base-VLM split in video_report_gen's mixed-routing path).
+
+    - If ``sensor_ids`` is empty/None → no header.
+    - If ``total_videos`` is set and larger than ``len(sensor_ids)`` → "Setting prompt
+      for X out of Y videos: ..." so the user knows this popup applies to a subset.
+    - Otherwise → "Analyzing X video(s): ..." (popup covers all videos in the request).
+
+    If ``total_videos`` is less than ``len(sensor_ids)`` the caller wired it up wrong;
+    we log a warning and fall back to the safe "Analyzing N video(s)" wording rather
+    than raising, since this helper only renders popup text and must never abort an
+    in-progress video analysis over a cosmetic bug.
+    """
+    if not sensor_ids:
+        return ""
+    subset = len(sensor_ids)
+    if total_videos is not None and total_videos < subset:
+        logger.warning(
+            "format_hitl_popup_header: total_videos (%d) < len(sensor_ids) (%d); "
+            "ignoring total_videos and falling back to 'Analyzing N video(s)' wording. "
+            "sensor_ids=%s",
+            total_videos,
+            subset,
+            sensor_ids,
+        )
+        total_videos = None
+    video_list = ", ".join(f"`{sid}`" for sid in sensor_ids)
+    if total_videos is not None and total_videos > subset:
+        return f"**Setting prompt for {subset} out of {total_videos} videos:** {video_list}\n\n"
+    return f"**Analyzing {subset} video(s):** {video_list}\n\n"

--- a/agent/src/vss_agents/utils/uuid_string.py
+++ b/agent/src/vss_agents/utils/uuid_string.py
@@ -12,10 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import uuid
 
-from . import front_end_config
-from . import health_endpoint
-from . import rtsp_stream_api
-from . import video_upload_url
 
-__all__ = ["front_end_config", "health_endpoint", "rtsp_stream_api", "video_upload_url"]
+def is_standard_uuid_string(value: object) -> bool:
+    """Return True if ``value`` parses as a UUID (hex digit groups and separators).
+
+    A naive ``len == 36`` and ``count('-') == 4`` check misclassifies camera names that look
+    similar, which skips wildcard/regexp Elasticsearch fallbacks and can yield zero hits.
+    """
+    if not value or not isinstance(value, str):
+        return False
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        return False
+    return True

--- a/agent/src/vss_agents/video_analytics/query_builders.py
+++ b/agent/src/vss_agents/video_analytics/query_builders.py
@@ -87,8 +87,8 @@ class IncidentQueryBuilder:
             elif source_type == "place":
                 # Use wildcard matching to allow partial place name matches
                 # Works for both city names and intersection names
-                # Example: "Dubuque" matches "city=Dubuque/intersection=HWY_20_AND_LOCUST"
-                # Example: "HWY_20_AND_LOCUST" matches "city=Dubuque/intersection=HWY_20_AND_LOCUST"
+                # Example: "Dubuque" matches "city=Dubuque/intersection=HWY_20_AND_LOCUST"  # pragma: allowlist secret
+                # Example: "HWY_20_AND_LOCUST" matches "city=Dubuque/intersection=HWY_20_AND_LOCUST"  # pragma: allowlist secret
                 query["query"]["bool"]["must"].append({"wildcard": {"place.name.keyword": f"*{source}*"}})
 
         # VLM verdict filter - only if vlm_verified is enabled and verdict is provided

--- a/agent/src/vss_agents/video_analytics/query_builders.py
+++ b/agent/src/vss_agents/video_analytics/query_builders.py
@@ -87,8 +87,8 @@ class IncidentQueryBuilder:
             elif source_type == "place":
                 # Use wildcard matching to allow partial place name matches
                 # Works for both city names and intersection names
-                # Example: "Dubuque" matches "city=Dubuque/intersection=HWY_20_AND_LOCUST"  # pragma: allowlist secret
-                # Example: "HWY_20_AND_LOCUST" matches "city=Dubuque/intersection=HWY_20_AND_LOCUST"  # pragma: allowlist secret
+                # Example: "Dubuque" matches "city=Dubuque/intersection=HWY_20_AND_LOCUST"
+                # Example: "HWY_20_AND_LOCUST" matches "city=Dubuque/intersection=HWY_20_AND_LOCUST"
                 query["query"]["bool"]["must"].append({"wildcard": {"place.name.keyword": f"*{source}*"}})
 
         # VLM verdict filter - only if vlm_verified is enabled and verdict is provided

--- a/agent/tests/unit_test/api/test_rtsp_stream_api.py
+++ b/agent/tests/unit_test/api/test_rtsp_stream_api.py
@@ -100,12 +100,12 @@ class TestAddStreamRequest:
             sensor_url="rtsp://camera:554/stream",
             name="camera-1",
             username="admin",
-            password="pw",  # pragma: allowlist secret
+            password="pw",
             location="Building A",
             tags="entrance,security",
         )
         assert request.username == "admin"
-        assert request.password == "pw"  # pragma: allowlist secret
+        assert request.password == "pw"
         assert request.location == "Building A"
         assert request.tags == "entrance,security"
 
@@ -265,12 +265,12 @@ class TestAddToRtviEmbed:
         mock_client = MagicMock()
         config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="")
 
-        success, _msg, stream_id = await add_to_rtvi_embed(
+        success, msg, stream_id = await add_to_rtvi_embed(
             mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
         )
 
         assert success is True
-        assert "Skipped" in _msg
+        assert "Skipped" in msg
         assert stream_id == "sensor-123"  # Falls back to sensor_id
 
     @pytest.mark.asyncio

--- a/agent/tests/unit_test/api/test_rtsp_stream_api.py
+++ b/agent/tests/unit_test/api/test_rtsp_stream_api.py
@@ -100,12 +100,12 @@ class TestAddStreamRequest:
             sensor_url="rtsp://camera:554/stream",
             name="camera-1",
             username="admin",
-            password="pw",
+            password="pw",  # pragma: allowlist secret
             location="Building A",
             tags="entrance,security",
         )
         assert request.username == "admin"
-        assert request.password == "pw"
+        assert request.password == "pw"  # pragma: allowlist secret
         assert request.location == "Building A"
         assert request.tags == "entrance,security"
 

--- a/agent/tests/unit_test/embed/test_cosmos_embed.py
+++ b/agent/tests/unit_test/embed/test_cosmos_embed.py
@@ -16,7 +16,6 @@
 
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
-from unittest.mock import patch
 
 import httpx
 import pytest
@@ -40,177 +39,280 @@ class TestCosmosEmbedClient:
         # Note: the current implementation doesn't strip trailing slash
         assert client.endpoint == "http://localhost:8080/"
 
+    def test_init_lazy_client(self):
+        # Client is lazily initialized — not created in __init__
+        client = CosmosEmbedClient("http://localhost:8080")
+        assert client._client is None
+
+    def test_init_has_cache(self):
+        client = CosmosEmbedClient("http://localhost:8080")
+        assert len(client._text_cache) == 0
+
+
+def _make_client_with_mock() -> tuple[CosmosEmbedClient, AsyncMock]:
+    """Create a CosmosEmbedClient with a mocked httpx client for testing."""
+    client = CosmosEmbedClient("http://localhost:8080")
+    mock_http = AsyncMock()
+    client._client = mock_http
+    return client, mock_http
+
 
 class TestGetImageEmbedding:
     """Test get_image_embedding method."""
 
-    @pytest.fixture
-    def client(self):
-        return CosmosEmbedClient("http://localhost:8080")
+    @pytest.mark.asyncio
+    async def test_get_image_embedding_base64(self):
+        client, mock_http = _make_client_with_mock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
+        mock_http.post.return_value = mock_response
+
+        result = await client.get_image_embedding("data:image/jpeg;base64,abc123")
+
+        assert result == [0.1, 0.2, 0.3]
+        mock_http.post.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_image_embedding_base64(self, client):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
+    async def test_get_image_embedding_url(self):
+        client, mock_http = _make_client_with_mock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"embedding": [0.4, 0.5, 0.6]}]}
+        mock_http.post.return_value = mock_response
 
-            mock_response = MagicMock()
-            mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
-            mock_client.post.return_value = mock_response
+        result = await client.get_image_embedding("http://example.com/image.jpg")
 
-            result = await client.get_image_embedding("data:image/jpeg;base64,abc123")
-
-            assert result == [0.1, 0.2, 0.3]
-            mock_client.post.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_get_image_embedding_url(self, client):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-
-            mock_response = MagicMock()
-            mock_response.json.return_value = {"data": [{"embedding": [0.4, 0.5, 0.6]}]}
-            mock_client.post.return_value = mock_response
-
-            result = await client.get_image_embedding("http://example.com/image.jpg")
-
-            assert result == [0.4, 0.5, 0.6]
-            # Check that presigned_url format was used
-            call_args = mock_client.post.call_args
-            payload = call_args[1]["json"]
-            assert "presigned_url" in payload["input"][0]
+        assert result == [0.4, 0.5, 0.6]
+        # Check that presigned_url format was used
+        call_args = mock_http.post.call_args
+        payload = call_args[1]["json"]
+        assert "presigned_url" in payload["input"][0]
 
     @pytest.mark.asyncio
-    async def test_get_image_embedding_http_error(self, client):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.post.side_effect = httpx.HTTPError("Connection failed")
+    async def test_get_image_embedding_http_error(self):
+        client, mock_http = _make_client_with_mock()
+        mock_http.post.side_effect = httpx.HTTPError("Connection failed")
 
-            with pytest.raises(httpx.HTTPError):
-                await client.get_image_embedding("http://example.com/image.jpg")
+        with pytest.raises(httpx.HTTPError):
+            await client.get_image_embedding("http://example.com/image.jpg")
 
 
 class TestGetTextEmbedding:
     """Test get_text_embedding method."""
 
-    @pytest.fixture
-    def client(self):
-        return CosmosEmbedClient("http://localhost:8080")
+    @pytest.mark.asyncio
+    async def test_get_text_embedding_success(self):
+        client, mock_http = _make_client_with_mock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"embeddings": [0.7, 0.8, 0.9]}]}
+        mock_http.post.return_value = mock_response
+
+        result = await client.get_text_embedding("hello world")
+
+        assert result == [0.7, 0.8, 0.9]
+        call_args = mock_http.post.call_args
+        payload = call_args[1]["json"]
+        assert payload["text_input"] == ["hello world"]
 
     @pytest.mark.asyncio
-    async def test_get_text_embedding_success(self, client):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
+    async def test_get_text_embedding_http_error(self):
+        client, mock_http = _make_client_with_mock()
+        mock_http.post.side_effect = httpx.HTTPError("Connection failed")
 
-            mock_response = MagicMock()
-            mock_response.json.return_value = {"data": [{"embeddings": [0.7, 0.8, 0.9]}]}
-            mock_client.post.return_value = mock_response
-
-            result = await client.get_text_embedding("hello world")
-
-            assert result == [0.7, 0.8, 0.9]
-            call_args = mock_client.post.call_args
-            payload = call_args[1]["json"]
-            assert payload["text_input"] == ["hello world"]
+        with pytest.raises(httpx.HTTPError):
+            await client.get_text_embedding("test text")
 
     @pytest.mark.asyncio
-    async def test_get_text_embedding_http_error(self, client):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.post.side_effect = httpx.HTTPError("Connection failed")
+    async def test_get_text_embedding_cache_hit(self):
+        client, mock_http = _make_client_with_mock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"embeddings": [0.1, 0.2]}]}
+        mock_http.post.return_value = mock_response
 
-            with pytest.raises(httpx.HTTPError):
-                await client.get_text_embedding("test text")
+        # First call — cache miss
+        result1 = await client.get_text_embedding("hello")
+        assert result1 == [0.1, 0.2]
+        assert mock_http.post.call_count == 1
+
+        # Second call — cache hit, no additional HTTP call
+        result2 = await client.get_text_embedding("hello")
+        assert result2 == [0.1, 0.2]
+        assert mock_http.post.call_count == 1  # still 1
+
+    @pytest.mark.asyncio
+    async def test_get_text_embedding_different_keys(self):
+        client, mock_http = _make_client_with_mock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"embeddings": [0.1, 0.2]}]}
+        mock_http.post.return_value = mock_response
+
+        await client.get_text_embedding("hello")
+        await client.get_text_embedding("world")
+        assert mock_http.post.call_count == 2  # different keys, both fetched
 
 
 class TestGetVideoEmbedding:
     """Test get_video_embedding method."""
 
-    @pytest.fixture
-    def client(self):
-        return CosmosEmbedClient("http://localhost:8080")
-
     @pytest.mark.asyncio
-    async def test_get_video_embedding_success(self, client):
-        with patch.object(client, "get_video_embeddings_from_urls") as mock_get:
-            mock_get.return_value = [[0.1, 0.2, 0.3]]
+    async def test_get_video_embedding_success(self):
+        client = CosmosEmbedClient("http://localhost:8080")
+        mock_get = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+        client.get_video_embeddings_from_urls = mock_get
 
-            result = await client.get_video_embedding("http://example.com/video.mp4")
+        result = await client.get_video_embedding("http://example.com/video.mp4")
 
-            assert result == [0.1, 0.2, 0.3]
-            mock_get.assert_called_once_with(["http://example.com/video.mp4"])
+        assert result == [0.1, 0.2, 0.3]
+        mock_get.assert_called_once_with(["http://example.com/video.mp4"])
 
 
 class TestGetVideoEmbeddingsFromUrls:
     """Test get_video_embeddings_from_urls method."""
 
-    @pytest.fixture
-    def client(self):
-        return CosmosEmbedClient("http://localhost:8080")
+    @pytest.mark.asyncio
+    async def test_get_video_embeddings_single_url(self):
+        client, mock_http = _make_client_with_mock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
+        mock_http.post.return_value = mock_response
+
+        result = await client.get_video_embeddings_from_urls(["http://example.com/video.mp4"])
+
+        assert result == [[0.1, 0.2, 0.3]]
+        call_args = mock_http.post.call_args
+        payload = call_args[1]["json"]
+        assert "presigned_url" in payload["input"][0]
+        assert payload["request_type"] == "bulk_video"
 
     @pytest.mark.asyncio
-    async def test_get_video_embeddings_single_url(self, client):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
+    async def test_get_video_embeddings_multiple_urls(self):
+        client, mock_http = _make_client_with_mock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"embedding": [0.1, 0.2, 0.3]},
+                {"embedding": [0.4, 0.5, 0.6]},
+            ]
+        }
+        mock_http.post.return_value = mock_response
 
-            mock_response = MagicMock()
-            mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
-            mock_client.post.return_value = mock_response
+        result = await client.get_video_embeddings_from_urls(
+            [
+                "http://example.com/video1.mp4",
+                "http://example.com/video2.mp4",
+            ]
+        )
 
-            result = await client.get_video_embeddings_from_urls(["http://example.com/video.mp4"])
-
-            assert result == [[0.1, 0.2, 0.3]]
-            call_args = mock_client.post.call_args
-            payload = call_args[1]["json"]
-            assert "presigned_url" in payload["input"][0]
-            assert payload["request_type"] == "bulk_video"
-
-    @pytest.mark.asyncio
-    async def test_get_video_embeddings_multiple_urls(self, client):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-
-            mock_response = MagicMock()
-            mock_response.json.return_value = {
-                "data": [
-                    {"embedding": [0.1, 0.2, 0.3]},
-                    {"embedding": [0.4, 0.5, 0.6]},
-                ]
-            }
-            mock_client.post.return_value = mock_response
-
-            result = await client.get_video_embeddings_from_urls(
-                [
-                    "http://example.com/video1.mp4",
-                    "http://example.com/video2.mp4",
-                ]
-            )
-
-            assert len(result) == 2
-            assert result[0] == [0.1, 0.2, 0.3]
-            assert result[1] == [0.4, 0.5, 0.6]
+        assert len(result) == 2
+        assert result[0] == [0.1, 0.2, 0.3]
+        assert result[1] == [0.4, 0.5, 0.6]
 
     @pytest.mark.asyncio
-    async def test_get_video_embeddings_url_formatting(self, client):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
+    async def test_get_video_embeddings_url_formatting(self):
+        client, mock_http = _make_client_with_mock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"embedding": [0.1]}]}
+        mock_http.post.return_value = mock_response
 
-            mock_response = MagicMock()
-            mock_response.json.return_value = {"data": [{"embedding": [0.1]}]}
-            mock_client.post.return_value = mock_response
+        await client.get_video_embeddings_from_urls(["http://test.com/video.mp4"])
 
-            await client.get_video_embeddings_from_urls(["http://test.com/video.mp4"])
+        call_args = mock_http.post.call_args
+        payload = call_args[1]["json"]
+        # Check URL formatting
+        assert payload["input"][0] == "data:video/mp4;presigned_url,http://test.com/video.mp4"
+        assert payload["model"] == "cosmos-embed1-448p"
+        assert payload["encoding_format"] == "float"
 
-            call_args = mock_client.post.call_args
-            payload = call_args[1]["json"]
-            # Check URL formatting
-            assert payload["input"][0] == "data:video/mp4;presigned_url,http://test.com/video.mp4"
-            assert payload["model"] == "cosmos-embed1-448p"
-            assert payload["encoding_format"] == "float"
+
+class TestLRUCache:
+    """Test bounded LRU cache behavior on CosmosEmbedClient."""
+
+    @pytest.mark.asyncio
+    async def test_lru_cache_eviction_evicts_oldest(self):
+        """Filling the cache past maxsize evicts the LRU entry and its lock."""
+        client, mock_http = _make_client_with_mock()
+        # Shrink cache for the test
+        from vss_agents.embed.embed import LRUEmbeddingCache
+
+        client._text_cache = LRUEmbeddingCache(maxsize=2)
+
+        def _make_response(vec):
+            resp = MagicMock()
+            resp.json.return_value = {"data": [{"embeddings": vec}]}
+            return resp
+
+        mock_http.post.side_effect = [
+            _make_response([1.0]),
+            _make_response([2.0]),
+            _make_response([3.0]),
+        ]
+
+        await client.get_text_embedding("a")
+        await client.get_text_embedding("b")
+        await client.get_text_embedding("c")  # evicts "a"
+
+        # "a" evicted, "b" and "c" present
+        assert client._text_cache.get("a") is None
+        assert client._text_cache.get("b") == [2.0]
+        assert client._text_cache.get("c") == [3.0]
+        # matching lock for "a" also evicted
+        assert "a" not in client._text_cache._locks
+
+    @pytest.mark.asyncio
+    async def test_lru_cache_touch_on_access(self):
+        """Accessing an entry marks it as recently used, avoiding eviction."""
+        client, mock_http = _make_client_with_mock()
+        from vss_agents.embed.embed import LRUEmbeddingCache
+
+        client._text_cache = LRUEmbeddingCache(maxsize=2)
+
+        def _make_response(vec):
+            resp = MagicMock()
+            resp.json.return_value = {"data": [{"embeddings": vec}]}
+            return resp
+
+        mock_http.post.side_effect = [
+            _make_response([1.0]),
+            _make_response([2.0]),
+            _make_response([3.0]),
+        ]
+
+        await client.get_text_embedding("a")
+        await client.get_text_embedding("b")
+        # Touch "a" so it becomes MRU
+        await client.get_text_embedding("a")
+        await client.get_text_embedding("c")  # should evict "b", not "a"
+
+        assert client._text_cache.get("a") == [1.0]
+        assert client._text_cache.get("b") is None
+        assert client._text_cache.get("c") == [3.0]
+
+
+class TestAClose:
+    """Test resource cleanup via aclose()."""
+
+    @pytest.mark.asyncio
+    async def test_aclose_closes_client_and_clears_cache(self):
+        """aclose() closes the http client (sets to None) and clears the cache."""
+        client, mock_http = _make_client_with_mock()
+        mock_http.aclose = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"embeddings": [0.1]}]}
+        mock_http.post.return_value = mock_response
+
+        # Populate cache
+        await client.get_text_embedding("hello")
+        assert len(client._text_cache) == 1
+
+        await client.aclose()
+
+        mock_http.aclose.assert_called_once()
+        assert client._client is None
+        assert len(client._text_cache) == 0
+
+    @pytest.mark.asyncio
+    async def test_aclose_no_client_noop(self):
+        """aclose() is safe when no client was ever created."""
+        client = CosmosEmbedClient("http://localhost:8080")
+        assert client._client is None
+        await client.aclose()  # must not raise
+        assert client._client is None

--- a/agent/tests/unit_test/evaluators/test_custom_trajectory.py
+++ b/agent/tests/unit_test/evaluators/test_custom_trajectory.py
@@ -410,6 +410,202 @@ class TestGetAgentSelectedUuids:
         assert tool_uuid in result, "Tool matched via OpenAI format name should be included"
 
 
+class TestParseToolResult:
+    """Test parse_tool_result utility function."""
+
+    def test_dict(self):
+        from vss_agents.evaluators.utils import parse_tool_result
+
+        assert parse_tool_result({"key": "val"}) == {"key": "val"}
+
+    def test_json_string(self):
+        from vss_agents.evaluators.utils import parse_tool_result
+
+        assert parse_tool_result('{"key": "val"}') == {"key": "val"}
+
+    def test_python_repr(self):
+        from vss_agents.evaluators.utils import parse_tool_result
+
+        assert parse_tool_result("{'key': 'val'}") == {"key": "val"}
+
+    def test_plain_string(self):
+        from vss_agents.evaluators.utils import parse_tool_result
+
+        assert parse_tool_result("hello") == "hello"
+
+
+class TestResolveRefs:
+    """Test _resolve_refs method."""
+
+    @pytest.fixture
+    def evaluator(self):
+        mock_llm = MagicMock()
+        return CustomizedTrajectoryEvaluator(llm=mock_llm, tools=None)
+
+    def test_resolve_same_turn_ref(self, evaluator):
+        ground_truth = [
+            {"step": 1, "name": "tool_a", "params": {}},
+            {
+                "step": 2,
+                "name": "tool_b",
+                "params": {
+                    "id": {"$ref": {"tool": "tool_a", "path": ["items", 0, "name"]}},
+                    "start": 1,
+                },
+            },
+        ]
+        tool_results = {
+            "tool_a": [{"items": [{"name": "item-1"}, {"name": "item-2"}]}],
+        }
+
+        resolved = evaluator._resolve_refs(ground_truth, tool_results)
+
+        assert resolved[0]["params"] == {}
+        assert resolved[1]["params"]["id"] == "item-1"
+        assert resolved[1]["params"]["start"] == 1
+        # Original must not be mutated
+        assert isinstance(ground_truth[1]["params"]["id"], dict)
+
+    def test_resolve_ref_with_index(self, evaluator):
+        """index selects which occurrence when a tool is called multiple times."""
+        ground_truth = [
+            {
+                "step": 2,
+                "name": "tool_b",
+                "params": {"val": {"$ref": {"tool": "tool_a", "index": 1, "path": ["result"]}}},
+            },
+        ]
+        tool_results = {
+            "tool_a": [{"result": "first_call"}, {"result": "second_call"}],
+        }
+
+        resolved = evaluator._resolve_refs(ground_truth, tool_results)
+        assert resolved[0]["params"]["val"] == "second_call"
+
+    def test_resolve_ref_missing_tool_leaves_ref(self, evaluator):
+        """If referenced tool has no result, the $ref is left unchanged."""
+        ground_truth = [
+            {
+                "step": 2,
+                "name": "tool_b",
+                "params": {"x": {"$ref": {"tool": "nonexistent", "path": ["a"]}}},
+            },
+        ]
+
+        resolved = evaluator._resolve_refs(ground_truth, {})
+        assert "$ref" in resolved[0]["params"]["x"]
+
+    def test_resolve_ref_bad_path_leaves_ref(self, evaluator):
+        """If path traversal fails, the $ref is left unchanged."""
+        ground_truth = [
+            {
+                "step": 2,
+                "name": "tool_b",
+                "params": {"x": {"$ref": {"tool": "tool_a", "path": ["no_such_key"]}}},
+            },
+        ]
+        tool_results = {"tool_a": [{"other_key": "val"}]}
+
+        resolved = evaluator._resolve_refs(ground_truth, tool_results)
+        assert "$ref" in resolved[0]["params"]["x"]
+
+    def test_resolve_ref_missing_tool_key_leaves_ref(self, evaluator):
+        """$ref without required 'tool' key is left unchanged."""
+        ground_truth = [
+            {
+                "step": 1,
+                "name": "tool_a",
+                "params": {"x": {"$ref": {"path": ["a"]}}},
+            },
+        ]
+
+        resolved = evaluator._resolve_refs(ground_truth, {})
+        assert "$ref" in resolved[0]["params"]["x"]
+
+    def test_resolve_no_refs_unchanged(self, evaluator):
+        """Ground truth without any $ref is returned as-is (deep copy)."""
+        ground_truth = [
+            {"step": 1, "name": "tool_a", "params": {"key": "val"}},
+        ]
+
+        resolved = evaluator._resolve_refs(ground_truth, {})
+        assert resolved == ground_truth
+
+    def test_resolve_cross_turn_ref(self, evaluator):
+        """$ref with 'turn' + 'tool' resolves from previous_turn_results."""
+        ground_truth = [
+            {
+                "step": 1,
+                "name": "tool_b",
+                "params": {
+                    "id": {"$ref": {"turn": "turn_1", "tool": "tool_a", "path": ["items", 1, "name"]}},
+                },
+            },
+        ]
+        previous_turn_results = {
+            "turn_1": {
+                "tool_a": [{"items": [{"name": "item-1"}, {"name": "item-2"}]}],
+            }
+        }
+
+        resolved = evaluator._resolve_refs(ground_truth, {}, previous_turn_results)
+        assert resolved[0]["params"]["id"] == "item-2"
+
+    def test_resolve_cross_turn_ref_disambiguates_tool(self, evaluator):
+        """Cross-turn $ref picks the correct tool when multiple exist."""
+        ground_truth = [
+            {
+                "step": 1,
+                "name": "tool_c",
+                "params": {
+                    "val": {"$ref": {"turn": "turn_1", "tool": "tool_b", "path": [0]}},
+                },
+            },
+        ]
+        previous_turn_results = {
+            "turn_1": {
+                "tool_a": [["wrong"]],
+                "tool_b": [["correct"]],
+            }
+        }
+
+        resolved = evaluator._resolve_refs(ground_truth, {}, previous_turn_results)
+        assert resolved[0]["params"]["val"] == "correct"
+
+    def test_resolve_cross_turn_ref_missing_turn_leaves_ref(self, evaluator):
+        """If referenced turn doesn't exist, the $ref is left unchanged."""
+        ground_truth = [
+            {
+                "step": 1,
+                "name": "tool_a",
+                "params": {"x": {"$ref": {"turn": "turn_99", "tool": "tool_a", "path": ["a"]}}},
+            },
+        ]
+
+        resolved = evaluator._resolve_refs(ground_truth, {}, {})
+        assert "$ref" in resolved[0]["params"]["x"]
+
+    def test_resolve_cross_turn_ref_parses_string_result(self, evaluator):
+        """Cross-turn results stored as JSON strings get parsed before path traversal."""
+        ground_truth = [
+            {
+                "step": 1,
+                "name": "tool_b",
+                "params": {
+                    "val": {"$ref": {"turn": "turn_1", "tool": "tool_a", "path": ["items", 0]}},
+                },
+            },
+        ]
+        previous_turn_results = {
+            "turn_1": {
+                "tool_a": ['{"items": ["first", "second"]}'],
+            }
+        }
+
+        resolved = evaluator._resolve_refs(ground_truth, {}, previous_turn_results)
+        assert resolved[0]["params"]["val"] == "first"
+
+
 _EVAL_MODULE = "vss_agents.evaluators.customized_trajectory_evaluator.evaluate"
 _ADAPTER_CLASS = "nat.plugins.eval.utils.intermediate_step_adapter.IntermediateStepAdapter"
 
@@ -623,6 +819,63 @@ class TestEvaluateItem:
         actual = build_reasoning({"reasoning": "r"})["actual_tool_calls"]
         assert actual[0]["params"] == {"key": "value"}
 
+    # --- $ref resolution through evaluate_item ---
+
+    @pytest.mark.asyncio
+    @patch(f"{_EVAL_MODULE}.invoke_llm_with_retry", new_callable=AsyncMock)
+    @patch(f"{_EVAL_MODULE}.extract_tool_results_from_trajectory")
+    @patch(_ADAPTER_CLASS)
+    async def test_ref_resolved_in_prompt_reference(self, mock_adapter, mock_extract, mock_invoke):
+        """$ref in trajectory_ground_truth is resolved to concrete value before sending to LLM judge."""
+        mock_prompt = MagicMock()
+        mock_prompt.format.return_value = "prompt"
+        evaluator = self._make_evaluator(prompt_with_ref=mock_prompt)
+
+        mock_adapter.return_value.get_agent_actions.return_value = [
+            (self._make_agent_action("", ""), "plan\n\nTool calls: [{'name': 'tool_a'}]"),
+            (self._make_agent_action("tool_a", {}), "result"),
+            (self._make_agent_action("", ""), "plan\n\nTool calls: [{'name': 'tool_b'}]"),
+            (self._make_agent_action("tool_b", {"id": "item-1", "start": 1}), "done"),
+        ]
+        mock_extract.return_value = {
+            "tool_a": [{"items": [{"name": "item-1"}, {"name": "item-2"}]}],
+        }
+        mock_invoke.return_value = MagicMock(id="test_001", score=1.0)
+
+        ground_truth = [
+            {"step": 1, "name": "tool_a", "params": {}},
+            {
+                "step": 2,
+                "name": "tool_b",
+                "params": {
+                    "id": {"$ref": {"tool": "tool_a", "path": ["items", 0, "name"]}},
+                    "start": 1,
+                },
+            },
+        ]
+        item = self._make_item(
+            full_dataset_entry={
+                "evaluation_method": ["trajectory"],
+                "trajectory_ground_truth": ground_truth,
+            }
+        )
+
+        await evaluator.evaluate_item(item)
+
+        # The reference sent to the prompt should have the resolved value
+        import json
+
+        reference_str = mock_prompt.format.call_args.kwargs["reference"]
+        resolved = json.loads(reference_str)
+        assert resolved[1]["params"]["id"] == "item-1"
+        assert resolved[1]["params"]["start"] == 1
+
+        # build_reasoning should have both original and resolved
+        build_reasoning = mock_invoke.call_args.kwargs["build_reasoning"]
+        reasoning = build_reasoning({"reasoning": "r"})
+        assert "$ref" in str(reasoning["expected_tool_calls"])
+        assert reasoning["resolved_expected_tool_calls"][1]["params"]["id"] == "item-1"
+
     # --- Conversation history ---
 
     @pytest.mark.asyncio
@@ -706,6 +959,7 @@ class TestEvaluateItem:
         assert result["reasoning"] == "my reasoning"
         assert result["query"] == "What is X?"
         assert result["expected_tool_calls"] == ground_truth
+        assert result["resolved_expected_tool_calls"] is not None
         assert result["final_answer"] == "X is Y"
         assert isinstance(result["actual_tool_calls"], list)
         assert result["conversation_history"] == conv_history

--- a/agent/tests/unit_test/tools/test_incidents.py
+++ b/agent/tests/unit_test/tools/test_incidents.py
@@ -26,7 +26,7 @@ class TestVARetrievalConfig:
         config = VARetrievalConfig()
         assert config.minio_url == "http://localhost:9000"
         assert config.access_key == "minioadmin"
-        assert config.secret_key == "minioadmin"  # pragma: allowlist secret
+        assert config.secret_key == "minioadmin"
         assert config.bucket_name == "incidents-bucket"
         assert config.prefix == ""
         assert config.db_path == ":memory:"
@@ -37,7 +37,7 @@ class TestVARetrievalConfig:
         config = VARetrievalConfig(
             minio_url="http://custom-minio:9000",
             access_key="custom-access",
-            secret_key="custom-secret",  # pragma: allowlist secret
+            secret_key="custom-secret",
             bucket_name="custom-bucket",
             prefix="incidents/",
             db_path="/tmp/incidents.duckdb",
@@ -46,7 +46,7 @@ class TestVARetrievalConfig:
         )
         assert config.minio_url == "http://custom-minio:9000"
         assert config.access_key == "custom-access"
-        assert config.secret_key == "custom-secret"  # pragma: allowlist secret
+        assert config.secret_key == "custom-secret"
         assert config.bucket_name == "custom-bucket"
         assert config.prefix == "incidents/"
         assert config.db_path == "/tmp/incidents.duckdb"

--- a/agent/tests/unit_test/tools/test_incidents.py
+++ b/agent/tests/unit_test/tools/test_incidents.py
@@ -26,7 +26,7 @@ class TestVARetrievalConfig:
         config = VARetrievalConfig()
         assert config.minio_url == "http://localhost:9000"
         assert config.access_key == "minioadmin"
-        assert config.secret_key == "minioadmin"
+        assert config.secret_key == "minioadmin"  # pragma: allowlist secret
         assert config.bucket_name == "incidents-bucket"
         assert config.prefix == ""
         assert config.db_path == ":memory:"
@@ -37,7 +37,7 @@ class TestVARetrievalConfig:
         config = VARetrievalConfig(
             minio_url="http://custom-minio:9000",
             access_key="custom-access",
-            secret_key="custom-secret",
+            secret_key="custom-secret",  # pragma: allowlist secret
             bucket_name="custom-bucket",
             prefix="incidents/",
             db_path="/tmp/incidents.duckdb",
@@ -46,7 +46,7 @@ class TestVARetrievalConfig:
         )
         assert config.minio_url == "http://custom-minio:9000"
         assert config.access_key == "custom-access"
-        assert config.secret_key == "custom-secret"
+        assert config.secret_key == "custom-secret"  # pragma: allowlist secret
         assert config.bucket_name == "custom-bucket"
         assert config.prefix == "incidents/"
         assert config.db_path == "/tmp/incidents.duckdb"

--- a/agent/tests/unit_test/tools/test_s3_picture_url.py
+++ b/agent/tests/unit_test/tools/test_s3_picture_url.py
@@ -29,19 +29,19 @@ class TestS3PictureURLConfig:
         config = S3PictureURLConfig()
         assert config.minio_url == "http://localhost:9000"
         assert config.access_key == "minioadmin"
-        assert config.secret_key == "minioadmin"  # pragma: allowlist secret
+        assert config.secret_key == "minioadmin"
         assert config.bucket_name == "my-bucket"
 
     def test_custom_values(self):
         config = S3PictureURLConfig(
             minio_url="http://minio-server:9000",
             access_key="custom-access",
-            secret_key="custom-secret",  # pragma: allowlist secret
+            secret_key="custom-secret",
             bucket_name="custom-bucket",
         )
         assert config.minio_url == "http://minio-server:9000"
         assert config.access_key == "custom-access"
-        assert config.secret_key == "custom-secret"  # pragma: allowlist secret
+        assert config.secret_key == "custom-secret"
         assert config.bucket_name == "custom-bucket"
 
 

--- a/agent/tests/unit_test/tools/test_s3_picture_url.py
+++ b/agent/tests/unit_test/tools/test_s3_picture_url.py
@@ -29,19 +29,19 @@ class TestS3PictureURLConfig:
         config = S3PictureURLConfig()
         assert config.minio_url == "http://localhost:9000"
         assert config.access_key == "minioadmin"
-        assert config.secret_key == "minioadmin"
+        assert config.secret_key == "minioadmin"  # pragma: allowlist secret
         assert config.bucket_name == "my-bucket"
 
     def test_custom_values(self):
         config = S3PictureURLConfig(
             minio_url="http://minio-server:9000",
             access_key="custom-access",
-            secret_key="custom-secret",
+            secret_key="custom-secret",  # pragma: allowlist secret
             bucket_name="custom-bucket",
         )
         assert config.minio_url == "http://minio-server:9000"
         assert config.access_key == "custom-access"
-        assert config.secret_key == "custom-secret"
+        assert config.secret_key == "custom-secret"  # pragma: allowlist secret
         assert config.bucket_name == "custom-bucket"
 
 

--- a/agent/tests/unit_test/tools/vst/test_bounding_box.py
+++ b/agent/tests/unit_test/tools/vst/test_bounding_box.py
@@ -219,6 +219,7 @@ class TestSnapshotBoundingBox:
                     "2025-01-01T00:05:00.000Z",
                     "http://10.0.0.1:30888",
                     overlay_enabled=True,
+                    timeout_seconds=10.0,
                 )
 
 

--- a/agent/tests/unit_test/utils/test_uuid_string.py
+++ b/agent/tests/unit_test/utils/test_uuid_string.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import uuid
+
+from vss_agents.utils.uuid_string import is_standard_uuid_string
+
+
+def test_is_standard_uuid_string_accepts_valid_uuid() -> None:
+    u = str(uuid.uuid4())
+    assert is_standard_uuid_string(u) is True
+    assert is_standard_uuid_string(u.upper()) is True
+
+
+def test_is_standard_uuid_string_rejects_camera_like_name() -> None:
+    # 36 chars, 4 hyphens, but not hex — old heuristic wrongly treated this as UUID
+    assert is_standard_uuid_string("camera-rtsp-stream-name-with-4-hyphens-ok") is False
+
+
+def test_is_standard_uuid_string_rejects_wrong_grouping() -> None:
+    assert is_standard_uuid_string("aaa-aaaaaaa-aaaa-aaaa-aaaaaaaaaaaa") is False
+
+
+def test_is_standard_uuid_string_rejects_empty() -> None:
+    assert is_standard_uuid_string("") is False
+
+
+def test_is_standard_uuid_string_rejects_non_string() -> None:
+    assert is_standard_uuid_string(123) is False
+    assert is_standard_uuid_string(None) is False


### PR DESCRIPTION
## Summary

Sync the `agent/` directory with the latest changes from the internal `deep-search` develop branch (commit `a23beae4`) on top of the prior OSS sync (#86). Preserves the OSS-specific `pyproject.toml`, `uv.lock`, `README.md`, `AGENTS.md`, and `LICENSE*` files.

## Highlights

- **Critic agent**: new response/button functionality and `critique_result` → `critic_result` rename
- **Search profile**: follow-up Q&A, `object_id`-based image search, latency improvements, compound-query support, disabled URL validator
- **LVS profile**: RTVI VLM as default, multi-video parallel report generation, new LVS endpoint, HITL popup scoping, configurable VST snapshot timeout
- **Edge 4B**: improved handling and simplified prompt
- **New modules**: `api/front_end_config.py`, `utils/hitl.py`, `utils/uuid_string.py`
- **New unit test**: `test_uuid_string.py`

## Style / CI compliance

- Applied `ruff check --fix --unsafe-fixes` + `ruff format` so the synced files match the OSS conventions already on develop (e.g. `enum.StrEnum` instead of `(str, enum.Enum)`).
- Kept `typing_extensions.override` in place of `typing.override` since the OSS `pyproject.toml` still has `mypy python_version = "3.11"`.
- All three pre-commit hooks from the repo-root config pass locally: `ruff check`, `ruff format --check`, `mypy`.

## Test plan

- [ ] `cd agent && uv sync && uv run pytest tests/unit_test/` passes in CI
- [ ] `ruff check`, `ruff format --check`, `mypy` CI jobs are green
- [ ] Frontend CI jobs remain untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
