### PR TITLE
Fix lvs profile deployment

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -201,22 +201,13 @@ RTVI_VLM_ENDPOINT=http://${HOST_IP}:${VLM_PORT}/v1
 
 USE_RTVI_VLM=true
 RTVI_VLM_URL=http://${HOST_IP}:${RTVI_VLM_PORT}
-RTVI_VLM_URL_PASSTHROUGH=true
 RTVI_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${VLM_NAME}
-RTVI_VLM_MODEL_TO_USE=openai-compat
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
 RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos-reason2-8b:hf-1208'
 
 # RTVI VLM Kafka Configuration
-RTVI_VLM_KAFKA_ENABLED=true
-RTVI_VLM_KAFKA_TOPIC=mdx-vlm
 RTVI_VLM_KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 RTVI_VLM_KAFKA_INCIDENT_TOPIC=mdx-vlm-incidents
-
-# RTVI VLM input dimensions and frame rate
-RTVI_VLM_INPUT_WIDTH=1280
-RTVI_VLM_INPUT_HEIGHT=720
-# RTVI_VLM_DEFAULT_NUM_FRAMES_PER_SECOND_OR_FIXED_FRAMES_CHUNK=20
 
 # =============================================================================
 # VST (VIDEO STORAGE TOOL) CONFIGURATION
@@ -246,11 +237,18 @@ VST_MCP_URL=http://${HOST_IP}:${VST_MCP_PORT}
 VST_ADAPTOR=vst_rtsp
 
 # VST Image tags for common all platforms
-VST_STREAM_PROCESSOR_IMAGE_TAG="2.1.0-26.04.1"
-VST_SENSOR_IMAGE_TAG="2.1.0-26.04.1"
-NVSTREAMER_IMAGE_TAG="2.1.0-26.04.1"
-VST_MCP_IMAGE_TAG="2.1.0-26.04.1"
-VST_INGRESS_IMAGE_TAG="2.1.0-26.04.1"
+VST_MCP_IMAGE_TAG="3.1.0"
+VST_INGRESS_IMAGE_TAG="3.1.0"
+
+# VST Image tags for x86 and DGX-THOR
+VST_STREAM_PROCESSOR_IMAGE_TAG="3.1.0"
+VST_SENSOR_IMAGE_TAG="3.1.0"
+NVSTREAMER_IMAGE_TAG="3.1.0"
+
+# Uncomment below VST Image tags for DGX-SPARK
+# VST_STREAM_PROCESSOR_IMAGE_TAG="3.1.0-sbsa"
+# VST_SENSOR_IMAGE_TAG="3.1.0-sbsa"
+# NVSTREAMER_IMAGE_TAG="3.1.0-sbsa"
 
 # =============================================================================
 # AGENT STORAGE & REPORT CONFIGURATION
@@ -284,10 +282,6 @@ NEXT_PUBLIC_SIDEBAR_CHAT_WORKFLOW="VSS Agent"
 NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_API_CUSTOM_AGENT_PARAMS_JSON={"params":[{"name":"llm_reasoning","label":"LLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""},{"name":"vlm_reasoning","label":"VLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""}]}
 NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_UPLOAD_FILE_ENABLE=true
 NEXT_PUBLIC_SIDEBAR_CHAT_WEB_SOCKET_DEFAULT_ON=true
-NEXT_PUBLIC_WORKFLOW="VSS Agent"
-NEXT_PUBLIC_CHAT_API_CUSTOM_AGENT_PARAMS_JSON={"params":[{"name":"llm_reasoning","label":"LLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""},{"name":"vlm_reasoning","label":"VLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""}]}
-NEXT_PUBLIC_CHAT_UPLOAD_FILE_ENABLE=true
-NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON=true
 NEXT_PUBLIC_ENABLE_ALERTS_TAB=false
 NEXT_PUBLIC_ENABLE_SEARCH_TAB=false
 NEXT_PUBLIC_ENABLE_DASHBOARD_TAB=true

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -174,7 +174,7 @@ EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.04.2-c4f5e8b
+VSS_AGENT_VERSION=3.2.0-26.04.3-9a93dc9b
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000
@@ -302,10 +302,10 @@ NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE=false
 # Used by: LVS service
 
 # LVS Image name
-LVS_IMAGE="nvcr.io/nvidia/vss-core/vss-long-video-summarization"
+LVS_IMAGE="nvcr.io/nvstaging/vss-core/vss-video-summarization"
 
 # LVS Image tags for x86 and DGX-THOR
