### PR TITLE
Add video_search_frag extension with Enterprise RAG and NemoClaw skill

### DIFF
--- a/agent/app/video_search_frag/Dockerfile
+++ b/agent/app/video_search_frag/Dockerfile
@@ -1,0 +1,47 @@
+# Extension Dockerfile for video_search_frag
+# Layers Enterprise RAG + HITL LVS tools on top of the base vss-agent image.
+#
+# Two-step build:
+#   1. Build base:  docker build -f docker/Dockerfile -t vss-agent-base .
+#   2. Build frag:  docker build -f app/video_search_frag/Dockerfile \
+#                     --build-arg BASE_IMAGE=vss-agent-base -t vss-agent-frag .
+#
+# Build context must be the repository root.
+
+ARG BASE_IMAGE
+
+# --- Stage 1: Pull the pre-built base vss-agent image ---
+FROM ${BASE_IMAGE} AS base
+
+# --- Stage 2: Extend the base venv with frag packages ---
+FROM python:3.13-bookworm AS frag-builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/
+
+COPY --from=base /vss-agent/.venv /vss-agent/.venv
+
+WORKDIR /vss-agent
+
+COPY app/video_search_frag /vss-agent/app/video_search_frag
+
+RUN . .venv/bin/activate && \
+    uv pip install --no-deps /vss-agent/app/video_search_frag && \
+    uv pip install --no-deps "nvidia-rag" && \
+    uv pip install \
+      "minio" \
+      "lark>=1.2.2" \
+      "bleach>=6.2,<7.0" \
+      "dataclass-wizard>=0.27,<1.0" \
+      "redis>=4.3.4" \
+      "pymilvus-model>=0.3,<1.0" \
+      "pdfplumber>=0.11.9"
+
+# --- Stage 3: Final image = base + frag overlay ---
+FROM ${BASE_IMAGE}
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+COPY --from=frag-builder --chown=${USER_ID}:${GROUP_ID} /vss-agent/.venv /vss-agent/.venv
+
+COPY --chown=${USER_ID}:${GROUP_ID} app/video_search_frag/configs /vss-agent/configs/video_search_frag

--- a/agent/app/video_search_frag/configs/config.yml
+++ b/agent/app/video_search_frag/configs/config.yml
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+general:
+  use_uvloop: true
+  front_end:
+    _type: fastapi
+    enable_interactive_extensions: true
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}
+    endpoints:
+    - path: /api/v1/videos
+      method: POST
+      description: Generate VST upload URL
+      function_name: video_upload_url
+    cors:
+      allow_origins: ['*']
+      allow_methods: ['*']
+      allow_headers: ['*']
+      allow_credentials: false
+  telemetry:
+    tracing:
+      phoenix:
+        _type: phoenix
+        endpoint: ${PHOENIX_ENDPOINT}/v1/traces
+        project: FRAG-vss-agent-${VSS_AGENT_VERSION}
+
+object_stores:
+  local_object_store:
+    _type: in_memory
+
+functions:
+  enterprise_rag:
+    _type: enterprise_rag
+  video_upload_url:
+    _type: video_upload_url
+    vst_external_url: ${VST_EXTERNAL_URL}
+    agent_base_url: http://${EXTERNAL_IP}:${VSS_AGENT_PORT}
+
+  video_understanding:
+    _type: video_understanding
+    vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
+    max_frames: 60
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
+    video_url_tool: vst_video_clip
+    time_format: offset
+    vlm_mode: ${VLM_MODE}
+    internal_ip: "${INTERNAL_IP}"
+    external_ip: "${EXTERNAL_IP}"
+    system_prompt: |
+      You are a monitoring system analyzing video footage.
+      Your task is to describe the events in the video in detail or answer the user's question about the video.
+        IMPORTANT:
+        - You must respond only in English and in plain text.
+        - You must respond only in the format specified in the OUTPUT REQUIREMENTS section.
+        - Timestamp must be in pts format, seconds since the start of the video.
+        - Always provide a direct answer to the question asked.
+        - Never return an empty response. If you cannot find what the user is asking about, acknowledge it to the user.
+
+  vst_video_duration:
+    _type: vst.duration
+    vst_internal_url: ${VST_INTERNAL_URL}
+    vst_external_url: ${VST_EXTERNAL_URL}
+
+  vst_video_clip:
+    _type: vst.video_clip
+    vst_internal_url: ${VST_INTERNAL_URL}
+    vst_external_url: ${VST_EXTERNAL_URL}
+
+  vst_snapshot:
+    _type: vst.snapshot
+    vst_internal_url: ${VST_INTERNAL_URL}
+    vst_external_url: ${VST_EXTERNAL_URL}
+
+  vst_video_list:
+    _type: vst.video_list
+    vst_internal_url: ${VST_INTERNAL_URL}
+
+  lvs_video_understanding:
+    _type: lvs_video_understanding_frag
+    llm_name: nim_llm
+    lvs_backend_url: ${LVS_BACKEND_URL}
+    model: ${VLM_NAME}
+    video_url_tool: vst_video_clip
+    vlm_mode: ${VLM_MODE}
+    internal_ip: "${INTERNAL_IP}"
+    external_ip: "${EXTERNAL_IP}"
+    conn_timeout_ms: 5000
+    read_timeout_ms: 600000
+    chunk_duration: 10
+    num_frames_per_chunk: 20
+    hitl_scenario_template: |
+      Scenario (REQUIRED):
+      Please provide a scenario description for the video analysis.
+
+      Example: "traffic monitoring", "warehouse monitoring"
+
+      Enter your scenario or press Submit to keep current value:
+    hitl_events_template: |
+      Events (REQUIRED):
+      Please provide a comma-separated list of events to detect.
+
+      Examples:
+      - accident, pedestrian crossing, vehicle crossing, traffic violation
+      - boxes falling, accident, forklift stuck, workers not wearing PPE, person entering restricted area
+
+      Enter events (comma-separated) or press Submit to keep current value:
+    hitl_objects_template: |
+      Objects of Interest (OPTIONAL):
+      Please provide a comma-separated list of objects to focus on, or write "skip" to skip.
+
+      Examples:
+      - cars, trucks, pedestrians
+      - forklifts, pallets, workers
+
+      Enter objects (comma-separated), "skip" to skip or press Submit to keep current value:
+    hitl_confirmation_template: |
+      Please review the above configuration that will be sent for video analysis.
+
+      **Options:**
+      - Press Submit (empty) → Confirm and proceed with video analysis
+      - Type `/redo` → Modify parameters
+      - Type `/cancel` → Cancel analysis
+
+      Enter your choice or press Submit to proceed:
+    default_scenario: "traffic monitoring"
+    default_events:
+    - accident
+    - pedestrian crossing
+    - vehicle crossing
+    - traffic violation
+
+  video_report_gen:
+    _type: video_report_gen_frag
+    object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}
+    base_url: ${VSS_AGENT_REPORTS_BASE_URL}
+    video_understanding_tool: video_understanding
+    lvs_video_understanding_tool: lvs_video_understanding
+    video_url_tool: vst_video_clip
+    picture_url_tool: vst_snapshot
+    vst_internal_url: ${VST_INTERNAL_URL}
+    vst_external_url: ${VST_EXTERNAL_URL}
+    vlm_prompt: |
+      Describe in detail what is happening in this video,
+      including all visible people, vehicles, equipments, objects,
+      actions, and environmental conditions.
+      OUTPUT REQUIREMENTS:
+      [timestamp-timestamp] Description of what is happening.
+      EXAMPLE:
+      [0.0s-4.0s] <description of the first event>
+      [4.0s-12.0s] <description of the second event>
+
+  report_agent:
+    _type: report_agent
+    log_level: INFO
+    video_report_tool: video_report_gen
+
+llms:
+  # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
+  nim_llm:
+    _type: nim
+    model_name: ${LLM_NAME}
+    base_url: ${LLM_BASE_URL}/v1
+    max_tokens: 4096
+    temperature: 0.0
+
+  openai_llm:
+    _type: openai
+    model_name: ${LLM_NAME}
+    base_url: ${LLM_BASE_URL}/v1
+    max_tokens: 4096
+    temperature: 0.0
+
+  # --- VLM profiles (selected by VLM_MODEL_TYPE) ---
+  nim_vlm:
+    _type: nim
+    model_name: ${VLM_NAME}
+    base_url: ${VLM_BASE_URL}/v1
+    temperature: 0.0
+    max_tokens: 4096
+
+  openai_vlm:
+    _type: openai
+    model_name: ${VLM_NAME}
+    temperature: 0.0
+    max_tokens: 4096
+
+  vllm_vlm:
+    _type: openai
+    model_name: ${VLM_NAME}
+    base_url: ${VLM_BASE_URL}/v1
+    temperature: 0.0
+    max_tokens: 4096
+
+  # --- Others ---
+  eval_llm_judge:
+    _type: nim
+    model_name: ${EVAL_LLM_JUDGE_NAME}
+    base_url: ${EVAL_LLM_JUDGE_BASE_URL}/v1
+    max_tokens: 4096
+    temperature: 0.0
+
+workflow:
+  _type: top_agent
+  llm_name: ${LLM_MODEL_TYPE:-nim}_llm
+  log_level: INFO
+  max_iterations: 30
+  llm_reasoning: false
+  planning_enabled: true
+  tool_names:
+  - video_understanding
+  - vst_video_clip
+  - vst_snapshot
+  - vst_video_list
+  - vst_video_duration
+  subagent_names:
+  - report_agent
+  # yamllint disable rule:line-length
+  prompt: |
+    You are a routing agent for a video surveillance system. Your job is to route requests to the correct tool.
+    ## Routing Rules:
+      **vst_video_list** -
+      - Videos can be added/removed from the backend system. dont rely on previous conversations for questions about available videos.
+      - If user ask to show a video not in the list from previous interactions, call this tool to verify if the video is available then call the appropriate tool to show the video or snapshot.
+      - Examples: "What videos are available?", "List all available videos" "list sensors"
+      **report_agent**
+      - Only call report_agent when user mentions "report" in the question.
+      - Don't use the report from previous interactions.
+      - Examples: "Generate a report for, "Create an analysis report", "Generate a report using long video summarization", "Generate a report using lvs"
+      **video_understanding** - For any question about short videos or quick queries for a video clip.
+      - Use when video is less than 1 minute.
+      - Use when user asks "what happens in the video", "describe the video", "analyze this video", "what is happening in the video", or "what is wrong in the video"
+      - Do NOT use when user asks to "generate a report"
+      **vst_video_clip** - For queries asking for showing videos (e.g., "Let's show the videos just uploaded"), call this tool in parallel with each video name as a separate input.
+      - CRITICAL: If a video clip for the same video has already been generated from previous interactions, return the answer with the EXACT URLs from conversation history - DO NOT call vst_video_clip, DO NOT modify any parts of the URLs. However, if the query asks for video clip of a different video, you MUST call vst_video_clip tool to get the URL. You should NEVER generate the URL yourself.
+      **vst_snapshot** - For queries asking for a snapshot of a video at a specific timestamp.
+      - CRITICAL: If a snapshot for the same video AND at the same timestamp has already been generated from previous interactions, return the answer with the EXACT URLs from conversation history - DO NOT call vst_snapshot, DO NOT modify any parts of the URLs. However, if the query asks for snapshot of a new video or a new timestamp for the same video, you MUST call vst_snapshot tool to get the URL. You should NEVER generate the URL yourself.
+    ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
+
+
+  tool_call_prompt: |
+    - ALWAYS include ALL required parameters when calling tools
+    - If a tool call fails with a validation error, RETRY IMMEDIATELY: Fix the error and call the tool again with correct parameters.
+    - Error Handling: if a tool fails more than 3 times, just return a summarized error message. Do not endlessly try again.
+
+  response_format_prompt: |
+    - Do not include phrases like "I should", "Let me", "The user".
+    - Convert json to markdown format.
+      - EXCEPTION: For queries about listing sensors, output sensors as plain text, NOT as code blocks or markdown code.
+    - Wrap urls in html tags. CRITICAL: ONLY do this when a url is EXACTLY the one returned from a tool call or the url is EXACTLY the same as one from the conversation history. NEVER generate urls yourself. NEVER modify an existing url to create a new url (e.g. changing timestamps, IDs, or any part of the url). If you need a url that wasn't returned by a tool call, you MUST call the appropriate tool to get it. Examples:
+      <video src="video_url" alt="Video Name">Video Name</video>
+      <image src="image_url" alt="Image Name">Image Name</image>
+  postprocessing:
+    enabled: true
+    validation_order:
+    - [url_validator]
+    validators:
+      url_validator:
+        internal_ip: ${HOST_IP}
+        timeout: 10.0
+        feedback_template: |
+          The following URLs are not accessible: {issues}
+          You have a hallucinated URL in the response, consider removing it or calling the appropriate tool to fetch the correct URL.
+        # yamllint enable rule:line-length

