### PR TITLE
Update lvs helm chart

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
@@ -35,7 +35,7 @@ global:
   externalHost: "EXTERNAL_HOST" # e.g. vss.140.238.75.84.nip.io
   externalPort: "" # Default 80 (http) / 443 (https): use "" — chart omits :port in URLs. Non-default port only: e.g. "8080", "8443".
   # Must be a real browser URL; Helm does not substitute EXTERNAL_HOST here from global.externalHost. Match your ingress host (often http://kibana.<same-as-externalHost>).
-  kibanaPublicUrl: "http://kibana.EXTERNAL_HOST"
+  kibanaPublicUrl: ""
   # Remote NIM: one place for vss-agent + vss-summarization. Use the same base URL for both (e.g. http://host:31081); vss-summarization adds /v1 internally when absent.
   llmBaseUrl: ""
   vlmBaseUrl: ""

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -179,17 +179,6 @@ vss-summarization:
       value: '{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $svc := "vss-rtvi-vlm" }}{{- printf "http://%s:8000" (ternary (printf "%s-%s" .Release.Name $svc) $svc $pfx) -}}'
     - name: RTVI_VLM_URL_PASSTHROUGH
       value: "true"
-    # LVS streams support (PR #196): enable Kafka integration in
-    # vss-summarization — consume RTVI captions and publish structured
-    # summaries to `structured-events-summary`. Compose parity:
-    # dev-profile-lvs/.env KAFKA_ENABLED=true, KAFKA_BOOTSTRAP_SERVERS,
-    # KAFKA_STRUCTURED_SUMMARY_TOPIC.
-    - name: KAFKA_ENABLED
-      value: "true"
-    - name: KAFKA_BOOTSTRAP_SERVERS
-      value: '{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $svc := "kafka" }}{{- printf "%s:9092" (ternary (printf "%s-%s" .Release.Name $svc) $svc $pfx) -}}'
-    - name: KAFKA_STRUCTURED_SUMMARY_TOPIC
-      value: "structured-events-summary"
 
 agent:
   enabled: true


### PR DESCRIPTION
…add vst_internal_url to vss-agent config

* Commented out KAFKA_ENABLED, KAFKA_BOOTSTRAP_SERVERS, and KAFKA_STRUCTURED_SUMMARY_TOPIC in values.yaml since they are duplicate and causing issues in deployment.
* Added vst_internal_url to the vss-agent configuration in config.yml to enhance functionality.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
