### PR TITLE
feat: add compliance CI — copyright headers, DCO, license checks

### DIFF
--- a/.github/scripts/check_copyright_headers.py
+++ b/.github/scripts/check_copyright_headers.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Check that source files contain an SPDX copyright header.
+
+Scans Python (.py) and TypeScript/JavaScript (.ts, .tsx, .js, .jsx)
+files tracked by git. Files matching EXCLUDE_PATTERNS are skipped.
+
+Exit code 0 if all files pass, 1 if any are missing headers.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+import sys
+from pathlib import Path
+
+# SPDX identifier that must appear in the first 5 lines of each file
+REQUIRED_MARKER = "SPDX-License-Identifier"
+
+# File extensions to check
+CHECK_EXTENSIONS = {".py", ".ts", ".tsx", ".js", ".jsx"}
+
+# Glob patterns to skip (relative to repo root)
+EXCLUDE_PATTERNS = (
+    # Auto-generated / third-party
+    "**/node_modules/**",
+    "**/__pycache__/**",
+    "**/.venv/**",
+    "**/3rdparty/**",
+    # Next.js generated type declarations
+    "**/*-env.d.ts",
+    "**/next-env.d.ts",
+    # Config files that are too short for headers
+    "**/.eslintrc.js",
+    # Lock files
+    "**/uv.lock",
+    "**/package-lock.json",
+    # Stubs (third-party type stubs)
+    "**/stubs/**",
+    # UI — original MIT-licensed code; headers will be added incrementally
+    "ui/**",
+    "services/ui/**",
+)
+
+
+def git_ls_files() -> list[str]:
+    """Return all git-tracked files."""
+    result = subprocess.run(
+        ["git", "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip().splitlines()
+
+
+def is_excluded(path: str) -> bool:
+    """Check if path matches any exclude pattern."""
+    return any(fnmatch.fnmatch(path, pat) for pat in EXCLUDE_PATTERNS)
+
+
+def has_spdx_header(filepath: str) -> bool:
+    """Check if the first 5 lines contain the SPDX marker."""
+    try:
+        with open(filepath, encoding="utf-8", errors="ignore") as f:
+            for i, line in enumerate(f):
+                if i >= 5:
+                    break
+                if REQUIRED_MARKER in line:
+                    return True
+    except (OSError, UnicodeDecodeError):
+        return True  # skip unreadable files
+    return False
+
+
+def main() -> int:
+    files = git_ls_files()
+    missing: list[str] = []
+
+    for filepath in files:
+        ext = Path(filepath).suffix
+        if ext not in CHECK_EXTENSIONS:
+            continue
+        if is_excluded(filepath):
+            continue
+        if not has_spdx_header(filepath):
+            missing.append(filepath)
+
+    if missing:
+        print(f"ERROR: {len(missing)} file(s) missing SPDX copyright header:\n")
+        for f in sorted(missing):
+            print(f"  {f}")
+        print(f"\nExpected '{REQUIRED_MARKER}' in the first 5 lines.")
+        print("See CONTRIBUTING.md for the required header format.")
+        return 1
+
+    print(f"OK: All {len(files)} tracked files checked — no missing headers.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,136 @@ jobs:
         run: npm run build
 
   # ---------------------------------------------------------------------------
-  # Job 7: Trigger downstream pipeline on main
+  # Job 7: Copyright header check
+  # ---------------------------------------------------------------------------
+  copyright-headers:
+    name: Copyright Headers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check SPDX headers
+        run: python3 .github/scripts/check_copyright_headers.py
+
+  # ---------------------------------------------------------------------------
+  # Job 8: DCO sign-off check
+  # ---------------------------------------------------------------------------
+  dco:
+    name: DCO Sign-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off
+        run: |
+          MERGE_BASE=$(git merge-base HEAD origin/${GITHUB_BASE_REF:-main} 2>/dev/null || echo HEAD~1)
+          COMMITS=$(git rev-list "$MERGE_BASE"..HEAD 2>/dev/null || echo "")
+          if [ -z "$COMMITS" ]; then
+            echo "No new commits to check."
+            exit 0
+          fi
+          FAILED=0
+          for sha in $COMMITS; do
+            MSG=$(git log -1 --format="%B" "$sha")
+            if ! echo "$MSG" | grep -q "^Signed-off-by:"; then
+              echo "FAIL: Commit $sha missing DCO sign-off"
+              echo "  Subject: $(git log -1 --format='%s' "$sha")"
+              FAILED=1
+            fi
+          done
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "All commits must include a Signed-off-by line."
+            echo "Use: git commit -s -m 'your message'"
+            echo "Or amend: git commit --amend -s --no-edit"
+            exit 1
+          fi
+          echo "OK: All commits have DCO sign-off."
+
+  # ---------------------------------------------------------------------------
+  # Job 9: Dependency license check (Python)
+  # ---------------------------------------------------------------------------
+  license-check-python:
+    name: License Check (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: agent
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.2"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev pkg-config
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Install pip-licenses
+        run: uv run pip install pip-licenses
+
+      - name: Check Python dependency licenses
+        run: |
+          echo "=== Dependency License Report ==="
+          uv run pip-licenses --format=table --order=license
+
+          echo ""
+          echo "=== Checking for disallowed licenses ==="
+          DISALLOWED=$(uv run pip-licenses --format=csv | grep -iE 'GPL|AGPL|SSPL|BUSL' | grep -v 'LGPL' || true)
+          if [ -n "$DISALLOWED" ]; then
+            echo "ERROR: Found packages with disallowed licenses:"
+            echo "$DISALLOWED"
+            exit 1
+          fi
+          echo "OK: No disallowed licenses found."
+
+  # ---------------------------------------------------------------------------
+  # Job 10: Dependency license check (UI)
+  # ---------------------------------------------------------------------------
+  license-check-ui:
+    name: License Check (UI)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check UI dependency licenses
+        run: |
+          npx license-checker \
+            --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;0BSD;Unlicense;CC0-1.0;CC-BY-4.0;CC-BY-3.0;Python-2.0;BlueOak-1.0.0" \
+            --excludePrivatePackages
+
+  # ---------------------------------------------------------------------------
+  # Job 11: Trigger downstream pipeline on main
   # ---------------------------------------------------------------------------
   trigger-downstream-pipeline:
     name: Trigger Downstream Pipeline
@@ -251,6 +380,10 @@ jobs:
       - security
       - frontend-lint
       - frontend-build
+      - copyright-headers
+      - dco
+      - license-check-python
+      - license-check-ui
     runs-on: self-hosted
     timeout-minutes: 10
     env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,14 @@ repos:
         entry: trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail
         language: golang
         stages: [pre-commit]
+
+  - repo: local
+    hooks:
+      # DCO sign-off check — ensures every commit has Signed-off-by
+      - id: dco-signoff
+        name: DCO sign-off check
+        entry: bash -c 'git log -1 --format="%B" | grep -q "^Signed-off-by" || { echo "ERROR - Commit missing DCO sign-off. Use git commit -s"; exit 1; }'
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary

Closes compliance gaps vs GitHub-First Playbook and Dynamo. Targeting `main` so new jobs apply to all PRs.

### New CI jobs (4)

| Job | What it checks |
|-----|---------------|
| **Copyright Headers** | SPDX-License-Identifier in .py/.ts/.tsx/.js files (UI excluded) |
| **DCO Sign-off** | All commits have `Signed-off-by:` line |
| **License Check (Python)** | `pip-licenses` rejects GPL/AGPL/SSPL/BUSL |
| **License Check (UI)** | `license-checker` validates npm deps |

### Pre-commit hook

- `dco-signoff` — catches missing sign-off before commit

### Files

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | 4 new jobs + updated downstream `needs` |
| `.github/scripts/check_copyright_headers.py` | New — SPDX header validator |
| `.pre-commit-config.yaml` | Added `dco-signoff` hook |

## Test plan

- [x] All 4 new CI jobs pass
- [x] Downstream trigger waits for new jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)