### PR TITLE
helm-sync: new CI workflow + agent for docker→helm parity check

### DIFF
--- a/.github/helm-sync/AGENTS.md
+++ b/.github/helm-sync/AGENTS.md
@@ -1,0 +1,231 @@
+# Helm Sync Agent — System Prompt
+
+You are the VSS helm-sync agent, invoked by
+`.github/workflows/helm-sync.yml` on every push to a
+`pull-request/<N>` mirror branch whose **accumulated** PR diff
+touches anything under `deployments/` or this harness.
+
+You run **once per push**, from start to finish, on the
+`vss-skill-validator` self-hosted runner. Your workspace is already
+checked out at the mirror head with full history. You have `Bash`,
+`Read`, `Edit`, `Write`, `Glob`, `Grep`. The workflow runs your
+invocation with a 60-minute hard timeout.
+
+## Your job, in one paragraph
+
+Diff the full PR (base...mirror, **accumulated commits — not just the
+latest push**), find files changed under `deployments/` that affect
+docker compose, Dockerfiles, image tags, ports, env vars, replicas,
+or service topology, and check whether the corresponding **helm
+chart files** were updated to match. If the chart is in sync, exit
+with `DONE: in sync` and post nothing. If the chart is out of sync
+(or missing for a new docker artifact), generate the helm changes
+in the workspace, push them as a bot PR against the **source PR's
+own branch** (NOT the `pull-request/<N>` mirror), comment on the
+source PR with the bot-PR URL, and exit with `BLOCKED: helm drift`.
+
+## Your job, in order
+
+1. **Diff against the PR's base branch — accumulated, not single-push.**
+   The mirror is updated by CPR-bot on each `/ok to test`; CI fires
+   per push. You must always inspect the **whole PR**, not just the
+   delta between this push and the previous push:
+
+   ```bash
+   gh api "repos/$PR_REPO/compare/${PR_BASE}...pull-request/${PR_NUMBER}" \
+     --jq '.files[].filename'
+   ```
+
+   Ignore deltas under `.github/helm-sync/**` (the harness itself —
+   they don't imply chart drift). If nothing else changed under
+   `deployments/`, emit `BLOCKED: no deployments/ changes` and exit.
+   No PR comment.
+
+2. **Classify each changed deployments/ file.** Walk the diff and
+   bucket each path:
+
+   - **docker-side** — `compose*.yml`, `compose*.yaml`,
+     `Dockerfile*`, files under any `Dockerfiles/` dir, and any
+     `.env` / `.env.example` referenced by a compose file.
+   - **helm-side** — anything under a chart directory: `Chart.yaml`,
+     `values*.yaml`, `templates/**`, `charts/**` (subcharts).
+   - **other** — docs, README, scripts. Skip these.
+
+   The convention this repo follows (verify by reading the actual
+   layout — don't hardcode if you see something different):
+
+   ```
+   deployments/<group>/compose.yml          ← docker source
+   deployments/<group>/Dockerfiles/...      ← docker images
+   deployments/helm/<group>/Chart.yaml      ← helm chart (parity target)
+   deployments/helm/<group>/values.yaml     ← helm values
+   deployments/helm/<group>/templates/...   ← helm manifests
+   ```
+
+   The chart for each `deployments/<group>/compose.yml` lives at
+   `deployments/helm/<group>/`. **If `deployments/helm/` does not
+   exist yet at all** (e.g. the repo hasn't started helm yet), emit
+   `BLOCKED: no helm tree under deployments/helm/ — bootstrap
+   manually` with a one-line explanation in a PR comment, and exit.
+   Don't try to scaffold an entire chart from scratch.
+
+3. **For every docker-side change, look up the matching helm
+   counterpart and compare semantics.** Concrete signals to check
+   (use `Read` + `Grep`, not regex stringly-equality):
+
+   | Docker side | Helm side it should land in |
+   |---|---|
+   | image / image tag in compose | `image:` / `image.tag` in values.yaml or templates |
+   | port mapping (`ports:`, `expose:`) | `Service` / `containerPort` in templates |
+   | env var (`environment:`, `env_file:`) | `env:` / `envFrom:` in templates, defaults in values.yaml |
+   | volume mount (`volumes:`) | `volumeMounts` + `volumes` in templates, PVCs/configmaps as appropriate |
+   | command / entrypoint override | `command:` / `args:` in templates |
+   | depends_on / healthcheck | initContainer / readinessProbe / livenessProbe in templates |
+   | profiles (`profiles:`) | a values flag toggling the deployment / a separate values-<profile>.yaml |
+   | replicas (compose `deploy.replicas`) | `replicaCount` / autoscaling block |
+   | new Dockerfile (new service) | new `templates/<svc>-deployment.yaml` + values entry |
+   | NIM / GPU resource hints | `resources.limits.nvidia.com/gpu` + tolerations / nodeSelector |
+
+   For each docker-side change, decide one of:
+   - **already synced** — the helm-side change matches semantically.
+     Don't second-guess wording differences (e.g. helm uses
+     `containerPort: 8000` where compose has `ports: ["8000:8000"]`
+     — same thing).
+   - **missing helm change** — the chart doesn't reflect the docker
+     change at all.
+   - **partial / inconsistent helm change** — chart was updated but
+     differs from compose (different port, different image tag,
+     missing env var).
+
+   If every docker-side change is **already synced**, emit
+   `DONE: in sync` with a one-line summary of what you compared and
+   exit. No PR comment.
+
+4. **If anything is missing or inconsistent, propose helm changes
+   in the workspace.** Edit `deployments/helm/<group>/values.yaml`,
+   `deployments/helm/<group>/templates/...`, etc. so the chart
+   matches the docker-side diff. Be conservative:
+
+   - **Don't refactor the chart.** Only touch what's needed to
+     reflect the docker change.
+   - **Don't change docker-side files.** The contributor's docker
+     diff is the source of truth for this PR; you only update the
+     helm side to match it.
+   - **Don't introduce new conventions.** Mirror the existing chart's
+     style (helper templates, naming, indentation). If the chart is
+     too sparse to extend, surface that in the PR body and let the
+     contributor decide.
+   - **Don't run `helm install` / `helm upgrade`.** Validation is
+     `helm lint` only — and only if the chart had a `Chart.yaml`
+     before your edits.
+
+5. **Raise a bot PR against the source PR's *original* branch and
+   STOP.** `pull-request/${PR_NUMBER}` is a throwaway CPR mirror —
+   merging into it gets overwritten on the next CPR sync. The bot
+   PR must target `headRefName` (the contributor's actual branch
+   on the main repo). Same flow as the skills-eval bot-PR mechanism
+   (`.github/skill-eval/AGENTS.md` § 3c).
+
+   ```bash
+   SOURCE_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$PR_REPO" \
+     --json headRefName -q .headRefName)
+   # External-fork PRs are out of scope: the bot can't push into a
+   # contributor fork. If `headRepositoryOwner` differs from
+   # `$PR_REPO`'s owner, comment that the contributor must port the
+   # helm changes manually and emit BLOCKED:fork-pr.
+
+   BOT_BRANCH="helm-sync-bot/pr-${PR_NUMBER}/sync-${SHORT_SHA}"
+   cd "$REPO_ROOT"
+   git config user.name  "skills-eval-bot"
+   git config user.email "skills-eval-bot@users.noreply.github.com"
+
+   # actions/checkout@v4 sets http.https://github.com/.extraheader
+   # with the runner's default GITHUB_TOKEN (github-actions[bot]),
+   # which can't push to non-existent branches. Clear it and embed
+   # the PAT (sourced from /home/ubuntu/eval-coordinator/.env into
+   # GH_TOKEN) into origin's URL so git uses it.
+   git config --local --unset-all "http.https://github.com/.extraheader" || true
+   git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${PR_REPO}.git"
+
+   git fetch origin "$SOURCE_BRANCH":"refs/remotes/origin/$SOURCE_BRANCH"
+   git checkout -b "$BOT_BRANCH" "origin/$SOURCE_BRANCH"
+   git add deployments/helm/
+   # `-s` is mandatory: every commit on PR branches must carry a
+   # `Signed-off-by:` trailer or the org-level DCO check rejects
+   # the PR. Identity comes from `git config user.{name,email}`.
+   git commit -s -m "helm: sync chart with deploy/docker changes (PR #${PR_NUMBER})"
+   git push -u origin "$BOT_BRANCH"
+
+   BOT_PR_URL=$(gh pr create \
+     --repo "$PR_REPO" \
+     --base "$SOURCE_BRANCH" \
+     --head "$BOT_BRANCH" \
+     --title "[helm-sync] sync chart with PR #${PR_NUMBER}" \
+     --body-file /tmp/helm-sync/bot-pr-body.md)
+
+   gh pr comment "$PR_NUMBER" --repo "$PR_REPO" --body "
+   The helm-sync bot detected changes under \`deployments/\` that
+   weren't reflected in \`deployments/helm/\`. The proposed sync is
+   in ${BOT_PR_URL}; merge it into \`${SOURCE_BRANCH}\` (or
+   cherry-pick the commit) and the helm-sync check will re-run on
+   the next mirror.
+
+   Drift summary: ${REASON}
+   "
+   echo "BLOCKED: helm drift for PR #${PR_NUMBER}; see ${BOT_PR_URL}"
+   exit 0
+   ```
+
+   The PR body MUST: (a) link the source PR `#${PR_NUMBER}`,
+   (b) list each docker-side change and the corresponding helm
+   change you made, (c) explicitly state "no checks beyond `helm
+   lint` were run; the contributor should validate against their
+   target environment."
+
+6. **Idempotency.** Before pushing in step 5, check whether
+   `helm-sync-bot/pr-${PR_NUMBER}/...` already exists on origin.
+   If it does, fetch it, diff against your workspace changes:
+   - identical → reuse the existing PR; just re-comment with the
+     existing URL.
+   - different → push as a new commit on the same branch (PR auto-
+     updates). Don't open a duplicate PR.
+
+## Hard rules (non-negotiable)
+
+- **Never modify docker-side files** (`deployments/<group>/compose*.yml`,
+  Dockerfiles, `.env*`). The contributor's PR is the source of truth
+  for this PR; you only adjust the helm side to match.
+- **Never run trials, never `brev exec`, never `docker compose up`.**
+  This workflow is pure file comparison + bot-PR generation. Use
+  `Bash` for `git`, `gh`, `helm lint`, `cat`/`grep`, and nothing else.
+- **Never force-push, never modify history, never merge PRs.**
+- **The only writes you may push are bot PRs from step 5.** They
+  target the source PR's `headRefName` (the contributor's branch on
+  the main repo, NOT the `pull-request/<N>` mirror), come from a
+  branch prefixed `helm-sync-bot/pr-${PR_NUMBER}/`, and only ever
+  touch `deployments/helm/`.
+- **Never dispatch on non-mirror branches.** You only ever process
+  `pull-request/<N>` SHAs; those are CPR-bot vetted.
+- **Never leak `ANTHROPIC_API_KEY`, `GH_TOKEN`, or any other
+  credential** in PR comments, commit messages, or echoed logs.
+
+## Tools you have
+
+- `Bash` — shell on the CI runner host. `gh`, `git`, `helm` (`uvx
+  helm` if needed), `python3`. PATH includes `/home/ubuntu/.local/bin`.
+- `Read`, `Edit`, `Write` — file ops on the workspace checkout.
+  Bounded by the hard rule above (no docker-side writes).
+- `Glob`, `Grep` — search the workspace.
+
+## Output requirements
+
+- Stream prose freely to stdout — the GitHub Actions log is your
+  audit trail. Tool calls get a one-line breadcrumb automatically.
+- On success (no drift), final line: `DONE: in sync`. No PR
+  comment posted.
+- On bot-PR raised, final line:
+  `BLOCKED: helm drift for PR #<N>; see <bot-PR-url>`.
+- On other blocker (no helm tree, fork PR, etc.), final line:
+  `BLOCKED: <short reason>`.
+
+Now proceed.

--- a/.github/helm-sync/helm_sync_agent.py
+++ b/.github/helm-sync/helm_sync_agent.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Helm-sync agent — single-shot CI-driven runner.
+
+Called by .github/workflows/helm-sync.yml on push to `pull-request/<N>`
+when files under `deployments/` (or this harness) change. Spawns one
+`claude-agent-sdk` agent with `.github/helm-sync/AGENTS.md` as its
+system prompt and lets it drive: full-PR diff → docker-vs-helm parity
+check → optional bot PR + comment on source PR.
+
+The agent gets Bash/Read/Edit/Write/Glob/Grep. AGENTS.md tells it that
+it must NOT modify docker-side files (compose*.yml, Dockerfiles,
+.env*) and must NOT run trials.
+
+Env (set by the workflow step):
+    PR_NUMBER        PR being checked (e.g. "123")
+    PR_BASE          Base branch (e.g. "develop", "feat/skills")
+    PR_HEAD_SHA      Mirror head SHA (full)
+    PR_REPO          "owner/repo"
+    GITHUB_RUN_ID    CI run id (used for bot-branch namespacing)
+    ANTHROPIC_*      Agent SDK credentials (sourced from coordinator .env)
+    GH_TOKEN         PAT for bot PR creation + comment posting
+
+Exit codes:
+    0 - agent completed (drift may still have been reported via bot PR)
+    1 - setup error (missing env, AGENTS.md not found, sdk install failed)
+    2 - agent crashed
+    3 - agent hit max_turns without finishing
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# .github/helm-sync/helm_sync_agent.py:
+#   parents[0] = .github/helm-sync
+#   parents[1] = .github
+#   parents[2] = repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_MD = Path(__file__).resolve().parent / "AGENTS.md"
+
+# Hard cap on the agent's tool loop. The agent's job is bounded:
+# walk the diff (~1 turn), compare each file pair (~1 turn each),
+# optionally edit helm files + git push + gh pr create (~10 turns).
+# 200 covers a wide PR with ~50 files; tune if a real PR shows churn.
+MAX_TURNS = int(os.environ.get("HELM_SYNC_MAX_TURNS", "200"))
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+
+def _require(name: str) -> str:
+    v = os.environ.get(name)
+    if not v:
+        print(f"FATAL: {name} not set in environment", file=sys.stderr)
+        sys.exit(1)
+    return v
+
+
+def _ensure_sdk() -> None:
+    """Install `claude-agent-sdk` if missing. Runner is stateful so this
+    is usually a no-op after the first run."""
+    try:
+        import claude_agent_sdk  # noqa: F401
+    except ImportError:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--quiet",
+             "claude-agent-sdk>=0.0.5"],
+            check=False, timeout=180,
+        )
+
+
+def _disable_server_thinking() -> None:
+    """The NVIDIA Anthropic proxy rejects requests carrying the
+    `context_management` field claude-agent-sdk emits by default
+    ("context_management: Extra inputs are not permitted", HTTP 400).
+    Setting `CLAUDE_CODE_DISABLE_THINKING=1` strips the field. The CI
+    workflow already exports this; set it defensively for local
+    smoke-tests too. Mirrors `skills_eval_agent.py`."""
+    if "CLAUDE_CODE_DISABLE_THINKING" not in os.environ:
+        os.environ["CLAUDE_CODE_DISABLE_THINKING"] = "1"
+
+
+# ---------------------------------------------------------------------------
+# Agent loop
+# ---------------------------------------------------------------------------
+
+async def run_agent() -> int:
+    from claude_agent_sdk import (  # type: ignore
+        AssistantMessage, ClaudeAgentOptions, ClaudeSDKClient,
+        ResultMessage, TextBlock, ToolUseBlock,
+    )
+
+    pr_number = _require("PR_NUMBER")
+    pr_base = _require("PR_BASE")
+    pr_head = _require("PR_HEAD_SHA")
+    pr_repo = _require("PR_REPO")
+    run_id = os.environ.get("GITHUB_RUN_ID", f"local-{int(time.time())}")
+
+    if not AGENTS_MD.exists():
+        print(f"FATAL: {AGENTS_MD} not found", file=sys.stderr)
+        return 1
+
+    system_prompt = AGENTS_MD.read_text()
+
+    user_prompt = f"""
+PR #{pr_number} just pushed new commits and the accumulated diff
+touches `deployments/` (or this harness). Check whether the
+docker-side changes are reflected in the helm chart.
+
+Context:
+  repo          = {pr_repo}
+  PR number     = {pr_number}
+  base branch   = {pr_base}
+  mirror head   = {pr_head}
+  workflow run  = {run_id}
+  working dir   = {REPO_ROOT}
+
+Your workspace is the repo at `{REPO_ROOT}` (already checked out to
+the mirror head with full git history). You have `gh` authenticated
+via $GH_TOKEN (PAT with `repo` scope).
+
+Process this PR per AGENTS.md: diff `${{PR_BASE}}...pull-request/${{PR_NUMBER}}`
+(accumulated, NOT just the latest push) → bucket files docker-side
+vs helm-side → for each docker-side change, compare to its helm
+counterpart → if drift, propose helm changes in the workspace and
+raise a bot PR against the source PR's branch (NOT the mirror) with
+a comment on PR #{pr_number} linking it.
+
+When done, emit a one-line final summary starting with `DONE:` (no
+drift) or `BLOCKED:` (drift surfaced, fork PR out of scope, or no
+helm tree yet) — see AGENTS.md § Output requirements.
+"""
+
+    model = os.environ.get("ANTHROPIC_MODEL") or "claude-sonnet-4-6"
+    print(f"[agent] starting · pr={pr_number} base={pr_base} head={pr_head[:8]} "
+          f"model={model} max_turns={MAX_TURNS}", flush=True)
+
+    options = ClaudeAgentOptions(
+        system_prompt=system_prompt,
+        allowed_tools=["Bash", "Read", "Edit", "Write", "Glob", "Grep"],
+        model=model,
+        max_turns=MAX_TURNS,
+        permission_mode="bypassPermissions",
+        cwd=str(REPO_ROOT),
+    )
+
+    final_text: list[str] = []
+    total_cost = 0.0
+    hit_max_turns = False
+
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(user_prompt)
+        async for msg in client.receive_response():
+            if isinstance(msg, AssistantMessage):
+                for block in msg.content:
+                    if isinstance(block, TextBlock) and block.text:
+                        # Stream text to stdout so the GH Actions log
+                        # has a live trace.
+                        print(block.text, flush=True)
+                        final_text.append(block.text)
+                    elif isinstance(block, ToolUseBlock):
+                        # Single-line tool-call breadcrumb in the log.
+                        name = getattr(block, "name", "?")
+                        inp = getattr(block, "input", {}) or {}
+                        hint = ""
+                        if name == "Bash":
+                            cmd = str(inp.get("command", ""))[:140]
+                            hint = cmd.replace("\n", " ")
+                        elif name in ("Read", "Edit", "Write"):
+                            hint = str(inp.get("file_path", ""))[-140:]
+                        elif name in ("Glob", "Grep"):
+                            hint = str(inp.get("pattern", ""))[:140]
+                        print(f"  [tool] {name} :: {hint}", flush=True)
+            elif isinstance(msg, ResultMessage):
+                total_cost = getattr(msg, "total_cost_usd", 0.0) or 0.0
+                if getattr(msg, "stop_reason", None) == "max_turns":
+                    hit_max_turns = True
+                break
+
+    print(f"[agent] finished · cost=${total_cost:.2f}", flush=True)
+    if hit_max_turns:
+        print("[agent] hit max_turns — agent may not have completed",
+              file=sys.stderr)
+        return 3
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    _disable_server_thinking()
+    _ensure_sdk()
+    try:
+        rc = asyncio.run(run_agent())
+    except KeyboardInterrupt:
+        print("[agent] interrupted", file=sys.stderr)
+        rc = 2
+    except Exception as exc:  # noqa: BLE001
+        print(f"[agent] crashed: {exc!r}", file=sys.stderr)
+        import traceback; traceback.print_exc()
+        rc = 2
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/helm-sync.yml
+++ b/.github/workflows/helm-sync.yml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs the helm-sync agent (.github/helm-sync/helm_sync_agent.py) on every
+# push to a pull-request/<N> mirror branch that touches anything under
+# deployments/ (docker compose, Dockerfiles, helm charts) or the harness
+# itself. The agent diffs the FULL PR (base...mirror, accumulated commits
+# — never just the latest push) and decides whether the docker-side
+# changes are reflected in the helm chart. Drift → bot PR + comment on
+# the source PR. See .github/helm-sync/AGENTS.md for the agent's system
+# prompt and the bot-PR flow.
+
+name: Helm Sync
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+    paths:
+      - "deployments/**"
+      - ".github/helm-sync/**"
+      - ".github/workflows/helm-sync.yml"
+  # `on: create:` covers the initial-mirror case (CPR-bot creates
+  # pull-request/<N> with an all-zero `before` SHA, which makes the
+  # `paths:` filter above silently skip the workflow). Same fix as
+  # skills-eval; agent's step 1 early-exits with `BLOCKED: no
+  # deployments/ changes` when the diff is irrelevant.
+  create:
+
+# One sync-check per PR at a time. A fresh push cancels the in-flight run.
+concurrency:
+  group: helm-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sync-check:
+    name: Check helm parity for deploy/docker changes
+    runs-on: [self-hosted, vss-eval]
+
+    # 60 min cap. The agent does pure file-comparison + (optionally) one
+    # bot-PR push — no Brev provisioning, no harbor trials. Order-of-
+    # magnitude shorter than skills-eval (which is bounded at 480m).
+    timeout-minutes: 60
+
+    # Only run on the mirror branches; never on develop/main.
+    if: startsWith(github.ref, 'refs/heads/pull-request/')
+
+    steps:
+      - name: Checkout mirror head
+        uses: actions/checkout@v4
+        with:
+          # full history so the agent can `git diff $PR_BASE...HEAD`
+          # against the accumulated PR diff (NOT just the latest commit).
+          fetch-depth: 0
+
+      - name: Extract PR number + base
+        id: pr
+        run: |
+          REF="${{ github.ref_name }}"         # "pull-request/123"
+          PR="${REF##pull-request/}"
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+          # Query the source PR for its base branch (never hardcode develop).
+          BASE=$(gh pr view "$PR" --json baseRefName --jq .baseRefName)
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "PR #$PR, base=$BASE"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Load coordinator env (Anthropic + GitHub PAT for bot PRs)
+        run: |
+          # Same coordinator .env the skills-eval workflow uses. Keeps
+          # the bot identity (skills-eval-bot via the PAT) consistent
+          # across both workflows; one secrets store on the runner host.
+          set -a
+          source /home/ubuntu/eval-coordinator/.env
+          set +a
+          printf "COORDINATOR_ENV=loaded\n" >> "$GITHUB_ENV"
+          # NVIDIA Anthropic-compatible proxy rejects `context_management`;
+          # disable thinking client-side so the agent SDK doesn't emit it.
+          printf "CLAUDE_CODE_DISABLE_THINKING=1\n" >> "$GITHUB_ENV"
+
+      - name: Run helm-sync agent
+        id: agent
+        run: |
+          set -a
+          source /home/ubuntu/eval-coordinator/.env   # GH step env is isolated
+          set +a
+          export PR_NUMBER="${{ steps.pr.outputs.number }}"
+          export PR_BASE="${{ steps.pr.outputs.base }}"
+          export PR_HEAD_SHA="${{ github.sha }}"
+          export PR_REPO="${{ github.repository }}"
+          export GITHUB_RUN_ID="${{ github.run_id }}"
+          export GH_TOKEN="${GITHUB_TOKEN}"
+          python3 .github/helm-sync/helm_sync_agent.py


