### PR TITLE
Updated workaround config to enable videos-for-search/complete endpoint

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
@@ -22,6 +22,10 @@ general:
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}
       enable_video_delete: true
+      enable_videos_for_search: true
+      # `disabled` is a non-empty placeholder that satisfies the boot-time must be set guard.
+      rtvi_embed_base_url: disabled
+      rtvi_cv_base_url: disabled
     endpoints:
     - path: /api/v1/videos
       method: POST

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -22,6 +22,10 @@ general:
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}
       enable_video_delete: true
+      enable_videos_for_search: true
+      # `disabled` is a non-empty placeholder that satisfies the boot-time must be set guard.
+      rtvi_embed_base_url: disabled
+      rtvi_cv_base_url: disabled
     endpoints:
     - path: /api/v1/videos
       method: POST

--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
@@ -16,9 +16,11 @@
 general:
   use_uvloop: true
   front_end:
-    _type: fastapi
+    _type: vss_fastapi
     runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}
+    streaming_ingest:
+      vst_internal_url: ${VST_INTERNAL_URL}
     cors:
       allow_origins: ['*']
       allow_methods: ['*']

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
@@ -22,6 +22,10 @@ general:
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}
       enable_video_delete: true
+      enable_videos_for_search: true
+      # `disabled` is a non-empty placeholder that satisfies the boot-time must be set guard.
+      rtvi_embed_base_url: disabled
+      rtvi_cv_base_url: disabled
     endpoints:
     - path: /api/v1/videos
       method: POST

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -22,6 +22,10 @@ general:
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}
       enable_video_delete: true
+      enable_videos_for_search: true
+      # `disabled` is a non-empty placeholder that satisfies the boot-time must be set guard.
+      rtvi_embed_base_url: disabled
+      rtvi_cv_base_url: disabled
     endpoints:
     - path: /api/v1/videos
       method: POST


### PR DESCRIPTION
Updated workaround config to enable videos-for-search/complete endpoint for base and lvs profile

## Description
1. Enabled enable_videos_for_search flag in config
2. Added rtvi_cv and rtvi embed endpoint with "disabled" keyword
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
