### PR TITLE
[helm-sync] sync chart with PR #289

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -117,7 +117,7 @@ functions:
     read_timeout_ms: 600000
     # Video processing parameters for better event detection
     chunk_duration: 10  # Split video into 10-second chunks (0 = entire video in one request)
-    num_frames_per_chunk: 20  # Sample 20 frames per chunk
+    num_frames_per_chunk: 5  # Remote VLM endpoint accepts at most 5 images per prompt
     # HITL Templates (shown each for each query to the user during interaction)
     hitl_scenario_template: |
       Scenario (REQUIRED):
@@ -321,7 +321,7 @@ llms:
     temperature: 0.0
     model_kwargs:
       extra_body:
-        num_frames_per_second_or_fixed_frames_chunk: 20
+        num_frames_per_second_or_fixed_frames_chunk: 5
         use_fps_for_chunking: false
         vlm_input_width: 1280
         vlm_input_height: 720
@@ -361,15 +361,17 @@ workflow:
       - If user ask to show a video not in the list from previous interactions, call this tool to verify if the video is available then call the appropriate tool to show the video or snapshot.
       - Examples: "What videos are available?", "List all available videos" "list sensors"
       **report_agent**
-      - Only call report_agent when user mentions "report" in the question (works for both uploaded videos AND live streams).
-      - For "report" requests, call report_agent DIRECTLY as the first tool — do NOT call lvs_stream_understanding, lvs_config_media, or any other tool first to "check"/"verify" anything.
+      - HIGHEST PRIORITY: If the user mentions "report" anywhere in the question, call report_agent (works for both uploaded videos AND live streams).
+      - For "report" requests, call report_agent DIRECTLY as the first tool. Do NOT call lvs_video_understanding, lvs_stream_understanding, lvs_config_media, or any other tool first to "check"/"verify" anything.
+      - If the user asks for a report "using long video summarization" or includes both "report" and "summarize/summarization", still call report_agent, not lvs_video_understanding.
       - Don't use the report from previous interactions.
       - CRITICAL: For multiple uploaded videos, pass them as a list in a SINGLE call (e.g., sensor_id=['video1', 'video2']). Do NOT make separate sequential calls.
       - For uploaded videos: pass sensor_id (str or list[str]) and user_query.
       - For live streams: pass media_type='stream', a single sensor_id (the stream name), start_time and end_time as floats in seconds (use end_time=0 for "until now"), and user_query.
-      - Examples: "Generate a report for video1" → ONE call report_agent(sensor_id='video1', user_query=...). "Generate a report for stream CAM_1 from 0 to 60 seconds" → ONE call report_agent(media_type='stream', sensor_id='CAM_1', start_time=0, end_time=60, user_query=...).
+      - Examples: "Generate a report for video1" -> ONE call report_agent(sensor_id='video1', user_query=...). "Generate a report using long video summarization for warehouse_sample" -> ONE call report_agent(sensor_id='warehouse_sample', user_query=...). "Generate a report for stream CAM_1 from 0 to 60 seconds" -> ONE call report_agent(media_type='stream', sensor_id='CAM_1', start_time=0, end_time=60, user_query=...).
       **lvs_video_understanding** - For SUMMARIZING uploaded videos (not streams, not reports).
       - Use when user asks to "summarize" or "give a summary of" a video, optionally over a time range.
+      - NEVER use this tool when the user mentions "report"; report_agent owns report generation and artifact creation.
       - Pass sensor_id (the video name from vst_video_list); start_time/end_time are floats in seconds (omit both for the whole video).
       - Examples: "Summarize video warehouse_sample" (no times), "Summarize video warehouse_sample from start to second 45" (start_time=0, end_time=45)
       **lvs_stream_understanding** - For SUMMARIZING live streams (not videos, not reports).


### PR DESCRIPTION
## What

Automated sync of the helm chart to mirror the `deploy/docker/` changes in
source PR #289 (`feat/apply-vss-lvs-patch`).

The helm-sync agent detected that `deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml`
was modified in that PR, but the mirrored chart copy at
`deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml`
still held the previous values. This PR brings them back in sync.

## Changes

Applied to `deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml`:

- `functions.lvs_video_understanding.num_frames_per_chunk`: `20` → `5`
  (comment updated: "Remote VLM endpoint accepts at most 5 images per prompt").
- `llms.rtvi_vlm.model_kwargs.extra_body.num_frames_per_second_or_fixed_frames_chunk`:
  `20` → `5`.
- `workflow.prompt` routing rules for `report_agent` and `lvs_video_understanding`:
  - `report_agent` elevated to "HIGHEST PRIORITY" when the user mentions "report".
  - `lvs_video_understanding` explicitly excluded from the "report" path.
  - Added "long video summarization" example to the `report_agent` examples.

## What this PR does NOT do

- Does **not** touch any file under `deploy/docker/` — the contributor's docker
  diff is the source of truth; this bot only updates the helm side.
- Does **not** reconcile the other pre-existing differences between the docker
  and helm copies of `config.yml` (e.g. `HOST_IP` vs `INTERNAL_IP`,
  `lvs_caption_retrieval` block, citation-formatting prose). Those predate this
  PR and are out of scope for helm-sync.
- The compose change in `deploy/docker/services/agent/compose.yml`
  (`image: ${VSS_AGENT_IMAGE:-…}`) is already semantically covered by the
  chart's existing `image.repository` + `image.tag` values — no helm edit
  required there.

## Validation

- `helm lint deploy/helm/developer-profiles/dev-profile-lvs/` passes.
- **No checks beyond `helm lint` were run; please validate against your target
  environment before merging.**

## How to land

Merge this PR into `feat/apply-vss-lvs-patch` (or cherry-pick the commit) and
the helm-sync check will re-run on the next mirror push and mark PR #289 as
in-sync.

Closes the drift detected on commit `49074ec` of PR #289.
