### PR TITLE
ci: port full compliance pipeline from main + pin Action SHAs

### DIFF
--- a/.github/scripts/check_copyright_headers.py
+++ b/.github/scripts/check_copyright_headers.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Check that source files contain an SPDX copyright header.
+
+Scans Python (.py) and TypeScript/JavaScript (.ts, .tsx, .js, .jsx)
+files tracked by git. Files matching EXCLUDE_PATTERNS are skipped.
+
+Exit code 0 if all files pass, 1 if any are missing headers.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+import sys
+from pathlib import Path
+
+# SPDX identifier that must appear in the first 5 lines of each file
+REQUIRED_MARKER = "SPDX-License-Identifier"
+
+# File extensions to check
+CHECK_EXTENSIONS = {".py", ".ts", ".tsx", ".js", ".jsx"}
+
+# Glob patterns to skip (relative to repo root)
+EXCLUDE_PATTERNS = (
+    # Auto-generated / third-party
+    "**/node_modules/**",
+    "**/__pycache__/**",
+    "**/.venv/**",
+    "**/3rdparty/**",
+    # Next.js generated type declarations
+    "**/*-env.d.ts",
+    "**/next-env.d.ts",
+    # Config files that are too short for headers
+    "**/.eslintrc.js",
+    # Lock files
+    "**/uv.lock",
+    "**/package-lock.json",
+    # Stubs (third-party type stubs)
+    "**/stubs/**",
+    # UI — original MIT-licensed code; headers will be added incrementally
+    "ui/**",
+    "services/ui/**",
+)
+
+
+def git_ls_files() -> list[str]:
+    """Return all git-tracked files."""
+    result = subprocess.run(
+        ["git", "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip().splitlines()
+
+
+def is_excluded(path: str) -> bool:
+    """Check if path matches any exclude pattern."""
+    return any(fnmatch.fnmatch(path, pat) for pat in EXCLUDE_PATTERNS)
+
+
+def has_spdx_header(filepath: str) -> bool:
+    """Check if the first 5 lines contain the SPDX marker."""
+    try:
+        with open(filepath, encoding="utf-8", errors="ignore") as f:
+            for i, line in enumerate(f):
+                if i >= 5:
+                    break
+                if REQUIRED_MARKER in line:
+                    return True
+    except (OSError, UnicodeDecodeError):
+        return True  # skip unreadable files
+    return False
+
+
+def main() -> int:
+    files = git_ls_files()
+    missing: list[str] = []
+
+    for filepath in files:
+        ext = Path(filepath).suffix
+        if ext not in CHECK_EXTENSIONS:
+            continue
+        if is_excluded(filepath):
+            continue
+        if not has_spdx_header(filepath):
+            missing.append(filepath)
+
+    if missing:
+        print(f"ERROR: {len(missing)} file(s) missing SPDX copyright header:\n")
+        for f in sorted(missing):
+            print(f"  {f}")
+        print(f"\nExpected '{REQUIRED_MARKER}' in the first 5 lines.")
+        print("See CONTRIBUTING.md for the required header format.")
+        return 1
+
+    print(f"OK: All {len(files)} tracked files checked — no missing headers.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_folder_structure.py
+++ b/.github/scripts/check_folder_structure.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Validate that selected directories only contain expected entries.
 
 Each rule lists the directory to inspect plus the file / sub-directory

--- a/.github/scripts/check_python_licenses.sh
+++ b/.github/scripts/check_python_licenses.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Mirrors CI Job 9 (license-check-python). Scans only runtime deps that
+# actually ship — dev-only tools (yamllint is GPL, others vary) are
+# excluded via --no-default-groups. We use `uv pip install` (not
+# `uv run pip install`) and `uv run --no-sync` so uv does not auto-resync
+# the dev group back into the venv.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)/services/agent"
+
+uv sync --frozen --no-default-groups --quiet
+uv pip install --quiet pip-licenses
+
+DISALLOWED=$(uv run --no-sync --quiet pip-licenses --format=csv | grep -iE 'GPL|AGPL|SSPL|BUSL' | grep -v 'LGPL' || true)
+if [ -n "$DISALLOWED" ]; then
+  echo "ERROR: Found packages with disallowed licenses:"
+  echo "$DISALLOWED"
+  exit 1
+fi
+echo "OK: No disallowed licenses found."

--- a/.github/scripts/check_ui_licenses.sh
+++ b/.github/scripts/check_ui_licenses.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Mirrors CI Job 10 (license-check-ui). Runs license-checker against the
+# resolved npm tree and fails if any package's license is not on the allow list.
+# Used by pre-commit so devs see the same failure locally that CI surfaces.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)/services/ui"
+
+npm ci --silent
+npx --yes license-checker --json --excludePrivatePackages > /tmp/_ui_licenses.json
+
+node <<'EOF'
+const licenses = require("/tmp/_ui_licenses.json");
+const allowed = new Set([
+  "MIT","MIT-0","Apache-2.0","BSD-2-Clause","BSD-3-Clause","ISC","0BSD",
+  "Unlicense","CC0-1.0","CC-BY-4.0","CC-BY-3.0","Python-2.0",
+  "BlueOak-1.0.0","MPL-2.0",
+]);
+const excludePrefixes = ["@img/sharp-libvips", "@aiqtoolkit-ui/common"];
+const failures = [];
+for (const [pkg, info] of Object.entries(licenses)) {
+  const name = pkg.replace(/@[^@]+$/, "");
+  if (excludePrefixes.some(p => name.startsWith(p))) continue;
+  const lic = String(info.licenses || "UNKNOWN");
+  const parts = lic.replace(/[()]/g, "").split(/ OR | AND /);
+  const ok = parts.some(p => allowed.has(p.trim().replace(/\*$/, "")));
+  if (!ok) failures.push(pkg + ": " + lic);
+}
+if (failures.length) {
+  console.error("ERROR: " + failures.length + " package(s) with disallowed licenses:");
+  failures.forEach(f => console.error("  " + f));
+  process.exit(1);
+}
+console.log("OK: " + Object.keys(licenses).length + " packages checked.");
+EOF

--- a/.github/scripts/poll-downstream-pipeline.py
+++ b/.github/scripts/poll-downstream-pipeline.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Poll a downstream GitLab pipeline and report per-job progress.
 
 Runs inline right after ``trigger-downstream-pipeline.sh`` in the same

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,15 @@ jobs:
       run:
         working-directory: services/agent
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           version: "0.6.2"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.13"
 
@@ -89,15 +89,15 @@ jobs:
       run:
         working-directory: services/agent
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           version: "0.6.2"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.13"
 
@@ -123,15 +123,15 @@ jobs:
       run:
         working-directory: services/agent
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           version: "0.6.2"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.13"
 
@@ -153,7 +153,7 @@ jobs:
             -m "not slow and not integration"
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: always()
         with:
           name: coverage-report
@@ -170,12 +170,12 @@ jobs:
       run:
         working-directory: services/agent
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.13"
 
@@ -199,10 +199,10 @@ jobs:
       run:
         working-directory: services/ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "lts/*"
           cache: "npm"
@@ -246,10 +246,10 @@ jobs:
       run:
         working-directory: services/ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "lts/*"
           cache: "npm"
@@ -262,20 +262,164 @@ jobs:
         run: npm run build
 
   # ---------------------------------------------------------------------------
-  # Job 7: Folder structure enforcement
+  # Job 7: Copyright header check
+  # ---------------------------------------------------------------------------
+  copyright-headers:
+    name: Copyright Headers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Check SPDX headers
+        run: python3 .github/scripts/check_copyright_headers.py
+
+  # ---------------------------------------------------------------------------
+  # Job 8: DCO sign-off check
+  # ---------------------------------------------------------------------------
+  dco:
+    name: DCO Sign-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off
+        run: |
+          MERGE_BASE=$(git merge-base HEAD origin/${GITHUB_BASE_REF:-develop} 2>/dev/null || echo HEAD~1)
+          COMMITS=$(git rev-list "$MERGE_BASE"..HEAD 2>/dev/null || echo "")
+          if [ -z "$COMMITS" ]; then
+            echo "No new commits to check."
+            exit 0
+          fi
+          FAILED=0
+          for sha in $COMMITS; do
+            MSG=$(git log -1 --format="%B" "$sha")
+            if ! echo "$MSG" | grep -q "^Signed-off-by:"; then
+              echo "FAIL: Commit $sha missing DCO sign-off"
+              echo "  Subject: $(git log -1 --format='%s' "$sha")"
+              FAILED=1
+            fi
+          done
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "All commits must include a Signed-off-by line."
+            echo "Use: git commit -s -m 'your message'"
+            echo "Or amend: git commit --amend -s --no-edit"
+            exit 1
+          fi
+          echo "OK: All commits have DCO sign-off."
+
+  # ---------------------------------------------------------------------------
+  # Job 9: Dependency license check (Python)
+  # ---------------------------------------------------------------------------
+  license-check-python:
+    name: License Check (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: services/agent
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
+        with:
+          version: "0.6.2"
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev pkg-config
+
+      # Delegates to .github/scripts/check_python_licenses.sh which is
+      # also called by .pre-commit-config.yaml so local pre-commit and
+      # CI run the exact same scan. The script uses --no-default-groups
+      # so only runtime deps that actually ship are scanned (dev tools
+      # like yamllint are GPL but never distributed).
+      - name: Check Python dependency licenses
+        working-directory: ${{ github.workspace }}
+        run: bash .github/scripts/check_python_licenses.sh
+
+  # ---------------------------------------------------------------------------
+  # Job 10: Dependency license check (UI)
+  # ---------------------------------------------------------------------------
+  license-check-ui:
+    name: License Check (UI)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: services/ui
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          cache-dependency-path: services/ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check UI dependency licenses
+        run: |
+          # Dump all licenses as JSON, then validate in Node.
+          # OSRB-approved exceptions are filtered by package name prefix.
+          npx license-checker --json --excludePrivatePackages > /tmp/licenses.json
+
+          node -e '
+            const licenses = require("/tmp/licenses.json");
+            const allowed = new Set([
+              "MIT","MIT-0","Apache-2.0","BSD-2-Clause","BSD-3-Clause","ISC","0BSD",
+              "Unlicense","CC0-1.0","CC-BY-4.0","CC-BY-3.0","Python-2.0",
+              "BlueOak-1.0.0","MPL-2.0"
+            ]);
+            // OSRB-approved exceptions (dynamically linked, reviewed)
+            const excludePrefixes = ["@img/sharp-libvips","@aiqtoolkit-ui/common"];
+            const failures = [];
+            for (const [pkg, info] of Object.entries(licenses)) {
+              const name = pkg.replace(/@[^@]+$/, "");
+              if (excludePrefixes.some(p => name.startsWith(p))) continue;
+              const lic = String(info.licenses || "UNKNOWN");
+              // license-checker appends * when license is inferred from file (e.g. "MIT*")
+              const parts = lic.replace(/[()]/g, "").split(/ OR | AND /);
+              const ok = parts.some(p => allowed.has(p.trim().replace(/\*$/, "")));
+              if (!ok) failures.push(pkg + ": " + lic);
+            }
+            if (failures.length) {
+              console.error("ERROR: " + failures.length + " package(s) with disallowed licenses:\n");
+              failures.forEach(f => console.error("  " + f));
+              process.exit(1);
+            }
+            console.log("OK: " + Object.keys(licenses).length + " packages checked.");
+          '
+
+  # ---------------------------------------------------------------------------
+  # Job 11: Folder structure enforcement (develop-only)
   # ---------------------------------------------------------------------------
   folder-structure:
     name: Check folder structure
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Validate folder structures
         run: python3 .github/scripts/check_folder_structure.py
 
   # ---------------------------------------------------------------------------
-  # Job 8: Trigger downstream pipeline on main and poll it to completion
+  # Job 12: Trigger downstream pipeline and poll it to completion
   # ---------------------------------------------------------------------------
   trigger-downstream-pipeline:
     name: Trigger Downstream Pipeline
@@ -286,6 +430,10 @@ jobs:
       - security
       - frontend-lint
       - frontend-build
+      - copyright-headers
+      - dco
+      - license-check-python
+      - license-check-ui
       - folder-structure
     runs-on: [self-hosted, downstream-pipeline]
     # Holds the runner until the downstream pipeline completes. Must be
@@ -301,7 +449,7 @@ jobs:
       VSS_TARGET_BRANCH: ${{ github.ref_name }}
       VSS_COMPARE_BRANCH: ${{ github.base_ref || 'develop' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Trigger pipeline
         id: trigger

--- a/.openclaw/index.ts
+++ b/.openclaw/index.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,39 @@ repos:
     files: ^services/agent/src/vss_agents/
     pass_filenames: false
     require_serial: true
+
+  # DCO sign-off check — mirrors CI job "DCO Sign-off"
+  - id: dco-signoff
+    name: DCO sign-off check
+    entry: bash -c 'git log -1 --format="%B" | grep -q "^Signed-off-by" || { echo "ERROR - Commit missing DCO sign-off. Use git commit -s"; exit 1; }'
+    language: system
+    always_run: true
+    pass_filenames: false
+    stages: [pre-commit]
+
+  # Mirrors CI Job 7 — SPDX copyright headers on source files
+  - id: copyright-headers
+    name: SPDX copyright headers
+    entry: python3 .github/scripts/check_copyright_headers.py
+    language: system
+    pass_filenames: false
+    stages: [pre-commit]
+
+  # Mirrors CI Job 9 — Python dep license denylist (GPL/AGPL/SSPL/BUSL, LGPL allowed)
+  # Triggers on pyproject.toml or uv.lock changes so lockfile-only edits still gate.
+  - id: license-check-python
+    name: License Check (Python deps)
+    entry: bash .github/scripts/check_python_licenses.sh
+    language: system
+    files: ^services/agent/(pyproject\.toml|uv\.lock)$
+    pass_filenames: false
+    stages: [pre-commit]
+
+  # Mirrors CI Job 10 — UI dep license allowlist
+  - id: license-check-ui
+    name: License Check (UI deps)
+    entry: bash .github/scripts/check_ui_licenses.sh
+    language: system
+    files: ^services/ui/(package\.json|package-lock\.json)$
+    pass_filenames: false
+    stages: [pre-commit]

--- a/deployments/scripts/nemoclaw/update_openclaw_config.py
+++ b/deployments/scripts/nemoclaw/update_openclaw_config.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import json
 import os

--- a/deployments/scripts/orchestrator_mcp_helper.py
+++ b/deployments/scripts/orchestrator_mcp_helper.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 import re


### PR DESCRIPTION
## Summary

Brings develop's CI in parity with main so develop is no longer a compliance gap behind the publishing branch.

Closes the gaps identified in the GitHub-First Infra Requirements audit:
- **UR-19** branch-protection-required CI (jobs added so develop has the same compliance gates)
- **UR-20** all 3rd-party Actions pinned to full commit SHAs
- **CO-3, CO-4, CO-5** compliance gates run on every PR
- **EX-2** dep changes can't bypass scanning

## Workflow changes (`.github/workflows/ci.yml`)

**SHA pins (UR-20):**
| Action | SHA | Tag |
|---|---|---|
| actions/checkout | 34e1148... | v4.3.1 |
| actions/setup-node | 49933ea... | v4.4.0 |
| actions/setup-python | a26af69... | v5.6.0 |
| actions/upload-artifact | ea165f8... | v4.6.2 |
| astral-sh/setup-uv | d4b2f3b... | v5.4.2 |

**4 jobs added** (translated to `services/agent` / `services/ui` paths):
- Copyright Headers (Job 7)
- DCO Sign-off (Job 8) — `MERGE_BASE` defaults to `develop` instead of `main`
- License Check (Python) (Job 9, `services/agent`) — uses `uv sync --frozen --no-default-groups` to scan only runtime deps that ship; dev-only tools like yamllint (GPL) are excluded
- License Check (UI) (Job 10, `services/ui`) — allowlist now includes `MIT-0` (strictly permissive, OSI/SPDX-recognized) and excludes `@aiqtoolkit-ui/common` (workspace-internal)

`trigger-downstream-pipeline.needs[]` updated to depend on the new compliance jobs.

## New scripts

- `.github/scripts/check_copyright_headers.py` — ported verbatim from main
- `.github/scripts/check_ui_licenses.sh` — runs the same allowlist locally so pre-commit and CI agree

## SPDX headers added (UR-17 / CO-20)

5 files were missing SPDX headers — now added:
- `.github/scripts/check_folder_structure.py`
- `.github/scripts/poll-downstream-pipeline.py`
- `.openclaw/index.ts`
- `deployments/scripts/nemoclaw/update_openclaw_config.py`
- `deployments/scripts/orchestrator_mcp_helper.py`

## Pre-commit additions (`.pre-commit-config.yaml`)

- `dco-signoff` — mirrors CI Job 8
- `copyright-headers` — mirrors CI Job 7
- `license-check-python` — gated on `services/agent/pyproject.toml` and `services/agent/uv.lock`
- `license-check-ui` — gated on `services/ui/package.json` and `services/ui/package-lock.json`

## Test plan

- [x] Lint, typecheck, test, security jobs pass (existing — should be unaffected)
- [x] New Copyright Headers job passes
- [x] New DCO Sign-off job passes
- [x] New License Check (Python) job passes — yamllint excluded
- [x] New License Check (UI) job passes — MIT-0 allowed
- [x] Folder structure job still passes
- [x] All Action SHAs resolve and run successfully
- [x] `pre-commit install --hook-type pre-commit && pre-commit run --all-files` passes locally

## After merge

- Companion PR #145 (SHA pins for main) should merge first
- Then enable required-status-checks on the develop ruleset (separate ops change)