### PR TITLE
fix agent VST media URL handling

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
@@ -74,8 +74,6 @@ functions:
     reasoning: true
     video_url_tool: vst_video_clip
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
 
   # Video understanding for incidents (uses ISO timestamps)
@@ -89,8 +87,6 @@ functions:
     video_url_tool: vst_video_url
     use_base64: true
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
 
   vst_video_clip:

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
@@ -69,8 +69,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     system_prompt: |
       You are a monitoring system analyzing video footage.

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -68,8 +68,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     system_prompt: |
       You are a monitoring system analyzing video footage.

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -70,8 +70,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     system_prompt: |
       You are a monitoring system analyzing video footage.
@@ -108,9 +106,6 @@ functions:
     lvs_backend_url: ${LVS_BACKEND_URL}
     model: ${VLM_NAME}
     video_url_tool: vst_video_clip
-    vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
     conn_timeout_ms: 5000

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -64,8 +64,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     system_prompt: |
       You are a monitoring system analyzing video footage.
@@ -102,9 +100,6 @@ functions:
     lvs_backend_url: ${LVS_BACKEND_URL}
     model: ${VLM_NAME}
     video_url_tool: vst_video_clip
-    vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
     conn_timeout_ms: 5000

--- a/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
@@ -150,8 +150,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
 
 llms:

--- a/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
@@ -30,9 +30,6 @@ general:
       rtvi_embed_model: ${RTVI_EMBED_MODEL:-cosmos-embed1-448p}
       rtvi_embed_chunk_duration: 5
       rtvi_cv_base_url: http://${HOST_IP}:${RTVI_CV_PORT}
-      vlm_mode: ${VLM_MODE}
-      internal_ip: ${HOST_IP}
-      external_ip: ${EXTERNAL_IP}
       elasticsearch_url: ${ELASTIC_SEARCH_ENDPOINT}
       rtvi_embed_es_index: ${ELASTIC_SEARCH_INDEX}
     endpoints:

