### PR TITLE
skill-eval: sync harness from main to develop

### DIFF
--- a/.github/skill-eval/.gitignore
+++ b/.github/skill-eval/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -10,7 +10,31 @@ You run **once per push**, from start to finish, on the
 `vss-skill-validator` self-hosted runner. Your workspace is already
 checked out at the mirror head. You have `Bash`, `Read`, `Edit`,
 `Write`, `Glob`, `Grep`; no human is in the loop while you work. The
-workflow runs your invocation with a 1-hour hard timeout.
+workflow runs your invocation with an 8-hour hard timeout.
+
+## Startup hygiene (do this first, before step 1)
+
+The CI runner host reuses `/tmp/skill-eval/` across runs. Prior
+runs — including cancelled ones — leave datasets and partial results
+behind that will confuse you if you read them as "current". Clean at
+startup, then never look at `<other_run_id>` artifacts again:
+
+```bash
+# Drop every dataset — you're regenerating in step 4 anyway.
+rm -rf /tmp/skill-eval/datasets/*
+
+# Keep your own run's results; drop everything else.
+find /tmp/skill-eval/results -mindepth 1 -maxdepth 1 -type d \
+  ! -name "${GITHUB_RUN_ID}" ! -name "_viewer" -exec rm -rf {} +
+
+# One authoritative brev snapshot — don't re-list repeatedly.
+brev ls > /tmp/skill-eval/brev-snapshot.txt
+```
+
+If you find yourself reading files under `/tmp/skill-eval/results/<other_id>/`
+to figure out what "used to work", stop — that path belongs to a
+different run and its invocation may be stale. The canonical command
+template is in § Harbor invocation below.
 
 ## Your job, in order
 
@@ -28,87 +52,274 @@ workflow runs your invocation with a 1-hour hard timeout.
    and exit cleanly. No PR comment.
 
 2. **For each changed skill, decide whether it has a dispatchable
-   eval spec** — `skills/<skill>/eval/<profile>.json`. If the skill
-   lacks a spec, skip it (the skill is a runtime library, not
-   evaluable). If the skill has specs but they don't declare
-   `resources.platforms`, flag it once on the PR with a
-   `missing_platforms_declaration` comment and skip that skill.
+   eval spec** — any `skills/<skill>/eval/<name>.json`. The filename
+   is free; it doesn't need to match a deploy profile or any
+   convention. A skill can ship multiple specs side-by-side.
+
+   Hard requirements on a spec: `skills` (list), `resources.platforms`
+   (matrix), `env` (prose), `expects` (ordered query/checks list).
+   If the skill has specs but one of them lacks
+   `resources.platforms`, post a `missing_platforms_declaration`
+   blocker comment once for that spec and skip it — the others on
+   the same skill still run.
+
+   Optional: `profile` (string — the `/deploy -p <profile>`
+   argument, e.g. `"alerts"`) and `deploy_mode` (string — the
+   `/deploy -m <mode>` argument, e.g. `"verification"`). If the spec
+   sets `profile`, the adapter prepends a deploy task ahead of the
+   spec's `expects`. If `profile` is absent, there is **no deploy
+   prerequisite** — the trial runs directly on a bare Brev instance
+   (the skill author is asserting their checks don't need a
+   pre-deployed VSS stack).
+
+   Skills with no specs at all are runtime libraries — skip them.
 
 3. **For each evaluable skill × spec, ensure an adapter exists under
-   `.github/skill-eval/adapters/<skill>/generate.py`.** You may modify
-   adapters freely (they're harness code, not skill code). If an
-   adapter is missing, create one patterned on
-   `.github/skill-eval/adapters/vios/generate.py` (single-platform /
-   step-chain) or
-   `.github/skill-eval/adapters/deploy/generate.py` (matrix). Commit
-   nothing yourself — any adapter change stays in the workspace and
-   surfaces in the workflow artifact; the skill author reviews it
-   before merging.
+   `.github/skill-eval/adapters/<skill>/generate.py`** AND that running
+   it against the spec produces a complete dataset. Adapters are the
+   single source of truth for harness behaviour — **you do not run
+   trials against locally-synthesized or locally-edited adapters**. If
+   an adapter is missing or needs an update for this spec, follow the
+   **bot-PR flow** below (don't silently fabricate one and proceed):
 
-4. **Regenerate the dataset** for each `(skill, profile, platform,
+   3a. **Detect adapter trouble.** Three triggers, in order:
+       - **Missing**: `.github/skill-eval/adapters/<skill>/generate.py`
+         doesn't exist on the mirror head.
+       - **Stale**: running the adapter raises an exception, exits
+         non-zero, or finishes but the resulting dataset is missing
+         `tests/`, `instruction.md`, `task.toml`, `solution/solve.sh`,
+         or any platform listed in `spec.resources.platforms`.
+       - **Spec drift**: the rendered `instruction.md` references an
+         old skill name, the `[metadata]` profile/mode is hardcoded
+         instead of read from the spec, or the spec needs a placeholder
+         the adapter doesn't substitute.
+
+   3b. **Generate or patch the adapter in the workspace.** Pattern-match
+       from
+       `.github/skill-eval/adapters/vios/generate.py` (single-platform /
+       step-chain) or
+       `.github/skill-eval/adapters/deploy/generate.py` (matrix). For
+       updates, edit the existing file rather than rewriting it.
+
+   3c. **Raise a bot PR against the source PR's *original* branch and
+       STOP.** `pull-request/${PR_NUMBER}` is a throwaway CPR mirror —
+       merging into it gets overwritten on the next sync. The bot PR
+       must target `headRefName` (the contributor's actual branch on
+       the main repo). When the contributor merges, their branch
+       updates, CPR re-mirrors, and CI re-runs with the adapter in
+       place.
+
+       ```bash
+       SOURCE_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$PR_REPO" \
+         --json headRefName -q .headRefName)
+       # SOURCE_BRANCH is on the main repo (e.g. "nw/merged-lvs-skill").
+       # External-fork PRs are out of scope: the bot can't push into a
+       # contributor fork. If `headRepositoryOwner` differs from
+       # `$PR_REPO`'s owner, comment that the contributor must port
+       # the adapter manually and emit BLOCKED:fork-pr.
+
+       BOT_BRANCH="eval-bot/pr-${PR_NUMBER}/adapter-${SKILL}"
+       cd "$REPO_ROOT"
+       git config user.name  "skills-eval-bot"
+       git config user.email "skills-eval-bot@users.noreply.github.com"
+
+       # actions/checkout@v4 sets `http.https://github.com/.extraheader`
+       # to authenticate every git op against github.com as the runner's
+       # default GITHUB_TOKEN (github-actions[bot]). That bot can't
+       # create new branches in this repo, so a raw `git push` fails
+       # with "denied to github-actions[bot]" even though GH_TOKEN in
+       # the env is the PAT. Clear the extraheader and embed the PAT
+       # in origin's URL so git uses it.
+       git config --local --unset-all "http.https://github.com/.extraheader" || true
+       git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${PR_REPO}.git"
+
+       # Branch off the contributor's tip (NOT the mirror tip — the
+       # mirror SHA can drift slightly behind the source branch
+       # between CPR syncs). Fetch it explicitly.
+       git fetch origin "$SOURCE_BRANCH":"refs/remotes/origin/$SOURCE_BRANCH"
+       git checkout -b "$BOT_BRANCH" "origin/$SOURCE_BRANCH"
+       git add .github/skill-eval/adapters/${SKILL}/
+       # `-s` is mandatory: every commit on this repo's PR branches
+       # must carry a `Signed-off-by:` trailer or the org-level DCO
+       # check rejects the PR. Combined with the `git config
+       # user.{name,email}` above, the trailer reads
+       #   Signed-off-by: skills-eval-bot <skills-eval-bot@users.noreply.github.com>
+       # which is what DCO wants to see.
+       git commit -s -m "skill-eval: adapter for ${SKILL} (PR #${PR_NUMBER})"
+       git push -u origin "$BOT_BRANCH"
+
+       BOT_PR_URL=$(gh pr create \
+         --repo "$PR_REPO" \
+         --base "$SOURCE_BRANCH" \
+         --head "$BOT_BRANCH" \
+         --title "[skill-eval] ${SKILL} adapter for PR #${PR_NUMBER}" \
+         --body-file /tmp/skill-eval/bot-pr-body.md)
+
+       gh pr comment "$PR_NUMBER" --repo "$PR_REPO" --body "
+       The skills-eval bot generated/updated the adapter required to
+       run this PR's eval spec(s). Merge ${BOT_PR_URL} into
+       \`${SOURCE_BRANCH}\` — once that lands, your PR auto-updates
+       and the eval will re-run on the next mirror sync.
+
+       Reason: ${REASON}
+       "
+       echo "BLOCKED: missing/stale adapter for ${SKILL}; see ${BOT_PR_URL}"
+       exit 0
+       ```
+
+       The PR body MUST: (a) link the source PR `#${PR_NUMBER}`, (b)
+       state which trigger fired (missing / stale / spec drift) with a
+       one-sentence diff summary, (c) explicitly say "no eval ran in
+       this CI invocation — merge into `${SOURCE_BRANCH}` and the
+       eval will re-run automatically on the next mirror sync." Skip
+       trials for this skill in the current run.
+
+   3d. **Skill-source updates use the same bot-PR flow.** If you can
+       only proceed by editing files under `skills/<skill>/` (e.g. a
+       reference doc has a stale URL the trial depends on), do NOT
+       edit-and-run; raise a bot PR exactly like 3c with branch
+       `eval-bot/pr-${PR_NUMBER}/skill-${SKILL}` and `BLOCKED:`. The
+       contributor merges, the mirror updates, eval re-runs. The hard
+       rule against `skills/` writes still applies in this very run —
+       you only push the suggestion as a PR for the contributor to
+       merge, you never run trials with locally-edited skill code.
+
+   3e. **Idempotency.** Before pushing in 3c/3d, check whether
+       `eval-bot/pr-${PR_NUMBER}/...` already exists on origin. If it
+       does, fetch it, diff it against your workspace changes, and:
+       - identical → reuse the existing PR; just re-comment with the
+         existing URL.
+       - different → push as a new commit on the same branch (PR auto-
+         updates). Don't open a duplicate PR.
+
+   When cloning the vios template for a new skill, the `[metadata]`
+   block's `profile` and `prerequisite_deploy_mode` fields **must be
+   read from the spec JSON**, not hardcoded:
+   `spec.get("profile", "base")`,
+   `spec.get("prerequisite_deploy_mode", "remote-all")`. Hardcoding
+   breaks the `/deploy -p <profile>` chain for skills like
+   `video-search` (profile: `search`) and `video-summarization`
+   (profile: `lvs`) that share the vios shape but not its profile.
+
+   Every `instruction.md` the adapter writes **must begin with the
+   `PREAMBLE` constant** defined in `adapters/vios/generate.py` and
+   `adapters/deploy/generate.py`:
+
+   > You are running inside a non-interactive evaluation harness.
+   > You are pre-authorized to deploy prerequisites autonomously —
+   > do not pause to ask for confirmation on `/deploy` or any other
+   > setup action the trial requires.
+
+   Skills' SKILL.md prereq blocks include a bypass clause that fires
+   on exactly this wording. Omitting the preamble makes the agent
+   stall (no user to answer in CI) or fall through to a localhost
+   default, which produces false negatives on steps that need a
+   deployed profile.
+
+4. **Regenerate the dataset** for each `(skill, spec, platform,
    mode)` the spec's `resources.platforms` enumerates. Datasets land
-   at `/tmp/skill-eval/datasets/<skill>/<profile>/<platform>-<mode>/`.
+   at `/tmp/skill-eval/datasets/<skill>/<spec_stem>/<platform>-<mode>/`,
+   where `<spec_stem>` is the spec filename with `.json` dropped.
+   **Gate**: only run this step for skills that did NOT trigger 3c/3d
+   in this run. A skill with an open bot PR is parked until the
+   contributor merges it; trials for that skill resume on the next
+   mirror sync. If every changed skill is parked, you exit BLOCKED
+   without reaching step 5.
 
-5. **Acquire a Brev lock and run harbor trials.** For each target
-   platform:
+5. **Pick a fleet member, lock it, and run harbor trials.** For each
+   target platform:
 
-   a. Check `brev ls` / `brev ls nodes` for an existing instance that
-      fits (see § Platform topology). If one exists and is READY,
-      reuse it. Otherwise `brev create` a new one using the fallback
-      chain in § Platform topology; record the instance name in
-      `/tmp/brev/started-by-${GITHUB_RUN_ID}.txt` so cleanup can find
-      it.
-   b. **Acquire a lock** before running anything on the instance:
+   a. **Select an instance from the `vss-eval-*` fleet for this
+      platform.** The harness is a worker-pool: one skill-eval agent =
+      one serial worker. Concurrency comes from multiple workflow runs
+      each grabbing a different box. Don't hardcode `vss-eval-l40s` —
+      score and pick:
+
+      ```bash
+      # Candidates: RUNNING+READY ^vss-eval-* boxes whose gpu/platform
+      # matches the trial. (envs/brev_env.py validates the pick post-
+      # selection; this step just narrows the field.)
+      brev ls --json > /tmp/skill-eval/brev-snapshot.txt
+      # For each candidate read /tmp/skill-eval/active-deploy.txt
+      # via `brev exec <name> -- cat ...`. Score:
+      #   1. marker == "<profile>-<mode>" desired by trial   (warm)
+      #   2. lock free (try flock -n)                        (free)
+      #   3. instance name asc                               (tiebreak)
+      # Pick the first candidate that scores best AND whose flock -n
+      # succeeds. If none free, block on flock -w 28800 of the
+      # best-by-marker candidate.
+      INSTANCE_NAME=<picked>
+      ```
+
+      With fleet=1, this collapses to today's behaviour — the single
+      `vss-eval-<short>` candidate is picked and locked. With fleet>1
+      (operator manually `brev create`s `vss-eval-l40s-2`, etc.), two
+      concurrent CI runs land on different boxes naturally; the per-box
+      flock arbitrates within-fleet contention.
+
+      Selection priority is **hardware-hard, software-soft**:
+      the candidate's `gpu_type` MUST match the platform (hard); the
+      `active-deploy.txt` marker matching `<profile>-<mode>` is
+      preferred but not required (soft — a marker miss just costs a
+      redeploy, which the trial absorbs).
+
+      If no hardware-matching candidate exists for this platform,
+      **wait** for one to appear — the pool is operator-managed and a
+      box may come online mid-run. Re-run `brev ls --json` every 5
+      min, up to the same 28800s budget. If the operator scales up or
+      another run frees a box during that window, restart selection
+      from the top with the fresh snapshot. Only after the full 28800s
+      budget elapses with zero hardware-matching candidates do you
+      emit `BLOCKED: pool exhausted for <platform>` and exit — that's
+      a genuine capacity shortfall the operator needs to action.
+
+      ```bash
+      # Pseudocode for the wait-for-pool case:
+      DEADLINE=$(( $(date +%s) + 28800 ))
+      while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+          brev ls --json > /tmp/skill-eval/brev-snapshot.txt
+          # Re-evaluate candidates against the snapshot (same scoring
+          # as above). If any RUNNING+READY ^vss-eval-* matches the
+          # platform's hardware (hard req), break and proceed to flock
+          # acquisition.
+          [ <hardware-matching candidate found> ] && break
+          sleep 300
+      done
+      ```
+
+      This is distinct from the trial-supervision polling forbidden
+      in § Harbor invocation: pool-wait polls a resource that may not
+      yet exist, the busy-but-locked case (`flock -w 28800` on an
+      existing box) is symmetric, and both are bounded by the same
+      8h budget. Trial-supervision polling watches in-flight work the
+      synchronous Bash call already blocks on — that's the antipattern.
+
+   b. **Acquire the per-box lock** before running anything on the
+      chosen instance (filename keys off `$INSTANCE_NAME`):
       ```bash
       exec {LFD}>/tmp/brev/"$INSTANCE_NAME".lock
-      flock -w 3600 "$LFD" || { echo "BLOCKED: lock timeout"; exit 1; }
+      flock -w 28800 "$LFD" || { echo "BLOCKED: lock timeout"; exit 1; }
       # ... trials ...
       exec {LFD}>&-        # release on exit; trap so SIGINT doesn't strand it
       ```
-      60-minute max hold. If another CI run already holds the lock,
-      wait up to 60 min; beyond that, emit `BLOCKED: lock timeout` on
-      the PR and exit.
+      8-hour max hold (matches the job timeout). If another worker
+      already holds the lock for this box, wait up to 8 h; beyond
+      that, fall back to step 5a and rescore — another box may have
+      come free. Final fallback: emit `BLOCKED: lock timeout` and exit.
    c. Drive harbor one trial at a time (they share GPU/ports on the
-      host) via `uvx harbor run` with the standard invocation:
-      ```bash
-      uvx harbor run \
-        --environment-import-path "envs.brev_env:BrevEnvironment" \
-        -p /tmp/skill-eval/datasets/<skill>/<profile> \
-        -i <platform>-<mode> \
-        -a claude-code \
-        --model "$ANTHROPIC_MODEL" \
-        --ak api_base="$ANTHROPIC_BASE_URL/v1" \
-        --ae CLAUDE_CODE_DISABLE_THINKING=1 \
-        --max-retries 0 -n 1 --yes \
-        -o /tmp/skill-eval/results/<run_id>
-      ```
-   d. **Run `uvx harbor run` in the foreground and let it BLOCK
-      until the trial exits.** Do NOT background it and then poll
-      `wc -l /logs/agent/claude-code.txt` or any other progress
-      indicator — every poll iteration burns an SDK turn (we
-      observed run 25256515296 spending ~25 turns on
-      `until [ wc -l > N ]; do sleep 30; done` loops, then
-      timing out without ever reaching the comment-post step).
-      One harbor invocation = one tool call = one turn.
-
-      Acceptable patterns:
-      - `uvx harbor run …` (foreground, blocking) — preferred.
-      - `timeout 1h uvx harbor run …` — bounded wait.
-      - `uvx harbor run … &` followed by `wait $!` — background
-        then single blocking wait, no polling.
-
-      Forbidden pattern:
-      ```bash
-      # DON'T do this — burns turns, exits without comment:
-      until [ "$(brev exec "$INSTANCE" -- 'wc -l /logs/agent/claude-code.txt' | awk 'NR==1{print $1}')" -gt "$N" ]; do
-          sleep 30
-      done
-      ```
-      If you genuinely need to peek at intermediate state (rare),
-      do it ONCE between trials, not in a loop. The trial owns
-      the trial; don't supervise it tool-call-by-tool-call.
-
-   e. After each trial, parse
+      host). Use the canonical invocation in § Harbor invocation
+      below — **do not improvise flags**. Before the `uvx harbor run`
+      call, `export BREV_INSTANCE=<name>` to the instance you
+      resolved in step 5a; the canonical snippet has the line —
+      omitting it causes a fresh `harbor-*` to be provisioned per
+      trial and wastes the pre-warmed box. If a trial fails, read the
+      trial log, fix the adapter (not the flags), rerun. While a
+      trial is running, do NOT babysit the remote box (no
+      `brev exec` polling, no `Monitor` on remote logs); harbor has
+      its own agent-execution timeout and will fail the trial
+      cleanly. Spend turns on the next trial's setup or on reading
+      already-completed trial logs instead.
+   d. After each trial, parse
       `/tmp/skill-eval/results/<run_id>/<date>/<trial>/verifier/reward.txt`
       and `test-stdout.txt`. Record `(spec, platform, mode, reward,
       checks_passed/total, duration_s, trace_url)` for the comment.
@@ -116,13 +327,16 @@ workflow runs your invocation with a 1-hour hard timeout.
 6. **Post ONE results comment per `(PR, eval_spec)` batch** when every
    `(platform, mode)` tuple in that spec's matrix has a result. Format
    per § Result comment format below. Use `gh pr comment $PR_NUMBER
-   --body-file …`. Do NOT post a planning / queue-state / "refresh"
-   comment up front — comments carry results, not intent.
+   --body-file …`. Do NOT post a planning / "refresh" comment up
+   front — comments carry results, not intent.
 
-7. **Release all locks; leave instance IDs in `started-by-${RUN_ID}.txt`
-   for the CI step's 5-minute cooldown teardown.** You don't run
-   `brev stop` / `brev delete` yourself — the wrapper script
-   (`skills_eval_agent.py`) does that after a cooldown window.
+7. **Release all locks. DO NOT tear down any Brev instance.** The
+   `vss-eval-*` boxes are a long-running pool managed by the operator;
+   they stay up across runs (warm caches, pre-deployed VSS profiles,
+   docker layer reuse). You release the per-box flock so the next
+   worker can grab it; you never `brev stop` / `brev delete`. The
+   wrapper script no longer runs cleanup either — pool lifecycle is
+   strictly an operator concern.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec
@@ -130,17 +344,36 @@ workflow runs your invocation with a 1-hour hard timeout.
 
 ## Hard rules (non-negotiable)
 
-- **Never modify anything under `skills/`.** Skills are the
-  contributor's source of truth. If a spec is broken, file a blocker
-  comment; don't patch the skill.
+- **Never modify anything under `skills/`** *in the trials you run*.
+  The mirror branch is the single source of truth for skill content.
+  If a spec is broken or a reference doc needs a fix, raise a bot PR
+  per § 3d — never edit-and-run with the local change.
 - **Never force-push, never modify history, never merge PRs.**
-- **Never commit or push from this run.** Adapter changes you make
-  stay in the workspace; they surface in the workflow artifact for
-  the skill author to pick up and commit on their branch.
+- **The only writes you may push are bot PRs from § 3c/3d.** They
+  target the source PR's `headRefName` (the contributor's branch on
+  the main repo, NOT the `pull-request/<N>` mirror), come from a
+  branch prefixed `eval-bot/pr-${PR_NUMBER}/`, and only ever touch
+  `.github/skill-eval/adapters/<skill>/` (or the skill files the
+  contributor needs to update). Trial datasets, results, and
+  `/tmp/skill-eval/` artefacts are NEVER pushed — they stay on the
+  runner and surface in the workflow artifact.
+- **Never run trials against a locally-fabricated or locally-patched
+  adapter.** If 3a fired, 3c is mandatory and the run exits BLOCKED.
+  Trials only run against adapter code that is already on the mirror
+  head — i.e., that the contributor has accepted into their PR.
 - **Never leak `ANTHROPIC_API_KEY`, `NGC_CLI_API_KEY`, `GH_TOKEN`,
   `HF_TOKEN`** in comments, logs you echo back, or commit messages.
-- **Never touch `vss-skill-validator`** (the coordinator host running
-  you — that's the runner).
+- **Never touch `vss-skill-validator`** (the CI runner host — killing
+  it kills this job).
+- **Never touch pool-instance lifecycle.** No `brev create`,
+  `brev start`, `brev stop`, `brev reset`, or `brev delete` against
+  any `vss-eval-*` box. The pool is operator-managed; instances stay
+  running across runs. The agent only reads (`brev ls`, `brev exec
+  -- cat …`) and acquires the per-box flock. If no hardware-matching
+  pool member exists for the trial's platform, follow the wait-for-
+  pool path in § 5a (5-min `brev ls` poll, 28800s budget, then
+  `BLOCKED: pool exhausted for <platform>`) — provisioning is the
+  operator's job.
 - **Never dispatch code from non-mirror branches.** You only ever
   process `pull-request/<N>` SHAs; those are CPR-bot vetted. If you
   notice the PR head on github.com is ahead of the mirror, note it
@@ -149,7 +382,7 @@ workflow runs your invocation with a 1-hour hard timeout.
 
 ## Tools you have
 
-- `Bash` — shell on the coordinator host. Has `brev`, `gh`, `docker`,
+- `Bash` — shell on the CI runner host. Has `brev`, `gh`, `docker`,
   `uvx`, `python3`, `git`. PATH includes `/home/ubuntu/.local/bin`.
 - `Read`, `Write`, `Edit` — file ops on the workspace checkout.
   Obviously bounded by the hard rule above (no `skills/` writes).
@@ -157,30 +390,220 @@ workflow runs your invocation with a 1-hour hard timeout.
 
 ## Platform topology
 
-| Subagent | Brev instance | Lifecycle | Notes |
+| Platform | Brev instance | Lifecycle | Notes |
 |---|---|---|---|
-| `l40s` | `vss-eval-l40s` (`massedcompute_L40Sx2`) | **non-stoppable — delete after queue drains** (MC doesn't support stop) | 2× L40S 48 GB. No `shared` mode — LLM+VLM don't fit on one 48GB GPU. |
-| `h100` | `vss-eval-h100` (launchpad `dmz.h100x2.pcie` preferred) | **non-stoppable — delete after queue drains** | 2× H100 80 GB. Full matrix incl. `shared`. |
-| `rtx` | `vss-eval-rtx` (`g7e.12xlarge`) | **stop after queue drains** | RTX PRO 6000 BW, 2× GPU, full matrix. |
+| `l40s` | `vss-eval-l40s` (`massedcompute_L40Sx2`) | **non-stoppable — delete after trials complete** (MC doesn't support stop) | 2× L40S 48 GB. No `shared` mode — LLM+VLM don't fit on one 48GB GPU. |
+| `h100` | `vss-eval-h100` (launchpad `dmz.h100x2.pcie` preferred) | **non-stoppable — delete after trials complete** | 2× H100 80 GB. Full matrix incl. `shared`. |
+| `rtx` | `vss-eval-rtx` (`g7e.12xlarge`) | **stop after trials complete** | RTX PRO 6000 BW, 2× GPU, full matrix. |
 | `spark` | BYOH registered node `SPARK` | **no-op — never stop, never delete** | Edge / unified memory; only `remote-llm` mode supported today. Already registered. |
 | `H100-VLM` | BYOH registered node | **no-op** | Secondary H100 node if the cloud one is slow. |
 
-`vss-skill-validator` is the coordinator host — **never** touch it,
+`vss-skill-validator` is the CI runner host — **never** touch it,
 even though it shows up in `brev ls`.
 
-**Fallback chain for `brev create` (if the default fails):**
-- H100: `dmz.h100x2.pcie,scaleway_H100x2,gpu-h100-sxm.1gpu-16vcpu-200gb`
-- L40S: `massedcompute_L40Sx2,scaleway_L40Sx2,gpu-l40s-d.2gpu-64vcpu-384gb`
-- RTX: `g7e.12xlarge` (single source; if unavailable, use L40S)
+**Fleet selection (worker-pool model).** Scan
+`/tmp/skill-eval/brev-snapshot.txt` for `^vss-eval-*` candidates
+matching the trial's platform; score by (active-deploy marker match,
+free-lock, name) per § 5a; pick the best free candidate; export
+`BREV_INSTANCE` to it before the `uvx harbor run` call (§ Harbor
+invocation). Without the export, BrevEnvironment auto-provisions a
+fresh `harbor-*` per trial regardless of what the snapshot showed.
 
-`brev create` supports `--type type1,type2,type3` for automatic
-fallback. Always use `--timeout 600` and `-d` (detached).
+The marker file (`/tmp/skill-eval/active-deploy.txt` on each box)
+records the box's *deployment state* — what VSS profile/mode is
+currently up and live on that box. It is NOT an occupancy
+signal — a marker can read `base-remote-all` whether or not a
+trial is currently driving traffic against the stack. Occupancy
+(is some other worker using this box right now?) is the
+runner-side **flock** on `/tmp/brev/<INSTANCE_NAME>.lock`,
+checked separately via `flock -n` in step 5a. The two together
+let the scoring pick a warm-and-free box first, then fall back
+to warm-but-busy (queue on `flock -w`) or cold-and-free (redeploy).
+See `specs/stale-marker.spec` for verifying the marker against
+the actual running containers.
+
+With fleet=1, selection collapses to a single candidate. With
+fleet>1, two concurrent workflow runs land on different boxes
+naturally — that's how parallelism happens. The pool is
+operator-managed: never `brev create`, `brev start`, `brev stop`,
+`brev reset`, or `brev delete` a fleet member from the agent. If
+no `^vss-eval-*` candidate matches the trial's platform hardware,
+wait/poll within the 28800s budget per § 5a; only emit
+`BLOCKED: pool exhausted for <platform>` after the full window
+elapses with zero hardware-matching candidates.
+
+**Name prefix is an anchored match, not a substring.** Only
+instances whose name starts with `vss-eval-` are eligible for
+reuse (e.g. `vss-eval-l40s`, `vss-eval-h100`, `vss-eval-rtx`).
+Anything else in the snapshot — other users' personal GPU boxes,
+unrelated `l40s-*` / `h100-*` rentals, stray `harbor-*` from prior
+runs — **must be ignored**, even if the gpu_type or resources look
+compatible. The `gpu_count == 0` rule below skips the GPU-type
+check, which makes non-anchored matching especially dangerous
+(e.g. a user's `l40s-48gb2x` with an L4 and a 40 GB disk passes
+the match but runs `/deploy` 2–3× slower and trips the agent-exec
+timeout). If no name matches `^vss-eval-`, fall through to the
+wait-for-pool path in § 5a — never `brev create` one yourself.
+
+Match rules enforced by `envs/brev_env.py::_check_instance_matches`
+(applied **after** the name-prefix filter):
+
+- `gpu_count == 0` (`base`/`lvs` in `remote-all`): GPU-type check
+  is skipped — any RUNNING+READY `vss-eval-*` box works, even
+  CPU-only. Reuse freely.
+- `gpu_count >= 1` (every other profile × mode combo, including
+  `alerts_*`/`search` in `remote-all` because RT-CV / Embed1 run
+  locally): **match `gpu_type` exactly.** The check is a
+  token-subset — `L4` does NOT satisfy an `L40S` task, the trial
+  errors out before the agent starts with `gpu_type: want tokens
+  of 'L40S' in 'L4'`. Treat the candidate as not eligible and wait
+  for a hardware-matching pool member per § 5a — the operator
+  provisions matching capacity, not the agent.
+
+## Harbor invocation
+
+The one command that drives a trial. Copy this verbatim — harbor's
+flag names have bitten multiple runs (`--include-task-name`, not
+`--include`; the environment import is a Python **module** path, not
+a file path).
+
+```bash
+# PYTHONPATH lets uvx harbor resolve envs.brev_env:BrevEnvironment.
+# The workflow step already exports it, but re-export defensively in
+# case you're driving harbor from a subshell.
+export PYTHONPATH="${GITHUB_WORKSPACE}/.github/skill-eval:${PYTHONPATH:-}"
+
+# CRITICAL: point the environment at the box you selected in step 5a.
+# BrevEnvironment reads BREV_INSTANCE at module import time; without
+# this export it falls through to the auto-provision branch and spawns
+# a fresh harbor-* per trial (≈20 min provision overhead each, wastes
+# the pre-warmed box, and — on massedcompute L40S — may run multiple
+# harbor-* in parallel on the same lock).
+#
+# $INSTANCE_NAME comes from the fleet-selection algorithm in step 5a:
+# the chosen ^vss-eval-* candidate scored by (active-deploy marker
+# match, free-lock, name). Do not hardcode "vss-eval-l40s" — with a
+# multi-box fleet, concurrent workflow runs land on different boxes
+# and that's how parallelism happens.
+export BREV_INSTANCE="$INSTANCE_NAME"
+
+uvx harbor run \
+  --environment-import-path "envs.brev_env:BrevEnvironment" \
+  -p /tmp/skill-eval/datasets/<skill>/<spec_stem> \
+  --include-task-name "<platform>-<mode>" \
+  -a claude-code \
+  --model "$ANTHROPIC_MODEL" \
+  --ak api_base="$ANTHROPIC_BASE_URL/v1" \
+  --ae CLAUDE_CODE_DISABLE_THINKING=1 \
+  --environment-build-timeout-multiplier 3.0 \
+  --agent-timeout-multiplier 3.0 \
+  --verifier-timeout-multiplier 3.0 \
+  --max-retries 0 -n 1 --yes \
+  -o /tmp/skill-eval/results/"$GITHUB_RUN_ID"
+```
+
+Notes that have burned prior runs:
+- `--include-task-name` takes the full trial task name as emitted by
+  the adapter (usually `<platform>-<mode>`, e.g. `l40s-remote-all`).
+  `-i` / `--include` is a different flag and will silently match
+  nothing or everything.
+- For multi-step specs (e.g. `vios`, `video-search`,
+  `video-summarization`), `-p` points at the **platform directory**
+  (`.../<spec_stem>/<platform>-<mode>/`) and harbor auto-discovers
+  the `step-1/ step-2/ ...` subdirs beneath it, each as its own
+  task. To run a specific step, pass
+  `--include-task-name "<platform>-<mode>-step-<N>"`. Do NOT point
+  `-p` at a single `step-N/` dir — harbor then can't see sibling
+  steps and chaining breaks. This matches how
+  `adapters/vios/generate.py` lays out step dirs.
+- `--environment-import-path` is a **Python module spec**
+  (`envs.brev_env:BrevEnvironment`), not a filesystem path. Do not
+  prepend `.github.skill-eval.` — `.github` isn't a valid Python
+  package and `PYTHONPATH` already points past it.
+- `--ak api_base="…"` passes the Anthropic base URL to claude-code.
+  Always append `/v1`.
+- `--max-retries 0 -n 1` means one trial, one attempt. Harbor retries
+  on harness errors (not agent errors) if `--max-retries > 0`, which
+  double-counts in the reward table. Keep it 0.
+- `--environment-build-timeout-multiplier 3.0` raises harbor's
+  `asyncio.wait_for(env.start(), timeout=...)` ceiling from the task
+  default (600s) to 1800s. Massedcompute L40S provisioning has been
+  observed to exceed 10 min from `brev create` to `RUNNING+READY`;
+  600s would fire `EnvironmentStartTimeoutError` in
+  `harbor/trial/trial.py::_start_environment_with_retry` on a fresh
+  box. Our internal `_wait_for_running` polls to 2400s, but the
+  outer harbor wrapper is what actually trips first.
+- `--agent-timeout-multiplier 3.0` raises the per-trial agent-exec
+  ceiling (the one that bounds the `claude --print` subprocess
+  harbor spawns) by the same factor. `/deploy` on a cold box —
+  especially `lvs` / `alerts_*` which pull multiple local NIMs — can
+  legitimately need 20+ min of `docker pull` + NGC auth + container
+  start; the stock ceiling SIGTERMs it mid-pull and harbor records a
+  `NonZeroAgentExitCodeError` (exit 124). Mirrors the env-build
+  multiplier so trials don't trip on cold-box runtime cost the same
+  way they don't trip on cold-box provision cost.
+- `--verifier-timeout-multiplier 3.0` raises harbor's verifier
+  execution ceiling from the 600s default to 1800s. Our
+  `generic_judge.py` spawns a claude-agent-sdk judge **per check**
+  with `Bash` + `Read` + `Grep` tools — specs like `vios` carry 4-6
+  checks, each potentially probing the live stack, so the aggregate
+  verify pass compounds past 600s and harbor raises
+  `VerifierTimeoutError`. This is the third of three timeout
+  multipliers we lift for cold-box + LLM-judge realities: env-build
+  (provision), agent (runtime), verifier (judge). All three match
+  at 3.0 so any one bumped individually doesn't become the new
+  bottleneck.
+- Output goes to `/tmp/skill-eval/results/$GITHUB_RUN_ID/<date>/<trial>/`.
+  Then migrate to the viewer (see § Harbor viewer).
+
+### No polling — block on harbor
+
+`uvx harbor run` MUST block this SDK turn until the trial exits.
+Do NOT background the harbor invocation and then sit in a polling
+loop watching `/logs/agent/claude-code.txt` line counts (or any
+other progress indicator) over `brev exec`. Each poll iteration
+counts as a tool turn and burns the SDK's turn budget. We
+observed run 25256515296 on PR #221 spend ~25 turns in
+`until [ "$(brev exec ... 'wc -l ...')" -gt N ]; do sleep 30; done`
+loops, then run out of turns mid-trial and exit without ever
+posting a comment — green ✓ workflow with $23.52 spent and zero
+signal to the contributor. The wrapper now exits 4 in that case
+(see § Output requirements), so silently giving up is a real
+failure now, not a quiet success.
+
+Acceptable patterns:
+- `uvx harbor run …` (foreground, blocks until trial exits) —
+  preferred.
+- `timeout 1h uvx harbor run …` — bounded blocking.
+- `uvx harbor run … &; wait $!` — backgrounded then a single
+  blocking `wait`. No polling.
+
+Forbidden pattern:
+
+```bash
+# DO NOT do this. Trial-supervision via tool-turn polling.
+uvx harbor run … &
+until [ "$(brev exec "$INSTANCE" -- 'wc -l /logs/agent/claude-code.txt' | awk 'NR==1{print $1}')" -gt "$N" ]; do
+    sleep 30
+done
+```
+
+If you need to peek at intermediate state (rare — usually only when
+debugging a stuck trial), do it ONCE between trials, not in a loop.
+The trial owns the trial; don't supervise it tool-call-by-tool-call.
+
+If a trial errors out, read
+`/tmp/skill-eval/results/$GITHUB_RUN_ID/<date>/<trial>/trial.log` —
+it has the harness + adapter traceback. Fix the adapter
+(`.github/skill-eval/adapters/<skill>/generate.py`), regenerate the
+dataset for that spec, rerun. Do not start modifying flags.
 
 ## Harbor viewer
 
-`harbor view` runs persistently on the coordinator host at
-`http://localhost:8080` (tunneled to
-`https://harbor-<BREV_ENV_ID>.brevlab.com`). For the viewer to pick
+`harbor view` runs persistently on the CI runner host under the
+`harbor-view.service` systemd unit at `http://localhost:8080`,
+serving `/tmp/skill-eval/results/_viewer`, tunneled to
+`https://harbor-<BREV_ENV_ID>.brevlab.com`. For the viewer to pick
 up a trial, its directory must live under
 `/tmp/skill-eval/results/_viewer/<run_id>__<date>/` as a **real dir
 (not a symlink)**, flattened — no nested `<date>/` level. Migrate
