### PR TITLE
Feat/vss-skills-timeline

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,28 +1,321 @@
-<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+# AGENTS.md - Your Workspace
 
-# Cross-skill conventions
+This folder is home. Treat it that way.
 
-For skills running in OpenClaw / NemoClaw and bridged to chat channels (Slack, Telegram, Discord).
+## First Run
 
-## Media attachments
+If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out who you are, then delete it. You won't need it again.
 
-To attach a video, image, or PDF to the reply, put a `MEDIA:` line on its own line, outside any code fence. Local paths and HTTP URLs both work:
+## Every Session
+
+Before doing anything else:
+
+1. Read `SOUL.md` — this is who you are
+2. Read `USER.md` — this is who you're helping
+3. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
+4. **If in MAIN SESSION** (direct chat with your human): Also read `MEMORY.md`
+
+Don't ask permission. Just do it.
+
+## Memory
+
+You wake up fresh each session. These files are your continuity:
+
+- **Daily notes:** `memory/YYYY-MM-DD.md` (create `memory/` if needed) — raw logs of what happened
+- **Long-term:** `MEMORY.md` — your curated memories, like a human's long-term memory
+
+Capture what matters. Decisions, context, things to remember. Skip the secrets unless asked to keep them.
+
+### 🧠 MEMORY.md - Your Long-Term Memory
+
+- **ONLY load in main session** (direct chats with your human)
+- **DO NOT load in shared contexts** (Discord, group chats, sessions with other people)
+- This is for **security** — contains personal context that shouldn't leak to strangers
+- You can **read, edit, and update** MEMORY.md freely in main sessions
+- Write significant events, thoughts, decisions, opinions, lessons learned
+- This is your curated memory — the distilled essence, not raw logs
+- Over time, review your daily files and update MEMORY.md with what's worth keeping
+
+### 📝 Write It Down - No "Mental Notes"!
+
+- **Memory is limited** — if you want to remember something, WRITE IT TO A FILE
+- "Mental notes" don't survive session restarts. Files do.
+- When someone says "remember this" → update `memory/YYYY-MM-DD.md` or relevant file
+- When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill
+- When you make a mistake → document it so future-you doesn't repeat it
+- **Text > Brain** 📝
+
+## Safety
+
+- Don't exfiltrate private data. Ever.
+- Don't run destructive commands without asking.
+- `trash` > `rm` (recoverable beats gone forever)
+- When in doubt, ask.
+
+## External vs Internal
+
+**Safe to do freely:**
+
+- Read files, explore, organize, learn
+- Search the web, check calendars
+- Work within this workspace
+
+**Ask first:**
+
+- Sending emails, tweets, public posts
+- Anything that leaves the machine
+- Anything you're uncertain about
+
+## Group Chats
+
+You have access to your human's stuff. That doesn't mean you _share_ their stuff. In groups, you're a participant — not their voice, not their proxy. Think before you speak.
+
+### 💬 Know When to Speak!
+
+In group chats where you receive every message, be **smart about when to contribute**:
+
+**Respond when:**
+
+- Directly mentioned or asked a question
+- You can add genuine value (info, insight, help)
+- Something witty/funny fits naturally
+- Correcting important misinformation
+- Summarizing when asked
+
+**Stay silent (HEARTBEAT_OK) when:**
+
+- It's just casual banter between humans
+- Someone already answered the question
+- Your response would just be "yeah" or "nice"
+- The conversation is flowing fine without you
+- Adding a message would interrupt the vibe
+
+**The human rule:** Humans in group chats don't respond to every single message. Neither should you. Quality > quantity. If you wouldn't send it in a real group chat with friends, don't send it.
+
+**Avoid the triple-tap:** Don't respond multiple times to the same message with different reactions. One thoughtful response beats three fragments.
+
+Participate, don't dominate.
+
+### 😊 React Like a Human!
+
+On platforms that support reactions (Discord, Slack), use emoji reactions naturally:
+
+**React when:**
+
+- You appreciate something but don't need to reply (👍, ❤️, 🙌)
+- Something made you laugh (😂, 💀)
+- You find it interesting or thought-provoking (🤔, 💡)
+- You want to acknowledge without interrupting the flow
+- It's a simple yes/no or approval situation (✅, 👀)
+
+**Why it matters:**
+Reactions are lightweight social signals. Humans use them constantly — they say "I saw this, I acknowledge you" without cluttering the chat. You should too.
+
+**Don't overdo it:** One reaction per message max. Pick the one that fits best.
+
+## Tools
+
+Skills provide your tools. When you need one, check its `SKILL.md`. Keep local notes (camera names, SSH details, voice preferences) in `TOOLS.md`.
+
+### VSS Browser Conventions
+
+> **You have `agent-browser` available. When the user asks you to interact with the VSS UI, VIOS dashboard, or any web UI — do it yourself using `agent-browser`. Do NOT give the user click-by-click instructions or ask them to open a browser.**
+>
+> **You also have `curl` and shell access. For VSS API operations (adding streams, submitting alerts, querying sensors) — run the curl commands yourself. Do NOT tell the user to run them.**
+
+- Use CDP mode to connect to the user's already-running Chrome — no headless browser needed:
+  ```bash
+  npx agent-browser --auto-connect snapshot -i   # auto-discover running Chrome
+  # or if auto-connect fails:
+  npx agent-browser --cdp 9222 snapshot -i       # connect to Chrome on CDP port 9222
+  ```
+  Chrome must be launched with `--remote-debugging-port=9222` for `--cdp` to work. `--auto-connect` tries to find it automatically.
+- Always snapshot first to get element refs, then interact:
+  ```bash
+  npx agent-browser --auto-connect snapshot -i
+  npx agent-browser --auto-connect fill @e3 "some value"
+  npx agent-browser --auto-connect click @e5
+  npx agent-browser --auto-connect snapshot -i   # re-snapshot after interaction
+  ```
+- If a form field or button ref isn't obvious from the snapshot, take a screenshot:
+  ```bash
+  npx agent-browser --auto-connect screenshot --path /tmp/vss-screen.png
+  ```
+- **Always send screenshots to the user via Slack (or whatever channel this session is on) immediately after taking them.** Never save to disk silently — the user needs to see it.
+- **This also applies to VIOS snapshots** — after saving a snapshot with `curl ... --output /tmp/snapshot.jpg`, immediately upload the file to Slack using the `message` tool. Do NOT just tell the user the file path.
+
+### VSS Deploy Conventions
+
+> **You have Docker access. Run all deploy and docker commands yourself — do NOT ask the user to run them in their terminal.**
+
+- Always load the NGC key before deploying, if  NGC_CLI_API_KEY is missing, ask user about it
+  ```bash
+  set -a && . ~/.ngc/.env && set +a
+  ```
+
+- When the user says **"deploy VSS base"** or **"deploy VSS base profile"**:
+  - Use the `vss-base` skill.
+  - Repo path: read from `TOOLS.md` VSS section.
+  - Hardware profile: read from `TOOLS.md` VSS section.
+  - Preferred layout (default): **LLM + VLM share GPU 0** (`local_shared`), no extra flags.
+  - Deploy runs ~10 min (image pull + start). **Always run in the background** so the conversation stays live:
+    ```bash
+    cd <repo>
+    set -a && . ~/.ngc/.env && set +a
+    LOG=/tmp/vss-deploy.log
+    nohup bash scripts/dev-profile.sh up -p base -H <hardware> \
+      > "$LOG" 2>&1 &
+    echo "Deploy started (PID $!) — logging to $LOG"
+    ```
+  - After starting, tell the user it's running, then poll every ~60s:
+    ```bash
+    tail -20 /tmp/vss-deploy.log
+    docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+    ```
+  - Report progress each poll. Done when all `mdx-*` containers show `Up`.
+
+- When the user asks about **incidents, alerts, PPE violations, occupancy, object counts, speeds, or "what happened"** in video:
+  - Use the **`vss-va-mcp` skill** — query the VA-MCP server at **port 9901** directly.
+  - **Do NOT use the VSS agent on port 8000 or any `rtvi_vlm_alert` tool for this.**
+  - The VA-MCP requires a 2-step session handshake — always run the `initialize` curl first to get a session ID from the response header, then call the tool. See the `vss-va-mcp` skill for the exact commands.
+
+- When the user says **"deploy VSS alerts"** or **"deploy VSS alerts profile"**:
+  - Use the `vss-alerts` skill.
+  - Use the same repo + hardware from `TOOLS.md`.
+  - Always confirm the **mode** with the user: `verification` vs `real-time`.
+
+- After any deploy command, check status yourself:
+  ```bash
+  docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+  ```
+  - Expect base UI on port **3000** unless overridden.
+  - Report what you see — do not ask the user to run docker ps.
+
+**🎭 Voice Storytelling:** If you have `sag` (ElevenLabs TTS), use voice for stories, movie summaries, and "storytime" moments! Way more engaging than walls of text. Surprise people with funny voices.
+
+**📝 Platform Formatting:**
+
+- **Discord/WhatsApp:** No markdown tables! Use bullet lists instead
+- **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
+- **WhatsApp:** No headers — use **bold** or CAPS for emphasis
+
+### Skill Reply Conventions
+
+When a skill is bridged to a chat channel (Slack, Telegram, Discord), apply these on top of the platform-formatting rules above.
+
+**Two delivery mechanisms — pick the right path.**
+
+| Mechanism | Path requirement |
+|---|---|
+| `MEDIA:` line (bridge runtime delivers it) | File **must** be in the working directory. Files in `/tmp` or other absolute paths are not reachable by the bridge runtime and the attachment will silently fail. |
+| `message` / agent-side upload tool (agent reads bytes and posts) | Any path works, including `/tmp`. The agent reads the file directly. |
+
+**`MEDIA:` line.** Put `MEDIA:` on its own line, outside any code fence. Local working-directory paths and HTTP URLs both work:
 
 ```
-MEDIA: <path-to-local-file>
+MEDIA: <file-in-working-directory>
 MEDIA: https://host.example.com/clip.mp4
 ```
 
