### PR TITLE
fix: correct VIOS config and agent compose mounts

### DIFF
--- a/deploy/docker/services/agent/vss-agent-docker-compose.yml
+++ b/deploy/docker/services/agent/vss-agent-docker-compose.yml
@@ -141,7 +141,7 @@ services:
       REPORT_REFERENCE_BASE_DIR: ${REPORT_REFERENCE_BASE_DIR}
 
     volumes:
-    - ${MDX_SAMPLE_APPS_DIR}:/vss-agent/deployments:ro
+    - ${MDX_SAMPLE_APPS_DIR}:/vss-agent/deploy/docker:ro
     - agent-eval:/vss-agent/agent_eval:rw
     command:
     - serve

--- a/deploy/docker/services/vios/compose-defaults.env
+++ b/deploy/docker/services/vios/compose-defaults.env
@@ -41,7 +41,7 @@ NVSTREAMER_IMAGE_TAG=''
 NVSTREAMER_HTTP_PORT=''
 RTSP_SERVER_PORT=''
 SAMPLE_VIDEO_DATASET=''
-# Override in blueprint `.env`; compose interpolates ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs} when unset.
+# Override in blueprint `.env`; compose interpolates ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs} when unset.
 VST_CONFIG_PATH=''
 SDR_HTTP_REPLAYSTREAM_PORT=''
 SDR_HTTP_LIVESTREAM_PORT=''

--- a/deploy/docker/services/vios/foundational/docker-compose.yaml
+++ b/deploy/docker/services/vios/foundational/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - ${VST_VOLUME}/postgres/db:/var/lib/postgresql/data
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}/postgresql.conf:/etc/postgresql/postgresql.conf
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}/postgresql.conf:/etc/postgresql/postgresql.conf
       - ${VST_DATA_PATH}:/var/run/postgresql
     network_mode: host
     container_name: vss-vios-postgres
@@ -49,7 +49,7 @@ services:
     environment:
       - VST_INGRESS_HTTP_PORT=${VST_INGRESS_HTTP_PORT}
     volumes:
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}/nginx-${VST_NGINX_MODE:-2d}.conf:/etc/nginx/nginx.conf:ro
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}/nginx-${VST_NGINX_MODE:-2d}.conf:/etc/nginx/nginx.conf:ro
       - ${VST_LOGS}/nginx_logs:/var/log/nginx
     network_mode: host
     container_name: vss-vios-ingress

--- a/deploy/docker/services/vios/initiator/docker-compose.yaml
+++ b/deploy/docker/services/vios/initiator/docker-compose.yaml
@@ -73,8 +73,8 @@ services:
       - RECORDER_MODULE_ENDPOINT=${RECORDER_MODULE_ENDPOINT}
       - STORAGE_MODULE_ENDPOINT=${STORAGE_MODULE_ENDPOINT}
     volumes:
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}:/home/vst/vst_release/configs
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
     network_mode: host
@@ -121,8 +121,8 @@ services:
       - CENTRALIZE_DB_USERNAME=${CENTRALIZE_DB_USERNAME}
       - STREAM_PROCESSOR_MODULE_ENDPOINT=${STREAM_PROCESSOR_MODULE_ENDPOINT}
     volumes:
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}:/home/vst/vst_release/configs
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
     network_mode: host

--- a/deploy/docker/services/vios/sdr/recorder/docker-compose.yaml
+++ b/deploy/docker/services/vios/sdr/recorder/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
-      - ${MDX_SAMPLE_APPS_DIR}/vst/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+      - ${MDX_SAMPLE_APPS_DIR}/services/vios/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
     deploy:
       restart_policy:
         condition: always

--- a/deploy/docker/services/vios/sdr/rtspserver/docker-compose.yaml
+++ b/deploy/docker/services/vios/sdr/rtspserver/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
-      - ${MDX_SAMPLE_APPS_DIR}/vst/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+      - ${MDX_SAMPLE_APPS_DIR}/services/vios/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
     deploy:
       restart_policy:
         condition: always

--- a/deploy/docker/services/vios/sdr/streamprocessing/docker-compose.yaml
+++ b/deploy/docker/services/vios/sdr/streamprocessing/docker-compose.yaml
@@ -33,12 +33,12 @@ services:
       - SENSOR_MODULE_ENDPOINT=${SENSOR_MODULE_ENDPOINT}
       - VST_INGRESS_ENDPOINT=${VST_INGRESS_ENDPOINT}
     volumes:
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}:/home/vst/vst_release/configs
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${CLIP_STORAGE_PATH}:/home/vst/vst_release/streamer_videos
       - ${VST_TEMP_FILES_PATH}:/home/vst/vst_release/webroot/temp_files
-      - ${MDX_SAMPLE_APPS_DIR}/vst/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+      - ${MDX_SAMPLE_APPS_DIR}/services/vios/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
     restart: unless-stopped
     deploy:
       restart_policy:


### PR DESCRIPTION
## Description
- Update VIOS compose mounts to resolve config files and install scripts from `services/vios`.
- Mount `MDX_SAMPLE_APPS_DIR` at `/vss-agent/deploy/docker` so existing `./deploy/docker/...` agent config paths resolve inside the container.
- Fix startup failures for Postgres, VIOS stream processing, and `vss-agent`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
