### PR TITLE
refactor(api): drop "streaming" from videos-for-search ingest naming

### DIFF
--- a/services/agent/src/vss_agents/api/custom_fastapi_worker.py
+++ b/services/agent/src/vss_agents/api/custom_fastapi_worker.py
@@ -27,7 +27,7 @@ from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontE
 
 from vss_agents.api.rtsp_stream_api import register_rtsp_stream_api_routes
 from vss_agents.api.video_delete import register_video_delete_routes
-from vss_agents.api.video_search_ingest import register_streaming_routes
+from vss_agents.api.video_search_ingest import register_video_search_ingest_routes
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ class CustomFastApiFrontEndWorker(FastApiFrontEndPluginWorker):
         )
 
         if enable_videos_for_search:
-            register_streaming_routes(app, self.config)
+            register_video_search_ingest_routes(app, self.config)
 
         if enable_rtsp_streams:
             register_rtsp_stream_api_routes(app, self.config)

--- a/services/agent/src/vss_agents/api/video_search_ingest.py
+++ b/services/agent/src/vss_agents/api/video_search_ingest.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 """
-Custom streaming video ingest endpoint for VSS Search.
-This bypasses NAT's standard endpoint pattern to support file streaming.
+Custom video ingest endpoint for VSS Search.
+This bypasses NAT's standard endpoint pattern to support direct file upload to VST.
 """
 
 import json
@@ -280,7 +280,7 @@ async def _run_post_upload_processing(
     )
 
 
