### PR TITLE
[helm-sync] sync chart with PR #277

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -299,10 +299,10 @@ NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE=true
 LVS_IMAGE="nvcr.io/nvstaging/vss-core/vss-video-summarization"
 
 # LVS Image tags for x86 and DGX-THOR
-LVS_TAG="3.2.0-rc5-c45f19c"
+LVS_TAG="3.2.0-rc6-eec0a57"
 
 # Uncomment below LVS Image tags for DGX-SPARK
-# LVS_TAG="3.2.0-rc5-c45f19c-arm64-sbsa"
+# LVS_TAG="3.2.0-rc6-eec0a57-arm64-sbsa"
 
 # Kafka integration: route LVS structured summaries through Kafka
 KAFKA_ENABLED=true

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -204,6 +204,7 @@ functions:
   lvs_stream_understanding:
     _type: lvs_stream_understanding
     lvs_backend_url: ${LVS_BACKEND_URL}
+    vst_internal_url: ${VST_INTERNAL_URL}
     model: ${VLM_NAME}
     conn_timeout_ms: 5000
     read_timeout_ms: 600000

--- a/deploy/docker/services/video-summarization/.env
+++ b/deploy/docker/services/video-summarization/.env
@@ -17,7 +17,7 @@
 # Copy this file to .env.lvs-server and fill in the values
 
 # Container Configuration
-CONTAINER_IMAGE=${LVS_IMAGE:-nvcr.io/nvstaging/vss-core/vss-video-summarization}:${LVS_TAG:-3.2.0-rc5-c45f19c}
+CONTAINER_IMAGE=${LVS_IMAGE:-nvcr.io/nvstaging/vss-core/vss-video-summarization}:${LVS_TAG:-3.2.0-rc6-eec0a57}
 
 # API Keys and Authentication
 # NGC_API_KEY=nvapi-xxxxx

--- a/deploy/docker/services/video-summarization/compose.yml
+++ b/deploy/docker/services/video-summarization/compose.yml
@@ -104,7 +104,7 @@ services:
     restart: unless-stopped
 
   lvs-server:
-    image: ${CONTAINER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc5-c45f19c}
+    image: ${CONTAINER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-video-summarization:3.2.0-rc6-eec0a57}
     container_name: vss-lvs
 
     profiles: ["bp_developer_lvs_2d"]

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -204,6 +204,7 @@ functions:
   lvs_stream_understanding:
     _type: lvs_stream_understanding
     lvs_backend_url: ${LVS_BACKEND_URL}
+    vst_internal_url: ${VST_INTERNAL_URL}
     model: ${VLM_NAME}
     conn_timeout_ms: 5000
     read_timeout_ms: 600000

--- a/deploy/helm/services/video-summarization/values.yaml
+++ b/deploy/helm/services/video-summarization/values.yaml
@@ -17,7 +17,7 @@ enabled: false
 global: {}
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-video-summarization
-  tag: "3.2.0-rc5-c45f19c"
+  tag: "3.2.0-rc6-eec0a57"
   pullPolicy: IfNotPresent
 replicas: 1
 # Backend (API), MCP ports — match Compose

--- a/services/agent/src/vss_agents/tools/lvs_stream_understanding.py
+++ b/services/agent/src/vss_agents/tools/lvs_stream_understanding.py
@@ -16,6 +16,7 @@
 """LVS stream summary/report tool."""
 
 from collections.abc import AsyncGenerator
+from datetime import timedelta
 import json
 import logging
 import re
@@ -37,6 +38,10 @@ from vss_agents.tools.lvs_config_media import CAPTION_GENERATION_STARTED_MESSAGE
 from vss_agents.tools.lvs_config_media import LVSMediaStatus
 from vss_agents.tools.lvs_config_media import _coerce_lvs_response
 from vss_agents.tools.lvs_media_state import configured_media
+from vss_agents.tools.vst.timeline import get_timeline
+from vss_agents.tools.vst.utils import VSTError
+from vss_agents.utils.time_convert import datetime_to_iso8601
+from vss_agents.utils.time_convert import iso8601_to_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +53,7 @@ class LVSStreamUnderstandingConfig(FunctionBaseConfig, name="lvs_stream_understa
     """Configuration for the LVS stream summary/report tool."""
 
     lvs_backend_url: str = Field(..., description="The URL of the LVS backend service.")
+    vst_internal_url: str = Field(..., description="Internal VST URL used to resolve live stream timelines.")
     model: str = Field(default="gpt-4o", description="Model to use for LVS stream summarization.")
     conn_timeout_ms: int = Field(default=5000, description="Connection timeout in milliseconds.")
     read_timeout_ms: int = Field(default=600000, description="Read timeout in milliseconds.")
@@ -180,12 +186,47 @@ async def lvs_stream_understanding(config: LVSStreamUnderstandingConfig, _: Buil
                 ),
             )
 