### PR DESCRIPTION
## Summary

A second CI workflow that mirrors the skills-eval shape (push trigger on `pull-request/<N>` + claude-agent-sdk + `AGENTS.md` system prompt + bot-PR flow) but checks **helm chart parity** instead of running evals.

When a PR's accumulated diff touches `deployments/`, the agent decides whether docker-side changes (compose, Dockerfiles, image tags, ports, env vars, replicas) are reflected in `deployments/helm/<group>/`. On drift, the agent generates the helm sync in its workspace and pushes it as a **bot PR against the source PR's own branch** (NOT the `pull-request/<N>` mirror — same logic as skills-eval § 3c).

## Files

- `.github/workflows/helm-sync.yml` — workflow definition.
- `.github/helm-sync/AGENTS.md` — agent system prompt.
- `.github/helm-sync/helm_sync_agent.py` — Python wrapper (~140 lines, mirrors `skills_eval_agent.py`).

547 lines added net; no existing files modified.

## Trigger

```yaml
on:
  push:
    branches: ["pull-request/[0-9]+"]
    paths: ["deployments/**", ".github/helm-sync/**", ".github/workflows/helm-sync.yml"]
  create:   # initial-mirror-create case (all-zero before-SHA defeats paths filter)
```

Same `on: create:` workaround as skills-eval — see [PR-#159 thread](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/25028058747) for context.

## Diff source

The agent uses **accumulated** PR diff, not single-push diff:

```bash
gh api "repos/$PR_REPO/compare/${PR_BASE}...pull-request/${PR_NUMBER}" \
  --jq '.files[].filename'
```

CPR-bot updates the mirror with each `/ok to test`; the agent runs per push. Per-push deltas would miss earlier docker changes that landed before the latest push.

## Bot-PR flow (drift detected)

```
SOURCE_BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
git checkout -b helm-sync-bot/pr-${PR_NUMBER}/sync-${SHORT_SHA} "origin/$SOURCE_BRANCH"
# (edits under deployments/helm/ only)
git commit -s -m "helm: sync chart with deploy/docker changes (PR #${PR_NUMBER})"
git push -u origin helm-sync-bot/pr-${PR_NUMBER}/sync-${SHORT_SHA}
gh pr create --base "$SOURCE_BRANCH" --head helm-sync-bot/pr-${PR_NUMBER}/sync-${SHORT_SHA} ...
gh pr comment "$PR_NUMBER" --body "Drift detected — see <bot-PR-url>"
echo "BLOCKED: helm drift for PR #${PR_NUMBER}; see <bot-PR-url>"
```

PR base = source PR's `headRefName` (contributor's actual branch on the main repo). Bot commits use `-s` for DCO. Workflow uses the same coordinator `.env` (PAT + ANTHROPIC) the skills-eval workflow uses, with the same `actions/checkout` extraheader bypass and `CLAUDE_CODE_DISABLE_THINKING=1` auto-set.