-def create_streaming_video_ingest_router(
+def create_video_search_ingest_router(
     vst_internal_url: str,
     rtvi_embed_base_url: str,
     rtvi_cv_base_url: str = "",
@@ -288,7 +288,7 @@ def create_streaming_video_ingest_router(
     rtvi_embed_chunk_duration: int = 5,
 ) -> APIRouter:
     """
-    Create a FastAPI router for streaming video ingest.
+    Create a FastAPI router for video search ingest.
 
     This router handles raw binary data uploads and streams them directly
     to VST without buffering the entire file in memory/disk.
@@ -301,18 +301,18 @@ def create_streaming_video_ingest_router(
         rtvi_embed_chunk_duration: Chunk duration in seconds for embedding generation (default: 5)
 
     Returns:
-        APIRouter with the streaming video ingest route
+        APIRouter with the video search ingest route
     """
     router = APIRouter()
 
     @router.put(
         "/api/v1/videos-for-search/{filename}",
         response_model=VideoIngestResponse,
-        summary="Upload video with streaming (no buffering) to VST",
-        description="Streams video file directly from client to VST without ANY intermediate storage",
+        summary="Upload video to VST",
+        description="Upload video file directly from client to VST without ANY intermediate storage",
         tags=["Video Ingest"],
     )
-    async def stream_video_to_vst(
+    async def upload_video_to_vst(
         filename: str,
         request: Request,
     ) -> VideoIngestResponse:
@@ -448,7 +448,7 @@ def create_streaming_video_ingest_router(
         description=(
             "Called after a chunked upload directly to VST is finished. "
             "Triggers timeline lookup, RTVI-CV registration, and embedding generation. "
-            "This bypasses the streaming PUT endpoint to avoid Cloudflare's 100s timeout "
+            "This bypasses the PUT upload endpoint to avoid Cloudflare's 100s timeout "
             "for large files (the UI uploads chunks directly to VST, then calls this)."
         ),
         tags=["Video Ingest"],
@@ -466,7 +466,7 @@ def create_streaming_video_ingest_router(
         """
         vst_url = vst_internal_url.rstrip("/")
         # Strip the file extension so RTVI-CV's camera_name matches the value
-        # the streaming PUT path produces for the same filename (line ~322).
+        # the PUT upload path produces for the same filename (line ~322).
         camera_name = filename.rsplit(".", 1)[0] if "." in filename else filename
 
         try:
@@ -490,9 +490,9 @@ def create_streaming_video_ingest_router(
 
 
 # This function will be called by custom FastAPI worker to register the router
-def register_streaming_routes(app: "FastAPI", config: "Any") -> None:
+def register_video_search_ingest_routes(app: "FastAPI", config: "Any") -> None:
     """
-    Register streaming video ingest (videos-for-search) routes to the FastAPI app.
+    Register videos-for-search routes to the FastAPI app.
 
     Reads configuration from ``general.front_end.streaming_ingest`` in the YAML.
     The caller (``CustomFastApiFrontEndWorker``) gates this on the
@@ -528,7 +528,7 @@ def register_streaming_routes(app: "FastAPI", config: "Any") -> None:
                 "(this endpoint is search-only and requires the embedding service)"
             )
 
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url=vst_internal_url,
             rtvi_embed_base_url=rtvi_embed_base_url,
             rtvi_cv_base_url=rtvi_cv_base_url,

--- a/services/agent/tests/unit_test/api/test_custom_fastapi_worker.py
+++ b/services/agent/tests/unit_test/api/test_custom_fastapi_worker.py
@@ -70,7 +70,7 @@ def patched_register_fns():
     """Patch the three register fns the dispatcher delegates to so we can
     inspect which ones were called for a given capability set."""
     with (
-        patch("vss_agents.api.custom_fastapi_worker.register_streaming_routes") as videos_for_search,
+        patch("vss_agents.api.custom_fastapi_worker.register_video_search_ingest_routes") as videos_for_search,
         patch("vss_agents.api.custom_fastapi_worker.register_rtsp_stream_api_routes") as rtsp_streams,
         patch("vss_agents.api.custom_fastapi_worker.register_video_delete_routes") as video_delete,
     ):

--- a/services/agent/tests/unit_test/api/test_video_search_ingest.py
+++ b/services/agent/tests/unit_test/api/test_video_search_ingest.py
@@ -28,8 +28,8 @@ from vss_agents.api.video_search_ingest import VideoIngestResponse
 from vss_agents.api.video_search_ingest import VideoUploadCompleteInput
 from vss_agents.api.video_search_ingest import _parse_optional_http_url
 from vss_agents.api.video_search_ingest import _run_post_upload_processing
-from vss_agents.api.video_search_ingest import create_streaming_video_ingest_router
-from vss_agents.api.video_search_ingest import register_streaming_routes
+from vss_agents.api.video_search_ingest import create_video_search_ingest_router
+from vss_agents.api.video_search_ingest import register_video_search_ingest_routes
 
 
 class TestAllowedVideoTypes:
@@ -72,17 +72,17 @@ class TestVideoIngestResponse:
         assert data["chunks_processed"] == 5
 
 
-class TestCreateStreamingVideoIngestRouter:
-    """Test create_streaming_video_ingest_router function."""
+class TestCreateVideoSearchIngestRouter:
+    """Test create_video_search_ingest_router function."""
 
     def test_create_router(self):
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
         assert router is not None
 
     def test_create_router_custom_params(self):
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080",
             rtvi_embed_base_url="http://rtvi:8080",
             rtvi_embed_model="custom-model",
@@ -91,20 +91,20 @@ class TestCreateStreamingVideoIngestRouter:
         assert router is not None
 
     def test_router_has_routes(self):
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
         # Router should have routes registered
         assert len(router.routes) > 0
 
 
-class TestStreamVideoToVstEndpoint:
-    """Test stream_video_to_vst endpoint logic."""
+class TestUploadVideoToVstEndpoint:
+    """Test upload_video_to_vst endpoint logic."""
 
     @pytest.mark.asyncio
     async def test_successful_upload(self):
         """Test successful video upload flow."""
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
 
@@ -155,7 +155,7 @@ class TestStreamVideoToVstEndpoint:
     @pytest.mark.asyncio
     async def test_missing_content_type(self):
         """Test error when Content-Type header is missing."""
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
 
@@ -173,7 +173,7 @@ class TestStreamVideoToVstEndpoint:
     @pytest.mark.asyncio
     async def test_invalid_content_type(self):
         """Test error when Content-Type is not allowed."""
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
 
@@ -194,7 +194,7 @@ class TestStreamVideoToVstEndpoint:
     @pytest.mark.asyncio
     async def test_missing_content_length(self):
         """Test error when Content-Length header is missing."""
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
 
@@ -212,7 +212,7 @@ class TestStreamVideoToVstEndpoint:
     @pytest.mark.asyncio
     async def test_zero_content_length(self):
         """Test error when Content-Length is zero."""
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
 
@@ -230,7 +230,7 @@ class TestStreamVideoToVstEndpoint:
     @pytest.mark.asyncio
     async def test_invalid_content_length_format(self):
         """Test error when Content-Length is not a valid integer."""
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
 
@@ -248,7 +248,7 @@ class TestStreamVideoToVstEndpoint:
     @pytest.mark.asyncio
     async def test_vst_upload_failure(self):
         """Test error when VST upload fails."""
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
 
@@ -280,7 +280,7 @@ class TestStreamVideoToVstEndpoint:
     @pytest.mark.asyncio
     async def test_filename_without_extension(self):
         """Test handling filename without extension."""
-        router = create_streaming_video_ingest_router(
+        router = create_video_search_ingest_router(
             vst_internal_url="http://vst:8080", rtvi_embed_base_url="http://rtvi:8080"
         )
 
@@ -318,8 +318,8 @@ class TestStreamVideoToVstEndpoint:
             assert response.video_id == "sensor-123"
 
 
-class TestRegisterStreamingRoutes:
-    """Test register_streaming_routes function (videos-for-search routes)."""
+class TestRegisterVideoSearchIngestRoutes:
+    """Test register_video_search_ingest_routes function (videos-for-search routes)."""
 
     def test_register_with_config(self):
         """Test registering routes using config object."""
@@ -335,7 +335,7 @@ class TestRegisterStreamingRoutes:
 
         mock_config.general.front_end.streaming_ingest = mock_streaming_config
 
-        register_streaming_routes(mock_app, mock_config)
+        register_video_search_ingest_routes(mock_app, mock_config)
 
         assert mock_app.include_router.called
 
@@ -346,7 +346,7 @@ class TestRegisterStreamingRoutes:
         mock_config.general.front_end = MagicMock(spec=[])
 
         with pytest.raises(ValueError, match="streaming_ingest"):
-            register_streaming_routes(mock_app, mock_config)
+            register_video_search_ingest_routes(mock_app, mock_config)
 
     def test_register_missing_vst_url_raises(self):
         """streaming_ingest present but vst_internal_url empty must raise."""
@@ -363,7 +363,7 @@ class TestRegisterStreamingRoutes:
         mock_config.general.front_end.streaming_ingest = mock_streaming_config
 
         with pytest.raises(ValueError, match="vst_internal_url"):
-            register_streaming_routes(mock_app, mock_config)
+            register_video_search_ingest_routes(mock_app, mock_config)
 
     def test_register_missing_rtvi_embed_url_raises(self):
         """videos-for-search is search-only — rtvi_embed_base_url is required."""
@@ -380,7 +380,7 @@ class TestRegisterStreamingRoutes:
         mock_config.general.front_end.streaming_ingest = mock_streaming_config
 
         with pytest.raises(ValueError, match="rtvi_embed_base_url"):
-            register_streaming_routes(mock_app, mock_config)
+            register_video_search_ingest_routes(mock_app, mock_config)
 
 
 class TestParseOptionalHttpUrl:


### PR DESCRIPTION
## Summary

Users were confusing the videos-for-search PUT endpoint's HTTP body streaming with RTSP video streams. This PR drops the word *streaming* from the user-facing surface (route names, OpenAPI summary/description, public function names, docstrings).

## Renames

| Before | After |
| --- | --- |
| `create_streaming_video_ingest_router` | `create_video_search_ingest_router` |
| `stream_video_to_vst` | `upload_video_to_vst` |
| `register_streaming_routes` | `register_video_search_ingest_routes` |

OpenAPI summary/description on `PUT /api/v1/videos-for-search/{filename}` and the description on the `/complete` endpoint were updated to match. Tests and the worker import/call site follow.

## Intentionally untouched

- The `streaming_ingest` config key — covers RTSP + video_delete + videos-for-search, not just this endpoint.
- `CustomFastApiFrontEndWorker._register_streaming_routes` — same: a private dispatcher that fans out to all three.
- Internal log strings / `TimeMeasure` labels — describe accurate HTTP behavior, not user-facing.

## Test plan

- [ ] `pytest services/agent/tests/unit_test/api/test_video_search_ingest.py`
- [ ] `pytest services/agent/tests/unit_test/api/test_custom_fastapi_worker.py`
- [ ] Smoke-deploy a search profile and hit `PUT /api/v1/videos-for-search/{filename}` + `/complete`
- [ ] Confirm OpenAPI docs render the new summary/description