### PR TITLE
fix(skills-eval): use cumulative PR diff for path gate

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -9,13 +9,18 @@
 name: Skills Eval
 
 on:
+  # No top-level `paths:` filter: GitHub evaluates `paths:` against the
+  # diff of the *pushed commits*, not the cumulative PR diff against
+  # base. That silently skipped the workflow when CPR-bot updated a
+  # mirror branch with a merge commit that didn't itself touch
+  # skills/** (observed: PR #188's mirror push was a develop-merge
+  # carrying only RTVI files, so skills-eval never fired even though
+  # the PR's full diff touches 16 skills/ files). The path gate is now
+  # done inside the job by `dorny/paths-filter`, which diffs the
+  # cumulative head...base range.
   push:
     branches:
       - "pull-request/[0-9]+"
-    paths:
-      - "skills/**"
-      - ".github/skill-eval/**"
-      - ".github/workflows/skills-eval.yml"
 
 # Only one eval runs per PR at a time. A fresh push cancels the in-flight
 # run (lock on /tmp/brev/<id>.lock will be released by the agent's trap).
@@ -59,7 +64,19 @@ jobs:
           # Repo-scoped token from the workflow context is fine for `gh pr view`.
           GH_TOKEN: ${{ github.token }}
 
+      - name: Detect relevant changes vs PR base
+        id: changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          filters: |
+            relevant:
+              - 'skills/**'
+              - '.github/skill-eval/**'
+              - '.github/workflows/skills-eval.yml'
+
       - name: Load coordinator env (Anthropic, NGC, Brev, remote endpoints)
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           # The runner lives on vss-skill-validator; the coordinator keeps
           # its secrets in a single .env file there. Don't echo contents.
@@ -72,6 +89,7 @@ jobs:
 
       - name: Run skills eval agent
         id: agent
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           set -a
           source /home/ubuntu/eval-coordinator/.env   # re-source; GH step env is isolated
@@ -90,7 +108,7 @@ jobs:
           python3 .github/skill-eval/skills_eval_agent.py
 
       - name: Collect results for workflow artifact
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         run: |
           # Agent writes harbor output to /tmp/skill-eval/results/<run_id>/
           # (runtime-only; not tracked under the repo). Blocker paths
@@ -109,7 +127,7 @@ jobs:
           fi
 
       - name: Upload results artifact
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: skills-eval-results-pr-${{ steps.pr.outputs.number }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary

- Drop the workflow-level `on.push.paths:` filter, which evaluates only the diff of the pushed commits and silently skipped Skills Eval whenever a mirror branch was updated by a develop-merge that didn't itself touch `skills/**`.
- Add `dorny/paths-filter@v4.0.1` (pinned by SHA `fbd0ab8f`) as a job step that diffs `HEAD` against `${{ steps.pr.outputs.base }}` — the cumulative PR range, matching the semantics of the built-in `paths:` on `pull_request` events.
- Guard the heavy steps (`Load coordinator env`, `Run skills eval agent`, `Collect/Upload results`) with `steps.changes.outputs.relevant == 'true'`.

## Why this matters

PR #188 ("skills: sync skills/ tree from feat/skills") touches 16 files under `skills/` cumulatively, but its most recent mirror push was a "Merge branch 'develop' into sync/skills-from-feat-skills" carrying only 2 RTVI files from PR #179. GitHub's path filter evaluated against that single push's diff, so Skills Eval never enqueued — see [run 25090487485](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/25090487485) (only `CI` ran).

The trust boundary is unchanged: only `pull-request/[0-9]+` mirror branches (created by CPR-bot) can trigger the workflow, so the self-hosted `vss-eval` runner is still safe from arbitrary fork code.

## Test plan

- [ ] Merge → CPR-bot mirrors a follow-up PR that touches `skills/**` cumulatively but whose latest commit is a base-merge → confirm Skills Eval enqueues and the agent runs.
- [ ] CPR-bot mirrors a PR that does NOT touch `skills/**` → confirm Skills Eval enqueues, dorny step reports `relevant=false`, downstream steps skip cleanly, job ends green without spinning up Brev.
- [ ] CPR-bot creates a brand-new `pull-request/<N>` for a skills-touching PR (initial-mirror case with all-zero `before` SHA) → confirm the eval runs (this was the case `feat/skills` patched separately with `on: create:`; `dorny/paths-filter` handles it via cumulative-diff semantics, so `on: create:` is no longer needed — see companion PR to `feat/skills`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)