### PR TITLE
Add LVS operations to video summarization skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,8 +265,46 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO sign-off
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          MERGE_BASE=$(git merge-base HEAD origin/${GITHUB_BASE_REF:-main} 2>/dev/null || echo HEAD~1)
+          BASE_REF="${GITHUB_BASE_REF:-}"
+          if [ -z "$BASE_REF" ] && [[ "${GITHUB_REF_NAME:-}" =~ ^pull-request/([0-9]+)$ ]]; then
+            PR_NUMBER="${BASH_REMATCH[1]}"
+            BASE_REF=$(PR_NUMBER="$PR_NUMBER" python3 - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          repo = os.environ.get("GITHUB_REPOSITORY")
+          token = os.environ.get("GITHUB_TOKEN")
+          pr_number = os.environ.get("PR_NUMBER")
+          if not repo or not token or not pr_number:
+              sys.exit(0)
+
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {token}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=10) as response:
+                  payload = json.load(response)
+          except Exception:
+              sys.exit(0)
+
+          print(payload.get("base", {}).get("ref", ""))
+          PY
+          )
+          fi
+
+          BASE_REF="${BASE_REF:-main}"
+          echo "Checking DCO sign-off against origin/${BASE_REF}"
+          MERGE_BASE=$(git merge-base HEAD "origin/${BASE_REF}" 2>/dev/null || echo HEAD~1)
           COMMITS=$(git rev-list "$MERGE_BASE"..HEAD 2>/dev/null || echo "")
           if [ -z "$COMMITS" ]; then
             echo "No new commits to check."

--- a/skills/video-summarization/SKILL.md
+++ b/skills/video-summarization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-summarization
-description: Summarize a video by calling the VLM NIM or the Long Video Summarization (LVS) microservice directly. For short videos (<60s) call the VLM's OpenAI-compatible chat completions endpoint; for long videos (>=60s) call the LVS microservice. Use when asked to summarize a video, describe what happens in a video, or analyze a recording.
+description: Summarize a video by calling the VLM NIM or the Long Video Summarization (LVS) microservice directly. For short videos (<60s) call the VLM's OpenAI-compatible chat completions endpoint; for long videos (>=60s) call the LVS microservice. Use when asked to summarize a video, describe what happens in a video, analyze a recording, call or debug LVS summarize/model/health/recommended-config/metrics endpoints, or configure and troubleshoot the LVS service that backs long-video summarization.
 version: "3.1.0"
 license: "Apache License 2.0"
 ---
@@ -8,7 +8,44 @@ license: "Apache License 2.0"
 You are a video summarization assistant. You call the VLM NIM or the LVS
 microservice **directly**. Always run `curl` commands yourself; never instruct the user to run them.
 
-Single query type: **"Summarize this video."**
+Primary video workflow query type: **"Summarize this video."** Direct LVS API
+and service-ops requests are handled by the reference-routed sections below.
+
+## Reference Map
+
+Use these references only when the user asks for the relevant detail, or when
+the core workflow below needs deeper LVS information:
+
+- **LVS API details**: [`references/lvs-api.md`](references/lvs-api.md) for
+  `/summarize`, `/v1/summarize`, health probes, `/models`,
+  `/recommended_config`, `/metrics`, request fields, response shapes, and API
+  gotchas.
+- **LVS service configuration and ops**:
+  [`references/deploy-lvs-service.md`](references/deploy-lvs-service.md) for
+  the LVS service compose profile, ports, required env vars, logs, status,
+  dry-runs, teardown, model/backend swaps, and service-level troubleshooting.
+- **Extended LVS ops references**:
+  [`references/lvs-environment-variables.md`](references/lvs-environment-variables.md),
+  [`references/lvs-debugging.md`](references/lvs-debugging.md), and
+  [`references/lvs.env.example`](references/lvs.env.example).
+
+Do not load these references for routine short-video VLM summaries. Load
+`lvs-api.md` for long-video LVS request details or direct LVS API requests.
+Load `deploy-lvs-service.md` only for deployment, configuration, or service
+operations.
+
+## LVS API And Service Ops Requests
+
+If the user asks to call or debug LVS endpoints directly, answer from
+[`references/lvs-api.md`](references/lvs-api.md) instead of running the
+end-to-end video summarization workflow. Examples: list LVS models, check
+readiness, get recommended chunking config, inspect metrics, explain a 422
+response, or build a `/summarize` request body.
+
+If the user asks to configure, deploy, restart, tear down, or troubleshoot the
+LVS service, prefer the `deploy` skill for full VSS profile deployment and use
+[`references/deploy-lvs-service.md`](references/deploy-lvs-service.md) for
+LVS-specific service details.
 
 ## Routing
 
@@ -29,9 +66,10 @@ into the response, before the summary):
 > produced by the VLM alone. Deploy the `lvs` profile for higher-quality
 > long-video summaries.
 
-## Deployment prerequisite
+## Deployment Prerequisite For Summarization
 
-This skill requires the VSS **lvs** profile running on the host at `$HOST_IP`. Before any request:
+The video summarization workflow requires the VSS **lvs** profile running on
+the host at `$HOST_IP`. Before any summarization request:
 
 1. Probe the LVS microservice:
    ```bash
@@ -54,6 +92,10 @@ This skill requires the VSS **lvs** profile running on the host at `$HOST_IP`. B
 
 3. If the probe passes, proceed.
 
+For LVS-specific service status, compose profile, ports, logs, or environment
+debugging, read [`references/deploy-lvs-service.md`](references/deploy-lvs-service.md).
+The `deploy` skill remains canonical for full VSS profile deployment.
+
 ---
 
 ## Setup
@@ -75,6 +117,9 @@ This skill requires the VSS **lvs** profile running on the host at `$HOST_IP`. B
 
 **Model name:** read `${VLM_NAME}` (default `nvidia/cosmos-reason2-8b`).
 Both VLM and LVS requests use the same model name.
+
+For full LVS endpoint schemas, optional request fields, response envelopes,
+and error handling, read [`references/lvs-api.md`](references/lvs-api.md).
 
 **Availability checks** (run both before routing):
 
@@ -242,6 +287,11 @@ are applied server-side; no client-side prep is required when you pass a
 ---
 
 ## Step 2b — Long video (>= 60s) → LVS microservice direct
+
+This section contains the narrow long-video summarization path. For advanced
+LVS fields such as `media_info`, `schema`, structured output, chunk overlap,
+live stream timestamps, metrics, or recommended config, read
+[`references/lvs-api.md`](references/lvs-api.md).
 
 ### HITL: collect scenario and events first (REQUIRED — do not skip)
 
@@ -515,3 +565,5 @@ output, not mixed into it.
 - **vios** (VIOS API) — upload videos, list streams, get clip URLs
 - **video-search** — semantic search across the archive (different profile)
 - **video-analytics** — query incidents/events from Elasticsearch
+- **LVS API reference** — [`references/lvs-api.md`](references/lvs-api.md)
+- **LVS service ops reference** — [`references/deploy-lvs-service.md`](references/deploy-lvs-service.md)

--- a/skills/video-summarization/eval/lvs_api_ops.json
+++ b/skills/video-summarization/eval/lvs_api_ops.json
@@ -1,0 +1,40 @@
+{
+  "skills": ["video-summarization"],
+  "profile": "lvs",
+  "prerequisite_deploy_mode": "remote-all",
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": ["remote-all"]
+      }
+    }
+  },
+  "env": "A full-remote deployed VSS lvs profile (deploy mode = `remote-all` - the agent LLM and LVS VLM dependencies are served by remote endpoints, no local NIMs). Run on one platform only: the LVS API surface tested here is independent of GPU model once the lvs profile is deployed. Required: LVS REST API reachable at http://localhost:38111, VSS Agent reachable at http://localhost:8000/docs, Docker available for non-destructive service status checks, and `jq` available for response validation. These checks intentionally avoid full video summarization because `skills/video-summarization/eval/lvs_profile_summarize.json` owns end-to-end summarization coverage.",
+  "expects": [
+    {
+      "query": "Using the `video-summarization` skill's LVS API reference, verify the running LVS service without summarizing a video: check readiness, list available models, request a recommended config for a 300-second video with a 60-second target response time and a 5-second target event duration, fetch metrics, and report the key results.",
+      "checks": [
+        "`curl -sf --max-time 15 http://localhost:38111/v1/ready` returns exit 0",
+        "`curl -sf --max-time 15 http://localhost:38111/models | jq -e '.data | length > 0'` returns exit 0",
+        "`curl -sf --max-time 15 -X POST http://localhost:38111/recommended_config -H 'Content-Type: application/json' -d '{\"video_length\":300,\"target_response_time\":60,\"usecase_event_duration\":5}' | jq -e '.chunk_size'` returns exit 0",
+        "`curl -sf --max-time 15 http://localhost:38111/metrics | grep -q .` returns exit 0",
+        "The agent reads or explicitly cites `references/lvs-api.md` when answering direct LVS API usage details.",
+        "The agent trajectory contains API calls to `/v1/ready`, `/models`, `/recommended_config`, and `/metrics` on port 38111.",
+        "The POST `/recommended_config` request body contains exactly the requested numeric values: video_length=300, target_response_time=60, and usecase_event_duration=5.",
+        "The agent does not call `/v1/summarize`, `/summarize`, or any VLM `/v1/chat/completions` endpoint for this query.",
+        "The final response reports LVS readiness, at least one model id, the recommended chunk size or text returned by `/recommended_config`, and that metrics were reachable."
+      ]
+    },
+    {
+      "query": "Using the `video-summarization` skill's LVS deployment reference, produce a non-destructive LVS deployment status report: identify the REST port, readiness endpoint, expected compose profile or container signal, whether the service is currently reachable, and where the detailed deployment runbook lives.",
+      "checks": [
+        "`curl -sf --max-time 15 http://localhost:38111/v1/ready` returns exit 0",
+        "The agent reads or explicitly cites `references/deploy-lvs-service.md` when answering deployment/status details.",
+        "The agent uses a non-destructive status probe such as `docker ps`, `docker compose ps`, `docker logs --tail`, or `curl` readiness checks.",
+        "The agent does not run destructive or state-changing deployment commands such as `docker compose down`, `docker stop`, `docker rm`, `docker compose up`, or `docker compose up --force-recreate`.",
+        "The final response identifies REST port 38111, readiness endpoint `/v1/ready`, and the `bp_developer_lvs_2d` compose profile or the `vss-lvs` / `lvs-server` service signal.",
+        "The final response points deployment, teardown, logs, or model/database swap details back to `references/deploy-lvs-service.md` rather than inventing a separate runbook path."
+      ]
+    }
+  ]
+}

