### PR TITLE
skill-eval: archive prior trials' session JSONLs at trial start

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -589,6 +589,48 @@ Values for `<source>` / `<agent>` / `<model>` / `<task>` come from
 `GET http://localhost:8080/api/jobs/<run_id>__<date>/tasks`; slashes
 in `<model>` and `<task>` must be URL-encoded (`%2F`).
 
+### Per-trial trajectory isolation
+
+`BrevEnvironment.start()` archives any session JSONLs from prior
+trials before this trial's `claude --print` runs:
+
+```bash
+# Equivalent to:
+mv /logs/agent/sessions/projects/* $HOME/.claude-archive/<ts>/
+```
+
+This is required because **harbor's claude-code mapper merges every
+`*.jsonl` it finds in `<logs_dir>/sessions/projects/<project>/` into
+one trajectory.json** — and on a warm-pool box that dir accumulates
+JSONLs from every prior trial. Without the archive, this trial's
+trajectory.json contains a soup of unrelated agent sessions (observed:
+one step-1 trial showed 7549 steps spanning 50 hours of prior runs).
+
+Three things you should know when debugging:
+
+- **Per-trial trajectory.json is clean.** Each trial's harbor
+  copy-back at `/tmp/skill-eval/results/<run>/<date>/<trial>/agent/`
+  contains only that trial's `claude-code.txt` + session JSONL. The
+  trace tab in the harbor viewer scopes correctly. Step counts
+  reflect just that trial.
+- **Box-side history lives at `$HOME/.claude-archive/`.** SSH to the
+  pool member to inspect prior runs (e.g.
+  `ssh vss-eval-l40s "ls .claude-archive/"`); each archive entry is
+  named `<ts>` and contains the project dir(s) from before that
+  trial started.
+- **Each prior trial remains independently visitable** at its own
+  harbor viewer URL (`_viewer/<run>__<date>/<trial>/`) — that
+  per-trial snapshot was captured intact at the time, so visiting
+  any prior trial's trajectory works exactly as it did when the run
+  finished.
+
+We do *not* force a per-trial `cwd` (which would also work in theory
+by giving each trial its own `projects/<key>/` namespace) because
+harbor's claude-code agent invokes `claude --print` without a cwd
+override and patching that would require forking harbor. Archive-on-
+start gives the same end-state from the developer's perspective and
+lives entirely in our `BrevEnvironment` code.
+
 ## Result comment format
 
 One comment per `(PR, eval_spec)` batch, posted only after every

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -245,6 +245,39 @@ class BrevEnvironment(BaseEnvironment):
             timeout=30,
         )
 
+        # Archive any session JSONLs left by prior trials on this warm-pool
+        # box. Without this, harbor's claude-code mapper merges every
+        # `*.jsonl` file under `/logs/agent/sessions/projects/<project>/`
+        # into one trajectory.json — producing thousand-step trajectories
+        # that conflate this trial with every preceding one (observed:
+        # trial 25083019759/.../step-1__XZNnjCX showed 7549 steps spanning
+        # 50h of prior runs).
+        #
+        # We *move* (not delete) the JSONLs into `$HOME/.claude-archive/<ts>/`
+        # so they remain visitable via SSH for forensic debugging. Each
+        # trial's own snapshot is preserved per-trial under
+        # `/tmp/skill-eval/results/<run>/<date>/<trial>/agent/sessions/`
+        # already (harbor's per-trial copy-back), so this archive is just
+        # box-side history.
+        #
+        # Why archive only, not also per-trial cwd: harbor's claude-code
+        # agent (vendor cache) invokes `claude --print` with no cwd
+        # override, so all trials share `cwd=/home/shadeform` and the
+        # project key is `-home-shadeform`. Forcing a per-trial cwd would
+        # require forking harbor — out of scope. Empty-on-start is
+        # sufficient for the harbor mapper's "exactly one session dir"
+        # heuristic to produce a clean per-trial trajectory.
+        archive_cmd = (
+            "ts=$(date +%Y%m%d-%H%M%S); "
+            "PROJ=/logs/agent/sessions/projects; "
+            'if [ -d "$PROJ" ] && [ -n "$(ls -A "$PROJ" 2>/dev/null)" ]; then '
+            '  ARCHIVE=$HOME/.claude-archive/$ts; '
+            '  mkdir -p "$ARCHIVE" && mv "$PROJ"/* "$ARCHIVE/" 2>/dev/null || true; '
+            '  echo "[trajectory-isolation] archived prior project dirs to $ARCHIVE"; '
+            "fi"
+        )
+        await _run_brev_exec(self._instance_name, archive_cmd, timeout=30)
+
         # Forward task-critical env vars from the local shell into the
         # instance's ~/.eval_env (sourced by ~/.profile, which every
         # brev exec then sources).  Harbor's claude-code agent only


