### PR TITLE
fix(pre-commit): move DCO check to commit-msg stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+# Install both git-hook types when contributors run `pre-commit install`,
+# so the `commit-msg`-stage DCO check (below) is wired up automatically
+# without a second `--hook-type commit-msg` flag.
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/trufflesecurity/trufflehog
     rev: v3.94.2
@@ -10,11 +15,13 @@ repos:
 
   - repo: local
     hooks:
-      # DCO sign-off check — ensures every commit has Signed-off-by
+      # DCO sign-off check — ensures every commit has Signed-off-by.
+      # Runs at `commit-msg` stage so we read the *new* commit's message
+      # (passed in as $1) instead of `git log -1` on the parent — which
+      # was happily inheriting a Signed-off-by from the previous HEAD
+      # and letting unsigned commits through.
       - id: dco-signoff
         name: DCO sign-off check
-        entry: bash -c 'git log -1 --format="%B" | grep -q "^Signed-off-by" || { echo "ERROR - Commit missing DCO sign-off. Use git commit -s"; exit 1; }'
+        entry: bash -c 'grep -q "^Signed-off-by" "$1" || { echo "ERROR - Commit missing DCO sign-off. Use git commit -s"; exit 1; }' --
         language: system
-        always_run: true
-        pass_filenames: false
-        stages: [pre-commit]
+        stages: [commit-msg]


### PR DESCRIPTION
## Summary

Companion to PR #191 (which targets \`develop\`). Same fix applied to \`feat/skills\`'s simpler \`.pre-commit-config.yaml\`.

The DCO hook ran at the \`pre-commit\` stage and read \`git log -1 --format=%B\` — which at that stage is the *parent* HEAD, not the about-to-be-created commit. So unsigned commits landing on top of signed parents passed locally but failed the GitHub-side \`DCO Sign-off\` action (observed on PR #189).

## Fix

- Move \`dco-signoff\` to \`stages: [commit-msg]\` and read the commit message file pre-commit passes as \`\$1\`.
- Add \`default_install_hook_types: [pre-commit, commit-msg]\` so plain \`pre-commit install\` installs both git hooks.

## Verified locally

\`\`\`
TEST 1 (unsigned): ERROR - Commit missing DCO sign-off. Use git commit -s   ✓ rejected
TEST 2 (signed):   DCO sign-off check ... Passed                            ✓ accepted
\`\`\`

## Test plan

- [ ] Reviewer pulls the branch, runs \`pre-commit install\`, attempts an unsigned commit → rejected.
- [ ] Reviewer attempts \`git commit -s\` → accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)