### PR TITLE
skills: restore per-skill eval specs (deploy, video-summarization, vios)

### DIFF
--- a/skills/deploy/eval/alerts_cv.json
+++ b/skills/deploy/eval/alerts_cv.json
@@ -1,0 +1,26 @@
+{
+  "skills": ["deploy"],
+  "resources": {
+    "platforms": {
+      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
+      "L40S":         {"modes": ["dedicated", "remote-all"]},
+      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]},
+      "DGX-SPARK":    {"modes": ["remote-llm"]}
+    }
+  },
+  "env": "Multi-GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must be set. The **alerts-verification (CV)** mode uses `deploy -m verification`: RT-CV perception generates candidate alerts upstream (one dedicated GPU), and the VLM reviews each candidate to reduce false positives. On H100/RTX-PRO-6000 two GPUs are enough (CV on GPU 0, shared LLM+VLM on GPU 1). On L40S 48GB × 2, LLM+VLM can't fit on one GPU, so only `remote-*` modes are supported. DGX-Spark (single GPU) can't run this mode at all. See `skills/deploy/references/alerts.md` § *Two Modes*.",
+  "expects": [
+    {
+      "query": "Deploy the VSS **alerts** profile on {{platform}} in {{mode}} mode using `/deploy -m verification` (CV-driven alert generation with VLM-as-verifier). Run end-to-end and autonomously.",
+      "checks": [
+        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0 (shared message bus)",
+        "`docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (RT-CV perception — the 'CV' in this mode)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (rule-based alert generation on CV output)",
+        "`docker ps --format '{{.Names}}' | grep -qx alert-bridge` returns exit 0 (routes CV-generated alerts to VLM verifier)",
+        "`docker ps --format '{{.Names}}' | grep -qx nvstreamer-alerts` returns exit 0 (video ingestion source)"
+      ]
+    }
+  ]
+}

--- a/skills/deploy/eval/alerts_vlm.json
+++ b/skills/deploy/eval/alerts_vlm.json
@@ -1,0 +1,25 @@
+{
+  "skills": ["deploy"],
+  "resources": {
+    "platforms": {
+      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
+      "L40S":         {"modes": ["dedicated", "remote-all"]},
+      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]},
+      "DGX-SPARK":    {"modes": ["remote-llm"]}
+    }
+  },
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must be set. The **alerts-real-time (VLM)** mode uses `deploy -m real-time`: the VLM continuously processes live video at periodic intervals, producing alerts directly without upstream CV filtering — broader coverage, higher GPU load. See `skills/deploy/references/alerts.md` § *Two Modes*.",
+  "expects": [
+    {
+      "query": "Deploy the VSS **alerts** profile on {{platform}} in {{mode}} mode using `/deploy -m real-time` (continuous VLM-driven alert generation). Run end-to-end and autonomously.",
+      "checks": [
+        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0 (shared message bus)",
+        "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor — the 'VLM' in this mode)",
+        "`docker ps --format '{{.Names}}' | grep -qx nvstreamer-alerts` returns exit 0 (video ingestion source)",
+        "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (real-time mode does NOT run the CV perception pipeline)"
+      ]
+    }
+  ]
+}

--- a/skills/deploy/eval/base.json
+++ b/skills/deploy/eval/base.json
@@ -1,0 +1,26 @@
+{
+  "skills": ["deploy"],
+  "resources": {
+    "platforms": {
+      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
+      "L40S":         {"modes": ["dedicated", "remote-all"]},
+      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]},
+      "DGX-SPARK":    {"modes": ["remote-llm"]}
+    }
+  },
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack, not the contents of any `.env` file.",
+  "expects": [
+    {
+      "query": "Deploy the VSS **base** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",
+      "checks": [
+        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx metropolis-vss-ui` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx centralizedb-dev` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx phoenix` returns exit 0"
+      ]
+    }
+  ]
+}

--- a/skills/deploy/eval/lvs.json
+++ b/skills/deploy/eval/lvs.json
@@ -1,0 +1,25 @@
+{
+  "skills": ["deploy"],
+  "resources": {
+    "platforms": {
+      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
+      "L40S":         {"modes": ["dedicated", "remote-all"]},
+      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]}
+    }
+  },
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The LVS profile brings up the full long-video-summarization workflow (agent + UI + NIMs) on top of the base stack. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack.",
+  "expects": [
+    {
+      "query": "Deploy the VSS **lvs** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",
+      "checks": [
+        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx metropolis-vss-ui` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx centralizedb-dev` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx phoenix` returns exit 0"
+      ]
+    }
+  ]
+}

