### PR TITLE
refactor: invert compose profiles

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -86,8 +86,14 @@ VLM_ENV_FILE=''
 VLM_BASE_URL=''
 VLM_MODEL_TYPE=nim
 
-# Computed compose profiles (DO NOT MODIFY)
-COMPOSE_PROFILES=${BP_PROFILE}_${MODE},${BP_PROFILE}_${MODE}_${HARDWARE_PROFILE},llm_${LLM_MODE}_${LLM_NAME_SLUG}
+# Services for CV mode (2d_cv): perception pipeline, no rtvi-vlm
+COMPOSE_PROFILES_CV=elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,kibana,logstash,broker-health-check,vss-haproxy-ingress,vss-ui,vss-agent,vss-va-mcp,alert-bridge,vss-behavior-analytics-alerts,nvstreamer-alerts,perception-sdr-alerts,perception-alerts,kibana-init-container-alerts,vss-video-analytics-api-alerts,centralizedb,vst-ingress,vst-mcp,streamprocessing-ms,sdr-streamprocessing,envoy-streamprocessing,llm_${LLM_MODE}_${LLM_NAME_SLUG}
+
+# Services for VLM mode (2d_vlm): rtvi-vlm replaces pure-CV perception services
+COMPOSE_PROFILES_VLM=elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,kibana,logstash,broker-health-check,vss-haproxy-ingress,vss-ui,vss-agent,vss-va-mcp,alert-bridge,rtvi-vlm,nvstreamer-alerts,kibana-init-container-alerts,vss-video-analytics-api-alerts,centralizedb,vst-ingress,vst-mcp,streamprocessing-ms,sdr-streamprocessing,envoy-streamprocessing,llm_${LLM_MODE}_${LLM_NAME_SLUG}
+
+# Active profile (script sets this to COMPOSE_PROFILES_VLM for --mode real-time)
+COMPOSE_PROFILES=${COMPOSE_PROFILES_CV}
 
 # =============================================================================
 # CORE INFRASTRUCTURE PATHS

--- a/deploy/docker/developer-profiles/dev-profile-alerts/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/compose.yml
@@ -19,7 +19,7 @@ services:
     extends:
       file: ${MDX_SAMPLE_APPS_DIR}/services/analytics/behavior-analytics/compose.yml
       service: vss-behavior-analytics-base
-    profiles: ["bp_developer_alerts_2d_cv"]
+    profiles: ["vss-behavior-analytics-alerts"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/developer-profiles/dev-profile-alerts/vss-behavior-analytics/configs/vss-behavior-analytics-config.json:/resources/vss-behavior-analytics-config.json
     container_name: vss-behavior-analytics
@@ -28,7 +28,7 @@ services:
   nvstreamer-alerts:
     image: nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
     user: "0:0"
-    profiles: ["bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["nvstreamer-alerts"]
     entrypoint: [ "/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst" ]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
@@ -54,7 +54,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/rtvi/rtvi-cv/compose.yaml
       service: perception-sdr
-    profiles: ["bp_developer_alerts_2d_cv"]
+    profiles: ["perception-sdr-alerts"]
     container_name: vss-rtvi-cv-sdr
     volumes:
       - $MDX_SAMPLE_APPS_DIR/developer-profiles/dev-profile-alerts/sdr:/wdm-configs
@@ -73,7 +73,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/rtvi/rtvi-cv/compose.yaml
       service: perception
-    profiles: ["bp_developer_alerts_2d_cv"]
+    profiles: ["perception-alerts"]
     container_name: vss-rtvi-cv
     volumes:
       - $MDX_DATA_DIR/models/:/opt/storage/
@@ -101,7 +101,7 @@ services:
       context: $MDX_SAMPLE_APPS_DIR/developer-profiles/dev-profile-alerts
       dockerfile: $MDX_SAMPLE_APPS_DIR/developer-profiles/dev-profile-alerts/Dockerfiles/kibana-dashboard.Dockerfile
     network_mode: "host"
-    profiles: ["bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["kibana-init-container-alerts"]
     container_name: vss-kibana-init
     command: bash /opt/mdx/init-scripts/kibana-import-dashboard.sh
     depends_on:
@@ -112,7 +112,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/analytics/video-analytics-api/compose.yml
       service: vss-video-analytics-api
-    profiles: ["bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["vss-video-analytics-api-alerts"]
     container_name: vss-video-analytics-api
     volumes:
       - $MDX_SAMPLE_APPS_DIR/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json:/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -82,8 +82,8 @@ VLM_ENV_FILE=''
 VLM_BASE_URL=''
 VLM_MODEL_TYPE=nim
 
-# Computed compose profiles (DO NOT MODIFY)
-COMPOSE_PROFILES=${BP_PROFILE}_${MODE},${BP_PROFILE}_${MODE}_${HARDWARE_PROFILE},llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}
+# Services for this profile (NIM tokens appended; script adds rtvi-vlm for THOR hardware)
+COMPOSE_PROFILES=phoenix,redis,broker-health-check,vss-haproxy-ingress,vss-ui,vss-agent,centralizedb,vst-ingress,vst-mcp,sensor-ms,streamprocessing-ms,sdr-streamprocessing,envoy-streamprocessing,llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}
 
 # =============================================================================
 # CORE INFRASTRUCTURE PATHS

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -82,8 +82,8 @@ VLM_ENV_FILE=''
 VLM_BASE_URL=''
 VLM_MODEL_TYPE=rtvi
 
-# Computed compose profiles (DO NOT MODIFY)
-COMPOSE_PROFILES=${BP_PROFILE}_${MODE},llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}
+# Services for LVS profile
+COMPOSE_PROFILES=phoenix,elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,logstash,broker-health-check,vss-haproxy-ingress,vss-ui,vss-agent,rtvi-vlm,kibana-init-container-lvs,lvs-server,centralizedb,vst-ingress,vst-mcp,streamprocessing-ms,sdr-streamprocessing,envoy-streamprocessing,llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}
 
 # =============================================================================
 # CORE INFRASTRUCTURE PATHS

