### PR TITLE
docs(skills): cap GPU memory utilization on shared devices and fix Brev haproxy 404

### DIFF
--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -343,6 +343,65 @@ See the profile reference doc for full env override recipes.
 
 **Do NOT set `COMPOSE_PROFILES` directly** — it is computed from `BP_PROFILE`, `MODE`, `HARDWARE_PROFILE`, `LLM_MODE`, `LLM_NAME_SLUG`, `VLM_MODE`, `VLM_NAME_SLUG`.
 
+**Cap GPU memory utilization on every shared device.**
+
+Every vLLM-backed service grabs `gpu_memory_utilization=0.9` of the
+device by default. That's safe when the service has the GPU to itself,
+but on a device shared with another inference container it leaves no
+room for the second process and causes a silent crash-loop (the
+co-located container OOMs on KV-cache init while the rest of the stack
+stays "healthy" because compose marks it as an *optional* dependency).
+
+`scripts/dev-profile.sh` sets these caps automatically; the
+compose-direct flow does not, so you must apply them yourself. The
+rule is the same regardless of profile or mode — **decide per device,
+based on what else is on it.**
+
+1. **Build the device → services map.** From the resolved env, group
+   services by GPU index:
+   - `RT_CV_DEVICE_ID` → rtvi-cv
+   - `RT_VLM_DEVICE_ID` → rtvi-vlm
+   - `LLM_DEVICE_ID` → LLM NIM (only when `LLM_MODE=local*`)
+   - `VLM_DEVICE_ID` → VLM NIM (only when `VLM_MODE=local*`)
+   - `SHARED_LLM_VLM_DEVICE_ID` (if set) overrides LLM/VLM device when `*_MODE=local_shared`
+
+   The placement table for the chosen profile is in
+   `references/<profile>.md` under "GPU Layout".
+
+2. **For every device with two or more vLLM-backed services**, cap each
+   to ~0.4 of the GPU. Concretely:
+
+   | Service env var | When the device is shared | When the device is dedicated |
+   |---|---|---|
+   | `RTVI_VLLM_GPU_MEMORY_UTILIZATION` | `0.35` | leave default (or `0.8` on DGX-SPARK / L40S) |
+   | NIM `*_KVCACHE_PERCENT` (read by `hw-${HARDWARE_PROFILE}-shared.env`) | `0.4` (set by the shipped `*-shared.env` file when the right compose profile is selected) | per the non-shared `hw-*.env` |
+
+   The NIM cap is applied automatically when the resolved compose
+   profile is `*_local_shared_*` — that pulls in
+   `hw-<HW>-shared.env`. You don't write it by hand. **You do** have
+   to write `RTVI_VLLM_GPU_MEMORY_UTILIZATION` because the rtvi-vlm
+   container has no per-hardware shared overlay.
+
+3. **VRAM-tight hardware (≤48 GB / GPU like L40S, or unified memory
+   like DGX-Spark / Thor) needs lower caps even in dedicated mode**
+   because the VLM's KV cache + prefix cache eats into what would
+   otherwise be headroom on a 96 GB+ device. `dev-profile.sh` uses
+   `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.8` for `DGX-SPARK` and `L40S`
+   in dedicated mode; do the same.
+
+4. **Verify after writing.** `grep -E '^(LLM_MODE|VLM_MODE|RTVI_VLLM_GPU_MEMORY_UTILIZATION)=' <env-file>`
+   and confirm the cap is present whenever the device map shows
+   colocation. A missing cap presents as a healthy stack with the LLM
+   container `Restarting` or `unhealthy` and a `CUDA out of memory`
+   line in `docker logs <llm-container>`.
+
+| Concrete example | Caps to write |
+|---|---|
+| `alerts` real-time, `RTXPRO6000BW`, `local_shared` (LLM+VLM share GPU 1, rtvi-vlm also on GPU 1) | `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35` |
+| `alerts` real-time, dedicated (LLM on GPU 2, rtvi-vlm on GPU 1) | leave `RTVI_VLLM_GPU_MEMORY_UTILIZATION` empty |
+| `base` `local_shared` on H100 (LLM+VLM share GPU 0, no rtvi-vlm) | nothing — NIM `*-shared.env` overlay handles both |
+| `lvs` on L40S, dedicated | `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.8` (low-VRAM cap) |
+
 ### Step 3 — Config / dry-run
 
 **Env file location:** `<repo>/deployments/developer-workflow/dev-profile-<profile>/.env`

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -266,10 +266,27 @@ and `BREV_LINK_PREFIX=77770` (launchable default; override with
 `BREV_LINK_PREFIX=7777` if the secure link was created manually without
 the `0` suffix). On non-Brev instances the script is a no-op.
 