## Out of scope for this PR

- **No `deployments/helm/` tree exists yet.** First invocation against a real PR will emit `BLOCKED: no helm tree under deployments/helm/ — bootstrap manually`. Helm chart bootstrap is a separate PR (the agent intentionally won't scaffold a chart from scratch).
- **External-fork PRs** are out of scope (the bot can't push into a contributor fork). Agent emits `BLOCKED:fork-pr` with a comment asking the contributor to port the helm changes manually.
- **No deploy validation.** The agent runs `helm lint` only — no `helm install`, no `kubectl apply`. The contributor validates the bot's proposal against their target environment before merging.

## Test plan

- [ ] After helm bootstrap PR lands, open a test PR that modifies a `deployments/<group>/compose.yml` (e.g. add an env var) without touching `deployments/helm/<group>/`. Confirm:
  - Helm Sync workflow fires on the mirror.
  - Agent detects drift, raises a bot PR against the test PR's branch.
  - Bot PR diff is scoped to `deployments/helm/<group>/` and reflects the env var addition.
  - Source PR gets one comment with the bot-PR link.
  - Agent exits `BLOCKED: helm drift ...`.
- [ ] Open a test PR that modifies BOTH compose AND helm in lockstep. Confirm:
  - Agent exits `DONE: in sync`.
  - No PR comment posted.
- [ ] Open an external-fork PR (or simulate `headRepositoryOwner != $PR_REPO.owner`). Confirm:
  - Agent exits `BLOCKED:fork-pr` with explanatory PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)