### PR TITLE
helm-sync: switch runner from ubuntu-latest to self-hosted [helm-sync]

### DIFF
--- a/.github/workflows/helm-sync.yml
+++ b/.github/workflows/helm-sync.yml
@@ -45,10 +45,19 @@ defaults:
 jobs:
   sync-check:
     name: Check helm parity for deploy/docker changes
-    # GitHub-hosted runner — repo is public, so usage is unmetered. The
-    # agent is pure file comparison + (optionally) one bot-PR push;
-    # no GPU, no Brev provisioning, no harbor trials.
-    runs-on: ubuntu-latest
+    # Self-hosted runner labelled `helm-sync`, registered on the
+    # vss-skill-validator coordinator host as a SECOND runner process
+    # alongside the existing `vss-eval` runner. We tried ubuntu-latest
+    # first but `inference-api.nvidia.com` is IP-allowlisted to NVIDIA
+    # infra and refused TCP from Azure runners (run 25220887217
+    # attempt 2: `API Error: Unable to connect to API
+    # (ConnectionRefused)`). The vss-skill-validator host IS allowlisted
+    # since it's where the coordinator already runs, and adding a
+    # second runner there is $0 incremental cost. The two runner
+    # processes share the box but pick up jobs by label, so a long
+    # skills-eval batch on `vss-eval` doesn't block helm-sync (and
+    # vice versa).
+    runs-on: [self-hosted, helm-sync]
 
     # 60 min cap. The agent does pure file comparison + at most one
     # bot-PR push. Order-of-magnitude shorter than skills-eval (480m).


### PR DESCRIPTION
## Why

`ubuntu-latest` GitHub-hosted runners can't reach the NVIDIA inference proxy. Confirmed empirically by [run 25220887217 attempt 2](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/25220887217) on PR #206:

```
[agent] starting · pr=206 base=develop head=35c40b35 model=*** max_turns=200
API Error: Unable to connect to API (ConnectionRefused)
[agent] finished · cost=$0.00
```

Auth side worked (`ANTHROPIC_API_KEY` was populated as a repo secret), but the Azure runner's egress couldn't TCP-handshake `inference-api.nvidia.com` (resolves to `54.212.x` / `44.253.x` AWS IPs on the `aws.csp.nvidia.com` infra). The `vss-skill-validator` coordinator host (also Brev) reaches the same endpoint fine — `HTTP 405` from a HEAD probe — so the allowlist is the actual gate.

## What

Switch the workflow's `runs-on` from `ubuntu-latest` to `[self-hosted, helm-sync]`. A second GitHub Actions runner process is now registered on the existing `vss-skill-validator` Brev box with label `helm-sync`, alongside the existing `vss-eval` runner that handles skills-eval. The two runners pick up jobs by label, so a long skills-eval batch and a helm-sync run don't block each other.

**$0 incremental cost** — `vss-skill-validator` is already running and paid for. The new runner is a second process in `/home/ubuntu/actions-runner-helm-sync/`, registered as runner name `vss-helm-sync`, with its own systemd unit (`actions.runner.NVIDIA-AI-Blueprints-video-search-and-summarization.vss-helm-sync.service`).

## What's unchanged

- Repo secrets (`ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL`) keep working as-is — Actions injects them per-job regardless of runner host.
- All other workflow steps unchanged: dorny/paths-filter cumulative diff, Python+SDK install, agent invocation.
- AGENTS.md unchanged (the agent doesn't care which runner it's on).

## Test plan

- [x] Re-run helm-sync on PR #206. Expect: agent now connects to the NVIDIA proxy successfully and either reports `DONE: in sync` or raises a bot PR with helm-side changes.
- [x] Confirm runner status: `gh api repos/.../actions/runners` shows `vss-helm-sync` online with label `helm-sync`.
- [x] Confirm no contention: trigger skills-eval and helm-sync simultaneously; both should run in parallel (different runner processes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)