--- a/skills/video-summarization/references/deploy-lvs-service.md
+++ b/skills/video-summarization/references/deploy-lvs-service.md
@@ -1,0 +1,492 @@
+# Deploy LVS Service - Long Video Summarization Blueprint
+
+## Contents
+
+- 1. Overview
+- 2. Related Skill Entry Point
+- 3. Prerequisites
+- 4. NGC / Registry Preflight
+- 5. Required Secrets & Credentials
+- 6. Required Volume Mounts
+- 7. Required Environment Variables
+- 8. GPU Selection & Hardware
+- 9. Port Map
+- 10. Models & Swap Guide
+- 11. Deploy
+- 12. Dry Run
+- 13. Verify Deployment
+- 14. Logs & Status
+- 15. Debugging Common Failures
+- 16. Upgrade & Rollback
+- 17. Tear Down
+- 18. Gotchas & Known Issues
+- 19. Discrepancies Between This Compose And The Public Docs
+- 20. References
+
+## 1. Overview
+
+> **Service**: `lvs-server` (container name `vss-lvs`)
+> **Image**: `nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f`
+> **Compose profile**: `bp_developer_lvs_2d` (required — nothing starts without it)
+> **Health endpoint**: `http://<HOST_IP>:${BACKEND_PORT:-38111}/v1/ready`
+> **Primary ports** (host network): `38111` REST API, `38112` MCP/SSE, `38113` frontend
+> **Hardware**: ≥1 NVIDIA GPU. VRAM ≤50 GB triggers `VLLM_GPU_MEMORY_UTILIZATION=0.7`
+> auto-tune in the entrypoint.
+
+LVS orchestrates VLM-based caption generation and LLM-based summarization over
+long videos, backed by Elasticsearch (default) or Milvus for event storage. This
+compose ships the **single `lvs-server` container** plus a catalog of 16
+`depends_on` NIM sidecar services (LLM + VLM), all declared `required: false`
+— they only start when **their own profiles** are also activated. In this
+blueprint you point LVS at pre-running external LLM/VLM NIMs via
+`LVS_LLM_BASE_URL` / `VLM_BASE_URL` or their `HOST_IP:<port>` equivalents.
+
+## 2. Related Skill Entry Point
+
+The `video-summarization` skill owns the user-facing summarization workflow.
+Its [`lvs-api.md`](lvs-api.md) reference owns direct LVS API usage: summarize
+calls, model listing, health probes, recommended config, and metrics. This
+reference only deploys, operates, and debugs the LVS service container.
+
+## 3. Prerequisites
+
+- Docker Engine ≥ 20.10 with Compose plugin (`docker compose version` to verify)
+- NVIDIA Container Toolkit installed and wired to the docker daemon
+  *(scaffolded — GPU is requested via `deploy.resources.reservations.devices`)*
+- ~20 GB free disk for the container image + more for model cache (depends on
+  whether you pre-mount `MODEL_ROOT_DIR`)
+- **Free host ports**: 38111, 38112, 38113 (compose uses `network_mode: host`,
+  so the container binds these directly — port remapping is NOT possible
+  without switching off host networking)
+- Outbound network access to `nvcr.io` (image pull) and whichever LLM/VLM NIM
+  endpoints you are pointing at
+- **External services already reachable**: Elasticsearch (or Milvus), an LLM
+  NIM, a VLM NIM — LVS does not provision these; this blueprint only runs the
+  summarization app itself
+- A **git checkout of `met-blueprints`** since the compose reads
+  `$MDX_SAMPLE_APPS_DIR/lvs/.env` and `$MDX_SAMPLE_APPS_DIR/lvs/configs/config.yaml`
+
+## 4. NGC / Registry Preflight
+
+> **(scaffolded by microservice-runbook-generator — not literally in your compose;
+> audit before following)** — inferred because the image namespace is
+> `nvcr.io/nvstaging/vss-core/...`.
+
+```bash
+# Get an NGC API key from https://ngc.nvidia.com/setup/api-key
+export NGC_API_KEY="nvapi-..."
+docker login nvcr.io -u '$oauthtoken' -p "$NGC_API_KEY"
+
+# Verify your key has pull access to the nvstaging org (this is a staging build —
+# most users need an internal NGC org; if you get "unauthorized" try the
+# public 3.1.0 tag from the docs instead, see Discrepancies in §19).
+docker pull nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f
+
+# Warm the image cache (the `lvs-server` image is the only one pulled by
+# this compose; sidecar LLM/VLM NIMs only pull if their profiles are on).
+docker compose --profile bp_developer_lvs_2d -f ~/met-blueprints/deployments/lvs/compose.yml pull
+```
+
+## 5. Required Secrets & Credentials
+
+See [`lvs.env.example`](lvs.env.example) for the full template. Never commit
+your populated `.env`.
+
+| Env var | Purpose | Where to get | Notes |
+|---|---|---|---|
+| `NGC_API_KEY` | Pull `nvcr.io/nvstaging/*` image | <https://ngc.nvidia.com/setup/api-key> | scaffolded — used for `docker login`, not passed into the container |
+| `NVIDIA_API_KEY` | LLM API key (fallback when `OPENAI_API_KEY` is unset) | <https://build.nvidia.com> | `nvapi-…`; effectively required — `LVS_LLM_API_KEY` chains `${OPENAI_API_KEY:-${NVIDIA_API_KEY}}` |
+| `OPENAI_API_KEY` | Preferred LLM / VLM API key | OpenAI or matching provider | If set, overrides `NVIDIA_API_KEY` for both LLM and VLM |
+| `VIA_VLM_API_KEY` | VLM API key (fallback if `OPENAI_API_KEY` unset) | your VLM provider | Defaults to the literal string `not-used` — only required when the VLM endpoint actually enforces auth |
+
+> The compose file itself does **not** contain any secret literals. One
+> plaintext-secret audit done.
+
+## 6. Required Volume Mounts
+
+Two bind mounts, both defined in `compose.yml` (`volumes:` block):
+
+| Source (host) | Target (container) | Purpose | Stateful? | `down -v` safe? |
+|---|---|---|---|---|
+| `$MDX_SAMPLE_APPS_DIR/lvs/configs/config.yaml` | `/app/config.yaml` (ro) | CA-RAG pipeline config (tools + summarization function) | no — read-only | yes (bind mount unaffected) |
+| `${MODEL_ROOT_DIR:-/tmp/model_cache}` | same path inside container | VLM weight download cache (identical mount on both sides — set `MODEL_PATH` inside this dir) | yes | yes (bind mount) |
+
+**Pre-create before first `up`:**
+
+```bash
+# 1) met-blueprints checkout must be present; set MDX_SAMPLE_APPS_DIR so the
+#    env_file and config.yaml mount resolve. The compose references
+#    $MDX_SAMPLE_APPS_DIR/lvs/.env AND $MDX_SAMPLE_APPS_DIR/lvs/configs/config.yaml
+export MDX_SAMPLE_APPS_DIR=~/met-blueprints/deployments
+ls "$MDX_SAMPLE_APPS_DIR/lvs/.env" "$MDX_SAMPLE_APPS_DIR/lvs/configs/config.yaml"
+
+# 2) Model cache on the host (bind-mount target). Keep off /tmp if you don't
+#    want it wiped on reboot.
+export MODEL_ROOT_DIR=/opt/models
+sudo mkdir -p "$MODEL_ROOT_DIR"
+sudo chown -R "$(id -u):$(id -g)" "$MODEL_ROOT_DIR"
+```
+
+> **Named-volume warning**: this compose declares no named volumes, only
+> bind mounts. `docker compose down -v` will not wipe `$MODEL_ROOT_DIR` —
+> but it also won't clean it, so you must delete the host path manually.
+
+## 7. Required Environment Variables
+
+All loaded via the `env_file: $MDX_SAMPLE_APPS_DIR/lvs/.env` reference. The
+compose's `environment:` block re-exports values under canonical names the
+container expects.
+
+| Var | Required | Default (compose) | Provenance | Notes |
+|---|---|---|---|---|
+| `MDX_SAMPLE_APPS_DIR` | **yes** (effectively) | — | from-compose | interpolated into `env_file` and volume `source`; unset → the compose resolves to literal `/lvs/...` and fails |
+| `CONTAINER_IMAGE` | no | `nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f` | from-compose | pin a different tag by setting in `.env` |
+| `GPU_DEVICES` | no | `0` | from-compose | comma-separated GPU device IDs (e.g. `"2,3"`) |
+| `HOST_IP` | **yes** (effectively) | — | from-compose | interpolated into `LLM_BASE_URL` and `VLM_BASE_URL` when those are not explicitly set |
+| `LVS_LLM_MODEL_NAME` | **yes** | — | from-compose + docs | docs example: `openai/gpt-oss-120b` or `meta/llama-3.1-70b-instruct` |
+| `LLM_BASE_URL` **or** (`HOST_IP` + `LLM_PORT`) | **yes** | — | from-compose | one or the other must resolve; LVS builds `LVS_LLM_BASE_URL` from `${LLM_BASE_URL:-http://${HOST_IP}:${LLM_PORT}}/v1` |
+| `VLM_BASE_URL` **or** (`HOST_IP` + `VLM_PORT`) | **yes** | — | from-compose | same pattern as LLM; LVS builds `VIA_VLM_ENDPOINT=${VLM_BASE_URL:-http://${HOST_IP}:${VLM_PORT}}/v1/` |
+| `NVIDIA_API_KEY` | **yes** (unless `OPENAI_API_KEY` set) | — | from-compose + docs | see §5 |
+| `LVS_DATABASE_BACKEND` | no | `elasticsearch_db` | from-compose | or `vector_db` for Milvus |
+| `ES_HOST` + `ES_PORT` | **yes** when `LVS_DATABASE_BACKEND=elasticsearch_db` | — | from-compose | docs default `ES_PORT=9202`; the sample `.env` in met-blueprints uses `9200` — see §19 Discrepancies |
+| `MILVUS_DB_HOST` + `MILVUS_DB_GRPC_PORT` | **yes** when `LVS_DATABASE_BACKEND=vector_db` | — | from-compose | default Milvus gRPC port `19530` |
+| `LVS_EMB_ENABLE` | **yes** | — | from-compose | set `false` to skip the embedding-NIM requirement entirely (simplest standalone setup); `true` requires the next three |
+| `LVS_EMB_MODEL_NAME` | required when `LVS_EMB_ENABLE=true` | — | from-compose | e.g. `nvidia/nv-embedqa-e5-v5` |
+| `LVS_EMB_BASE_URL` | required when `LVS_EMB_ENABLE=true` | — | from-compose | e.g. `http://${HOST_IP}:9232/v1` |
+
+See [`lvs-environment-variables.md`](lvs-environment-variables.md) for **optional / feature-flag** vars
+(OTEL, log level, RTVI-VLM integration, VLM input dimensions, audio/Riva,
+etc.) and the full docs ↔ compose alignment table.
+
+## 8. GPU Selection & Hardware
+
+The compose requests a single GPU slot via the modern `deploy.resources` API
+(it does **not** use the `runtime: nvidia` legacy flag). The specific device
+is bound by `GPU_DEVICES`:
+
+```yaml
+# from compose.yml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          device_ids: ['${GPU_DEVICES:-0}']
+          capabilities: [gpu]
+```
+
+Patterns:
+
+| Goal | Set in `.env` |
+|---|---|
+| Default GPU 0 | `GPU_DEVICES=0` (or leave unset) |
+| Specific GPU | `GPU_DEVICES=2` |
+| Multiple GPUs | `GPU_DEVICES=0,1` |
+| Pin by UUID | `GPU_DEVICES=GPU-abc123...` (from `nvidia-smi -L`) |
+
+The entrypoint (`start_via.sh`) auto-tunes `VLM_BATCH_SIZE` from detected VRAM:
+- ≤46 GB → batch 1–3
+- 46–80 GB → batch 2–16
+- \>80 GB → batch 16–128 (int4 path)
+
+Override with `VLM_BATCH_SIZE=<n>` in `.env` if you want a specific size.
+Override `VLLM_GPU_MEMORY_UTILIZATION` if you are co-tenanting another model.
+
+SM 10.x GPUs have an automatic `TRT_LLM_MODE=fp16` override in the entrypoint
+(int4_awq is skipped). SM 12.1 also sets `TRT_LLM_ATTN_BACKEND=FLASHINFER`.
+
+## 9. Port Map
+
+This compose uses **`network_mode: host`** — the container shares the host's
+network namespace and binds directly. The compose has no `ports:` block
+because host networking ignores it.
+
+| Port | Service | Notes |
+|---|---|---|
+| 38111 | REST API (`BACKEND_PORT`) | `curl http://<host-ip>:38111/v1/ready` |
+| 38112 | MCP server (`LVS_MCP_PORT`) | SSE transport at `/sse`; gated by `LVS_ENABLE_MCP=true` |
+| 38113 | Frontend (`FRONTEND_PORT`) | served directly from the backend |
+
+**Remapping** is NOT possible without switching off host networking. If you
+must co-deploy a second LVS on one host, change `BACKEND_PORT` /
+`LVS_MCP_PORT` / `FRONTEND_PORT` in `.env` so the two instances don't collide
+— *and* remove or change `container_name: vss-lvs` (see §19).
+
+Common co-tenant collisions: Elasticsearch (9200), Milvus (19530), NIM
+containers (most default to 8000 — unlikely to touch these 38xxx ports).
+
+## 10. Models & Swap Guide
+
+LVS is **client-only** for VLM/LLM: it calls remote OpenAI-compatible
+endpoints (LLM NIM, VLM NIM, or third-party APIs). It does NOT host the
+models itself — model weights that the docs reference (`Qwen3-VL-8B`, etc.)
+live in whatever NIM you point `VLM_BASE_URL` at.
+
+### LLM (summarization)
+
+- **Controlled by**: `LVS_LLM_MODEL_NAME`, `LVS_LLM_BASE_URL`, `LVS_LLM_API_KEY`
+- **Docs default**: `openai/gpt-oss-120b` via a co-deployed LLM NIM
+- **Swap example (external LLM NIM)**:
+  ```bash
+  echo 'LVS_LLM_MODEL_NAME=meta/llama-3.1-70b-instruct' >> .env
+  echo 'LLM_BASE_URL=http://llm-nim.internal:8002'      >> .env
+  echo 'NVIDIA_API_KEY=nvapi-...'                       >> .env
+  docker compose --profile bp_developer_lvs_2d up -d --force-recreate
+  ```
+- **Swap example (build.nvidia.com API)**:
+  ```bash
+  echo 'LVS_LLM_MODEL_NAME=meta/llama-3.1-70b-instruct' >> .env
+  echo 'LLM_BASE_URL=https://integrate.api.nvidia.com'  >> .env
+  echo 'NVIDIA_API_KEY=nvapi-...'                       >> .env
+  ```
+
+### VLM (frame captioning)
+
+- **Controlled by**: `VLM_BASE_URL` (or `HOST_IP`+`VLM_PORT`), `VIA_VLM_API_KEY`,
+  `VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME`, `VLM_MODEL_TO_USE`
+- **Docs default**: `Qwen3-VL-8B-Instruct` via a vLLM-compatible NIM
+  (docs default `VLM_MODEL_TO_USE=vllm-compatible`; the blueprint's sample
+  `.env` uses `openai-compat` — either works, both are remote endpoints)
+- **Swap to RTVI-VLM sidecar**:
+  ```bash
+  echo 'USE_RTVI_VLM=true'                              >> .env
+  echo 'RTVI_VLM_URL=http://rtvi-vlm.internal:9191'    >> .env
+  # optional: echo 'RTVI_VLM_URL_PASSTHROUGH=true'     >> .env
+  ```
+
+### Embedding model (optional)
+
+Gated by `LVS_EMB_ENABLE`. Set `false` to turn off embedding entirely; set
+`true` plus `LVS_EMB_MODEL_NAME` + `LVS_EMB_BASE_URL`.
+
+## 11. Deploy
+
+```bash
+# 1) Blueprints checkout must exist; export its deployments dir
+export MDX_SAMPLE_APPS_DIR=~/met-blueprints/deployments
+ls "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml"  # sanity-check
+
+# 2) Populate .env — use the example shipped with video-summarization as a
+#    starting point, OR edit met-blueprints/deployments/lvs/.env directly.
+export VIDEO_SUMMARIZATION_SKILL_DIR=/path/to/skills/video-summarization
+cp "$VIDEO_SUMMARIZATION_SKILL_DIR/references/lvs.env.example" "$MDX_SAMPLE_APPS_DIR/lvs/.env"
+$EDITOR "$MDX_SAMPLE_APPS_DIR/lvs/.env"    # fill every REQUIRED field
+
+# 3) Model cache bind mount (skip if you already have one)
+export MODEL_ROOT_DIR=/opt/models
+sudo mkdir -p "$MODEL_ROOT_DIR"
+sudo chown -R "$(id -u):$(id -g)" "$MODEL_ROOT_DIR"
+
+# 4) NGC login (image is on nvcr.io/nvstaging/...)
+docker login nvcr.io -u '$oauthtoken' -p "$NGC_API_KEY"
+
+# 5) Warm the image cache — the profile flag is REQUIRED or nothing resolves
+docker compose \
+  -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d \
+  pull
+
+# 6) Bring up. The healthcheck's start_period is 120s — expect up to ~2
+#    minutes before readiness, longer if the VLM NIM you point at is
+#    downloading weights.
+docker compose \
+  -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d \
+  up -d
+
+# 7) Wait for healthy
+until [ "$(docker compose -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" --profile bp_developer_lvs_2d ps --format json | jq -r '[.[].Health] | all(. == "healthy")')" = "true" ]; do
+  echo "waiting for health..."
+  sleep 5
+done
+
+# 8) Verify. Host networking → use the host's IP (or localhost).
+curl -f http://localhost:${BACKEND_PORT:-38111}/v1/ready
+```
+
+**Profiles in this compose** (only one is defined):
+
+| Profile | Enables |
+|---|---|
+| `bp_developer_lvs_2d` | `lvs-server` (the summarization container) |
+
+Every `docker compose` invocation below must include
+`--profile bp_developer_lvs_2d` or nothing matches.
+
+## 12. Dry Run
+
+```bash
+# Print the fully-resolved compose (env substitution applied, anchors
+# expanded) for human audit. Pass the profile or services disappear.
+docker compose \
+  -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d \
+  config
+
+# Exit-code-only validation
+docker compose \
+  -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d \
+  config --quiet && echo "compose is valid"
+
+# Create containers and check volume mounts, without starting them
+docker compose \
+  -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d \
+  up --no-start
+```
+
+## 13. Verify Deployment
+
+```bash
+# Health
+curl -f http://localhost:38111/v1/ready
+# Expected: 200 OK (body format not documented; service-readiness signal)
+
+# List available models (see lvs-api.md for endpoint details)
+curl -s http://localhost:38111/v1/models | jq
+
+# Primary path - summarize a test video (see the video-summarization skill for
+# the full summarize flow)
+```
+
+Healthy log signatures (grep `docker compose logs vss-lvs`):
+
+- `Starting VIA server in release mode`
+- `VIA Server loaded`
+- `Backend is running at http://0.0.0.0:38111`
+- `Auto-selecting VLM Batch Size to <N>` or `Using VLM Batch Size <N>`
+
+## 14. Logs & Status
+
+```bash
+# Snapshot
+docker compose -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d ps
+
+# Live tail (compose service name is lvs-server; container name is vss-lvs)
+docker compose -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d logs -f lvs-server
+# — or directly by container name, no profile flag needed:
+docker logs -f vss-lvs
+
+# History, bounded
+docker logs --tail 200 --since 10m vss-lvs
+
+# Resource usage
+docker stats vss-lvs
+```
+
+Log verbosity: set `VSS_LOG_LEVEL=DEBUG` (default in the sample `.env`),
+`INFO`, `WARN`, or `ERROR`. Logs inside the container live at
+`/tmp/via-logs/` (set `VIA_LOG_DIR` to redirect; nothing is bind-mounted, so
+they disappear on `down`).
+
+## 15. Debugging Common Failures
+
+See [`lvs-debugging.md`](lvs-debugging.md) for the long-form table. Quick reference:
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| `services.lvs-server: 'profiles' configured ... but nothing matched` | You forgot `--profile bp_developer_lvs_2d` | Add the flag to every `docker compose` call |
+| `invalid mount config for type "bind": bind source path does not exist: /lvs/.env` | `MDX_SAMPLE_APPS_DIR` unset | `export MDX_SAMPLE_APPS_DIR=~/met-blueprints/deployments` before compose runs |
+| `Exited (1)` immediately, logs say `unauthorized` | NGC login missing or no access to `nvstaging` org | `docker login nvcr.io`; if still blocked, this is a staging tag — try the public docs tag `nvcr.io/nvidia/vss-core/vss-long-video-summarization:3.1.0` (see §19 Discrepancies) |
+| `Exited (137)` (OOM) | VRAM exhausted | Lower `VLM_BATCH_SIZE`, lower `VLLM_GPU_MEMORY_UTILIZATION`, or set `GPU_DEVICES` to a larger GPU |
+| `bind: address already in use` for 38111/38112/38113 | Another process on host networking binds same port | Stop the other process or set `BACKEND_PORT` / `LVS_MCP_PORT` / `FRONTEND_PORT` in `.env` |
+| Healthcheck keeps failing past 120s `start_period` | Upstream LLM/VLM NIM unreachable; LVS blocks on first request | `curl` `LVS_LLM_BASE_URL/models` and the VLM endpoint from the host to verify; check `docker logs vss-lvs` for the exact HTTP error |
+| `could not select device driver "nvidia"` | NVIDIA Container Toolkit not installed / daemon not restarted | `sudo apt install nvidia-container-toolkit && sudo systemctl restart docker` |
+| API returns 503 "Another video is being processed" | LVS processes one video at a time | Wait, or scale by running a second LVS on a different host / different ports + container_name |
+| VLM returns incomplete JSON | Model couldn't satisfy schema | Simplify events list, increase frames-per-chunk, retry; docs' Known Issue |
+| MCP server unreachable | `LVS_ENABLE_MCP` not `true`, or port 38112 blocked | Check env; check host firewall |
+
+## 16. Upgrade & Rollback
+
+```bash
+# Bump image tag: edit CONTAINER_IMAGE in .env or export inline
+export CONTAINER_IMAGE=nvcr.io/nvstaging/vss-core/vss-video-summarization:<new-tag>
+
+docker compose -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d pull
+docker compose -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d up -d
+```
+
+**Rollback**: set `CONTAINER_IMAGE` back to the previous tag and re-run `pull`
++ `up -d --force-recreate`. The bind-mounted model cache at `MODEL_ROOT_DIR`
+survives — no re-download unless the new image needs a different model.
+
+## 17. Tear Down
+
+```bash
+# Stop + remove container; bind mounts (config.yaml, MODEL_ROOT_DIR) untouched
+docker compose -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d down
+
+# -v is a no-op here since the compose declares no named volumes. Bind mounts
+# are host-owned; delete them manually if you want to reclaim the space:
+# sudo rm -rf "$MODEL_ROOT_DIR"
+
+# Remove the pulled image too (optional)
+docker rmi nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f
+```
+
+> There are **no named volumes** in this compose, so `down -v` has no
+> destructive effect here. The only stateful data is whatever lives under
+> `$MODEL_ROOT_DIR` on the host.
+
+## 18. Gotchas & Known Issues
+
+- **`profiles: ["bp_developer_lvs_2d"]` on `lvs-server` (compose.yml:21)** —
+  plain `docker compose up` is a no-op. Every command must pass
+  `--profile bp_developer_lvs_2d`. *(from compose)*
+- **`container_name: vss-lvs` is hardcoded (compose.yml:19)** — you cannot
+  run two LVS instances on one host without editing the compose; the second
+  `up` fails with a name conflict. *(from compose)*
+- **`network_mode: host` on compose.yml:32** — port remapping via `ports:` is
+  impossible; change the `BACKEND_PORT` / `LVS_MCP_PORT` / `FRONTEND_PORT`
+  env vars to avoid host-port collisions instead. *(from compose)*
+- **16 × `depends_on` with `required: false` (compose.yml:102–150)** — all
+  the LLM/VLM NIM sidecars (`nvidia-nemotron-*`, `gpt-oss-*`, `qwen3-vl-*`,
+  `cosmos-reason*`, etc.) are defined in sibling blueprint composes. With
+  `required: false`, LVS starts even when those services aren't running or
+  their profiles aren't on — meaning the stack will happily come up
+  "healthy" (container process up) while the upstream LLM/VLM you configured
+  is down. Always verify the LLM endpoint independently. *(from compose)*
+- **`start_period: 120s`** — the healthcheck grace window. If the VLM/LLM
+  endpoint is slow to warm up on its end, LVS may still be unhealthy after
+  120s; that's expected, not a bug. *(from compose)*
+- **Single-video serialization** — VIA processes one video at a time; parallel
+  requests get HTTP 503. Docs' Known Issue. *(from docs)*
+- **Incomplete JSON from VLM** — simplify event lists, bump frames-per-chunk,
+  retry. Docs' Known Issue. *(from docs)*
+- **Entrypoint VRAM auto-tune** — if VRAM ≤50 GB, entrypoint forces
+  `VLLM_GPU_MEMORY_UTILIZATION=0.7` and a smaller `VLM_BATCH_SIZE`. Look for
+  the `Auto-selecting VLM Batch Size to <N>` log line. *(from entrypoint)*
+- **SM 10.x → fp16 override** — entrypoint skips int4_awq on Blackwell-class
+  GPUs and forces fp16, regardless of `TRT_LLM_MODE`. *(from entrypoint)*
+- **Docs ↔ compose drift** — compose uses `nvcr.io/nvstaging/...:3.2.0-rc1-...`
+  (staging RC build), while the public docs describe
+  `nvcr.io/nvidia/vss-core/vss-long-video-summarization:3.1.0`. The repo names
+  also differ (`vss-video-summarization` vs `vss-long-video-summarization`).
+  If you lack `nvstaging` org access, pin `CONTAINER_IMAGE` to the public
+  tag. See §19 Discrepancies.
+
+## 19. Discrepancies between this compose and the public docs
+
+| Field | Compose value | Docs value | Impact |
+|---|---|---|---|
+| Image registry + repo | `nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f` | `nvcr.io/nvidia/vss-core/vss-long-video-summarization:3.1.0` | Different NGC org + repo name. Users without `nvstaging` access will hit `unauthorized` — fall back to the public tag. |
+| `ES_PORT` default | no compose default; sample `.env` uses `9200` | `9202` | Align with whatever Elasticsearch you're pointing at. |
+| `ES_TRANSPORT_PORT` | sample `.env` uses `9300` | `9302` | Only matters if you run ES on the same host. |
+| `VLM_MODEL_TO_USE` default | `openai-compat` (sample `.env`) | `vllm-compatible` | Both are client-side selectors; match to what your VLM NIM actually is. |
+| AWS creds (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`) | not passed in compose `environment:` | listed in docs for S3 video URLs | Add to `.env` if you want S3-hosted inputs (they'll be picked up via `env_file`). |
+
+## 20. References
+
+- **Docs**: https://docs.nvidia.com/vss/latest/long-video-summarization.html
+- **Compose source**: `~/met-blueprints/deployments/lvs/compose.yml`
+- **Dockerfile source**: `~/long-video-summarization/docker/Dockerfile`
+- **Entrypoint source**: `~/long-video-summarization/start_via.sh`
+- **CA-RAG config sample**: `~/met-blueprints/deployments/lvs/configs/config.yaml`
+- **Sample `.env`**: `~/met-blueprints/deployments/lvs/.env`
+- Generated by the `microservice-runbook-generator` skill.

--- a/skills/video-summarization/references/lvs-api.md
+++ b/skills/video-summarization/references/lvs-api.md
@@ -1,0 +1,330 @@
+# LVS API Reference
+
+This reference documents the LVS 3.1.0 GA OpenAPI surface. Do not infer API fields or behaviors
+from newer branches, deployment runbooks, or implementation code unless the user explicitly asks
+to go beyond this OpenAPI spec.
+
+LVS provides video summarization and insight extraction endpoints. It accepts a summarization
+query, returns OpenAI-style completion objects, lists configured models, exposes health probes,
+returns Prometheus metrics, and recommends chunking parameters.
+
+## Setup
+
+The OpenAPI spec declares a relative server URL (`/`), so `BASE_URL` is deployment-specific.
+Confirm the deployed LVS host and port from the compose/Helm output, service runbook, or the
+operator before calling the API. Common deployments expose LVS on a host port such as `38111`,
+but some dev containers use `8000`.
+
+If an Agent's sandbox cannot reach `localhost:<port>`, do not assume LVS is down. The sandbox
+may have a different network view than the host. Confirm the port from the host/deployment
+context and retry from a host-visible shell or with the externally reachable host:port.
+
+```bash
+export BASE_URL="http://localhost:38111"
+export API_KEY="your-bearer-token"
+```
+
+The spec declares bearer auth globally. Use this header on calls:
+
+```bash
+-H "Authorization: Bearer $API_KEY"
+```
+
+## Quick Start
+
+List models, then summarize a video URL:
+
+```bash
+MODEL=$(curl -s "$BASE_URL/models" \
+  -H "Authorization: Bearer $API_KEY" | jq -r '.data[0].id')
+
+curl -s -X POST "$BASE_URL/v1/summarize" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"$MODEL\",
+    \"scenario\": \"warehouse\",
+    \"events\": [\"safety violation\", \"unauthorized access\"],
+    \"url\": \"https://www.example.com/video.mp4\",
+    \"prompt\": \"Write a concise summary with timestamps.\"
+  }" | jq '.choices[0].message.content'
+```
+
+## Endpoints
+
+### Health Check
+
+#### `GET /v1/live` - Liveness
+
+Get LVS liveness status.
+
+```bash
+curl -s "$BASE_URL/v1/live" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+#### `GET /v1/ready` - Readiness
+
+Get LVS readiness status.
+
+```bash
+curl -s "$BASE_URL/v1/ready" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+#### `GET /v1/startup` - Startup
+
+Get LVS startup status.
+
+```bash
+curl -s "$BASE_URL/v1/startup" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+#### `GET /v1/metadata` - Metadata
+
+Get LVS service metadata information.
+
+```bash
+curl -s "$BASE_URL/v1/metadata" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+### Models
+
+#### `GET /models` - List models
+
+Lists currently available models and basic model information.
+
+```bash
+curl -s "$BASE_URL/models" \
+  -H "Authorization: Bearer $API_KEY" \
+  | jq '.data[] | {id, created, object, owned_by, api_type}'
+```
+
+**Response (200) top-level fields:** `object`, `data`.
+
+Each model has: `id`, `created`, `object`, `owned_by`, `api_type`.
+
+### Summarization
+
+The spec exposes both `POST /v1/summarize` and `POST /summarize`; both use the same
+`SummarizationQuery` request schema and `CompletionResponse` response schema.
+
+#### `POST /v1/summarize` - Summarize a video
+
+Required request fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Model to use for this query, for example `cosmos-reason1`. |
+| `scenario` | string | Scenario or use-case context, for example `warehouse`, `retail`, or `security`. |
+| `events` | array[string] | Events to detect or extract from the video. Use `[]` if there are no target events. |
+
+Source-related optional fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | string or null | Video URL. Examples include `https://www.example.com/video.mp4` and `s3://bucket/video.mp4`. |
+| `id` | UUID string, array[UUID], or null | Unique ID or list of IDs of files or live streams to summarize. |
+| `media_info` | object | Segment selection. Use `{"type":"offset","start_offset":0,"end_offset":60}` for files or `{"type":"timestamp","start_timestamp":"2024-05-30T01:41:25.000Z","end_timestamp":"2024-05-30T02:14:51.000Z"}` for live streams. |
+
+Common optional fields from the OpenAPI schema:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `system_prompt` | string | `""` | System prompt for the VLM. The spec notes Cosmos Reason1 reasoning can be enabled by adding `<think></think>` and `<answer></answer>` tags. |
+| `prompt` | string | `""` | Prompt for summary generation. |
+| `max_tokens` | integer | - | Maximum tokens to generate in a call. |
+| `temperature` | number | - | Sampling temperature, range 0 to 1. |
+| `top_p` | number | - | Top-p sampling mass, range 0 to 1. |
+| `top_k` | number | - | Number of highest probability vocabulary tokens to keep, range 1 to 1000. |
+| `seed` | integer | - | Seed value. |
+| `chunk_duration` | integer | `0` | Chunk videos into this many seconds. `0` means no chunking. |
+| `chunk_overlap_duration` | integer | `0` | Overlap between chunks in seconds. `0` means no overlap. |
+| `summary_duration` | integer | `0` | Summarize every N seconds of video. Spec says applicable to live streams only. |
+| `num_frames_per_chunk` | integer | `0` | Number of frames per chunk to use for the VLM. |
+| `vlm_input_width` | integer | `0` | VLM input width. |
+| `vlm_input_height` | integer | `0` | VLM input height. |
+| `custom_metadata` | object | - | Key-value metadata. Spec says supported only with user-managed Milvus DB collections. |
+| `delete_external_collection` | boolean | `false` | Delete the external collection at the end of the summarization request. |
+| `schema` | string | - | JSON schema string for structured output extraction. |
+| `batch_response_method` | string | - | Batch response method. Examples: `json_schema`, `text`. |
+| `auto_generate_prompt` | boolean | - | Generate a prompt from schema and events. |
+| `override_vlm_prompt` | boolean | `false` | Override the VLM prompt with the supplied prompt. |
+| `enable_vlm_structured_output` | boolean | `true` | Enable VLM structured output. |
+| `objects_of_interest` | array[string] | `[]` | Objects to detect or extract from the video. |
+| `min_tokens` | integer or null | - | Minimum tokens to generate. Used with `ignore_eos` for benchmarking. |
+| `ignore_eos` | boolean or null | - | Ignore EOS and continue until `max_tokens`; useful for fixed-output benchmarking. |
+
+Basic URL request:
+
+```bash
+curl -s -X POST "$BASE_URL/v1/summarize" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "cosmos-reason1",
+    "scenario": "security",
+    "events": ["intrusion", "loitering"],
+    "url": "https://www.example.com/video.mp4",
+    "chunk_duration": 60,
+    "chunk_overlap_duration": 10,
+    "prompt": "Summarize the video and call out any target events."
+  }'
+```
+
+Structured extraction request:
+
+```bash
+SCHEMA='{"type":"object","properties":{"events":{"type":"array","items":{"type":"object","properties":{"timestamp":{"type":"string"},"event_type":{"type":"string"},"description":{"type":"string"}}}}}}'
+
+curl -s -X POST "$BASE_URL/v1/summarize" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n \
+    --arg model "cosmos-reason1" \
+    --arg scenario "warehouse" \
+    --argjson events '["safety violation","forklift near person"]' \
+    --arg url "https://www.example.com/warehouse.mp4" \
+    --arg schema "$SCHEMA" \
+    '{
+      model: $model,
+      scenario: $scenario,
+      events: $events,
+      url: $url,
+      schema: $schema,
+      auto_generate_prompt: true,
+      enable_vlm_structured_output: true
+    }')"
+```
+
+**Response (200) top-level fields:** `id`, `video_id`, `choices`, `created`, `model`,
+`media_info`, `object`, `usage`.
+
+`choices[].message` has `content`, `tool_calls`, and `role`. Tool calls use type `alert`
+and include alert fields such as `name`, `detectedEvents`, `details`, plus `offset` for
+files or `ntpTimestamp` for live streams.
+
+#### `POST /summarize` - Summarize a video
+
+Legacy or unversioned route with the same schema as `/v1/summarize`.
+
+```bash
+curl -s -X POST "$BASE_URL/summarize" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "cosmos-reason1",
+    "scenario": "retail",
+    "events": ["theft"],
+    "url": "https://www.example.com/store.mp4"
+  }'
+```
+
+### Recommended Config
+
+#### `POST /recommended_config` - Recommend chunking parameters
+
+The `RecommendedConfig` schema has no required fields, but it defines these optional fields:
+
+| Field | Type | Range | Description |
+|-------|------|-------|-------------|
+| `video_length` | integer | 1 to 864000000 | Video length in seconds. |
+| `target_response_time` | integer | 1 to 86400 | Target LVS response time in seconds. |
+| `usecase_event_duration` | integer | 1 to 86400 | Duration of the target event, for example how long a box-falling event takes. |
+
+```bash
+curl -s -X POST "$BASE_URL/recommended_config" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "video_length": 300,
+    "target_response_time": 60,
+    "usecase_event_duration": 5
+  }'
+```
+
+**Response (200) top-level fields:** `chunk_size`, `text`.
+
+### Metrics
+
+#### `GET /metrics` - Prometheus metrics
+
+Get LVS metrics in Prometheus format.
+
+```bash
+curl -s "$BASE_URL/metrics" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+## Common Workflows
+
+### Summarize A Video With The First Available Model
+
+```bash
+until curl -sf "$BASE_URL/v1/ready" -H "Authorization: Bearer $API_KEY" >/dev/null; do
+  sleep 5
+done
+
+MODEL=$(curl -s "$BASE_URL/models" \
+  -H "Authorization: Bearer $API_KEY" | jq -r '.data[0].id')
+
+curl -s -X POST "$BASE_URL/v1/summarize" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"$MODEL\",
+    \"scenario\": \"security\",
+    \"events\": [\"intrusion\", \"fighting\"],
+    \"url\": \"https://www.example.com/security.mp4\",
+    \"chunk_duration\": 60
+  }" | jq '{video_id, model, content: .choices[0].message.content}'
+```
+
+### Ask For A Recommended Chunk Size Then Summarize
+
+```bash
+CHUNK=$(curl -s -X POST "$BASE_URL/recommended_config" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"video_length": 600, "target_response_time": 120, "usecase_event_duration": 5}' \
+  | jq -r '.chunk_size')
+
+curl -s -X POST "$BASE_URL/v1/summarize" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"cosmos-reason1\",
+    \"scenario\": \"warehouse\",
+    \"events\": [\"safety violation\"],
+    \"url\": \"https://www.example.com/warehouse.mp4\",
+    \"chunk_duration\": $CHUNK
+  }"
+```
+
+## Error Reference
+
+| Code | Spec description | Common API cause |
+|------|------------------|------------------|
+| 400 | Bad Request | Invalid syntax or bad request body. |
+| 401 | Unauthorized request | Missing or invalid bearer token. |
+| 422 | Failed to process request | Schema validation failure, including extra fields where schemas set `additionalProperties: false`. |
+| 429 | Rate limiting exceeded | Too many requests for the service limits. |
+| 500 | Internal Server Error | Server-side LVS processing failure. |
+| 503 | Server is busy processing another file / live-stream | Summarize endpoint is busy; try again later. |
+
+## Gotchas
+
+- **Only OpenAPI fields are valid here** - do not add fields absent from `SummarizationQuery`.
+- **`model`, `scenario`, and `events` are required** - the schema requires all three for both
+  `/v1/summarize` and `/summarize`.
+- **Most request/response schemas set `additionalProperties: false`** - extra fields are schema
+  violations and can produce 422 responses.
+- **`schema` is a string** - pass a JSON schema serialized as a string, not a nested JSON object.
+- **`enable_vlm_structured_output` defaults to `true`** - set it explicitly only when you want to
+  override the default.
+- **`chunk_duration: 0` means no chunking** and `chunk_overlap_duration: 0` means no overlap.
+- **`summary_duration` is for live streams** according to the field description.
+- **`media_info` has two shapes** - use `type: "offset"` with second offsets for files and
+  `type: "timestamp"` with ISO timestamp strings for live streams.

--- a/skills/video-summarization/references/lvs-debugging.md
+++ b/skills/video-summarization/references/lvs-debugging.md
@@ -1,0 +1,218 @@
+# LVS Debugging — Long-form Reference
+
+`deploy-lvs-service.md` §15 has the short table. This reference expands each row.
+
+## "Nothing happens" on `docker compose up`
+
+**Symptom**: `docker compose up -d` succeeds but `docker ps` shows no container;
+`docker compose ps` reports zero services.
+
+**Root cause**: The LVS blueprint compose puts `lvs-server` under
+`profiles: ["bp_developer_lvs_2d"]`. Without `--profile bp_developer_lvs_2d`,
+compose treats the service as profile-gated and skips it.
+
+**Fix**:
+```bash
+docker compose \
+  -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d \
+  up -d
+```
+
+Add the flag to every `config`, `pull`, `up`, `down`, `logs`, and `ps`
+invocation. A shell function is convenient:
+```bash
+dcl() {
+  docker compose \
+    -f "${MDX_SAMPLE_APPS_DIR}/lvs/compose.yml" \
+    --profile bp_developer_lvs_2d \
+    "$@"
+}
+dcl up -d && dcl logs -f lvs-server
+```
+
+## `bind source path does not exist: /lvs/.env`
+
+**Symptom**: compose fails with a bind-mount error referencing a literal
+path that starts with `/lvs/...`.
+
+**Root cause**: `MDX_SAMPLE_APPS_DIR` is unset, so compose interpolates the
+variable into an empty string and the `env_file` / volume `source` paths
+collapse to `/lvs/.env` etc.
+
+**Fix**:
+```bash
+export MDX_SAMPLE_APPS_DIR=~/met-blueprints/deployments
+ls "$MDX_SAMPLE_APPS_DIR/lvs/.env" "$MDX_SAMPLE_APPS_DIR/lvs/configs/config.yaml"
+```
+
+You can also set it in your shell rc / systemd unit so it persists across
+terminals.
+
+## `docker: Error response from daemon: unauthorized`
+
+**Symptom**: `docker compose pull` or first `up` fails with an NGC auth error
+on the `nvcr.io/nvstaging/vss-core/vss-video-summarization` image.
+
+**Root cause options**:
+
+1. No `docker login nvcr.io` performed.
+2. Your NGC API key doesn't have access to the `nvstaging` org — this tag is
+   a staging / release-candidate build, often gated to internal users.
+
+**Fix 1 (auth)**:
+```bash
+docker login nvcr.io -u '$oauthtoken' -p "$NGC_API_KEY"
+```
+
+**Fix 2 (pin a public tag instead)**:
+```bash
+echo 'CONTAINER_IMAGE=nvcr.io/nvidia/vss-core/vss-long-video-summarization:3.1.0' \
+  >> "$MDX_SAMPLE_APPS_DIR/lvs/.env"
+```
+
+The `3.1.0` tag has different behavior from the `3.2.0-rc1` build — some
+env vars (e.g. `USE_RTVI_VLM`) may not be wired up. Consult the public docs.
+
+## Container exits immediately (`Exited (1)`)
+
+**Diagnose**:
+```bash
+docker logs --tail 200 vss-lvs
+```
+
+Look for the specific line that preceded the exit:
+
+| Log line | Meaning | Fix |
+|---|---|---|
+| `Error: No GPUs were found` | `nvidia-smi` returns no devices inside container | Install / reinstall NVIDIA Container Toolkit; restart docker daemon; verify `docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi` works |
+| `Error: annoy is not installed in the image` | Wrong image (some baseline without `annoy`) | Verify `CONTAINER_IMAGE` matches an LVS release |
+| `Please set BACKEND_PORT env variable` | `BACKEND_PORT` unset | Set in `.env` (default `38111`) |
+| FastAPI startup error re: database connection | ES/Milvus unreachable | `curl $ES_HOST:$ES_PORT` from host; fix network or point at a live backend |
+| pydantic / OpenAI SDK error re: `api_key` | `LVS_LLM_API_KEY` resolves to empty | Set `NVIDIA_API_KEY` or `OPENAI_API_KEY` in `.env` |
+
+## OOM (`Exited (137)` or `OOMKilled: true`)
+
+```bash
+docker inspect vss-lvs | grep -A2 OOMKilled
+nvidia-smi
+```
+
+**Fixes** (in escalating order):
+
+1. Lower `VLM_BATCH_SIZE` in `.env` — start with `1` or `2` on ≤48 GB cards.
+2. Lower `VLLM_GPU_MEMORY_UTILIZATION` (e.g. `0.5`).
+3. Lower `VLM_INPUT_WIDTH` / `VLM_INPUT_HEIGHT`.
+4. Increase `VLM_DEFAULT_NUM_FRAMES_PER_CHUNK` to reduce parallel calls.
+5. Pin to a larger GPU: `GPU_DEVICES=<idx>`.
+
+Remember: this LVS container does NOT host the VLM — the OOM might be on the
+**upstream VLM NIM's** GPU, not this one. Check `nvidia-smi` on whichever
+host runs the NIM.
+
+## Port already in use
+
+**Symptom**: `bind: address already in use` for 38111 / 38112 / 38113.
+
+**Why port-remapping won't help here**: the compose uses `network_mode:
+host`, which ignores any `ports:` mapping. You must change the app's own
+listening port.
+
+**Fix**:
+```bash
+# Pick new free ports
+cat >> "$MDX_SAMPLE_APPS_DIR/lvs/.env" <<EOF
+BACKEND_PORT=48111
+LVS_MCP_PORT=48112
+FRONTEND_PORT=48113
+EOF
+docker compose -f "$MDX_SAMPLE_APPS_DIR/lvs/compose.yml" \
+  --profile bp_developer_lvs_2d up -d --force-recreate
+```
+
+Then probe the new port: `curl http://localhost:48111/v1/ready`.
+
+## Healthcheck failing past the 120 s grace period
+
+The healthcheck is `curl -f http://localhost:$BACKEND_PORT/v1/ready`. If it
+still fails after `start_period: 120s`:
+
+1. Is the process up? `docker exec vss-lvs ps aux | head`
+2. Is it listening on the expected port?
+   `docker exec vss-lvs ss -tnlp | grep 381`
+3. Does `curl -v http://localhost:38111/v1/ready` work from the **host**?
+4. Check for upstream failure — the `/v1/ready` endpoint returns not-ready
+   if a declared LLM/VLM is unreachable:
+   ```bash
+   docker logs vss-lvs | grep -Ei "llm|vlm|endpoint|unreachable|connect"
+   ```
+
+Common upstream causes:
+- LLM NIM down: `curl $LLM_BASE_URL/v1/models`
+- VLM NIM down: `curl $VLM_BASE_URL/v1/models`
+- Firewall between LVS host and NIM host
+- `HOST_IP` misconfigured (e.g. set to a docker-bridge IP not reachable from
+  inside host-networked LVS)
+
+## `could not select device driver "nvidia" with capabilities: [[gpu]]`
+
+Missing NVIDIA Container Toolkit.
+```bash
+# Ubuntu
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt update && sudo apt install -y nvidia-container-toolkit
+sudo systemctl restart docker
+```
+
+## 503 "Another video is being processed"
+
+By design: VIA processes one video at a time. Options:
+
+- Poll `/v1/files` + `/v1/summarize` and serialize from the client.
+- Run a second LVS instance on another host (not another container on the
+  same host — `container_name: vss-lvs` is hardcoded).
+
+## Incomplete JSON from VLM
+
+Docs' Known Issue. The VLM sometimes fails to satisfy the CA-RAG schema's
+`events[]` requirements.
+
+Tunables in `$MDX_SAMPLE_APPS_DIR/lvs/configs/config.yaml`:
+- `functions.summarization_using_llm.events` — simpler list → fewer failures
+- `functions.summarization_using_llm.prompts.caption` — more explicit prompt
+- Increase `VLM_DEFAULT_NUM_FRAMES_PER_CHUNK`
+- Retry failed chunks at the client level
+
+## MCP server unreachable
+
+```bash
+# Is the env flag on?
+docker exec vss-lvs env | grep -E 'LVS_ENABLE_MCP|LVS_MCP_PORT'
+
+# Is the port listening?
+curl -I http://localhost:38112/sse
+
+# If not, check logs for mcp startup
+docker logs vss-lvs | grep -i mcp
+```
+
+Make sure any host firewall allows 38112.
+
+## Stale logs from a previous run polluting diagnostics
+
+The entrypoint clears `$VIA_LOG_DIR/*` on startup if `VIA_LOG_DIR` is set and
+exists. If you're not bind-mounting logs and want to preserve them across
+recreates, set `VIA_LOG_DIR=/var/log/via` and mount that path.
+
+## Fast-path: "is LVS up and serving"?
+
+```bash
+docker ps --filter name=vss-lvs --format '{{.Status}}' && \
+  curl -fsSL http://localhost:${BACKEND_PORT:-38111}/v1/ready && \
+  echo "LVS is ready"
+```

