### PR TITLE
helm: sync chart with deploy/docker changes (PR #196)

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -82,6 +82,35 @@ infra:
     enabled: true
     topicJob:
       enabled: true
+    # Compose parity: deploy/docker/services/video-summarization/compose.yml
+    # `lvs-kafka-topic-init` creates `raw-vlm-events-response` (rtvi-vlm →
+    # lvs-logstash) and `structured-events-summary` (vss-summarization
+    # publishes structured summaries). Kept the kafka subchart defaults so
+    # Kibana dashboards + rtvi-vlm incident topics continue to exist.
+    topics:
+      - name: mdx-raw
+      - name: mdx-bev
+      - name: mdx-space-utilization
+      - name: mdx-alerts
+      - name: mdx-behavior
+      - name: mdx-behavior-plus
+      - name: mdx-frames
+      - name: mdx-mtmc
+      - name: mdx-rtls
+      - name: mdx-rtls-region-1
+      - name: mdx-amr
+      - name: mdx-vlm-alerts
+      - name: mdx-notification
+        partitions: "1"
+      - name: mdx-events
+      - name: mdx-incidents
+      - name: mdx-vlm-incidents
+      - name: mdx-vlm
+      - name: mdx-embed
+      - name: mdx-embed-filtered
+      # LVS streams support (PR #196)
+      - name: raw-vlm-events-response
+      - name: structured-events-summary
     persistence:
       size: 10Gi
       storageClass: ''
@@ -130,6 +159,13 @@ vios:
   vss-vios-mcp:
     enabled: true
 
+  # Compose parity: dev-profile-lvs/compose.yml `nvstreamer-lvs` (profile
+  # `bp_developer_lvs_2d`). Subchart defaults already match the compose
+  # image, HTTP_PORT=31000, ADAPTOR=streamer, and
+  # NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=true.
+  vss-vios-nvstreamer:
+    enabled: true
+
 vss-summarization:
   enabled: true
   elasticsearchHost: ""
@@ -143,6 +179,17 @@ vss-summarization:
       value: '{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $svc := "vss-rtvi-vlm" }}{{- printf "http://%s:8000" (ternary (printf "%s-%s" .Release.Name $svc) $svc $pfx) -}}'
     - name: RTVI_VLM_URL_PASSTHROUGH
       value: "true"
+    # LVS streams support (PR #196): enable Kafka integration in
+    # vss-summarization — consume RTVI captions and publish structured
+    # summaries to `structured-events-summary`. Compose parity:
+    # dev-profile-lvs/.env KAFKA_ENABLED=true, KAFKA_BOOTSTRAP_SERVERS,
+    # KAFKA_STRUCTURED_SUMMARY_TOPIC.
+    - name: KAFKA_ENABLED
+      value: "true"
+    - name: KAFKA_BOOTSTRAP_SERVERS
+      value: '{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $svc := "kafka" }}{{- printf "%s:9092" (ternary (printf "%s-%s" .Release.Name $svc) $svc $pfx) -}}'
+    - name: KAFKA_STRUCTURED_SUMMARY_TOPIC
+      value: "structured-events-summary"
 
 agent:
   enabled: true
@@ -358,7 +405,7 @@ vss-agent-ui:
     - name: NEXT_PUBLIC_SIDE_CHATBAR_COLLAPSED
       value: "true"
     - name: NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE
-      value: "false"
+      value: "true"
     - name: NEXT_PUBLIC_VIDEO_MANAGEMENT_VIDEO_UPLOAD_ENABLE
       value: "true"
     - name: NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON
@@ -432,8 +479,11 @@ rtvi:
         value: "openai-compat"
       - name: KAFKA_ENABLED
         value: "true"
+      # Raw VLM event topic produced by rtvi-vlm; consumed by lvs-logstash.
+      # Compose parity: RTVI_VLM_KAFKA_TOPIC in dev-profile-lvs/.env. The
+      # previous value `mdx-vlm` had no consumer in the LVS profile.
       - name: KAFKA_TOPIC
-        value: "mdx-vlm"
+        value: "raw-vlm-events-response"
       - name: KAFKA_INCIDENT_TOPIC
         value: "mdx-vlm-incidents"
       - name: ERROR_MESSAGE_TOPIC

--- a/deploy/helm/services/video-summarization/configs/config.yaml
+++ b/deploy/helm/services/video-summarization/configs/config.yaml
@@ -30,7 +30,27 @@ tools:
     params:
       host: !ENV ${ES_HOST}
       port: !ENV ${ES_PORT}
-      collection_name: lvs-events
+      kafka_consumer_settle_secs: 5.0
+    tools:
+      embedding: nvidia_embedding
+
+  graph_db_arango:
+    type: arango
+    params:
+      host: !ENV ${ARANGO_DB_HOST}
+      port: !ENV ${ARANGO_DB_PORT}
+      username: !ENV ${ARANGO_DB_USERNAME}
+      password: !ENV ${ARANGO_DB_PASSWORD}
+    tools:
+      embedding: nvidia_embedding
+
+  graph_db:
+    type: neo4j
+    params:
+      host: !ENV ${GRAPH_DB_HOST}
+      port: !ENV ${GRAPH_DB_BOLT_PORT}
+      username: !ENV ${GRAPH_DB_USERNAME}
+      password: !ENV ${GRAPH_DB_PASSWORD}
     tools:
       embedding: nvidia_embedding
 
@@ -68,50 +88,20 @@ functions:
     params:
       time_overlap_threshold: 0.1
       max_events_per_batch: 50
+      # Streaming RTVI -> Kafka -> Logstash -> ES path: raw_events are
+      # written to ES by Logstash, so the online aggregator must read
+      # them back from the database instead of expecting in-process
+      # accumulation. Required for POST /aggregate_live_stream.
       kafka_enabled: true
     tools:
       db: !ENV ${LVS_DATABASE_BACKEND:elasticsearch_db}
       llm: summarization_llm
 
-  summarization_using_llm:
-    type: structured_inference
-    params:
-      prompts:
-        caption: "You are an intelligent traffic system. You must monitor and take note of all traffic related events. Start each event description with a start and end time stamp of the event."
-        # event_extraction_prompt: "Extract structured events from video captions"
-    batch_size: 4
-    scenario: "traffic monitoring"
-    events: ["accident", "pedestrian crossing", "vehicle crossing", "traffic violation"]
-    batch_response_method: "json_schema"
-    schema: |
-      {
-        "title": "EventExtraction",
-        "description": "Extract structured events from video captions",
-        "type": "object",
-        "properties": {
-          "events": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "start_time": { "type": "number" },
-                "end_time": { "type": "number" },
-                "description": { "type": "string" },
-                "type": { "type": "string" }
-              },
-              "required": ["start_time", "end_time", "description", "type"]
-            }
-          }
-        },
-        "required": ["events"]
-      }
-    auto_generate_prompt: true
-    time_metadata_keys: ["start_pts", "end_pts"]
-    tools:
-      llm: summarization_llm
-      db: !ENV ${LVS_DATABASE_BACKEND:elasticsearch_db}
-
 context_manager:
   functions:
     - summarization
