### PR TITLE
feat: add LVS caption QA over Elasticsearch

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -134,6 +134,9 @@ ELASTICSEARCH_ILM_MIN_AGE=4h
 # Maximum number of attempts to connect to Elasticsearch
 ELASTICSEARCH_CONNECTION_MAX_ATTEMPTS=20
 
+# Agent-side Elasticsearch endpoint for LVS stored caption/event Q&A
+ELASTIC_SEARCH_ENDPOINT=http://${HOST_IP}:9200
+
 # =============================================================================
 # MESSAGE BROKER CONFIGURATION
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -152,6 +152,16 @@ functions:
     - vehicle crossing
     - traffic violation
 
+  lvs_caption_qa:
+    _type: lvs_caption_qa
+    llm_name: ${LLM_MODEL_TYPE:-nim}_llm
+    es_endpoint: ${ELASTIC_SEARCH_ENDPOINT:-http://${HOST_IP}:9200}
+    es_index: lvs-events
+    video_understanding_tool: video_understanding
+    max_results: 8
+    max_evidence_chars: 12000
+    default_timestamp_window_seconds: 30
+
   video_report_gen:
     _type: video_report_gen
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}
@@ -231,6 +241,7 @@ workflow:
   llm_reasoning: false
   planning_enabled: true
   tool_names:
+  - lvs_caption_qa
   - video_understanding
   - vst_video_clip
   - vst_snapshot
@@ -250,9 +261,12 @@ workflow:
       - Only call report_agent when user mentions "report" in the question.
       - Don't use the report from previous interactions.
       - Examples: "Generate a report for, "Create an analysis report", "Generate a report using long video summarization", "Generate a report using lvs"
-      **video_understanding** - For any question about short videos or quick queries for a video clip.
-      - Use when video is less than 1 minute.
-      - Use when user asks "what happens in the video" or "describe the video" or "analyze this video" or "what is happening in the video"
+      **lvs_caption_qa** - For Q&A about a stored/uploaded video or live stream in the LVS profile.
+      - Use this first for user questions about video content because it searches stored LVS dense captions/events in Elasticsearch and falls back to VLM if captions are unavailable.
+      - If the question mentions a timestamp or time range, pass start_timestamp and end_timestamp as seconds since the beginning of the video/stream when you can infer them.
+      - Examples: "What happened in the video?", "Did a white sedan park?", "What happened between 45s and 60s?"
+      **video_understanding** - For explicit direct VLM analysis of a video clip.
+      - Use only when the user specifically asks to bypass stored captions, asks for direct visual inspection, or when another tool instruction requires direct VLM analysis.
       - Do NOT use when user asks to "generate a report"
       **vst_video_clip** - For queries asking for showing videos (e.g., "Let's show the videos just uploaded"), call this tool in parallel with each video name as a separate input.
       - CRITICAL: Always call vst_video_clip to get the URL even though the video clip for the same video has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_video_clip.