-        payload = {
-            "id": configured.media_id,
-            "model": config.model,
-            "start_time": lvs_input.start_time,
-            "end_time": lvs_input.end_time,
-        }
+        # LVS now expects ISO 8601 timestamps for live streams. Anchor relative
+        # second offsets on the VST stream timeline's startTime so "second 0" is
+        # the start of the captioned timeline. When both bounds are 0 ("from
+        # start until now"), skip the VST round-trip and let LVS apply no filter.
+        if lvs_input.start_time == 0 and lvs_input.end_time == 0:
+            payload: dict[str, Any] = {
+                "id": configured.media_id,
+                "model": config.model,
+                "start_time": 0,
+                "end_time": 0,
+            }
+        else:
+            try:
+                timeline_start, _ = await get_timeline(configured.media_id, config.vst_internal_url)
+            except VSTError as e:
+                logger.error(
+                    "Failed to fetch VST timeline for stream=%r media_id=%s: %s",
+                    configured.media_name,
+                    configured.media_id,
+                    e,
+                )
+                return LVSStreamUnderstandingOutput(
+                    status=LVSMediaStatus.FAILED,
+                    stream_name=configured.media_name,
+                    stream_id=configured.media_id,
+                    configured=True,
+                    message=f"Failed to resolve VST timeline for stream '{configured.media_name}': {e}",
+                )
+
+            anchor = iso8601_to_datetime(timeline_start)
+            iso_start = datetime_to_iso8601(anchor + timedelta(seconds=lvs_input.start_time))
+            iso_end = (
+                datetime_to_iso8601(anchor + timedelta(seconds=lvs_input.end_time)) if lvs_input.end_time > 0 else ""
+            )
+
+            payload = {
+                "id": configured.media_id,
+                "model": config.model,
+                "start_time": iso_start,
+                "end_time": iso_end,
+            }
 
         request_url = f"{config.lvs_backend_url.rstrip('/')}{STREAM_SUMMARIZE_ENDPOINT}"
         logger.info(

--- a/services/agent/tests/unit_test/tools/test_lvs_stream_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_lvs_stream_understanding.py
@@ -37,8 +37,12 @@ class TestLVSStreamUnderstandingModels:
     """Test LVS stream understanding tool models."""
 
     def test_config_required_fields(self):
-        config = LVSStreamUnderstandingConfig(lvs_backend_url="http://localhost:38111")
+        config = LVSStreamUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+        )
         assert config.lvs_backend_url == "http://localhost:38111"
+        assert config.vst_internal_url == "http://localhost:30888"
         assert config.model == "gpt-4o"
         assert config.conn_timeout_ms == 5000
         assert config.read_timeout_ms == 600000
@@ -118,7 +122,10 @@ class TestLVSStreamUnderstandingInner:
 
     @pytest.mark.asyncio
     async def test_not_configured_returns_actionable_status(self):
-        config = LVSStreamUnderstandingConfig(lvs_backend_url="http://localhost:38111")
+        config = LVSStreamUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+        )
         inner_fn = await self._get_inner_fn(config)
 
         result = await inner_fn(
@@ -178,6 +185,7 @@ class TestLVSStreamUnderstandingInner:
 
         config = LVSStreamUnderstandingConfig(
             lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
             model="nvidia/cosmos-reason2-8b",
         )
 
@@ -188,7 +196,7 @@ class TestLVSStreamUnderstandingInner:
                     LVSStreamUnderstandingInput(
                         stream_name="CAM_1",
                         start_time=0,
-                        end_time=45,
+                        end_time=0,
                         response_type="report",
                     )
                 )
@@ -203,7 +211,7 @@ class TestLVSStreamUnderstandingInner:
                 "id": "stream-uuid",
                 "model": "nvidia/cosmos-reason2-8b",
                 "start_time": 0,
-                "end_time": 45,
+                "end_time": 0,
             },
         )
 
@@ -234,6 +242,7 @@ class TestLVSStreamUnderstandingInner:
 
         config = LVSStreamUnderstandingConfig(
             lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
         )
 
         with patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientSession", return_value=mock_session):