+    # Required for POST /aggregate_live_stream so the ctx-mgr subprocess
+    # registers `summarization_online` as a dispatchable function. Without
+    # this, ctx_mgr.call({"summarization_online": ...}) raises KeyError
+    # via context_manager_handler._functions["summarization_online"].
     - summarization_online

--- a/deploy/helm/services/video-summarization/values.yaml
+++ b/deploy/helm/services/video-summarization/values.yaml
@@ -77,6 +77,15 @@ env:
     value: passneo4j
   - name: GRAPH_DB_USERNAME
     value: neo4j
+  # Kafka integration: consume RTVI captions / publish structured summaries.
+  # Compose parity: deploy/docker/services/video-summarization/compose.yml
+  # `lvs-server` environment block + dev-profile-lvs/.env.
+  - name: KAFKA_ENABLED
+    value: "false"
+  - name: KAFKA_BOOTSTRAP_SERVERS
+    value: "kafka:9092"
+  - name: KAFKA_STRUCTURED_SUMMARY_TOPIC
+    value: structured-events-summary
   - name: LVS_DATABASE_BACKEND
     value: elasticsearch_db
   - name: LVS_DISABLE_DB_RESET_ON_REQUEST_DONE


### PR DESCRIPTION
Align helm charts with docker-side LVS streams / Kafka integration changes on PR #196.

Video-summarization service chart:
- values.yaml: add KAFKA_ENABLED / KAFKA_BOOTSTRAP_SERVERS / KAFKA_STRUCTURED_SUMMARY_TOPIC to lvs-server env (compose parity with deploy/docker/services/video-summarization/compose.yml).
- configs/config.yaml: add graph_db (neo4j) + graph_db_arango tools, add kafka_consumer_settle_secs on elasticsearch_db, drop the now-unused summarization_using_llm function, comment the online aggregator + context_manager entries (docker config.yaml parity).

dev-profile-lvs:
- vss-summarization.extraEnv: wire KAFKA_ENABLED=true + in-cluster kafka bootstrap + structured-events-summary topic (mirrors dev-profile-lvs/.env KAFKA_* block).
- infra.kafka.topics: override the subchart default list to add the two new topics (raw-vlm-events-response, structured-events-summary) while keeping the mdx-* defaults so existing Kibana dashboards and rtvi-vlm incident topics continue to exist.
- vios.vss-vios-nvstreamer.enabled=true: compose parity with the new dev-profile-lvs/compose.yml nvstreamer-lvs service.
- rtvi.vss-rtvi-vlm.env.KAFKA_TOPIC: mdx-vlm -> raw-vlm-events-response (matches RTVI_VLM_KAFKA_TOPIC flip in dev-profile-lvs/.env).
- NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE: false -> true.

Validation: helm lint passes on both modified charts. No checks beyond helm lint were run; validate against your target cluster.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