--- a/skills/deploy/eval/search.json
+++ b/skills/deploy/eval/search.json
@@ -1,0 +1,25 @@
+{
+  "skills": ["deploy"],
+  "resources": {
+    "platforms": {
+      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
+      "L40S":         {"modes": ["dedicated", "remote-all"]},
+      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]}
+    }
+  },
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The search profile adds Cosmos Embed1 semantic search on top of base. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack.",
+  "expects": [
+    {
+      "query": "Deploy the VSS **search** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",
+      "checks": [
+        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx metropolis-vss-ui` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx centralizedb-dev` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx phoenix` returns exit 0"
+      ]
+    }
+  ]
+}

--- a/skills/video-summarization/eval/lvs_profile_summarize.json
+++ b/skills/video-summarization/eval/lvs_profile_summarize.json
@@ -1,0 +1,38 @@
+{
+  "skills": ["video-summarization", "sensor-ops"],
+  "env": "A **full-remote deployed VSS lvs profile** (deploy mode = `remote-all` — the agent's LLM and the VLM that LVS calls are both served via remote launchpad endpoints, no local NIMs). Run on ONE platform only — summarization is throughput-bound on the remote VLM, so fanning out across platforms doesn't materially change coverage. Pick the cheapest available host (L40S recommended); the lvs profile uses `network_mode: host` so LVS reaches VST via the host IP. Required: LVS microservice reachable at http://localhost:38111/v1/ready (expect HTTP 200; 503 means still warming up — retry), VST reachable at http://localhost:30888/vst/api/v1 (for clip URL resolution via sensor-ops), a sample warehouse video pre-uploaded to VIOS (seed via the sensor-ops upload query before running these checks), AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770 per launchable convention — see skills/deploy/references/brev.md). LVS fetches the clip URL over HTTP from inside its own container; without the Brev secure link the URL will be http://localhost:... / http://<internal-ip>:... and LVS will either 404 or hang.",
+  "expects": [
+    {
+      "query": "Summarize the uploaded warehouse video with scenario 'warehouse monitoring' and events ['boxes falling', 'forklift stuck', 'person entering restricted area'].",
+      "checks": [
+        "Before any backend call, the agent surfaces the Step 2 HITL prompt — echoing scenario + events back to the user for confirmation — and only proceeds after an explicit go-ahead (it does NOT silently call LVS on the first turn)",
+        "The agent issues exactly one POST http://localhost:38111/summarize call — not zero, not two, no parallel hedging",
+        "The POST /summarize request body is application/json and contains the keys {url, model, scenario, events, chunk_duration, num_frames_per_chunk}; scenario equals 'warehouse monitoring' and events equals the three user-supplied strings verbatim",
+        "The url field points at a Brev secure-link clip URL (https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/...), NOT http://localhost:... and NOT http://<internal-ip>:...",
+        "The LVS response is HTTP 200 and the body is an OpenAI-style envelope with choices[0].message.content populated as a JSON-encoded string",
+        "Parsing choices[0].message.content as JSON yields an object with non-empty fields {video_summary, events, total_events, uuid}",
+        "events is a non-empty array and every element has the keys {id, start_time, end_time, type, description}",
+        "The agent renders the video_summary field verbatim in its final reply — no paraphrasing, no added emojis, no re-voicing",
+        "The agent renders every event returned by LVS (not a subset), preserving the description field in full",
+        "The agent never calls POST /v1/chat/completions on a VLM endpoint directly — all summarization traffic goes through LVS"
+      ]
+    },
+    {
+      "query": "Summarize the uploaded warehouse video using default scenario and events.",
+      "checks": [
+        "The agent surfaces the Step 2 HITL prompt and waits for the user to reply 'defaults' (or equivalent explicit opt-in) before calling LVS",
+        "The POST /summarize request body has scenario='activity monitoring' and events=['notable activity']",
+        "The LVS response is HTTP 200 with a non-empty video_summary and a non-empty events array",
+        "The agent's final reply notes that generic defaults were used and offers to redo the summary with more specific parameters"
+      ]
+    },
+    {
+      "query": "Summarize the uploaded warehouse video while LVS is stopped (simulate by `docker stop` of the LVS container before the query).",
+      "checks": [
+        "The agent's readiness probe against http://localhost:38111/v1/ready returns a connection error or non-200 status",
+        "The agent fails the request with an explicit 'LVS is unreachable' error message — it does NOT fall back to a VLM, does NOT summarize from metadata, and does NOT silently succeed",
+        "No POST /v1/chat/completions call is made to any VLM endpoint as a fallback"
+      ]
+    }
+  ]
+}

--- a/skills/vios/eval/base_profile_ops.json
+++ b/skills/vios/eval/base_profile_ops.json
@@ -1,0 +1,36 @@
+{
+  "skills": ["vios"],
+  "env": "A **full-remote deployed VSS base profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs). Run on ONE platform only — the vios skill exercises VIOS / VST which is GPU-independent, so there's no benefit to fanning out. Pick the cheapest available host (L40S recommended). Required: VST reachable at http://localhost:30888/vst/api/v1 AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770 per launchable convention — see skills/deploy/references/brev.md). Without BREV_ENV_ID the returned media URLs will be raw http://localhost:... and the Brev-link checks will fail.",
+  "expects": [
+    {
+      "query": "Upload the sample warehouse video to VIOS with timestamp 2025-01-01T00:00:00.000Z.",
+      "checks": [
+        "The upload API call (PUT /vst/api/v1/storage/file/<filename>?timestamp=...) returns HTTP 2xx",
+        "The response JSON contains both a sensorId and a streamId (non-empty UUIDs)",
+        "curl -sf http://localhost:30888/vst/api/v1/sensor/list returns a JSON array containing a sensor whose name matches the uploaded video's filename stem",
+        "curl -sf http://localhost:30888/vst/api/v1/sensor/<sensorId>/streams returns a non-empty streams array whose main stream's url is a local file path under /home/vst/... or similar (NOT rtsp://)"
+      ]
+    },
+    {
+      "query": "Extract a snapshot from 5 seconds into the uploaded video and return a shareable URL.",
+      "checks": [
+        "GET /vst/api/v1/replay/stream/<streamId>/picture/url?startTime=2025-01-01T00:00:05.000Z returns a JSON object with a non-empty imageUrl field",
+        "The returned imageUrl matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...)",
+        "curl -sfI <imageUrl> returns HTTP 200",
+        "The response Content-Type starts with image/ (typically image/jpeg)",
+        "The response Content-Length is greater than 2000 bytes (rejects empty / error-placeholder images)"
+      ]
+    },
+    {
+      "query": "Extract a video clip from 3 to 5 seconds (mp4 container) from the uploaded video and return a shareable URL.",
+      "checks": [
+        "GET /vst/api/v1/storage/file/<streamId>/url?startTime=2025-01-01T00:00:03.000Z&endTime=2025-01-01T00:00:05.000Z&container=mp4&disableAudio=true returns a JSON object with a non-empty videoUrl field",
+        "The returned videoUrl matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...)",
+        "curl -sfI <videoUrl> returns HTTP 200",
+        "The response Content-Type starts with video/ (typically video/mp4)",
+        "The response Content-Length is greater than 10000 bytes (rejects empty / error-page responses)",
+        "The response JSON's startTime is within a minute of the requested 00:00:03 and expiryISO is in the future"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Restore the 7 per-skill eval JSON specs that were dropped from \`feat/skills\` by the harness-split commit \`d0d3c38\`. They live next to each skill under \`skills/<name>/eval/\`:

- \`skills/deploy/eval/{alerts_cv,alerts_vlm,base,lvs,search}.json\` (5)
- \`skills/video-summarization/eval/lvs_profile_summarize.json\` (1)
- \`skills/vios/eval/base_profile_ops.json\` (1)

All 7 parse as valid JSON. Restored verbatim from \`d0d3c38^\`.

## Why now

PR #141 brought the skills to \`develop\` but not the per-skill eval specs (those were collateral damage from the harness split). PR #183 (open) brings the harness + Skills Eval workflow. Without these 7 spec files, the workflow will trigger on PRs touching \`skills/\*\*\` but find nothing to exercise.

This PR closes that gap. It is independent of #183 and can land in either order; it just delivers data, not the runner.

## Test plan

- [ ] CI green (Lint, Pytest, Mypy, Secret scan, Folder structure, DCO)
- [ ] After #183 also lands: a PR touching \`skills/deploy/\*\` triggers the Skills Eval workflow and the agent picks up at least one of \`skills/deploy/eval/\*.json\`
- [ ] Schema sanity: each spec round-trips through whatever validator the agent uses (deferred — not blocking this PR since the JSON is unchanged from prior history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)