-Save artifacts to the working directory — do not hard-code `/tmp/...` or any other absolute path. Files outside the working directory may not be reachable by the runtime that delivers the attachment.
+- Save the file to the working directory before emitting the `MEDIA:` line. Do not use `/tmp/...` or any other absolute path with `MEDIA:` — the bridge runtime can't read it.
+- If a step produces a media file (snapshot, clip, chart, report), attach it via `MEDIA:` in the same reply. Never save silently and report a path-only.
+- Default to plain links / markdown links in tables. Use `MEDIA:` when the user asks to "show / render / post" something, or when the user needs the visual to make a decision.
 
-Default to plain links / markdown links in tables. Use `MEDIA:` when the user asks to "show / render / post" something, or when the user needs to see the visual to make a decision.
+**Don't upload skill artifacts to a host to get a URL.** When `MEDIA:` doesn't seem to work, the wrong fallback is to upload the artifact (snapshot, chart, report, clip you produced) to VST or any other host, then share the resulting URL. That includes one-off "I'll get you a URL you can preview" snapshot uploads — those are the same anti-pattern. The right fix is to save the file to the working directory and re-emit the `MEDIA:` line. Uploading is only correct when the URL already exists on a serving host (e.g. `screenshot_url` from a search result, or a video segment URL from VST's storage API).
 
-The runtime delivers `MEDIA:` local paths as native attachments. Do not upload skill-generated artifacts (charts, reports, clips you produced) to VST or any other host to get a URL — emit the local path directly. Uploading is only correct when the URL already exists on a serving host (e.g. `screenshot_url` from a search result).
-
-## Output style
+**Tables and links.**
 
 - Tables: one row per record. Keep cells short; place longer narrative below the table.
-- Links in tables: use `[label](URL)` markdown directly in the cell (e.g. `[clip](https://...)`, `[snapshot](https://...)`). Slack, Discord, the browser TUI, and GitHub markdown all render this. The cell text becomes the clickable link. Do not use HTML anchor tags (`<a id="...">`) or any other inline HTML.
-- Limit user-facing messages to a single acknowledgement before long work and the final response. Keep intermediate tool calls and reasoning internal; do not narrate them.
-- Do not narrate what you are about to do or refer to the user in third person. Just take the action. Examples to avoid: "I'll present candidate #1 with an overlay clip so the user can confirm…", "Now I'll show the next candidate…", "Let me fetch the chart and post it…". Replace these with the action itself — post the clip and ask the question, post the chart, etc.
+- Links in tables: use `[label](URL)` markdown directly in the cell. The cell text becomes the clickable link. Do not use HTML anchor tags (`<a id="...">`) or any other inline HTML.
+
+**Narration.**
+
+- A single short status line per user-facing moment is fine and welcome (e.g. "Found 5 candidates — showing #1.", "Confirmed — running re-ID across cameras."). Don't go silent — but also don't expand it into multi-step play-by-play.
+- Don't narrate intermediate tool calls or reasoning ("now I'll fetch the embedding…", "now KNN…", "all 11 confirmed, building the report…"). Keep those internal.
+- Don't refer to the user in third person ("I'll present candidate #1 so the user can confirm…"). Speak in first/second person, or just take the action.
+
+## 💓 Heartbeats - Be Proactive!
+
+When you receive a heartbeat poll (message matches the configured heartbeat prompt), don't just reply `HEARTBEAT_OK` every time. Use heartbeats productively!
+
+Default heartbeat prompt:
+`Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`
+
+You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it small to limit token burn.
+
+### Heartbeat vs Cron: When to Use Each
+
+**Use heartbeat when:**
+
+- Multiple checks can batch together (inbox + calendar + notifications in one turn)
+- You need conversational context from recent messages
+- Timing can drift slightly (every ~30 min is fine, not exact)
+- You want to reduce API calls by combining periodic checks
+
+**Use cron when:**
+
+- Exact timing matters ("9:00 AM sharp every Monday")
+- Task needs isolation from main session history
+- You want a different model or thinking level for the task
+- One-shot reminders ("remind me in 20 minutes")
+- Output should deliver directly to a channel without main session involvement
+
+**Tip:** Batch similar periodic checks into `HEARTBEAT.md` instead of creating multiple cron jobs. Use cron for precise schedules and standalone tasks.
+
+**Things to check (rotate through these, 2-4 times per day):**
+
+- **Emails** - Any urgent unread messages?
+- **Calendar** - Upcoming events in next 24-48h?
+- **Mentions** - Twitter/social notifications?
+- **Weather** - Relevant if your human might go out?
+
+**Track your checks** in `memory/heartbeat-state.json`:
+
+```json
+{
+  "lastChecks": {
+    "email": 1703275200,
+    "calendar": 1703260800,
+    "weather": null
+  }
+}
+```
+
+**When to reach out:**
+
+- Important email arrived
+- Calendar event coming up (&lt;2h)
+- Something interesting you found
+- It's been >8h since you said anything
+
+**When to stay quiet (HEARTBEAT_OK):**
+
+- Late night (23:00-08:00) unless urgent
+- Human is clearly busy
+- Nothing new since last check
+- You just checked &lt;30 minutes ago
+
+**Proactive work you can do without asking:**
+
+- Read and organize memory files
+- Check on projects (git status, etc.)
+- Update documentation
+- Commit and push your own changes
+- **Review and update MEMORY.md** (see below)
+
+### 🔄 Memory Maintenance (During Heartbeats)
+
+Periodically (every few days), use a heartbeat to:
+
+1. Read through recent `memory/YYYY-MM-DD.md` files
+2. Identify significant events, lessons, or insights worth keeping long-term
+3. Update `MEMORY.md` with distilled learnings
+4. Remove outdated info from MEMORY.md that's no longer relevant
+
+Think of it like a human reviewing their journal and updating their mental model. Daily files are raw notes; MEMORY.md is curated wisdom.
+
+The goal: Be helpful without being annoying. Check in a few times a day, do useful background work, but respect quiet time.
+
+## Make It Yours
+
+This is a starting point. Add your own conventions, style, and rules as you figure out what works.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,28 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Cross-skill conventions
+
+For skills running in OpenClaw / NemoClaw and bridged to chat channels (Slack, Telegram, Discord).
+
+## Media attachments
+
+To attach a video, image, or PDF to the reply, put a `MEDIA:` line on its own line, outside any code fence. Local paths and HTTP URLs both work:
+
+```
+MEDIA: <path-to-local-file>
+MEDIA: https://host.example.com/clip.mp4
+```
+
+Save artifacts to the working directory — do not hard-code `/tmp/...` or any other absolute path. Files outside the working directory may not be reachable by the runtime that delivers the attachment.
+
+Default to plain links / markdown links in tables. Use `MEDIA:` when the user asks to "show / render / post" something, or when the user needs to see the visual to make a decision.
+
+The runtime delivers `MEDIA:` local paths as native attachments. Do not upload skill-generated artifacts (charts, reports, clips you produced) to VST or any other host to get a URL — emit the local path directly. Uploading is only correct when the URL already exists on a serving host (e.g. `screenshot_url` from a search result).
+
+## Output style
+
+- Tables: one row per record. Keep cells short; place longer narrative below the table.
+- Links in tables: use `[label](URL)` markdown directly in the cell (e.g. `[clip](https://...)`, `[snapshot](https://...)`). Slack, Discord, the browser TUI, and GitHub markdown all render this. The cell text becomes the clickable link. Do not use HTML anchor tags (`<a id="...">`) or any other inline HTML.
+- Limit user-facing messages to a single acknowledgement before long work and the final response. Keep intermediate tool calls and reasoning internal; do not narrate them.
+- Do not narrate what you are about to do or refer to the user in third person. Just take the action. Examples to avoid: "I'll present candidate #1 with an overlay clip so the user can confirm…", "Now I'll show the next candidate…", "Let me fetch the chart and post it…". Replace these with the action itself — post the clip and ask the question, post the chart, etc.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md - Your Workspace
 
+> Copy this file into your OpenClaw workspace (e.g. `~/.openclaw/AGENTS.md`) — OpenClaw loads it on agent startup. The skill files in `skills/<name>/SKILL.md` go under `~/.openclaw/skills/<name>/`.
+
 This folder is home. Treat it that way.
 
 ## First Run

--- a/skills/timeline/SKILL.md
+++ b/skills/timeline/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: timeline
+description: Build a cross-camera timeline for a person or object using embedding-based re-identification. Runs a semantic search, has the user pick the correct candidate from the top hits, then uses that object's behavior embedding to find all other appearances across cameras via KNN cosine similarity on Elasticsearch. Fetches the matching clips from VST, analyzes each with the VLM to confirm, and synthesizes a timeline showing where the subject went and when. Use for "timeline for the person in green vest", "track white-shirt worker across cameras", "where did the forklift go". Requires the search profile to be deployed.
+version: "3.1.0"
+license: "Apache License 2.0"
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Track Subject Across Cameras
+
+Orchestrates `video-search` + Elasticsearch KNN re-ID + `vios` + `video-summarization` (VLM-direct path) to produce a unified timeline of a specific subject's movements across cameras. Re-identification uses the subject's behavior embedding so the timeline follows the same physical person/object, not just "anyone matching the description".
+
+**User interaction pattern (important for chat surfaces like Slack):** the whole workflow surfaces to the user only at two moments — (1) the one-at-a-time candidate confirmation in Step 1, and (2) the final timeline output in Step 8. Everything in between (embedding fetch, KNN, window merge, clip fetch, VLM, filtering) runs silently. Do not post progress updates or intermediate results between those two moments.
+
+## Inputs
+
+Subject description (required) plus optional filters (`top_k`, `video sources`, `similarity_threshold`), all parsed from the natural-language query. See the `video-search` skill for fusion-search axes. `similarity_threshold` (default **0.9**) controls the KNN cutoff in Step 3.
+
+## Endpoint resolution
+
+Ask once at the start, cache for the run:
+- **Search agent** — host URL (local or remote)
+- **Elasticsearch** — same host as search agent, port `9200`
+- **VST** — inferred from `screenshot_url` in search results, no config needed
+- **VLM** — same VLM the search deployment uses (so descriptions match the critic). Order: `VLM_BASE_URL` env → deploy's `.env` → ask user. Never silently fall back to a different VLM
+
+---
+
+## Workflow
+
+### 1. Fusion search → one-at-a-time user confirmation
+
+Call `video-search` with the subject description and `top_k` (default 5). Do **not** dump the full candidate list at the user — that's noisy in chat surfaces like Slack. Instead, walk the top hits one at a time until the user confirms.
+
+For each candidate in similarity order:
+1. Fetch a short overlay clip via `vios` (clip-URL-with-overlay variant, `configuration.overlay.bbox` with `objectId` set to the hit's `object_ids`, `showObjId: true`). See `vios` skill for the exact request.
+2. Post one message: the overlay clip embedded or linked, plus **"Is this the subject you want tracked? (yes/no)"**. Nothing else.
+3. If **yes** → save the selected hit's `(video_name, object_id, start_time, end_time)` and proceed silently to Step 2. Do not narrate intermediate progress. The next message to the user should be the final timeline output from Step 8.
+4. If **no** → move to the next candidate and repeat. If all `top_k` exhausted, tell the user "no more candidates, refine the description" and stop.
+
+Extract the VST host from any `screenshot_url` — reuse it later for clip URL fetches.
+
+### 2. Fetch the seed behavior embedding
+
+The seed's embedding lives in `mdx-behavior-*` — one doc per tracked object appearance, with a 1536-dim nested `embeddings.vector`. Pin to the exact `(video_name, object_id, time window)` — do **not** query by `object_id` alone (ids are reused across sensors).
+
+```bash
+cat > /tmp/seed_query.json <<'JSON'
+{
+  "size": 1,
+  "query": {
+    "bool": {
+      "filter": [
+        { "term":  { "sensor.id.keyword": "<video_name>" } },
+        { "term":  { "object.id.keyword": "<object_id>" } },
+        { "range": { "timestamp": { "gte": "<selected start>", "lte": "<selected end>" } } }
+      ]
+    }
+  },
+  "_source": ["sensor.id", "object.id", "timestamp", "end", "embeddings.vector"]
+}
+JSON
+curl -s -X POST "<es-endpoint>/mdx-behavior-*/_search" -H "Content-Type: application/json" -d @/tmp/seed_query.json
+```
+
+Extract `hits[0]._source.embeddings[0].vector` → save to `/tmp/seed_vec.json`. If `embeddings` is empty or missing, treat as "no seed available" — see fallback below.
+
+> **Behavior-only, not raw.** `mdx-raw-*` has per-frame detections which are too noisy as seeds. Behavior events are already condensed by object-tracking and give one stable embedding per appearance window.
+
+> **If zero matches or no embedding** — the behavior pipeline may not have produced an event for this object yet (raw detection alone isn't enough). Offer: (a) pick a different candidate from Step 1 that does have behavior coverage, or (b) skip the re-ID expansion and build the timeline from only the Step 1 candidates.
+
+### 3. KNN similarity search on `mdx-behavior-*`
+
+Use the seed vector, apply the `video sources` filter from the original query if any, use `min_score` as the cutoff.
+
+```bash
+cat > /tmp/build_knn.py <<'PY'
+import json
+v = json.load(open("/tmp/seed_vec.json"))
+body = {
+    "knn": {
+        "field": "embeddings.vector",
+        "query_vector": v,
+        "k": 500,
+        "num_candidates": 1000,
+        # Carry over video sources from original query; omit to search all sensors
+        "filter": [
+            { "terms": { "sensor.id.keyword": ["<video_name_1>", "<video_name_2>"] } }
+        ]
+    },
+    "min_score": 0.9,   # similarity_threshold; 1.0 = self-match, 0.9+ = same subject, 0.8–0.9 = same subject but short/noisy tracks, <0.8 = likely different
+    "_source": ["sensor.id", "object.id", "timestamp", "end"],
+    "size": 500
+}
+json.dump(body, open("/tmp/knn_body.json", "w"))
+PY
+python3 /tmp/build_knn.py
+curl -s -X POST "<es-endpoint>/mdx-behavior-*/_search" -H "Content-Type: application/json" -d @/tmp/knn_body.json
+```
+
+The seed's self-match returns `score=1.0` — keep it. Each hit has `timestamp` (start), `end`, `sensor.id` (= video_name), `object.id`. Emit `(video_name, object_id, start_time, end_time, similarity)` tuples.
+
+> **Map `video_name` → VST sensor UUID** once before the next step: `GET http://<vst-host>/vst/api/v1/sensor/list` → match `name == video_name` → use its `sensorId`. `vios` needs the UUID, not the video name.
+
+### 4. Group overlapping windows per sensor
+
+Merge two windows **only if** same `sensor_id` AND time ranges overlap or are directly adjacent.
+
+- Same sensor `[0:00–0:30]` + `[0:20–0:45]` → merge
+- Same sensor `[0:00–0:30]` + `[2:00–2:30]` → **do not merge** (gap)
+- Different sensors → **never merge** (those are simultaneous observations)
+
+Merging non-intersecting windows creates fake ranges and pulls back unrelated footage — do not do it.
+
+### 5. Fetch clip URLs (via `vios`)
+
+For each merged `(sensor_id, start, end)`:
+
+```bash
+curl -s "http://<vst-host>/vst/api/v1/storage/file/<sensor_id>/url?startTime=<start>&endTime=<end>&container=mp4&disableAudio=true" | python3 -m json.tool
+```
+
+Save the returned `videoUrl` tied to its `(sensor_id, start, end, video_name)` tuple — carry through Steps 6–7. Verify the response's `streamId` matches the requested `sensor_id`; discard any row where the returned `startTime` differs from the requested one by more than a few seconds.
+
+### 6. VLM analysis per clip
+
+Defer to the **`video-summarization` skill's direct-VLM path** for each `videoUrl`. Force VLM, not LVS — the summarization skill routes ≥60s videos to LVS by default, but timeline needs per-clip VLM output consistent with the search critic.
+
+Prompt (substitute `<subject>`; broaden narrow color terms, e.g. `green vest` → `hi-vis safety vest (green/yellow/lime)` — the VLM names the same fluorescent vest differently across camera angles):
+
+```
+Focus only on <subject>. For this clip:
+1. If the subject is NOT present, respond with exactly: SUBJECT NOT FOUND
+2. Otherwise describe what they do, where they move, and what they interact with. Note timing (e.g. "at 5s", "from 10–15s").
+```
+
+### 7. Filter mismatches
+
+Discard `SUBJECT NOT FOUND` responses. If rejection rate is high, the prompt was likely too strict on attribute terms, not an identity mismatch — loosen per Step 6's note.
+
+### 8. Synthesize output
+
+Produce three sections, ordered chronologically by `start_time`.
+
+#### 8a. Gantt chart (PNG + inline renders)
+
+Install matplotlib once if missing:
+```bash
+python3 -c "import matplotlib" 2>/dev/null || pip install --quiet --break-system-packages matplotlib
+```
+
+Build `/tmp/timeline_sightings.json` (list of `{sensor, start, end}`), then run:
+
+```bash
+cat > /tmp/timeline_chart.py <<'PY'
+import json, matplotlib.pyplot as plt, matplotlib.dates as mdates
+from datetime import datetime
+sightings = json.load(open("/tmp/timeline_sightings.json"))
+sensors = sorted({s["sensor"] for s in sightings})
+fig, ax = plt.subplots(figsize=(12, max(2, 0.5*len(sensors)+1)))
+for s in sightings:
+    start = datetime.fromisoformat(s["start"].replace("Z","+00:00"))
+    end   = datetime.fromisoformat(s["end"].replace("Z","+00:00"))
+    ax.barh(sensors.index(s["sensor"]), end-start, left=start, height=0.6,
+            color="#4a90e2", edgecolor="#1f4e8c")
+ax.set_yticks(range(len(sensors))); ax.set_yticklabels(sensors)
+ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M:%S"))
+ax.set_xlabel("Time (UTC)"); ax.set_title("Subject sightings across cameras")
+ax.grid(axis="x", linestyle=":", alpha=0.5); plt.tight_layout()
+plt.savefig("/tmp/subject_timeline.png", dpi=120)
+PY
+python3 /tmp/timeline_chart.py
+```
+
+**Embed the PNG as base64 markdown in the chat reply** so it renders inline in the OpenClaw UI (a bare file path doesn't):
+```python
+import base64
+b64 = base64.b64encode(open("/tmp/subject_timeline.png","rb").read()).decode()
+# include in reply: ![Timeline](data:image/png;base64,{b64})
+```
+
+**Also emit a Mermaid Gantt block inline** (second fallback if base64 decode fails):
+
+````markdown
+```mermaid
+gantt
+    title Subject sightings across cameras
+    dateFormat  YYYY-MM-DDTHH:mm:ss
+    axisFormat  %H:%M:%S
+    section warehouse_aisle_3
+    sighting 1 :a1, 2025-01-01T00:02:08, 81s
+    sighting 2 :a2, 2025-01-01T00:04:08, 31s
+```
+````
+
+One `section` per sensor; one `<label> :<id>, <ISO-start>, <duration>s` per merged window.
+
+#### 8b. Detail table
+
+| Time (UTC) | Sensor | VLM analysis | Proof |
+|---|---|---|---|
+| `start–end` | `video_name` | 1–2 sentences from Step 6 | [clip](videoUrl) · [frame](screenshot_url) |
+
+One row per surviving clip. Keep VLM analysis concise.
+
+#### 8c. Trajectory summary
+
+Combine all per-clip VLM captions into one flowing narrative (paragraph, not bullets). Cover: entry, chronological path across sensors, actions per location, simultaneous multi-camera observations, dwell / repeat visits, notable interactions, exit. Someone reading only the summary should understand the full trajectory.
+
+Save everything (chart + table + summary) to `/tmp/subject_timeline.md`, and render the base64 PNG + Mermaid + summary inline in the chat reply.
+
+---
+
+## Tips
+
+- **similarity_threshold** — 0.9 default. <0.9 includes more track fragments, >0.95 risks dropping real distant sightings
+- **Cluster fragmented tracks** — after Step 4's strict merge, also combine same-sensor windows within ~30s to avoid N VLM calls on one real appearance that got split into micro-tracks by tracker resets
+- **Sparse behavior coverage** — if KNN returns only the self-match, skip re-ID and use Step 1 candidates
+- **Simultaneous observations** across sensors are valuable — keep all
+- **Time format** — ISO 8601 UTC, keep the `Z`
+
+## Related skills
+
+- `video-search` — Step 1 (fusion search, user selection)
+- `vios` — Step 5 (clip URL from sensor UUID + time range)
+- `video-summarization` — Step 6 (VLM-direct path, not LVS)
+- `deploy` — provides `ELASTIC_SEARCH_PORT` and `VLM_BASE_URL` for the active deployment

--- a/skills/timeline/SKILL.md
+++ b/skills/timeline/SKILL.md
@@ -5,9 +5,6 @@ version: "3.1.0"
 license: "Apache License 2.0"
 ---
 
-<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 # Track Subject Across Cameras
 
 Orchestrates `video-search` (initial fusion search) → Elasticsearch KNN re-ID → `vios` (clip retrieval) → `video-summarization` (per-clip VLM analysis) to produce a chronological timeline of a specific subject's appearances across multiple cameras.
@@ -16,7 +13,7 @@ The default flow has two user-facing moments: confirm the correct candidate (Ste
 
 ## Inputs
 
-Subject description (required) plus optional filters (`top_k`, `video sources`, `similarity_threshold`), all parsed from the natural-language query. See the `video-search` skill for fusion-search axes. `similarity_threshold` (default **0.9**) controls the KNN cutoff in Step 3.
+Subject description (required) plus optional filters (`top_k`, `video sources`, `similarity_threshold`), all parsed from the natural-language query. See the `video-search` skill for fusion-search axes. `similarity_threshold` (default **0.85**) controls the KNN cutoff in Step 3.
 
 ## Endpoint resolution
 
@@ -40,70 +37,42 @@ Use the same VLM as the active search deployment so descriptions remain consiste
 Call `video-search` with the subject description and `top_k` (default `5`). Walk top hits in similarity order; for each candidate:
 
 1. Fetch a short overlay clip via `vios` with `configuration.overlay.bbox` set to the hit's `object_ids` and `showObjId: true`.
-2. Reply with exactly two lines: a `MEDIA:` line attaching the overlay clip, and the question "Is this the subject you want tracked? (yes/no)". No other text — no preface like "Got 5 candidates. Let me fetch an overlay clip…" or "Showing candidate #1 for confirmation". Extracting search results, picking a candidate, and fetching the overlay are internal steps; do not narrate them.
-3. On `yes`: save `(video_name, object_id, start_time, end_time)` and proceed to Step 2.
+2. Reply with three short lines: a one-line status header (e.g. "Found 5 candidates from fusion search — showing #1." for the first, "Candidate 2 of 5." for subsequent ones), a `MEDIA:` line attaching the overlay clip, and the question "Is this the subject you want tracked? (yes/no)". One acknowledgement only — do not narrate the search, embedding fetch, or overlay rendering steps.
+3. On `yes`: post a single line acknowledging the confirmation and that re-ID is starting (e.g. "Confirmed — running re-ID across cameras. This will take a couple minutes."), save `(video_name, object_id, start_time, end_time)`, and proceed to Step 2.
 4. On `no`: continue to the next candidate; if exhausted, report "no more candidates, refine the description".
 
 Extract the VST host from any `screenshot_url` for later clip URL fetches.
 
 ### 2. Fetch the seed behavior embedding
 
-Query `mdx-behavior-*` for the seed embedding, pinning to the exact `(video_name, object_id, time window)` from Step 1:
+Query `mdx-behavior-*` for the seed embedding, pinning to the exact `(sensor.id, object.id, time window)` from Step 1. Behavior events are already condensed by object-tracking and provide stable seed vectors; the per-frame `mdx-raw-*` index is too noisy for this purpose.
 
-```bash
-cat > /tmp/seed_query.json <<'JSON'
-{
-  "size": 1,
-  "query": {
-    "bool": {
-      "filter": [
-        { "term":  { "sensor.id.keyword": "<video_name>" } },
-        { "term":  { "object.id.keyword": "<object_id>" } },
-        { "range": { "timestamp": { "gte": "<start>", "lte": "<end>" } } }
-      ]
-    }
-  },
-  "_source": ["sensor.id", "object.id", "timestamp", "end", "embeddings.vector"]
-}
-JSON
-curl -s -X POST "<es-endpoint>/mdx-behavior-*/_search" -H "Content-Type: application/json" -d @/tmp/seed_query.json
-```
-
-Save `hits[0]._source.embeddings[0].vector` to `/tmp/seed_vec.json`. Behavior events are already condensed by object-tracking and provide stable seed vectors; the per-frame `mdx-raw-*` index is too noisy for this purpose.
-
-If no embedding is available, ask the user to pick a different candidate, or proceed using only the Step 1 candidates without re-ID expansion.
+The 1536-dim `hits[0]._source.embeddings[0].vector` is the seed for Step 3. If no embedding is available, ask the user to pick a different candidate, or proceed using only the Step 1 candidates without re-ID expansion.
 
 ### 3. KNN similarity search
 
-Use the seed vector against `mdx-behavior-*`, applying any `video sources` filter from the original query and `min_score` from `similarity_threshold`:
+Run a KNN query on `mdx-behavior-*` against the seed vector from Step 2, applying any `video sources` filter from the original query and `min_score` from `similarity_threshold` (default `0.85`). Request body shape:
 
-```bash
-cat > /tmp/build_knn.py <<'PY'
-import json
-v = json.load(open("/tmp/seed_vec.json"))
-body = {
-    "knn": {
-        "field": "embeddings.vector",
-        "query_vector": v,
-        "k": 500,
-        "num_candidates": 1000,
-        "filter": [
-            { "terms": { "sensor.id.keyword": ["<video_name_1>", "<video_name_2>"] } }
-        ]
-    },
-    "min_score": 0.9,
-    "_source": ["sensor.id", "object.id", "timestamp", "end"],
-    "size": 500
+```json
+{
+  "knn": {
+    "field": "embeddings.vector",
+    "query_vector": [<1536 floats from Step 2>],
+    "k": 500,
+    "num_candidates": 1000,
+    "filter": [{ "terms": { "sensor.id.keyword": ["<video_name_1>", "<video_name_2>"] } }]
+  },
+  "min_score": 0.85,
+  "_source": ["sensor.id", "object.id", "timestamp", "end"],
+  "size": 500
 }
-json.dump(body, open("/tmp/knn_body.json", "w"))
-PY
-python3 /tmp/build_knn.py
-curl -s -X POST "<es-endpoint>/mdx-behavior-*/_search" -H "Content-Type: application/json" -d @/tmp/knn_body.json
 ```
 
-Score interpretation: `1.0` self-match, `0.9+` same subject, `0.8–0.9` same subject in short or noisy tracks, `<0.8` likely different. Each hit becomes a `(video_name, object_id, start_time, end_time, similarity)` tuple.
+POST to `<es-endpoint>/mdx-behavior-*/_search`. Score interpretation: `1.0` self-match, `0.9+` same subject, `0.8–0.9` same subject in short or noisy tracks, `<0.8` likely different. Each hit becomes a `(video_name, object_id, start_time, end_time, similarity)` tuple.
 
 Map `video_name` → VST sensor UUID once via `GET http://<vst-host>/vst/api/v1/sensor/list` (matching `name == video_name`). The `vios` clip-URL endpoint requires the UUID.
+
+Post a one-line status: e.g. "KNN re-ID found N candidate sightings across X cameras." No more detail than that.
 
 ### 4. Group windows per sensor
 
@@ -150,6 +119,8 @@ The `EVENTS` block enables Step 9 (sub-clip extraction) by mapping textual event
 
 Discard clips whose response is `SUBJECT NOT FOUND`. A high rejection rate usually indicates over-strict attribute terms in the prompt (per Step 6) rather than identity mismatch.
 
+Post a one-line status: e.g. "VLM confirmed N of M sightings as subject." Then proceed directly to Step 8.
+
 ### 8. Default output: sightings table
 
 Send a single reply consisting of:
@@ -175,7 +146,16 @@ When the user asks for a chart or visual of the timeline, render a PNG Gantt: se
 
 ### 11. PDF report
 
-When the user asks for a report or PDF, generate one containing the title, the Step 8 table, the Step 9 summary, the Step 10 Gantt chart, and one screenshot per surviving sighting (peak-similarity timestamp on each sensor, fetched via VST's `replay/stream/<sensor_uuid>/picture` endpoint). Save the PDF to the working directory and attach it via a `MEDIA:` line pointing at that path.
+When the user asks for a report or PDF, generate one containing:
+
+- Title
+- The seed reference image — the confirmed Step 1 candidate, fetched from its `screenshot_url` or VST's `replay/stream/<sensor_uuid>/picture` at the seed timestamp
+- The Step 8 sightings table
+- The Step 9 summary
+- The Step 10 Gantt chart
+- One screenshot per sensor — pick the surviving sighting with the highest KNN similarity score (already in the Step 3 results retained per Step 8), and fetch a frame at its `start_time` via VST's `replay/stream/<sensor_uuid>/picture`
+
+All images must be downloaded and embedded directly in the PDF (as image bytes); do not just link the URLs. Save the PDF to the working directory and attach it via a `MEDIA:` line pointing at that path.
 
 ### 12. Sub-clip extraction
 
@@ -190,7 +170,7 @@ When the user asks for a clip of a specific moment (e.g. "send me the clip where
 
 ## Notes
 
-- `similarity_threshold` of `0.9` is the validated default. Lower values include more track fragments; higher values may drop legitimate distant sightings.
+- `similarity_threshold` of `0.85` is the validated default. Lower values include more track fragments and may pick up brief distant sightings; higher values (≥0.9) drop noisy short tracks but can also drop legitimate distant sightings.
 - After Step 4's strict merge, same-sensor windows within ~10 seconds of each other can optionally be combined into a single appearance cluster to absorb brief tracker-reset fragments without merging genuinely distinct visits.
 - If KNN returns only the self-match, fall back to using the Step 1 candidates without re-ID expansion.
 - All timestamps are ISO 8601 UTC; retain the trailing `Z`.

--- a/skills/timeline/SKILL.md
+++ b/skills/timeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: timeline
-description: Build a cross-camera timeline for a person or object using embedding-based re-identification. Runs a semantic search, has the user pick the correct candidate from the top hits, then uses that object's behavior embedding to find all other appearances across cameras via KNN cosine similarity on Elasticsearch. Fetches the matching clips from VST, analyzes each with the VLM to confirm, and synthesizes a timeline showing where the subject went and when. Use for "timeline for the person in green vest", "track white-shirt worker across cameras", "where did the forklift go". Requires the search profile to be deployed.
+description: Build a cross-camera timeline for a person or object using embedding-based re-identification. Runs a semantic search, has the user confirm the correct candidate, then uses the object's behavior embedding to find further appearances across cameras via KNN cosine similarity in Elasticsearch. Fetches the matching clips from VST, analyzes each with the VLM, and synthesizes a chronological timeline. Use for queries like "timeline for the person in green vest", "track white-shirt worker across cameras", "where did the forklift go". Requires the search profile to be deployed.
 version: "3.1.0"
 license: "Apache License 2.0"
 ---
@@ -10,9 +10,9 @@ license: "Apache License 2.0"
 
 # Track Subject Across Cameras
 
-Orchestrates `video-search` + Elasticsearch KNN re-ID + `vios` + `video-summarization` (VLM-direct path) to produce a unified timeline of a specific subject's movements across cameras. Re-identification uses the subject's behavior embedding so the timeline follows the same physical person/object, not just "anyone matching the description".
+Orchestrates `video-search` (initial fusion search) → Elasticsearch KNN re-ID → `vios` (clip retrieval) → `video-summarization` (per-clip VLM analysis) to produce a chronological timeline of a specific subject's appearances across multiple cameras.
 
-**User interaction pattern (important for chat surfaces like Slack):** the whole workflow surfaces to the user only at two moments — (1) the one-at-a-time candidate confirmation in Step 1, and (2) the final timeline output in Step 8. Everything in between (embedding fetch, KNN, window merge, clip fetch, VLM, filtering) runs silently. Do not post progress updates or intermediate results between those two moments.
+The default flow has two user-facing moments: confirm the correct candidate (Step 1), then return a table of sightings (Step 8). Steps 2–7 run internally. The user can then opt in to additional outputs — timeline summary, Gantt chart, PDF report, or a specific sub-clip — as separate follow-up requests. See [`../AGENTS.md`](../AGENTS.md) for chat-channel output conventions.
 
 ## Inputs
 
@@ -20,31 +20,35 @@ Subject description (required) plus optional filters (`top_k`, `video sources`, 
 
 ## Endpoint resolution
 
-Ask once at the start, cache for the run:
-- **Search agent** — host URL (local or remote)
-- **Elasticsearch** — same host as search agent, port `9200`
-- **VST** — inferred from `screenshot_url` in search results, no config needed
-- **VLM** — same VLM the search deployment uses (so descriptions match the critic). Order: `VLM_BASE_URL` env → deploy's `.env` → ask user. Never silently fall back to a different VLM
+Resolve once and cache for the run:
+
+| Endpoint | Source |
+|---|---|
+| Search agent | host URL, local or remote |
+| Elasticsearch | same host as search agent, port `9200` |
+| VST | inferred from `screenshot_url` in search results |
+| VLM | `VLM_BASE_URL` env → deployment `.env` → ask user |
+
+Use the same VLM as the active search deployment so descriptions remain consistent with the search critic.
 
 ---
 
 ## Workflow
 
-### 1. Fusion search → one-at-a-time user confirmation
+### 1. Candidate confirmation
 
-Call `video-search` with the subject description and `top_k` (default 5). Do **not** dump the full candidate list at the user — that's noisy in chat surfaces like Slack. Instead, walk the top hits one at a time until the user confirms.
+Call `video-search` with the subject description and `top_k` (default `5`). Walk top hits in similarity order; for each candidate:
 
-For each candidate in similarity order:
-1. Fetch a short overlay clip via `vios` (clip-URL-with-overlay variant, `configuration.overlay.bbox` with `objectId` set to the hit's `object_ids`, `showObjId: true`). See `vios` skill for the exact request.
-2. Post one message: the overlay clip embedded or linked, plus **"Is this the subject you want tracked? (yes/no)"**. Nothing else.
-3. If **yes** → save the selected hit's `(video_name, object_id, start_time, end_time)` and proceed silently to Step 2. Do not narrate intermediate progress. The next message to the user should be the final timeline output from Step 8.
-4. If **no** → move to the next candidate and repeat. If all `top_k` exhausted, tell the user "no more candidates, refine the description" and stop.
+1. Fetch a short overlay clip via `vios` with `configuration.overlay.bbox` set to the hit's `object_ids` and `showObjId: true`.
+2. Reply with exactly two lines: a `MEDIA:` line attaching the overlay clip, and the question "Is this the subject you want tracked? (yes/no)". No other text — no preface like "Got 5 candidates. Let me fetch an overlay clip…" or "Showing candidate #1 for confirmation". Extracting search results, picking a candidate, and fetching the overlay are internal steps; do not narrate them.
+3. On `yes`: save `(video_name, object_id, start_time, end_time)` and proceed to Step 2.
+4. On `no`: continue to the next candidate; if exhausted, report "no more candidates, refine the description".
 
-Extract the VST host from any `screenshot_url` — reuse it later for clip URL fetches.
+Extract the VST host from any `screenshot_url` for later clip URL fetches.
 
 ### 2. Fetch the seed behavior embedding
 
-The seed's embedding lives in `mdx-behavior-*` — one doc per tracked object appearance, with a 1536-dim nested `embeddings.vector`. Pin to the exact `(video_name, object_id, time window)` — do **not** query by `object_id` alone (ids are reused across sensors).
+Query `mdx-behavior-*` for the seed embedding, pinning to the exact `(video_name, object_id, time window)` from Step 1:
 
 ```bash
 cat > /tmp/seed_query.json <<'JSON'
@@ -55,7 +59,7 @@ cat > /tmp/seed_query.json <<'JSON'
       "filter": [
         { "term":  { "sensor.id.keyword": "<video_name>" } },
         { "term":  { "object.id.keyword": "<object_id>" } },
-        { "range": { "timestamp": { "gte": "<selected start>", "lte": "<selected end>" } } }
+        { "range": { "timestamp": { "gte": "<start>", "lte": "<end>" } } }
       ]
     }
   },
@@ -65,15 +69,13 @@ JSON
 curl -s -X POST "<es-endpoint>/mdx-behavior-*/_search" -H "Content-Type: application/json" -d @/tmp/seed_query.json
 ```
 
-Extract `hits[0]._source.embeddings[0].vector` → save to `/tmp/seed_vec.json`. If `embeddings` is empty or missing, treat as "no seed available" — see fallback below.
+Save `hits[0]._source.embeddings[0].vector` to `/tmp/seed_vec.json`. Behavior events are already condensed by object-tracking and provide stable seed vectors; the per-frame `mdx-raw-*` index is too noisy for this purpose.
 
-> **Behavior-only, not raw.** `mdx-raw-*` has per-frame detections which are too noisy as seeds. Behavior events are already condensed by object-tracking and give one stable embedding per appearance window.
+If no embedding is available, ask the user to pick a different candidate, or proceed using only the Step 1 candidates without re-ID expansion.
 
-> **If zero matches or no embedding** — the behavior pipeline may not have produced an event for this object yet (raw detection alone isn't enough). Offer: (a) pick a different candidate from Step 1 that does have behavior coverage, or (b) skip the re-ID expansion and build the timeline from only the Step 1 candidates.
+### 3. KNN similarity search
 
-### 3. KNN similarity search on `mdx-behavior-*`
-
-Use the seed vector, apply the `video sources` filter from the original query if any, use `min_score` as the cutoff.
+Use the seed vector against `mdx-behavior-*`, applying any `video sources` filter from the original query and `min_score` from `similarity_threshold`:
 
 ```bash
 cat > /tmp/build_knn.py <<'PY'
@@ -85,12 +87,11 @@ body = {
         "query_vector": v,
         "k": 500,
         "num_candidates": 1000,
-        # Carry over video sources from original query; omit to search all sensors
         "filter": [
             { "terms": { "sensor.id.keyword": ["<video_name_1>", "<video_name_2>"] } }
         ]
     },
-    "min_score": 0.9,   # similarity_threshold; 1.0 = self-match, 0.9+ = same subject, 0.8–0.9 = same subject but short/noisy tracks, <0.8 = likely different
+    "min_score": 0.9,
     "_source": ["sensor.id", "object.id", "timestamp", "end"],
     "size": 500
 }
@@ -100,130 +101,103 @@ python3 /tmp/build_knn.py
 curl -s -X POST "<es-endpoint>/mdx-behavior-*/_search" -H "Content-Type: application/json" -d @/tmp/knn_body.json
 ```
 
-The seed's self-match returns `score=1.0` — keep it. Each hit has `timestamp` (start), `end`, `sensor.id` (= video_name), `object.id`. Emit `(video_name, object_id, start_time, end_time, similarity)` tuples.
+Score interpretation: `1.0` self-match, `0.9+` same subject, `0.8–0.9` same subject in short or noisy tracks, `<0.8` likely different. Each hit becomes a `(video_name, object_id, start_time, end_time, similarity)` tuple.
 
-> **Map `video_name` → VST sensor UUID** once before the next step: `GET http://<vst-host>/vst/api/v1/sensor/list` → match `name == video_name` → use its `sensorId`. `vios` needs the UUID, not the video name.
+Map `video_name` → VST sensor UUID once via `GET http://<vst-host>/vst/api/v1/sensor/list` (matching `name == video_name`). The `vios` clip-URL endpoint requires the UUID.
 
-### 4. Group overlapping windows per sensor
+### 4. Group windows per sensor
 
-Merge two windows **only if** same `sensor_id` AND time ranges overlap or are directly adjacent.
+Merge two windows only when both conditions hold:
+- Same `sensor_id`.
+- Time ranges overlap or are directly adjacent.
 
-- Same sensor `[0:00–0:30]` + `[0:20–0:45]` → merge
-- Same sensor `[0:00–0:30]` + `[2:00–2:30]` → **do not merge** (gap)
-- Different sensors → **never merge** (those are simultaneous observations)
+Windows from different sensors with overlapping wall-clock times are simultaneous observations and must remain separate. Windows on the same sensor with a time gap between them are distinct visits and must not be merged.
 
-Merging non-intersecting windows creates fake ranges and pulls back unrelated footage — do not do it.
-
-### 5. Fetch clip URLs (via `vios`)
+### 5. Fetch clip URLs
 
 For each merged `(sensor_id, start, end)`:
 
 ```bash
-curl -s "http://<vst-host>/vst/api/v1/storage/file/<sensor_id>/url?startTime=<start>&endTime=<end>&container=mp4&disableAudio=true" | python3 -m json.tool
+curl -s "http://<vst-host>/vst/api/v1/storage/file/<sensor_id>/url?startTime=<start>&endTime=<end>&container=mp4&disableAudio=true"
 ```
 
-Save the returned `videoUrl` tied to its `(sensor_id, start, end, video_name)` tuple — carry through Steps 6–7. Verify the response's `streamId` matches the requested `sensor_id`; discard any row where the returned `startTime` differs from the requested one by more than a few seconds.
+Carry the returned `videoUrl` together with `(sensor_id, start, end, video_name)` through Steps 6 and 7. Verify the response's `streamId` matches the requested `sensor_id`; discard any row where the returned `startTime` differs from the requested one by more than a few seconds.
 
 ### 6. VLM analysis per clip
 
-Defer to the **`video-summarization` skill's direct-VLM path** for each `videoUrl`. Force VLM, not LVS — the summarization skill routes ≥60s videos to LVS by default, but timeline needs per-clip VLM output consistent with the search critic.
+Use the `video-summarization` skill's VLM-direct path. Skip its HITL prompt-confirmation gate — timeline supplies a fixed prompt below; pass it directly without prompting the user.
 
-Prompt (substitute `<subject>`; broaden narrow color terms, e.g. `green vest` → `hi-vis safety vest (green/yellow/lime)` — the VLM names the same fluorescent vest differently across camera angles):
+Run requests concurrently with a cap of 6 (`ThreadPoolExecutor(max_workers=6)`, `asyncio.Semaphore(6)`, or `xargs -P 6`).
+
+Prompt (substitute `<subject>` from the user's query):
 
 ```
 Focus only on <subject>. For this clip:
 1. If the subject is NOT present, respond with exactly: SUBJECT NOT FOUND
-2. Otherwise describe what they do, where they move, and what they interact with. Note timing (e.g. "at 5s", "from 10–15s").
+2. Otherwise describe what they do, where they move, and what they interact with in 1–3 sentences.
+3. Then append a structured event list:
+
+EVENTS:
+- <start_sec>-<end_sec>s: <short event description>
+- <start_sec>-<end_sec>s: <short event description>
+
+Use seconds-into-clip (not wall-clock). One line per discrete event. Keep descriptions under 10 words.
 ```
+
+The `EVENTS` block enables Step 9 (sub-clip extraction) by mapping textual event references to time offsets.
 
 ### 7. Filter mismatches
 
-Discard `SUBJECT NOT FOUND` responses. If rejection rate is high, the prompt was likely too strict on attribute terms, not an identity mismatch — loosen per Step 6's note.
+Discard clips whose response is `SUBJECT NOT FOUND`. A high rejection rate usually indicates over-strict attribute terms in the prompt (per Step 6) rather than identity mismatch.
 
-### 8. Synthesize output
+### 8. Default output: sightings table
 
-Produce three sections, ordered chronologically by `start_time`.
+Send a single reply consisting of:
 
-#### 8a. Gantt chart (PNG + inline renders)
+- Title line: `Timeline Analysis — <subject>`
+- A table with columns: Time (UTC), Sensor, Summary. One row per surviving sighting, ordered by `start_time`. Cells should be short (≤15 words).
 
-Install matplotlib once if missing:
-```bash
-python3 -c "import matplotlib" 2>/dev/null || pip install --quiet --break-system-packages matplotlib
-```
+That is the entire default reply. After it, the user can ask follow-up questions — summary, chart, report, or a specific clip — each handled by a step below.
 
-Build `/tmp/timeline_sightings.json` (list of `{sensor, start, end}`), then run:
-
-```bash
-cat > /tmp/timeline_chart.py <<'PY'
-import json, matplotlib.pyplot as plt, matplotlib.dates as mdates
-from datetime import datetime
-sightings = json.load(open("/tmp/timeline_sightings.json"))
-sensors = sorted({s["sensor"] for s in sightings})
-fig, ax = plt.subplots(figsize=(12, max(2, 0.5*len(sensors)+1)))
-for s in sightings:
-    start = datetime.fromisoformat(s["start"].replace("Z","+00:00"))
-    end   = datetime.fromisoformat(s["end"].replace("Z","+00:00"))
-    ax.barh(sensors.index(s["sensor"]), end-start, left=start, height=0.6,
-            color="#4a90e2", edgecolor="#1f4e8c")
-ax.set_yticks(range(len(sensors))); ax.set_yticklabels(sensors)
-ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M:%S"))
-ax.set_xlabel("Time (UTC)"); ax.set_title("Subject sightings across cameras")
-ax.grid(axis="x", linestyle=":", alpha=0.5); plt.tight_layout()
-plt.savefig("/tmp/subject_timeline.png", dpi=120)
-PY
-python3 /tmp/timeline_chart.py
-```
-
-**Embed the PNG as base64 markdown in the chat reply** so it renders inline in the OpenClaw UI (a bare file path doesn't):
-```python
-import base64
-b64 = base64.b64encode(open("/tmp/subject_timeline.png","rb").read()).decode()
-# include in reply: ![Timeline](data:image/png;base64,{b64})
-```
-
-**Also emit a Mermaid Gantt block inline** (second fallback if base64 decode fails):
-
-````markdown
-```mermaid
-gantt
-    title Subject sightings across cameras
-    dateFormat  YYYY-MM-DDTHH:mm:ss
-    axisFormat  %H:%M:%S
-    section warehouse_aisle_3
-    sighting 1 :a1, 2025-01-01T00:02:08, 81s
-    sighting 2 :a2, 2025-01-01T00:04:08, 31s
-```
-````
-
-One `section` per sensor; one `<label> :<id>, <ISO-start>, <duration>s` per merged window.
-
-#### 8b. Detail table
-
-| Time (UTC) | Sensor | VLM analysis | Proof |
-|---|---|---|---|
-| `start–end` | `video_name` | 1–2 sentences from Step 6 | [clip](videoUrl) · [frame](screenshot_url) |
-
-One row per surviving clip. Keep VLM analysis concise.
-
-#### 8c. Trajectory summary
-
-Combine all per-clip VLM captions into one flowing narrative (paragraph, not bullets). Cover: entry, chronological path across sensors, actions per location, simultaneous multi-camera observations, dwell / repeat visits, notable interactions, exit. Someone reading only the summary should understand the full trajectory.
-
-Save everything (chart + table + summary) to `/tmp/subject_timeline.md`, and render the base64 PNG + Mermaid + summary inline in the chat reply.
+Retain in memory across the session: the surviving sighting tuples `(video_name, sensor_uuid, start_time, end_time, similarity)` and the per-clip VLM responses (free-form prose plus the `EVENTS` block) so follow-ups can be served without re-running Steps 2–7.
 
 ---
 
-## Tips
+## Follow-up steps (on user request)
 
-- **similarity_threshold** — 0.9 default. <0.9 includes more track fragments, >0.95 risks dropping real distant sightings
-- **Cluster fragmented tracks** — after Step 4's strict merge, also combine same-sensor windows within ~30s to avoid N VLM calls on one real appearance that got split into micro-tracks by tracker resets
-- **Sparse behavior coverage** — if KNN returns only the self-match, skip re-ID and use Step 1 candidates
-- **Simultaneous observations** across sensors are valuable — keep all
-- **Time format** — ISO 8601 UTC, keep the `Z`
+### 9. Timeline summary
+
+When the user asks for a summary, narrative, or how the subject moved across cameras, return a single paragraph combining the per-clip VLM captions chronologically. Describe transitions between sensors, simultaneous appearances, dwell time, repeat visits, and the final exit. The reader should be able to reconstruct the subject's full path and activities from the summary alone.
+
+### 10. Gantt chart
+
+When the user asks for a chart or visual of the timeline, render a PNG Gantt: sensors on the y-axis, time on the x-axis, one bar per sighting. Save the PNG to the working directory and attach it via a `MEDIA:` line pointing at that path.
+
+### 11. PDF report
+
+When the user asks for a report or PDF, generate one containing the title, the Step 8 table, the Step 9 summary, the Step 10 Gantt chart, and one screenshot per surviving sighting (peak-similarity timestamp on each sensor, fetched via VST's `replay/stream/<sensor_uuid>/picture` endpoint). Save the PDF to the working directory and attach it via a `MEDIA:` line pointing at that path.
+
+### 12. Sub-clip extraction
+
+When the user asks for a clip of a specific moment (e.g. "send me the clip where they place the box on shelf D"):
+
+1. Match the request against `EVENTS` lines from Step 6.
+2. Compute the wall-clock window: parent clip's `start_time` + the matching event's `start_sec`/`end_sec`, padded by ±1–2 seconds.
+3. Fetch via `vios`, optionally with `configuration.overlay.bbox` to highlight the subject.
+4. Attach the clip via `MEDIA:`.
+
+---
+
+## Notes
+
+- `similarity_threshold` of `0.9` is the validated default. Lower values include more track fragments; higher values may drop legitimate distant sightings.
+- After Step 4's strict merge, same-sensor windows within ~10 seconds of each other can optionally be combined into a single appearance cluster to absorb brief tracker-reset fragments without merging genuinely distinct visits.
+- If KNN returns only the self-match, fall back to using the Step 1 candidates without re-ID expansion.
+- All timestamps are ISO 8601 UTC; retain the trailing `Z`.
 
 ## Related skills
 
-- `video-search` — Step 1 (fusion search, user selection)
-- `vios` — Step 5 (clip URL from sensor UUID + time range)
-- `video-summarization` — Step 6 (VLM-direct path, not LVS)
+- `video-search` — Step 1 (fusion search and candidate selection)
+- `vios` — Step 5 (clip URL retrieval)
+- `video-summarization` — Step 6 (VLM-direct path; the timeline skill bypasses the HITL gate and supplies its own fixed prompt)
 - `deploy` — provides `ELASTIC_SEARCH_PORT` and `VLM_BASE_URL` for the active deployment

--- a/skills/timeline/eval/timeline.json
+++ b/skills/timeline/eval/timeline.json
@@ -1,0 +1,66 @@
+{
+  "skills": ["timeline"],
+  "profile": "search",
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": ["remote-all"]
+      }
+    }
+  },
+  "env": "A **full-remote deployed VSS search profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs; Cosmos Embed1 still runs locally on the GPU). Run on ONE platform only — re-ID is hardware-agnostic and the LLM/VLM run remotely, so fanning out discovers nothing new. Pick the cheapest available host (L40S recommended). Required: VSS agent reachable at http://localhost:8000/docs (OpenAPI visible), VST reachable at http://localhost:30888/vst/api/v1, Elasticsearch reachable at http://localhost:9200, the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770 per launchable convention — see skills/deploy/references/brev.md), AND a multi-camera sample dataset ingested (the warehouse angle_01_warehouse / angle_02_warehouse / angle_03_warehouse triplet, downloaded from `ngc registry resource download-version nvidia/vss-developer/dev-profile-sample-data:3.1.0` then extracted with `tar -xzvf`, then pre-ingested by curling the videos-for-search API for each video per the troubleshooting.md video ingestion section). After ingest, mdx-behavior-* must contain at least one behavior event per camera with non-empty `embeddings[].vector` — otherwise re-ID has nothing to query against.",
+  "expects": [
+    {
+      "query": "Build a timeline for the person in hardhat and safety vest across all cameras. Agent backend is on localhost. You are pre-authorized to confirm the top candidate from the initial search without asking for yes/no confirmation.",
+      "checks": [
+        "The agent issued exactly one initial `POST http://localhost:8000/generate` call whose `input_message` contains the subject phrase (`person in hardhat and safety vest` or close paraphrase) — any search mode the decomposer picks is acceptable (fusion, embed-only, or attribute-only); the eval only requires that the call ran and seeded the timeline",
+        "The agent fetched a single overlay clip via `vios` (`POST http://localhost:30888/vst/api/v1/storage/file/<sensor_uuid>/url` with `configuration.overlay.bbox` populated and `showObjId: true`) for the top candidate before confirmation — not multiple overlays in parallel, not a screenshot",
+        "The agent did NOT pause and ask `Is this the subject you want tracked? (yes/no)` — the pre-authorization in the query was honored, the top candidate was auto-confirmed and the workflow proceeded",
+        "The agent queried `mdx-behavior-*` for the seed embedding pinned to the exact `(sensor.id, object.id, timestamp range)` of the confirmed candidate — the request body filter included `term sensor.id.keyword`, `term object.id.keyword`, AND a `range timestamp` clause; the agent did NOT query by `object.id` alone",
+        "The agent extracted a 1536-dim vector from the seed query response (`hits[0]._source.embeddings[0].vector`) and used it as the `query_vector` in a follow-up KNN call",
+        "The agent issued a `POST http://localhost:9200/mdx-behavior-*/_search` KNN request with `min_score: 0.85` (the timeline default), `field: embeddings.vector`, and a non-empty `query_vector` — the threshold was NOT silently raised to 0.9 or lowered below 0.8",
+        "The agent mapped each KNN hit's `sensor.id` (video_name) to a VST sensor UUID via `GET http://localhost:30888/vst/api/v1/sensor/list` exactly once — it did NOT attempt clip URL fetches with the raw video name",
+        "For each merged `(sensor_uuid, start, end)` window, the agent issued `GET http://localhost:30888/vst/api/v1/storage/file/<sensor_uuid>/url?startTime=...&endTime=...&container=mp4&disableAudio=true` and verified the response's `streamId` matched the requested UUID",
+        "Per-clip VLM analysis ran concurrently with a cap of 6 — the trajectory shows multiple parallel VLM calls but never more than 6 in flight at once",
+        "The VLM prompt sent for each clip contained the substituted subject phrase (`hardhat and safety vest` or close paraphrase) AND the literal `SUBJECT NOT FOUND` sentinel instruction AND an `EVENTS:` block specification — it was NOT the generic video-summarization HITL prompt, and the agent did NOT pause to ask the user to confirm the prompt",
+        "The agent discarded clips whose VLM response was exactly `SUBJECT NOT FOUND` and kept the rest — the final table count equals (KNN hits surviving merge) minus (SUBJECT NOT FOUND responses), not the raw KNN count",
+        "The agent's final reply is a single message titled `Timeline Analysis — <subject>` followed by a markdown table with exactly three columns: `Time (UTC)`, `Sensor`, `Summary` — not a JSON dump, not multiple progressive messages, not a per-camera breakdown",
+        "The table contains one row per surviving sighting ordered by `start_time` ascending — same-sensor windows that overlapped or were directly adjacent appear merged into a single row; different-sensor windows with overlapping wall-clock times appear as separate rows",
+        "The agent posted at most three short status lines during the run: a confirmation acknowledgement after Step 1, a one-line KNN result count after Step 3, and a one-line VLM confirmation count after Step 7 — no multi-step narration like `now I'll fetch the embedding…` or `now KNN…`",
+        "The agent did NOT upload any skill-generated artifact (overlay clip, snapshot, chart, report) to VST or any other host to obtain a URL — every URL cited in the final reply is either a `screenshot_url` from the initial search response or a `videoUrl` from VST's storage API, never a freshly-uploaded artifact"
+      ]
+    },
+    {
+      "query": "Build a timeline for the person in hardhat and safety vest, then send me a clip of the moment where the subject places a box on a shelf. Agent backend is on localhost. You are pre-authorized to confirm the top candidate from the initial search.",
+      "checks": [
+        "The agent ran the default timeline flow first (Step 1 search via `/generate` + Step 3 KNN on `mdx-behavior-*` + Step 6 per-clip VLM analysis) and emitted a `Timeline Analysis — <subject>` table before handling the sub-clip request",
+        "The agent matched the user's textual moment description (`places a box on a shelf`) against the `EVENTS:` block lines retained in memory from the Step 6 VLM responses — the trajectory shows no second pass of VLM calls and no new KNN call",
+        "The agent computed the sub-clip's wall-clock window as `parent_clip.start_time + matching_event.start_sec` with a ±1–2 second pad — it did NOT use the full parent clip range",
+        "The agent fetched exactly one sub-clip via `vios` (`GET http://localhost:30888/vst/api/v1/storage/file/<sensor_uuid>/url?startTime=...&endTime=...&container=mp4`) for the matched window — optionally with `configuration.overlay.bbox` set to highlight the subject",
+        "The agent's final reply attaches the sub-clip via a `MEDIA:` line — not a path-only mention, not a re-uploaded URL on a third-party host",
+        "The agent did NOT re-run Steps 2 through 7 of the timeline pipeline to satisfy this follow-up — the surviving sighting tuples and per-clip VLM responses were reused from memory"
+      ]
+    },
+    {
+      "query": "Build a timeline for the person in hardhat and safety vest, then give me a Gantt chart of all the sightings. Agent backend is on localhost. You are pre-authorized to confirm the top candidate from the initial search.",
+      "checks": [
+        "The agent ran the default timeline flow first and emitted a `Timeline Analysis — <subject>` table before producing the chart",
+        "The agent rendered a PNG Gantt chart directly to a file (matplotlib, Pillow, or equivalent pure-image library) — the trajectory does NOT show generation of HTML/SVG followed by a conversion step (no `weasyprint`, `wkhtmltopdf`, headless Chrome, or similar)",
+        "The Gantt has sensors on the y-axis and time on the x-axis, with one bar per surviving sighting from the Step 8 table — bar count equals the table row count, never more, never less",
+        "The agent's final reply attaches the PNG via a `MEDIA:` line — never a path-only reference, never a freshly-uploaded URL on a third-party host",
+        "The agent did NOT re-run Steps 2 through 7 of the timeline pipeline to produce the chart — the surviving sighting tuples were reused from memory"
+      ]
+    },
+    {
+      "query": "Build a timeline for the person in hardhat and safety vest, then generate a PDF report. Agent backend is on localhost. You are pre-authorized to confirm the top candidate from the initial search.",
+      "checks": [
+        "The agent ran the default timeline flow first and emitted a `Timeline Analysis — <subject>` table before producing the PDF",
+        "The agent rendered the PDF directly with a pure-Python library (`fpdf2` or `reportlab`) — the trajectory does NOT show HTML-to-PDF conversion via `weasyprint`, `pdfkit`, `wkhtmltopdf`, or headless Chrome",
+        "The PDF contents include all six required elements: title, seed reference image of the confirmed Step 1 candidate, the Step 8 sightings table, the Step 9 narrative summary, the Step 10 Gantt chart, and one screenshot per sensor selected at the highest-similarity sighting from the retained Step 3 KNN results",
+        "All images embedded in the PDF are downloaded as bytes from VST's `screenshot_url` / `replay/stream/<sensor_uuid>/picture` endpoints and inserted as raw image data — the PDF does NOT contain only URL placeholders or hyperlinks where images should be",
+        "The agent's final reply attaches the PDF via a `MEDIA:` line — never a path-only reference, never a freshly-uploaded URL on a third-party host",
+        "The agent did NOT re-run Steps 2 through 7 of the timeline pipeline to produce the report — the surviving sighting tuples and per-clip VLM responses were reused from memory; for screenshots, the agent picked the highest-similarity sighting per sensor from the retained Step 3 results without issuing a new KNN call"
+      ]
+    }
+  ]
+}

--- a/skills/vios/SKILL.md
+++ b/skills/vios/SKILL.md
@@ -301,7 +301,30 @@ Note: `startTime` in the response reflects the actual segment boundary, which ma
 | `disableAudio` | No | Always pass `true` — VIOS does not support audio for files with B-frames; disabled by default to avoid failures |
 | `transcode` | No | `none` (default, fastest) or `full` (re-encode) |
 | `fullLength` | No | boolean; if true, snaps to full segment boundaries |
+| `blocking` | No | `true` waits until the rendered file is ready before returning the URL (useful with `configuration` overlays) |
+| `configuration` | No | URL-encoded JSON; enables server-side overlays (see below) |
 | `expiryMinutes` | No (URL only) | minutes until URL expires, default 10080 (7 days) |
+
+**Clip with bounding-box overlays** — pass a `configuration` JSON blob (nested under an `overlay` key) to have VST bake bboxes and object-ID labels into the returned video. Useful for disambiguating candidate objects visually.
+
+```bash
+curl -sG "http://<VST_ENDPOINT>/vst/api/v1/storage/file/<streamId>/url" \
+  --data-urlencode 'startTime=<startTime>' \
+  --data-urlencode 'endTime=<endTime>' \
+  --data-urlencode 'blocking=true' \
+  --data-urlencode 'disableAudio=true' \
+  --data-urlencode 'configuration={"overlay":{"bbox":{"showAll":false,"objectId":[38,97,41],"showObjId":true,"objIdTextColor":"white","objIdTextBGColor":"red"},"color":"red","thickness":6}}' \
+  | python3 -m json.tool
+```
+
+Fields (all nested under `overlay`):
+- `bbox.showAll` — `true` = all tracked objects, `false` = only `objectId` list
+- `bbox.objectId` — integer ids from `mdx-raw-*` / `mdx-behavior-*` or search results
+- `bbox.showObjId` — label each bbox with its object ID
+- `bbox.classType` (optional) — class allowlist, e.g. `["Person"]`
+- `color`, `thickness` — bbox style
+
+The same schema also works on `/live/stream/<id>/picture?configuration=...` and `/replay/stream/<id>/picture?configuration=...` for single-frame thumbnails with overlays.
 
 ---
 


### PR DESCRIPTION
## Description

Adds a new `timeline` skill that builds a cross-camera timeline for a person or object via embedding-based re-identification. Workflow: fusion search → user-confirmed candidate → seed behavior embedding → KNN cosine-similarity re-ID across `mdx-behavior-*` → clip retrieval via VST → per-clip VLM analysis → chronological sightings table. Default reply is just the sightings table; follow-ups (timeline summary, Gantt chart, PDF report, sub-clip extraction)
are opt-in.

Also lands two supporting changes:

- **`skills/AGENTS.md`** — cross-skill conventions for skills bridged to chat channels (Slack / Telegram / Discord). Documents the `MEDIA:` attachment convention and its working-directory requirement, the anti-pattern of uploading skill artifacts to a host to obtain a URL, table/link rendering rules, and a narration discipline that allows one short status line per user-facing moment but forbids multi-step play-by-play. Includes an install callout so users know to copy it to `~/.openclaw/AGENTS.md`.

- **`skills/vios/SKILL.md`** — bbox-overlay support on clip-URL retrieval (`configuration.overlay.bbox` with per-object `objectId` and `showObjId`), used by the timeline skill's Step 1 candidate confirmation overlay clip.

CI eval coverage: `skills/timeline/eval/timeline.json` with four scenarios (default flow, sub-clip extraction, Gantt chart, PDF report). 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.