### PR TITLE
skill-eval: forbid polling loops + fail loud when no DONE/BLOCKED verdict

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -544,6 +544,42 @@ Notes that have burned prior runs:
 - Output goes to `/tmp/skill-eval/results/$GITHUB_RUN_ID/<date>/<trial>/`.
   Then migrate to the viewer (see § Harbor viewer).
 
+### No polling — block on harbor
+
+`uvx harbor run` MUST block this SDK turn until the trial exits.
+Do NOT background the harbor invocation and then sit in a polling
+loop watching `/logs/agent/claude-code.txt` line counts (or any
+other progress indicator) over `brev exec`. Each poll iteration
+counts as a tool turn and burns the SDK's turn budget. We
+observed run 25256515296 on PR #221 spend ~25 turns in
+`until [ "$(brev exec ... 'wc -l ...')" -gt N ]; do sleep 30; done`
+loops, then run out of turns mid-trial and exit without ever
+posting a comment — green ✓ workflow with $23.52 spent and zero
+signal to the contributor. The wrapper now exits 4 in that case
+(see § Output requirements), so silently giving up is a real
+failure now, not a quiet success.
+
+Acceptable patterns:
+- `uvx harbor run …` (foreground, blocks until trial exits) —
+  preferred.
+- `timeout 1h uvx harbor run …` — bounded blocking.
+- `uvx harbor run … &; wait $!` — backgrounded then a single
+  blocking `wait`. No polling.
+
+Forbidden pattern:
+
+```bash
+# DO NOT do this. Trial-supervision via tool-turn polling.
+uvx harbor run … &
+until [ "$(brev exec "$INSTANCE" -- 'wc -l /logs/agent/claude-code.txt' | awk 'NR==1{print $1}')" -gt "$N" ]; do
+    sleep 30
+done
+```
+
+If you need to peek at intermediate state (rare — usually only when
+debugging a stuck trial), do it ONCE between trials, not in a loop.
+The trial owns the trial; don't supervise it tool-call-by-tool-call.
+
 If a trial errors out, read
 `/tmp/skill-eval/results/$GITHUB_RUN_ID/<date>/<trial>/trial.log` —
 it has the harness + adapter traceback. Fix the adapter
@@ -695,9 +731,19 @@ separate; don't conflate the two.
 
 - Stream prose freely to stdout — the GitHub Actions log is your
   audit trail. Tool calls get a one-line breadcrumb automatically.
-- On success, final line: `DONE: <N>/<M> specs passed; <K> blockers`
-- On blocker: final line: `BLOCKED: <short reason>` (no DONE
-  needed).
+- **Mandatory final marker.** Your last printed line MUST start with
+  either `DONE:` or `BLOCKED:`. The Python wrapper checks for this
+  and **fails the workflow with exit code 4** if neither appears —
+  so a workflow that "completed successfully" but didn't reach a
+  verdict is treated as a real failure (it isn't a green ✓ anymore).
+  Examples:
+    - `DONE: 3/3 specs passed; 0 blockers`
+    - `DONE: 2/3 specs passed; 1 spec failed (rt-vlm/step-2 reward=0.83)`
+    - `BLOCKED: anthropic rate limit after 3 retries`
+    - `BLOCKED: lock timeout on vss-eval-l40s`
+  If you ran trials, you MUST also have called `gh pr comment
+  $PR_NUMBER` with the per-batch results before printing
+  `DONE:` — otherwise the contributor sees no signal on their PR.
 - Don't tear down or `brev stop` / `brev delete` any instance. The
   `vss-eval-*` pool is operator-managed and stays warm across runs.
 

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -192,14 +192,34 @@ line starting with `BLOCKED:` followed by the reason.
 
     print(f"[agent] finished · cost=${total_cost:.2f}", flush=True)
     if hit_max_turns:
-        print("[agent] hit max_turns — agent may not have completed", file=sys.stderr)
+        print("[agent] hit max_turns — agent may not have completed",
+              file=sys.stderr)
         return 3
 
+    # Protocol enforcement: the agent must end with `DONE:` or `BLOCKED:`
+    # in its last few text blocks. Without this guard, an agent that
+    # quits mid-flow (model decided the conversation was over without
+    # reaching the comment-post step — observed on run 25256515296,
+    # PR #221, where the agent burned ~25 turns polling and then
+    # stopped without DONE/BLOCKED, leaving the workflow green ✓ but
+    # the source PR with no result comment) would produce a silent
+    # green check. Treat that as a real failure with exit code 4.
     summary = "\n".join(final_text[-10:])
     if "BLOCKED:" in summary:
         print("[agent] reported blocker", file=sys.stderr)
         return 0   # blocker is a valid outcome, not a crash
-    return 0
+    if "DONE:" in summary:
+        return 0
+    print(
+        "[agent] exited without a final DONE: or BLOCKED: marker — "
+        "protocol failure (no verdict reached). This typically means "
+        "the agent gave up mid-trial without posting a results comment. "
+        "Look at the trial logs and the workflow artifact; per AGENTS.md "
+        "§ Output requirements the final printed line must start with "
+        "DONE: or BLOCKED:.",
+        file=sys.stderr,
+    )
+    return 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

Run [25256515296](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/25256515296) on PR #221 ran for **1h35m**, cost **\$23.52**, completed with exit code 0 / green ✓ — and posted nothing on PR #221. The contributor sees a "successful" run with zero feedback.

What actually happened:
- Agent fired off `uvx harbor run` on `vss-eval-l40s`, then sat in 25 polling loops of the form `until [ "$(brev exec ... 'wc -l /logs/agent/claude-code.txt' | awk '{print $1}')" -gt "$N" ]; do sleep 30; done` — each iteration counts as one SDK tool turn.
- Burned through the 600-turn budget watching the trial. The agent's main loop ended cleanly (`[agent] finished · cost=\$23.52`) without ever printing `DONE:` or `BLOCKED:` and without invoking `gh pr comment`.
- Wrapper returned 0 because neither max_turns nor an exception fired. Job conclusion: success.

## Two fixes, applied together

### 1. AGENTS.md: new "No polling — block on harbor" subsection

Right after the Notes-on-harbor-flags list. Acceptable patterns enumerated (foreground, `timeout`, `&; wait \$!`); the polling antipattern called out verbatim from run 25256515296. The trial owns the trial; the agent should not supervise it tool-call-by-tool-call.

### 2. AGENTS.md § Output requirements: mandate DONE/BLOCKED final marker

Reframes the existing soft "On success / on blocker" guidance as a HARD requirement enforced by the wrapper (exit 4 on protocol violation). Spells out that comment posting is mandatory before DONE.

### 3. `skills_eval_agent.py`: fail loud (exit 4) when no verdict

After the SDK stream ends and we've already routed `max_turns` to exit 3, check whether the agent's last 10 text blocks contain `DONE:` or `BLOCKED:`. If neither, return 4 with a clear stderr message pointing to the artifact and AGENTS.md §. This converts the previous silent-green-success into an actual workflow failure.

## Companion PR

Same fix targeted at `develop` (which has diverged ~860 lines from `feat/skills` for these files) is in PR #228. Both PRs carry the same conceptual change adapted to each branch's content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)