### PR TITLE
skills: sync skills/ tree from feat/skills

### DIFF
--- a/skills/alerts/SKILL.md
+++ b/skills/alerts/SKILL.md
@@ -19,6 +19,35 @@ The alerts profile is deployed in **one** of two modes at a time. The mode is ch
 
 ---
 
+## Deployment prerequisite
+
+This skill requires the VSS **alerts** profile running on the host at `$HOST_IP`, in either `verification` or `real-time` mode. Before any request:
+
+1. Probe the stack:
+   ```bash
+   # Either perception-alerts (CV mode) OR rtvi-vlm (VLM mode) must be present.
+   curl -sf --max-time 5 "http://${HOST_IP}:8000/docs" >/dev/null \
+     && docker ps --format '{{.Names}}' \
+        | grep -qE '^(perception-alerts|rtvi-vlm)$'
+   ```
+
+2. **If the probe fails**, ask the user:
+   > *"The VSS `alerts` profile isn't running on `$HOST_IP`. Which mode should I deploy — `verification` (CV) or `real-time` (VLM)?"*
+
+   - Answer → hand off to the `/deploy` skill with `-p alerts -m <mode>`. Return here once it succeeds.
+   - If the user declines → stop. Do not run this skill against a missing stack.
+
+   (If your caller has granted explicit pre-authorization to deploy
+   autonomously — e.g. the request says "pre-authorized to deploy
+   prerequisites", or you are running in a non-interactive evaluation
+   harness with that permission — skip the confirmation and invoke
+   `/deploy` directly. Default the mode to `verification` unless the
+   request specifies otherwise.)
+
+3. If the probe passes, detect the mode per § Step 1 below.
+
+---
+
 ## The Two Modes (Deploy-Time Choice)
 
 | Mode | Deploy flag | Env (`.env`) | What runs | How alerts are created |

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -49,7 +49,7 @@ Run docker compose commands directly on the host:
 
 1. **Repo path** — find `video-search-and-summarization/` on disk. Check `TOOLS.md` if available.
 2. **NGC CLI & API key** — see [`references/ngc.md`](references/ngc.md). Check `$NGC_CLI_API_KEY` is set.
