### PR TITLE
fix: include runtime search params to top agent

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
@@ -219,7 +219,7 @@ workflow:
       and stream names from the query text — do not filter these out.
     - agent_mode: always set to true (enables query decomposition)
     - use_attribute_search: always set to true (enables fusion reranking)
-    - use_critic: always set to true (verify results with VLM critic agent)
+    - use_critic: use the current request option value (verify results with VLM critic agent)
     Optional:
     - max_results: Number of final results to return to the user (default: 5)
     - top_k: Number of internal candidates to fetch before reranking (default: 10)
@@ -230,6 +230,14 @@ workflow:
     - end_time: Leave as None unless the user provides explicit timestamps or time references.
 
     Directly return the entire search result to user, no filtering or summarization.
+
+    Runtime request options:
+    - request_options is passed automatically to search_agent; do not fill it manually.
+    - On follow-up turns, the system prompt may include current_request_options and previous_request_options.
+    - For search requests and search follow-ups, treat search_source_type as the current media source selection
+      and use_critic as the current critic selection.
+    - If search_source_type or use_critic differs from previous_request_options, call search_agent again for
+      the relevant search query instead of answering from previous search results.
 
     Conversation history guidelines:
     - Always call search_agent for any search query, even if it looks similar

--- a/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
@@ -219,7 +219,7 @@ workflow:
       and stream names from the query text — do not filter these out.
     - agent_mode: always set to true (enables query decomposition)
     - use_attribute_search: always set to true (enables fusion reranking)
-    - use_critic: always set to true (verify results with VLM critic agent)
+    - use_critic: use the current request option value (verify results with VLM critic agent)
     Optional:
     - max_results: Number of final results to return to the user (default: 5)
     - top_k: Number of internal candidates to fetch before reranking (default: 10)
@@ -230,6 +230,14 @@ workflow:
     - end_time: Leave as None unless the user provides explicit timestamps or time references.
 
     Directly return the entire search result to user, no filtering or summarization.
+
+    Runtime request options:
+    - request_options is passed automatically to search_agent; do not fill it manually.
+    - On follow-up turns, the system prompt may include current_request_options and previous_request_options.
+    - For search requests and search follow-ups, treat search_source_type as the current media source selection
+      and use_critic as the current critic selection.
+    - If search_source_type or use_critic differs from previous_request_options, call search_agent again for
+      the relevant search query instead of answering from previous search results.
 
     Conversation history guidelines:
     - Always call search_agent for any search query, even if it looks similar

--- a/services/agent/src/vss_agents/agents/data_models.py
+++ b/services/agent/src/vss_agents/agents/data_models.py
@@ -49,6 +49,17 @@ class AgentMessageChunk(BaseModel):
     content: str = Field("", description="The content of the message chunk")
 
 