@@ -243,7 +252,7 @@ class TestLVSStreamUnderstandingInner:
                     LVSStreamUnderstandingInput(
                         stream_name="CAM_1",
                         start_time=0,
-                        end_time=45,
+                        end_time=0,
                     )
                 )
 
@@ -267,7 +276,10 @@ class TestLVSStreamUnderstandingInner:
 
         other_conversation_token = ContextState.get().conversation_id.set("other-conversation")
         try:
-            config = LVSStreamUnderstandingConfig(lvs_backend_url="http://localhost:38111")
+            config = LVSStreamUnderstandingConfig(
+                lvs_backend_url="http://localhost:38111",
+                vst_internal_url="http://localhost:30888",
+            )
             inner_fn = await self._get_inner_fn(config)
 
             result = await inner_fn(
@@ -282,3 +294,214 @@ class TestLVSStreamUnderstandingInner:
 
         assert result.status == LVSMediaStatus.NOT_CONFIGURED
         assert result.configured is False
+
+    @pytest.mark.asyncio
+    async def test_zero_zero_skips_vst_timeline_lookup(self):
+        """When start=0 and end=0, the agent should pass the bounds through
+        unchanged and skip the VST timeline round-trip entirely."""
+        remember_configured_media(
+            LVSConfiguredMedia(
+                media_type="stream",
+                media_name="CAM_1",
+                media_id="stream-uuid",
+                media_url="rtsp://example/stream",
+                scenario="test scenario",
+                events=("test event",),
+                objects_of_interest=("test object",),
+            )
+        )
+
+        response_payload = {"choices": [{"message": {"content": json.dumps({"summary": "ok"})}}]}
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value=json.dumps(response_payload))
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        config = LVSStreamUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+        )
+
+        with (
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientSession", return_value=mock_session),
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientTimeout"),
+            patch("vss_agents.tools.lvs_stream_understanding.get_timeline", new=AsyncMock()) as mock_get_timeline,
+        ):
+            inner_fn = await self._get_inner_fn(config)
+            result = await inner_fn(
+                LVSStreamUnderstandingInput(
+                    stream_name="CAM_1",
+                    start_time=0,
+                    end_time=0,
+                )
+            )
+
+        assert result.status == LVSMediaStatus.SUCCESS
+        # VST timeline should NOT be queried in the 0/0 short-circuit path.
+        mock_get_timeline.assert_not_called()
+        # And the payload should pass numeric 0/0 through unchanged.
+        sent_payload = mock_session.post.call_args.kwargs["json"]
+        assert sent_payload["start_time"] == 0
+        assert sent_payload["end_time"] == 0
+
+    @pytest.mark.asyncio
+    async def test_iso_conversion_anchors_on_vst_start_time(self):
+        """Non-zero offsets must be converted to ISO 8601 strings anchored on
+        the VST stream timeline's startTime."""
+        remember_configured_media(
+            LVSConfiguredMedia(
+                media_type="stream",
+                media_name="CAM_1",
+                media_id="stream-uuid",
+                media_url="rtsp://example/stream",
+                scenario="test scenario",
+                events=("test event",),
+                objects_of_interest=("test object",),
+            )
+        )
+
+        response_payload = {"choices": [{"message": {"content": json.dumps({"summary": "ok"})}}]}
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value=json.dumps(response_payload))
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        config = LVSStreamUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+        )
+        timeline_mock = AsyncMock(return_value=("2026-05-06T01:01:13.623Z", "2026-05-06T01:42:56.504Z"))
+
+        with (
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientSession", return_value=mock_session),
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientTimeout"),
+            patch("vss_agents.tools.lvs_stream_understanding.get_timeline", new=timeline_mock) as mock_get_timeline,
+        ):
+            inner_fn = await self._get_inner_fn(config)
+            result = await inner_fn(
+                LVSStreamUnderstandingInput(
+                    stream_name="CAM_1",
+                    start_time=0,
+                    end_time=45,
+                )
+            )
+
+        assert result.status == LVSMediaStatus.SUCCESS
+        mock_get_timeline.assert_awaited_once_with("stream-uuid", config.vst_internal_url)
+        sent_payload = mock_session.post.call_args.kwargs["json"]
+        # iso_start = startTime + 0s; iso_end = startTime + 45s
+        # datetime_to_iso8601 emits microsecond precision (".623000Z")
+        assert sent_payload["start_time"] == "2026-05-06T01:01:13.623000Z"
+        assert sent_payload["end_time"] == "2026-05-06T01:01:58.623000Z"
+
+    @pytest.mark.asyncio
+    async def test_iso_conversion_with_end_time_zero_emits_empty_iso_end(self):
+        """When end_time is 0 with a non-zero start_time, iso_end should be
+        the empty string (LVS treats this as 'until now')."""
+        remember_configured_media(
+            LVSConfiguredMedia(
+                media_type="stream",
+                media_name="CAM_1",
+                media_id="stream-uuid",
+                media_url="rtsp://example/stream",
+                scenario="test scenario",
+                events=("test event",),
+                objects_of_interest=("test object",),
+            )
+        )
+
+        response_payload = {"choices": [{"message": {"content": json.dumps({"summary": "ok"})}}]}
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value=json.dumps(response_payload))
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        config = LVSStreamUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+        )
+        timeline_mock = AsyncMock(return_value=("2026-05-06T01:01:13.623Z", "2026-05-06T01:42:56.504Z"))
+
+        with (
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientSession", return_value=mock_session),
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientTimeout"),
+            patch("vss_agents.tools.lvs_stream_understanding.get_timeline", new=timeline_mock),
+        ):
+            inner_fn = await self._get_inner_fn(config)
+            await inner_fn(
+                LVSStreamUnderstandingInput(
+                    stream_name="CAM_1",
+                    start_time=30,
+                    end_time=0,
+                )
+            )
+
+        sent_payload = mock_session.post.call_args.kwargs["json"]
+        assert sent_payload["start_time"] == "2026-05-06T01:01:43.623000Z"
+        assert sent_payload["end_time"] == ""
+
+    @pytest.mark.asyncio
+    async def test_vst_timeline_failure_returns_failed_status(self):
+        """If VST timeline lookup fails, the tool should surface a FAILED
+        status and skip the LVS call entirely."""
+        from vss_agents.tools.vst.utils import VSTError
+
+        remember_configured_media(
+            LVSConfiguredMedia(
+                media_type="stream",
+                media_name="CAM_1",
+                media_id="stream-uuid",
+                media_url="rtsp://example/stream",
+                scenario="test scenario",
+                events=("test event",),
+                objects_of_interest=("test object",),
+            )
+        )
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        config = LVSStreamUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+        )
+        timeline_mock = AsyncMock(side_effect=VSTError("VST unavailable"))
+
+        with (
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientSession", return_value=mock_session),
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientTimeout"),
+            patch("vss_agents.tools.lvs_stream_understanding.get_timeline", new=timeline_mock),
+        ):
+            inner_fn = await self._get_inner_fn(config)
+            result = await inner_fn(
+                LVSStreamUnderstandingInput(
+                    stream_name="CAM_1",
+                    start_time=0,
+                    end_time=45,
+                )
+            )
+
+        assert result.status == LVSMediaStatus.FAILED
+        assert result.configured is True
+        assert "Failed to resolve VST timeline" in result.message
+        # Must NOT call LVS if the VST anchor lookup failed.
+        mock_session.post.assert_not_called()


