### PR TITLE
Combine chunks based on similarity

### DIFF
--- a/services/agent/src/vss_agents/tools/search.py
+++ b/services/agent/src/vss_agents/tools/search.py
@@ -680,6 +680,9 @@ async def fusion_search_rerank(
     return final_results
 
 
+_SIMILARITY_RATIO_THRESHOLD = 0.9
+
+
 def _merge_consecutive_results(results: list["SearchResult"]) -> list["SearchResult"]:
     """Merge consecutive/overlapping SearchResult chunks from the same sensor.
 
@@ -694,59 +697,61 @@ def _merge_consecutive_results(results: list["SearchResult"]) -> list["SearchRes
         return results
 
     # Results without timestamps (or with malformed ones) cannot be time-merged; pass them through as-is
-    timestamped: list[tuple[int, SearchResult]] = []
-    no_timestamp: list[tuple[int, SearchResult]] = []
-    for i, r in enumerate(results):
+    timestamped: list[SearchResult] = []
+    no_timestamp: list[SearchResult] = []
+    for r in results:
         if not r.start_time or not r.end_time:
-            no_timestamp.append((i, r))
+            no_timestamp.append(r)
             continue
         try:
             iso8601_to_datetime(r.start_time)
             iso8601_to_datetime(r.end_time)
-            timestamped.append((i, r))
+            timestamped.append(r)
         except (ValueError, TypeError) as e:
             logger.warning(f"Skipping merge for result with malformed timestamp (sensor={r.sensor_id}): {e}")
-            no_timestamp.append((i, r))
+            no_timestamp.append(r)
 
-    merged_with_pos: list[tuple[int, SearchResult]] = list(no_timestamp)
+    merged: list[SearchResult] = list(no_timestamp)
 
     if not timestamped:
-        merged_with_pos.sort(key=lambda x: x[0])
-        return [r for _, r in merged_with_pos]
+        merged.sort(key=lambda r: r.similarity, reverse=True)
+        return merged
 
-    # Group by sensor_id, tracking original list position for final ordering
-    by_sensor: dict[str, list[tuple[int, SearchResult]]] = {}
-    for i, result in timestamped:
-        by_sensor.setdefault(result.sensor_id, []).append((i, result))
+    # Group by sensor_id
+    by_sensor: dict[str, list[SearchResult]] = {}
+    for result in timestamped:
+        by_sensor.setdefault(result.sensor_id, []).append(result)
 
-    for sensor_id, indexed_results in by_sensor.items():
+    for sensor_id, sensor_results in by_sensor.items():
         # Sort by start_time within each sensor group
-        sorted_results = sorted(indexed_results, key=lambda x: x[1].start_time)
+        sorted_results = sorted(sensor_results, key=lambda r: r.start_time)
 
         # Build contiguous groups of overlapping/adjacent chunks
-        groups: list[tuple[int, list[SearchResult]]] = []  # (min original index, chunks)
-        group_min_idx = sorted_results[0][0]
-        group_chunks: list[SearchResult] = [sorted_results[0][1]]
-        group_end_dt = iso8601_to_datetime(sorted_results[0][1].end_time)
+        groups: list[list[SearchResult]] = []
+        group_chunks: list[SearchResult] = [sorted_results[0]]
+        group_end_dt = iso8601_to_datetime(sorted_results[0].end_time)
 
-        for idx, result in sorted_results[1:]:
+        for result in sorted_results[1:]:
             result_start_dt = iso8601_to_datetime(result.start_time)
-            if result_start_dt <= group_end_dt:
-                # Overlapping or adjacent — extend the current group
+            group_avg_sim = sum(c.similarity for c in group_chunks) / len(group_chunks)
+            pair_max = max(group_avg_sim, result.similarity)
+            pair_min = min(group_avg_sim, result.similarity)
+            sim_compatible = pair_max == 0 or (pair_min / pair_max) >= _SIMILARITY_RATIO_THRESHOLD
+
+            if result_start_dt <= group_end_dt and sim_compatible:
+                # Overlapping or adjacent with compatible similarity — extend the current group
                 result_end_dt = iso8601_to_datetime(result.end_time)
                 if result_end_dt > group_end_dt:
                     group_end_dt = result_end_dt
                 group_chunks.append(result)
-                group_min_idx = min(group_min_idx, idx)
             else:
-                groups.append((group_min_idx, group_chunks))
-                group_min_idx = idx
+                groups.append(group_chunks)
                 group_chunks = [result]
                 group_end_dt = iso8601_to_datetime(result.end_time)
-        groups.append((group_min_idx, group_chunks))
+        groups.append(group_chunks)
 
         # Collapse each group into a single SearchResult
-        for min_idx, group in groups:
+        for group in groups:
             first = group[0]
             end_dt = max(iso8601_to_datetime(g.end_time) for g in group)
             similarity = sum(g.similarity for g in group) / len(group)
@@ -759,28 +764,23 @@ def _merge_consecutive_results(results: list["SearchResult"]) -> list["SearchRes
                         merged_object_ids.append(oid)
                         seen_ids.add(oid)
 
-            merged_critic = None
-
-            merged_with_pos.append(
-                (
-                    min_idx,
-                    SearchResult(
-                        video_name=first.video_name,
-                        description=first.description,
-                        start_time=first.start_time,
-                        end_time=datetime_to_iso8601(end_dt),
-                        sensor_id=sensor_id,
-                        screenshot_url=first.screenshot_url,
-                        similarity=similarity,
-                        object_ids=merged_object_ids,
-                        critic_result=merged_critic,
-                    ),
+            merged.append(
+                SearchResult(
+                    video_name=first.video_name,
+                    description=first.description,
+                    start_time=first.start_time,
+                    end_time=datetime_to_iso8601(end_dt),
+                    sensor_id=sensor_id,
+                    screenshot_url=first.screenshot_url,
+                    similarity=similarity,
+                    object_ids=merged_object_ids,
+                    critic_result=None,
                 )
             )
 
-    # Restore ranking order by minimum original index of each merged group
-    merged_with_pos.sort(key=lambda x: x[0])
-    return [r for _, r in merged_with_pos]
+    # Sort by descending similarity so best matches come first
+    merged.sort(key=lambda r: r.similarity, reverse=True)
+    return merged
 
 
 # ===== SHARED CORE SEARCH LOGIC =====

--- a/services/agent/tests/unit_test/tools/test_merge_consecutive_results.py
+++ b/services/agent/tests/unit_test/tools/test_merge_consecutive_results.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for _merge_consecutive_results improvements: similarity threshold and sort order."""
+
+import pytest
+
+from vss_agents.tools.search import _SIMILARITY_RATIO_THRESHOLD
+from vss_agents.tools.search import SearchResult
+from vss_agents.tools.search import _merge_consecutive_results
+
+
+def _make_result(start: str, end: str, similarity: float, sensor_id: str = "s1") -> SearchResult:
+    return SearchResult(
+        video_name="v.mp4",
+        description="desc",
+        start_time=start,
+        end_time=end,
+        sensor_id=sensor_id,
+        screenshot_url="",
+        similarity=similarity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Improvement 1: similarity threshold prevents merging dissimilar chunks
+# ---------------------------------------------------------------------------
+
+
+class TestSimilarityThreshold:
+    def test_compatible_chunks_are_merged(self):
+        # similarity 0.90 and 0.95 → ratio = 0.90/0.95 ≈ 0.947 ≥ 0.9
+        r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 0.90)
+        r2 = _make_result("2025-01-01T00:00:30Z", "2025-01-01T00:01:30Z", 0.95)
+        results = _merge_consecutive_results([r1, r2])
+        assert len(results) == 1, "Compatible chunks should be merged into one"
+
+    def test_incompatible_chunks_are_not_merged(self):
+        # similarity 0.95 and 0.50 → ratio = 0.50/0.95 ≈ 0.526 < 0.9
+        r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 0.95)
+        r2 = _make_result("2025-01-01T00:00:30Z", "2025-01-01T00:01:30Z", 0.50)
+        results = _merge_consecutive_results([r1, r2])
+        assert len(results) == 2, "Incompatible similarity chunks must NOT be merged"
+
+    def test_non_overlapping_chunks_not_merged_regardless_of_similarity(self):
+        # No time overlap; should never merge even with identical similarity
+        r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 0.90)
+        r2 = _make_result("2025-01-01T00:02:00Z", "2025-01-01T00:03:00Z", 0.91)
+        results = _merge_consecutive_results([r1, r2])
+        assert len(results) == 2
+
+    def test_boundary_ratio_at_threshold(self):
+        # ratio == _SIMILARITY_RATIO_THRESHOLD exactly should be merged (>= threshold)
+        r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 1.0)
+        r2 = _make_result("2025-01-01T00:00:30Z", "2025-01-01T00:01:30Z", _SIMILARITY_RATIO_THRESHOLD)
+        results = _merge_consecutive_results([r1, r2])
+        assert len(results) == 1
+
+    def test_both_zero_similarity_merged(self):
+        # pair_max == 0 branch: both zeros should merge
+        r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 0.0)
+        r2 = _make_result("2025-01-01T00:00:30Z", "2025-01-01T00:01:30Z", 0.0)
+        results = _merge_consecutive_results([r1, r2])
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Improvement 2: output is sorted by descending similarity
+# ---------------------------------------------------------------------------
+
+
+class TestSortByDescendingSimilarity:
+    def test_results_ordered_high_to_low_similarity(self):
+        # Two non-overlapping groups on same sensor; lower-similarity group first in input
+        r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 0.60)
+        r2 = _make_result("2025-01-01T00:02:00Z", "2025-01-01T00:03:00Z", 0.95)
+        results = _merge_consecutive_results([r1, r2])
+        assert len(results) == 2
+        assert results[0].similarity >= results[1].similarity, "Best match should come first"
+
+    def test_single_result_unchanged(self):
+        r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 0.75)
+        results = _merge_consecutive_results([r1])
+        assert len(results) == 1
+        assert results[0].similarity == pytest.approx(0.75)
+
+    def test_merged_result_sorted_among_others(self):
+        # sensor s1: two compatible overlapping chunks (0.78, 0.82 → ratio 0.951 ≥ 0.9) merge to avg 0.80
+        # sensor s2: single chunk with similarity 0.90
+        # Expected order: s2 (0.90), then s1 merged (0.80)
+        s1_r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 0.78, sensor_id="s1")
+        s1_r2 = _make_result("2025-01-01T00:00:30Z", "2025-01-01T00:01:30Z", 0.82, sensor_id="s1")
+        s2_r1 = _make_result("2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z", 0.90, sensor_id="s2")
+        results = _merge_consecutive_results([s1_r1, s1_r2, s2_r1])
+        assert len(results) == 2
+        assert results[0].sensor_id == "s2"
+        assert results[1].sensor_id == "s1"
+        assert results[0].similarity > results[1].similarity
+
+    def test_no_timestamps_pass_through_sorted_by_similarity(self):
+        # Results without timestamps bypass time-merge; should still be sorted by similarity
+        r1 = SearchResult(
+            video_name="v",
+            description="d",
+            start_time="",
+            end_time="",
+            sensor_id="s1",
+            screenshot_url="",
+            similarity=0.4,
+        )
+        r2 = SearchResult(
+            video_name="v",
+            description="d",
+            start_time="",
+            end_time="",
+            sensor_id="s1",
+            screenshot_url="",
+            similarity=0.9,
+        )
+        results = _merge_consecutive_results([r1, r2])
+        assert len(results) == 2
+        assert results[0].similarity >= results[1].similarity


### PR DESCRIPTION
### Problem
Currently, _merge_consecutive_results merges all overlapping/adjacent chunks from the same sensor purely based on time overlap, regardless of how different their similarity scores are. This can merge a high-relevance chunk (e.g. similarity=0.95) with a low-relevance adjacent chunk (e.g. similarity=0.5), diluting the result quality. Additionally, the merged results are returned in original index order rather than ranked by relevance.

#### Improvement 1: Similarity threshold for merging
Only merge consecutive chunks if the candidate chunk's similarity is within 90% of the current group's average (i.e. min(group_avg, candidate) / max(group_avg, candidate) >= 0.9). This prevents merging high-relevance chunks with low-relevance adjacent ones.

#### Improvement 2: Sort merged results by similarity (descending)
After merging, sort by descending similarity so best matches are returned first.