### PR TITLE
skill-eval/alerts: per-step instruction scope; drop multi-step env na…

### DIFF
--- a/.github/skill-eval/adapters/alerts/generate.py
+++ b/.github/skill-eval/adapters/alerts/generate.py
@@ -232,30 +232,52 @@ def generate_platform_mode(
     platform_dir = output_root / spec_stem / f"{short}-{mode}"
     platform_dir.mkdir(parents=True, exist_ok=True)
 
+    n = len(expects)
     for idx, expect in enumerate(expects, 1):
-        step_dir = platform_dir / f"step-{idx}" if len(expects) > 1 else platform_dir
+        step_dir = platform_dir / f"step-{idx}" if n > 1 else platform_dir
         step_dir.mkdir(parents=True, exist_ok=True)
-        step_suffix = f"-step-{idx}" if len(expects) > 1 else ""
+        step_suffix = f"-step-{idx}" if n > 1 else ""
 
         # ---- instruction.md ------------------------------------------------
+        # Per-step scoping: step 1 deploys (host is bare); steps 2+ run
+        # against the already-deployed stack. We deliberately do NOT include
+        # the spec's `env` field — it's a multi-step narrative ("deploy then
+        # add then verify then poll") that, when pasted into a single step's
+        # instruction, reads as a directive to run the whole chain in this
+        # trial. Each step's `query` already carries the step-specific intent;
+        # static host context lives in the leading paragraph below.
+        if idx == 1:
+            leading = [
+                f"Use the `/alerts` skill (and `/deploy` as needed) on this bare `{platform}` host.",
+                "Docker + NVIDIA Container Toolkit are available, `NGC_CLI_API_KEY` is set,",
+                "and the remote LLM/VLM endpoints are configured via "
+                "`LLM_REMOTE_URL` / `LLM_REMOTE_MODEL` / `VLM_REMOTE_URL` / `VLM_REMOTE_MODEL`.",
+            ]
+        else:
+            leading = [
+                f"Use the `/alerts` skill on this `{platform}` host.",
+                "The VSS **alerts** profile is already deployed in **real-time (VLM)** mode "
+                "with `remote-all` placement (deployed by step 1).",
+            ]
+
         instruction_lines = [
             PREAMBLE,
             "",
-            f"Use the `/alerts` skill (and `/deploy` as needed) on this `{platform}` host.",
-            "The VSS **alerts** profile is deployed in **real-time (VLM)** mode",
-            "with remote LLM and remote VLM endpoints (`remote-all` placement).",
+            *leading,
             "",
-            f"## Query {idx} of {len(expects)}",
+            (f"## Query (step {idx} of {n})" if n > 1 else "## Query"),
             "",
             expect.get("query", ""),
             "",
-            "## Environment notes",
-            "",
-            rendered_spec.get("env", ""),
-            "",
-            "Run autonomously without prompting for confirmation.",
-            "",
         ]
+        if n > 1:
+            instruction_lines.append(
+                f"Complete only step {idx} and stop. The remaining steps run "
+                "as separate trials — do not pre-execute them in this one."
+            )
+            instruction_lines.append("")
+        instruction_lines.append("Run autonomously without prompting for confirmation.")
+        instruction_lines.append("")
         (step_dir / "instruction.md").write_text("\n".join(instruction_lines) + "\n")
 
         # ---- task.toml -----------------------------------------------------

--- a/skills/alerts/eval/alerts_vlm_real_time.json
+++ b/skills/alerts/eval/alerts_vlm_real_time.json
@@ -7,10 +7,10 @@
       }
     }
   },