-3. **System prerequisites (GPU VRAM, driver, Docker, NVIDIA Container Toolkit)** — canonical reference is the [**VSS prerequisites page**](https://docs.nvidia.com/vss/3.1.0/prerequisites.html). That page lists supported hardware, per-profile GPU requirements, and the minimum driver/CUDA version per NIM. Read it and pick the LLM/VLM placement that fits the host — don't guess thresholds from this skill.
+3. **System prerequisites (GPU VRAM, driver, Docker, NVIDIA Container Toolkit)** — canonical reference is the [**VSS prerequisites page**](https://docs.nvidia.com/vss/3.2.0/prerequisites.html). That page lists supported hardware, per-profile GPU requirements, and the minimum driver/CUDA version per NIM. Read it and pick the LLM/VLM placement that fits the host — don't guess thresholds from this skill.
 
 ### Pre-flight Check
 
@@ -72,10 +72,49 @@ If check 2 or 3 fails, see [`references/prerequisites.md`](references/prerequisi
 
 Always follow this sequence. Never skip the dry-run.
 
+### Step 0 — Tear down any existing deployment
+
+Before every deploy, **always** stop any prior VSS stack. This is
+mandatory even if you think the host is clean, and especially when
+switching profiles (`base` → `search`, `alerts` verification →
+`alerts` real-time, etc.). Compose profile flags only *start* the
+services listed under the selected profile — they do NOT stop
+services from a previously-active profile, so containers from the
+prior deploy linger and pass unrelated container-name checks,
+contaminate results, and can bind ports the new deploy needs.
+
+```bash
+# If a resolved.yml from a prior deploy exists, prefer it — it
+# knows about all compose-profile services that were brought up.
+if [ -f "$REPO/deployments/resolved.yml" ]; then
+  docker compose -f "$REPO/deployments/resolved.yml" down --remove-orphans
+fi
+
+# Catch-all: remove every VSS-stack container the dev-profile compose
+# files bring up. Without this, leftovers from a prior deploy linger
+# (especially the *-smc set, which the alerts compose profile shares
+# with the *-dev set on host networking and port 30000) and either:
+#   - bind ports the new deploy needs → second sensor-ms fails to bind
+#     → /sensor/list returns 502 (issue #151), or
+#   - pass the new deploy's container-name health checks while serving
+#     stale data from the prior deploy's DB.
+# The patterns below cover everything declared in
+# deployments/vst/{2d,3d,smc,developer,ps}/, deployments/foundational/,
+# deployments/agents/, deployments/proxy/, and the dev-profile-*
+# compose files.
+docker ps -a --format '{{.Names}}' \
+  | grep -E '^(vss-|mdx-|perception-|rtvi-|alert-|nvstreamer-|sensor-ms-|vst-ingress-|vst-mcp-|vst-file-proxy|centralizedb-|storage-ms-|streamprocessing-ms-|sdr-(http|streamprocessing)-|envoy-(http|streamprocessing)-|rtspserver-ms-|recorder-ms-|replaystream-ms-|livestream-ms-|metropolis-vss-ui|phoenix)' \
+  | xargs -r docker rm -f
+```
+
+If this is the host's first deploy, the `docker compose down`
+line is a no-op (exit 0 with no containers to stop) — safe to run
+unconditionally.
+
 ### Step 1 — Gather context
 
 Discover what's available on the host and cross-reference with the
-[VSS prerequisites page](https://docs.nvidia.com/vss/3.1.0/prerequisites.html)
+[VSS prerequisites page](https://docs.nvidia.com/vss/3.2.0/prerequisites.html)
 to choose a deployment shape that fits.
 
 | Value | How to determine |
@@ -100,7 +139,7 @@ to choose a deployment shape that fits.
 | Other | `OTHER` | — |
 
 **Minimum GPU count per (profile × mode × platform).** Canonical source
-is the [VSS prerequisites page](https://docs.nvidia.com/vss/3.1.0/prerequisites.html);
+is the [VSS prerequisites page](https://docs.nvidia.com/vss/3.2.0/prerequisites.html);
 reproduced here so the skill can fail fast when the host is too small:
 
 | Profile | Mode | H100 / RTX PRO 6000 (Blackwell) | L40S | DGX-Spark / IGX-Thor / AGX-Thor |
@@ -335,6 +374,29 @@ docker compose --env-file $ENV_FILE config > resolved.yml
 ```
 
 The resolved YAML is saved to `<repo>/deployments/resolved.yml`.
+
+### Step 3b — Verify resolved.yml has no unexpanded ${...} tokens
+
+**Skipping this is the #1 cause of "I deployed `search` but it brought
+up `base` + `lvs` + `search` services."** The `.env` line near 90 is
+literal `COMPOSE_PROFILES=${BP_PROFILE}_${MODE},...` — docker compose
+expands it at `config` time using the same env file. If any upstream
+var (`BP_PROFILE`, `MODE`, `HARDWARE_PROFILE`, `LLM_MODE`,
+`VLM_MODE`) is missing from the env, the rendered profile list
+collapses to the empty string, and compose then includes **every**
+service from **every** profile.
+
+```bash
+if grep -q '\${' "$REPO/deployments/resolved.yml"; then
+  echo "FAIL: resolved.yml has unexpanded variables:"
+  grep -n '\${' "$REPO/deployments/resolved.yml" | head -5
+  exit 1
+fi
+```
+
+If this check fails, re-apply the Step 2 env overrides directly to
+the `.env` file at the path above, regenerate `resolved.yml` (Step 3),
+and re-run this check before continuing.
 
 ### Step 4 — Review
 

--- a/skills/deploy/eval/alerts_cv.json
+++ b/skills/deploy/eval/alerts_cv.json
@@ -1,14 +1,17 @@
 {
-  "skills": ["deploy"],
+  "skills": [
+    "deploy"
+  ],
   "resources": {
     "platforms": {
-      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
-      "L40S":         {"modes": ["dedicated", "remote-all"]},
-      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]},
-      "DGX-SPARK":    {"modes": ["remote-llm"]}
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
     }
   },
-  "env": "Multi-GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must be set. The **alerts-verification (CV)** mode uses `deploy -m verification`: RT-CV perception generates candidate alerts upstream (one dedicated GPU), and the VLM reviews each candidate to reduce false positives. On H100/RTX-PRO-6000 two GPUs are enough (CV on GPU 0, shared LLM+VLM on GPU 1). On L40S 48GB × 2, LLM+VLM can't fit on one GPU, so only `remote-*` modes are supported. DGX-Spark (single GPU) can't run this mode at all. See `skills/deploy/references/alerts.md` § *Two Modes*.",
+  "env": "Multi-GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must be set. The **alerts-verification (CV)** mode uses `deploy -m verification`: RT-CV perception generates candidate alerts upstream (one dedicated GPU), and the VLM reviews each candidate to reduce false positives. On H100/RTX-PRO-6000 two GPUs are enough (CV on GPU 0, shared LLM+VLM on GPU 1). On L40S 48GB \u00d7 2, LLM+VLM can't fit on one GPU, so only `remote-*` modes are supported. DGX-Spark (single GPU) can't run this mode at all. See `skills/deploy/references/alerts.md` \u00a7 *Two Modes*.",
   "expects": [
     {
       "query": "Deploy the VSS **alerts** profile on {{platform}} in {{mode}} mode using `/deploy -m verification` (CV-driven alert generation with VLM-as-verifier). Run end-to-end and autonomously.",
@@ -16,10 +19,10 @@
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0 (shared message bus)",
-        "`docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (RT-CV perception — the 'CV' in this mode)",
+        "`docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (RT-CV perception \u2014 the 'CV' in this mode)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (rule-based alert generation on CV output)",
         "`docker ps --format '{{.Names}}' | grep -qx alert-bridge` returns exit 0 (routes CV-generated alerts to VLM verifier)",
-        "`docker ps --format '{{.Names}}' | grep -qx nvstreamer-alerts` returns exit 0 (video ingestion source)"
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (video ingestion source)"
       ]
     }
   ]

--- a/skills/deploy/eval/alerts_vlm.json
+++ b/skills/deploy/eval/alerts_vlm.json
@@ -1,14 +1,17 @@
 {
-  "skills": ["deploy"],
+  "skills": [
+    "deploy"
+  ],
   "resources": {
     "platforms": {
-      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
-      "L40S":         {"modes": ["dedicated", "remote-all"]},
-      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]},
-      "DGX-SPARK":    {"modes": ["remote-llm"]}
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
     }
   },
-  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must be set. The **alerts-real-time (VLM)** mode uses `deploy -m real-time`: the VLM continuously processes live video at periodic intervals, producing alerts directly without upstream CV filtering — broader coverage, higher GPU load. See `skills/deploy/references/alerts.md` § *Two Modes*.",
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must be set. The **alerts-real-time (VLM)** mode uses `deploy -m real-time`: the VLM continuously processes live video at periodic intervals, producing alerts directly without upstream CV filtering \u2014 broader coverage, higher GPU load. See `skills/deploy/references/alerts.md` \u00a7 *Two Modes*.",
   "expects": [
     {
       "query": "Deploy the VSS **alerts** profile on {{platform}} in {{mode}} mode using `/deploy -m real-time` (continuous VLM-driven alert generation). Run end-to-end and autonomously.",
@@ -16,8 +19,8 @@
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0 (shared message bus)",
-        "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor — the 'VLM' in this mode)",
-        "`docker ps --format '{{.Names}}' | grep -qx nvstreamer-alerts` returns exit 0 (video ingestion source)",
+        "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor \u2014 the 'VLM' in this mode)",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (video ingestion source)",
         "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (real-time mode does NOT run the CV perception pipeline)"
       ]
     }

--- a/skills/deploy/eval/base.json
+++ b/skills/deploy/eval/base.json
@@ -1,14 +1,17 @@
 {
-  "skills": ["deploy"],
+  "skills": [
+    "deploy"
+  ],
   "resources": {
     "platforms": {
-      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
-      "L40S":         {"modes": ["dedicated", "remote-all"]},
-      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]},
-      "DGX-SPARK":    {"modes": ["remote-llm"]}
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
     }
   },
-  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack, not the contents of any `.env` file.",
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The `/deploy` skill is responsible for the full deploy workflow \u2014 this spec verifies the resulting state by probing the live stack, not the contents of any `.env` file.",
   "expects": [
     {
       "query": "Deploy the VSS **base** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",

--- a/skills/deploy/eval/lvs.json
+++ b/skills/deploy/eval/lvs.json
@@ -1,13 +1,17 @@
 {
-  "skills": ["deploy"],
+  "skills": [
+    "deploy"
+  ],
   "resources": {
     "platforms": {
-      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
-      "L40S":         {"modes": ["dedicated", "remote-all"]},
-      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]}
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
     }
   },
-  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The LVS profile brings up the full long-video-summarization workflow (agent + UI + NIMs) on top of the base stack. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack.",
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The LVS profile brings up the full long-video-summarization workflow (agent + UI + NIMs) on top of the base stack. The `/deploy` skill is responsible for the full deploy workflow \u2014 this spec verifies the resulting state by probing the live stack.",
   "expects": [
     {
       "query": "Deploy the VSS **lvs** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",

--- a/skills/deploy/eval/search.json
+++ b/skills/deploy/eval/search.json
@@ -1,13 +1,17 @@
 {
-  "skills": ["deploy"],
+  "skills": [
+    "deploy"
+  ],
   "resources": {
     "platforms": {
-      "H100":         {"modes": ["shared", "dedicated", "remote-all"]},
-      "L40S":         {"modes": ["dedicated", "remote-all"]},
-      "RTXPRO6000BW": {"modes": ["shared", "dedicated", "remote-all"]}
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
     }
   },
-  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The search profile adds Cosmos Embed1 semantic search on top of base. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack.",
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The search profile adds Cosmos Embed1 semantic search on top of base. The `/deploy` skill is responsible for the full deploy workflow \u2014 this spec verifies the resulting state by probing the live stack.",
   "expects": [
     {
       "query": "Deploy the VSS **search** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: report-generation
-description: Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as the standard Video Analysis Report markdown. 
+name: report
+description: Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as the standard Video Analysis Report markdown.
 version: "3.2.0"
 license: "Apache License 2.0"
 ---
 
-# Report Generation
+# Report
 
 Build **timestamped video analysis reports** by **querying the VSS agent** for a description of the video using `POST …/generate`. The agent runs **`video_understanding`** (and related tools) internally. Take the agent’s **caption-style text with timestamps** and paste it into the **Video Analysis Report** template below.
 
@@ -20,7 +20,32 @@ Build **timestamped video analysis reports** by **querying the VSS agent** for a
 
 ---
 
-## OpenClaw workflow
+## Deployment prerequisite
+
+This skill requires the VSS **base** profile running on the host at `$HOST_IP`. Before any request:
+
+1. Probe the VSS agent:
+   ```bash
+   curl -sf --max-time 5 "http://${HOST_IP}:8000/docs" >/dev/null
+   ```
+
+2. **If the probe fails**, ask the user:
+   > *"The VSS `base` profile isn't running on `$HOST_IP`. Shall I deploy it now using the `/deploy` skill with `-p base`?"*
+
+   - If yes → hand off to the `/deploy` skill. Return here once it succeeds.
+   - If no → stop. Do not run this skill against a missing stack.
+
+   (If your caller has granted explicit pre-authorization to deploy
+   autonomously — e.g. the request says "pre-authorized to deploy
+   prerequisites", or you are running in a non-interactive evaluation
+   harness with that permission — skip the confirmation and invoke
+   `/deploy` directly.)
+
+3. If the probe passes, proceed.
+
+---
+
+## Agent workflow
 
 Run these steps **in order**:
 

--- a/skills/video-analytics/SKILL.md
+++ b/skills/video-analytics/SKILL.md
@@ -13,6 +13,33 @@ Queries incidents, alerts, and metrics stored in Elasticsearch via MCP JSON-RPC 
 
 ---
 
+## Deployment prerequisite
+
+This skill reads from the Elasticsearch/VA-MCP stack brought up by the VSS **alerts** profile (either `verification` or `real-time` mode). Before any query:
+
+1. Probe the VA-MCP endpoint:
+   ```bash
+   curl -sf --max-time 5 "http://${HOST_IP}:9901/mcp" >/dev/null 2>&1 || \
+     curl -sf --max-time 5 "http://${HOST_IP}:9901/" >/dev/null
+   ```
+
+2. **If the probe fails**, ask the user:
+   > *"The VSS `alerts` profile isn't running on `$HOST_IP` (VA-MCP unreachable). Which mode should I deploy — `verification` (CV) or `real-time` (VLM)?"*
+
+   - Answer → hand off to the `/deploy` skill with `-p alerts -m <mode>`. Return here once it succeeds.
+   - If the user declines → stop. No incidents/alerts/metrics to query without the alerts stack up.
+
+   (If your caller has granted explicit pre-authorization to deploy
+   autonomously — e.g. the request says "pre-authorized to deploy
+   prerequisites", or you are running in a non-interactive evaluation
+   harness with that permission — skip the confirmation and invoke
+   `/deploy` directly. Default the mode to `verification` unless the
+   request specifies otherwise.)
+
+3. If the probe passes, proceed.
+
+---
+
 ## REQUIRED: Two-Step Pattern (copy this exactly)
 
 **Every query requires two shell commands run in sequence:**

--- a/skills/video-search/SKILL.md
+++ b/skills/video-search/SKILL.md
@@ -21,6 +21,33 @@ Search video archives by natural language using Cosmos Embed1 embeddings. Requir
 
 ---
 
+## Deployment prerequisite
+
+This skill requires the VSS **search** profile running on the host at `$HOST_IP`. Before any request:
+
+1. Probe the stack:
+   ```bash
+   curl -sf --max-time 5 "http://${HOST_IP}:8000/docs" >/dev/null \
+     && curl -sf --max-time 5 "http://${HOST_IP}:9200/" >/dev/null
+   ```
+   (The second check confirms Elasticsearch is up — unique to the search profile.)
+
+2. **If the probe fails**, ask the user:
+   > *"The VSS `search` profile isn't running on `$HOST_IP`. Shall I deploy it now using the `/deploy` skill with `-p search`?"*
+
+   - If yes → hand off to the `/deploy` skill. Return here once it succeeds.
+   - If no → stop. Do not run this skill against a missing or wrong-profile stack.
+
+   (If your caller has granted explicit pre-authorization to deploy
+   autonomously — e.g. the request says "pre-authorized to deploy
+   prerequisites", or you are running in a non-interactive evaluation
+   harness with that permission — skip the confirmation and invoke
+   `/deploy` directly.)
+
+3. If the probe passes, proceed.
+
+---
+
 ## How Search Works
 
 1. **Ingest** — Videos are uploaded or streamed via VIOS. The RTVI-Embed service (Cosmos Embed1) generates vector embeddings for video segments.
@@ -38,7 +65,13 @@ This search orchestrated by VSS agent can lead to 3 behaviors:
 ## Mandatory workflow
 
 When using this skill, ALWAYS follow this high-level workflow:
-1. Resolve inputs from user instructions
+1. **Resolve inputs from user instructions — HARD STOP if `$HOST_IP`
+   is not explicitly provided.** See § Input resolution below. Do NOT
+   default to `localhost`, `127.0.0.1`, the host the agent itself is
+   running on, or any other guess. Do NOT issue a
+   `POST http://.../generate` request until the user has supplied an
+   endpoint. Respond to the user with a single question asking for
+   `HOST_IP` / the VSS agent endpoint and wait.
 2. Run the search(es) via approach chosen
 3. Present the results to the user query. Format response as a professional inspection report but name it `Video Search Results`:
    — Use clear section headers

--- a/skills/video-search/eval/search.json
+++ b/skills/video-search/eval/search.json
@@ -1,0 +1,58 @@
+{
+  "skills": ["video-search"],
+  "profile": "search",
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": ["remote-all"]
+      }
+    }
+  },
+  "env": "A **full-remote deployed VSS search profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs; Cosmos Embed1 still runs locally on the GPU, so the profile requires a GPU host even in remote-all). Run on ONE platform only — the search answers come from Cosmos Embed1 and Elasticsearch, which are hardware-agnostic and the LLM/VLM run remotely, so fanning out discovers nothing new. Pick the cheapest available host (L40S recommended). Required: VSS agent reachable at http://localhost:8000/docs (OpenAPI visible), VST reachable at http://localhost:30888/vst/api/v1, Elasticsearch reachable at http://localhost:9200, the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770 per launchable convention — see skills/deploy/references/brev.md), AND all sample videos downloaded from ngc registry resource download-version nvidia/vss-developer/dev-profile-sample-data:3.2.0 then extracted with tar -xzvf then pre-ingested by curling the videos-for-search API for each extracted video according to the video ingestion section of troubleshooting.md, before running these checks.",
+  "expects": [
+    {
+      "query": "Find all instances of forklifts in the airport video. Agent backend is on localhost.",
+      "checks": [
+        "The agent listed the available video sources via a `GET http://localhost:30888/vst/api/v1/sensor/list` call (per the vios skill's guidance on resolving unknown source names) before attempting any search",
+        "The agent's final reply explicitly acknowledges that no `airport` video is registered in VST and asks the user to clarify which source to search or to ingest the airport video first — it did NOT silently fall back to a similar-sounding registered source (e.g. the warehouse video) and did NOT fabricate search hits for a video it never queried",
+        "The trajectory contains zero `POST http://.../generate` requests — the agent correctly paused to resolve the missing source instead of firing the search blindly on a guessed alternative",
+        "The agent did NOT call `PUT /api/v1/videos-for-search/...` during this step — ingesting a video on the user's behalf is an explicit opt-in action"
+      ]
+    },
+    {
+      "query": "Find all instances of forklifts in the sample warehouse video. Agent backend is on localhost.",
+      "checks": [
+        "The agent issued exactly one `POST http://localhost:8000/generate` call AND no parallel calls with separate underlying embed / attribute endpoints",
+        "The POST /generate request body contained an `input_message` field whose value paraphrases or contains `forklifts` — not a different user query, not a paraphrase that dropped the object noun",
+        "The /generate response returned HTTP 200 with a body that contains a non-empty array of search hits (each hit has similarity score and timestamped clip metadata)",
+        "The agent's final reply is formatted as an inspection report titled `Video Search Results` with clear section headers — not a raw JSON dump, not a chat-style bullet list",
+        "Every search hit rendered in the report cites its start time, end time, similarity score, screenshot url or clip url verbatim from the /generate response — no fabricated timestamps, no paraphrased similarity scores",
+        "Every screenshot_url / clip_url cited in the agent's final report matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...) — otherwise the user cannot open them from outside the Brev box",
+        "The agent's final reply includes a `Verification Step` offer at the end of the report, telling the user that screenshots can be downloaded and inspected — it does NOT silently download screenshots without opt-in",
+        "The agent did NOT call `PUT /api/v1/videos-for-search/...` during this step, it considered the video was in the system already"
+      ]
+    },
+    {
+      "query": "Find a person wearing a white jacket climbing a ladder in sample-warehouse-ladder. Agent backend is on localhost. You are pre-authorized to run the Verification Step autonomously, without asking for confirmation.",
+      "checks": [
+        "The agent issued exactly one `POST http://localhost:8000/generate` call AND no parallel calls with separate underlying embed / attribute endpoints",
+        "The POST /generate request body contained an `input_message` that preserves both halves of the fused query — it contains the appearance attribute (`red jacket`) AND the action (`running`) — the agent did NOT silently drop one half to simplify the search",
+        "The /generate response returned HTTP 200 with a body that contains a non-empty array of search hits (each hit has similarity score and timestamped clip metadata)",
+        "The agent's final reply is formatted as an inspection report titled `Video Search Results` with clear section headers — not a raw JSON dump, not a chat-style bullet list",
+        "Every search hit rendered in the report cites its start time, end time, similarity score, screenshot url or clip url verbatim from the /generate response — no fabricated timestamps, no paraphrased similarity scores",
+        "Every screenshot_url / clip_url cited in the agent's final report matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...) — otherwise the user cannot open them from outside the Brev box",
+        "The agent did NOT pause to re-ask the user for consent before running the Verification Step — the query pre-authorized it, so the agent proceeded autonomously to download and inspect screenshots instead of re-offering the `Verification Step` as an opt-in",
+        "The trajectory shows the agent running curl against each `screenshot_url` returned in the /generate response to save it under `/tmp/`, AND then reading the saved image file with its image-inspection capability — a well-formed download is not sufficient, the agent must actually look at the pixels",
+        "The agent's final `Video Search Results` report includes, for every inspected hit, an explicit verdict (confirmed match / rejected / uncertain) grounded in the screenshot content — not just the raw similarity score echoed from /generate"
+      ]
+    },
+    {
+      "query": "Find a neon-pink monster truck in the ingested sample warehouse video. Agent backend is on localhost.",
+      "checks": [
+        "The agent issued a `POST http://localhost:8000/generate` call with `input_message` containing `neon-pink monster truck` (or an equivalent paraphrase) — it did NOT refuse the query up front",
+        "The /generate response returned zero hits because this object is not present in the video (i.e. the embed stage found nothing or the default-enabled critic rejected the low-confidence candidates). The agent did NOT claim success, did NOT fabricate matches, and did NOT silently return an empty report — per the skill's mandatory workflow, zero matches trigger the troubleshooting loop",
+        "The agent's final reply explicitly acknowledges the zero-hit outcome and explains why (e.g. the query may be too specific, the object may not be present, or suggests the user loosen the query / lower similarity threshold) — per the troubleshooting.md guidance"
+      ]
+    }
+  ]
+}

--- a/skills/video-summarization/SKILL.md
+++ b/skills/video-summarization/SKILL.md
@@ -29,6 +29,33 @@ into the response, before the summary):
 > produced by the VLM alone. Deploy the `lvs` profile for higher-quality
 > long-video summaries.
 
+## Deployment prerequisite
+
+This skill requires the VSS **lvs** profile running on the host at `$HOST_IP`. Before any request:
+
+1. Probe the LVS microservice:
+   ```bash
+   curl -sf --max-time 5 "http://${HOST_IP}:8000/docs" >/dev/null \
+     && curl -sf --max-time 5 "http://${HOST_IP}:38111/v1/ready" >/dev/null
+   ```
+   (Port 38111 is LVS. HTTP 200 → ready; 503 → still warming, retry in a moment.)
+
+2. **If the probe fails**, ask the user:
+   > *"The VSS `lvs` profile isn't running on `$HOST_IP`. Shall I deploy it now using the `/deploy` skill with `-p lvs`?"*
+
+   - If yes → hand off to the `/deploy` skill. Return here once it succeeds.
+   - If no → stop. Long-video summarization without LVS falls back to VLM-only, which is a different (lower-quality) path — confirm with the user before substituting.
+
+   (If your caller has granted explicit pre-authorization to deploy
+   autonomously — e.g. the request says "pre-authorized to deploy
+   prerequisites", or you are running in a non-interactive evaluation
+   harness with that permission — skip the confirmation and invoke
+   `/deploy` directly.)
+
+3. If the probe passes, proceed.
+
+---
+
 ## Setup
 
 **Endpoints (defaults for a local VSS deployment):**

--- a/skills/video-summarization/eval/lvs_profile_summarize.json
+++ b/skills/video-summarization/eval/lvs_profile_summarize.json
@@ -1,11 +1,18 @@
 {
   "skills": ["video-summarization", "sensor-ops"],
+  "profile": "lvs",
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": ["remote-all"]
+      }
+    }
+  },
   "env": "A **full-remote deployed VSS lvs profile** (deploy mode = `remote-all` — the agent's LLM and the VLM that LVS calls are both served via remote launchpad endpoints, no local NIMs). Run on ONE platform only — summarization is throughput-bound on the remote VLM, so fanning out across platforms doesn't materially change coverage. Pick the cheapest available host (L40S recommended); the lvs profile uses `network_mode: host` so LVS reaches VST via the host IP. Required: LVS microservice reachable at http://localhost:38111/v1/ready (expect HTTP 200; 503 means still warming up — retry), VST reachable at http://localhost:30888/vst/api/v1 (for clip URL resolution via sensor-ops), a sample warehouse video pre-uploaded to VIOS (seed via the sensor-ops upload query before running these checks), AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770 per launchable convention — see skills/deploy/references/brev.md). LVS fetches the clip URL over HTTP from inside its own container; without the Brev secure link the URL will be http://localhost:... / http://<internal-ip>:... and LVS will either 404 or hang.",
   "expects": [
     {
       "query": "Summarize the uploaded warehouse video with scenario 'warehouse monitoring' and events ['boxes falling', 'forklift stuck', 'person entering restricted area'].",
       "checks": [
-        "Before any backend call, the agent surfaces the Step 2 HITL prompt — echoing scenario + events back to the user for confirmation — and only proceeds after an explicit go-ahead (it does NOT silently call LVS on the first turn)",
         "The agent issues exactly one POST http://localhost:38111/summarize call — not zero, not two, no parallel hedging",
         "The POST /summarize request body is application/json and contains the keys {url, model, scenario, events, chunk_duration, num_frames_per_chunk}; scenario equals 'warehouse monitoring' and events equals the three user-supplied strings verbatim",
         "The url field points at a Brev secure-link clip URL (https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/...), NOT http://localhost:... and NOT http://<internal-ip>:...",
@@ -20,7 +27,6 @@
     {
       "query": "Summarize the uploaded warehouse video using default scenario and events.",
       "checks": [
-        "The agent surfaces the Step 2 HITL prompt and waits for the user to reply 'defaults' (or equivalent explicit opt-in) before calling LVS",
         "The POST /summarize request body has scenario='activity monitoring' and events=['notable activity']",
         "The LVS response is HTTP 200 with a non-empty video_summary and a non-empty events array",
         "The agent's final reply notes that generic defaults were used and offers to redo the summary with more specific parameters"

--- a/skills/video-understanding/SKILL.md
+++ b/skills/video-understanding/SKILL.md
@@ -21,7 +21,33 @@ Do **not** use this skill when a **database / MCP / prior tool output** already 
 
 ---
 
-## OpenClaw workflow
+## Deployment prerequisite
+
+This skill requires a VSS profile that serves the `video_understanding` tool — typically **base** (recommended) or **lvs**. Before any request:
+
+1. Probe the VSS agent:
+   ```bash
+   curl -sf --max-time 5 "http://${HOST_IP}:8000/docs" >/dev/null
+   ```
+
+2. **If the probe fails**, ask the user:
+   > *"No VSS profile is running on `$HOST_IP`. Shall I deploy `base` (recommended for per-clip VLM QnA) using the `/deploy` skill? If you prefer `lvs`, say so."*
+
+   - If yes → hand off to `/deploy -p base` (or `-p lvs` if the user prefers). Return here once it succeeds.
+   - If no → stop.
+
+   (If your caller has granted explicit pre-authorization to deploy
+   autonomously — e.g. the request says "pre-authorized to deploy
+   prerequisites", or you are running in a non-interactive evaluation
+   harness with that permission — skip the confirmation and invoke
+   `/deploy -p base` directly. Prefer `base` unless the request names
+   another profile.)
+
+3. If the probe passes, proceed.
+
+---
+
+## Agent workflow
 
 1. **Clip** — Identify **sensor id**, **filename**, or **URL** for one video segment. If ambiguous, ask the user.
 2. Call vss agent with the sensor id and ask for it to call video_understanding tool to answer the user's question.

--- a/skills/vios/SKILL.md
+++ b/skills/vios/SKILL.md
@@ -7,6 +7,117 @@ license: "Apache License 2.0"
 
 You are a VIOS API assistant. Interact with the VIOS microservice to manage cameras/sensors, RTSP streams, recordings, snapshots, and storage. Use when asked to: add a camera, add an RTSP stream, list sensors, show configured sensors/cameras/streams, check stream status, get a snapshot, download a clip, upload a video file, or manage video storage. Always query the VIOS API directly using curl — do not navigate the UI.
 
+## Deployment prerequisite
+
+This skill requires any VSS profile that brings up VIOS / VST — **base** (recommended), or any of `lvs` / `search` / `alerts`. Before any request:
+
+1. Probe VIOS:
+   ```bash
+   curl -sf --max-time 5 "http://${HOST_IP}:30888/vst/api/v1/sensor/list" >/dev/null
+   ```
+
+2. **If the probe fails**, ask the user:
+   > *"No VSS profile appears to be running on `$HOST_IP` (VIOS unreachable). Shall I deploy `base` using the `/deploy` skill? If you'd like a different profile, say which."*
+
+   - If yes → hand off to `/deploy -p base` (or the profile the user names). Return here once it succeeds.
+   - If no → stop. VIOS operations require the VST backend to be up.
+
+   (If your caller has granted explicit pre-authorization to deploy
+   autonomously — e.g. the request says "pre-authorized to deploy
+   prerequisites", or you are running in a non-interactive evaluation
+   harness with that permission — skip the confirmation and invoke
+   `/deploy -p base` directly. Prefer `base` unless the request names
+   another profile.)
+
+3. If the probe passes, proceed.
+
+---
+
+## Known limitation — leftover containers from prior deploys
+
+The following VIOS API paths can return **HTTP 502 Bad Gateway** or
+stale results when the host has leftover containers from an earlier
+deploy:
+
+- `GET /vst/api/v1/sensor/list`
+- `GET /vst/api/v1/sensor/<sensorId>/streams`
+
+Root cause: the alerts compose profile (`bp_developer_alerts_2d_cv` /
+`bp_developer_alerts_2d_vlm`) brings up the `*-smc` set of VST
+microservices alongside the `*-dev` set, both with `network_mode: host`
+binding the same host ports (30000 for `sensor-ms`, 30888 for
+`vst-ingress`). When a subsequent base/lvs/search deploy runs, those
+`*-smc` containers can survive past the `/deploy` skill's Step 0
+teardown if the teardown grep doesn't catch them — and one
+sensor-ms loses the port-bind race, returning 502 to anything that
+proxies through `vst-ingress`. See
+[issue #151](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/issues/151).
+
+The `/deploy` skill's Step 0 teardown grep was extended to cover the
+full set (`sensor-ms-*`, `vst-ingress-*`, `centralizedb-*`,
+`storage-ms-*`, `sdr-*`, `envoy-*`, `rtspserver-ms-*`, etc.), so
+fresh deploys via `/deploy` should not hit this. If you inherit a
+host without re-deploying and see 502s, re-run `/deploy` to clean.
+
+Other VIOS paths (`storage/file/*` upload, `replay/stream/*/picture/url`
+snapshot, `storage/file/*/url` clip extraction) are unaffected.
+
+---
+
+## Sample data bootstrap
+
+VIOS stores videos uploaded by the user. For requests that reference a
+**"sample"** video by friendly name (e.g. *"the sample warehouse
+video"*, *"sample-warehouse-ladder"*, *"warehouse_safety_0001"*) the
+expected file is one of the 8 mp4s shipped in NGC bundle
+`nvidia/vss-developer/dev-profile-sample-data:3.2.0`. Before any
+upload-style request, ensure the bundle is extracted locally:
+
+```bash
+SAMPLE_DIR="/tmp/vss-sample-data/dev-profile-sample-data"
+
+if [ ! -d "$SAMPLE_DIR" ]; then
+  mkdir -p /tmp/vss-sample-data
+  cd /tmp/vss-sample-data
+
+  # NGC CLI required (export NGC_CLI_API_KEY first if not already set).
+  ngc registry resource download-version \
+    nvidia/vss-developer/dev-profile-sample-data:3.2.0 \
+    --org nvidia --team vss-developer
+
+  # Bundle ships as a single tar.gz inside dev-profile-sample-data_v3.2.0/.
+  tar -xzf dev-profile-sample-data_v3.2.0/dev-profile-sample-data.tar.gz
+fi
+
+ls "$SAMPLE_DIR"/  # verify expected mp4s present
+```
+
+Bundle contents (use these filenames verbatim when asked for *"the
+&lt;name&gt; video"*):
+
+| Friendly name in user query | Local filename |
+|---|---|
+| sample warehouse video | `warehouse_sample.mp4` |
+| sample-warehouse-ladder | `sample-warehouse-ladder.mp4` |
+| warehouse safety 1 / 2 | `warehouse_safety_0001.mp4` / `warehouse_safety_0002.mp4` |
+| sample-sim-traffic | `sample-sim-traffic.mp4` |
+| sample-sim-jaywalking | `sample-sim-jaywalking.mp4` |
+| sample-sim-box-conveyor | `sample-sim-box-conveyor.mp4` |
+| sample-drone-bridge | `sample-drone-bridge.mp4` |
+
+If the user names a video that isn't in this list (e.g. *"airport
+video"*, *"neon-pink monster truck"*), do **not** substitute a
+similar-sounding bundle file — list the available names back to the
+user and ask which one they meant. Don't invent paths or fabricate
+upload responses.
+
+`NGC_CLI_API_KEY` must be set in the environment for `ngc registry`
+calls to authenticate. The variable is provided by the deploy/eval
+harness; if it's missing, fail with the actionable error rather than
+trying to proceed.
+
+---
+
 ## Setup
 
 **Base URL:** `http://<VST_ENDPOINT>/vst/api/v1`

--- a/skills/vios/eval/base_profile_ops.json
+++ b/skills/vios/eval/base_profile_ops.json
@@ -1,6 +1,14 @@
 {
   "skills": ["vios"],
-  "env": "A **full-remote deployed VSS base profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs). Run on ONE platform only — the vios skill exercises VIOS / VST which is GPU-independent, so there's no benefit to fanning out. Pick the cheapest available host (L40S recommended). Required: VST reachable at http://localhost:30888/vst/api/v1 AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770 per launchable convention — see skills/deploy/references/brev.md). Without BREV_ENV_ID the returned media URLs will be raw http://localhost:... and the Brev-link checks will fail.",
+  "profile": "base",
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": ["remote-all"]
+      }
+    }
+  },
+  "env": "A **full-remote deployed VSS base profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs). Run on ONE platform only — the vios skill exercises VIOS / VST which is GPU-independent, so there's no benefit to fanning out. Required: VST reachable at http://localhost:30888/vst/api/v1 AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770 per launchable convention — see skills/deploy/references/brev.md). Without BREV_ENV_ID the returned media URLs will be raw http://localhost:... and the Brev-link checks will fail.",
   "expects": [
     {
       "query": "Upload the sample warehouse video to VIOS with timestamp 2025-01-01T00:00:00.000Z.",
@@ -15,20 +23,18 @@
       "query": "Extract a snapshot from 5 seconds into the uploaded video and return a shareable URL.",
       "checks": [
         "GET /vst/api/v1/replay/stream/<streamId>/picture/url?startTime=2025-01-01T00:00:05.000Z returns a JSON object with a non-empty imageUrl field",
-        "The returned imageUrl matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...)",
-        "curl -sfI <imageUrl> returns HTTP 200",
-        "The response Content-Type starts with image/ (typically image/jpeg)",
-        "The response Content-Length is greater than 2000 bytes (rejects empty / error-placeholder images)"
+        "curl -sf -o /dev/null -w '%{http_code}' <imageUrl> returns 200 (use GET, not HEAD — VST lazy-renders snapshots and HEAD returns 404 until first GET materializes the file)",
+        "curl -sf -o /dev/null -w '%{content_type}' <imageUrl> returns a value starting with image/ (typically image/jpeg)",
+        "curl -sf -o /dev/null -w '%{size_download}' <imageUrl> returns a value greater than 2000 (rejects empty / error-placeholder images)"
       ]
     },
     {
       "query": "Extract a video clip from 3 to 5 seconds (mp4 container) from the uploaded video and return a shareable URL.",
       "checks": [
         "GET /vst/api/v1/storage/file/<streamId>/url?startTime=2025-01-01T00:00:03.000Z&endTime=2025-01-01T00:00:05.000Z&container=mp4&disableAudio=true returns a JSON object with a non-empty videoUrl field",
-        "The returned videoUrl matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...)",
-        "curl -sfI <videoUrl> returns HTTP 200",
-        "The response Content-Type starts with video/ (typically video/mp4)",
-        "The response Content-Length is greater than 10000 bytes (rejects empty / error-page responses)",
+        "curl -sf -o /dev/null -w '%{http_code}' <videoUrl> returns 200 (use GET, not HEAD — VST lazy-renders clips and HEAD returns 404 until first GET materializes the file)",
+        "curl -sf -o /dev/null -w '%{content_type}' <videoUrl> returns a value starting with video/ (typically video/mp4)",
+        "curl -sf -o /dev/null -w '%{size_download}' <videoUrl> returns a value greater than 1000 (rejects empty / error-page responses; a 2s 360p clip can legitimately render at a few KB)",
         "The response JSON's startTime is within a minute of the requested 00:00:03 and expiryISO is in the future"
       ]
     }


### PR DESCRIPTION
## Summary

Bring develop's `skills/` folder in line with `feat/skills`. **Scoped strictly to `skills/`** — `feat/skills` carries ~187 unrelated `ui/` tsconfig + package.json changes that are not included here.

This builds on PR #185 ("skills: restore per-skill eval specs") which already merged a partial sync of `deploy`, `video-summarization`, and `vios` eval files. The remaining delta from that point is what this PR captures.

## Changes (16 files, +484 / −57)

| Skill | Change |
|---|---|
| `skills/alerts/SKILL.md` | +31 |
| `skills/deploy/SKILL.md` | +64 |
| `skills/deploy/eval/{alerts_cv,alerts_vlm,base,lvs,search}.json` | refined test cases |
| **`skills/report-generation/SKILL.md` → `skills/report/SKILL.md`** | **renamed** (76% similarity) |
| `skills/video-analytics/SKILL.md` | +29 |
| `skills/video-search/SKILL.md` | +37 |
| **`skills/video-search/eval/search.json`** | **new file** (+58 lines) |
| `skills/video-summarization/SKILL.md` | +29 |
| `skills/video-summarization/eval/lvs_profile_summarize.json` | refined |
| `skills/video-understanding/SKILL.md` | +30 |
| `skills/vios/SKILL.md` | **+113** (largest expansion) |
| `skills/vios/eval/base_profile_ops.json` | refined |

## Heads-up: rename

`skills/report-generation/` → `skills/report/`. Anything outside this PR that references the old path will need updating. Quick search shows no refs in the rest of the repo — verified with `git grep report-generation` (returns nothing). The `feat/skills` branch already adopted the new name; this PR brings develop along.

## Out of scope

`feat/skills` also has these areas of change that are **not** in this PR (deferred — should be reviewed separately):

- `ui/.eslintrc.js` + UI workspace tsconfigs
- `ui/apps/{nemo-agent-toolkit-ui,nv-metropolis-bp-vss-ui}/{tsconfig,package}.json`
- `ui/packages/nemo-agent-toolkit-ui/lib-src/`
- ~187 files outside `skills/`

If any of those are required to land in develop, they should come via a separate UI-focused PR.

## Test plan

- [ ] CI passes (no Python / runtime impact expected — `skills/` is config + docs)
- [ ] Eval files validate as JSON
- [ ] No remaining references to `skills/report-generation/` outside this PR