### PR TITLE
feat/add media config to get stream id for Q&A retival and add config

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -278,6 +278,18 @@ functions:
     # No Video Analytics MCP tools configured = Video(uploaded) Report mode
     video_report_tool: video_report_gen
 
+  lvs_caption_retrieval:
+    _type: knowledge_retrieval
+    backend: es_caption
+    top_k: 5
+    backend_config:
+      elasticsearch_url: ${ELASTIC_SEARCH_ENDPOINT:-http://${HOST_IP}:9200}
+      index: default_*                                  # per-stream `default_<stream_id>` indices
+      default_doc_type: raw_events
+      api_key: ""
+      verify_ssl: false
+      timeout: 30
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:
@@ -347,6 +359,7 @@ workflow:
   - lvs_video_understanding
   - lvs_config_media
   - lvs_stream_understanding
+  - lvs_caption_retrieval
   - vst_video_clip
   - vst_snapshot
   - vst_video_list
@@ -369,12 +382,18 @@ workflow:
       - For uploaded videos: pass sensor_id (str or list[str]) and user_query.
       - For live streams: pass media_type='stream', a single sensor_id (the stream name), start_time and end_time as floats in seconds (use end_time=0 for "until now"), and user_query.
       - Examples: "Generate a report for video1" → ONE call report_agent(sensor_id='video1', user_query=...). "Generate a report for stream CAM_1 from 0 to 60 seconds" → ONE call report_agent(media_type='stream', sensor_id='CAM_1', start_time=0, end_time=60, user_query=...).
+      **lvs_caption_retrieval** - DEFAULT path for content questions about a captioned live stream.
+      - REQUIRED args: `query` (keyword string, e.g. "PPE violations") AND `collection` (stream's friendly name, e.g. "warehouse_sample_test"). Missing `query` will fail validation.
+      - Add `filters={"time_range": {"start": "<ISO 8601 UTC>", "end": "<ISO 8601 UTC>"}}` only when the user gives a time window. Use today's date from the system prompt.
+      - Never pass numeric/stream-relative times ("first 2 minutes") — captions use absolute timestamps. Route those to `lvs_stream_understanding` instead.
+      - If the result has `chunks=[]`, fall back to `lvs_stream_understanding`.
+      - Example: "PPE violations in CAM_1 in the last 5 minutes" at 22:32 UTC → `query="PPE violations", collection="CAM_1", filters={"time_range": {"start": "2026-05-05T22:27:00Z", "end": "2026-05-05T22:32:00Z"}}`.
       **lvs_video_understanding** - For SUMMARIZING uploaded videos (not streams, not reports).
       - Use when user asks to "summarize" or "give a summary of" a video, optionally over a time range.
       - Pass sensor_id (the video name from vst_video_list); start_time/end_time are floats in seconds (omit both for the whole video).
       - Examples: "Summarize video warehouse_sample" (no times), "Summarize video warehouse_sample from start to second 45" (start_time=0, end_time=45)
-      **lvs_stream_understanding** - For SUMMARIZING live streams (not videos, not reports).
-      - Use when user asks to "summarize" or "describe" a stream over a time range.
+      **lvs_stream_understanding** - For SUMMARIZING live streams (not videos, not reports), AND as the VLM fallback when `lvs_caption_retrieval` returns `chunks=[]`.
+      - Use when user asks to "summarize" or "describe" a stream over a time range, OR when a prior `lvs_caption_retrieval` call returned no chunks.
       - Do NOT use this tool to "check" whether a stream is configured before calling another tool — it is for showing summaries to the user.
       - Pass stream_name, numeric start_time, numeric end_time, response_type='summary'.
       - If the response status is "not_configured", surface the response message VERBATIM to the user and STOP. Do NOT auto-call lvs_config_media — caption generation must be confirmed by the user first.
@@ -408,6 +427,12 @@ workflow:
     - Wrap urls in html tags. CRITICAL: ONLY do this when a url is EXACTLY the one returned from a tool call or the url is EXACTLY the same as one from the conversation history. NEVER generate urls yourself. NEVER modify an existing url to create a new url (e.g. changing timestamps, IDs, or any part of the url). If you need a url that wasn't returned by a tool call, you MUST call the appropriate tool to get it. Examples:
       <video src="video_url" alt="Video Name">Video Name</video>
       <image src="image_url" alt="Image Name">Image Name</image>
+    - When answering from `lvs_caption_retrieval` results:
+      - Cite each event by its ISO 8601 timestamp from the events JSON (e.g. "At 2026-05-05T21:03:30Z, ...") and the stream name from the Citation line (e.g. "in `warehouse_sample_test.mp4`").
+      - Quote the event's `description` verbatim when it directly answers the question.
+      - Do NOT refer to results as "Result 1", "Result 2", etc. — that's tool-internal numbering. Refer to events by stream name + timestamp.
+      - If excerpts conflict (e.g. some show compliance, some don't), call that out explicitly with both timestamps rather than collapsing.
+      - Refer to the stream by its friendly name (Citation line), not its UUID, even if the user typed the UUID.
   postprocessing:
     enabled: false
     validation_order:

--- a/services/agent/src/lib/knowledge/adapters/es_caption.py
+++ b/services/agent/src/lib/knowledge/adapters/es_caption.py
@@ -65,13 +65,11 @@ class EsCaptionConfig(BaseModel):
         ),
     )
     default_doc_type: DocType = Field(
-        default="aggregated_summary",
+        default="raw_events",
         description=(
             "doc_type used when callers don't override via filters. "
-            "`aggregated_summary` is the chronological narrative per video — "
-            "timestamps are embedded in the prose, so it covers both general "
-            "and time-windowed Q&A. `raw_events` / `structured_events` are "
-            "escape hatches for JSON-grained retrieval."
+            "`raw_events` is the per-chunk JSON event stream — reliable across "
+            "LVS versions and the safe default. other choices - structured_events or aggregated_summary"
         ),
     )
     api_key: str | None = None

--- a/services/agent/src/vss_agents/register_knowledge_layers.py
+++ b/services/agent/src/vss_agents/register_knowledge_layers.py
@@ -33,6 +33,7 @@ from pydantic import Field
 
 from lib.knowledge import RetrievalResult
 from lib.knowledge import get_retriever
+from vss_agents.tools.lvs_media_state import configured_media
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +146,16 @@ async def knowledge_retrieval(config: KnowledgeRetrievalConfig, builder: Builder
         # substitutes its own backend-configured default (e.g. FragApi's
         # `collection_name`) when the value is falsy.
         target_collection = tool_input.collection or ""
+
+        # es_caption only: resolve LVS sensor names into the stream_id the adapter
+        # filters on using `lvs_config_media`'s per-conversation cache;
+        # lvs_stream_understanding fallback still runs. Skipped for other
+        # backends (e.g. frag_api Milvus collections aren't LVS streams).
+        if target_collection and config.backend == "es_caption":
+            cached = configured_media("stream", target_collection)
+            if cached is not None:
+                target_collection = cached.media_id
+
         top_k = tool_input.top_k or config.top_k
 
         result = await retriever.retrieve(

--- a/services/agent/tests/unit_test/knowledge_retrieval/test_es_caption_adapter.py
+++ b/services/agent/tests/unit_test/knowledge_retrieval/test_es_caption_adapter.py
@@ -139,7 +139,7 @@ class TestEsCaptionAdapter:
 
     @pytest.fixture
     def adapter(self):
-        # Exercises the production default (`aggregated_summary`).
+        # Exercises the production default (`raw_events`).
         return EsCaptionAdapter(
             EsCaptionConfig(
                 elasticsearch_url="http://es:9200",
@@ -191,13 +191,13 @@ class TestEsCaptionAdapter:
         assert self._must(body) == [{"match": {"text": "graffiti on bridge"}}]
         # Default doc_type + collection->uuid lifted in automatically.
         assert {"term": {"metadata.content_metadata.uuid": "stream-A"}} in self._filters(body)
-        assert {"term": {"metadata.content_metadata.doc_type": "aggregated_summary"}} in self._filters(body)
+        assert {"term": {"metadata.content_metadata.doc_type": "raw_events"}} in self._filters(body)
 
     def test_doc_type_override_via_filters(self, adapter):
-        body = adapter._build_query("q", "s", top_k=5, filters={"doc_type": "raw_events"})
+        body = adapter._build_query("q", "s", top_k=5, filters={"doc_type": "aggregated_summary"})
         # Override wins, default is dropped.
         doc_terms = [f for f in self._filters(body) if "metadata.content_metadata.doc_type" in str(f)]
-        assert doc_terms == [{"term": {"metadata.content_metadata.doc_type": "raw_events"}}]
+        assert doc_terms == [{"term": {"metadata.content_metadata.doc_type": "aggregated_summary"}}]
 
     def test_camera_id_lifted_to_term_filter(self, adapter):
         body = adapter._build_query("q", "s", top_k=5, filters={"camera_id": "cam-A"})

--- a/services/agent/tests/unit_test/knowledge_retrieval/test_register_knowledge_layers.py
+++ b/services/agent/tests/unit_test/knowledge_retrieval/test_register_knowledge_layers.py
@@ -32,6 +32,7 @@ from vss_agents.register_knowledge_layers import KnowledgeRetrievalInput
 from vss_agents.register_knowledge_layers import _format_results
 from vss_agents.register_knowledge_layers import _setup_backend
 from vss_agents.register_knowledge_layers import knowledge_retrieval
+from vss_agents.tools.lvs_media_state import LVSConfiguredMedia
 
 
 class TestKnowledgeRetrievalConfig:
@@ -245,3 +246,40 @@ class TestKnowledgeRetrievalInner:
 
         kwargs = mock_retriever.retrieve.call_args.kwargs
         assert kwargs["filters"] == {"filter_expr": 'content_metadata["filename"] == "F.pdf"'}
+
+
+class TestStreamNameResolution:
+    """Cache-hit path: friendly name swapped for the cached `media_id` before
+    the adapter sees it. Miss/empty paths are exercised by the existing
+    `TestKnowledgeRetrievalInner` tests, which run with an empty cache and
+    assert the input passes through verbatim."""
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_resolves_friendly_name_to_media_id(self):
+        config = KnowledgeRetrievalConfig(
+            backend="es_caption", top_k=5, backend_config={"elasticsearch_url": "http://es:9200"}
+        )
+        mock_retriever = AsyncMock()
+        mock_retriever.retrieve.return_value = RetrievalResult(query="q", backend="es_caption", success=True, chunks=[])
+        resolved_uuid = "90465930-cab4-4ede-b106-aae5c54ab814"
+        cached = LVSConfiguredMedia(
+            media_type="stream",
+            media_name="warehouse_sample_test",
+            media_id=resolved_uuid,
+            media_url="rtsp://x",
+            scenario="warehouse",
+            events=(),
+            objects_of_interest=(),
+        )
+        with (
+            patch(
+                "vss_agents.register_knowledge_layers.get_retriever",
+                new=AsyncMock(return_value=mock_retriever),
+            ),
+            patch("vss_agents.register_knowledge_layers.configured_media", return_value=cached),
+        ):
+            gen = knowledge_retrieval.__wrapped__(config, AsyncMock())
+            inner_fn = (await gen.__anext__()).single_fn
+            await inner_fn(KnowledgeRetrievalInput(query="q", collection="warehouse_sample_test"))
+
+        assert mock_retriever.retrieve.call_args.kwargs["collection_name"] == resolved_uuid


### PR DESCRIPTION
Two small follow-ups to the `lvs_caption_retrieval` Q&A flow:

1. Stream-name resolution at the bridge boundary. The LLM passes the friendly stream name (e.g. warehouse_sample_test) but ES indexes filter on `metadata.content_metadata.uuid `(the VST stream_id). Before this change, every Q&A returned chunks=[] because the friendly name never matched the uuid. We now look up the name in lvs_media_state's per-conversation cache — the same cache lvs_config_media already seeds and lvs_stream_understanding already reads. Gated on backend == "es_caption" so frag_api collections (Milvus) are unaffected. Cache miss falls through unchanged → adapter returns chunks=[] → agent's documented lvs_stream_understanding fallback runs (no new failure mode).

2. Flip default_doc_type from aggregated_summary to raw_events.Other doc types have not been reliable (empty content or time taken to form summary doc or strucutred event); raw_events is what always works in current LVS containers. We can always flip to other doc types or mention in query to use particular doc type as filter. Future improvement : keep it doc type agnostic 

3. config update to include this in lvs profile

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
