### PR TITLE
Add generalized fusion search script only

### DIFF
--- a/services/agent/src/vss_agents/tools/fusion.py
+++ b/services/agent/src/vss_agents/tools/fusion.py
@@ -601,7 +601,13 @@ def run_fusion(inp: FusionInput) -> FusionOutput:
 
     fused = fuse(bucketed, method=inp.method, rrf_k=inp.rrf_k)
 
-    threshold = score_threshold(inp, inp.min_fused_score_ratio) if inp.min_fused_score_ratio is not None else None
+    threshold: float | None = None
+    if inp.min_fused_score_ratio is not None:
+        # Skip empty lists. They contribute 0, so counting their weight inflates the ceiling
+        contributing_weights = [rl.weight for rl in bucketed if rl.chunks]
+        ceiling = _theoretical_ceiling(inp.method, inp.rrf_k, contributing_weights)
+        threshold = ceiling * inp.min_fused_score_ratio
+
     fused = apply_global_filters(
         fused,
         min_contributing_spaces=inp.min_contributing_spaces,

--- a/services/agent/src/vss_agents/tools/fusion.py
+++ b/services/agent/src/vss_agents/tools/fusion.py
@@ -250,9 +250,24 @@ def snap(ts: datetime, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> datetime:
     return epoch + timedelta(seconds=snapped)
 
 
+def _score_with_tiebreak(score: float, sensor_id: str, start: datetime) -> tuple[float, str, datetime]:
+    """Deterministic sort key for the fusion pipeline.
+
+    Ties on raw score are broken by ``(sensor_id, start)`` so identical inputs
+    in any order produce identical rank assignments. Without an explicit
+    tie-breaker, Python's stable sort would preserve input-list order, leaking
+    non-determinism to downstream consumers of fusion.
+    """
+    # -score makes high scores come first hence DESC, and tie breakers like sensor_id stays ASC
+    return (-score, sensor_id, start)
+
+
 def _rerank_by_score(rl: RankedList, survivors: Iterable[RankedChunk]) -> RankedList:
     """Reorders chunks by importance for fusion."""
-    sorted_chunks = sorted(survivors, key=lambda c: c.score, reverse=True)
+    sorted_chunks = sorted(
+        survivors,
+        key=lambda c: _score_with_tiebreak(c.score, c.key.sensor_id, c.key.start),
+    )
     reranked = [RankedChunk(key=c.key, score=c.score, rank=i + 1) for i, c in enumerate(sorted_chunks)]
     return RankedList(space=rl.space, weight=rl.weight, chunks=reranked)
 
@@ -505,7 +520,7 @@ def merge_adjacent_rows(
         if group:
             segments.append(_finalize_group(group, chunk_seconds, aggregation))
 
-    segments.sort(key=lambda s: s.fused_score, reverse=True)
+    segments.sort(key=lambda s: _score_with_tiebreak(s.fused_score, s.sensor_id, s.start))
     return segments
 
 
@@ -615,7 +630,10 @@ def run_fusion(inp: FusionInput) -> FusionOutput:
         score_threshold=threshold,
     )
 
-    rows = sorted(fused.values(), key=lambda r: r.score, reverse=True)
+    rows = sorted(
+        fused.values(),
+        key=lambda r: _score_with_tiebreak(r.score, r.key.sensor_id, r.key.start),
+    )
     if inp.merge_adjacent:
         segments = merge_adjacent_rows(
             rows,

--- a/services/agent/src/vss_agents/tools/fusion.py
+++ b/services/agent/src/vss_agents/tools/fusion.py
@@ -25,13 +25,22 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from dataclasses import field
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from typing import Literal
 
+from pydantic import AwareDatetime
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
+
+FusionMethod = Literal["rrf", "weighted_linear"]
+Aggregation = Literal["max", "mean"]
+DEFAULT_CHUNK_SECONDS = 5
+DEFAULT_RRF_K = 60
+
 
 # ---------------------------------------------------------------------------
 # Public data contract
@@ -39,15 +48,31 @@ from pydantic import Field
 
 
 class ChunkKey(BaseModel):
-    """Unique identifier for a 5-second video chunk on the snapped grid."""
+    """Unique identifier for a 5-second video chunk on the snapped grid.
+
+    Note: End of the chunk is intentionally not a field of the key. End is fully derived
+    as ``start + chunk_seconds`` post-bucketize.
+    """
 
     # Makes model hashable so it can be used as a ``dict`` key during the outer-join
-    # in ``fuse`` and as a list element in ``FusedSegment.member_keys``
     model_config = ConfigDict(frozen=True)
 
     sensor_id: str
-    start: datetime  # raw upstream timestamp; bucketize snaps to chunk_seconds grid
-    end: datetime  # raw upstream end; after bucketize: start + chunk_seconds
+    start: AwareDatetime = Field(
+        description=(
+            "Raw upstream timestamp; bucketize snaps to chunk_seconds grid. "
+            "Must be tz-aware (naive rejected; non-UTC coerced to UTC)."
+        ),
+    )
+
+    @field_validator("start")
+    @classmethod
+    def _coerce_to_utc(cls, v: datetime) -> datetime:
+        """Normalize any tz-aware datetime to UTC.
+
+        Note: ``AwareDatetime`` has already rejected naive non-tz inputs at this point.
+        """
+        return v.astimezone(UTC)
 
 
 class RankedChunk(BaseModel):
@@ -57,6 +82,8 @@ class RankedChunk(BaseModel):
     Hence no VST URLs, screenshots, descriptions, object_ids, they live on the
     original search results in ``search.py``.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     key: ChunkKey
 
@@ -73,6 +100,8 @@ class RankedChunk(BaseModel):
 class RankedList(BaseModel):
     """A ranked list of chunks from one embedding space."""
 
+    model_config = ConfigDict(frozen=True)
+
     # Kept dynamic (not a literal) for ease of extensibility when consumers add new spaces
     # "embed", "attribute", "caption", "face", ...
     space: str
@@ -86,18 +115,20 @@ class RankedList(BaseModel):
 class FusionInput(BaseModel):
     """Request body for fusion. Carries only what the math needs."""
 
+    model_config = ConfigDict(frozen=True)
+
     # N per-space ranked lists from upstream search tools, e.g. [embed, attribute, caption]
     lists: list[RankedList] = Field(default_factory=list)
 
     # Chunk grid in seconds - drives snap/dedup and merge gap math, e.g. =5 -> 00:03 and 00:04 collapse to one bucket
-    chunk_seconds: int = 5
+    chunk_seconds: int = DEFAULT_CHUNK_SECONDS
 
     # Fusion math
     # - rrf uses ranks (unit-free, robust)
     # - weighted_linear uses min-max normalized raw scores
-    method: Literal["rrf", "weighted_linear"] = "rrf"
+    method: FusionMethod = "rrf"
     # RRF damping (larger k flattens, smaller k amplifies top ranks), e.g. 60 is the TREC standard
-    rrf_k: int = 60
+    rrf_k: int = DEFAULT_RRF_K
 
     # Filter knobs (Pre-fuse)
     # Drop per-space chunks early below a raw-unit threshold, e.g. {"embed": 0.7} -> cosine < 0.7 chunks dropped
@@ -121,7 +152,7 @@ class FusionInput(BaseModel):
     # ``mean`` matches legacy behavior ``search.py``/``_merge_consecutive_results``
     # (sustained events outrank single-chunk spikes)
     # ``max`` opts in to surfacing peak moments instead
-    segment_score_aggregation: Literal["max", "mean"] = "mean"
+    segment_score_aggregation: Aggregation = "mean"
 
     # End of pipeline knobs
     # Cap the final segments by fused_score, e.g. =5 -> only top 5 returned
@@ -193,7 +224,7 @@ class _FusedRow:
 # ---------------------------------------------------------------------------
 
 
-def snap(ts: datetime, chunk_seconds: int = 5) -> datetime:
+def snap(ts: datetime, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> datetime:
     """Snap an arbitrary timestamp down to the chunk-grid floor.
 
     Different search tools may return chunks at slightly different timestamps
@@ -215,7 +246,7 @@ def snap(ts: datetime, chunk_seconds: int = 5) -> datetime:
     return epoch + timedelta(seconds=snapped)
 
 
-def bucketize(rl: RankedList, chunk_seconds: int = 5) -> RankedList:
+def bucketize(rl: RankedList, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> RankedList:
     """Snap timestamps onto the ``chunk_seconds`` grid, dedupe, recompute ranks.
 
     Idempotent for already-snapped inputs (the case for trusted callers like
@@ -235,12 +266,9 @@ def bucketize(rl: RankedList, chunk_seconds: int = 5) -> RankedList:
     """
     best: dict[ChunkKey, RankedChunk] = {}
     for chunk in rl.chunks:
-        snapped_start = snap(chunk.key.start, chunk_seconds)
-        snapped_end = snapped_start + timedelta(seconds=chunk_seconds)
         snapped_key = ChunkKey(
             sensor_id=chunk.key.sensor_id,
-            start=snapped_start,
-            end=snapped_end,
+            start=snap(chunk.key.start, chunk_seconds),
         )
         existing = best.get(snapped_key)
         if existing is None or chunk.score > existing.score:
@@ -277,8 +305,8 @@ def apply_per_space_filter(rl: RankedList, per_space_min_score: dict[str, float]
 
 def fuse(
     lists: list[RankedList],
-    method: Literal["rrf", "weighted_linear"] = "rrf",
-    rrf_k: int = 60,
+    method: FusionMethod = "rrf",
+    rrf_k: int = DEFAULT_RRF_K,
 ) -> dict[ChunkKey, _FusedRow]:
     """Outer-join ``lists`` on :class:`ChunkKey` and compute the fused score.
 
@@ -342,7 +370,7 @@ def fuse(
 
 
 def _theoretical_ceiling(
-    method: Literal["rrf", "weighted_linear"],
+    method: FusionMethod,
     rrf_k: int,
     weights: list[float],
 ) -> float:
@@ -365,7 +393,7 @@ def apply_global_filters(
     min_contributing_spaces: int,
     keep_if_top_n_in_any_space: int | None,
     min_fused_score_ratio: float | None,
-    method: Literal["rrf", "weighted_linear"],
+    method: FusionMethod,
     rrf_k: int,
     weights: list[float],
 ) -> dict[ChunkKey, _FusedRow]:
@@ -414,7 +442,7 @@ def _row_to_segment(row: _FusedRow, chunk_seconds: int) -> FusedSegment:
     )
 
 
-def rows_to_segments(rows: list[_FusedRow], chunk_seconds: int = 5) -> list[FusedSegment]:
+def rows_to_segments(rows: list[_FusedRow], chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> list[FusedSegment]:
     """Convert fused rows to length-1 segments without merging.
 
     Used by :func:`run_fusion` when ``merge_adjacent=False``. Preserves the
@@ -425,14 +453,14 @@ def rows_to_segments(rows: list[_FusedRow], chunk_seconds: int = 5) -> list[Fuse
 
 def merge_adjacent(
     rows: list[_FusedRow],
-    chunk_seconds: int = 5,
+    chunk_seconds: int = DEFAULT_CHUNK_SECONDS,
     merge_gap_chunks: int = 0,
-    aggregation: Literal["max", "mean"] = "mean",
+    aggregation: Aggregation = "mean",
 ) -> list[FusedSegment]:
     """Coalesce contiguous (or near-contiguous) chunks per sensor.
 
     Group by ``sensor_id``, sort by ``start``, walk left -> right and merge when
-    ``next.start - prev.end <= merge_gap_chunks * chunk_seconds``. Aggregate
+    ``next.start - (prev.start + chunk_seconds) <= merge_gap_chunks * chunk_seconds``.
     per-segment ``fused_score`` via ``aggregation`` and union the
     ``contributing_spaces`` across members.
 
@@ -474,7 +502,7 @@ def merge_adjacent(
 def _finalize_group(
     group: list[_FusedRow],
     chunk_seconds: int,
-    aggregation: Literal["max", "mean"],
+    aggregation: Aggregation,
 ) -> FusedSegment:
     """Collapse a contiguous run of :class:`_FusedRow` items into one :class:`FusedSegment`.
 

--- a/services/agent/src/vss_agents/tools/fusion.py
+++ b/services/agent/src/vss_agents/tools/fusion.py
@@ -1,0 +1,590 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generalized N-space ranked-list fusion
+
+Fusion is a ranker only (pure math, no side effects). It does not call ``embed_search``, ``attribute_search``, etc.
+These are still left to the coordinator ``search.py`` to orchestrate.
+
+A clip can appear in some lists and not others. "Missing" is equivalent to rank = ∞ in that space -> contributes 0.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+from datetime import timedelta
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+# ---------------------------------------------------------------------------
+# Public data contract
+# ---------------------------------------------------------------------------
+
+
+class ChunkKey(BaseModel):
+    """Unique identifier for a 5-second video chunk on the snapped grid."""
+
+    # Makes model hashable so it can be used as a ``dict`` key during the outer-join
+    # in ``fuse`` and as a list element in ``FusedSegment.member_keys``
+    model_config = ConfigDict(frozen=True)
+
+    sensor_id: str
+    start: datetime  # raw upstream timestamp; bucketize snaps to chunk_seconds grid
+    end: datetime  # raw upstream end; after bucketize: start + chunk_seconds
+
+
+class RankedChunk(BaseModel):
+    """One ranked entry from a single embedding space.
+
+    Pure data model. Fusion is blind to payloads.
+    Hence no VST URLs, screenshots, descriptions, object_ids, they live on the
+    original search results in ``search.py``.
+    """
+
+    key: ChunkKey
+
+    # Raw score in space-native units (cosine, frame_score, …)
+    score: float
+
+    # 1-based position inside its source list
+    # Note: Fusion does not compute initial ranks - it receives them
+    # (the ranks come baked into the input from upstream search tools)
+    # e.g. each embedding space tool -> emits ``RankedList(rank=1..K)``
+    rank: int
+
+
+class RankedList(BaseModel):
+    """A ranked list of chunks from one embedding space."""
+
+    # Kept dynamic (not a literal) for ease of extensibility when consumers add new spaces
+    # "embed", "attribute", "caption", "face", ...
+    space: str
+
+    # Trust knob for this space (used in RRF / weighted_linear etc.)
+    # Makes this space's votes count for more
+    weight: float = 1.0
+    chunks: list[RankedChunk] = Field(default_factory=list)
+
+
+class FusionInput(BaseModel):
+    """Request body for fusion. Carries only what the math needs."""
+
+    # N per-space ranked lists from upstream search tools, e.g. [embed, attribute, caption]
+    lists: list[RankedList] = Field(default_factory=list)
+
+    # Chunk grid in seconds - drives snap/dedup and merge gap math, e.g. =5 -> 00:03 and 00:04 collapse to one bucket
+    chunk_seconds: int = 5
+
+    # Fusion math
+    # - rrf uses ranks (unit-free, robust)
+    # - weighted_linear uses min-max normalized raw scores
+    method: Literal["rrf", "weighted_linear"] = "rrf"
+    # RRF damping (larger k flattens, smaller k amplifies top ranks), e.g. 60 is the TREC standard
+    rrf_k: int = 60
+
+    # Filter knobs (Pre-fuse)
+    # Drop per-space chunks early below a raw-unit threshold, e.g. {"embed": 0.7} -> cosine < 0.7 chunks dropped
+    per_space_min_score: dict[str, float] = Field(default_factory=dict)
+
+    # Filter knobs (Post-fuse)
+    # Chunk must appear in >=N spaces to survive, e.g. =2 -> at least 2 spaces voted for it
+    min_contributing_spaces: int = 1
+    # Drop chunks below ratio x theoretical ceiling, e.g. 0.3 -> keep only >=30% of best-possible fused_score
+    min_fused_score_ratio: float | None = None
+    # OR-exemption - top-N in any space bypasses post-fuse gates here
+    # e.g. =3 -> rank <=3 anywhere survives
+    keep_if_top_n_in_any_space: int | None = None
+
+    # Merge knobs (applied after filtering and fusion)
+    # Collapse touching chunks into one segment, e.g. [0-5]+[5-10] -> [0-10]
+    merge_adjacent: bool = True
+    # Tolerate up to N missing chunks between merges, e.g. =1 keeps [0-5]+[10-15] as one
+    merge_gap_chunks: int = 0
+    # How per-chunk fused scores collapse/aggregate into one segment score
+    # ``mean`` matches legacy behavior ``search.py``/``_merge_consecutive_results``
+    # (sustained events outrank single-chunk spikes)
+    # ``max`` opts in to surfacing peak moments instead
+    segment_score_aggregation: Literal["max", "mean"] = "mean"
+
+    # End of pipeline knobs
+    # Cap the final segments by fused_score, e.g. =5 -> only top 5 returned
+    top_k_segments: int | None = 10
+
+
+class FusedSegment(BaseModel):
+    """One merged segment in the fusion output.
+
+             INPUT                               OUTPUT
+             ─────                               ───────
+
+    RankedChunk.key  ────────►  fuse() ────►  FusedSegment.member_keys[i]
+         │                         ▲                       │
+         │                         │                       │
+         └──────────► ChunkKey ◄───┴───► ChunkKey ◄────────┘
+                      (frozen)              (frozen)
+                         ▲                     ▲
+                         └─── same value ──────┘
+                         identity preserved end-to-end
+                         -> enables payload re-join in search.py
+    """
+
+    sensor_id: str
+    start: datetime  # earliest start of merged members
+    end: datetime  # latest end of merged members
+
+    # Rank-derived voting score (not a similarity)
+    # Gotcha: Unitless and varies by method (e.g. RRF, rrf_k=60, 3 spaces, weights=1, ceiling ≈ 0.0492)
+    # Always interpret and compare fused_score as a *ratio* of this ceiling (see ``_theoretical_ceiling``), not as an absolute value.
+    # TODO: maybe revisit model to have this more meaningful ratio for easy interpretation
+    fused_score: float
+
+    # Union across member chunks
+    # Reflects the breadth of evidence for this segment (i.e. more contributing spaces means more trustworthy)
+    contributing_spaces: list[str]
+
+    # Original chunk keys that fed this segment
+    member_keys: list[ChunkKey]
+
+    # Convenience field (=len(member_keys))
+    # How many 5-second chunks were merged into this segment
+    member_chunk_count: int
+
+
+class FusionOutput(BaseModel):
+    """Response body. Already filtered, merged, sorted desc by ``fused_score``."""
+
+    segments: list[FusedSegment] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Internal structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FusedRow:
+    """Outer-join accumulator used inside :func:`fuse` and the global filter pass."""
+
+    key: ChunkKey
+    score: float = 0.0
+    contributing_spaces: list[str] = field(default_factory=list)
+    per_space_ranks: dict[str, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def snap(ts: datetime, chunk_seconds: int = 5) -> datetime:
+    """Snap an arbitrary timestamp down to the chunk-grid floor.
+
+    Different search tools may return chunks at slightly different timestamps
+    even when describing the same moment of video. Snapping lines them up onto a deterministic grid
+    so the outer-join in :func:`fuse` matches the same chunk across spaces.
+
+    Timezone-shape agnostic: Preserves ``ts.tzinfo`` (works for both naive and tz-aware inputs).
+
+    Example:
+    - `embed_search` (Cosmos clip embeddings) -> 00:01:25.300 (sliding window started)
+    - `attribute_search` (CV per-frame) -> 00:01:27.100 (bounding box landed)
+    -> both snap to 00:01:25
+
+    TODO consumed by ``search.py`` adapters later, maybe make it a separate util?
+    """
+    epoch = datetime(1970, 1, 1, tzinfo=ts.tzinfo)
+    seconds_since_epoch = (ts - epoch).total_seconds()
+    snapped = (seconds_since_epoch // chunk_seconds) * chunk_seconds
+    return epoch + timedelta(seconds=snapped)
+
+
+def bucketize(rl: RankedList, chunk_seconds: int = 5) -> RankedList:
+    """Snap timestamps onto the ``chunk_seconds`` grid, dedupe, recompute ranks.
+
+    Idempotent for already-snapped inputs (the case for trusted callers like
+    ``search.py``'s per-space adapters). Stays in place as a defensive safety
+    net for naive HTTP callers (eval scripts, notebooks) that may post
+    unsnapped raw timestamps.
+
+    Within a single space, multiple raw hits that snap to the same
+    :class:`ChunkKey` are deduped with **max-score-wins** semantics.
+    Ranks are then reassigned 1-based by descending score among the survivors,
+    so the output is a valid input to :func:`fuse`.
+
+    Example:
+    - 3 raw embed hits on cam-1 at 25.3s, 27.1s, 29.5s with scores [0.9, 0.7, 0.95]
+    - all snap to the same chunk [00:25, 00:30] on the 5s grid
+    -> 1 chunk: score=0.95 (max wins), rank=1
+    """
+    best: dict[ChunkKey, RankedChunk] = {}
+    for chunk in rl.chunks:
+        snapped_start = snap(chunk.key.start, chunk_seconds)
+        snapped_end = snapped_start + timedelta(seconds=chunk_seconds)
+        snapped_key = ChunkKey(
+            sensor_id=chunk.key.sensor_id,
+            start=snapped_start,
+            end=snapped_end,
+        )
+        existing = best.get(snapped_key)
+        if existing is None or chunk.score > existing.score:
+            best[snapped_key] = RankedChunk(key=snapped_key, score=chunk.score, rank=0)
+
+    survivors = sorted(best.values(), key=lambda c: c.score, reverse=True)
+    reranked = [RankedChunk(key=c.key, score=c.score, rank=i + 1) for i, c in enumerate(survivors)]
+    return RankedList(space=rl.space, weight=rl.weight, chunks=reranked)
+
+
+def apply_per_space_filter(rl: RankedList, per_space_min_score: dict[str, float]) -> RankedList:
+    """Drop below-threshold chunks for one space and recompute ranks.
+
+    Gotcha: Score survives a drop. Rank does not - it is a relative property in the list.
+    Hence rank must be reassigned after dropping chunks.
+    (e.g. a chunk that was rank 5 with two dropped above must become rank 3, otherwise :func:`fuse` uses stale ranks).
+
+    Threshold is keyed by space name; spaces missing from the dict get no filter (raw scores pass
+    through unchanged).
+
+    Example: per_space_min_score = {"embed": 0.70}
+    - input embed list: 5 chunks with scores [0.92, 0.85, 0.62, 0.71, 0.45], ranks 1..5
+    - drop the two below 0.70 (scores 0.62 and 0.45)
+    -> 3 chunks with scores [0.92, 0.85, 0.71], ranks re-densified to 1, 2, 3
+    """
+    threshold = per_space_min_score.get(rl.space)
+    if threshold is None:
+        return rl
+    survivors = [c for c in rl.chunks if c.score >= threshold]
+    survivors.sort(key=lambda c: c.score, reverse=True)
+    reranked = [RankedChunk(key=c.key, score=c.score, rank=i + 1) for i, c in enumerate(survivors)]
+    return RankedList(space=rl.space, weight=rl.weight, chunks=reranked)
+
+
+def fuse(
+    lists: list[RankedList],
+    method: Literal["rrf", "weighted_linear"] = "rrf",
+    rrf_k: int = 60,
+) -> dict[ChunkKey, _FusedRow]:
+    """Outer-join ``lists`` on :class:`ChunkKey` and compute the fused score.
+
+    1) ``rrf``: ``fused = Σ_i  w_i / (rrf_k + rank_i)``. Missing rank -> 0.
+
+        Intuition: Throw away scores because they are not comparable across different embedding spaces.
+        Every space gets a single ballot. First preference, second preference, third preference. Whoever appears highest on the most ballots wins.
+        i.e. ``reward(rank) = 1 / (rrf_k + rank)``. Sum the rewards across judges. Highest sum wins.
+
+        The constant ``rrf_k`` (=60) is a softener. Otherwise clip #1 would steamroll everything. 60 squashes the curve.
+
+        query ─┬─► [embed model: Cosmos]    ─► ranked list A:  C1, C2, C3
+            │
+            └─► [attribute model: CV]    ─► ranked list B:  C2, C1, C4
+                                                │
+                                                ▼
+                                            RRF fuses A + B
+                                                │
+                                                ▼
+                                            C1 > C2 > C3 > C4
+
+    2) ``weighted_linear``: per-space min-max normalize raw scores into ``[0, 1]``,
+        then ``fused = Σ_i  w_i * norm_score_i``. Missing -> 0.
+
+        Intuition: Scores are from different embedding spaces so we have to normalize them.
+        Every space rates each chunk on a 0-1 scale, and we average those ratings.
+
+    Returns a dict keyed by the snapped :class:`ChunkKey` carrying the fused score
+    plus per-space rank witnesses (used by global filters like ``keep_if_top_n_in_any_space``).
+    The dict is pre-sort; callers sort by ``score`` descending before merging.
+    """
+    out: dict[ChunkKey, _FusedRow] = {}
+
+    if method == "rrf":
+        for rl in lists:
+            for chunk in rl.chunks:
+                row = out.setdefault(chunk.key, _FusedRow(key=chunk.key))
+                row.score += rl.weight / (rrf_k + chunk.rank)
+                if rl.space not in row.contributing_spaces:
+                    row.contributing_spaces.append(rl.space)
+                row.per_space_ranks[rl.space] = chunk.rank
+        return out
+
+    if method == "weighted_linear":
+        for rl in lists:
+            if not rl.chunks:
+                continue
+            scores = [c.score for c in rl.chunks]
+            lo, hi = min(scores), max(scores)
+            spread = hi - lo
+            for chunk in rl.chunks:
+                norm = 1.0 if spread == 0 else (chunk.score - lo) / spread
+                row = out.setdefault(chunk.key, _FusedRow(key=chunk.key))
+                row.score += rl.weight * norm
+                if rl.space not in row.contributing_spaces:
+                    row.contributing_spaces.append(rl.space)
+                row.per_space_ranks[rl.space] = chunk.rank
+        return out
+
+    raise ValueError(f"Unknown fusion method: {method!r}")
+
+
+def _theoretical_ceiling(
+    method: Literal["rrf", "weighted_linear"],
+    rrf_k: int,
+    weights: list[float],
+) -> float:
+    """Compute the maximum achievable fused score for ``min_fused_score_ratio``.
+
+    - RRF ceiling = Σ w_i / (k + 1) (rank 1 in every space)
+    - Weighted_linear ceiling = Σ w_i (max-normalized score 1 in every space)
+    """
+    if method == "rrf":
+        return sum(w / (rrf_k + 1) for w in weights)
+    if method == "weighted_linear":
+        return sum(weights)
+
+    raise ValueError(f"Unknown fusion method: {method!r}")
+
+
+def apply_global_filters(
+    fused: dict[ChunkKey, _FusedRow],
+    *,
+    min_contributing_spaces: int,
+    keep_if_top_n_in_any_space: int | None,
+    min_fused_score_ratio: float | None,
+    method: Literal["rrf", "weighted_linear"],
+    rrf_k: int,
+    weights: list[float],
+) -> dict[ChunkKey, _FusedRow]:
+    """Apply the post-fusion filters.
+
+    ``keep_if_top_n_in_any_space`` is an OR exemption: a chunk that ranks ``<= N``
+    in at least one space survives even if it would otherwise fail the vote-count
+    or score-ratio filters ("strong somewhere" override).
+
+    Example: min_contributing_spaces=2, keep_if_top_n_in_any_space=3
+    - C1 (3 spaces voted, ranks [1, 2, 1]) -> kept (passes vote-count gate)
+    - C2 (1 space, rank=2)                 -> kept via exemption (top-3 somewhere)
+    - C3 (1 space, rank=8)                 -> dropped (no agreement, no top-3 vote)
+    """
+    threshold: float | None = None
+    if min_fused_score_ratio is not None:
+        ceiling = _theoretical_ceiling(method, rrf_k, weights)
+        threshold = min_fused_score_ratio * ceiling
+
+    out: dict[ChunkKey, _FusedRow] = {}
+    for key, row in fused.items():
+        is_strong_somewhere = keep_if_top_n_in_any_space is not None and any(
+            rank <= keep_if_top_n_in_any_space for rank in row.per_space_ranks.values()
+        )
+        if is_strong_somewhere:
+            out[key] = row
+            continue
+        if len(row.contributing_spaces) < min_contributing_spaces:
+            continue
+        if threshold is not None and row.score < threshold:
+            continue
+        out[key] = row
+    return out
+
+
+def _row_to_segment(row: _FusedRow, chunk_seconds: int) -> FusedSegment:
+    """Wrap a single fused row as a length-1 segment (no merging)."""
+    return FusedSegment(
+        sensor_id=row.key.sensor_id,
+        start=row.key.start,
+        end=row.key.start + timedelta(seconds=chunk_seconds),
+        fused_score=row.score,
+        member_chunk_count=1,
+        contributing_spaces=list(row.contributing_spaces),
+        member_keys=[row.key],
+    )
+
+
+def rows_to_segments(rows: list[_FusedRow], chunk_seconds: int = 5) -> list[FusedSegment]:
+    """Convert fused rows to length-1 segments without merging.
+
+    Used by :func:`run_fusion` when ``merge_adjacent=False``. Preserves the
+    incoming row order (callers sort by ``fused_score`` desc beforehand).
+    """
+    return [_row_to_segment(r, chunk_seconds) for r in rows]
+
+
+def merge_adjacent(
+    rows: list[_FusedRow],
+    chunk_seconds: int = 5,
+    merge_gap_chunks: int = 0,
+    aggregation: Literal["max", "mean"] = "mean",
+) -> list[FusedSegment]:
+    """Coalesce contiguous (or near-contiguous) chunks per sensor.
+
+    Group by ``sensor_id``, sort by ``start``, walk left -> right and merge when
+    ``next.start - prev.end <= merge_gap_chunks * chunk_seconds``. Aggregate
+    per-segment ``fused_score`` via ``aggregation`` and union the
+    ``contributing_spaces`` across members.
+
+    The output is sorted descending by ``fused_score`` so callers don't need
+    to re-sort before applying ``top_k_segments``.
+
+    Example: merge_gap_chunks=0
+    - 4 surviving chunks on cam-1: [0-5], [5-10], [10-15], [25-30]
+    - first three touch end->start -> merged into one segment [0-15]
+    - [25-30] has a 10s gap (2 missing chunks) -> stays alone
+    -> 2 segments
+    """
+    by_sensor: dict[str, list[_FusedRow]] = defaultdict(list)
+    for row in rows:
+        by_sensor[row.key.sensor_id].append(row)
+
+    segments: list[FusedSegment] = []
+    gap_seconds = merge_gap_chunks * chunk_seconds
+
+    for _sensor_id, sensor_rows in by_sensor.items():
+        sensor_rows.sort(key=lambda r: r.key.start)
+        group: list[_FusedRow] = []
+        prev_end: datetime | None = None
+        for row in sensor_rows:
+            if prev_end is not None:
+                gap = (row.key.start - prev_end).total_seconds()
+                if gap > gap_seconds:
+                    segments.append(_finalize_group(group, chunk_seconds, aggregation))
+                    group = []
+            group.append(row)
+            prev_end = row.key.start + timedelta(seconds=chunk_seconds)
+        if group:
+            segments.append(_finalize_group(group, chunk_seconds, aggregation))
+
+    segments.sort(key=lambda s: s.fused_score, reverse=True)
+    return segments
+
+
+def _finalize_group(
+    group: list[_FusedRow],
+    chunk_seconds: int,
+    aggregation: Literal["max", "mean"],
+) -> FusedSegment:
+    """Collapse a contiguous run of :class:`_FusedRow` items into one :class:`FusedSegment`.
+
+    Example: aggregation="mean"
+    - 3 contiguous rows on cam-1: scores [0.045, 0.040, 0.038], spaces [embed,attr], [embed,caption], [embed]
+    - fused_score = (0.045 + 0.040 + 0.038) / 3 = 0.041
+    - contributing_spaces = union -> [embed, attr, caption]
+    -> 1 segment: [00:00 - 00:15], fused_score=0.041
+    """
+    member_scores = [r.score for r in group]
+    if aggregation == "max":
+        fused_score = max(member_scores)
+    elif aggregation == "mean":
+        fused_score = sum(member_scores) / len(member_scores)
+    else:
+        raise ValueError(f"Unknown aggregation: {aggregation!r}")
+
+    # Dedupe loop to keep unique contributing spaces
+    # Order-preserving for stability
+    contributing: list[str] = []
+    for row in group:
+        for space in row.contributing_spaces:
+            if space not in contributing:
+                contributing.append(space)
+
+    sensor_id = group[0].key.sensor_id
+    start = group[0].key.start
+    end = group[-1].key.start + timedelta(seconds=chunk_seconds)
+    return FusedSegment(
+        sensor_id=sensor_id,
+        start=start,
+        end=end,
+        fused_score=fused_score,
+        member_chunk_count=len(group),
+        contributing_spaces=contributing,
+        member_keys=[r.key for r in group],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint and end-to-end pipeline:
+#
+#                          ┌─ RankedList(space="embed",     chunks=[RC,RC,…])
+#  e.g. search.py          │
+#  builds N lists ───────► ├─ RankedList(space="attribute", chunks=[RC,RC,…])
+#                          │
+#                          └─ RankedList(space="caption",   chunks=[RC,RC,…])
+#                                              │
+#                                              ▼
+#                                   ┌────────────────┐
+#                                   │  FusionInput   │
+#                                   └────────┬───────┘
+#                                            │
+#                                            ▼
+#                  ┌──────────────────────────────────────────────────────────┐
+#                  │ run_fusion(inp):                                         │
+#                  │   1. bucketize            (snap + dedupe)                │
+#                  │   2. apply_per_space_filter                              │
+#                  │   3. fuse                 (RRF or weighted_linear)       │
+#                  │   4. apply_global_filters                                │
+#                  │   5. merge_adjacent       (or rows_to_segments)          │
+#                  │   6. sort desc by fused_score, top_k cut                 │
+#                  └────────────────────────────┬─────────────────────────────┘
+#                                               │
+#                                               ▼
+#                                        ┌────────────────┐
+#                                        │  FusionOutput  │
+#                                        └────────┬───────┘
+#                                                 │
+#                                                 ▼
+#                      ┌─ FusedSegment(member_keys=[CK,CK,CK])  fused_score=0.0483  (~98% of ceiling)
+#                      │
+#   search.py   ◄──────┤─ FusedSegment(member_keys=[CK,CK])     fused_score=0.0309  (~63% of ceiling)
+#   re-joins           │
+#   payload via        ├─ FusedSegment(member_keys=[CK])        fused_score=0.0143  (~29% of ceiling)
+#   ChunkKey           │
+#                      └─ … up to top_k_segments
+#
+# ---------------------------------------------------------------------------
+
+
+def run_fusion(inp: FusionInput) -> FusionOutput:
+    """Run the full pipeline declaratively: bucketize -> filter raw -> fuse -> filter fused -> sort -> merge -> cap etc."""
+    bucketed = [bucketize(rl, inp.chunk_seconds) for rl in inp.lists]
+    bucketed = [apply_per_space_filter(rl, inp.per_space_min_score) for rl in bucketed]
+
+    fused = fuse(bucketed, method=inp.method, rrf_k=inp.rrf_k)
+
+    fused = apply_global_filters(
+        fused,
+        min_contributing_spaces=inp.min_contributing_spaces,
+        keep_if_top_n_in_any_space=inp.keep_if_top_n_in_any_space,
+        min_fused_score_ratio=inp.min_fused_score_ratio,
+        method=inp.method,
+        rrf_k=inp.rrf_k,
+        weights=[rl.weight for rl in bucketed],
+    )
+
+    rows = sorted(fused.values(), key=lambda r: r.score, reverse=True)
+    if inp.merge_adjacent:
+        segments = merge_adjacent(
+            rows,
+            chunk_seconds=inp.chunk_seconds,
+            merge_gap_chunks=inp.merge_gap_chunks,
+            aggregation=inp.segment_score_aggregation,
+        )
+    else:
+        segments = rows_to_segments(rows, chunk_seconds=inp.chunk_seconds)
+
+    if inp.top_k_segments is not None:
+        segments = segments[: inp.top_k_segments]
+
+    return FusionOutput(segments=segments)

--- a/services/agent/src/vss_agents/tools/fusion.py
+++ b/services/agent/src/vss_agents/tools/fusion.py
@@ -92,7 +92,7 @@ class RankedChunk(BaseModel):
     key: ChunkKey
 
     # Raw score in space-native units (cosine, frame_score, …)
-    score: float
+    score: float = Field(allow_inf_nan=False)
 
     # 1-based position inside its source list
     # Note: Fusion does not compute initial ranks - it receives them
@@ -112,7 +112,7 @@ class RankedList(BaseModel):
 
     # Trust knob for this space (used in RRF / weighted_linear etc.)
     # Makes this space's votes count for more
-    weight: float = Field(default=1.0, ge=0)
+    weight: float = Field(default=1.0, ge=0, allow_inf_nan=False)
     chunks: list[RankedChunk] = Field(default_factory=list)
 
 
@@ -140,18 +140,18 @@ class FusionInput(BaseModel):
 
     # Filter knobs (Post-fuse)
     # Chunk must appear in >=N spaces to survive, e.g. =2 -> at least 2 spaces voted for it
-    min_contributing_spaces: int = 1
+    min_contributing_spaces: int = Field(default=1, ge=0)
     # Drop chunks below ratio x theoretical ceiling, e.g. 0.3 -> keep only >=30% of best-possible fused_score
-    min_fused_score_ratio: float | None = None
+    min_fused_score_ratio: float | None = Field(default=None, allow_inf_nan=False)
     # OR-exemption - top-N in any space bypasses post-fuse gates here
     # e.g. =3 -> rank <=3 anywhere survives
-    keep_if_top_n_in_any_space: int | None = None
+    keep_if_top_n_in_any_space: int | None = Field(default=None, gt=0)
 
     # Merge knobs (applied after filtering and fusion)
     # Collapse touching chunks into one segment, e.g. [0-5]+[5-10] -> [0-10]
     merge_adjacent: bool = True
     # Tolerate up to N missing chunks between merges, e.g. =1 keeps [0-5]+[10-15] as one
-    merge_gap_chunks: int = 0
+    merge_gap_chunks: int = Field(default=0, ge=0)
     # How per-chunk fused scores collapse/aggregate into one segment score
     # ``mean`` matches legacy behavior ``search.py``/``_merge_consecutive_results``
     # (sustained events outrank single-chunk spikes)
@@ -160,7 +160,7 @@ class FusionInput(BaseModel):
 
     # End of pipeline knobs
     # Cap the final segments by fused_score, e.g. =5 -> only top 5 returned
-    top_k_segments: int | None = 10
+    top_k_segments: int | None = Field(default=10, gt=0)
 
 
 class FusedSegment(BaseModel):
@@ -228,14 +228,24 @@ class FusedRow:
 # ---------------------------------------------------------------------------
 
 
-def snap(ts: datetime, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> datetime:
+def _validate_chunk_seconds(chunk_seconds: int) -> None:
+    """Invariant for callers that bypass :class:`FusionInput`."""
+    if chunk_seconds <= 0:
+        raise ValueError(f"chunk_seconds must be > 0, got {chunk_seconds!r}")
+
+
+def _validate_rrf_k(rrf_k: int) -> None:
+    """Invariant for callers that bypass :class:`FusionInput`."""
+    if rrf_k <= 0:
+        raise ValueError(f"rrf_k must be > 0, got {rrf_k!r}")
+
+
+def snap(ts: AwareDatetime, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> datetime:
     """Snap an arbitrary timestamp down to the chunk-grid floor.
 
     Different search tools may return chunks at slightly different timestamps
     even when describing the same moment of video. Snapping lines them up onto a deterministic grid
     so the outer-join in :func:`fuse` matches the same chunk across spaces.
-
-    Timezone-shape agnostic: Preserves ``ts.tzinfo`` (works for both naive and tz-aware inputs).
 
     Example:
     - `embed_search` (Cosmos clip embeddings) -> 00:01:25.300 (sliding window started)
@@ -244,6 +254,9 @@ def snap(ts: datetime, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> datetime:
 
     TODO consumed by ``search.py`` adapters later, maybe make it a separate util?
     """
+    _validate_chunk_seconds(chunk_seconds)
+    if ts.tzinfo is None:
+        raise ValueError(f"snap requires a tz-aware datetime, got naive {ts!r}")
     epoch = datetime(1970, 1, 1, tzinfo=ts.tzinfo)
     seconds_since_epoch = (ts - epoch).total_seconds()
     snapped = (seconds_since_epoch // chunk_seconds) * chunk_seconds
@@ -359,6 +372,7 @@ def fuse(
     plus per-space rank witnesses (used by global filters like ``keep_if_top_n_in_any_space``).
     The dict is pre-sort; callers sort by ``score`` descending before merging.
     """
+    _validate_rrf_k(rrf_k)
     out: dict[ChunkKey, FusedRow] = {}
 
     if method == "rrf":
@@ -408,7 +422,12 @@ def _theoretical_ceiling(
     raise ValueError(f"Unknown fusion method: {method!r}")
 
 
-def score_threshold(fusion_input: FusionInput, fraction: float = 0.5) -> float:
+def compute_score_threshold(
+    method: FusionMethod,
+    rrf_k: int,
+    lists: list[RankedList],
+    fraction: float = 0.5,
+) -> float:
     """Returns meaningful score cutoff.
 
     Example: Setting fraction=0.6 applies a threshold at 60% of the theoretical maximum
@@ -416,8 +435,10 @@ def score_threshold(fusion_input: FusionInput, fraction: float = 0.5) -> float:
     weights, using a fraction ensures the threshold remains meaningful. This helps calibrate
     filtering based on "how close to the best possible score" a chunk came.
     """
-    weights = [rl.weight for rl in fusion_input.lists]
-    return _theoretical_ceiling(fusion_input.method, fusion_input.rrf_k, weights) * fraction
+    _validate_rrf_k(rrf_k)
+    # Skip empty lists. They contribute 0, so counting their weight inflates the ceiling.
+    contributing_weights = [rl.weight for rl in lists if rl.chunks]
+    return _theoretical_ceiling(method, rrf_k, contributing_weights) * fraction
 
 
 def apply_global_filters(
@@ -473,6 +494,7 @@ def rows_to_segments(rows: list[FusedRow], chunk_seconds: int = DEFAULT_CHUNK_SE
     Used by :func:`run_fusion` when ``merge_adjacent=False``. Preserves the
     incoming row order (callers sort by ``fused_score`` desc beforehand).
     """
+    _validate_chunk_seconds(chunk_seconds)
     return [_row_to_segment(r, chunk_seconds) for r in rows]
 
 
@@ -498,6 +520,10 @@ def merge_adjacent_rows(
     - [25-30] has a 10s gap (2 missing chunks) -> stays alone
     -> 2 segments
     """
+    _validate_chunk_seconds(chunk_seconds)
+    if merge_gap_chunks < 0:
+        raise ValueError(f"merge_gap_chunks must be >= 0, got {merge_gap_chunks!r}")
+
     by_sensor: dict[str, list[FusedRow]] = defaultdict(list)
     for row in rows:
         by_sensor[row.key.sensor_id].append(row)
@@ -618,10 +644,7 @@ def run_fusion(inp: FusionInput) -> FusionOutput:
 
     threshold: float | None = None
     if inp.min_fused_score_ratio is not None:
-        # Skip empty lists. They contribute 0, so counting their weight inflates the ceiling
-        contributing_weights = [rl.weight for rl in bucketed if rl.chunks]
-        ceiling = _theoretical_ceiling(inp.method, inp.rrf_k, contributing_weights)
-        threshold = ceiling * inp.min_fused_score_ratio
+        threshold = compute_score_threshold(inp.method, inp.rrf_k, bucketed, fraction=inp.min_fused_score_ratio)
 
     fused = apply_global_filters(
         fused,

--- a/services/agent/src/vss_agents/tools/fusion.py
+++ b/services/agent/src/vss_agents/tools/fusion.py
@@ -28,6 +28,7 @@ from dataclasses import field
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
+from typing import TYPE_CHECKING
 from typing import Literal
 
 from pydantic import AwareDatetime
@@ -35,6 +36,9 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import field_validator
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 FusionMethod = Literal["rrf", "weighted_linear"]
 Aggregation = Literal["max", "mean"]
@@ -108,7 +112,7 @@ class RankedList(BaseModel):
 
     # Trust knob for this space (used in RRF / weighted_linear etc.)
     # Makes this space's votes count for more
-    weight: float = 1.0
+    weight: float = Field(default=1.0, ge=0)
     chunks: list[RankedChunk] = Field(default_factory=list)
 
 
@@ -121,14 +125,14 @@ class FusionInput(BaseModel):
     lists: list[RankedList] = Field(default_factory=list)
 
     # Chunk grid in seconds - drives snap/dedup and merge gap math, e.g. =5 -> 00:03 and 00:04 collapse to one bucket
-    chunk_seconds: int = DEFAULT_CHUNK_SECONDS
+    chunk_seconds: int = Field(default=DEFAULT_CHUNK_SECONDS, gt=0)
 
     # Fusion math
     # - rrf uses ranks (unit-free, robust)
     # - weighted_linear uses min-max normalized raw scores
     method: FusionMethod = "rrf"
     # RRF damping (larger k flattens, smaller k amplifies top ranks), e.g. 60 is the TREC standard
-    rrf_k: int = DEFAULT_RRF_K
+    rrf_k: int = Field(default=DEFAULT_RRF_K, gt=0)
 
     # Filter knobs (Pre-fuse)
     # Drop per-space chunks early below a raw-unit threshold, e.g. {"embed": 0.7} -> cosine < 0.7 chunks dropped
@@ -210,7 +214,7 @@ class FusionOutput(BaseModel):
 
 
 @dataclass
-class _FusedRow:
+class FusedRow:
     """Outer-join accumulator used inside :func:`fuse` and the global filter pass."""
 
     key: ChunkKey
@@ -246,6 +250,13 @@ def snap(ts: datetime, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> datetime:
     return epoch + timedelta(seconds=snapped)
 
 
+def _rerank_by_score(rl: RankedList, survivors: Iterable[RankedChunk]) -> RankedList:
+    """Reorders chunks by importance for fusion."""
+    sorted_chunks = sorted(survivors, key=lambda c: c.score, reverse=True)
+    reranked = [RankedChunk(key=c.key, score=c.score, rank=i + 1) for i, c in enumerate(sorted_chunks)]
+    return RankedList(space=rl.space, weight=rl.weight, chunks=reranked)
+
+
 def bucketize(rl: RankedList, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> RankedList:
     """Snap timestamps onto the ``chunk_seconds`` grid, dedupe, recompute ranks.
 
@@ -274,9 +285,7 @@ def bucketize(rl: RankedList, chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> Ran
         if existing is None or chunk.score > existing.score:
             best[snapped_key] = RankedChunk(key=snapped_key, score=chunk.score, rank=0)
 
-    survivors = sorted(best.values(), key=lambda c: c.score, reverse=True)
-    reranked = [RankedChunk(key=c.key, score=c.score, rank=i + 1) for i, c in enumerate(survivors)]
-    return RankedList(space=rl.space, weight=rl.weight, chunks=reranked)
+    return _rerank_by_score(rl, best.values())
 
 
 def apply_per_space_filter(rl: RankedList, per_space_min_score: dict[str, float]) -> RankedList:
@@ -297,17 +306,14 @@ def apply_per_space_filter(rl: RankedList, per_space_min_score: dict[str, float]
     threshold = per_space_min_score.get(rl.space)
     if threshold is None:
         return rl
-    survivors = [c for c in rl.chunks if c.score >= threshold]
-    survivors.sort(key=lambda c: c.score, reverse=True)
-    reranked = [RankedChunk(key=c.key, score=c.score, rank=i + 1) for i, c in enumerate(survivors)]
-    return RankedList(space=rl.space, weight=rl.weight, chunks=reranked)
+    return _rerank_by_score(rl, (c for c in rl.chunks if c.score >= threshold))
 
 
 def fuse(
     lists: list[RankedList],
     method: FusionMethod = "rrf",
     rrf_k: int = DEFAULT_RRF_K,
-) -> dict[ChunkKey, _FusedRow]:
+) -> dict[ChunkKey, FusedRow]:
     """Outer-join ``lists`` on :class:`ChunkKey` and compute the fused score.
 
     1) ``rrf``: ``fused = Σ_i  w_i / (rrf_k + rank_i)``. Missing rank -> 0.
@@ -338,12 +344,12 @@ def fuse(
     plus per-space rank witnesses (used by global filters like ``keep_if_top_n_in_any_space``).
     The dict is pre-sort; callers sort by ``score`` descending before merging.
     """
-    out: dict[ChunkKey, _FusedRow] = {}
+    out: dict[ChunkKey, FusedRow] = {}
 
     if method == "rrf":
         for rl in lists:
             for chunk in rl.chunks:
-                row = out.setdefault(chunk.key, _FusedRow(key=chunk.key))
+                row = out.setdefault(chunk.key, FusedRow(key=chunk.key))
                 row.score += rl.weight / (rrf_k + chunk.rank)
                 if rl.space not in row.contributing_spaces:
                     row.contributing_spaces.append(rl.space)
@@ -359,7 +365,7 @@ def fuse(
             spread = hi - lo
             for chunk in rl.chunks:
                 norm = 1.0 if spread == 0 else (chunk.score - lo) / spread
-                row = out.setdefault(chunk.key, _FusedRow(key=chunk.key))
+                row = out.setdefault(chunk.key, FusedRow(key=chunk.key))
                 row.score += rl.weight * norm
                 if rl.space not in row.contributing_spaces:
                     row.contributing_spaces.append(rl.space)
@@ -387,16 +393,25 @@ def _theoretical_ceiling(
     raise ValueError(f"Unknown fusion method: {method!r}")
 
 
+def score_threshold(fusion_input: FusionInput, fraction: float = 0.5) -> float:
+    """Returns meaningful score cutoff.
+
+    Example: Setting fraction=0.6 applies a threshold at 60% of the theoretical maximum
+    score ("ceiling"). Since fused_score is unitless and depends on the fusion method and
+    weights, using a fraction ensures the threshold remains meaningful. This helps calibrate
+    filtering based on "how close to the best possible score" a chunk came.
+    """
+    weights = [rl.weight for rl in fusion_input.lists]
+    return _theoretical_ceiling(fusion_input.method, fusion_input.rrf_k, weights) * fraction
+
+
 def apply_global_filters(
-    fused: dict[ChunkKey, _FusedRow],
+    fused: dict[ChunkKey, FusedRow],
     *,
     min_contributing_spaces: int,
     keep_if_top_n_in_any_space: int | None,
-    min_fused_score_ratio: float | None,
-    method: FusionMethod,
-    rrf_k: int,
-    weights: list[float],
-) -> dict[ChunkKey, _FusedRow]:
+    score_threshold: float | None,
+) -> dict[ChunkKey, FusedRow]:
     """Apply the post-fusion filters.
 
     ``keep_if_top_n_in_any_space`` is an OR exemption: a chunk that ranks ``<= N``
@@ -408,12 +423,7 @@ def apply_global_filters(
     - C2 (1 space, rank=2)                 -> kept via exemption (top-3 somewhere)
     - C3 (1 space, rank=8)                 -> dropped (no agreement, no top-3 vote)
     """
-    threshold: float | None = None
-    if min_fused_score_ratio is not None:
-        ceiling = _theoretical_ceiling(method, rrf_k, weights)
-        threshold = min_fused_score_ratio * ceiling
-
-    out: dict[ChunkKey, _FusedRow] = {}
+    out: dict[ChunkKey, FusedRow] = {}
     for key, row in fused.items():
         is_strong_somewhere = keep_if_top_n_in_any_space is not None and any(
             rank <= keep_if_top_n_in_any_space for rank in row.per_space_ranks.values()
@@ -423,13 +433,13 @@ def apply_global_filters(
             continue
         if len(row.contributing_spaces) < min_contributing_spaces:
             continue
-        if threshold is not None and row.score < threshold:
+        if score_threshold is not None and row.score < score_threshold:
             continue
         out[key] = row
     return out
 
 
-def _row_to_segment(row: _FusedRow, chunk_seconds: int) -> FusedSegment:
+def _row_to_segment(row: FusedRow, chunk_seconds: int) -> FusedSegment:
     """Wrap a single fused row as a length-1 segment (no merging)."""
     return FusedSegment(
         sensor_id=row.key.sensor_id,
@@ -442,7 +452,7 @@ def _row_to_segment(row: _FusedRow, chunk_seconds: int) -> FusedSegment:
     )
 
 
-def rows_to_segments(rows: list[_FusedRow], chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> list[FusedSegment]:
+def rows_to_segments(rows: list[FusedRow], chunk_seconds: int = DEFAULT_CHUNK_SECONDS) -> list[FusedSegment]:
     """Convert fused rows to length-1 segments without merging.
 
     Used by :func:`run_fusion` when ``merge_adjacent=False``. Preserves the
@@ -451,8 +461,8 @@ def rows_to_segments(rows: list[_FusedRow], chunk_seconds: int = DEFAULT_CHUNK_S
     return [_row_to_segment(r, chunk_seconds) for r in rows]
 
 
-def merge_adjacent(
-    rows: list[_FusedRow],
+def merge_adjacent_rows(
+    rows: list[FusedRow],
     chunk_seconds: int = DEFAULT_CHUNK_SECONDS,
     merge_gap_chunks: int = 0,
     aggregation: Aggregation = "mean",
@@ -473,7 +483,7 @@ def merge_adjacent(
     - [25-30] has a 10s gap (2 missing chunks) -> stays alone
     -> 2 segments
     """
-    by_sensor: dict[str, list[_FusedRow]] = defaultdict(list)
+    by_sensor: dict[str, list[FusedRow]] = defaultdict(list)
     for row in rows:
         by_sensor[row.key.sensor_id].append(row)
 
@@ -482,7 +492,7 @@ def merge_adjacent(
 
     for _sensor_id, sensor_rows in by_sensor.items():
         sensor_rows.sort(key=lambda r: r.key.start)
-        group: list[_FusedRow] = []
+        group: list[FusedRow] = []
         prev_end: datetime | None = None
         for row in sensor_rows:
             if prev_end is not None:
@@ -500,11 +510,11 @@ def merge_adjacent(
 
 
 def _finalize_group(
-    group: list[_FusedRow],
+    group: list[FusedRow],
     chunk_seconds: int,
     aggregation: Aggregation,
 ) -> FusedSegment:
-    """Collapse a contiguous run of :class:`_FusedRow` items into one :class:`FusedSegment`.
+    """Collapse a contiguous run of :class:`FusedRow` items into one :class:`FusedSegment`.
 
     Example: aggregation="mean"
     - 3 contiguous rows on cam-1: scores [0.045, 0.040, 0.038], spaces [embed,attr], [embed,caption], [embed]
@@ -563,7 +573,7 @@ def _finalize_group(
 #                  │   2. apply_per_space_filter                              │
 #                  │   3. fuse                 (RRF or weighted_linear)       │
 #                  │   4. apply_global_filters                                │
-#                  │   5. merge_adjacent       (or rows_to_segments)          │
+#                  │   5. merge_adjacent_rows  (or rows_to_segments)          │
 #                  │   6. sort desc by fused_score, top_k cut                 │
 #                  └────────────────────────────┬─────────────────────────────┘
 #                                               │
@@ -591,19 +601,17 @@ def run_fusion(inp: FusionInput) -> FusionOutput:
 
     fused = fuse(bucketed, method=inp.method, rrf_k=inp.rrf_k)
 
+    threshold = score_threshold(inp, inp.min_fused_score_ratio) if inp.min_fused_score_ratio is not None else None
     fused = apply_global_filters(
         fused,
         min_contributing_spaces=inp.min_contributing_spaces,
         keep_if_top_n_in_any_space=inp.keep_if_top_n_in_any_space,
-        min_fused_score_ratio=inp.min_fused_score_ratio,
-        method=inp.method,
-        rrf_k=inp.rrf_k,
-        weights=[rl.weight for rl in bucketed],
+        score_threshold=threshold,
     )
 
     rows = sorted(fused.values(), key=lambda r: r.score, reverse=True)
     if inp.merge_adjacent:
-        segments = merge_adjacent(
+        segments = merge_adjacent_rows(
             rows,
             chunk_seconds=inp.chunk_seconds,
             merge_gap_chunks=inp.merge_gap_chunks,

--- a/services/agent/tests/unit_test/tools/test_fusion.py
+++ b/services/agent/tests/unit_test/tools/test_fusion.py
@@ -21,7 +21,9 @@ the pure fusion pipeline on the worked-example fixture.
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
+from zoneinfo import ZoneInfo
 
+from pydantic import ValidationError
 import pytest
 
 from vss_agents.tools.fusion import ChunkKey
@@ -51,14 +53,9 @@ def _ts(seconds: int) -> datetime:
     return datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC) + timedelta(seconds=seconds)
 
 
-def _chunk(sensor: str, start_seconds: int, score: float, rank: int, *, chunk_seconds: int = 5) -> RankedChunk:
-    start = _ts(start_seconds)
+def _chunk(sensor: str, start_seconds: int, score: float, rank: int) -> RankedChunk:
     return RankedChunk(
-        key=ChunkKey(
-            sensor_id=sensor,
-            start=start,
-            end=start + timedelta(seconds=chunk_seconds),
-        ),
+        key=ChunkKey(sensor_id=sensor, start=_ts(start_seconds)),
         score=score,
         rank=rank,
     )
@@ -146,13 +143,11 @@ class TestBucketize:
             weight=1.0,
             chunks=[
                 _chunk("s", 0, 0.50, 1),
-                # Use timedelta to build a non-snapped start while still
-                # producing a valid 5s-window key.
+                # Build a non-snapped start to verify bucketize snaps it down.
                 RankedChunk(
                     key=ChunkKey(
                         sensor_id="s",
                         start=_ts(0) + timedelta(milliseconds=2400),
-                        end=_ts(0) + timedelta(milliseconds=2400, seconds=5),
                     ),
                     score=0.90,
                     rank=2,
@@ -161,7 +156,6 @@ class TestBucketize:
                     key=ChunkKey(
                         sensor_id="s",
                         start=_ts(0) + timedelta(milliseconds=4900),
-                        end=_ts(0) + timedelta(milliseconds=4900, seconds=5),
                     ),
                     score=0.30,
                     rank=3,
@@ -172,7 +166,6 @@ class TestBucketize:
         assert len(out.chunks) == 1
         survivor = out.chunks[0]
         assert survivor.key.start == _ts(0)
-        assert survivor.key.end == _ts(5)
         assert survivor.score == 0.90  # max wins
         assert survivor.rank == 1
 
@@ -200,7 +193,6 @@ class TestBucketize:
                     key=ChunkKey(
                         sensor_id="s",
                         start=_ts(0) + timedelta(milliseconds=3000),
-                        end=_ts(5) + timedelta(milliseconds=3000),
                     ),
                     score=0.50,
                     rank=3,
@@ -510,9 +502,8 @@ def _row(sensor: str, start_seconds: int, score: float, contributing=("embed",))
     """Construct a private _FusedRow for merge tests without going through fuse()."""
     from vss_agents.tools.fusion import _FusedRow
 
-    start = _ts(start_seconds)
     return _FusedRow(
-        key=ChunkKey(sensor_id=sensor, start=start, end=start + timedelta(seconds=5)),
+        key=ChunkKey(sensor_id=sensor, start=_ts(start_seconds)),
         score=score,
         contributing_spaces=list(contributing),
         per_space_ranks=dict.fromkeys(contributing, 1),
@@ -747,3 +738,66 @@ class TestRunFusion:
         )
         # No cap -> all 5 unique chunks survive default min_contributing_spaces=1.
         assert len(out.segments) == 5
+
+    def test_same_moment_two_timezones_fuse_into_one_segment(self):
+        """End-to-end regression: same wall moment from two spaces in
+        different tz shapes must produce ONE FusedSegment (not two)
+        contributed by both spaces. Pins the silent miss-merge fix.
+        """
+        ts_utc = datetime(2025, 1, 1, 0, 1, 25, tzinfo=UTC)
+        ts_paris = datetime(2025, 1, 1, 1, 1, 25, tzinfo=ZoneInfo("Europe/Paris"))
+
+        embed = RankedList(
+            space="embed",
+            chunks=[
+                RankedChunk(
+                    key=ChunkKey(sensor_id="cam-1", start=ts_utc),
+                    score=0.9,
+                    rank=1,
+                )
+            ],
+        )
+        attribute = RankedList(
+            space="attribute",
+            chunks=[
+                RankedChunk(
+                    key=ChunkKey(sensor_id="cam-1", start=ts_paris),
+                    score=0.8,
+                    rank=1,
+                )
+            ],
+        )
+
+        out = run_fusion(FusionInput(lists=[embed, attribute]))
+
+        assert len(out.segments) == 1
+        assert set(out.segments[0].contributing_spaces) == {"embed", "attribute"}
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class TestChunkKeyTimezoneContract:
+    """Pin the tz-awareness contract on ChunkKey.start"""
+
+    def test_naive_datetime_rejected_at_construction(self):
+        """Loud failure: naive datetime in -> ValidationError out."""
+        naive = datetime(2025, 1, 1, 12, 0, 0)
+        assert naive.tzinfo is None  # sanity: this really is naive
+
+        with pytest.raises(ValidationError):
+            ChunkKey(sensor_id="cam-1", start=naive)
+
+    def test_same_moment_two_timezones_produce_identical_keys(self):
+        """Two ChunkKeys built from the same wall moment in different tz must
+        be ``==`` AND hash-equal (so they collide in fuse()'s dict join)."""
+        ts_utc = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        ts_paris = datetime(2025, 1, 1, 13, 0, 0, tzinfo=ZoneInfo("Europe/Paris"))
+
+        key_utc = ChunkKey(sensor_id="cam-1", start=ts_utc)
+        key_paris = ChunkKey(sensor_id="cam-1", start=ts_paris)
+
+        assert key_utc == key_paris
+        assert hash(key_utc) == hash(key_paris)

--- a/services/agent/tests/unit_test/tools/test_fusion.py
+++ b/services/agent/tests/unit_test/tools/test_fusion.py
@@ -30,13 +30,13 @@ from vss_agents.tools.fusion import ChunkKey
 from vss_agents.tools.fusion import FusionInput
 from vss_agents.tools.fusion import RankedChunk
 from vss_agents.tools.fusion import RankedList
-from vss_agents.tools.fusion import _theoretical_ceiling
 from vss_agents.tools.fusion import apply_global_filters
 from vss_agents.tools.fusion import apply_per_space_filter
 from vss_agents.tools.fusion import bucketize
 from vss_agents.tools.fusion import fuse
-from vss_agents.tools.fusion import merge_adjacent
+from vss_agents.tools.fusion import merge_adjacent_rows
 from vss_agents.tools.fusion import run_fusion
+from vss_agents.tools.fusion import score_threshold
 from vss_agents.tools.fusion import snap
 
 # ---------------------------------------------------------------------------
@@ -400,18 +400,15 @@ class TestGlobalFilters:
         # fixture, post-fusion (no merging). Convenient input for
         # global-filter tests.
         bucketed = [bucketize(_warehouse_embed_list(), 5), bucketize(_warehouse_attribute_list(), 5)]
-        return fuse(bucketed, method="rrf", rrf_k=60), [rl.weight for rl in bucketed]
+        return fuse(bucketed, method="rrf", rrf_k=60)
 
     def test_min_contributing_spaces_2_drops_single_space_hits(self):
-        fused, weights = self._two_space_fused()
+        fused = self._two_space_fused()
         out = apply_global_filters(
             fused,
             min_contributing_spaces=2,
             keep_if_top_n_in_any_space=None,
-            min_fused_score_ratio=None,
-            method="rrf",
-            rrf_k=60,
-            weights=weights,
+            score_threshold=None,
         )
         # Only the two warehouse_01 chunks have contributions from both spaces.
         kept_starts = {row.key.start for row in out.values()}
@@ -421,32 +418,30 @@ class TestGlobalFilters:
         # keep_if_top_n_in_any_space=5 keeps chunks ranked <=5 in at
         # least one space. Combined with min_contributing_spaces=2 (which
         # would otherwise drop them), this exemption rescues them.
-        fused, weights = self._two_space_fused()
+        fused = self._two_space_fused()
         out = apply_global_filters(
             fused,
             min_contributing_spaces=2,
             keep_if_top_n_in_any_space=5,
-            min_fused_score_ratio=None,
-            method="rrf",
-            rrf_k=60,
-            weights=weights,
+            score_threshold=None,
         )
         # All 5 chunks have rank <= 5 in at least one space (max rank is 4).
         assert len(out) == 5
 
-    def test_min_fused_score_ratio_uses_theoretical_ceiling(self):
+    def test_score_threshold_drops_below_floor(self):
         # With k=60, w=[1.0, 0.5], ratio=0.5 -> threshold = 0.5 * 0.02459 = 0.01230.
-        fused, weights = self._two_space_fused()
-        ceiling = _theoretical_ceiling("rrf", 60, weights)
-        threshold = 0.5 * ceiling
+        fused = self._two_space_fused()
+        inp = FusionInput(
+            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+            method="rrf",
+            rrf_k=60,
+        )
+        threshold = score_threshold(inp, fraction=0.5)
         out = apply_global_filters(
             fused,
             min_contributing_spaces=1,
             keep_if_top_n_in_any_space=None,
-            min_fused_score_ratio=0.5,
-            method="rrf",
-            rrf_k=60,
-            weights=weights,
+            score_threshold=threshold,
         )
         # Cliff: warehouse_01 chunks (cross-validated, ~0.024) survive;
         # warehouse_01 @ 00:01:35 (~0.0159), dock @ 00:03:10 (~0.0156),
@@ -460,17 +455,19 @@ class TestGlobalFilters:
             assert fused[key].score < threshold
 
     def test_top_n_exemption_overrides_score_ratio(self):
-        # Strong single-space hits are kept even when min_fused_score_ratio
+        # Strong single-space hits are kept even when score_threshold
         # would drop them - "strong somewhere" override.
-        fused, weights = self._two_space_fused()
+        fused = self._two_space_fused()
+        inp = FusionInput(
+            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+            method="rrf",
+            rrf_k=60,
+        )
         out = apply_global_filters(
             fused,
             min_contributing_spaces=2,
             keep_if_top_n_in_any_space=1,  # rank-1 anywhere -> keep
-            min_fused_score_ratio=0.99,  # would otherwise drop nearly everything
-            method="rrf",
-            rrf_k=60,
-            weights=weights,
+            score_threshold=score_threshold(inp, fraction=0.99),  # would otherwise drop nearly everything
         )
         # Each space's rank-1 chunk must survive; vote-count and ratio
         # filters are bypassed for top-N exempt rows.
@@ -479,30 +476,53 @@ class TestGlobalFilters:
         assert _ts(_W_130) in kept_starts  # rank 1 in attribute
 
 
-class TestTheoreticalCeiling:
+class TestScoreThreshold:
+    """``score_threshold`` is fraction * ceiling; ceiling math is method-specific."""
+
     def test_rrf_ceiling(self):
-        # Σ w_i / (k + 1)
-        assert _theoretical_ceiling("rrf", 60, [1.0, 0.5]) == pytest.approx(1.5 / 61)
+        # ceiling = Σ w_i / (k + 1); fraction=1.0 returns the full ceiling.
+        inp = FusionInput(
+            lists=[
+                RankedList(space="a", weight=1.0),
+                RankedList(space="b", weight=0.5),
+            ],
+            method="rrf",
+            rrf_k=60,
+        )
+        assert score_threshold(inp, fraction=1.0) == pytest.approx(1.5 / 61)
 
     def test_weighted_linear_ceiling(self):
-        # Σ w_i (max-normalized)
-        assert _theoretical_ceiling("weighted_linear", 60, [1.0, 0.5, 0.4]) == pytest.approx(1.9)
+        # ceiling = Σ w_i (max-normalized); fraction=1.0 returns the full ceiling.
+        inp = FusionInput(
+            lists=[
+                RankedList(space="a", weight=1.0),
+                RankedList(space="b", weight=0.5),
+                RankedList(space="c", weight=0.4),
+            ],
+            method="weighted_linear",
+        )
+        assert score_threshold(inp, fraction=1.0) == pytest.approx(1.9)
 
-    def test_unknown_method_raises(self):
-        with pytest.raises(ValueError, match="Unknown fusion method"):
-            _theoretical_ceiling("bogus", 60, [1.0])  # type: ignore[arg-type]
+    def test_fraction_scales_ceiling(self):
+        # fraction=0.5 -> threshold is half the ceiling.
+        inp = FusionInput(
+            lists=[RankedList(space="a", weight=1.0)],
+            method="rrf",
+            rrf_k=60,
+        )
+        assert score_threshold(inp, fraction=0.5) == pytest.approx(0.5 / 61)
 
 
 # ---------------------------------------------------------------------------
-# merge_adjacent()
+# merge_adjacent_rows()
 # ---------------------------------------------------------------------------
 
 
 def _row(sensor: str, start_seconds: int, score: float, contributing=("embed",)):
-    """Construct a private _FusedRow for merge tests without going through fuse()."""
-    from vss_agents.tools.fusion import _FusedRow
+    """Construct a FusedRow for merge tests without going through fuse()."""
+    from vss_agents.tools.fusion import FusedRow
 
-    return _FusedRow(
+    return FusedRow(
         key=ChunkKey(sensor_id=sensor, start=_ts(start_seconds)),
         score=score,
         contributing_spaces=list(contributing),
@@ -520,7 +540,7 @@ class TestMergeAdjacent:
             _row("s", 5, 0.20),
             _row("s", 10, 0.30),
         ]
-        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0, aggregation="mean")
+        segments = merge_adjacent_rows(rows, chunk_seconds=5, merge_gap_chunks=0, aggregation="mean")
         assert len(segments) == 1
         seg = segments[0]
         assert seg.start == _ts(0)
@@ -535,7 +555,7 @@ class TestMergeAdjacent:
             _row("s", 5, 0.20),
             _row("s", 10, 0.30),
         ]
-        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0, aggregation="max")
+        segments = merge_adjacent_rows(rows, chunk_seconds=5, merge_gap_chunks=0, aggregation="max")
         assert len(segments) == 1
         assert segments[0].fused_score == pytest.approx(0.30)
 
@@ -544,7 +564,7 @@ class TestMergeAdjacent:
         # vs single spike 0.024. Under default `mean`, sustained wins.
         sustained = [_row("a", i * 5, 0.025) for i in range(4)]
         spike = [_row("b", 0, 0.024)]
-        segments = merge_adjacent(sustained + spike, chunk_seconds=5, merge_gap_chunks=0, aggregation="mean")
+        segments = merge_adjacent_rows(sustained + spike, chunk_seconds=5, merge_gap_chunks=0, aggregation="mean")
         assert len(segments) == 2
         # Output is sorted desc by fused_score -> sustained first.
         assert segments[0].sensor_id == "a"
@@ -556,7 +576,7 @@ class TestMergeAdjacent:
         # Same fixture under aggregation="max": spike wins.
         sustained = [_row("a", i * 5, 0.020) for i in range(4)]  # max=0.020
         spike = [_row("b", 0, 0.030)]
-        segments = merge_adjacent(sustained + spike, chunk_seconds=5, merge_gap_chunks=0, aggregation="max")
+        segments = merge_adjacent_rows(sustained + spike, chunk_seconds=5, merge_gap_chunks=0, aggregation="max")
         assert len(segments) == 2
         assert segments[0].sensor_id == "b"
         assert segments[0].fused_score == pytest.approx(0.030)
@@ -564,7 +584,7 @@ class TestMergeAdjacent:
     def test_does_not_merge_across_sensors(self):
         # Two sensors with same timestamps must stay as two separate segments.
         rows = [_row("a", 0, 0.5), _row("b", 0, 0.4)]
-        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0)
+        segments = merge_adjacent_rows(rows, chunk_seconds=5, merge_gap_chunks=0)
         assert len(segments) == 2
         assert {s.sensor_id for s in segments} == {"a", "b"}
 
@@ -572,14 +592,14 @@ class TestMergeAdjacent:
         # Two chunks with a 5s gap (one empty chunk between them); with
         # merge_gap_chunks=0 they must stay separate.
         rows = [_row("s", 0, 0.5), _row("s", 10, 0.4)]
-        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0)
+        segments = merge_adjacent_rows(rows, chunk_seconds=5, merge_gap_chunks=0)
         assert len(segments) == 2
 
     def test_gap_within_merge_gap_chunks_merges(self):
         # Same gap as above but merge_gap_chunks=1 -> merge into one segment
         # of length 15s (start of first -> end of second).
         rows = [_row("s", 0, 0.5), _row("s", 10, 0.4)]
-        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=1)
+        segments = merge_adjacent_rows(rows, chunk_seconds=5, merge_gap_chunks=1)
         assert len(segments) == 1
         assert segments[0].start == _ts(0)
         assert segments[0].end == _ts(15)
@@ -591,13 +611,13 @@ class TestMergeAdjacent:
             _row("s", 5, 0.4, contributing=("attribute",)),
             _row("s", 10, 0.3, contributing=("embed", "caption")),
         ]
-        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0)
+        segments = merge_adjacent_rows(rows, chunk_seconds=5, merge_gap_chunks=0)
         assert len(segments) == 1
         assert sorted(segments[0].contributing_spaces) == ["attribute", "caption", "embed"]
 
     def test_member_keys_preserve_order(self):
         rows = [_row("s", 0, 0.1), _row("s", 5, 0.2), _row("s", 10, 0.3)]
-        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0)
+        segments = merge_adjacent_rows(rows, chunk_seconds=5, merge_gap_chunks=0)
         assert [k.start for k in segments[0].member_keys] == [_ts(0), _ts(5), _ts(10)]
 
 

--- a/services/agent/tests/unit_test/tools/test_fusion.py
+++ b/services/agent/tests/unit_test/tools/test_fusion.py
@@ -1,0 +1,749 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the pure fusion script (commit 1).
+
+Test in isolation - pydantic models, pure functions, filter knobs, and
+the pure fusion pipeline on the worked-example fixture.
+"""
+
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+
+import pytest
+
+from vss_agents.tools.fusion import ChunkKey
+from vss_agents.tools.fusion import FusionInput
+from vss_agents.tools.fusion import RankedChunk
+from vss_agents.tools.fusion import RankedList
+from vss_agents.tools.fusion import _theoretical_ceiling
+from vss_agents.tools.fusion import apply_global_filters
+from vss_agents.tools.fusion import apply_per_space_filter
+from vss_agents.tools.fusion import bucketize
+from vss_agents.tools.fusion import fuse
+from vss_agents.tools.fusion import merge_adjacent
+from vss_agents.tools.fusion import run_fusion
+from vss_agents.tools.fusion import snap
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _ts(seconds: int) -> datetime:
+    """Build a UTC datetime offset by ``seconds`` from a fixed epoch.
+
+    All tests use 2025-01-01T00:00:00Z as the anchor so test fixtures stay
+    readable as offsets in seconds.
+    """
+    return datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC) + timedelta(seconds=seconds)
+
+
+def _chunk(sensor: str, start_seconds: int, score: float, rank: int, *, chunk_seconds: int = 5) -> RankedChunk:
+    start = _ts(start_seconds)
+    return RankedChunk(
+        key=ChunkKey(
+            sensor_id=sensor,
+            start=start,
+            end=start + timedelta(seconds=chunk_seconds),
+        ),
+        score=score,
+        rank=rank,
+    )
+
+
+# Worked-example fixture: warehouse/ladder query.
+# Top embed/attribute results converge on warehouse_01 @ 00:01:25 (ranks 1, 2)
+# and 00:01:30 (ranks 2, 1); attribute also has a noisy hit on dock @ 00:05:00.
+_W = "warehouse_01"
+_D = "dock"
+_W_125 = 85  # 00:01:25 -> 85 s offset from 00:00:00
+_W_130 = 90
+_W_135 = 95
+_D_310 = 190  # 00:03:10 -> 190 s
+_D_500 = 300  # 00:05:00 -> 300 s
+
+
+def _warehouse_embed_list() -> RankedList:
+    return RankedList(
+        space="embed",
+        weight=1.0,
+        chunks=[
+            _chunk(_W, _W_125, 0.84, 1),
+            _chunk(_W, _W_130, 0.81, 2),
+            _chunk(_W, _W_135, 0.78, 3),
+            _chunk(_D, _D_310, 0.62, 4),
+        ],
+    )
+
+
+def _warehouse_attribute_list() -> RankedList:
+    return RankedList(
+        space="attribute",
+        weight=0.5,
+        chunks=[
+            _chunk(_W, _W_130, 0.71, 1),
+            _chunk(_W, _W_125, 0.69, 2),
+            _chunk(_D, _D_500, 0.41, 3),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# snap()
+# ---------------------------------------------------------------------------
+
+
+class TestSnap:
+    """Snap an arbitrary timestamp down to the chunk-grid floor."""
+
+    def test_snaps_below_chunk_boundary(self):
+        # 00:01:27.500 with chunk=5 -> 00:01:25
+        ts = _ts(85) + timedelta(seconds=2.5)
+        assert snap(ts, 5) == _ts(85)
+
+    def test_already_snapped_is_noop(self):
+        assert snap(_ts(90), 5) == _ts(90)
+
+    def test_preserves_tzinfo(self):
+        # Naive input -> naive output.
+        ts = datetime(2025, 1, 1, 0, 1, 27, 500_000)
+        snapped = snap(ts, 5)
+        assert snapped.tzinfo is None
+        assert snapped == datetime(2025, 1, 1, 0, 1, 25)
+
+    def test_negative_offsets_floor_correctly(self):
+        # 1969 (pre-epoch) edge: start = -10s, chunk=5 -> -10s (already on grid).
+        ts = datetime(1969, 12, 31, 23, 59, 50, tzinfo=UTC)
+        assert snap(ts, 5) == ts
+
+
+# ---------------------------------------------------------------------------
+# bucketize()
+# ---------------------------------------------------------------------------
+
+
+class TestBucketize:
+    """Snap + dedupe (max-score-wins) + recompute ranks."""
+
+    def test_unsnapped_clips_collapse_to_same_bucket(self):
+        # Clips at 0.0s / 2.4s / 4.9s with chunk_seconds=5 all
+        # collapse to bucket [0, 5); max score wins; ranks recomputed.
+        rl = RankedList(
+            space="embed",
+            weight=1.0,
+            chunks=[
+                _chunk("s", 0, 0.50, 1),
+                # Use timedelta to build a non-snapped start while still
+                # producing a valid 5s-window key.
+                RankedChunk(
+                    key=ChunkKey(
+                        sensor_id="s",
+                        start=_ts(0) + timedelta(milliseconds=2400),
+                        end=_ts(0) + timedelta(milliseconds=2400, seconds=5),
+                    ),
+                    score=0.90,
+                    rank=2,
+                ),
+                RankedChunk(
+                    key=ChunkKey(
+                        sensor_id="s",
+                        start=_ts(0) + timedelta(milliseconds=4900),
+                        end=_ts(0) + timedelta(milliseconds=4900, seconds=5),
+                    ),
+                    score=0.30,
+                    rank=3,
+                ),
+            ],
+        )
+        out = bucketize(rl, 5)
+        assert len(out.chunks) == 1
+        survivor = out.chunks[0]
+        assert survivor.key.start == _ts(0)
+        assert survivor.key.end == _ts(5)
+        assert survivor.score == 0.90  # max wins
+        assert survivor.rank == 1
+
+    def test_idempotent_for_already_snapped_input(self):
+        # Feeding an already-snapped RankedList through bucketize
+        # produces an output structurally equal to the input.
+        rl = _warehouse_embed_list()
+        out = bucketize(rl, 5)
+        assert out.space == rl.space
+        assert out.weight == rl.weight
+        assert [c.key for c in out.chunks] == [c.key for c in rl.chunks]
+        assert [c.score for c in out.chunks] == [c.score for c in rl.chunks]
+        assert [c.rank for c in out.chunks] == [c.rank for c in rl.chunks]
+
+    def test_recomputes_ranks_after_dedupe(self):
+        # Two raw hits collapse into bucket A; one raw hit lands in bucket B.
+        # After dedupe + sort by score desc, ranks must be 1, 2.
+        rl = RankedList(
+            space="embed",
+            weight=1.0,
+            chunks=[
+                _chunk("s", 0, 0.30, 1),  # bucket [0, 5) - loses to 0.5
+                _chunk("s", 5, 0.40, 2),  # bucket [5, 10)
+                RankedChunk(
+                    key=ChunkKey(
+                        sensor_id="s",
+                        start=_ts(0) + timedelta(milliseconds=3000),
+                        end=_ts(5) + timedelta(milliseconds=3000),
+                    ),
+                    score=0.50,
+                    rank=3,
+                ),
+            ],
+        )
+        out = bucketize(rl, 5)
+        assert len(out.chunks) == 2
+        assert out.chunks[0].score == 0.50
+        assert out.chunks[0].rank == 1
+        assert out.chunks[1].score == 0.40
+        assert out.chunks[1].rank == 2
+
+    def test_does_not_merge_across_sensors(self):
+        rl = RankedList(
+            space="embed",
+            weight=1.0,
+            chunks=[
+                _chunk("a", 0, 0.5, 1),
+                _chunk("b", 0, 0.6, 2),
+            ],
+        )
+        out = bucketize(rl, 5)
+        assert len(out.chunks) == 2
+        sensors = {c.key.sensor_id for c in out.chunks}
+        assert sensors == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# fuse()
+# ---------------------------------------------------------------------------
+
+
+class TestFuseRRF:
+    """RRF outer-join: ``fused = Σ_i  w_i / (rrf_k + rank_i)``."""
+
+    def test_warehouse_ladder_two_space_rrf(self):
+        # End-to-end with exact values on the warehouse/ladder fixture
+        fused = fuse(
+            [_warehouse_embed_list(), _warehouse_attribute_list()],
+            method="rrf",
+            rrf_k=60,
+        )
+        rows = sorted(fused.values(), key=lambda r: r.score, reverse=True)
+
+        # warehouse_01 @ 00:01:25 - ranks 1 (embed) and 2 (attribute)
+        top = rows[0]
+        assert top.key.sensor_id == _W
+        assert top.key.start == _ts(_W_125)
+        assert top.score == pytest.approx(1 / 61 + 0.5 / 62, abs=1e-5)
+        assert top.score == pytest.approx(0.02446, abs=1e-4)
+        assert sorted(top.contributing_spaces) == ["attribute", "embed"]
+        assert top.per_space_ranks == {"embed": 1, "attribute": 2}
+
+        # warehouse_01 @ 00:01:30 - ranks 2 (embed) and 1 (attribute)
+        second = rows[1]
+        assert second.key.start == _ts(_W_130)
+        assert second.score == pytest.approx(1 / 62 + 0.5 / 61, abs=1e-5)
+        assert second.score == pytest.approx(0.02433, abs=1e-4)
+
+        # warehouse_01 @ 00:01:35 - embed-only
+        assert rows[2].score == pytest.approx(1 / 63, abs=1e-5)
+        assert rows[2].contributing_spaces == ["embed"]
+
+        # dock @ 00:03:10 - embed-only rank 4
+        assert rows[3].score == pytest.approx(1 / 64, abs=1e-5)
+
+        # dock @ 00:05:00 - attribute-only rank 3
+        assert rows[4].score == pytest.approx(0.5 / 63, abs=1e-5)
+        assert rows[4].contributing_spaces == ["attribute"]
+
+    def test_missing_rank_contributes_zero(self):
+        # A chunk in space A but absent from space B: the B contribution is 0.
+        a_only = RankedList(space="A", weight=1.0, chunks=[_chunk("s", 0, 0.5, 1)])
+        b_only = RankedList(space="B", weight=1.0, chunks=[_chunk("s", 100, 0.5, 1)])
+        fused = fuse([a_only, b_only], method="rrf", rrf_k=60)
+        # Two distinct keys, each scored only by its source space.
+        assert len(fused) == 2
+        for row in fused.values():
+            assert row.score == pytest.approx(1 / 61, abs=1e-5)
+            assert len(row.contributing_spaces) == 1
+
+
+class TestFuseWeightedLinear:
+    """``weighted_linear``: per-space min-max norm + weighted sum."""
+
+    def test_warehouse_ladder_two_space_weighted_linear(self):
+        # End-to-end with exact values on the warehouse/ladder fixture
+        fused = fuse(
+            [_warehouse_embed_list(), _warehouse_attribute_list()],
+            method="weighted_linear",
+        )
+        rows = sorted(fused.values(), key=lambda r: r.score, reverse=True)
+
+        # warehouse_01 @ 00:01:25 - embed top + attribute strong
+        assert rows[0].key.start == _ts(_W_125)
+        assert rows[0].score == pytest.approx(1.0 + 0.5 * (0.69 - 0.41) / 0.30, abs=1e-5)
+        assert rows[0].score == pytest.approx(1.46667, abs=1e-4)
+        assert sorted(rows[0].contributing_spaces) == ["attribute", "embed"]
+
+        # warehouse_01 @ 00:01:30 - both strong, attribute tops here
+        assert rows[1].key.start == _ts(_W_130)
+        assert rows[1].score == pytest.approx((0.81 - 0.62) / 0.22 + 0.5 * 1.0, abs=1e-5)
+        assert rows[1].score == pytest.approx(1.36364, abs=1e-4)
+
+        # warehouse_01 @ 00:01:35 - embed only, mid-list normalization
+        assert rows[2].score == pytest.approx((0.78 - 0.62) / 0.22, abs=1e-5)
+        assert rows[2].contributing_spaces == ["embed"]
+
+        # dock chunks both hit the per-space normalization floor -> score=0.0
+        assert rows[3].score == pytest.approx(0.0, abs=1e-9)
+        assert rows[4].score == pytest.approx(0.0, abs=1e-9)
+
+    def test_normalization_invariance(self):
+        # Multiplying one space's raw scores by 100 must not
+        # change order under weighted_linear.
+        original = RankedList(
+            space="A",
+            weight=1.0,
+            chunks=[
+                _chunk("s", 0, 0.50, 1),
+                _chunk("s", 5, 0.40, 2),
+                _chunk("s", 10, 0.30, 3),
+            ],
+        )
+        scaled = RankedList(
+            space="A",
+            weight=1.0,
+            chunks=[
+                _chunk("s", 0, 50.0, 1),
+                _chunk("s", 5, 40.0, 2),
+                _chunk("s", 10, 30.0, 3),
+            ],
+        )
+        a = fuse([original], method="weighted_linear")
+        b = fuse([scaled], method="weighted_linear")
+        a_order = [r.key.start for r in sorted(a.values(), key=lambda r: r.score, reverse=True)]
+        b_order = [r.key.start for r in sorted(b.values(), key=lambda r: r.score, reverse=True)]
+        assert a_order == b_order
+
+    def test_constant_score_space_normalizes_to_one(self):
+        # All scores equal -> spread=0 -> norm=1.0 for every chunk (no NaN).
+        rl = RankedList(
+            space="A",
+            weight=1.0,
+            chunks=[_chunk("s", 0, 0.5, 1), _chunk("s", 5, 0.5, 2)],
+        )
+        fused = fuse([rl], method="weighted_linear")
+        for row in fused.values():
+            assert row.score == pytest.approx(1.0)
+
+    def test_unknown_method_raises(self):
+        with pytest.raises(ValueError, match="Unknown fusion method"):
+            fuse([], method="bogus", rrf_k=60)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# apply_per_space_filter()
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPerSpaceFilter:
+    """Drop below-threshold chunks AND recompute ranks."""
+
+    def test_filters_in_raw_score_units(self):
+        # per_space_min_score filters before fusion (raw-score units).
+        rl = _warehouse_attribute_list()
+        out = apply_per_space_filter(rl, {"attribute": 0.5})
+        # 0.41 attribute on dock gets dropped; 0.69 / 0.71 survive.
+        kept_scores = [c.score for c in out.chunks]
+        assert 0.41 not in kept_scores
+        assert sorted(kept_scores) == [0.69, 0.71]
+
+    def test_recomputes_ranks_after_drop(self):
+        # Two of three chunks pass; surviving ranks must be 1 and 2.
+        rl = RankedList(
+            space="A",
+            weight=1.0,
+            chunks=[
+                _chunk("s", 0, 0.10, 1),  # drops
+                _chunk("s", 5, 0.90, 2),  # survives, becomes rank 1
+                _chunk("s", 10, 0.50, 3),  # survives, becomes rank 2
+            ],
+        )
+        out = apply_per_space_filter(rl, {"A": 0.3})
+        assert [c.rank for c in out.chunks] == [1, 2]
+        assert [c.score for c in out.chunks] == [0.90, 0.50]
+
+    def test_no_threshold_for_space_passes_through(self):
+        rl = _warehouse_attribute_list()
+        out = apply_per_space_filter(rl, {"unrelated": 0.99})
+        assert len(out.chunks) == len(rl.chunks)
+        assert [c.score for c in out.chunks] == [c.score for c in rl.chunks]
+
+
+# ---------------------------------------------------------------------------
+# apply_global_filters()
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalFilters:
+    """Vote-count gate, top-N exemption, ratio floor."""
+
+    def _two_space_fused(self):
+        # fixture, post-fusion (no merging). Convenient input for
+        # global-filter tests.
+        bucketed = [bucketize(_warehouse_embed_list(), 5), bucketize(_warehouse_attribute_list(), 5)]
+        return fuse(bucketed, method="rrf", rrf_k=60), [rl.weight for rl in bucketed]
+
+    def test_min_contributing_spaces_2_drops_single_space_hits(self):
+        fused, weights = self._two_space_fused()
+        out = apply_global_filters(
+            fused,
+            min_contributing_spaces=2,
+            keep_if_top_n_in_any_space=None,
+            min_fused_score_ratio=None,
+            method="rrf",
+            rrf_k=60,
+            weights=weights,
+        )
+        # Only the two warehouse_01 chunks have contributions from both spaces.
+        kept_starts = {row.key.start for row in out.values()}
+        assert kept_starts == {_ts(_W_125), _ts(_W_130)}
+
+    def test_keep_if_top_n_in_any_space_exempts_single_space_hits(self):
+        # keep_if_top_n_in_any_space=5 keeps chunks ranked <=5 in at
+        # least one space. Combined with min_contributing_spaces=2 (which
+        # would otherwise drop them), this exemption rescues them.
+        fused, weights = self._two_space_fused()
+        out = apply_global_filters(
+            fused,
+            min_contributing_spaces=2,
+            keep_if_top_n_in_any_space=5,
+            min_fused_score_ratio=None,
+            method="rrf",
+            rrf_k=60,
+            weights=weights,
+        )
+        # All 5 chunks have rank <= 5 in at least one space (max rank is 4).
+        assert len(out) == 5
+
+    def test_min_fused_score_ratio_uses_theoretical_ceiling(self):
+        # With k=60, w=[1.0, 0.5], ratio=0.5 -> threshold = 0.5 * 0.02459 = 0.01230.
+        fused, weights = self._two_space_fused()
+        ceiling = _theoretical_ceiling("rrf", 60, weights)
+        threshold = 0.5 * ceiling
+        out = apply_global_filters(
+            fused,
+            min_contributing_spaces=1,
+            keep_if_top_n_in_any_space=None,
+            min_fused_score_ratio=0.5,
+            method="rrf",
+            rrf_k=60,
+            weights=weights,
+        )
+        # Cliff: warehouse_01 chunks (cross-validated, ~0.024) survive;
+        # warehouse_01 @ 00:01:35 (~0.0159), dock @ 00:03:10 (~0.0156),
+        # dock @ 00:05:00 (~0.0079) all fall below the 0.01230 threshold
+        # only if it is between them. Compute and assert:
+        kept = sorted(out.values(), key=lambda r: r.score, reverse=True)
+        for row in kept:
+            assert row.score >= threshold
+        dropped_keys = set(fused.keys()) - {row.key for row in kept}
+        for key in dropped_keys:
+            assert fused[key].score < threshold
+
+    def test_top_n_exemption_overrides_score_ratio(self):
+        # Strong single-space hits are kept even when min_fused_score_ratio
+        # would drop them - "strong somewhere" override.
+        fused, weights = self._two_space_fused()
+        out = apply_global_filters(
+            fused,
+            min_contributing_spaces=2,
+            keep_if_top_n_in_any_space=1,  # rank-1 anywhere -> keep
+            min_fused_score_ratio=0.99,  # would otherwise drop nearly everything
+            method="rrf",
+            rrf_k=60,
+            weights=weights,
+        )
+        # Each space's rank-1 chunk must survive; vote-count and ratio
+        # filters are bypassed for top-N exempt rows.
+        kept_starts = {row.key.start for row in out.values()}
+        assert _ts(_W_125) in kept_starts  # rank 1 in embed
+        assert _ts(_W_130) in kept_starts  # rank 1 in attribute
+
+
+class TestTheoreticalCeiling:
+    def test_rrf_ceiling(self):
+        # Σ w_i / (k + 1)
+        assert _theoretical_ceiling("rrf", 60, [1.0, 0.5]) == pytest.approx(1.5 / 61)
+
+    def test_weighted_linear_ceiling(self):
+        # Σ w_i (max-normalized)
+        assert _theoretical_ceiling("weighted_linear", 60, [1.0, 0.5, 0.4]) == pytest.approx(1.9)
+
+    def test_unknown_method_raises(self):
+        with pytest.raises(ValueError, match="Unknown fusion method"):
+            _theoretical_ceiling("bogus", 60, [1.0])  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# merge_adjacent()
+# ---------------------------------------------------------------------------
+
+
+def _row(sensor: str, start_seconds: int, score: float, contributing=("embed",)):
+    """Construct a private _FusedRow for merge tests without going through fuse()."""
+    from vss_agents.tools.fusion import _FusedRow
+
+    start = _ts(start_seconds)
+    return _FusedRow(
+        key=ChunkKey(sensor_id=sensor, start=start, end=start + timedelta(seconds=5)),
+        score=score,
+        contributing_spaces=list(contributing),
+        per_space_ranks=dict.fromkeys(contributing, 1),
+    )
+
+
+class TestMergeAdjacent:
+    """Coalesce contiguous chunks per sensor; aggregate score."""
+
+    def test_three_contiguous_merge_with_default_mean(self):
+        # 3 contiguous 5s chunks -> one 15s segment with score = mean(member).
+        rows = [
+            _row("s", 0, 0.10),
+            _row("s", 5, 0.20),
+            _row("s", 10, 0.30),
+        ]
+        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0, aggregation="mean")
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.start == _ts(0)
+        assert seg.end == _ts(15)
+        assert seg.member_chunk_count == 3
+        assert seg.fused_score == pytest.approx((0.10 + 0.20 + 0.30) / 3)
+
+    def test_three_contiguous_merge_with_max_aggregation(self):
+        # Same fixture; flipping aggregation to "max" inverts ranking.
+        rows = [
+            _row("s", 0, 0.10),
+            _row("s", 5, 0.20),
+            _row("s", 10, 0.30),
+        ]
+        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0, aggregation="max")
+        assert len(segments) == 1
+        assert segments[0].fused_score == pytest.approx(0.30)
+
+    def test_aggregation_default_mean_promotes_sustained_over_spike(self):
+        # Inverse fixture: 4-chunk sustained at 0.025 each (mean=0.025)
+        # vs single spike 0.024. Under default `mean`, sustained wins.
+        sustained = [_row("a", i * 5, 0.025) for i in range(4)]
+        spike = [_row("b", 0, 0.024)]
+        segments = merge_adjacent(sustained + spike, chunk_seconds=5, merge_gap_chunks=0, aggregation="mean")
+        assert len(segments) == 2
+        # Output is sorted desc by fused_score -> sustained first.
+        assert segments[0].sensor_id == "a"
+        assert segments[0].fused_score == pytest.approx(0.025)
+        assert segments[1].sensor_id == "b"
+        assert segments[1].fused_score == pytest.approx(0.024)
+
+    def test_aggregation_max_promotes_spike_over_sustained(self):
+        # Same fixture under aggregation="max": spike wins.
+        sustained = [_row("a", i * 5, 0.020) for i in range(4)]  # max=0.020
+        spike = [_row("b", 0, 0.030)]
+        segments = merge_adjacent(sustained + spike, chunk_seconds=5, merge_gap_chunks=0, aggregation="max")
+        assert len(segments) == 2
+        assert segments[0].sensor_id == "b"
+        assert segments[0].fused_score == pytest.approx(0.030)
+
+    def test_does_not_merge_across_sensors(self):
+        # Two sensors with same timestamps must stay as two separate segments.
+        rows = [_row("a", 0, 0.5), _row("b", 0, 0.4)]
+        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0)
+        assert len(segments) == 2
+        assert {s.sensor_id for s in segments} == {"a", "b"}
+
+    def test_gap_above_merge_gap_chunks_does_not_merge(self):
+        # Two chunks with a 5s gap (one empty chunk between them); with
+        # merge_gap_chunks=0 they must stay separate.
+        rows = [_row("s", 0, 0.5), _row("s", 10, 0.4)]
+        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0)
+        assert len(segments) == 2
+
+    def test_gap_within_merge_gap_chunks_merges(self):
+        # Same gap as above but merge_gap_chunks=1 -> merge into one segment
+        # of length 15s (start of first -> end of second).
+        rows = [_row("s", 0, 0.5), _row("s", 10, 0.4)]
+        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=1)
+        assert len(segments) == 1
+        assert segments[0].start == _ts(0)
+        assert segments[0].end == _ts(15)
+        assert segments[0].member_chunk_count == 2
+
+    def test_unions_contributing_spaces(self):
+        rows = [
+            _row("s", 0, 0.5, contributing=("embed",)),
+            _row("s", 5, 0.4, contributing=("attribute",)),
+            _row("s", 10, 0.3, contributing=("embed", "caption")),
+        ]
+        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0)
+        assert len(segments) == 1
+        assert sorted(segments[0].contributing_spaces) == ["attribute", "caption", "embed"]
+
+    def test_member_keys_preserve_order(self):
+        rows = [_row("s", 0, 0.1), _row("s", 5, 0.2), _row("s", 10, 0.3)]
+        segments = merge_adjacent(rows, chunk_seconds=5, merge_gap_chunks=0)
+        assert [k.start for k in segments[0].member_keys] == [_ts(0), _ts(5), _ts(10)]
+
+
+# ---------------------------------------------------------------------------
+# run_fusion() - end-to-end pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestRunFusion:
+    """Full pipeline end-to-end"""
+
+    def test_warehouse_ladder_end_to_end_default_mean_aggregation(self):
+        inp = FusionInput(
+            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+            chunk_seconds=5,
+            method="rrf",
+            rrf_k=60,
+            per_space_min_score={"embed": 0.0, "attribute": 0.3},
+            min_contributing_spaces=1,
+            top_k_segments=10,
+            merge_adjacent=True,
+            merge_gap_chunks=0,
+            # default segment_score_aggregation="mean"
+        )
+        out = run_fusion(inp)
+
+        # Warehouse_01 merges to one 15s segment;
+        # dock @ 00:03:10 and dock @ 00:05:00 stay as two separate 5s segments.
+        assert len(out.segments) == 3
+
+        # First segment is the merged warehouse run, score = mean of three
+        # member RRF voting scores.
+        seg = out.segments[0]
+        assert seg.sensor_id == _W
+        assert seg.start == _ts(_W_125)
+        assert seg.end == _ts(_W_135 + 5)  # 00:01:40
+        assert seg.member_chunk_count == 3
+        assert sorted(seg.contributing_spaces) == ["attribute", "embed"]
+        member_scores = [
+            1 / 61 + 0.5 / 62,  # @ 00:01:25 - embed rank 1, attribute rank 2
+            1 / 62 + 0.5 / 61,  # @ 00:01:30 - embed rank 2, attribute rank 1
+            1 / 63,  # @ 00:01:35 - embed rank 3 only
+        ]
+        assert seg.fused_score == pytest.approx(sum(member_scores) / 3, abs=1e-5)
+
+        # Member keys are the original snapped chunk keys, in time order.
+        assert [k.start for k in seg.member_keys] == [
+            _ts(_W_125),
+            _ts(_W_130),
+            _ts(_W_135),
+        ]
+
+        # Other segments are the unmerged dock chunks, sorted by score desc.
+        sensor_ids = [s.sensor_id for s in out.segments[1:]]
+        assert sensor_ids == [_D, _D]
+        # dock @ 00:03:10 (embed-only, score=1/64) > dock @ 00:05:00 (attr-only, score=0.5/63).
+        assert out.segments[1].start == _ts(_D_310)
+        assert out.segments[2].start == _ts(_D_500)
+
+    def test_per_space_min_score_drops_noisy_dock_attribute_hit(self):
+        # Same fixture but with per_space_min_score={"attribute": 0.5}: the
+        # 0.41 dock-attribute hit gets dropped before fusion.
+        inp = FusionInput(
+            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+            chunk_seconds=5,
+            method="rrf",
+            rrf_k=60,
+            per_space_min_score={"attribute": 0.5},
+            top_k_segments=10,
+        )
+        out = run_fusion(inp)
+        # dock @ 00:05:00 was attribute-only at 0.41 -> filtered out.
+        sensor_starts = {(s.sensor_id, s.start) for s in out.segments}
+        assert (_D, _ts(_D_500)) not in sensor_starts
+
+    def test_min_contributing_spaces_2_keeps_only_warehouse(self):
+        inp = FusionInput(
+            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+            min_contributing_spaces=2,
+            top_k_segments=10,
+        )
+        out = run_fusion(inp)
+        # Only warehouse_01 has cross-validation; merges into one segment.
+        # The lone warehouse_01 @ 00:01:35 chunk (embed-only) is dropped, so
+        # the merged segment shrinks to 10s.
+        assert len(out.segments) == 1
+        seg = out.segments[0]
+        assert seg.sensor_id == _W
+        assert seg.member_chunk_count == 2
+        assert seg.start == _ts(_W_125)
+        assert seg.end == _ts(_W_130 + 5)  # 00:01:35
+
+    def test_top_k_segments_caps_response_length(self):
+        # top_k_segments=10 caps response length even if more
+        # segments survive filtering. Inverse: cap at 1 should truncate.
+        inp = FusionInput(
+            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+            top_k_segments=1,
+        )
+        out = run_fusion(inp)
+        assert len(out.segments) == 1
+
+    def test_merge_adjacent_false_yields_one_segment_per_chunk(self):
+        inp = FusionInput(
+            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+            merge_adjacent=False,
+            top_k_segments=10,
+        )
+        out = run_fusion(inp)
+        # 5 unique chunks across the two spaces, no merging.
+        assert len(out.segments) == 5
+        for seg in out.segments:
+            assert seg.member_chunk_count == 1
+            assert seg.end - seg.start == timedelta(seconds=5)
+
+    def test_empty_lists_produce_empty_output(self):
+        out = run_fusion(FusionInput(lists=[]))
+        assert out.segments == []
+
+    def test_descending_sort_by_fused_score(self):
+        out = run_fusion(
+            FusionInput(
+                lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+                merge_adjacent=False,
+                top_k_segments=10,
+            )
+        )
+        scores = [s.fused_score for s in out.segments]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_top_k_segments_none_returns_all_survivors(self):
+        out = run_fusion(
+            FusionInput(
+                lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
+                top_k_segments=None,
+                merge_adjacent=False,
+            )
+        )
+        # No cap -> all 5 unique chunks survive default min_contributing_spaces=1.
+        assert len(out.segments) == 5

--- a/services/agent/tests/unit_test/tools/test_fusion.py
+++ b/services/agent/tests/unit_test/tools/test_fusion.py
@@ -620,6 +620,20 @@ class TestMergeAdjacent:
         segments = merge_adjacent_rows(rows, chunk_seconds=5, merge_gap_chunks=0)
         assert [k.start for k in segments[0].member_keys] == [_ts(0), _ts(5), _ts(10)]
 
+    def test_ties_resolved_deterministically_by_sensor_then_start(self):
+        """Two segments tied on ``fused_score`` must keep the same final order
+        regardless of input row order. Pins the deterministic tie-breaker on
+        the final ``segments.sort`` inside :func:`merge_adjacent_rows`.
+        """
+        forward = [_row("cam-1", 0, 0.5), _row("cam-2", 0, 0.5)]
+        reversed_rows = list(reversed(forward))
+
+        seg_forward = merge_adjacent_rows(forward, chunk_seconds=5, merge_gap_chunks=0)
+        seg_reversed = merge_adjacent_rows(reversed_rows, chunk_seconds=5, merge_gap_chunks=0)
+
+        assert [s.sensor_id for s in seg_forward] == ["cam-1", "cam-2"]
+        assert [s.sensor_id for s in seg_reversed] == ["cam-1", "cam-2"]
+
 
 # ---------------------------------------------------------------------------
 # run_fusion() - end-to-end pipeline
@@ -795,6 +809,47 @@ class TestRunFusion:
         )
         # No cap -> all 5 unique chunks survive default min_contributing_spaces=1.
         assert len(out.segments) == 5
+
+    def test_tied_rrf_score_winner_independent_of_input_list_order(self):
+        """Regression: tied fused_score must resolve via deterministic
+        tie-breaker, not via dict insertion order from the input lists.
+
+        Setup: two equally-weighted spaces with rank 1 ↔ 2 swapped across
+        sensors. Under RRF with k=60, w=1, both chunks score exactly
+        1/61 + 1/62 - i.e. they tie. Without a deterministic tie-breaker,
+        whichever list is first determines the dict insertion order, which
+        then determines the winner of ``top_k_segments=1`` because
+        Python's ``sorted`` is stable.
+
+        Ensure this is deterministic via a tie-breaker.
+        """
+        embed = RankedList(
+            space="embed",
+            weight=1.0,
+            chunks=[
+                _chunk("cam-1", 0, 0.9, 1),
+                _chunk("cam-2", 0, 0.8, 2),
+            ],
+        )
+        attribute = RankedList(
+            space="attribute",
+            weight=1.0,
+            chunks=[
+                _chunk("cam-2", 0, 0.9, 1),
+                _chunk("cam-1", 0, 0.8, 2),
+            ],
+        )
+
+        fwd = run_fusion(FusionInput(lists=[embed, attribute], merge_adjacent=False, top_k_segments=1))
+        rev = run_fusion(FusionInput(lists=[attribute, embed], merge_adjacent=False, top_k_segments=1))
+
+        assert len(fwd.segments) == 1
+        assert len(rev.segments) == 1
+        # cam-1 wins both ways via deterministic tie-break (cam-1 < cam-2 lex).
+        assert fwd.segments[0].sensor_id == "cam-1"
+        assert rev.segments[0].sensor_id == "cam-1"
+        # Sanity: the two chunks really did tie on fused_score.
+        assert fwd.segments[0].fused_score == pytest.approx(1 / 61 + 1 / 62)
 
     def test_same_moment_two_timezones_fuse_into_one_segment(self):
         """End-to-end regression: same wall moment from two spaces in

--- a/services/agent/tests/unit_test/tools/test_fusion.py
+++ b/services/agent/tests/unit_test/tools/test_fusion.py
@@ -21,6 +21,7 @@ the pure fusion pipeline on the worked-example fixture.
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
+import math
 from zoneinfo import ZoneInfo
 
 from pydantic import ValidationError
@@ -33,10 +34,10 @@ from vss_agents.tools.fusion import RankedList
 from vss_agents.tools.fusion import apply_global_filters
 from vss_agents.tools.fusion import apply_per_space_filter
 from vss_agents.tools.fusion import bucketize
+from vss_agents.tools.fusion import compute_score_threshold
 from vss_agents.tools.fusion import fuse
 from vss_agents.tools.fusion import merge_adjacent_rows
 from vss_agents.tools.fusion import run_fusion
-from vss_agents.tools.fusion import score_threshold
 from vss_agents.tools.fusion import snap
 
 # ---------------------------------------------------------------------------
@@ -114,12 +115,19 @@ class TestSnap:
     def test_already_snapped_is_noop(self):
         assert snap(_ts(90), 5) == _ts(90)
 
-    def test_preserves_tzinfo(self):
-        # Naive input -> naive output.
-        ts = datetime(2025, 1, 1, 0, 1, 27, 500_000)
+    def test_preserves_tzinfo_for_aware_input(self):
+        # Non-UTC tz-aware input -> tzinfo preserved on the snapped output.
+        paris = ZoneInfo("Europe/Paris")
+        ts = datetime(2025, 1, 1, 0, 1, 27, 500_000, tzinfo=paris)
         snapped = snap(ts, 5)
-        assert snapped.tzinfo is None
-        assert snapped == datetime(2025, 1, 1, 0, 1, 25)
+        assert snapped.tzinfo is paris
+        assert snapped == datetime(2025, 1, 1, 0, 1, 25, tzinfo=paris)
+
+    def test_naive_datetime_rejected(self):
+        # Tightened contract: naive datetime in -> ValueError out.
+        naive = datetime(2025, 1, 1, 0, 1, 27, 500_000)
+        with pytest.raises(ValueError):
+            snap(naive, 5)
 
     def test_negative_offsets_floor_correctly(self):
         # 1969 (pre-epoch) edge: start = -10s, chunk=5 -> -10s (already on grid).
@@ -345,7 +353,7 @@ class TestFuseWeightedLinear:
             assert row.score == pytest.approx(1.0)
 
     def test_unknown_method_raises(self):
-        with pytest.raises(ValueError, match="Unknown fusion method"):
+        with pytest.raises(ValueError):
             fuse([], method="bogus", rrf_k=60)  # type: ignore[arg-type]
 
 
@@ -431,12 +439,8 @@ class TestGlobalFilters:
     def test_score_threshold_drops_below_floor(self):
         # With k=60, w=[1.0, 0.5], ratio=0.5 -> threshold = 0.5 * 0.02459 = 0.01230.
         fused = self._two_space_fused()
-        inp = FusionInput(
-            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
-            method="rrf",
-            rrf_k=60,
-        )
-        threshold = score_threshold(inp, fraction=0.5)
+        lists = [_warehouse_embed_list(), _warehouse_attribute_list()]
+        threshold = compute_score_threshold("rrf", rrf_k=60, lists=lists, fraction=0.5)
         out = apply_global_filters(
             fused,
             min_contributing_spaces=1,
@@ -458,16 +462,13 @@ class TestGlobalFilters:
         # Strong single-space hits are kept even when score_threshold
         # would drop them - "strong somewhere" override.
         fused = self._two_space_fused()
-        inp = FusionInput(
-            lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
-            method="rrf",
-            rrf_k=60,
-        )
+        lists = [_warehouse_embed_list(), _warehouse_attribute_list()]
         out = apply_global_filters(
             fused,
             min_contributing_spaces=2,
             keep_if_top_n_in_any_space=1,  # rank-1 anywhere -> keep
-            score_threshold=score_threshold(inp, fraction=0.99),  # would otherwise drop nearly everything
+            # would otherwise drop nearly everything
+            score_threshold=compute_score_threshold("rrf", rrf_k=60, lists=lists, fraction=0.99),
         )
         # Each space's rank-1 chunk must survive; vote-count and ratio
         # filters are bypassed for top-N exempt rows.
@@ -476,41 +477,43 @@ class TestGlobalFilters:
         assert _ts(_W_130) in kept_starts  # rank 1 in attribute
 
 
-class TestScoreThreshold:
-    """``score_threshold`` is fraction * ceiling; ceiling math is method-specific."""
+class TestComputeScoreThreshold:
+    """compute_score_threshold returns a fraction of the maximum possible fused score (ceiling)."""
+
+    @staticmethod
+    def _list(space: str, weight: float) -> RankedList:
+        return RankedList(space=space, weight=weight, chunks=[_chunk(_W, _W_125, 0.5, 1)])
 
     def test_rrf_ceiling(self):
         # ceiling = Σ w_i / (k + 1); fraction=1.0 returns the full ceiling.
-        inp = FusionInput(
-            lists=[
-                RankedList(space="a", weight=1.0),
-                RankedList(space="b", weight=0.5),
-            ],
-            method="rrf",
-            rrf_k=60,
-        )
-        assert score_threshold(inp, fraction=1.0) == pytest.approx(1.5 / 61)
+        lists = [self._list("a", 1.0), self._list("b", 0.5)]
+        assert compute_score_threshold("rrf", rrf_k=60, lists=lists, fraction=1.0) == pytest.approx(1.5 / 61)
 
     def test_weighted_linear_ceiling(self):
         # ceiling = Σ w_i (max-normalized); fraction=1.0 returns the full ceiling.
-        inp = FusionInput(
-            lists=[
-                RankedList(space="a", weight=1.0),
-                RankedList(space="b", weight=0.5),
-                RankedList(space="c", weight=0.4),
-            ],
-            method="weighted_linear",
-        )
-        assert score_threshold(inp, fraction=1.0) == pytest.approx(1.9)
+        lists = [self._list("a", 1.0), self._list("b", 0.5), self._list("c", 0.4)]
+        assert compute_score_threshold("weighted_linear", rrf_k=60, lists=lists, fraction=1.0) == pytest.approx(1.9)
 
     def test_fraction_scales_ceiling(self):
         # fraction=0.5 -> threshold is half the ceiling.
-        inp = FusionInput(
-            lists=[RankedList(space="a", weight=1.0)],
-            method="rrf",
-            rrf_k=60,
-        )
-        assert score_threshold(inp, fraction=0.5) == pytest.approx(0.5 / 61)
+        lists = [self._list("a", 1.0)]
+        assert compute_score_threshold("rrf", rrf_k=60, lists=lists, fraction=0.5) == pytest.approx(0.5 / 61)
+
+    def test_empty_lists_excluded_from_ceiling(self):
+        # A list with no chunks contributes 0 to every fused score, so its weight
+        # MUST NOT count toward the ceiling. Otherwise the threshold over-tightens
+        # and drops legitimate survivors.
+        populated = self._list("a", 1.0)
+        empty = RankedList(space="b", weight=1.0, chunks=[])
+        # Buggy ceiling would be (1.0 + 1.0) / 61 = 2/61.
+        # Fixed ceiling skips the empty list -> 1.0 / 61 = 1/61.
+        assert compute_score_threshold("rrf", rrf_k=60, lists=[populated, empty], fraction=1.0) == pytest.approx(1 / 61)
+
+    def test_zero_weight_does_not_inflate_ceiling(self):
+        # A weight=0 list is a "disabled space": adds 0 to every fused score, so
+        # it must add 0 to the ceiling - matching the disabled-space intent end-to-end.
+        lists = [self._list("a", 1.0), self._list("b", 0.0)]
+        assert compute_score_threshold("rrf", rrf_k=60, lists=lists, fraction=1.0) == pytest.approx(1 / 61)
 
 
 # ---------------------------------------------------------------------------
@@ -744,6 +747,48 @@ class TestRunFusion:
         assert out.segments[0].fused_score == pytest.approx(1 / 61)
         assert out.segments[0].contributing_spaces == ["embed"]
 
+    def test_min_fused_score_ratio_zero_is_no_op(self):
+        # ratio=0.0 -> threshold=0; every non-negative fused score passes, matching the None baseline.
+        common = {
+            "lists": [_warehouse_embed_list(), _warehouse_attribute_list()],
+            "top_k_segments": None,
+        }
+        baseline = run_fusion(FusionInput(**common, min_fused_score_ratio=None))
+        zero = run_fusion(FusionInput(**common, min_fused_score_ratio=0.0))
+        assert [s.fused_score for s in zero.segments] == [s.fused_score for s in baseline.segments]
+
+    def test_min_fused_score_ratio_one_keeps_only_ceiling_equivalent(self):
+        # ratio=1.0 -> threshold=ceiling; only chunks scoring at the ceiling survive
+        # (off-by-one guard: filter uses score < threshold, so equality keeps).
+        embed = RankedList(
+            space="embed",
+            weight=1.0,
+            chunks=[
+                _chunk(_W, _W_125, 0.9, 1),  # rank 1 in BOTH spaces -> ties ceiling
+                _chunk(_D, _D_310, 0.5, 2),
+            ],
+        )
+        attribute = RankedList(
+            space="attribute",
+            weight=1.0,
+            chunks=[
+                _chunk(_W, _W_125, 0.9, 1),  # rank 1 in BOTH spaces -> ties ceiling
+                _chunk(_D, _D_500, 0.5, 2),
+            ],
+        )
+        inp = FusionInput(
+            lists=[embed, attribute],
+            method="rrf",
+            rrf_k=60,
+            min_fused_score_ratio=1.0,
+            merge_adjacent=False,
+        )
+        out = run_fusion(inp)
+        assert len(out.segments) == 1
+        assert out.segments[0].sensor_id == _W
+        assert out.segments[0].start == _ts(_W_125)
+        assert out.segments[0].fused_score == pytest.approx(2 / 61)
+
     def test_min_contributing_spaces_2_keeps_only_warehouse(self):
         inp = FusionInput(
             lists=[_warehouse_embed_list(), _warehouse_attribute_list()],
@@ -760,6 +805,18 @@ class TestRunFusion:
         assert seg.member_chunk_count == 2
         assert seg.start == _ts(_W_125)
         assert seg.end == _ts(_W_130 + 5)  # 00:01:35
+
+    def test_min_contributing_spaces_zero_keeps_single_space_hits(self):
+        # 0 disables the vote-count gate; output matches the default min=1 baseline
+        # (every chunk has at least one contributing space).
+        common = {
+            "lists": [_warehouse_embed_list(), _warehouse_attribute_list()],
+            "merge_adjacent": False,
+            "top_k_segments": None,
+        }
+        baseline = run_fusion(FusionInput(**common, min_contributing_spaces=1))
+        zero = run_fusion(FusionInput(**common, min_contributing_spaces=0))
+        assert {s.start for s in zero.segments} == {s.start for s in baseline.segments}
 
     def test_top_k_segments_caps_response_length(self):
         # top_k_segments=10 caps response length even if more
@@ -787,6 +844,21 @@ class TestRunFusion:
     def test_empty_lists_produce_empty_output(self):
         out = run_fusion(FusionInput(lists=[]))
         assert out.segments == []
+
+    def test_single_list_fusion_preserves_input_ranking(self):
+        # Degenerate case: 1 list. Every chunk has 1 contributing space (passes default
+        # min=1), and fused scores reduce to RRF for that single space (sorted by rank).
+        inp = FusionInput(
+            lists=[_warehouse_embed_list()],
+            method="rrf",
+            rrf_k=60,
+            merge_adjacent=False,
+            top_k_segments=None,
+        )
+        out = run_fusion(inp)
+        assert [s.fused_score for s in out.segments] == pytest.approx([1 / 61, 1 / 62, 1 / 63, 1 / 64])
+        for seg in out.segments:
+            assert seg.contributing_spaces == ["embed"]
 
     def test_descending_sort_by_fused_score(self):
         out = run_fusion(
@@ -889,6 +961,64 @@ class TestRunFusion:
 # ---------------------------------------------------------------------------
 # Models
 # ---------------------------------------------------------------------------
+
+
+class TestRankedListContract:
+    """Lock in important contracts for `:class:`RankedList``."""
+
+    def test_negative_weight_rejected(self):
+        with pytest.raises(ValidationError):
+            RankedList(space="embed", weight=-0.1)
+
+    @pytest.mark.parametrize("bad_weight", [math.nan, math.inf, -math.inf])
+    def test_non_finite_weight_rejected(self, bad_weight):
+        """Loud failure: NaN/Inf weight in -> ValidationError out.
+
+        A NaN weight propagates through every fused_score and the
+        theoretical ceiling. An Inf weight steamrolls every score gate.
+        Reject at the model boundary so downstream math stays trusting.
+        """
+        with pytest.raises(ValidationError):
+            RankedList(space="embed", weight=bad_weight)
+
+
+class TestRankedChunkContract:
+    """Lock in important contracts for :class:`RankedChunk`."""
+
+    @pytest.mark.parametrize("bad_score", [math.nan, math.inf, -math.inf])
+    def test_non_finite_score_rejected(self, bad_score):
+        """Loud failure: NaN/Inf score in -> ValidationError out.
+
+        Reject at the model boundary instead so every downstream call site can trust the input.
+        """
+        with pytest.raises(ValidationError):
+            RankedChunk(
+                key=ChunkKey(sensor_id="s", start=_ts(0)),
+                score=bad_score,
+                rank=1,
+            )
+
+
+class TestFusionInputContract:
+    """Lock in important contracts for :class:`FusionInput`."""
+
+    @pytest.mark.parametrize("bad_ratio", [math.nan, math.inf, -math.inf])
+    def test_non_finite_min_fused_score_ratio_rejected(self, bad_ratio):
+        """Loud failure: NaN/Inf ratio in -> ValidationError out."""
+        with pytest.raises(ValidationError):
+            FusionInput(min_fused_score_ratio=bad_ratio)
+
+    def test_top_k_segments_none_accepted(self):
+        """``top_k_segments=None`` means "no cap" and must remain valid."""
+        FusionInput(top_k_segments=None)
+
+    def test_min_contributing_spaces_zero_accepted(self):
+        """``min_contributing_spaces=0`` disables the gate and must remain valid."""
+        FusionInput(min_contributing_spaces=0)
+
+    def test_keep_if_top_n_in_any_space_none_accepted(self):
+        """``keep_if_top_n_in_any_space=None`` disables the exemption and must remain valid."""
+        FusionInput(keep_if_top_n_in_any_space=None)
 
 
 class TestChunkKeyTimezoneContract:

--- a/services/agent/tests/unit_test/tools/test_fusion.py
+++ b/services/agent/tests/unit_test/tools/test_fusion.py
@@ -693,6 +693,43 @@ class TestRunFusion:
         sensor_starts = {(s.sensor_id, s.start) for s in out.segments}
         assert (_D, _ts(_D_500)) not in sensor_starts
 
+    def test_min_fused_score_ratio_ignores_emptied_lists_in_ceiling(self):
+        # Regression: a list emptied by per_space_min_score (or bucketize dedupe)
+        # contributes 0 to every fused score; its weight must NOT count toward
+        # the ceiling, otherwise min_fused_score_ratio over-tightens and drops
+        # legitimate survivors.
+        #
+        # Setup: 2 lists [embed w=1.0, attribute w=1.0] under RRF (k=60).
+        # per_space_min_score wipes the entire attribute list.
+        # The lone embed rank-1 hit fuses to score 1/61 ~= 0.01639.
+        #
+        #   buggy ceiling = (1.0 + 1.0) / 61 = 2/61   -> threshold 0.6 * 2/61 = 1.2/61 -> DROP (1/61 < 1.2/61)
+        #   fixed ceiling = 1.0 / 61         = 1/61   -> threshold 0.6 * 1/61 = 0.6/61 -> KEEP (1/61 > 0.6/61)
+        embed = RankedList(
+            space="embed",
+            weight=1.0,
+            chunks=[_chunk(_W, _W_125, 0.9, 1)],
+        )
+        attribute = RankedList(
+            space="attribute",
+            weight=1.0,
+            chunks=[_chunk(_W, _W_125, 0.5, 1)],
+        )
+        inp = FusionInput(
+            lists=[embed, attribute],
+            chunk_seconds=5,
+            method="rrf",
+            rrf_k=60,
+            per_space_min_score={"attribute": 0.99},
+            min_fused_score_ratio=0.6,
+        )
+        out = run_fusion(inp)
+
+        assert len(out.segments) == 1
+        assert out.segments[0].sensor_id == _W
+        assert out.segments[0].fused_score == pytest.approx(1 / 61)
+        assert out.segments[0].contributing_spaces == ["embed"]
+
     def test_min_contributing_spaces_2_keeps_only_warehouse(self):
         inp = FusionInput(
             lists=[_warehouse_embed_list(), _warehouse_attribute_list()],


### PR DESCRIPTION
## Description
2 spaces → N spaces. Today fusion is hardcoded to embed + attribute. In the new design, we make it extensible. We can add new embedding spaces (caption, face, …) and have fusion work with them seamlessly.

First adding the fusion script/algo separately, isolated and testable. Fusion algo is pulled into its own module (pure math, no side-effects) and only takes ranked lists. Should be easier to test, reuse, and reason about.

<img width="1241" height="649" alt="Screenshot 2026-04-29" src="https://github.com/user-attachments/assets/a8b3bc79-9c6f-42d7-8cbc-00832d83e6cb" />

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