+**You must also rewrite the four `VSS_PUBLIC_*` vars in the profile
+`.env`** so haproxy's `known_host` ACL accepts the brev hostname and
+the agent emits public-facing URLs. Without this the browser sees
+404 on every request even though `curl http://localhost:7777/` works:
+
+```bash
+ENV=<repo>/deploy/docker/developer-profiles/dev-profile-<profile>/.env
+BREV_HOST="${BREV_LINK_PREFIX}-${BREV_ENV_ID}.brevlab.com"
+sed -i \
+  -e "s|^VSS_PUBLIC_HOST=.*|VSS_PUBLIC_HOST=${BREV_HOST}|" \
+  -e 's|^VSS_PUBLIC_PORT=.*|VSS_PUBLIC_PORT=443|' \
+  -e 's|^VSS_PUBLIC_HTTP_PROTOCOL=.*|VSS_PUBLIC_HTTP_PROTOCOL=https|' \
+  -e 's|^VSS_PUBLIC_WS_PROTOCOL=.*|VSS_PUBLIC_WS_PROTOCOL=wss|' \
+  "$ENV"
+```
+
 See [`references/brev.md`](references/brev.md) for:
 - Per-profile secure-link requirements (base needs 1, lvs/search/alerts need 2–3)
 - The launchable `0`-suffix quirk
-- Common CORS / 502 troubleshooting
+- Per-var rationale for the `VSS_PUBLIC_*` overrides
+- Common CORS / 502 / 404 troubleshooting
 
 ### Step 2 — Build env_overrides
 

--- a/skills/deploy/references/alerts.md
+++ b/skills/deploy/references/alerts.md
@@ -31,33 +31,19 @@ Both GPUs required:
 | 0 | RT-CV perception (reserved — object detection) |
 | 1 | LLM + VLM (`local_shared`) |
 
-## Required env override for `local_shared` mode
+## Shared-device caveat — set `RTVI_VLLM_GPU_MEMORY_UTILIZATION`
 
-When `LLM_MODE=local_shared` and `VLM_MODE=local_shared` for this profile, you
-**must** set `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35` in the `.env` before
-`docker compose up`. The profile's `.env` ships this value empty, which
-makes vLLM in the `rtvi-vlm` container fall back to its default of `0.9`.
-On a 97 GB GPU that reserves ~87 GB for the VLM, leaving the LLM NIM
-(asks for 0.4 of the GPU under shared mode) no room for KV cache → the
-LLM crashloops with `CUDA out of memory ... Tried to allocate 5.05 GiB ...
-GPU 0 has ... 2.76 GiB free`. Compose treats the LLM as an *optional*
-dependency of the alerts stack, so the rest of the services come up
-healthy and the failure is silent until the agent is asked to answer.
+Whenever rtvi-vlm shares its GPU with another inference container — most
+commonly when `LLM_MODE=local_shared` puts the LLM NIM on the same GPU as
+rtvi-vlm — you must cap `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35` in the
+profile `.env`. Without it, vLLM defaults to `0.9` of the device, the
+LLM NIM OOMs on KV-cache init, and compose lets the rest of the stack
+come up "healthy" (the LLM is an *optional* dependency).
 
