### PR TITLE
generic_judge: stop misrouting negative-assertion + enumeration checks

### DIFF
--- a/.github/skill-eval/verifiers/generic_judge.py
+++ b/.github/skill-eval/verifiers/generic_judge.py
@@ -82,16 +82,59 @@ _SHELL_VERBS = {
     "sudo", "find", "test",
 }
 
+# Phrases that flip the check's polarity — the author is asserting the
+# agent did NOT do something, not asking the verifier to run it. A
+# backtick-wrapped command in such a check is an example, not a directive.
+# Compared case-insensitively against the whole check string.
+_NEGATIVE_ASSERTION_PATTERNS = re.compile(
+    r"\b(does not|did not|do not|doesn't|didn't|don't|"
+    r"never|without|no\s+\w+\s+(call|request|invocation|attempt)s?|"
+    r"must not|should not|shouldn't|mustn't|"
+    r"avoided?|skipped?|refused?|"
+    r"zero\s+\w+\s+(call|request|invocation|attempt)s?|"
+    r"not\s+(call|run|invoke|issue|fire|trigger)\b)",
+    re.IGNORECASE,
+)
 
-def extract_shell_command(check: str) -> str | None:
-    """If the check contains a runnable shell command in backticks, return it.
-    Conservative — only extracts commands beginning with safe verbs."""
+
+def _backtick_shell_commands(check: str) -> list[str]:
+    """Return every backtick-wrapped substring whose first token is in
+    `_SHELL_VERBS`. Used by `extract_shell_command` to count how many
+    distinct example commands a check enumerates."""
+    out: list[str] = []
     for match in re.finditer(r"`([^`]{5,400})`", check):
         cmd = match.group(1).strip()
         first = cmd.split()[0] if cmd.split() else ""
         if first in _SHELL_VERBS:
-            return cmd
-    return None
+            out.append(cmd)
+    return out
+
+
+def extract_shell_command(check: str) -> str | None:
+    """If the check contains a runnable shell command in backticks, return
+    it. Conservative — only extracts commands beginning with safe verbs.
+
+    Two refinements over a naive first-backtick-wins extractor:
+
+    1) **Negative-assertion bypass.** Checks phrased as "the agent does
+       not run X", "never calls Y", "no /generate request", etc. are
+       trajectory assertions, not shell directives. Running the
+       backticked example would be wrong (and often actively harmful —
+       e.g. `docker compose down` in the verifier's CWD). When the
+       check matches `_NEGATIVE_ASSERTION_PATTERNS`, return None and
+       let the LLM trajectory route handle it.
+
+    2) **Enumeration bypass.** A check that lists 2+ distinct
+       backtick-wrapped commands ("such as `A`, `B`, or `C`") is an
+       enumeration of examples, not a request to run any single one.
+       Return None so the LLM can reason about the set as a whole.
+    """
+    if _NEGATIVE_ASSERTION_PATTERNS.search(check):
+        return None
+    cmds = _backtick_shell_commands(check)
+    if len(cmds) >= 2:
+        return None
+    return cmds[0] if cmds else None
 
 
 def judge_shell(check: str) -> dict:


### PR DESCRIPTION
## Summary

Two heuristics in `extract_shell_command` to keep the shell fast-path from swallowing checks that the spec author meant for the LLM trajectory route.

**Concrete failure that motivated this** (vios/base step-2, L40S remote-all):

> "The agent does not run destructive or state-changing deployment commands such as \`docker compose down\`, \`docker stop\`, \`docker rm\`, \`docker compose up\`, or \`docker compose up --force-recreate\`."

The first backtick contained a `docker`-prefixed string, so the classifier extracted `docker compose down` and `judge_shell` ran it in the trial's `tests/` dir. No `compose.yml` there → `no configuration file provided: not found` → exit 1 → check reported as failed. The agent's actual trajectory had zero destructive calls; this was a verifier bug.

## Heuristics

1. **Negative-assertion bypass** — if the check contains `does not` / `did not` / `never` / `without` / `no <noun> call` / `must not` / `zero <noun> requests` etc., return `None` from `extract_shell_command` so the LLM trajectory route handles it.

2. **Enumeration bypass** — if the check contains 2+ distinct backtick-wrapped commands matching `_SHELL_VERBS` (e.g. *"such as A, B, or C"*), return `None` and let the LLM reason about the set as a whole.

## Self-test (8 cases)

| # | Check | Expected | Got |
|---|---|---|---|
| 1 | The vios step-2 destructive-command check | `None` | `None` ✅ |
| 2 | "The agent did not call \`PUT /api/v1/videos-for-search/...\`" | `None` | `None` ✅ |
| 3 | "The trajectory contains zero \`POST .../generate\` requests" | `None` | `None` ✅ |
| 4 | "Never call \`docker compose up\` in this trial" | `None` | `None` ✅ |
| 5 | Positive curl directive | extracted | extracted ✅ |
| 6 | Positive docker ps directive | extracted | extracted ✅ |
| 7 | "Run \`docker ps\` and \`curl ...\`" (enumeration) | `None` | `None` ✅ |
| 8 | "Verify the API responds with \`curl ...\` returning 200" | extracted | extracted ✅ |

All 8 pass.

## What this is *not*

The judge model (Sonnet 4.6 via the `JUDGE_MODEL` → `ANTHROPIC_MODEL` cascade) was never the issue — these checks never reached the LLM because the shell fast-path consumed them first. No model-cascade or prompt changes here.

## Test plan

- [x] Self-test on the 8 cases above.
- [ ] Re-run the vios step-2 trial that hit this on a real CI run (PR #155 / #156's batch will exercise it).
- [ ] Watch a positive-shell check (e.g. deploy/base's docker ps probes) still pass after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)