--- a/agent/app/video_search_frag/docker-compose.yml
+++ b/agent/app/video_search_frag/docker-compose.yml
@@ -1,0 +1,115 @@
+# Docker Compose for VSS Agent with video_search_frag extension
+#
+# Two-step build:
+#   1. Build base image from repo root:
+#        docker build -f docker/Dockerfile -t vss-agent-base .
+#   2. Build frag image:
+#        docker compose -f app/video_search_frag/docker-compose.yml \
+#          --env-file deployments/developer-workflow/dev-profile-lvs/.env build
+#
+# Run:
+#   docker compose -f app/video_search_frag/docker-compose.yml \
+#     --env-file deployments/developer-workflow/dev-profile-lvs/.env \
+#     --profile bp_developer_lvs_2d up -d
+
+services:
+  vss-agent:
+    image: vss-agent-frag:latest
+    build:
+      context: ../../
+      dockerfile: app/video_search_frag/Dockerfile
+      args:
+        BASE_IMAGE: ${VSS_AGENT_BASE_IMAGE:-vss-agent-base}
+      network: host
+    container_name: vss-agent
+    network_mode: host
+    profiles:
+    - bp_developer_lvs_2d
+    environment:
+      # URL rewriting configuration
+      EXTERNAL_IP: ${EXTERNAL_IP}
+      INTERNAL_IP: ${HOST_IP}
+      LLM_MODE: ${LLM_MODE}
+      VLM_MODE: ${VLM_MODE}
+      LLM_MODEL_TYPE: ${LLM_MODEL_TYPE}
+      VLM_MODEL_TYPE: ${VLM_MODEL_TYPE}
+
+      # NAT Configuration
+      HOST_IP: ${HOST_IP}
+      VSS_AGENT_VERSION: ${VSS_AGENT_VERSION}
+      VSS_AGENT_CONFIG_FILE: ${VSS_AGENT_CONFIG_FILE}
+      VSS_AGENT_HOST: ${VSS_AGENT_HOST}
+      VSS_AGENT_PORT: ${VSS_AGENT_PORT}
+      LVS_BACKEND_URL: ${LVS_BACKEND_URL}
+      RTVI_EMBED_PORT: ${RTVI_EMBED_PORT}
+      RTVI_CV_PORT: ${RTVI_CV_PORT}
+      VSS_ES_PORT: ${VSS_ES_PORT}
+
+      # Phoenix Telemetry
+      PHOENIX_ENDPOINT: ${PHOENIX_ENDPOINT}
+
+      # VST (Video Storage Tool)
+      VST_BASE_URL: ${VST_BASE_URL}
+      VST_INTERNAL_URL: ${VST_INTERNAL_URL}
+      VST_EXTERNAL_URL: ${VST_EXTERNAL_URL}
+      VST_MCP_URL: ${VST_MCP_URL}
+
+      # MCP Server
+      VIDEO_ANALYSIS_MCP_URL: http://${VSS_AGENT_HOST}:${VSS_VA_MCP_PORT}
+
+      # LLM Endpoints
+      LLM_NAME: ${LLM_NAME}
+      LLM_BASE_URL: ${LLM_BASE_URL:-http://${HOST_IP}:${LLM_PORT}}
+      VLM_NAME: ${VLM_NAME}
+      VLM_BASE_URL: ${VLM_BASE_URL:-http://${HOST_IP}:${VLM_PORT}}
+      EVAL_LLM_JUDGE_NAME: ${EVAL_LLM_JUDGE_NAME}
+      EVAL_LLM_JUDGE_BASE_URL: ${EVAL_LLM_JUDGE_BASE_URL}
+      RTVI_VLM_BASE_URL: ${RTVI_VLM_BASE_URL}
+
+      # NVIDIA API Key (for remote NIM)
+      NVIDIA_API_KEY: ${NVIDIA_API_KEY}
+      # OpenAI API Key (for remote openai LLM/VLM)
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+
+      # Object Store & Report Generation
+      VSS_AGENT_OBJECT_STORE_TYPE: ${VSS_AGENT_OBJECT_STORE_TYPE}
+      VSS_AGENT_REPORTS_BASE_URL: ${VSS_AGENT_REPORTS_BASE_URL}
+      VSS_AGENT_TEMPLATE_PATH: ${VSS_AGENT_TEMPLATE_PATH}
+      VSS_AGENT_TEMPLATE_NAME: ${VSS_AGENT_TEMPLATE_NAME}
+
+      # Enterprise RAG (Milvus)
+      ENTERPRISE_RAG_COLLECTION_NAMES: ${ENTERPRISE_RAG_COLLECTION_NAMES:-}
+      ENTERPRISE_RAG_VDB_ENDPOINT: ${ENTERPRISE_RAG_VDB_ENDPOINT:-}
+      ENTERPRISE_RAG_EMBEDDING_MODEL: ${ENTERPRISE_RAG_EMBEDDING_MODEL:-}
+      ENTERPRISE_RAG_EMBEDDING_BASE_URL: ${ENTERPRISE_RAG_EMBEDDING_BASE_URL:-}
+      ENTERPRISE_RAG_RERANKER_MODEL: ${ENTERPRISE_RAG_RERANKER_MODEL:-}
+      ENTERPRISE_RAG_RERANKER_ENDPOINT: ${ENTERPRISE_RAG_RERANKER_ENDPOINT:-}
+
+      # RTSP Stream Mode
+      STREAM_MODE: ${STREAM_MODE:-other}
+
+    volumes:
+    - ${MDX_SAMPLE_APPS_DIR}:/vss-agent/deployments:ro
+    command:
+    - serve
+    - --config_file
+    - ${VSS_AGENT_CONFIG_FILE}
+    - --host
+    - ${VSS_AGENT_HOST}
+    - --port
+    - ${VSS_AGENT_PORT}
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/python3
+      - -c
+      - >-
+        import urllib.request; import sys;
+        sys.exit(0 if urllib.request.urlopen(
+        'http://${VSS_AGENT_HOST}:${VSS_AGENT_PORT}/health',
+        timeout=5).status == 200 else 1)
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 240s
+    restart: unless-stopped

--- a/agent/app/video_search_frag/pyproject.toml
+++ b/agent/app/video_search_frag/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/video_search_frag"]
+
+[project]
+name = "video_search_frag"
+version = "0.0.1"
+dependencies = [
+  "vss_agents",
+]
+requires-python = ">=3.13,<3.15"
+description = "Video Search FRAG (Enterprise RAG + HITL LVS) Agent"
+keywords = ["ai", "rag", "agents", "video", "enterprise-rag"]
+classifiers = ["Programming Language :: Python"]
+
+[project.entry-points.'nat.components']
+video_search_frag = "video_search_frag.register"

--- a/agent/app/video_search_frag/src/video_search_frag/__init__.py
+++ b/agent/app/video_search_frag/src/video_search_frag/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/agent/app/video_search_frag/src/video_search_frag/enterprise_rag.py
+++ b/agent/app/video_search_frag/src/video_search_frag/enterprise_rag.py
@@ -114,15 +114,11 @@ class EnterpriseRAGConfig(FunctionBaseConfig, name="enterprise_rag"):
 
     # Embedding model + endpoint.
     embedding_model: str = Field(
-        default_factory=lambda: os.getenv(
-            "ENTERPRISE_RAG_EMBEDDING_MODEL", "nvidia/llama-3.2-nv-embedqa-1b-v2"
-        ),
+        default_factory=lambda: os.getenv("ENTERPRISE_RAG_EMBEDDING_MODEL", "nvidia/llama-3.2-nv-embedqa-1b-v2"),
         description="Embedding model name to use for query embedding.",
     )
     embedding_base_url: str = Field(
-        default_factory=lambda: os.getenv(
-            "ENTERPRISE_RAG_EMBEDDING_BASE_URL", "https://integrate.api.nvidia.com/v1"
-        ),
+        default_factory=lambda: os.getenv("ENTERPRISE_RAG_EMBEDDING_BASE_URL", "https://integrate.api.nvidia.com/v1"),
         description="Embedding service base URL (commonly the NVIDIA Integrate API base URL).",
     )
     embedding_endpoint: str | None = Field(
@@ -310,9 +306,7 @@ async def enterprise_rag(config: EnterpriseRAGConfig, _builder: Builder) -> Asyn
         vdb_top_k = input_data.vdb_top_k or config.default_vdb_top_k
         reranker_top_k = input_data.reranker_top_k or config.default_reranker_top_k
 
-        enable_reranker = bool(
-            config.enable_reranker and config.reranker_model and config.reranker_endpoint
-        )
+        enable_reranker = bool(config.enable_reranker and config.reranker_model and config.reranker_endpoint)
 
         search_kwargs: dict[str, Any] = {
             "query": query,
@@ -388,4 +382,3 @@ async def enterprise_rag(config: EnterpriseRAGConfig, _builder: Builder) -> Asyn
         input_schema=EnterpriseRAGInput,
         single_output_schema=EnterpriseRAGOutput,
     )
-

--- a/agent/app/video_search_frag/src/video_search_frag/enterprise_rag.py
+++ b/agent/app/video_search_frag/src/video_search_frag/enterprise_rag.py
@@ -1,0 +1,391 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Enterprise RAG tool (Blueprint integration) for VSS 3.0.
+
+This tool provides a minimal wrapper around the NVIDIA RAG Blueprint search API
+via `nvidia_rag.rag_server.main.NvidiaRAG`.
+
+Design goals:
+- Keep this tool purely retrieval: input query -> returned context string.
+- Make it safe to call from other tools (e.g., HITL-enabled LVS tool) without
+  requiring the top-level agent to have direct access to it.
+- Keep configuration explicit (collections, vdb endpoint, embedding + reranker endpoints).
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+import json
+import logging
+import os
+from typing import Any
+from typing import Literal
+
+from nat.builder.builder import Builder
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.function import FunctionBaseConfig
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+
+def _int_env(name: str, default: int) -> int:
+    """Parse an int environment variable safely."""
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid int for %s=%r; using default %s", name, raw, default)
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid float for %s=%r; using default %s", name, raw, default)
+        return default
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def _json_list_env(name: str, default: list[str]) -> list[str]:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        val = json.loads(raw)
+        if isinstance(val, list) and all(isinstance(x, str) for x in val):
+            return val
+        logger.warning("Invalid JSON list for %s=%r; using default %r", name, raw, default)
+        return default
+    except Exception:
+        logger.warning("Invalid JSON for %s=%r; using default %r", name, raw, default)
+        return default
+
+
+class EnterpriseRAGConfig(FunctionBaseConfig, name="enterprise_rag"):
+    """Configuration for the Enterprise RAG (Blueprint) retrieval tool."""
+
+    # Collection(s) to query; allow comma-separated for convenience.
+    collection_names: str = Field(
+        default_factory=lambda: os.getenv("ENTERPRISE_RAG_COLLECTION_NAMES", ""),
+        description=(
+            'Comma-separated collection names in the Enterprise RAG Blueprint (e.g., "policies,manuals"). '
+            "If empty, this tool returns an empty context string."
+        ),
+    )
+
+    # Vector DB endpoint (Milvus) the RAG server should query.
+    vdb_endpoint: str = Field(
+        default_factory=lambda: os.getenv("ENTERPRISE_RAG_VDB_ENDPOINT", ""),
+        description=(
+            'Vector DB endpoint/URI (e.g., "http://milvus:19530" or "tcp://milvus:19530"). '
+            "If empty, this tool returns an empty context string."
+        ),
+    )
+
+    # Embedding model + endpoint.
+    embedding_model: str = Field(
+        default_factory=lambda: os.getenv(
+            "ENTERPRISE_RAG_EMBEDDING_MODEL", "nvidia/llama-3.2-nv-embedqa-1b-v2"
+        ),
+        description="Embedding model name to use for query embedding.",
+    )
+    embedding_base_url: str = Field(
+        default_factory=lambda: os.getenv(
+            "ENTERPRISE_RAG_EMBEDDING_BASE_URL", "https://integrate.api.nvidia.com/v1"
+        ),
+        description="Embedding service base URL (commonly the NVIDIA Integrate API base URL).",
+    )
+    embedding_endpoint: str | None = Field(
+        default_factory=lambda: os.getenv("ENTERPRISE_RAG_EMBEDDING_ENDPOINT") or None,
+        description=(
+            "Optional full embedding endpoint. If omitted and embedding_base_url ends with '/v1', "
+            "this tool will use '{embedding_base_url}/embeddings'. Otherwise it will use embedding_base_url directly."
+        ),
+    )
+
+    # Optional reranker model + endpoint.
+    reranker_model: str | None = Field(
+        default_factory=lambda: os.getenv("ENTERPRISE_RAG_RERANKER_MODEL") or None,
+        description="Optional reranker model name. If set, reranking is enabled.",
+    )
+    reranker_endpoint: str | None = Field(
+        default_factory=lambda: os.getenv("ENTERPRISE_RAG_RERANKER_ENDPOINT") or None,
+        description="Optional reranker endpoint URL. Required if reranker_model is set.",
+    )
+
+    enable_query_rewriting: bool = Field(
+        default_factory=lambda: _bool_env("ENTERPRISE_RAG_ENABLE_QUERY_REWRITING", True),
+        description="Enable query rewriting in the RAG Blueprint search call.",
+    )
+
+    filter_expr: str = Field(
+        default_factory=lambda: os.getenv("ENTERPRISE_RAG_FILTER_EXPR", ""),
+        description="Optional filter expression for Enterprise RAG search.",
+    )
+
+    # Defaults used when the caller doesn't provide overrides.
+    default_vdb_top_k: int = Field(
+        default_factory=lambda: _int_env("ENTERPRISE_RAG_VDB_TOP_K", 10),
+        ge=1,
+        description="Default top-k for vector DB retrieval.",
+    )
+    default_reranker_top_k: int = Field(
+        default_factory=lambda: _int_env("ENTERPRISE_RAG_RERANKER_TOP_K", 5),
+        ge=1,
+        description="Default top-k for reranking.",
+    )
+
+    # Whether to enable reranking for remote /v1/generate. If env var is unset, infer from model/endpoint presence.
+    enable_reranker: bool = Field(
+        default_factory=lambda: _bool_env(
+            "ENTERPRISE_RAG_ENABLE_RERANKER",
+            bool(os.getenv("ENTERPRISE_RAG_RERANKER_MODEL") and os.getenv("ENTERPRISE_RAG_RERANKER_ENDPOINT")),
+        ),
+        description="Enable reranker in the Enterprise RAG call.",
+    )
+
+    timeout_sec: int = Field(
+        default=15,
+        ge=1,
+        description="Timeout in seconds for the Enterprise RAG search call.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class EnterpriseRAGInput(BaseModel):
+    """Input schema for an Enterprise RAG query."""
+
+    query: str = Field(..., description="The enterprise query to search for.", min_length=1)
+    vdb_top_k: int | None = Field(default=None, ge=1, description="Optional override for vector DB top-k.")
+    reranker_top_k: int | None = Field(default=None, ge=1, description="Optional override for reranker top-k.")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class EnterpriseRAGOutput(BaseModel):
+    """Structured output for Enterprise RAG retrieval."""
+
+    status: Literal[
+        "ok",
+        "no_results",
+        "not_configured",
+        "timeout",
+        "unreachable",
+        "error",
+        "dependency_missing",
+    ] = Field(..., description="Outcome status of the retrieval attempt.")
+    query: str = Field(default="", description="The query that was attempted (after trimming).")
+    context: str = Field(default="", description="Retrieved context string (may be empty).")
+    error: str = Field(default="", description="Error details when status is not ok/no_results.")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def _parse_search_results(search_results: Any) -> str:
+    """
+    Extract a single context string from NvidiaRAG search results.
+
+    NvidiaRAG returns an object with a `.results` attribute; each item typically has `.content`.
+    """
+
+    doc_list: list[str] = []
+    results = getattr(search_results, "results", None)
+    if not results:
+        return ""
+
+    for result in results:
+        content = getattr(result, "content", "")
+        if content:
+            doc_list.append(str(content))
+
+    return "\n".join(doc_list)
+
+
+@register_function(config_type=EnterpriseRAGConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
+async def enterprise_rag(config: EnterpriseRAGConfig, _builder: Builder) -> AsyncGenerator[FunctionInfo]:
+    """
+    Query the Enterprise RAG Blueprint and return retrieved context.
+
+    This tool is intended to be called from other tools (e.g., `lvs_video_understanding`)
+    after a HITL turn that collects the enterprise query.
+    """
+
+    # VSS 2.4 behavior: call NvidiaRAG.search(...) for retrieval context.
+    #
+    # IMPORTANT:
+    # - Do NOT import or instantiate NvidiaRAG at NAT startup time.
+    #   In some environments, importing NvidiaRAG triggers imports of optional dependencies,
+    #   and constructing NvidiaRAG() may validate runtime connectivity / env vars.
+    # - We defer both import and construction until the first time the tool is called.
+    rag_instance = None
+    rag_init_error: str = ""
+
+    def _get_rag():
+        nonlocal rag_instance, rag_init_error
+        if rag_instance is not None:
+            return rag_instance
+        if rag_init_error:
+            return None
+        try:
+            from nvidia_rag.rag_server.main import NvidiaRAG  # type: ignore
+
+            rag_instance = NvidiaRAG()
+            return rag_instance
+        except Exception as e:
+            rag_init_error = str(e)
+            logger.warning(
+                "Enterprise RAG tool invoked but failed to import/initialize NvidiaRAG (%s).",
+                e,
+                exc_info=True,
+            )
+            return None
+
+    def _resolve_embedding_endpoint() -> str:
+        if config.embedding_endpoint:
+            return config.embedding_endpoint
+        # IMPORTANT: langchain-nvidia-ai-endpoints expects the base URL (ending in /v1),
+        # not the full /embeddings endpoint, because it performs model listing calls
+        # relative to this base. Appending /embeddings manually causes 404s on model listing.
+        return config.embedding_base_url
+
+    collection_names = [c.strip() for c in config.collection_names.split(",") if c.strip()]
+    embedding_endpoint = _resolve_embedding_endpoint()
+
+    async def _enterprise_rag(input_data: EnterpriseRAGInput) -> EnterpriseRAGOutput:
+        query = input_data.query.strip()
+        if not query:
+            return EnterpriseRAGOutput(status="error", query="", context="", error="Empty query")
+
+        rag = _get_rag()
+        if rag is None:
+            return EnterpriseRAGOutput(
+                status="dependency_missing",
+                query=query,
+                context="",
+                error=rag_init_error or "'nvidia-rag' package is not installed/available",
+            )
+
+        if not config.collection_names.strip() or not config.vdb_endpoint.strip():
+            logger.warning(
+                "Enterprise RAG is not configured (collection_names/vdb_endpoint missing). Returning empty context."
+            )
+            return EnterpriseRAGOutput(
+                status="not_configured",
+                query=query,
+                context="",
+                error="Missing ENTERPRISE_RAG_COLLECTION_NAMES and/or ENTERPRISE_RAG_VDB_ENDPOINT",
+            )
+
+        vdb_top_k = input_data.vdb_top_k or config.default_vdb_top_k
+        reranker_top_k = input_data.reranker_top_k or config.default_reranker_top_k
+
+        enable_reranker = bool(
+            config.enable_reranker and config.reranker_model and config.reranker_endpoint
+        )
+
+        search_kwargs: dict[str, Any] = {
+            "query": query,
+            "messages": [],
+            "reranker_top_k": reranker_top_k,
+            "vdb_top_k": vdb_top_k,
+            "collection_names": collection_names,
+            "vdb_endpoint": config.vdb_endpoint,
+            "enable_query_rewriting": config.enable_query_rewriting,
+            "embedding_model": config.embedding_model,
+            "embedding_endpoint": embedding_endpoint,
+            "enable_reranker": enable_reranker,
+        }
+
+        if config.filter_expr.strip():
+            search_kwargs["filter_expr"] = config.filter_expr
+
+        if enable_reranker:
+            search_kwargs.update(
+                {
+                    "reranker_model": config.reranker_model,
+                    "reranker_endpoint": config.reranker_endpoint,
+                }
+            )
+
+        logger.info(
+            "Enterprise RAG query: collections=%s, vdb_top_k=%s, reranker_top_k=%s, reranker=%s",
+            collection_names,
+            vdb_top_k,
+            reranker_top_k,
+            "enabled" if enable_reranker else "disabled",
+        )
+
+        try:
+            # FIX: NvidiaRAG.search is async in the installed version of nvidia-rag.
+            # We must await it directly instead of running it in an executor.
+            # If the library version changes to sync in future, this await might need adjustment,
+            # but current evidence (RuntimeWarning: coroutine never awaited) proves it is async.
+            search_results = await asyncio.wait_for(
+                rag.search(**search_kwargs),
+                timeout=config.timeout_sec,
+            )
+        except TimeoutError:
+            logger.warning("Enterprise RAG query timed out after %ss", config.timeout_sec)
+            return EnterpriseRAGOutput(
+                status="timeout",
+                query=query,
+                context="",
+                error=f"Timed out after {config.timeout_sec}s",
+            )
+        except Exception as e:
+            logger.exception("Enterprise RAG query failed: %s", e)
+            # The exact exception types depend on deployment network/HTTP stack inside nvidia-rag.
+            # We report a generic "unreachable" when it looks like a connectivity issue; otherwise "error".
+            err = str(e)
+            status = (
+                "unreachable"
+                if any(s in err.lower() for s in ("connection", "connect", "timeout", "refused", "unreachable"))
+                else "error"
+            )
+            return EnterpriseRAGOutput(status=status, query=query, context="", error=err)
+
+        context = _parse_search_results(search_results)
+        if context:
+            logger.info("Enterprise RAG returned context (first 200 chars): %s", context[:200])
+            return EnterpriseRAGOutput(status="ok", query=query, context=context, error="")
+        logger.info("Enterprise RAG returned no context")
+        return EnterpriseRAGOutput(status="no_results", query=query, context="", error="")
+
+    yield FunctionInfo.create(
+        single_fn=_enterprise_rag,
+        description=_enterprise_rag.__doc__,
+        input_schema=EnterpriseRAGInput,
+        single_output_schema=EnterpriseRAGOutput,
+    )
+

--- a/agent/app/video_search_frag/src/video_search_frag/lvs_video_understanding_frag.py
+++ b/agent/app/video_search_frag/src/video_search_frag/lvs_video_understanding_frag.py
@@ -29,12 +29,9 @@ Key features:
 """
 
 from collections.abc import AsyncGenerator
-from enum import Enum
+from enum import StrEnum
 import json
 import logging
-import asyncio
-
-from vss_agents.utils.url_translation import translate_url
 
 import aiohttp
 from langchain_core.prompts import ChatPromptTemplate
@@ -51,10 +48,12 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from vss_agents.utils.url_translation import translate_url
+
 logger = logging.getLogger(__name__)
 
 
-class LVSStatus(str, Enum):
+class LVSStatus(StrEnum):
     """Status values for LVS video understanding operations."""
 
     ABORTED = "aborted"
@@ -219,7 +218,7 @@ class LVSVideoUnderstandingConfig(FunctionBaseConfig, name="lvs_video_understand
         default="",
         description="Public IP accessible from the internet for URL translation",
     )
-    
+
     # Enterprise RAG Configuration
     enterprise_rag_enabled: bool = Field(
         default=True,
@@ -267,7 +266,7 @@ async def lvs_video_understanding(
 
     # Persistent state: maps thread_id -> (scenario, events, objects_of_interest, rag_query)
     lvs_params_state: dict[str, tuple[str, list[str], list[str], str]] = {}
-    
+
     # Load Enterprise RAG tool if enabled.
     # IMPORTANT: config.yml for this profile already registers `enterprise_rag`,
     # but we still guard failures so LVS doesn't crash agent startup.
@@ -392,7 +391,7 @@ async def lvs_video_understanding(
         """
         logger.info("Starting HITL parameter collection workflow")
 
-        current_rag_query = ""
+        _current_rag_query = ""
 
         # Cancel info to append to each prompt
         cancel_info = "\n\n**Note:** Type `/cancel` at any time to abort the video analysis."
@@ -401,12 +400,14 @@ async def lvs_video_understanding(
         if current_params:
             # Handle backward compatibility if state tuple size differs
             if len(current_params) == 4:
-                current_scenario, current_events, current_objects, current_rag_query = current_params
+                current_scenario, current_events, current_objects, _current_rag_query = current_params
             else:
                 current_scenario, current_events, current_objects = current_params[:3]
-                
+
             scenario_prompt = f"**CURRENTLY SET:** `{current_scenario}`\n\n{config.hitl_scenario_template}{cancel_info}"
-            events_prompt = f"**CURRENTLY SET:** `{', '.join(current_events)}`\n\n{config.hitl_events_template}{cancel_info}"
+            events_prompt = (
+                f"**CURRENTLY SET:** `{', '.join(current_events)}`\n\n{config.hitl_events_template}{cancel_info}"
+            )
             if current_objects:
                 objects_prompt = (
                     f"**CURRENTLY SET:** `{', '.join(current_objects)}`\n\n{config.hitl_objects_template}{cancel_info}"
@@ -525,13 +526,11 @@ async def lvs_video_understanding(
                 "**Enterprise RAG Query (OPTIONAL):**\n"
                 "Enter a search query to retrieve relevant enterprise knowledge, or leave empty to skip."
             )
-            
+
             user_input = await _prompt_user_input(
-                rag_prompt_text, 
-                required=False, 
-                placeholder="e.g., What are the principles of STCC?"
+                rag_prompt_text, required=False, placeholder="e.g., What are the principles of STCC?"
             )
-            
+
             rag_query = user_input.strip()
             if rag_query:
                 logger.info(f"Enterprise RAG query: {rag_query}")
@@ -625,7 +624,7 @@ async def lvs_video_understanding(
         # Update state for this thread
         lvs_params_state[thread_id] = (scenario, events, objects_of_interest, rag_query)
         logger.info(f"Updated parameters state for thread {thread_id}")
-        
+
         # Enterprise RAG Integration
         enterprise_rag_result = {"status": "disabled", "query": "", "context": "", "error": ""}
         enterprise_rag_query = ""
@@ -674,8 +673,11 @@ async def lvs_video_understanding(
         # - remote: INTERNAL_IP -> EXTERNAL_IP (VLM needs public URLs)
         # - local/local_shared: EXTERNAL_IP -> INTERNAL_IP (VLM needs internal URLs)
         video_url = translate_url(
-            video_url, config.vlm_mode, config.internal_ip,
-            config.external_ip, config.vst_internal_url,
+            video_url,
+            config.vlm_mode,
+            config.internal_ip,
+            config.external_ip,
+            config.vst_internal_url,
         )
         logger.info(f"[LVS Video Understanding] VIDEO URL FOR VLM ANALYSIS: {video_url}")
 
@@ -736,26 +738,30 @@ async def lvs_video_understanding(
                     enterprise_context = enterprise_rag_result.get("context", "")
                     try:
                         llm = await builder.get_llm(config.llm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
-                        enrichment_prompt = ChatPromptTemplate.from_messages([
-                            (
-                                "system",
-                                "You are enriching a video summary with additional enterprise knowledge. "
-                                "Preserve the exact format, all timestamps, and all 'Watch clip' references. "
-                                "Do not reorder or remove existing content, simply seek to enrich it "
-                                "wherever it makes sense with what was retrieved from the enterprise knowledge base.",
-                            ),
-                            (
-                                "user",
-                                "Video Summary:\n{video_summary}\n\n"
-                                "Enterprise Knowledge:\n{enterprise_context}\n\n"
-                                "Return the enriched video summary.",
-                            ),
-                        ])
+                        enrichment_prompt = ChatPromptTemplate.from_messages(
+                            [
+                                (
+                                    "system",
+                                    "You are enriching a video summary with additional enterprise knowledge. "
+                                    "Preserve the exact format, all timestamps, and all 'Watch clip' references. "
+                                    "Do not reorder or remove existing content, simply seek to enrich it "
+                                    "wherever it makes sense with what was retrieved from the enterprise knowledge base.",
+                                ),
+                                (
+                                    "user",
+                                    "Video Summary:\n{video_summary}\n\n"
+                                    "Enterprise Knowledge:\n{enterprise_context}\n\n"
+                                    "Return the enriched video summary.",
+                                ),
+                            ]
+                        )
                         chain = enrichment_prompt | llm
-                        resp = await chain.ainvoke({
-                            "video_summary": video_summary,
-                            "enterprise_context": enterprise_context,
-                        })
+                        resp = await chain.ainvoke(
+                            {
+                                "video_summary": video_summary,
+                                "enterprise_context": enterprise_context,
+                            }
+                        )
                         enriched = resp.content.strip()
                         if enriched:
                             video_summary = enriched
@@ -783,7 +789,7 @@ async def lvs_video_understanding(
                     result["note"] = (
                         "The video may not contain the types of events specified in the search criteria, or the content may not be clear enough for detection."
                     )
-                
+
                 # We return JSON string as the original contract requires string return
                 formatted_response = json.dumps(result, indent=2, ensure_ascii=False)
                 logger.info(f"LVS response received with {len(events)} events")

--- a/agent/app/video_search_frag/src/video_search_frag/lvs_video_understanding_frag.py
+++ b/agent/app/video_search_frag/src/video_search_frag/lvs_video_understanding_frag.py
@@ -1,0 +1,804 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+LVS Video Understanding Tool with Mandatory HITL Prompt Configuration.
+
+This tool wraps the LVS (Long Video Summarization) service API to provide
+video understanding capabilities for long videos. It has a similar interface
+to the video_understanding tool but uses LVS's chunk-based processing.
+
+Key features:
+- Uses LVS service for hierarchical summarization (chunk-based processing)
+- Better suited for long videos (> 2 minutes)
+- MANDATORY Human-in-the-Loop (HITL) prompt configuration before every analysis
+- Prompts come from config and can be accepted or overridden by user during HITL
+- User must explicitly accept or modify all 3 prompts before video analysis begins
+"""
+
+from collections.abc import AsyncGenerator
+from enum import Enum
+import json
+import logging
+import asyncio
+
+from vss_agents.utils.url_translation import translate_url
+
+import aiohttp
+from langchain_core.prompts import ChatPromptTemplate
+from nat.builder.builder import Builder
+from nat.builder.context import Context
+from nat.builder.context import ContextState
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.function import FunctionBaseConfig
+from nat.data_models.interactive import HumanPromptText
+from nat.data_models.interactive import InteractionResponse
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+
+class LVSStatus(str, Enum):
+    """Status values for LVS video understanding operations."""
+
+    ABORTED = "aborted"
+    SUCCESS = "success"
+
+
+# Default HITL confirmation template
+DEFAULT_HITL_CONFIRMATION_TEMPLATE = """
+Please review the above configuration that will be sent for video analysis:
+
+**Options:**
+• Press Submit (empty) → Confirm and proceed with video analysis
+• Type `/redo` → Modify parameters
+• Type `/cancel` → Cancel analysis
+
+Enter your choice or press Submit to proceed:"""
+
+
+class LVSVideoUnderstandingConfig(FunctionBaseConfig, name="lvs_video_understanding_frag"):
+    """Configuration for the LVS Video Understanding tool."""
+
+    lvs_backend_url: str = Field(
+        ...,
+        description="The URL of the LVS backend service (e.g., http://localhost:38111).",
+    )
+
+    llm_name: str = Field(
+        default="llm",
+        description="The name of the LLM component to use for enrichment.",
+    )
+
+    # Timeout configuration
+    conn_timeout_ms: int = Field(
+        default=5000,
+        description="Connection timeout in milliseconds for LVS API calls.",
+    )
+
+    read_timeout_ms: int = Field(
+        default=600000,  # 10 minutes for long videos
+        description="Read timeout in milliseconds for LVS API calls.",
+    )
+
+    model: str = Field(
+        default="gpt-4o",
+        description="LVS model to use for video analysis.",
+    )
+
+    # Video URL tool for getting video URL from sensor ID
+    video_url_tool: str = Field(
+        default="vst_video_url",
+        description="A tool to be used to get the video URL by sensor ID and timestamp (default to use VST service)",
+    )
+
+    # API Parameters (configurable from config file)
+    response_format_type: str = Field(
+        default="text",
+        description="Response format type (e.g., 'text', 'json')",
+    )
+
+    enable_chat: bool = Field(
+        default=False,
+        description="Enable chat mode for LVS",
+    )
+
+    enable_cv_metadata: bool = Field(
+        default=False,
+        description="Enable computer vision metadata in response",
+    )
+
+    temperature: float = Field(
+        default=0.4,
+        description="Temperature for LLM sampling (0.0 to 1.0)",
+    )
+
+    seed: int | None = Field(
+        default=1,
+        description="Random seed for reproducibility",
+    )
+
+    top_p: float = Field(
+        default=1.0,
+        description="Top-p (nucleus) sampling parameter",
+    )
+
+    top_k: int = Field(
+        default=10,
+        description="Top-k sampling parameter",
+    )
+
+    max_tokens: int = Field(
+        default=512,
+        description="Maximum tokens in response",
+    )
+
+    chunk_duration: int = Field(
+        default=10,
+        description="Duration of each video chunk in seconds (0 = entire video in one request)",
+    )
+
+    num_frames_per_chunk: int = Field(
+        default=20,
+        description="Number of frames to sample per chunk",
+    )
+
+    enable_audio: bool = Field(
+        default=False,
+        description="Enable audio processing",
+    )
+
+    stream: bool = Field(
+        default=True,
+        description="Enable streaming response",
+    )
+
+    include_usage: bool = Field(
+        default=True,
+        description="Include usage statistics in response",
+    )
+
+    # HITL Templates (mandatory - configured in YAML)
+    hitl_scenario_template: str = Field(
+        ...,
+        description="HITL template for collecting scenario from user",
+    )
+
+    hitl_events_template: str = Field(
+        ...,
+        description="HITL template for collecting events from user",
+    )
+
+    hitl_objects_template: str = Field(
+        ...,
+        description="HITL template for collecting objects_of_interest from user",
+    )
+
+    hitl_confirmation_template: str | None = Field(
+        default=None,
+        description="HITL template for final confirmation before video analysis. If None, uses default template.",
+    )
+
+    # Default values for HITL parameters
+    default_scenario: str = Field(
+        default="",
+        description="Default scenario to use when no persistent state exists (e.g., 'traffic monitoring')",
+    )
+
+    default_events: list[str] = Field(
+        default_factory=list,
+        description="Default events list to use when no persistent state exists (e.g., ['accident', 'pedestrian crossing'])",
+    )
+
+    # URL translation configuration for VLM
+    vlm_mode: str = Field(
+        default="local",
+        description="VLM mode: 'remote' (VLM is external, needs public URLs), 'local' or 'local_shared' (VLM is local, needs internal URLs)",
+    )
+    internal_ip: str = Field(
+        default="",
+        description="Internal IP / docker host IP for URL translation",
+    )
+    external_ip: str = Field(
+        default="",
+        description="Public IP accessible from the internet for URL translation",
+    )
+    
+    # Enterprise RAG Configuration
+    enterprise_rag_enabled: bool = Field(
+        default=True,
+        description="Enable Enterprise RAG context retrieval (default: enabled)",
+    )
+
+    vst_internal_url: str | None = Field(
+        default=None,
+        description="Internal VST base URL (e.g., 'http://HOST_IP:30888'). "
+        "Used for URL translation when behind a reverse proxy.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class LVSVideoUnderstandingInput(BaseModel):
+    """Input for the LVS Video Understanding tool with mandatory HITL."""
+
+    sensor_id: str = Field(
+        ...,
+        description="The sensor ID of the video to understand.",
+        min_length=1,
+    )
+
+
+@register_function(config_type=LVSVideoUnderstandingConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
+async def lvs_video_understanding(
+    config: LVSVideoUnderstandingConfig, builder: Builder
+) -> AsyncGenerator[FunctionInfo]:
+    """
+    LVS Video Understanding Tool with HITL for Scenario, Events, and Objects.
+
+    This tool uses the LVS (Long Video Summarization) service to analyze videos
+    and supports Human-in-the-Loop configuration of analysis parameters.
+
+    HITL collects:
+    - scenario (REQUIRED): Description of the video scenario
+    - events (REQUIRED): List of events to detect
+    - objects_of_interest (OPTIONAL): List of objects to focus on
+
+    Parameters are persisted per conversation thread.
+    """
+
+    logger.info(f"Initializing LVS Video Understanding tool (backend: {config.lvs_backend_url})")
+
+    # Persistent state: maps thread_id -> (scenario, events, objects_of_interest, rag_query)
+    lvs_params_state: dict[str, tuple[str, list[str], list[str], str]] = {}
+    
+    # Load Enterprise RAG tool if enabled.
+    # IMPORTANT: config.yml for this profile already registers `enterprise_rag`,
+    # but we still guard failures so LVS doesn't crash agent startup.
+    enterprise_rag_tool = None
+    if config.enterprise_rag_enabled:
+        try:
+            enterprise_rag_tool = await builder.get_tool("enterprise_rag", wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+            logger.info("Enterprise RAG tool loaded")
+        except Exception as e:
+            logger.warning(f"Failed to load Enterprise RAG tool: {e}")
+            enterprise_rag_tool = None
+
+    rag_available = bool(enterprise_rag_tool)
+
+    async def _prompt_user_input(prompt_text: str, required: bool = True, placeholder: str = "") -> str:
+        """
+        Prompt user for input using HITL.
+
+        Args:
+            prompt_text: The prompt text to show to the user
+            required: Whether the input is required
+            placeholder: Placeholder text for the input
+
+        Returns:
+            str: User's input
+        """
+        nat_context = Context.get()
+        user_input_manager = nat_context.user_interaction_manager
+
+        human_prompt = HumanPromptText(text=prompt_text, required=required, placeholder=placeholder)
+        response: InteractionResponse = await user_input_manager.prompt_user_input(human_prompt)
+        response_text: str = str(response.content.text).strip()
+
+        return response_text
+
+    def _format_lvs_config_summary(
+        scenario: str,
+        events: list[str],
+        objects_of_interest: list[str],
+    ) -> str:
+        """
+        Format a summary of LVS configuration for user review.
+
+        Args:
+            scenario: The scenario description
+            events: List of events to detect
+            objects_of_interest: List of objects to focus on
+
+        Returns:
+            str: Formatted configuration summary
+        """
+        summary_lines = [
+            "**Scenario:**",
+            f"```\n{scenario}\n```",
+            "",
+            "**Events to Detect:**",
+            f"```\n{', '.join(events)}\n```",
+            "",
+        ]
+
+        if objects_of_interest:
+            summary_lines.extend(
+                [
+                    "**Objects of Interest:**",
+                    f"```\n{', '.join(objects_of_interest)}\n```",
+                ]
+            )
+        else:
+            summary_lines.extend(
+                [
+                    "**Objects of Interest:**",
+                    "```\nNone\n```",
+                ]
+            )
+
+        return "\n".join(summary_lines)
+
+    async def _confirm_lvs_request(
+        scenario: str,
+        events: list[str],
+        objects_of_interest: list[str],
+    ) -> str:
+        """
+        Show all LVS configuration and get user confirmation.
+
+        Args:
+            scenario: The scenario description
+            events: List of events to detect
+            objects_of_interest: List of objects to focus on
+
+        Returns:
+            str: Normalized user choice ("/redo", "/cancel", or empty string for proceed)
+        """
+        config_summary = _format_lvs_config_summary(scenario, events, objects_of_interest)
+
+        hitl_template = config.hitl_confirmation_template or DEFAULT_HITL_CONFIRMATION_TEMPLATE
+        prompt_text = f"{config_summary}\n\n{hitl_template}"
+
+        user_choice = await _prompt_user_input(
+            prompt_text,
+            required=False,
+            placeholder="/redo, /cancel, or press Submit to proceed",
+        )
+
+        # Return normalized choice
+        return user_choice.lower().strip()
+
+    async def _collect_hitl_parameters(
+        current_params: tuple[str, list[str], list[str], str] | None = None,
+    ) -> tuple[str, list[str], list[str], str] | None:
+        """
+        Collect scenario, events, objects_of_interest, and rag_query via HITL.
+
+        If current_params is provided, shows current values and allows user to accept or modify.
+        User can type /cancel at any step to abort.
+
+        Args:
+            current_params: Optional current parameters (scenario, events, objects_of_interest, rag_query)
+
+        Returns:
+            tuple: (scenario, events, objects_of_interest, rag_query), or None if cancelled
+        """
+        logger.info("Starting HITL parameter collection workflow")
+
+        current_rag_query = ""
+
+        # Cancel info to append to each prompt
+        cancel_info = "\n\n**Note:** Type `/cancel` at any time to abort the video analysis."
+
+        # Build prompt with current values if they exist
+        if current_params:
+            # Handle backward compatibility if state tuple size differs
+            if len(current_params) == 4:
+                current_scenario, current_events, current_objects, current_rag_query = current_params
+            else:
+                current_scenario, current_events, current_objects = current_params[:3]
+                
+            scenario_prompt = f"**CURRENTLY SET:** `{current_scenario}`\n\n{config.hitl_scenario_template}{cancel_info}"
+            events_prompt = f"**CURRENTLY SET:** `{', '.join(current_events)}`\n\n{config.hitl_events_template}{cancel_info}"
+            if current_objects:
+                objects_prompt = (
+                    f"**CURRENTLY SET:** `{', '.join(current_objects)}`\n\n{config.hitl_objects_template}{cancel_info}"
+                )
+            else:
+                objects_prompt = f"**CURRENTLY SET:** None\n\n{config.hitl_objects_template}{cancel_info}"
+        else:
+            # Use default values from config when no persistent state exists
+            current_scenario = config.default_scenario
+            current_events = config.default_events
+            current_objects = []  # Always empty by default
+
+            if current_scenario or current_events:
+                # Show defaults if they exist
+                if current_scenario:
+                    scenario_prompt = (
+                        f"**DEFAULT:** `{current_scenario}`\n\n{config.hitl_scenario_template}{cancel_info}"
+                    )
+                else:
+                    scenario_prompt = f"{config.hitl_scenario_template}{cancel_info}"
+
+                if current_events:
+                    events_prompt = (
+                        f"**DEFAULT:** `{', '.join(current_events)}`\n\n{config.hitl_events_template}{cancel_info}"
+                    )
+                else:
+                    events_prompt = f"{config.hitl_events_template}{cancel_info}"
+
+                objects_prompt = f"{config.hitl_objects_template}{cancel_info}"
+            else:
+                # No defaults configured
+                scenario_prompt = f"{config.hitl_scenario_template}{cancel_info}"
+                events_prompt = f"{config.hitl_events_template}{cancel_info}"
+                objects_prompt = f"{config.hitl_objects_template}{cancel_info}"
+
+        # Collect scenario (REQUIRED)
+        scenario = ""
+        while not scenario:
+            user_input = await _prompt_user_input(
+                scenario_prompt,
+                required=not bool(current_scenario),  # Not required if we have a current value
+                placeholder="e.g., traffic monitoring or /cancel",
+            )
+
+            # Check for /cancel
+            if user_input and user_input.strip().lower() == "/cancel":
+                logger.info("User cancelled during scenario collection")
+                return None
+
+            if not user_input and current_scenario:
+                scenario = current_scenario
+                logger.info(f"User accepted current scenario: {scenario}")
+            elif user_input:
+                scenario = user_input
+                logger.info(f"User provided new scenario: {scenario}")
+            else:
+                logger.warning("Scenario is required, prompting again")
+
+        # Collect events (REQUIRED)
+        events: list[str] = []
+        while not events:
+            user_input = await _prompt_user_input(
+                events_prompt,
+                required=not bool(current_events),  # Not required if we have current values
+                placeholder="e.g., accident, pedestrian crossing or /cancel",
+            )
+
+            # Check for /cancel
+            if user_input and user_input.strip().lower() == "/cancel":
+                logger.info("User cancelled during events collection")
+                return None
+
+            # If user pressed Enter and we have current values, use them
+            if not user_input and current_events:
+                events = current_events
+                logger.info(f"User accepted current events: {events}")
+            elif user_input:
+                events = [e.strip() for e in user_input.split(",") if e.strip()]
+                logger.info(f"User provided new events: {events}")
+            else:
+                logger.warning("Events are required, prompting again")
+
+        # Collect objects_of_interest (OPTIONAL - requires explicit "skip" to skip)
+        user_input = await _prompt_user_input(
+            objects_prompt,
+            required=False,
+            placeholder='e.g., cars, trucks, pedestrians OR type "skip" to skip or /cancel',
+        )
+
+        # Check for /cancel
+        if user_input and user_input.strip().lower() == "/cancel":
+            logger.info("User cancelled during objects collection")
+            return None
+
+        # Check if user explicitly typed "skip"
+        if user_input.lower() == "skip":
+            objects_of_interest = []
+            logger.info("User explicitly skipped objects_of_interest")
+        elif not user_input and current_objects:
+            # Empty input with existing state -> keep current values
+            objects_of_interest = current_objects
+            logger.info(f"User accepted current objects_of_interest: {objects_of_interest}")
+        elif user_input:
+            # User provided new values
+            objects_of_interest = [o.strip() for o in user_input.split(",") if o.strip()]
+            logger.info(f"User provided new objects_of_interest: {objects_of_interest}")
+        else:
+            # Empty input with no existing state -> require explicit input
+            logger.warning("Please provide objects_of_interest or type 'skip' to skip")
+            objects_of_interest = []
+
+        # Collect Enterprise RAG Query (OPTIONAL)
+        rag_query = ""
+        if rag_available:
+            rag_prompt_text = (
+                "**Enterprise RAG Query (OPTIONAL):**\n"
+                "Enter a search query to retrieve relevant enterprise knowledge, or leave empty to skip."
+            )
+            
+            user_input = await _prompt_user_input(
+                rag_prompt_text, 
+                required=False, 
+                placeholder="e.g., What are the principles of STCC?"
+            )
+            
+            rag_query = user_input.strip()
+            if rag_query:
+                logger.info(f"Enterprise RAG query: {rag_query}")
+            else:
+                logger.info("No Enterprise RAG query provided, skipping")
+
+        logger.info("HITL parameter collection completed")
+        return scenario, events, objects_of_interest, rag_query
+
+    async def _lvs_video_understanding(lvs_input: LVSVideoUnderstandingInput) -> str:
+        """
+        Use LVS(Long Video Summarization) service to understand and summarize a video.
+
+        This tool is optimized for long videos and uses
+        chunk-based processing with event detection.
+
+
+        Args:
+            lvs_input: LVSVideoUnderstandingInput with sensor_id(sensor name or video file name in VST)
+        Returns:
+            str: The summary/analysis from LVS service
+        """
+        # Get thread_id for state persistence
+        thread_id = ContextState.get().conversation_id.get()
+        logger.info(f"Processing LVS request for thread {thread_id}")
+
+        logger.info(f"LVS Video Understanding: Processing '{lvs_input.sensor_id}'")
+
+        # Get current parameters for this thread (if any)
+        current_params = lvs_params_state.get(thread_id)
+
+        if current_params:
+            logger.info(f"Found existing parameters for thread {thread_id}")
+        else:
+            logger.info(f"No existing parameters for thread {thread_id}, will collect new ones")
+
+        # Initialize variables for type checker
+        scenario: str = ""
+        events: list[str] = []
+        objects_of_interest: list[str] = []
+        rag_query: str = ""
+
+        # HITL workflow with confirmation loop
+        while True:
+            # Step 1: Collect parameters via HITL
+            logger.info("Running HITL workflow to collect/confirm parameters")
+            params_result = await _collect_hitl_parameters(current_params)
+
+            # Handle cancellation
+            if params_result is None:
+                logger.info("LVS analysis cancelled by user during parameter collection")
+                return json.dumps(
+                    {
+                        "status": LVSStatus.ABORTED.value,
+                        "message": "Video analysis was cancelled by user.",
+                    },
+                    indent=2,
+                )
+
+            scenario, events, objects_of_interest, rag_query = params_result
+
+            # Step 2: Show all configs and get confirmation (before fetching video URL)
+            logger.info("Showing LVS configuration for user confirmation")
+            user_choice = await _confirm_lvs_request(scenario, events, objects_of_interest)
+
+            if user_choice == "/redo":
+                # User wants to modify parameters - loop back with current values
+                logger.info("User requested redo - restarting parameter collection")
+                current_params = (scenario, events, objects_of_interest, rag_query)
+                continue
+            elif user_choice == "/cancel":
+                # User cancelled
+                logger.info("LVS analysis cancelled by user")
+                return json.dumps(
+                    {
+                        "status": LVSStatus.ABORTED.value,
+                        "message": "Video analysis was cancelled by user.",
+                    },
+                    indent=2,
+                )
+            else:
+                # Empty string or any other input - proceed with LVS request
+                logger.info("User confirmed - proceeding with LVS analysis")
+                break
+
+        # Store HITL parameters for later inclusion in the report
+        hitl_scenario = scenario
+        hitl_events = events
+        hitl_objects_of_interest = objects_of_interest
+
+        # Update state for this thread
+        lvs_params_state[thread_id] = (scenario, events, objects_of_interest, rag_query)
+        logger.info(f"Updated parameters state for thread {thread_id}")
+        
+        # Enterprise RAG Integration
+        enterprise_rag_result = {"status": "disabled", "query": "", "context": "", "error": ""}
+        enterprise_rag_query = ""
+
+        if rag_available and rag_query:
+            enterprise_rag_query = rag_query
+
+            logger.info(f"Querying Enterprise RAG with: {enterprise_rag_query}")
+            try:
+                rag_output = await enterprise_rag_tool.ainvoke({"query": enterprise_rag_query})
+
+                if isinstance(rag_output, BaseModel):
+                    enterprise_rag_result = rag_output.model_dump()
+                elif isinstance(rag_output, str):
+                    enterprise_rag_result = json.loads(rag_output)
+                else:
+                    enterprise_rag_result = rag_output
+
+            except Exception as e:
+                logger.error(f"Enterprise RAG query failed: {e}")
+                enterprise_rag_result = {
+                    "status": "error",
+                    "query": enterprise_rag_query,
+                    "context": "",
+                    "error": str(e),
+                }
+        elif rag_available and not rag_query:
+            enterprise_rag_result = {"status": "skipped", "query": "", "context": "", "error": ""}
+        else:
+            enterprise_rag_result = {"status": "disabled", "query": "", "context": "", "error": ""}
+
+        # Load video URL tool (deferred to runtime to avoid initialization order issues)
+        logger.info(f"Loading video URL tool: {config.video_url_tool}")
+        video_url_tool = await builder.get_tool(config.video_url_tool, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+        # Get video URL using the video_url_tool (e.g., vst_video_url)
+        logger.info(f"Using {config.video_url_tool} to get video URL for file {lvs_input.sensor_id}")
+        video_url_args = {
+            "sensor_id": lvs_input.sensor_id,
+        }
+        logger.debug(f"Video URL tool arguments: {video_url_args}")
+        video_url_result = await video_url_tool.ainvoke(input=video_url_args)
+        video_url = video_url_result.video_url
+
+        # Translate URL for VLM based on vlm_mode:
+        # - remote: INTERNAL_IP -> EXTERNAL_IP (VLM needs public URLs)
+        # - local/local_shared: EXTERNAL_IP -> INTERNAL_IP (VLM needs internal URLs)
+        video_url = translate_url(
+            video_url, config.vlm_mode, config.internal_ip,
+            config.external_ip, config.vst_internal_url,
+        )
+        logger.info(f"[LVS Video Understanding] VIDEO URL FOR VLM ANALYSIS: {video_url}")
+
+        # Build LVS request using new API contract
+        lvs_request = {
+            "url": video_url,
+            "model": config.model,
+            # HITL parameters
+            "scenario": scenario,
+            "events": events,
+            # Video processing parameters
+            "chunk_duration": config.chunk_duration,
+            "num_frames_per_chunk": config.num_frames_per_chunk,
+        }
+        logger.info(f"LVS request: {lvs_request}")
+
+        # Add seed if configured
+        if config.seed is not None:
+            lvs_request["seed"] = config.seed
+
+        if objects_of_interest:
+            lvs_request["objects_of_interest"] = objects_of_interest
+
+        logger.info(f"Calling LVS service: {config.lvs_backend_url}/summarize")
+        logger.debug(f"LVS request: {lvs_request}")
+
+        # Call LVS service
+        try:
+            timeout = aiohttp.ClientTimeout(connect=config.conn_timeout_ms / 1000, total=config.read_timeout_ms / 1000)
+            async with (
+                aiohttp.ClientSession(timeout=timeout) as session,
+                session.post(f"{config.lvs_backend_url}/summarize", json=lvs_request) as response,
+            ):
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise RuntimeError(f"LVS service returned {response.status}: {error_text}")
+
+                response_json = await response.json()
+
+                # Parse OpenAI-style response format: choices[0].message.content contains JSON string
+                content = response_json["choices"][0]["message"]["content"]
+                content_json = json.loads(content)
+                logger.info(f"LVS response: {content_json}")
+                video_summary = content_json.get("video_summary", "").strip()
+                events = content_json.get("events", [])
+
+                # Generate friendly message only if no summary and no events
+                if not video_summary and not events:
+                    video_summary = "No significant events or activities were detected in this video."
+                    logger.warning("LVS returned no summary and no events")
+                elif not video_summary:
+                    logger.info(f"LVS returned no summary but has {len(events)} events")
+                if not events:
+                    logger.warning("LVS returned no events")
+
+                # Enrich video_summary with Enterprise RAG context via LLM
+                if video_summary and enterprise_rag_result.get("status") == "ok":
+                    enterprise_context = enterprise_rag_result.get("context", "")
+                    try:
+                        llm = await builder.get_llm(config.llm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+                        enrichment_prompt = ChatPromptTemplate.from_messages([
+                            (
+                                "system",
+                                "You are enriching a video summary with additional enterprise knowledge. "
+                                "Preserve the exact format, all timestamps, and all 'Watch clip' references. "
+                                "Do not reorder or remove existing content, simply seek to enrich it "
+                                "wherever it makes sense with what was retrieved from the enterprise knowledge base.",
+                            ),
+                            (
+                                "user",
+                                "Video Summary:\n{video_summary}\n\n"
+                                "Enterprise Knowledge:\n{enterprise_context}\n\n"
+                                "Return the enriched video summary.",
+                            ),
+                        ])
+                        chain = enrichment_prompt | llm
+                        resp = await chain.ainvoke({
+                            "video_summary": video_summary,
+                            "enterprise_context": enterprise_context,
+                        })
+                        enriched = resp.content.strip()
+                        if enriched:
+                            video_summary = enriched
+                            logger.info("Video summary enriched with Enterprise RAG context via LLM")
+                    except Exception as e:
+                        logger.warning(f"LLM enrichment failed, using original summary: {e}")
+
+                rag_summary = {
+                    "status": enterprise_rag_result.get("status", "disabled"),
+                    "query": enterprise_rag_result.get("query", ""),
+                }
+                result = {
+                    "video_summary": video_summary,
+                    "events": events,
+                    "hitl_prompts": {
+                        "scenario": hitl_scenario,
+                        "events": hitl_events,
+                        "objects_of_interest": hitl_objects_of_interest,
+                        "enterprise_rag_query": enterprise_rag_query,
+                    },
+                    "enterprise_rag": rag_summary,
+                    "lvs_backend_response": response_json,
+                }
+                if not video_summary and not events:
+                    result["note"] = (
+                        "The video may not contain the types of events specified in the search criteria, or the content may not be clear enough for detection."
+                    )
+                
+                # We return JSON string as the original contract requires string return
+                formatted_response = json.dumps(result, indent=2, ensure_ascii=False)
+                logger.info(f"LVS response received with {len(events)} events")
+                return formatted_response
+
+        except aiohttp.ClientError as e:
+            logger.error(f"LVS service connection error: {e}")
+            raise RuntimeError(f"Failed to connect to LVS service: {e}") from e
+        except Exception as e:
+            logger.error(f"LVS video understanding failed: {e}")
+            raise
+
+    yield FunctionInfo.create(
+        single_fn=_lvs_video_understanding,
+        description=_lvs_video_understanding.__doc__,
+        input_schema=LVSVideoUnderstandingInput,
+        single_output_schema=str,
+    )

--- a/agent/app/video_search_frag/src/video_search_frag/register.py
+++ b/agent/app/video_search_frag/src/video_search_frag/register.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+NAT component registration for video_search_frag.
+
+Importing this module triggers @register_function decorators in the tool modules,
+making them discoverable by NAT via the entry-point defined in pyproject.toml.
+"""
+
+import video_search_frag.enterprise_rag  # noqa: F401
+import video_search_frag.lvs_video_understanding_frag  # noqa: F401
+import video_search_frag.video_report_gen_frag  # noqa: F401

--- a/agent/app/video_search_frag/src/video_search_frag/register.py
+++ b/agent/app/video_search_frag/src/video_search_frag/register.py
@@ -20,6 +20,6 @@ Importing this module triggers @register_function decorators in the tool modules
 making them discoverable by NAT via the entry-point defined in pyproject.toml.
 """
 
-import video_search_frag.enterprise_rag  # noqa: F401
-import video_search_frag.lvs_video_understanding_frag  # noqa: F401
+import video_search_frag.enterprise_rag
+import video_search_frag.lvs_video_understanding_frag
 import video_search_frag.video_report_gen_frag  # noqa: F401

--- a/agent/app/video_search_frag/src/video_search_frag/video_report_gen_frag.py
+++ b/agent/app/video_search_frag/src/video_search_frag/video_report_gen_frag.py
@@ -1,0 +1,1866 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Report Generation Tool for uploaded videos.
+
+Generates reports for uploaded videos without Video Analytics MCP infrastructure.
+Handles VLM prompt sanitization, video analysis, and report formatting.
+"""
+
+import asyncio
+from collections import OrderedDict
+from collections.abc import AsyncGenerator
+from datetime import datetime
+from datetime import timedelta
+import json
+import logging
+import os
+import re
+import tempfile
+from typing import Any
+from typing import NamedTuple
+import urllib.parse
+
+try:
+    import markdown
+    from xhtml2pdf import pisa
+
+    PDF_CONVERSION_AVAILABLE = True
+except ImportError:
+    PDF_CONVERSION_AVAILABLE = False
+
+
+from nat.builder.builder import Builder
+from nat.builder.context import Context
+from nat.builder.context import ContextState
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.component_ref import FunctionRef
+from nat.data_models.component_ref import ObjectStoreRef
+from nat.data_models.function import FunctionBaseConfig
+from nat.data_models.interactive import HumanPromptText
+from nat.data_models.interactive import InteractionResponse
+from nat.object_store.models import ObjectStoreItem
+from pydantic import BaseModel
+from pydantic import Field
+
+from video_search_frag.lvs_video_understanding_frag import LVSStatus
+from vss_agents.tools.vst.timeline import get_timeline
+from vss_agents.tools.vst.utils import get_stream_id
+from vss_agents.tools.vst.video_clip import get_video_url
+from vss_agents.utils.reasoning_parsing import parse_reasoning_content
+from vss_agents.utils.time_convert import datetime_to_iso8601
+from vss_agents.utils.time_convert import iso8601_to_datetime
+
+logger = logging.getLogger(__name__)
+
+
+CHUNK_TIMESTAMP_PROMPT = """
+    All events from the video should fall within the time range:
+    START_TIME: {start_time}s
+    END_TIME: {end_time}s
+"""
+
+
+def _get_object_store_url(object_store: Any, filename: str, config: "VideoReportGenConfig") -> str:
+    """
+    Get HTTP URL for a file from any object store type.
+
+    Supports:
+    - S3/MinIO object store (construct URL from endpoint)
+    - in_memory and other stores (use NAT file server /static/ endpoint)
+
+    Args:
+        object_store: The object store instance
+        filename: The file key/name
+        config: The Video report gen config
+
+    Returns:
+        str: HTTP URL to access the file
+    """
+    # S3/MinIO object store - construct URL from attributes
+    if hasattr(object_store, "endpoint_url") and hasattr(object_store, "bucket_name"):
+        endpoint = object_store.endpoint_url
+        bucket = object_store.bucket_name
+        endpoint = endpoint.rstrip("/")
+        return f"{endpoint}/{bucket}/{filename}"
+
+    # For in_memory and other stores - use NAT's /static/ endpoint from config
+    base_url = config.base_url.rstrip("/")
+    return f"{base_url}/{filename}"
+
+
+def _divide_video_into_chunks(
+    duration_seconds: float,
+    chunk_duration_seconds: int = 60,
+) -> list[tuple[float, float]]:
+    """
+    Divide a video timeframe into chunks.
+
+    Args:
+        duration_seconds: Duration of the video in seconds
+        chunk_duration_seconds: Duration of each chunk in seconds
+
+    Returns:
+        List of (chunk_start, chunk_end) tuples in seconds(offset from the start of the video)
+    """
+    if chunk_duration_seconds <= 0:
+        raise ValueError(
+            f"Video Analysis Report: chunk_duration_seconds must be positive, got {chunk_duration_seconds}"
+        )
+
+    chunks: list[tuple[float, float]] = []
+    current_start: float = 0.0
+
+    while current_start < duration_seconds:
+        current_end = min(current_start + chunk_duration_seconds, duration_seconds)
+        chunks.append(
+            (
+                current_start,
+                current_end,
+            )
+        )
+        current_start = current_end
+
+    return chunks
+
+
+def _remove_som_markers(prompt: str) -> str:
+    """
+    Remove Set-of-Mark (SOM) markers from VLM prompts.
+
+    SOM markers are used in Video Analytics MCP mode to reference specific tracked objects,
+    but are not applicable for Video(uploaded) Report mode where videos lack object tracking data.
+
+    Removes:
+    - {object_ids} placeholder
+    - Sentences mentioning "object ids" or "object IDs"
+    - Any remaining object ID references
+
+    Args:
+        prompt: The original VLM prompt
+
+    Returns:
+        Cleaned prompt without SOM markers
+    """
+    # Remove {object_ids} placeholder
+    cleaned = re.sub(r"\{object_ids\}", "", prompt)
+
+    # Remove sentences mentioning object IDs
+    cleaned = re.sub(
+        r"Focus only on.*?object ids[^.]*\.\s*",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"Include only.*?object ids[^.]*\.\s*",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+
+    # Clean up any extra whitespace
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+
+    return cleaned
+
+
+def _replace_public_urls_with_private(
+    markdown_content: str, vst_internal_url: str | None, vst_external_url: str | None
+) -> str:
+    """
+    Replace external (public) URLs in image tags with internal (private) IP URLs for PDF generation.
+
+    Args:
+        markdown_content: Markdown content with image URLs
+        vst_internal_url: Internal VST URL (e.g., 'http://10.0.0.1:30888') - private IP for PDF
+        vst_external_url: External VST URL (e.g., 'http://public.example.com:30888') - public URL to replace
+
+    Returns:
+        Markdown content with image URLs updated to use private IP
+    """
+    if not vst_internal_url or not vst_external_url:
+        logger.debug(
+            f"URL replacement skipped - vst_internal_url: {vst_internal_url is not None}, "
+            f"vst_external_url: {vst_external_url is not None}"
+        )
+        return markdown_content
+
+    # Extract base URLs (scheme + host + port)
+    internal_match = re.match(r"(https?://[^/]+)", vst_internal_url)
+    external_match = re.match(r"(https?://[^/]+)", vst_external_url)
+
+    if not internal_match or not external_match:
+        logger.warning(f"Could not parse URLs - internal: {vst_internal_url}, external: {vst_external_url}")
+        return markdown_content
+
+    internal_base = internal_match.group(1)  # e.g., 'http://10.0.0.1:30888'
+    external_base = external_match.group(1)  # e.g., 'http://203.0.113.1:30888'
+
+    logger.info(f"Replacing external URL '{external_base}' with internal URL '{internal_base}' in image URLs for PDF")
+
+    # Replace URLs in image tags only (both <img src="..." and ![alt](url) formats)
+    # Pattern 1: <img src="URL" ...>
+    def replace_img_src(match: re.Match[str]) -> str:
+        full_match = match.group(0)
+        url = match.group(1)
+
+        # Replace external base with internal base if found
+        if external_base in url:
+            new_url = url.replace(external_base, internal_base)
+            return full_match.replace(url, new_url)
+
+        return full_match
+
+    # Replace in <img src="..." tags
+    result = re.sub(r'<img\s+src="([^"]+)"', replace_img_src, markdown_content)
+
+    # Pattern 2: ![alt](URL) - markdown image syntax
+    def replace_md_img(match: re.Match[str]) -> str:
+        full_match = match.group(0)
+        url = match.group(2)
+
+        # Replace external base with internal base if found
+        if external_base in url:
+            new_url = url.replace(external_base, internal_base)
+            return full_match.replace(url, new_url)
+
+        return full_match
+
+    # Replace in ![alt](url) format
+    result = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", replace_md_img, result)
+
+    return result
+
+
+def _convert_markdown_to_pdf(markdown_file_path: str, output_pdf_path: str) -> bool:
+    """Convert markdown file to PDF using Python packages."""
+    if not PDF_CONVERSION_AVAILABLE:
+        logger.warning(
+            "Video Analysis Report: PDF conversion not available. Install 'markdown' and 'xhtml2pdf' packages."
+        )
+        return False
+
+    try:
+        # Read markdown file
+        with open(markdown_file_path, encoding="utf-8") as f:
+            markdown_content = f.read()
+
+        # Convert markdown to HTML
+        html_content = markdown.markdown(markdown_content, extensions=["tables", "fenced_code"])
+
+        # Add professional CSS styling with NVIDIA branding
+        styled_html = f"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8">
+            <style>
+                * {{ box-sizing: border-box; }}
+                body {{
+                    font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, Arial, sans-serif;
+                    font-size: 12px;
+                    line-height: 1.6;
+                    margin: 12mm;
+                    color: #000000;
+                    background-color: #ffffff;
+                }}
+                h1 {{
+                    color: #000000;
+                    font-size: 26px;
+                    font-weight: bold;
+                    margin-top: 1.5em;
+                    margin-bottom: 0.75em;
+                    padding-bottom: 0.5em;
+                    border-bottom: 4px solid #76B900;
+                    text-transform: uppercase;
+                }}
+                h2 {{
+                    color: #000000;
+                    font-size: 20px;
+                    font-weight: bold;
+                    margin-top: 1.5em;
+                    margin-bottom: 0.6em;
+                    padding-bottom: 0.4em;
+                    border-bottom: 3px solid #76B900;
+                }}
+                h3 {{
+                    color: #000000;
+                    font-size: 16px;
+                    font-weight: bold;
+                    margin-top: 1.25em;
+                    margin-bottom: 0.5em;
+                }}
+                p {{ margin: 0.6em 0; text-align: justify; }}
+                /* FIX: Long URLs in <a> tags could not wrap, causing xhtml2pdf
+                   to stretch inter-word spaces on justified lines (e.g. the
+                   "Video Playback:" label and URL). word-break/overflow-wrap
+                   allow URLs to break across lines for proper PDF layout. */
+                a {{
+                    word-break: break-all;
+                    overflow-wrap: break-word;
+                }}
+                ul {{
+                    margin: 0.5em 0;
+                    padding-left: 1.5em;
+                }}
+                li {{
+                    margin: 0.3em 0;
+                    padding: 0;
+                }}
+                img {{
+                    max-width: 400px;
+                    height: auto;
+                    display: block;
+                    margin: 0.5em auto;
+                    border-radius: 2px;
+                    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+                }}
+            </style>
+        </head>
+        <body>
+            {html_content}
+        </body>
+        </html>
+        """
+
+        # Convert HTML to PDF
+        with open(output_pdf_path, "wb") as pdf_file:
+            pisa_status = pisa.CreatePDF(styled_html, dest=pdf_file)
+
+        if pisa_status.err:
+            logger.error(f"Video Analysis Report: PDF conversion had errors: {pisa_status.err}")
+            return False
+
+        logger.info(f"Successfully converted markdown to PDF: {output_pdf_path}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Video Analysis Report: Error converting markdown to PDF: {e}")
+        return False
+
+
+class VideoReportGenConfig(FunctionBaseConfig, name="video_report_gen_frag"):
+    """Configuration for Video(uploaded) Report generation tool."""
+
+    object_store: ObjectStoreRef = Field(
+        ...,
+        description="Reference to the object store for serving files via HTTP",
+    )
+
+    base_url: str = Field(
+        default="http://localhost:8000/static",
+        description="Base URL for file server (used for in_memory and other non-S3 object stores)",
+    )
+
+    video_understanding_tool: FunctionRef = Field(
+        ...,
+        description="Name of the video understanding tool to use for short videos",
+    )
+
+    lvs_video_understanding_tool: str | None = Field(
+        default=None,
+        description="Name of the LVS video understanding tool to use for long videos. If None, LVS is disabled.",
+    )
+
+    lvs_video_length: int = Field(
+        default=60,
+        description="Minimum length of a video in seconds to use LVS for analysis. If the video duration is longer than this value, LVS will be used for analysis.",
+    )
+    vlm_prompt: str = Field(
+        default="Describe in detail what is happening in this video, including all visible people, objects, actions, and environmental conditions.",
+        description="Prompt to query the VLM for video understanding. SOM markers will be automatically removed.",
+    )
+    normalize_timestamps: bool = Field(
+        default=True,
+        description="Normalize timestamps in the VLM response content to absolute video time, set to true for CR1",
+    )
+    chunk_duration_seconds: int = Field(
+        default=60,
+        description="Duration of each video chunk in seconds for parallel processing.",
+    )
+    max_duration_for_chunking: int = Field(
+        default=300,
+        description="Maximum duration of a video in seconds for chunking.",
+    )
+
+    video_url_tool: FunctionRef | None = Field(
+        default=None,
+        description="Tool to get video playback URL by sensor ID (optional)",
+    )
+
+    picture_url_tool: FunctionRef | None = Field(
+        default=None,
+        description="Tool to get snapshot picture URL by sensor ID and timestamp (optional)",
+    )
+
+    vst_internal_url: str | None = Field(
+        default=None,
+        description="Internal VST URL for API calls (e.g., 'http://${INTERNAL_IP}:30888'). If not provided, uses VST_INTERNAL_URL env var.",
+    )
+
+    vst_external_url: str | None = Field(
+        default=None,
+        description="External VST URL for client-facing URLs (e.g., 'http://${EXTERNAL_IP}:30888'). If not provided, uses VST_EXTERNAL_URL env var.",
+    )
+
+    # HITL Configuration (optional - if not set, HITL is disabled)
+    hitl_enabled: bool = Field(
+        default=False,
+        description="Enable HITL for VLM prompt confirmation before report generation.",
+    )
+
+    hitl_vlm_prompt_template: str | None = Field(
+        default=None,
+        description="HITL template for collecting/confirming VLM prompt from user. If None and hitl_enabled=True, uses a default template.",
+    )
+
+    hitl_prompt_llm: str | None = Field(
+        default=None,
+        description="LLM to use for AI-assisted prompt generation (/generate and /refine commands). If None, AI features disabled.",
+    )
+
+    hitl_generate_system_prompt: str = Field(
+        default="""You are a prompt engineer specializing in video analysis.
+Your task is to create a clear, detailed prompt for a Vision Language Model (VLM) that will analyze video footage.
+
+Requirements for the generated prompt:
+- Be specific about what to look for in the video
+- Include instructions to describe events with timestamps in chronological[Xs-Ys] format
+- Focus on the user's described scenario/goals
+- Keep the prompt concise but comprehensive
+
+Output ONLY the VLM prompt, no explanations or preamble.""",
+        description="System prompt for the /generate command. User's description will be appended.",
+    )
+
+    hitl_refine_system_prompt: str = Field(
+        default="""You are a prompt engineer specializing in video analysis.
+Your task is to modify an existing VLM prompt based on the user's instructions.
+
+Requirements:
+- Preserve the timestamp format [Xs-Ys] requirement
+- Incorporate the user's requested changes
+- Keep the prompt structure clear and actionable
+- Output ONLY the modified prompt, no explanations
+
+Current prompt to modify:
+{current_prompt}
+
+User's modification request:""",
+        description="System prompt for the /refine command. Contains {current_prompt} placeholder.",
+    )
+
+
+class VideoReportGenInput(BaseModel):
+    """Input for Video(uploaded) Report generation."""
+
+    sensor_id: str = Field(
+        ...,
+        description="VST sensor ID (filename of uploaded video, e.g., 'warehouse_01.mp4')",
+    )
+    user_query: str = Field(
+        ...,
+        description="The user's question or analysis request for this video",
+    )
+    vlm_reasoning: bool | None = Field(
+        default=None,
+        description="Enable VLM reasoning mode for video analysis",
+    )
+    model_config = {
+        "extra": "forbid",
+    }
+
+
+class VideoReportGenOutput(BaseModel):
+    """Output from Video(uploaded) Report generation."""
+
+    http_url: str | None = Field(default=None, description="HTTP URL to access the markdown report file")
+    pdf_url: str | None = Field(default=None, description="HTTP URL to access the PDF report file (if generated)")
+    object_store_key: str | None = Field(default=None, description="Key/filename in the object store")
+    summary: str | None = Field(default=None, description="Brief summary of the report (or cancellation message)")
+    file_size: int = Field(default=0, description="Size of the markdown report file in bytes")
+    pdf_file_size: int = Field(default=0, description="Size of the PDF report file in bytes")
+    content: str | None = Field(default=None, description="The actual markdown content of the generated report")
+    video_url: str | None = Field(default=None, description="The URL of the video playback")
+    hitl_prompts: dict | None = Field(default=None, description="HITL prompts used for the report")
+
+
+async def _save_markdown_to_object_store(
+    markdown_content: str,
+    filename: str,
+    object_store: Any,
+    config: VideoReportGenConfig,
+) -> tuple[str, int]:
+    """Save markdown content to object store."""
+    content_bytes = markdown_content.encode("utf-8")
+    file_size = len(content_bytes)
+
+    timestamp = datetime.now()
+    metadata = {
+        "timestamp": timestamp.strftime("%Y%m%d_%H%M%S"),
+        "generated_at": timestamp.isoformat(),
+        "file_size": str(file_size),
+        "content_type": "text/markdown",
+        "report_type": "video report",
+    }
+
+    object_store_item = ObjectStoreItem(data=content_bytes, content_type="text/markdown", metadata=metadata)
+    await object_store.upsert_object(filename, object_store_item)
+    logger.info(f"Markdown report saved to object store: {filename}")
+
+    # Get HTTP URL
+    http_url = _get_object_store_url(object_store, filename, config)
+
+    return http_url, file_size
+
+
+async def _save_pdf_to_object_store(
+    markdown_content: str,
+    filename: str,
+    pdf_filename: str,
+    object_store: Any,
+    config: VideoReportGenConfig,
+) -> tuple[str | None, int]:
+    """Generate PDF from markdown and save to object store. Returns URL and size."""
+    pdf_file_size = 0
+    pdf_url = None
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_md_path = os.path.join(temp_dir, filename)
+        temp_pdf_path = os.path.join(temp_dir, pdf_filename)
+
+        # Replace public URLs with private IPs for image URLs before PDF generation
+        pdf_markdown_content = _replace_public_urls_with_private(
+            markdown_content, config.vst_internal_url, config.vst_external_url
+        )
+
+        # Log the complete markdown content before saving to temp file
+        logger.debug("=" * 80)
+        logger.debug("MARKDOWN CONTENT BEFORE PDF GENERATION (with internal IPs)")
+        logger.debug("=" * 80)
+        logger.debug(pdf_markdown_content)
+        logger.debug("=" * 80)
+        logger.debug("END OF MARKDOWN CONTENT")
+        logger.debug("=" * 80)
+
+        # Write markdown to temp file and convert to PDF
+        with open(temp_md_path, "w", encoding="utf-8") as f:
+            f.write(pdf_markdown_content)
+
+        if _convert_markdown_to_pdf(temp_md_path, temp_pdf_path):
+            with open(temp_pdf_path, "rb") as f:
+                pdf_bytes = f.read()
+            pdf_file_size = len(pdf_bytes)
+
+            timestamp = datetime.now()
+            pdf_object_store_item = ObjectStoreItem(
+                data=pdf_bytes,
+                content_type="application/pdf",
+                metadata={
+                    "timestamp": timestamp.strftime("%Y%m%d_%H%M%S"),
+                    "generated_at": timestamp.isoformat(),
+                    "file_size": str(pdf_file_size),
+                    "content_type": "application/pdf",
+                    "report_type": "video report",
+                },
+            )
+            await object_store.upsert_object(pdf_filename, pdf_object_store_item)
+
+            # Get HTTP URL
+            pdf_url = _get_object_store_url(object_store, pdf_filename, config)
+
+            logger.info(f"PDF report saved to object store: {pdf_filename}")
+        else:
+            logger.warning("Video Analysis Report: Failed to generate PDF report")
+
+    return pdf_url, pdf_file_size
+
+
+class TimestampMatch(NamedTuple):
+    """Parsed timestamp from VLM response content."""
+
+    position: int  # Character position in content string
+    seconds: float  # Timestamp in seconds
+
+
+def _parse_timestamps(content: str) -> list[TimestampMatch]:
+    """
+    Parse timestamps from content in [Xs-Ys] format.
+
+    Matches: [5.2s-8.0s] or [15s - 20s] etc.
+    Uses midpoint of the span for snapshot.
+
+    Returns list of TimestampMatch with position and midpoint seconds.
+    """
+    matches: list[TimestampMatch] = []
+
+    # [Xs-Ys] format
+    pattern = re.compile(
+        r"(?:\*\*\s*)?"  # optional leading ** and spaces
+        r"\[\s*"  # literal [
+        r"(\d+(?:\.\d+)?)(?:s)?"  # group 1: start time
+        r"\s*-\s*"
+        r"(\d+(?:\.\d+)?)(?:s)?"  # group 2: end time
+        r"\s*\]"  # literal ]
+        r"(?:\s*\*\*)?"  # optional trailing ** and spaces
+    )
+    for match in re.finditer(pattern, content):
+        start_seconds = float(match.group(1))
+        end_seconds = float(match.group(2))
+        midpoint = (start_seconds + end_seconds) / 2
+        matches.append(TimestampMatch(position=match.start(), seconds=midpoint))
+
+    return matches
+
+
+def _normalize_chunk_timestamps(content: str, chunk_start: float, chunk_end: float) -> str:
+    """
+    Normalize timestamps in VLM response content by adding chunk offset.
+
+    VLM returns timestamps relative to the chunk (starting from 0s).
+    This function:
+    1. Finds the max end timestamp in the content
+    2. Computes ratio = max_end / chunk_duration
+    3. If ratio > 1, scales all timestamps down by the ratio
+    4. Adds chunk_start offset to convert to absolute video time
+
+    Args:
+        content: VLM response content with relative timestamps in [Xs-Ys] format
+        chunk_start: Start time of the chunk in seconds (offset to add)
+        chunk_end: End time of the chunk in seconds (for ratio calculation)
+
+    Returns:
+        Content with timestamps normalized to absolute video time
+    """
+    # [Xs-Ys] format
+    pattern = re.compile(
+        r"(?:\*\*\s*)?"  # optional leading ** and spaces
+        r"\[\s*"  # literal [
+        r"(\d+(?:\.\d+)?)(?:s)?"  # group 1: start time
+        r"\s*-\s*"
+        r"(\d+(?:\.\d+)?)(?:s)?"  # group 2: end time
+        r"\s*\]"  # literal ]
+        r"(?:\s*\*\*)?"  # optional trailing ** and spaces
+    )
+
+    # First pass: find all timestamps and the max end value
+    matches_data: list[tuple[re.Match, float, float]] = []
+    max_end_sec = 0.0
+    for match in re.finditer(pattern, content):
+        start_sec = float(match.group(1))
+        end_sec = float(match.group(2))
+        matches_data.append((match, start_sec, end_sec))
+        max_end_sec = max(max_end_sec, end_sec)
+    chunk_duration = chunk_end - chunk_start
+    if not matches_data or chunk_duration <= 0:
+        return content
+    # Compute normalization ratio
+    ratio = max_end_sec / chunk_duration
+    should_normalize = ratio > 1.0
+
+    if should_normalize:
+        logger.info(
+            f"Normalizing chunk timestamps: max_end_sec={max_end_sec:.1f}s, "
+            f"chunk_duration={chunk_duration:.1f}s, ratio={ratio:.2f}"
+        )
+
+    # Second pass: replace timestamps with normalized values
+    result = content
+    for match, start_sec, end_sec in matches_data:
+        # Scale timestamps if ratio differs significantly from 1.0
+
+        if should_normalize:
+            start_sec /= ratio
+            end_sec /= ratio
+
+        # Add chunk offset to convert to absolute time
+        abs_start = chunk_start + start_sec
+        abs_end = chunk_start + end_sec
+        replacement = f"[{abs_start:.1f}s-{abs_end:.1f}s]"
+        result = result.replace(match.group(0), replacement, 1)
+    return result
+
+
+def _filter_short_duration_from_markdown(content: str, min_duration_seconds: float = 2.0) -> str:
+    """
+    Filter out sentences/lines containing timestamp ranges with duration less than the specified threshold.
+
+    Parses markdown content for [Xs-Ys] timestamp patterns, calculates duration,
+    and removes lines describing events shorter than min_duration_seconds.
+
+    Args:
+        content: Markdown content with timestamps in [Xs-Ys] format
+        min_duration_seconds: Minimum event duration in seconds (default: 2.0)
+
+    Returns:
+        Filtered markdown content with short duration events removed
+    """
+    if not content:
+        return content
+
+    # Pattern to match [Xs-Ys] timestamps
+    timestamp_pattern = re.compile(r"\[\s*(\d+(?:\.\d+)?)(?:s)?\s*-\s*(\d+(?:\.\d+)?)(?:s)?\s*\]")
+
+    # Process line by line
+    lines = content.split("\n")
+    filtered_lines = []
+
+    for line in lines:
+        # Find all timestamps in the line
+        matches = list(timestamp_pattern.finditer(line))
+
+        if not matches:
+            # No timestamps, keep the line
+            filtered_lines.append(line)
+            continue
+
+        # Check if any timestamp in this line has sufficient duration
+        has_valid_duration = False
+        for match in matches:
+            start_time = float(match.group(1))
+            end_time = float(match.group(2))
+            duration = end_time - start_time
+
+            if duration >= min_duration_seconds:
+                has_valid_duration = True
+                break
+
+        if has_valid_duration:
+            filtered_lines.append(line)
+        else:
+            # Log the filtered line for debugging
+            duration = float(matches[0].group(2)) - float(matches[0].group(1))
+            line_preview = line.strip()[:100]
+            logger.info(
+                f"Filtered out short duration line (duration={duration:.1f}s < {min_duration_seconds:.1f}s): "
+                f"{line_preview}"
+            )
+
+    return "\n".join(filtered_lines)
+
+
+def _mmss_to_iso(time_str: str, ref_timestamp: str) -> str:
+    """
+    Convert MM:SS or Xs to ISO 8601 timestamp by adding offset to reference timestamp.
+
+    Args:
+        time_str: Time string in "MM:SS" format (e.g., "01:30") or "Xs" format (e.g., "5.2s")
+        ref_timestamp: Reference timestamp in ISO 8601 format to add the offset to
+
+    Returns:
+        ISO timestamp string with offset added to ref_timestamp
+    """
+    if time_str.endswith("s"):
+        # Seconds format from LVS (e.g., "5.2s")
+        total_seconds = int(float(time_str[:-1]))
+    else:
+        # MM:SS format from regular VLM
+        parts = time_str.split(":")
+        minutes = int(parts[0])
+        seconds = int(parts[1])
+        total_seconds = minutes * 60 + seconds
+
+    # Parse reference timestamp and add offset
+    ref_dt = iso8601_to_datetime(ref_timestamp)
+    result_dt = ref_dt + timedelta(seconds=total_seconds)
+
+    return datetime_to_iso8601(result_dt)
+
+
+async def _inject_video_clips(
+    content: str,
+    sensor_id: str,
+    vst_internal_url: str | None,
+    vst_external_url: str | None,
+) -> str:
+    """
+    Parse timestamps from content and inject video clip links.
+
+    For each timestamp range [Xs-Ys] found:
+    1. Parse start and end times
+    2. Generate video clip URL using VST
+    3. Inject [Watch Clip] link right after the timestamp
+
+    Args:
+        content: Markdown content with timestamps in [Xs-Ys] format
+        sensor_id: Video sensor ID
+        vst_internal_url: VST internal URL
+        vst_external_url: VST external URL
+
+    Returns:
+        Content with [Watch Clip] links injected after timestamps
+
+    Note:
+        Video clip durations may be slightly longer than the timestamp range due to
+        VST aligning clips to video keyframes (I-frames) for proper playback.
+        For example, [120s-130s] (10s) may result in a 12-13 second clip.
+    """
+    if not (vst_internal_url and vst_external_url):
+        logger.debug("Video Analysis Report: VST URLs not configured, skipping video clip injection")
+        return content
+
+    # Pattern to match [Xs-Ys] timestamps
+    pattern = re.compile(
+        r"(\[\s*"  # group 1: opening bracket and spaces
+        r"(\d+(?:\.\d+)?)(?:s)?"  # group 2: start time
+        r"\s*-\s*"
+        r"(\d+(?:\.\d+)?)(?:s)?"  # group 3: end time
+        r"\s*\])"  # closing bracket
+    )
+
+    matches = list(pattern.finditer(content))
+    if not matches:
+        logger.debug("Video Analysis Report: No timestamps found in content for video clip injection")
+        return content
+
+    try:
+        stream_id = await get_stream_id(sensor_id, vst_internal_url)
+    except Exception as e:
+        logger.warning(f"Failed to get stream_id for video clips: {e}")
+        return content
+
+    # Process matches in reverse order to preserve positions
+    result_content = content
+    for match in reversed(matches):
+        start_time = float(match.group(2))
+        end_time = float(match.group(3))
+
+        try:
+            logger.info(f"Generating video clip URL for [{start_time}s-{end_time}s]")
+            clip_url = await get_video_url(
+                stream_id=stream_id,
+                start_time=start_time,
+                end_time=end_time,
+                vst_internal_url=vst_internal_url,
+            )
+            # Replace internal URL with external URL for client access
+            clip_url = f"{vst_external_url}{urllib.parse.urlparse(clip_url).path}"
+            video_clip_link = f" [[Watch Clip]({clip_url})]"
+
+            # Inject right after the timestamp
+            insert_pos = match.end()
+            result_content = result_content[:insert_pos] + video_clip_link + result_content[insert_pos:]
+        except Exception as e:
+            logger.warning(f"Failed to generate video clip URL for [{start_time}s-{end_time}s]: {e}")
+            continue
+
+    return result_content
+
+
+async def _inject_snapshots(
+    content: str,
+    sensor_id: str,
+    picture_url_tool: Any,
+) -> str:
+    """
+    Parse timestamps from content, fetch snapshots, and inject images after the sentence.
+
+    For each timestamp span found:
+    1. Extract the midpoint of the timestamp span
+    2. Call picture_url_tool to get snapshot at that time
+    3. Find the next period after the timestamp
+    4. Insert image markdown after that period
+
+    Args:
+        content: VLM markdown content with normalized timestamps
+        sensor_id: Video sensor ID
+        picture_url_tool: Tool to fetch snapshot URLs
+
+    Returns:
+        Content with snapshot images injected
+    """
+    if not picture_url_tool:
+        logger.warning("Video Analysis Report: No picture_url_tool configured, skipping snapshot injection")
+        return content
+    timestamps = _parse_timestamps(content)
+
+    if not timestamps:
+        logger.warning("Video Analysis Report: No timestamps found in VLM response for snapshot injection")
+        return content
+
+    # Snapshot injection is best-effort: failures should not prevent report generation.
+    image_urls = await asyncio.gather(
+        *[
+            picture_url_tool.ainvoke(
+                input={
+                    "sensor_id": sensor_id,
+                    "start_time": ts.seconds,
+                }
+            )
+            for ts in timestamps
+        ],
+        return_exceptions=True,
+    )
+    result_content = content
+    for ts, image_url in reversed(list(zip(timestamps, image_urls, strict=False))):
+        if isinstance(image_url, Exception):
+            logger.warning(
+                "Video Analysis Report: Snapshot injection failed at t=%.2fs for %s: %s",
+                ts.seconds,
+                sensor_id,
+                image_url,
+            )
+            continue
+        # Format seconds to readable string for alt text
+        mins = int(ts.seconds) // 60
+        secs = int(ts.seconds) % 60
+        time_str = f"{mins:02d}:{secs:02d}"
+        # Use HTML img tag for size control with minimal spacing
+        # Add style to control margins for PDF rendering
+        image_md = (
+            f'\n\n<img src="{image_url.image_url}" alt="Snapshot at {time_str}" width="400" style="margin: 10px 0;">\n'
+        )
+        result_content = result_content[: ts.position] + image_md + result_content[ts.position :]
+    return result_content
+
+
+def _clean_vlm_response(vlm_response: str) -> str:
+    """
+    Clean and validate the VLM markdown response.
+
+    Removes code block wrappers, thinking/answer tags, and extracts
+    the actual markdown report content.
+    """
+    cleaned = vlm_response.strip()
+
+    # Remove <think>...</think> blocks (with closing tag)
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL | re.IGNORECASE)
+
+    # If response starts with <think> but no closing tag, find the first markdown heading
+    if cleaned.strip().lower().startswith("<think>"):
+        # Find the first markdown heading (# at start of line)
+        heading_match = re.search(r"^#+ ", cleaned, re.MULTILINE)
+        if heading_match:
+            cleaned = cleaned[heading_match.start() :].strip()
+        else:
+            # Just remove the <think> tag
+            cleaned = re.sub(r"^<think>\s*", "", cleaned, flags=re.IGNORECASE)
+
+    # If there's a </think> tag, delete everything before it (including the tag itself)
+    # This handles cases where LLM outputs thinking without opening <think> tag
+    think_end_match = re.search(r"</think>", cleaned, flags=re.IGNORECASE)
+    if think_end_match:
+        # Keep everything after the </think> tag
+        cleaned = cleaned[think_end_match.end() :].strip()
+
+    # Check for <answer> tags and extract content within them
+    answer_match = re.search(r"<answer>(.*?)</answer>", cleaned, flags=re.DOTALL | re.IGNORECASE)
+    if answer_match:
+        cleaned = answer_match.group(1).strip()
+    else:
+        # Remove <answer> and </answer> tags if present but not properly paired
+        cleaned = re.sub(r"</?answer>", "", cleaned, flags=re.IGNORECASE)
+
+    # Clean up whitespace
+    cleaned = cleaned.strip()
+
+    # Remove markdown code block wrappers (do this after think tag removal)
+    # Handle various code block types: ```markdown, ```plaintext, ```text, ```
+    code_block_prefixes = ["```markdown", "```plaintext", "```text", "```"]
+    for prefix in code_block_prefixes:
+        if cleaned.startswith(prefix):
+            cleaned = cleaned[len(prefix) :].strip()
+            break
+
+    if cleaned.endswith("```"):
+        cleaned = cleaned[:-3].strip()
+
+    return cleaned
+
+
+def _filter_short_events(events: list[dict | Any], min_duration_seconds: float = 2.0) -> list[dict | Any]:
+    """
+    Filter out events with duration less than the specified threshold.
+
+    Events shorter than min_duration_seconds are removed to reduce noise in reports.
+    Events with invalid or missing timestamps are kept as-is.
+
+    Args:
+        events: List of event dictionaries with start_time and end_time fields
+        min_duration_seconds: Minimum event duration in seconds (default: 2.0)
+
+    Returns:
+        List of events with duration >= min_duration_seconds
+    """
+    filtered_events = []
+    for event in events:
+        if isinstance(event, dict):
+            start_time = event.get("start_time", "N/A")
+            end_time = event.get("end_time", "N/A")
+            # Skip events with invalid times or duration less than threshold
+            if start_time != "N/A" and end_time != "N/A":
+                try:
+                    duration = float(end_time) - float(start_time)
+                    if duration >= min_duration_seconds:
+                        filtered_events.append(event)
+                    else:
+                        logger.info(
+                            f"Filtered out short event (duration={duration:.1f}s < {min_duration_seconds:.1f}s): "
+                            f"{event.get('description', '')[:50]}"
+                        )
+                except (ValueError, TypeError):
+                    # If we can't parse times, keep the event
+                    filtered_events.append(event)
+            else:
+                # If times are missing, keep the event
+                filtered_events.append(event)
+        else:
+            # Non-dict events are kept as-is
+            filtered_events.append(event)
+    return filtered_events
+
+
+def _format_lvs_response(lvs_response: str) -> str:
+    """
+    Format the LVS video understanding tool response into a readable markdown template.
+
+    The lvs_video_understanding tool returns JSON like:
+    {
+        "video_summary": "...",
+        "events": [...],
+        "hitl_prompts": {
+            "scenario": "...",
+            "events": [...],
+            "objects_of_interest": [...],
+            "enterprise_rag_query": "..."
+        },
+        "enterprise_rag": {
+            "status": "...",
+            "query": "...",
+            "context": "...",
+            "error": "..."
+        },
+        "lvs_backend_response": {...}
+    }
+
+    Note: The LVS backend service itself only returns video_summary and events.
+    The hitl_prompts are added by the lvs_video_understanding tool wrapper.
+    Video clip links are injected later by _inject_video_clips in the main workflow.
+
+    Args:
+        lvs_response: JSON string from LVS tool
+    """
+    try:
+        lvs_data = json.loads(lvs_response)
+
+        # Extract fields
+        video_summary = lvs_data.get("video_summary", "")
+        events = lvs_data.get("events", [])
+        enterprise_rag = lvs_data.get("enterprise_rag") or {}
+
+        # Clean thinking tags from video_summary
+        video_summary = _clean_vlm_response(video_summary)
+
+        # Build formatted output
+        formatted_lines = []
+
+        if video_summary:
+            formatted_lines.extend(
+                [
+                    "**Video Summary:**",
+                    "",
+                    video_summary,
+                    "",
+                ]
+            )
+
+        # Enterprise RAG section (if present)
+        if isinstance(enterprise_rag, dict) and enterprise_rag:
+            status = str(enterprise_rag.get("status", "")).strip()
+            query = str(enterprise_rag.get("query", "")).strip()
+            answer = str(enterprise_rag.get("answer", "")).strip()
+            context = str(enterprise_rag.get("context", "")).strip()
+            error = str(enterprise_rag.get("error", "")).strip()
+
+            formatted_lines.extend(["**Enterprise RAG:**", ""])
+            if status:
+                formatted_lines.append(f"- **Status:** `{status}`")
+            if query:
+                formatted_lines.append(f"- **Query:** {query}")
+            if answer:
+                formatted_lines.extend(["", "**Generated Answer:**", "", answer, ""])
+            if error and status not in ("ok", "no_results"):
+                formatted_lines.append(f"- **Error:** {error}")
+            if context:
+                formatted_lines.extend(["", "**Retrieved Context:**", "", context, ""])
+
+        if events:
+            # Filter out events that are less than 2 seconds in duration
+            filtered_events = _filter_short_events(events, min_duration_seconds=2.0)
+
+            if filtered_events:
+                event_count = len(filtered_events)
+                formatted_lines.extend(
+                    [
+                        "**Events:**",
+                        "",
+                        f"{event_count} event(s) were detected in the video. See details below.",
+                        "",
+                    ]
+                )
+                for event in filtered_events:
+                    if isinstance(event, dict):
+                        start_time = event.get("start_time", "N/A")
+                        end_time = event.get("end_time", "N/A")
+                        description = event.get("description", "")
+                        # Clean thinking tags from description
+                        description = _clean_vlm_response(description)
+                        formatted_lines.append(f"- **[{start_time}s - {end_time}s]**: {description}")
+                    else:
+                        formatted_lines.append(f"- {event}")
+            else:
+                formatted_lines.append("*No events detected.*")
+        else:
+            formatted_lines.append("*No events detected.*")
+
+        return "\n".join(formatted_lines)
+
+    except (json.JSONDecodeError, Exception) as e:
+        logger.warning(f"Video Analysis Report: Failed to parse LVS response as JSON: {e}, returning raw response")
+        return lvs_response
+
+
+def _create_report_header(
+    sensor_id: str,
+    user_query: str,
+    hitl_prompts: dict | None = None,
+) -> str:
+    """
+    Create the standard report header with metadata.
+
+    Args:
+        sensor_id: The video sensor ID
+        user_query: The user's analysis request
+        hitl_prompts: Optional HITL prompts dict (scenario, events, objects_of_interest) from LVS
+    """
+    now = datetime.now()
+    report_date = now.strftime("%Y-%m-%d")
+    report_time = now.strftime("%H:%M:%S")
+    report_timestamp = now.strftime("%Y%m%d_%H%M%S")
+    vss_agent_version = os.getenv("VSS_AGENT_VERSION", "dev")
+
+    report_lines = [
+        "# Video Analysis Report",
+        "",
+        "## Basic Information",
+        "",
+        "| Field | Value |",
+        "|-------|-------|",
+        f"| **Report Identifier** | vss_report_{report_timestamp} |",
+        f"| **Date of Analysis** | {report_date} |",
+        f"| **Time of Analysis** | {report_time} |",
+        f"| **Reporting AI Agent** | vss_agent {vss_agent_version} |",
+        f"| **Video Source** | {sensor_id} |",
+        f"| **Analysis Request** | {user_query} |",
+    ]
+    if hitl_prompts:
+        # Add HITL prompts to Basic Information table
+        scenario = hitl_prompts.get("scenario", "")
+        if scenario:
+            report_lines.append(f"| **Prompt - Scenario** | {scenario} |")
+
+        events_list = hitl_prompts.get("events", [])
+        if events_list:
+            report_lines.append(f"| **Prompt - Events of Interest** | {', '.join(events_list)} |")
+
+        objects_list = hitl_prompts.get("objects_of_interest", [])
+        if objects_list:
+            report_lines.append(f"| **Prompt - Objects of Interest** | {', '.join(objects_list)} |")
+
+    report_lines.append("")  # Close table with empty line
+
+    report_lines.extend(
+        [
+            "## Analysis Results",
+            "",
+            "",
+        ]
+    )
+
+    return "\n".join(report_lines)
+
+
+@register_function(config_type=VideoReportGenConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
+async def video_report_gen(config: VideoReportGenConfig, builder: Builder) -> AsyncGenerator[FunctionInfo]:
+    """
+    Video(uploaded) Report Generation Tool.
+
+    Generates comprehensive video analysis reports for uploaded videos without Video Analytics MCP.
+    Handles VLM prompt sanitization, video analysis, and optional template-based formatting.
+    """
+
+    # Load tools
+    object_store = await builder.get_object_store_client(config.object_store)
+    video_understanding_tool = await builder.get_tool(
+        config.video_understanding_tool, wrapper_type=LLMFrameworkEnum.LANGCHAIN
+    )
+
+    # Load LVS tool if configured (optional)
+    lvs_video_understanding_tool = None
+    if config.lvs_video_understanding_tool is not None:
+        try:
+            lvs_video_understanding_tool = await builder.get_tool(
+                config.lvs_video_understanding_tool, wrapper_type=LLMFrameworkEnum.LANGCHAIN
+            )
+        except ValueError as e:
+            logger.warning(
+                f"Video Analysis Report: LVS tool '{config.lvs_video_understanding_tool}' not found, LVS features will be disabled: {e}"
+            )
+            lvs_video_understanding_tool = None
+
+    video_url_tool = None
+    if config.video_url_tool:
+        video_url_tool = await builder.get_tool(config.video_url_tool, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    picture_url_tool = None
+    if config.picture_url_tool:
+        picture_url_tool = await builder.get_tool(config.picture_url_tool, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    # Load HITL LLM if configured (for /generate and /refine commands)
+    hitl_llm = None
+    if config.hitl_prompt_llm:
+        try:
+            hitl_llm = await builder.get_llm(config.hitl_prompt_llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+            logger.info(f"HITL LLM loaded: {config.hitl_prompt_llm}")
+        except Exception as e:
+            logger.warning(f"Failed to load HITL LLM '{config.hitl_prompt_llm}': {e}. AI prompt generation disabled.")
+            hitl_llm = None
+
+    # HITL state: maps thread_id -> vlm_prompt (persisted per conversation)
+    # Uses OrderedDict as LRU cache to prevent unbounded memory growth.
+    #
+    # max_conversations: Maximum number of conversation states to retain.
+    # - Each entry stores ~1-2KB (thread_id + prompt string)
+    # - At 1000 conversations: ~1-2MB memory footprint
+    # - Oldest entries are evicted when limit is exceeded (LRU policy)
+    # - Operators can adjust this value based on expected concurrent users
+    #   and available memory. For high-traffic deployments, consider 500-2000.
+    max_conversations = 1000
+    vlm_prompt_state: OrderedDict[str, str] = OrderedDict()
+
+    def _store_prompt(thread_id: str, prompt: str) -> None:
+        """Store a prompt for a thread, evicting oldest entries if over capacity."""
+        # If key exists, remove it first to update insertion order (LRU behavior)
+        if thread_id in vlm_prompt_state:
+            vlm_prompt_state.move_to_end(thread_id)
+        vlm_prompt_state[thread_id] = prompt
+
+        # Evict oldest entries if over capacity
+        while len(vlm_prompt_state) > max_conversations:
+            evicted_id, _ = vlm_prompt_state.popitem(last=False)
+            logger.debug(f"Evicted prompt state for thread {evicted_id} (LRU capacity: {max_conversations})")
+
+    def _get_prompt(thread_id: str) -> str | None:
+        """Get a prompt for a thread, updating access order (LRU behavior)."""
+        if thread_id in vlm_prompt_state:
+            vlm_prompt_state.move_to_end(thread_id)
+            return vlm_prompt_state[thread_id]
+        return None
+
+    # Default HITL template if not provided in config
+    default_hitl_vlm_prompt_template = """**VLM Prompt for Report Generation**
+
+**OPTIONS:**
+
+• Press Submit (empty) → Approve and generate report
+
+• Type a new prompt → Use it directly
+
+• Type `/generate <description>` → AI creates a prompt based on your description
+
+• Type `/refine <instructions>` → AI modifies the current prompt
+
+• Type `/cancel` → Cancel report generation
+
+Enter your choice or press Submit to keep current value:"""
+
+    async def _prompt_user_input(prompt_text: str, required: bool = True, placeholder: str = "") -> str | None:
+        """Prompt user for input using HITL with option to cancel via /cancel.
+
+        Args:
+            prompt_text: The prompt text to show to the user
+            required: Whether the input is required
+            placeholder: Placeholder text for the input field
+
+        Returns:
+            str: User's input text, or None if user cancelled
+        """
+        nat_context = Context.get()
+        user_input_manager = nat_context.user_interaction_manager
+
+        human_prompt = HumanPromptText(text=prompt_text, required=required, placeholder=placeholder)
+
+        response: InteractionResponse = await user_input_manager.prompt_user_input(human_prompt)
+
+        # Check if user cancelled - content will be None when cancelled
+        if response.content is None:
+            logger.info("User cancelled HITL prompt")
+            return None
+
+        # Check if content.text is None (another possible cancel indicator)
+        if hasattr(response.content, "text") and response.content.text is None:
+            logger.info("User cancelled HITL prompt")
+            return None
+
+        # Return raw text (no strip) so caller can treat only truly empty input as "approve default"
+        return response.content.text  # type: ignore
+
+    def _wrap_text_at_words(text: str, words_per_line: int = 12) -> str:
+        """
+        Insert newlines to wrap text at approximately the specified number of words per line.
+
+        Preserves existing newlines and only wraps within continuous text segments.
+
+        Args:
+            text: The text to wrap
+            words_per_line: Number of words before inserting a newline (default: 12)
+
+        Returns:
+            str: Text with newlines inserted for wrapping
+        """
+        if not text:
+            return text
+
+        # Split by existing newlines to preserve them
+        lines = text.split("\n")
+        wrapped_lines = []
+
+        for line in lines:
+            if not line.strip():
+                # Preserve empty lines
+                wrapped_lines.append(line)
+                continue
+
+            words = line.split()
+            if len(words) <= words_per_line:
+                wrapped_lines.append(line)
+                continue
+
+            # Wrap long lines
+            current_line_words = []
+            for word in words:
+                current_line_words.append(word)
+                if len(current_line_words) >= words_per_line:
+                    wrapped_lines.append(" ".join(current_line_words))
+                    current_line_words = []
+
+            # Add remaining words
+            if current_line_words:
+                wrapped_lines.append(" ".join(current_line_words))
+
+        return "\n".join(wrapped_lines)
+
+    async def _llm_generate_prompt(description: str) -> str:
+        """Generate a VLM prompt using LLM based on user's description.
+
+        Raises:
+            ValueError: If LLM is not configured or if LLM call/response processing fails.
+        """
+        if not hitl_llm:
+            raise ValueError("AI prompt generation not available. Configure hitl_prompt_llm in config.")
+
+        from langchain_core.messages import HumanMessage
+        from langchain_core.messages import SystemMessage
+
+        messages = [
+            SystemMessage(content=config.hitl_generate_system_prompt),
+            HumanMessage(content=description),
+        ]
+
+        # Call LLM with error handling
+        try:
+            response = await hitl_llm.ainvoke(messages)
+        except Exception as e:
+            logger.error(f"LLM prompt generation failed during ainvoke: {type(e).__name__}: {e}")
+            raise ValueError(f"Failed to generate prompt: LLM call failed - {e}") from e
+
+        # Process response with error handling - use shared reasoning parser
+        try:
+            _, generated = parse_reasoning_content(response)
+            generated = (generated or "").strip()
+            # Wrap text for better readability in UI
+            generated = _wrap_text_at_words(generated)
+        except Exception as e:
+            logger.error(f"LLM prompt generation failed during response processing: {type(e).__name__}: {e}")
+            raise ValueError(f"Failed to generate prompt: response processing failed - {e}") from e
+
+        logger.info(f"LLM generated prompt: {generated[:100]}...")
+        return generated
+
+    async def _llm_refine_prompt(current_prompt: str, instructions: str) -> str:
+        """Refine existing prompt using LLM based on user's instructions.
+
+        Raises:
+            ValueError: If LLM is not configured or if LLM call/response processing fails.
+        """
+        if not hitl_llm:
+            raise ValueError("AI prompt refinement not available. Configure hitl_prompt_llm in config.")
+
+        from langchain_core.messages import HumanMessage
+        from langchain_core.messages import SystemMessage
+
+        # Replace {current_prompt} placeholder in system prompt
+        system_prompt = config.hitl_refine_system_prompt.replace("{current_prompt}", current_prompt)
+
+        messages = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=instructions),
+        ]
+
+        # Call LLM with error handling
+        try:
+            response = await hitl_llm.ainvoke(messages)
+        except Exception as e:
+            logger.error(f"LLM prompt refinement failed during ainvoke: {type(e).__name__}: {e}")
+            raise ValueError(f"Failed to refine prompt: LLM call failed - {e}") from e
+
+        # Process response with error handling - use shared reasoning parser
+        try:
+            _, refined = parse_reasoning_content(response)
+            refined = (refined or "").strip()
+            # Wrap text for better readability in UI
+            refined = _wrap_text_at_words(refined)
+        except Exception as e:
+            logger.error(f"LLM prompt refinement failed during response processing: {type(e).__name__}: {e}")
+            raise ValueError(f"Failed to refine prompt: response processing failed - {e}") from e
+
+        logger.info(f"LLM refined prompt: {refined[:100]}...")
+        return refined
+
+    async def _collect_hitl_vlm_prompt(current_prompt: str | None) -> str | None:
+        """
+        Collect/confirm VLM prompt via HITL with support for /generate and /refine commands.
+
+        Flow:
+        1. Show current prompt
+        2. User can: approve (empty), edit directly, /generate, /refine, or /cancel
+        3. If /generate or /refine, show result and loop for approval
+        4. Plain text or empty = final answer (no loop)
+
+        Args:
+            current_prompt: Current prompt from state (if any)
+
+        Returns:
+            str: The confirmed or updated VLM prompt, or None if cancelled
+        """
+        logger.info("Starting HITL VLM prompt collection workflow")
+
+        hitl_template = config.hitl_vlm_prompt_template or default_hitl_vlm_prompt_template
+
+        # Track the working prompt and its source
+        working_prompt = current_prompt or config.vlm_prompt
+        prompt_source = "CURRENTLY SET" if current_prompt else "DEFAULT"
+        error_message = ""  # Error message to display to user (cleared after each prompt)
+
+        while True:
+            # Build the display text, including any error message from previous iteration
+            if error_message:
+                prompt_text = f"**⚠️ ERROR:** {error_message}\n\n**{prompt_source}:**\n```\n{working_prompt}\n```\n\n{hitl_template}"
+                error_message = ""  # Clear after displaying
+            else:
+                prompt_text = f"**{prompt_source}:**\n```\n{working_prompt}\n```\n\n{hitl_template}"
+
+            user_input = await _prompt_user_input(
+                prompt_text,
+                required=False,
+                placeholder="Enter prompt, /generate, /refine, /cancel, or press Submit to approve",
+            )
+
+            # User clicked Cancel button
+            if user_input is None:
+                logger.info("User cancelled report generation")
+                return None
+
+            # Only truly empty input = approve (do not strip before check; space-only is not approval)
+            if user_input == "":
+                logger.info(f"User approved {prompt_source.lower()} prompt")
+                return working_prompt
+
+            stripped = user_input.strip()
+            # Handle /cancel command
+            if stripped.lower() == "/cancel":
+                logger.info("User cancelled report generation via /cancel command")
+                return None
+
+            # Handle /generate command
+            if stripped.lower().startswith("/generate "):
+                description = stripped[10:].strip()
+                if not description:
+                    logger.warning("Empty description for /generate, prompting again")
+                    error_message = "Please provide a description after /generate"
+                    continue
+                try:
+                    working_prompt = await _llm_generate_prompt(description)
+                    prompt_source = "AI-GENERATED"
+                    continue  # Loop to show generated prompt for approval
+                except ValueError as e:
+                    logger.error(f"Failed to generate prompt: {e!s}")
+                    error_message = f"Failed to generate prompt: {e!s}"
+                    continue
+
+            # Handle /refine command
+            if stripped.lower().startswith("/refine "):
+                instructions = stripped[8:].strip()
+                if not instructions:
+                    logger.warning("Empty instructions for /refine, prompting again")
+                    error_message = "Please provide instructions after /refine"
+                    continue
+                try:
+                    working_prompt = await _llm_refine_prompt(working_prompt, instructions)
+                    prompt_source = "AI-REFINED"
+                    continue  # Loop to show refined prompt for approval
+                except ValueError as e:
+                    logger.error(f"Failed to refine prompt: {e!s}")
+                    error_message = f"Failed to refine prompt: {e!s}"
+                    continue
+
+            # Whitespace-only = not valid; re-prompt
+            if not stripped:
+                error_message = "Input is empty or whitespace. Press Submit with no text to approve the default, or enter a prompt."
+                continue
+
+            # Plain text = use directly (no further approval needed)
+            logger.info(f"User provided custom prompt: {stripped[:100]}...")
+            return stripped
+
+    async def _video_report_gen(report_input: VideoReportGenInput) -> VideoReportGenOutput:
+        """
+        Generate a video analysis report for uploaded videos (Video(uploaded) Report mode).
+
+        This tool:
+        1. Sanitizes VLM prompts (removes SOM markers)
+        2. Calls video_understanding tool for each prompt
+        3. Formats results using optional template and LLM
+        4. Saves markdown and PDF to object store
+        5. Returns URLs and metadata
+        """
+        logger.info(f"Generating report for sensor '{report_input.sensor_id}'")
+        logger.info(f"User query: {report_input.user_query}")
+
+        # Decide which video understanding tool to use based on user's explicit request
+        selected_tool = video_understanding_tool  # Default to regular tool
+        tool_name = "video_understanding"
+        lvs_fallback_warning = ""
+
+        # Use LVS only if explicitly requested by user
+
+        # based on config, use lvs if video duration is longer than config.lvs_video_length
+        stream_id = await get_stream_id(report_input.sensor_id, config.vst_internal_url)
+        start_timestamp, end_timestamp = await get_timeline(stream_id, config.vst_internal_url)
+        start_dt = iso8601_to_datetime(start_timestamp)
+        end_dt = iso8601_to_datetime(end_timestamp)
+        duration_seconds = (end_dt - start_dt).total_seconds()
+        if duration_seconds > config.lvs_video_length:
+            if lvs_video_understanding_tool is not None:
+                selected_tool = lvs_video_understanding_tool
+                tool_name = "lvs_video_understanding"
+                logger.info(f"Using LVS tool (video duration {duration_seconds:.1f}s > {config.lvs_video_length}s)")
+            else:
+                logger.warning(
+                    "Video Analysis Report: LVS tool is not configured. "
+                    f"Falling back to standard video_understanding tool. for video duration {duration_seconds:.1f}s > {config.lvs_video_length}s"
+                )
+                lvs_fallback_warning = (
+                    f"⚠️ **Note:** Input video {report_input.sensor_id} is {duration_seconds:.1f}s long. \n"
+                    f"Please use Long video Summarization' for videos longer than {config.lvs_video_length}s.\n\n"
+                )
+        else:
+            logger.info(
+                f"Using standard video_understanding tool (video duration {duration_seconds:.1f}s <= {config.lvs_video_length}s)"
+            )
+
+        # Step 2: Determine prompt and chunks based on tool selection
+        chunks: list[tuple[float, float]] | None = None  # Only used for standard VLM
+        clean_prompt = None  # Track the VLM prompt for report header
+        if tool_name == "lvs_video_understanding":
+            # LVS tool manages its own prompts via HITL - no chunking needed
+            logger.info("Using LVS tool (prompts managed by HITL workflow)")
+
+            # Step 3: Run LVS analysis on entire video
+            vlm_input: dict[str, str | bool] = {
+                "sensor_id": report_input.sensor_id,
+            }
+
+            # Add vlm_reasoning if specified
+            if report_input.vlm_reasoning is not None:
+                vlm_input["vlm_reasoning"] = report_input.vlm_reasoning
+
+            try:
+                vlm_results = [await selected_tool.ainvoke(input=vlm_input)]
+            except Exception as e:
+                logger.exception(f"Video Analysis Report: Failed to run LVS analysis: {e}")
+                raise ValueError(
+                    f"Video Analysis Report: Failed to analyze video '{report_input.sensor_id}': {e}"
+                ) from e
+        else:
+            # Standard VLM: divide video into chunks and process in parallel
+
+            # HITL: Collect/confirm VLM prompt if enabled
+            if config.hitl_enabled:
+                thread_id = ContextState.get().conversation_id.get()
+                current_prompt = _get_prompt(thread_id)
+                resolved_prompt = await _collect_hitl_vlm_prompt(current_prompt)
+
+                # Check if user cancelled
+                if resolved_prompt is None:
+                    logger.info("Report generation cancelled by user")
+                    return VideoReportGenOutput(
+                        summary="Report generation was cancelled by the user.",
+                        http_url=None,
+                        pdf_url=None,
+                        object_store_key=None,
+                        file_size=0,
+                        pdf_file_size=0,
+                        content=None,
+                        video_url=None,
+                    )
+
+                _store_prompt(thread_id, resolved_prompt)
+                logger.info(f"[PROMPT LOADED] video_report_gen.vlm_prompt from HITL: '{resolved_prompt[:100]}...'")
+                clean_prompt = _remove_som_markers(resolved_prompt)
+            else:
+                logger.info(f"[PROMPT LOADED] video_report_gen.vlm_prompt from CONFIG: '{config.vlm_prompt[:100]}...'")
+                clean_prompt = _remove_som_markers(config.vlm_prompt)
+
+            stream_id = await get_stream_id(report_input.sensor_id, config.vst_internal_url)
+            start_timestamp, end_timestamp = await get_timeline(stream_id, config.vst_internal_url)
+            start_dt = iso8601_to_datetime(start_timestamp)
+            end_dt = iso8601_to_datetime(end_timestamp)
+            duration_seconds = (end_dt - start_dt).total_seconds()
+
+            if duration_seconds > config.max_duration_for_chunking:
+                # Video too long for chunking - process as single chunk
+                logger.warning(
+                    f"Video duration ({duration_seconds:.1f}s) exceeds chunking threshold ({config.max_duration_for_chunking}s). "
+                    f"Processing entire video as single chunk. Quality may be degraded."
+                )
+                chunks = [(0.0, duration_seconds)]
+            else:
+                # Divide video into chunks
+                chunks = _divide_video_into_chunks(
+                    duration_seconds,
+                    config.chunk_duration_seconds,
+                )
+                logger.info(f"Divided video into {len(chunks)} chunks of {config.chunk_duration_seconds}s each")
+
+            # Step 3: Run VLM analysis tasks in parallel (one per chunk)
+            logger.info(f"Running {len(chunks)} VLM analysis tasks with {tool_name}")
+
+            # FIX: The video understanding tool has two input modes:
+            #   - stream_mode=true  -> VideoUnderstandingInput (start_timestamp: str, ISO 8601)
+            #   - stream_mode=false -> VideoUnderstandingInputNonStream (start_timestamp: float, seconds offset)
+            # Previously, ISO strings were always passed regardless of the tool's mode,
+            # which caused a "could not convert string to float" validation error when
+            # the tool was configured with stream_mode=false (e.g. dev-profile-base).
+            # We now inspect the tool's input schema to detect which format it expects.
+            uses_float_timestamps = True
+            tool_args_schema = getattr(selected_tool, "args_schema", None)
+            if tool_args_schema and hasattr(tool_args_schema, "model_fields"):
+                ts_field = tool_args_schema.model_fields.get("start_timestamp")
+                if ts_field:
+                    field_type = ts_field.annotation
+                    uses_float_timestamps = field_type is float or (
+                        hasattr(field_type, "__args__") and float in field_type.__args__
+                    )
+
+            chunk_process_start_time = datetime.now()
+            vlm_tasks = []
+            for chunk_idx, (chunk_start, chunk_end) in enumerate(chunks):
+                vlm_prompt = (
+                    clean_prompt
+                    + "\n\n"
+                    + CHUNK_TIMESTAMP_PROMPT.format(start_time=0, end_time=chunk_end - chunk_start)
+                )
+
+                if uses_float_timestamps:
+                    # Non-stream mode: pass float offsets (seconds since beginning of stream)
+                    chunk_vlm_input: dict[str, Any] = {
+                        "sensor_id": report_input.sensor_id,
+                        "start_timestamp": chunk_start,
+                        "end_timestamp": chunk_end,
+                        "user_prompt": vlm_prompt,
+                    }
+                else:
+                    # Stream mode: convert chunk offsets to ISO timestamp strings
+                    chunk_start_dt = start_dt + timedelta(seconds=chunk_start)
+                    chunk_end_dt = start_dt + timedelta(seconds=chunk_end)
+                    chunk_vlm_input = {
+                        "sensor_id": report_input.sensor_id,
+                        "start_timestamp": datetime_to_iso8601(chunk_start_dt),
+                        "end_timestamp": datetime_to_iso8601(chunk_end_dt),
+                        "user_prompt": vlm_prompt,
+                    }
+
+                # Add vlm_reasoning if specified
+                if report_input.vlm_reasoning is not None:
+                    chunk_vlm_input["vlm_reasoning"] = report_input.vlm_reasoning
+
+                logger.info(f"Chunk {chunk_idx + 1}/{len(chunks)}: {chunk_start} to {chunk_end}")
+                vlm_tasks.append(selected_tool.ainvoke(input=chunk_vlm_input))
+
+            try:
+                vlm_results = await asyncio.gather(*vlm_tasks)
+                chunk_process_elapsed = (datetime.now() - chunk_process_start_time).total_seconds()
+                logger.info(
+                    f"Successfully completed {len(vlm_results)} VLM chunk analyses in {chunk_process_elapsed:.2f}s"
+                )
+            except Exception as e:
+                logger.exception(f"Video Analysis Report: Failed to run VLM analysis: {e}")
+                raise ValueError(
+                    f"Video Analysis Report: Failed to analyze video '{report_input.sensor_id}': {e}"
+                ) from e
+
+        # Step 4: Create report with header and VLM analysis
+        logger.info(f"Processing {tool_name} response")
+
+        # Extract HITL prompts if using LVS (needed for header)
+        hitl_prompts = None
+        if tool_name == "lvs_video_understanding" and vlm_results:
+            try:
+                # Parse the first LVS result to extract HITL prompts
+                lvs_data = json.loads(vlm_results[0])
+
+                # Check if LVS was aborted by user
+                if lvs_data.get("status") == LVSStatus.ABORTED.value:
+                    logger.info("LVS analysis was aborted by user, returning aborted message")
+                    return VideoReportGenOutput(
+                        http_url=None,
+                        summary=lvs_data.get("message", "Video analysis was cancelled by user."),
+                    )
+
+                hitl_prompts = lvs_data.get("hitl_prompts")
+
+            except Exception as e:
+                logger.warning(f"Failed to extract HITL prompts from LVS response: {e}")
+
+        report_header = _create_report_header(
+            report_input.sensor_id,
+            report_input.user_query,
+            hitl_prompts=hitl_prompts,
+        )
+
+        # Format results based on tool type
+        if tool_name == "lvs_video_understanding":
+            # Format LVS responses (video clip links will be injected later)
+            vlm_content = "\n\n".join([_format_lvs_response(result) for result in vlm_results])
+        else:
+            # Normalize timestamps in each chunk result and combine
+            # VLM returns timestamps relative to chunk (starting from 0s)
+            # We need to offset them by chunk_start to get absolute video time
+            assert chunks is not None  # chunks is always set for non-LVS tools
+            normalized_results = []
+            for (chunk_start, chunk_end), result in zip(chunks, vlm_results, strict=True):
+                cleaned = _clean_vlm_response(result)
+                if config.normalize_timestamps:
+                    normalized = _normalize_chunk_timestamps(cleaned, chunk_start, chunk_end)
+                else:
+                    normalized = cleaned
+                # Filter out short duration events from markdown
+                filtered = _filter_short_duration_from_markdown(normalized, min_duration_seconds=2.0)
+                normalized_results.append(filtered)
+            vlm_content = "\n\n".join(normalized_results)
+
+        # Step 4b: Inject snapshots for timestamps found in VLM response
+        if picture_url_tool:
+            vlm_content = await _inject_snapshots(
+                vlm_content,
+                report_input.sensor_id,
+                picture_url_tool,
+            )
+
+        # Step 4c: Inject video clip links for timestamps found in VLM response
+        if config.vst_internal_url and config.vst_external_url:
+            vlm_content = await _inject_video_clips(
+                vlm_content,
+                report_input.sensor_id,
+                config.vst_internal_url,
+                config.vst_external_url,
+            )
+
+        markdown_content = report_header + vlm_content
+
+        # Step 5: Fetch video URL
+        video_url = None
+
+        if video_url_tool:
+            try:
+                video_result = await video_url_tool.ainvoke(
+                    input={
+                        "sensor_id": report_input.sensor_id,
+                    }
+                )
+                video_url = video_result.video_url
+                logger.info(f"Video URL: {video_url}")
+            except Exception as e:
+                logger.warning(f"Video Analysis Report: Failed to fetch video URL: {e}")
+
+        # Append video URL to report
+        # FIX: The URL is placed in its own paragraph (separated by \n\n) instead of
+        # inline with the label. When both were on the same line, the CSS
+        # text-align:justify caused xhtml2pdf to stretch the space between "Video
+        # Playback:" and the URL across the full page width in the PDF output.
+        if video_url:
+            markdown_content += "\n\n## Resources\n\n"
+            markdown_content += f"**Video Playback:**\n\n{video_url}\n\n"
+
+        # Step 6: Save reports to object store
+        timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"vss_report_{timestamp_str}.md"
+        pdf_filename = filename.replace(".md", ".pdf")
+
+        # Save markdown
+        http_url, file_size = await _save_markdown_to_object_store(markdown_content, filename, object_store, config)
+
+        # Save PDF
+        pdf_url, pdf_file_size = await _save_pdf_to_object_store(
+            markdown_content, filename, pdf_filename, object_store, config
+        )
+
+        # Step 7: Create summary
+        summary = ""
+        if lvs_fallback_warning:
+            summary += lvs_fallback_warning
+        summary += f"Report generated for '{report_input.sensor_id}'.\n\n"
+
+        logger.info(f"report generation complete: {http_url}")
+
+        return VideoReportGenOutput(
+            http_url=http_url,
+            pdf_url=pdf_url,
+            object_store_key=filename,
+            summary=summary,
+            file_size=file_size,
+            pdf_file_size=pdf_file_size,
+            content=markdown_content,
+            video_url=video_url,
+            hitl_prompts=hitl_prompts,
+        )
+
+    desc = _video_report_gen.__doc__ if _video_report_gen.__doc__ is not None else ""
+    if config.lvs_video_understanding_tool is not None:
+        desc += f"\nlvs is available. report agent will call lvs to generate a report for videos longer than {config.lvs_video_length}s.\n\n"
+
+    function_info = FunctionInfo.create(
+        single_fn=_video_report_gen,
+        description=desc,
+        input_schema=VideoReportGenInput,
+        single_output_schema=VideoReportGenOutput,
+    )
+
+    yield function_info

--- a/agent/app/video_search_frag/src/video_search_frag/video_report_gen_frag.py
+++ b/agent/app/video_search_frag/src/video_search_frag/video_report_gen_frag.py
@@ -1532,7 +1532,9 @@ Enter your choice or press Submit to keep current value:"""
 
             # Whitespace-only = not valid; re-prompt
             if not stripped:
-                error_message = "Input is empty or whitespace. Press Submit with no text to approve the default, or enter a prompt."
+                error_message = (
+                    "Input is empty or whitespace. Press Submit with no text to approve the default, or enter a prompt."
+                )
                 continue
 
             # Plain text = use directly (no further approval needed)

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -73,22 +73,17 @@ RUN find /vss-agent/.venv -type f -path "*/torch/bin/test_*" -delete && \
 # Remove imageio_ffmpeg binary if present (~76 MB) - not needed since we use opencv
 RUN rm -rf /vss-agent/.venv/lib/python3.13/site-packages/imageio_ffmpeg 2>/dev/null || true
 
-# Security patch stage - download patched OpenSSL libraries
-# CVE-2025-69419, CVE-2025-69420, CVE-2025-15467: Upgrade libssl3 to 3.0.19-1~deb12u1
+# Security patch stage - install patched OpenSSL libraries
+# CVE-2025-69419, CVE-2025-69420, CVE-2025-15467: Upgrade libssl3 to latest bookworm security release
 FROM debian:bookworm AS security-patches
-ARG TARGETARCH
 
-# Download the patched libssl3 package for the target architecture
+# Install the latest libssl3 via apt (avoids hardcoding a .deb URL that can go 404
+# when Debian publishes a newer point release).
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget ca-certificates && \
-    mkdir -p /patches && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        wget -O /patches/libssl3.deb http://deb.debian.org/debian/pool/main/o/openssl/libssl3_3.0.19-1~deb12u1_amd64.deb; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-        wget -O /patches/libssl3.deb http://deb.debian.org/debian/pool/main/o/openssl/libssl3_3.0.19-1~deb12u1_arm64.deb; \
-    fi && \
-    cd /patches && \
-    dpkg-deb -x libssl3.deb /patches/libssl3-extracted && \
+    apt-get install -y --no-install-recommends libssl3 && \
+    mkdir -p /patches/libssl3-extracted && \
+    cp -a --parents /usr/lib/*-linux-gnu*/libssl.so.* /patches/libssl3-extracted/ && \
+    cp -a --parents /usr/lib/*-linux-gnu*/libcrypto.so.* /patches/libssl3-extracted/ && \
     rm -rf /var/lib/apt/lists/*
 
 # Runtime stage - using NVIDIA distroless production image (supports AMD64 and ARM64)
@@ -117,7 +112,7 @@ RUN ["/usr/local/bin/python3", "-c", "import os; os.remove('/tmp/cleanup_vulnera
 RUN ["/usr/local/bin/python3", "-c", "import os; os.path.exists('/usr/bin/openssl') and os.remove('/usr/bin/openssl')"]
 
 # Copy patched OpenSSL libraries to fix CVE-2025-69419, CVE-2025-69420, CVE-2025-15467
-# These replace the base image libssl3 with 3.0.19-1~deb12u1
+# These replace the base image libssl3 with the latest Debian bookworm security release
 # Copy directly to architecture-specific paths where the runtime image expects them
 COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/libssl.so.* /usr/lib/x86_64-linux-gnu/
 COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/libssl.so.* /usr/lib/aarch64-linux-gnu/

--- a/skills/vss-frag/SKILL.md
+++ b/skills/vss-frag/SKILL.md
@@ -13,23 +13,116 @@ human-in-the-loop (HITL) parameter collection on top of the base VSS agent.
 
 Always run `curl` commands yourself; never instruct the user to run them.
 
-## Deployment prerequisite
+## Deploying the Frag Extension
 
-This skill requires the VSS **video_search_frag** profile running on the host.
-The frag extension builds on top of the base VSS agent image with Enterprise RAG
-and HITL LVS tools.
+The frag extension layers Enterprise RAG and HITL LVS tools on top of the base
+VSS agent image. Deployment is a two-step Docker build followed by compose up.
 
-Before any request, probe the agent:
+> **Environment variables:** All commands use values from the `.env` file at
+> `deployments/developer-workflow/dev-profile-lvs/.env`. Edit it before deploying.
+> Key variables: `HOST_IP`, `VSS_AGENT_PORT` (default `8000`), `NGC_CLI_API_KEY`,
+> `NVIDIA_API_KEY`, `ENTERPRISE_RAG_*`.
+
+### Step 1: Configure the .env file
 
 ```bash
+nano deployments/developer-workflow/dev-profile-lvs/.env
+```
+
+Set at minimum:
+- `HOST_IP` — your machine's IP (`hostname -I | awk '{print $1}'`)
+- `NGC_CLI_API_KEY` — from https://ngc.nvidia.com/
+- `NVIDIA_API_KEY` — from https://build.nvidia.com/
+- `VSS_AGENT_CONFIG_FILE=./configs/video_search_frag/config.yml`
+- `ENTERPRISE_RAG_VDB_ENDPOINT` — your Milvus endpoint (e.g., `tcp://127.0.0.1:19530`)
+- `ENTERPRISE_RAG_COLLECTION_NAMES` — your Milvus collection name
+
+### Step 2: Log in to NGC registry
+
+```bash
+echo "$NGC_CLI_API_KEY" | docker login nvcr.io --username '$oauthtoken' --password-stdin
+```
+
+### Step 3: Build the base agent image
+
+```bash
+cd agent
+docker build -f docker/Dockerfile -t vss-agent-base .
+```
+
+### Step 4: Build the frag extension image
+
+```bash
+docker compose \
+  -f app/video_search_frag/docker-compose.yml \
+  --env-file ../deployments/developer-workflow/dev-profile-lvs/.env \
+  build
+```
+
+This produces `vss-agent-frag:latest` — the base agent extended with
+`video_search_frag` (Enterprise RAG, HITL LVS, PDF report generation).
+
+### Step 5: Deploy with docker compose
+
+```bash
+docker compose \
+  -f app/video_search_frag/docker-compose.yml \
+  -f ../deployments/agents/agent_ui/compose.yml \
+  --env-file ../deployments/developer-workflow/dev-profile-lvs/.env \
+  --profile bp_developer_lvs_2d \
+  up -d
+```
+
+Two `-f` flags: the frag compose defines `vss-agent`, the UI compose defines
+`metropolis-vss-ui`. They merge into a single deployment.
+
+### Step 6: Verify deployment
+
+```bash
+# Check containers are running
+docker ps --format "table {{.Names}}\t{{.Status}}"
+
+# Health check
 curl -sf --max-time 5 "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/health" >/dev/null \
   && echo "VSS frag agent is running" \
   || echo "VSS frag agent is NOT reachable"
 ```
 
-> **Environment variables:** All endpoints in this skill use `${HOST_IP}` and
-> `${VSS_AGENT_PORT}` (default `8000`). These are set in the deployment `.env` file.
-> Example: `http://localhost:8000` if running locally.
+### Tear down
+
+```bash
+docker compose \
+  -f app/video_search_frag/docker-compose.yml \
+  -f ../deployments/agents/agent_ui/compose.yml \
+  --env-file ../deployments/developer-workflow/dev-profile-lvs/.env \
+  --profile bp_developer_lvs_2d \
+  down
+```
+
+### Rebuild after code changes
+
+Always `down` then rebuild and `up` — never just `up -d` alone after changes.
+
+```bash
+docker compose \
+  -f app/video_search_frag/docker-compose.yml \
+  --env-file ../deployments/developer-workflow/dev-profile-lvs/.env \
+  build
+
+docker compose \
+  -f app/video_search_frag/docker-compose.yml \
+  -f ../deployments/agents/agent_ui/compose.yml \
+  --env-file ../deployments/developer-workflow/dev-profile-lvs/.env \
+  --profile bp_developer_lvs_2d \
+  down
+
+docker compose \
+  -f app/video_search_frag/docker-compose.yml \
+  -f ../deployments/agents/agent_ui/compose.yml \
+  --env-file ../deployments/developer-workflow/dev-profile-lvs/.env \
+  --profile bp_developer_lvs_2d \
+  up -d
+```
 
 ## When to Use
 

--- a/skills/vss-frag/SKILL.md
+++ b/skills/vss-frag/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: vss-frag
+description: "Generate video summary reports using the VSS video_search_frag extension with Long Video Summarization (LVS), Enterprise RAG knowledge retrieval, and human-in-the-loop parameter collection. Use when: user wants to generate a video summary, report, or analysis using the frag pipeline."
+version: "3.1.0"
+license: "Apache License 2.0"
+---
+
+# VSS Frag — Video Analysis with Enterprise RAG
+
+Generate video summary reports using the VSS `video_search_frag` extension.
+This skill adds Enterprise RAG (Milvus) knowledge retrieval and guided
+human-in-the-loop (HITL) parameter collection on top of the base VSS agent.
+
+Always run `curl` commands yourself; never instruct the user to run them.
+
+## Deployment prerequisite
+
+This skill requires the VSS **video_search_frag** profile running on the host.
+The frag extension builds on top of the base VSS agent image with Enterprise RAG
+and HITL LVS tools.
+
+Before any request, probe the agent:
+
+```bash
+curl -sf --max-time 5 "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/health" >/dev/null \
+  && echo "VSS frag agent is running" \
+  || echo "VSS frag agent is NOT reachable"
+```
+
+> **Environment variables:** All endpoints in this skill use `${HOST_IP}` and
+> `${VSS_AGENT_PORT}` (default `8000`). These are set in the deployment `.env` file.
+> Example: `http://localhost:8000` if running locally.
+
+## When to Use
+
+- User wants to generate a video summary or report using the frag pipeline
+- User asks to analyze a video with Enterprise RAG knowledge context
+- User mentions "frag", "enterprise RAG", or "knowledge-enhanced report"
+
+## When NOT to Use
+
+- Simple video understanding queries (use `video-understanding` skill)
+- Direct LVS summarization without HITL (use `video-summarization` skill)
+- Deployment tasks (use `deploy` skill)
+- Real-time alerts (use `alerts` skill)
+
+## Workflow: Generate an LVS Report with Enterprise RAG
+
+### Step 1: List available videos
+
+```bash
+curl -sS -X POST "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/v1/chat" \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "What videos are available?"}]}' | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(d['choices'][0]['message']['content'])"
+```
+
+Show the user the video list and ask which one they want to analyze.
+
+### Step 2: Collect parameters from the user
+
+Ask the user for these four inputs one at a time:
+
+1. **Scenario** — What type of scenario is the video about?
+   Example: "warehouse monitoring", "traffic monitoring", "retail store activity"
+2. **Events** — What events should be detected? Comma-separated.
+   Example: "accident, forklift stuck, workers not wearing PPE, person entering restricted area"
+3. **Objects of Interest** — What objects should the analysis focus on? Or "skip" to skip.
+   Example: "forklifts, pallets, workers"
+4. **Enterprise RAG Query** — An optional question to search the enterprise knowledge base
+   for additional context to include in the report. Or "skip" to skip.
+   Example: "What are the principles of STCC?"
+
+### Step 3: Start the report (HTTP HITL)
+
+Send a POST to `/v1/chat`. This returns HTTP 202 with an execution_id and the first
+HITL prompt. Replace VIDEO_NAME with the chosen video:
+
+```bash
+curl -sS -X POST "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/v1/chat" \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "Generate a report for VIDEO_NAME using long video summarization"}]}'
+```
+
+The response contains:
+- `execution_id` — save this, used in all subsequent requests
+- `interaction_id` — identifies the current prompt
+- `prompt.text` — the HITL prompt text
+- `response_url` — the URL to POST the response to
+
+### Step 4: Respond to HITL prompts
+
+For each prompt, POST the user's parameter to the response_url.
+Replace EXECUTION_ID, INTERACTION_ID, and the text value:
+
+```bash
+curl -sS -X POST \
+  "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/executions/EXECUTION_ID/interactions/INTERACTION_ID/response" \
+  -H "Content-Type: application/json" \
+  -d '{"response": {"type": "text", "text": "USER_VALUE_HERE"}}'
+```
+
+Then poll for the next prompt:
+
+```bash
+curl -sS "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/executions/EXECUTION_ID" | python3 -m json.tool
+```
+
+The HITL prompts come in this order:
+1. **Scenario** — respond with the scenario from Step 2
+2. **Events** — respond with the events from Step 2
+3. **Objects of Interest** — respond with the objects from Step 2, or "skip"
+4. **Enterprise RAG Query** — respond with the query from Step 2, or "skip"
+5. **Confirmation** — respond with empty string "" to confirm and start processing
+
+Repeat the POST-then-poll cycle for each prompt.
+
+### Step 5: Wait for completion
+
+After the confirmation prompt, the system processes the video. This takes 3-5 minutes.
+Keep polling until the status changes from "running" to "completed":
+
+```bash
+curl -sS "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/executions/EXECUTION_ID" | python3 -m json.tool
+```
+
+Tell the user to wait — this takes 3-5 minutes. Poll every 30 seconds.
+
+### Step 6: Present the results
+
+When status is "completed", the response contains the full report with:
+- Detected events with timestamps
+- Narrative analysis summary
+- Enterprise RAG context (if queried)
+- PDF report download link (if available)
+
+Present the report content to the user in a readable format.
+
+## Quick Commands
+
+### Health check
+
+```bash
+curl -sS "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/health"
+```
+
+### Simple chat query (non-report)
+
+For simple questions that do NOT involve report generation:
+
+```bash
+curl -sS -X POST "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/v1/chat" \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "YOUR_QUESTION_HERE"}]}' | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(d['choices'][0]['message']['content'])"
+```
+
+## Notes
+
+- LVS reports take 3-5 minutes for a ~3.5 minute video — always tell the user to wait
+- Enterprise RAG requires a Milvus vector database with data ingested
+- If objects or rag_query are not needed, respond with "skip"
+- The HITL response format is always: `{"response": {"type": "text", "text": "value"}}`
+- `enable_interactive_extensions: true` must be set in the frag config for HTTP HITL to work
+- See also: `video-summarization`, `video-understanding`, `report`, `vios`, `deploy`


### PR DESCRIPTION
Adds the video_search_frag subpackage — an extension that layers Enterprise RAG (Milvus vector database) knowledge retrieval, human-in-the-loop (HITL) LVS parameter collection, and PDF report generation on top of the base VSS agent.

New files:
- agent/app/video_search_frag/ — Extension subpackage with Dockerfile, docker-compose, config, and Python source (enterprise_rag.py, lvs_video_understanding_frag.py, video_report_gen_frag.py)
- skills/vss-frag/SKILL.md — NemoClaw skill for programmatic access via HTTP HITL (POST /v1/chat returning 202 + execution polling)

Bug fix:
- agent/docker/Dockerfile — Replace hardcoded libssl3 .deb URL with apt-get install. The previous wget downloaded a specific Debian package version (3.0.19-1~deb12u1) that has been removed from the Debian mirror after being superseded by 3.0.19-1~deb12u2. This caused the base image build to fail with HTTP 404. Using apt-get install instead fetches whatever the current version is, so the build won't break again when Debian publishes future point releases.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
