### PR TITLE
helm-sync: temporary egress diagnostic step

### DIFF
--- a/.github/workflows/helm-sync.yml
+++ b/.github/workflows/helm-sync.yml
@@ -114,6 +114,30 @@ jobs:
               - '.github/helm-sync/**'
               - '.github/workflows/helm-sync.yml'
 
+      - name: Diagnose runner egress (TEMPORARY — revert once root-cause known)
+        if: steps.changes.outputs.relevant == 'true'
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+        run: |
+          set +e
+          echo "=== url byte length (catches trailing newline / whitespace) ==="
+          printf '%s' "$ANTHROPIC_BASE_URL" | wc -c
+          echo "=== printable form (chars X-masked, shape visible) ==="
+          printf '%s' "$ANTHROPIC_BASE_URL" | tr 'a-zA-Z0-9' 'X'; echo
+          echo "=== /etc/resolv.conf (top 5) ==="
+          cat /etc/resolv.conf | head -5
+          echo "=== getent hosts inference-api.nvidia.com ==="
+          getent hosts inference-api.nvidia.com | head -3
+          echo "=== curl HEAD via configured URL (5s budget) ==="
+          curl -sI -o /dev/null -w "HTTP %{http_code} (resolved %{remote_ip}, total %{time_total}s)\n" --max-time 5 "${ANTHROPIC_BASE_URL}/v1/messages"
+          echo "=== curl HEAD against api.anthropic.com (5s budget) ==="
+          curl -sI -o /dev/null -w "HTTP %{http_code} (resolved %{remote_ip}, total %{time_total}s)\n" --max-time 5 https://api.anthropic.com/v1/messages
+          echo "=== outbound public IP (what an allowlist sees) ==="
+          curl -s --max-time 5 https://api.ipify.org; echo
+          echo "=== whoami + process tree ==="
+          whoami
+          ps -ef --forest 2>/dev/null | grep -E "Runner.Listener|runsvc|/bin/bash" | head -10
+
       - name: Run helm-sync agent
         id: agent
         if: steps.changes.outputs.relevant == 'true'


### PR DESCRIPTION
Debug-only PR to find why GHA helm-sync runs hit `API Error: Unable to connect to API (ConnectionRefused)` even though the SDK works on the same runner host when invoked manually.

Adds one diagnostic step before the agent step that dumps:
- byte-length + masked shape of `$ANTHROPIC_BASE_URL` secret (catches trailing newline)
- DNS resolution for `inference-api.nvidia.com`
- curl reachability with 5s budget against the configured URL **and** `api.anthropic.com`
- outbound public IP (what an allowlist would see)
- whoami + process tree

Will revert once we know the root cause. Not for merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)