-  "env": "Bare GPU host matching `{{platform}}` with Docker + NVIDIA Container Toolkit, `NGC_CLI_API_KEY`, and remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`, `LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`, `VLM_REMOTE_MODEL`). The eval runs the full sequence end-to-end: deploy the VSS **alerts** profile in **real-time** (VLM) mode with **remote-all** placement, add the `warehouse_sample.mp4` sample video through NVStreamer (`mdx-nvstreamer-alerts` on port `31000` HTTP / `31554` RTSP) so it becomes a simulated live camera, verify the sensor appears in VIOS (port `30888`), then poll VA-MCP (port `9901`) for incidents until one shows up. Sample data ships in NGC bundle `nvidia/vss-developer/dev-profile-sample-data:3.1.0`. Pre-authorized to deploy prerequisites and start any alerts needed to drive incident generation in real-time mode.",
+  "env": "Bare GPU host matching `{{platform}}` with Docker + NVIDIA Container Toolkit, `NGC_CLI_API_KEY`, and remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`, `LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`, `VLM_REMOTE_MODEL`). Sample data ships in NGC bundle `nvidia/vss-developer/dev-profile-sample-data:3.1.0`. Pre-authorized to deploy prerequisites and start any alerts needed to drive incident generation in real-time mode.",
   "expects": [
     {
-      "query": "Deploy the VSS alerts profile on {{platform}} in real-time (VLM) mode using remote LLM and remote VLM endpoints. Run end-to-end and autonomously.",
+      "query": "Deploy the VSS alerts profile on {{platform}} in real-time (VLM) mode using remote LLM and remote VLM endpoints.",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (VSS Agent REST API responsive).",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",


### PR DESCRIPTION
## Summary

Addresses Finding #1 from the skills-eval comment on PR #221 (run 25298841990 attempt 3).

In that run, step 1 (deploy) timed out at the 57-min agent-exec ceiling because the agent ran ~30 min finishing the deploy and then continued into step-2's NVStreamer registration. Root cause: the spec's `env` field narrates the full 4-step flow ("deploy then add then verify then poll") and was pasted verbatim into every step's `instruction.md`. Step 1 read as a directive to run all 4.

Fix is in two places — adapter and spec. The spec change is the durable fix; fixing only the adapter would let the trap re-emerge next time someone regenerates the adapter against this spec.

## What changed

### Adapter — `.github/skill-eval/adapters/alerts/generate.py`
- Step 1's leading paragraph now frames the host as **bare** (Docker + NCT, `NGC_CLI_API_KEY`, remote LLM/VLM endpoint env vars) and the agent's job as deploying the alerts profile.
- Steps 2+'s leading paragraph frames the stack as **already deployed** in real-time/remote-all by step 1.
- The spec's `env` block is no longer pasted into any step's `instruction.md`. Each step's `query` already carries the step-specific intent; static host context lives in the leading paragraph.
- When `n>1`, an explicit `Complete only step <i> and stop. The remaining steps run as separate trials — do not pre-execute them` tail is appended.

### Spec — `skills/alerts/eval/alerts_vlm_real_time.json`
- `env` — drop the sentence narrating the full 4-step flow. Keep host context (Docker, `NGC_CLI_API_KEY`, remote endpoint env vars), the NGC sample-data bundle ref, and the pre-auth clause — those apply to every step.
- step-1 `query` — remove "Run end-to-end and autonomously". The adapter `PREAMBLE` already grants autonomous execution; the "end-to-end" wording was being read as "do all 4 steps". Step 1 is now just `Deploy the VSS alerts profile … using remote LLM and remote VLM endpoints.`
- step-1 verifier checks unchanged — they only assert deploy outcomes (containers up, `perception-alerts` NOT running, etc.), so dropping "end-to-end" doesn't change what step 1 needs to satisfy.

## What this does NOT fix

- **Finding #2 (harbor agent-setup 360s cap)** — separate issue. Harbor's `ClaudeCode.install()` (`apt-get update` + `claude.ai/install.sh`) blows past the **fixed** 360s ceiling on cold boxes, and there's no `--agent-setup-timeout-multiplier` flag. Workaround is operator-side: pre-stage `claude` on pool members. Filing separately.
- **Finding #3 (pool instability)** — three CSP failures in one day for `vss-eval-l40s`. Operator concern, not a code fix.

## Test plan

- [ ] Re-trigger PR #221 once a healthy `vss-eval-l40s` is in the pool — step 1 should stop at deploy completion instead of running into step-2's work.
- [ ] Per-step trace URLs in the next results comment should show step 1's trajectory ending after the alerts containers are up (no NVStreamer calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)