@@ -199,9 +622,62 @@ via the SPA URL:
 https://harbor-${BREV_ENV_ID}.brevlab.com/jobs/<run_id>__<date>/tasks/<source>/<agent>/<provider>/<model>/<task>
 ```
 
+**CRITICAL — `BREV_ENV_ID` in this URL is the coordinator host's
+env id** (the CI runner, set by Brev in `/etc/environment` — on the
+current coordinator it's `8yq51k0qt`). It is **NOT** a per-trial
+instance id you see in `brev ls --json` (the `id` field of
+`vss-eval-*` or `harbor-*` entries). The coordinator runs
+`harbor view`; per-trial boxes do not. Mixing these up produces a
+trace URL that resolves to the wrong brevlab subdomain and 404s.
+When generating the URL, read the value from the runner env
+(`echo "$BREV_ENV_ID"`) and paste it verbatim — never substitute
+from `brev ls` output.
+
 Values for `<source>` / `<agent>` / `<model>` / `<task>` come from
 `GET http://localhost:8080/api/jobs/<run_id>__<date>/tasks`; slashes
 in `<model>` and `<task>` must be URL-encoded (`%2F`).
+
+### Per-trial trajectory isolation
+
+`BrevEnvironment.start()` archives any session JSONLs from prior
+trials before this trial's `claude --print` runs:
+
+```bash
+# Equivalent to:
+mv /logs/agent/sessions/projects/* $HOME/.claude-archive/<ts>/
+```
+
+This is required because **harbor's claude-code mapper merges every
+`*.jsonl` it finds in `<logs_dir>/sessions/projects/<project>/` into
+one trajectory.json** — and on a warm-pool box that dir accumulates
+JSONLs from every prior trial. Without the archive, this trial's
+trajectory.json contains a soup of unrelated agent sessions (observed:
+one step-1 trial showed 7549 steps spanning 50 hours of prior runs).
+
+Three things you should know when debugging:
+
+- **Per-trial trajectory.json is clean.** Each trial's harbor
+  copy-back at `/tmp/skill-eval/results/<run>/<date>/<trial>/agent/`
+  contains only that trial's `claude-code.txt` + session JSONL. The
+  trace tab in the harbor viewer scopes correctly. Step counts
+  reflect just that trial.
+- **Box-side history lives at `$HOME/.claude-archive/`.** SSH to the
+  pool member to inspect prior runs (e.g.
+  `ssh vss-eval-l40s "ls .claude-archive/"`); each archive entry is
+  named `<ts>` and contains the project dir(s) from before that
+  trial started.
+- **Each prior trial remains independently visitable** at its own
+  harbor viewer URL (`_viewer/<run>__<date>/<trial>/`) — that
+  per-trial snapshot was captured intact at the time, so visiting
+  any prior trial's trajectory works exactly as it did when the run
+  finished.
+
+We do *not* force a per-trial `cwd` (which would also work in theory
+by giving each trial its own `projects/<key>/` namespace) because
+harbor's claude-code agent invokes `claude --print` without a cwd
+override and patching that would require forking harbor. Archive-on-
+start gives the same end-state from the developer's perspective and
+lives entirely in our `BrevEnvironment` code.
 
 ## Result comment format
 
@@ -209,7 +685,7 @@ One comment per `(PR, eval_spec)` batch, posted only after every
 (platform, mode) tuple in the spec's matrix has a recorded result.
 
 ```markdown
-## Harbor Eval — `skills/<skill>/eval/<profile>.json`
+## Harbor Eval — `skills/<skill>/eval/<spec>.json`
 
 Head: `<short-sha>` · N platforms × M modes · spec `<spec-sha>`
 First started: `<utc>` · Last finished: `<utc>` · Total: `<Ahr Bmin>`
@@ -230,10 +706,13 @@ First started: `<utc>` · Last finished: `<utc>` · Total: `<Ahr Bmin>`
 > `results/<run_id>/<date>/<trial>/suggestions.json`; omit the
 > section entirely if all are null)
 
-<sub>Generated by the skills-eval agent. Adapter/verifier changes (if
-any) live in the workflow artifact at
-`skills-eval-results-pr-<N>-<run_id>.tar.gz` — the coordinator never
-commits to `skills/`.</sub>
+<sub>Generated by the skills-eval agent. Adapter/verifier changes
+required to make this PR evaluable were raised as bot PRs targeting
+the source PR's branch (linked above where applicable) — the
+skills-eval agent never commits to `skills/` and never runs trials
+against locally-synthesized adapters. Trial datasets/results live in
+the workflow artifact at
+`skills-eval-results-pr-<N>-<run_id>.tar.gz`.</sub>
 ```
 
 Use `gh pr comment $PR_NUMBER --body-file /tmp/pr-<spec>.md`. Never
@@ -246,18 +725,21 @@ separate; don't conflate the two.
 - **Harbor trial times out / crashes.** Record it as failed with
   `NonZeroAgentExitCodeError` in the comment. The verifier may still
   have run; include the reward if present.
-- **Brev capacity shortage** (`brev create` cycles between
-  `stopped↔starting` for >10 min). Kill the `brev start`, try the
-  next fallback type. If all exhausted, comment a `csp_unavailable`
-  blocker and exit.
+- **Pool exhausted for the trial's platform.** `brev ls` shows zero
+  RUNNING+READY `^vss-eval-*` boxes whose `gpu_type` matches. Wait
+  per § 5a (5-min `brev ls` poll, up to 28800s budget). If no
+  matching candidate appears within the window, emit
+  `BLOCKED: pool exhausted for <platform>` and exit. Do NOT
+  `brev create`, `brev start`, or `brev reset` — the operator
+  provisions capacity, not the agent.
 - **Brev auth expired mid-run.** Emit `BLOCKED: brev auth expired` —
-  the `brev-keepalive.timer` systemd unit on the coordinator host
-  will retry; a human needs to `brev login --auth nvidia`.
+  the `brev-keepalive.timer` systemd unit on the CI runner host will
+  retry; a human needs to `brev login --auth nvidia`.
 - **Claude-agent-sdk / API rate limit.** Back off 60s, retry up to
   3x. If still failing, emit `BLOCKED: anthropic rate limit` and
   exit.
 - **Lock contention** (another CI run holds the Brev lock). Wait up