-LVS_TAG="3.1.0"
+LVS_TAG="3.2.0-rc1-d3e1a8f"
 
 # Uncomment below LVS Image tags for DGX-SPARK
-# LVS_TAG="3.1.0-sbsa"
+# LVS_TAG="3.2.0-rc1-d3e1a8f-arm64-sbsa"

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -208,6 +208,8 @@ RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
 RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos-reason2-8b:hf-1208'
 
 # RTVI VLM Kafka Configuration
+RTVI_VLM_KAFKA_ENABLED=true
+RTVI_VLM_KAFKA_TOPIC=mdx-vlm
 RTVI_VLM_KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 RTVI_VLM_KAFKA_INCIDENT_TOPIC=mdx-vlm-incidents
 
@@ -244,18 +246,11 @@ VST_MCP_URL=http://${HOST_IP}:${VST_MCP_PORT}
 VST_ADAPTOR=vst_rtsp
 
 # VST Image tags for common all platforms
-VST_MCP_IMAGE_TAG="3.1.0"
-VST_INGRESS_IMAGE_TAG="3.1.0"
-
-# VST Image tags for x86 and DGX-THOR
-VST_STREAM_PROCESSOR_IMAGE_TAG="3.1.0"
-VST_SENSOR_IMAGE_TAG="3.1.0"
-NVSTREAMER_IMAGE_TAG="3.1.0"
-
-# Uncomment below VST Image tags for DGX-SPARK
-# VST_STREAM_PROCESSOR_IMAGE_TAG="3.1.0-sbsa"
-# VST_SENSOR_IMAGE_TAG="3.1.0-sbsa"
-# NVSTREAMER_IMAGE_TAG="3.1.0-sbsa"
+VST_STREAM_PROCESSOR_IMAGE_TAG="2.1.0-26.04.1"
+VST_SENSOR_IMAGE_TAG="2.1.0-26.04.1"
+NVSTREAMER_IMAGE_TAG="2.1.0-26.04.1"
+VST_MCP_IMAGE_TAG="2.1.0-26.04.1"
+VST_INGRESS_IMAGE_TAG="2.1.0-26.04.1"
 
 # =============================================================================
 # AGENT STORAGE & REPORT CONFIGURATION
@@ -283,8 +278,13 @@ PHOENIX_ENDPOINT=http://${HOST_IP}:6006
 
 NEXT_PUBLIC_APP_TITLE="VSS BLUEPRINT"
 NEXT_PUBLIC_APP_SUBTITLE="Vision (LVS)"
+NEXT_PUBLIC_ENABLE_CHAT_TAB=false
+NEXT_PUBLIC_ENABLE_CHAT_SIDEBAR=true
+NEXT_PUBLIC_SIDEBAR_CHAT_WORKFLOW="VSS Agent"
+NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_API_CUSTOM_AGENT_PARAMS_JSON={"params":[{"name":"llm_reasoning","label":"LLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""},{"name":"vlm_reasoning","label":"VLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""}]}
+NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_UPLOAD_FILE_ENABLE=true
+NEXT_PUBLIC_SIDEBAR_CHAT_WEB_SOCKET_DEFAULT_ON=true
 NEXT_PUBLIC_WORKFLOW="VSS Agent"
-NEXT_PUBLIC_ENABLE_CHAT_TAB=true
 NEXT_PUBLIC_CHAT_API_CUSTOM_AGENT_PARAMS_JSON={"params":[{"name":"llm_reasoning","label":"LLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""},{"name":"vlm_reasoning","label":"VLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""}]}
 NEXT_PUBLIC_CHAT_UPLOAD_FILE_ENABLE=true
 NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON=true
@@ -293,6 +293,7 @@ NEXT_PUBLIC_ENABLE_SEARCH_TAB=false
 NEXT_PUBLIC_ENABLE_DASHBOARD_TAB=true
 NEXT_PUBLIC_ENABLE_MAP_TAB=false
 NEXT_PUBLIC_ENABLE_VIDEO_MANAGEMENT_TAB=true
+NEXT_PUBLIC_VIDEO_MANAGEMENT_VIDEO_UPLOAD_ENABLE=true
 NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE=false
 
 

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -276,12 +276,16 @@ PHOENIX_ENDPOINT=http://${HOST_IP}:6006
 
 NEXT_PUBLIC_APP_TITLE="VSS BLUEPRINT"
 NEXT_PUBLIC_APP_SUBTITLE="Vision (LVS)"
