### PR TITLE
fix rtvi cv and embed model issues, cherry picked from develop

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
@@ -27,7 +27,7 @@ general:
       # storage in place when an RTSP stream is removed.
       delete_vst_storage_on_stream_remove: false
       rtvi_embed_base_url: ${RTVI_EMBED_BASE_URL}
-      rtvi_embed_model: {{ .Values.rtviEmbedModel | default "cosmos-embed1-448p" }}
+      rtvi_embed_model: {{ .Values.rtviEmbedModel | default "cosmos-embed1-448p-anomaly-detection" }}
       rtvi_embed_chunk_duration: 5
       rtvi_cv_base_url: ${RTVI_CV_BASE_URL}
       vlm_mode: ${VLM_MODE}

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -208,6 +208,9 @@ rtvi:
         sourcePath: siglip_v2_vdeployable_v1.1/siglip2_v1.1.onnx
         destPath: siglip2_v1.1.onnx
       - model: nvstaging/tao/siglip_v2:deployable_v1.1
+        sourcePath: siglip_v2_vdeployable_v1.1/siglip2_v1.1_weights.bin
+        destPath: siglip2_v1.1_weights.bin
+      - model: nvstaging/tao/siglip_v2:deployable_v1.1
         sourcePath: siglip_v2_vdeployable_v1.1/siglip2_v1.1_tokenizer
         destPath: siglip2_v1.1_tokenizer
     models:
@@ -414,6 +417,7 @@ agent:
       imagePullPolicy: IfNotPresent
     profile: search
     replicas: 1
+    rtviEmbedModelName: cosmos-embed1-448p-anomaly-detection
     llmName: nvidia/nvidia-nemotron-nano-9b-v2
     vlmName: nvidia/cosmos-reason2-8b
     llmBaseUrl: ''
@@ -533,6 +537,8 @@ agent:
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $ipRaw := index $g "externalHost" | default "127.0.0.1" | trim }}{{- $ip := $ipRaw }}{{- if and (hasPrefix "vss-search." $ipRaw) (hasSuffix "nip.io" $ipRaw) }}{{- $ip = $ipRaw | trimPrefix "vss-search." | trimSuffix ".nip.io" }}{{- end }}{{- $mainHostDef := printf "vss-search.%s.nip.io" $ip }}{{- $mainHost := .Values.vstPublicIngressHost | default $mainHostDef | trim }}{{- $useNip := default true .Values.vstPublicBaseUseNipIo }}{{- $nipBase := ternary (printf "http://%s" $mainHost) "" (and $useNip (ne $mainHost "")) }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{- $agentBaseExplicit := coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl }}{{ if $agentBaseExplicit }}{{ $agentBaseExplicit }}{{ else if and $useNip (ne $nipBase "") }}{{ $nipBase }}{{ else }}{{ coalesce $globalBase $vssAgentHttp }}{{ end }}'
       - name: ENABLE_CRITIC
         value: '{{- if and .Values.global (hasKey .Values.global "enableCritic") }}{{ (index .Values.global "enableCritic") | toString }}{{- else }}true{{- end }}'
+      - name: RTVI_EMBED_MODEL
+        value: '{{ .Values.rtviEmbedModelName | default "cosmos-embed1-448p-anomaly-detection" }}'
       - name: VSS_AGENT_VERSION
         value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-55f5cd1d7a59" }}'
 


### PR DESCRIPTION
## Description
Search Profile now defaults to using [siglip2](https://catalog.ngc.nvidia.com/orgs/nvstaging/teams/tao/models/siglip_v2?version=deployable_v1.1) as the vision encoder and text embedder in RTVI-CV, instead of radio-clip (can still be used by setting env vars).

### 1. RTVI CV - missing siglip2 weights file variable

#### Issue
While it works with docker-compose deployments currently, in k8s it fails with the following error - 
```
[TRT-1] WeightsContext.cpp:190: Failed to open file: /opt/storage/siglip2_v1.1_weights.bin
```

#### Root Cause
The SigLIP v2 ONNX model (`siglip2_v1.1.onnx`) uses **external weights** stored in a companion file `siglip2_v1.1_weights.bin`. When TensorRT parses the ONNX graph, it tries to load this external weights file from the same directory and fails because it was never downloaded.

The Docker Compose init script (`download-vision-encoder.sh`) downloads the entire NGC model package and copies **all files** into `/opt/storage/`, hence it works.

The Helm download Job (`job-download-models.yaml`) cherry-picks only the files listed in `ngcModelsToDownload`. The `siglip2_v1.1_weights.bin` external weights file was **not in the list** and was deleted by `rm -rf`.

#### Fix
Add the missing weights file entry to `ngcModelsToDownload` in `deploy/helm/developer-profiles/dev-profile-search/values.yaml`.

#### Future scope (tentative)
Align helm with docker-compose in the long-term.

---

### 2. RTVI Embed - missing env var in helm chart `RTVI_EMBED_MODEL`

#### Issue
RTVI Embed client in vss-agent invokes the `rtvi-embed` service with the wrong embedding model name:
Expected: `cosmos-embed1-448p-anomaly-detection`
Runtime: `cosmos-embed1-448p`

#### Root Cause
The client code defaults to the wrong model name in case the env var `RTVI_EMBED_MODEL` is missing:
```
_EMBED_MODEL = os.getenv("RTVI_EMBED_MODEL", "cosmos-embed1-448p")
```

While the var is declared in docker-compose env, it's missing in case of helm.

#### Fix
Declared the env var in helm values.yaml.

#### Future scope (tentative)
Either the default must be changed in the code or should fail fast in case the env var is missing.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
