### PR TITLE
feat: add freshyjmp to copy-pr-bot vetters

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -5,6 +5,7 @@ additional_vetters:
   - akshayanv
   - ayyappa-dev
   - daviddu0425
+  - freshyjmp
   - hugoverjus
   - jiayin-nvidia
   - kaushikc-nvidia


### PR DESCRIPTION
## Summary

Add `freshyjmp` to `additional_vetters` in `.github/copy-pr-bot.yaml` so they can approve external PRs for CI.

## Test plan

- [ ] copy-pr-bot recognizes freshyjmp as a vetter