### PR TITLE
skills/alerts: add VLM real-time eval spec

### DIFF
--- a/.github/skill-eval/adapters/alerts/generate.py
+++ b/.github/skill-eval/adapters/alerts/generate.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the alerts skill.
+
+The alerts skill exercises the VSS **alerts** profile end-to-end:
+deploy, onboard a sample video via NVStreamer, register the sensor in
+VIOS, start a VLM real-time alert through the VSS Agent, and poll
+VA-MCP for incidents.
+
+The spec (`alerts_vlm_real_time.json`) declares:
+    profile = "alerts"        → deploy step is prepended in the dataset
+    resources.platforms:
+        L40S: modes: [remote-all]
+
+Because the alerts real-time (VLM) mode runs `rtvi-vlm` locally (a
+continuous GPU-backed inference loop) alongside NVStreamer + VIOS +
+Kafka, the trial requires a **GPU** even in `remote-all` placement.
+The `remote-all` label refers to LLM/VLM NIM placement (both remote),
+but RT-CV / `rtvi-vlm` is always local on the alerts profile.
+
+Directory layout (one platform × mode per directory):
+
+    datasets/alerts/<spec_stem>/<platform_short>-<mode>/
+        step-1/
+            instruction.md, task.toml, tests/, solution/, skills/, environment/
+        step-2/
+            ...
+        step-3/
+            ...
+        step-4/
+            ...
+
+Usage:
+    python3 generate.py \\
+        --output-dir /tmp/skill-eval/datasets/alerts \\
+        --skill-dir   skills/alerts \\
+        --deploy-skill-dir skills/deploy \\
+        --spec        skills/alerts/eval/alerts_vlm_real_time.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+# Prepended to every instruction.md so the skill's bypass clause fires.
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
+# ---------------------------------------------------------------------------
+# Platforms
+# ---------------------------------------------------------------------------
+
+PLATFORMS: dict[str, dict] = {
+    "H100": {
+        "short_name": "h100",
+        "gpu_type": "H100",
+        "min_vram_per_gpu": 80,
+        "brev_search": "H100",
+    },
+    "L40S": {
+        "short_name": "l40s",
+        "gpu_type": "L40S",
+        "min_vram_per_gpu": 48,
+        "brev_search": "L40S",
+    },
+    "RTXPRO6000BW": {
+        "short_name": "rtxpro6000bw",
+        "gpu_type": "RTX PRO 6000",
+        "min_vram_per_gpu": 96,
+        "brev_search": "RTX PRO",
+    },
+}
+
+DEFAULT_PLATFORM = "L40S"
+DEFAULT_SPEC = "alerts_vlm_real_time.json"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SUBST_RE = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+
+
+def _substitute(value: object, subs: dict[str, str]) -> object:
+    """Replace {{key}} placeholders in strings/lists/dicts."""
+    if isinstance(value, str):
+        return _SUBST_RE.sub(lambda m: str(subs.get(m.group(1), m.group(0))), value)
+    if isinstance(value, list):
+        return [_substitute(v, subs) for v in value]
+    if isinstance(value, dict):
+        return {k: _substitute(v, subs) for k, v in value.items()}
+    return value
+
+
+def _platform_modes(spec: dict, platform_filter: str | None) -> list[tuple[str, str]]:
+    declared: dict = ((spec.get("resources") or {}).get("platforms") or {})
+    tasks: list[tuple[str, str]] = []
+    for platform, cfg in declared.items():
+        if platform_filter and platform != platform_filter:
+            continue
+        if platform not in PLATFORMS:
+            print(
+                f"  WARN  unknown platform '{platform}' in spec — skipped",
+                file=sys.stderr,
+            )
+            continue
+        for mode in (cfg or {}).get("modes") or ["remote-all"]:
+            tasks.append((platform, mode))
+    return tasks or [(platform_filter or DEFAULT_PLATFORM, "remote-all")]
+
+
+# ---------------------------------------------------------------------------
+# Generation helpers
+# ---------------------------------------------------------------------------
+
+def _test_sh(step_idx: int, spec_name: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f"# alerts verifier step {step_idx}: delegates to generic LLM-as-judge.\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step_idx}\n'
+        "exit 0\n"
+    )
+
+
+def _solve_sh(platform: str, mode: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution stub: alerts on {platform}/{mode}\n"
+        "# The verifier drives the assertions directly.\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 http://localhost:8000/docs >/dev/null || {\n"
+        "    echo 'VSS alerts stack is not deployed — cannot solve'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'VSS alerts stack is live — verifier will drive the queries.'\n"
+    )
+
+
+def _task_toml(
+    *,
+    platform: str,
+    mode: str,
+    profile: str,
+    step_idx: int,
+    step_count: int,
+    check_count: int,
+    pspec: dict,
+    spec_stem: str,
+    step_suffix: str,
+    prerequisite_deploy_mode: str,
+) -> str:
+    short = pspec["short_name"]
+    lines = [
+        "[task]",
+        f'name = "nvidia-vss/alerts-{spec_stem}-{short}-{mode}{step_suffix}"',
+        f'description = "Alerts VLM real-time step {step_idx}/{step_count} on {platform}/{mode}"',
+        f'keywords = ["alerts", "vlm", "real-time", "{platform}", "{mode}"]',
+        "",
+        "[environment]",
+        'skills_dir = "/skills"',
+        "",
+        "[verifier.env]",
+        'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+        'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+        'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
+        "",
+        "[metadata]",
+        'skill = "alerts"',
+        f'profile = "{profile}"',
+        f'platform = "{platform}"',
+        f'mode = "{mode}"',
+        f'gpu_type = "{pspec["gpu_type"]}"',
+        f'brev_search = "{pspec["brev_search"]}"',
+        # alerts real-time requires a GPU even in remote-all (rtvi-vlm runs
+        # locally as a continuous VLM inference loop)
+        "gpu_count = 1",
+        f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+        "min_root_disk_gb = 200",
+        "requires_deployed_vss = true",
+        f'prerequisite_deploy_mode = "{prerequisite_deploy_mode}"',
+        f"step_index = {step_idx}",
+        f"step_count = {step_count}",
+        f"check_count = {check_count}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def generate_platform_mode(
+    *,
+    platform: str,
+    mode: str,
+    spec: dict,
+    rendered_spec: dict,
+    output_root: Path,
+    skill_dir: Path,
+    deploy_skill_dir: Path | None,
+    spec_stem: str,
+) -> None:
+    pspec = PLATFORMS[platform]
+    short = pspec["short_name"]
+    expects = rendered_spec.get("expects") or []
+    profile: str = str(spec.get("profile", "alerts"))
+    # prerequisite_deploy_mode drives the /deploy -m flag the coordinator
+    # injects before this task. Read from spec, fall back to `real-time`.
+    prerequisite_deploy_mode: str = str(
+        spec.get("deploy_mode") or spec.get("prerequisite_deploy_mode") or "real-time"
+    )
+
+    platform_dir = output_root / spec_stem / f"{short}-{mode}"
+    platform_dir.mkdir(parents=True, exist_ok=True)
+
+    for idx, expect in enumerate(expects, 1):
+        step_dir = platform_dir / f"step-{idx}" if len(expects) > 1 else platform_dir
+        step_dir.mkdir(parents=True, exist_ok=True)
+        step_suffix = f"-step-{idx}" if len(expects) > 1 else ""
+
+        # ---- instruction.md ------------------------------------------------
+        instruction_lines = [
+            PREAMBLE,
+            "",
+            f"Use the `/alerts` skill (and `/deploy` as needed) on this `{platform}` host.",
+            "The VSS **alerts** profile is deployed in **real-time (VLM)** mode",
+            "with remote LLM and remote VLM endpoints (`remote-all` placement).",
+            "",
+            f"## Query {idx} of {len(expects)}",
+            "",
+            expect.get("query", ""),
+            "",
+            "## Environment notes",
+            "",
+            rendered_spec.get("env", ""),
+            "",
+            "Run autonomously without prompting for confirmation.",
+            "",
+        ]
+        (step_dir / "instruction.md").write_text("\n".join(instruction_lines) + "\n")
+
+        # ---- task.toml -----------------------------------------------------
+        toml_content = _task_toml(
+            platform=platform,
+            mode=mode,
+            profile=profile,
+            step_idx=idx,
+            step_count=len(expects),
+            check_count=len(expect.get("checks") or []),
+            pspec=pspec,
+            spec_stem=spec_stem,
+            step_suffix=step_suffix,
+            prerequisite_deploy_mode=prerequisite_deploy_mode,
+        )
+        (step_dir / "task.toml").write_text(toml_content)
+
+        # ---- environment/ --------------------------------------------------
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        # ---- tests/ --------------------------------------------------------
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        spec_filename = f"{spec_stem}.json"
+        (tests_dir / "test.sh").write_text(_test_sh(idx, spec_filename))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        # Write the rendered spec so the judge can read checks[] at verify time
+        (tests_dir / spec_filename).write_text(json.dumps(rendered_spec, indent=2))
+
+        # ---- solution/ -----------------------------------------------------
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(_solve_sh(platform, mode))
+
+        # ---- skills/ -------------------------------------------------------
+        for src_dir, skill_name in [
+            (skill_dir, "alerts"),
+            (deploy_skill_dir, "deploy"),
+        ]:
+            if src_dir and src_dir.exists():
+                dst = step_dir / "skills" / skill_name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src_dir, dst)
+
+    print(
+        f"  GEN  alerts/{spec_stem}/{short}-{mode}  "
+        f"({len(expects)} steps, "
+        f"{sum(len(e.get('checks') or []) for e in expects)} checks)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--output-dir", required=True,
+                        help="Dataset output root (e.g. /tmp/skill-eval/datasets/alerts)")
+    parser.add_argument("--skill-dir", required=True,
+                        help="Path to skills/alerts")
+    parser.add_argument("--deploy-skill-dir", default=None,
+                        help="Path to skills/deploy (included so agent can diagnose issues)")
+    parser.add_argument("--spec", default=None,
+                        help=f"Path to spec JSON (default: <skill-dir>/eval/{DEFAULT_SPEC})")
+    parser.add_argument("--platform", default=None,
+                        choices=list(PLATFORMS.keys()),
+                        help="Generate for this platform only")
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+    spec_path = (
+        Path(args.spec) if args.spec
+        else (skill_dir / "eval" / DEFAULT_SPEC)
+    )
+
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+
+    spec: dict = json.loads(spec_path.read_text())
+    spec["_source_path"] = str(spec_path)
+
+    # Spec_stem = filename without .json
+    spec_stem = spec_path.stem  # e.g. "alerts_vlm_real_time"
+
+    # Substitute {{platform}} and {{mode}} at generation time using
+    # the first platform/mode from the matrix as defaults; the adapter
+    # renders per-task below.
+    tasks = _platform_modes(spec, args.platform)
+
+    print("=== Inputs ===")
+    print(f"  output_dir       : {output_root}")
+    print(f"  skill_dir        : {skill_dir}")
+    print(f"  spec             : {spec_path}")
+    print(f"  profile          : {spec.get('profile', '(none)')}")
+    print(f"  deploy_mode      : {spec.get('deploy_mode', '(none — defaults to real-time)')}")
+    print(f"  tasks            : {tasks}")
+    print(f"  queries          : {len(spec.get('expects', []))}")
+    print(
+        f"  total checks     : "
+        f"{sum(len(q.get('checks', [])) for q in spec.get('expects', []))}"
+    )
+    print()
+
+    for platform, mode in tasks:
+        subs = {"platform": platform, "mode": mode}
+        rendered_spec = _substitute(spec, subs)
+        generate_platform_mode(
+            platform=platform,
+            mode=mode,
+            spec=spec,
+            rendered_spec=rendered_spec,
+            output_root=output_root,
+            skill_dir=skill_dir,
+            deploy_skill_dir=deploy_skill_dir,
+            spec_stem=spec_stem,
+        )
+
+    print()
+    print(f"Generated {len(tasks)} platform×mode combinations under {output_root}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/alerts/eval/alerts_vlm_real_time.json
+++ b/skills/alerts/eval/alerts_vlm_real_time.json
@@ -7,39 +7,44 @@
       }
     }
   },
