### PR TITLE
Add initial vetters list from Access-VSS-Github-Devs DL

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -8,3 +8,7 @@ additional_vetters:
   - kaushikc-nvidia
   - liamy-nv
   - zac-wang-nv
+  - nv-mpandele
+  - prisrivastav-nv
+  - ayyappa-dev
+  

--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,3 +1,10 @@
 enabled: true
 auto_sync_draft: false
 auto_sync_ready: true
+additional_vetters:
+  - daviddu0425
+  - hugoverjus
+  - jiayin-nvidia
+  - kaushikc-nvidia
+  - liamy-nv
+  - zac-wang-nv


### PR DESCRIPTION
## Summary

Populates the `copy-pr-bot` `additional_vetters` list with NVIDIA VSS
team members whose GitHub handles are known.

Source: M365 DL **Access-VSS-Github-Devs** (+ nested Admins/Maintainers
groups). This first PR lands 6 of the ~19 DL members whose NVIDIA
email → GitHub handle mapping could be resolved automatically from
git history across NVIDIA org repos.

### Vetters added
- \`daviddu0425\` — David Du
- \`hugoverjus\` — Hugo Verjus
- \`jiayin-nvidia\` — Jia Yin
- \`kaushikc-nvidia\` — Kaushik Chandrashekar
- \`liamy-nv\` — Amy Li (SW-TEGRA)
- \`zac-wang-nv\` — Zac Wang

### Follow-ups
Remaining DL members (banose, gaiyer, kartikayt, kumaabhishek,
lia, malardo, mkalra, mpandele, prakhars, prbhatt, prisrivastav,
vraina, zhliu) don't yet have a discoverable public GitHub handle
via commit history. A follow-up PR will add them as their handles
are confirmed.

## Test plan
- [x] CI green (no workflow touched)
- [x] copy-pr-bot config still parses after the new key is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)