### PR DESCRIPTION
## Summary

Automated helm-sync for #277.

The PR added `vst_internal_url: ${VST_INTERNAL_URL}` to the
`lvs_stream_understanding` function in
`deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml`,
but the corresponding helm chart config at
`deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml`
was not updated to match.

## Changes

- `deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml`:
  added `vst_internal_url: ${VST_INTERNAL_URL}` under the
  `lvs_stream_understanding` block to mirror the compose-side config.

## Drift reconciled

| Docker-side change (PR #277) | Helm-side status before | Action taken |
|---|---|---|
| `lvs_stream_understanding.vst_internal_url` added to `config.yml` | missing | **added** to helm `config.yml` (this PR) |
| `LVS_TAG` bump `rc5-c45f19c` → `rc6-eec0a57` in `dev-profile-lvs/.env` | — | already in sync via `values.yaml` image.tag bump (shipped in #277) |
| `CONTAINER_IMAGE` default bump in `services/video-summarization/.env` and `compose.yml` | — | already in sync via `values.yaml` image.tag bump (shipped in #277) |

## Validation

- `helm lint deploy/helm/developer-profiles/dev-profile-lvs/` passes (only
  pre-existing dependency warnings).
- **No checks beyond `helm lint` were run; the contributor should validate
  against their target environment.**

## How to apply

Merge this PR into `feat/lvs_iso_timestamp` (or cherry-pick the commit).
The helm-sync check will re-run on the next mirror update and clear.

🤖 Generated by the helm-sync bot for #277.