-  "env": "Bare GPU host matching `{{platform}}` with Docker + NVIDIA Container Toolkit, `NGC_CLI_API_KEY`, and remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`, `LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`, `VLM_REMOTE_MODEL`). The first query runs the **`deploy`** skill end-to-end to bring up the VSS **alerts** profile in **real-time** (VLM) mode with **remote-all** placement (no local NIMs). The second query exercises the **`alerts`** skill via the VSS Agent on port `8000` (Workflow B — VLM mode); on this profile, NVStreamer (`mdx-nvstreamer-alerts`) auto-loads the `warehouse_sample` sensor used by the canonical examples in `skills/alerts/SKILL.md`. The third query exercises the **`video-analytics`** skill against VA-MCP on port `9901` using the required two-step session pattern.",
+  "env": "Bare GPU host matching `{{platform}}` with Docker + NVIDIA Container Toolkit, `NGC_CLI_API_KEY`, and remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`, `LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`, `VLM_REMOTE_MODEL`). The eval runs the full sequence end-to-end: deploy the VSS **alerts** profile in **real-time** (VLM) mode with **remote-all** placement, add the `warehouse_sample.mp4` sample video through NVStreamer (`mdx-nvstreamer-alerts` on port `31000` HTTP / `31554` RTSP) so it becomes a simulated live camera, verify the sensor appears in VIOS (port `30888`), then poll VA-MCP (port `9901`) for incidents until one shows up. Sample data ships in NGC bundle `nvidia/vss-developer/dev-profile-sample-data:3.1.0`. Pre-authorized to deploy prerequisites and start any alerts needed to drive incident generation in real-time mode.",
   "expects": [
     {
-      "query": "Deploy the VSS **alerts** profile on {{platform}} in **real-time** (VLM) mode with **remote-all** placement using the **deploy** skill (`/deploy -p alerts -m real-time`, remote LLM + remote VLM). Run end-to-end and autonomously — assume pre-authorization to deploy prerequisites.",
+      "query": "Deploy the VSS alerts profile on {{platform}} in real-time (VLM) mode using remote LLM and remote VLM endpoints. Run end-to-end and autonomously.",
       "checks": [
-        "The agent used the `/deploy` skill to deploy the VSS `alerts` profile in `real-time` mode with remote LLM + remote VLM placement (not `verification`, not local).",
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (VSS Agent REST API responsive).",
-        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",
         "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor — required for VLM real-time mode).",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (NVStreamer simulates live cameras for the alerts profile, including the `warehouse_sample` sensor).",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (NVStreamer simulates live cameras).",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-kafka` returns exit 0 (Kafka backplane for alert/incident topics).",
-        "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (CV-only perception is NOT running — confirms VLM real-time, not verification).",
-        "`! docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (CV-only behavior-analytics is NOT running)."
+        "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (CV-only perception is NOT running — confirms VLM real-time, not verification)."
       ]
     },
     {
-      "query": "Set up a real-time alert for **boxes being dropped** on sensor `warehouse_sample`. Use the **alerts** skill (Workflow B — VLM mode): drive the request through the VSS Agent's `POST /generate` endpoint. The agent will internally dispatch `rtvi_prompt_gen` and `rtvi_vlm_alert action=start` to register the stream with `rtvi-vlm` and begin continuous monitoring. Do NOT call the `rtvi-vlm` microservice (`http://localhost:8018/v1/...`) directly — always go through the agent.",
+      "query": "Add the `warehouse_sample.mp4` sample video through NVStreamer so it becomes a live camera that the alerts pipeline can monitor, then start a real-time alert on it for boxes being dropped.",
       "checks": [
-        "The run performed at least one successful `POST http://localhost:8000/generate` (or equivalent agent base URL) with `Content-Type: application/json` and a JSON body containing `input_message` returning HTTP 2xx.",
-        "The `input_message` text asks the agent to **start** a real-time alert on sensor `warehouse_sample` and references **boxes** / **dropped** (the user's detection target).",
-        "The trajectory does NOT call `http://localhost:8018/v1/streams/add`, `http://localhost:8018/v1/generate_captions_alerts`, or any other `rtvi-vlm` microservice endpoint directly — those are dispatched by the agent's `rtvi_vlm_alert` tool, not by the skill.",
-        "After the start request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response includes a stream whose description / sensor_name references `warehouse_sample` (confirms the agent registered the stream with rtvi-vlm).",
-        "The final assistant reply confirms that real-time monitoring has started for `warehouse_sample` (e.g. references `started`, `monitoring`, or `running` and the sensor name) without errors in the response body."
+        "The trajectory uploaded the file to NVStreamer (`PUT http://localhost:31000/vst/api/v1/storage/file/...`) — i.e. used the NVStreamer VST API on port `31000`, NOT VIOS on port `30888` or the `rtvi-vlm` microservice on `8018`.",
+        "After upload, the resulting NVStreamer-served RTSP (port `31554`) was registered in VIOS via `POST http://localhost:30888/vst/api/v1/sensor/add` with a `sensorUrl` referencing `:31554` — i.e. VIOS points at NVStreamer, not at any external/public RTSP host.",
+        "The trajectory issued at least one `POST http://localhost:8000/generate` whose `input_message` references **start** + the sensor name + **boxes**/**dropped** (drives `rtvi_prompt_gen` + `rtvi_vlm_alert action=start` through the agent, not via direct `rtvi-vlm` calls).",
+        "The trajectory does NOT call `http://localhost:8018/v1/streams/add` or `http://localhost:8018/v1/generate_captions_alerts` directly.",
+        "After the start, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and includes a stream whose URL contains `:31554` or whose description references the warehouse sample sensor (confirms the agent registered the NVStreamer-served stream with rtvi-vlm)."
       ]
     },
     {
-      "query": "List recent incidents/alerts for sensor `warehouse_sample`. Use the **video-analytics** skill — call VA-MCP at `http://localhost:9901/mcp` with the required two-step pattern (`initialize` → capture `mcp-session-id` from the response **header** → `tools/call` with that header) and invoke the `video_analytics__get_incidents` tool filtered to that sensor.",
+      "query": "List all sensors currently configured in VIOS.",
       "checks": [
-        "The trajectory shows two sequential POSTs to `http://localhost:9901/mcp` — first an `initialize` JSON-RPC method, then a `tools/call` — not a single one-shot call.",
-        "The trajectory captures the `mcp-session-id` from the initialize **response header** (not the body) and passes it as the `mcp-session-id` request header on the `tools/call` POST.",
-        "The `tools/call` payload invokes the tool name `video_analytics__get_incidents` with arguments referencing `warehouse_sample` (e.g. `\"source\": \"warehouse_sample\"` and `\"source_type\": \"sensor\"`, optionally with `max_count`).",
-        "The trajectory does NOT bypass VA-MCP by hitting Elasticsearch directly (no `:9200/_search` calls) and does NOT route this query through the VSS Agent's `/generate` endpoint (the video-analytics skill is the canonical path for this question, not the agent).",
-        "The final assistant reply is plain text or light markdown that either lists incidents for `warehouse_sample` OR clearly states that no incidents have been recorded yet for that sensor — not an error trace, not a raw tool dump, not a `Bad Request: Missing session ID` failure (which would indicate the two-step pattern was not followed)."
+        "The trajectory issued a `GET http://localhost:30888/vst/api/v1/sensor/list` (or equivalent VIOS sensor-list call) — not a direct database query, not via NVStreamer's port `31000`.",
+        "`curl -sf http://localhost:30888/vst/api/v1/sensor/list` returns a JSON array containing at least one sensor whose name references the warehouse sample (e.g. `warehouse_sample`, `warehouse_sample.mp4`, or similar) — confirms the prior NVStreamer onboarding propagated into VIOS.",
+        "The final assistant reply renders the sensor list as readable text/markdown including each sensor's name and state — not a raw response dump or an error trace."
+      ]
+    },
+    {
+      "query": "List incidents from the past 5 minutes for the warehouse sample sensor. If none have been recorded yet, keep polling every 30 seconds until at least one incident shows up (or fail clearly after a reasonable timeout).",
+      "checks": [
+        "The trajectory issued at least two POSTs to `http://localhost:9901/mcp` — one `initialize` to obtain `mcp-session-id` from the response **header**, then `tools/call` invocations passing that header (the required two-step VA-MCP pattern; one-shot calls fail with `Bad Request: Missing session ID`).",
+        "At least one `tools/call` payload invoked `video_analytics__get_incidents` with arguments scoping the query to the warehouse sample sensor and to the past 5 minutes (e.g. `source` set to the sensor and `start_time` ~5 minutes before now in ISO 8601 UTC).",
+        "The trajectory shows polling behaviour — multiple `get_incidents` calls separated in time (e.g. ~30s apart) until the result returned a non-empty incident list, rather than a single one-shot call.",
+        "The final assistant reply summarizes at least one real incident returned by `get_incidents` (timestamp, sensor, and either a category/description or verdict) — not `[]`, not an error trace, not a `Missing session ID` failure, and not a fabricated incident absent from the tool response."
       ]
     }
   ]

