### PR TITLE
fix(rtvi_vlm_alert): drop chunk/fps/vlm-input fields from realtime payload

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
@@ -185,8 +185,6 @@ functions:
     vst_internal_url: ${VST_INTERNAL_URL}
     va_get_incidents_tool: video_analytics_mcp.video_analytics.get_incidents
     default_model: ${VLM_NAME}
-    default_chunk_duration: 2
-    default_fps: 1
     timeout: 180
 
   # Prompt generator for RTVI-VLM alerts (LLM-based)

--- a/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
@@ -185,8 +185,6 @@ functions:
     vst_internal_url: ${VST_INTERNAL_URL}
     va_get_incidents_tool: video_analytics_mcp.video_analytics.get_incidents
     default_model: ${VLM_NAME}
-    default_chunk_duration: 2
-    default_fps: 1
     timeout: 180
 
   # Prompt generator for RTVI-VLM alerts (LLM-based)

--- a/services/agent/src/vss_agents/tools/rtvi_vlm_alert.py
+++ b/services/agent/src/vss_agents/tools/rtvi_vlm_alert.py
@@ -56,30 +56,6 @@ class RTVIVLMAlertConfig(FunctionBaseConfig, name="rtvi_vlm_alert"):
         "alert",
         description="Default alert_type label assigned to created rules when not provided",
     )
-    default_chunk_duration: int = Field(
-        20,
-        description="Default chunk duration in seconds",
-    )
-    default_chunk_overlap_duration: int = Field(
-        0,
-        description="Default chunk overlap duration in seconds",
-    )
-    default_fps: int = Field(
-        1,
-        description="Default frames per second to analyze",
-    )
-    default_vlm_input_width: int = Field(
-        256,
-        description="Default VLM input width",
-    )
-    default_vlm_input_height: int = Field(
-        256,
-        description="Default VLM input height",
-    )
-    default_enable_reasoning: bool = Field(
-        False,
-        description="Whether to enable VLM reasoning by default",
-    )
     default_prompt: str | None = Field(
         None,
         description="Default detection prompt (if not provided via tool call)",
@@ -302,13 +278,6 @@ async def rtvi_vlm_alert(config: RTVIVLMAlertConfig, builder: Builder) -> AsyncG
                         "prompt": prompt,
                         "system_prompt": system_prompt,
                         "model": config.default_model,
-                        "chunk_duration": config.default_chunk_duration,
-                        "chunk_overlap_duration": config.default_chunk_overlap_duration,
-                        "num_frames_per_second_or_fixed_frames_chunk": config.default_fps,
-                        "use_fps_for_chunking": True,
-                        "vlm_input_width": config.default_vlm_input_width,
-                        "vlm_input_height": config.default_vlm_input_height,
-                        "enable_reasoning": config.default_enable_reasoning,
                     }
 
                     async with session.post(f"{base_url}/api/v1/realtime", json=payload) as response:

--- a/services/agent/tests/unit_test/tools/test_rtvi_vlm_alert.py
+++ b/services/agent/tests/unit_test/tools/test_rtvi_vlm_alert.py
@@ -35,8 +35,6 @@ class TestRTVIVLMAlertConfig:
         assert config.vst_internal_url == "http://10.0.0.1:30888"
         assert config.default_model == "nvidia/cosmos-reason1-7b"
         assert config.default_alert_type == "alert"
-        assert config.default_chunk_duration == 20
-        assert config.default_fps == 1
         assert config.timeout == 180
 
     def test_custom_defaults(self):
@@ -45,16 +43,12 @@ class TestRTVIVLMAlertConfig:
             vst_internal_url="http://10.0.0.1:30888",
             default_model="custom-model",
             default_alert_type="collision",
-            default_chunk_duration=10,
-            default_fps=2,
             default_prompt="Detect collisions",
             default_system_prompt="You are a monitor",
             timeout=30,
         )
         assert config.default_model == "custom-model"
         assert config.default_alert_type == "collision"
-        assert config.default_chunk_duration == 10
-        assert config.default_fps == 2
         assert config.default_prompt == "Detect collisions"
         assert config.default_system_prompt == "You are a monitor"
         assert config.timeout == 30


### PR DESCRIPTION
## Summary

Drops VLM/chunking knobs from the realtime alert payload and the matching `default_*` config fields. Alert Bridge owns these defaults now and applies them when forwarding to RTVI VLM, so the agent should not pass them on `POST /api/v1/realtime`.

Removed from the request body and config:
- `chunk_duration`
- `chunk_overlap_duration`
- `num_frames_per_second_or_fixed_frames_chunk`
- `use_fps_for_chunking`
- `vlm_input_width`
- `vlm_input_height`
- `enable_reasoning`

Agent still sends `live_stream_url`, `alert_type`, `sensor_name`, `prompt`, `system_prompt`, `model` — i.e. only the user-driven fields plus the model selection.

## Files

- `services/agent/src/vss_agents/tools/rtvi_vlm_alert.py` — drop the seven `default_*` fields from `RTVIVLMAlertConfig` and the matching keys from the realtime POST payload.
- `deploy/{docker,helm}/developer-profiles/dev-profile-alerts/.../config.yml` — drop `default_chunk_duration: 2` and `default_fps: 1` from the `rtvi_vlm_alert` block.
- `services/agent/tests/unit_test/tools/test_rtvi_vlm_alert.py` — drop assertions tied to the removed config defaults.

## UI alignment

`aiqtoolkit-ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useRealtimeAlertRules.ts` already POSTs only `{live_stream_url, alert_type, prompt, sensor_name?}` and treats the chunk/vlm/reasoning fields as optional read-only on the response (`types.ts` has the comment: "accepted but currently ignored by the UI; they fall back to server-side defaults"). UI and agent are now consistent — both rely on Alert Bridge for server-side defaults.

## Test plan

- [x] `pytest tests/unit_test/tools/test_rtvi_vlm_alert.py tests/unit_test/tools/test_rtvi_vlm_alert_inner.py` — 28 passed locally
- [ ] Deploy alerts profile and confirm `POST /api/v1/realtime` succeeds without those fields and the rule is created
- [ ] Confirm captions/alerts continue to flow on the resulting RTVI stream (Alert Bridge defaults applied)
