### PR TITLE
Fix search agent similarity threshold

### DIFF
--- a/services/agent/src/vss_agents/tools/search.py
+++ b/services/agent/src/vss_agents/tools/search.py
@@ -72,7 +72,6 @@ Extract the following parameters from the user query:
 - has_action: REQUIRED boolean. Set to True if the query explicitly mentions an action/event/activity (e.g., running, walking, carrying, pushing, entering, leaving, moving). Set to False if the query only describes visual/physical attributes (what someone/something LOOKS LIKE) without any action. Examples: "person" → false, "person walking" → true, "red car" → false, "person carrying box" → true, "forklift" → false.
 - object_ids: List of integer object IDs if explicitly mentioned in the query (e.g., "find object 5" → [5], "search for objects 10, 20" → [10, 20]). null if no object IDs are mentioned.
 - top_k: Number of results to return (integer, only if explicitly mentioned, e.g., "top 5", "first 10")
-- min_cosine_similarity: Minimum similarity threshold between -1.0 and 1.0 (e.g., "highly similar" = 0.8, "somewhat similar" = 0.5, "exact match" = 0.9, "any match" = -1.0)
 
 Examples:
 {few_shot_examples}
@@ -136,7 +135,6 @@ class DecomposedQuery(BaseModel):
         default=None, description="List of integer object IDs if explicitly mentioned in the query"
     )
     top_k: int | None = Field(default=None, description="Number of results to return")
