### PR TITLE
ci(codeowners): require OSRB approval for dependency lockfiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,19 @@
 
 # Default — all files
 * @NVIDIA-AI-Blueprints/VSS-developers
+
+# Lockfiles and 3rd-party license inventory.
+# Resolved-dependency state is the authoritative record of which packages
+# (and which licenses) ship in VSS, so OSRB must approve any change.
+# CODEOWNERS is last-match-wins, so these rules override the default
+# `*` owner above for the listed paths only.
+uv.lock                 @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+package-lock.json       @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+yarn.lock               @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+pnpm-lock.yaml          @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+poetry.lock             @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+Pipfile.lock            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+Cargo.lock              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+go.sum                  @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+Gemfile.lock            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+LICENSE-3rd-party.txt   @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers


### PR DESCRIPTION
## Summary

Adds `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers` as the code owner for **lockfiles and the 3rd-party license inventory** — the resolved-dependency state that is the authoritative record of which packages (and which licenses) ship in VSS.

CODEOWNERS is last-match-wins, so these rules override the default `*` owner (VSS-developers) for the listed paths only. Manifest files (`pyproject.toml`, `package.json`) and all non-lockfile changes continue to flow through VSS-developers.

## Files now requiring OSRB review

| Pattern | Currently in repo |
|---|---|
| `uv.lock` | `services/agent/uv.lock` |
| `package-lock.json` | `services/ui/package-lock.json` |
| `LICENSE-3rd-party.txt` | repo root + `services/agent/` |
| `yarn.lock`, `pnpm-lock.yaml`, `poetry.lock`, `Pipfile.lock`, `Cargo.lock`, `go.sum`, `Gemfile.lock` | not currently in repo — defensive coverage for future polyglot additions |

Manifests (`pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, etc.) are intentionally **not** in the OSRB scope to avoid blocking unrelated changes (ruff config, project metadata, scripts) on OSRB review. The lockfile is the gate — every dep declaration eventually shows up there.

## Effect on PR review flow

- A PR that touches a lockfile → requires approval from a `VSS_OSRB_Approvers` member.
- A PR that touches a lockfile + other code → requires approval from both an OSRB member (for the lockfile) and a VSS-developer (for the rest).
- A PR with no lockfile changes → unchanged, VSS-developer review only.

## Why this is needed

Per the [Consolidated GitHub-First Infra Requirements](https://docs.google.com/document/d/1jjN1ru9PyCR113PkHi3qCcmHDYgcGQJLeyygrnt_yBY/edit) (CO-3..22, UR-19), every commit that introduces or modifies third-party packages must clear OSRB before merge. Codeowners-based review is the cleanest enforcement: GitHub blocks merge until OSRB approves.

This complements the in-CI `license-check-python` / `check_python_licenses.sh` / `check_ui_licenses.sh` jobs (which gate by license allowlist) — codeowners gates by *human* OSRB review.

## Branch protection prerequisite

Done in parallel with this PR: `Protect main` ruleset (`15323750`) flipped to `require_code_owner_review: true`. `Protect develop` (`15323753`) and `Protect release branches` (`15323756`) already had it on.

## Test plan

- [x] Once merged, open a no-op test PR that touches `services/agent/uv.lock` (e.g., bump a patch version) and confirm GitHub auto-requests review from `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers`.
- [x] Open a no-op test PR that touches only `services/agent/pyproject.toml` and confirm OSRB is **not** auto-requested (manifests are intentionally out of scope).
- [x] Confirm the merge button stays disabled until an OSRB member approves the lockfile-touching PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
