### PR TITLE
Added retry mecahnism to RTVI-embed during video ingestion

### DIFF
--- a/services/agent/src/vss_agents/api/rtsp_stream_api.py
+++ b/services/agent/src/vss_agents/api/rtsp_stream_api.py
@@ -236,9 +236,7 @@ async def add_to_rtvi_embed(
     logger.debug(f"Payload: {payload}")
 
     try:
-        async for retry in create_retry_strategy(
-            delay=2, retries=6, exceptions=(httpx.TransportError, httpx.TimeoutException, RuntimeError)
-        ):
+        async for retry in create_retry_strategy(delay=2, retries=6, exceptions=(httpx.TransportError, RuntimeError)):
             with retry:
                 response = await client.post(url, json=payload)
                 if response.status_code not in (200, 201):

--- a/services/agent/src/vss_agents/api/rtsp_stream_api.py
+++ b/services/agent/src/vss_agents/api/rtsp_stream_api.py
@@ -258,7 +258,7 @@ async def add_to_rtvi_embed(
         logger.error(error, exc_info=True)
         return False, error, None
 
-    return False, "RTVI-embed add failed after retries", None  # pragma: no cover
+    raise AssertionError("RTVI-embed: tenacity produced no retry attempt")
 
 
 async def start_embedding_generation(

--- a/services/agent/src/vss_agents/api/rtsp_stream_api.py
+++ b/services/agent/src/vss_agents/api/rtsp_stream_api.py
@@ -236,13 +236,17 @@ async def add_to_rtvi_embed(
     logger.debug(f"Payload: {payload}")
 
     try:
-        async for retry in create_retry_strategy(delay=2, retries=6, exceptions=(Exception,)):
+        async for retry in create_retry_strategy(
+            delay=2, retries=6, exceptions=(httpx.TransportError, httpx.TimeoutException, RuntimeError)
+        ):
             with retry:
                 response = await client.post(url, json=payload)
                 if response.status_code not in (200, 201):
                     error = f"RTVI-embed returned {response.status_code}: {response.text}"
-                    logger.warning(f"RTVI-embed add failed: {error}, retrying...")
-                    raise RuntimeError(error)
+                    if response.status_code in (408, 429) or response.status_code >= 500:
+                        raise RuntimeError(error)
+                    logger.error(f"RTVI-embed add failed (non-retryable): {error}")
+                    return False, error, None
 
                 result = response.json()
 

--- a/services/agent/src/vss_agents/api/rtsp_stream_api.py
+++ b/services/agent/src/vss_agents/api/rtsp_stream_api.py
@@ -34,6 +34,7 @@ from vss_agents.tools.vst.utils import delete_sensor as vst_delete_sensor
 from vss_agents.tools.vst.utils import delete_storage as vst_delete_storage
 from vss_agents.tools.vst.utils import get_rtsp_url as vst_get_rtsp_url
 from vss_agents.tools.vst.utils import get_stream_info_by_name as vst_get_stream_info_by_name
+from vss_agents.utils.retry import create_retry_strategy
 from vss_agents.utils.time_measure import TimeMeasure
 
 
@@ -212,7 +213,12 @@ async def add_to_rtvi_embed(
     client: httpx.AsyncClient, config: ServiceConfig, sensor_id: str, name: str, sensor_url: str
 ) -> tuple[bool, str, str | None]:
     """
-    Add stream to RTVI-embed.
+    Add stream to RTVI-embed with retries.
+
+    During new stream ingestion the RTSP URL may exist but not yet be ready for
+    consumption.  This function retries the POST to RTVI-embed so transient
+    "stream not ready" failures are tolerated.
+
     Returns: (success, message, rtvi_stream_id)
     """
     if not config.rtvi_embed_url:
@@ -230,25 +236,27 @@ async def add_to_rtvi_embed(
     logger.debug(f"Payload: {payload}")
 
     try:
-        response = await client.post(url, json=payload)
-        if response.status_code not in (200, 201):
-            error = f"RTVI-embed returned {response.status_code}: {response.text}"
-            logger.error(error)
-            return False, error, None
+        async for retry in create_retry_strategy(delay=2, retries=6, exceptions=(Exception,)):
+            with retry:
+                response = await client.post(url, json=payload)
+                if response.status_code not in (200, 201):
+                    error = f"RTVI-embed returned {response.status_code}: {response.text}"
+                    logger.warning(f"RTVI-embed add failed: {error}, retrying...")
+                    raise RuntimeError(error)
 
-        result = response.json()
+                result = response.json()
 
-        # Response format: {"streams": [{"id": "...", ...}]}
-        streams = result.get("streams", [])
-        rtvi_stream_id = (streams[0].get("id") if streams else None) or sensor_id
+                streams = result.get("streams", [])
+                rtvi_stream_id = (streams[0].get("id") if streams else None) or sensor_id
 
-        logger.info(f"RTVI-embed stream registered: {rtvi_stream_id}")
-        return True, "Success", rtvi_stream_id
-
+                logger.info(f"RTVI-embed stream registered: {rtvi_stream_id}")
+                return True, "Success", rtvi_stream_id
     except Exception as e:
         error = f"RTVI-embed request failed: {e!s}"
         logger.error(error, exc_info=True)
         return False, error, None
+
+    return False, "RTVI-embed add failed after retries", None  # pragma: no cover
 
 
 async def start_embedding_generation(

--- a/services/agent/tests/unit_test/api/test_rtsp_stream_api.py
+++ b/services/agent/tests/unit_test/api/test_rtsp_stream_api.py
@@ -19,7 +19,12 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import httpx
 import pytest
+from tenacity import AsyncRetrying
+from tenacity import retry_if_exception_type
+from tenacity import stop_after_attempt
+from tenacity import wait_none
 
 from vss_agents.api.rtsp_stream_api import AddStreamRequest
 from vss_agents.api.rtsp_stream_api import AddStreamResponse
@@ -38,6 +43,21 @@ from vss_agents.api.rtsp_stream_api import create_rtsp_stream_api_router
 from vss_agents.api.rtsp_stream_api import get_stream_info_by_name
 from vss_agents.api.rtsp_stream_api import register_rtsp_stream_api_routes
 from vss_agents.api.rtsp_stream_api import start_embedding_generation
+
+
+def _single_attempt_retry() -> AsyncRetrying:
+    """Return a retry strategy that executes exactly once with no delay (for unit tests)."""
+    return AsyncRetrying(stop=stop_after_attempt(1), wait=wait_none(), reraise=True)
+
+
+def _multi_attempt_retry(attempts: int = 3) -> AsyncRetrying:
+    """Return a retry strategy with *attempts* tries, no delay, retrying on any Exception."""
+    return AsyncRetrying(
+        retry=retry_if_exception_type(Exception),
+        stop=stop_after_attempt(attempts),
+        wait=wait_none(),
+        reraise=True,
+    )
 
 
 class TestStreamMode:
@@ -244,7 +264,8 @@ class TestAddToRtviEmbed:
     """Test add_to_rtvi_embed function."""
 
     @pytest.mark.asyncio
-    async def test_successful_add(self):
+    @patch("vss_agents.api.rtsp_stream_api.create_retry_strategy")
+    async def test_successful_add(self, mock_retry):
         mock_client = MagicMock()
         config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
 
@@ -252,6 +273,8 @@ class TestAddToRtviEmbed:
         mock_response.status_code = 200
         mock_response.json = MagicMock(return_value={"streams": [{"id": "rtvi-stream-123"}]})
         mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_retry.return_value = _single_attempt_retry()
 
         success, _msg, stream_id = await add_to_rtvi_embed(
             mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
@@ -271,18 +294,21 @@ class TestAddToRtviEmbed:
 
         assert success is True
         assert "Skipped" in msg
-        assert stream_id == "sensor-123"  # Falls back to sensor_id
+        assert stream_id == "sensor-123"
 
     @pytest.mark.asyncio
-    async def test_fallback_to_sensor_id(self):
+    @patch("vss_agents.api.rtsp_stream_api.create_retry_strategy")
+    async def test_fallback_to_sensor_id(self, mock_retry):
         """Test that stream_id falls back to sensor_id when not in response."""
         mock_client = MagicMock()
         config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
 
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json = MagicMock(return_value={"streams": []})  # Empty streams
+        mock_response.json = MagicMock(return_value={"streams": []})
         mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_retry.return_value = _single_attempt_retry()
 
         success, _msg, stream_id = await add_to_rtvi_embed(
             mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
@@ -290,6 +316,80 @@ class TestAddToRtviEmbed:
 
         assert success is True
         assert stream_id == "sensor-123"
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.api.rtsp_stream_api.create_retry_strategy")
+    async def test_retry_succeeds_after_transient_failure(self, mock_retry):
+        """Test that a transient 503 followed by 200 succeeds."""
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        fail_response = MagicMock()
+        fail_response.status_code = 503
+        fail_response.text = "Service Unavailable"
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json = MagicMock(return_value={"streams": [{"id": "rtvi-stream-123"}]})
+
+        mock_client.post = AsyncMock(side_effect=[fail_response, ok_response])
+
+        mock_retry.return_value = _multi_attempt_retry(attempts=3)
+
+        success, _msg, stream_id = await add_to_rtvi_embed(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is True
+        assert stream_id == "rtvi-stream-123"
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.api.rtsp_stream_api.create_retry_strategy")
+    async def test_all_retries_exhausted(self, mock_retry):
+        """Test that persistent failures return an error after retries are exhausted."""
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        fail_response = MagicMock()
+        fail_response.status_code = 500
+        fail_response.text = "Internal Server Error"
+
+        mock_client.post = AsyncMock(return_value=fail_response)
+
+        mock_retry.return_value = _multi_attempt_retry(attempts=3)
+
+        success, msg, stream_id = await add_to_rtvi_embed(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is False
+        assert "RTVI-embed" in msg
+        assert stream_id is None
+        assert mock_client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.api.rtsp_stream_api.create_retry_strategy")
+    async def test_connection_error_retried(self, mock_retry):
+        """Test that network-level exceptions are retried."""
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json = MagicMock(return_value={"streams": [{"id": "rtvi-stream-123"}]})
+
+        mock_client.post = AsyncMock(side_effect=[httpx.ConnectError("connection refused"), ok_response])
+
+        mock_retry.return_value = _multi_attempt_retry(attempts=3)
+
+        success, _msg, stream_id = await add_to_rtvi_embed(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is True
+        assert stream_id == "rtvi-stream-123"
+        assert mock_client.post.call_count == 2
 
 
 class TestStartEmbeddingGeneration:

--- a/services/agent/tests/unit_test/api/test_rtsp_stream_api.py
+++ b/services/agent/tests/unit_test/api/test_rtsp_stream_api.py
@@ -392,6 +392,118 @@ class TestAddToRtviEmbed:
         assert mock_client.post.call_count == 2
 
 
+class TestAddToRtviEmbedRealRetry:
+    """Tests that exercise the real create_retry_strategy to pin configured retry parameters."""
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.utils.retry.wait_random", return_value=wait_none())
+    async def test_retries_on_transport_error(self, _mock_wait):
+        """Real retry strategy retries httpx.TransportError and eventually succeeds."""
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json = MagicMock(return_value={"streams": [{"id": "rtvi-stream-123"}]})
+
+        mock_client.post = AsyncMock(
+            side_effect=[
+                httpx.ConnectError("connection refused"),
+                httpx.ConnectError("connection refused"),
+                ok_response,
+            ]
+        )
+
+        success, _msg, stream_id = await add_to_rtvi_embed(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is True
+        assert stream_id == "rtvi-stream-123"
+        assert mock_client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.utils.retry.wait_random", return_value=wait_none())
+    async def test_retries_on_timeout(self, _mock_wait):
+        """httpx.TimeoutException (subclass of TransportError) is retried."""
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json = MagicMock(return_value={"streams": [{"id": "rtvi-stream-123"}]})
+
+        mock_client.post = AsyncMock(side_effect=[httpx.ReadTimeout("timed out"), ok_response])
+
+        success, _msg, stream_id = await add_to_rtvi_embed(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is True
+        assert stream_id == "rtvi-stream-123"
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.utils.retry.wait_random", return_value=wait_none())
+    async def test_does_not_retry_on_non_retryable_exception(self, _mock_wait):
+        """Real retry strategy does NOT retry exceptions outside the configured tuple."""
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        mock_client.post = AsyncMock(side_effect=KeyError("unexpected"))
+
+        success, _msg, stream_id = await add_to_rtvi_embed(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is False
+        assert stream_id is None
+        mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.utils.retry.wait_random", return_value=wait_none())
+    async def test_exhausts_all_six_retries_on_server_error(self, _mock_wait):
+        """Real retry strategy attempts exactly 6 times before giving up on 500s."""
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        fail_response = MagicMock()
+        fail_response.status_code = 500
+        fail_response.text = "Internal Server Error"
+
+        mock_client.post = AsyncMock(return_value=fail_response)
+
+        success, _msg, stream_id = await add_to_rtvi_embed(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is False
+        assert stream_id is None
+        assert mock_client.post.call_count == 6
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.utils.retry.wait_random", return_value=wait_none())
+    async def test_4xx_not_retried(self, _mock_wait):
+        """Real retry strategy returns immediately on 4xx client errors."""
+        mock_client = MagicMock()
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        bad_request = MagicMock()
+        bad_request.status_code = 400
+        bad_request.text = "Bad Request"
+
+        mock_client.post = AsyncMock(return_value=bad_request)
+
+        success, msg, stream_id = await add_to_rtvi_embed(
+            mock_client, config, "sensor-123", "camera-1", "rtsp://vst:554/sensor-123"
+        )
+
+        assert success is False
+        assert "400" in msg
+        assert stream_id is None
+        mock_client.post.assert_called_once()
+
+
 class TestStartEmbeddingGeneration:
     """Test start_embedding_generation function."""
 


### PR DESCRIPTION
## Description
When RTSP stream is ingested, it is sometimes not ready to be consumed and thus RTVI-embed times out.
Adding the retry mechanism to RTVI-embed helps resolve this time out issue.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