-    min_cosine_similarity: float | None = Field(default=None, description="Minimum similarity threshold (-1.0 to 1.0)")
 
 
 async def _run_attribute_only_search(
@@ -338,14 +336,6 @@ async def decompose_query(
             except (ValueError, TypeError):
                 logger.debug("Failed to parse top_k value: %s", extracted["top_k"])
 
-        # Parse min_cosine_similarity if present
-        min_cosine_similarity = None
-        if extracted.get("min_cosine_similarity") is not None:
-            try:
-                min_cosine_similarity = float(extracted["min_cosine_similarity"])
-            except (ValueError, TypeError):
-                logger.debug("Failed to parse min_cosine_similarity value: %s", extracted["min_cosine_similarity"])
-
         # Parse has_action if present
         has_action = None
         if extracted.get("has_action") is not None:
@@ -374,7 +364,6 @@ async def decompose_query(
             has_action=has_action,
             object_ids=object_ids,
             top_k=top_k,
-            min_cosine_similarity=min_cosine_similarity,
         )
     except Exception as e:
         logger.warning(f"Failed to decompose query, using original: {e}")
@@ -949,8 +938,6 @@ async def execute_core_search(
                     logger.warning(f"Failed to parse decomposed timestamp_end: {e}")
             if decomposed.top_k is not None:
                 search_input.top_k = decomposed.top_k
-            if decomposed.min_cosine_similarity is not None:
-                search_input.min_cosine_similarity = decomposed.min_cosine_similarity
 
             # Yield decomposition summary
             decomp_summary: dict[str, Any] = {
@@ -1006,7 +993,7 @@ async def execute_core_search(
                     behavior_index=config.behavior_index,
                     es=es,
                     top_k=top_k,
-                    min_similarity=search_input.min_cosine_similarity or 0.0,
+                    min_similarity=0.0,
                     video_sources=search_input.video_sources if search_input.video_sources else None,
                     timestamp_start=search_input.timestamp_start,
                     timestamp_end=search_input.timestamp_end,
@@ -1047,7 +1034,6 @@ async def execute_core_search(
     top_k = search_input.top_k if search_input.top_k is not None else config.default_max_results
     original_top_k = top_k
     top_k = top_k * 2
-    min_similarity = search_input.min_cosine_similarity
 
     # Build query_params for embed_search (used by embed-only and fusion paths)
     query_params: dict[str, str] = {"query": search_input.query}
@@ -1064,7 +1050,8 @@ async def execute_core_search(
     if search_input.timestamp_end:
         query_params["timestamp_end"] = search_input.timestamp_end.isoformat()
 
-    query_params["min_cosine_similarity"] = str(search_input.min_cosine_similarity)
+    if not search_input.agent_mode:
+        query_params["min_cosine_similarity"] = str(search_input.min_cosine_similarity)
 
     # Extract attributes list and check if attribute-only (used by both attribute-only and fusion paths)
     attribute_list = []
@@ -1138,7 +1125,7 @@ async def execute_core_search(
                     search_input=search_input,
                     attribute_search_fn=attribute_search_fn,
                     top_k=original_top_k,
-                    min_similarity=min_similarity,
+                    min_similarity=0.0,
                 )
 
             yield AgentMessageChunk(
@@ -1230,7 +1217,7 @@ async def execute_core_search(
                             search_input=search_input,
                             attribute_search_fn=attribute_search_fn,
                             top_k=top_k,
-                            min_similarity=min_similarity,
+                            min_similarity=0.0,
                         )
 
                     yield AgentMessageChunk(
@@ -1601,7 +1588,7 @@ class SearchInput(BaseModel):
 
     min_cosine_similarity: float = Field(
         default=0.0,
-        description="Minimum cosine similarity to filter the results. Default is 0.",
+        description="Minimum cosine similarity to filter non-agent embed-only search results. Default is 0.",
     )
 
     agent_mode: bool = Field(

--- a/services/agent/tests/unit_test/tools/test_search.py
+++ b/services/agent/tests/unit_test/tools/test_search.py
@@ -381,7 +381,6 @@ class TestDecomposedQuery:
         assert dq.timestamp_end is None
         assert dq.attributes == []
         assert dq.top_k is None
-        assert dq.min_cosine_similarity is None
 
     def test_with_values(self):
         dq = DecomposedQuery(
@@ -392,7 +391,6 @@ class TestDecomposedQuery:
             timestamp_end="2025-01-01T14:00:00Z",
             attributes=["man", "beige shirt"],
             top_k=10,
-            min_cosine_similarity=0.7,
         )
         assert dq.query == "man pushing cart"
         assert dq.video_sources == ["Endeavor heart"]
@@ -401,15 +399,6 @@ class TestDecomposedQuery:
         assert dq.timestamp_end == "2025-01-01T14:00:00Z"
         assert dq.attributes == ["man", "beige shirt"]
         assert dq.top_k == 10
-        assert dq.min_cosine_similarity == 0.7
-
-    def test_with_negative_min_cosine_similarity(self):
-        """Test that negative min_cosine_similarity values are valid (-1.0 to 1.0 range)."""
-        dq = DecomposedQuery(
-            query="any match",
-            min_cosine_similarity=-0.5,
-        )
-        assert dq.min_cosine_similarity == -0.5
 
 
 class TestQueryDecompositionPrompt:
@@ -428,8 +417,7 @@ class TestQueryDecompositionPrompt:
         assert "timestamp_end" in QUERY_DECOMPOSITION_PROMPT
         assert "attributes" in QUERY_DECOMPOSITION_PROMPT
         assert "top_k" in QUERY_DECOMPOSITION_PROMPT
-        assert "min_cosine_similarity" in QUERY_DECOMPOSITION_PROMPT
-        assert "-1.0" in QUERY_DECOMPOSITION_PROMPT  # Verify correct range is documented
+        assert "min_cosine_similarity" not in QUERY_DECOMPOSITION_PROMPT
 
 
 class TestDecomposeQuery:
@@ -643,27 +631,14 @@ Output: {"query": "forklift", "source_type": "stream"}"""
         assert result.top_k == 5
 
     @pytest.mark.asyncio
-    async def test_query_with_min_cosine_similarity(self, mock_llm):
-        """Test extraction of min_cosine_similarity from query."""
-        mock_llm.ainvoke.return_value = MagicMock(content='{"query": "person running", "min_cosine_similarity": 0.8}')
-
-        result = await decompose_query("find highly similar matches of person running", mock_llm)
-
-        assert result.query == "person running"
-        assert result.min_cosine_similarity == 0.8
-
-    @pytest.mark.asyncio
     async def test_query_with_all_filtering_params(self, mock_llm):
-        """Test extraction of both top_k and min_cosine_similarity."""
-        mock_llm.ainvoke.return_value = MagicMock(
-            content='{"query": "blue truck", "top_k": 10, "min_cosine_similarity": 0.7}'
-        )
+        """Test extraction of filtering params."""
+        mock_llm.ainvoke.return_value = MagicMock(content='{"query": "blue truck", "top_k": 10}')
 
         result = await decompose_query("find top 10 highly similar blue trucks", mock_llm)
 
         assert result.query == "blue truck"
         assert result.top_k == 10
-        assert result.min_cosine_similarity == 0.7
 
     @pytest.mark.asyncio
     async def test_invalid_top_k_ignored(self, mock_llm):
@@ -674,26 +649,6 @@ Output: {"query": "forklift", "source_type": "stream"}"""
 
         assert result.query == "car"
         assert result.top_k is None
-
-    @pytest.mark.asyncio
-    async def test_invalid_min_cosine_similarity_ignored(self, mock_llm):
-        """Test that invalid min_cosine_similarity values are ignored."""
-        mock_llm.ainvoke.return_value = MagicMock(content='{"query": "car", "min_cosine_similarity": "high"}')
-
-        result = await decompose_query("find similar cars", mock_llm)
-
-        assert result.query == "car"
-        assert result.min_cosine_similarity is None
-
-    @pytest.mark.asyncio
-    async def test_negative_min_cosine_similarity(self, mock_llm):
-        """Test extraction of negative min_cosine_similarity (valid range is -1.0 to 1.0)."""
-        mock_llm.ainvoke.return_value = MagicMock(content='{"query": "any object", "min_cosine_similarity": -0.5}')
-
-        result = await decompose_query("find any matching objects", mock_llm)
-
-        assert result.query == "any object"
-        assert result.min_cosine_similarity == -0.5
 
 
 class TestQueryInputSourceType:

--- a/services/agent/tests/unit_test/tools/test_search_inner.py
+++ b/services/agent/tests/unit_test/tools/test_search_inner.py
@@ -99,6 +99,48 @@ class TestSearchInner:
         assert result.data[0].similarity == 0.95
 
     @pytest.mark.asyncio
+    async def test_non_agent_embed_search_passes_min_cosine_similarity(self, config, mock_builder):
+        embed_output = _make_embed_output_with_results(
+            [
+                {
+                    "video_name": "camera1.mp4",
+                    "similarity_score": 0.95,
+                    "start_time": "2025-01-15T10:00:00Z",
+                    "end_time": "2025-01-15T10:30:00Z",
+                }
+            ]
+        )
+        inner_fn = await self._get_inner_fn(config, mock_builder, embed_output)
+
+        inp = SearchInput(query="find cars", source_type="video_file", agent_mode=False, min_cosine_similarity=0.7)
+        result = await inner_fn(inp)
+
+        assert isinstance(result, SearchOutput)
+        embed_input = json.loads(mock_builder.get_function.return_value.ainvoke.call_args.args[0])
+        assert embed_input["params"]["min_cosine_similarity"] == "0.7"
+
+    @pytest.mark.asyncio
+    async def test_agent_mode_request_min_cosine_similarity_not_forwarded(self, config, mock_builder):
+        embed_output = _make_embed_output_with_results(
+            [
+                {
+                    "video_name": "camera1.mp4",
+                    "similarity_score": 0.95,
+                    "start_time": "2025-01-15T10:00:00Z",
+                    "end_time": "2025-01-15T10:30:00Z",
+                }
+            ]
+        )
+        inner_fn = await self._get_inner_fn(config, mock_builder, embed_output)
+
+        inp = SearchInput(query="find cars", source_type="video_file", agent_mode=True, min_cosine_similarity=0.7)
+        result = await inner_fn(inp)
+
+        assert isinstance(result, SearchOutput)
+        embed_input = json.loads(mock_builder.get_function.return_value.ainvoke.call_args.args[0])
+        assert "min_cosine_similarity" not in embed_input["params"]
+
+    @pytest.mark.asyncio
     async def test_search_with_video_sources(self, config, mock_builder):
         embed_output = _make_embed_output_with_results(
             [
@@ -370,6 +412,8 @@ class TestSearchInner:
         inp = SearchInput(query="test", source_type="video_file", agent_mode=True)
         result = await inner_fn(inp)
         assert isinstance(result, SearchOutput)
+        embed_input = json.loads(mock_embed.ainvoke.call_args.args[0])
+        assert "min_cosine_similarity" not in embed_input["params"]
 
     @pytest.mark.asyncio
     async def test_search_agent_mode_invalid_json(self, config, mock_builder):
@@ -532,8 +576,8 @@ class TestSearchInner:
         assert len(result.data) == 1
 
     @pytest.mark.asyncio
-    async def test_search_agent_mode_with_min_cosine_similarity(self, config, mock_builder):
-        """Test agent mode extracting min_cosine_similarity."""
+    async def test_search_agent_mode_ignores_deprecated_min_cosine_similarity(self, config, mock_builder):
+        """Test agent mode ignores deprecated min_cosine_similarity."""
         embed_output = _make_embed_output_with_results(
             [
                 {
@@ -595,7 +639,6 @@ class TestSearchInner:
                 "query": "test",
                 "timestamp_start": "invalid-date",
                 "timestamp_end": "also-invalid",
-                "min_cosine_similarity": "not-a-number",
             }
         )
         mock_llm.ainvoke.return_value = mock_llm_response


### PR DESCRIPTION
## Description
Removes similarity-threshold handling from agent-mode search while preserving min_cosine_similarity for non-agent embed-only /search requests. Query decomposition no longer extracts or applies cosine thresholds, and tests cover both agent and non-agent search behavior.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
