### PR TITLE
Add report generation and vlm video understanding skills

### DIFF
--- a/skills/incident-report/SKILL.md
+++ b/skills/incident-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: incident-report
-description: Generate and query incident reports from VSS — look up incidents in Elasticsearch, analyze incident patterns, generate narrative reports. Use when asked about incidents, incident reports, PPE violations, safety events, or "what happened". Requires the alerts profile to be deployed.
+description: Generate and query incident reports from VSS — look up incidents in Elasticsearch, analyze incident patterns, generate narrative reports. Use when asked about incidents, incident reports, PPE violations, safety events, or "what happened". Requires the alerts profile to be deployed. DO NOT use if user doesn't mention incidents and only asks for report.
 version: "3.1.0"
 license: "Apache License 2.0"
 ---

--- a/skills/report-generation/SKILL.md
+++ b/skills/report-generation/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: report-generation
+description: Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as the standard Video Analysis Report markdown. 
+version: "3.1.0"
+license: "Apache License 2.0"
+---
+
+# Report Generation
+
+Build **timestamped video analysis reports** by **querying the VSS agent** for a description of the video using `POST …/generate`. The agent runs **`video_understanding`** (and related tools) internally. Take the agent’s **caption-style text with timestamps** and paste it into the **Video Analysis Report** template below.
+
+---
+
+## When to Use
+
+- "Generate a report for this video" / "for `<sensor-id>`"
+- "Create an analysis report"
+- "Report on what happens in the uploaded video"
+- "Give me a report"
+
+---
+
+## OpenClaw workflow
+
+Run these steps **in order**:
+
+1. **Sensor / clip** — Confirm which **sensor id** or **video** the user means. If unclear, ask before proceeding. If the sensor or video is not mentioned directly in the user request, the user may be referring to a video they mentioned previously.
+
+2. **VSS agent deployment** — Resolve the agent **HTTP base URL**. Read **`VSS_AGENT_PORT`**, **`EXTERNAL_IP` / `HOST_IP`**, or compose / deployment docs for the machine where the stack runs. Typical pattern: **`http://<host>:<port>`** with port from env (often **`8000`** for the agent API).
+
+3. **Query the agent** — **`POST ${VSS_AGENT_BASE_URL}/generate`** with JSON **`{"input_message": "<prompt>"}`**. Ask for a **captioned summary with timestamps** (chronological segments, seconds from clip start), e.g. describe scenes and events with time ranges. Name the **sensor / file** in the message so the agent has the necessary information.
+   - DO NOT mention a report to vss agent
+
+4. **Report template** — Copy the agent’s final text (timestamped caption/summary) into **Analysis Results** and fill **Basic Information**; **return that markdown** to the user.
+0l
+---
+
+## Query VSS agent (`/generate`)
+
+```bash
+# Set from deployment (compose / .env / host where vss-agent listens)
+export VSS_AGENT_BASE_URL="http://localhost:8000"
+
+curl -s -X POST "${VSS_AGENT_BASE_URL}/generate" \
+  -H "Content-Type: application/json" \
+  -d '{"input_message": "Describe in detail what happens in the video for sensor <sensor-id>, with timestamps (start–end in seconds from clip start) for each segment or event."}' | jq .
+```
+
+---
+
+## Video Analysis Report template
+
+Paste the **agent’s timestamped summary** under **Analysis Results**. Fill the table fields (timestamps, source, request).
+
+```markdown
+# Video Analysis Report
+
+## Basic Information
+
+| Field | Value |
+|-------|-------|
+| **Report Identifier** | vss_report_<YYYYMMDD_HHMMSS> |
+| **Date of Analysis** | <YYYY-MM-DD> |
+| **Time of Analysis** | <HH:MM:SS> |
+| **Reporting AI Agent** | <e.g. your label> |
+| **Video Source** | <sensor_id or filename> |
+| **Analysis Request** | <description of user's request to you> |
+
+## Analysis Results
+
+<agent output: timestamped caption / summary>
+```
+
+---
+
+## Cross-Reference
+
+- **sensor-ops** — VST sensors, storage, and clip URLs if you need to verify the video exists before calling the agent.
+- **video-summarization** / **incident-report** — other **`/generate`** patterns; this skill focuses on **timestamped captions → report template**.

--- a/skills/video-analytics/SKILL.md
+++ b/skills/video-analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-analytics
-description: Query video analytics incidents, alerts, sensor data, and metrics from Elasticsearch via the VA-MCP server (port 9901). Use for any question about what happened in video — PPE violations, alerts, incidents, object counts, speeds, occupancy, or anything that requires looking up recorded events. This is the primary way to answer "what happened", "show me alerts", "any violations", "how many people", etc.
+description: Query video analytics data and metrics from Elastic search via the VA-MCP server (port 9901). This includes incidents, alerts, sensor data, and metrics. Use for any question about violations, alerts, incidents, object counts, speeds, occupancy, or anything that requires looking up recorded events. This is the primary way to answer a question that requires incidents, alerts and other metrics such as people counts and violations.
 version: "3.1.0"
 license: "Apache License 2.0"
 ---

--- a/skills/video-understanding/SKILL.md
+++ b/skills/video-understanding/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: video-understanding
+description: Call the vss agent to run video understanding on video to answer a text question. Use when the user asks about video content, or about visual details that cannot be answered from conversation history, search hits, or metadata alone.
+version: "3.1.0"
+license: "Apache License 2.0"
+---
+
+# Video QnA using VLM through VSS Agent
+
+Use this skill when you need details about the video which requires VLM to look at the video frames — for example the agent has **no** usable prior answer and needs a **fresh look at the pixels** for a specific clip.
+
+---
+
+## When to Use
+
+- The user asks **what happens in the video**, what **objects / people / actions** appear, **colors**, **timing**, **safety**, or other **visual facts** that require watching the clip.
+- The user asks for **details** that **cannot be answered** from existing messages, summaries, Elasticsearch/MCP results, or filenames alone—you need **model inference on the video**.
+- Follow-up questions about **content details** after a coarse summary or after report generation.
+
+Do **not** use this skill when a **database / MCP / prior tool output** already answers the question, unless the user explicitly wants **verification** against the video.
+
+---
+
+## OpenClaw workflow
+
+1. **Clip** — Identify **sensor id**, **filename**, or **URL** for one video segment. If ambiguous, ask the user.
+2. Call vss agent with the sensor id and ask for it to call video_understanding tool to answer the user's question.
+3. Return the vss agent's answer back to the user.
+
+
+## Query VSS agent (`/generate`)
+
+```bash
+# Set from deployment (compose / .env / host where vss-agent listens)
+export VSS_AGENT_BASE_URL="http://localhost:8000"
+
+curl -s -X POST "${VSS_AGENT_BASE_URL}/generate" \
+  -H "Content-Type: application/json" \
+  -d '{"input_message": "Call video_understanding tool to answer the following question about <sensor-id>: <user query>"}' | jq .
+```
+
+---
+
+## Cross-Reference
+
+- **sensor-ops** — VST storage/replay URLs so **`VIDEO_URL`** is valid for the VLM.
+- **report-generation** — timestamped **reports** via the **VSS agent** (`/generate`); this skill is **direct VLM** for ad-hoc **video Q&A**.


### PR DESCRIPTION
## Description
Adding report generation and video understanding (vlm qna) skills

Changes:

Report generation skill added which uses vss agent to call video understanding to generate captions using VLM and then report is formatted using template by agent
Video understanding skill that uses vss agent to call video understanding to answer video detail questions and follow ups
Tweak and refined other skill descriptors to be less confusing and more specific to prevent incorrect skill usage

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