--- a/skills/video-summarization/references/lvs-environment-variables.md
+++ b/skills/video-summarization/references/lvs-environment-variables.md
@@ -1,0 +1,143 @@
+# LVS Environment Variables — Full Reference
+
+Canonical spelling: as declared in the `environment:` block of
+`met-blueprints/deployments/lvs/compose.yml`. Values that start with `${VAR}`
+come from the `env_file` (`$MDX_SAMPLE_APPS_DIR/lvs/.env`). Variables NOT in
+this table are either scaffolded or consumed only by the entrypoint script
+(`start_via.sh`) or the docs.
+
+## Required / Effectively Required
+
+Covered in `deploy-lvs-service.md` §7. TL;DR:
+
+- `MDX_SAMPLE_APPS_DIR`
+- `HOST_IP` (plus `LLM_PORT`, `VLM_PORT` unless you pass `LLM_BASE_URL` /
+  `VLM_BASE_URL` directly)
+- `LVS_LLM_MODEL_NAME`
+- `NVIDIA_API_KEY` (or `OPENAI_API_KEY`)
+- `ES_HOST` + `ES_PORT` (for `elasticsearch_db`) **or**
+  `MILVUS_DB_HOST` + `MILVUS_DB_GRPC_PORT` (for `vector_db`)
+- `LVS_EMB_ENABLE` — if `true`, also `LVS_EMB_MODEL_NAME` + `LVS_EMB_BASE_URL`
+
+## Core configuration
+
+| Var | Default | Purpose |
+|---|---|---|
+| `CONTAINER_IMAGE` | `nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f` | image pinning |
+| `CA_RAG_CONFIG` | `/app/config.yaml` (set in compose) | path to mounted CA-RAG config inside container |
+| `BACKEND_PORT` | `38111` | REST API port (host network) |
+| `LVS_MCP_PORT` | `38112` | MCP SSE port |
+| `FRONTEND_PORT` | `38113` | UI port |
+| `LVS_ENABLE_MCP` | `true` (sample `.env`) | toggle MCP server |
+| `LVS_DATABASE_BACKEND` | `elasticsearch_db` | or `vector_db` |
+
+## LLM / VLM / embeddings
+
+| Var | Default | Purpose |
+|---|---|---|
+| `LVS_LLM_MODEL_NAME` | — | summarization LLM model ID |
+| `LVS_LLM_BASE_URL` | built from `${LLM_BASE_URL:-http://${HOST_IP}:${LLM_PORT}}/v1` | LLM endpoint |
+| `LVS_LLM_API_KEY` | `${OPENAI_API_KEY:-${NVIDIA_API_KEY}}` | LLM auth |
+| `VIA_VLM_ENDPOINT` | `${VLM_BASE_URL:-http://${HOST_IP}:${VLM_PORT}}/v1/` | VLM endpoint |
+| `VIA_VLM_API_KEY` | `${OPENAI_API_KEY:-${VIA_VLM_API_KEY:-not-used}}` | VLM auth; literal `not-used` if neither is set |
+| `VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME` | `gpt-4o` (entrypoint default) | VLM model name sent in API requests |
+| `VLM_MODEL_TO_USE` | `openai-compat` (sample `.env`) / `vllm-compatible` (docs default) | VLM backend type |
+| `LVS_EMB_ENABLE` | (required) | toggle embedding generation |
+| `LVS_EMB_MODEL_NAME` | — | embedding model ID |
+| `LVS_EMB_BASE_URL` | — | embedding endpoint |
+
+## VLM runtime tuning
+
+| Var | Default | Purpose |
+|---|---|---|
+| `VLM_INPUT_WIDTH` | `1312` | VLM input frame width |
+| `VLM_INPUT_HEIGHT` | `736` | VLM input frame height |
+| `VLM_BATCH_SIZE` | auto (entrypoint) | override to pin batch size |
+| `VLLM_GPU_MEMORY_UTILIZATION` | `0.85` docs / `0.7` auto-set by entrypoint when VRAM ≤50 GB | vLLM VRAM fraction |
+| `NUM_VLM_PROCS` | `16` (entrypoint default for openai-compat) | parallel VLM request workers |
+| `VLM_DEFAULT_NUM_FRAMES_PER_CHUNK` | entrypoint passes to `--num-frames-per-chunk` | frames per VLM call |
+| `TRT_LLM_MODE` | `int4_awq` / forced `fp16` on SM 10.x | quantization mode |
+| `TRT_LLM_ATTN_BACKEND` | auto-`FLASHINFER` on SM 12.1 | attention backend |
+
+## RTVI-VLM integration
+
+| Var | Default | Purpose |
+|---|---|---|
+| `USE_RTVI_VLM` | `false` | route VLM calls to an RTVI sidecar's `/generate_captions` |
+| `RTVI_VLM_URL` | empty | RTVI endpoint base URL |
+| `RTVI_VLM_URL_PASSTHROUGH` | `false` | pass request through without rewrite |
+
+## Database / storage
+
+| Var | Default | Purpose |
+|---|---|---|
+| `ES_HOST` | (required when `elasticsearch_db`) | Elasticsearch host |
+| `ES_PORT` | `9202` (docs), `9200` (sample `.env`) | Elasticsearch HTTP port |
+| `ES_TRANSPORT_PORT` | `9302` (docs), `9300` (sample `.env`) | ES transport port |
+| `MILVUS_DB_HOST` | (required when `vector_db`) | Milvus host |
+| `MILVUS_DB_GRPC_PORT` | `19530` | Milvus gRPC |
+| `MODEL_ROOT_DIR` | `/tmp/model_cache` | bind-mount target + `NGC_MODEL_CACHE` |
+| `NGC_MODEL_CACHE` | `${MODEL_ROOT_DIR}` | NGC model download dir |
+| `LVS_DISABLE_DB_RESET_ON_REQUEST_DONE` | `true` | keep events in ES after request completes |
+| `ASSET_STORAGE_DIR` | `/tmp/assets` (entrypoint default) | uploaded asset dir inside container |
+| `MAX_ASSET_STORAGE_SIZE_GB` | unset | cap asset dir size |
+
+## Pipeline toggles
+
+| Var | Default | Purpose |
+|---|---|---|
+| `DISABLE_GUARDRAILS` | `true` (sample `.env`) | disable NeMo Guardrails filter |
+| `DISABLE_CA_RAG` | `false` (entrypoint) | disable the CA-RAG aggregation step |
+| `DISABLE_CV_PIPELINE` | `true` (entrypoint) | disable DeepStream + GSAM CV pipeline |
+| `ENABLE_AUDIO` | unset (disabled) | enable Riva ASR audio transcription |
+| `ENABLE_VIA_HEALTH_EVAL` | `false` | health-eval module toggle |
+| `INSTALL_PROPRIETARY_CODECS` | unset | install extra codecs at container start |
+| `APPLY_GSTREAMER_RTSP_FIX` | unset | patch gstreamer RTSP manager |
+
+## Audio / Riva ASR (only when `ENABLE_AUDIO=true`)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `RIVA_ASR_SERVER_URI` | — | Riva ASR host |
+| `RIVA_ASR_GRPC_PORT` | — | Riva gRPC port |
+| `RIVA_ASR_HTTP_PORT` | — | Riva HTTP port (for readiness probe) |
+| `RIVA_ASR_SERVER_IS_NIM` | — | set `true` for NIM-hosted Riva |
+| `RIVA_ASR_MODEL_NAME` | — | Riva model name |
+| `RIVA_ASR_SERVER_USE_SSL` | — | enable TLS |
+| `RIVA_ASR_SERVER_FUNC_ID` | — | NIM function ID |
+| `RIVA_ASR_SERVER_API_KEY` | — | bearer token |
+| `ENABLE_RIVA_SERVER_READINESS_CHECK` | unset | block entrypoint until Riva ready |
+
+## Observability (OpenTelemetry)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `VIA_ENABLE_OTEL` | `false` | enable OTEL for VIA engine |
+| `VIA_OTEL_ENDPOINT` | `http://localhost:4318` | OTEL collector |
+| `VIA_OTEL_EXPORTER` | `console` | exporter format |
+| `VIA_CTX_RAG_ENABLE_OTEL` | `false` | enable OTEL for CA-RAG layer |
+| `VIA_CTX_RAG_EXPORTER` | `console` | CA-RAG exporter format |
+| `VIA_CTX_RAG_OTEL_ENDPOINT` | `http://localhost:4318` | CA-RAG OTEL collector |
+
+## S3 / object storage (docs-mentioned, NOT passed by this compose)
+
+Add to `$MDX_SAMPLE_APPS_DIR/lvs/.env` if you need S3-hosted video URLs — the
+`env_file` reference picks them up automatically.
+
+| Var | Purpose |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | S3 access key |
+| `AWS_SECRET_ACCESS_KEY` | S3 secret |
+| `AWS_ENDPOINT_URL_S3` | S3 endpoint (for MinIO etc.) |
+
+## Logging & misc
+
+| Var | Default | Purpose |
+|---|---|---|
+| `VSS_LOG_LEVEL` | `DEBUG` (sample `.env`) | `DEBUG`/`INFO`/`WARN`/`ERROR` |
+| `VIA_LOG_DIR` | `/tmp/via-logs/` | log output directory inside container |
+| `MODE` | `release` | `release` runs packaged code; `dev` runs from `src/` |
+| `VSS_EXTRA_ARGS` | unset | appended to `via_server.py` command line |
+| `TRT_ENGINE_PATH` | unset | pre-built TRT engine dir |
+| `MODEL_PATH` | `/opt/models/...` (entrypoint default) | VLM weight path for non-openai-compat backends |
+| `ENABLE_NSYS_PROFILER` | `false` | wrap server in `nsys profile` |