-NEXT_PUBLIC_ENABLE_CHAT_TAB=false
+NEXT_PUBLIC_WORKFLOW="VSS Agent"
+NEXT_PUBLIC_ENABLE_CHAT_TAB=true
 NEXT_PUBLIC_ENABLE_CHAT_SIDEBAR=true
 NEXT_PUBLIC_SIDEBAR_CHAT_WORKFLOW="VSS Agent"
 NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_API_CUSTOM_AGENT_PARAMS_JSON={"params":[{"name":"llm_reasoning","label":"LLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""},{"name":"vlm_reasoning","label":"VLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""}]}
 NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_UPLOAD_FILE_ENABLE=true
 NEXT_PUBLIC_SIDEBAR_CHAT_WEB_SOCKET_DEFAULT_ON=true
+NEXT_PUBLIC_CHAT_API_CUSTOM_AGENT_PARAMS_JSON={"params":[{"name":"llm_reasoning","label":"LLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""},{"name":"vlm_reasoning","label":"VLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""}]}
+NEXT_PUBLIC_CHAT_UPLOAD_FILE_ENABLE=true
+NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON=true
 NEXT_PUBLIC_ENABLE_ALERTS_TAB=false
 NEXT_PUBLIC_ENABLE_SEARCH_TAB=false
 NEXT_PUBLIC_ENABLE_DASHBOARD_TAB=true

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -16,7 +16,7 @@
 general:
   use_uvloop: true
   front_end:
-    _type: fastapi
+    _type: vss_fastapi
     runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     endpoints:
@@ -171,6 +171,49 @@ functions:
       EXAMPLE:
       [0.0s-4.0s] <description of the first event>
       [4.0s-12.0s] <description of the second event>
+    # HITL Configuration - prompts user to confirm/edit VLM prompt before report generation
+    hitl_enabled: true
+    hitl_prompt_llm: ${LLM_MODEL_TYPE:-nim}_llm  # LLM for AI-assisted prompt generation e.g. nim_llm, openai_llm
+    hitl_vlm_prompt_template: |
+      **VLM Prompt for Report Generation**
+
+      **OPTIONS:**
+
+      • Press Submit (empty) → Approve and generate report
+
+      • Type a new prompt directly or paste current prompt and edit it manually
+
+      • Type `/generate <description>` → AI creates a prompt based on your description
+
+      • Type `/refine <instructions>` → AI modifies the current prompt
+
+      • Type `/cancel` → Cancel report generation
+
+      Enter your choice or press Submit to keep current value:
+    hitl_generate_system_prompt: |
+      You are a prompt engineer specializing in video analysis.
+      Create a clear, detailed prompt for a Vision Language Model (VLM)
+      that will analyze video footage and generate a report.
+
+      Requirements:
+      - Be specific about what to look for in the video
+      - Include instructions to describe events with timestamps in chronological[Xs-Ys] format
+      - Focus on the user's described scenario/goals and create the prompt that will be understandable for the VLM
+      - Keep the prompt concise but detailed
+
+      Output ONLY the VLM prompt, no explanations.
+    hitl_refine_system_prompt: |
+      You are a prompt engineer specializing in video analysis.
+      Modify the existing VLM prompt based on the user's instructions.
+
+      Requirements:
+      - Preserve the timestamp format [Xs-Ys] requirement
+      - Maintain the original prompt structure and content and add on to it the user's requested changes
+
+      Current prompt to modify:
+      {current_prompt}
+
+      Output ONLY the modified prompt, no explanations.
 
   report_agent:
     _type: report_agent
@@ -215,6 +258,18 @@ llms:
     temperature: 0.0
     max_tokens: 4096
 
+  rtvi_vlm:
+    _type: openai
+    model_name: nvidia/cosmos-reason2-8b
+    base_url: ${RTVI_VLM_BASE_URL}/v1
+    temperature: 0.0
+    model_kwargs:
+      extra_body:
+        num_frames_per_second_or_fixed_frames_chunk: 20
+        use_fps_for_chunking: false
+        vlm_input_width: 1280
+        vlm_input_height: 720
+
   # --- Others ---
   eval_llm_judge:
     _type: nim
@@ -249,7 +304,8 @@ workflow:
       **report_agent**
       - Only call report_agent when user mentions "report" in the question.
       - Don't use the report from previous interactions.
-      - Examples: "Generate a report for, "Create an analysis report", "Generate a report using long video summarization", "Generate a report using lvs"
+      - CRITICAL: For multiple videos, pass them as a list in a SINGLE call (e.g., sensor_id=['video1', 'video2']). Do NOT make separate sequential calls.
+      - Examples: "Generate a report for video1", "Create an analysis report", "Generate a report using long video summarization", "Generate a report for video1 & video2 using lvs"
       **video_understanding** - For any question about short videos or quick queries for a video clip.
       - Use when video is less than 1 minute.
       - Use when user asks "what happens in the video" or "describe the video" or "analyze this video" or "what is happening in the video"