### PR DESCRIPTION
## Symptom

Trials on warm-pool boxes report wildly inflated trajectory step counts. Concrete case: [trial 25083019759/.../step-1__XZNnjCX](https://harbor-8yq51k0qt.brevlab.com/jobs/25083019759__2026-04-28__23-43-28/tasks/l40s/claude-code/aws/anthropic%2Fbedrock-claude-sonnet-4-6/nvidia-vss%2Fvideo-understanding-base-l40s-step-1/trials/step-1__XZNnjCX) shows **7549 steps** in its trajectory.json, spanning **2026-04-26T21:39 → 2026-04-28T23:47** (~50 hours of unrelated prior runs). The actual trial ran for 16.5 minutes on 2026-04-28T23:43.

## Root cause

`harbor/agents/installed/claude_code.py:_get_session_dir` merges every `*.jsonl` under `<logs_dir>/sessions/projects/<project>/` into one Trajectory. claude-code persists session state at `$CLAUDE_CONFIG_DIR/projects/-home-shadeform/<session_uuid>.jsonl` per `claude --print` invocation. On the warm `vss-eval-*` pool, that directory persists across trials, so when harbor's per-trial copy-back pulls `/logs/agent/` → `/tmp/skill-eval/results/<run>/<date>/<trial>/agent/`, the runner-side dataset includes JSONLs from every prior trial. The mapper sees them all as one project and concatenates.

The verifier (`generic_judge.py`) reads `claude-code.txt` (per-trial `tee`-streamed stdout, clean), so reward/check verdicts were unaffected. Only the trajectory.json artifact harbor's viewer renders was contaminated.

## Fix

In `BrevEnvironment.start()`, before harbor's claude-code agent setup runs, **move** existing project dirs from `/logs/agent/sessions/projects/` to `$HOME/.claude-archive/<ts>/`:

```bash
ts=$(date +%Y%m%d-%H%M%S)
PROJ=/logs/agent/sessions/projects
if [ -d "$PROJ" ] && [ -n "$(ls -A "$PROJ" 2>/dev/null)" ]; then
  ARCHIVE=$HOME/.claude-archive/$ts
  mkdir -p "$ARCHIVE" && mv "$PROJ"/* "$ARCHIVE/" 2>/dev/null || true
fi
```

Move (not delete) — prior history stays on the box at `$HOME/.claude-archive/<ts>/` for SSH inspection. The archive lives outside `/logs/agent/` so it doesn't pollute this trial's copy-back. Each prior trial's `_viewer/<run>__<date>/<trial>/` snapshot was captured intact at the time, so visiting any prior trial's trajectory still works exactly as before.

## Why not per-trial cwd

Initially considered forcing each trial to run from a unique `cwd` like `/home/shadeform/trials/<trial-name>/`, which would naturally split sessions into per-trial `projects/<key>/` namespaces. **Doesn't work in practice**: harbor's claude-code agent invokes `claude --print` without a `cwd` argument (`harbor/agents/installed/claude_code.py:1126-1136`), and patching that would require forking harbor in vendor cache. Archive-on-start achieves the same end-state from the developer's perspective and lives entirely in our `BrevEnvironment` code — no upstream patch needed.

## Tradeoff

Project key stays `-home-shadeform` for all trials (cosmetic). Each trial's `projects/-home-shadeform/` contains only its own session at copy-back time, so the mapper's "exactly one session dir" heuristic produces a clean trajectory.

## Test plan

- [ ] Trigger a fresh trial on a warm `vss-eval-l40s` (e.g., re-trigger PR #161 or any open eval). Confirm:
  - `/tmp/skill-eval/results/<run>/<date>/<trial>/agent/sessions/projects/-home-shadeform/` contains exactly **one** `*.jsonl` file.
  - `trajectory.json` step count is in the dozens-to-hundreds range (single trial), not thousands.
  - Harbor viewer's trajectory tab for the trial renders only that trial's session events.
- [ ] Verify `$HOME/.claude-archive/` on the box has timestamped subdirs after multiple trial runs.
- [ ] Verify prior trials' viewer URLs still work (e.g. `_viewer/25083019759__2026-04-28__23-43-28/step-1__XZNnjCX/`).

## Files

- `.github/skill-eval/envs/brev_env.py` — archive step in `start()`.
- `.github/skill-eval/AGENTS.md` — new "Per-trial trajectory isolation" subsection under § Harbor viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)