--- a/skills/video-summarization/references/lvs.env.example
+++ b/skills/video-summarization/references/lvs.env.example
@@ -1,0 +1,105 @@
+# LVS deployment — .env.example
+#
+# Target: ~/met-blueprints/deployments/lvs/.env
+# (the compose's env_file reference is $MDX_SAMPLE_APPS_DIR/lvs/.env)
+#
+# Fill every REQUIRED value. See deploy-lvs-service.md §7 for full semantics.
+
+# ---- Effectively required host-shell vars (set in your shell, not here) ----
+# export MDX_SAMPLE_APPS_DIR=~/met-blueprints/deployments
+# export HOST_IP=$(hostname -I | awk '{print $1}')
+
+# ---- Container image (override if you lack nvstaging access) -------------
+# Default compose pin: nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f
+# Public fallback:     nvcr.io/nvidia/vss-core/vss-long-video-summarization:3.1.0
+CONTAINER_IMAGE=nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f
+
+# ---- Secrets (REQUIRED) --------------------------------------------------
+# Used to pull images from nvcr.io (docker login step only — not passed into the container).
+# NGC_API_KEY=nvapi-REPLACE_ME
+
+# LLM + VLM auth. At least ONE of NVIDIA_API_KEY / OPENAI_API_KEY must be set.
+# NVIDIA_API_KEY=nvapi-REPLACE_ME
+# OPENAI_API_KEY=sk-REPLACE_ME
+
+# VLM auth override (only if your VLM endpoint enforces auth and differs from the LLM)
+# VIA_VLM_API_KEY=REPLACE_ME
+
+# ---- Ports (host-network mode — these bind directly on the host) --------
+BACKEND_PORT=38111
+LVS_MCP_PORT=38112
+FRONTEND_PORT=38113
+LVS_ENABLE_MCP=true
+
+# ---- GPU selection ------------------------------------------------------
+# Comma-separated device IDs. "0" for first GPU, "0,1" for first two.
+GPU_DEVICES=0
+NUM_GPUS=1
+
+# ---- Database backend (pick ONE) ----------------------------------------
+# Default: Elasticsearch.
+LVS_DATABASE_BACKEND=elasticsearch_db
+
+# Elasticsearch — required when LVS_DATABASE_BACKEND=elasticsearch_db
+ES_HOST=${HOST_IP}
+ES_PORT=9200          # docs default is 9202; use whatever your ES listens on
+ES_TRANSPORT_PORT=9300
+
+# Milvus — required when LVS_DATABASE_BACKEND=vector_db
+# MILVUS_DB_HOST=${HOST_IP}
+# MILVUS_DB_GRPC_PORT=19530
+
+# ---- LLM (summarization) ------------------------------------------------
+# Model name and endpoint for the summarization LLM NIM.
+LVS_LLM_MODEL_NAME=meta/llama-3.1-70b-instruct
+LLM_BASE_URL=http://${HOST_IP}:9233
+# (Compose builds LVS_LLM_BASE_URL=${LLM_BASE_URL:-http://${HOST_IP}:${LLM_PORT}}/v1 automatically)
+# LLM_PORT=9233
+
+# ---- VLM (frame captioning) ---------------------------------------------
+# Backend selector: openai-compat | vllm-compatible | vila | nvila | custom
+VLM_MODEL_TO_USE=openai-compat
+VLM_BASE_URL=http://${HOST_IP}:9234
+# VLM_PORT=9234
+
+# Model name string the VLM endpoint expects
+VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=Qwen/Qwen3-VL-8B-Instruct
+
+# VLM pre-processing (defaults below match the compose)
+VLM_INPUT_WIDTH=1312
+VLM_INPUT_HEIGHT=736
+
+# ---- Optional: RTVI-VLM sidecar routing ---------------------------------
+USE_RTVI_VLM=false
+# RTVI_VLM_URL=http://<rtvi-host>:9191
+# RTVI_VLM_URL_PASSTHROUGH=false
+
+# ---- Embedding (disable for simplest standalone) ------------------------
+LVS_EMB_ENABLE=false
+# LVS_EMB_MODEL_NAME=nvidia/nv-embedqa-e5-v5
+# LVS_EMB_BASE_URL=http://${HOST_IP}:9232/v1
+
+# ---- Model cache (bind-mounted) -----------------------------------------
+# Only relevant for self-hosted VLM modes. Keep off /tmp to survive reboot.
+MODEL_ROOT_DIR=/opt/models
+
+# ---- Feature flags ------------------------------------------------------
+DISABLE_GUARDRAILS=true
+LVS_DISABLE_DB_RESET_ON_REQUEST_DONE=true
+ENABLE_VIA_HEALTH_EVAL=false
+
+# ---- Logging ------------------------------------------------------------
+VSS_LOG_LEVEL=DEBUG
+
+# ---- S3 (only when fetching videos from S3) -----------------------------
+# AWS_ACCESS_KEY_ID=REPLACE_ME
+# AWS_SECRET_ACCESS_KEY=REPLACE_ME
+# AWS_ENDPOINT_URL_S3=https://s3.amazonaws.com
+
+# ---- Observability (OpenTelemetry) --------------------------------------
+# VIA_ENABLE_OTEL=false
+# VIA_OTEL_ENDPOINT=http://localhost:4318
+# VIA_OTEL_EXPORTER=console
+# VIA_CTX_RAG_ENABLE_OTEL=false
+# VIA_CTX_RAG_OTEL_ENDPOINT=http://localhost:4318
+# VIA_CTX_RAG_EXPORTER=console


### PR DESCRIPTION
## Summary
- extend the video-summarization skill with LVS API and service-ops routing
- add LVS API, deployment, debugging, environment-variable, and example env references
- add an LVS API ops eval fixture

## Validation
- fetched latest upstream feat/skills
- created branch from upstream/feat/skills
- verified JSON eval files with jq
- verified diff is scoped to skills/video-summarization