--- a/deploy/docker/services/agent/vss-agent-docker-compose.yml
+++ b/deploy/docker/services/agent/vss-agent-docker-compose.yml
@@ -130,7 +130,7 @@ services:
       # RTSP Stream Mode ('search' for search profile, rest other)
       STREAM_MODE: ${STREAM_MODE:-other}
       # Critic agent toggles (for search profile)
-      ENABLE_CRITIC: ${ENABLE_CRITIC:-false}
+      ENABLE_CRITIC: ${ENABLE_CRITIC:-true}
       # Evaluation, used with nat eval workflow
       EVAL_LLM_JUDGE_NAME: ${EVAL_LLM_JUDGE_NAME}
       EVAL_LLM_JUDGE_BASE_URL: ${EVAL_LLM_JUDGE_BASE_URL:-http://${HOST_IP}:${LLM_PORT}}

--- a/deploy/docker/services/infra/mdx-foundational.yml
+++ b/deploy/docker/services/infra/mdx-foundational.yml
@@ -29,7 +29,7 @@ services:
 
   elasticsearch:
     build:
-      context: $MDX_SAMPLE_APPS_DIR/foundational
+      context: $MDX_SAMPLE_APPS_DIR/services/infra
       dockerfile: Dockerfiles/elasticsearch.Dockerfile
       network: "host"
     image: elasticsearch
@@ -39,7 +39,7 @@ services:
       discovery.type: single-node
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     volumes:
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/configs/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/configs/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
       - mdx-elastic-data:/tmp/elastic/data:rw
       - mdx-elastic-logs:/tmp/elastic/logs:rw
     container_name: elasticsearch
@@ -53,7 +53,7 @@ services:
 
   elasticsearch-init-container:
     build:
-      context: $MDX_SAMPLE_APPS_DIR/foundational
+      context: $MDX_SAMPLE_APPS_DIR/services/infra
       dockerfile: Dockerfiles/elastic-init.Dockerfile
       network: "host"
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
@@ -78,7 +78,7 @@ services:
     network_mode: "host"
     volumes:
       - mdx-kafka:/tmp/kafka-data
-      - $MDX_SAMPLE_APPS_DIR/foundational/kafka-entrypoint.sh:/usr/local/bin/kafka-entrypoint.sh:ro
+      - $MDX_SAMPLE_APPS_DIR/services/infra/kafka-entrypoint.sh:/usr/local/bin/kafka-entrypoint.sh:ro
     profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","playback_kafka_2d","playback_kafka_3d","bp_developer_search_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     environment:
       KAFKA_BROKER_ID: 1
@@ -115,7 +115,7 @@ services:
     network_mode: "host"
     profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","playback_kafka_2d","playback_kafka_3d","bp_developer_search_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     volumes:
-      - $MDX_SAMPLE_APPS_DIR/foundational/kafka/init-scripts/create-kafka-topics.sh:/usr/bin/create-kafka-topics.sh
+      - $MDX_SAMPLE_APPS_DIR/services/infra/kafka/init-scripts/create-kafka-topics.sh:/usr/bin/create-kafka-topics.sh
     environment:
       DEFAULT_PARTITIONS: "8"
       DEFAULT_RETENTION_MS: "14400000"
@@ -155,7 +155,7 @@ services:
     network_mode: host
     container_name: redis
     volumes:
-      - $MDX_SAMPLE_APPS_DIR/foundational/redis/configs/redis.conf:/config/redis.conf
+      - $MDX_SAMPLE_APPS_DIR/services/infra/redis/configs/redis.conf:/config/redis.conf
       - $MDX_DATA_DIR/data_log/redis/data:/data
       - $MDX_DATA_DIR/data_log/redis/log:/log
 
@@ -164,7 +164,7 @@ services:
     network_mode: "host"
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     volumes:
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/configs/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/configs/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
     container_name: kibana
     restart: always
     depends_on:
@@ -183,13 +183,13 @@ services:
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     volumes:
       - mdx-logstash-libs:/opt/logstash-data-libs
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/pb_definitions/ruby/ext_pb.rb:/opt/logstash-data-libs/logstash/pb_definitions/ext_pb.rb
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/pb_definitions/ruby/schema_pb.rb:/opt/logstash-data-libs/logstash/pb_definitions/schema_pb.rb
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/pb_definitions/descriptors/ext.desc:/opt/logstash-data-libs/logstash/pb_definitions/descriptors/ext.desc
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/pb_definitions/descriptors/schema.desc:/opt/logstash-data-libs/logstash/pb_definitions/descriptors/schema.desc
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/configs/logstash.yml:/usr/share/logstash/config/logstash.yml
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/configs/mdx-${STREAM_TYPE}-logstash.conf:/usr/share/logstash/pipeline/logstash.conf
-      - $MDX_SAMPLE_APPS_DIR/foundational/elk/gems/logstash-input-redis_stream-3.1.0-java.gem:/usr/share/logstash/gems/logstash-redis-stream-input-java.gem
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/pb_definitions/ruby/ext_pb.rb:/opt/logstash-data-libs/logstash/pb_definitions/ext_pb.rb
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/pb_definitions/ruby/schema_pb.rb:/opt/logstash-data-libs/logstash/pb_definitions/schema_pb.rb
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/pb_definitions/descriptors/ext.desc:/opt/logstash-data-libs/logstash/pb_definitions/descriptors/ext.desc
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/pb_definitions/descriptors/schema.desc:/opt/logstash-data-libs/logstash/pb_definitions/descriptors/schema.desc
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/configs/logstash.yml:/usr/share/logstash/config/logstash.yml
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/configs/mdx-${STREAM_TYPE}-logstash.conf:/usr/share/logstash/pipeline/logstash.conf
+      - $MDX_SAMPLE_APPS_DIR/services/infra/elk/gems/logstash-input-redis_stream-3.1.0-java.gem:/usr/share/logstash/gems/logstash-redis-stream-input-java.gem
     environment:
       LS_JAVA_OPTS: "-Xmx1024m -Xms256m"
       STREAM_TYPE: ${STREAM_TYPE}
@@ -217,7 +217,7 @@ services:
   
   broker-health-check:
     build:
-      context: $MDX_SAMPLE_APPS_DIR/foundational
+      context: $MDX_SAMPLE_APPS_DIR/services/infra
       dockerfile: Dockerfiles/${STREAM_TYPE}-health-check.Dockerfile
       network: host
     profiles: ["bp_wh_2d","bp_wh_redis_3d","bp_wh_redis_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]

--- a/deploy/docker/services/video-summarization/.env
+++ b/deploy/docker/services/video-summarization/.env
@@ -13,19 +13,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Environment variables for LVS Server
+# Environment variables for standalone LVS Server docker run
+# Copy this file to .env.lvs-server and fill in the values
+
+# Container Configuration
+CONTAINER_IMAGE=${LVS_IMAGE:-nvcr.io/nvidia/vss-core/vss-long-video-summarization}:${LVS_TAG:-3.1.0}
+
+# API Keys and Authentication
+# NGC_API_KEY=nvapi-xxxxx
+# NVIDIA_API_KEY=nvapi-xxxxx
+# OPENAI_API_KEY=<>
+
+# Port Configuration
+BACKEND_PORT=38111
+LVS_MCP_PORT=38112
+FRONTEND_PORT=38113
+
+# CA RAG Configuration
+# This will be set via mount path - do not override here
+# CA_RAG_CONFIG=/opt/nvidia/via/config/default_config.yaml
+
+# Feature Flags
+DISABLE_GUARDRAILS=true
+ENABLE_VIA_HEALTH_EVAL=false
+LVS_ENABLE_MCP=true
 
 # Database Configuration - Elasticsearch
+# Update these to point to your external Elasticsearch service
 ES_HOST=${HOST_IP}
 ES_PORT=9200
 ES_TRANSPORT_PORT=9300
 
-# VLM Configuration
-VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${VLM_NAME}
+# # Database Configuration - Milvus DB
+# MILVUS_DB_HOST=${HOST_IP}
+# MILVUS_DB_GRPC_PORT=19530
+
+# GPU Configuration
+# GPU_DEVICES: Comma-separated list of GPU device IDs to use (e.g., "2,3" or "0,1")
+GPU_DEVICES=0
+NVIDIA_VISIBLE_DEVICES=0
+NUM_GPUS=1
+
+# VLM (Vision-Language Model) Configuration
 VLM_MODEL_TO_USE=openai-compat
+VIA_VLM_ENDPOINT=${VLM_BASE_URL}/v1/
+VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${VLM_NAME}
+VIA_VLM_API_KEY="not-used"
+# VLLM_GPU_MEMORY_UTILIZATION=0.85
+# MODEL_PATH=git:https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct
+MODEL_ROOT_DIR=/opt/models/ # path to mount in the container
+NGC_MODEL_CACHE=/opt/models/ # path to download the model
+
+# OpenTelemetry Configuration
+# VIA_ENABLE_OTEL=false
+# VIA_OTEL_ENDPOINT=http://localhost:4318
+# VIA_OTEL_EXPORTER=console
+# VIA_CTX_RAG_ENABLE_OTEL=false
+# VIA_CTX_RAG_EXPORTER=console
+# VIA_CTX_RAG_OTEL_ENDPOINT=http://localhost:4318
+
+# Logging and Debug
+VSS_LOG_LEVEL=DEBUG
 
 # LLM Configuration
+# Update these to point to your external LLM NIM services
 LVS_LLM_MODEL_NAME=${LLM_NAME}
+
 
 # Disable Embeddings
 LVS_EMB_ENABLE=false

--- a/deploy/docker/services/video-summarization/.env
+++ b/deploy/docker/services/video-summarization/.env
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Environment variables for LVS Server
+
+# Database Configuration - Elasticsearch
+ES_HOST=${HOST_IP}
+ES_PORT=9200
+ES_TRANSPORT_PORT=9300
+
+# VLM Configuration
+VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${VLM_NAME}
+VLM_MODEL_TO_USE=openai-compat
+
+# LLM Configuration
+LVS_LLM_MODEL_NAME=${LLM_NAME}
+
+# Disable Embeddings
+LVS_EMB_ENABLE=false
+
+# Database Selection
+LVS_DATABASE_BACKEND=elasticsearch_db

--- a/deploy/docker/services/video-summarization/compose.yml
+++ b/deploy/docker/services/video-summarization/compose.yml
@@ -15,7 +15,7 @@
 
 services:
   lvs-server:
-    image: ${CONTAINER_IMAGE:-${LVS_IMAGE:-nvcr.io/nvidia/vss-core/vss-long-video-summarization}:${LVS_TAG:-3.1.0}}
+    image: ${CONTAINER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f}
     container_name: vss-lvs
 
     profiles: ["bp_developer_lvs_2d"]
@@ -46,8 +46,12 @@ services:
       # Database configuration
       - MILVUS_DB_HOST=${MILVUS_DB_HOST}
       - MILVUS_DB_GRPC_PORT=${MILVUS_DB_GRPC_PORT}
+      - ES_HOST=${ES_HOST:-${HOST_IP}}
+      - ES_PORT=${ES_PORT:-9200}
+      - LVS_DATABASE_BACKEND=${LVS_DATABASE_BACKEND:-elasticsearch_db}
 
       # LLM configuration
+      - LVS_LLM_MODEL_NAME=${LVS_LLM_MODEL_NAME:-${LLM_NAME}}
       - LVS_LLM_BASE_URL=${LLM_BASE_URL:-http://${HOST_IP}:${LLM_PORT}}/v1
       - LVS_LLM_API_KEY=${OPENAI_API_KEY:-${NVIDIA_API_KEY}}
       - VIA_VLM_ENDPOINT=${VLM_BASE_URL:-http://${HOST_IP}:${VLM_PORT}}/v1/
@@ -55,6 +59,7 @@ services:
       - NVIDIA_API_KEY=${NVIDIA_API_KEY}
 
       # Embedding configuration
+      - LVS_EMB_ENABLE=${LVS_EMB_ENABLE:-false}
       - LVS_EMB_MODEL_NAME=${LVS_EMB_MODEL_NAME}
       - LVS_EMB_BASE_URL=${LVS_EMB_BASE_URL}
 
@@ -76,9 +81,14 @@ services:
       - VLM_INPUT_WIDTH=${VLM_INPUT_WIDTH:-1312}
       - VLM_INPUT_HEIGHT=${VLM_INPUT_HEIGHT:-736}
 
+      # RTVI-VLM integration (routes VLM calls to the RTVI container /generate_captions)
+      - USE_RTVI_VLM=${USE_RTVI_VLM:-false}
+      - RTVI_VLM_URL=${RTVI_VLM_URL:-}
+      - RTVI_VLM_URL_PASSTHROUGH=true
+
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
 
-    # Alternative: Load LVS defaults from env file
+    # Alternative: Load all variables from .env file
     env_file:
       - $MDX_SAMPLE_APPS_DIR/services/video-summarization/.env
 

--- a/deploy/docker/services/video-summarization/compose.yml
+++ b/deploy/docker/services/video-summarization/compose.yml
@@ -15,7 +15,7 @@
 
 services:
   lvs-server:
-    image: ${CONTAINER_IMAGE:-nvcr.io/nvidia/vss-core/vss-long-video-summarization:3.1.0}
+    image: ${CONTAINER_IMAGE:-${LVS_IMAGE:-nvcr.io/nvidia/vss-core/vss-long-video-summarization}:${LVS_TAG:-3.1.0}}
     container_name: vss-lvs
 
     profiles: ["bp_developer_lvs_2d"]
@@ -51,11 +51,13 @@ services:
       - LVS_DATABASE_BACKEND=${LVS_DATABASE_BACKEND:-elasticsearch_db}
 
       # LLM configuration
-      - LVS_LLM_MODEL_NAME=${LVS_LLM_MODEL_NAME}
+      - LVS_LLM_MODEL_NAME=${LVS_LLM_MODEL_NAME:-${LLM_NAME}}
       - LVS_LLM_BASE_URL=${LLM_BASE_URL:-http://${HOST_IP}:${LLM_PORT}}/v1
       - LVS_LLM_API_KEY=${OPENAI_API_KEY:-${NVIDIA_API_KEY}}
       - VIA_VLM_ENDPOINT=${VLM_BASE_URL:-http://${HOST_IP}:${VLM_PORT}}/v1/
       - VIA_VLM_API_KEY=${OPENAI_API_KEY:-${VIA_VLM_API_KEY:-not-used}}
+      - VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${RTVI_VLM_OPENAI_MODEL_DEPLOYMENT_NAME:-${VLM_NAME}}
+      - VLM_MODEL_TO_USE=${RTVI_VLM_MODEL_TO_USE:-openai-compat}
       - NVIDIA_API_KEY=${NVIDIA_API_KEY}
 
       # Embedding configuration

--- a/deploy/docker/services/video-summarization/compose.yml
+++ b/deploy/docker/services/video-summarization/compose.yml
@@ -46,22 +46,15 @@ services:
       # Database configuration
       - MILVUS_DB_HOST=${MILVUS_DB_HOST}
       - MILVUS_DB_GRPC_PORT=${MILVUS_DB_GRPC_PORT}
-      - ES_HOST=${ES_HOST}
-      - ES_PORT=${ES_PORT}
-      - LVS_DATABASE_BACKEND=${LVS_DATABASE_BACKEND:-elasticsearch_db}
 
       # LLM configuration
-      - LVS_LLM_MODEL_NAME=${LVS_LLM_MODEL_NAME:-${LLM_NAME}}
       - LVS_LLM_BASE_URL=${LLM_BASE_URL:-http://${HOST_IP}:${LLM_PORT}}/v1
       - LVS_LLM_API_KEY=${OPENAI_API_KEY:-${NVIDIA_API_KEY}}
       - VIA_VLM_ENDPOINT=${VLM_BASE_URL:-http://${HOST_IP}:${VLM_PORT}}/v1/
       - VIA_VLM_API_KEY=${OPENAI_API_KEY:-${VIA_VLM_API_KEY:-not-used}}
-      - VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${RTVI_VLM_OPENAI_MODEL_DEPLOYMENT_NAME:-${VLM_NAME}}
-      - VLM_MODEL_TO_USE=${RTVI_VLM_MODEL_TO_USE:-openai-compat}
       - NVIDIA_API_KEY=${NVIDIA_API_KEY}
 
       # Embedding configuration
-      - LVS_EMB_ENABLE=${LVS_EMB_ENABLE:-false}
       - LVS_EMB_MODEL_NAME=${LVS_EMB_MODEL_NAME}
       - LVS_EMB_BASE_URL=${LVS_EMB_BASE_URL}
 
@@ -84,6 +77,10 @@ services:
       - VLM_INPUT_HEIGHT=${VLM_INPUT_HEIGHT:-736}
 
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+
+    # Alternative: Load LVS defaults from env file
+    env_file:
+      - $MDX_SAMPLE_APPS_DIR/services/video-summarization/.env
 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${BACKEND_PORT:-38111}/v1/ready"]

--- a/deploy/docker/services/video-summarization/compose.yml
+++ b/deploy/docker/services/video-summarization/compose.yml
@@ -61,7 +61,7 @@ services:
       - NVIDIA_API_KEY=${NVIDIA_API_KEY}
 
       # Embedding configuration
-      - LVS_EMB_ENABLE=${LVS_EMB_ENABLE}
+      - LVS_EMB_ENABLE=${LVS_EMB_ENABLE:-false}
       - LVS_EMB_MODEL_NAME=${LVS_EMB_MODEL_NAME}
       - LVS_EMB_BASE_URL=${LVS_EMB_BASE_URL}
 

--- a/deploy/docker/services/vios/initiator/docker-compose.yaml
+++ b/deploy/docker/services/vios/initiator/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     container_name: sensor-bp-wait-sdr-streaming
     restart: "no"
     volumes:
-      - ${MDX_SAMPLE_APPS_DIR}/vst/initiator/scripts/sensor-bp-wait-sdr-streaming.sh:/scripts/sensor-bp-wait-sdr-streaming.sh:ro
+      - ${MDX_SAMPLE_APPS_DIR}/services/vios/initiator/scripts/sensor-bp-wait-sdr-streaming.sh:/scripts/sensor-bp-wait-sdr-streaming.sh:ro
     environment:
       SDR_HTTP_REPLAYSTREAM_PORT: ${SDR_HTTP_REPLAYSTREAM_PORT:-4004}
       SDR_HTTP_LIVESTREAM_PORT: ${SDR_HTTP_LIVESTREAM_PORT:-4005}
@@ -35,7 +35,7 @@ services:
     container_name: sensor-bp-wait-bp-configurator
     restart: "no"
     volumes:
-      - ${MDX_SAMPLE_APPS_DIR}/vst/initiator/scripts/sensor-bp-wait-bp-configurator.sh:/scripts/sensor-bp-wait-bp-configurator.sh:ro
+      - ${MDX_SAMPLE_APPS_DIR}/services/vios/initiator/scripts/sensor-bp-wait-bp-configurator.sh:/scripts/sensor-bp-wait-bp-configurator.sh:ro
     environment:
       BP_CONFIGURATOR_READYZ_URL: ${BP_CONFIGURATOR_READYZ_URL:-http://127.0.0.1:5001/readyz}
       SENSOR_BP_WAIT_BP_CONFIGURATOR_MAX_SEC: ${SENSOR_BP_WAIT_BP_CONFIGURATOR_MAX_SEC:-300}
@@ -48,7 +48,7 @@ services:
     container_name: sensor-bp-wait-storage
     restart: "no"
     volumes:
-      - ${MDX_SAMPLE_APPS_DIR}/vst/initiator/scripts/sensor-bp-wait-storage.sh:/scripts/sensor-bp-wait-storage.sh:ro
+      - ${MDX_SAMPLE_APPS_DIR}/services/vios/initiator/scripts/sensor-bp-wait-storage.sh:/scripts/sensor-bp-wait-storage.sh:ro
     environment:
       STORAGE_HTTP_PORT: ${STORAGE_HTTP_PORT:-30011}
       SENSOR_BP_WAIT_STORAGE_MAX_SEC: ${SENSOR_BP_WAIT_STORAGE_MAX_SEC:-300}

--- a/deploy/docker/services/vios/sdr/recorder/docker-compose.yaml
+++ b/deploy/docker/services/vios/sdr/recorder/docker-compose.yaml
@@ -29,8 +29,8 @@ services:
       - CENTRALIZE_DB_USERNAME=${CENTRALIZE_DB_USERNAME}
       - STORAGE_MODULE_ENDPOINT=${STORAGE_MODULE_ENDPOINT}
     volumes:
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}:/home/vst/vst_release/configs
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${MDX_SAMPLE_APPS_DIR}/services/vios/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh

--- a/deploy/docker/services/vios/sdr/rtspserver/docker-compose.yaml
+++ b/deploy/docker/services/vios/sdr/rtspserver/docker-compose.yaml
@@ -32,8 +32,8 @@ services:
       - STORAGE_MODULE_ENDPOINT=${STORAGE_MODULE_ENDPOINT}
       - SENSOR_MODULE_ENDPOINT=${SENSOR_MODULE_ENDPOINT}
     volumes:
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}:/home/vst/vst_release/configs
-      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/vst/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
+      - ${VST_CONFIG_PATH:-${MDX_SAMPLE_APPS_DIR}/services/vios/configs}/vst_config_${STREAM_TYPE:-redis}.json:/home/vst/vst_release/configs/vst_config.json
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${MDX_SAMPLE_APPS_DIR}/services/vios/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh


### PR DESCRIPTION
## Description
- Fix relocated Docker paths for foundational and VIOS services under `deploy/docker/services`.
- Align LVS service compose/env defaults with the met-blueprints LVS setup.
- Add LVS RTVI-VLM passthrough configuration so long-video requests route through `rtvi-vlm`.
- Update `dev-profile-lvs` agent/LVS/RTVI image and environment defaults.
- Add LVS agent config updates for `vss_fastapi`, RTVI VLM, HITL report prompts, and multi-video report routing.

## Checklist
-  [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