--- a/skills/alerts/eval/alerts_vlm_real_time.json
+++ b/skills/alerts/eval/alerts_vlm_real_time.json
@@ -9,54 +9,59 @@
       }
     }
   },
-  "env": "VSS **alerts** profile deployed in **real-time** (VLM) mode on the target host: VSS agent HTTP API on **8000** (e.g. `http://localhost:8000/docs`), VST/VIOS reachable at `http://localhost:30888/vst/api/v1`, and the `rtvi-vlm` and `mdx-kafka` containers running. Use **remote-all** (remote LLM + VLM) so no local NIMs are required. The skill's canonical pattern is to drive every alert action through the VSS Agent's `POST /generate` endpoint — never call the `rtvi-vlm` microservice directly. A public NVIDIA sample RTSP stream (`rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4`) must be reachable from the host (see `skills/alerts/SKILL.md` § *Workflow B — VLM Mode*).",
+  "env": "VSS **alerts** profile deployed in **real-time** (VLM) mode on the target host: VSS agent HTTP API on **8000**, VIOS at `http://localhost:30888/vst/api/v1`, **NVStreamer (`mdx-nvstreamer-alerts`) reachable at `http://localhost:31000/vst/api/v1` (HTTP) and `rtsp://localhost:31554/...` (RTSP)**, plus the `rtvi-vlm` and `mdx-kafka` containers running. Use **remote-all** (remote LLM + VLM) so no local NIMs are required. The skill's canonical pattern is to drive every alert action through the VSS Agent's `POST /generate` endpoint — never call the `rtvi-vlm` microservice directly. Sample data: NGC bundle `nvidia/vss-developer/dev-profile-sample-data:3.1.0` (per `skills/vios/SKILL.md` § *Sample data bootstrap*) provides `warehouse_sample.mp4`. The eval simulates a live camera by uploading that mp4 to NVStreamer and registering the resulting NVStreamer-served RTSP URL in VIOS.",
   "expects": [
     {
-      "query": "Verify the VSS **alerts** profile is running in **real-time** (VLM) mode and is ready for the alerts skill. Confirm the agent serves OpenAPI at `/docs`, that the container layout matches VLM mode (rtvi-vlm present, perception-alerts absent), and that VIOS is reachable. Report the detected mode using the `docker ps` signal from the skill.",
+      "query": "Verify the VSS **alerts** profile is running in **real-time** (VLM) mode and is ready for the alerts skill. Confirm the agent serves OpenAPI at `/docs`, that the container layout matches VLM mode (rtvi-vlm present, perception-alerts absent), that NVStreamer (`mdx-nvstreamer-alerts`) is up, and that VIOS is reachable. Report the detected mode using the `docker ps` signal from the skill.",
       "checks": [
         "`curl -sf --max-time 10 http://localhost:8000/docs` returns exit 0 (VSS Agent REST API responsive).",
         "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor — required for VLM real-time mode).",
         "`! docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (CV-only behavior-analytics container is NOT running — confirms VLM mode, not CV).",
         "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (CV-only perception container is NOT running).",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-kafka` returns exit 0 (Kafka backplane for alert/incident topics).",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (NVStreamer simulates live cameras for the alerts profile).",
         "`curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/list` returns exit 0 (VIOS reachable).",
+        "`curl -sf --max-time 10 http://localhost:31000/vst/api/v1/sensor/version` returns exit 0 (NVStreamer's VST API on port 31000 reachable).",
         "Trajectory or final reply names the deployed mode as VLM / real-time (e.g. `mode=VLM`, `real-time`, or equivalent), derived from the `docker ps` mode-detection signal in `skills/alerts/SKILL.md` § *Step 1*."
       ]
     },
     {
-      "query": "Onboard the public NVIDIA sample RTSP `rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4` to VIOS as a sensor named `alerts-eval-warehouse`. If a sensor with that name already exists, skip onboarding. Use the `vios` skill (`POST /sensor/add`) — do NOT call the `rtvi-vlm` `/v1/streams/add` endpoint directly.",
+      "query": "Onboard `warehouse_sample.mp4` into the alerts pipeline so it appears in VIOS as sensor `warehouse_sample`. NVStreamer is what simulates a live camera in this profile, so do this in two steps: (1) upload `warehouse_sample.mp4` to NVStreamer at `http://localhost:31000/vst/api/v1/storage/file/warehouse_sample.mp4` (NVStreamer is a VST instance running on port 31000 — use the same `PUT /storage/file/<filename>` API as VIOS, per the `vios` skill); (2) take the RTSP URL that NVStreamer now serves for that file (RTSP server runs on port 31554; resolve the exact URL from NVStreamer's `GET /sensor/streams` `url` field) and register it in VIOS via `POST http://localhost:30888/vst/api/v1/sensor/add` with `sensorUrl` set to that NVStreamer RTSP URL and `name` set to `warehouse_sample`. If a VIOS sensor named `warehouse_sample` already exists, skip both steps. The sample mp4 ships in NGC bundle `nvidia/vss-developer/dev-profile-sample-data:3.1.0` — extract per the `vios` skill's *Sample data bootstrap* section if not already on disk. Do NOT call the `rtvi-vlm` `/v1/streams/add` endpoint directly, do NOT pass an external/public RTSP URL to VIOS, and do NOT use VIOS `/sensor/add` for the file upload itself (only for registering the NVStreamer RTSP URL).",
       "checks": [
-        "Trajectory shows the agent probed `GET http://localhost:30888/vst/api/v1/sensor/list` for the `alerts-eval-warehouse` sensor BEFORE deciding to add it (skip-if-exists behavior, not unconditional add).",
-        "If the sensor was added, the trajectory shows a `POST http://localhost:30888/vst/api/v1/sensor/add` (or equivalent VIOS add-sensor call) with the RTSP URL exactly `rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4`.",
+        "Trajectory shows the agent probed `GET http://localhost:30888/vst/api/v1/sensor/list` for the `warehouse_sample` sensor BEFORE deciding to upload/add it (skip-if-exists behavior, not unconditional add).",
+        "If onboarding ran, the trajectory shows a `PUT http://localhost:31000/vst/api/v1/storage/file/warehouse_sample.mp4` (or equivalent NVStreamer file upload on port 31000) — the file goes to NVStreamer, NOT to VIOS port 30888.",
+        "If onboarding ran, the trajectory then shows `POST http://localhost:30888/vst/api/v1/sensor/add` to VIOS with a `sensorUrl` whose value starts with `rtsp://` and references port `31554` (the NVStreamer RTSP server port) — i.e. VIOS is registering the NVStreamer-served RTSP, not a public/internet RTSP.",
+        "The `sensor/add` request body sets `name` to exactly `warehouse_sample`.",
         "The trajectory does NOT show a direct call to `http://localhost:8018/v1/streams/add` or any other `rtvi-vlm` microservice endpoint (skill rule: always go through the VSS Agent / VIOS, never `rtvi-vlm` directly).",
-        "`curl -sf http://localhost:30888/vst/api/v1/sensor/list` returns a JSON array containing a sensor whose name is exactly `alerts-eval-warehouse`.",
-        "`curl -sf http://localhost:30888/vst/api/v1/sensor/alerts-eval-warehouse/streams` returns HTTP 200 and a non-empty streams array whose main stream's url begins with `rtsp://`."
+        "The trajectory does NOT pass an external/public RTSP URL (e.g. `rtsp://nv-wowza-pdc.nvidia.com…` or any non-localhost RTSP host) to VIOS `/sensor/add` — the only RTSP given to VIOS must come from NVStreamer.",
+        "`curl -sf http://localhost:30888/vst/api/v1/sensor/list` returns a JSON array containing a sensor whose name is exactly `warehouse_sample`.",
+        "`curl -sf http://localhost:30888/vst/api/v1/sensor/<warehouse_sample_id>/streams` returns HTTP 200 and a non-empty streams array whose main stream's `url` begins with `rtsp://` and includes `:31554` (i.e. points at NVStreamer)."
       ]
     },
     {
-      "query": "Start a real-time alert on sensor `alerts-eval-warehouse` for boxes being dropped. Drive the request through the VSS Agent's `/generate` endpoint per the alerts skill — let the agent dispatch `rtvi_prompt_gen` and `rtvi_vlm_alert action=start` internally.",
+      "query": "Start a real-time alert on sensor `warehouse_sample` for boxes being dropped. Drive the request through the VSS Agent's `/generate` endpoint per the alerts skill — let the agent dispatch `rtvi_prompt_gen` and `rtvi_vlm_alert action=start` internally.",
       "checks": [
         "The run performed at least one successful `POST http://localhost:8000/generate` (or equivalent agent base URL) with `Content-Type: application/json` and a JSON body containing `input_message` returning HTTP 2xx.",
-        "The `input_message` text asks the agent to **start** a real-time alert on sensor `alerts-eval-warehouse` and references **boxes** / **dropped** (the user's detection target).",
+        "The `input_message` text asks the agent to **start** a real-time alert on sensor `warehouse_sample` and references **boxes** / **dropped** (the user's detection target).",
         "The trajectory does NOT call `http://localhost:8018/v1/streams/add` or `http://localhost:8018/v1/generate_captions_alerts` directly — those are dispatched by the agent's `rtvi_vlm_alert` tool, not by the skill.",
-        "After the start request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response includes a stream whose URL matches `rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4` or whose description references the `alerts-eval-warehouse` sensor (confirms the agent registered the stream with rtvi-vlm).",
-        "The final assistant reply confirms that real-time monitoring has started for `alerts-eval-warehouse` (e.g. references `started`, `monitoring`, or `running` and the sensor name) without errors in the response body."
+        "After the start request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response includes a stream whose URL points at NVStreamer (contains `:31554`) or whose description / sensor_name references `warehouse_sample` (confirms the agent registered the NVStreamer-served RTSP with rtvi-vlm).",
+        "The final assistant reply confirms that real-time monitoring has started for `warehouse_sample` (e.g. references `started`, `monitoring`, or `running` and the sensor name) without errors in the response body."
       ]
     },
     {
-      "query": "Show me recent alerts for sensor `alerts-eval-warehouse`. Drive the query through the VSS Agent's `/generate` endpoint — the agent should dispatch `video_analytics_mcp.get_incidents` internally (see `skills/alerts/SKILL.md` § *Workflow C*).",
+      "query": "Show me recent alerts for sensor `warehouse_sample`. Drive the query through the VSS Agent's `/generate` endpoint — the agent should dispatch `video_analytics_mcp.get_incidents` internally (see `skills/alerts/SKILL.md` § *Workflow C*).",
       "checks": [
-        "The run performed at least one successful `POST http://localhost:8000/generate` with an `input_message` that asks for **alerts** / **incidents** for sensor `alerts-eval-warehouse` and returns HTTP 2xx.",
+        "The run performed at least one successful `POST http://localhost:8000/generate` with an `input_message` that asks for **alerts** / **incidents** for sensor `warehouse_sample` and returns HTTP 2xx.",
         "The trajectory or agent reasoning shows the agent called the `video_analytics_mcp.get_incidents` tool (or equivalent VA-MCP `get_incidents` invocation) — not a direct Elasticsearch query and not a direct `rtvi-vlm` call.",
-        "The final assistant reply is plain text or light markdown that either lists incidents for `alerts-eval-warehouse` OR clearly states that no incidents have been recorded yet for that sensor — not an error trace, not a raw tool dump."
+        "The final assistant reply is plain text or light markdown that either lists incidents for `warehouse_sample` OR clearly states that no incidents have been recorded yet for that sensor — not an error trace, not a raw tool dump."
       ]
     },
     {
-      "query": "Stop the real-time alert on sensor `alerts-eval-warehouse`. Drive the stop through the VSS Agent's `/generate` endpoint — the agent should tear down both the caption stream and the rtvi-vlm stream registration.",
+      "query": "Stop the real-time alert on sensor `warehouse_sample`. Drive the stop through the VSS Agent's `/generate` endpoint — the agent should tear down both the caption stream and the rtvi-vlm stream registration.",
       "checks": [
-        "The run performed at least one successful `POST http://localhost:8000/generate` with an `input_message` containing **stop** and the sensor name `alerts-eval-warehouse`, returning HTTP 2xx.",
-        "After the stop request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response no longer contains any stream whose URL matches `rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4` or whose description references `alerts-eval-warehouse` (confirms the agent un-registered the stream).",
-        "The final assistant reply confirms that monitoring has stopped for `alerts-eval-warehouse` (e.g. references `stopped`, `terminated`, or `removed` and the sensor name) without errors."
+        "The run performed at least one successful `POST http://localhost:8000/generate` with an `input_message` containing **stop** and the sensor name `warehouse_sample`, returning HTTP 2xx.",
+        "After the stop request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response no longer contains any stream whose URL points at NVStreamer (`:31554`) for `warehouse_sample` or whose description references `warehouse_sample` (confirms the agent un-registered the stream).",
+        "The final assistant reply confirms that monitoring has stopped for `warehouse_sample` (e.g. references `stopped`, `terminated`, or `removed` and the sensor name) without errors."
       ]
     }
   ]