--- a/deploy/docker/developer-profiles/dev-profile-lvs/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/compose.yml
@@ -19,7 +19,7 @@ services:
       context: $MDX_SAMPLE_APPS_DIR/developer-profiles/dev-profile-lvs
       dockerfile: $MDX_SAMPLE_APPS_DIR/developer-profiles/dev-profile-lvs/Dockerfiles/kibana-dashboard.Dockerfile
     network_mode: "host"
-    profiles: ["bp_developer_lvs_2d"]
+    profiles: ["kibana-init-container-lvs"]
     container_name: vss-kibana-init
     command: bash /opt/mdx/init-scripts/kibana-import-dashboard.sh
     restart: on-failure

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -84,8 +84,8 @@ VLM_ENV_FILE=''
 VLM_BASE_URL=''
 VLM_MODEL_TYPE=nim
 
-# Computed compose profiles (DO NOT MODIFY)
-COMPOSE_PROFILES=${BP_PROFILE}_${MODE},llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}
+# Services for search profile; script removes vlm token when ENABLE_CRITIC=false
+COMPOSE_PROFILES=phoenix,elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,kibana,logstash,broker-health-check,vss-haproxy-ingress,vss-ui,vss-agent,rtvi-embed,kibana-init-container-search,vss-search-analytics-2d-fusion,vss-video-analytics-api-fusion,nvstreamer-2d-fusion,perception-2d-init,perception-2d-fusion,centralizedb,vst-ingress,vst-mcp,sensor-ms,streamprocessing-ms,sdr-streamprocessing,envoy-streamprocessing,llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}
 
 # OpenTelemetry Configuration
 OTEL_SDK_DISABLED=true

--- a/deploy/docker/developer-profiles/dev-profile-search/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/compose.yml
@@ -22,7 +22,7 @@ services:
       dockerfile: $MDX_SAMPLE_APPS_DIR/developer-profiles/dev-profile-search/Dockerfiles/kibana-dashboard.Dockerfile
       network: "host"
     network_mode: "host"
-    profiles: ["bp_developer_search_2d"]
+    profiles: ["kibana-init-container-search"]
     container_name: vss-kibana-init
     command: bash /opt/mdx/init-scripts/kibana-import-dashboard.sh
     depends_on:

--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
@@ -19,7 +19,7 @@ services:
     extends:
       file: ${MDX_SAMPLE_APPS_DIR}/services/analytics/behavior-analytics/compose.yml
       service: vss-behavior-analytics-base
