### PR TITLE
added config change in search to support higher streams

### DIFF
--- a/deployments/developer-workflow/dev-profile-search/.env
+++ b/deployments/developer-workflow/dev-profile-search/.env
@@ -159,7 +159,7 @@ PERCEPTION_TAG="3.1.0"
 # PERCEPTION_TAG="3.1.0-sbsa"
 
 # Number of concurrent streams to process
-NUM_STREAMS=8
+NUM_STREAMS=16
 
 # =============================================================================
 # NVSTREAMER CONFIGURATION

--- a/deployments/developer-workflow/dev-profile-search/video-analytics-2d-app/deepstream/configs/cnn-models/ds-main-config.txt
+++ b/deployments/developer-workflow/dev-profile-search/video-analytics-2d-app/deepstream/configs/cnn-models/ds-main-config.txt
@@ -35,7 +35,7 @@ num-source-bins=0
 # Set use-nvmultiurisrcbin to 1 to enable sensor provisioning/update feature
 use-nvmultiurisrcbin=1
 stream-name-display=1
-max-batch-size=8
+max-batch-size=16
 http-ip=localhost
 http-port=9000
 extract-sei-type5-data=1
@@ -161,7 +161,7 @@ nvbuf-memory-type=0
 gpu-id=0
 ##Boolean property to inform muxer that sources are live
 live-source=1
-batch-size=8
+batch-size=16
 ##time out in usec, to wait after the first buffer is available
 ##to push the batch even if the complete batch is not formed
 batched-push-timeout=33000
@@ -188,7 +188,7 @@ enable=1
 gpu-id=0
 #Required to display the PGIE labels, should be added even when using config-file
 #property
-batch-size=8
+batch-size=16
 #Required by the app for OSD, not a plugin property
 bbox-border-color0=1;0;0;1
 bbox-border-color1=0;1;1;1
@@ -219,11 +219,13 @@ enable=1
 backend=tensorrt
 tensorrt-engine=/opt/storage/model_batch16.plan
 onnx-model=/opt/storage/radio-clip_v1.0.onnx
-batch-size=3
+batch-size=128
 min-crop-size=32
 verbose=1
 gpu-id=0
 skip-interval=0
+smart-infer=1
+ofa-predict=1
 
 [secondary-gie0]
 enable=0

--- a/deployments/developer-workflow/dev-profile-search/video-analytics-2d-app/deepstream/configs/cnn-models/ds-main-redis-config.txt
+++ b/deployments/developer-workflow/dev-profile-search/video-analytics-2d-app/deepstream/configs/cnn-models/ds-main-redis-config.txt
@@ -215,11 +215,13 @@ enable=1
 backend=tensorrt
 tensorrt-engine=/opt/storage/model_batch16.plan
 onnx-model=/opt/storage/radio-clip_v1.0.onnx
-batch-size=3
+batch-size=128
 min-crop-size=32
 verbose=1
 gpu-id=0
 skip-interval=0
+smart-infer=1
+ofa-predict=1
 
 [secondary-gie0]
 enable=0

--- a/deployments/developer-workflow/dev-profile-search/video-analytics-2d-app/nvstreamer/configs/vst-config.json
+++ b/deployments/developer-workflow/dev-profile-search/video-analytics-2d-app/nvstreamer/configs/vst-config.json
@@ -56,7 +56,7 @@
 	  "onvif_request_timeout_secs": 10,
 	  "device_discovery_freq_secs": 5,
 	  "device_discovery_interfaces": [],
-	  "max_devices_supported": 8,
+	  "max_devices_supported": 16,
 	  "bitrate_kbps": 8000,
 	  "framerate": 30,
 	  "resolution": "1920x1080",


### PR DESCRIPTION
## Description
Scaled the `dev-profile-search` pipeline to support **16 high-definition concurrent streams** with stable FPS.
### Changes
#### RTVI-CV config updates
Aligned batch sizes across the DeepStream pipeline to sustain 16 streams:
- **`[source-list]`** — `max-batch-size`: cap for batched sources; aligned with the muxer batch.
- **`[streammux]`** — `batch-size` and `batched-push-timeout`: controls how frames are batched before downstream inference.
- **`[primary-gie]`** — `batch-size`: detector batch; matches the streammux batch for this app.
- **`[visionencoder]`** — `batch-size = streammux batch × 8` (assuming 8 images per frame).
#### RTVI-CV optimizations
Applied optimizations from [NVBug 4946710](https://nvbugspro.nvidia.com/bug/4946710) to stabilize FPS drops.
#### NVStreamer config
Raised `max_devices_supported` to allow creating up to **16 streams**.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
