### PR TITLE
fix(test): align mock ES endpoint with config in embed_search tests

### DIFF
--- a/services/agent/tests/unit_test/tools/test_embed_search_edge_cases.py
+++ b/services/agent/tests/unit_test/tools/test_embed_search_edge_cases.py
@@ -55,7 +55,10 @@ class TestEmbedSearchEdgeCases:
     def mock_es(self, monkeypatch):
         client = AsyncMock()
         client.indices.exists.return_value = True
-        monkeypatch.setattr(VSSESClient, "_clients", {"http://mock:9200": client})
+        # Key MUST match config.es_endpoint — VSSESClient.get_es_client looks up
+        # the cache by exact endpoint string. Mismatched key would fall through
+        # to creating a real AsyncElasticsearch and trying to dial live ES.
+        monkeypatch.setattr(VSSESClient, "_clients", {"http://localhost:9200": client})
         monkeypatch.setattr(VSSESClient, "close_all", AsyncMock())
         return client
 

--- a/services/agent/tests/unit_test/tools/test_embed_search_inner.py
+++ b/services/agent/tests/unit_test/tools/test_embed_search_inner.py
@@ -61,7 +61,10 @@ class TestEmbedSearchInner:
     def mock_es(self, monkeypatch):
         client = AsyncMock()
         client.indices.exists.return_value = True
-        monkeypatch.setattr(VSSESClient, "_clients", {"http://mock:9200": client})
+        # Key MUST match config.es_endpoint — VSSESClient.get_es_client looks up
+        # the cache by exact endpoint string. Mismatched key would fall through
+        # to creating a real AsyncElasticsearch and trying to dial live ES.
+        monkeypatch.setattr(VSSESClient, "_clients", {"http://localhost:9200": client})
         monkeypatch.setattr(VSSESClient, "close_all", AsyncMock())
         return client
 


### PR DESCRIPTION
## Summary

Restores `Test (pytest)` to green on develop. **30 of 31 tests in `test_embed_search_inner.py` and `test_embed_search_edge_cases.py` were failing** since #109 merged earlier today.

## Root cause

PR #109 (`es client refactoring in the search path`) replaced direct `AsyncElasticsearch(...)` construction with the new endpoint-keyed registry:

```python
# embed_search.py
es = await VSSESClient.get_es_client(es_endpoint=config.es_endpoint)
```

`VSSESClient.get_es_client` does an exact-string lookup in `_clients[es_endpoint]`. The two affected test fixtures pre-populated the registry with **the wrong key**:

| | Fixture key | Config asks for |
|---|---|---|
| `test_embed_search_inner.py` | `"http://mock:9200"` | `"http://localhost:9200"` |
| `test_embed_search_edge_cases.py` | `"http://mock:9200"` | `"http://localhost:9200"` |

Cache miss → fall through to `AsyncElasticsearch(...)` → real connection attempt to `localhost:9200` inside the GH-hosted runner → timeout via `elastic_transport/_async_transport.py` → 30 `FAILED`s.

Note: PR #109 was actually merged with **failing CI** ([pull-request/109 mirror runs](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/24764264869) and [follow-up](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/24764799454) both ❌). It was mergeable because rulesets don't currently require status checks to pass — separate governance gap that the required-status-checks ruleset update will close.

## Fix

Change the cache key in both fixtures to match `config.es_endpoint`:

```python
monkeypatch.setattr(VSSESClient, "_clients", {"http://localhost:9200": client})
```

Plus a comment explaining the invariant so the bug doesn't recur.

## Verification

Local run with both files, dev group synced, on a clean `services/agent` venv:

```
$ uv run pytest tests/unit_test/tools/test_embed_search_inner.py \
                tests/unit_test/tools/test_embed_search_edge_cases.py
======================== 30 passed in 63.52s (0:01:03) =========================
```

## Test plan

- [ ] CI `Test (pytest)` job goes green on this PR
- [ ] After merge, develop's CI returns to all-green
- [ ] PR #173 (deploy/scripts move) auto-rebases on develop and its CI passes

## Follow-ups

- After this lands, rebase #173.
- Worth considering: enable required-status-checks on the `Protect develop` ruleset so future PRs that fail CI can't be merged the way #109 was. (Tracked in the broader compliance audit.)