--- a/skills/alerts/eval/alerts_vlm_real_time.json
+++ b/skills/alerts/eval/alerts_vlm_real_time.json
@@ -1,0 +1,63 @@
+{
+  "skills": ["alerts", "vios"],
+  "profile": "alerts",
+  "deploy_mode": "real-time",
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": ["remote-all"]
+      }
+    }
+  },
+  "env": "VSS **alerts** profile deployed in **real-time** (VLM) mode on the target host: VSS agent HTTP API on **8000** (e.g. `http://localhost:8000/docs`), VST/VIOS reachable at `http://localhost:30888/vst/api/v1`, and the `rtvi-vlm` and `mdx-kafka` containers running. Use **remote-all** (remote LLM + VLM) so no local NIMs are required. The skill's canonical pattern is to drive every alert action through the VSS Agent's `POST /generate` endpoint — never call the `rtvi-vlm` microservice directly. A public NVIDIA sample RTSP stream (`rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4`) must be reachable from the host (see `skills/alerts/SKILL.md` § *Workflow B — VLM Mode*).",
+  "expects": [
+    {
+      "query": "Verify the VSS **alerts** profile is running in **real-time** (VLM) mode and is ready for the alerts skill. Confirm the agent serves OpenAPI at `/docs`, that the container layout matches VLM mode (rtvi-vlm present, perception-alerts absent), and that VIOS is reachable. Report the detected mode using the `docker ps` signal from the skill.",
+      "checks": [
+        "`curl -sf --max-time 10 http://localhost:8000/docs` returns exit 0 (VSS Agent REST API responsive).",
+        "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor — required for VLM real-time mode).",
+        "`! docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (CV-only behavior-analytics container is NOT running — confirms VLM mode, not CV).",
+        "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (CV-only perception container is NOT running).",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-kafka` returns exit 0 (Kafka backplane for alert/incident topics).",
+        "`curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/list` returns exit 0 (VIOS reachable).",
+        "Trajectory or final reply names the deployed mode as VLM / real-time (e.g. `mode=VLM`, `real-time`, or equivalent), derived from the `docker ps` mode-detection signal in `skills/alerts/SKILL.md` § *Step 1*."
+      ]
+    },
+    {
+      "query": "Onboard the public NVIDIA sample RTSP `rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4` to VIOS as a sensor named `alerts-eval-warehouse`. If a sensor with that name already exists, skip onboarding. Use the `vios` skill (`POST /sensor/add`) — do NOT call the `rtvi-vlm` `/v1/streams/add` endpoint directly.",
+      "checks": [
+        "Trajectory shows the agent probed `GET http://localhost:30888/vst/api/v1/sensor/list` for the `alerts-eval-warehouse` sensor BEFORE deciding to add it (skip-if-exists behavior, not unconditional add).",
+        "If the sensor was added, the trajectory shows a `POST http://localhost:30888/vst/api/v1/sensor/add` (or equivalent VIOS add-sensor call) with the RTSP URL exactly `rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4`.",
+        "The trajectory does NOT show a direct call to `http://localhost:8018/v1/streams/add` or any other `rtvi-vlm` microservice endpoint (skill rule: always go through the VSS Agent / VIOS, never `rtvi-vlm` directly).",
+        "`curl -sf http://localhost:30888/vst/api/v1/sensor/list` returns a JSON array containing a sensor whose name is exactly `alerts-eval-warehouse`.",
+        "`curl -sf http://localhost:30888/vst/api/v1/sensor/alerts-eval-warehouse/streams` returns HTTP 200 and a non-empty streams array whose main stream's url begins with `rtsp://`."
+      ]
+    },
+    {
+      "query": "Start a real-time alert on sensor `alerts-eval-warehouse` for boxes being dropped. Drive the request through the VSS Agent's `/generate` endpoint per the alerts skill — let the agent dispatch `rtvi_prompt_gen` and `rtvi_vlm_alert action=start` internally.",
+      "checks": [
+        "The run performed at least one successful `POST http://localhost:8000/generate` (or equivalent agent base URL) with `Content-Type: application/json` and a JSON body containing `input_message` returning HTTP 2xx.",
+        "The `input_message` text asks the agent to **start** a real-time alert on sensor `alerts-eval-warehouse` and references **boxes** / **dropped** (the user's detection target).",
+        "The trajectory does NOT call `http://localhost:8018/v1/streams/add` or `http://localhost:8018/v1/generate_captions_alerts` directly — those are dispatched by the agent's `rtvi_vlm_alert` tool, not by the skill.",
+        "After the start request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response includes a stream whose URL matches `rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4` or whose description references the `alerts-eval-warehouse` sensor (confirms the agent registered the stream with rtvi-vlm).",
+        "The final assistant reply confirms that real-time monitoring has started for `alerts-eval-warehouse` (e.g. references `started`, `monitoring`, or `running` and the sensor name) without errors in the response body."
+      ]
+    },
+    {
+      "query": "Show me recent alerts for sensor `alerts-eval-warehouse`. Drive the query through the VSS Agent's `/generate` endpoint — the agent should dispatch `video_analytics_mcp.get_incidents` internally (see `skills/alerts/SKILL.md` § *Workflow C*).",
+      "checks": [
+        "The run performed at least one successful `POST http://localhost:8000/generate` with an `input_message` that asks for **alerts** / **incidents** for sensor `alerts-eval-warehouse` and returns HTTP 2xx.",
+        "The trajectory or agent reasoning shows the agent called the `video_analytics_mcp.get_incidents` tool (or equivalent VA-MCP `get_incidents` invocation) — not a direct Elasticsearch query and not a direct `rtvi-vlm` call.",
+        "The final assistant reply is plain text or light markdown that either lists incidents for `alerts-eval-warehouse` OR clearly states that no incidents have been recorded yet for that sensor — not an error trace, not a raw tool dump."
+      ]
+    },
+    {
+      "query": "Stop the real-time alert on sensor `alerts-eval-warehouse`. Drive the stop through the VSS Agent's `/generate` endpoint — the agent should tear down both the caption stream and the rtvi-vlm stream registration.",
+      "checks": [
+        "The run performed at least one successful `POST http://localhost:8000/generate` with an `input_message` containing **stop** and the sensor name `alerts-eval-warehouse`, returning HTTP 2xx.",
+        "After the stop request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response no longer contains any stream whose URL matches `rtsp://nv-wowza-pdc.nvidia.com:1935/vod/warehouse_1.mp4` or whose description references `alerts-eval-warehouse` (confirms the agent un-registered the stream).",
+        "The final assistant reply confirms that monitoring has stopped for `alerts-eval-warehouse` (e.g. references `stopped`, `terminated`, or `removed` and the sensor name) without errors."
+      ]
+    }
+  ]
+}