-    profiles: ["bp_developer_search_2d"]
+    profiles: ["vss-search-analytics-2d-fusion"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/developer-profiles/dev-profile-search/video-analytics-2d-app/vss-search-analytics/configs/vss-search-analytics-$STREAM_TYPE-config.json:/resources/vss-search-analytics-config.json
     container_name: vss-behavior-analytics
@@ -29,7 +29,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/analytics/video-analytics-api/compose.yml
       service: vss-video-analytics-api
-    profiles: ["bp_developer_search_2d"]
+    profiles: ["vss-video-analytics-api-fusion"]
     container_name: vss-video-analytics-api
     volumes:
       - $MDX_SAMPLE_APPS_DIR/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json:/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
@@ -41,7 +41,7 @@ services:
     image: nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
     user: "0:0"
     #runtime: nvidia
-    profiles: ["bp_developer_search_2d"]
+    profiles: ["nvstreamer-2d-fusion"]
     entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
@@ -130,7 +130,7 @@ services:
 
   perception-2d-init:
     image: debian:12-slim
-    profiles: ["bp_developer_search_2d"]
+    profiles: ["perception-2d-init"]
     container_name: vss-rtvi-cv-init
     network_mode: "host"
     deploy:
@@ -165,7 +165,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/rtvi/rtvi-cv/compose.yaml
       service: perception
-    profiles: ["bp_developer_search_2d"]
+    profiles: ["perception-2d-fusion"]
     container_name: vss-rtvi-cv
     volumes:
         # Config file mounts (read-only staging; ds-search-start.sh copies to the writable app dir)

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -107,8 +107,53 @@ VLM_MODEL_TYPE=nim
 RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-1208
 RTVI_VLM_MODEL_TO_USE=cosmos-reason2
 
-# Computed compose profiles (DO NOT MODIFY)
-COMPOSE_PROFILES=${BP_PROFILE}_${MODE},llm_${LLM_MODE}_${LLM_NAME_SLUG}
+# =============================================================================
+# SERVICE COMPOSITION — Profile inversion model
+# =============================================================================
+# Base services shared across all warehouse variants
+_WH_BASE=redis,vss-auto-calibration-ui,vss-auto-calibration,centralizedb,vst-ingress,vst-mcp,sensor-bp-wait-bp-configurator,sdr-streamprocessing,envoy-streamprocessing
+# Kafka transport services
+_WH_KAFKA=kafka,kafka-topic-init-container
+# Extended (non-minimal) services
+_WH_EXTENDED_COMMON=elasticsearch,elasticsearch-init-container,vss-haproxy-ingress,dcgm-exporter,prometheus,grafana,node-exporter,cadvisor
+# 2D warehouse app services
+_WH_2D_APP=vss-behavior-analytics-2d,nvstreamer-2d,perception-sdr-2d,bp-configurator-2d,ds-configurator-2d,perception-2d,streamprocessing-ms-2d,sensor-ms-2d
+# 3D warehouse app services
+_WH_3D_APP=vss-behavior-analytics-3d,nvstreamer-3d,perception-sdr-3d,bp-configurator-3d,ds-configurator-3d,perception-3d,streamprocessing-ms-3d,sensor-ms-3d
+# Extended 2D services (omitted in minimal mode)
+_WH_2D_EXTENDED=kibana,logstash,kibana-init-container-2d,vss-video-analytics-api-2d,import-calibration-output-container-2d
+# Extended 3D services (omitted in minimal mode)
+_WH_3D_EXTENDED=kibana,logstash,kibana-init-container-3d,vss-video-analytics-api-3d,import-calibration-output-container-3d
+# bp_wh_2d only: agent, UI, alerts, rtvi-vlm (LLM appended by script)
+_WH_2D_FULL_ONLY=vss-ui,vss-agent,rtvi-vlm,alert-bridge,perception-sdr-alerts-2d
+
+# Playback 2D services
+_WH_PLAYBACK_2D_APP=vss-behavior-analytics-playback-2d,streamprocessing-ms-2d,sensor-ms-2d
+# Playback 3D services
+_WH_PLAYBACK_3D_APP=vss-behavior-analytics-playback-3d,streamprocessing-ms-3d,sensor-ms-3d
+
+# --- Per-variant COMPOSE_PROFILES (non-minimal) ---
+COMPOSE_PROFILES_WH_2D=${_WH_BASE},${_WH_KAFKA},${_WH_2D_APP},${_WH_2D_FULL_ONLY},${_WH_EXTENDED_COMMON},${_WH_2D_EXTENDED},llm_${LLM_MODE}_${LLM_NAME_SLUG}
+COMPOSE_PROFILES_WH_KAFKA_2D=${_WH_BASE},${_WH_KAFKA},${_WH_2D_APP},${_WH_EXTENDED_COMMON},${_WH_2D_EXTENDED}
+COMPOSE_PROFILES_WH_REDIS_2D=${_WH_BASE},${_WH_2D_APP},${_WH_EXTENDED_COMMON},${_WH_2D_EXTENDED}
+COMPOSE_PROFILES_WH_KAFKA_3D=${_WH_BASE},${_WH_KAFKA},${_WH_3D_APP},${_WH_EXTENDED_COMMON},${_WH_3D_EXTENDED}
+COMPOSE_PROFILES_WH_REDIS_3D=${_WH_BASE},${_WH_3D_APP},${_WH_EXTENDED_COMMON},${_WH_3D_EXTENDED}
+
+# --- Minimal variants (no ELK, no monitoring, no extended) ---
+COMPOSE_PROFILES_WH_2D_MINIMAL=${_WH_BASE},${_WH_KAFKA},${_WH_2D_APP},${_WH_2D_FULL_ONLY},llm_${LLM_MODE}_${LLM_NAME_SLUG}
+COMPOSE_PROFILES_WH_KAFKA_2D_MINIMAL=${_WH_BASE},${_WH_KAFKA},${_WH_2D_APP}
+COMPOSE_PROFILES_WH_REDIS_2D_MINIMAL=${_WH_BASE},${_WH_2D_APP}
+COMPOSE_PROFILES_WH_KAFKA_3D_MINIMAL=${_WH_BASE},${_WH_KAFKA},${_WH_3D_APP}
+COMPOSE_PROFILES_WH_REDIS_3D_MINIMAL=${_WH_BASE},${_WH_3D_APP}
+
+# --- Playback variants ---
+COMPOSE_PROFILES_PLAYBACK_KAFKA_2D=${_WH_BASE},${_WH_KAFKA},${_WH_PLAYBACK_2D_APP},${_WH_EXTENDED_COMMON},${_WH_2D_EXTENDED}
+COMPOSE_PROFILES_PLAYBACK_REDIS_2D=${_WH_BASE},${_WH_PLAYBACK_2D_APP},${_WH_EXTENDED_COMMON},${_WH_2D_EXTENDED}
+COMPOSE_PROFILES_PLAYBACK_KAFKA_3D=${_WH_BASE},${_WH_KAFKA},${_WH_PLAYBACK_3D_APP},${_WH_EXTENDED_COMMON},${_WH_3D_EXTENDED}
+COMPOSE_PROFILES_PLAYBACK_REDIS_3D=${_WH_BASE},${_WH_PLAYBACK_3D_APP},${_WH_EXTENDED_COMMON},${_WH_3D_EXTENDED}
+
+# Active profile (script updates this based on BP_PROFILE, MODE, and MINIMAL_PROFILE)
+COMPOSE_PROFILES=${COMPOSE_PROFILES_WH_2D}
 
 # OpenTelemetry Configuration
 OTEL_SDK_DISABLED=true

--- a/deploy/docker/industry-profiles/warehouse-operations/compose.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/compose.yml
@@ -20,5 +20,5 @@ include:
   # Warehouse Configuration - includes both 2D and 3D apps
 
   # Services are differentiated by -2d and -3d suffixes
-  # Use profiles: bp_wh_2d, bp_wh_kafka_2d, bp_wh_redis_2d (2D)
-  # bp_wh_kafka_3d, bp_wh_redis_3d (3D) to activate services
+  # Each service carries profiles: ["<service-name>"]; active services are
+  # selected via COMPOSE_PROFILES in .env (COMPOSE_PROFILES_WH_2D, etc.)

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
@@ -22,7 +22,7 @@ services:
       file: ${MDX_SAMPLE_APPS_DIR}/services/analytics/behavior-analytics/compose.yml
       service: vss-behavior-analytics-base
     network_mode: "host"
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d","playback_kafka_2d","playback_redis_2d"]
+    profiles: ["vss-behavior-analytics-2d"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app/vss-behavior-analytics/configs/vss-behavior-analytics-config.json:/resources/vss-behavior-analytics-config.json
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app/calibration/sample-data/$SAMPLE_VIDEO_DATASET/calibration.json:/resources/calibration.json
@@ -33,7 +33,7 @@ services:
     extends:
       file: ${MDX_SAMPLE_APPS_DIR}/services/analytics/behavior-analytics/compose.yml
       service: vss-behavior-analytics-base
-    profiles: ["playback_kafka_2d","playback_redis_2d"]
+    profiles: ["vss-behavior-analytics-playback-2d"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app/vss-behavior-analytics/configs/vss-behavior-analytics-config.json:/resources/vss-behavior-analytics-config.json
       - $MDX_DATA_DIR/playback/warehouse_loading_dock_playback.json:/opt/mdx/playback/warehouse_loading_dock_playback.json
@@ -45,7 +45,7 @@ services:
     image: nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
     user: "0:0"
     #runtime: nvidia
-    profiles: ["bp_wh_redis_2d","bp_wh_kafka_2d","bp_wh_2d"]
+    profiles: ["nvstreamer-2d"]
     entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
@@ -78,7 +78,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/rtvi/rtvi-cv/compose.yaml
       service: perception-sdr
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d"]
+    profiles: ["perception-sdr-2d"]
     container_name: vss-rtvi-cv-sdr
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app/sdr:/wdm-configs
@@ -99,7 +99,7 @@ services:
 
   bp-configurator-2d:
     image: nvcr.io/nvstaging/vss-core/vss-configurator:3.2-2026.05.04
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d"]
+    profiles: ["bp-configurator-2d"]
     container_name: vss-configurator
     network_mode: "host"
     user: "0:0"
@@ -169,7 +169,7 @@ services:
   ds-configurator-2d:
     image: nvcr.io/nvstaging/vss-core/vss-rt-config-adaptor:3.2-2026.05.01
     network_mode: "host"
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_redis_2d"]
+    profiles: ["ds-configurator-2d"]
     container_name: vss-rtvi-cv-config-adaptor
     user: "0:0"
     environment:
@@ -187,7 +187,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/rtvi/rtvi-cv/compose.yaml
       service: perception
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d"]
+    profiles: ["perception-2d"]
     container_name: vss-rtvi-cv
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app/deepstream/configs/:/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/configs/
@@ -217,7 +217,7 @@ services:
       context: $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app
       dockerfile: Dockerfiles/kibana-dashboard.Dockerfile
     network_mode: "host"
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_redis_2d"]
+    profiles: ["kibana-init-container-2d"]
     container_name: vss-kibana-init
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app/kibana-dashboard/warehouse-2d-kibana-objects.ndjson:/opt/vss/kibana-objects.ndjson
@@ -230,7 +230,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/analytics/video-analytics-api/compose.yml
       service: vss-video-analytics-api
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_redis_2d"]
+    profiles: ["vss-video-analytics-api-2d"]
     container_name: vss-video-analytics-api
     volumes:
       - $MDX_SAMPLE_APPS_DIR/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json:/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
@@ -240,7 +240,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/rtvi/rtvi-cv/compose.yaml
       service: perception-sdr
-    profiles: ["bp_wh_2d"]
+    profiles: ["perception-sdr-alerts-2d"]
     container_name: vss-sdr-alerts
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app/sdr-vlm:/wdm-configs
@@ -264,7 +264,7 @@ services:
       context: $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app
       dockerfile: Dockerfiles/import-calibration.Dockerfile
     network_mode: "host"
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_redis_2d"]
+    profiles: ["import-calibration-output-container-2d"]
     container_name: vss-import-calibration-output
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-2d-app/calibration/sample-data/$SAMPLE_VIDEO_DATASET/calibration.json:/opt/vss/calibration.json

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
@@ -21,7 +21,7 @@ services:
     extends:
       file: ${MDX_SAMPLE_APPS_DIR}/services/analytics/behavior-analytics/compose.yml
       service: vss-behavior-analytics-base
-    profiles: ["bp_wh_kafka_3d","bp_wh_redis_3d","playback_kafka_3d","playback_redis_3d"]
+    profiles: ["vss-behavior-analytics-3d"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-3d-app/calibration/sample-data/$SAMPLE_VIDEO_DATASET/calibration.json:/resources/calibration.json
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-3d-app/vss-behavior-analytics/configs/vss-behavior-analytics-config.json:/resources/vss-behavior-analytics-config.json
@@ -32,7 +32,7 @@ services:
     extends:
       file: ${MDX_SAMPLE_APPS_DIR}/services/analytics/behavior-analytics/compose.yml
       service: vss-behavior-analytics-base
-    profiles: ["playback_kafka_3d","playback_redis_3d"]
+    profiles: ["vss-behavior-analytics-playback-3d"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-3d-app/vss-behavior-analytics/configs/vss-behavior-analytics-config.json:/resources/vss-behavior-analytics-config.json
       - $MDX_DATA_DIR/playback/warehouse_20x20_playback.txt:/opt/mdx/playback/warehouse_20x20_playback.txt
@@ -44,7 +44,7 @@ services:
     image: nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
     user: "0:0"
     runtime: nvidia
-    profiles: ["bp_wh_kafka_3d","bp_wh_redis_3d"]
+    profiles: ["nvstreamer-3d"]
     entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
@@ -78,7 +78,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/rtvi/rtvi-cv/compose.yaml
       service: perception-sdr
-    profiles: ["bp_wh_kafka_3d","bp_wh_redis_3d"]
+    profiles: ["perception-sdr-3d"]
     container_name: vss-rtvi-cv-sdr
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-3d-app/sdr:/wdm-configs
@@ -100,7 +100,7 @@ services:
     image: nvcr.io/nvstaging/vss-core/vss-configurator:3.2-2026.05.04
     container_name: vss-configurator
     network_mode: "host"
-    profiles: ["bp_wh_kafka_3d","bp_wh_redis_3d"]
+    profiles: ["bp-configurator-3d"]
     user: "0:0"
     environment:
       SENSOR_INFO_SOURCE: ${SENSOR_INFO_SOURCE:-nvstreamer}
@@ -162,7 +162,7 @@ services:
   ds-configurator-3d:
     image: nvcr.io/nvstaging/vss-core/vss-rt-config-adaptor:3.2-2026.05.01
     network_mode: "host"
-    profiles: ["bp_wh_kafka_3d","bp_wh_redis_3d"]
+    profiles: ["ds-configurator-3d"]
     container_name: vss-rtvi-cv-config-adaptor
     user: "0:0"
     environment:
@@ -183,7 +183,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/rtvi/rtvi-cv/compose.yaml
       service: perception
-    profiles: ["bp_wh_kafka_3d","bp_wh_redis_3d"]
+    profiles: ["perception-3d"]
     container_name: vss-rtvi-cv
     volumes:
       # General mountings
@@ -231,7 +231,7 @@ services:
       context: $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-3d-app
       dockerfile: Dockerfiles/kibana-dashboard.Dockerfile
     network_mode: "host"
-    profiles: ["bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_3d","playback_redis_3d"]
+    profiles: ["kibana-init-container-3d"]
     container_name: vss-kibana-init
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-3d-app/kibana-dashboard/warehouse-3d-kibana-objects.ndjson:/opt/vss/kibana-objects.ndjson
@@ -244,7 +244,7 @@ services:
     extends:
       file: $MDX_SAMPLE_APPS_DIR/services/analytics/video-analytics-api/compose.yml
       service: vss-video-analytics-api
-    profiles: ["bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_3d","playback_redis_3d"]
+    profiles: ["vss-video-analytics-api-3d"]
     container_name: vss-video-analytics-api
     volumes:
       - $MDX_SAMPLE_APPS_DIR/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json:/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
@@ -255,7 +255,7 @@ services:
       context: $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-3d-app
       dockerfile: Dockerfiles/import-calibration.Dockerfile
     network_mode: "host"
-    profiles: ["bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_3d","playback_redis_3d"]
+    profiles: ["import-calibration-output-container-3d"]
     container_name: vss-import-calibration-output
     volumes:
       - $MDX_SAMPLE_APPS_DIR/industry-profiles/warehouse-operations/warehouse-3d-app/calibration/sample-data/$SAMPLE_VIDEO_DATASET/calibration.json:/opt/vss/calibration.json

--- a/deploy/docker/scripts/blueprint-deploy.sh
+++ b/deploy/docker/scripts/blueprint-deploy.sh
@@ -725,6 +725,25 @@ function state_up() {
     fi
     set_env_var "SAMPLE_VIDEO_DATASET" "${_sample_dataset}"
     set_env_var "NUM_STREAMS" "${_num_streams}"
+
+    # Select the appropriate COMPOSE_PROFILES variable based on BP_PROFILE, MODE, and MINIMAL_PROFILE
+    local _minimal_profile _cp_var
+    _minimal_profile="$(get_env_value "${_source_env}" "MINIMAL_PROFILE")"
+    case "${bp_profile}_${mode}" in
+      bp_wh_2d)       _cp_var="COMPOSE_PROFILES_WH_2D" ;;
+      bp_wh_kafka_2d) _cp_var="COMPOSE_PROFILES_WH_KAFKA_2D" ;;
+      bp_wh_redis_2d) _cp_var="COMPOSE_PROFILES_WH_REDIS_2D" ;;
+      bp_wh_kafka_3d) _cp_var="COMPOSE_PROFILES_WH_KAFKA_3D" ;;
+      bp_wh_redis_3d) _cp_var="COMPOSE_PROFILES_WH_REDIS_3D" ;;
+      *)
+        echo "[ERROR] Unknown bp_profile/mode combination: ${bp_profile}/${mode}"
+        return 1
+        ;;
+    esac
+    if [[ -n "${_minimal_profile}" ]] && [[ "${bp_profile}" != "bp_wh" ]]; then
+      _cp_var="${_cp_var}_MINIMAL"
+    fi
+    set_env_var "COMPOSE_PROFILES" "\${${_cp_var}}"
   fi
 
   # When hardware profile is DGX-SPARK: for any env var that has a commented line with sbsa in the value,

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1047,6 +1047,10 @@ function state_up() {
   fi
   if [[ "${profile}" == "alerts" ]]; then
     set_alerts_ui_subtitle_from_mode "${_generated_env}"
+    # Alerts VLM mode: switch COMPOSE_PROFILES to the VLM service list
+    if [[ "${mode_env}" == "2d_vlm" ]]; then
+      set_env_var "COMPOSE_PROFILES" "\${COMPOSE_PROFILES_VLM}"
+    fi
   fi
 
   # ===== LLM Configuration =====
@@ -1236,6 +1240,9 @@ function state_up() {
   # Base profile only on IGX-THOR or AGX-THOR: set VLM_MODEL_TYPE to rtvi (alerts does not use rtvi)
   if ([[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]) && [[ "${profile}" == "base" ]]; then
     set_env_var "VLM_MODEL_TYPE" "rtvi"
+    # Also append rtvi-vlm to the explicit service list (profile inversion model)
+    local _p; _p="$(get_env_value "${_generated_env}" "COMPOSE_PROFILES")"
+    set_env_var "COMPOSE_PROFILES" "${_p},rtvi-vlm"
   fi
 
   # When hardware profile is DGX-SPARK: for any env var that has a commented line with sbsa in the value,

--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -20,10 +20,7 @@ services:
     image: nvcr.io/nvstaging/vss-core/vss-agent:${VSS_AGENT_VERSION}
     container_name: vss-va-mcp
     network_mode: host
-    profiles:
-    - bp_wh_2d
-    - bp_developer_alerts_2d_cv
-    - bp_developer_alerts_2d_vlm
+    profiles: ["vss-va-mcp"]
     volumes:
     - ${MDX_SAMPLE_APPS_DIR}:/vss-agent/deploy/docker:ro
     environment:
@@ -64,13 +61,7 @@ services:
     image: nvcr.io/nvstaging/vss-core/vss-agent:${VSS_AGENT_VERSION}
     container_name: vss-agent
     network_mode: host
-    profiles:
-    - bp_wh_2d
-    - bp_developer_base_2d
-    - bp_developer_search_2d
-    - bp_developer_lvs_2d
-    - bp_developer_alerts_2d_cv
-    - bp_developer_alerts_2d_vlm
+    profiles: ["vss-agent"]
     environment:
       # URL rewriting configuration
       EXTERNAL_IP: ${EXTERNAL_IP}

--- a/deploy/docker/services/alert/compose.yml
+++ b/deploy/docker/services/alert/compose.yml
@@ -17,7 +17,7 @@ services:
   alert-bridge:
     image: nvcr.io/nvstaging/vss-core/vss-alert-verification:0.0.62
     container_name: vss-alert-bridge
-    profiles: ["bp_wh_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["alert-bridge"]
     network_mode: host
     restart: unless-stopped
     environment:

--- a/deploy/docker/services/auto-calibration/ms/compose.yml
+++ b/deploy/docker/services/auto-calibration/ms/compose.yml
@@ -17,7 +17,7 @@ services:
   vss-auto-calibration:
     image: nvcr.io/nvstaging/vss-core/vss-auto-calibration:3.2.0-0
     container_name: vss-auto-calibration
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","bp_wh_redis_2d","bp_wh_redis_3d","auto-calib"]
+    profiles: ["vss-auto-calibration"]
     network_mode: "host"
     
     # GPU support

--- a/deploy/docker/services/auto-calibration/ui/compose.yml
+++ b/deploy/docker/services/auto-calibration/ui/compose.yml
@@ -17,7 +17,7 @@ services:
   vss-auto-calibration-ui:
     image: nvcr.io/nvstaging/vss-core/vss-auto-calibration-ui:3.2.0-1
     container_name: vss-auto-calibration-ui
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","bp_wh_redis_2d","bp_wh_redis_3d","auto-calib"]
+    profiles: ["vss-auto-calibration-ui"]
 
     # network_mode: "host"
     ports:

--- a/deploy/docker/services/infra/compose.yml
+++ b/deploy/docker/services/infra/compose.yml
@@ -21,7 +21,7 @@ services:
   phoenix:
     container_name: phoenix
     image: 'arizephoenix/phoenix:14.15.0'
-    profiles: ["bp_wh_2d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["phoenix"]
     environment:
       PHOENIX_WORKING_DIR: '/.phoenix/'
       PHOENIX_HOST_ROOT_PATH: '/phoenix'
@@ -40,7 +40,7 @@ services:
     environment:
       ES_JAVA_OPTS: "-Xmx1024m -Xms256m"
       discovery.type: single-node
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["elasticsearch"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/services/infra/elk/configs/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
       - mdx-elastic-data:/tmp/elastic/data:rw
@@ -59,7 +59,7 @@ services:
       context: $MDX_SAMPLE_APPS_DIR/services/infra
       dockerfile: Dockerfiles/elastic-init.Dockerfile
       network: "host"
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["elasticsearch-init-container"]
     network_mode: "host"
     container_name: vss-elasticsearch-init
     environment:
@@ -83,7 +83,7 @@ services:
     volumes:
       - mdx-kafka:/tmp/kafka-data
       - $MDX_SAMPLE_APPS_DIR/services/infra/kafka-entrypoint.sh:/usr/local/bin/kafka-entrypoint.sh:ro
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","playback_kafka_2d","playback_kafka_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["kafka"]
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_PROCESS_ROLES: 'broker,controller'
@@ -117,7 +117,7 @@ services:
     image: confluentinc/cp-kafka:8.2.0
     container_name: vss-kafka-topics
     network_mode: "host"
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","playback_kafka_2d","playback_kafka_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["kafka-topic-init-container"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/services/infra/kafka/init-scripts/create-kafka-topics.sh:/usr/bin/create-kafka-topics.sh
     environment:
@@ -153,7 +153,7 @@ services:
 
   redis:
     image: redis:8.6.2-alpine
-    profiles: ["bp_wh_2d","bp_wh_redis_2d","bp_wh_redis_3d","bp_wh_kafka_2d","bp_wh_kafka_3d","bp_developer_base_2d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["redis"]
     restart: always
     command: redis-server /config/redis.conf
     network_mode: host
@@ -166,7 +166,7 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:9.3.3
     network_mode: "host"
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["kibana"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/services/infra/elk/configs/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
     container_name: kibana
@@ -184,7 +184,7 @@ services:
   logstash:
     image: docker.elastic.co/logstash/logstash:9.3.3
     network_mode: "host"
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["logstash"]
     volumes:
       - mdx-logstash-libs:/opt/logstash-data-libs
       - $MDX_SAMPLE_APPS_DIR/services/infra/elk/pb_definitions/ruby/ext_pb.rb:/opt/logstash-data-libs/logstash/pb_definitions/ext_pb.rb
@@ -224,7 +224,7 @@ services:
       context: $MDX_SAMPLE_APPS_DIR/services/infra
       dockerfile: Dockerfiles/${STREAM_TYPE}-health-check.Dockerfile
       network: host
-    profiles: ["bp_wh_2d","bp_wh_redis_3d","bp_wh_redis_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["broker-health-check"]
     network_mode: "host"
     environment:
       MAX_RETRIES: 60

--- a/deploy/docker/services/infra/haproxy/compose.yml
+++ b/deploy/docker/services/infra/haproxy/compose.yml
@@ -21,20 +21,7 @@ services:
   vss-haproxy-ingress:
     image: haproxy:3.0-alpine
     profiles:
-      - "bp_developer_base_2d"
-      - "bp_developer_search_2d"
-      - "bp_developer_lvs_2d"
-      - "bp_developer_alerts_2d_cv"
-      - "bp_developer_alerts_2d_vlm"
-      - "bp_wh_2d"
-      - "bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}"
-      - "bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}"
-      - "bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}"
-      - "bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}"
-      - "playback_kafka_2d"
-      - "playback_kafka_3d"
-      - "playback_redis_2d"
-      - "playback_redis_3d"
+      - "vss-haproxy-ingress"
     container_name: vss-haproxy-ingress
     network_mode: host
     restart: always

--- a/deploy/docker/services/monitoring/compose.yml
+++ b/deploy/docker/services/monitoring/compose.yml
@@ -17,7 +17,7 @@ services:
   dcgm-exporter:
     image: nvidia/dcgm-exporter:3.3.6-3.4.2-ubuntu22.04
     container_name: dcgm-exporter
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d"]
+    profiles: ["dcgm-exporter"]
     runtime: nvidia
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
@@ -28,7 +28,7 @@ services:
   prometheus:
     image: quay.io/prometheus/prometheus:v3.11.3
     container_name: prometheus
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d"]
+    profiles: ["prometheus"]
     volumes:
       - $MDX_SAMPLE_APPS_DIR/services/monitoring/config/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
@@ -38,7 +38,7 @@ services:
   grafana:
     image: grafana/grafana:13.0.1-ubuntu
     container_name: grafana
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d"]
+    profiles: ["grafana"]
     ports:
       - "35000:3000"
     volumes:
@@ -53,7 +53,7 @@ services:
 
   node-exporter:
     image: quay.io/prometheus/node-exporter:v1.11.1
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d"]
+    profiles: ["node-exporter"]
     ports:
       - "19100:9100"
     restart: always
@@ -68,7 +68,7 @@ services:
 
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.52.0
-    profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d"]
+    profiles: ["cadvisor"]
     ports:
       - "18080:8080"
     volumes:

--- a/deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml
+++ b/deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: ${RTVI_EMBED_IMAGE:-nvcr.io/nvstaging/vss-core/vss-rt-embed}:${RTVI_EMBED_TAG:-3.2.0-26.04.2}
     container_name: vss-rtvi-embed
     user: "1001:1001"
-    profiles: ["bp_developer_search_2d"]
+    profiles: ["rtvi-embed"]
     deploy:
       resources:
         reservations:

--- a/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
+++ b/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
@@ -23,7 +23,7 @@ services:
     user: "1001:1001"
     shm_size: '16gb'
     runtime: nvidia
-    profiles: ["bp_wh_2d", "bp_developer_alerts_2d_vlm", "bp_developer_alerts_2d_cv", "bp_developer_base_2d_IGX-THOR", "bp_developer_base_2d_AGX-THOR", "bp_developer_lvs_2d"]
+    profiles: ["rtvi-vlm"]
     deploy:
       resources:
         reservations:

--- a/deploy/docker/services/ui/compose.yml
+++ b/deploy/docker/services/ui/compose.yml
@@ -17,7 +17,7 @@ services:
 
   vss-ui:
     image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.04.4-3
-    profiles: ["bp_wh_2d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    profiles: ["vss-ui"]
     container_name: vss-agent-ui
     ports:
       - 3000:3000

--- a/deploy/docker/services/video-summarization/compose.yml
+++ b/deploy/docker/services/video-summarization/compose.yml
@@ -18,7 +18,7 @@ services:
     image: ${CONTAINER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc1-d3e1a8f}
     container_name: vss-lvs
 
-    profiles: ["bp_developer_lvs_2d"]
+    profiles: ["lvs-server"]
 
     # GPU configuration
     deploy:

--- a/deploy/docker/services/vios/foundational/docker-compose.yaml
+++ b/deploy/docker/services/vios/foundational/docker-compose.yaml
@@ -16,7 +16,7 @@
 services:
   centralizedb:
     image: ${POSTGRES_IMAGE}
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d","bp_wh_kafka_3d","bp_wh_redis_3d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv","bp_developer_alerts_2d_vlm"]
+    profiles: ["centralizedb"]
     user: "0:0"
     environment:
       - POSTGRES_USER=${CENTRALIZE_DB_USERNAME}
@@ -44,7 +44,7 @@ services:
 
   vst-ingress:
     image: ${NGINX_IMAGE}
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d","bp_wh_kafka_3d","bp_wh_redis_3d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv","bp_developer_alerts_2d_vlm"]
+    profiles: ["vst-ingress"]
     user: "0:0"
     environment:
       - VST_INGRESS_HTTP_PORT=${VST_INGRESS_HTTP_PORT}
@@ -74,7 +74,7 @@ services:
 
   vst-mcp:
     image: ${VST_MCP_IMAGE}
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d","bp_wh_kafka_3d","bp_wh_redis_3d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv","bp_developer_alerts_2d_vlm"]
+    profiles: ["vst-mcp"]
     user: "0:0"
     environment:
       - MCP_GATEWAY_CPP_API_BASE_URL=${MCP_GATEWAY_CPP_API_BASE_URL}

--- a/deploy/docker/services/vios/initiator/docker-compose.yaml
+++ b/deploy/docker/services/vios/initiator/docker-compose.yaml
@@ -16,7 +16,7 @@
 services:
   sensor-bp-wait-bp-configurator:
     image: busybox:1.37.0
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d","bp_wh_kafka_3d","bp_wh_redis_3d"]
+    profiles: ["sensor-bp-wait-bp-configurator"]
     network_mode: host
     container_name: sensor-bp-wait-bp-configurator
     restart: "no"
@@ -29,12 +29,7 @@ services:
 
   sensor-ms:
     image: ${VST_SENSOR_IMAGE}
-    profiles:
-      - bp_developer_base_2d
-      - bp_developer_search_2d
-      - bp_developer_lvs_2d
-      - bp_developer_alerts_2d_cv
-      - bp_developer_alerts_2d_vlm
+    profiles: ["sensor-ms"]
     user: "0:0"
     runtime: nvidia
     entrypoint: ["/bin/bash", "-c", "exec /home/vst/vst_release/launch_vst"]
@@ -74,10 +69,7 @@ services:
 
   sensor-ms-2d:
     image: ${VST_SENSOR_IMAGE}
-    profiles:
-      - bp_wh_kafka_2d
-      - bp_wh_redis_2d
-      - bp_wh_2d
+    profiles: ["sensor-ms-2d"]
     user: "0:0"
     runtime: nvidia
     entrypoint: ["/bin/bash", "-c", "exec /home/vst/vst_release/launch_vst"]
@@ -118,9 +110,7 @@ services:
 
   sensor-ms-3d:
     image: ${VST_SENSOR_IMAGE}
-    profiles:
-      - bp_wh_kafka_3d
-      - bp_wh_redis_3d
+    profiles: ["sensor-ms-3d"]
     user: "0:0"
     runtime: nvidia
     entrypoint: ["/bin/bash", "-c", "exec /home/vst/vst_release/launch_vst"]

--- a/deploy/docker/services/vios/sdr/streamprocessing/docker-compose.yaml
+++ b/deploy/docker/services/vios/sdr/streamprocessing/docker-compose.yaml
@@ -16,7 +16,7 @@
 services:
   streamprocessing-ms:
     image: ${VST_STREAM_PROCESSOR_IMAGE}
-    profiles: ["bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv","bp_developer_alerts_2d_vlm"]
+    profiles: ["streamprocessing-ms"]
     container_name: vss-vios-streamprocessing
     network_mode: host
     runtime: nvidia
@@ -64,7 +64,7 @@ services:
 
   streamprocessing-ms-2d:
     image: ${VST_STREAM_PROCESSOR_IMAGE}
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d"]
+    profiles: ["streamprocessing-ms-2d"]
     container_name: vss-vios-streamprocessing
     network_mode: host
     runtime: nvidia
@@ -111,7 +111,7 @@ services:
 
   streamprocessing-ms-3d:
     image: ${VST_STREAM_PROCESSOR_IMAGE}
-    profiles: ["bp_wh_kafka_3d","bp_wh_redis_3d"]
+    profiles: ["streamprocessing-ms-3d"]
     container_name: vss-vios-streamprocessing
     network_mode: host
     runtime: nvidia
@@ -160,7 +160,7 @@ services:
 
   sdr-streamprocessing:
     image: ${SDR_IMAGE}
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d","bp_wh_kafka_3d","bp_wh_redis_3d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv","bp_developer_alerts_2d_vlm"]
+    profiles: ["sdr-streamprocessing"]
     user: "0:0"
     network_mode: "host"
     logging:
@@ -238,7 +238,7 @@ services:
 
   envoy-streamprocessing:
     image: ${ENVOY_PROXY_IMAGE}
-    profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d","bp_wh_kafka_3d","bp_wh_redis_3d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv","bp_developer_alerts_2d_vlm"]
+    profiles: ["envoy-streamprocessing"]
     user: "0:0"
     command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml --concurrency 16 --base-id 1
     network_mode: "host"


### PR DESCRIPTION
## Description

Services do not list the profiles they are activated on, individual deployment profiles list the services needed for their bootstrap.

## Details

Each non-NIM service now carries exactly one profile entry equal to its own Docker service key.  Profile .env files contain the explicit, flat list of service names that make up each deployment variant (NIM tokens kept as variable references so Docker Compose expands them at runtime).

NIM services (services/nim/**) are completely unchanged.

Part 1 — service compose files: replace long profile arrays with single self-named profile across infra, haproxy, rtvi-vlm, rtvi-embed, ui, agent, alert, auto-calibration, monitoring, video-summarization, vios/foundational, vios/initiator, vios/sdr/streamprocessing, dev-profile-alerts, dev-profile- search, dev-profile-lvs, warehouse-2d-app, and warehouse-3d-app.

Part 2 — profile .env files: replace formula-based COMPOSE_PROFILES with explicit service lists in dev-profile-base, dev-profile-alerts (with COMPOSE_PROFILES_CV / COMPOSE_PROFILES_VLM split), dev-profile-search, dev-profile-lvs, and warehouse-operations (with per-variant named variables covering non-minimal, minimal, and playback combinations).

Part 3 — scripts: dev-profile.sh switches COMPOSE_PROFILES to COMPOSE_PROFILES_VLM for alerts 2d_vlm mode and appends rtvi-vlm for base profile on IGX-THOR/AGX-THOR; blueprint-deploy.sh selects the correct named COMPOSE_PROFILES_WH_* variable based on bp_profile, mode, and MINIMAL_PROFILE.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