--- a/services/agent/src/vss_agents/tools/lvs_caption_qa.py
+++ b/services/agent/src/vss_agents/tools/lvs_caption_qa.py
@@ -1,0 +1,706 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Question answering over stored LVS dense-caption/event documents."""
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+import json
+import logging
+import re
+from typing import Any
+
+from elasticsearch import AsyncElasticsearch
+from elasticsearch import NotFoundError as ESNotFoundError
+from langchain_core.messages import HumanMessage
+from langchain_core.messages import SystemMessage
+from nat.builder.builder import Builder
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.component_ref import FunctionRef
+from nat.data_models.component_ref import LLMRef
+from nat.data_models.function import FunctionBaseConfig
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import model_validator
+
+logger = logging.getLogger(__name__)
+
+PTS_NS_PER_SECOND = 1_000_000_000
+RAW_EVENTS_DOC_TYPE = "raw_events"
+STRUCTURED_EVENTS_DOC_TYPE = "structured_events"
+AGGREGATED_SUMMARY_DOC_TYPE = "aggregated_summary"
+
+DEFAULT_SOURCE_FIELDS = [
+    "metadata.content_metadata.uuid",
+    "metadata.content_metadata.streamId",
+    "metadata.content_metadata.camera_id",
+    "metadata.content_metadata.file",
+    "metadata.source",
+]
+DEFAULT_TEXT_FIELDS = [
+    "text^4",
+    "metadata.content_metadata.camera_id^2",
+    "metadata.content_metadata.file",
+    "metadata.source",
+]
+
+ANSWER_SYSTEM_PROMPT = """You answer questions about video using stored LVS caption and event evidence.
+Use only the evidence provided in the prompt. If the evidence is insufficient, say that directly.
+When useful, cite the relevant timestamp ranges from the evidence. Do not invent visual details."""
+
+ANSWER_USER_PROMPT = """Video or stream: {sensor_id}
+
+User question:
+{question}
+
+Stored LVS caption/event evidence:
+{evidence}
+
+Answer the user question in plain English."""
+
+
+class LVSCaptionQAConfig(FunctionBaseConfig, name="lvs_caption_qa"):
+    """Configuration for Q&A over stored LVS dense-caption/event documents."""
+
+    llm_name: LLMRef = Field(
+        ...,
+        description="The LLM used to answer from retrieved stored LVS captions.",
+    )
+    es_endpoint: str = Field(
+        ...,
+        description="Elasticsearch endpoint where LVS documents are stored.",
+    )
+    es_index: str = Field(
+        default="lvs-events",
+        description="Elasticsearch index containing LVS dense-caption/event documents.",
+    )
+    video_understanding_tool: FunctionRef = Field(
+        default="video_understanding",
+        description="Fallback VLM tool used when stored LVS captions are unavailable.",
+    )
+    max_results: int = Field(
+        default=8,
+        ge=1,
+        le=50,
+        description="Maximum ES documents to retrieve for caption evidence.",
+    )
+    max_evidence_chars: int = Field(
+        default=12000,
+        ge=1000,
+        description="Maximum characters of caption evidence injected into the LLM prompt.",
+    )
+    default_timestamp_window_seconds: float = Field(
+        default=30.0,
+        ge=1.0,
+        description="Fallback VLM clip duration when the user mentions a single timestamp.",
+    )
+    fallback_to_vlm: bool = Field(
+        default=True,
+        description="Whether to call the configured VLM tool when no usable stored captions are found.",
+    )
+    source_fields: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_SOURCE_FIELDS),
+        description="ES fields used to match the requested video or stream.",
+    )
+    text_fields: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_TEXT_FIELDS),
+        description="ES text fields used for BM25 keyword search.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class LVSCaptionQAInput(BaseModel):
+    """Input for Q&A over stored LVS captions."""
+
+    sensor_id: str = Field(
+        ...,
+        min_length=1,
+        description="The video file name, camera ID, or stream ID to answer about.",
+    )
+    question: str = Field(
+        ...,
+        min_length=1,
+        description="The user question to answer from stored LVS captions.",
+    )
+    start_timestamp: float | None = Field(
+        default=None,
+        description="Optional start time in seconds since the beginning of the video/stream.",
+    )
+    end_timestamp: float | None = Field(
+        default=None,
+        description="Optional end time in seconds since the beginning of the video/stream.",
+    )
+    top_k: int | None = Field(
+        default=None,
+        ge=1,
+        le=50,
+        description="Optional maximum number of ES documents to retrieve.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_time_range(cls, info: dict) -> dict:
+        start = info.get("start_timestamp")
+        end = info.get("end_timestamp")
+
+        if start is not None:
+            start = float(start)
+            if start < 0:
+                raise ValueError("start_timestamp must be non-negative")
+            info["start_timestamp"] = start
+
+        if end is not None:
+            end = float(end)
+            if end < 0:
+                raise ValueError("end_timestamp must be non-negative")
+            info["end_timestamp"] = end
+
+        if start is not None and end is not None and start >= end:
+            raise ValueError("start_timestamp must be before end_timestamp")
+
+        return info
+
+
+@dataclass(frozen=True)
+class CaptionEvidence:
+    """Normalized evidence extracted from an LVS ES document."""
+
+    text: str
+    doc_type: str
+    score: float
+    start_seconds: float | None = None
+    end_seconds: float | None = None
+    event_type: str | None = None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _seconds_to_pts_ns(value: float) -> int:
+    return round(value * PTS_NS_PER_SECOND)
+
+
+def _pts_ns_to_seconds(value: Any) -> float | None:
+    coerced = _coerce_float(value)
+    if coerced is None:
+        return None
+    return coerced / PTS_NS_PER_SECOND
+
+
+def _format_seconds(value: float) -> str:
+    value_float = float(value)
+    if value_float.is_integer():
+        return f"{int(value_float)}s"
+    return f"{value_float:.2f}".rstrip("0").rstrip(".") + "s"
+
+
+def _parse_time_value(value: str, unit: str | None = None) -> float | None:
+    value = value.strip()
+    if not value:
+        return None
+
+    try:
+        if ":" in value:
+            parts = [float(part) for part in value.split(":")]
+            if len(parts) == 2:
+                return parts[0] * 60 + parts[1]
+            if len(parts) == 3:
+                return parts[0] * 3600 + parts[1] * 60 + parts[2]
+            return None
+
+        seconds = float(value)
+    except ValueError:
+        return None
+
+    normalized_unit = (unit or "").lower()
+    if normalized_unit in {"ms", "millisecond", "milliseconds"}:
+        return seconds / 1000.0
+    if normalized_unit in {"m", "min", "mins", "minute", "minutes"}:
+        return seconds * 60.0
+    return seconds
+
+
+_TIME_VALUE_PATTERN = r"\d+(?::\d{1,2}){1,2}(?:\.\d+)?|\d+(?:\.\d+)?"
+_TIME_UNIT_PATTERN = r"ms|milliseconds?|s|sec|secs|seconds?|m|min|mins|minutes?"
+_TIME_TOKEN = rf"({_TIME_VALUE_PATTERN})\s*({_TIME_UNIT_PATTERN})?"
+_TIME_TOKEN_NAMED = rf"(?P<value>{_TIME_VALUE_PATTERN})" rf"\s*(?P<unit>{_TIME_UNIT_PATTERN})?"
+
+
+def _infer_time_scope_from_question(question: str) -> tuple[float | None, float | None]:
+    """Infer a simple seconds-based time scope from natural language text."""
+    text = question.lower()
+
+    bracket_match = re.search(rf"\[\s*{_TIME_TOKEN}\s*,\s*{_TIME_TOKEN}\s*\]", text)
+    if bracket_match:
+        values = re.findall(_TIME_TOKEN, bracket_match.group(0))
+        if len(values) >= 2:
+            start = _parse_time_value(values[0][0], values[0][1])
+            end = _parse_time_value(values[1][0], values[1][1])
+            if start is not None and end is not None and start < end:
+                return start, end
+
+    range_match = re.search(rf"(?:between|from)\s+{_TIME_TOKEN}\s+(?:and|to|-)\s+{_TIME_TOKEN}", text)
+    if range_match:
+        values = re.findall(_TIME_TOKEN, range_match.group(0))
+        if len(values) >= 2:
+            start = _parse_time_value(values[0][0], values[0][1])
+            end = _parse_time_value(values[1][0], values[1][1])
+            if start is not None and end is not None and start < end:
+                return start, end
+
+    after_match = re.search(rf"(?:after|since)\s+{_TIME_TOKEN_NAMED}", text)
+    if after_match:
+        value, unit = after_match.group("value"), after_match.group("unit")
+        return _parse_time_value(value, unit), None
+
+    before_match = re.search(rf"(?:before|until|up to)\s+{_TIME_TOKEN_NAMED}", text)
+    if before_match:
+        value, unit = before_match.group("value"), before_match.group("unit")
+        return None, _parse_time_value(value, unit)
+
+    point_match = re.search(rf"(?:at|around|near)\s+{_TIME_TOKEN_NAMED}", text)
+    if point_match:
+        value, unit = point_match.group("value"), point_match.group("unit")
+        return _parse_time_value(value, unit), None
+
+    return None, None
+
+
+def _resolve_time_scope(input_data: LVSCaptionQAInput) -> tuple[float | None, float | None]:
+    if input_data.start_timestamp is not None or input_data.end_timestamp is not None:
+        return input_data.start_timestamp, input_data.end_timestamp
+    return _infer_time_scope_from_question(input_data.question)
+
+
+def _has_time_scope(start_seconds: float | None, end_seconds: float | None) -> bool:
+    return start_seconds is not None or end_seconds is not None
+
+
+def _get_time_overlap_pts_filter(start_seconds: float | None, end_seconds: float | None) -> list[dict[str, Any]]:
+    if not _has_time_scope(start_seconds, end_seconds):
+        return []
+
+    query_start = 0.0 if start_seconds is None else start_seconds
+    query_end = end_seconds if end_seconds is not None else query_start
+
+    return [
+        {"range": {"metadata.content_metadata.start_pts": {"lte": _seconds_to_pts_ns(query_end)}}},
+        {"range": {"metadata.content_metadata.end_pts": {"gte": _seconds_to_pts_ns(query_start)}}},
+    ]
+
+
+def _term_or_keyword_clauses(field: str, value: str) -> list[dict[str, Any]]:
+    fields = [field] if field.endswith(".keyword") else [field, f"{field}.keyword"]
+    clauses: list[dict[str, Any]] = []
+    for field_name in fields:
+        clauses.append({"term": {field_name: value}})
+    return clauses
+
+
+def _doc_type_filter(doc_types: list[str]) -> dict[str, Any]:
+    should: list[dict[str, Any]] = []
+    for doc_type in doc_types:
+        should.extend(_term_or_keyword_clauses("metadata.content_metadata.doc_type", doc_type))
+    return {"bool": {"should": should, "minimum_should_match": 1}}
+
+
+def _source_filter(sensor_id: str, source_fields: list[str]) -> dict[str, Any]:
+    should: list[dict[str, Any]] = []
+    for field in source_fields:
+        should.extend(_term_or_keyword_clauses(field, sensor_id))
+        should.append({"match_phrase": {field: sensor_id}})
+        if not field.endswith(".keyword"):
+            should.append({"wildcard": {f"{field}.keyword": {"value": f"*{sensor_id}*", "case_insensitive": True}}})
+    return {"bool": {"should": should, "minimum_should_match": 1}}
+
+
+def _build_lvs_caption_query(
+    *,
+    question: str,
+    sensor_id: str,
+    doc_types: list[str],
+    source_fields: list[str] | None = None,
+    text_fields: list[str] | None = None,
+    start_seconds: float | None = None,
+    end_seconds: float | None = None,
+    include_time_filter: bool = True,
+    use_keyword_query: bool = True,
+    size: int = 8,
+) -> dict[str, Any]:
+    """Build the Elasticsearch BM25 query for stored LVS documents."""
+    filter_clauses: list[dict[str, Any]] = [
+        _doc_type_filter(doc_types),
+        _source_filter(sensor_id, source_fields or DEFAULT_SOURCE_FIELDS),
+    ]
+    if include_time_filter:
+        filter_clauses.extend(_get_time_overlap_pts_filter(start_seconds, end_seconds))
+
+    if use_keyword_query:
+        must_clauses: list[dict[str, Any]] = [
+            {
+                "multi_match": {
+                    "query": question,
+                    "fields": text_fields or DEFAULT_TEXT_FIELDS,
+                    "type": "best_fields",
+                    "operator": "or",
+                }
+            }
+        ]
+    else:
+        must_clauses = [{"match_all": {}}]
+
+    return {
+        "query": {
+            "bool": {
+                "must": must_clauses,
+                "filter": filter_clauses,
+            }
+        },
+        "size": size,
+        "_source": ["text", "metadata"],
+    }
+
+
+def _content_metadata(source: dict[str, Any]) -> dict[str, Any]:
+    metadata = source.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    content_metadata = metadata.get("content_metadata")
+    return content_metadata if isinstance(content_metadata, dict) else {}
+
+
+def _parse_events_payload(text: str) -> list[dict[str, Any]]:
+    try:
+        payload = json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+
+    events = payload.get("events", [])
+    return [event for event in events if isinstance(event, dict)] if isinstance(events, list) else []
+
+
+def _normalize_event_seconds(
+    doc_type: str,
+    metadata: dict[str, Any],
+    event_start: float | None,
+    event_end: float | None,
+) -> tuple[float | None, float | None]:
+    metadata_start = _pts_ns_to_seconds(metadata.get("start_pts"))
+    metadata_end = _pts_ns_to_seconds(metadata.get("end_pts"))
+
+    if event_start is None and event_end is None:
+        return metadata_start, metadata_end
+
+    start = event_start
+    end = event_end if event_end is not None else event_start
+
+    # Raw chunk event times may be relative to the chunk. If the event starts before the
+    # chunk start, treat it as relative and shift it into full-video seconds.
+    if (
+        doc_type == RAW_EVENTS_DOC_TYPE
+        and metadata_start is not None
+        and start is not None
+        and start < max(metadata_start - 1e-6, 0.0)
+    ):
+        start += metadata_start
+        if end is not None:
+            end += metadata_start
+
+    return start, end
+
+
+def _overlaps_time_scope(
+    evidence: CaptionEvidence,
+    start_seconds: float | None,
+    end_seconds: float | None,
+) -> bool:
+    if not _has_time_scope(start_seconds, end_seconds):
+        return True
+    if evidence.start_seconds is None and evidence.end_seconds is None:
+        return False
+
+    query_start = 0.0 if start_seconds is None else start_seconds
+    query_end = end_seconds if end_seconds is not None else query_start
+    evidence_start = evidence.start_seconds if evidence.start_seconds is not None else evidence.end_seconds
+    evidence_end = evidence.end_seconds if evidence.end_seconds is not None else evidence_start
+
+    if evidence_start is None or evidence_end is None:
+        return False
+    return evidence_start <= query_end and evidence_end >= query_start
+
+
+def _extract_evidence_from_hit(hit: dict[str, Any]) -> list[CaptionEvidence]:
+    source = hit.get("_source", {})
+    if not isinstance(source, dict):
+        return []
+
+    text = str(source.get("text") or "").strip()
+    metadata = _content_metadata(source)
+    doc_type = str(metadata.get("doc_type") or "")
+    score = float(hit.get("_score") or 0.0)
+
+    if not text:
+        return []
+
+    if doc_type == AGGREGATED_SUMMARY_DOC_TYPE:
+        return [CaptionEvidence(text=text, doc_type=doc_type, score=score)]
+
+    events = _parse_events_payload(text)
+    if not events:
+        start, end = _normalize_event_seconds(doc_type, metadata, None, None)
+        return [CaptionEvidence(text=text, doc_type=doc_type, score=score, start_seconds=start, end_seconds=end)]
+
+    evidence: list[CaptionEvidence] = []
+    for event in events:
+        description = str(event.get("description") or event.get("text") or "").strip()
+        if not description:
+            description = json.dumps(event, ensure_ascii=False)
+
+        event_type = str(event.get("type") or "").strip() or None
+        event_start = _coerce_float(event.get("start_time"))
+        event_end = _coerce_float(event.get("end_time"))
+        start, end = _normalize_event_seconds(doc_type, metadata, event_start, event_end)
+
+        evidence.append(
+            CaptionEvidence(
+                text=description,
+                doc_type=doc_type,
+                score=score,
+                start_seconds=start,
+                end_seconds=end,
+                event_type=event_type,
+            )
+        )
+
+    return evidence
+
+
+def _format_evidence(
+    hits: list[dict[str, Any]],
+    *,
+    start_seconds: float | None,
+    end_seconds: float | None,
+    max_chars: int,
+) -> str:
+    extracted: list[CaptionEvidence] = []
+    seen: set[tuple[str, float | None, float | None, str | None]] = set()
+
+    for hit in hits:
+        for item in _extract_evidence_from_hit(hit):
+            if not _overlaps_time_scope(item, start_seconds, end_seconds):
+                continue
+            key = (item.text, item.start_seconds, item.end_seconds, item.event_type)
+            if key in seen:
+                continue
+            seen.add(key)
+            extracted.append(item)
+
+    extracted.sort(
+        key=lambda item: (
+            item.start_seconds is None,
+            item.start_seconds if item.start_seconds is not None else 0.0,
+            -item.score,
+        )
+    )
+
+    lines: list[str] = []
+    total_chars = 0
+    for item in extracted:
+        if item.start_seconds is not None and item.end_seconds is not None:
+            prefix = f"[{_format_seconds(item.start_seconds)}-{_format_seconds(item.end_seconds)}]"
+        elif item.start_seconds is not None:
+            prefix = f"[{_format_seconds(item.start_seconds)}]"
+        else:
+            prefix = "[summary]"
+
+        type_prefix = f" {item.event_type}:" if item.event_type else ""
+        line = f"{prefix}{type_prefix} {item.text}".strip()
+        if total_chars + len(line) > max_chars:
+            break
+        lines.append(line)
+        total_chars += len(line)
+
+    return "\n".join(lines)
+
+
+def _fallback_window(
+    start_seconds: float | None,
+    end_seconds: float | None,
+    default_window_seconds: float,
+) -> tuple[float | None, float | None]:
+    if start_seconds is not None and end_seconds is not None:
+        return start_seconds, end_seconds
+    if start_seconds is not None:
+        return start_seconds, start_seconds + default_window_seconds
+    if end_seconds is not None:
+        return 0.0, end_seconds
+    return None, None
+
+
+@register_function(config_type=LVSCaptionQAConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
+async def lvs_caption_qa(config: LVSCaptionQAConfig, builder: Builder) -> AsyncGenerator[FunctionInfo]:
+    """Answer video questions from stored LVS dense captions, falling back to VLM when needed."""
+
+    llm = await builder.get_llm(config.llm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    async def _search_hits(
+        es_client: AsyncElasticsearch,
+        input_data: LVSCaptionQAInput,
+        start_seconds: float | None,
+        end_seconds: float | None,
+    ) -> list[dict[str, Any]]:
+        size = input_data.top_k or config.max_results
+        has_time_scope = _has_time_scope(start_seconds, end_seconds)
+        attempts: list[tuple[list[str], bool, bool]]
+        if has_time_scope:
+            attempts = [
+                ([RAW_EVENTS_DOC_TYPE], True, True),
+                ([RAW_EVENTS_DOC_TYPE], True, False),
+                ([STRUCTURED_EVENTS_DOC_TYPE], False, True),
+            ]
+        else:
+            attempts = [
+                ([STRUCTURED_EVENTS_DOC_TYPE, AGGREGATED_SUMMARY_DOC_TYPE], False, True),
+                ([STRUCTURED_EVENTS_DOC_TYPE, AGGREGATED_SUMMARY_DOC_TYPE], False, False),
+                ([RAW_EVENTS_DOC_TYPE], False, True),
+            ]
+
+        for doc_types, include_time_filter, use_keyword_query in attempts:
+            query = _build_lvs_caption_query(
+                question=input_data.question,
+                sensor_id=input_data.sensor_id,
+                doc_types=doc_types,
+                source_fields=config.source_fields,
+                text_fields=config.text_fields,
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+                include_time_filter=include_time_filter,
+                use_keyword_query=use_keyword_query,
+                size=size,
+            )
+            logger.debug("LVS caption QA ES query: %s", query)
+            response = await es_client.search(index=config.es_index, body=query)
+            hits = response.get("hits", {}).get("hits", [])
+            if hits:
+                logger.info(
+                    "Found %d LVS caption docs for doc_types=%s (keyword_query=%s)",
+                    len(hits),
+                    doc_types,
+                    use_keyword_query,
+                )
+                return list(hits)
+
+        return []
+
+    async def _fallback_to_vlm(
+        input_data: LVSCaptionQAInput,
+        start_seconds: float | None,
+        end_seconds: float | None,
+    ) -> str:
+        if not config.fallback_to_vlm:
+            return "No stored LVS captions were found for this video and question."
+
+        video_understanding_tool = await builder.get_tool(
+            config.video_understanding_tool,
+            wrapper_type=LLMFrameworkEnum.LANGCHAIN,
+        )
+        fallback_start, fallback_end = _fallback_window(
+            start_seconds,
+            end_seconds,
+            config.default_timestamp_window_seconds,
+        )
+        payload = {
+            "sensor_id": input_data.sensor_id,
+            "start_timestamp": fallback_start,
+            "end_timestamp": fallback_end,
+            "user_prompt": input_data.question,
+        }
+        logger.info("Falling back to VLM video understanding with payload: %s", payload)
+        result = await video_understanding_tool.ainvoke(input=payload)
+        return str(result)
+
+    async def _lvs_caption_qa(input_data: LVSCaptionQAInput) -> str:
+        """
+        Answer a question about a video using stored LVS dense captions/events.
+
+        The primary path searches Elasticsearch for LVS documents using BM25 over
+        stored event text, optionally scoped by a time range. If no usable stored
+        captions are found, the tool falls back to direct VLM video understanding.
+        """
+        start_seconds, end_seconds = _resolve_time_scope(input_data)
+
+        es_client = AsyncElasticsearch(config.es_endpoint)
+        try:
+            if not await es_client.indices.exists(index=config.es_index):
+                logger.info("LVS caption ES index '%s' does not exist", config.es_index)
+                return await _fallback_to_vlm(input_data, start_seconds, end_seconds)
+
+            hits = await _search_hits(es_client, input_data, start_seconds, end_seconds)
+            evidence = _format_evidence(
+                hits,
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+                max_chars=config.max_evidence_chars,
+            )
+
+            if not evidence:
+                logger.info("No usable stored LVS caption evidence found")
+                return await _fallback_to_vlm(input_data, start_seconds, end_seconds)
+
+            messages = [
+                SystemMessage(content=ANSWER_SYSTEM_PROMPT),
+                HumanMessage(
+                    content=ANSWER_USER_PROMPT.format(
+                        sensor_id=input_data.sensor_id,
+                        question=input_data.question,
+                        evidence=evidence,
+                    )
+                ),
+            ]
+            response = await llm.ainvoke(messages)
+            answer = str(getattr(response, "content", response)).strip()
+            if not answer:
+                return "Stored LVS captions were found, but no answer could be generated from them."
+            return answer
+        except ESNotFoundError:
+            logger.info("LVS caption ES index '%s' was not found", config.es_index)
+            return await _fallback_to_vlm(input_data, start_seconds, end_seconds)
+        except Exception as e:
+            logger.warning("Stored LVS caption QA failed; falling back to VLM: %s", e, exc_info=True)
+            return await _fallback_to_vlm(input_data, start_seconds, end_seconds)
+        finally:
+            await es_client.close()
+
+    yield FunctionInfo.create(
+        single_fn=_lvs_caption_qa,
+        description=_lvs_caption_qa.__doc__,
+        input_schema=LVSCaptionQAInput,
+        single_output_schema=str,
+    )

--- a/services/agent/src/vss_agents/tools/register.py
+++ b/services/agent/src/vss_agents/tools/register.py
@@ -18,6 +18,7 @@ from . import embed_search
 from . import fov_counts_with_chart
 from . import geolocation
 from . import incidents
+from . import lvs_caption_qa
 from . import lvs_video_understanding
 from . import multi_incident_formatter
 from . import prompt_gen
@@ -39,6 +40,7 @@ __all__ = [
     "fov_counts_with_chart",
     "geolocation",
     "incidents",
+    "lvs_caption_qa",
     "lvs_video_understanding",
     "multi_incident_formatter",
     "prompt_gen",

--- a/services/agent/tests/unit_test/tools/test_lvs_caption_qa.py
+++ b/services/agent/tests/unit_test/tools/test_lvs_caption_qa.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for LVS caption Q&A."""
+
+import json
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from pydantic import ValidationError
+import pytest
+
+from vss_agents.tools.lvs_caption_qa import LVSCaptionQAConfig
+from vss_agents.tools.lvs_caption_qa import LVSCaptionQAInput
+from vss_agents.tools.lvs_caption_qa import _build_lvs_caption_query
+from vss_agents.tools.lvs_caption_qa import _format_evidence
+from vss_agents.tools.lvs_caption_qa import _infer_time_scope_from_question
+from vss_agents.tools.lvs_caption_qa import _seconds_to_pts_ns
+from vss_agents.tools.lvs_caption_qa import lvs_caption_qa
+
+
+class TestLVSCaptionQAConfig:
+    """Test LVS caption Q&A config."""
+
+    def test_required_fields(self):
+        config = LVSCaptionQAConfig(llm_name="mock_llm", es_endpoint="http://localhost:9200")
+        assert config.llm_name == "mock_llm"
+        assert config.es_endpoint == "http://localhost:9200"
+        assert config.es_index == "lvs-events"
+        assert config.video_understanding_tool == "video_understanding"
+        assert config.max_results == 8
+
+    def test_missing_llm_name_raises(self):
+        with pytest.raises(ValidationError):
+            LVSCaptionQAConfig(es_endpoint="http://localhost:9200")
+
+    def test_missing_es_endpoint_raises(self):
+        with pytest.raises(ValidationError):
+            LVSCaptionQAConfig(llm_name="mock_llm")
+
+
+class TestLVSCaptionQAInput:
+    """Test LVS caption Q&A input validation."""
+
+    def test_basic_input(self):
+        inp = LVSCaptionQAInput(sensor_id="camera-1", question="What happened?")
+        assert inp.sensor_id == "camera-1"
+        assert inp.question == "What happened?"
+
+    def test_invalid_time_range_raises(self):
+        with pytest.raises(ValidationError):
+            LVSCaptionQAInput(sensor_id="camera-1", question="What happened?", start_timestamp=20, end_timestamp=10)
+
+    def test_negative_time_raises(self):
+        with pytest.raises(ValidationError):
+            LVSCaptionQAInput(sensor_id="camera-1", question="What happened?", start_timestamp=-1)
+
+
+class TestTimeInference:
+    """Test simple timestamp inference from question text."""
+
+    def test_between_seconds(self):
+        assert _infer_time_scope_from_question("What happened between 45s and 60s?") == (45.0, 60.0)
+
+    def test_from_mmss_to_mmss(self):
+        assert _infer_time_scope_from_question("Describe from 1:05 to 1:20") == (65.0, 80.0)
+
+    def test_single_timestamp(self):
+        assert _infer_time_scope_from_question("What is visible at 12 seconds?") == (12.0, None)
+
+    def test_before_timestamp(self):
+        assert _infer_time_scope_from_question("What happened before 30s?") == (None, 30.0)
+
+
+class TestQueryBuilding:
+    """Test ES query construction."""
+
+    def test_time_filter_uses_pts_nanoseconds(self):
+        query = _build_lvs_caption_query(
+            question="white sedan",
+            sensor_id="camera-1",
+            doc_types=["raw_events"],
+            start_seconds=45.0,
+            end_seconds=60.0,
+            size=5,
+        )
+
+        assert query["size"] == 5
+        filters = query["query"]["bool"]["filter"]
+        assert {"range": {"metadata.content_metadata.start_pts": {"lte": _seconds_to_pts_ns(60.0)}}} in filters
+        assert {"range": {"metadata.content_metadata.end_pts": {"gte": _seconds_to_pts_ns(45.0)}}} in filters
+
+    def test_doc_type_and_source_filters_present(self):
+        query = _build_lvs_caption_query(
+            question="delivery truck",
+            sensor_id="abc123-stream-id",
+            doc_types=["structured_events", "aggregated_summary"],
+        )
+        filters = query["query"]["bool"]["filter"]
+        assert filters[0]["bool"]["minimum_should_match"] == 1
+        assert filters[1]["bool"]["minimum_should_match"] == 1
+        assert query["query"]["bool"]["must"][0]["multi_match"]["query"] == "delivery truck"
+
+    def test_can_build_source_only_fallback_query(self):
+        query = _build_lvs_caption_query(
+            question="What happened in the video?",
+            sensor_id="camera-1",
+            doc_types=["structured_events", "aggregated_summary"],
+            use_keyword_query=False,
+        )
+
+        assert query["query"]["bool"]["must"] == [{"match_all": {}}]
+
+
+class TestEvidenceFormatting:
+    """Test extraction and formatting from LVS ES documents."""
+
+    def test_raw_event_relative_times_shift_to_chunk_pts(self):
+        hit = {
+            "_score": 7.0,
+            "_source": {
+                "text": json.dumps(
+                    {
+                        "events": [
+                            {
+                                "start_time": 0.0,
+                                "end_time": 15.0,
+                                "type": "vehicle_moving",
+                                "description": "A white sedan enters and parks.",
+                            }
+                        ]
+                    }
+                ),
+                "metadata": {
+                    "content_metadata": {
+                        "doc_type": "raw_events",
+                        "start_pts": 45_000_000_000,
+                        "end_pts": 60_000_000_000,
+                    }
+                },
+            },
+        }
+
+        evidence = _format_evidence([hit], start_seconds=45.0, end_seconds=60.0, max_chars=2000)
+
+        assert "[45s-60s] vehicle_moving: A white sedan enters and parks." in evidence
+
+    def test_structured_events_are_chronological(self):
+        hit = {
+            "_score": 3.0,
+            "_source": {
+                "text": json.dumps(
+                    {
+                        "events": [
+                            {"start_time": 20.0, "end_time": 25.0, "description": "Second event"},
+                            {"start_time": 0.0, "end_time": 5.0, "description": "First event"},
+                        ]
+                    }
+                ),
+                "metadata": {"content_metadata": {"doc_type": "structured_events"}},
+            },
+        }
+
+        evidence = _format_evidence([hit], start_seconds=None, end_seconds=None, max_chars=2000)
+
+        assert evidence.splitlines()[0] == "[0s-5s] First event"
+        assert evidence.splitlines()[1] == "[20s-25s] Second event"
+
+    def test_aggregated_summary_excluded_for_time_scoped_question(self):
+        hit = {
+            "_score": 1.0,
+            "_source": {
+                "text": "Overall video summary.",
+                "metadata": {"content_metadata": {"doc_type": "aggregated_summary"}},
+            },
+        }
+
+        evidence = _format_evidence([hit], start_seconds=10.0, end_seconds=20.0, max_chars=2000)
+
+        assert evidence == ""
+
+
+class TestLVSCaptionQAInner:
+    """Test the registered tool inner function."""
+
+    @pytest.fixture
+    def config(self):
+        return LVSCaptionQAConfig(llm_name="mock_llm", es_endpoint="http://localhost:9200")
+
+    @pytest.fixture
+    def mock_builder(self):
+        builder = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.return_value = MagicMock(content="The answer came from stored captions.")
+        builder.get_llm.return_value = mock_llm
+        return builder
+
+    @pytest.mark.asyncio
+    async def test_answers_from_stored_captions(self, config, mock_builder):
+        mock_es = MagicMock()
+        mock_es.indices.exists = AsyncMock(return_value=True)
+        mock_es.search = AsyncMock(
+            return_value={
+                "hits": {
+                    "hits": [
+                        {
+                            "_score": 4.0,
+                            "_source": {
+                                "text": json.dumps(
+                                    {"events": [{"start_time": 0, "end_time": 5, "description": "A person walks."}]}
+                                ),
+                                "metadata": {"content_metadata": {"doc_type": "structured_events"}},
+                            },
+                        }
+                    ]
+                }
+            }
+        )
+        mock_es.close = AsyncMock()
+
+        with patch("vss_agents.tools.lvs_caption_qa.AsyncElasticsearch", return_value=mock_es):
+            gen = lvs_caption_qa.__wrapped__(config, mock_builder)
+            fi = await gen.__anext__()
+            result = await fi.single_fn(LVSCaptionQAInput(sensor_id="camera-1", question="What happened?"))
+
+        assert result == "The answer came from stored captions."
+        mock_builder.get_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uses_source_only_es_fallback_before_vlm(self, config, mock_builder):
+        mock_es = MagicMock()
+        mock_es.indices.exists = AsyncMock(return_value=True)
+        mock_es.search = AsyncMock(
+            side_effect=[
+                {"hits": {"hits": []}},
+                {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "text": json.dumps(
+                                        {
+                                            "events": [
+                                                {
+                                                    "start_time": 0,
+                                                    "end_time": 5,
+                                                    "description": "A person walks.",
+                                                }
+                                            ]
+                                        }
+                                    ),
+                                    "metadata": {"content_metadata": {"doc_type": "structured_events"}},
+                                },
+                            }
+                        ]
+                    }
+                },
+            ]
+        )
+        mock_es.close = AsyncMock()
+
+        with patch("vss_agents.tools.lvs_caption_qa.AsyncElasticsearch", return_value=mock_es):
+            gen = lvs_caption_qa.__wrapped__(config, mock_builder)
+            fi = await gen.__anext__()
+            result = await fi.single_fn(LVSCaptionQAInput(sensor_id="camera-1", question="What happened?"))
+
+        assert result == "The answer came from stored captions."
+        assert mock_es.search.await_count == 2
+        second_query = mock_es.search.await_args_list[1].kwargs["body"]
+        assert second_query["query"]["bool"]["must"] == [{"match_all": {}}]
+        mock_builder.get_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_index_missing(self, config, mock_builder):
+        fallback_tool = AsyncMock()
+        fallback_tool.ainvoke.return_value = "VLM fallback answer"
+        mock_builder.get_tool.return_value = fallback_tool
+
+        mock_es = MagicMock()
+        mock_es.indices.exists = AsyncMock(return_value=False)
+        mock_es.close = AsyncMock()
+
+        with patch("vss_agents.tools.lvs_caption_qa.AsyncElasticsearch", return_value=mock_es):
+            gen = lvs_caption_qa.__wrapped__(config, mock_builder)
+            fi = await gen.__anext__()
+            result = await fi.single_fn(LVSCaptionQAInput(sensor_id="camera-1", question="What happened at 12s?"))
+
+        assert result == "VLM fallback answer"
+        fallback_tool.ainvoke.assert_awaited_once()
+        payload = fallback_tool.ainvoke.await_args.kwargs["input"]
+        assert payload["start_timestamp"] == 12.0
+        assert payload["end_timestamp"] == 42.0
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_hits_have_no_usable_evidence(self, config, mock_builder):
+        fallback_tool = AsyncMock()
+        fallback_tool.ainvoke.return_value = "VLM fallback answer"
+        mock_builder.get_tool.return_value = fallback_tool
+
+        mock_es = MagicMock()
+        mock_es.indices.exists = AsyncMock(return_value=True)
+        mock_es.search = AsyncMock(return_value={"hits": {"hits": [{"_score": 1.0, "_source": {"text": ""}}]}})
+        mock_es.close = AsyncMock()
+
+        with patch("vss_agents.tools.lvs_caption_qa.AsyncElasticsearch", return_value=mock_es):
+            gen = lvs_caption_qa.__wrapped__(config, mock_builder)
+            fi = await gen.__anext__()
+            result = await fi.single_fn(LVSCaptionQAInput(sensor_id="camera-1", question="What happened?"))
+
+        assert result == "VLM fallback answer"
+        fallback_tool.ainvoke.assert_awaited_once()


### PR DESCRIPTION
## Description
Adds an LVS-profile Q&A path over stored Elasticsearch dense captions/events.

This introduces a new `lvs_caption_qa` tool that first searches LVS documents in the `lvs-events` Elasticsearch index using BM25 over stored event/caption text. It supports both full-video questions and timestamp-scoped questions by filtering `raw_events` with `start_pts` / `end_pts` overlap. Retrieved LVS evidence is normalized into timestamped context and injected into an LLM prompt to answer the user’s question.

If stored captions are unavailable, empty, or the index is missing, the tool falls back to the existing `video_understanding` VLM path. The tool is registered and wired only into the LVS developer profile, where normal video Q&A now routes through stored captions first while direct VLM analysis remains available for explicit visual-inspection requests.

Adds unit coverage for query construction, timestamp inference, event extraction/formatting, and VLM fallback behavior.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.