--- a/skills/alerts/eval/alerts_vlm_real_time.json
+++ b/skills/alerts/eval/alerts_vlm_real_time.json
@@ -1,7 +1,5 @@
 {
-  "skills": ["alerts", "vios"],
-  "profile": "alerts",
-  "deploy_mode": "real-time",
+  "skills": ["alerts", "deploy", "video-analytics"],
   "resources": {
     "platforms": {
       "L40S": {
@@ -9,59 +7,39 @@
       }
     }
   },
-  "env": "VSS **alerts** profile deployed in **real-time** (VLM) mode on the target host: VSS agent HTTP API on **8000**, VIOS at `http://localhost:30888/vst/api/v1`, **NVStreamer (`mdx-nvstreamer-alerts`) reachable at `http://localhost:31000/vst/api/v1` (HTTP) and `rtsp://localhost:31554/...` (RTSP)**, plus the `rtvi-vlm` and `mdx-kafka` containers running. Use **remote-all** (remote LLM + VLM) so no local NIMs are required. The skill's canonical pattern is to drive every alert action through the VSS Agent's `POST /generate` endpoint — never call the `rtvi-vlm` microservice directly. Sample data: NGC bundle `nvidia/vss-developer/dev-profile-sample-data:3.1.0` (per `skills/vios/SKILL.md` § *Sample data bootstrap*) provides `warehouse_sample.mp4`. The eval simulates a live camera by uploading that mp4 to NVStreamer and registering the resulting NVStreamer-served RTSP URL in VIOS.",
+  "env": "Bare GPU host matching `{{platform}}` with Docker + NVIDIA Container Toolkit, `NGC_CLI_API_KEY`, and remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`, `LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`, `VLM_REMOTE_MODEL`). The first query runs the **`deploy`** skill end-to-end to bring up the VSS **alerts** profile in **real-time** (VLM) mode with **remote-all** placement (no local NIMs). The second query exercises the **`alerts`** skill via the VSS Agent on port `8000` (Workflow B — VLM mode); on this profile, NVStreamer (`mdx-nvstreamer-alerts`) auto-loads the `warehouse_sample` sensor used by the canonical examples in `skills/alerts/SKILL.md`. The third query exercises the **`video-analytics`** skill against VA-MCP on port `9901` using the required two-step session pattern.",
   "expects": [
     {
-      "query": "Verify the VSS **alerts** profile is running in **real-time** (VLM) mode and is ready for the alerts skill. Confirm the agent serves OpenAPI at `/docs`, that the container layout matches VLM mode (rtvi-vlm present, perception-alerts absent), that NVStreamer (`mdx-nvstreamer-alerts`) is up, and that VIOS is reachable. Report the detected mode using the `docker ps` signal from the skill.",
+      "query": "Deploy the VSS **alerts** profile on {{platform}} in **real-time** (VLM) mode with **remote-all** placement using the **deploy** skill (`/deploy -p alerts -m real-time`, remote LLM + remote VLM). Run end-to-end and autonomously — assume pre-authorization to deploy prerequisites.",
       "checks": [
-        "`curl -sf --max-time 10 http://localhost:8000/docs` returns exit 0 (VSS Agent REST API responsive).",
+        "The agent used the `/deploy` skill to deploy the VSS `alerts` profile in `real-time` mode with remote LLM + remote VLM placement (not `verification`, not local).",
+        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (VSS Agent REST API responsive).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend).",
         "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor — required for VLM real-time mode).",
-        "`! docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (CV-only behavior-analytics container is NOT running — confirms VLM mode, not CV).",
-        "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (CV-only perception container is NOT running).",
+        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (NVStreamer simulates live cameras for the alerts profile, including the `warehouse_sample` sensor).",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-kafka` returns exit 0 (Kafka backplane for alert/incident topics).",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (NVStreamer simulates live cameras for the alerts profile).",
-        "`curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/list` returns exit 0 (VIOS reachable).",
-        "`curl -sf --max-time 10 http://localhost:31000/vst/api/v1/sensor/version` returns exit 0 (NVStreamer's VST API on port 31000 reachable).",
-        "Trajectory or final reply names the deployed mode as VLM / real-time (e.g. `mode=VLM`, `real-time`, or equivalent), derived from the `docker ps` mode-detection signal in `skills/alerts/SKILL.md` § *Step 1*."
+        "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (CV-only perception is NOT running — confirms VLM real-time, not verification).",
+        "`! docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (CV-only behavior-analytics is NOT running)."
       ]
     },
     {
-      "query": "Onboard `warehouse_sample.mp4` into the alerts pipeline so it appears in VIOS as sensor `warehouse_sample`. NVStreamer is what simulates a live camera in this profile, so do this in two steps: (1) upload `warehouse_sample.mp4` to NVStreamer at `http://localhost:31000/vst/api/v1/storage/file/warehouse_sample.mp4` (NVStreamer is a VST instance running on port 31000 — use the same `PUT /storage/file/<filename>` API as VIOS, per the `vios` skill); (2) take the RTSP URL that NVStreamer now serves for that file (RTSP server runs on port 31554; resolve the exact URL from NVStreamer's `GET /sensor/streams` `url` field) and register it in VIOS via `POST http://localhost:30888/vst/api/v1/sensor/add` with `sensorUrl` set to that NVStreamer RTSP URL and `name` set to `warehouse_sample`. If a VIOS sensor named `warehouse_sample` already exists, skip both steps. The sample mp4 ships in NGC bundle `nvidia/vss-developer/dev-profile-sample-data:3.1.0` — extract per the `vios` skill's *Sample data bootstrap* section if not already on disk. Do NOT call the `rtvi-vlm` `/v1/streams/add` endpoint directly, do NOT pass an external/public RTSP URL to VIOS, and do NOT use VIOS `/sensor/add` for the file upload itself (only for registering the NVStreamer RTSP URL).",
-      "checks": [
-        "Trajectory shows the agent probed `GET http://localhost:30888/vst/api/v1/sensor/list` for the `warehouse_sample` sensor BEFORE deciding to upload/add it (skip-if-exists behavior, not unconditional add).",
-        "If onboarding ran, the trajectory shows a `PUT http://localhost:31000/vst/api/v1/storage/file/warehouse_sample.mp4` (or equivalent NVStreamer file upload on port 31000) — the file goes to NVStreamer, NOT to VIOS port 30888.",
-        "If onboarding ran, the trajectory then shows `POST http://localhost:30888/vst/api/v1/sensor/add` to VIOS with a `sensorUrl` whose value starts with `rtsp://` and references port `31554` (the NVStreamer RTSP server port) — i.e. VIOS is registering the NVStreamer-served RTSP, not a public/internet RTSP.",
-        "The `sensor/add` request body sets `name` to exactly `warehouse_sample`.",
-        "The trajectory does NOT show a direct call to `http://localhost:8018/v1/streams/add` or any other `rtvi-vlm` microservice endpoint (skill rule: always go through the VSS Agent / VIOS, never `rtvi-vlm` directly).",
-        "The trajectory does NOT pass an external/public RTSP URL (e.g. `rtsp://nv-wowza-pdc.nvidia.com…` or any non-localhost RTSP host) to VIOS `/sensor/add` — the only RTSP given to VIOS must come from NVStreamer.",
-        "`curl -sf http://localhost:30888/vst/api/v1/sensor/list` returns a JSON array containing a sensor whose name is exactly `warehouse_sample`.",
-        "`curl -sf http://localhost:30888/vst/api/v1/sensor/<warehouse_sample_id>/streams` returns HTTP 200 and a non-empty streams array whose main stream's `url` begins with `rtsp://` and includes `:31554` (i.e. points at NVStreamer)."
-      ]
-    },
-    {
-      "query": "Start a real-time alert on sensor `warehouse_sample` for boxes being dropped. Drive the request through the VSS Agent's `/generate` endpoint per the alerts skill — let the agent dispatch `rtvi_prompt_gen` and `rtvi_vlm_alert action=start` internally.",
+      "query": "Set up a real-time alert for **boxes being dropped** on sensor `warehouse_sample`. Use the **alerts** skill (Workflow B — VLM mode): drive the request through the VSS Agent's `POST /generate` endpoint. The agent will internally dispatch `rtvi_prompt_gen` and `rtvi_vlm_alert action=start` to register the stream with `rtvi-vlm` and begin continuous monitoring. Do NOT call the `rtvi-vlm` microservice (`http://localhost:8018/v1/...`) directly — always go through the agent.",
       "checks": [
         "The run performed at least one successful `POST http://localhost:8000/generate` (or equivalent agent base URL) with `Content-Type: application/json` and a JSON body containing `input_message` returning HTTP 2xx.",
         "The `input_message` text asks the agent to **start** a real-time alert on sensor `warehouse_sample` and references **boxes** / **dropped** (the user's detection target).",
-        "The trajectory does NOT call `http://localhost:8018/v1/streams/add` or `http://localhost:8018/v1/generate_captions_alerts` directly — those are dispatched by the agent's `rtvi_vlm_alert` tool, not by the skill.",
-        "After the start request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response includes a stream whose URL points at NVStreamer (contains `:31554`) or whose description / sensor_name references `warehouse_sample` (confirms the agent registered the NVStreamer-served RTSP with rtvi-vlm).",
+        "The trajectory does NOT call `http://localhost:8018/v1/streams/add`, `http://localhost:8018/v1/generate_captions_alerts`, or any other `rtvi-vlm` microservice endpoint directly — those are dispatched by the agent's `rtvi_vlm_alert` tool, not by the skill.",
+        "After the start request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response includes a stream whose description / sensor_name references `warehouse_sample` (confirms the agent registered the stream with rtvi-vlm).",
         "The final assistant reply confirms that real-time monitoring has started for `warehouse_sample` (e.g. references `started`, `monitoring`, or `running` and the sensor name) without errors in the response body."
       ]
     },
     {
-      "query": "Show me recent alerts for sensor `warehouse_sample`. Drive the query through the VSS Agent's `/generate` endpoint — the agent should dispatch `video_analytics_mcp.get_incidents` internally (see `skills/alerts/SKILL.md` § *Workflow C*).",
+      "query": "List recent incidents/alerts for sensor `warehouse_sample`. Use the **video-analytics** skill — call VA-MCP at `http://localhost:9901/mcp` with the required two-step pattern (`initialize` → capture `mcp-session-id` from the response **header** → `tools/call` with that header) and invoke the `video_analytics__get_incidents` tool filtered to that sensor.",
       "checks": [
-        "The run performed at least one successful `POST http://localhost:8000/generate` with an `input_message` that asks for **alerts** / **incidents** for sensor `warehouse_sample` and returns HTTP 2xx.",
-        "The trajectory or agent reasoning shows the agent called the `video_analytics_mcp.get_incidents` tool (or equivalent VA-MCP `get_incidents` invocation) — not a direct Elasticsearch query and not a direct `rtvi-vlm` call.",
-        "The final assistant reply is plain text or light markdown that either lists incidents for `warehouse_sample` OR clearly states that no incidents have been recorded yet for that sensor — not an error trace, not a raw tool dump."
-      ]
-    },
-    {
-      "query": "Stop the real-time alert on sensor `warehouse_sample`. Drive the stop through the VSS Agent's `/generate` endpoint — the agent should tear down both the caption stream and the rtvi-vlm stream registration.",
-      "checks": [
-        "The run performed at least one successful `POST http://localhost:8000/generate` with an `input_message` containing **stop** and the sensor name `warehouse_sample`, returning HTTP 2xx.",
-        "After the stop request, `curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns HTTP 200 and the response no longer contains any stream whose URL points at NVStreamer (`:31554`) for `warehouse_sample` or whose description references `warehouse_sample` (confirms the agent un-registered the stream).",
-        "The final assistant reply confirms that monitoring has stopped for `warehouse_sample` (e.g. references `stopped`, `terminated`, or `removed` and the sensor name) without errors."
+        "The trajectory shows two sequential POSTs to `http://localhost:9901/mcp` — first an `initialize` JSON-RPC method, then a `tools/call` — not a single one-shot call.",
+        "The trajectory captures the `mcp-session-id` from the initialize **response header** (not the body) and passes it as the `mcp-session-id` request header on the `tools/call` POST.",
+        "The `tools/call` payload invokes the tool name `video_analytics__get_incidents` with arguments referencing `warehouse_sample` (e.g. `\"source\": \"warehouse_sample\"` and `\"source_type\": \"sensor\"`, optionally with `max_count`).",
+        "The trajectory does NOT bypass VA-MCP by hitting Elasticsearch directly (no `:9200/_search` calls) and does NOT route this query through the VSS Agent's `/generate` endpoint (the video-analytics skill is the canonical path for this question, not the agent).",
+        "The final assistant reply is plain text or light markdown that either lists incidents for `warehouse_sample` OR clearly states that no incidents have been recorded yet for that sensor — not an error trace, not a raw tool dump, not a `Bad Request: Missing session ID` failure (which would indicate the two-step pattern was not followed)."
       ]
     }
   ]


### PR DESCRIPTION
Exercises Workflow B + C from skills/alerts/SKILL.md against the alerts profile in real-time mode: mode detection, VIOS sensor onboarding, start/query/stop of a real-time alert via the VSS Agent /generate endpoint, with checks asserting the skill's "go through the agent, never rtvi-vlm directly" rule.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