-  to 60 min (flock `-w 3600`). If you time out, emit `BLOCKED: lock
+  to 8 h (flock `-w 28800`). If you time out, emit `BLOCKED: lock
   timeout on <instance>`.
 
 ## Output requirements
@@ -277,8 +759,7 @@ separate; don't conflate the two.
   If you ran trials, you MUST also have called `gh pr comment
   $PR_NUMBER` with the per-batch results before printing
   `DONE:` — otherwise the contributor sees no signal on their PR.
-- Always populate `/tmp/brev/started-by-${GITHUB_RUN_ID}.txt` with
-  instance names you brought online (one per line). The CI wrapper
-  uses it for the 5-minute cooldown teardown.
+- Don't tear down or `brev stop` / `brev delete` any instance. The
+  `vss-eval-*` pool is operator-managed and stays warm across runs.
 
 Now proceed.

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -1,164 +1,88 @@
-# VSS Harbor Evaluation
+# VSS Skills Eval
 
-Evaluate VSS skills (deploy, alerts, vios, incident-report, video-analytics, video-search, video-summarization) against a live GPU deployment using [Harbor](https://github.com/laude-institute/harbor).
+Evaluate VSS skills (deploy, alerts, vios, video-analytics, video-search, video-summarization, incident-report, report) against a live GPU deployment using [Harbor](https://github.com/laude-institute/harbor).
 
-The framework is run by a **long-running coordinator agent** ([`AGENTS.md`](AGENTS.md) is the playbook). You launch it once with `claude` + `/loop AGENTS.md`, and it:
+Evaluation is **fully CI-driven**. [`.github/workflows/skills-eval.yml`](../workflows/skills-eval.yml) fires on every push to a `pull-request/<N>` mirror branch whose diff touches `skills/` or `.github/skill-eval/`, and runs a single claude-agent-sdk session ([`skills_eval_agent.py`](skills_eval_agent.py)) that:
 
-1. Watches the `pull-request/<N>` mirror branches for CPR-vetted contributor PRs
-2. Detects which skill specs changed, generates Harbor datasets per spec via the adapters
-3. Provisions / reuses Brev GPU instances per platform (L40S, H100, RTX 6000 Pro, SPARK)
-4. Fans out eval tasks to per-platform subagents, each of which invokes Claude Code against a goal-oriented instruction
-5. Verifies the outcome (containers running, endpoints healthy, trajectory checks, etc.) and scores each trial 0.0–1.0
-6. Posts a Markdown results summary as a PR comment, with links to traces served by `harbor view`
-7. Stops / deletes Brev instances when queues drain
+1. Diffs the PR against its base branch and picks out changed skills with an eval spec at `skills/<skill>/eval/<profile>.json`.
+2. Generates Harbor datasets per `(skill, profile, platform, mode)` via the adapter at [`adapters/<skill>/generate.py`](adapters/).
+3. Acquires a per-instance `flock` on a Brev GPU host, reusing one that matches the target platform or creating one via the fallback chain in [`AGENTS.md`](AGENTS.md).
+4. Runs `uvx harbor run` against each dataset, one trial at a time, with the canonical invocation captured in [`AGENTS.md § Harbor invocation`](AGENTS.md).
+5. Verifies each trial (containers running, endpoints healthy, trajectory / response / rubric checks — see `verifiers/generic_judge.py`) and scores 0.0–1.0.
+6. Posts one Markdown results summary per `(PR, eval-spec)` batch as a PR comment, with trace URLs served by `harbor view`.
+7. Leaves instance IDs in `/tmp/brev/started-by-<run_id>.txt`; the workflow wrapper deletes / stops them after a 5-min cooldown.
 
-You don't run skills manually — you let the coordinator pick them up from PRs.
+The whole thing runs inside the 8-hour GitHub Actions job timeout. The `.github/skill-eval/AGENTS.md` file **is** the agent's system prompt — keep it readable.
 
 ## Prerequisites
 
-Run these on the **coordinator host** (a long-running Brev CPU instance; `vss-skill-validator` in the NVIDIA org serves this role):
+The workflow runs on a self-hosted GitHub Actions runner installed on `vss-skill-validator` (a long-running Brev CPU instance in the NVIDIA org). That host needs:
 
-- **[uv](https://github.com/astral-sh/uv)** (Python package manager) — harbor is invoked via `uvx harbor`
-- **[Brev CLI](https://docs.brev.nvidia.com/)** — authenticated via `brev login --auth nvidia` (refresh token lasts ~30 days; a user-level systemd timer `brev-keepalive.timer` runs `brev ls` every 15 min to keep the access token warm)
-- **[Claude Code](https://docs.claude.com/claude-code)** — the coordinator runs as a `claude` session using `/loop AGENTS.md`
-- **`git`**, **`gh` (GitHub CLI)** — authenticated against the VSS repo fork
-- **Python 3** — for the dataset generators
+- **[uv](https://github.com/astral-sh/uv)** — harbor is invoked as `uvx harbor`.
+- **[Brev CLI](https://docs.brev.nvidia.com/)** — authenticated via `brev login --auth nvidia` (refresh token lasts ~30 days; a user-level `brev-keepalive.timer` keeps the access token warm).
+- **`git`**, **`gh` (GitHub CLI)** — authenticated against the VSS repo.
+- **Python 3** — for the adapters.
+- **A `.env` at `/home/ubuntu/eval-coordinator/.env`** with the keys below — the workflow step `Load coordinator env` sources this file.
 
-### GPU requirements (eval targets, not the coordinator host)
+### GPU targets (provisioned on demand, not on the runner)
 
-The coordinator dispatches across four first-class platform subagents. You don't need all four running at all times — the coordinator spins them up on demand:
+The runner has no GPU. Eval trials run on per-platform Brev instances the agent provisions (and the workflow tears down):
 
-| Subagent | Instance type | Lifecycle |
+| Platform | Instance type | Lifecycle |
 |---|---|---|
-| `l40s` | `l40s-48gb.2x` (2× L40S 48 GB) | `brev start` on demand, `brev stop` after queue drains |
-| `h100` | `dmz.h100x2.pcie` (2× H100 80 GB) | non-stoppable; `brev delete` after queue drains |
-| `rtx` | `g7e.12xlarge` (RTX PRO Server 6000) | `brev start` / `brev stop` like L40S |
-| `spark` | BYOH DGX Spark node | never stopped; stays online across runs |
+| `l40s` | `massedcompute_L40Sx2` (2× L40S 48 GB) | `brev delete` after trials complete (MC is non-stoppable) |
+| `h100` | `dmz.h100x2.pcie` (2× H100 80 GB) | `brev delete` after trials complete |
+| `rtx` | `g7e.12xlarge` (RTX PRO 6000) | `brev stop` after trials complete |
+| `spark` | BYOH DGX Spark node | no-op — stays online across runs |
 
-Each instance needs Ubuntu/Debian, network egress to `nvcr.io`, and passwordless `sudo` for the default user (standard on Brev).
+Fallback chains and matrix constraints live in [`AGENTS.md § Platform topology`](AGENTS.md).
 
-### API keys
+### API keys (`/home/ubuntu/eval-coordinator/.env` on the runner)
 
-| Variable | Purpose | Required |
-|---|---|---|
-| `ANTHROPIC_API_KEY` | Claude Code authentication (NVIDIA inference API key works) | Yes |
-| `ANTHROPIC_BASE_URL` | Custom API base (e.g. `https://inference-api.nvidia.com`) | If using a proxy |
-| `ANTHROPIC_MODEL` | Model ID (e.g. `aws/anthropic/bedrock-claude-sonnet-4-6`) | If using a proxy |
-| `NGC_CLI_API_KEY` | Pull VSS NIM containers from `nvcr.io` | For deploy skill |
-| `BREV_INSTANCE` | Name of pre-existing Brev instance | Optional (auto-creates `vss-eval-gpu` if unset) |
-| `BREV_INSTANCE_TYPE` | Instance type when auto-creating | Optional (default `l40s-48gb.1x`) |
-
-Create a `.env` file at the repo root (see [`.env.example`](.env.example)):
-
-```bash
-cp tools/eval/harbor/.env.example .env
-# edit .env with your keys
-```
-
-The eval script auto-loads `.env` at the repo root.
-
-## Quick start
-
-From a fresh clone on the coordinator host:
-
-```bash
-# 1. Clone the repo (feat/skills until the skills work merges to develop)
-git clone --branch feat/skills https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization.git
-cd video-search-and-summarization
-
-# 2. Log in to Brev (needs to be repeated every ~30 days when the refresh token expires)
-brev login --auth nvidia
-
-# 3. Create your .env — place it at the coordinator's eval-coordinator workspace,
-#    not in the VSS repo (the coordinator sources it on every wake).
-cp tools/eval/harbor/.env.example ~/eval-coordinator/.env
-$EDITOR ~/eval-coordinator/.env
-
-# 4. Launch the coordinator agent inside a `claude` session:
-claude --dangerously-skip-permissions
-# then at the prompt:
-/loop AGENTS.md
-```
-
-`/loop AGENTS.md` starts the self-paced coordinator loop described in [`AGENTS.md`](AGENTS.md). Each wake-up it:
-
-- Sources `~/eval-coordinator/.env` (API keys, remote endpoints, git identity)
-- Lists `pull-request/<N>` mirror branches and diffs any with new SHAs against their base
-- For each changed skill with an eval spec, regenerates the Harbor dataset via the adapter and enqueues tasks in the per-platform queue JSON under `/tmp/subagents/`
-- Spawns a subagent per platform with pending tasks (using the `Agent` tool in background mode)
-- Monitors results, posts PR comments, raises adapter PRs as needed
-- Tears down Brev instances when queues drain
-- Sleeps 25 min when idle, wakes immediately on subagent completion events
-
-You interact with the coordinator by pushing commits to PRs, adding `/ok to test` for the copy-pr-bot to re-mirror, and reading the comments it posts. It does not need imperative CLI commands.
-
-## Architecture
-
-```
-Coordinator host                     Per-platform Brev instance
-(vss-skill-validator)                (vss-eval-l40s, -h100, -rtx, spark)
-────────────────────                 ──────────────────────────────────
-
-claude /loop AGENTS.md               (provisioned on demand)
-  │
-  ├── Sources .env                   Claude Code + NIMs/Docker stack
-  ├── gh api branches                Per-trial: /tests /skills /logs
-  │     pull-request/*
-  ├── python3 adapters/*/generate.py
-  │     → datasets/<skill>/<profile>/<platform>/<mode>/
-  │
-  ├── Agent tool (background)
-  │     └── platform subagent
-  │           └── uvx harbor run
-  │                 └── BrevEnvironment (tools/eval/harbor/envs/brev_env.py)
-  │                       └── brev exec → Claude Code on the GPU host
-  │                             └── /<skill> executes the task
-  │
-  ├── Watches results/<run_id>/
-  │     → moves to results/_viewer/<run_id>__<date>/
-  │     → posts PR comment with trace URLs
-  │
-  └── harbor view (persistent, port 8080, Cloudflare-tunnelled)
-        → https://harbor-<BREV_ENV_ID>.brevlab.com/jobs/<run_id>__<date>
-```
-
-State lives on the coordinator host in `/tmp/subagents/`:
-
-- `{l40s,h100,rtx,spark}.json` — per-platform queue + results
-- `_prs_seen.json` — PR → (head_sha, batches, draft comment) ledger
-- `<platform>.pid` — subagent liveness markers
-- `_alerts.json` — blocker alerts the coordinator can't self-resolve (e.g. expired Brev auth)
-
-`tools/eval/harbor/envs/brev_env.py` is the Harbor environment provider. It connects to a pre-existing Brev instance (does not create one per trial) and transfers files via `tar` over `brev exec` (faster and more reliable than `brev copy`).
+| Variable | Purpose |
+|---|---|
+| `ANTHROPIC_API_KEY` | Claude Code authentication (NVIDIA inference API key works) |
+| `ANTHROPIC_BASE_URL` | Custom API base (e.g. `https://inference-api.nvidia.com`) |
+| `ANTHROPIC_MODEL` | Model ID (e.g. `aws/anthropic/bedrock-claude-sonnet-4-6`) |
+| `NGC_CLI_API_KEY` | Pull VSS NIM containers from `nvcr.io` |
+| `LLM_REMOTE_URL` / `LLM_REMOTE_MODEL` | Remote-LLM endpoint used by `remote-*` deploy modes |
+| `VLM_REMOTE_URL` / `VLM_REMOTE_MODEL` | Remote-VLM endpoint used by `remote-*` deploy modes |
+| `HF_TOKEN` | Required by the Edge 4B vLLM on SPARK / Thor `shared` mode |
+| `GITHUB_TOKEN` | Issued to `gh pr comment` when the agent posts results |
 
 ## Layout
 
 ```
-tools/eval/harbor/
+.github/skill-eval/
 ├── README.md              ← you are here
-├── AGENTS.md              ← coordinator playbook (source of truth for /loop)
-├── .env.example           ← template for the coordinator's .env
-├── adapters/              ← skill-specific dataset generators (human-maintained)
+├── AGENTS.md              ← skills-eval agent's system prompt
+├── skills_eval_agent.py   ← the CI entrypoint (spawns the agent)
+├── adapters/              ← per-skill dataset generators
 │   ├── deploy/            ← profile × platform × mode matrix
 │   │   └── generate.py
-│   ├── vios/              ← single-task-per-platform, step-chained
+│   ├── vios/              ← single-platform, step-chained
 │   │   └── generate.py
-│   └── <skill>/           ← coordinator may raise an adapter PR when a new
-│       └── generate.py      eval spec lands for a skill that lacks one
+│   └── <skill>/           ← the agent creates one if missing
+│       └── generate.py
 ├── envs/
 │   └── brev_env.py        ← Harbor environment for pre-existing Brev instances
-├── verifiers/
-│   └── generic_judge.py   ← routes checks to shell / trajectory /
-│                            response / rubric evaluators
-├── datasets/              ← generated per spec, gitignored
-│   └── <skill>/<profile>/<platform>-<mode>/
-│       ├── environment/Dockerfile  (placeholder; Brev env pre-exists)
-│       ├── skills/<skill>/         (uploaded into the trial)
-│       ├── solution/solve.sh       (gold solution, for oracle agent)
-│       └── tests/{instruction.md, task.toml, test.sh, <spec>.json}
-└── results/               ← harbor run outputs, gitignored
-    ├── <run_id>/<date>/…            (raw harbor output)
-    └── _viewer/<run_id>__<date>/…   (flattened for `harbor view`)
+└── verifiers/
+    └── generic_judge.py   ← routes checks to shell / trajectory /
+                             response / rubric evaluators
+```
+
+Runtime state (not checked in):
+
+```
+/tmp/skill-eval/
+├── datasets/<skill>/<profile>/<platform>-<mode>/
+│   ├── environment/Dockerfile            (placeholder; Brev env pre-exists)
+│   ├── skills/<skill>/                   (copy of the skill the trial uses)
+│   ├── solution/solve.sh                 (gold solution, for oracle agent)
+│   └── tests/{instruction.md, task.toml, test.sh, <spec>.json}
+└── results/
+    ├── <run_id>/<date>/<trial>/…         (raw harbor output)
+    └── _viewer/<run_id>__<date>/<trial>/ (flattened for `harbor view`)
 ```
 
 Each generated task contains:
@@ -167,36 +91,29 @@ Each generated task contains:
 - `task.toml` — metadata, environment config, `skills_dir = "/skills"`
 - `tests/test.sh` — verifier, writes reward to `/logs/verifier/reward.txt`
 - `solution/solve.sh` — gold solution (for oracle agent)
-- `skills/<skill>/` — copy of the skill that harbor registers with Claude Code
+- `skills/<skill>/` — copy of the skill harbor registers with Claude Code
 - `environment/Dockerfile` — placeholder (not used — Brev env is pre-existing)
 
 ## Eval spec format
 
-Each evaluable skill ships a spec at
-`skills/<skill>/eval/<profile>.json`. This is the **only file a skill
-author writes** — the coordinator agent (see [`AGENTS.md`](AGENTS.md))
-derives the Harbor adapter, dataset, and queue entries from it.
+Each evaluable skill ships a spec at `skills/<skill>/eval/<profile>.json`. This is the **only file a skill author writes** — the skills-eval agent derives the Harbor adapter, dataset, and dispatch matrix from it.
 
-The **spec is the source of truth** for dispatch. Adapters iterate
-exactly what `resources.platforms` lists; they never invent platforms
-or modes a spec did not declare. This keeps PR authors in control of
-which `(platform, mode)` combos actually run.
+The **spec is the source of truth** for dispatch. Adapters iterate exactly what `resources.platforms` lists; they never invent platforms or modes a spec did not declare. This keeps PR authors in control of which `(platform, mode)` combos actually run.
 
 Schema:
 
 | Key | Type | Description |
 |---|---|---|
 | `skills` | `string[]` | Skill names this spec exercises (usually just one). |
-| `resources.platforms` | `object` | `{<platform>: {"modes": [...]}}` — the Cartesian matrix the adapter will fan out. E.g. `{"L40S": {"modes": ["remote-all"]}}` produces exactly one dataset. Platforms: `H100`, `L40S`, `RTXPRO6000BW`, `DGX-SPARK`. Omitted → adapter falls back to its internal defaults (back-compat only; new specs should declare explicitly). |
-| `env` | `string` | Prose describing prerequisites: target platform(s), deployed VSS profile (if any), required env vars, Brev secure-link assumptions, etc. The coordinator parses this for prerequisite deploy injection and platform intent. |
-| `expects` | `array` | Ordered list — **each entry becomes one Harbor task in the subagent queue**, chained to the previous via `requires_previous_passed`. |
+| `resources.platforms` | `object` | `{<platform>: {"modes": [...]}}` — the Cartesian matrix the adapter fans out. E.g. `{"L40S": {"modes": ["remote-all"]}}` produces exactly one dataset. Platforms: `H100`, `L40S`, `RTXPRO6000BW`, `DGX-SPARK`. **Required** — the agent files a `missing_platforms_declaration` blocker comment and skips any spec without it. |
+| `env` | `string` | Prose describing prerequisites: target platform(s), deployed VSS profile (if any), required env vars, Brev secure-link assumptions, etc. |
+| `expects` | `array` | Ordered list — **each entry becomes one Harbor task**, chained to the previous via `requires_previous_passed`. |
 | `expects[].query` | `string` | What the agent is asked to do at this step, in plain English. Can embed `{{platform}}`, `{{mode}}`, `{{llm_mode}}`, `{{vlm_mode}}`, `{{repo_root}}` — the adapter substitutes these per-dataset. |
-| `expects[].checks` | `string[]` | Assertions the verifier runs after the agent acts. Backtick-wrapped `curl`/`docker`/`grep`/etc. commands are extracted and run as shell subprocesses (pass if exit 0). Everything else is handed to a `claude-agent-sdk` judge agent with `Bash` + `Read` + `Grep` tools — so trajectory-style checks ("agent called X exactly once", "response renders a 'Verification Step' section") are first-class; no per-skill probe scripts required. |
+| `expects[].checks` | `string[]` | Assertions the verifier runs after the agent acts. Backtick-wrapped `curl` / `docker` / `grep` commands are extracted and run as shell subprocesses (pass if exit 0). Everything else is handed to a `claude-agent-sdk` judge agent with `Bash` + `Read` + `Grep` tools — so trajectory-style checks ("agent called X exactly once", "response renders a 'Verification Step' section") are first-class; no per-skill probe scripts required. |
 
 ### Eval-profile vs deploy-profile (deploy adapter only)
 
-The `deploy` adapter also exposes a small `PROFILES` dict that maps
-**eval-profile names** to the underlying `/deploy` invocation:
+The `deploy` adapter exposes a small `PROFILES` dict that maps **eval-profile names** to the underlying `/deploy` invocation:
 
 ```python
 PROFILES = {
@@ -208,29 +125,24 @@ PROFILES = {
 }
 ```
 
-An empty or absent `profile` means the dict key *is* the deploy profile
-(the `base` case). When `profile` is set, the agent is told to invoke
-`/deploy -p <profile>`; the optional `deploy_mode` becomes `-m <mode>`.
-This is how one skill profile (`alerts`) produces multiple eval variants
-(`alerts_cv`, `alerts_vlm`) with distinct spec files and distinct
-container-check sets while still deploying a shared compose stack.
+An empty or absent `profile` means the dict key *is* the deploy profile (the `base` case). When `profile` is set, the agent is told to invoke `/deploy -p <profile>`; the optional `deploy_mode` becomes `-m <mode>`. This is how one skill profile (`alerts`) produces multiple eval variants (`alerts_cv`, `alerts_vlm`) with distinct spec files and distinct container-check sets while still deploying a shared compose stack.
 
 ### Worked example — `skills/vios/eval/base_profile_ops.json`
 
-Three-step thread against a deployed VSS base: upload video → snapshot URL → clip URL. Produces 3 queued tasks per targeted platform.
+Three-step thread against a deployed VSS base: upload video → snapshot URL → clip URL. Produces 3 chained tasks on the targeted platform.
 
 ```json
 {
   "skills": ["vios"],
-  "env": "A **full-remote deployed VSS base profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs). Run on ONE platform only — the vios skill exercises VIOS / VST which is GPU-independent, so there's no benefit to fanning out. Pick the cheapest available host (L40S recommended). Required: VST reachable at http://localhost:30888/vst/api/v1 AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770 per launchable convention — see skills/deploy/references/brev.md). Without BREV_ENV_ID the returned media URLs will be raw http://localhost:... and the Brev-link checks will fail.",
+  "resources": {"platforms": {"L40S": {"modes": ["remote-all"]}}},
+  "env": "A **full-remote deployed VSS base profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs). Run on ONE platform only — the vios skill exercises VIOS / VST which is GPU-independent, so there's no benefit to fanning out. Required: VST reachable at http://localhost:30888/vst/api/v1 AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770). Without BREV_ENV_ID the returned media URLs will be raw http://localhost:... and the Brev-link checks will fail.",
   "expects": [
     {
       "query": "Upload the sample warehouse video to VIOS with timestamp 2025-01-01T00:00:00.000Z.",
       "checks": [
         "The upload API call (PUT /vst/api/v1/storage/file/<filename>?timestamp=...) returns HTTP 2xx",
         "The response JSON contains both a sensorId and a streamId (non-empty UUIDs)",
-        "curl -sf http://localhost:30888/vst/api/v1/sensor/list returns a JSON array containing a sensor whose name matches the uploaded video's filename stem",
-        "curl -sf http://localhost:30888/vst/api/v1/sensor/<sensorId>/streams returns a non-empty streams array whose main stream's url is a local file path under /home/vst/... or similar (NOT rtsp://)"
+        "curl -sf http://localhost:30888/vst/api/v1/sensor/list returns a JSON array containing a sensor whose name matches the uploaded video's filename stem"
       ]
     },
     {
@@ -238,158 +150,109 @@ Three-step thread against a deployed VSS base: upload video → snapshot URL →
       "checks": [
         "GET /vst/api/v1/replay/stream/<streamId>/picture/url?startTime=2025-01-01T00:00:05.000Z returns a JSON object with a non-empty imageUrl field",
         "The returned imageUrl matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...)",
-        "curl -sfI <imageUrl> returns HTTP 200",
-        "The response Content-Type starts with image/ (typically image/jpeg)",
-        "The response Content-Length is greater than 2000 bytes (rejects empty / error-placeholder images)"
+        "curl -sfI <imageUrl> returns HTTP 200"
       ]
     },
     {
       "query": "Extract a video clip from 3 to 5 seconds (mp4 container) from the uploaded video and return a shareable URL.",
       "checks": [
         "GET /vst/api/v1/storage/file/<streamId>/url?startTime=2025-01-01T00:00:03.000Z&endTime=2025-01-01T00:00:05.000Z&container=mp4&disableAudio=true returns a JSON object with a non-empty videoUrl field",
-        "The returned videoUrl matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...)",
         "curl -sfI <videoUrl> returns HTTP 200",
-        "The response Content-Type starts with video/ (typically video/mp4)",
-        "The response Content-Length is greater than 10000 bytes (rejects empty / error-page responses)",
-        "The response JSON's startTime is within a minute of the requested 00:00:03 and expiryISO is in the future"
+        "The response Content-Length is greater than 10000 bytes"
       ]
     }
   ]
 }
 ```
 
-Source: [`skills/vios/eval/base_profile_ops.json`](../../../skills/vios/eval/base_profile_ops.json)
+Source: [`skills/vios/eval/base_profile_ops.json`](../../skills/vios/eval/base_profile_ops.json)
 
-What the coordinator derives from this spec:
+What the agent derives from this spec:
 - `env` says **"full-remote deployed VSS base profile"** → inject a `deploy` task with `mode=remote-all` + `profile=base` ahead of the vios tasks.
-- `env` says **"Run on ONE platform only … L40S recommended"** → target a single subagent (`l40s`), not a fan-out. VIOS/VST is GPU-independent, so there's no value in running it four times.
-- `expects[]` has 3 entries → 3 sequential vios tasks on that one platform, each chained via `requires_previous_passed`.
-- `checks` use regex on Brev-link URLs + HEAD `Content-Type` probing → the generic judge (`tools/eval/harbor/verifiers/generic_judge.py`) routes them: the curl-prefixed ones run as shell probes, the regex-style ones go through the LLM judge.
+- `resources.platforms` is `{L40S: [remote-all]}` → one dataset, one platform. No fan-out.
+- `expects[]` has 3 entries → 3 chained vios tasks, each gated on `requires_previous_passed`.
+- `checks` use a mix of curl probes and trajectory-style assertions — the generic judge routes each to the right evaluator.
 
-## Running individual commands
+## Running a trial by hand
 
-The coordinator does all of this automatically — these manual commands are for debugging or bootstrapping a new skill's adapter.
-
-### Generate a dataset for one spec
+For debugging an adapter or verifier locally, outside CI:
 
 ```bash
-set -a && source ~/eval-coordinator/.env && set +a
+set -a && source /home/ubuntu/eval-coordinator/.env && set +a
 
-# Deploy skill — profile × platform × mode matrix
-python3 tools/eval/harbor/adapters/deploy/generate.py \
-  --output-dir tools/eval/harbor/datasets/deploy \
-  --skill-dir skills/deploy \
-  --profile base --platform L40S
-
-# Single-platform skill (e.g. vios)
-python3 tools/eval/harbor/adapters/vios/generate.py \
-  --output-dir tools/eval/harbor/datasets/vios \
+# 1. Generate the dataset for one spec.
+python3 .github/skill-eval/adapters/vios/generate.py \
+  --output-dir /tmp/skill-eval/datasets/vios \
   --skill-dir skills/vios \
   --platform L40S
-```
 
-### Run a single Harbor trial by hand
-
-```bash
-set -a && source ~/eval-coordinator/.env && set +a
+# 2. Make sure you have a Brev instance for the target platform
+#    (or let the skills-eval agent manage it).
 export BREV_INSTANCE=vss-eval-l40s
 
+# 3. Run one trial. The flags here mirror the canonical invocation in
+#    AGENTS.md § Harbor invocation — don't improvise.
+export PYTHONPATH="$(pwd)/.github/skill-eval:${PYTHONPATH:-}"
+
 uvx harbor run \
-  --environment-import-path "tools.eval.harbor.envs.brev_env:BrevEnvironment" \
-  -p tools/eval/harbor/datasets/deploy/base \
-  -i l40s-remote-all \
+  --environment-import-path "envs.brev_env:BrevEnvironment" \
+  -p /tmp/skill-eval/datasets/vios/base_profile_ops \
+  --include-task-name "l40s-remote-all" \
   -a claude-code \
   --model "$ANTHROPIC_MODEL" \
   --ak api_base="$ANTHROPIC_BASE_URL/v1" \
   --ae CLAUDE_CODE_DISABLE_THINKING=1 \
   --max-retries 0 -n 1 --yes \
-  -o tools/eval/harbor/results/manual-$(date +%Y%m%d-%H%M%S)
+  -o /tmp/skill-eval/results/manual-$(date +%Y%m%d-%H%M%S)
 ```
 
 `CLAUDE_CODE_DISABLE_THINKING=1` is required when routing through the NVIDIA Anthropic proxy — claude-code ≥ 2.1.x otherwise emits a `context_management` field the proxy rejects with HTTP 400.
 
 ### Inspect a result
 
-After harbor exits, flatten the run into the viewer directory so `harbor view` can index it:
+```
+/tmp/skill-eval/results/<run_id>/<date>/<trial>/
+├── config.json
+├── trial.log
+├── verifier/
+│   ├── reward.txt        ← 0.0–1.0
+│   └── test-stdout.txt   ← verifier output
+└── agent/
+    └── claude-code.txt   ← agent trace
+```
+
+To view in the browser, flatten into the viewer dir:
 
 ```bash
-cd tools/eval/harbor/results
+cd /tmp/skill-eval/results
 mv "<run_id>/<date>" "_viewer/<run_id>__<date>"
 rmdir "<run_id>" 2>/dev/null || true
 ```
 
