### PR TITLE
skill-eval: forward LLM/VLM remote vars to brev instance

### DIFF
--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -241,7 +241,11 @@ class BrevEnvironment(BaseEnvironment):
             # Revisit if/when the proxy accepts the field.
             ("CLAUDE_CODE_DISABLE_THINKING", "1"),
         ]
-        for key in ("NGC_CLI_API_KEY", "NVIDIA_API_KEY", "HF_TOKEN"):
+        for key in (
+            "NGC_CLI_API_KEY", "NVIDIA_API_KEY", "HF_TOKEN",
+            "LLM_REMOTE_URL", "LLM_REMOTE_MODEL",
+            "VLM_REMOTE_URL", "VLM_REMOTE_MODEL",
+        ):
             val = os.environ.get(key)
             if val:
                 forwarded.append((key, val))


### PR DESCRIPTION
Without these, the deploy skill on the eval instance falls back to local NIM placement even when the trial requested remote-all, because the remote endpoint env vars never reach the instance. claude-code's harness only propagates ANTHROPIC_*, so anything else needed by the deploy step must land in ~/.eval_env via brev_env.py's forwarded list.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
