### PR TITLE
fix: pass zero through unchanged for live stream time bounds

### DIFF
--- a/services/agent/src/vss_agents/tools/lvs_stream_understanding.py
+++ b/services/agent/src/vss_agents/tools/lvs_stream_understanding.py
@@ -188,8 +188,14 @@ async def lvs_stream_understanding(config: LVSStreamUnderstandingConfig, _: Buil
 
         # LVS now expects ISO 8601 timestamps for live streams. Anchor relative
         # second offsets on the VST stream timeline's startTime so "second 0" is
-        # the start of the captioned timeline. When both bounds are 0 ("from
-        # start until now"), skip the VST round-trip and let LVS apply no filter.
+        # the start of the captioned timeline.
+        #
+        # Per LVS contract:
+        #   - end_time=0   => consider all captions from start_time until now
+        #   - start_time=0 => consider all captions until end_time
+        #   - both start_time=0 and end_time=0 => consider all captions stored in db
+
+        # When both bounds are 0, skip the VST round-trip entirely.
         if lvs_input.start_time == 0 and lvs_input.end_time == 0:
             payload: dict[str, Any] = {
                 "id": configured.media_id,
@@ -216,16 +222,19 @@ async def lvs_stream_understanding(config: LVSStreamUnderstandingConfig, _: Buil
                 )
 
             anchor = iso8601_to_datetime(timeline_start)
-            iso_start = datetime_to_iso8601(anchor + timedelta(seconds=lvs_input.start_time))
-            iso_end = (
-                datetime_to_iso8601(anchor + timedelta(seconds=lvs_input.end_time)) if lvs_input.end_time > 0 else ""
+            # Convert non-zero offsets to ISO 8601; pass 0 through unchanged
+            start_payload: str | int = (
+                datetime_to_iso8601(anchor + timedelta(seconds=lvs_input.start_time)) if lvs_input.start_time > 0 else 0
+            )
+            end_payload: str | int = (
+                datetime_to_iso8601(anchor + timedelta(seconds=lvs_input.end_time)) if lvs_input.end_time > 0 else 0
             )
 
             payload = {
                 "id": configured.media_id,
                 "model": config.model,
-                "start_time": iso_start,
-                "end_time": iso_end,
+                "start_time": start_payload,
+                "end_time": end_payload,
             }
 
         request_url = f"{config.lvs_backend_url.rstrip('/')}{STREAM_SUMMARIZE_ENDPOINT}"

--- a/services/agent/tests/unit_test/tools/test_lvs_stream_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_lvs_stream_understanding.py
@@ -393,7 +393,7 @@ class TestLVSStreamUnderstandingInner:
             result = await inner_fn(
                 LVSStreamUnderstandingInput(
                     stream_name="CAM_1",
-                    start_time=0,
+                    start_time=10,
                     end_time=45,
                 )
             )
@@ -401,15 +401,67 @@ class TestLVSStreamUnderstandingInner:
         assert result.status == LVSMediaStatus.SUCCESS
         mock_get_timeline.assert_awaited_once_with("stream-uuid", config.vst_internal_url)
         sent_payload = mock_session.post.call_args.kwargs["json"]
-        # iso_start = startTime + 0s; iso_end = startTime + 45s
+        # iso_start = startTime + 10s; iso_end = startTime + 45s
         # datetime_to_iso8601 emits microsecond precision (".623000Z")
-        assert sent_payload["start_time"] == "2026-05-06T01:01:13.623000Z"
+        assert sent_payload["start_time"] == "2026-05-06T01:01:23.623000Z"
         assert sent_payload["end_time"] == "2026-05-06T01:01:58.623000Z"
 
     @pytest.mark.asyncio
-    async def test_iso_conversion_with_end_time_zero_emits_empty_iso_end(self):
+    async def test_iso_conversion_with_start_time_zero_passes_zero_through(self):
+        """When start_time is 0 with a non-zero end_time, iso_start should be
+        passed through as 0."""
+        remember_configured_media(
+            LVSConfiguredMedia(
+                media_type="stream",
+                media_name="CAM_1",
+                media_id="stream-uuid",
+                media_url="rtsp://example/stream",
+                scenario="test scenario",
+                events=("test event",),
+                objects_of_interest=("test object",),
+            )
+        )
+
+        response_payload = {"choices": [{"message": {"content": json.dumps({"summary": "ok"})}}]}
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value=json.dumps(response_payload))
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        config = LVSStreamUnderstandingConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+        )
+        timeline_mock = AsyncMock(return_value=("2026-05-06T01:01:13.623Z", "2026-05-06T01:42:56.504Z"))
+
+        with (
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientSession", return_value=mock_session),
+            patch("vss_agents.tools.lvs_stream_understanding.aiohttp.ClientTimeout"),
+            patch("vss_agents.tools.lvs_stream_understanding.get_timeline", new=timeline_mock),
+        ):
+            inner_fn = await self._get_inner_fn(config)
+            await inner_fn(
+                LVSStreamUnderstandingInput(
+                    stream_name="CAM_1",
+                    start_time=0,
+                    end_time=45,
+                )
+            )
+
+        sent_payload = mock_session.post.call_args.kwargs["json"]
+        assert sent_payload["start_time"] == 0
+        assert sent_payload["end_time"] == "2026-05-06T01:01:58.623000Z"
+
+    @pytest.mark.asyncio
+    async def test_iso_conversion_with_end_time_zero_passes_zero_through(self):
         """When end_time is 0 with a non-zero start_time, iso_end should be
-        the empty string (LVS treats this as 'until now')."""
+        passed through as 0."""
         remember_configured_media(
             LVSConfiguredMedia(
                 media_type="stream",
@@ -456,7 +508,7 @@ class TestLVSStreamUnderstandingInner:
 
         sent_payload = mock_session.post.call_args.kwargs["json"]
         assert sent_payload["start_time"] == "2026-05-06T01:01:43.623000Z"
-        assert sent_payload["end_time"] == ""
+        assert sent_payload["end_time"] == 0
 
     @pytest.mark.asyncio
     async def test_vst_timeline_failure_returns_failed_status(self):


### PR DESCRIPTION
## Description
- Pass 0 through unchanged on `start_time` / `end_time` when calling LVS `/v1/stream_summarize` for live streams, instead of converting it to an ISO 8601 timestamp anchored on VST's `startTime`, according to the LVS contract.  

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