-Then browse `https://harbor-<BREV_ENV_ID>.brevlab.com/jobs/<run_id>__<date>`. The viewer is launched once per coordinator host:
+Then open `https://harbor-<BREV_ENV_ID>.brevlab.com/jobs/<run_id>__<date>`.
+
+`harbor view` runs persistently on the CI runner host. If it's down:
 
 ```bash
-nohup uvx harbor view tools/eval/harbor/results/_viewer --jobs \
+nohup uvx harbor view /tmp/skill-eval/results/_viewer --jobs \
   --host 0.0.0.0 --port 8080 > /tmp/harbor-view.log 2>&1 &
 disown
 ```
 
-### Spawn the coordinator headlessly
-
-If you want the coordinator running in the background of a tmux session (so it survives your ssh disconnect):
-
-```bash
-tmux new -d -s coordinator \
-  "cd ~/eval-coordinator && claude --dangerously-skip-permissions"
-# then attach and type:
-tmux attach -t coordinator
-# at the claude prompt:
-/loop AGENTS.md
-# detach: Ctrl-b d
-```
-
-## Interpreting results
-
-After a run, find the result in `tools/eval/harbor/results/<timestamp>/<skill>/`:
-
-```
-results/20260416-192758/deploy/base/
-├── 2026-04-16__19-27-59/
-│   └── base__<trial-id>/
-│       ├── config.json
-│       ├── trial.log
-│       ├── verifier/
-│       │   ├── reward.txt        ← 0.0–1.0
-│       │   └── test-stdout.txt   ← verifier output
-│       └── agent/
-│           └── claude-code.txt   ← agent trace
-└── result.json                   ← aggregate stats
-```
-
-`result.json` shows the mean reward across trials:
-
-```json
-{
-  "stats": {
-    "n_trials": 1,
-    "n_errors": 0,
-    "evals": {
-      "claude-code__anthropic/bedrock-claude-sonnet-4-6__deploy": {
-        "metrics": [{"mean": 1.0}]
-      }
-    }
-  }
-}
-```
-
 ## Troubleshooting
 
-**Agent returns "Not logged in"**
-API key not set or invalid. Check `ANTHROPIC_API_KEY` and (if using a proxy) `ANTHROPIC_BASE_URL`.
+**CI didn't fire after a push.** The workflow only triggers on pushes to `pull-request/<N>` mirror branches, created by copy-pr-bot after a maintainer comments `/ok to test <sha>` on the source PR. Check that the comment was posted on the correct head SHA.
 
-**"Invalid beta flag"**
-Your API endpoint doesn't support Claude Code's beta headers. Harbor's `--ak api_base=...` handles most proxies automatically.
+**"missing_platforms_declaration" blocker on a spec.** The spec has no `resources.platforms`. Add one — see the worked example above.
 
-**`AddTestsDirError` / `DownloadVerifierDirError`**
-File upload/download to the Brev instance failed. Check `brev exec <instance> "echo ok"` works manually. Clear `/tests /logs /skills` on the instance and retry.
+**Agent returns "Not logged in."** `ANTHROPIC_API_KEY` is not set in `/home/ubuntu/eval-coordinator/.env` or is invalid. If using a proxy, also confirm `ANTHROPIC_BASE_URL` and `ANTHROPIC_MODEL`.
 
-**Instance creation fails**
-Some Brev providers have capacity issues. Retry manually, or flag it in the PR comment — the coordinator won't auto-select an alternate instance type; platform → instance mapping is fixed in AGENTS.md §2.
+**`AddTestsDirError` / `DownloadVerifierDirError`.** File upload/download to the Brev instance failed. Check `brev exec <instance> "echo ok"` works manually. Clear `/tests /logs /skills` on the instance and retry.
 
-**Brev auth expired mid-run**
-Look for a `brev_auth_expired` entry in `/tmp/subagents/_alerts.json`. Fix by running `brev login --auth nvidia` on the coordinator host. The `brev-keepalive.timer` systemd user unit fires `brev ls` every 15 min to keep the access token warm, but it cannot recover when the refresh token itself expires — only an interactive login can.
+**Instance creation fails.** Some Brev providers have capacity issues. Harbor's fallback chain (see [`AGENTS.md § Platform topology`](AGENTS.md)) cycles through alternatives. If all are exhausted, the agent posts a `csp_unavailable` blocker.
 
-**Agent deployment fails with "pull access denied"**
-`NGC_CLI_API_KEY` missing or invalid. The agent needs it to pull VSS NIM containers from `nvcr.io`.
+**Brev auth expired mid-run.** The CI run emits `BLOCKED: brev auth expired`. The `brev-keepalive.timer` systemd user unit keeps the access token warm, but only an interactive `brev login --auth nvidia` can refresh a fully-expired refresh token.
+
+**Agent deployment fails with "pull access denied".** `NGC_CLI_API_KEY` missing or invalid — the agent needs it to pull VSS NIM containers from `nvcr.io`.
+
+**Cancelled run leaves orphan Brev instances.** A cancelled CI job never gets to the cooldown teardown step. Clean up by listing owned instances in `/tmp/brev/started-by-<run_id>.txt` on the runner host and `brev delete` them manually.