+class AgentRequestOptions(BaseModel):
+    """Per-request options passed from the UI/client through the agent pipeline."""
+
+    llm_reasoning: bool = Field(default=False, description="Enable LLM reasoning mode")
+    vlm_reasoning: bool | None = Field(default=None, description="Enable VLM reasoning mode (None = use tool default)")
+    search_source_type: Literal["video_file", "rtsp"] = Field(
+        default="video_file", description="Video source type for search: 'video_file' or 'rtsp'"
+    )
+    use_critic: bool = Field(default=True, description="Whether to verify search results with VLM critic agent")
+
+
 class AgentOutput(BaseModel):
     """
     Standardized output model for agents (report_agent, multi_report_agent, etc.).

--- a/services/agent/src/vss_agents/agents/search_agent.py
+++ b/services/agent/src/vss_agents/agents/search_agent.py
@@ -49,6 +49,7 @@ from pydantic import Field
 from vss_agents.agents.data_models import AgentMessageChunk
 from vss_agents.agents.data_models import AgentMessageChunkType
 from vss_agents.agents.data_models import AgentOutput
+from vss_agents.agents.data_models import AgentRequestOptions
 from vss_agents.tools.attribute_search import DEFAULT_BEHAVIOR_INDEX
 from vss_agents.tools.search import SearchInput
 from vss_agents.tools.search import SearchOutput
@@ -109,6 +110,22 @@ class SearchAgentInput(BaseModel):
         description="Type of video source: 'video_file' for uploaded videos, 'rtsp' for live/camera streams",
     )
     use_critic: bool = Field(default=True, description="Whether to verify search results with VLM critic agent")
+    request_options: AgentRequestOptions | None = Field(
+        default=None,
+        description="Per-request options passed by the parent agent. When present, these override matching fields.",
+    )
+
+
+def _effective_search_runtime_options(
+    search_agent_input: SearchAgentInput,
+) -> tuple[Literal["video_file", "rtsp"], bool]:
+    """Resolve runtime search options from the parent request-options interface."""
+    if search_agent_input.request_options is None:
+        return search_agent_input.source_type, search_agent_input.use_critic
+    return (
+        search_agent_input.request_options.search_source_type,
+        search_agent_input.request_options.use_critic,
+    )
 
 
 class SearchAgentConfig(FunctionBaseConfig, name="search_agent"):
@@ -396,15 +413,16 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
         # top_k = input.top_k if input.top_k else default_max_result
         # User's top_k overrides default_max_result (no capping)
         top_k = search_agent_input.top_k if search_agent_input.top_k is not None else config.default_max_results
+        source_type, use_critic = _effective_search_runtime_options(search_agent_input)
 
         search_input = SearchInput(
             query=search_agent_input.query,
-            source_type=search_agent_input.source_type,
+            source_type=source_type,
             top_k=top_k,
             agent_mode=search_agent_input.agent_mode,
             timestamp_start=timestamp_start,
             timestamp_end=timestamp_end,
-            use_critic=search_agent_input.use_critic,
+            use_critic=use_critic,
         )
 
         # Use shared core search function (async generator, collect all progress and return final result)
@@ -447,7 +465,7 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
         top_k = search_agent_input.top_k
         start_time = search_agent_input.start_time
         end_time = search_agent_input.end_time
-        source_type = search_agent_input.source_type
+        source_type, use_critic = _effective_search_runtime_options(search_agent_input)
 
         logger.info(f"Search agent executing: {search_agent_input.model_dump_json()}")
 
@@ -478,7 +496,7 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
             agent_mode=agent_mode,
             timestamp_start=timestamp_start,
             timestamp_end=timestamp_end,
-            use_critic=search_agent_input.use_critic,
+            use_critic=use_critic,
         )
 
         try:

--- a/services/agent/src/vss_agents/agents/top_agent.py
+++ b/services/agent/src/vss_agents/agents/top_agent.py
@@ -23,6 +23,7 @@ import logging
 import re
 import time
 from typing import Any
+from typing import Literal
 from typing import cast
 from uuid import uuid4
 
@@ -69,6 +70,7 @@ from vss_agents.agents.data_models import AgentDecision
 from vss_agents.agents.data_models import AgentMessageChunk
 from vss_agents.agents.data_models import AgentMessageChunkType
 from vss_agents.agents.data_models import AgentOutput
+from vss_agents.agents.data_models import AgentRequestOptions
 from vss_agents.agents.postprocessing import POSTPROCESSING_FEEDBACK_MARKER
 from vss_agents.agents.postprocessing import PostprocessingConfig
 from vss_agents.agents.postprocessing import PostprocessingNode
@@ -85,17 +87,7 @@ NO_INPUT_ERROR_MESSAGE = "No human input received to the agent, Please ask a val
 EMPTY_MESSAGES_ERROR = 'No input received in state: "current_message"'
 EMPTY_SCRATCHPAD_ERROR = 'No tool input received in state: "agent_scratchpad"'
 _TOOL_RESULTS_DELIMITER = "\n\n---\n### Latest Tool Results\n"
-
-
-class AgentRequestOptions(BaseModel):
-    """Per-request options passed from the UI/client through the agent pipeline."""
-
-    llm_reasoning: bool = Field(default=False, description="Enable LLM reasoning mode")
-    vlm_reasoning: bool | None = Field(default=None, description="Enable VLM reasoning mode (None = use tool default)")
-    search_source_type: str = Field(
-        default="video_file", description="Video source type for search: 'video_file' or 'rtsp'"
-    )
-    use_critic: bool = Field(default=True, description="Whether to verify search results with VLM critic agent")
+_REQUEST_OPTIONS_CONTEXT_MARKERS = ("current_request_options", "previous_request_options")
 
 
 class TopAgentRequest(ChatRequestOrMessage):
@@ -103,7 +95,7 @@ class TopAgentRequest(ChatRequestOrMessage):
 
     llm_reasoning: bool | None = Field(default=None, description="Enable LLM reasoning mode")
     vlm_reasoning: bool | None = Field(default=None, description="Enable VLM reasoning mode")
-    search_source_type: str = Field(
+    search_source_type: Literal["video_file", "rtsp"] | None = Field(
         default="video_file", description="Video source type for search: 'video_file' or 'rtsp'"
     )
     use_critic: bool | None = Field(default=None, description="Whether to verify search results with VLM critic agent")
@@ -193,6 +185,10 @@ class TopAgentState(BaseModel):
         default_factory=list,
         description="Accumulated sub-agent side effects (download links, media URLs)",
     )
+    previous_options: AgentRequestOptions | None = Field(
+        default=None,
+        description="Per-request options from the previous conversation turn.",
+    )
 
 
 class TopAgentConfig(FunctionBaseConfig, name="top_agent"):
@@ -261,6 +257,7 @@ class TopAgent(AsyncMixin):
     plan_system_prompt: str
     tool_call_prompt: str
     response_format_prompt: str
+    request_options_context_enabled: bool
 
     @override
     async def __ainit__(
@@ -322,9 +319,26 @@ class TopAgent(AsyncMixin):
         self.plan_system_prompt = plan_system_prompt
         self.tool_call_prompt = tool_call_prompt
         self.response_format_prompt = response_format_prompt
+        self.request_options_context_enabled = self._prompt_requests_request_options_context(
+            str(prompt),
+            plan_prompt,
+            plan_system_prompt,
+            tool_call_prompt,
+            response_format_prompt,
+        )
         self.tools_dict = {tool.name: tool for tool in subagents_plus_tools}
         self.graph = await self._build_graph()
         logger.info("Successfully initialized Top Agent with %d total tools", len(self.tools_dict))
+
+    @staticmethod
+    def _prompt_requests_request_options_context(*prompt_parts: str | None) -> bool:
+        """Return True when config prompts explicitly request request-option context."""
+        return any(
+            marker in prompt_part
+            for prompt_part in prompt_parts
+            if prompt_part
+            for marker in _REQUEST_OPTIONS_CONTEXT_MARKERS
+        )
 
     def _get_tool(self, tool_name: str) -> BaseTool | None:
         """Get a tool by name from the tools dict."""
@@ -441,6 +455,24 @@ class TopAgent(AsyncMixin):
             return param_name in schema_fields
         return False
 
+    def _request_options_context(self, state: TopAgentState) -> str:
+        """Return generic request option context for prompts that need it."""
+        if not getattr(self, "request_options_context_enabled", False) or state.previous_options is None:
+            return ""
+        options_context = json.dumps(
+            {
+                "current_request_options": state.options.model_dump(mode="json"),
+                "previous_request_options": state.previous_options.model_dump(mode="json"),
+            },
+            sort_keys=True,
+            default=str,
+        )
+        return (
+            "\n\nRequest options context for the current and previous user turns. "
+            "Use this only when it is relevant to the user's request.\n"
+            f"{options_context}"
+        )
+
     async def astream(
         self,
         input_messages: list[BaseMessage],
@@ -530,6 +562,7 @@ class TopAgent(AsyncMixin):
                 agent_scratchpad=[],
                 final_answer="",
                 options=options,
+                previous_options=copy.deepcopy(previous_state.get("options")),
             )
         else:
             input_state = TopAgentState(
@@ -633,11 +666,13 @@ class TopAgent(AsyncMixin):
         if state.previous_conversation:
             summary_block = f"\n\nPrevious conversation summary:\n{state.previous_conversation}\n\n"
             logger.debug("Summary: " + summary_block)
+        request_options_context = self._request_options_context(state)
         system_content = (
             self.plan_system_prompt
             + planning_instruction
             + tool_descriptions_block
             + summary_block
+            + request_options_context
             + previous_exec_feedback
         )
 
@@ -711,6 +746,7 @@ class TopAgent(AsyncMixin):
 
             llm_kwargs = get_llm_reasoning_bind_kwargs(self.llm, state.options.llm_reasoning)
             llm_to_use = self.llm_with_tools.bind(**llm_kwargs) if llm_kwargs else self.llm_with_tools
+            request_options_context = self._request_options_context(state)
 
             if state.plan and self.plan_exec_prompt is not None:
                 prompt_to_use = self.plan_exec_prompt
@@ -718,6 +754,7 @@ class TopAgent(AsyncMixin):
                 invoke_kwargs: dict[str, Any] = {
                     "question": question,
                     "plan_section": state.plan,  # Already updated by plan_update node
+                    "request_options_context": request_options_context,
                     "current_time": datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
                     "thinking_tag": thinking_tag_formatted,
                 }
@@ -728,6 +765,7 @@ class TopAgent(AsyncMixin):
                     "conversation_summary": state.previous_conversation,
                     "agent_scratchpad": state.agent_scratchpad,
                     "conversation_history": state.conversation_history,
+                    "request_options_context": request_options_context,
                     "current_time": datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
                     "thinking_tag": thinking_tag_formatted,
                 }
@@ -839,19 +877,17 @@ class TopAgent(AsyncMixin):
                     tool_name = tool_call["name"]
                     is_subagent = tool_name in self.subagent_names
 
-                    # Build tool args once, filtering None values and injecting llm_reasoning/vlm_reasoning if supported
+                    # Build tool args once, filtering None values and injecting request options when supported.
                     tool_args = {k: v for k, v in tool_call["args"].items() if v is not None}
+                    if self._tool_accepts_param(tool_name, "request_options"):
+                        tool_args["request_options"] = state.options.model_dump(mode="json")
+                        logger.info("Passing request_options to %s", tool_name)
                     if self._tool_accepts_param(tool_name, "llm_reasoning"):
                         tool_args["llm_reasoning"] = state.options.llm_reasoning
                         logger.info(f"Passing llm_reasoning={state.options.llm_reasoning} to {tool_name}")
                     if self._tool_accepts_param(tool_name, "vlm_reasoning"):
                         tool_args["vlm_reasoning"] = state.options.vlm_reasoning
                         logger.info(f"Passing vlm_reasoning={state.options.vlm_reasoning} to {tool_name}")
-                    # Only inject search_source_type for search_agent (video_file/rtsp). report_agent and
-                    # others use source_type with different semantics (e.g. sensor/place)
-                    if tool_name == "search_agent" and self._tool_accepts_param(tool_name, "source_type"):
-                        tool_args["source_type"] = state.options.search_source_type
-                        logger.info(f"Passing source_type={state.options.search_source_type} to {tool_name}")
                     if self._tool_accepts_param(tool_name, "use_critic"):
                         tool_args["use_critic"] = state.options.use_critic
                         logger.info(f"Passing use_critic={state.options.use_critic} to {tool_name}")
@@ -860,7 +896,7 @@ class TopAgent(AsyncMixin):
                     final_chunks = []
                     if is_subagent:
                         # Yield sub-agent call message before processing
-                        subagent_msg = f"Calling sub-agent: {tool_name}\nArgs: {tool_call['args']}"
+                        subagent_msg = f"Calling sub-agent: {tool_name}\nArgs: {tool_args}"
                         writer(AgentMessageChunk(type=AgentMessageChunkType.SUBAGENT_CALL, content=subagent_msg))
 
                         # Emit TOOL_START telemetry for subagent
@@ -878,8 +914,8 @@ class TopAgent(AsyncMixin):
                                 framework=LLMFrameworkEnum.LANGCHAIN,
                                 name=tool_name,
                                 UUID=subagent_run_id,
-                                data=StreamEventData(input=json.dumps(tool_call["args"])),
-                                metadata=TraceMetadata(tool_inputs=tool_call["args"]),
+                                data=StreamEventData(input=json.dumps(tool_args)),
+                                metadata=TraceMetadata(tool_inputs=tool_args),
                                 usage_info=UsageInfo(token_usage=TokenUsageBaseModel()),
                             )
                             step_manager.push_intermediate_step(tool_start_payload)
@@ -989,7 +1025,7 @@ class TopAgent(AsyncMixin):
                                 UUID=subagent_run_id,
                                 metadata=TraceMetadata(tool_outputs=subagent_output),
                                 usage_info=UsageInfo(token_usage=TokenUsageBaseModel()),
-                                data=StreamEventData(input=json.dumps(tool_call["args"]), output=subagent_output),
+                                data=StreamEventData(input=json.dumps(tool_args), output=subagent_output),
                             )
                             step_manager.push_intermediate_step(tool_end_payload)
                             logger.info(f"TOOL_END telemetry emitted for {tool_name}")
@@ -1037,9 +1073,7 @@ class TopAgent(AsyncMixin):
                     # Sub-agents already yielded their call message earlier
                     if not is_subagent:
                         # For regular tools, yield TOOL_CALL with call info and result
-                        result_msg = (
-                            f"Tool: {tool_call['name']}\nArgs: {tool_call['args']}\nResult: {tool_response_str}"
-                        )
+                        result_msg = f"Tool: {tool_call['name']}\nArgs: {tool_args}\nResult: {tool_response_str}"
                         writer(AgentMessageChunk(type=AgentMessageChunkType.TOOL_CALL, content=result_msg))
 
                     logger.debug(
@@ -1406,6 +1440,7 @@ async def top_agent(config: TopAgentConfig, builder: Builder) -> AsyncGenerator[
                 + "\n\n"
                 + "current time: {current_time}"
                 + "\n\nPrevious conversation summary: {conversation_summary}"
+                + "{request_options_context}"
                 + "{thinking_tag}",
             ),
             MessagesPlaceholder(variable_name="conversation_history", optional=True),
@@ -1425,6 +1460,7 @@ async def top_agent(config: TopAgentConfig, builder: Builder) -> AsyncGenerator[
             "Summarize and return the final answer to the user after all steps are completed.\n"
             "- Your final answer MUST answer ALL parts of the user's question (User's Question: {question}). "
             "If the user asked multiple things, you MUST answer each one. "
+            "{request_options_context}"
         )
         if tool_call_prompt:
             plan_exec_system += "\n\n## Tool call rules:\n " + _escape_template_literals(tool_call_prompt)
@@ -1501,14 +1537,16 @@ async def top_agent(config: TopAgentConfig, builder: Builder) -> AsyncGenerator[
         context = Context.get()
         if hasattr(context.metadata, "payload") and isinstance(context.metadata.payload, dict):
             payload = context.metadata.payload
+            options_payload = options.model_dump(mode="json")
             if "llm_reasoning" in payload:
-                options.llm_reasoning = bool(payload["llm_reasoning"])
+                options_payload["llm_reasoning"] = bool(payload["llm_reasoning"])
             if "vlm_reasoning" in payload:
-                options.vlm_reasoning = bool(payload["vlm_reasoning"])
+                options_payload["vlm_reasoning"] = bool(payload["vlm_reasoning"])
             if "search_source_type" in payload:
-                options.search_source_type = str(payload["search_source_type"])
+                options_payload["search_source_type"] = payload["search_source_type"]
             if "use_critic" in payload:
-                options.use_critic = bool(payload["use_critic"])
+                options_payload["use_critic"] = bool(payload["use_critic"])
+            options = AgentRequestOptions.model_validate(options_payload)
             logger.info(f"Extracted from WebSocket payload - {options}")
 
         logger.info("Creating Top Agent with options=%s", options)

--- a/services/agent/tests/unit_test/agents/test_search_agent.py
+++ b/services/agent/tests/unit_test/agents/test_search_agent.py
@@ -22,8 +22,10 @@ import json
 from pydantic import ValidationError
 import pytest
 
+from vss_agents.agents.data_models import AgentRequestOptions
 from vss_agents.agents.search_agent import SearchAgentConfig
 from vss_agents.agents.search_agent import SearchAgentInput
+from vss_agents.agents.search_agent import _effective_search_runtime_options
 from vss_agents.agents.search_agent import _helper_markdown_bullet_list
 from vss_agents.agents.search_agent import _to_chat_response
 from vss_agents.agents.search_agent import _to_chat_response_chunk
@@ -105,6 +107,7 @@ class TestSearchAgentInput:
         assert input_data.top_k is None
         assert input_data.start_time is None
         assert input_data.end_time is None
+        assert input_data.request_options is None
 
     def test_all_fields(self):
         """Test input with all fields."""
@@ -186,6 +189,34 @@ class TestSearchAgentInput:
         )
         assert input_data.start_time is None
         assert input_data.end_time == "2025-01-01T12:00:00Z"
+
+    def test_request_options_field(self):
+        """Test request options accepted by the subagent input schema."""
+        input_data = SearchAgentInput(
+            query="test query",
+            request_options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+        )
+
+        assert input_data.request_options is not None
+        assert input_data.request_options.search_source_type == "rtsp"
+        assert input_data.request_options.use_critic is False
+
+    def test_effective_search_runtime_options_default_to_input_fields(self):
+        """Test runtime search options use explicit input fields when no request options are present."""
+        input_data = SearchAgentInput(query="test query", source_type="video_file", use_critic=True)
+
+        assert _effective_search_runtime_options(input_data) == ("video_file", True)
+
+    def test_effective_search_runtime_options_prefer_request_options(self):
+        """Test runtime request options override matching LLM/tool-call fields."""
+        input_data = SearchAgentInput(
+            query="test query",
+            source_type="video_file",
+            use_critic=True,
+            request_options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+        )
+
+        assert _effective_search_runtime_options(input_data) == ("rtsp", False)
 
 
 class TestDecomposedQueryObjectIds:

--- a/services/agent/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/tests/unit_test/agents/test_top_agent.py
@@ -14,14 +14,28 @@
 # limitations under the License.
 """Unit tests for top_agent module."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+from langchain_core.messages import AIMessage
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.prompts import MessagesPlaceholder
+from langchain_core.runnables import RunnableLambda
 import pytest
 
