### PR TITLE
helm: sync chart with deploy/docker changes (PR #265)

### DIFF
--- a/deploy/helm/services/alert/values.yaml
+++ b/deploy/helm/services/alert/values.yaml
@@ -19,7 +19,7 @@ global: {}
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-alert-verification
-  tag: "0.0.62"
+  tag: "0.0.63"
   pullPolicy: IfNotPresent
 replicas: 1
 


### PR DESCRIPTION
Bump vss-alert-verification image tag 0.0.62 -> 0.0.63 in deploy/helm/services/alert/values.yaml to match
deploy/docker/services/alert/compose.yml.

Generated by .github/workflows/helm-sync.yml for PR #265.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