-`scripts/dev-profile.sh` applies this override automatically (see the
-`alerts + local_shared` branch in the script). The compose-direct
-deploy flow in [`SKILL.md`](../SKILL.md) bypasses that, so set it
-manually:
-
-```bash
-sed -i "s|^RTVI_VLLM_GPU_MEMORY_UTILIZATION=.*|RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.35'|" \
-  "$REPO/deploy/docker/developer-profiles/dev-profile-alerts/.env"
-```
-
-The same cap applies to all hardware profiles except `OTHER`, `IGX-THOR`,
-and `AGX-THOR` (those have separate handling). For `dedicated` /
-`local` mode the rtvi-vlm has its own GPU and this override is not
-needed.
+The general rule and the dedicated-mode values for VRAM-tight hardware
+live in [`SKILL.md` → Step 2 → "Cap GPU memory utilization on every
+shared device"](../SKILL.md). `scripts/dev-profile.sh` applies these
+automatically; the compose-direct flow does not.
 
 ## Use Cases
 

--- a/skills/deploy/references/alerts.md
+++ b/skills/deploy/references/alerts.md
@@ -31,6 +31,34 @@ Both GPUs required:
 | 0 | RT-CV perception (reserved — object detection) |
 | 1 | LLM + VLM (`local_shared`) |
 
+## Required env override for `local_shared` mode
+
+When `LLM_MODE=local_shared` and `VLM_MODE=local_shared` for this profile, you
+**must** set `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35` in the `.env` before
+`docker compose up`. The profile's `.env` ships this value empty, which
+makes vLLM in the `rtvi-vlm` container fall back to its default of `0.9`.
+On a 97 GB GPU that reserves ~87 GB for the VLM, leaving the LLM NIM
+(asks for 0.4 of the GPU under shared mode) no room for KV cache → the
+LLM crashloops with `CUDA out of memory ... Tried to allocate 5.05 GiB ...
+GPU 0 has ... 2.76 GiB free`. Compose treats the LLM as an *optional*
+dependency of the alerts stack, so the rest of the services come up
+healthy and the failure is silent until the agent is asked to answer.
+
+`scripts/dev-profile.sh` applies this override automatically (see the
+`alerts + local_shared` branch in the script). The compose-direct
+deploy flow in [`SKILL.md`](../SKILL.md) bypasses that, so set it
+manually:
+
+```bash
+sed -i "s|^RTVI_VLLM_GPU_MEMORY_UTILIZATION=.*|RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.35'|" \
+  "$REPO/deploy/docker/developer-profiles/dev-profile-alerts/.env"
+```
+
+The same cap applies to all hardware profiles except `OTHER`, `IGX-THOR`,
+and `AGX-THOR` (those have separate handling). For `dedicated` /
+`local` mode the rtvi-vlm has its own GPU and this override is not
+needed.
+
 ## Use Cases
 
 - PPE compliance verification (hard hats, safety vests)

--- a/skills/deploy/references/brev.md
+++ b/skills/deploy/references/brev.md
@@ -85,6 +85,49 @@ The compose stack reads those via `${VAR:-default}` so missing vars fall back
 to internal IPs — you can skip the source step on non-Brev hosts without
 breaking anything.
 
+## Required `.env` overrides for Brev — the haproxy `Host`-header trap
+
+Sourcing `brev_setup.sh` is **not enough**. The reverse proxy
+(`vss-haproxy-ingress`) gates every request on a `known_host` ACL that
+matches `VSS_PUBLIC_HOST`, `EXTERNAL_IP`, `HOST_IP`, and `localhost`
+only. The Brev tunnel forwards Cloudflare's `Host: <link-prefix>-<id>.brevlab.com`
+header verbatim — that string isn't in the ACL, so haproxy returns
+**404 to every request from the browser** even though `curl
+http://localhost:7777/` from the host returns 200.
+
+Before `docker compose up`, write the four `VSS_PUBLIC_*` vars
+into the profile `.env` so the haproxy ACL matches the brev hostname
+and the agent constructs report / VST URLs against the public origin
+(not `http://172.x.x.x:7777`):
+
+```bash
+ENV=<repo>/deploy/docker/developer-profiles/dev-profile-<profile>/.env
+BREV_HOST="${BREV_LINK_PREFIX}-${BREV_ENV_ID}.brevlab.com"
+
+sed -i \
+  -e "s|^VSS_PUBLIC_HOST=.*|VSS_PUBLIC_HOST=${BREV_HOST}|" \
+  -e 's|^VSS_PUBLIC_PORT=.*|VSS_PUBLIC_PORT=443|' \
+  -e 's|^VSS_PUBLIC_HTTP_PROTOCOL=.*|VSS_PUBLIC_HTTP_PROTOCOL=https|' \
+  -e 's|^VSS_PUBLIC_WS_PROTOCOL=.*|VSS_PUBLIC_WS_PROTOCOL=wss|' \
+  "$ENV"
+```
+
+Rationale per var:
+
+| Var | Brev value | Why |
+|---|---|---|
+| `VSS_PUBLIC_HOST` | `${BREV_LINK_PREFIX}-${BREV_ENV_ID}.brevlab.com` | Matches the haproxy `known_host` / `h_main` ACL so requests don't 404 |
+| `VSS_PUBLIC_PORT` | `443` | Cloudflare terminates HTTPS on 443; the secure link tunnels to 7777 internally, but the browser-facing URL has no port suffix |
+| `VSS_PUBLIC_HTTP_PROTOCOL` | `https` | Reports / VST URLs that the agent emits to the UI must be `https://` or the browser blocks mixed content |
+| `VSS_PUBLIC_WS_PROTOCOL` | `wss` | WebSocket equivalent — the alert-bridge real-time stream and chat sockets need `wss://` over Cloudflare |
+
+`scripts/dev-profile.sh` does **not** apply these — it sets
+`VSS_PUBLIC_HOST=${EXTERNAL_IP}` (the internal IP), which works for
+host-local browsers but breaks every Brev tunnel deploy. The
+compose-direct flow has to set them manually until either
+`brev_setup.sh` writes them or the profile `.env` defaults are
+re-templated.
+
 ## Verifying the deploy is reachable externally
 
 After `docker compose up -d`:
@@ -121,4 +164,5 @@ suffix may or may not be there — in which case set `BREV_LINK_PREFIX=7777`
 | UI loads but AJAX calls to `/api/*` CORS-fail | A second secure link was created for port 8000 → browser treats it as a different origin. Delete the extra link; the UI should use the proxy only. |
 | `curl https://77770-...brevlab.com` → 502 | nginx container (`vss-proxy`) is down — `docker logs vss-proxy` |
 | `curl https://77770-...brevlab.com` → Cloudflare Access login page forever | User hasn't been granted access in the Brev org; not a deploy issue |
-| Agent-generated report URLs don't open | `BREV_LINK_PREFIX` wasn't exported before compose → reports hard-code internal IPs. Source `brev_setup.sh` and redeploy |
+| `curl https://77770-...brevlab.com/` → 404 (haproxy default page) **after** Cloudflare login succeeds | `VSS_PUBLIC_HOST` still set to the internal IP. Apply the four `VSS_PUBLIC_*` overrides above and recreate `vss-haproxy-ingress`, `vss-agent`, `vss-ui`. |
+| Agent-generated report URLs don't open | `BREV_LINK_PREFIX` wasn't exported before compose → reports hard-code internal IPs. Source `brev_setup.sh`, apply the `VSS_PUBLIC_*` overrides, and redeploy |


### PR DESCRIPTION
## Summary

Two related deploy-skill gaps in `skills/deploy/SKILL.md`'s compose-direct flow that the legacy `scripts/dev-profile.sh` happens to paper over:

1. **GPU memory caps for shared devices.** `RTVI_VLLM_GPU_MEMORY_UTILIZATION` defaults to vLLM's `0.9` when empty, so any deploy with two vLLM-backed services on one device (`alerts + local_shared` is the most visible case, but also `base` on edge unified memory, `lvs` on L40S, etc.) silently crashloops the LLM with `CUDA out of memory` while the rest of the stack stays "healthy" because compose marks the LLM as an *optional* dependency. Fix: a general "cap utilization on every shared device" section in `SKILL.md` Step 2 with concrete cap tables for the relevant `(profile × hardware × mode)` combos.

2. **HAProxy `Host`-header trap on Brev.** `brev_setup.sh` exports `BREV_ENV_ID` / `PROXY_PORT` / `BREV_LINK_PREFIX` but does *not* rewrite `VSS_PUBLIC_HOST`. The haproxy ingress's `known_host` ACL only matches `VSS_PUBLIC_HOST`, `EXTERNAL_IP`, `HOST_IP`, and `localhost`, so the brev hostname (`77770-<id>.brevlab.com`) gets a 404 — even though `curl http://localhost:7777/` from the host returns 200. The fix is four `.env` overrides (`VSS_PUBLIC_HOST=<brev-host>`, `VSS_PUBLIC_PORT=443`, `VSS_PUBLIC_HTTP_PROTOCOL=https`, `VSS_PUBLIC_WS_PROTOCOL=wss`) and a `--force-recreate` of `vss-haproxy-ingress`, `vss-agent`, `vss-ui`.

Both gaps were hit during real Brev deploys on RTX PRO 6000 Blackwell. Both fail in ways that are easy to miss because the surface symptoms (one container "Restarting" in a 22-container stack; a 404 from a public URL after Cloudflare Access login) look like infrastructure noise rather than misconfiguration.

## What this PR adds

- `skills/deploy/SKILL.md` Step 2: new "Cap GPU memory utilization on every shared device" subsection. Walks the agent through building a device → services map, identifying co-located vLLM services, applying the right cap (0.35 default; 0.8 on DGX-Spark / L40S in dedicated mode), and grep-verifying before `docker compose up`. Concrete cap table for alerts / base / lvs.
- `skills/deploy/SKILL.md` Step 1c: adds the `VSS_PUBLIC_*` sed snippet right after `source brev_setup.sh`, so the brev hostname lands in haproxy's `known_host` ACL and the agent emits public-facing report / VST URLs.
- `skills/deploy/references/alerts.md`: trimmed to a brief shared-device caveat that points at the SKILL.md section.
- `skills/deploy/references/brev.md`: new "Required `.env` overrides for Brev — the haproxy `Host`-header trap" section with per-var rationale plus a corresponding 404 row in the troubleshooting table.

## Why centralize in SKILL.md

The first cut of this PR added the GPU mem cap only to `references/alerts.md`. Per maintainer review, the issue is fundamentally about GPU sizing across any profile, not about alerts — any future profile that lands two inference containers on one device will hit it. Same logic for the brev fix: it's a property of the haproxy ingress (used by every profile), not of any one profile. Centralizing in `SKILL.md` keeps per-profile docs slim and ensures future profiles inherit both checks.

## Reproduction

### GPU mem (RTXPRO6000BW, alerts real-time, local_shared)
- Default `.env` ships `RTVI_VLLM_GPU_MEMORY_UTILIZATION=''` → vLLM uses 0.9 of the GPU
- nvidia-nemotron-nano-9b-v2 NIM in shared mode requests 0.4 of the GPU for KV cache
- 0.9 + 0.4 > 1.0 on a 97 GB device → `CUDA out of memory. Tried to allocate 5.05 GiB. GPU 0 has ... 2.76 GiB free.`
- Compose marks LLM as optional → rest of stack stays healthy → silent until agent is queried
- After `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35`: GPU 1 sits at ~71 GB / 97 GB, LLM healthy, smoke test passes

### Brev hostname (any profile, any mode)
- `curl https://<link-prefix>-<id>.brevlab.com/` → Cloudflare Access login → after auth → 404 from haproxy
- `curl -H "Host: <link-prefix>-<id>.brevlab.com" http://localhost:7777/` → also 404 (proves haproxy is the gate, not Cloudflare)
- After the four `VSS_PUBLIC_*` overrides + recreate of haproxy/agent/ui → 200 from the same brev URL

## Test plan
- [x] Reproduced and fixed both on a live RTXPRO6000BW Brev deploy
- [x] Smoke-tested LLM `:30081/v1/chat/completions` and the brev URL after the fix
- [x] Verified the brev troubleshooting table catches the 404 case
- [ ] Reviewer confirms cap tables cover their planned `(profile, hw, mode)` combos
- [ ] Follow-up: extend `brev_setup.sh` to optionally write the four `VSS_PUBLIC_*` vars into a target `.env` so the user never has to remember the sed snippet
- [ ] Follow-up: small auto-helper that consumes the resolved env, builds the device map, and writes the right GPU caps before `docker compose config`
