### PR TITLE
fix: repair broken yamllint step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,15 @@ jobs:
       - name: ruff format
         run: uv run ruff format --check .
 
+      # Run from repo root so `git ls-files` sees YAML files outside
+      # services/agent (the job's default working-directory). `uv run
+      # --project` pins the uv environment to services/agent regardless.
       - name: yamllint
+        working-directory: ${{ github.workspace }}
         run: |
-          uv run yamllint \
-            -d '{extends: default, rules: {line-length: {max: 120}, document-start: disable, indentation: {spaces: 2, indent-sequences: false}}}' \
-            $(git ls-files '*.yml' '*.yaml' | grep -v '\.gitlab-ci\.yml')
+          uv run --project services/agent yamllint \
+            -d "{extends: default, rules: {line-length: {max: 200}, document-start: disable, indentation: {spaces: 2, indent-sequences: consistent}}}" \
+            $(git ls-files '.github/**/*.yml' '.github/**/*.yaml' '.pre-commit-config.yaml' 'services/**/*.yml' 'services/**/*.yaml')
 
   # ---------------------------------------------------------------------------
   # Job 2: Python type checking (mypy)


### PR DESCRIPTION
## Description
The lint job runs from services/agent/, so `git ls-files '*.yml' '*.yaml'` returns zero files and yamllint fails with `one of the arguments FILE_OR_DIR - is required`.                                                        
                                                                                                                                                                                                                                 
  - Run the yamllint step from $GITHUB_WORKSPACE with `uv run --project services/agent`.                                                                                                                                         
  - Scope to **.github/**, **.pre-commit-config.yaml, services/** (**deployments/** excluded; separate cleanup).                                                                                                                       
  - Relax `indent-sequences` to `consistent` and bump `line-length` to 200 to match the codebase's existing style.                     

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
