### PR TITLE
Update VSS_AGENT_VERSION to 3.2.0-26.05.1-4648c6ac8160 across develop…

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -225,7 +225,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.04.2-c4f5e8b
+VSS_AGENT_VERSION=3.2.0-26.05.1-4648c6ac8160
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -171,7 +171,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.04.3-9388d6486f30
+VSS_AGENT_VERSION=3.2.0-26.05.1-4648c6ac8160
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -174,7 +174,7 @@ EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.04.3-9388d6486f30
+VSS_AGENT_VERSION=3.2.0-26.05.1-4648c6ac8160
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -231,7 +231,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.04.3-9388d6486f30
+VSS_AGENT_VERSION=3.2.0-26.05.1-4648c6ac8160
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000


### PR DESCRIPTION
…er profiles

Bump vss-agent image tag for base, lvs, search, and alerts dev profiles so they all track the same 26.05.1 release.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