--- a/.github/skill-eval/adapters/alerts/generate.py
+++ b/.github/skill-eval/adapters/alerts/generate.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the alerts skill.
+
+The alerts skill exercises the VSS **alerts** profile end-to-end:
+deploy, onboard a sample video via NVStreamer, register the sensor in
+VIOS, start a VLM real-time alert through the VSS Agent, and poll
+VA-MCP for incidents.
+
+The spec (`alerts_vlm_real_time.json`) declares:
+    profile = "alerts"        → deploy step is prepended in the dataset
+    resources.platforms:
+        L40S: modes: [remote-all]
+
+Because the alerts real-time (VLM) mode runs `rtvi-vlm` locally (a
+continuous GPU-backed inference loop) alongside NVStreamer + VIOS +
+Kafka, the trial requires a **GPU** even in `remote-all` placement.
+The `remote-all` label refers to LLM/VLM NIM placement (both remote),
+but RT-CV / `rtvi-vlm` is always local on the alerts profile.
+
+Directory layout (one platform × mode per directory):
+
+    datasets/alerts/<spec_stem>/<platform_short>-<mode>/
+        step-1/
+            instruction.md, task.toml, tests/, solution/, skills/, environment/
+        step-2/
+            ...
+        step-3/
+            ...
+        step-4/
+            ...
+
+Usage:
+    python3 generate.py \\
+        --output-dir /tmp/skill-eval/datasets/alerts \\
+        --skill-dir   skills/alerts \\
+        --deploy-skill-dir skills/deploy \\
+        --spec        skills/alerts/eval/alerts_vlm_real_time.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+# Prepended to every instruction.md so the skill's bypass clause fires.
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
+# ---------------------------------------------------------------------------
+# Platforms
+# ---------------------------------------------------------------------------
+
+PLATFORMS: dict[str, dict] = {
+    "H100": {
+        "short_name": "h100",
+        "gpu_type": "H100",
+        "min_vram_per_gpu": 80,
+        "brev_search": "H100",
+    },
+    "L40S": {
+        "short_name": "l40s",
+        "gpu_type": "L40S",
+        "min_vram_per_gpu": 48,
+        "brev_search": "L40S",
+    },
+    "RTXPRO6000BW": {
+        "short_name": "rtxpro6000bw",
+        "gpu_type": "RTX PRO 6000",
+        "min_vram_per_gpu": 96,
+        "brev_search": "RTX PRO",
+    },
+}
+
+DEFAULT_PLATFORM = "L40S"
+DEFAULT_SPEC = "alerts_vlm_real_time.json"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SUBST_RE = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+
+
+def _substitute(value: object, subs: dict[str, str]) -> object:
+    """Replace {{key}} placeholders in strings/lists/dicts."""
+    if isinstance(value, str):
+        return _SUBST_RE.sub(lambda m: str(subs.get(m.group(1), m.group(0))), value)
+    if isinstance(value, list):
+        return [_substitute(v, subs) for v in value]
+    if isinstance(value, dict):
+        return {k: _substitute(v, subs) for k, v in value.items()}
+    return value
+
+
+def _platform_modes(spec: dict, platform_filter: str | None) -> list[tuple[str, str]]:
+    declared: dict = ((spec.get("resources") or {}).get("platforms") or {})
+    tasks: list[tuple[str, str]] = []
+    for platform, cfg in declared.items():
+        if platform_filter and platform != platform_filter:
+            continue
+        if platform not in PLATFORMS:
+            print(
+                f"  WARN  unknown platform '{platform}' in spec — skipped",
+                file=sys.stderr,
+            )
+            continue
+        for mode in (cfg or {}).get("modes") or ["remote-all"]:
+            tasks.append((platform, mode))
+    return tasks or [(platform_filter or DEFAULT_PLATFORM, "remote-all")]
+
+
+# ---------------------------------------------------------------------------
+# Generation helpers
+# ---------------------------------------------------------------------------
+
+def _test_sh(step_idx: int, spec_name: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f"# alerts verifier step {step_idx}: delegates to generic LLM-as-judge.\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step_idx}\n'
+        "exit 0\n"
+    )
+
+
+def _solve_sh(platform: str, mode: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution stub: alerts on {platform}/{mode}\n"
+        "# The verifier drives the assertions directly.\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 http://localhost:8000/docs >/dev/null || {\n"
+        "    echo 'VSS alerts stack is not deployed — cannot solve'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'VSS alerts stack is live — verifier will drive the queries.'\n"
+    )
+
+
+def _task_toml(
+    *,
+    platform: str,
+    mode: str,
+    profile: str,
+    step_idx: int,
+    step_count: int,
+    check_count: int,
+    pspec: dict,
+    spec_stem: str,
+    step_suffix: str,
+    prerequisite_deploy_mode: str,
+) -> str:
+    short = pspec["short_name"]
+    lines = [
+        "[task]",
+        f'name = "nvidia-vss/alerts-{spec_stem}-{short}-{mode}{step_suffix}"',
+        f'description = "Alerts VLM real-time step {step_idx}/{step_count} on {platform}/{mode}"',
+        f'keywords = ["alerts", "vlm", "real-time", "{platform}", "{mode}"]',
+        "",
+        "[environment]",
+        'skills_dir = "/skills"',
+        "",
+        "[verifier.env]",
+        'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+        'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+        'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
+        "",
+        "[metadata]",
+        'skill = "alerts"',
+        f'profile = "{profile}"',
+        f'platform = "{platform}"',
+        f'mode = "{mode}"',
+        f'gpu_type = "{pspec["gpu_type"]}"',
+        f'brev_search = "{pspec["brev_search"]}"',
+        # alerts real-time requires a GPU even in remote-all (rtvi-vlm runs
+        # locally as a continuous VLM inference loop)
+        "gpu_count = 1",
+        f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+        "min_root_disk_gb = 200",
+        "requires_deployed_vss = true",
+        f'prerequisite_deploy_mode = "{prerequisite_deploy_mode}"',
+        f"step_index = {step_idx}",
+        f"step_count = {step_count}",
+        f"check_count = {check_count}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def generate_platform_mode(
+    *,
+    platform: str,
+    mode: str,
+    spec: dict,
+    rendered_spec: dict,
+    output_root: Path,
+    skill_dir: Path,
+    deploy_skill_dir: Path | None,
+    spec_stem: str,
+) -> None:
+    pspec = PLATFORMS[platform]
+    short = pspec["short_name"]
+    expects = rendered_spec.get("expects") or []
+    profile: str = str(spec.get("profile", "alerts"))
+    # prerequisite_deploy_mode drives the /deploy -m flag the coordinator
+    # injects before this task. Read from spec, fall back to `real-time`.
+    prerequisite_deploy_mode: str = str(
+        spec.get("deploy_mode") or spec.get("prerequisite_deploy_mode") or "real-time"
+    )
+
+    platform_dir = output_root / spec_stem / f"{short}-{mode}"
+    platform_dir.mkdir(parents=True, exist_ok=True)
+
+    n = len(expects)
+    for idx, expect in enumerate(expects, 1):
+        step_dir = platform_dir / f"step-{idx}" if n > 1 else platform_dir
+        step_dir.mkdir(parents=True, exist_ok=True)
+        step_suffix = f"-step-{idx}" if n > 1 else ""
+
+        # ---- instruction.md ------------------------------------------------
+        # Per-step scoping: step 1 deploys (host is bare); steps 2+ run
+        # against the already-deployed stack. We deliberately do NOT include
+        # the spec's `env` field — it's a multi-step narrative ("deploy then
+        # add then verify then poll") that, when pasted into a single step's
+        # instruction, reads as a directive to run the whole chain in this
+        # trial. Each step's `query` already carries the step-specific intent;
+        # static host context lives in the leading paragraph below.
+        if idx == 1:
+            leading = [
+                f"Use the `/alerts` skill (and `/deploy` as needed) on this bare `{platform}` host.",
+                "Docker + NVIDIA Container Toolkit are available, `NGC_CLI_API_KEY` is set,",
+                "and the remote LLM/VLM endpoints are configured via "
+                "`LLM_REMOTE_URL` / `LLM_REMOTE_MODEL` / `VLM_REMOTE_URL` / `VLM_REMOTE_MODEL`.",
+            ]
+        else:
+            leading = [
+                f"Use the `/alerts` skill on this `{platform}` host.",
+                "The VSS **alerts** profile is already deployed in **real-time (VLM)** mode "
+                "with `remote-all` placement (deployed by step 1).",
+            ]
+
+        instruction_lines = [
+            PREAMBLE,
+            "",
+            *leading,
+            "",
+            (f"## Query (step {idx} of {n})" if n > 1 else "## Query"),
+            "",
+            expect.get("query", ""),
+            "",
+        ]
+        if n > 1:
+            instruction_lines.append(
+                f"Complete only step {idx} and stop. The remaining steps run "
+                "as separate trials — do not pre-execute them in this one."
+            )
+            instruction_lines.append("")
+        instruction_lines.append("Run autonomously without prompting for confirmation.")
+        instruction_lines.append("")
+        (step_dir / "instruction.md").write_text("\n".join(instruction_lines) + "\n")
+
+        # ---- task.toml -----------------------------------------------------
+        toml_content = _task_toml(
+            platform=platform,
+            mode=mode,
+            profile=profile,
+            step_idx=idx,
+            step_count=len(expects),
+            check_count=len(expect.get("checks") or []),
+            pspec=pspec,
+            spec_stem=spec_stem,
+            step_suffix=step_suffix,
+            prerequisite_deploy_mode=prerequisite_deploy_mode,
+        )
+        (step_dir / "task.toml").write_text(toml_content)
+
+        # ---- environment/ --------------------------------------------------
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        # ---- tests/ --------------------------------------------------------
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        spec_filename = f"{spec_stem}.json"
+        (tests_dir / "test.sh").write_text(_test_sh(idx, spec_filename))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        # Write the rendered spec so the judge can read checks[] at verify time
+        (tests_dir / spec_filename).write_text(json.dumps(rendered_spec, indent=2))
+
+        # ---- solution/ -----------------------------------------------------
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(_solve_sh(platform, mode))
+
+        # ---- skills/ -------------------------------------------------------
+        for src_dir, skill_name in [
+            (skill_dir, "alerts"),
+            (deploy_skill_dir, "deploy"),
+        ]:
+            if src_dir and src_dir.exists():
+                dst = step_dir / "skills" / skill_name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src_dir, dst)
+
+    print(
+        f"  GEN  alerts/{spec_stem}/{short}-{mode}  "
+        f"({len(expects)} steps, "
+        f"{sum(len(e.get('checks') or []) for e in expects)} checks)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--output-dir", required=True,
+                        help="Dataset output root (e.g. /tmp/skill-eval/datasets/alerts)")
+    parser.add_argument("--skill-dir", required=True,
+                        help="Path to skills/alerts")
+    parser.add_argument("--deploy-skill-dir", default=None,
+                        help="Path to skills/deploy (included so agent can diagnose issues)")
+    parser.add_argument("--spec", default=None,
+                        help=f"Path to spec JSON (default: <skill-dir>/eval/{DEFAULT_SPEC})")
+    parser.add_argument("--platform", default=None,
+                        choices=list(PLATFORMS.keys()),
+                        help="Generate for this platform only")
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+    spec_path = (
+        Path(args.spec) if args.spec
+        else (skill_dir / "eval" / DEFAULT_SPEC)
+    )
+
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+
+    spec: dict = json.loads(spec_path.read_text())
+    spec["_source_path"] = str(spec_path)
+
+    # Spec_stem = filename without .json
+    spec_stem = spec_path.stem  # e.g. "alerts_vlm_real_time"
+
+    # Substitute {{platform}} and {{mode}} at generation time using
+    # the first platform/mode from the matrix as defaults; the adapter
+    # renders per-task below.
+    tasks = _platform_modes(spec, args.platform)
+
+    print("=== Inputs ===")
+    print(f"  output_dir       : {output_root}")
+    print(f"  skill_dir        : {skill_dir}")
+    print(f"  spec             : {spec_path}")
+    print(f"  profile          : {spec.get('profile', '(none)')}")
+    print(f"  deploy_mode      : {spec.get('deploy_mode', '(none — defaults to real-time)')}")
+    print(f"  tasks            : {tasks}")
+    print(f"  queries          : {len(spec.get('expects', []))}")
+    print(
+        f"  total checks     : "
+        f"{sum(len(q.get('checks', [])) for q in spec.get('expects', []))}"
+    )
+    print()
+
+    for platform, mode in tasks:
+        subs = {"platform": platform, "mode": mode}
+        rendered_spec = _substitute(spec, subs)
+        generate_platform_mode(
+            platform=platform,
+            mode=mode,
+            spec=spec,
+            rendered_spec=rendered_spec,
+            output_root=output_root,
+            skill_dir=skill_dir,
+            deploy_skill_dir=deploy_skill_dir,
+            spec_stem=spec_stem,
+        )
+
+    print()
+    print(f"Generated {len(tasks)} platform×mode combinations under {output_root}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skill-eval/adapters/deploy/generate.py
+++ b/.github/skill-eval/adapters/deploy/generate.py
@@ -209,6 +209,13 @@ def effective_mode_spec(platform: str, mode: str) -> dict:
 #                        `-p alerts -m verification`). Empty or absent means
 #                        the dict key is itself the deploy profile.
 #   - deploy_mode      → value of `/deploy -m ...` for this eval variant
+#   - local_extras     → additional **always-local** GPUs this profile needs
+#                        beyond LLM/VLM placement. alerts runs RT-CV locally in
+#                        every mode; search runs Cosmos Embed1 locally in every
+#                        mode. Added on top of MODES[mode]["gpus_needed"] when
+#                        computing task-file `gpu_count`. See
+#                        skills/deploy/SKILL.md § Platform × Mode table and
+#                        skills/deploy/references/{alerts,search}.md.
 # Everything else (platforms, modes, checks) lives in the spec.
 PROFILES: dict[str, dict] = {
     "base": {
@@ -220,18 +227,21 @@ PROFILES: dict[str, dict] = {
                        "RT-CV generates candidate alerts, VLM reviews each",
         "profile": "alerts",
         "deploy_mode": "verification",
+        "local_extras": 1,  # RT-CV perception GPU (always local)
     },
     "alerts_vlm": {
         "description": "VSS alerts profile, VLM mode (`deploy -m real-time`) — "
                        "VLM continuously processes live video",
         "profile": "alerts",
         "deploy_mode": "real-time",
+        "local_extras": 1,  # RT-CV perception GPU (always local)
     },
     "lvs": {
         "description": "VSS LVS profile — long video summarization",
     },
     "search": {
         "description": "VSS search profile — Cosmos Embed1 semantic search",
+        "local_extras": 1,  # RTVI-Embed (Cosmos Embed1) GPU (always local)
     },
 }
 
@@ -300,6 +310,17 @@ def _query_hint(mode_spec: dict, llm_remote: dict | None,
     return ""
 
 
+# Prepended to every instruction.md so the skill's own HITL bypass
+# clause fires. Skills default to "ask the user" before /deploy; in CI
+# there's no user, so without this preamble the agent stalls.
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
+
 def generate_instruction(
     profile: str,
     platform: str,
@@ -330,6 +351,8 @@ def generate_instruction(
     verb_phrase += " autonomously — do not ask for confirmation before running."
 
     body = [
+        PREAMBLE,
+        "",
         verb_phrase,
         "",
         "Use the `/deploy` skill.",
@@ -398,10 +421,18 @@ def _render_eval_spec(spec: dict, profile: str, platform: str, mode: str,
     return _sub(spec)
 
 
-def generate_test_script(spec_name: str) -> str:
+def generate_test_script(spec_name: str, profile: str, mode: str) -> str:
     """Wrapper test.sh that invokes the generic LLM-as-judge verifier
     against the rendered eval spec shipped alongside it. Harbor reads
-    /logs/verifier/reward.txt."""
+    /logs/verifier/reward.txt.
+
+    On a full-pass (reward == 1.0), OVERWRITES the canonical active
+    marker `/tmp/skill-eval/active-deploy.txt` with this trial's
+    `<underlying_profile>-<mode>` so dependent trials (vios, video-*)
+    reading the marker via `BrevEnvironment._ensure_prerequisite_deployed`
+    see what is currently RUNNING on the box rather than a per-flag
+    deploy log. See specs/stale-marker.spec for why per-flag was wrong."""
+    underlying_profile = deploy_profile(profile)
     return (
         "#!/bin/bash\n"
         "# deploy verifier: delegates to the generic LLM-as-judge\n"
@@ -415,6 +446,17 @@ def generate_test_script(spec_name: str) -> str:
         "\n"
         'python3 "$TEST_DIR/generic_judge.py" \\\n'
         f'    --spec "$TEST_DIR/{spec_name}" --step 1\n'
+        "\n"
+        "# On full pass, overwrite the canonical active-deploy marker so\n"
+        "# downstream trials (vios/video-*) reuse the running deployment\n"
+        "# instead of re-running /deploy. Overwrite, never append — the\n"
+        "# marker is what is currently RUNNING, not a deploy log.\n"
+        'reward="$(cat /logs/verifier/reward.txt 2>/dev/null || echo 0)"\n'
+        f'if [ "$reward" = "1.0" ] || [ "$reward" = "1" ]; then\n'
+        f'  mkdir -p /tmp/skill-eval && '
+        f"printf '%s\\n' '{underlying_profile}-{mode}' "
+        f"> /tmp/skill-eval/active-deploy.txt\n"
+        "fi\n"
         "exit 0\n"
     )
 
@@ -556,7 +598,7 @@ def generate_task(
         "# GPU requirements — BrevEnvironment checks these against the",
         "# instance's actual GPU capacity before the trial runs.",
         f'gpu_type = "{platform_spec["gpu_type"]}"',
-        f'gpu_count = {mode_spec["gpus_needed"]}',
+        f'gpu_count = {mode_spec["gpus_needed"] + profile_def.get("local_extras", 0)}',
         f'min_vram_gb_per_gpu = {platform_spec["min_vram_per_gpu"]}',
         f'brev_search = "{platform_spec["brev_search"]}"',
         "# Disk + driver requirements — BrevEnvironment validates both via",
@@ -580,7 +622,12 @@ def generate_task(
         "[verifier.env]",
         'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
         'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
-        'JUDGE_MODEL = "${JUDGE_MODEL:-claude-haiku-4-5}"',
+        # ANTHROPIC_MODEL gives the verifier's judge model cascade
+        # (JUDGE_MODEL → ANTHROPIC_MODEL → literal) a working
+        # fallback when JUDGE_MODEL is unset. Forwarding a literal
+        # default for JUDGE_MODEL would bake it in and short-circuit
+        # the cascade — the proxy 401s the literal default outright.
+        'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
         "",
     ]
     (task_dir / "task.toml").write_text("\n".join(meta_lines))
@@ -604,7 +651,7 @@ def generate_task(
         )
         spec_name = spec_path.name
         (tests_dir / spec_name).write_text(json.dumps(rendered, indent=2))
-        (tests_dir / "test.sh").write_text(generate_test_script(spec_name))
+        (tests_dir / "test.sh").write_text(generate_test_script(spec_name, profile, mode))
         if GENERIC_JUDGE.exists():
             shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
     else:
@@ -612,7 +659,7 @@ def generate_task(
         # reports a clear failure instead of silently passing.
         (tests_dir / "test.sh").write_text(
             "#!/bin/bash\n"
-            f"echo 'FAIL: no eval spec at skills/deploy/eval/{underlying}.json' >&2\n"
+            f"echo 'FAIL: no eval spec at skills/deploy/eval/{profile}.json' >&2\n"
             "mkdir -p /logs/verifier\n"
             "echo 0 > /logs/verifier/reward.txt\n"
             "exit 0\n"

--- a/.github/skill-eval/adapters/report/__init__.py
+++ b/.github/skill-eval/adapters/report/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/.github/skill-eval/adapters/report/generate.py
+++ b/.github/skill-eval/adapters/report/generate.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the report skill.
+
+The report skill produces video analysis reports by querying the VSS agent's
+``POST /generate`` endpoint and formatting the timestamped response as a
+structured Video Analysis Report markdown.  It requires a **full-remote
+deployed VSS base profile** (deploy mode = ``remote-all``; LLM and VLM both
+via remote launchpad endpoints, no local NIMs). It does NOT deploy VSS
+itself; the coordinator chains a deploy task in front and a vios seed task
+before these checks.
+
+Because the report skill is a thin wrapper around POST /generate — purely
+HTTP, GPU-independent at the harness level — the spec targets **ONE platform**
+by default (L40S — cheapest available host).  Override with ``--platform``.
+
+## Directory layout
+
+    datasets/report/<profile>/<platform>/           (single-step spec)
+        task.toml
+        instruction.md
+        tests/test.sh
+        tests/<spec>.json
+        tests/generic_judge.py
+        solution/solve.sh
+        skills/report/
+        skills/deploy/
+        skills/vios/
+        environment/Dockerfile
+
+``<profile>`` comes from ``spec.profile`` (here: ``base``).
+
+Usage:
+    python3 generate.py --output-dir ../../datasets/report \\
+        --skill-dir ../../../../../skills/report \\
+        --deploy-skill-dir ../../../../../skills/deploy \\
+        --vios-skill-dir ../../../../../skills/vios \\
+        --spec ../../../../../skills/report/eval/base_profile_report.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Platforms — same table as the other adapters; spec.resources.platforms
+# narrows it down further.
+# ---------------------------------------------------------------------------
+
+PLATFORMS: dict[str, dict] = {
+    "H100":         {"short_name": "h100",         "gpu_type": "H100",         "min_vram_per_gpu": 80, "brev_search": "H100"},
+    "L40S":         {"short_name": "l40s",         "gpu_type": "L40S",         "min_vram_per_gpu": 48, "brev_search": "L40S"},
+    "RTXPRO6000BW": {"short_name": "rtxpro6000bw", "gpu_type": "RTX PRO 6000", "min_vram_per_gpu": 96, "brev_search": "RTX PRO"},
+    "DGX-SPARK":    {"short_name": "spark",        "gpu_type": "GB10",         "min_vram_per_gpu": 96, "brev_search": "GB10"},
+    "IGX-THOR":     {"short_name": "thor",         "gpu_type": "Thor",         "min_vram_per_gpu": 64, "brev_search": "Thor"},
+}
+
+DEFAULT_PLATFORM = "L40S"
+
+# Prepended to every instruction.md so the skill's own HITL bypass clause
+# fires.  Skills default to "ask the user" before /deploy; in CI there is no
+# user, so without this preamble the agent stalls or falls through to a
+# localhost default.
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+
+# ---------------------------------------------------------------------------
+# Generation helpers
+# ---------------------------------------------------------------------------
+
+def generate_test_script(step: int, spec_name: str) -> str:
+    """Shell wrapper that invokes the generic LLM-as-judge verifier for
+    a single step's checks.  Harbor reads /logs/verifier/reward.txt."""
+    return (
+        "#!/bin/bash\n"
+        f"# report verifier (step {step}): delegates to the generic\n"
+        "# LLM-as-judge (.github/skill-eval/verifiers/generic_judge.py).\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def generate_solve_script(platform: str) -> str:
+    """Gold solution — assumes VSS base profile is already deployed and a
+    sample warehouse video is already uploaded via vios.  The verifier drives
+    the POST /generate assertion; the solution script asserts the agent is
+    live, then defers."""
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution: report on {platform}\n"
+        "# The verifier calls POST /generate directly — the solution script\n"
+        "# just asserts VSS agent is reachable then defers to the verifier.\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 "
+        "${VSS_AGENT_URL:-http://localhost:8000}/docs "
+        ">/dev/null || {\n"
+        "    echo 'VSS agent is not deployed — cannot solve report task'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'VSS agent is live — verifier will drive POST /generate.'\n"
+    )
+
+
+def _platforms_from_spec(spec: dict) -> list[str]:
+    declared = ((spec.get("resources") or {}).get("platforms") or {})
+    if not declared:
+        return [DEFAULT_PLATFORM]
+    return [p for p in declared if p in PLATFORMS] or [DEFAULT_PLATFORM]
+
+
+# ---------------------------------------------------------------------------
+# Task generation
+# ---------------------------------------------------------------------------
+
+def generate_task(
+    platform: str,
+    profile: str,
+    spec: dict,
+    output_root: Path,
+    skill_dir: Path,
+    deploy_skill_dir: Path | None,
+    vios_skill_dir: Path | None,
+) -> None:
+    """Emit one Harbor task directory per entry in spec['expects'] — i.e.
+    step-<k>/ subdirs under ``<profile>/<platform_short>/`` per AGENTS.md § 4.
+    Single-step specs collapse to a flat ``<profile>/<platform_short>/``."""
+    pspec = PLATFORMS[platform]
+    platform_short = pspec["short_name"]
+    expects = spec.get("expects") or []
+    spec_name = Path(spec.get("_source_path", "spec.json")).name or "spec.json"
+
+    for idx, expect in enumerate(expects, 1):
+        step_dir = output_root / profile / platform_short
+        if len(expects) > 1:
+            step_dir = step_dir / f"step-{idx}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+
+        # instruction.md — ONE step's query + environment notes ONLY.
+        # Never leak the verifier's checks[] into the instruction so the
+        # agent can't write to the test rather than do the actual work.
+        step_suffix = f"-step-{idx}" if len(expects) > 1 else ""
+        lines = [
+            PREAMBLE,
+            "",
+            f"Use the `/report` skill against the VSS **{profile}** profile "
+            f"already running on this `{platform}` host "
+            "(`http://localhost:8000/docs` must respond, and a sample "
+            "warehouse video must already be uploaded per the env notes below).",
+            "",
+            f"## Query {idx} of {len(expects)}",
+            "",
+            expect.get("query", ""),
+            "",
+            "## Environment notes",
+            "",
+            spec.get("env", ""),
+            "",
+            "Run autonomously without prompting for confirmation.",
+            "",
+        ]
+        (step_dir / "instruction.md").write_text("\n".join(lines) + "\n")
+
+        # task.toml
+        meta_lines = [
+            "[task]",
+            f'name = "nvidia-vss/report-{profile}-{platform_short}{step_suffix}"',
+            f'description = "report query {idx}/{len(expects)} on {platform}"',
+            f'keywords = ["report", "generate", "{profile}", "{platform}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[verifier.env]",
+            'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+            'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+            # ANTHROPIC_MODEL gives the verifier's judge model cascade
+            # (JUDGE_MODEL → ANTHROPIC_MODEL → literal) a working fallback
+            # when JUDGE_MODEL is unset. Forwarding a literal default for
+            # JUDGE_MODEL would bake it in and short-circuit the cascade.
+            'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
+            "",
+            "[metadata]",
+            'skill = "report"',
+            f'profile = "{spec.get("profile", "base")}"',
+            f'platform = "{platform}"',
+            f'gpu_type = "{pspec["gpu_type"]}"',
+            f'brev_search = "{pspec["brev_search"]}"',
+            f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+            "requires_deployed_vss = true",
+            "# Deploy mode is FULL-REMOTE (LLM + VLM both remote) — report",
+            "# exercises POST /generate only, so there is no benefit to local NIMs.",
+            f'prerequisite_deploy_mode = "{spec.get("prerequisite_deploy_mode", "remote-all")}"',
+            f"step_index = {idx}",
+            f"step_count = {len(expects)}",
+            f"check_count = {len(expect.get('checks') or [])}",
+            "",
+        ]
+        (step_dir / "task.toml").write_text("\n".join(meta_lines))
+
+        # environment/ placeholder (BrevEnvironment takes over)
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        # tests/ — wrapper + generic judge + spec copy
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        spec_src = skill_dir / "eval" / spec_name
+        if spec_src.exists():
+            shutil.copy(spec_src, tests_dir / spec_name)
+        else:
+            # Fallback: write the in-memory spec so tests/ is complete
+            (tests_dir / spec_name).write_text(json.dumps(spec, indent=2))
+
+        # solution/
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(generate_solve_script(platform))
+
+        # skills/ — report + deploy + vios (the spec env mentions pre-uploading
+        # a sample warehouse video via vios before running report checks).
+        copies = [
+            (skill_dir,        "report"),
+            (deploy_skill_dir, "deploy"),
+            (vios_skill_dir,   "vios"),
+        ]
+        for src, name in copies:
+            if src and src.exists():
+                dst = step_dir / "skills" / name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--output-dir", required=True,
+        help="Dataset output root (e.g. .github/skill-eval/datasets/report)",
+    )
+    parser.add_argument(
+        "--skill-dir", required=True,
+        help="Path to skills/report",
+    )
+    parser.add_argument(
+        "--deploy-skill-dir", default=None,
+        help="Path to skills/deploy (optional — included for agent diagnosis)",
+    )
+    parser.add_argument(
+        "--vios-skill-dir", default=None,
+        help="Path to skills/vios (optional — spec env references vios video upload)",
+    )
+    parser.add_argument(
+        "--spec", default=None,
+        help="Path to spec JSON (default: <skill-dir>/eval/base_profile_report.json)",
+    )
+    parser.add_argument(
+        "--platform", default=None, choices=list(PLATFORMS.keys()),
+        help=f"Generate for one platform only (overrides spec.resources.platforms; "
+             f"default: {DEFAULT_PLATFORM})",
+    )
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+    vios_skill_dir = Path(args.vios_skill_dir) if args.vios_skill_dir else None
+    spec_path = (
+        Path(args.spec)
+        if args.spec
+        else (skill_dir / "eval" / "base_profile_report.json")
+    )
+
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+    spec = json.loads(spec_path.read_text())
+    spec["_source_path"] = str(spec_path)
+
+    profile = spec.get("profile", "base")
+    platforms = [args.platform] if args.platform else _platforms_from_spec(spec)
+
+    print("=== Inputs ===")
+    print(f"  output_dir   : {output_root}")
+    print(f"  skill_dir    : {skill_dir}")
+    print(f"  spec         : {spec_path}")
+    print(f"  profile      : {profile}")
+    print(f"  platforms    : {platforms}")
+    print(f"  queries      : {len(spec.get('expects', []))}")
+    print(f"  total checks : {sum(len(q.get('checks', [])) for q in spec.get('expects', []))}")
+    print()
+    for platform in platforms:
+        task_id = PLATFORMS[platform]["short_name"]
+        print(f"  GEN  report/{profile}/{task_id}")
+        generate_task(
+            platform, profile, spec, output_root, skill_dir,
+            deploy_skill_dir, vios_skill_dir,
+        )
+    print()
+    print(f"Generated {len(platforms)} platform(s) under {output_root}/{profile}/")
+    print()
+    print("Note: these tasks assume VSS base is already deployed on the target")
+    print("Brev instance and a sample warehouse video has been uploaded via vios.")
+    print("The coordinator is responsible for chaining those prerequisites ahead")
+    print("of each report task in the same subagent queue.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skill-eval/adapters/rt-vlm/__init__.py
+++ b/.github/skill-eval/adapters/rt-vlm/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RT-VLM skill-eval adapter."""

--- a/.github/skill-eval/adapters/rt-vlm/generate.py
+++ b/.github/skill-eval/adapters/rt-vlm/generate.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the rt-vlm skill.
+
+The rt-vlm skill tests the RTVI VLM microservice API directly. Specs can
+cover either the standalone RT-VLM compose service or RT-VLM as part of
+the full VSS alerts real-time profile.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+PLATFORMS: dict[str, dict] = {
+    "H100": {"short_name": "h100", "gpu_type": "H100", "min_vram_per_gpu": 80, "brev_search": "H100"},
+    "L40S": {"short_name": "l40s", "gpu_type": "L40S", "min_vram_per_gpu": 48, "brev_search": "L40S"},
+    "RTXPRO6000BW": {
+        "short_name": "rtxpro6000bw",
+        "gpu_type": "RTX PRO 6000",
+        "min_vram_per_gpu": 96,
+        "brev_search": "RTX PRO",
+    },
+    "DGX-SPARK": {"short_name": "spark", "gpu_type": "GB10", "min_vram_per_gpu": 96, "brev_search": "GB10"},
+    "IGX-THOR": {"short_name": "thor", "gpu_type": "Thor", "min_vram_per_gpu": 64, "brev_search": "Thor"},
+}
+
+DEFAULT_PLATFORM = "L40S"
+DEFAULT_SPEC = "standalone_api.json"
+COMPOSE_PROFILE = "bp_developer_alerts_2d_vlm"
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
+
+def _substitute_spec(spec: dict, platform: str, mode: str) -> dict:
+    substitutions = {
+        "platform": platform,
+        "mode": mode,
+        "repo_root": "$HOME/video-search-and-summarization",
+    }
+    import re
+
+    pattern = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+
+    def _sub(value):
+        if isinstance(value, str):
+            return pattern.sub(lambda m: str(substitutions.get(m.group(1), m.group(0))), value)
+        if isinstance(value, list):
+            return [_sub(v) for v in value]
+        if isinstance(value, dict):
+            return {k: _sub(v) for k, v in value.items()}
+        return value
+
+    return _sub(spec)
+
+
+def _platform_modes_from_spec(spec: dict, platform_filter: str | None) -> list[tuple[str, str]]:
+    declared = ((spec.get("resources") or {}).get("platforms") or {})
+    if not declared:
+        default_mode = "remote-all" if spec.get("profile") else "standalone"
+        declared = {DEFAULT_PLATFORM: {"modes": [default_mode]}}
+
+    tasks: list[tuple[str, str]] = []
+    for platform, cfg in declared.items():
+        if platform_filter and platform != platform_filter:
+            continue
+        if platform not in PLATFORMS:
+            continue
+        default_mode = "remote-all" if spec.get("profile") else "standalone"
+        for mode in (cfg or {}).get("modes") or [default_mode]:
+            tasks.append((platform, mode))
+    fallback_mode = "remote-all" if spec.get("profile") else "standalone"
+    return tasks or [(platform_filter or DEFAULT_PLATFORM, fallback_mode)]
+
+
+def _is_profile_spec(spec: dict) -> bool:
+    return bool(spec.get("profile"))
+
+
+def _dataset_group(spec: dict) -> str:
+    if _is_profile_spec(spec):
+        profile = str(spec.get("profile"))
+        deploy_mode = str(spec.get("deploy_mode", ""))
+        return f"{profile}-{deploy_mode}" if deploy_mode else profile
+    return "standalone"
+
+
+def _instruction_intro(spec: dict) -> str:
+    if _is_profile_spec(spec):
+        profile = spec.get("profile")
+        deploy_mode = spec.get("deploy_mode")
+        return (
+            "Use `/deploy` first, then `/rt-vlm`. Deploy the full VSS "
+            f"`{profile}` profile"
+            + (f" in `{deploy_mode}` mode" if deploy_mode else "")
+            + ", then test the RT-VLM microservice directly."
+        )
+
+    return (
+        "Use `/rt-vlm` only. Deploy RT-VLM as a standalone compose service from "
+        "`deployments/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml`; do not use "
+        "`/deploy`, `scripts/dev-profile.sh`, or a full VSS profile. The Docker "
+        f"Compose profile that activates the service is `{COMPOSE_PROFILE}`."
+    )
+
+
+def generate_test_script(step: int, spec_name: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f"# rt-vlm verifier (step {step}): delegates to the generic\n"
+        "# LLM-as-judge (.github/skill-eval/verifiers/generic_judge.py).\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def generate_solve_script(platform: str, mode: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution: rt-vlm on {platform}/{mode}\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 http://localhost:8018/v1/health/ready >/dev/null || {\n"
+        "    echo 'RT-VLM is not ready — cannot solve rt-vlm task'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'RT-VLM is live — verifier will drive the assertions.'\n"
+    )
+
+
+def generate_task(
+    platform: str,
+    mode: str,
+    spec: dict,
+    output_root: Path,
+    skill_dir: Path,
+    deploy_skill_dir: Path | None,
+) -> None:
+    pspec = PLATFORMS[platform]
+    platform_short = pspec["short_name"]
+    expects = spec.get("expects") or []
+    spec_name = Path(spec.get("_source_path", DEFAULT_SPEC)).name or DEFAULT_SPEC
+    rendered_spec = _substitute_spec(spec, platform, mode)
+    dataset_group = _dataset_group(spec)
+    profile_spec = _is_profile_spec(spec)
+
+    for idx, expect in enumerate(rendered_spec.get("expects") or [], 1):
+        step_dir = output_root / dataset_group / f"{platform_short}-{mode}"
+        if len(expects) > 1:
+            step_dir = step_dir / f"step-{idx}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+
+        instruction = [
+            PREAMBLE,
+            "",
+            _instruction_intro(spec),
+            "",
+            f"## Query {idx} of {len(expects)}",
+            "",
+            expect.get("query", ""),
+            "",
+            "## Environment notes",
+            "",
+            rendered_spec.get("env", ""),
+            "",
+            "Run autonomously without prompting for confirmation.",
+            "",
+        ]
+        (step_dir / "instruction.md").write_text("\n".join(instruction) + "\n")
+
+        step_suffix = f"-step-{idx}" if len(expects) > 1 else ""
+        meta_lines = [
+            "[task]",
+            f'name = "nvidia-vss/rt-vlm-{dataset_group}-{platform_short}-{mode}{step_suffix}"',
+            f'description = "RT-VLM API query {idx}/{len(expects)} on {platform}/{mode}"',
+            f'keywords = ["rt-vlm", "rtvi-vlm", "{dataset_group}", "{platform}", "{mode}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[verifier.env]",
+            'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+            'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+            'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
+            "",
+            "[metadata]",
+            'skill = "rt-vlm"',
+            f'deployment = "{"profile" if profile_spec else "standalone"}"',
+            f'platform = "{platform}"',
+            f'mode = "{mode}"',
+            f'gpu_type = "{pspec["gpu_type"]}"',
+            f'brev_search = "{pspec["brev_search"]}"',
+            # RT-VLM alerts real-time in remote-all still needs one local GPU
+            # for the continuous video processor.
+            "gpu_count = 1",
+            f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+            "min_root_disk_gb = 160",
+            f"step_index = {idx}",
+            f"step_count = {len(expects)}",
+            f"check_count = {len(expect.get('checks') or [])}",
+            "",
+        ]
+        if profile_spec:
+            meta_lines.insert(meta_lines.index(f'platform = "{platform}"'), f'profile = "{spec.get("profile")}"')
+            if spec.get("deploy_mode"):
+                meta_lines.insert(
+                    meta_lines.index(f'platform = "{platform}"'),
+                    f'deploy_mode = "{spec.get("deploy_mode")}"',
+                )
+            meta_lines.insert(
+                meta_lines.index(f'platform = "{platform}"'),
+                f'prerequisite_deploy_mode = "{mode}"',
+            )
+        else:
+            meta_lines.insert(meta_lines.index(f'platform = "{platform}"'), f'compose_profile = "{COMPOSE_PROFILE}"')
+        (step_dir / "task.toml").write_text("\n".join(meta_lines))
+
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        (tests_dir / spec_name).write_text(json.dumps(rendered_spec, indent=2))
+
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(generate_solve_script(platform, mode))
+
+        skills_to_copy = [(skill_dir, "rt-vlm")]
+        if profile_spec and deploy_skill_dir:
+            skills_to_copy.append((deploy_skill_dir, "deploy"))
+        for src, name in skills_to_copy:
+            if src and src.exists():
+                dst = step_dir / "skills" / name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--skill-dir", required=True)
+    parser.add_argument("--deploy-skill-dir", default=None)
+    parser.add_argument("--spec", default=None, help=f"Path to {DEFAULT_SPEC}")
+    parser.add_argument("--platform", default=None, choices=list(PLATFORMS.keys()))
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / DEFAULT_SPEC)
+
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+
+    spec = json.loads(spec_path.read_text())
+    spec["_source_path"] = str(spec_path)
+    tasks = _platform_modes_from_spec(spec, args.platform)
+
+    print("=== Inputs ===")
+    print(f"  output_dir   : {output_root}")
+    print(f"  skill_dir    : {skill_dir}")
+    print(f"  spec         : {spec_path}")
+    print(f"  tasks        : {tasks}")
+    print(f"  queries      : {len(spec.get('expects', []))}")
+    print(f"  total checks : {sum(len(q.get('checks', [])) for q in spec.get('expects', []))}")
+    print()
+
+    for platform, mode in tasks:
+        print(f"  GEN  rt-vlm/{_dataset_group(spec)}/{PLATFORMS[platform]['short_name']}-{mode}")
+        generate_task(platform, mode, spec, output_root, skill_dir, deploy_skill_dir)
+
+    print()
+    print(f"Generated {len(tasks)} task(s) under {output_root}/{_dataset_group(spec)}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skill-eval/adapters/video-search/__init__.py
+++ b/.github/skill-eval/adapters/video-search/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/.github/skill-eval/adapters/video-search/generate.py
+++ b/.github/skill-eval/adapters/video-search/generate.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the video-search skill.
+
+The video-search skill exercises the VSS agent's `POST /generate` endpoint
+for fused semantic + attribute search across pre-ingested video sources.
+It runs against a **full-remote-deployed VSS search profile** (deploy mode
+= `remote-all`; LLM and VLM both remote — Cosmos Embed1 and Elasticsearch
+still run locally on the GPU host). It does NOT deploy VSS itself; the
+coordinator chains a deploy task in front, then a vios upload step seeds
+the sample videos.
+
+Mirrors the vios adapter's shape — single-task-per-platform, step-chained
+under the spec's prerequisite profile name. Default platform is L40S
+because the agent path is GPU-independent (Cosmos Embed1 inference happens
+once during ingest; the search itself is an Elasticsearch query) and the
+spec pins this in `resources.platforms`.
+
+## Directory layout
+
+    datasets/video-search/<profile>/<platform>/step-<k>/
+        task.toml
+        instruction.md
+        tests/test.sh
+        tests/<spec>.json
+        tests/generic_judge.py
+        solution/solve.sh
+        skills/video-search/  (full skill copy)
+        skills/deploy/        (for prerequisite diagnostics)
+        skills/vios/          (the search spec's first checks reference vios
+                               as the canonical source-list lookup)
+        environment/Dockerfile  (FROM scratch; BrevEnvironment takes over)
+
+`<profile>` comes from `spec.profile` (here: `search`). `<k>` is the
+1-based index into `expects[]`; single-step specs collapse the step
+subdir.
+
+Usage:
+    python3 generate.py --output-dir ../../datasets/video-search \\
+        --skill-dir ../../../../../skills/video-search \\
+        --deploy-skill-dir ../../../../../skills/deploy \\
+        --vios-skill-dir ../../../../../skills/vios
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Platforms — mirrors the vios/deploy adapters so video-search runs on the
+# same hosts. The spec's `resources.platforms` further filters this set.
+# ---------------------------------------------------------------------------
+
+PLATFORMS: dict[str, dict] = {
+    "H100":          {"short_name": "h100",          "gpu_type": "H100",         "min_vram_per_gpu": 80, "brev_search": "H100"},
+    "L40S":          {"short_name": "l40s",          "gpu_type": "L40S",         "min_vram_per_gpu": 48, "brev_search": "L40S"},
+    "RTXPRO6000BW":  {"short_name": "rtxpro6000bw",  "gpu_type": "RTX PRO 6000", "min_vram_per_gpu": 96, "brev_search": "RTX PRO"},
+    "DGX-SPARK":     {"short_name": "spark",         "gpu_type": "GB10",         "min_vram_per_gpu": 96, "brev_search": "GB10"},
+    "IGX-THOR":      {"short_name": "thor",          "gpu_type": "Thor",         "min_vram_per_gpu": 64, "brev_search": "Thor"},
+}
+
+# Default when the spec doesn't pin a platform.
+DEFAULT_PLATFORM = "L40S"
+
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+def generate_test_script(step: int, spec_name: str) -> str:
+    """Wrapper that invokes the generic judge for one step's checks."""
+    return (
+        "#!/bin/bash\n"
+        f"# video-search verifier (step {step}): delegates to the generic\n"
+        "# LLM-as-judge (.github/skill-eval/verifiers/generic_judge.py).\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def generate_solve_script(platform: str) -> str:
+    """Gold solution — assumes the search profile is already deployed and
+    the sample videos are ingested. The verifier drives the assertions
+    independently against the agent's `/generate` output."""
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution: video-search on {platform}\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 "
+        "${VSS_AGENT_URL:-http://localhost:8000}/docs "
+        ">/dev/null || {\n"
+        "    echo 'VSS agent is not deployed — cannot solve video-search task'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'VSS agent is live — verifier will drive the queries.'\n"
+    )
+
+
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+
+def _platforms_from_spec(spec: dict) -> list[str]:
+    """Filter PLATFORMS by the spec's `resources.platforms` map (if any).
+    Spec-declared platforms not in our table are silently dropped — the
+    coordinator should already have rejected unsupported platforms."""
+    declared = ((spec.get("resources") or {}).get("platforms") or {})
+    if not declared:
+        return [DEFAULT_PLATFORM]
+    return [p for p in declared if p in PLATFORMS] or [DEFAULT_PLATFORM]
+
+
+def generate_task(platform: str, profile: str, spec: dict, output_root: Path,
+                  skill_dir: Path, deploy_skill_dir: Path | None,
+                  vios_skill_dir: Path | None) -> None:
+    pspec = PLATFORMS[platform]
+    platform_short = pspec["short_name"]
+    expects = spec.get("expects") or []
+    spec_name = Path(spec.get("_source_path", "spec.json")).name or "spec.json"
+
+    for idx, expect in enumerate(expects, 1):
+        step_dir = output_root / profile / platform_short
+        if len(expects) > 1:
+            step_dir = step_dir / f"step-{idx}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+
+        # instruction.md — query + env notes only. Never leak checks[].
+        lines = [
+            PREAMBLE,
+            "",
+            f"Use the `/video-search` skill against the VSS **{profile}** "
+            f"profile already running on this `{platform}` host "
+            "(`http://localhost:8000/docs` must respond, and sample videos "
+            "must already be ingested per the env notes below).",
+            "",
+            f"## Query {idx} of {len(expects)}",
+            "",
+            expect.get("query", ""),
+            "",
+            "## Environment notes",
+            "",
+            spec.get("env", ""),
+            "",
+            "Run autonomously without prompting for confirmation.",
+            "",
+        ]
+        (step_dir / "instruction.md").write_text("\n".join(lines) + "\n")
+
+        # task.toml
+        step_suffix = f"-step-{idx}" if len(expects) > 1 else ""
+        meta_lines = [
+            "[task]",
+            f'name = "nvidia-vss/video-search-{profile}-{platform_short}{step_suffix}"',
+            f'description = "video-search query {idx}/{len(expects)} on {platform}"',
+            f'keywords = ["video-search", "{profile}", "{platform}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[verifier.env]",
+            'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+            'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+            'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
+            "",
+            "[metadata]",
+            'skill = "video-search"',
+            f'profile = "{profile}"',
+            f'platform = "{platform}"',
+            f'gpu_type = "{pspec["gpu_type"]}"',
+            f'brev_search = "{pspec["brev_search"]}"',
+            f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+            "requires_deployed_vss = true",
+            f'prerequisite_deploy_mode = "{spec.get("prerequisite_deploy_mode", "remote-all")}"',
+            f"step_index = {idx}",
+            f"step_count = {len(expects)}",
+            f"check_count = {len(expect.get('checks') or [])}",
+            "",
+        ]
+        (step_dir / "task.toml").write_text("\n".join(meta_lines))
+
+        # environment/
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        # tests/
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        spec_src = skill_dir / "eval" / spec_name
+        if spec_src.exists():
+            shutil.copy(spec_src, tests_dir / spec_name)
+        else:
+            (tests_dir / spec_name).write_text(json.dumps(spec, indent=2))
+
+        # solution/
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(generate_solve_script(platform))
+
+        # skills/ — primary + deploy (for prereq diagnostics) + vios
+        # (search spec's first checks reference vios for source-list lookup).
+        copies = [(skill_dir, "video-search"),
+                  (deploy_skill_dir, "deploy"),
+                  (vios_skill_dir, "vios")]
+        for src, name in copies:
+            if src and src.exists():
+                dst = step_dir / "skills" / name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--output-dir", required=True,
+                        help="Dataset output root (e.g. .github/skill-eval/datasets/video-search)")
+    parser.add_argument("--skill-dir", required=True,
+                        help="Path to skills/video-search")
+    parser.add_argument("--deploy-skill-dir", default=None,
+                        help="Path to skills/deploy (optional — included for agent debug)")
+    parser.add_argument("--vios-skill-dir", default=None,
+                        help="Path to skills/vios (optional — referenced by the spec for source-list lookup)")
+    parser.add_argument("--spec", default=None,
+                        help="Path to search.json (default: <skill-dir>/eval/search.json)")
+    parser.add_argument("--platform", default=None, choices=list(PLATFORMS.keys()),
+                        help=f"Generate for one platform only (overrides spec.resources.platforms)")
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+    vios_skill_dir = Path(args.vios_skill_dir) if args.vios_skill_dir else None
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / "search.json")
+
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+    spec = json.loads(spec_path.read_text())
+    spec["_source_path"] = str(spec_path)
+
+    profile = spec.get("profile", "search")
+    platforms = [args.platform] if args.platform else _platforms_from_spec(spec)
+
+    print("=== Inputs ===")
+    print(f"  output_dir   : {output_root}")
+    print(f"  skill_dir    : {skill_dir}")
+    print(f"  spec         : {spec_path}")
+    print(f"  profile      : {profile}")
+    print(f"  platforms    : {platforms}")
+    print(f"  queries      : {len(spec.get('expects', []))}")
+    print(f"  total checks : {sum(len(q.get('checks', [])) for q in spec.get('expects', []))}")
+    print()
+    for platform in platforms:
+        task_id = PLATFORMS[platform]["short_name"]
+        print(f"  GEN  video-search/{profile}/{task_id}")
+        generate_task(platform, profile, spec, output_root, skill_dir,
+                      deploy_skill_dir, vios_skill_dir)
+    print()
+    print(f"Generated {len(platforms)} platform(s) under {output_root}/{profile}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skill-eval/adapters/video-summarization/__init__.py
+++ b/.github/skill-eval/adapters/video-summarization/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/.github/skill-eval/adapters/video-summarization/generate.py
+++ b/.github/skill-eval/adapters/video-summarization/generate.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the video-summarization skill.
+
+The video-summarization skill exercises the LVS microservice on
+`http://localhost:38111` against a **full-remote-deployed VSS lvs profile**
+(deploy mode = `remote-all`; the agent's LLM and the VLM that LVS calls
+are both served via remote launchpad endpoints, no local NIMs). It does
+NOT deploy VSS itself; the coordinator chains a deploy task in front and
+seeds the sample warehouse video via the vios skill before this trial.
+
+Mirrors the vios adapter — single-task-per-platform, step-chained under
+the spec's prerequisite profile name. Default platform is L40S because
+summarization is throughput-bound on the remote VLM and the spec pins
+this in `resources.platforms`.
+
+## Directory layout
+
+    datasets/video-summarization/<profile>/<platform>/step-<k>/
+        task.toml
+        instruction.md
+        tests/test.sh
+        tests/<spec>.json
+        tests/generic_judge.py
+        solution/solve.sh
+        skills/video-summarization/
+        skills/deploy/                (for prerequisite diagnostics)
+        skills/vios/                  (the spec's env mentions seeding the
+                                       sample video via vios upload first)
+        environment/Dockerfile        (FROM scratch; BrevEnvironment takes over)
+
+`<profile>` comes from `spec.profile` (here: `lvs`). `<k>` is the
+1-based index into `expects[]`; single-step specs collapse the step
+subdir.
+
+Usage:
+    python3 generate.py --output-dir ../../datasets/video-summarization \\
+        --skill-dir ../../../../../skills/video-summarization \\
+        --deploy-skill-dir ../../../../../skills/deploy \\
+        --vios-skill-dir ../../../../../skills/vios
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Platforms — same table as the other adapters; spec.resources.platforms
+# narrows it down further.
+# ---------------------------------------------------------------------------
+
+PLATFORMS: dict[str, dict] = {
+    "H100":          {"short_name": "h100",          "gpu_type": "H100",         "min_vram_per_gpu": 80, "brev_search": "H100"},
+    "L40S":          {"short_name": "l40s",          "gpu_type": "L40S",         "min_vram_per_gpu": 48, "brev_search": "L40S"},
+    "RTXPRO6000BW":  {"short_name": "rtxpro6000bw",  "gpu_type": "RTX PRO 6000", "min_vram_per_gpu": 96, "brev_search": "RTX PRO"},
+    "DGX-SPARK":     {"short_name": "spark",         "gpu_type": "GB10",         "min_vram_per_gpu": 96, "brev_search": "GB10"},
+    "IGX-THOR":      {"short_name": "thor",          "gpu_type": "Thor",         "min_vram_per_gpu": 64, "brev_search": "Thor"},
+}
+
+DEFAULT_PLATFORM = "L40S"
+
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+def generate_test_script(step: int, spec_name: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        f"# video-summarization verifier (step {step}): delegates to the\n"
+        "# generic LLM-as-judge (.github/skill-eval/verifiers/generic_judge.py).\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def generate_solve_script(platform: str) -> str:
+    """Gold solution — assumes the lvs profile is already deployed and
+    a sample warehouse video is uploaded. Verifier drives the assertions."""
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution: video-summarization on {platform}\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 "
+        "${LVS_URL:-http://localhost:38111}/v1/ready "
+        ">/dev/null || {\n"
+        "    echo 'LVS is not deployed — cannot solve video-summarization task'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'LVS is live — verifier will drive the queries.'\n"
+    )
+
+
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+
+def _platforms_from_spec(spec: dict) -> list[str]:
+    declared = ((spec.get("resources") or {}).get("platforms") or {})
+    if not declared:
+        return [DEFAULT_PLATFORM]
+    return [p for p in declared if p in PLATFORMS] or [DEFAULT_PLATFORM]
+
+
+def generate_task(platform: str, profile: str, spec: dict, output_root: Path,
+                  skill_dir: Path, deploy_skill_dir: Path | None,
+                  vios_skill_dir: Path | None) -> None:
+    pspec = PLATFORMS[platform]
+    platform_short = pspec["short_name"]
+    expects = spec.get("expects") or []
+    spec_name = Path(spec.get("_source_path", "spec.json")).name or "spec.json"
+
+    for idx, expect in enumerate(expects, 1):
+        step_dir = output_root / profile / platform_short
+        if len(expects) > 1:
+            step_dir = step_dir / f"step-{idx}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+
+        lines = [
+            PREAMBLE,
+            "",
+            f"Use the `/video-summarization` skill against the VSS **{profile}** "
+            f"profile already running on this `{platform}` host "
+            "(`http://localhost:38111/v1/ready` must respond, and a sample "
+            "warehouse video must already be uploaded per the env notes below).",
+            "",
+            f"## Query {idx} of {len(expects)}",
+            "",
+            expect.get("query", ""),
+            "",
+            "## Environment notes",
+            "",
+            spec.get("env", ""),
+            "",
+            "Run autonomously without prompting for confirmation.",
+            "",
+        ]
+        (step_dir / "instruction.md").write_text("\n".join(lines) + "\n")
+
+        step_suffix = f"-step-{idx}" if len(expects) > 1 else ""
+        meta_lines = [
+            "[task]",
+            f'name = "nvidia-vss/video-summarization-{profile}-{platform_short}{step_suffix}"',
+            f'description = "video-summarization query {idx}/{len(expects)} on {platform}"',
+            f'keywords = ["video-summarization", "lvs", "{profile}", "{platform}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[verifier.env]",
+            'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+            'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+            'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
+            "",
+            "[metadata]",
+            'skill = "video-summarization"',
+            f'profile = "{profile}"',
+            f'platform = "{platform}"',
+            f'gpu_type = "{pspec["gpu_type"]}"',
+            f'brev_search = "{pspec["brev_search"]}"',
+            f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+            "requires_deployed_vss = true",
+            f'prerequisite_deploy_mode = "{spec.get("prerequisite_deploy_mode", "remote-all")}"',
+            f"step_index = {idx}",
+            f"step_count = {len(expects)}",
+            f"check_count = {len(expect.get('checks') or [])}",
+            "",
+        ]
+        (step_dir / "task.toml").write_text("\n".join(meta_lines))
+
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        spec_src = skill_dir / "eval" / spec_name
+        if spec_src.exists():
+            shutil.copy(spec_src, tests_dir / spec_name)
+        else:
+            (tests_dir / spec_name).write_text(json.dumps(spec, indent=2))
+
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(generate_solve_script(platform))
+
+        # skills/ — primary + deploy + vios (the spec env mentions seeding
+        # the sample video via vios upload before these checks run).
+        copies = [(skill_dir, "video-summarization"),
+                  (deploy_skill_dir, "deploy"),
+                  (vios_skill_dir, "vios")]
+        for src, name in copies:
+            if src and src.exists():
+                dst = step_dir / "skills" / name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--output-dir", required=True,
+                        help="Dataset output root (e.g. .github/skill-eval/datasets/video-summarization)")
+    parser.add_argument("--skill-dir", required=True,
+                        help="Path to skills/video-summarization")
+    parser.add_argument("--deploy-skill-dir", default=None,
+                        help="Path to skills/deploy (optional — included for agent debug)")
+    parser.add_argument("--vios-skill-dir", default=None,
+                        help="Path to skills/vios (optional — referenced by the spec for video upload prerequisite)")
+    parser.add_argument("--spec", default=None,
+                        help="Path to lvs_profile_summarize.json "
+                             "(default: <skill-dir>/eval/lvs_profile_summarize.json)")
+    parser.add_argument("--platform", default=None, choices=list(PLATFORMS.keys()),
+                        help=f"Generate for one platform only (overrides spec.resources.platforms)")
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+    vios_skill_dir = Path(args.vios_skill_dir) if args.vios_skill_dir else None
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / "lvs_profile_summarize.json")
+
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+    spec = json.loads(spec_path.read_text())
+    spec["_source_path"] = str(spec_path)
+
+    profile = spec.get("profile", "lvs")
+    platforms = [args.platform] if args.platform else _platforms_from_spec(spec)
+
+    print("=== Inputs ===")
+    print(f"  output_dir   : {output_root}")
+    print(f"  skill_dir    : {skill_dir}")
+    print(f"  spec         : {spec_path}")
+    print(f"  profile      : {profile}")
+    print(f"  platforms    : {platforms}")
+    print(f"  queries      : {len(spec.get('expects', []))}")
+    print(f"  total checks : {sum(len(q.get('checks', [])) for q in spec.get('expects', []))}")
+    print()
+    for platform in platforms:
+        task_id = PLATFORMS[platform]["short_name"]
+        print(f"  GEN  video-summarization/{profile}/{task_id}")
+        generate_task(platform, profile, spec, output_root, skill_dir,
+                      deploy_skill_dir, vios_skill_dir)
+    print()
+    print(f"Generated {len(platforms)} platform(s) under {output_root}/{profile}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skill-eval/adapters/video-understanding/__init__.py
+++ b/.github/skill-eval/adapters/video-understanding/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/.github/skill-eval/adapters/video-understanding/generate.py
+++ b/.github/skill-eval/adapters/video-understanding/generate.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the video-understanding skill.
+
+The video-understanding skill answers visual questions about a named sensor
+by calling ``POST /generate`` on the VSS agent, instructing it to invoke the
+``video_understanding`` tool.  It requires a **full-remote deployed VSS base
+profile** (deploy mode = ``remote-all``; both LLM and VLM via remote
+launchpad endpoints, no local NIMs required). It does NOT deploy VSS itself;
+the coordinator chains a deploy task in front, plus a vios seed step to
+upload the sample warehouse video.
+
+Because video-understanding is a thin wrapper around POST /generate — purely
+HTTP, GPU-independent at the harness level — the spec targets **ONE platform**
+by default (L40S — cheapest available host).  Override with ``--platform``.
+
+## Directory layout
+
+    datasets/video-understanding/<profile>/<platform>/   (multi-step spec)
+        step-1/
+            task.toml, instruction.md, tests/, solution/, skills/, environment/
+        step-2/
+            ...
+        step-N/
+            ...
+
+``<profile>`` comes from ``spec.profile`` (here: ``base``).
+
+Usage:
+    python3 generate.py --output-dir ../../datasets/video-understanding \\
+        --skill-dir ../../../../../skills/video-understanding \\
+        --deploy-skill-dir ../../../../../skills/deploy \\
+        --vios-skill-dir ../../../../../skills/vios \\
+        --spec ../../../../../skills/video-understanding/eval/base_profile_video_understanding.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Platforms — same table as the other adapters; spec.resources.platforms
+# narrows it down further.
+# ---------------------------------------------------------------------------
+
+PLATFORMS: dict[str, dict] = {
+    "H100":         {"short_name": "h100",         "gpu_type": "H100",         "min_vram_per_gpu": 80, "brev_search": "H100"},
+    "L40S":         {"short_name": "l40s",         "gpu_type": "L40S",         "min_vram_per_gpu": 48, "brev_search": "L40S"},
+    "RTXPRO6000BW": {"short_name": "rtxpro6000bw", "gpu_type": "RTX PRO 6000", "min_vram_per_gpu": 96, "brev_search": "RTX PRO"},
+    "DGX-SPARK":    {"short_name": "spark",        "gpu_type": "GB10",         "min_vram_per_gpu": 96, "brev_search": "GB10"},
+    "IGX-THOR":     {"short_name": "thor",         "gpu_type": "Thor",         "min_vram_per_gpu": 64, "brev_search": "Thor"},
+}
+
+DEFAULT_PLATFORM = "L40S"
+
+# Prepended to every instruction.md so the skill's own HITL bypass clause
+# fires.  Skills default to "ask the user" before /deploy; in CI there is no
+# user, so without this preamble the agent stalls or falls through to a
+# localhost default.
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+
+# ---------------------------------------------------------------------------
+# Generation helpers
+# ---------------------------------------------------------------------------
+
+def generate_test_script(step: int, spec_name: str) -> str:
+    """Shell wrapper that invokes the generic LLM-as-judge verifier for
+    a single step's checks.  Harbor reads /logs/verifier/reward.txt."""
+    return (
+        "#!/bin/bash\n"
+        f"# video-understanding verifier (step {step}): delegates to the generic\n"
+        "# LLM-as-judge (.github/skill-eval/verifiers/generic_judge.py).\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def generate_solve_script(platform: str) -> str:
+    """Gold solution — assumes VSS base profile is already deployed and a
+    sample warehouse video is already uploaded via vios.  The verifier drives
+    the POST /generate assertion; the solution script asserts the agent is
+    live, then defers."""
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution: video-understanding on {platform}\n"
+        "# The verifier calls POST /generate directly — the solution script\n"
+        "# just asserts VSS agent is reachable then defers to the verifier.\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 "
+        "${VSS_AGENT_URL:-http://localhost:8000}/docs "
+        ">/dev/null || {\n"
+        "    echo 'VSS agent is not deployed — cannot solve video-understanding task'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'VSS agent is live — verifier will drive POST /generate.'\n"
+    )
+
+
+def _platforms_from_spec(spec: dict) -> list[str]:
+    declared = ((spec.get("resources") or {}).get("platforms") or {})
+    if not declared:
+        return [DEFAULT_PLATFORM]
+    return [p for p in declared if p in PLATFORMS] or [DEFAULT_PLATFORM]
+
+
+# ---------------------------------------------------------------------------
+# Task generation
+# ---------------------------------------------------------------------------
+
+def generate_task(
+    platform: str,
+    profile: str,
+    spec: dict,
+    output_root: Path,
+    skill_dir: Path,
+    deploy_skill_dir: Path | None,
+    vios_skill_dir: Path | None,
+) -> None:
+    """Emit one Harbor task directory per entry in spec['expects'] — i.e.
+    step-<k>/ subdirs under ``<profile>/<platform_short>/`` per AGENTS.md § 4.
+    Single-step specs collapse to a flat ``<profile>/<platform_short>/``."""
+    pspec = PLATFORMS[platform]
+    platform_short = pspec["short_name"]
+    expects = spec.get("expects") or []
+    spec_name = Path(spec.get("_source_path", "spec.json")).name or "spec.json"
+
+    for idx, expect in enumerate(expects, 1):
+        step_dir = output_root / profile / platform_short
+        if len(expects) > 1:
+            step_dir = step_dir / f"step-{idx}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+
+        # instruction.md — ONE step's query + environment notes ONLY.
+        # Never leak the verifier's checks[] into the instruction so the
+        # agent can't write to the test rather than do the actual work.
+        step_suffix = f"-step-{idx}" if len(expects) > 1 else ""
+        lines = [
+            PREAMBLE,
+            "",
+            f"Use the `/video-understanding` skill against the VSS **{profile}** "
+            f"profile already running on this `{platform}` host "
+            "(`http://localhost:8000/docs` must respond, and a sample "
+            "warehouse video must already be uploaded per the env notes below).",
+            "",
+            f"## Query {idx} of {len(expects)}",
+            "",
+            expect.get("query", ""),
+            "",
+            "## Environment notes",
+            "",
+            spec.get("env", ""),
+            "",
+            "Run autonomously without prompting for confirmation.",
+            "",
+        ]
+        (step_dir / "instruction.md").write_text("\n".join(lines) + "\n")
+
+        # task.toml
+        meta_lines = [
+            "[task]",
+            f'name = "nvidia-vss/video-understanding-{profile}-{platform_short}{step_suffix}"',
+            f'description = "video-understanding query {idx}/{len(expects)} on {platform}"',
+            f'keywords = ["video-understanding", "generate", "{profile}", "{platform}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[verifier.env]",
+            'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+            'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+            # ANTHROPIC_MODEL gives the verifier's judge model cascade
+            # (JUDGE_MODEL → ANTHROPIC_MODEL → literal) a working fallback
+            # when JUDGE_MODEL is unset. Forwarding a literal default for
+            # JUDGE_MODEL would bake it in and short-circuit the cascade.
+            'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
+            "",
+            "[metadata]",
+            'skill = "video-understanding"',
+            f'profile = "{spec.get("profile", "base")}"',
+            f'platform = "{platform}"',
+            f'gpu_type = "{pspec["gpu_type"]}"',
+            f'brev_search = "{pspec["brev_search"]}"',
+            f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+            "requires_deployed_vss = true",
+            "# Deploy mode is FULL-REMOTE (LLM + VLM both remote) — video-understanding",
+            "# exercises POST /generate only, so there is no benefit to local NIMs.",
+            f'prerequisite_deploy_mode = "{spec.get("prerequisite_deploy_mode", "remote-all")}"',
+            f"step_index = {idx}",
+            f"step_count = {len(expects)}",
+            f"check_count = {len(expect.get('checks') or [])}",
+            "",
+        ]
+        (step_dir / "task.toml").write_text("\n".join(meta_lines))
+
+        # environment/ placeholder (BrevEnvironment takes over)
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        # tests/ — wrapper + generic judge + spec copy
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        spec_src = skill_dir / "eval" / spec_name
+        if spec_src.exists():
+            shutil.copy(spec_src, tests_dir / spec_name)
+        else:
+            # Fallback: write the in-memory spec so tests/ is complete
+            (tests_dir / spec_name).write_text(json.dumps(spec, indent=2))
+
+        # solution/
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(generate_solve_script(platform))
+
+        # skills/ — video-understanding + deploy + vios (the spec env mentions
+        # pre-uploading a sample warehouse video via vios before running checks).
+        copies = [
+            (skill_dir,        "video-understanding"),
+            (deploy_skill_dir, "deploy"),
+            (vios_skill_dir,   "vios"),
+        ]
+        for src, name in copies:
+            if src and src.exists():
+                dst = step_dir / "skills" / name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--output-dir", required=True,
+        help="Dataset output root (e.g. .github/skill-eval/datasets/video-understanding)",
+    )
+    parser.add_argument(
+        "--skill-dir", required=True,
+        help="Path to skills/video-understanding",
+    )
+    parser.add_argument(
+        "--deploy-skill-dir", default=None,
+        help="Path to skills/deploy (optional — included for agent diagnosis)",
+    )
+    parser.add_argument(
+        "--vios-skill-dir", default=None,
+        help="Path to skills/vios (optional — spec env references vios video upload)",
+    )
+    parser.add_argument(
+        "--spec", default=None,
+        help="Path to spec JSON "
+             "(default: <skill-dir>/eval/base_profile_video_understanding.json)",
+    )
+    parser.add_argument(
+        "--platform", default=None, choices=list(PLATFORMS.keys()),
+        help=f"Generate for one platform only (overrides spec.resources.platforms; "
+             f"default: {DEFAULT_PLATFORM})",
+    )
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+    vios_skill_dir = Path(args.vios_skill_dir) if args.vios_skill_dir else None
+    spec_path = (
+        Path(args.spec)
+        if args.spec
+        else (skill_dir / "eval" / "base_profile_video_understanding.json")
+    )
+
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+    spec = json.loads(spec_path.read_text())
+    spec["_source_path"] = str(spec_path)
+
+    profile = spec.get("profile", "base")
+    platforms = [args.platform] if args.platform else _platforms_from_spec(spec)
+
+    print("=== Inputs ===")
+    print(f"  output_dir   : {output_root}")
+    print(f"  skill_dir    : {skill_dir}")
+    print(f"  spec         : {spec_path}")
+    print(f"  profile      : {profile}")
+    print(f"  platforms    : {platforms}")
+    print(f"  queries      : {len(spec.get('expects', []))}")
+    print(f"  total checks : {sum(len(q.get('checks', [])) for q in spec.get('expects', []))}")
+    print()
+    for platform in platforms:
+        task_id = PLATFORMS[platform]["short_name"]
+        print(f"  GEN  video-understanding/{profile}/{task_id}")
+        generate_task(
+            platform, profile, spec, output_root, skill_dir,
+            deploy_skill_dir, vios_skill_dir,
+        )
+    print()
+    print(f"Generated {len(platforms)} platform(s) under {output_root}/{profile}/")
+    print()
+    print("Note: these tasks assume VSS base is already deployed on the target")
+    print("Brev instance and a sample warehouse video has been uploaded via vios.")
+    print("The coordinator is responsible for chaining those prerequisites ahead")
+    print("of each video-understanding task in the same subagent queue.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skill-eval/adapters/vios/generate.py
+++ b/.github/skill-eval/adapters/vios/generate.py
@@ -85,6 +85,17 @@ DEFAULT_VIDEO_URL = (
 )
 DEFAULT_VIDEO_NAME = "warehouse_forklift_pexels_6079421"
 
+# Prepended to every instruction.md so the skill's own HITL bypass
+# clause fires. Skills default to "ask the user" before /deploy; in CI
+# there's no user, so without this preamble the agent either stalls or
+# falls through to a localhost default.
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/deploy` or any other "
+    "setup action the trial requires."
+)
+
 
 # ---------------------------------------------------------------------------
 # Generation
@@ -156,6 +167,8 @@ def generate_task(platform: str, spec: dict, output_root: Path,
         # verifier evaluates them independently. If the agent sees the checks
         # it can write to the test rather than do the work.
         lines = [
+            PREAMBLE,
+            "",
             f"Use the `/vios` skill against the VSS base profile "
             f"already running on this `{platform}` host "
             "(`http://localhost:30888/vst/api/v1/sensor/version` must respond).",
@@ -187,11 +200,16 @@ def generate_task(platform: str, spec: dict, output_root: Path,
             "[verifier.env]",
             'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
             'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
-            'JUDGE_MODEL = "${JUDGE_MODEL:-claude-haiku-4-5}"',
+            # ANTHROPIC_MODEL gives the verifier's judge model cascade
+            # (JUDGE_MODEL → ANTHROPIC_MODEL → literal) a working
+            # fallback when JUDGE_MODEL is unset. Forwarding a literal
+            # default for JUDGE_MODEL would bake it in and short-circuit
+            # the cascade — the proxy 401s the literal default outright.
+            'ANTHROPIC_MODEL = "${ANTHROPIC_MODEL}"',
             "",
             "[metadata]",
             'skill = "vios"',
-            'profile = "base"',
+            f'profile = "{spec.get("profile", "base")}"',
             f'platform = "{platform}"',
             f'gpu_type = "{pspec["gpu_type"]}"',
             f'brev_search = "{pspec["brev_search"]}"',
@@ -199,7 +217,7 @@ def generate_task(platform: str, spec: dict, output_root: Path,
             "requires_deployed_vss = true",
             "# Deploy mode is FULL-REMOTE (LLM + VLM both remote) — vios",
             "# exercises VIOS/VST only, so there's no benefit to running local NIMs.",
-            'prerequisite_deploy_mode = "remote-all"',
+            f'prerequisite_deploy_mode = "{spec.get("prerequisite_deploy_mode", "remote-all")}"',
             f"step_index = {idx}",
             f"step_count = {len(expects)}",
             f"check_count = {len(expect.get('checks') or [])}",

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -48,6 +48,23 @@ BREV_EXEC_TIMEOUT = int(os.environ.get("BREV_EXEC_TIMEOUT", "1800"))
 BREV_COPY_TIMEOUT = int(os.environ.get("BREV_COPY_TIMEOUT", "300"))
 
 
+def _record_started_instance(name: str) -> None:
+    """Append an auto-provisioned instance name to the wrapper's
+    cleanup marker (`/tmp/brev/started-by-<run_id>.txt`) so
+    skills_eval_agent.cleanup_instances() tears it down even if the
+    agent never observes the name. No-op outside CI (no GITHUB_RUN_ID)."""
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if not run_id:
+        return
+    try:
+        marker = Path(f"/tmp/brev/started-by-{run_id}.txt")
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        with marker.open("a") as fh:
+            fh.write(f"{name}\n")
+    except OSError as exc:
+        logger.warning("failed to record %s in started-by marker: %s", name, exc)
+
+
 class BrevEnvironmentType(str, Enum):
     BREV = "brev"
 
@@ -189,6 +206,11 @@ class BrevEnvironment(BaseEnvironment):
             )
             if create_result.return_code != 0:
                 raise RuntimeError(f"brev create failed: {create_result.stderr}")
+            # Record the harbor-* instance in the wrapper's cleanup marker
+            # so skills_eval_agent.cleanup_instances() tears it down even if
+            # the trial fails before the agent tracks it. Append before
+            # _wait_for_running so a timeout there doesn't leak an orphan.
+            _record_started_instance(self._instance_name)
             await _wait_for_running(self._instance_name)
 
         # Quick smoke test — ensure exec works
@@ -222,6 +244,39 @@ class BrevEnvironment(BaseEnvironment):
             "sudo chown -R $(whoami):$(id -gn) /logs /tests /solution /skills",
             timeout=30,
         )
+
+        # Archive any session JSONLs left by prior trials on this warm-pool
+        # box. Without this, harbor's claude-code mapper merges every
+        # `*.jsonl` file under `/logs/agent/sessions/projects/<project>/`
+        # into one trajectory.json — producing thousand-step trajectories
+        # that conflate this trial with every preceding one (observed:
+        # trial 25083019759/.../step-1__XZNnjCX showed 7549 steps spanning
+        # 50h of prior runs).
+        #
+        # We *move* (not delete) the JSONLs into `$HOME/.claude-archive/<ts>/`
+        # so they remain visitable via SSH for forensic debugging. Each
+        # trial's own snapshot is preserved per-trial under
+        # `/tmp/skill-eval/results/<run>/<date>/<trial>/agent/sessions/`
+        # already (harbor's per-trial copy-back), so this archive is just
+        # box-side history.
+        #
+        # Why archive only, not also per-trial cwd: harbor's claude-code
+        # agent (vendor cache) invokes `claude --print` with no cwd
+        # override, so all trials share `cwd=/home/shadeform` and the
+        # project key is `-home-shadeform`. Forcing a per-trial cwd would
+        # require forking harbor — out of scope. Empty-on-start is
+        # sufficient for the harbor mapper's "exactly one session dir"
+        # heuristic to produce a clean per-trial trajectory.
+        archive_cmd = (
+            "ts=$(date +%Y%m%d-%H%M%S); "
+            "PROJ=/logs/agent/sessions/projects; "
+            'if [ -d "$PROJ" ] && [ -n "$(ls -A "$PROJ" 2>/dev/null)" ]; then '
+            '  ARCHIVE=$HOME/.claude-archive/$ts; '
+            '  mkdir -p "$ARCHIVE" && mv "$PROJ"/* "$ARCHIVE/" 2>/dev/null || true; '
+            '  echo "[trajectory-isolation] archived prior project dirs to $ARCHIVE"; '
+            "fi"
+        )
+        await _run_brev_exec(self._instance_name, archive_cmd, timeout=30)
 
         # Forward task-critical env vars from the local shell into the
         # instance's ~/.eval_env (sourced by ~/.profile, which every
@@ -273,8 +328,118 @@ class BrevEnvironment(BaseEnvironment):
             logger.info("Uploading skills from %s to /skills on instance", task_skills_dir)
             await self.upload_dir(str(task_skills_dir), "/skills")
 
+        # Pre-deploy any prerequisite profile declared in task.toml [metadata].
+        # Idempotent via marker file on the box, so dependent trials reuse the
+        # deployment without re-running it.
+        await self._ensure_prerequisite_deployed(meta)
+
         self._started = True
         logger.info("Brev instance %s is reachable", self._instance_name)
+
+    async def _ensure_prerequisite_deployed(self, meta: dict) -> None:
+        """If task.toml [metadata] declares both `profile` and
+        `prerequisite_deploy_mode`, ensure /deploy has run on the Brev
+        box for that profile-mode pair. Reads a single canonical
+        marker that records what is currently RUNNING on the box —
+        not a deploy log. See specs/stale-marker.spec.
+
+        Algorithm:
+          1. cat /tmp/skill-eval/active-deploy.txt on the box.
+          2. If contents == f"{profile}-{deploy_mode}" → no-op (hot).
+          3. Else → run /deploy via claude --print; the deploy skill's
+             own step-0 teardown handles any prior stack. On success
+             OVERWRITE the marker. On failure leave it alone — next
+             trial re-evaluates.
+
+        Trials with NO `profile` (skills that don't need a deployed
+        VSS) skip this entirely. Deploy/* trials set `profile` but NOT
+        `prerequisite_deploy_mode` (they ARE the deploy), so they also
+        early-return; their test.sh writes the marker on reward=1.0.
+
+        claude-code is expected on the box from a prior deploy/* trial's
+        harbor agent setup; persists across trials on the reused
+        vss-eval-* instance. Override the wall clock via
+        PRE_DEPLOY_TIMEOUT_SEC (default 1800s)."""
+        profile = meta.get("profile")
+        deploy_mode = meta.get("prerequisite_deploy_mode")
+        if not profile or not deploy_mode:
+            return
+
+        desired = f"{profile}-{deploy_mode}"
+        marker_path = "/tmp/skill-eval/active-deploy.txt"
+        probe = await _run_brev_exec(
+            self._instance_name,
+            f"cat {shlex.quote(marker_path)} 2>/dev/null || true",
+            timeout=30,
+        )
+        current = (probe.stdout or "").strip()
+        if current == desired:
+            logger.info(
+                "prerequisite %s already running on %s; skipping pre-deploy",
+                desired, self._instance_name,
+            )
+            return
+        logger.info(
+            "prerequisite mismatch on %s (active=%r, desired=%r); pre-deploying",
+            self._instance_name, current or "<empty>", desired,
+        )
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        base_url = os.environ.get("ANTHROPIC_BASE_URL", "")
+        model = (
+            os.environ.get("ANTHROPIC_MODEL")
+            or "claude-sonnet-4-6"
+        )
+        if not api_key:
+            raise RuntimeError(
+                "ANTHROPIC_API_KEY must be set on the coordinator to "
+                "pre-deploy a prerequisite profile via claude --print."
+            )
+
+        env_prefix_parts = [
+            f"ANTHROPIC_API_KEY={shlex.quote(api_key)}",
+            f"ANTHROPIC_MODEL={shlex.quote(model)}",
+            "CLAUDE_CODE_DISABLE_THINKING=1",
+        ]
+        if base_url:
+            env_prefix_parts.append(f"ANTHROPIC_BASE_URL={shlex.quote(base_url)}")
+        env_prefix = " ".join(env_prefix_parts)
+
+        prompt = f"/deploy -p {profile} -m {deploy_mode}"
+        # Overwrite (>) the canonical marker on /deploy success — the
+        # marker reflects what is currently running, not a deploy log.
+        # PATH prepend: brev exec runs a non-interactive shell that does
+        # not source ~/.bashrc, where harbor writes
+        # `export PATH="$HOME/.local/bin:$PATH"`. claude-code installs
+        # to ~/.local/bin via its curl installer, so a bare `claude`
+        # invocation here resolves "command not found" without this.
+        cmd = (
+            f'export PATH="$HOME/.local/bin:$PATH" && '
+            f"mkdir -p /tmp/skill-eval && "
+            f"{env_prefix} claude --print --dangerously-skip-permissions "
+            f"{shlex.quote(prompt)} "
+            f"&& printf '%s\\n' {shlex.quote(desired)} > {shlex.quote(marker_path)}"
+        )
+
+        timeout_sec = int(os.environ.get("PRE_DEPLOY_TIMEOUT_SEC", "1800"))
+        logger.info(
+            "Pre-deploying %s on %s (timeout=%ds)",
+            desired, self._instance_name, timeout_sec,
+        )
+        result = await _run_brev_exec(
+            self._instance_name, cmd, timeout=timeout_sec,
+        )
+        if result.return_code != 0:
+            tail = (result.stderr or result.stdout or "")[-500:]
+            raise RuntimeError(
+                f"pre-deploy /deploy -p {profile} -m {deploy_mode} failed "
+                f"on {self._instance_name}: exit {result.return_code}; "
+                f"output tail: {tail!r}"
+            )
+        logger.info(
+            "Pre-deploy %s succeeded on %s; active marker overwritten",
+            desired, self._instance_name,
+        )
 
     async def stop(self, delete: bool) -> None:
         """No-op — the instance stays running for reuse."""
@@ -769,7 +934,16 @@ def _check_instance_matches(instance: dict, req: dict) -> None:
         )
         return
 
+    if int(req.get("gpu_count", 1) or 0) == 0:
+        logger.info(
+            "Instance '%s' gpu_count=0 (remote-all or GPU-independent task) — "
+            "skipping GPU-type match; any live instance is acceptable",
+            instance.get("name"),
+        )
+        return
+
     gpu = (instance.get("gpu") or "").upper()
+    instance_type = (instance.get("instance_type") or "").upper()
     required_type = (req.get("gpu_type") or "").upper()
 
     # Loose GPU name match: `RTX PRO 6000` ⊆ `RTX PRO SERVER 6000`
@@ -780,9 +954,33 @@ def _check_instance_matches(instance: dict, req: dict) -> None:
         have_tokens = set(have.replace("-", " ").split())
         return want_tokens.issubset(have_tokens) or want in have
 
+    # Brev API transient-flake soft-fail: `brev ls --json` occasionally
+    # returns gpu="-" (or "") for a healthy instance for a few seconds while
+    # the catalog refreshes. If the catalog instance_type carries the GPU
+    # token (e.g. "massedcompute_L40Sx2" carries "L40S"), accept the
+    # instance and defer the strict check to live nvidia-smi in
+    # _check_live_resources. Without this we raise spuriously and the next
+    # trial wastes ~20 min running pre-deploy from scratch.
+    gpu_blank = gpu in ("", "-", "N/A", "NONE")
+    type_carries_token = (
+        required_type and instance_type
+        and _loose_match(required_type, instance_type)
+    )
+
     errors = []
     if required_type and not _loose_match(required_type, gpu):
-        errors.append(f"gpu_type: want tokens of {required_type!r} in {gpu!r}")
+        if gpu_blank and type_carries_token:
+            logger.warning(
+                "Instance '%s' brev ls returned gpu=%r (likely transient "
+                "API flake); instance_type=%r carries %r — accepting and "
+                "deferring to live nvidia-smi check",
+                instance.get("name"), instance.get("gpu"),
+                instance.get("instance_type"), required_type,
+            )
+        else:
+            errors.append(
+                f"gpu_type: want tokens of {required_type!r} in {gpu!r}"
+            )
 
     if errors:
         raise RuntimeError(

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -51,15 +51,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 AGENTS_MD = Path(__file__).resolve().parent / "AGENTS.md"
 
-# Hard cap on the agent's tool loop — one `/deploy` trial is ~15 min of
-# `Bash(uvx harbor run ...)`, plus its own tool calls. 300 turns covers
-# a full fan-out with room for retries.
-MAX_TURNS = int(os.environ.get("AGENT_MAX_TURNS", "300"))
-
-# How long to sleep after the agent exits before stopping/deleting Brev
-# instances it spun up. Lets a human see last-minute logs / traces.
-COOLDOWN_SEC = int(os.environ.get("POST_EVAL_COOLDOWN_SEC", "300"))
-
+# Hard cap on the agent's tool loop — one trial burns ~20-30 harness
+# turns (startup + brev wait + `uvx harbor run` exec + reading results +
+# migrating to _viewer), so a full-PR fan-out of 10-15 trials plus
+# recon/retry overhead exceeds the previous 300 ceiling. Run
+# 24879743425 burned ~270 turns on only 3 trials before hitting it
+# mid-lvs with 10+ trials unstarted. 600 is a safety valve against
+# runaway loops, not a budget knob — the workflow's 8h wall-clock
+# (skills-eval.yml timeout-minutes: 480) is the real ceiling.
+MAX_TURNS = int(os.environ.get("AGENT_MAX_TURNS", "600"))
 
 # ---------------------------------------------------------------------------
 # Pre-flight
@@ -139,10 +139,6 @@ adapter under `.github/skill-eval/adapters/<skill>/` → generate the dataset �
 a Brev lock for the target platform(s) → run harbor trials → gather results →
 post ONE comment per (PR, spec) batch → release the lock → stop/delete any Brev
 instance you brought online.
-
-Write the list of Brev instance IDs you provisioned to
-`/tmp/brev/started-by-{run_id}.txt` (one per line). The CI step will use that file
-to drive cleanup after a {COOLDOWN_SEC}s cooldown.
 
 When done, emit a one-line final summary starting with `DONE:` so the workflow
 can grep for it. On blocker (missing_probe, env issue, nothing to eval), emit a
@@ -230,77 +226,6 @@ line starting with `BLOCKED:` followed by the reason.
 # Cleanup
 # ---------------------------------------------------------------------------
 
-_STOPPABLE_TYPES = {"l40s", "rtx"}   # see AGENTS.md lifecycle table
-_DELETE_TYPES = {"h100", "massedcompute"}
-# SPARK / BYOH are no-op
-
-def cleanup_instances() -> None:
-    """After the agent exits, wait COOLDOWN_SEC then stop or delete any
-    Brev instance the agent brought online. Identification comes from
-    `/tmp/brev/started-by-<run_id>.txt`, which the agent is told to
-    populate. Unknown entries are logged and skipped — never delete an
-    instance we can't identify."""
-    run_id = os.environ.get("GITHUB_RUN_ID", "")
-    if not run_id:
-        print("[cleanup] no GITHUB_RUN_ID → skipping teardown", flush=True)
-        return
-
-    marker = Path(f"/tmp/brev/started-by-{run_id}.txt")
-    if not marker.exists() or not marker.read_text().strip():
-        print(f"[cleanup] {marker} missing/empty — nothing to tear down", flush=True)
-        return
-
-    names = [line.strip() for line in marker.read_text().splitlines() if line.strip()]
-    if not names:
-        return
-
-    print(f"[cleanup] {COOLDOWN_SEC}s cooldown before tearing down: {names}", flush=True)
-    time.sleep(COOLDOWN_SEC)
-
-    # Re-check live state — name → (status, instance_type)
-    try:
-        import json as _json
-        out = subprocess.check_output(
-            ["brev", "ls", "--json"], timeout=30,
-        ).decode()
-        data = _json.loads(out)
-        instances = data if isinstance(data, list) else [data]
-        by_name = {i.get("name"): i for i in instances if isinstance(i, dict)}
-    except Exception as exc:
-        print(f"[cleanup] brev ls --json failed: {exc}; skipping", flush=True)
-        return
-
-    for name in names:
-        inst = by_name.get(name)
-        if inst is None:
-            print(f"[cleanup] {name}: not found in brev ls — skip", flush=True)
-            continue
-        itype = (inst.get("instance_type") or "").lower()
-        # Decide stop vs delete based on the AGENTS.md § lifecycle rules.
-        if any(k in itype for k in ("h100", "dmz.h100", "massedcompute",
-                                     "scaleway", "nebius", "hyperstack",
-                                     "latitude", "oci")):
-            action = ["brev", "delete", name]
-            reason = "non-stoppable provider — delete"
-        elif any(k in itype for k in ("l40s-48gb.2x", "l40s-48gb.1x",
-                                       "g7e", "g6e", "crusoe")):
-            action = ["brev", "stop", name]
-            reason = "stoppable — stop"
-        elif inst.get("_registered") or inst.get("kind") == "registered":
-            print(f"[cleanup] {name}: BYOH registered node — no-op", flush=True)
-            continue
-        else:
-            # Unknown provider — default to stop (safer than delete).
-            action = ["brev", "stop", name]
-            reason = f"unknown provider {itype!r} — defaulting to stop"
-
-        print(f"[cleanup] {name}: {reason}  →  {' '.join(action)}", flush=True)
-        try:
-            subprocess.run(action, timeout=120, check=False)
-        except subprocess.TimeoutExpired:
-            print(f"[cleanup] {name}: {action[1]} timed out after 120s", flush=True)
-
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -317,8 +242,6 @@ def main() -> int:
         print(f"[agent] crashed: {exc!r}", file=sys.stderr)
         import traceback; traceback.print_exc()
         rc = 2
-    finally:
-        cleanup_instances()
     return rc
 
 

--- a/.github/skill-eval/specs/stale-marker.spec
+++ b/.github/skill-eval/specs/stale-marker.spec
@@ -1,0 +1,172 @@
+# Stale-marker auto-deploy fix + multi-instance selection
+
+Status: accepted (2026-04-27)
+Owner: skill-eval-main
+Related: multi-agent.spec (separate concern)
+
+## Context
+
+Two related problems with the pre-deploy hook added to
+`BrevEnvironment._ensure_prerequisite_deployed`:
+
+**(1) Stale-marker silent skip.** Markers were per-(profile, mode) flag
+files (`/tmp/skill-eval/deployed-<profile>-<mode>.flag`) that accumulated
+as a deploy log instead of tracking what is currently running. Sequence:
+`deploy/base` writes `deployed-base-remote-all.flag`, then `deploy/search`
+tears down base + brings up search but the base flag stays on disk. A
+subsequent `vios` trial requiring base sees the stale flag, skips
+pre-deploy, and runs against search — silent wrong answer. The invariant
+we wanted but didn't enforce: *the marker is what is currently RUNNING on
+this box, not what has at any point been deployed here.*
+
+**(2) Single-box bottleneck.** The orchestrator hardcodes
+`BREV_INSTANCE=vss-eval-l40s` (one box per platform). Concurrent CI runs
+serialize on this one box's flock — even when more `vss-eval-l40s-*`
+boxes exist or could be added. The harness has no selection logic; it
+just trusts the env var.
+
+The two are related because the marker concept naturally extends per-box:
+each `vss-eval-*` has its own `/tmp/skill-eval/active-deploy.txt`. With
+selection over a fleet, the orchestrator can prefer a warm box (marker
+matches desired profile-mode) over a cold one, turning what would
+otherwise be a redeploy into a hot reuse across runs.
+
+The **worker-pool model** (per zac): one skill-eval agent = one serial
+worker processing trials in order. Multiple agents = multiple workers
+running concurrently, each grabbing a different box from the fleet.
+Within a worker, trials are serial; across workers, parallelism comes
+for free from however many `vss-eval-*` boxes exist. No orchestrator
+concurrency rework — it stays serial.
+
+## Design
+
+### 1. Single canonical "active marker" per instance — overwrite-only
+
+Replace the per-profile flag fan-out with **one canonical file per Brev
+instance** at `/tmp/skill-eval/active-deploy.txt`. Holds the literal
+`<profile>-<mode>` of what is currently RUNNING on the box. Writes are
+**overwrite, never append**. Empty / missing means "nothing is up."
+
+Single owner: whoever last successfully ran `/deploy` on the box. Two
+write paths in practice — the harness pre-deploy hook (when called) and
+the deploy/* trial's `test.sh` (its scored task IS running /deploy) —
+both overwrite the same file with `<profile>-<mode>`. Equivalent
+semantics; pick one or both, just never `touch` per-flag.
+
+### 2. Pre-deploy hook reads canonical marker, compares contents
+
+In `BrevEnvironment._ensure_prerequisite_deployed`:
+
+1. `cat /tmp/skill-eval/active-deploy.txt 2>/dev/null || echo ""` on the
+   box.
+2. If `stdout.strip() == f"{profile}-{deploy_mode}"` → skip pre-deploy.
+   Box is hot.
+3. Else → run `/deploy -p <profile> -m <mode>` via
+   `claude --print --dangerously-skip-permissions`; the deploy skill's
+   own step-0 teardown handles any prior stack. On success, **overwrite**
+   `active-deploy.txt` with `<profile>-<mode>`. On failure, leave the
+   marker alone — next trial re-evaluates.
+
+After the trial: do not teardown, do not clear the marker. Same-profile
+back-to-back trials hit the marker hot.
+
+### 3. Multi-instance selection at orchestrator level
+
+In AGENTS.md § 5a (instance pick) and § 5b (lock acquisition), the
+orchestrator stops hardcoding `BREV_INSTANCE=vss-eval-<short>`. Selection
+algorithm, executed once per trial (cheap — three short brev exec
+calls):
+
+```
+candidates = [b for b in brev_ls_json
+              if b.name.startswith("vss-eval-")
+              and platform_matches(b, trial.platform)
+              and b.status in ("RUNNING", "READY")]
+# Score: warm marker beats cold; free lock beats waiting; tiebreak is
+# instance name (deterministic).
+for b in sorted(candidates, key=(marker_match, lock_free, name)):
+    if try_flock(b.name, nonblocking=True):
+        BREV_INSTANCE=b.name; proceed
+        break
+else:
+    # Nothing free in fleet — block on the best-by-marker candidate
+    # for the existing 3-hour wall.
+    flock -w 10800 candidates[0].lock
+    BREV_INSTANCE=candidates[0].name; proceed
+```
+
+Per-box lock files: `/tmp/brev/<resolved-instance-name>.lock` (already
+keyed on `$INSTANCE_NAME` in today's flock; just stop hardcoding the
+name). With fleet=1 this collapses to today's behavior (one candidate,
+same lock path). With fleet>1, two concurrent CI runs land on different
+boxes naturally.
+
+Selection lives in the orchestrator (AGENTS.md prose + small shell
+helper in step 5a), NOT in `BrevEnvironment.start()`. The contract for
+`BrevEnvironment` is unchanged: it honors `BREV_INSTANCE` if set and
+validates the chosen box.
+
+### 4. Cross-worker safety
+
+- Each box's `active-deploy.txt` is on its own /tmp; no shared state.
+- Per-box flock prevents two workers from running trials on the same
+  box simultaneously, even within /deploy.
+- The `started-by-<run_id>.txt` cleanup marker (used by
+  `cleanup_instances`) is already per-run — workers don't step on each
+  other at teardown.
+
+### 5. Concurrency from CI run multiplicity, not orchestrator code
+
+No change to AGENTS.md § 5c trial-by-trial serial loop. No change to
+`skills_eval_agent.py`'s tool loop. If two PRs trigger runs at the same
+time, GitHub Actions launches two workflow runs, each instantiates one
+serial-worker skill-eval agent, and the per-box flock arbitrates fleet
+access. With fleet=1: workers wait, behaviour unchanged. With fleet=N:
+up to N parallel.
+
+## Net effect
+
+- Stale-marker silent-skip bug is gone — one marker, one truth.
+- Same-profile back-to-back trials redeploy zero times after the first
+  (within a worker AND across workers, via warm-marker selection).
+- Profile transitions redeploy once per box per transition.
+- Concurrent CI runs naturally use the fleet: with fleet=N, up to N PRs
+  evaluated in parallel without orchestrator changes.
+- Fleet sizing is an ops concern (manually `brev create` more
+  `vss-eval-l40s-2`, etc.) — harness picks them up automatically.
+- Redeploy cost falls under `PRE_DEPLOY_TIMEOUT_SEC` (1800s harness
+  budget), not the agent_timeout, so trial scoring measures skill
+  quality, not deploy time.
+
+## Verification
+
+1. **Stale-flag regression test.** Reproduce the run 24969145586 pattern:
+   `deploy/lvs` → `deploy/search` → `vios step-1`. Confirm `vios` now
+   redeploys base (marker reads `search-remote-all`, not
+   `base-remote-all`) instead of skipping on a stale flag.
+2. **Same-profile reuse.** `deploy/base` → `vios step-1` → `vios step-2`
+   → `vios step-3`. Three vios trials share the marker set by
+   `deploy/base`; pre-deploy hook fires zero times.
+3. **Profile transition.** `deploy/base` → `vios step-1` →
+   `deploy/search` → `video-search step-1`. Each transition triggers
+   exactly one /deploy.
+4. **Fleet=1 baseline.** With one `vss-eval-l40s`, behaviour is
+   indistinguishable from today.
+5. **Fleet>1 concurrency smoke test.** Manually `brev create
+   vss-eval-l40s-2`. Trigger two PRs simultaneously. Confirm the two
+   workflow runs land on different boxes and complete in parallel.
+6. **Marker file shape.** After any run, `cat
+   /tmp/skill-eval/active-deploy.txt` returns one profile-mode token;
+   no `deployed-*.flag` files exist (or they're harmless leftovers
+   from before the migration).
+
+## Out of scope
+
+- Auto-creating fleet members (`brev create vss-eval-*` from the
+  orchestrator). Today fleet sizing is manual via ops.
+- Per-trial parallelism inside a single worker. The orchestrator still
+  dispatches trials serially within one CI run; cross-run parallelism
+  is the model.
+- Marker GC for the bug-period `deployed-*.flag` orphans — one-time
+  manual `rm -f` on existing boxes.
+- Multi-agent harness support — separate spec at `multi-agent.spec`.

--- a/.github/skill-eval/verifiers/generic_judge.py
+++ b/.github/skill-eval/verifiers/generic_judge.py
@@ -7,18 +7,17 @@ Reads a skill's `eval/<profile>.json` spec + Harbor's agent trajectory,
 evaluates every check in the named step (1-based index), and writes
 Harbor's expected reward.
 
-Design goal: spec authors write **natural-language checks**. This judge
-encapsulates all Harbor filesystem conventions + shell-probing + LLM-
-agent-as-judge wiring, so the spec stays declarative and portable.
-
-Routing:
-  - Checks with a backtick-wrapped `curl`/`docker`/`grep`/etc. command —
-    run as subprocess, pass if exit 0 (cheap, deterministic, no LLM).
-  - All other checks — dispatched to a `claude-agent-sdk` judge **agent**
-    with `Bash` + `Read` + `Grep` tools. The judge can inspect the
-    trajectory file, probe the live deployed system, grep logs, etc.
-    before deciding pass/fail. This obsoletes per-skill probe scripts
-    (`skills/<skill>/scripts/test_*.py`) — the judge has tool access.
+Design goal: spec authors write **natural-language checks**. Every
+check is dispatched to a `claude-agent-sdk` judge **agent** with
+`Bash` + `Read` + `Grep` tools — the judge decides per check whether
+to run a shell probe, grep the trajectory, inspect the agent's final
+reply, or some combination. There is no Python-level routing or
+regex command extraction: the judge has the tools the spec author
+would reach for, and reads the check itself to decide which to use.
+This obsoletes per-skill probe scripts (`skills/<skill>/scripts/
+test_*.py`) and the prior shell fast-path that misclassified
+negative-assertion checks ("the agent does NOT call X") as shell
+directives and ran the example command verbatim.
 
 Usage (inside a Harbor trial):
     python3 generic_judge.py --spec /tests/<profile>.json --step 1
@@ -30,10 +29,15 @@ Outputs:
                                  `=== Results: X passed, Y failed (of N) ===`
 
 Env (from `[verifier.env]` in task.toml, plumbed by Harbor):
-    ANTHROPIC_API_KEY    required for LLM-judge routes
+    ANTHROPIC_API_KEY    required (no shell fallback exists)
     ANTHROPIC_BASE_URL   optional, for proxies (e.g. NVIDIA inference API)
-    ANTHROPIC_MODEL      overrides default judge model (claude-haiku-4-5)
-    JUDGE_MAX_TURNS      per-check agent turn cap (default 10)
+    JUDGE_MODEL          explicit judge model (preferred; adapter sets
+                         this via [verifier.env]); falls back to
+                         ANTHROPIC_MODEL, then "claude-sonnet-4-6"
+    JUDGE_MAX_TURNS              per-check agent turn cap (default 25)
+    JUDGE_PER_CHECK_TIMEOUT_S    per-check wall-clock cap (default 600s)
+    JUDGE_PARALLELISM            concurrent checks per step
+                                 (default 4, clamped to 1..8)
 """
 from __future__ import annotations
 
@@ -41,7 +45,6 @@ import argparse
 import asyncio
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -68,56 +71,7 @@ def locate_trajectory() -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Shell fast-path — extract runnable commands from backticks, run them.
-# ---------------------------------------------------------------------------
-
-_SHELL_VERBS = {
-    "curl", "docker", "grep", "ls", "cat", "file", "ss",
-    "netstat", "nc", "jq", "awk", "sed", "wc", "head", "tail",
-    "sudo", "find", "test",
-}
-
-
-def extract_shell_command(check: str) -> str | None:
-    """If the check contains a runnable shell command in backticks, return it.
-    Conservative — only extracts commands beginning with safe verbs."""
-    for match in re.finditer(r"`([^`]{5,400})`", check):
-        cmd = match.group(1).strip()
-        first = cmd.split()[0] if cmd.split() else ""
-        if first in _SHELL_VERBS:
-            return cmd
-    return None
-
-
-def judge_shell(check: str) -> dict:
-    cmd = extract_shell_command(check) or ""
-    try:
-        result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30,
-        )
-    except subprocess.TimeoutExpired:
-        return {
-            "route": "shell",
-            "pass": False,
-            "command": cmd,
-            "rationale": "shell command timed out after 30s",
-            "matched": None,
-        }
-    passed = result.returncode == 0
-    preview = (result.stdout or result.stderr or "")[:500].strip()
-    return {
-        "route": "shell",
-        "pass": passed,
-        "command": cmd,
-        "rationale": (
-            f"exit {result.returncode}" + (f"; output: {preview!r}" if preview else "")
-        ),
-        "matched": preview if passed else None,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Agent-based LLM judge (claude-agent-sdk)
+# Agent-based LLM judge (claude-agent-sdk) — the only routing tier.
 # ---------------------------------------------------------------------------
 
 _JUDGE_SYSTEM_PROMPT = """You are a strict eval judge for an agent-deploy evaluation framework.
@@ -128,6 +82,27 @@ You have read-only access to the trial artifacts via tools:
 - The agent's trajectory is at one of /logs/agent/trajectory.jsonl, /logs/agent/trajectory.json, /logs/agent/claude-code.txt, /logs/agent/agent.log — use Read + Grep to inspect tool-use records, request bodies, response bodies, final assistant text.
 - The live deployed system is reachable through Bash — you can `docker ps`, `curl http://localhost:...`, `cat /some/file`, etc. Use this to independently verify response-structure claims against the live endpoint, not just transcript pattern-matching.
 - The trial's `/tests/` dir has the task spec and verifier helpers if you need them.
+
+# Picking the right tool per check
+
+Read the check carefully and pick the cheapest evidence that actually answers it. There is no Python-level routing — you are the router.
+
+- **Live-system probe (Bash).** When the check is a positive statement about the *current* state of the deployed system — e.g. "`curl -sf http://localhost:8000/docs` returns exit 0", "container `vss-agent` is running", "the `/v1/ready` endpoint responds 200" — run the probe via Bash and pass iff its semantics match. If the check quotes a literal command in backticks, use that command verbatim (don't paraphrase). Pass iff the exit code / output matches what the check claims.
+
+- **Trajectory inspection (Read / Grep).** When the check is about what the agent *did* during the trial — e.g. "the agent issued exactly one POST /generate", "the agent's request body contained `forklifts`", "the trajectory shows X before Y" — open the trajectory file and search for the relevant tool-use records. Don't run live probes for these; the trial may be over by the time the judge runs.
+
+- **Negative-assertion check (Grep, NOT Bash).** When the check says the agent did NOT do something — e.g. "the agent does not run `docker compose down`", "no POST to /generate", "the trial never called PUT /api/v1/videos-for-search" — search the trajectory for the *absence* of those calls. **Never run the listed command yourself** — the check is asserting it didn't happen, not asking you to do it. Pass iff the trajectory has zero matches.
+
+- **Final-reply inspection (Read).** When the check is about the agent's last assistant message — e.g. "the final reply is formatted as a Video Analysis Report", "the agent's reply mentions a Brev secure-link" — read the tail of the trajectory and inspect the last assistant turn.
+
+- **Multi-step check (combine).** Some checks need two probes: e.g. "the agent's reply cites a screenshot URL that returns HTTP 200". Inspect the trajectory for the URL, then `curl -sfI` it via Bash to verify the live response.
+
+Watch for:
+- **Backticks as examples vs. directives.** "`curl http://x` returns 200" → directive (run it). "such as `docker compose down`, `docker stop`, `docker rm`" → enumeration of examples (don't run any of them; verify absence in trajectory).
+- **CWD assumptions.** When a check says "`docker compose ...`" it usually presumes the deploy's compose dir; don't run it from `/tests/` and conclude "no compose file" — find the right CWD first, or treat the check as a trajectory assertion if no compose dir exists.
+- **Stale trajectory.** If the trajectory file is empty or missing the relevant turn, say so in `rationale` and pass=false rather than guessing.
+
+# Discipline
 
 Gather only the evidence you need to decide, then stop. Typically 1–3 tool calls is enough; hard cap is 10.
 
@@ -182,8 +157,25 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
             "matched": None,
         }
 
-    model = os.environ.get("ANTHROPIC_MODEL") or "claude-haiku-4-5"
-    max_turns = int(os.environ.get("JUDGE_MAX_TURNS", "10"))
+    # Model resolution: JUDGE_MODEL is the explicit knob the adapter
+    # plumbs via [verifier.env] in task.toml. If unset, fall back to
+    # ANTHROPIC_MODEL (the agent's model — proven to work against the
+    # NVIDIA proxy whitelist). The literal "claude-sonnet-4-6" is the
+    # last-resort default for dev/test outside CI; sonnet is the right
+    # judge default given the per-check workload (trajectory inspection
+    # + live-stack probes need real reasoning). Bump to opus or change
+    # JUDGE_MODEL on the host if a heavier model is needed.
+    model = (
+        os.environ.get("JUDGE_MODEL")
+        or os.environ.get("ANTHROPIC_MODEL")
+        or "claude-sonnet-4-6"
+    )
+    # Judge agent runs Bash+Read+Grep to inspect trajectory + probe live
+    # stack per check. Specs with rich trajectories (vios PUT/GET flows)
+    # legitimately need >10 turns; observed timeouts at 180s on the
+    # default budget. Generous cap; the harbor verifier multiplier
+    # (3.0 → 1800s total) still bounds the full pass.
+    max_turns = int(os.environ.get("JUDGE_MAX_TURNS", "25"))
 
     options = ClaudeAgentOptions(
         system_prompt=_JUDGE_SYSTEM_PROMPT,
@@ -195,9 +187,10 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
 
     collected_text: list[str] = []
     cost_usd = 0.0
+    saw_result = False
 
     async def _run() -> None:
-        nonlocal cost_usd
+        nonlocal cost_usd, saw_result
         async with ClaudeSDKClient(options=options) as client:
             await client.query(_assemble_judge_prompt(check, traj_path))
             async for message in client.receive_response():
@@ -207,6 +200,7 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
                             collected_text.append(block.text)
                 elif isinstance(message, ResultMessage):
                     cost_usd = getattr(message, "total_cost_usd", 0.0) or 0.0
+                    saw_result = True
                     break
 
     try:
@@ -231,10 +225,27 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
     full_text = "\n".join(collected_text).strip()
     verdict = _parse_verdict_json(full_text)
     if verdict is None:
+        # Surface enough raw text + signals to debug judge non-compliance.
+        # Common causes: ran out of turns mid-analysis without emitting the
+        # final {"pass": ...} object; SDK closed the stream early
+        # (saw_result=False); or the agent returned only tool-use blocks.
+        head = full_text[:600]
+        tail = full_text[-400:] if len(full_text) > 1000 else ""
+        signals = (
+            f"saw_result_message={saw_result} "
+            f"text_chars={len(full_text)} "
+            f"text_blocks={len(collected_text)}"
+        )
+        rationale = (
+            f"judge returned no compliant verdict ({signals}); "
+            f"head: {head!r}"
+        )
+        if tail:
+            rationale += f"; tail: {tail!r}"
         return {
             "route": "agent",
             "pass": False,
-            "rationale": f"judge returned no parseable JSON; raw: {full_text[:200]!r}",
+            "rationale": rationale,
             "matched": None,
             "cost_usd": cost_usd,
         }
@@ -248,19 +259,32 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
 
 
 def _parse_verdict_json(text: str) -> dict | None:
-    """Grab the last `{...}` block from the agent's text. The agent's
-    system prompt asks for one JSON object, but models sometimes add
-    prose; last-match is the safest pick."""
-    matches = list(re.finditer(r"\{[^{}]*\"pass\"\s*:[^{}]*\}", text, re.DOTALL))
-    if not matches:
-        # fall back to any {...}
-        matches = list(re.finditer(r"\{.*?\}", text, re.DOTALL))
-    for match in reversed(matches):
+    """Grab the judge's verdict JSON object from agent prose.
+
+    Walks every `{` in the text and tries `json.JSONDecoder().raw_decode`
+    forward — handles nested braces (e.g. when the judge quotes an API
+    response body into `matched`). Returns the **last** decoded object
+    that has a `"pass"` key; the system prompt mandates that key, so
+    objects without it are treated as incidental quotes (trajectory
+    snippets, API bodies) and discarded — no fallback. None means the
+    judge did not emit a compliant verdict; caller should surface raw
+    text for triage."""
+    decoder = json.JSONDecoder()
+    candidates: list[dict] = []
+    idx = 0
+    while True:
+        idx = text.find("{", idx)
+        if idx == -1:
+            break
         try:
-            return json.loads(match.group(0))
-        except Exception:
+            obj, end = decoder.raw_decode(text, idx)
+        except ValueError:
+            idx += 1
             continue
-    return None
+        if isinstance(obj, dict) and "pass" in obj:
+            candidates.append(obj)
+        idx = end if isinstance(obj, dict) else idx + 1
+    return candidates[-1] if candidates else None
 
 
 # ---------------------------------------------------------------------------
@@ -269,18 +293,27 @@ def _parse_verdict_json(text: str) -> dict | None:
 
 def _run_checks(checks: list[str], traj_path: str | None,
                 per_check_timeout_s: int) -> list[dict]:
-    results: list[dict] = []
+    """Evaluate all checks for one step. Every check runs through an
+    independent claude-agent-sdk judge agent, concurrently under a
+    Semaphore (JUDGE_PARALLELISM, default 4, max 8). Each agent has
+    Bash/Read/Grep against the shared trajectory + live stack, with
+    no cross-check mutation. Order is preserved: results[i]
+    corresponds to checks[i]."""
+    parallelism = max(1, min(int(os.environ.get("JUDGE_PARALLELISM", "4")), 8))
+    sem = asyncio.Semaphore(parallelism)
 
-    async def _eval_non_shell(check: str) -> dict:
-        return await _judge_llm_agent(check, traj_path, timeout_s=per_check_timeout_s)
+    async def _eval(check: str) -> dict:
+        async with sem:
+            return await _judge_llm_agent(
+                check, traj_path, timeout_s=per_check_timeout_s,
+            )
 
-    for check in checks:
-        if extract_shell_command(check):
-            result = judge_shell(check)
-        else:
-            result = asyncio.run(_eval_non_shell(check))
+    async def _gather() -> list[dict]:
+        return await asyncio.gather(*(_eval(c) for c in checks))
+
+    results = asyncio.run(_gather())
+    for check, result in zip(checks, results):
         result["check"] = check
-        results.append(result)
     return results
 
 
@@ -293,7 +326,7 @@ def main() -> int:
     ap.add_argument("--reward-file", default="/logs/verifier/reward.txt")
     ap.add_argument("--details-file", default="/logs/verifier/judge.json")
     ap.add_argument("--per-check-timeout", type=int,
-                    default=int(os.environ.get("JUDGE_PER_CHECK_TIMEOUT_S", "180")),
+                    default=int(os.environ.get("JUDGE_PER_CHECK_TIMEOUT_S", "600")),
                     help="Seconds the judge agent has to evaluate one LLM-route check")
     args = ap.parse_args()
 

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -13,11 +13,16 @@ on:
   # diff of the *pushed commits*, not the cumulative PR diff against
   # base. That silently skipped the workflow when CPR-bot updated a
   # mirror branch with a merge commit that didn't itself touch
-  # skills/** (observed: PR #188's mirror push was a develop-merge
-  # carrying only RTVI files, so skills-eval never fired even though
-  # the PR's full diff touches 16 skills/ files). The path gate is now
-  # done inside the job by `dorny/paths-filter`, which diffs the
-  # cumulative head...base range.
+  # skills/** (observed on PR #188: 16 skills/ files in the PR, but
+  # the latest mirror push was a develop-merge carrying only 2 RTVI
+  # files). The path gate is now done inside the job by
+  # `dorny/paths-filter`, which diffs the cumulative head...base range.
+  #
+  # The `on: create:` trigger that previously worked around the
+  # initial-mirror all-zero-`before`-SHA case is no longer needed:
+  # `dorny/paths-filter` computes its diff from the PR base regardless
+  # of how the branch came to exist, so the very first push (whether
+  # branch-create or normal push) gets the same correct answer.
   push:
     branches:
       - "pull-request/[0-9]+"
@@ -37,9 +42,18 @@ jobs:
     name: Eval changed skills against PR
     runs-on: [self-hosted, vss-eval]
 
-    # 1 hour hard cap on the whole job. The agent targets ~40m plus a 5m
-    # post-eval wait before brev teardown; 60m gives a margin.
-    timeout-minutes: 60
+    # 8-hour hard cap on the whole job. A full PR touching every skill
+    # queues ~13 trials (5 deploy + 3 vios + 4 video-search + 1+
+    # video-summarization). Run 24980753743 hit the prior 180m cap with
+    # 3 video-search done and video-summarization not yet started —
+    # observed avg trial wall-clock is closer to ~30m once /deploy +
+    # ingest + judge per-check gather complete. 480m gives margin for
+    # cold-box transitions and redeploys at profile boundaries (handled
+    # by the active-deploy.txt marker but still ~20m each). No
+    # teardown cooldown — the vss-eval-* pool is operator-managed and
+    # stays warm across runs. The lock-hold timeout in AGENTS.md
+    # (flock -w) is set in lockstep below.
+    timeout-minutes: 480
 
     # Extra safety: only run on the mirror branches, never on develop/main.
     if: startsWith(github.ref, 'refs/heads/pull-request/')


### PR DESCRIPTION
## Summary

Mirrors the `.github/skill-eval/` harness and `.github/workflows/skills-eval.yml` workflow on `develop` to match `main` after #257 landed. develop's harness was stale — only `deploy` and `vios` adapters, older `brev_env.py`, older judge.

## What changes

- **6 new adapters**: `alerts`, `report`, `rt-vlm`, `video-search`, `video-summarization`, `video-understanding`
- **`envs/brev_env.py`**: forwards LLM/VLM remote endpoint env vars to the eval instance, auto-provision cleanup-marker tracking, pre-deploys prerequisite profile in `start()`
- **`verifiers/generic_judge.py`**: concurrent per-step checks, robust verdict JSON parser, larger judge-agent budgets, `JUDGE_MODEL` resolution order
- **`skills_eval_agent.py`**: tighter trial dispatch, spec-filename freedom, raised MAX_TURNS / job + lock timeouts
- **`specs/stale-marker.spec`**: stale-marker recovery test fixture
- **`.github/workflows/skills-eval.yml`**: paths-filter + create triggers, `vss-skill-validator` self-hosted runner targeting

21 files, +3287 / −576. Directory-level mirror of `main`'s harness — no develop-only edits existed under `.github/skill-eval/` to preserve.

## Test plan
- [x] DCO sign-off (single signed commit)
- [x] CI checks pass on develop
- [x] Skills Eval workflow triggers correctly on PRs to develop touching `skills/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)