+from vss_agents.agents.data_models import AgentMessageChunk
+from vss_agents.agents.data_models import AgentMessageChunkType
+from vss_agents.agents.data_models import AgentRequestOptions
+from vss_agents.agents.search_agent import SearchAgentInput
 from vss_agents.agents.top_agent import EMPTY_MESSAGES_ERROR
 from vss_agents.agents.top_agent import EMPTY_SCRATCHPAD_ERROR
 from vss_agents.agents.top_agent import NO_INPUT_ERROR_MESSAGE
 from vss_agents.agents.top_agent import TOOL_NOT_FOUND_ERROR_MESSAGE
-from vss_agents.agents.top_agent import AgentRequestOptions
+from vss_agents.agents.top_agent import TopAgent
 from vss_agents.agents.top_agent import TopAgentRequest
+from vss_agents.agents.top_agent import TopAgentState
 from vss_agents.agents.top_agent import strip_frontend_tags
 
 
@@ -129,6 +143,344 @@ class TestAgentRequestOptions:
         assert opts.vlm_reasoning is True
         assert opts.search_source_type == "rtsp"
         assert opts.use_critic is False
+
+
+class TestRequestOptionsContext:
+    """Tests for generic request option context."""
+
+    def _agent_with_search_tool(self, request_options_context_enabled: bool = True):
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"search_agent": MagicMock()}
+        agent.request_options_context_enabled = request_options_context_enabled
+        search_tool = agent.tools_dict["search_agent"]
+        search_tool.name = "search_agent"
+        search_tool.description = "Search videos"
+        search_tool.args_schema = MagicMock()
+        search_tool.args_schema.model_fields = {
+            "request_options": MagicMock(),
+            "use_critic": MagicMock(),
+        }
+        return agent
+
+    def test_request_options_context_omits_without_previous_options(self):
+        agent = self._agent_with_search_tool()
+        state = TopAgentState(options=AgentRequestOptions(search_source_type="rtsp", use_critic=False))
+
+        assert agent._request_options_context(state) == ""
+
+    def test_request_options_context_omits_when_prompt_does_not_opt_in(self):
+        agent = self._agent_with_search_tool(request_options_context_enabled=False)
+        state = TopAgentState(options=AgentRequestOptions(search_source_type="rtsp", use_critic=False))
+
+        assert agent._request_options_context(state) == ""
+
+    @pytest.mark.parametrize(
+        "prompt_parts,expected",
+        [
+            (("Main profile prompt uses current_request_options for runtime choices.",), True),
+            (("Compare previous_request_options before reusing results.",), True),
+            (("Generic assistant prompt.", "No runtime params here."), False),
+            ((None, "", "Generic assistant prompt."), False),
+        ],
+    )
+    def test_prompt_requests_request_options_context(self, prompt_parts, expected):
+        assert TopAgent._prompt_requests_request_options_context(*prompt_parts) is expected
+
+    def test_request_options_context_includes_current_and_previous_options(self):
+        agent = self._agent_with_search_tool()
+        state = TopAgentState(
+            options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+            previous_options=AgentRequestOptions(search_source_type="video_file", use_critic=True),
+        )
+
+        context = agent._request_options_context(state)
+
+        assert "Request options context" in context
+        assert '"current_request_options"' in context
+        assert '"previous_request_options"' in context
+        assert '"search_source_type": "rtsp"' in context
+        assert '"search_source_type": "video_file"' in context
+        assert '"use_critic": false' in context
+        assert '"use_critic": true' in context
+
+    @pytest.mark.asyncio
+    async def test_astream_restores_previous_options_from_checkpoint(self, monkeypatch):
+        previous_options = AgentRequestOptions(search_source_type="video_file", use_critic=True)
+        current_options = AgentRequestOptions(search_source_type="rtsp", use_critic=False)
+        captured = {}
+
+        class FakeGraph:
+            def get_state(self, config):
+                return SimpleNamespace(
+                    values={
+                        "conversation_history": [
+                            HumanMessage(content="find a person"),
+                            AIMessage(content="previous results"),
+                        ],
+                        "previous_conversation": "",
+                        "options": previous_options.model_dump(mode="json"),
+                    }
+                )
+
+            async def astream(self, input, config=None, stream_mode=None):
+                captured["input_state"] = input
+                yield AgentMessageChunk(type=AgentMessageChunkType.FINAL, content="done")
+
+        monkeypatch.setattr(
+            "vss_agents.agents.top_agent.ContextState.get",
+            lambda: SimpleNamespace(conversation_id=SimpleNamespace(get=lambda: "thread-1")),
+        )
+
+        agent = TopAgent.__new__(TopAgent)
+        agent.graph = FakeGraph()
+        agent.max_history = 10
+        agent.max_iterations = 10
+        agent.llm = MagicMock()
+        agent.callbacks = []
+
+        chunks = [
+            chunk
+            async for chunk in agent.astream(
+                [HumanMessage(content="same search on live streams")],
+                options=current_options,
+            )
+        ]
+
+        assert chunks == [AgentMessageChunk(type=AgentMessageChunkType.FINAL, content="done")]
+        input_state = captured["input_state"]
+        assert input_state.options == current_options
+        assert input_state.previous_options == previous_options
+
+    @pytest.mark.asyncio
+    async def test_agent_node_passes_request_options_context_without_forcing_tool_call(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        captured = {}
+
+        def _capture_prompt(prompt_value):
+            captured["messages"] = prompt_value.to_messages()
+            return AIMessage(content="Here are the previous results.")
+
+        agent = self._agent_with_search_tool()
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm_with_tools = RunnableLambda(_capture_prompt)
+        agent.prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", "current time: {current_time}{request_options_context}{thinking_tag}"),
+                MessagesPlaceholder(variable_name="conversation_history", optional=True),
+                ("user", "{question}"),
+                MessagesPlaceholder(variable_name="agent_scratchpad", optional=True),
+            ]
+        )
+        agent.plan_exec_prompt = None
+        agent.callbacks = []
+        state = TopAgentState(
+            current_message=HumanMessage(content="person carrying boxes"),
+            options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+            previous_options=AgentRequestOptions(search_source_type="video_file", use_critic=True),
+        )
+
+        result = await agent.agent_node(state)
+
+        assert result.final_answer == "Here are the previous results."
+        assert len(result.agent_scratchpad) == 1
+        ai_message = result.agent_scratchpad[0]
+        assert isinstance(ai_message, AIMessage)
+        assert not ai_message.tool_calls
+        assert "Request options context" in captured["messages"][0].content
+
+    @pytest.mark.asyncio
+    async def test_agent_node_passes_request_options_context_to_plan_exec_prompt(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        captured = {}
+
+        def _capture_prompt(prompt_value):
+            captured["messages"] = prompt_value.to_messages()
+            return AIMessage(content="Here are the previous results.")
+
+        agent = self._agent_with_search_tool()
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm_with_tools = RunnableLambda(_capture_prompt)
+        agent.prompt = ChatPromptTemplate.from_messages([("user", "{question}")])
+        agent.plan_exec_prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", "{request_options_context}{thinking_tag}"),
+                ("user", "User Question: {question}\n\nExecution Plan:\n{plan_section}\n\n"),
+            ]
+        )
+        agent.callbacks = []
+        state = TopAgentState(
+            current_message=HumanMessage(content="person carrying boxes"),
+            plan="1. Answer from the current plan.",
+            options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+            previous_options=AgentRequestOptions(search_source_type="video_file", use_critic=True),
+        )
+
+        result = await agent.agent_node(state)
+
+        assert result.final_answer == "Here are the previous results."
+        assert "Request options context" in captured["messages"][0].content
+
+    @pytest.mark.asyncio
+    async def test_plan_node_includes_request_options_context(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        captured = {}
+
+        async def _capture_plan(messages, config=None):
+            captured["system"] = messages[0].content
+            return AIMessage(content="1. Call `search_agent` with the user's query.")
+
+        agent = self._agent_with_search_tool()
+        agent.llm = MagicMock()
+        agent.llm.model_name = "test-model"
+        agent.llm.ainvoke = AsyncMock(side_effect=_capture_plan)
+        agent.callbacks = []
+        agent.plan_prompt = None
+        agent.plan_system_prompt = "System prompt."
+        state = TopAgentState(
+            current_message=HumanMessage(content="person carrying boxes"),
+            options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+            previous_options=AgentRequestOptions(search_source_type="video_file", use_critic=True),
+        )
+
+        result = await agent._plan_node(state)
+
+        assert result.plan == "1. Call `search_agent` with the user's query."
+        assert "Request options context" in captured["system"]
+
+    @pytest.mark.asyncio
+    async def test_tool_node_forwards_request_options_to_accepting_tool(self, monkeypatch):
+        chunks = []
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
+
+        class SearchTool:
+            def __init__(self):
+                self.args_schema = MagicMock()
+                self.args_schema.model_fields = {
+                    "request_options": MagicMock(),
+                    "use_critic": MagicMock(),
+                }
+                self.received_input = None
+
+            async def astream(self, input, config=None):
+                self.received_input = input
+                yield "search ok"
+
+        search_tool = SearchTool()
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"search_agent": search_tool}
+        agent.subagent_names = set()
+        agent.callbacks = []
+        state = TopAgentState(
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling search",
+                    tool_calls=[{"name": "search_agent", "args": {"query": "boxes"}, "id": "call_1"}],
+                )
+            ],
+            options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+        )
+
+        await agent.tool_or_subagent_node(state)
+
+        assert search_tool.received_input["request_options"]["search_source_type"] == "rtsp"
+        assert search_tool.received_input["request_options"]["use_critic"] is False
+        assert search_tool.received_input["use_critic"] is False
+        assert any(
+            chunk.type == AgentMessageChunkType.TOOL_CALL
+            and "'request_options':" in chunk.content
+            and "'search_source_type': 'rtsp'" in chunk.content
+            and "'use_critic': False" in chunk.content
+            for chunk in chunks
+        )
+
+    @pytest.mark.asyncio
+    async def test_tool_node_forwards_request_options_with_search_agent_schema(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        class SearchTool:
+            args_schema = SearchAgentInput
+
+            def __init__(self):
+                self.received_input = None
+
+            async def astream(self, input, config=None):
+                self.received_input = input
+                yield "search ok"
+
+        search_tool = SearchTool()
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"search_agent": search_tool}
+        agent.subagent_names = set()
+        agent.callbacks = []
+        state = TopAgentState(
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling search",
+                    tool_calls=[{"name": "search_agent", "args": {"query": "boxes"}, "id": "call_1"}],
+                )
+            ],
+            options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+        )
+
+        await agent.tool_or_subagent_node(state)
+
+        assert search_tool.received_input["request_options"]["search_source_type"] == "rtsp"
+        assert search_tool.received_input["request_options"]["use_critic"] is False
+        assert "source_type" not in search_tool.received_input
+
+    @pytest.mark.asyncio
+    async def test_tool_node_forwards_request_options_to_accepting_subagent_trace(self, monkeypatch):
+        chunks = []
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: chunks.append)
+
+        search_tool = MagicMock()
+        search_tool.args_schema = MagicMock()
+        search_tool.args_schema.model_fields = {
+            "request_options": MagicMock(),
+            "use_critic": MagicMock(),
+        }
+
+        class SearchFunction:
+            def __init__(self):
+                self.received_input = None
+
+            async def astream(self, input):
+                self.received_input = input
+                yield AgentMessageChunk(type=AgentMessageChunkType.FINAL, content="search ok")
+
+        search_function = SearchFunction()
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"search_agent": search_tool}
+        agent.subagent_names = {"search_agent"}
+        agent.subagent_functions = {"search_agent": search_function}
+        agent.callbacks = []
+        state = TopAgentState(
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling search",
+                    tool_calls=[{"name": "search_agent", "args": {"query": "boxes"}, "id": "call_1"}],
+                )
+            ],
+            options=AgentRequestOptions(search_source_type="rtsp", use_critic=False),
+        )
+
+        await agent.tool_or_subagent_node(state)
+
+        assert search_function.received_input["request_options"]["search_source_type"] == "rtsp"
+        assert search_function.received_input["request_options"]["use_critic"] is False
+        assert search_function.received_input["use_critic"] is False
+        assert any(
+            chunk.type == AgentMessageChunkType.SUBAGENT_CALL
+            and "'request_options':" in chunk.content
+            and "'search_source_type': 'rtsp'" in chunk.content
+            and "'use_critic': False" in chunk.content
+            for chunk in chunks
+        )
 
 
 class TestTopAgentRequestUseCritic:


### PR DESCRIPTION
## Description
To address the case of LLM directly returning the result from conversation history instead of calling search_agent, when the runtime params (use_critic, etc.,) are toggled without modifying the query.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