--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
@@ -57,8 +57,6 @@ functions:
     reasoning: false
     video_url_tool: vst_video_url
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${HOST_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
 
   vst_video_url:

--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -72,9 +72,6 @@ services:
     - bp_developer_alerts_2d_cv
     - bp_developer_alerts_2d_vlm
     environment:
-      # URL rewriting configuration
-      EXTERNAL_IP: ${EXTERNAL_IP}
-      INTERNAL_IP: ${HOST_IP}
       LLM_MODE: ${LLM_MODE} # remote / local / local_shared
       VLM_MODE: ${VLM_MODE} # remote / local / local_shared
       LLM_MODEL_TYPE: ${LLM_MODEL_TYPE} # nim / openai
@@ -96,7 +93,6 @@ services:
       PHOENIX_ENDPOINT: ${PHOENIX_ENDPOINT}
 
       # VST (Video Storage Tool)
-      VST_BASE_URL: ${VST_BASE_URL}
       VST_INTERNAL_URL: ${VST_INTERNAL_URL}
       VST_EXTERNAL_URL: ${VST_EXTERNAL_URL}
       VST_MCP_URL: ${VST_MCP_URL}

--- a/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
@@ -74,8 +74,6 @@ functions:
     reasoning: true
     video_url_tool: vst_video_clip
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${INTERNAL_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
 
   # Video understanding for incidents (uses ISO timestamps)

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
@@ -69,8 +69,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${INTERNAL_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     system_prompt: |
       You are a monitoring system analyzing video footage.

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
@@ -65,8 +65,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${INTERNAL_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     system_prompt: |
       You are a monitoring system analyzing video footage.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -70,8 +70,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${INTERNAL_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     system_prompt: |
       You are a monitoring system analyzing video footage.
@@ -109,8 +107,6 @@ functions:
     model: ${VLM_NAME}
     video_url_tool: vst_video_clip
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${INTERNAL_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
     conn_timeout_ms: 5000

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
@@ -64,8 +64,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${INTERNAL_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     system_prompt: |
       You are a monitoring system analyzing video footage.
@@ -103,8 +101,6 @@ functions:
     model: ${VLM_NAME}
     video_url_tool: vst_video_clip
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${INTERNAL_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
     conn_timeout_ms: 5000

--- a/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
@@ -30,9 +30,6 @@ general:
       rtvi_embed_model: {{ .Values.rtviEmbedModel | default "cosmos-embed1-448p-anomaly-detection" }}
       rtvi_embed_chunk_duration: 5
       rtvi_cv_base_url: ${RTVI_CV_BASE_URL}
-      vlm_mode: ${VLM_MODE}
-      internal_ip: ${INTERNAL_IP}
-      external_ip: ${EXTERNAL_IP}
       elasticsearch_url: ${ELASTIC_SEARCH_ENDPOINT}
       rtvi_embed_es_index: ${ELASTIC_SEARCH_INDEX}
     endpoints:
@@ -150,8 +147,6 @@ functions:
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
-    internal_ip: ${INTERNAL_IP}
-    external_ip: ${EXTERNAL_IP}
     vst_internal_url: ${VST_INTERNAL_URL}
 
 llms:

--- a/services/agent/src/vss_agents/api/front_end_config.py
+++ b/services/agent/src/vss_agents/api/front_end_config.py
@@ -81,10 +81,6 @@ class StreamingIngestConfig(BaseModel):
     elasticsearch_url: str = Field(default="", description="Elasticsearch endpoint URL")
     rtvi_embed_es_index: str = Field(default="", description="Elasticsearch index for embeddings")
 
-    vlm_mode: str = Field(default="", description="VLM mode (remote/local/local_shared)")
-    internal_ip: str = Field(default="", description="Internal IP address of the host")
-    external_ip: str = Field(default="", description="External IP address for public-facing URLs")
-
 
 class VSSFastApiFrontEndConfig(FastApiFrontEndConfig, name="vss_fastapi"):  # type: ignore[call-arg]
     """

--- a/services/agent/src/vss_agents/tools/lvs_video_understanding.py
+++ b/services/agent/src/vss_agents/tools/lvs_video_understanding.py
@@ -51,7 +51,7 @@ from pydantic import Field
 from pydantic import field_validator
 
 from vss_agents.utils.hitl import format_hitl_popup_header
-from vss_agents.utils.url_translation import translate_url
+from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
 
 logger = logging.getLogger(__name__)
 
@@ -213,23 +213,10 @@ class LVSVideoUnderstandingConfig(FunctionBaseConfig, name="lvs_video_understand
         description="Default events list to use when no persistent state exists (e.g., ['accident', 'pedestrian crossing'])",
     )
 
-    # URL translation configuration for VLM
-    vlm_mode: str = Field(
-        default="local",
-        description="VLM mode: 'remote' (VLM is external, needs public URLs), 'local' or 'local_shared' (VLM is local, needs internal URLs)",
-    )
-    internal_ip: str = Field(
-        default="",
-        description="Internal IP / docker host IP for URL translation",
-    )
-    external_ip: str = Field(
-        default="",
-        description="Public IP accessible from the internet for URL translation",
-    )
     vst_internal_url: str | None = Field(
         default=None,
         description="Internal VST base URL (e.g., 'http://HOST_IP:30888'). "
-        "Used for URL translation when behind a reverse proxy.",
+        "Used because LVS runs inside the deployment and fetches VST media directly.",
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -665,17 +652,10 @@ async def lvs_video_understanding(
         video_url_result = await video_url_tool.ainvoke(input=video_url_args)
         video_url = video_url_result.video_url
 
-        # Translate URL for VLM based on vlm_mode:
-        # - remote: INTERNAL_IP -> EXTERNAL_IP (VLM needs public URLs)
-        # - local/local_shared: EXTERNAL_IP -> INTERNAL_IP (VLM needs internal URLs)
-        video_url = translate_url(
-            video_url,
-            config.vlm_mode,
-            config.internal_ip,
-            config.external_ip,
-            config.vst_internal_url,
-        )
-        logger.info(f"[LVS Video Understanding] VIDEO URL FOR VLM ANALYSIS: {video_url}")
+        # LVS runs inside the deployment, so it should fetch VST media through
+        # the internal VST base instead of the public/proxy URL.
+        video_url = rewrite_to_internal_vst_url(video_url, config.vst_internal_url)
+        logger.info(f"[LVS Video Understanding] INTERNAL VIDEO URL FOR LVS ANALYSIS: {video_url}")
 
         # Build LVS request using new API contract
         lvs_request: dict[str, Any] = {

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import base64
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from datetime import timedelta
@@ -43,9 +42,8 @@ from pydantic import model_validator
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import get_stream_id
 from vss_agents.utils.frame_select import frame_select
-from vss_agents.utils.reasoning_parsing import parse_content_blocks
 from vss_agents.utils.retry import create_retry_strategy
-from vss_agents.utils.url_translation import translate_url
+from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +97,20 @@ def _parse_thinking_from_content(content: str) -> tuple[str | None, str]:
 
     # No thinking tags found, return original content
     return None, content
+
+
+def _should_use_video_base64(
+    *,
+    use_base64: bool,
+    vlm_mode: str | None,
+) -> bool:
+    """Return whether the video payload should be downloaded locally and sent as base64."""
+    return use_base64 or _is_remote_vlm(vlm_mode)
+
+
+def _is_remote_vlm(vlm_mode: str | None) -> bool:
+    """Return whether the VLM backend is configured as remote."""
+    return (vlm_mode or "").lower() == "remote"
 
 
 class VideoUnderstandingConfig(FunctionBaseConfig, name="video_understanding"):
@@ -170,23 +182,15 @@ class VideoUnderstandingConfig(FunctionBaseConfig, name="video_understanding"):
         default=None,
         description="Optional custom system prompt for the VLM. If not provided, uses default reasoning prompt when reasoning=True, or no system prompt when reasoning=False.",
     )
-    # URL translation configuration for VLM
+    # VLM media access configuration.
     vlm_mode: str | None = Field(
         default="local",
-        description="VLM mode: 'remote' (VLM is external, needs public URLs), 'local' or 'local_shared' (VLM is local, needs internal URLs)",
-    )
-    internal_ip: str | None = Field(
-        default="",
-        description="Internal IP / docker host IP for URL translation",
-    )
-    external_ip: str | None = Field(
-        default="",
-        description="Public IP accessible from the internet for URL translation",
+        description="VLM mode: 'remote' (VLM is external), 'local' or 'local_shared' (VLM is inside the deployment)",
     )
     vst_internal_url: str | None = Field(
         default=None,
         description="Internal VST base URL (e.g., 'http://HOST_IP:30888'). "
-        "Used for URL translation when behind a reverse proxy.",
+        "Used when the agent or local VLM fetches VST media directly.",
     )
 
 
@@ -295,14 +299,13 @@ async def _build_vlm_messages(
     video_url: str,
     user_prompt: str,
     *,
-    use_frame_images: bool,
     use_base64: bool,
     video_length_seconds: float,
     num_frames: int,
     max_fps: int,
 ) -> list[HumanMessage]:
     """Download/transform video and build VLM messages for the appropriate backend."""
-    if use_frame_images:
+    if use_base64:
         timeout = aiohttp.ClientTimeout(total=300)
         async with aiohttp.ClientSession(timeout=timeout) as session, session.get(video_url) as resp:
             resp.raise_for_status()
@@ -329,14 +332,6 @@ async def _build_vlm_messages(
             )
         ]
 
-    if use_base64:
-        timeout = aiohttp.ClientTimeout(total=300)
-        async with aiohttp.ClientSession(timeout=timeout) as session, session.get(video_url) as resp:
-            resp.raise_for_status()
-            video_data = await resp.read()
-            video_base64 = base64.b64encode(video_data).decode("utf-8")
-            video_url = f"data:video/mp4;base64,{video_base64}"
-
     return [
         HumanMessage(
             content=[
@@ -355,12 +350,11 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
     is_cosmos_model = is_nim and "cosmos" in model_name
     is_cosmos_reason2 = is_nim and model_name == "nvidia/cosmos-reason2-8b"
 
-    # Dynamically determine if we extract frames for this model (only needed for official OpenAI endpoints for now)
-    # Supposes any vlm_name prefixed with "openai_" is from an official OpenAI endpoint
-    use_frame_images = str(config.vlm_name).startswith("openai_")
-    logger.info(
-        f"Using VLM profile: {config.vlm_name}, use_frame_images: {use_frame_images}, use_base64: {config.use_base64}"
+    use_video_base64 = _should_use_video_base64(
+        use_base64=config.use_base64,
+        vlm_mode=config.vlm_mode,
     )
+    logger.info(f"Using VLM profile: {config.vlm_name}, vlm_mode: {config.vlm_mode}, use_base64: {use_video_base64}")
 
     if not config.use_vst:
         s3_client = boto3.client(
@@ -490,15 +484,10 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             else config.reasoning
         )
 
-        if use_frame_images:  # OpenAI models (reasoning configuration through parameters)
-            if use_reasoning:
-                vlm = vlm.bind(reasoning={"effort": "medium", "summary": "auto"})
-            prompt_template = non_reasoning_prompt_template
-        else:
-            prompt_template = reasoning_prompt_template if use_reasoning else non_reasoning_prompt_template
+        prompt_template = reasoning_prompt_template if use_reasoning else non_reasoning_prompt_template
 
         vlm_chain = prompt_template | vlm
-        logger.info(f"VLM reasoning mode: {use_reasoning}, use_frame_images: {use_frame_images}")
+        logger.info(f"VLM reasoning mode: {use_reasoning}")
 
         # Step 1: Get the video URL (different paths for S3 vs VST)
         if not config.use_vst:
@@ -552,18 +541,16 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
                 video_url = vst_video_url_result.video_url
                 logger.debug(f"Video URL from VST: {video_url}")
 
-            # Translate URL for VLM based on vlm_mode:
-            # - remote: INTERNAL_IP -> EXTERNAL_IP (VLM needs public URLs)
-            # - local/local_shared: EXTERNAL_IP -> INTERNAL_IP (VLM needs internal URLs)
-            video_url = translate_url(
-                video_url,
-                config.vlm_mode,
-                config.internal_ip,
-                config.external_ip,
-                config.vst_internal_url,
-            )
+            if not config.vst_internal_url:
+                logger.warning("VST internal URL is not configured; using the original VST video URL.")
+            video_url = rewrite_to_internal_vst_url(video_url, config.vst_internal_url)
 
-        logger.info(f"[Video Understanding] VIDEO URL FOR VLM ANALYSIS: {video_url}")
+        if use_video_base64:
+            logger.info(f"[Video Understanding] VIDEO URL FOR LOCAL MEDIA DOWNLOAD: {video_url}")
+        elif config.use_vst:
+            logger.info(f"[Video Understanding] INTERNAL VIDEO URL FOR VLM ANALYSIS: {video_url}")
+        else:
+            logger.info(f"[Video Understanding] VIDEO URL FOR VLM ANALYSIS: {video_url}")
 
         user_prompt = video_understanding_input.user_prompt
         if is_cosmos_reason2 and use_reasoning:
@@ -576,8 +563,7 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
         messages = await _build_vlm_messages(
             video_url,
             user_prompt,
-            use_frame_images=use_frame_images,
-            use_base64=config.use_base64,
+            use_base64=use_video_base64,
             video_length_seconds=video_length_seconds,
             num_frames=num_frames,
             max_fps=config.max_fps,
@@ -595,14 +581,7 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
                     logger.error(f"Error understanding video {video_understanding_input.sensor_id}: {e}")
                     raise e
 
-        if use_frame_images:  # OpenAI models (output reasoning in content_blocks)
-            reasoning, answer = parse_content_blocks(response)
-            if reasoning or answer:
-                content = f"<think>{reasoning}</think>{answer or ''}" if reasoning else (answer or "")
-            else:
-                content = str(response.content) if response.content is not None else ""
-        else:
-            content = str(response.content) if response.content is not None else ""
+        content = str(response.content) if response.content is not None else ""
         # Filter thinking traces
         if config.filter_thinking:
             thinking, answer = _parse_thinking_from_content(content)

--- a/services/agent/src/vss_agents/utils/url_translation.py
+++ b/services/agent/src/vss_agents/utils/url_translation.py
@@ -14,22 +14,10 @@
 # limitations under the License.
 
 """
-URL Translation Utility for VSS Agent.
+URL Rewriting Utility for VSS Agent.
 
-Translates URLs based on VLM_MODE to ensure VLM can access video resources:
-- remote: INTERNAL_IP -> EXTERNAL_IP (external VLM needs public URLs)
-- local/local_shared: EXTERNAL_IP -> INTERNAL_IP (local VLM needs internal URLs)
-
-When the application is behind a reverse proxy (e.g., Brev secure links routing
-through nginx), the video URL hostname won't match either IP. In that case, if
-``vst_internal_url`` is provided, the proxy base URL is replaced with the internal
-VST base URL so the local VLM can reach the video directly.
-
-Configuration (passed as arguments from tool config):
-    vlm_mode: remote / local / local_shared
-    external_ip: Public IP accessible from the internet
-    internal_ip: Internal IP / docker host IP
-    vst_internal_url: (optional) Internal VST base URL for proxy fallback
+Rewrites service URLs when an in-deployment consumer needs to bypass a public
+reverse proxy and reach the internal service endpoint directly.
 """
 
 import logging
@@ -38,117 +26,6 @@ from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
 logger = logging.getLogger(__name__)
-
-
-def translate_url(
-    url: str,
-    vlm_mode: str | None,
-    internal_ip: str | None,
-    external_ip: str | None,
-    vst_internal_url: str | None = None,
-) -> str:
-    """Translate URL based on VLM_MODE.
-
-    - remote: Replace INTERNAL_IP with EXTERNAL_IP (VLM is external, needs public URLs)
-    - local/local_shared: Replace EXTERNAL_IP with INTERNAL_IP (VLM is local, needs internal URLs)
-
-    When the URL host doesn't match either IP (e.g., behind a reverse proxy),
-    falls back to replacing the base URL with ``vst_internal_url`` if provided.
-
-    Args:
-        url: The URL to translate
-        vlm_mode: VLM mode ('remote', 'local', or 'local_shared'), None to skip translation
-        internal_ip: Internal IP / docker host IP, None to skip translation
-        external_ip: Public IP accessible from the internet, None to skip translation
-        vst_internal_url: Internal VST base URL (e.g., 'http://10.0.0.1:30888').
-            Used as fallback when the URL host is a proxy hostname that doesn't
-            match either IP.  Only applies to local/local_shared modes.
-
-    Returns:
-        Translated URL, or original URL if no translation needed
-    """
-    if not url:
-        return url
-
-    # Validate vlm_mode
-    if not vlm_mode:
-        logger.warning(
-            "URL TRANSLATION: vlm_mode is not set. "
-            "Expected values: 'remote', 'local', or 'local_shared'. "
-            "URL translation will be skipped."
-        )
-        return url
-
-    vlm_mode = vlm_mode.lower()
-
-    # Check for missing external_ip
-    if not external_ip:
-        logger.error(
-            "URL TRANSLATION ERROR: external_ip is not set! "
-            "Set external_ip to the public IP accessible from the internet. "
-            "URLs will NOT be translated."
-        )
-        return url
-
-    # Check for missing internal_ip
-    if not internal_ip:
-        logger.error(
-            "URL TRANSLATION ERROR: internal_ip is not set! "
-            "Set internal_ip to the internal/docker host IP. "
-            "URLs will NOT be translated."
-        )
-        return url
-
-    # Check if IPs are the same (no translation needed)
-    if external_ip == internal_ip:
-        logger.debug(f"URL TRANSLATION: external_ip ({external_ip}) equals internal_ip - no translation needed.")
-        return url
-
-    # Parse the URL
-    parsed = urlparse(url)
-    if not parsed.netloc:
-        return url
-
-    # Extract host (without port)
-    host = parsed.netloc.split(":")[0]
-
-    # Determine translation direction based on vlm_mode
-    if vlm_mode == "remote":
-        # Remote VLM needs external/public URLs
-        source_ip = internal_ip
-        target_ip = external_ip
-        direction = "INTERNAL -> EXTERNAL"
-    elif vlm_mode in ("local", "local_shared"):
-        # Local VLM needs internal URLs
-        source_ip = external_ip
-        target_ip = internal_ip
-        direction = "EXTERNAL -> INTERNAL"
-    else:
-        logger.warning(
-            f"URL TRANSLATION: Unknown vlm_mode '{vlm_mode}'. Expected: 'remote', 'local', or 'local_shared'."
-        )
-        return url
-
-    # Only translate if the host matches the source IP
-    if host != source_ip:
-        # Proxy fallback: when the app is behind a reverse proxy (e.g., Brev
-        # secure links with nginx), the URL hostname is the proxy's hostname,
-        # not a direct IP.  For local VLM modes, replace the proxy base URL
-        # with the internal VST URL so the VLM can reach the video directly.
-        if vlm_mode in ("local", "local_shared") and vst_internal_url:
-            return _translate_proxy_url(url, parsed, vst_internal_url)
-
-        logger.debug(f"URL TRANSLATION: Host '{host}' does not match source IP '{source_ip}' - no translation needed.")
-        return url
-
-    # Replace source IP with target IP in netloc
-    new_netloc = parsed.netloc.replace(source_ip, target_ip, 1)
-    translated = urlunparse(parsed._replace(netloc=new_netloc))
-
-    logger.info(f"URL TRANSLATION [{direction}] (vlm_mode={vlm_mode}): Converting IP from {source_ip} to {target_ip}")
-    logger.info(f"URL TRANSLATION: {url} -> {translated}")
-
-    return translated
 
 
 # Routing table: path prefix -> internal port.
@@ -211,6 +88,28 @@ def rewrite_url_host(url: str, target_ip: str) -> str:
     return translated
 
 
+def rewrite_to_internal_vst_url(url: str, vst_internal_url: str | None) -> str:
+    """Replace any VST media URL base with the configured internal VST base.
+
+    Use this when the agent or another internal service will fetch VST media
+    directly. It is independent of VLM mode because the consumer is known to be
+    inside the deployment boundary.
+    """
+    if not url or not vst_internal_url:
+        return url
+
+    parsed = urlparse(url)
+    if not parsed.netloc:
+        return url
+
+    path = parsed.path or ""
+    if not path.startswith("/vst/"):
+        logger.debug(f"URL TRANSLATION: URL path '{path}' is not a VST path - no internal VST rewrite needed.")
+        return url
+
+    return _translate_proxy_url(url, parsed, vst_internal_url)
+
+
 def _translate_proxy_url(url: str, parsed: ParseResult, vst_internal_url: str) -> str:
     """Replace a proxy base URL with the internal VST base URL.
 
@@ -237,5 +136,4 @@ def _translate_proxy_url(url: str, parsed: ParseResult, vst_internal_url: str) -
         f"Replacing proxy base URL with internal VST URL ({vst_internal_url})"
     )
     logger.info(f"URL TRANSLATION: {url} -> {translated}")
-
     return translated

--- a/services/agent/tests/unit_test/tools/test_lvs_video_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_lvs_video_understanding.py
@@ -41,6 +41,11 @@ class TestLVSVideoUnderstandingConfig:
         assert config.model == "gpt-4o"
         assert config.video_url_tool == "vst_video_url"
 
+    def test_url_translation_fields_are_not_exposed(self):
+        assert "vlm_mode" not in LVSVideoUnderstandingConfig.model_fields
+        assert "internal_ip" not in LVSVideoUnderstandingConfig.model_fields
+        assert "external_ip" not in LVSVideoUnderstandingConfig.model_fields
+
     def test_custom_timeouts(self):
         config = LVSVideoUnderstandingConfig(
             lvs_backend_url="http://localhost:38111",

--- a/services/agent/tests/unit_test/tools/test_video_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_video_understanding.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 """Unit tests for video_understanding module."""
 
+import pytest
+
+from vss_agents.tools.video_understanding import VideoUnderstandingConfig
+from vss_agents.tools.video_understanding import _build_vlm_messages
 from vss_agents.tools.video_understanding import _parse_thinking_from_content
+from vss_agents.tools.video_understanding import _should_use_video_base64
 
 
 class TestParseThinkingFromContent:
@@ -94,3 +99,96 @@ class TestParseThinkingFromContent:
         thinking, answer = _parse_thinking_from_content(content)
         assert thinking == "All reasoning here."
         assert answer == ""
+
+
+class TestShouldUseVideoBase64:
+    """Test video base64 selection for remote VLMs."""
+
+    def test_explicit_base64_enabled_for_local_vlm(self):
+        assert _should_use_video_base64(
+            use_base64=True,
+            vlm_mode="local",
+        )
+
+    def test_remote_vlm_uses_base64(self):
+        assert _should_use_video_base64(
+            use_base64=False,
+            vlm_mode="remote",
+        )
+
+    def test_local_vlm_does_not_use_base64_by_default(self):
+        assert not _should_use_video_base64(
+            use_base64=False,
+            vlm_mode="local_shared",
+        )
+
+
+class TestBuildVlmMessages:
+    """Test VLM media message construction."""
+
+    @pytest.mark.asyncio
+    async def test_base64_uses_sampled_image_frames(self, monkeypatch):
+        class FakeResponse:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def raise_for_status(self):
+                return None
+
+            async def read(self):
+                return b"video-bytes"
+
+        class FakeSession:
+            def __init__(self, timeout):
+                self.timeout = timeout
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, url):
+                assert url == "http://10.0.0.1:30888/vst/storage/video.mp4"
+                return FakeResponse()
+
+        def fake_frame_select(path, start, end, step_size):
+            assert path.endswith(".mp4")
+            assert start == 0.0
+            assert end == 4.0
+            assert step_size == 2.0
+            return ["frame-a", "frame-b"]
+
+        monkeypatch.setattr("vss_agents.tools.video_understanding.aiohttp.ClientSession", FakeSession)
+        monkeypatch.setattr("vss_agents.tools.video_understanding.frame_select", fake_frame_select)
+
+        messages = await _build_vlm_messages(
+            "http://10.0.0.1:30888/vst/storage/video.mp4",
+            "What is happening?",
+            use_base64=True,
+            video_length_seconds=4.0,
+            num_frames=2,
+            max_fps=1,
+        )
+
+        content = messages[0].content
+        assert content[0]["type"] == "text"
+        assert "sequence of frames" in content[0]["text"]
+        assert content[1:] == [
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,frame-a"}},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,frame-b"}},
+        ]
+
+
+class TestVideoUnderstandingConfig:
+    """Test video understanding config shape."""
+
+    def test_ip_translation_fields_are_not_exposed(self):
+        assert "internal_ip" not in VideoUnderstandingConfig.model_fields
+        assert "external_ip" not in VideoUnderstandingConfig.model_fields
+
+    def test_remote_vlm_base64_toggle_is_not_exposed(self):
+        assert "use_base64_for_remote_vlm" not in VideoUnderstandingConfig.model_fields

--- a/services/agent/tests/unit_test/utils/test_url_translation.py
+++ b/services/agent/tests/unit_test/utils/test_url_translation.py
@@ -14,127 +14,28 @@
 # limitations under the License.
 """Unit tests for url_translation module."""
 
-from vss_agents.utils.url_translation import translate_url
+from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
 
 
-class TestTranslateUrl:
-    """Test translate_url function."""
+class TestRewriteToInternalVstUrl:
+    """Test direct VST internal URL rewriting."""
 
-    def test_empty_url_returns_empty(self):
-        result = translate_url("", "remote", "10.0.0.1", "1.2.3.4")
-        assert result == ""
-
-    def test_none_vlm_mode_returns_original(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, None, "10.0.0.1", "1.2.3.4")
-        assert result == url
-
-    def test_empty_vlm_mode_returns_original(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "", "10.0.0.1", "1.2.3.4")
-        assert result == url
-
-    def test_missing_external_ip_returns_original(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "remote", "10.0.0.1", None)
-        assert result == url
-
-    def test_empty_external_ip_returns_original(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "remote", "10.0.0.1", "")
-        assert result == url
-
-    def test_missing_internal_ip_returns_original(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "remote", None, "1.2.3.4")
-        assert result == url
-
-    def test_empty_internal_ip_returns_original(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "remote", "", "1.2.3.4")
-        assert result == url
-
-    def test_same_ips_returns_original(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "remote", "10.0.0.1", "10.0.0.1")
-        assert result == url
-
-    def test_remote_mode_internal_to_external(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "remote", "10.0.0.1", "1.2.3.4")
-        assert result == "http://1.2.3.4:8080/video.mp4"
-
-    def test_remote_mode_no_match(self):
-        url = "http://10.1.2.3:8080/video.mp4"
-        result = translate_url(url, "remote", "10.0.0.1", "1.2.3.4")
-        assert result == url
-
-    def test_local_mode_external_to_internal(self):
-        url = "http://1.2.3.4:8080/video.mp4"
-        result = translate_url(url, "local", "10.0.0.1", "1.2.3.4")
-        assert result == "http://10.0.0.1:8080/video.mp4"
-
-    def test_local_shared_mode_external_to_internal(self):
-        url = "http://1.2.3.4:8080/video.mp4"
-        result = translate_url(url, "local_shared", "10.0.0.1", "1.2.3.4")
-        assert result == "http://10.0.0.1:8080/video.mp4"
-
-    def test_unknown_vlm_mode_returns_original(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "unknown_mode", "10.0.0.1", "1.2.3.4")
-        assert result == url
-
-    def test_url_without_netloc_returns_original(self):
-        url = "/just/a/path"
-        result = translate_url(url, "remote", "10.0.0.1", "1.2.3.4")
-        assert result == url
-
-    def test_case_insensitive_vlm_mode(self):
-        url = "http://10.0.0.1:8080/video.mp4"
-        result = translate_url(url, "REMOTE", "10.0.0.1", "1.2.3.4")
-        assert result == "http://1.2.3.4:8080/video.mp4"
-
-    def test_local_mode_no_match(self):
-        url = "http://10.1.2.3:8080/video.mp4"
-        result = translate_url(url, "local", "10.0.0.1", "1.2.3.4")
-        assert result == url
-
-    # --- Reverse proxy fallback tests ---
-    # When behind a reverse proxy (e.g., Brev secure links with nginx),
-    # the URL host is the proxy hostname, not a direct IP.
-
-    def test_proxy_url_local_mode_with_vst_internal_url(self):
-        """Local VLM behind proxy: replace proxy base with internal VST URL."""
+    def test_rewrites_proxy_vst_url(self):
         url = "https://7777-abc123.brevlab.com/vst/storage/temp_files/video.mp4"
-        result = translate_url(url, "local_shared", "10.0.0.1", "1.2.3.4", "http://10.0.0.1:30888")
+        result = rewrite_to_internal_vst_url(url, "http://10.0.0.1:30888")
         assert result == "http://10.0.0.1:30888/vst/storage/temp_files/video.mp4"
 
-    def test_proxy_url_local_mode_without_vst_internal_url(self):
-        """Local VLM behind proxy without vst_internal_url: no translation (backwards compat)."""
-        url = "https://7777-abc123.brevlab.com/vst/storage/temp_files/video.mp4"
-        result = translate_url(url, "local_shared", "10.0.0.1", "1.2.3.4")
-        assert result == url
+    def test_preserves_query_and_fragment(self):
+        url = "https://proxy.example.com/vst/storage/video.mp4?token=abc#clip"
+        result = rewrite_to_internal_vst_url(url, "http://10.0.0.1:30888/")
+        assert result == "http://10.0.0.1:30888/vst/storage/video.mp4?token=abc#clip"
 
-    def test_proxy_url_remote_mode_no_fallback(self):
-        """Remote VLM behind proxy: no proxy fallback (only local modes use it)."""
-        url = "https://7777-abc123.brevlab.com/vst/storage/temp_files/video.mp4"
-        result = translate_url(url, "remote", "10.0.0.1", "1.2.3.4", "http://10.0.0.1:30888")
-        assert result == url
-
-    def test_proxy_url_preserves_path_and_query(self):
-        """Proxy fallback preserves full path and query string."""
-        url = "https://proxy.example.com/vst/api/v1/replay/stream/123/picture?startTime=2025-01-01"
-        result = translate_url(url, "local", "10.0.0.1", "1.2.3.4", "http://10.0.0.1:30888")
-        assert result == "http://10.0.0.1:30888/vst/api/v1/replay/stream/123/picture?startTime=2025-01-01"
-
-    def test_proxy_url_vst_internal_url_trailing_slash(self):
-        """Trailing slash on vst_internal_url doesn't cause double-slash."""
+    def test_missing_internal_url_returns_original(self):
         url = "https://proxy.example.com/vst/storage/video.mp4"
-        result = translate_url(url, "local", "10.0.0.1", "1.2.3.4", "http://10.0.0.1:30888/")
-        assert result == "http://10.0.0.1:30888/vst/storage/video.mp4"
+        result = rewrite_to_internal_vst_url(url, None)
+        assert result == url
 
-    def test_ip_match_takes_priority_over_proxy_fallback(self):
-        """When the IP matches, normal IP swap happens even if vst_internal_url is provided."""
-        url = "http://1.2.3.4:30888/vst/storage/video.mp4"
-        result = translate_url(url, "local", "10.0.0.1", "1.2.3.4", "http://10.0.0.1:30888")
-        assert result == "http://10.0.0.1:30888/vst/storage/video.mp4"
+    def test_non_vst_path_returns_original(self):
+        url = "https://proxy.example.com/api/v1/health"
+        result = rewrite_to_internal_vst_url(url, "http://10.0.0.1:30888")
+        assert result == url


### PR DESCRIPTION
## Summary
- route LVS video understanding through the internal VST media URL and remove its unused VLM/IP translation fields
- simplify video_understanding media handling: remote VLM always uses agent-local download plus sampled base64 image frames; local/local_shared VLM uses the internal VST URL
- keep legacy explicit use_base64 support on the same sampled-frame path, but remove the use_base64_for_remote_vlm toggle and direct external VST URL path
- remove the old IP-based translate_url helper and keep only direct internal VST URL rewriting
- drop dead agent-service env exports for EXTERNAL_IP, INTERNAL_IP, and VST_BASE_URL while keeping VST_INTERNAL_URL/VST_EXTERNAL_URL
- simplify the agent Dockerfile OpenSSL refresh stage to apt-install the current fixed libssl3 package instead of hard-coded Debian pool URLs

## Why
VST media URLs can be public/proxy URLs that are not reachable from internal services or remote VLM endpoints, especially on Brev where public URLs can redirect through access control. Internal deployment consumers should use the internal VST URL, and remote VLMs should not be required to fetch deployment-local media URLs.

The agent image uses a distroless runtime, so it still needs a Debian helper stage to obtain updated shared OpenSSL libraries. Installing libssl3 in that helper stage lets apt resolve the current bookworm-security package instead of pinning to a pool filename that can disappear when Debian publishes a newer security revision.

## Validation
- docker buildx build --platform linux/amd64 -f services/agent/docker/Dockerfile --target runtime --progress=plain services
- docker compose --env-file deploy/docker/developer-profiles/dev-profile-lvs/generated.env config --quiet
- SETUPTOOLS_SCM_PRETEND_VERSION=3.2.0 uv run --python 3.13 pytest tests/unit_test/utils/test_url_translation.py tests/unit_test/tools/test_video_understanding.py tests/unit_test/tools/test_lvs_video_understanding.py
- SETUPTOOLS_SCM_PRETEND_VERSION=3.2.0 uv run --python 3.13 ruff check src/vss_agents/utils/url_translation.py src/vss_agents/tools/lvs_video_understanding.py src/vss_agents/tools/video_understanding.py tests/unit_test/utils/test_url_translation.py tests/unit_test/tools/test_video_understanding.py tests/unit_test/tools/test_lvs_video_understanding.py
