### PR TITLE
Fix/brev haproxy storage proxy develop

### DIFF
--- a/deploy/docker/services/infra/haproxy/haproxy.cfg.template
+++ b/deploy/docker/services/infra/haproxy/haproxy.cfg.template
@@ -43,6 +43,11 @@ backend bk_vss_agent
 backend bk_vst_ingress
     server s1 "${HOST_IP}:${VST_PORT}" check
 
+backend bk_vst_storage_compat
+    http-request replace-path ^/storage/(.*) /vst/storage/\1
+    http-request replace-path ^/storage$ /vst/storage
+    server s1 "${HOST_IP}:${VST_PORT}" check
+
 backend bk_behavior_analytics
     server s1 "${HOST_IP}:${BEHAVIOR_ANALYTICS_PORT}" check
 
@@ -99,6 +104,18 @@ frontend fe_http
     acl h_main hdr(host) -i "localhost:${HAPROXY_PORT}"
     acl h_main hdr(host) -i 127.0.0.1
     acl h_main hdr(host) -i "127.0.0.1:${HAPROXY_PORT}"
+
+    acl p_vst_storage path /vst/storage
+    acl p_vst_storage path_beg /vst/storage/
+    acl p_storage path /storage
+    acl p_storage path_beg /storage/
+    acl m_head method HEAD
+    acl m_options method OPTIONS
+    http-request return status 200 hdr Accept-Ranges bytes if h_main m_head p_storage
+    http-request return status 200 hdr Accept-Ranges bytes if h_main m_head p_vst_storage
+    http-request return status 204 hdr Access-Control-Allow-Methods "GET,HEAD,OPTIONS" hdr Access-Control-Allow-Headers "Range,Content-Type" if h_main m_options p_storage
+    http-request return status 204 hdr Access-Control-Allow-Methods "GET,HEAD,OPTIONS" hdr Access-Control-Allow-Headers "Range,Content-Type" if h_main m_options p_vst_storage
+    use_backend bk_vst_storage_compat if h_main p_storage
 
     acl p_video_analytics path /video-analytics-api
     acl p_video_analytics path_beg /video-analytics-api/


### PR DESCRIPTION
## Description

  Fixes Brev launchable video playback failures where UI-generated media URLs can use bare `/storage/...` paths instead of `/vst/storage/...`.

  On Brev, `/storage/temp_files/*.mp4` requests were falling through HAProxy to the UI backend and returning 404. This affected playback from
  Search results and the Video Management tab.

  This PR adds HAProxy compatibility routing that:

  - rewrites `/storage/...` to `/vst/storage/...`
  - routes those requests to the VST ingress backend before the UI fallback
  - handles HEAD/OPTIONS probes for `/storage` and `/vst/storage`

  Validated with `git diff --check` and HAProxy syntax validation using `haproxy:3.0-alpine`. The same routing behavior was previously smoke-
  tested on Brev across Search, Base, LVS, and Alerts profiles.

  ## Checklist
  - [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/
  CONTRIBUTING.md).
  - [x] New or existing tests cover these changes.
  - [x] The documentation is up to date with these changes.

