### PR TITLE
helm-sync: remove temporary egress-diagnostic step

### DIFF
--- a/.github/workflows/helm-sync.yml
+++ b/.github/workflows/helm-sync.yml
@@ -114,30 +114,6 @@ jobs:
               - '.github/helm-sync/**'
               - '.github/workflows/helm-sync.yml'
 
-      - name: Diagnose runner egress (TEMPORARY — revert once root-cause known)
-        if: steps.changes.outputs.relevant == 'true'
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-        run: |
-          set +e
-          echo "=== url byte length (catches trailing newline / whitespace) ==="
-          printf '%s' "$ANTHROPIC_BASE_URL" | wc -c
-          echo "=== printable form (chars X-masked, shape visible) ==="
-          printf '%s' "$ANTHROPIC_BASE_URL" | tr 'a-zA-Z0-9' 'X'; echo
-          echo "=== /etc/resolv.conf (top 5) ==="
-          cat /etc/resolv.conf | head -5
-          echo "=== getent hosts inference-api.nvidia.com ==="
-          getent hosts inference-api.nvidia.com | head -3
-          echo "=== curl HEAD via configured URL (5s budget) ==="
-          curl -sI -o /dev/null -w "HTTP %{http_code} (resolved %{remote_ip}, total %{time_total}s)\n" --max-time 5 "${ANTHROPIC_BASE_URL}/v1/messages"
-          echo "=== curl HEAD against api.anthropic.com (5s budget) ==="
-          curl -sI -o /dev/null -w "HTTP %{http_code} (resolved %{remote_ip}, total %{time_total}s)\n" --max-time 5 https://api.anthropic.com/v1/messages
-          echo "=== outbound public IP (what an allowlist sees) ==="
-          curl -s --max-time 5 https://api.ipify.org; echo
-          echo "=== whoami + process tree ==="
-          whoami
-          ps -ef --forest 2>/dev/null | grep -E "Runner.Listener|runsvc|/bin/bash" | head -10
-
       - name: Run helm-sync agent
         id: agent
         if: steps.changes.outputs.relevant == 'true'


### PR DESCRIPTION
Removes the diagnostic step added in #223. It served its purpose:

The X-masked URL shape `XXXXX://XXXXXXXXX-XXX.XXXXXX.XX` (31 bytes, 2-letter TLD) on PR #206's run revealed that `ANTHROPIC_BASE_URL` was set to `https://inference-api.nvidia.co` instead of `.com`. The .co TLD NXDOMAINs immediately, which curl reports as `HTTP 000 (resolved , total 0.011s)`, and the SDK's underlying httpx surfaces as `API Error: Unable to connect to API (ConnectionRefused)` after a 3-min SYN-retry timeout.

Operator fixed the secret value. Helm-sync now connects fine. Cleaning up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)