### PR TITLE
Fix chat video upload completion

### DIFF
--- a/services/ui/packages/common/__tests__/utils/videoUpload.test.ts
+++ b/services/ui/packages/common/__tests__/utils/videoUpload.test.ts
@@ -93,11 +93,23 @@ describe('uploadFile', () => {
   });
 
   it('returns FileUploadResult after successful upload', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({ url: 'https://presigned.example.com/upload' }),
-    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ url: 'https://presigned.example.com/upload' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            message: 'Video upload and processing complete',
+            video_id: 'sensor-1',
+            filename: 'test.mp4',
+            chunks_processed: 0,
+          }),
+      });
 
     const mockResult = {
       filename: 'test.mp4',
@@ -139,7 +151,23 @@ describe('uploadFile', () => {
       { sensorId: 'sensor-1' }
     );
 
-    expect(result).toEqual(mockResult);
+    expect(result).toEqual({
+      ...mockResult,
+      message: 'Video upload and processing complete',
+      video_id: 'sensor-1',
+      chunks_processed: 0,
+    });
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      'http://api.test/videos-for-search/test/complete',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...mockResult,
+          custom_params: { sensorId: 'sensor-1' },
+        }),
+      })
+    );
   });
 
   it('throws when abortSignal is already aborted', async () => {
@@ -155,11 +183,23 @@ describe('uploadFile', () => {
 
   it('uses requestFilename when provided', async () => {
     const handlers: Record<string, () => void> = {};
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({ url: 'https://presigned.example.com/upload' }),
-    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ url: 'https://presigned.example.com/upload' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            message: 'Video upload and processing complete',
+            video_id: 'sensor-custom',
+            filename: 'custom-name',
+            chunks_processed: 0,
+          }),
+      });
 
     global.XMLHttpRequest = jest.fn().mockImplementation(() => ({
       open: jest.fn(),
@@ -171,7 +211,7 @@ describe('uploadFile', () => {
             value: JSON.stringify({
               filename: 'custom-name',
               bytes: 0,
-              sensorId: '',
+              sensorId: 'sensor-custom',
               streamId: '',
               filePath: '',
               timestamp: '',
@@ -200,5 +240,50 @@ describe('uploadFile', () => {
     expect(JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body)).toMatchObject({
       filename: 'custom-name.mp4',
     });
+    expect((global.fetch as jest.Mock).mock.calls[1][0]).toBe(
+      'http://api.test/videos-for-search/custom-name/complete'
+    );
+  });
+
+  it('fails when post-upload processing fails', async () => {
+    const handlers: Record<string, () => void> = {};
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ url: 'https://presigned.example.com/upload' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ detail: 'processing failed' }),
+      });
+
+    global.XMLHttpRequest = jest.fn().mockImplementation(() => ({
+      open: jest.fn(),
+      setRequestHeader: jest.fn(),
+      send: jest.fn(function (this: any) {
+        setTimeout(() => {
+          Object.defineProperty(this, 'status', { value: 200 });
+          Object.defineProperty(this, 'responseText', {
+            value: JSON.stringify({
+              filename: 'test.mp4',
+              sensorId: 'sensor-1',
+            }),
+          });
+          handlers['load']?.();
+        }, 0);
+      }),
+      upload: { addEventListener: jest.fn() },
+      addEventListener: jest.fn((ev: string, fn: () => void) => {
+        handlers[ev] = fn;
+      }),
+      abort: jest.fn(),
+    })) as any;
+
+    await expect(uploadFile(createMockFile(), 'http://api.test', {})).rejects.toThrow(
+      'processing failed'
+    );
   });
 });

--- a/services/ui/packages/common/lib-src/utils/videoUpload.ts
+++ b/services/ui/packages/common/lib-src/utils/videoUpload.ts
@@ -15,11 +15,14 @@ interface AgentUploadUrlResponse {
  */
 export interface FileUploadResult {
   filename: string;
-  bytes: number;
-  sensorId: string;
-  streamId: string;
-  filePath: string;
-  timestamp: string;
+  bytes?: number;
+  sensorId?: string;
+  streamId?: string;
+  filePath?: string;
+  timestamp?: string;
+  message?: string;
+  video_id?: string;
+  chunks_processed?: number;
 }
 
 /**
@@ -57,6 +60,66 @@ export async function getUploadUrl(
 
   const data: AgentUploadUrlResponse = await response.json();
   return data.url;
+}
+
+function removeFileExtension(filename: string): string {
+  const dotIndex = filename.lastIndexOf('.');
+  return dotIndex > 0 ? filename.substring(0, dotIndex) : filename;
+}
+
+/**
+ * Notify the agent that the direct VST upload has completed.
+ *
+ * Video Management already performs this step after chunked uploads. Chat uploads
+ * use the older direct VST PUT path, so they must call the same completion route
+ * before reporting success; otherwise the file exists in VST but the agent has
+ * not run timeline lookup / URL registration / downstream post-processing.
+ */
+async function notifyUploadComplete(
+  uploadUrl: string,
+  filename: string,
+  uploadResponse: FileUploadResult,
+  formData?: Record<string, any>,
+  signal?: AbortSignal
+): Promise<Partial<FileUploadResult>> {
+  const sensorId = uploadResponse.sensorId;
+  if (!sensorId) {
+    throw new Error('Upload response missing sensorId');
+  }
+
+  const filenameWithoutExt = removeFileExtension(filename);
+  const completeUrl = `${uploadUrl.replace(/\/$/, '')}/videos-for-search/${encodeURIComponent(filenameWithoutExt)}/complete`;
+  const body: Record<string, any> = { ...uploadResponse };
+
+  if (formData && Object.keys(formData).length > 0) {
+    body.custom_params = formData;
+  }
+
+  const response = await fetch(completeUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!response.ok) {
+    let message = `Post-processing failed with status ${response.status}`;
+    try {
+      const errorData = await response.json();
+      if (errorData?.detail != null) {
+        message = typeof errorData.detail === 'string' ? errorData.detail : JSON.stringify(errorData.detail);
+      }
+    } catch {
+      // ignore JSON parse failure, use default message
+    }
+    throw new Error(message);
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
 }
 
 /**
@@ -119,13 +182,20 @@ export async function uploadFile(
         }
       });
 
-      xhr.addEventListener('load', () => {
+      xhr.addEventListener('load', async () => {
         if (xhr.status >= 200 && xhr.status < 300) {
           try {
-            const result: FileUploadResult = JSON.parse(xhr.responseText);
-            resolve(result);
-          } catch {
-            reject(new Error('Failed to parse upload response'));
+            const uploadResult: FileUploadResult = JSON.parse(xhr.responseText);
+            const completionResult = await notifyUploadComplete(
+              uploadUrl,
+              filenameForRequest,
+              uploadResult,
+              formData,
+              abortSignal
+            );
+            resolve({ ...uploadResult, ...completionResult, sensorId: uploadResult.sensorId });
+          } catch (error) {
+            reject(error instanceof Error ? error : new Error('Failed to parse upload response'));
           }
         } else {
           reject(new Error(`Upload failed with status: ${xhr.status}`));

--- a/services/ui/packages/nemo-agent-toolkit-ui/components/Chat/Chat.tsx
+++ b/services/ui/packages/nemo-agent-toolkit-ui/components/Chat/Chat.tsx
@@ -895,6 +895,14 @@ export const Chat = () => {
 
   const handleSend = useCallback(
     async (message: Message, deleteCount = 0, retry = false) => {
+      if (
+        message.hidden &&
+        selectedConversation &&
+        selectedConversationRef.current?.id !== selectedConversation.id
+      ) {
+        return;
+      }
+
       // DON'T mutate the original message - create a new one with a new ID
       const messageWithNewId = {
         ...message,


### PR DESCRIPTION
## Description
Direct chat video uploads now notify the agent completion endpoint after the VST PUT succeeds, matching the Video Management post-upload flow. Upload success is only reported after post-processing completes, so the agent receives the registered video metadata before the hidden chat prompt is sent.

This also ignores stale hidden upload messages when async completion resolves after the user has switched away from or cleared the selected conversation, preventing deleted conversations from being restored.

## Testing
- `npm test -- --runTestsByPath __tests__/utils/videoUpload.test.ts`
- `npm run typecheck` in `services/ui/packages/common`
- `git diff --check`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.