### PR TITLE
refactor(deploy-skill): 3.2 restructure — RT-VLM + per-model sizing

### DIFF
--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -74,50 +74,9 @@ Always follow this sequence. Never skip the dry-run.
 
 ### Step 0 — Tear down any existing deployment + clear data volumes
 
-If a deployment already exists, tear it down AND clear stale data volumes before redeploying. Full procedure (resolved.yml-driven path, container-name catch-all patterns covering dev-profile compose files, why leftovers cause `/sensor/list` 502s) lives in [`references/teardown.md`](references/teardown.md).
+If a deployment already exists, tear it down AND clear stale data volumes before redeploying. 
 
-**Step 0a — Stop containers:**
-
-```bash
-# If a resolved.yml from a prior deploy exists, prefer it — it
-# knows about all compose-profile services that were brought up.
-if [ -f "$REPO/deployments/resolved.yml" ]; then
-  docker compose -f "$REPO/deployments/resolved.yml" down --remove-orphans
-fi
-
-# Catch-all: remove every VSS-stack container the dev-profile compose
-# files bring up (covers leftovers from prior deploys that linger and
-# bind ports the new deploy needs, or pass health checks while serving
-# stale data).
-docker ps -a --format '{{.Names}}' \
-  | grep -E '^(vss-|mdx-|perception-|rtvi-|alert-|nvstreamer-|sensor-ms-|vst-ingress-|vst-mcp-|vst-file-proxy|centralizedb-|storage-ms-|streamprocessing-ms-|sdr-(http|streamprocessing)-|envoy-(http|streamprocessing)-|rtspserver-ms-|recorder-ms-|replaystream-ms-|livestream-ms-|metropolis-vss-ui|phoenix)' \
-  | xargs -r docker rm -f
-```
-
-If this is the host's first deploy, the `docker compose down` line is a no-op (exit 0 with no containers to stop) — safe to run unconditionally.
-
-**Step 0b — Clear data volumes** (`$MDX_DATA_DIR/data_log/*`):
-
-Use the bundled cleanup helper. It clears every directory whose stale state can poison a fresh deploy: kafka logs, elasticsearch data + logs, redis data + log, behavior-learning data, video-analytics API state, calibration toolkit, VST/nvstreamer recordings, and any blueprint-configurator backup files. The same logic `dev-profile.sh` runs internally between deploys.
-
-```bash
-sudo bash "$REPO/deploy/docker/scripts/cleanup_all_datalog.sh" \
-    --env-file "$REPO/deploy/docker/developer-profiles/dev-profile-<profile>/.env"
-```
-
-What it deletes (paths under `$MDX_DATA_DIR/data_log/` unless noted):
-
-| Path | Always cleared | Toggle to skip |
-|---|---|---|
-| `kafka/*`, `elastic/data/*`, `elastic/logs/*`, `redis/data/*`, `redis/log/*` | yes | — |
-| `behavior_learning_data/*`, `vss_video_analytics_api/*` | yes | — |
-| `calibration_toolkit/*` | yes (default) | `--skip-delete-calibration-data` |
-| `vst/`, `nvstreamer/` (uploaded videos + clips) | yes (default) | `--skip-delete-vst-data` |
-| `*.backup_*` files under `$MDX_DATA_DIR`, repo root, `$MDX_SAMPLE_APPS_DIR` | yes (default) | `--skip-delete-backup-files` |
-
-> **Skip `--skip-delete-vst-data` when uploads must persist across redeploys.** This is the only flag with a real user-facing impact (loses uploaded videos). The other directories hold ephemeral broker/index state that must be wiped to avoid stale-data bugs (e.g. `centralizedb-dev` postgres schema mismatches, Kafka topic ID drift, Elasticsearch index conflicts).
-
-> **Skip Step 0b on a brand-new host with no prior deploy** — `cleanup_all_datalog.sh` is safe to no-op on missing dirs, but skipping the run avoids the `sudo` prompt entirely.
+Full procedure lives in [`references/teardown.md`](references/teardown.md).
 
 ### Step 1 — Gather context
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -187,11 +187,11 @@ before any container starts.
 
 > **The fix only touches the generated `resolved.yml` — never the source compose files.** The dependencies are correctly marked optional in the source; profile filtering is what creates the dangling references in the resolved artifact.
 
-Run the bundled normalizer:
+Run the bundled normalizer via `uv` (no install required — the script declares its `pyyaml` dep with PEP 723 inline metadata, and `uv run` pulls it into an ephemeral env on demand):
 
 ```bash
 # From the repo root
-python3 skills/deploy/scripts/normalize_resolved_yml.py "$REPO/deployments/resolved.yml"
+uv run skills/deploy/scripts/normalize_resolved_yml.py "$REPO/deployments/resolved.yml"
 ```
 
 The script ([`scripts/normalize_resolved_yml.py`](scripts/normalize_resolved_yml.py)):
@@ -202,7 +202,7 @@ The script ([`scripts/normalize_resolved_yml.py`](scripts/normalize_resolved_yml
 - Prints the list of removed `(service → dangling target)` pairs so the user can see what was cleaned.
 - Idempotent — running it on an already-clean file is a no-op.
 
-Requires `pyyaml` (`pip install pyyaml` if the deploy host doesn't have it).
+If `uv` isn't on the host, install it once with `curl -LsSf https://astral.sh/uv/install.sh | sh` (no root needed). Don't `pip install pyyaml` — many deploy hosts don't have pip configured for the system Python, and uv keeps the script's deps isolated.
 
 **Re-validate** before `up -d`:
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -175,6 +175,8 @@ Unexpanded `${VAR}` tokens in `resolved.yml` mean compose did not see those env 
 
 ### Step 3c — Strip dangling optional `depends_on` from resolved.yml
 
+**MUST run after Step 3, before Step 5.** Skipping this aborts the deploy:
+
 `docker compose --env-file .env config` filters out services that don't match the active `COMPOSE_PROFILES`, but it leaves `depends_on:` entries that point at those filtered-out services. Compose's schema validator rejects any `depends_on` target that isn't a defined service in the file — even when the entry is `required: false`. The result: `docker compose -f resolved.yml up -d` aborts with
 
 ```
@@ -183,64 +185,32 @@ service "vst-ingress" depends on undefined service "sensor-ms-2d": invalid compo
 
 before any container starts.
 
-> **Edit the generated `resolved.yml` only — never the source compose files.** The dependencies are correctly marked optional in the source; profile filtering is what creates the dangling references in the resolved artifact.
+> **The fix only touches the generated `resolved.yml` — never the source compose files.** The dependencies are correctly marked optional in the source; profile filtering is what creates the dangling references in the resolved artifact.
 
-**Detect:**
-
-```bash
-python3 - <<'PY'
-import yaml
-with open("resolved.yml") as f:
-    d = yaml.safe_load(f)
-defined = set((d.get("services") or {}).keys())
-dangling = []
-for name, svc in (d.get("services") or {}).items():
-    deps = (svc or {}).get("depends_on") or {}
-    targets = deps.keys() if isinstance(deps, dict) else deps
-    for t in targets:
-        if t not in defined:
-            dangling.append((name, t))
-for n, t in dangling:
-    print(f"{n} -> {t} (not defined)")
-print(f"\n{len(dangling)} dangling depends_on entries")
-PY
-```
-
-**Fix in place** (drops only the dangling entries; required active deps like `kafka`, `redis`, `rtvi-vlm`, `sensor-ms`, `streamprocessing-ms` are preserved):
+Run the bundled normalizer:
 
 ```bash
-python3 - <<'PY'
-import yaml
-with open("resolved.yml") as f:
-    d = yaml.safe_load(f)
-defined = set((d.get("services") or {}).keys())
-for name, svc in (d.get("services") or {}).items():
-    deps = (svc or {}).get("depends_on")
-    if not deps:
-        continue
-    if isinstance(deps, dict):
-        kept = {k: v for k, v in deps.items() if k in defined}
-        if kept:
-            svc["depends_on"] = kept
-        else:
-            svc.pop("depends_on", None)
-    elif isinstance(deps, list):
-        kept = [k for k in deps if k in defined]
-        if kept:
-            svc["depends_on"] = kept
-        else:
-            svc.pop("depends_on", None)
-with open("resolved.yml", "w") as f:
-    yaml.safe_dump(d, f, sort_keys=False)
-print("resolved.yml normalized")
-PY
+# From the repo root
+python3 skills/deploy/scripts/normalize_resolved_yml.py "$REPO/deployments/resolved.yml"
 ```
+
+The script ([`scripts/normalize_resolved_yml.py`](scripts/normalize_resolved_yml.py)):
+
+- Drops every `depends_on` target that isn't a defined service in the file.
+- Preserves required active dependencies (kafka, redis, rtvi-vlm, sensor-ms, streamprocessing-ms, etc.).
+- Removes the `depends_on:` key entirely if it ends up empty.
+- Prints the list of removed `(service → dangling target)` pairs so the user can see what was cleaned.
+- Idempotent — running it on an already-clean file is a no-op.
+
+Requires `pyyaml` (`pip install pyyaml` if the deploy host doesn't have it).
 
 **Re-validate** before `up -d`:
 
 ```bash
-docker compose -f resolved.yml config --quiet && echo "resolved.yml OK"
+docker compose -f "$REPO/deployments/resolved.yml" config --quiet && echo "resolved.yml OK"
 ```
+
+If validation still fails after the normalizer runs, capture the error and inspect — that's a different bug (a dependency that's not optional, or another schema violation), not the dangling-depends_on case.
 
 ### Step 4 — Review
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -72,9 +72,11 @@ If no combination on this host satisfies the profile's sizing requirements, **st
 
 Always follow this sequence. Never skip the dry-run.
 
-### Step 0 — Tear down any existing deployment
+### Step 0 — Tear down any existing deployment + clear data volumes
 
-If a deployment already exists, tear it down first. Full procedure (resolved.yml-driven path, container-name catch-all patterns covering dev-profile compose files, why leftovers cause `/sensor/list` 502s) lives in [`references/teardown.md`](references/teardown.md).
+If a deployment already exists, tear it down AND clear stale data volumes before redeploying. Full procedure (resolved.yml-driven path, container-name catch-all patterns covering dev-profile compose files, why leftovers cause `/sensor/list` 502s) lives in [`references/teardown.md`](references/teardown.md).
+
+**Step 0a — Stop containers:**
 
 ```bash
 # If a resolved.yml from a prior deploy exists, prefer it — it
@@ -93,6 +95,29 @@ docker ps -a --format '{{.Names}}' \
 ```
 
 If this is the host's first deploy, the `docker compose down` line is a no-op (exit 0 with no containers to stop) — safe to run unconditionally.
+
+**Step 0b — Clear data volumes** (`$MDX_DATA_DIR/data_log/*`):
+
+Use the bundled cleanup helper. It clears every directory whose stale state can poison a fresh deploy: kafka logs, elasticsearch data + logs, redis data + log, behavior-learning data, video-analytics API state, calibration toolkit, VST/nvstreamer recordings, and any blueprint-configurator backup files. The same logic `dev-profile.sh` runs internally between deploys.
+
+```bash
+sudo bash "$REPO/deploy/docker/scripts/cleanup_all_datalog.sh" \
+    --env-file "$REPO/deploy/docker/developer-profiles/dev-profile-<profile>/.env"
+```
+
+What it deletes (paths under `$MDX_DATA_DIR/data_log/` unless noted):
+
+| Path | Always cleared | Toggle to skip |
+|---|---|---|
+| `kafka/*`, `elastic/data/*`, `elastic/logs/*`, `redis/data/*`, `redis/log/*` | yes | — |
+| `behavior_learning_data/*`, `vss_video_analytics_api/*` | yes | — |
+| `calibration_toolkit/*` | yes (default) | `--skip-delete-calibration-data` |
+| `vst/`, `nvstreamer/` (uploaded videos + clips) | yes (default) | `--skip-delete-vst-data` |
+| `*.backup_*` files under `$MDX_DATA_DIR`, repo root, `$MDX_SAMPLE_APPS_DIR` | yes (default) | `--skip-delete-backup-files` |
+
+> **Skip `--skip-delete-vst-data` when uploads must persist across redeploys.** This is the only flag with a real user-facing impact (loses uploaded videos). The other directories hold ephemeral broker/index state that must be wiped to avoid stale-data bugs (e.g. `centralizedb-dev` postgres schema mismatches, Kafka topic ID drift, Elasticsearch index conflicts).
+
+> **Skip Step 0b on a brand-new host with no prior deploy** — `cleanup_all_datalog.sh` is safe to no-op on missing dirs, but skipping the run avoids the `sudo` prompt entirely.
 
 ### Step 1 — Gather context
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,42 +1,33 @@
 ---
 name: deploy
-description: Deploy, debug, or tear down any VSS profile using a compose-centric workflow — config (dry-run) with env overrides, review resolved compose, then compose up. Use this skill when the user says "deploy vss", "deploy <profile>", "debug deploy", "verify deployment", or "why is my vss deploy broken".
+description: Load when the user says "configure vss", "deploy vss", "deploy <profile>", "debug deploy", "verify deployment", or "why is my vss deploy broken".
 version: "3.2.0"
 license: "Apache License 2.0"
 ---
 
 # VSS Deploy
 
-Deploy any VSS profile using a compose-centric workflow: build env overrides, generate resolved compose (dry-run), review, then deploy. Replaces direct `dev-profile.sh` execution with validated, auditable steps.
+Deploy any VSS profile using a compose-centric workflow: build env overrides, generate resolved compose (dry-run), review, then deploy.
+
+This SKILL.md covers the cross-profile concerns (**profile routing**, **prerequisites**, **NGC**, **GPU setup**, and the deploy/teardown flow). Profile-specific service lists, sizing, env recipes, endpoints, and debugging live in per-profile reference docs — load the one that matches the user's intent.
 
 ## Profile Routing
 
+Match the user's request to a profile, then load that profile's reference for sizing, services, env recipes, and debugging.
+
 | User says | Profile | Reference |
 |---|---|---|
-| "deploy vss" / "deploy base" | `base` | `references/base.md` |
-| "deploy alerts" / "alert verification" / "real-time alerts" | `alerts` | `references/alerts.md` |
-| "deploy for incident report" | `alerts` | `references/alerts.md` |
-| "deploy lvs" / "video summarization" | `lvs` | `references/lvs.md` |
-| "deploy search" / "video search" | `search` | `references/search.md` |
+| "deploy vss" / "deploy base" | `base` | [`references/base.md`](references/base.md) |
+| "deploy alerts" / "alert verification" / "real-time alerts" / "deploy for incident report" | `alerts` | [`references/alerts.md`](references/alerts.md) |
+| "deploy lvs" / "video summarization" | `lvs` | [`references/lvs.md`](references/lvs.md) |
+| "deploy search" / "video search" | `search` | [`references/search.md`](references/search.md) |
 
-**Edge hardware routing** (DGX Spark, AGX/IGX Thor): see [`references/edge.md`](references/edge.md)
-for the 4B-LLM recipe (`config_edge.yml` + standalone vLLM on port 30081). Edge
-platforms share a single unified-memory GPU between LLM and VLM, so the
-Nemotron Edge 4B is the default and the Nemotron Nano 9B v2 FP8 is an option
-when memory allows.
+**Edge hardware routing** (DGX Spark, AGX/IGX Thor): see [`references/edge.md`](references/edge.md) for the 4B-LLM recipe (`config_edge.yml` + standalone vLLM on port 30081). Edge platforms share a single unified-memory GPU between LLM and VLM, so the Nemotron Edge 4B is the default and the Nemotron Nano 9B v2 FP8 is an option when memory allows.
 
-## When to Use
+**Each profile's reference owns its sizing table.** Don't pick a deployment shape from this file — open the profile reference and check minimum GPU count for the host's hardware against the (mode × platform) matrix there.
 
-- Deploy VSS / start VSS / bring up a profile
-- Deploy a specific profile (base, alerts, lvs, search)
-- Do a dry-run / preview what will be deployed
-- Change deployment config (hardware, LLM mode, GPU assignment)
-- Tear down a running deployment
-- **Debug or verify** an existing deployment (see [Debugging a Deployment](#debugging-a-deployment))
 
 ## How it works
-
-Run docker compose commands directly on the host:
 
 ```bash
 # 1. Apply env overrides to the profile .env file
@@ -45,13 +36,13 @@ Run docker compose commands directly on the host:
 # 4. docker compose -f resolved.yml up -d
 ```
 
-## Before Deploying
+## Prerequisites
 
 1. **Repo path** — find `video-search-and-summarization/` on disk. Check `TOOLS.md` if available.
-2. **NGC CLI & API key** — see [`references/ngc.md`](references/ngc.md). Check `$NGC_CLI_API_KEY` is set.
-3. **System prerequisites (GPU VRAM, driver, Docker, NVIDIA Container Toolkit)** — canonical reference is the [**VSS prerequisites page**](https://docs.nvidia.com/vss/3.2.0/prerequisites.html). That page lists supported hardware, per-profile GPU requirements, and the minimum driver/CUDA version per NIM. Read it and pick the LLM/VLM placement that fits the host — don't guess thresholds from this skill.
+2. **NGC CLI & API key** — see [`references/ngc.md`](references/ngc.md). Confirm `$NGC_CLI_API_KEY` is set.
+3. **System prerequisites (GPU driver, Docker, NVIDIA Container Toolkit, kernel sysctls)** — full checks in [`references/prerequisites.md`](references/prerequisites.md). Canonical hardware/driver matrix is the [VSS prerequisites page](https://docs.nvidia.com/vss/3.2.0/prerequisites.html).
 
-### Pre-flight Check
+### Pre-flight check
 
 Run before every deploy. Do not proceed if any check fails.
 
@@ -68,20 +59,22 @@ docker run --rm --gpus all ubuntu:22.04 nvidia-smi 2>&1 | head -5
 
 If check 2 or 3 fails, see [`references/prerequisites.md`](references/prerequisites.md).
 
+## Model Selection
+
+- `$LLM_REMOTE_URL` / `$VLM_REMOTE_URL` if the user asks for remote
+- `$NGC_CLI_API_KEY` (local NIMs) or `$NVIDIA_API_KEY` (remote)
+
+If no combination on this host satisfies the profile's sizing requirements, **stop and report the blocker** — don't silently pick another shape.
+
+> **Edge shared mode requires Edge 4B + `HF_TOKEN`.** On DGX Spark and AGX/IGX Thor, both LLM and VLM must fit in unified memory, AND the standard `nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2:1` image has a broken arm64 manifest. Run `NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8` as a standalone vLLM container on port 30081 with the agent pointed at it via `--use-remote-llm`. Full recipe and the mandatory `HF_TOKEN` verification step are in [`references/edge.md`](references/edge.md).
+
 ## Deployment Flow
 
 Always follow this sequence. Never skip the dry-run.
 
 ### Step 0 — Tear down any existing deployment
 
-Before every deploy, **always** stop any prior VSS stack. This is
-mandatory even if you think the host is clean, and especially when
-switching profiles (`base` → `search`, `alerts` verification →
-`alerts` real-time, etc.). Compose profile flags only *start* the
-services listed under the selected profile — they do NOT stop
-services from a previously-active profile, so containers from the
-prior deploy linger and pass unrelated container-name checks,
-contaminate results, and can bind ports the new deploy needs.
+If a deployment already exists, tear it down first. Full procedure (resolved.yml-driven path, container-name catch-all patterns covering dev-profile compose files, why leftovers cause `/sensor/list` 502s) lives in [`references/teardown.md`](references/teardown.md).
 
 ```bash
 # If a resolved.yml from a prior deploy exists, prefer it — it
@@ -91,167 +84,51 @@ if [ -f "$REPO/deployments/resolved.yml" ]; then
 fi
 
 # Catch-all: remove every VSS-stack container the dev-profile compose
-# files bring up. Without this, leftovers from a prior deploy linger
-# (especially the *-smc set, which the alerts compose profile shares
-# with the *-dev set on host networking and port 30000) and either:
-#   - bind ports the new deploy needs → second sensor-ms fails to bind
-#     → /sensor/list returns 502 (issue #151), or
-#   - pass the new deploy's container-name health checks while serving
-#     stale data from the prior deploy's DB.
-# The patterns below cover everything declared in
-# deployments/vst/{2d,3d,smc,developer,ps}/, deployments/foundational/,
-# deployments/agents/, deployments/proxy/, and the dev-profile-*
-# compose files.
+# files bring up (covers leftovers from prior deploys that linger and
+# bind ports the new deploy needs, or pass health checks while serving
+# stale data).
 docker ps -a --format '{{.Names}}' \
   | grep -E '^(vss-|mdx-|perception-|rtvi-|alert-|nvstreamer-|sensor-ms-|vst-ingress-|vst-mcp-|vst-file-proxy|centralizedb-|storage-ms-|streamprocessing-ms-|sdr-(http|streamprocessing)-|envoy-(http|streamprocessing)-|rtspserver-ms-|recorder-ms-|replaystream-ms-|livestream-ms-|metropolis-vss-ui|phoenix)' \
   | xargs -r docker rm -f
 ```
 
-If this is the host's first deploy, the `docker compose down`
-line is a no-op (exit 0 with no containers to stop) — safe to run
-unconditionally.
+If this is the host's first deploy, the `docker compose down` line is a no-op (exit 0 with no containers to stop) — safe to run unconditionally.
 
 ### Step 1 — Gather context
 
-Discover what's available on the host and cross-reference with the
-[VSS prerequisites page](https://docs.nvidia.com/vss/3.2.0/prerequisites.html)
-to choose a deployment shape that fits.
+Before building env overrides, confirm:
 
 | Value | How to determine |
 |---|---|
-| **Profile** | Match user intent to routing table above. Default: `base` |
+| **Profile** | Match user intent to the routing table above. Default: `base` |
 | **Repo path** | Find `video-search-and-summarization/` on disk |
-| **Hardware** | `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader` → look up per-GPU VRAM against the prerequisites page |
-| **LLM/VLM placement** | Pick `local_shared`, `local`, or `remote` per LLM/VLM based on available GPUs + `$LLM_REMOTE_URL` / `$VLM_REMOTE_URL` / `$NGC_CLI_API_KEY`. If no combination on this host satisfies the prerequisites, stop and report the blocker instead of silently picking another shape. |
+| **Hardware** | `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader` |
+| **LLM/VLM placement** | Cross-reference available GPUs against the chosen profile's **Minimum GPU count** table |
 | **API keys** | `NGC_CLI_API_KEY` for local NIMs, `NVIDIA_API_KEY` for remote |
-| **Host IP** | `hostname -I \| awk '{print $1}'` |
+| **`HOST_IP`** | `hostname -I \| awk '{print $1}'` — the host's primary internal IP |
+| **`EXTERNAL_IP`** | The address browsers will use to reach the deploy. **Must be a real reachable hostname/IP for the user.** On a bare-metal host this can be `${HOST_IP}` or the host's DNS name. **On Brev, this is the secure-link domain** (e.g. `77770-<BREV_ENV_ID>.brevlab.com`) — see [Step 1c](#step-1c--if-deploying-on-brev-set-up-secure-link-env-vars). |
+| **`HAPROXY_PORT`** | The browser-facing ingress port. Default `7777`. On Brev this stays `7777` internally; the secure link adds the `0` suffix externally. |
 
-**Hardware profile mapping:**
-
-| GPU name contains | HARDWARE_PROFILE | Recommended LLM path |
-|---|---|---|
-| H100 | `H100` | Nano 9B v2 (NIM) |
-| L40S | `L40S` | Nano 9B v2 (NIM) |
-| RTX 6000 Ada, RTX PRO 6000 | `RTXPRO6000BW` | Nano 9B v2 (NIM) |
-| GB10 (DGX Spark) | `DGX-SPARK` | **Edge 4B** (vLLM) — see [`references/edge.md`](references/edge.md) |
-| IGX | `IGX-THOR` | **Edge 4B** (vLLM) — see [`references/edge.md`](references/edge.md) |
-| AGX | `AGX-THOR` | **Edge 4B** (vLLM) — see [`references/edge.md`](references/edge.md) |
-| Other | `OTHER` | — |
-
-**Minimum GPU count per (profile × mode × platform).** Canonical source
-is the [VSS prerequisites page](https://docs.nvidia.com/vss/3.2.0/prerequisites.html);
-reproduced here so the skill can fail fast when the host is too small:
-
-| Profile | Mode | H100 / RTX PRO 6000 (Blackwell) | L40S | DGX-Spark / IGX-Thor / AGX-Thor |
-|---|---|---|---|---|
-| `base` | shared (`local_shared` LLM + VLM) | **1** | — (48 GB/GPU too small) | **1** (Edge 4B + VLM, unified memory) |
-| `base` | dedicated (`local` LLM + VLM) | **2** | **2** | — |
-| `base` | `remote-llm` | **1** (VLM local) | **1** (VLM local) | **1** (remote LLM only) |
-| `base` | `remote-vlm` | **1** (LLM local) | **1** (LLM local) | — |
-| `base` | `remote-all` | **0** | **0** | **0** |
-| `lvs` | shared | **1** | — | - |
-| `lvs` | dedicated | **2** | **2** | — |
-| `lvs` | `remote-llm/vlm` | 1 | 1 | - |
-| `lvs` | `remote-all` | 0 | 0 | - |
-| `alerts` (verification / CV) | shared | **2**  | — | — |
-| `alerts` (verification / CV) | dedicated | **3** | **3**  | — |
-| `alerts` (verification / CV) | `remote-all` | 1 | 1 | 1 |
-| `alerts` (verification / CV) | `remote-llm/vlm` | 2 | 2 | 1 |
-| `alerts` (real-time / VLM) | shared | **2** | — | — |
-| `alerts` (real-time / VLM) | dedicated | **3** | **3**  | — |
-| `alerts` (real-time / VLM) | `remote-llm` | 2 | 2 | 1 |
-| `search` | shared | **2** | — | - |
-| `search` | dedicated | **3** | **3**  | — |
-| `search` | `remote-*` | **2**  | **2** | - |
-
-A few hard rules encoded in the table:
-
-- **L40S can't do `shared`.** 48 GB is not enough VRAM for LLM + VLM
-  on a single GPU. Fall back to `dedicated` or a `remote-*` mode.
-- **L40S needs +1 GPU for alerts / search vs H100** because the
-  shared-on-one-GPU trick doesn't work — RT-CV / Embed1 must take
-  their own GPU, and LLM+VLM still need a second.
-- **DGX-Spark / Thor are early-access for most profiles.** Only
-  `base` + `lvs` are expected to fully land locally; `alerts` /
-  `search` currently require a remote LLM. See
-  [`references/edge.md`](references/edge.md).
-
-If the host's (GPU count × VRAM) combination doesn't appear above,
-**stop and report the blocker** — don't silently pick a different
-mode.
-
-> **Edge shared mode requires Edge 4B + `HF_TOKEN`.** On DGX Spark and AGX/IGX
-> Thor, both LLM and VLM must fit in unified memory, AND the standard
-> `nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2:1` image has a broken arm64
-> manifest. You must run `NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8` as a
-> standalone vLLM container on port 30081 with the agent pointed at it via
-> `--use-remote-llm`. Full recipe and the mandatory `HF_TOKEN` verification
-> step are in [`references/edge.md`](references/edge.md).
+> The haproxy ingress container (`services/infra/haproxy/compose.yml:46-47`) **also** reads `VSS_PUBLIC_HOST` and `VSS_PUBLIC_PORT` directly from the env to render its config templates and rewrite URLs.
+>
+> **Validation step the agent must run before `docker compose up`:**
+>
+> 1. Verify `EXTERNAL_IP` is set and reachable from the user's browser (not `localhost`, not `0.0.0.0`, not the host's internal-only IP if the deploy will be browsed remotely). confirm with the user if needed. assuming using brev secured link if deployed on brev.
+> 2. Verify `HAPROXY_PORT` is set (default `7777`) and the chosen value isn't already bound on the host.
+> 3. Confirm the resolved compose has `VSS_PUBLIC_HOST` and `VSS_PUBLIC_PORT` populated (no unexpanded `${...}` — see [Step 3b](#step-3b--verify-resolvedyml-has-no-unexpanded--tokens)).
+> Forgetting this is a silent footgun: containers come up healthy, but VST playback / report links / the UI's API calls all 404 or hit Cloudflare-Access loops because the URLs embed an internal-only address.
 
 ### Step 1b — Prepare the data directory
 
-**This is the #1 source of silent-deploy bugs. Follow it exactly.**
-
-The stack mounts several subdirs of `$MDX_DATA_DIR` into containers that each
-run as a different uid. Docker auto-creates empty bind-mount paths as
-`root:root`, which is read-only for the container processes. The reference
-`scripts/dev-profile.sh` uses `chmod -R 777` on the relevant subdirs — it
-does **not** `chown`.
-
-Run this verbatim before `docker compose up`:
-
-```bash
-DATA=$MDX_DATA_DIR      # e.g. <repo>/data
-mkdir -p \
-  "$DATA/data_log/analytics_cache" \
-  "$DATA/data_log/calibration_toolkit" \
-  "$DATA/data_log/elastic/data" \
-  "$DATA/data_log/elastic/logs" \
-  "$DATA/data_log/kafka" \
-  "$DATA/data_log/redis/data" \
-  "$DATA/data_log/redis/log" \
-  "$DATA/agent_eval/dataset" \
-  "$DATA/agent_eval/results"
-# Profile-specific subdirs:
-#   alerts → mkdir -p "$DATA/data_log/vss_video_analytics_api" "$DATA/videos/dev-profile-alerts" "$DATA/models/rtdetr-its" "$DATA/models/gdino"
-#   search → mkdir -p "$DATA/models"
-chmod -R 777 "$DATA/data_log" "$DATA/agent_eval"
-# If you created $DATA/models above, also: chmod -R 777 "$DATA/models"
-```
+Layout (asset paths, ownership, mount points, profile-specific subdirs) is documented in [`references/data-directory.md`](references/data-directory.md). Read that file before deploying for the first time on a host or when changing profiles.
 
 > **FORBIDDEN: `chown -R ubuntu:ubuntu $MDX_DATA_DIR` (or any recursive chown).**
 >
-> This is "good housekeeping" to a shell-admin instinct but is **the** deploy-
-> breaking command in this stack. You will observe a "healthy" deploy
-> (containers Up, endpoints 200) while the video pipeline is silently broken.
-> Use `chmod -R 777` on the specific subdirs above — nothing else.
-
-**Known per-container uid gotchas** (each uses a bind mount under `$DATA`):
-
-| Container | Image | Runs as | Mount path | Symptom if permissions wrong |
-|---|---|---|---|---|
-| `centralizedb-dev` | postgres:17.6-alpine | uid **70** | `$DATA/data_log/vst/postgres/db` | Can't read own PGDATA → VST `sensor_details` query fails → uploaded videos never appear in `/vst/api/v1/sensor/streams` → warehouse E2E check returns empty |
-| `mdx-redis` | redis:8.2.2-alpine | uid **999** | `$DATA/data_log/redis/log`, `/redis/data` | "Can't open the log file: Permission denied" → redis dies → `envoy-streamprocessing` dies (needs Redis Lua script) → stream pipeline broken |
-| `elasticsearch` | elasticsearch | uid **1000** | `$DATA/data_log/elastic/{data,logs}` | "AccessDeniedException" on startup → ES refuses to start |
-| `vst` / `sensor-ms-dev` | vst | uid **1000** | `$DATA/data_log/vst/*` (videos, clips) | 403 on ingest or stream write |
-
-`chmod -R 777 $DATA/data_log` covers all of these. Do NOT chown them to
-individual uids — containers that init their own dirs on first start (like
-postgres) will then re-chown to their uid and a later chown back to ubuntu
-breaks them.
-
-**If postgres is already broken** (common when redeploying without a clean
-`data-dir`):
-```bash
-sudo rm -rf "$DATA/data_log/vst/postgres"  # postgres re-initializes on next start
-docker restart centralizedb-dev
-```
+> This is "good housekeeping" to a shell-admin instinct but is **the** deploy-breaking command in this stack. You will observe a "healthy" deploy (containers Up, endpoints 200) while the video pipeline is silently broken. Use `chmod -R 777` on the specific subdirs documented in `data-directory.md` — nothing else.
 
 ### Step 1c — If deploying on Brev, set up secure-link env vars
 
-On a Brev-managed instance, VSS is accessed from the browser via a
-Cloudflare-fronted secure link that tunnels to an nginx proxy on port 7777.
-The proxy consolidates UI + Agent API + VST behind one origin (CORS-safe).
+On a Brev-managed instance, VSS is accessed from the browser via a Cloudflare-fronted secure link that tunnels to an nginx proxy on port 7777. The proxy consolidates UI + Agent API + VST behind one origin (CORS-safe).
 
 Source the helper **before** `docker compose up`:
 
@@ -259,106 +136,23 @@ Source the helper **before** `docker compose up`:
 source skills/deploy/scripts/brev_setup.sh
 ```
 
-It detects `/etc/environment`'s `BREV_ENV_ID` and exports `PROXY_PORT=7777`
-and `BREV_LINK_PREFIX=77770` (launchable default; override with
-`BREV_LINK_PREFIX=7777` if the secure link was created manually without
-the `0` suffix). On non-Brev instances the script is a no-op.
+It detects `/etc/environment`'s `BREV_ENV_ID` and exports `PROXY_PORT=7777` and `BREV_LINK_PREFIX=77770` (launchable default; override with `BREV_LINK_PREFIX=7777` if the secure link was created manually without the `0` suffix). On non-Brev instances the script is a no-op.
 
-See [`references/brev.md`](references/brev.md) for:
-- Per-profile secure-link requirements (base needs 1, lvs/search/alerts need 2–3)
-- The launchable `0`-suffix quirk
-- Common CORS / 502 troubleshooting
+> **Set `EXTERNAL_IP` to the Brev secure-link domain** in `dev-profile-<profile>/.env`. The profile `.env` derives `VSS_PUBLIC_HOST=${EXTERNAL_IP}` and feeds that to haproxy + the agent's external URLs (see [Step 1 callout](#step-1--gather-context)). For a launchable-created link on port 7777, that's `EXTERNAL_IP=${BREV_LINK_PREFIX}-${BREV_ENV_ID}.brevlab.com` (e.g. `77770-<id>.brevlab.com`). Leaving `EXTERNAL_IP=${HOST_IP}` makes report URLs and VST playback links unreachable from the browser even though haproxy is up — the most common Brev-deploy footgun.
+
+See [`references/brev.md`](references/brev.md) for per-profile secure-link requirements, the launchable `0`-suffix quirk, and common CORS / 502 troubleshooting.
 
 ### Step 2 — Build env_overrides
 
-Build a dictionary of env var overrides based on user intent. Only include vars that differ from the profile's `.env` defaults.
-
-**Always set (they have placeholder defaults in the template):**
-
-| Var | Value |
-|---|---|
-| `HARDWARE_PROFILE` | Detected or user-specified |
-| `MDX_SAMPLE_APPS_DIR` | `<repo>/deployments` |
-| `MDX_DATA_DIR` | `<repo>/data` (or user-specified) |
-| `HOST_IP` | Detected host IP |
-| `NGC_CLI_API_KEY` | From environment or user |
-
-**Common overrides by user intent:**
-
-| User intent | Env overrides |
-|---|---|
-| Remote LLM | `LLM_MODE=remote`, `LLM_BASE_URL=<host>` (no `/v1`), `LLM_NAME=<model>`, `NVIDIA_API_KEY=<key>` |
-| Remote VLM | `VLM_MODE=remote`, `VLM_BASE_URL=<host>` (no `/v1`), `VLM_NAME=<model>`, `NVIDIA_API_KEY=<key>` |
-| **Remote LLM AND remote VLM** (aka `remote-all`) | **BOTH of the above** — you must set `LLM_MODE=remote`, `VLM_MODE=remote`, `LLM_BASE_URL`, `VLM_BASE_URL`, `LLM_NAME`, `VLM_NAME`. The presence of a remote VLM endpoint does not imply `VLM_MODE=remote` — you have to write it explicitly. |
-| NVIDIA API for remote inference | `LLM_BASE_URL=https://integrate.api.nvidia.com` |
-| Dedicated GPUs | `LLM_MODE=local`, `VLM_MODE=local`, `LLM_DEVICE_ID=0`, `VLM_DEVICE_ID=1` |
-| Different LLM model | `LLM_NAME=<name>`, `LLM_NAME_SLUG=<slug>` |
-| Different VLM model | `VLM_NAME=<name>`, `VLM_NAME_SLUG=<slug>` |
-
-**Extracting remote endpoints from user intent.**
-
-If the user says "remote LLM" or mentions an LLM endpoint URL, you MUST do
-all of the following before `docker compose up`:
-
-1. Identify the endpoint URL and model name. If the user gave them in
-   their prompt (e.g. *"deploy with remote LLM at
-   `http://launchpad:11571` serving `nvidia/nvidia-nemotron-nano-9b-v2`"*),
-   use those values directly. Strip any trailing `/v1` (see callout below).
-2. If the user said "remote" without providing a URL or model, **stop and
-   ask the user** for:
-   - The LLM endpoint URL (without `/v1`)
-   - The LLM model name served there
-   - (same pair for VLM if they also said "remote VLM")
-   - An `NVIDIA_API_KEY` if the endpoint requires one
-3. Write `LLM_MODE=remote` + `LLM_BASE_URL=<url>` + `LLM_NAME=<model>` into
-   `deployments/developer-workflow/dev-profile-<profile>/.env`. Do the
-   same pair for VLM if the user said remote VLM. Use `sed -i
-   "s|^KEY=.*|KEY=VALUE|"` — the `.env` template ships with placeholder
-   rows for these keys.
-4. After writing, `grep -E '^(HARDWARE_PROFILE|LLM_MODE|VLM_MODE|LLM_BASE_URL|VLM_BASE_URL)=' <env-file>`
-   and verify every line shows the value you intended. A silent miss on
-   `LLM_MODE` / `VLM_MODE` is the #1 cause of deployments coming up with
-   wrong compose profiles.
-
-Never leave `LLM_MODE` or `VLM_MODE` unset when the user said "remote".
-The `.env` template's placeholder value is `LLM_MODE=local` — failing to
-overwrite it means you silently deployed in local mode with remote URLs
-dangling, which no `COMPOSE_PROFILES` path correctly supports.
-
-> **Important — `/v1` suffix on base URLs**
->
-> `LLM_BASE_URL` and `VLM_BASE_URL` must **not** include a trailing `/v1`.
-> The agent's `config.yml` appends `/v1` automatically (`base_url: ${LLM_BASE_URL}/v1`),
-> so including it yourself produces `/v1/v1/chat/completions` and requests will fail
-> with connection / 404 errors.
->
-> If a user or endpoint documentation gives you a URL ending in `/v1`, strip it
-> before writing to `.env`. Examples:
-> - User says: "LLM is at `http://10.0.0.5:31081/v1`" → write `LLM_BASE_URL=http://10.0.0.5:31081`
-> - User says: "Use `https://integrate.api.nvidia.com/v1`" → write `LLM_BASE_URL=https://integrate.api.nvidia.com`
-
-See the profile reference doc for full env override recipes.
-
-**Do NOT set `COMPOSE_PROFILES` directly** — it is computed from `BP_PROFILE`, `MODE`, `HARDWARE_PROFILE`, `LLM_MODE`, `LLM_NAME_SLUG`, `VLM_MODE`, `VLM_NAME_SLUG`.
+Produce an `env_overrides` dict from the user request and the gathered context: choose remote/local LLM/VLM, set credentials, point at endpoints, set platform-specific flags. The full mapping (every override key, when it applies, defaults, profile-specific differences) lives in [`references/env-overrides.md`](references/env-overrides.md). Each profile reference has worked examples for that profile's common scenarios.
 
 ### Step 3 — Config / dry-run
 
 **Env file location:** `<repo>/deployments/developer-workflow/dev-profile-<profile>/.env`
 
-> **This is the authoritative `.env`.** Every verifier, healthcheck, and
-> post-deploy tool reads from this path. When you apply env overrides
-> (from Step 2 or from the user's prompt), write them **directly to this
-> file** — not to `generated.env`.
+> **This is the authoritative `.env`.** Every verifier, healthcheck, and post-deploy tool reads from this path. When you apply env overrides (from Step 2 or from the user's prompt), write them **directly to this file** — not to `generated.env`.
 >
-> `generated.env` is a scratchpad that `dev-profile.sh` produces during
-> its own internal flow; it is NOT read by the verifier and is wiped on
-> the next invocation. An agent that uses `dev-profile.sh` as a one-shot
-> deploy but leaves the base `.env` untouched will silently fail env
-> checks even when the stack comes up cleanly. If you used
-> `dev-profile.sh` and see `generated.env` on disk, copy its key/value
-> lines back into the base `.env`, or re-apply your `sed` commands
-> against the base `.env` after the fact. The base `.env` is the source
-> of truth.
+> `generated.env` is a scratchpad that `dev-profile.sh` produces during its own internal flow; it is NOT read by the verifier and is wiped on the next invocation. The base `.env` is the source of truth.
 
 ```bash
 REPO=/path/to/video-search-and-summarization
@@ -377,26 +171,7 @@ The resolved YAML is saved to `<repo>/deployments/resolved.yml`.
 
 ### Step 3b — Verify resolved.yml has no unexpanded ${...} tokens
 
-**Skipping this is the #1 cause of "I deployed `search` but it brought
-up `base` + `lvs` + `search` services."** The `.env` line near 90 is
-literal `COMPOSE_PROFILES=${BP_PROFILE}_${MODE},...` — docker compose
-expands it at `config` time using the same env file. If any upstream
-var (`BP_PROFILE`, `MODE`, `HARDWARE_PROFILE`, `LLM_MODE`,
-`VLM_MODE`) is missing from the env, the rendered profile list
-collapses to the empty string, and compose then includes **every**
-service from **every** profile.
-
-```bash
-if grep -q '\${' "$REPO/deployments/resolved.yml"; then
-  echo "FAIL: resolved.yml has unexpanded variables:"
-  grep -n '\${' "$REPO/deployments/resolved.yml" | head -5
-  exit 1
-fi
-```
-
-If this check fails, re-apply the Step 2 env overrides directly to
-the `.env` file at the path above, regenerate `resolved.yml` (Step 3),
-and re-run this check before continuing.
+Unexpanded `${VAR}` tokens in `resolved.yml` mean compose did not see those env values. Diagnostic procedure and common culprits live in [`references/troubleshooting.md`](references/troubleshooting.md).
 
 ### Step 4 — Review
 
@@ -410,12 +185,7 @@ Show the user a summary of what will be deployed:
 
 Ask: **"Looks good — deploy now?"** and wait for confirmation before Step 5.
 
-**Exception — autonomous mode.** If the user's request already asks
-you to run autonomously (e.g. "deploy X autonomously", "run without
-confirmation", "non-interactive"), skip the confirmation prompt and
-proceed straight to Step 5. This path exists so automated eval /
-CI invocations don't hang waiting for a human reply they'll never
-get. In all other cases, a human must approve.
+**Exception — autonomous mode.** If the user's request already asks you to run autonomously (e.g. "deploy X autonomously", "run without confirmation", "non-interactive"), skip the confirmation prompt and proceed straight to Step 5. This path exists so automated eval / CI invocations don't hang waiting for a human reply they'll never get. In all other cases, a human must approve.
 
 ### Step 5 — Deploy
 
@@ -424,13 +194,9 @@ cd $REPO/deployments
 docker compose -f resolved.yml up -d
 ```
 
-> **Do NOT use `--force-recreate` on retries.** It destroys already-warm
-> NIM containers, forcing another 3–5 min torch.compile + CUDA-graph capture
-> per NIM. If the previous `up -d` partially failed, fix the root cause
-> (usually perms or an env typo) and just re-run `up -d` — Docker will
-> re-create only the containers whose config changed or that are down.
+> **Do NOT use `--force-recreate` on retries.** It destroys already-warm NIM containers, forcing another 3–5 min torch.compile + CUDA-graph capture per NIM. If the previous `up -d` partially failed, fix the root cause (usually perms or an env typo) and just re-run `up -d` — Docker will re-create only the containers whose config changed or that are down.
 
-Deploy takes ~10-20 min on first run (image pulls + model downloads). Monitor:
+Deploy takes ~10–20 min on first run (image pulls + model downloads). Monitor:
 
 ```bash
 # Container status
@@ -442,21 +208,9 @@ docker compose -f $REPO/deployments/resolved.yml logs --tail 50 <service>
 
 Deploy is complete when all `mdx-*` containers show `Up` status.
 
-### Step 6 — Report endpoints
+### Step 6 — 
+Fron
 
-| Profile | Agent UI | REST API | Other |
-|---|---|---|---|
-| base | `:3000` | `:8000` (Swagger at `/docs`) | — |
-| alerts | `:3000` | `:8000` | VIOS dashboard `:30888/vst/` |
-| lvs | `:3000` | `:8000` | — |
-| search | `:3000` | `:8000` | — |
-
-Use workflow skills after deployment:
-- **alerts** / **incident-report** → alert management and incident queries
-- **video-search** → semantic video search
-- **video-summarization** → long video summarization
-- **vios** → camera/stream management via VIOS
-- **video-analytics** → Elasticsearch queries
 
 ## Tear Down
 
@@ -465,14 +219,13 @@ cd $REPO/deployments
 docker compose -f resolved.yml down
 ```
 
+For switching profiles or recovering from a partial deploy, follow the full procedure in [`references/teardown.md`](references/teardown.md).
+
 ## Debugging a Deployment
 
-Use this workflow when the user asks to "debug the deploy", "verify it's working",
-"why is the agent not responding", or similar. The goal is to confirm the full
-video-ingestion-to-agent-answer path, not just that containers are "Up".
+Use this workflow when the user asks to "debug the deploy", "verify it's working", "why is the agent not responding", or similar. The goal is to confirm the full video-ingestion-to-agent-answer path, not just that containers are "Up".
 
-Each profile reference doc (e.g. [`references/base.md`](references/base.md)) has a
-**Debugging** section listing the exact commands to run for that profile.
+Each profile reference has a **Debugging** section listing the exact commands and failure-mode table for that profile.
 
 ### Quick checks (all profiles)
 
@@ -493,11 +246,7 @@ curl -sf http://localhost:30081/v1/models | python3 -m json.tool
 
 ### End-to-end video sanity check
 
-After the quick checks above pass, drive a real query through the agent — e.g.
-ask it over the REST API or UI to describe a video you've uploaded to VST.
-If the agent returns a non-empty answer, the upload → ingest → inference →
-reply path is healthy. If it fails, `docker logs vss-agent` shows which stage
-tripped.
+After the quick checks above pass, drive a real query through the agent — e.g. ask it over the REST API or UI to describe a video you've uploaded to VST. If the agent returns a non-empty answer, the upload → ingest → inference → reply path is healthy. If it fails, `docker logs vss-agent` shows which stage tripped.
 
 ## Troubleshooting
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -177,33 +177,13 @@ Unexpanded `${VAR}` tokens in `resolved.yml` mean compose did not see those env 
 
 **MUST run after Step 3, before Step 5.** Skipping this aborts the deploy:
 
-`docker compose --env-file .env config` filters out services that don't match the active `COMPOSE_PROFILES`, but it leaves `depends_on:` entries that point at those filtered-out services. Compose's schema validator rejects any `depends_on` target that isn't a defined service in the file — even when the entry is `required: false`. The result: `docker compose -f resolved.yml up -d` aborts with
-
-```
-service "vst-ingress" depends on undefined service "sensor-ms-2d": invalid compose project
-```
-
-before any container starts.
-
-> **The fix only touches the generated `resolved.yml` — never the source compose files.** The dependencies are correctly marked optional in the source; profile filtering is what creates the dangling references in the resolved artifact.
-
-Run the bundled normalizer via `uv` (no install required — the script declares its `pyyaml` dep with PEP 723 inline metadata, and `uv run` pulls it into an ephemeral env on demand):
+Normalize - drop optional dependencies for services filtered out from resolved.yml
 
 ```bash
 # From the repo root
 uv run skills/deploy/scripts/normalize_resolved_yml.py "$REPO/deployments/resolved.yml"
 ```
-
-The script ([`scripts/normalize_resolved_yml.py`](scripts/normalize_resolved_yml.py)):
-
-- Drops every `depends_on` target that isn't a defined service in the file.
-- Preserves required active dependencies (kafka, redis, rtvi-vlm, sensor-ms, streamprocessing-ms, etc.).
-- Removes the `depends_on:` key entirely if it ends up empty.
-- Prints the list of removed `(service → dangling target)` pairs so the user can see what was cleaned.
-- Idempotent — running it on an already-clean file is a no-op.
-
-If `uv` isn't on the host, install it once with `curl -LsSf https://astral.sh/uv/install.sh | sh` (no root needed). Don't `pip install pyyaml` — many deploy hosts don't have pip configured for the system Python, and uv keeps the script's deps isolated.
-
+If `uv` isn't on the host, install it once with `curl -LsSf https://astral.sh/uv/install.sh | sh` (no root needed).
 **Re-validate** before `up -d`:
 
 ```bash

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -173,6 +173,75 @@ The resolved YAML is saved to `<repo>/deployments/resolved.yml`.
 
 Unexpanded `${VAR}` tokens in `resolved.yml` mean compose did not see those env values. Diagnostic procedure and common culprits live in [`references/troubleshooting.md`](references/troubleshooting.md).
 
+### Step 3c — Strip dangling optional `depends_on` from resolved.yml
+
+`docker compose --env-file .env config` filters out services that don't match the active `COMPOSE_PROFILES`, but it leaves `depends_on:` entries that point at those filtered-out services. Compose's schema validator rejects any `depends_on` target that isn't a defined service in the file — even when the entry is `required: false`. The result: `docker compose -f resolved.yml up -d` aborts with
+
+```
+service "vst-ingress" depends on undefined service "sensor-ms-2d": invalid compose project
+```
+
+before any container starts.
+
+> **Edit the generated `resolved.yml` only — never the source compose files.** The dependencies are correctly marked optional in the source; profile filtering is what creates the dangling references in the resolved artifact.
+
+**Detect:**
+
+```bash
+python3 - <<'PY'
+import yaml
+with open("resolved.yml") as f:
+    d = yaml.safe_load(f)
+defined = set((d.get("services") or {}).keys())
+dangling = []
+for name, svc in (d.get("services") or {}).items():
+    deps = (svc or {}).get("depends_on") or {}
+    targets = deps.keys() if isinstance(deps, dict) else deps
+    for t in targets:
+        if t not in defined:
+            dangling.append((name, t))
+for n, t in dangling:
+    print(f"{n} -> {t} (not defined)")
+print(f"\n{len(dangling)} dangling depends_on entries")
+PY
+```
+
+**Fix in place** (drops only the dangling entries; required active deps like `kafka`, `redis`, `rtvi-vlm`, `sensor-ms`, `streamprocessing-ms` are preserved):
+
+```bash
+python3 - <<'PY'
+import yaml
+with open("resolved.yml") as f:
+    d = yaml.safe_load(f)
+defined = set((d.get("services") or {}).keys())
+for name, svc in (d.get("services") or {}).items():
+    deps = (svc or {}).get("depends_on")
+    if not deps:
+        continue
+    if isinstance(deps, dict):
+        kept = {k: v for k, v in deps.items() if k in defined}
+        if kept:
+            svc["depends_on"] = kept
+        else:
+            svc.pop("depends_on", None)
+    elif isinstance(deps, list):
+        kept = [k for k in deps if k in defined]
+        if kept:
+            svc["depends_on"] = kept
+        else:
+            svc.pop("depends_on", None)
+with open("resolved.yml", "w") as f:
+    yaml.safe_dump(d, f, sort_keys=False)
+print("resolved.yml normalized")
+PY
+```
+
+**Re-validate** before `up -d`:
+
+```bash
+docker compose -f resolved.yml config --quiet && echo "resolved.yml OK"
+```
+
 ### Step 4 — Review
 
 Show the user a summary of what will be deployed:

--- a/skills/deploy/references/alerts.md
+++ b/skills/deploy/references/alerts.md
@@ -215,9 +215,67 @@ Formula: `NIM_KVCACHE_PERCENT = 1 - 0.35 - 0.15 = 0.50`. Same fraction across GP
 deploy/docker/developer-profiles/dev-profile-alerts/.env
 ```
 
+## Stage perception models (RTDETR-ITS + GDINO)
+
+**MUST run before `docker compose -f resolved.yml up -d` for verification mode (`MODE=2d_cv`).** The alerts compose has no init container that downloads the perception detector models — `dev-profile.sh` stages them via NGC CLI, and since this skill doesn't run that script, the agent stages them directly.
+
+Real-time mode (`MODE=2d_vlm`) doesn't deploy RT-CV and skips this entirely.
+
+Symptom if skipped (verification mode): RT-CV starts but its TensorRT engine build fails because the ONNX detector files are missing under `${MDX_DATA_DIR}/models/`.
+
+```bash
+# Source: deploy/docker/scripts/dev-profile.sh (alerts profile, model staging block).
+# Requires NGC_CLI_API_KEY exported and ngc CLI on PATH (see references/ngc.md).
+
+DATA="$MDX_DATA_DIR"                                     # e.g. <repo>/data
+APPS="$MDX_SAMPLE_APPS_DIR"                              # e.g. <repo>/deploy/docker
+
+# Profile-specific dirs
+mkdir -p \
+    "$DATA/data_log/vss_video_analytics_api" \
+    "$DATA/videos/dev-profile-alerts" \
+    "$APPS/engines/gdino" \
+    "$APPS/engines/rtdetr-its"
+chmod -R 777 "$APPS/engines"
+
+# DESTRUCTIVE: dev-profile.sh wipes $DATA/models before re-staging. If the host
+# also runs other profiles whose models live under $DATA/models, gate this on
+# whether you really want a clean slate.
+rm -rf "$DATA/models"
+mkdir -p "$DATA/models/rtdetr-its" "$DATA/models/gdino"
+
+# 1. RTDETR-ITS (TrafficcamNet)
+NGC_CLI_API_KEY="$NGC_CLI_API_KEY" ngc registry model \
+    download-version \
+    nvidia/tao/trafficcamnet_transformer_lite:deployable_resnet50_v2.0
+mv trafficcamnet_transformer_lite_vdeployable_resnet50_v2.0/resnet50_trafficcamnet_rtdetr.fp16.onnx \
+    "$DATA/models/rtdetr-its/model_epoch_035.fp16.onnx"
+rm -rf trafficcamnet_transformer_lite_vdeployable_resnet50_v2.0
+
+# 2. Mask Grounding DINO
+NGC_CLI_API_KEY="$NGC_CLI_API_KEY" ngc registry model \
+    download-version \
+    nvidia/tao/mask_grounding_dino:mask_grounding_dino_swin_tiny_commercial_deployable_v2.1_wo_mask_arm
+mv mask_grounding_dino_vmask_grounding_dino_swin_tiny_commercial_deployable_v2.1_wo_mask_arm/mgdino_mask_head_pruned_dynamic_batch.onnx \
+    "$DATA/models/gdino/mgdino_mask_head_pruned_dynamic_batch.onnx"
+rm -rf mask_grounding_dino_vmask_grounding_dino_swin_tiny_commercial_deployable_v2.1_wo_mask_arm
+
+chmod -R 777 "$DATA/models"
+```
+
+**Verify** before deploying:
+
+```bash
+ls -l "$MDX_DATA_DIR/models/rtdetr-its/model_epoch_035.fp16.onnx" \
+      "$MDX_DATA_DIR/models/gdino/mgdino_mask_head_pruned_dynamic_batch.onnx"
+# expected: both files present, mode 777
+```
+
+After RT-CV starts, it builds TensorRT engines from these ONNX files (3–5 min on first start), cached under `$MDX_SAMPLE_APPS_DIR/engines/`.
+
 ## First-run note
 
-RT-VLM downloads `cosmos-reason2-8b:hf-1208` from NGC on first start (~10–20 min depending on bandwidth). RT-CV's perception model (`GDINO`) is downloaded by the `perception-2d-init` container into `$DATA/models/gdino`. Real-time mode skips RT-CV entirely.
+RT-VLM downloads `cosmos-reason2-8b:hf-1208` from NGC on first start (~10–20 min depending on bandwidth). For verification mode (`MODE=2d_cv`), RT-CV builds TensorRT engines from the ONNX models staged in [Stage perception models](#stage-perception-models-rtdetr-its--gdino) above. Real-time mode skips RT-CV entirely.
 
 ## Debugging
 

--- a/skills/deploy/references/alerts.md
+++ b/skills/deploy/references/alerts.md
@@ -1,43 +1,229 @@
 # VSS Alerts Profile — Reference
 
-## Two Modes
+Profile: `alerts` | Blueprint: `bp_developer_alerts` | Modes: `2d_cv` (verification) and `2d_vlm` (real-time)
 
-| Mode | Flag | How it works | GPU load |
+Real-time alert generation and verification on RTSP / live video. VLM is **always served by RT-VLM** (port 8018), same as LVS — there is no standalone Cosmos NIM in the alerts compose graph. The `COMPOSE_PROFILES` for alerts is `${BP_PROFILE}_${MODE},${BP_PROFILE}_${MODE}_${HARDWARE_PROFILE},llm_${LLM_MODE}_${LLM_NAME_SLUG}` — note the absence of `vlm_*_<slug>`. Setting `VLM_NAME_SLUG=none` for alerts is intentional and required.
+
+## Two modes
+
+| Mode | CLI | `MODE` env | How it works | VLM load |
+|---|---|---|---|---|
+| **verification** | `--mode verification` | `2d_cv` | DeepStream perception (RT-CV with Grounding DINO) generates alerts upstream; behavior analytics filters them; alert-bridge invokes VLM **only** to verify alert clips. | Lower — VLM runs per alert |
+| **real-time** | `--mode real-time` | `2d_vlm` | VLM continuously inspects live video at periodic intervals; broad coverage without upstream CV dependency. RT-CV not deployed. | Higher — VLM runs continuously |
+
+Switch modes by editing `MODE` in `dev-profile-alerts/.env` (`MODE=2d_cv` or `MODE=2d_vlm`) and re-resolving the compose. `dev-profile.sh` also rewrites the UI subtitle (`NEXT_PUBLIC_APP_SUBTITLE`) for the matching mode label.
+
+## What's different from `base` and `lvs`
+
+- **VLM is RT-VLM with the integrated Cosmos Reason 2 checkpoint.** Default `RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-1208`, `RTVI_VLM_MODEL_TO_USE=cosmos-reason2`. No standalone `cosmos-reason2-8b` NIM service is started.
+- **`VLM_NAME` must match RT-VLM's `/v1/models` basename.** Set `VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208` for the default Cosmos2 path; alert-bridge / agent get HTTP 400 "No such model" otherwise (see `vllm_compatible_model.py::get_model_info` for the lookup logic).
+- **`VLM_NAME_SLUG=none`** for alerts — `COMPOSE_PROFILES` does not include a `vlm_local_*_<slug>` segment. The only LLM/VLM compose profile that matters for alerts is `llm_${LLM_MODE}_${LLM_NAME_SLUG}`.
+- **`VLM_PORT=8018`** by default (RT-VLM). Set to `30082` when `VLM_MODE=remote` (RT-VLM not started; agent points at the remote endpoint).
+- **Alert-bridge** (port 9080) is the bridge between RT-VLM events / behavior analytics and the agent's realtime alerting API. Verification mode reads from RT-CV → behavior analytics → alert-bridge → VLM verification. Real-time mode reads from RT-VLM → alert-bridge directly.
+
+> **`VLM_MODE` is required in `.env` but is a runtime signal, not a deployment-shape selector.** The vss-agent container reads `VLM_MODE` at startup (`services/agent/compose.yml:79` → `dev-profile-alerts/vss-agent/configs/config.yml:76,91`) to configure its VLM tool. It does **not** flip a compose profile (alerts has no `vlm_*_<slug>`). Set it to match physical placement: `local_shared` (RT-VLM on the LLM's GPU), `local` (RT-VLM on its own GPU), or `remote` (no local RT-VLM).
+
+> **An LLM endpoint is required.** The alerts agent uses the LLM for incident-report generation and tool routing. `dev-profile-alerts/vss-agent/configs/config.yml:152,193,259` reference `nim_llm` / `prompt_gen_llm`, and `COMPOSE_PROFILES` always pulls in `llm_${LLM_MODE}_${LLM_NAME_SLUG}`. To skip the local LLM container, point at a remote endpoint (`LLM_MODE=remote`, set `LLM_BASE_URL`). The detection pipeline alone (RT-CV → behavior-analytics → RT-VLM, alerts in Kafka/ES) doesn't need the LLM, but the agent does — and without the agent the user has no UI / report flow.
+
+## What gets deployed
+
+| Service | Container | Port | Purpose | Mode |
+|---|---|---|---|---|
+| RT-CV (DeepStream perception) | vss-rtvi-cv | — (host net) | Object detection (Grounding DINO via `MODEL_NAME_2D=GDINO`) | **2d_cv only** |
+| Behavior analytics | vss-behavior-analytics | — | Rule-based alerts from RT-CV metadata | **2d_cv only** |
+| RT-VLM | vss-rtvi-vlm | 8018 | VLM runner (Cosmos Reason 2 by default) | both |
+| Alert-bridge | (alert-bridge) | 9080 | Realtime alerting API; drives `POST/DELETE /api/v1/realtime` on the agent | both |
+| LLM NIM | mdx-nim-llm-1 | 30081 | Same options as `base` (Nano 9B v2 default) | both |
+| nvstreamer-alerts | vss-vios-nvstreamer | 31000 | Plays back dataset video to simulate live cameras | both |
+| VST | mdx-vst-1 | 30888 | Video storage + ingest | both |
+| VSS Agent | mdx-vss-agent-1 | 8000 | Orchestrates alert verification and incident reports | both |
+| VSS UI | mdx-vss-ui-1 | 3000 | Alerts tab | both |
+| Video-Analytics MCP | vss-va-mcp | 9901 | Analytics API for the agent | both |
+| Elasticsearch + Kibana | mdx-elasticsearch-1, kibana | 9200, 5601 | Alert/event storage | both |
+| Kafka | mdx-kafka-1 | 9092 | Message bus | both |
+| Phoenix | mdx-phoenix-1 | 6006 | Observability | both |
+
+## Default models
+
+| Role | Model | `VLM_NAME` / slug | Served by |
 |---|---|---|---|
-| **verification** | `-m verification` | CV + behavior analytics generate candidate alerts upstream; VLM reviews each alert clip to reduce false positives | Lower — VLM invoked per alert |
-| **real-time** | `-m real-time` | VLM continuously processes live video at periodic intervals; broad coverage without upstream CV dependency | Higher — VLM runs continuously |
+| LLM | `nvidia/nvidia-nemotron-nano-9b-v2` | `nvidia-nemotron-nano-9b-v2` | NIM (port 30081) |
+| VLM | Cosmos Reason 2 8B (integrated) | **`nim_nvidia_cosmos-reason2-8b_hf-1208`** / slug **`none`** | RT-VLM (port 8018), `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` |
+| Perception (2d_cv only) | Grounding DINO | (`MODEL_NAME_2D=GDINO`, `MODEL_TYPE=cnn`) | RT-CV (DeepStream) |
 
-## What Gets Deployed
+LLM alternates: same as `base` — `NVIDIA-Nemotron-Nano-9B-v2-FP8`, `nemotron-3-nano`, `llama-3.3-nemotron-super-49b-v1.5`, `gpt-oss-20b`.
 
-| Service | Purpose |
+VLM alternates: see [VLM serving paths](#vlm-serving-paths) below.
+
+## Default GPU layout
+
+Reference defaults from `dev-profile-alerts/.env`:
+
+```bash
+RT_CV_DEVICE_ID=0           # perception (2d_cv only)
+RT_VLM_DEVICE_ID=1          # RT-VLM container
+LLM_DEVICE_ID=1             # LLM NIM
+VLM_DEVICE_ID=1
+LLM_MODE=local_shared       # LLM compose service: shared-GPU variant
+VLM_MODE=local_shared       # signals the agent that RT-VLM lives on the LLM's GPU
+RESERVED_DEVICE_IDS='0'     # GPU 0 reserved for RT-CV; not picked by shared-LLM compose
+```
+
+The default is a **2-GPU layout**: RT-CV alone on GPU 0, LLM + RT-VLM shared on GPU 1. `VLM_MODE=local_shared` here just tells the agent's runtime config that the VLM endpoint is co-located — it doesn't gate any compose service on its own. To move RT-VLM to its own GPU 2, change `RT_VLM_DEVICE_ID` and `VLM_DEVICE_ID` to `2`, set `VLM_MODE=local`, and bump `RTVI_VLLM_GPU_MEMORY_UTILIZATION` per [Sizing](#sizing). To use a remote VLM, see [Path B](#path-b--remote-vlm-user-supplied).
+
+Real-time mode (`MODE=2d_vlm`) doesn't deploy RT-CV, so GPU 0 is free in that mode — often given to RT-VLM for more KV-cache headroom.
+
+## VLM serving paths
+
+Pick the path that matches the user's VLM choice. Default is **integrated**.
+
+### Path A — Integrated (RT-VLM loads Cosmos Reason)
+
+Default. RT-VLM serves the VLM locally. Supported integrated checkpoints (same set as LVS):
+
+| VLM | `RTVI_VLM_MODEL_PATH` | `RTVI_VLM_MODEL_TO_USE` |
+|---|---|---|
+| Cosmos Reason 2 8B (default) | `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` | `cosmos-reason2` |
+| Cosmos Reason 1 7B | `ngc:nim/nvidia/cosmos-reason1-7b:hf-<tag>` | `cosmos-reason` |
+| Nemotron Nano V3 Omni 30B | `git:https://huggingface.co/nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8` | `vllm-compatible` (see [`lvs.md` § Nemotron Omni](lvs.md#path-a--integrated-rt-vlm-loads-the-checkpoint-itself)) |
+
+Switching VLMs is a `dev-profile-alerts/.env` edit; **`VLM_NAME_SLUG` stays `none`** and `VLM_NAME` must match the model basename returned by RT-VLM's `/v1/models` (otherwise alert-bridge fails with HTTP 400). For Cosmos Reason 1 the `VLM_NAME` becomes `nim_nvidia_cosmos-reason1-7b_hf-<tag>`.
+
+### Path B — Remote VLM (user supplied)
+
+Use when:
+
+1. **The user supplied a remote VLM endpoint URL**, or
+2. **The local GPU(s) can't fit the requested VLM alongside the LLM + RT-CV** per the sizing math (and the user agreed to go remote — same two-trigger rule as [`base.md` § When to use remote LLM/VLM](base.md#when-to-use-remote-llmvlm)).
+
+The full set of env vars the skill writes to `dev-profile-alerts/.env`:
+
+```bash
+VLM_MODE=remote                                          # agent reads this; switches its VLM tool to remote-endpoint mode
+VLM_PORT=30082                                           # was 8018; rtvi-vlm is not started in remote mode
+VLM_BASE_URL=<remote-endpoint>                           # no trailing /v1
+VLM_NAME=<model-name-served-there>                       # not nim_…; use the model id the remote actually advertises
+RTVI_VLM_ENDPOINT=<remote-endpoint>/v1                   # WITH /v1
+RTVI_VLM_MODEL_TO_USE=openai-compat
+RTVI_VLM_MODEL_PATH=none
+NVIDIA_API_KEY=<key if required>
+```
+
+> **`/v1` quirk** (same as LVS): `VLM_BASE_URL` no `/v1`; `RTVI_VLM_ENDPOINT` yes `/v1`. Always write both consistently.
+
+### Path C — BYO local VLM (model not in the integrated set)
+
+For VLMs RT-VLM can't load directly (e.g. Qwen3-VL or a third-party HF model): stand it up as a separate NIM/vLLM service per [`base.md` § Swapping a different LLM/VLM](base.md#swapping-a-different-llmvlm), then point RT-VLM at the local URL via Path B's env vars (`VLM_BASE_URL=http://${HOST_IP}:30082`, etc.). Keep `VLM_MODE=remote` so RT-VLM doesn't try to load the model itself.
+
+## Sizing
+
+For LLM weight cost, VLM weight cost, and the general formula, see [`base.md` § Sizing math](base.md#sizing-math) — it applies unchanged. The alerts profile adds **RT-VLM** and **RT-CV** as co-residents that the LLM has to share with.
+
+### Values the skill writes directly
+
+The skill writes these env vars to `dev-profile-alerts/.env` itself; there's no auto-tuning, so the agent has to apply the right values per the chosen layout. The numbers below are the upstream `dev-profile.sh:1200-1234` defaults — used as a precedent / starting point, not because the script ever runs.
+
+**`RTVI_VLLM_GPU_MEMORY_UTILIZATION`:**
+
+| Layout | Hardware | Value |
+|---|---|---|
+| RT-VLM shares GPU with LLM (`VLM_MODE=local_shared`) | any | **0.35** |
+| RT-VLM on its own GPU (`VLM_MODE=local`) | DGX-SPARK or L40S | **0.8** |
+| RT-VLM on its own GPU (`VLM_MODE=local`) | H100 / RTXPRO6000BW | leave blank → RT-VLM's hardcoded 0.7 fallback applies |
+| RT-VLM on its own GPU on edge | OTHER / IGX-THOR / AGX-THOR | leave blank |
+
+**`RT_VLM_DEVICE_ID`:**
+
+| Layout | Value |
 |---|---|
-| NVStreamer | Plays back dataset video to simulate live cameras |
-| VIOS | Video ingestion, live streaming, recording, playback |
-| RTVI CV | Real-time object detection (Grounding DINO, open-vocabulary) |
-| Behavior Analytics | Rule-based alert generation from RTVI CV metadata |
-| Alert Verification | VLM-based review of alert video clips |
-| Cosmos Reason (NIM) | VLM used by Alert Verification |
-| ELK | Log and alert storage |
-| VSS Agent | Orchestrates tool calls and queries |
-| Nemotron LLM (NIM) | Reasoning and response generation |
-| Phoenix | Observability and telemetry |
+| RT-VLM shares GPU with LLM | same as `LLM_DEVICE_ID` (GPU 1 default) |
+| RT-VLM on its own GPU | the dedicated GPU index (e.g. 2) |
+| `VLM_MODE=remote` | irrelevant; RT-VLM not started |
+| Edge (`IGX-THOR` / `AGX-THOR`) | `0` (unified memory) |
 
-## GPU Layout (RTXPRO6000BW)
+Edge platforms also need `VLM_AS_VERIFIER_CONFIG_FILE_PREFIX=EDGE-LOCAL-VLM-` so `vlm-as-verifier` picks up the matching config under `dev-profile-alerts/vlm-as-verifier/configs/EDGE-LOCAL-VLM-config.yml`.
 
-Both GPUs required:
+### Default shared-mode budget (H100 80 GB, MODE=2d_cv)
 
-| Device | Role |
-|---|---|
-| 0 | RT-CV perception (reserved — object detection) |
-| 1 | LLM + VLM (`local_shared`) |
+```text
+GPU 0 (RT-CV alone):
+  Grounding DINO + DeepStream pipeline ≤ NUM_SENSORS streams (default 1).
+  Plenty of headroom on a dedicated H100.
 
-## Use Cases
+GPU 1 (LLM + RT-VLM shared):
+  RT-VLM at 0.35 × 80 GB = 28 GB                           # set by dev-profile.sh
+  LLM    at NIM_KVCACHE_PERCENT × 80 GB                    # tune in nim/<llm-slug>/hw-H100-shared.env
+  framework/CUDA buffer ~ 15% of GPU = 12 GB
+  → leaves 80 - 28 - 12 = 40 GB for the LLM
+  → NIM_KVCACHE_PERCENT ≈ 0.50 (40 / 80)
+```
+
+So on H100 with the default Cosmos2 + Nano 9B pair:
+- `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.35` (already set by the script for shared mode).
+- `NIM_KVCACHE_PERCENT=0.50` in `nim/nvidia-nemotron-nano-9b-v2/hw-H100-shared.env`.
+
+For real-time mode (`MODE=2d_vlm`), GPU 0 is free (no RT-CV). Two layouts make sense:
+
+1. **Keep shared on GPU 1** — simpler. Same numbers as above; GPU 0 is unused.
+2. **Move RT-VLM to GPU 0** for more KV-cache headroom (`local` mode, `VLM_DEVICE_ID=0`, `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.7` → ~56 GB for VLM). LLM gets all of GPU 1. Useful when VLM throughput dominates.
+
+### Per-GPU `NIM_KVCACHE_PERCENT` quick-reference (shared mode, alerts)
+
+With RT-VLM at 0.35 and a 15% framework reservation, the LLM gets:
+
+| GPU | VRAM | RT-VLM (0.35) | Framework (0.15) | LLM gets | `NIM_KVCACHE_PERCENT` |
+|---|---|---|---|---|---|
+| H100 / A100-80 | 80 GB | 28 GB | 12 GB | 40 GB | **0.50** |
+| H200 | 141 GB | 49 GB | 21 GB | 71 GB | **0.50** |
+| RTX PRO 6000 (Blackwell) | 96 GB | 34 GB | 14 GB | 48 GB | **0.50** |
+| L40S | 48 GB | 17 GB | 7 GB | 24 GB | **0.50** (tight — Nano 9B at 23.4 GB barely fits) |
+
+Formula: `NIM_KVCACHE_PERCENT = 1 - 0.35 - 0.15 = 0.50`. Same fraction across GPUs because the script's RT-VLM util is fixed at 0.35 in shared mode.
+
+### Hard rules
+
+- **L40S is the floor for shared mode.** 24 GB for the LLM barely fits Nano 9B FP16 (23.4 GB total). Switch to FP8 (`nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8`, 11.7 GB total) for any breathing room, or move to dedicated mode (LLM on its own GPU, RT-VLM on its own GPU at 0.8 util).
+- **DGX-Spark / IGX-Thor / AGX-Thor — Cosmos Reason 2 still serves via RT-VLM** but the agent script uses `VLM_AS_VERIFIER_CONFIG_FILE_PREFIX=EDGE-LOCAL-VLM-` and pins `RT_VLM_DEVICE_ID=0` (unified memory). For the LLM side, follow [`edge.md`](edge.md) (Edge 4B mandatory for shared mode on edge).
+- **Don't co-deploy a standalone Cosmos NIM with alerts.** `COMPOSE_PROFILES` for alerts has no `vlm_*_<slug>` segment by design. Verify by checking `resolved.yml` doesn't have `cosmos-reason2-8b` / `cosmos-reason2-8b-shared-gpu` services alongside `rtvi-vlm`.
+- **`VLM_NAME` mismatch ⇒ HTTP 400.** dev-profile.sh sets `VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208` for the default Cosmos2 path. If you change `RTVI_VLM_MODEL_PATH` you must update `VLM_NAME` to match the new model basename — otherwise alert-bridge / agent get "No such model" from `/v1/models`.
+- **`VLM_NAME_SLUG=none` is required.** The alerts compose graph has no `vlm_local_*_<slug>` profiles. Setting a real slug doesn't bring up a VLM service — it just makes the COMPOSE_PROFILES reference dead.
+- **`/v1` suffix mismatch.** `VLM_BASE_URL` no `/v1`; `RTVI_VLM_ENDPOINT` yes `/v1`. dev-profile.sh writes them consistently in remote mode; if you edit by hand, mirror that.
+
+## Use cases
 
 - PPE compliance verification (hard hats, safety vests)
-- Restricted area monitoring
-- Asset presence/absence detection
-- Custom object detection scenarios
+- Restricted area / asset presence detection
+- Custom object detection scenarios (driven by behavior analytics rules in 2d_cv mode)
+- Continuous live-stream incident detection (in 2d_vlm mode)
 
-## First Run Note
+## Endpoints (after deploy)
 
-Downloads perception and VLM models from NGC on first run — expect extra time.
+| Service | URL |
+|---|---|
+| Agent UI | `http://<HOST_IP>:3000/` (Alerts tab) |
+| Agent REST API | `http://<HOST_IP>:8000/` |
+| Alert-bridge realtime API | `http://<HOST_IP>:9080/api/v1/realtime` |
+| RT-VLM | `http://<HOST_IP>:8018/v1/` (or remote if `VLM_MODE=remote`) |
+| Video-Analytics MCP | `http://<HOST_IP>:9901/` |
+| Kibana | `http://<HOST_IP>:5601/` |
+| nvstreamer | `http://<HOST_IP>:31000/` |
+| Phoenix | `http://<HOST_IP>:6006/` |
+
+## Env file location
+
+```
+deploy/docker/developer-profiles/dev-profile-alerts/.env
+```
+
+## First-run note
+
+RT-VLM downloads `cosmos-reason2-8b:hf-1208` from NGC on first start (~10–20 min depending on bandwidth). RT-CV's perception model (`GDINO`) is downloaded by the `perception-2d-init` container into `$DATA/models/gdino`. Real-time mode skips RT-CV entirely.
+
+## Debugging
+
+- **`docker logs vss-rtvi-vlm`** — confirms model load and `Maximum concurrency for X tokens per GPU: Y x` line. OOM → lower `RTVI_VLLM_GPU_MEMORY_UTILIZATION` by 0.05 or drop `RTVI_VLM_MAX_MODEL_LEN` / `RTVI_VLLM_MAX_NUM_SEQS`.
+- **`docker logs alert-bridge`** — if it logs HTTP 400 "No such model: …", check `VLM_NAME` matches RT-VLM's `/v1/models` basename. `curl http://${HOST_IP}:8018/v1/models | jq` confirms what's actually advertised.
+- **2d_cv: alerts never fire** — check `vss-behavior-analytics` is consuming RT-CV metadata: `docker logs vss-behavior-analytics`. RT-CV side: `curl http://${HOST_IP}:9000/v1/health`.
+- **2d_vlm: VLM not running over live streams** — confirm `MODE=2d_vlm` (not `2d_cv`) in `resolved.yml` and that nvstreamer-alerts is publishing streams.
+- **OOM on shared GPU 1** — drop `NIM_KVCACHE_PERCENT` for the LLM by 0.05; if RT-VLM is the OOM, raise its `RTVI_VLLM_GPU_MEMORY_UTILIZATION` ceiling and re-tune the LLM down (the 0.35/0.50 split assumes Nano 9B FP16; larger LLMs need different ratios).
+- **Edge: `vlm-as-verifier` config not loaded** — verify `VLM_AS_VERIFIER_CONFIG_FILE_PREFIX=EDGE-LOCAL-VLM-` is set in `generated.env` and the matching `EDGE-LOCAL-VLM-config.yml` exists under `dev-profile-alerts/vlm-as-verifier/configs/`.

--- a/skills/deploy/references/base.md
+++ b/skills/deploy/references/base.md
@@ -30,13 +30,273 @@ Video upload, Q&A, and report generation with HITL (Human-in-the-Loop) feedback.
 
 **Alternate VLMs:** `nvidia/cosmos-reason1-7b`, `Qwen/Qwen3-VL-8B-Instruct`
 
-## GPU Layout
+## Sizing — GPU memory per model
 
-| LLM/VLM Mode | LLM_DEVICE_ID | VLM_DEVICE_ID | Description |
+Sizing for `base` is per-model. The default pair is `cosmos-reason2-8b` (VLM) + `nvidia-nemotron-nano-9b-v2` (LLM); the user can swap either by editing `LLM_NAME` / `LLM_NAME_SLUG` / `VLM_NAME` / `VLM_NAME_SLUG` in the `dev-profile-base/.env` file. The compose system auto-resolves to the right service via the computed `COMPOSE_PROFILES` (`llm_<mode>_<slug>` and `vlm_<mode>_<slug>`).
+
+The tables below give the **VRAM cost per model** (weights × 1.3 overhead). Use this with the [Sizing math](#sizing-math) section to decide whether a (LLM, VLM, GPU) combo fits. 
+
+### LLMs (compose files under `deploy/docker/services/nim/`)
+
+| Model | Type | Compose file | Params | Precision | Est. VRAM (weights × 1.3) |
+|---|---|---|---|---|---|
+| `nvidia/nvidia-nemotron-nano-9b-v2` (default) | NIM (`nvcr.io/nim/...:1`) | `nim/nvidia-nemotron-nano-9b-v2/compose.yml` | 9 B | FP16 | **23.4 GB** |
+| `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8` | DLFW vLLM (`nvcr.io/nvidia/vllm:25.12.post1-py3`) | `nim/nvidia-nemotron-nano-9b-v2-fp8/compose.yml` | 9 B | FP8 | **11.7 GB** |
+| `nvidia/nemotron-3-nano` | NIM | `nim/nemotron-3-nano/compose.yml` | ~3 B | FP16 | ~7.8 GB |
+| `nvidia/llama-3.3-nemotron-super-49b-v1.5` | NIM | `nim/llama-3.3-nemotron-super-49b-v1.5/compose.yml` | 49 B | FP16 | **127 GB** (needs tp≥2 to fit on H100/L40S) |
+| `openai/gpt-oss-20b` | NIM | `nim/gpt-oss-20b/compose.yml` | 20 B | FP16 | **52 GB** |
+| `nvidia/NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8` | DLFW vLLM (standalone, edge only) | not in tree — see [`edge.md`](edge.md) | 4 B | FP8 | **5.2 GB** |
+
+### VLMs (compose files under `deploy/docker/services/nim/`)
+
+| Model | Type | Compose file | Params | Precision | Est. VRAM (weights × 1.3) |
+|---|---|---|---|---|---|
+| `nvidia/cosmos-reason2-8b` (default) | NIM (`nvcr.io/nim/...:1.6.0`) | `nim/cosmos-reason2-8b/compose.yml` | 8 B | FP16 | **20.8 GB** |
+| `nvidia/cosmos-reason1-7b` | NIM | `nim/cosmos-reason1-7b/compose.yml` | 7 B | FP16 | **18.2 GB** |
+| `Qwen/Qwen3-VL-8B-Instruct` | DLFW vLLM | `nim/qwen3-vl-8b-instruct/compose.yml` | 8 B | FP16 | **20.8 GB** |
+
+### GPU VRAM reference
+
+
+| GPU | VRAM | 85% usable | Notes |
 |---|---|---|---|
-| `local_shared` (default) | 0 | 0 | Both models share one GPU |
-| `local` | 0 | 1 | Dedicated GPU per model |
-| `remote` | — | — | No local GPU needed for inference |
+| H100 SXM / PCIe | 80 GB | 68 GB | Default for shared mode |
+| H200 | 141 GB | 119.85 GB | Plenty of headroom for any pair |
+| B200 / GB200 | 192 GB | 163.2 GB | Newest, highest-capacity |
+| RTX PRO 6000 (Blackwell) | 96 GB | 81.6 GB | Workstation Blackwell |
+| GB10 (DGX Spark) | 128 GB unified | ~108 GB | Shared with system; cap aggressively |
+| AGX/IGX Thor | 128 GB unified | ~108 GB | Edge unified memory |
+| L40S / L40 / RTX 6000 Ada | 48 GB | 40.8 GB | Too small for LLM + VLM shared at FP16 |
+| A100 80 GB | 80 GB | 68 GB | Hopper-era 80 GB option |
+
+The "85% usable" column is the budget you have for weights + KV cache + activations. we reserve the remaining 15% for framework/CUDA overhead (`SINGLE_GPU_MEMORY_THRESHOLD = 0.85`).
+
+## Sizing math
+
+
+```text
+weights_GB     = (num_params_B × bits_per_param) / 8
+total_GB       = weights_GB × 1.3                          # +30% for KV cache + activations
+fits_dedicated = total_GB                ≤  0.85 × gpu_vram_GB
+fits_shared    = total_GB(LLM) + total_GB(VLM)
+                                         ≤  0.85 × gpu_vram_GB
+
+# In single-GPU shared mode, KV / GPU-mem fraction per service:
+fraction       = (this_num_params / total_num_params) × 0.85
+# Set this in NIM_KVCACHE_PERCENT (NIMs) and --gpu-memory-utilization (vLLM/DLFW).
+```
+
+`bits_per_param` = 16 for FP16/BF16, 8 for FP8/INT8, 4 for INT4/MXFP4.
+
+### `NIM_KVCACHE_PERCENT` ↔ GB on common GPUs
+
+`NIM_KVCACHE_PERCENT` is a fraction (0.0–1.0) of **total GPU VRAM** the NIM container is allowed to consume (weights + KV cache + activations all included). For vLLM containers, the same fraction is `--gpu-memory-utilization`.
+
+| Fraction | H100 / A100-80 (80 GB) | H200 (141 GB) | RTX PRO 6000 (96 GB) | GB10 / Thor (128 GB) | L40S (48 GB) |
+|---|---|---|---|---|---|
+| 0.25 | 20 GB | 35.25 GB | 24 GB | 32 GB | 12 GB |
+| 0.40 | 32 GB | 56.4 GB | 38.4 GB | 51.2 GB | 19.2 GB |
+| 0.50 | 40 GB | 70.5 GB | 48 GB | 64 GB | 24 GB |
+| 0.70 (default dedicated for VLM) | **56 GB** | 98.7 GB | 67.2 GB | 89.6 GB | 33.6 GB |
+| 0.85 (max safe) | 68 GB | 119.85 GB | 81.6 GB | 108.8 GB | 40.8 GB |
+
+Read this as: at `NIM_KVCACHE_PERCENT=0.7` on an H100, the NIM is allowed 56 GB total. A 9B FP16 model uses ~23 GB of that for weights, leaving ~33 GB for KV cache — enough for long contexts at moderate concurrency.
+
+### Worked example — Nemotron Nano 9B + Cosmos Reason2 8B on H100 80 GB shared
+
+```text
+LLM weights = 9 × 16 / 8 = 18 GB        →  18 × 1.3 = 23.4 GB total
+VLM weights = 8 × 16 / 8 = 16 GB        →  16 × 1.3 = 20.8 GB total
+
+shared check: 23.4 + 20.8 = 44.2 GB     ≤  68 GB (0.85 × 80) ✓ fits
+
+LLM fraction = (9 / (9+8)) × 0.85 = 0.449   → NIM_KVCACHE_PERCENT=0.449
+VLM fraction = (8 / (9+8)) × 0.85 = 0.400   → NIM_KVCACHE_PERCENT=0.400
+reserved     = 1 - (0.449 + 0.400) = 0.151  (the 15% framework/CUDA buffer)
+```
+
+The in-tree `*-shared.env` files round these to `0.4` for both because the default 9B + 8B pair is symmetric enough; you don't need the exact `0.449` — anything within ±0.05 is fine.
+
+## Choosing dedicated vs shared
+
+| Available GPUs | Strategy |
+|---|---|
+| **2+ GPUs** | **Dedicated** — pick the lowest precision available for each model and put one per GPU. Set `LLM_MODE=local`, `VLM_MODE=local`, `LLM_DEVICE_ID=0`, `VLM_DEVICE_ID=1`. NIM defaults take care of KV cache (`NIM_KVCACHE_PERCENT` not needed). |
+| **1 GPU + the pair fits** | **Shared** — set `LLM_MODE=local_shared`, `VLM_MODE=local_shared`, both `LLM_DEVICE_ID` and `VLM_DEVICE_ID` to the same index. Set `NIM_KVCACHE_PERCENT` per the formula above. |
+| **1 GPU but the pair doesn't fit** | **Stop and ask the user about a remote endpoint** — see [When to use remote LLM/VLM](#when-to-use-remote-llmvlm). Don't silently switch to a smaller / lower-precision model; the user picked the model for a reason. |
+| **0 local GPUs** | **`remote-all`** — both `LLM_MODE=remote` and `VLM_MODE=remote`. Sizing math doesn't apply locally. |
+
+Rule of thumb: a config is **`single_gpu_viable`** iff every service has `gpu_count=1` AND the sum of all services' total VRAM ≤ 0.85 × GPU VRAM. If false, the agent must escalate to the user (don't auto-pick a smaller local fallback).
+
+## When to use remote LLM/VLM
+
+Two — and only two — triggers should put either side into `remote` mode.
+
+### Trigger 1 — User supplied an endpoint
+
+The user's prompt names an LLM and/or VLM endpoint URL (e.g. *"deploy with remote LLM at `http://launchpad:11571` serving `nvidia/nvidia-nemotron-nano-9b-v2`"*) or asks for `remote-all`. Action:
+
+- Set `LLM_MODE=remote` (and/or `VLM_MODE=remote`) in `dev-profile-base/.env`.
+- Set `LLM_BASE_URL` (no trailing `/v1`), `LLM_NAME`, and `NVIDIA_API_KEY` if the endpoint requires auth.
+- Local sizing math doesn't apply for the remote side.
+- See [Env Overrides — Common Scenarios](#env-overrides--common-scenarios) below for full recipes.
+
+### Trigger 2 — Local GPU can't fit the model the user wants
+
+The sizing math says the user's chosen LLM/VLM (or pair) doesn't fit on the available GPUs. **Stop the deploy and ask the user**:
+
+> The host has `<N>` × `<GPU>` (`<VRAM>` GB each). The model `<LLM_NAME>` needs `~<X>` GB at `<precision>`, which doesn't fit alongside `<VLM_NAME>` (`~<Y>` GB).
+>
+> Options:
+> 1. **Switch to a remote LLM (or VLM)** — give me the endpoint URL and the model name served there. NVIDIA's public API is `https://integrate.api.nvidia.com` if you have an `NVIDIA_API_KEY`.
+> 2. **Switch to a lower-precision build** of the same model (e.g. `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8` instead of FP16).
+> 3. **Use `remote-all`** — both LLM and VLM at remote endpoints; no local GPU used.
+
+Wait for the user to pick. **Don't silently substitute a different local model** — the user chose the original for a reason (eval consistency, behavior parity, license, etc.).
+
+### Hard rules
+
+- **L40S (48 GB) cannot host the default LLM + VLM shared.** 23.4 + 20.8 = 44.2 GB > 0.85 × 48 = 40.8 GB. Use a 2-GPU L40S host (one model per GPU), or escalate to the user per Trigger 2.
+- **DGX-Spark / IGX-Thor / AGX-Thor — shared mode must use the Edge 4B LLM.** Both models share unified memory, AND the standard `nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2:1` image has a broken arm64 manifest. Run `NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8` as a standalone vLLM on port 30081; full recipe and the mandatory `HF_TOKEN` verification step are in [`edge.md`](edge.md). The in-tree `nvidia-nemotron-nano-9b-v2-fp8` compose ships pre-tuned `hw-DGX-SPARK*.env` / `hw-AGX-THOR*.env` / `hw-IGX-THOR*.env` and is the production path on edge once `HF_TOKEN` is configured.
+- **Llama 3.3 49B FP16 doesn't fit on a single 80 GB GPU.** 49 × 16 / 8 × 1.3 = 127 GB > 68 GB usable. Either run dedicated with tensor parallelism (`tp=2` on two H100s → 63.7 GB/GPU) or use H200 (141 GB) / B200 (192 GB) — or escalate per Trigger 2.
+- **`HARDWARE_PROFILE` is just an env-file label, not a sizing oracle.** It selects the path `nim/<slug>/hw-<HARDWARE_PROFILE>(-shared).env` — that's all. Pre-tuned env files exist for known platforms as a convenience, but missing != unsupported. Compute the right `NIM_KVCACHE_PERCENT` (or `--gpu-memory-utilization`) from the [Sizing math](#sizing-math) and write it into a fresh `hw-<HARDWARE_PROFILE>(-shared).env` (or set `HARDWARE_PROFILE=OTHER` and edit `hw-OTHER(-shared).env`). The agent's correctness check is the **resolved compose**: does it include the right LLM/VLM service for the chosen `LLM_NAME_SLUG` / `VLM_NAME_SLUG`, and does that service's env carry the computed sizing values? If yes, the deploy will work regardless of which `HARDWARE_PROFILE` label is used.
+- **Remote side — no local GPU needed.** When `LLM_MODE=remote` or `VLM_MODE=remote`, the matching local NIM/vLLM service is skipped entirely. Sizing math doesn't apply for the remote side.
+
+## Tuning workflow
+
+`HARDWARE_PROFILE` only chooses which `nim/<slug>/hw-<HARDWARE_PROFILE>(-shared).env` file compose loads. The values inside that file are what actually matter, and they come from the sizing math — not from any hardware-specific knowledge baked into the label. So the procedure is the same whether or not the host has a "known" profile:
+
+1. **Compute** the start fraction from [Sizing math](#sizing-math). Round to 2 decimal places.
+2. **Write** it into the env file the resolved compose will load. The path is `deploy/docker/services/nim/<model-slug>/hw-<HARDWARE_PROFILE>(-shared).env` — pick or create whichever `HARDWARE_PROFILE` label fits (use the host's actual profile for documentation value, or `OTHER` if none matches and you're not contributing back).
+   - NIM: `NIM_KVCACHE_PERCENT=<value>` (also set `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` if you need to constrain context/concurrency)
+   - vLLM: edit the model's `compose.yml` to set `--gpu-memory-utilization <value>` (or pass through an env var if the compose supports it)
+3. **Re-resolve and deploy**: `docker compose --env-file <env> config > resolved.yml && docker compose -f resolved.yml up -d`. Before running `up -d`, verify `resolved.yml` includes the right LLM/VLM service for your `LLM_NAME_SLUG` / `VLM_NAME_SLUG` and that the sizing values you wrote are visible in its `environment:` block.
+4. **Watch container logs** for the KV-cache report on startup (NIM logs `KV cache size: X GB` once it boots; vLLM logs `Maximum concurrency for X tokens per GPU: Y x`):
+   - **OOM at model load** → lower fraction by 0.05 and redeploy.
+   - **OOM mid-inference** (after a few requests, on long prompts) → also lower `NIM_MAX_MODEL_LEN` / `--max-model-len` and `NIM_MAX_NUM_SEQS` (e.g. from `4096`/`16` to `2048`/`4`).
+   - **Container starts but "Out of memory for chunked prefill"** → lower `NIM_MAX_NUM_SEQS` only.
+   - **Plenty of headroom** (KV cache reports < 30% utilization under load) → raise fraction by 0.05 and redeploy to extract more concurrency.
+5. **Save** the working values into the `hw-*(.env)` so the combo is reproducible.
+
+> **Don't tune past 0.85.** The default 15% reserved is what NIMs/vLLM need for CUDA graphs, framework overhead, and activation buffers. Going higher reliably OOMs under non-trivial load.
+
+## Swapping a different LLM/VLM
+
+The skill never invokes `dev-profile.sh`. Swapping a model is purely an `.env` edit + (if needed) a new compose file under `deploy/docker/services/nim/<slug>/`. Use this decision tree.
+
+### Step 1 — Is the model already in tree?
+
+In-tree slugs are the directory names under `deploy/docker/services/nim/`:
+
+- **LLMs:** `nvidia-nemotron-nano-9b-v2`, `nvidia-nemotron-nano-9b-v2-fp8`, `nemotron-3-nano`, `llama-3.3-nemotron-super-49b-v1.5`, `gpt-oss-20b`
+- **VLMs:** `cosmos-reason2-8b`, `cosmos-reason1-7b`, `qwen3-vl-8b-instruct`
+
+If yes → set the four env vars in `deployments/developer-workflow/dev-profile-base/.env`:
+
+```bash
+# Example: switch LLM to Nano 9B FP8
+LLM_NAME=nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8
+LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2-fp8
+
+# Example: switch VLM to cosmos-reason1-7b
+VLM_NAME=nvidia/cosmos-reason1-7b
+VLM_NAME_SLUG=cosmos-reason1-7b
+```
+
+The slug must match the directory name exactly. `COMPOSE_PROFILES` then auto-includes `llm_<mode>_<slug>` and `vlm_<mode>_<slug>`, picking up the right service from the in-tree compose. Re-run the dry-run (`docker compose --env-file <env> config > resolved.yml`) and verify `resolved.yml` contains the expected service. Confirm the `hw-<HARDWARE_PROFILE>(-shared).env` exists for the new model on this host (per the [GPU VRAM reference](#gpu-vram-reference) above).
+
+### Step 2 — Is the model published as a NIM on build.nvidia.com?
+
+If yes (NGC catalog has an `nvcr.io/nim/<org>/<model>:<tag>` image): create a new in-tree NIM compose.
+
+1. Create `deploy/docker/services/nim/<your-slug>/compose.yml` modeled on `cosmos-reason2-8b/compose.yml`. Two services:
+   - `<your-slug>` with `profiles: [llm_local_<slug>]` (or `vlm_local_<slug>`) and the dedicated-GPU device assignment.
+   - `<your-slug>-shared-gpu` with `profiles: [llm_local_shared_<slug>]` (or `vlm_local_shared_<slug>`) and `device_ids: ["${SHARED_LLM_VLM_DEVICE_ID:-${LLM_DEVICE_ID:-0}}"]`.
+2. Add `hw-<HARDWARE_PROFILE>.env` and `hw-<HARDWARE_PROFILE>-shared.env` files. Compute starting `NIM_KVCACHE_PERCENT` from the formula in [Sizing math](#sizing-math). Add `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` per the model's documented limits.
+3. Add the new compose file to the `include:` list in `deploy/docker/services/nim/compose.yml`.
+4. Edit `dev-profile-base/.env` to set `LLM_NAME` / `LLM_NAME_SLUG` (or VLM equivalents).
+5. Run the [Tuning workflow](#tuning-workflow) above.
+
+### Step 3 — No NIM available → use a DLFW (vLLM) container
+
+For models that aren't packaged as NIMs but have weights on Hugging Face or NGC, deploy them via `nvcr.io/nvidia/vllm:<tag>-py3` (x86_64) or `ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor` (Jetson). The in-tree DLFW pattern lives in `deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2-fp8/compose.yml` — copy that as the template. Key shape:
+
+```yaml
+services:
+  <slug>:                                    # dedicated-GPU variant
+    image: nvcr.io/nvidia/vllm:25.12.post1-py3
+    command:
+      - python3
+      - -m
+      - vllm.entrypoints.openai.api_server
+      - --model
+      - <hf-org>/<hf-model>
+      - --trust-remote-code
+      - --tensor-parallel-size
+      - "1"
+      - --gpu-memory-utilization
+      - "0.85"                               # dedicated: leave 15% headroom
+      - --port
+      - "8000"
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - <parser>                             # qwen3_coder, nemotron_json, llama3_json, ...
+    profiles:
+      - llm_local_<slug>
+    runtime: nvidia
+    ports:
+      - ${LLM_PORT:-30081}:8000
+    env_file:
+      - ${MDX_SAMPLE_APPS_DIR}/services/nim/<slug>/hw-${HARDWARE_PROFILE}.env
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+              driver: nvidia
+              device_ids: ["${LLM_DEVICE_ID:-0}"]
+
+  <slug>-shared-gpu:                         # shared-GPU variant
+    # ... same shape, with these changes:
+    command:
+      # ...
+      - --gpu-memory-utilization
+      - "0.40"                               # shared default; refine via Sizing math
+    profiles:
+      - llm_local_shared_<slug>
+    env_file:
+      - ${MDX_SAMPLE_APPS_DIR}/services/nim/<slug>/hw-${HARDWARE_PROFILE}-shared.env
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+              driver: nvidia
+              device_ids: ["${SHARED_LLM_VLM_DEVICE_ID:-${LLM_DEVICE_ID:-0}}"]
+```
+
+Then add the file to `nim/compose.yml`'s `include:` list and edit `dev-profile-base/.env` to set `LLM_NAME` / `LLM_NAME_SLUG`. Use the [Tuning workflow](#tuning-workflow) to dial in `--gpu-memory-utilization`.
+
+> **Edge note.** On DGX-Spark / Thor, follow [`edge.md`](edge.md) instead — the Edge 4B currently runs as a standalone container outside the compose stack (with `--use-remote-llm` pointing the agent at port 30081). Folding it into a compose file is on the roadmap but not done yet.
+
+### Picking `--gpu-memory-utilization` quickly
+
+For shared mode, compute it via the formula. As sanity-check defaults / in-tree precedents:
+
+| Co-residency | LLM `--gpu-memory-utilization` | VLM `NIM_KVCACHE_PERCENT` | Source |
+|---|---|---|---|
+| Nano 9B v2 FP8 + Cosmos Reason2 8B (shared) | 0.40 | 0.40 | FP8 + Cosmos2 `*-shared.env` |
+| Edge 4B + Cosmos Reason2 8B on DGX-Spark | 0.25 | 0.40 | `edge.md` recipe |
+| Qwen3-VL 8B + Nano 9B (shared) | 0.40 | 0.40 | Qwen3 `*-shared.env` |
+
+Rules of thumb when adding a new model:
+
+- **FP8 / INT8 weights:** start at 0.40 shared, 0.85 dedicated.
+- **BF16 / FP16 weights:** start at 0.40–0.50 shared (only if the pair fits per the formula), 0.85 dedicated.
+- **Edge unified memory (DGX-Spark / Thor):** cap aggressively — 0.25 leaves room for the VLM and the OS.
+- **OOM at startup** → lower by 0.05. **OOM mid-inference** → also lower `NIM_MAX_MODEL_LEN` / `--max-model-len` and `NIM_MAX_NUM_SEQS`.
+
+If you're unsure what fits, deploy `remote-all` (both LLM and VLM at remote endpoints) — no local sizing required.
 
 ## Env Overrides — Common Scenarios
 

--- a/skills/deploy/references/data-directory.md
+++ b/skills/deploy/references/data-directory.md
@@ -1,0 +1,61 @@
+# Deploy — Data directory layout
+
+### Step 1b — Prepare the data directory
+
+**This is the #1 source of silent-deploy bugs. Follow it exactly.**
+
+The stack mounts several subdirs of `$MDX_DATA_DIR` into containers that each
+run as a different uid. Docker auto-creates empty bind-mount paths as
+`root:root`, which is read-only for the container processes. The reference
+`scripts/dev-profile.sh` uses `chmod -R 777` on the relevant subdirs — it
+does **not** `chown`.
+
+Run this verbatim before `docker compose up`:
+
+```bash
+DATA=$MDX_DATA_DIR      # e.g. <repo>/data
+mkdir -p \
+  "$DATA/data_log/analytics_cache" \
+  "$DATA/data_log/calibration_toolkit" \
+  "$DATA/data_log/elastic/data" \
+  "$DATA/data_log/elastic/logs" \
+  "$DATA/data_log/kafka" \
+  "$DATA/data_log/redis/data" \
+  "$DATA/data_log/redis/log" \
+  "$DATA/agent_eval/dataset" \
+  "$DATA/agent_eval/results"
+# Profile-specific subdirs:
+#   alerts → mkdir -p "$DATA/data_log/vss_video_analytics_api" "$DATA/videos/dev-profile-alerts" "$DATA/models/rtdetr-its" "$DATA/models/gdino"
+#   search → mkdir -p "$DATA/models"
+chmod -R 777 "$DATA/data_log" "$DATA/agent_eval"
+# If you created $DATA/models above, also: chmod -R 777 "$DATA/models"
+```
+
+> **FORBIDDEN: `chown -R ubuntu:ubuntu $MDX_DATA_DIR` (or any recursive chown).**
+>
+> This is "good housekeeping" to a shell-admin instinct but is **the** deploy-
+> breaking command in this stack. You will observe a "healthy" deploy
+> (containers Up, endpoints 200) while the video pipeline is silently broken.
+> Use `chmod -R 777` on the specific subdirs above — nothing else.
+
+**Known per-container uid gotchas** (each uses a bind mount under `$DATA`):
+
+| Container | Image | Runs as | Mount path | Symptom if permissions wrong |
+|---|---|---|---|---|
+| `centralizedb-dev` | postgres:17.6-alpine | uid **70** | `$DATA/data_log/vst/postgres/db` | Can't read own PGDATA → VST `sensor_details` query fails → uploaded videos never appear in `/vst/api/v1/sensor/streams` → warehouse E2E check returns empty |
+| `mdx-redis` | redis:8.2.2-alpine | uid **999** | `$DATA/data_log/redis/log`, `/redis/data` | "Can't open the log file: Permission denied" → redis dies → `envoy-streamprocessing` dies (needs Redis Lua script) → stream pipeline broken |
+| `elasticsearch` | elasticsearch | uid **1000** | `$DATA/data_log/elastic/{data,logs}` | "AccessDeniedException" on startup → ES refuses to start |
+| `vst` / `sensor-ms-dev` | vst | uid **1000** | `$DATA/data_log/vst/*` (videos, clips) | 403 on ingest or stream write |
+
+`chmod -R 777 $DATA/data_log` covers all of these. Do NOT chown them to
+individual uids — containers that init their own dirs on first start (like
+postgres) will then re-chown to their uid and a later chown back to ubuntu
+breaks them.
+
+**If postgres is already broken** (common when redeploying without a clean
+`data-dir`):
+
+```bash
+sudo rm -rf "$DATA/data_log/vst/postgres"  # postgres re-initializes on next start
+docker restart centralizedb-dev
+```

--- a/skills/deploy/references/env-overrides.md
+++ b/skills/deploy/references/env-overrides.md
@@ -1,0 +1,73 @@
+# Deploy — env_overrides reference
+
+### Step 2 — Build env_overrides
+
+Build a dictionary of env var overrides based on user intent. Only include vars that differ from the profile's `.env` defaults.
+
+**Always set (they have placeholder defaults in the template):**
+
+| Var | Value |
+|---|---|
+| `HARDWARE_PROFILE` | Detected or user-specified |
+| `MDX_SAMPLE_APPS_DIR` | `<repo>/deployments` |
+| `MDX_DATA_DIR` | `<repo>/data` (or user-specified) |
+| `HOST_IP` | Detected host IP |
+| `NGC_CLI_API_KEY` | From environment or user |
+
+**Common overrides by user intent:**
+
+| User intent | Env overrides |
+|---|---|
+| Remote LLM | `LLM_MODE=remote`, `LLM_BASE_URL=<host>` (no `/v1`), `LLM_NAME=<model>`, `NVIDIA_API_KEY=<key>` |
+| Remote VLM | `VLM_MODE=remote`, `VLM_BASE_URL=<host>` (no `/v1`), `VLM_NAME=<model>`, `NVIDIA_API_KEY=<key>` |
+| **Remote LLM AND remote VLM** (aka `remote-all`) | **BOTH of the above** — you must set `LLM_MODE=remote`, `VLM_MODE=remote`, `LLM_BASE_URL`, `VLM_BASE_URL`, `LLM_NAME`, `VLM_NAME`. The presence of a remote VLM endpoint does not imply `VLM_MODE=remote` — you have to write it explicitly. |
+| NVIDIA API for remote inference | `LLM_BASE_URL=https://integrate.api.nvidia.com` |
+| Dedicated GPUs | `LLM_MODE=local`, `VLM_MODE=local`, `LLM_DEVICE_ID=0`, `VLM_DEVICE_ID=1` |
+| Different LLM model | `LLM_NAME=<name>`, `LLM_NAME_SLUG=<slug>` |
+| Different VLM model | `VLM_NAME=<name>`, `VLM_NAME_SLUG=<slug>` |
+
+**Extracting remote endpoints from user intent.**
+
+If the user says "remote LLM" or mentions an LLM endpoint URL, you MUST do
+all of the following before `docker compose up`:
+
+1. Identify the endpoint URL and model name. If the user gave them in
+   their prompt (e.g. *"deploy with remote LLM at
+   `http://launchpad:11571` serving `nvidia/nvidia-nemotron-nano-9b-v2`"*),
+   use those values directly. Strip any trailing `/v1` (see callout below).
+2. If the user said "remote" without providing a URL or model, **stop and
+   ask the user** for:
+   - The LLM endpoint URL (without `/v1`)
+   - The LLM model name served there
+   - (same pair for VLM if they also said "remote VLM")
+   - An `NVIDIA_API_KEY` if the endpoint requires one
+3. Write `LLM_MODE=remote` + `LLM_BASE_URL=<url>` + `LLM_NAME=<model>` into
+   `deployments/developer-workflow/dev-profile-<profile>/.env`. Do the
+   same pair for VLM if the user said remote VLM. Use `sed -i
+   "s|^KEY=.*|KEY=VALUE|"` — the `.env` template ships with placeholder
+   rows for these keys.
+4. After writing, `grep -E '^(HARDWARE_PROFILE|LLM_MODE|VLM_MODE|LLM_BASE_URL|VLM_BASE_URL)=' <env-file>`
+   and verify every line shows the value you intended. A silent miss on
+   `LLM_MODE` / `VLM_MODE` is the #1 cause of deployments coming up with
+   wrong compose profiles.
+
+Never leave `LLM_MODE` or `VLM_MODE` unset when the user said "remote".
+The `.env` template's placeholder value is `LLM_MODE=local` — failing to
+overwrite it means you silently deployed in local mode with remote URLs
+dangling, which no `COMPOSE_PROFILES` path correctly supports.
+
+> **Important — `/v1` suffix on base URLs**
+>
+> `LLM_BASE_URL` and `VLM_BASE_URL` must **not** include a trailing `/v1`.
+> The agent's `config.yml` appends `/v1` automatically (`base_url: ${LLM_BASE_URL}/v1`),
+> so including it yourself produces `/v1/v1/chat/completions` and requests will fail
+> with connection / 404 errors.
+>
+> If a user or endpoint documentation gives you a URL ending in `/v1`, strip it
+> before writing to `.env`. Examples:
+> - User says: "LLM is at `http://10.0.0.5:31081/v1`" → write `LLM_BASE_URL=http://10.0.0.5:31081`
+> - User says: "Use `https://integrate.api.nvidia.com/v1`" → write `LLM_BASE_URL=https://integrate.api.nvidia.com`
+
+See the profile reference doc for full env override recipes.
+
+**Do NOT set `COMPOSE_PROFILES` directly** — it is computed from `BP_PROFILE`, `MODE`, `HARDWARE_PROFILE`, `LLM_MODE`, `LLM_NAME_SLUG`, `VLM_MODE`, `VLM_NAME_SLUG`.

--- a/skills/deploy/references/lvs.md
+++ b/skills/deploy/references/lvs.md
@@ -1,31 +1,194 @@
 # VSS LVS Profile — Reference
 
-## What Gets Deployed (adds to base)
+Profile: `lvs` | Blueprint: `bp_developer_lvs` | Mode: `2d`
 
-| Service | Purpose |
-|---|---|
-| VSS Agent | Orchestrates tool calls and model inference |
-| VSS Agent UI | Web UI at port 3000 |
-| VIOS | Video ingestion, recording, playback |
-| Nemotron LLM (NIM) | Reasoning and response generation |
-| Cosmos Reason 2 (NIM) | Vision-language model |
-| VSS Long Video Summarization | Segments and summarizes long-form video |
-| ELK (Elasticsearch + Kibana) | Log storage and analysis |
-| Phoenix | Observability and telemetry |
+Long-video summarization. The LLM stack is identical to `base` ([`base.md`](base.md)) — same supported models, same sizing math. **The VLM serving is different**: as of [PR #347](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/347), LVS no longer brings up a standalone Cosmos NIM; all VLM traffic goes through `rtvi-vlm` on port 8018, which loads the VLM checkpoint itself.
 
-## GPU Layout (RTXPRO6000BW)
+## What's different from `base`
 
-Same as base profile — LVS runs as a CPU-side microservice:
+- **No standalone VLM NIM service.** The `vlm_local_*_<slug>` compose profile is *not* enabled for LVS. The VLM lives inside the `rtvi-vlm` container.
+- **`rtvi-vlm` (port 8018) is the VLM serving layer.** It can load a VLM checkpoint directly (integrated mode) or proxy to a remote OpenAI-compatible endpoint.
+- **Default integrated checkpoint:** `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208`.
+- **GPU device for VLM is `RT_VLM_DEVICE_ID`** (defaults to `${VLM_DEVICE_ID:-0}` via the rtvi-vlm compose), not the standalone `VLM_DEVICE_ID`. In shared mode, LLM and RT-VLM both pin to GPU 0.
 
-| Mode | Device 0 | Device 1 |
-|---|---|---|
-| Shared GPU (default) | LLM + VLM (`local_shared`) | — |
-| Dedicated GPU | LLM | VLM |
+## What gets deployed
 
-## Key Capabilities
+| Service | Container | Port | Purpose |
+|---|---|---|---|
+| VSS Agent | mdx-vss-agent-1 | 8000 | Orchestrates tool calls and model inference |
+| VSS UI | mdx-vss-ui-1 | 3000 | Web UI — chat, video upload, views |
+| VST | mdx-vst-1 | 30888 | Video storage + ingest |
+| LLM NIM | mdx-nim-llm-1 | 30081 | Same options as `base` (Nano 9B v2 default) |
+| **RT-VLM** | **vss-rtvi-vlm** | **8018** | **VLM runner — loads `MODEL_PATH` or proxies remote** |
+| LVS service | — | — | Long-video segmentation + summarization |
+| LVS Logstash | — | — | RTVI → Kafka → ES pipeline |
+| Elasticsearch + Kibana | mdx-elasticsearch-1, kibana | 9200, 5601 | Log/event storage |
+| Kafka | mdx-kafka-1 | 9092 | Message broker (raw VLM events topic: `raw-vlm-events-response`) |
+| Redis | mdx-redis-1 | 6379 | Cache |
+| Phoenix | mdx-phoenix-1 | 6006 | Observability |
+
+## Default models
+
+| Role | Model | Slug | Served by |
+|---|---|---|---|
+| LLM | `nvidia/nvidia-nemotron-nano-9b-v2` | `nvidia-nemotron-nano-9b-v2` | NIM (port 30081) |
+| VLM | `nvidia/cosmos-reason2-8b` | `cosmos-reason2-8b` | RT-VLM (port 8018), `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` |
+
+LLM alternates: same as base — `NVIDIA-Nemotron-Nano-9B-v2-FP8`, `nemotron-3-nano`, `llama-3.3-nemotron-super-49b-v1.5`, `gpt-oss-20b`.
+
+VLM alternates: see [VLM serving paths](#vlm-serving-paths) below.
+
+## VLM serving paths
+
+Pick the path that matches the user's VLM choice. Default is **integrated**.
+
+### Path A — Integrated (RT-VLM loads the checkpoint itself)
+
+Use this when the requested VLM is one of the integrated-supported set:
+
+| VLM | `VLM_NAME` / `VLM_NAME_SLUG` | `RTVI_VLM_MODEL_PATH` | `RTVI_VLM_MODEL_TO_USE` | Extra env |
+|---|---|---|---|---|
+| Cosmos Reason 2 8B (default) | `nvidia/cosmos-reason2-8b` / `cosmos-reason2-8b` | `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` | `cosmos-reason` | — |
+| Cosmos Reason 1 7B | `nvidia/cosmos-reason1-7b` / `cosmos-reason1-7b` | `ngc:nim/nvidia/cosmos-reason1-7b:hf-<tag>` (confirm tag against rtvi-vlm release notes) | `cosmos-reason` | — |
+| **Nemotron Nano V3 Omni 30B** ([build.nvidia.com](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning)) | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` / `nemotron-3-nano-omni-30b-a3b-reasoning` | `git:https://huggingface.co/nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8` | `vllm-compatible` | `VLM_MODEL_SUPPORTS_AUDIO=true`, `VLM_TRUST_REMOTE_CODE=true`, `ENABLE_AUDIO=true` |
+
+To switch the integrated VLM, edit `deploy/docker/developer-profiles/dev-profile-lvs/.env`:
+
+```bash
+# Example — Cosmos Reason 1 7B
+VLM_NAME=nvidia/cosmos-reason1-7b
+VLM_NAME_SLUG=cosmos-reason1-7b
+VLM_MODE=local_shared                                    # or local for dedicated GPU
+RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos-reason1-7b:hf-<tag>
+RTVI_VLM_MODEL_TO_USE=cosmos-reason
+```
+
+`RTVI_VLM_ENDPOINT` stays empty in integrated mode — RT-VLM serves locally.
+
+**Nemotron Omni — additional env.** The Omni model adds audio support and pulls weights from Hugging Face (not NGC), so it needs a small extra block in `dev-profile-lvs/.env`:
+
+```bash
+# Model selection
+VLM_NAME=nvidia/nemotron-3-nano-omni-30b-a3b-reasoning
+VLM_NAME_SLUG=nemotron-3-nano-omni-30b-a3b-reasoning
+VLM_MODE=local_shared                                    # or local
+RTVI_VLM_MODEL_PATH=git:https://huggingface.co/nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8
+RTVI_VLM_MODEL_TO_USE=vllm-compatible
+HF_TOKEN=<token>                                         # weights gated on HF — request access first
+
+# Audio (LVS feature flag + RT-VLM passthrough)
+ENABLE_AUDIO=true                                        # LVS-side: enables audio ingest path
+VLM_MODEL_SUPPORTS_AUDIO=true                            # RT-VLM container env: vLLM loads with audio modality
+VLM_TRUST_REMOTE_CODE=true                               # Omni uses custom model code from the HF repo
+```
+
+`ENABLE_AUDIO` is an **LVS profile-level** env (read by the LVS agent / summarization service to enable the audio ingest path). It's wired up in upcoming PRs — set it whenever the chosen VLM advertises audio support, even if the underlying compose doesn't reference it yet (set-and-forget). `VLM_MODEL_SUPPORTS_AUDIO` and `VLM_TRUST_REMOTE_CODE` are RT-VLM container env vars that gate audio loading and trust HF custom code respectively.
+
+> **MoE sizing caveat (Omni 30B-A3B).** Omni is a Mixture-of-Experts model — the name `30B-A3B` means 30 B total parameters with ~3 B active per token. The `weights × 1.3` formula in [`base.md`](base.md#sizing-math) uses **total** parameters, so on FP8 the resident weight footprint is ≈ `30 × 8 / 8 × 1.3 = 39 GB`. The model still needs the full weight set in VRAM even though only the active subset runs per token. Plan for ~40 GB just for weights, plus KV cache.
+
+### Path B — Remote (RT-VLM proxies to an external VLM endpoint)
+
+Use this when:
+
+1. **The user supplied a remote VLM endpoint URL** (e.g. *"deploy LVS with VLM at `https://launchpad:11572` serving `cosmos-reason2-8b`"*), **OR**
+2. **The local GPU can't fit the requested VLM alongside the LLM** per the sizing math (and the user has agreed to go remote — same two-trigger rule as [`base.md` § When to use remote LLM/VLM](base.md#when-to-use-remote-llmvlm)).
+
+Edit `dev-profile-lvs/.env`:
+
+```bash
+VLM_MODE=remote
+VLM_BASE_URL=<remote-endpoint>                           # no trailing /v1
+VLM_NAME=<model-name-served-there>
+RTVI_VLM_ENDPOINT=<remote-endpoint>/v1                   # WITH /v1 — RT-VLM-specific
+RTVI_VLM_MODEL_TO_USE=openai-compat
+RTVI_VLM_MODEL_PATH=none
+NVIDIA_API_KEY=<key if required>
+```
+
+> **`/v1` quirk:** `VLM_BASE_URL` must NOT end in `/v1` (the agent appends it). `RTVI_VLM_ENDPOINT` MUST end in `/v1` (RT-VLM uses it verbatim). Don't mix them up.
+
+### Path C — BYO local VLM (model not in the integrated set)
+
+Use this when the user wants a VLM that RT-VLM can't load directly (e.g. Qwen3-VL, a third-party HF model, or an unreleased checkpoint).
+
+1. Stand the VLM up as a separate service per [`base.md` § Swapping a different LLM/VLM](base.md#swapping-a-different-llmvlm) — either an in-tree NIM compose under `deploy/docker/services/nim/<slug>/` or a DLFW vLLM compose. The service must expose an OpenAI-compatible endpoint.
+2. Point RT-VLM at the local URL using **Path B's env vars**, with `VLM_BASE_URL` / `RTVI_VLM_ENDPOINT` set to the localhost address (e.g. `http://${HOST_IP}:30082`).
+
+This is "remote mode pointed at a local container" — keep `VLM_MODE=remote` so RT-VLM doesn't try to load the model itself.
+
+## Sizing — RT-VLM-specific knobs
+
+For VLM **weight cost** (params × bits ÷ 8 × 1.3) and the general formula, see [`base.md` § Sizing math](base.md#sizing-math) — it applies unchanged. RT-VLM's own runtime is a thin wrapper around vLLM, so weights still dominate.
+
+The RT-VLM container reads sizing knobs from `dev-profile-lvs/.env` with the `RTVI_VLM_` / `RTVI_VLLM_` prefix; they propagate inside the container as the standard vLLM env vars (see `deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml`).
+
+| `dev-profile-lvs/.env` var | Inside-container var | Default | Purpose |
+|---|---|---|---|
+| `RTVI_VLLM_GPU_MEMORY_UTILIZATION` | `VLLM_GPU_MEMORY_UTILIZATION` | empty (vLLM default ≈ 0.9) | **Primary sizing knob.** Fraction of total GPU memory RT-VLM may use — weights + KV cache + activations included. Same semantics as `--gpu-memory-utilization` and `NIM_KVCACHE_PERCENT` (see [`base.md`](base.md#nim_kvcache_percent--gb-on-common-gpus)). |
+| `RTVI_VLM_MAX_MODEL_LEN` | `VLM_MAX_MODEL_LEN` | `32768` | Max context length. Lower this first when OOM mid-inference. |
+| `RTVI_VLLM_MAX_NUM_SEQS` | `VLLM_MAX_NUM_SEQS` | `256` | Max concurrent sequences. Lower if KV cache thrashes under load. |
+| `RTVI_VLLM_MAX_NUM_BATCHED_TOKENS` | `VLLM_MAX_NUM_BATCHED_TOKENS` | `5120` | Per-step token budget for chunked prefill. |
+| `RTVI_VLM_NUM_VLM_PROCS` | `NUM_VLM_PROCS` | empty (1) | Parallel VLM worker processes (rare to change). |
+| `VSS_NUM_GPUS_PER_VLM_PROC` | `VSS_NUM_GPUS_PER_VLM_PROC` | empty | Tensor parallelism for the VLM. Set when the VLM is too big for one GPU. |
+| `RT_VLM_DEVICE_ID` | (compose `device_ids`) | `${VLM_DEVICE_ID:-0}` | Which GPU RT-VLM pins to. In shared mode set this equal to `LLM_DEVICE_ID`. |
+
+The sizing flow is identical to base: pick the fraction with the formula in [`base.md`](base.md#sizing-math), write it into `dev-profile-lvs/.env` (one place — there is no per-hardware `hw-*.env` for RT-VLM), re-resolve the compose, deploy, watch the rtvi-vlm logs for `Maximum concurrency for X tokens per GPU: Y x` to confirm the KV-cache budget.
+
+## Worked example — shared mode, Nano 9B + CR2 8B on 1 × H100 80 GB
+
+Math is identical to [`base.md` § Worked example](base.md#worked-example--nemotron-nano-9b--cosmos-reason2-8b-on-h100-80-gb-shared) — LLM fraction `≈ 0.449`, VLM fraction `≈ 0.40`. The difference for LVS is **where** the VLM fraction is written:
+
+```bash
+# LLM — same file as base
+# deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/hw-H100-shared.env
+NIM_KVCACHE_PERCENT=0.449
+
+# VLM — RT-VLM, in the LVS profile env
+# deploy/docker/developer-profiles/dev-profile-lvs/.env
+RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.40
+RT_VLM_DEVICE_ID=0
+LLM_DEVICE_ID=0
+LLM_MODE=local_shared
+VLM_MODE=local_shared
+```
+
+For dedicated mode, set `LLM_DEVICE_ID=0`, `RT_VLM_DEVICE_ID=1`, leave `RTVI_VLLM_GPU_MEMORY_UTILIZATION` empty (RT-VLM gets the whole GPU 1 at vLLM's default ~0.9).
+
+## Hard rules
+
+- **L40S (48 GB) cannot host the LLM + RT-VLM shared.** 23.4 + 20.8 = 44.2 GB > 40.8 GB usable. Use a 2-GPU L40S host (LLM on device 0, RT-VLM on device 1) or escalate to the user about a remote VLM (Path B).
+- **Edge platforms (DGX-Spark / Thor) need the SBSA RT-VLM image.** Set `RTVI_VLM_IMAGE_TAG=3.2.0-26.04.1-sbsa` in `dev-profile-lvs/.env`. LLM-side, follow [`edge.md`](edge.md) (Edge 4B mandatory for shared mode on edge).
+- **Don't co-deploy a standalone Cosmos NIM with RT-VLM.** Since PR #347, the standalone `vlm_local_*_cosmos-reason2-8b` profile must NOT be active for LVS. Verify by checking that `resolved.yml` doesn't have a `cosmos-reason2-8b` or `cosmos-reason2-8b-shared-gpu` service alongside `rtvi-vlm`.
+- **`VLM_MODE=remote` ⇒ `RTVI_VLM_MODEL_PATH=none`.** Forgetting this leaves RT-VLM trying to load weights AND proxy at the same time → startup hang or OOM.
+- **`/v1` suffix mismatch.** `VLM_BASE_URL` no `/v1`; `RTVI_VLM_ENDPOINT` yes `/v1`. The skill should always write both consistently when going remote.
+
+## Key capabilities
 
 - Quickly generate a high-level narrative summary of a long video
 - Extract timestamped highlights based on user-defined events
 - Processes uploaded files from minutes to hours in duration
 - Results returned through the AI agent chat interface
 - Human-in-the-loop (HITL) prompt editing for report generation
+
+## Endpoints (after deploy)
+
+| Service | URL |
+|---|---|
+| Agent UI | `http://<HOST_IP>:3000/` |
+| Agent REST API | `http://<HOST_IP>:8000/` |
+| RT-VLM | `http://<HOST_IP>:8018/v1/` (OpenAI-compatible) |
+| Kibana | `http://<HOST_IP>:5601/` |
+| Phoenix | `http://<HOST_IP>:6006/` |
+
+## Env file location
+
+```
+deploy/docker/developer-profiles/dev-profile-lvs/.env
+```
+
+## Debugging
+
+- **`docker logs vss-rtvi-vlm`** — startup takes up to 20 min on first run (model download from NGC). Look for `Maximum concurrency for X tokens per GPU: Y x` to confirm vLLM is up and the KV-cache budget is what you set.
+- **VLM never produces summaries** — check that the topic `raw-vlm-events-response` is being written. `docker exec mdx-kafka-1 kafka-console-consumer --bootstrap-server localhost:9092 --topic raw-vlm-events-response --max-messages 1`.
+- **Empty Kibana dashboards** — `lvs-logstash` may have failed to load the protobuf codec; `docker logs lvs-logstash` should show plugin install completion. After bumping `LOGSTASH_VERSION`, run `docker volume rm lvs-logstash-plugins` so the gem is re-installed.
+- **OOM in RT-VLM under load** — lower `RTVI_VLLM_GPU_MEMORY_UTILIZATION` by 0.05; if that doesn't help, drop `RTVI_VLM_MAX_MODEL_LEN` to `16384` and `RTVI_VLLM_MAX_NUM_SEQS` to `64`.

--- a/skills/deploy/references/lvs.md
+++ b/skills/deploy/references/lvs.md
@@ -9,6 +9,7 @@ Long-video summarization. The LLM stack is identical to `base` ([`base.md`](base
 - **No standalone VLM NIM service.** The `vlm_local_*_<slug>` compose profile is *not* enabled for LVS. The VLM lives inside the `rtvi-vlm` container.
 - **`rtvi-vlm` (port 8018) is the VLM serving layer.** It can load a VLM checkpoint directly (integrated mode) or proxy to a remote OpenAI-compatible endpoint.
 - **Default integrated checkpoint:** `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208`.
+- **`VLM_NAME` is the model basename, NOT the friendly NIM name.** For the default integrated path: `VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208` (production-confirmed; using `nvidia/cosmos-reason2-8b` causes vss-lvs to return 400). Same caveat as alerts. Detail in [Default models](#default-models) and [Hard rules](#hard-rules).
 - **GPU device for VLM is `RT_VLM_DEVICE_ID`** (defaults to `${VLM_DEVICE_ID:-0}` via the rtvi-vlm compose), not the standalone `VLM_DEVICE_ID`. In shared mode, LLM and RT-VLM both pin to GPU 0.
 
 ## What gets deployed
@@ -29,10 +30,12 @@ Long-video summarization. The LLM stack is identical to `base` ([`base.md`](base
 
 ## Default models
 
-| Role | Model | Slug | Served by |
+| Role | `*_NAME` (env) | `*_NAME_SLUG` | Served by |
 |---|---|---|---|
 | LLM | `nvidia/nvidia-nemotron-nano-9b-v2` | `nvidia-nemotron-nano-9b-v2` | NIM (port 30081) |
-| VLM | `nvidia/cosmos-reason2-8b` | `cosmos-reason2-8b` | RT-VLM (port 8018), `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` |
+| VLM | **`nim_nvidia_cosmos-reason2-8b_hf-1208`** | `cosmos-reason2-8b` | RT-VLM (port 8018), `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` |
+
+> **`VLM_NAME` must be the basename of `RTVI_VLM_MODEL_PATH` — NOT the friendly NIM name.** RT-VLM advertises this exact string in `/v1/models`, and the LVS service / agent calls the model by that id. Setting `VLM_NAME=nvidia/cosmos-reason2-8b` (the friendly NIM name) reproduces a real production bug: vss-lvs returns `400 BadParameters: No such model 'nvidia/cosmos-reason2-8b'` and summarization fails. **Always set `VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208` for the default integrated path.** Same caveat as `alerts.md`.
 
 LLM alternates: same as base — `NVIDIA-Nemotron-Nano-9B-v2-FP8`, `nemotron-3-nano`, `llama-3.3-nemotron-super-49b-v1.5`, `gpt-oss-20b`.
 
@@ -46,17 +49,21 @@ Pick the path that matches the user's VLM choice. Default is **integrated**.
 
 Use this when the requested VLM is one of the integrated-supported set:
 
-| VLM | `VLM_NAME` / `VLM_NAME_SLUG` | `RTVI_VLM_MODEL_PATH` | `RTVI_VLM_MODEL_TO_USE` | Extra env |
-|---|---|---|---|---|
-| Cosmos Reason 2 8B (default) | `nvidia/cosmos-reason2-8b` / `cosmos-reason2-8b` | `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` | `cosmos-reason` | — |
-| Cosmos Reason 1 7B | `nvidia/cosmos-reason1-7b` / `cosmos-reason1-7b` | `ngc:nim/nvidia/cosmos-reason1-7b:hf-<tag>` (confirm tag against rtvi-vlm release notes) | `cosmos-reason` | — |
-| **Nemotron Nano V3 Omni 30B** ([build.nvidia.com](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning)) | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` / `nemotron-3-nano-omni-30b-a3b-reasoning` | `git:https://huggingface.co/nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8` | `vllm-compatible` | `VLM_MODEL_SUPPORTS_AUDIO=true`, `VLM_TRUST_REMOTE_CODE=true`, `ENABLE_AUDIO=true` |
+| VLM | `VLM_NAME` (must match `/v1/models` basename) | `VLM_NAME_SLUG` | `RTVI_VLM_MODEL_PATH` | `RTVI_VLM_MODEL_TO_USE` | Extra env |
+|---|---|---|---|---|---|
+| Cosmos Reason 2 8B (default) | `nim_nvidia_cosmos-reason2-8b_hf-1208` | `cosmos-reason2-8b` | `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` | `cosmos-reason` | — |
+| Cosmos Reason 1 7B | `nim_nvidia_cosmos-reason1-7b_hf-<tag>` | `cosmos-reason1-7b` | `ngc:nim/nvidia/cosmos-reason1-7b:hf-<tag>` (confirm tag against rtvi-vlm release notes) | `cosmos-reason` | — |
+| **Nemotron Nano V3 Omni 30B** ([build.nvidia.com](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning)) | confirm via `curl http://${HOST_IP}:8018/v1/models` after RT-VLM boots (HF git: paths don't transform via the `nim_…` rule) | `nemotron-3-nano-omni-30b-a3b-reasoning` | `git:https://huggingface.co/nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8` | `vllm-compatible` | `VLM_MODEL_SUPPORTS_AUDIO=true`, `VLM_TRUST_REMOTE_CODE=true`, `ENABLE_AUDIO=true` |
+
+**`VLM_NAME` transformation rule (NGC NIM paths):** `ngc:nim/<org>/<model>:<tag>` → `nim_<org>_<model>_<tag>`. Drop the `ngc:` prefix; replace `/` and `:` with `_`. RT-VLM advertises this exact string in `/v1/models`. A mismatch produces `400 BadParameters: No such model …` from vss-lvs (production-confirmed bug, 2026-05-10).
+
+For HF git paths (e.g. Nemotron Omni), the advertised name is determined by RT-VLM at load time — verify with `curl http://${HOST_IP}:8018/v1/models | jq` once it's healthy and copy that string verbatim into `VLM_NAME`.
 
 To switch the integrated VLM, edit `deploy/docker/developer-profiles/dev-profile-lvs/.env`:
 
 ```bash
 # Example — Cosmos Reason 1 7B
-VLM_NAME=nvidia/cosmos-reason1-7b
+VLM_NAME=nim_nvidia_cosmos-reason1-7b_hf-<tag>           # matches /v1/models basename
 VLM_NAME_SLUG=cosmos-reason1-7b
 VLM_MODE=local_shared                                    # or local for dedicated GPU
 RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos-reason1-7b:hf-<tag>
@@ -69,7 +76,7 @@ RTVI_VLM_MODEL_TO_USE=cosmos-reason
 
 ```bash
 # Model selection
-VLM_NAME=nvidia/nemotron-3-nano-omni-30b-a3b-reasoning
+VLM_NAME=<copy from `curl http://${HOST_IP}:8018/v1/models | jq -r '.data[0].id'` after RT-VLM boots>
 VLM_NAME_SLUG=nemotron-3-nano-omni-30b-a3b-reasoning
 VLM_MODE=local_shared                                    # or local
 RTVI_VLM_MODEL_PATH=git:https://huggingface.co/nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8
@@ -81,6 +88,8 @@ ENABLE_AUDIO=true                                        # LVS-side: enables aud
 VLM_MODEL_SUPPORTS_AUDIO=true                            # RT-VLM container env: vLLM loads with audio modality
 VLM_TRUST_REMOTE_CODE=true                               # Omni uses custom model code from the HF repo
 ```
+
+> **Two-step deploy for Omni:** because the advertised `VLM_NAME` for HF git paths isn't deterministic, deploy once with a placeholder `VLM_NAME` (any value), wait for RT-VLM to boot and report ready, `curl /v1/models` to read the real id, then edit `VLM_NAME` and recreate the agent. The same approach applies if a future RT-VLM image changes the basename derivation rule for NIM paths.
 
 `ENABLE_AUDIO` is an **LVS profile-level** env (read by the LVS agent / summarization service to enable the audio ingest path). It's wired up in upcoming PRs — set it whenever the chosen VLM advertises audio support, even if the underlying compose doesn't reference it yet (set-and-forget). `VLM_MODEL_SUPPORTS_AUDIO` and `VLM_TRUST_REMOTE_CODE` are RT-VLM container env vars that gate audio loading and trust HF custom code respectively.
 
@@ -156,6 +165,7 @@ For dedicated mode, set `LLM_DEVICE_ID=0`, `RT_VLM_DEVICE_ID=1`, leave `RTVI_VLL
 
 ## Hard rules
 
+- **`VLM_NAME` must equal RT-VLM's `/v1/models` basename.** This is the single most important field for LVS to function. For the default integrated Cosmos2: `VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208`. Using the friendly NIM name `nvidia/cosmos-reason2-8b` causes vss-lvs to return `400 BadParameters: No such model …` and summarization fails — confirmed in production (2026-05-10). Transformation rule for NGC NIM paths: `ngc:nim/<org>/<model>:<tag>` → `nim_<org>_<model>_<tag>`. For HF git paths or any custom MODEL_PATH, verify by `curl http://${HOST_IP}:8018/v1/models | jq` after RT-VLM boots and copy the `id` field.
 - **L40S (48 GB) cannot host the LLM + RT-VLM shared.** 23.4 + 20.8 = 44.2 GB > 40.8 GB usable. Use a 2-GPU L40S host (LLM on device 0, RT-VLM on device 1) or escalate to the user about a remote VLM (Path B).
 - **Edge platforms (DGX-Spark / Thor) need the SBSA RT-VLM image.** Set `RTVI_VLM_IMAGE_TAG=3.2.0-26.04.1-sbsa` in `dev-profile-lvs/.env`. LLM-side, follow [`edge.md`](edge.md) (Edge 4B mandatory for shared mode on edge).
 - **Don't co-deploy a standalone Cosmos NIM with RT-VLM.** Since PR #347, the standalone `vlm_local_*_cosmos-reason2-8b` profile must NOT be active for LVS. Verify by checking that `resolved.yml` doesn't have a `cosmos-reason2-8b` or `cosmos-reason2-8b-shared-gpu` service alongside `rtvi-vlm`.
@@ -189,6 +199,7 @@ deploy/docker/developer-profiles/dev-profile-lvs/.env
 ## Debugging
 
 - **`docker logs vss-rtvi-vlm`** — startup takes up to 20 min on first run (model download from NGC). Look for `Maximum concurrency for X tokens per GPU: Y x` to confirm vLLM is up and the KV-cache budget is what you set.
+- **`vss-lvs` returns `400 BadParameters: No such model '<id>'`** (summarization fails in the UI) — `VLM_NAME` doesn't match what RT-VLM advertises. Verify with `curl http://${HOST_IP}:8018/v1/models | jq`; the `id` field must equal `VLM_NAME` in `dev-profile-lvs/.env`. For the default integrated path that's `nim_nvidia_cosmos-reason2-8b_hf-1208` (NOT `nvidia/cosmos-reason2-8b`). Fix → `docker compose -f resolved.yml up -d --no-deps --force-recreate vss-lvs vss-agent`. If the same UI chat thread is stuck in the failed-tool loop, refresh or start a fresh prompt.
 - **VLM never produces summaries** — check that the topic `raw-vlm-events-response` is being written. `docker exec mdx-kafka-1 kafka-console-consumer --bootstrap-server localhost:9092 --topic raw-vlm-events-response --max-messages 1`.
 - **Empty Kibana dashboards** — `lvs-logstash` may have failed to load the protobuf codec; `docker logs lvs-logstash` should show plugin install completion. After bumping `LOGSTASH_VERSION`, run `docker volume rm lvs-logstash-plugins` so the gem is re-installed.
 - **OOM in RT-VLM under load** — lower `RTVI_VLLM_GPU_MEMORY_UTILIZATION` by 0.05; if that doesn't help, drop `RTVI_VLM_MAX_MODEL_LEN` to `16384` and `RTVI_VLLM_MAX_NUM_SEQS` to `64`.

--- a/skills/deploy/references/search.md
+++ b/skills/deploy/references/search.md
@@ -272,9 +272,43 @@ For Path B (default — VLM on GPU 0 with RT-CV), the math is on GPU 0 instead: 
 deploy/docker/developer-profiles/dev-profile-search/.env
 ```
 
+## Stage perception models (RT-DETR warehouse)
+
+**MUST run before `docker compose -f resolved.yml up -d`.** The compose's `perception-2d-init` container only fetches the SigLIP vision encoder. The RT-DETR detector model that RT-CV needs is staged separately by `dev-profile.sh` — and since this skill doesn't run that script, the agent must stage it directly.
+
+Symptom if skipped: RT-CV starts but its TensorRT engine build fails because `${MDX_DATA_DIR}/models/rtdetr_warehouse_v1.0.1.fp16.onnx` is missing. (User-confirmed on 2026-05-10.)
+
+```bash
+# Source: deploy/docker/scripts/dev-profile.sh (search profile, model staging block)
+# Requires NGC_CLI_API_KEY exported and ngc CLI on PATH (see references/ngc.md).
+
+DATA="$MDX_DATA_DIR"                                     # e.g. <repo>/data
+mkdir -p "$DATA/data_log/vss_video_analytics_api" "$DATA/models"
+
+NGC_CLI_API_KEY="$NGC_CLI_API_KEY" ngc registry model \
+    download-version \
+    nvstaging/tao/rtdetr_2d_warehouse:deployable_efficientvit_l2_v1.0.1 \
+    --org nvstaging
+
+mv rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1/rtdetr_warehouse_v1.0.1.fp16.onnx \
+    "$DATA/models/rtdetr_warehouse_v1.0.1.fp16.onnx"
+rm -rf rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1
+
+chmod -R 777 "$DATA/models"
+```
+
+**Verify** before deploying:
+
+```bash
+ls -l "$MDX_DATA_DIR/models/rtdetr_warehouse_v1.0.1.fp16.onnx"
+# expected: ~30–50 MB onnx file, mode 777
+```
+
+After RT-CV starts, it builds a TensorRT engine from this ONNX (3–5 min on first start) — those engines are cached under the same `models/` directory.
+
 ## First-run note
 
-RT-Embed downloads Cosmos-Embed1 weights from Hugging Face on first start; RT-CV's `perception-2d-init` downloads `siglip_v2` from NGC. Expect 10–20 min extra on the first deploy.
+RT-Embed downloads Cosmos-Embed1 weights from Hugging Face on first start; RT-CV's `perception-2d-init` downloads `siglip_v2` from NGC, then builds a TensorRT engine from the ONNX staged in [Stage perception models](#stage-perception-models-rt-detr-warehouse) above. Expect 15–25 min extra on the first deploy.
 
 ## Debugging
 

--- a/skills/deploy/references/search.md
+++ b/skills/deploy/references/search.md
@@ -1,38 +1,284 @@
 # VSS Search Profile — Reference
 
-> **Alpha Feature** — not recommended for production.
+Profile: `search` | Blueprint: `bp_developer_search` | Mode: `2d`
 
-## What Gets Deployed
+> **Alpha feature** — not recommended for production.
 
-| Service | Purpose |
+Semantic video search via Cosmos Embed1 embeddings indexed in Elasticsearch. The Search workflow uses an optional **Critique agent** that re-checks retrieval results — this requires a VLM endpoint (local or remote).
+
+## What's different from `base` and `lvs`
+
+- **Three always-on GPU services:** `rtvi-cv` (DeepStream perception), `rtvi-embed` (Cosmos Embed1 embeddings), and the **LLM**. There is no Cosmos VLM NIM in the default LVS-style integrated path; the VLM is only deployed when the Critique agent needs it.
+- **Critique agent needs a VLM.** If the user enables Critique (default in the UI: `use_critic=true`), the deploy must provide a reachable VLM endpoint — either remote or co-located on the available GPUs.
+- **LLM shares its GPU with RT-Embed by default.** Reference `dev-profile-search/.env` defaults: `RT_CV_DEVICE_ID=0`, `RT_EMBED_DEVICE_ID=1`, `LLM_DEVICE_ID=1`, `VLM_DEVICE_ID=2`. The LLM must leave headroom for RT-Embed on GPU 1.
+
+## What gets deployed
+
+| Service | Container | Port | Purpose |
+|---|---|---|---|
+| RT-CV (DeepStream perception) | vss-rtvi-cv | — (host net) | Object detection / tracking on incoming streams; default model family `rtdetr-warehouse` |
+| RT-Embed (Cosmos Embed1) | vss-rtvi-embed | 8017 | Video + text embedding generation |
+| LLM NIM | mdx-nim-llm-1 | 30081 | Same options as `base` (Nano 9B v2 default) |
+| VLM | (depends on placement) | 30082 (NIM) / 8018 (RT-VLM) | **Only if Critique enabled** — see [VLM placement](#vlm-placement) |
+| VSS Agent | mdx-vss-agent-1 | 8000 | Orchestrates tool calls, embed search, critique |
+| VSS UI | mdx-vss-ui-1 | 3000 | Search tab |
+| VST | mdx-vst-1 | 30888 | Video storage + ingest |
+| Elasticsearch + Logstash + Kibana | mdx-elasticsearch-1, lvs-logstash, kibana | 9200, 5601 | Index, ingest pipeline, dashboards |
+| Kafka | mdx-kafka-1 | 9092 | Embedding pipeline message bus |
+| Phoenix | mdx-phoenix-1 | 6006 | Observability |
+
+## Default models
+
+| Role | Model | Slug | Served by |
+|---|---|---|---|
+| LLM | `nvidia/nvidia-nemotron-nano-9b-v2` | `nvidia-nemotron-nano-9b-v2` | NIM (port 30081) |
+| Embed (RT-Embed) | `nvidia/Cosmos-Embed1-448p-anomaly-detection` | — | RT-Embed (port 8017), `MODEL_PATH=git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection` |
+| Perception (RT-CV) | siglip2 v1.1 + RTDETR (warehouse) | — | RT-CV (DeepStream pipeline) |
+| VLM (only when Critique on) | `nvidia/cosmos-reason2-8b` (default) | `cosmos-reason2-8b` | NIM or RT-VLM — see [VLM placement](#vlm-placement) |
+
+## VLM placement
+
+Decide where the VLM goes **before writing any env**. Pick the first option that applies, in order.
+
+```
+Critique disabled?                                   → no VLM at all; skip this section
+   │
+   ▼
+User supplied a remote VLM endpoint?                 → Path A: Remote VLM
+   │
+   ▼
+DEFAULT — co-locate VLM on GPU 0 with RT-CV          → Path B: VLM shares GPU 0
+   │                                                          (NUM_STREAMS=16 on H100/RTX PRO 6000;
+   │                                                           NUM_STREAMS=8 on L40S/A40/Thor/GB10)
+   ▼
+User explicitly wants a 3rd GPU layout
+AND a 3rd GPU is free?                               → Path C: VLM on dedicated 3rd GPU
+```
+
+The default placement is **Path B** — co-locate VLM on GPU 0 with RT-CV. Big GPUs (H100, RTX PRO 6000) hold the default `NUM_STREAMS=16` even with the VLM co-resident; smaller GPUs (L40S, A40, Thor, GB10) need `NUM_STREAMS=8` to leave VRAM for the VLM. This works on every supported 2- or 3-GPU host without escalation.
+
+Path C is rarely needed — only when the user explicitly asks for the dedicated-GPU layout (e.g. they have a 3rd GPU sitting idle and want to keep RT-CV's GPU 0 untouched).
+
+If even the per-GPU default doesn't fit (very large VLM, or smaller GPU than the supported set), drop `NUM_STREAMS` further but **confirm with the user before going below 8** — the perception pipeline becomes throughput-limited and the user should know. If even `NUM_STREAMS=1` won't close the math, escalate to Path A (remote) per the two-trigger rule in [`base.md` § When to use remote LLM/VLM](base.md#when-to-use-remote-llmvlm).
+
+### Path A — Remote VLM (user supplied)
+
+Triggered when the user provides a VLM endpoint URL or asks for `remote-vlm` / `remote-all`. Edit `dev-profile-search/.env`:
+
+```bash
+VLM_MODE=remote
+VLM_BASE_URL=<remote-endpoint>                           # no trailing /v1
+VLM_NAME=<model-name-served-there>
+NVIDIA_API_KEY=<key if required>
+# Free up the device that would otherwise host VLM
+VLM_DEVICE_ID=                                           # unused in remote mode
+```
+
+The Critique agent points the VLM tool at `${VLM_BASE_URL}/v1`. No local VLM container is started.
+
+### Path B — Default: co-locate VLM on GPU 0 with RT-CV
+
+This is the default placement for any 2- or 3-GPU host without a remote VLM. Put the VLM on GPU 0 next to RT-CV. `NUM_STREAMS` depends on the GPU:
+
+| GPU | `NUM_STREAMS` (Path B default) | Reason |
+|---|---|---|
+| H100 80 GB SXM/HBM3 | **16** | 80 GB has plenty of room for VLM + RT-CV at full throughput |
+| H100 PCIe / NVL (80 GB) | **16** | Same |
+| RTX PRO 6000 (Blackwell, 96 GB) | **16** | Same |
+| L40S (48 GB) | **8** | 48 GB needs RT-CV halved to leave VRAM for the VLM |
+| A40 (48 GB) | **8** | Same |
+| Thor / GB10 (DGX Spark, ≤ 64 GB unified) | **8** | Edge — unified memory, smaller VLM headroom |
+
+Edit `dev-profile-search/.env`:
+
+```bash
+RT_CV_DEVICE_ID=0
+RT_EMBED_DEVICE_ID=1
+LLM_DEVICE_ID=1                                          # LLM shares GPU 1 with RT-Embed
+VLM_DEVICE_ID=0                                          # VLM shares GPU 0 with RT-CV
+LLM_MODE=local_shared
+VLM_MODE=local_shared
+NUM_STREAMS=16                                           # 16 on H100/RTX PRO 6000; 8 on L40S/A40/Thor/GB10
+```
+
+**Sizing logic for GPU 0 (RT-CV + VLM):**
+
+1. **Compute the VLM budget.** From [`base.md` § Sizing math](base.md#sizing-math) — VLM weights × 1.3. E.g. Cosmos Reason2 8B at FP16 ≈ 20.8 GB; Cosmos Reason1 7B ≈ 18.2 GB.
+2. **Set `NIM_KVCACHE_PERCENT` on the VLM** = `VLM_total / GPU_VRAM`, rounded up by 0.05 for headroom. H100 80 GB with CR2: 20.8 / 80 = 0.26 → set **0.30**. L40S 48 GB with CR2: 20.8 / 48 = 0.43 → set **0.45**.
+3. **RT-CV takes the rest.** RT-CV doesn't have a `--gpu-memory-utilization` knob — it consumes whatever's free, scaled by `NUM_STREAMS`. With the per-GPU defaults above, it sits comfortably alongside any standard VLM.
+4. **Verify with logs.** `docker logs vss-rtvi-cv` for OOM, `docker logs <vlm>` for the KV-cache report. If RT-CV drops frames, lower `NUM_STREAMS` further (with user confirmation if going below 8).
+
+**`NUM_STREAMS=8` is the agent's floor.** If the per-GPU default doesn't fit (e.g. an unsupported small GPU, or a much larger VLM than the standard set), **stop and ask the user** before lowering past 8 — going below 8 means real perception throughput loss. The user should pick between (a) accepting fewer streams, (b) switching to a smaller VLM (CR1 7B vs CR2 8B), or (c) Path A (remote VLM). Same two-trigger rule as [`base.md` § When to use remote LLM/VLM](base.md#when-to-use-remote-llmvlm).
+
+**Escalate to Path A automatically** only if even `NUM_STREAMS=1` can't close — i.e. VLM resident size > 0.85 × GPU_VRAM. The standard CR1/CR2/Qwen3-VL set never hits that on H100 80 GB; on L40S 48 GB a Cosmos2 FP16 VLM fits with NUM_STREAMS=8 and no escalation needed.
+
+### Path C — VLM on a dedicated 3rd GPU (full RT-CV throughput)
+
+Use this when the user explicitly wants the full `NUM_STREAMS=16` perception throughput **and** has a 3rd GPU free. Edit `dev-profile-search/.env`:
+
+```bash
+RT_CV_DEVICE_ID=0
+RT_EMBED_DEVICE_ID=1
+LLM_DEVICE_ID=1                                          # shares GPU 1 with RT-Embed
+VLM_DEVICE_ID=2                                          # dedicated
+LLM_MODE=local_shared                                    # LLM + RT-Embed share GPU 1
+VLM_MODE=local                                           # VLM gets GPU 2 alone
+NUM_STREAMS=16                                           # full throughput — RT-CV has GPU 0 to itself
+```
+
+Sizing notes:
+
+- **GPU 0 (RT-CV) — full GPU.** With no co-resident, RT-CV's DeepStream pipeline runs `NUM_STREAMS=16` comfortably on any supported GPU (H100, RTX PRO 6000, L40S). The upstream perf guide doesn't publish a single GB number for RT-CV; the [RT-Embed max-streams table](#rt-embed-sizing) is for the embedding service, not perception. If you push beyond 16 streams, watch GPU 0 utilization with `nvidia-smi -l 5` and back off if it saturates.
+- **GPU 1 (LLM + RT-Embed)** — for the default Cosmos-Embed1 (Triton/ONNX), no util override is needed. The LLM keeps a normal `NIM_KVCACHE_PERCENT` per the per-GPU table in [Worked example](#worked-example--llm--rt-embed-on-gpu-1). Only override RT-Embed's `VLLM_GPU_MEMORY_UTILIZATION` if you've switched to `VLM_MODEL_TO_USE=vllm-compatible` — see [RT-Embed sizing](#rt-embed-sizing) below.
+- **GPU 2 (VLM) — dedicated.** Use the relevant compose under `nim/<vlm-slug>/` per [`base.md` § Swapping a different LLM/VLM](base.md#swapping-a-different-llmvlm). For default `cosmos-reason2-8b` at FP16, NIM defaults are fine.
+
+## Sizing — RT-Embed and RT-CV knobs
+
+For VLM and LLM weight cost + the general formula, see [`base.md` § Sizing math](base.md#sizing-math). RT-Embed and RT-CV add their own knobs.
+
+### RT-Embed sizing
+
+Image: `nvcr.io/nvstaging/vss-core/vss-rt-embed:3.2.0-26.04.2` (SBSA: `3.2.0-sbsa-...`). Compose: `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml`.
+
+Per the upstream `perf/benchmark/rtvi_embed_gpu_initial_stream_counts.json`, the **dedicated-GPU ceiling** — max concurrent streams when RT-Embed has the GPU to itself with **no co-resident** model:
+
+| GPU | Max streams (RT-Embed dedicated) |
 |---|---|
-| VSS Agent | Orchestrates tool calls and model inference |
-| VSS Agent UI | Web UI at port 3000 |
-| VIOS | Video ingestion, recording, playback |
-| Nemotron LLM (NIM) | Reasoning and response generation |
-| RTVI-Embed | Generates embeddings for video and text using Cosmos Embed1 |
-| ELK (Elasticsearch + Logstash + Kibana) | Indexes and searches embeddings |
-| Kafka | Real-time message bus for embedding pipeline |
-| Phoenix | Observability and telemetry |
+| H100 80 GB SXM / HBM3 | **140** |
+| H100 80 GB PCIe | 100 |
+| H100 NVL | 100 |
+| RTX PRO 6000 (Blackwell) | 120 |
+| L40S | 60 |
+| A40 | 30 |
+| Thor / GB10 (DGX Spark) | 30 |
 
-> VLM is **not deployed locally** — `VLM_MODE=remote` is forced by the script for this profile.
+These are upper bounds for the dedicated case (any layout where you give RT-Embed its own GPU and nothing else co-locates). The default search layout always has the LLM co-resident on RT-Embed's GPU, so the practical ceiling is lower — but with the 10-GB RT-Embed budget in [Worked example](#worked-example--llm--rt-embed-on-gpu-1), `NUM_STREAMS=16` runs comfortably on all H100/RTX PRO 6000 configs, and `NUM_STREAMS=8` is the safe value on L40S / Thor / GB10.
 
-## GPU Layout (RTXPRO6000BW)
+Knobs (in `dev-profile-search/.env` unless noted):
 
-Both GPUs required:
+| Var | Inside-container | Default | Effect |
+|---|---|---|---|
+| `MODEL_PATH` | `MODEL_PATH` | `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection` | Embedding checkpoint. Variants: `Cosmos-Embed1-224p`, `-336p`, `-448p` (smaller resolution = smaller VRAM). |
+| `RTVI_EMBED_MODEL` | (label) | `cosmos-embed1-448p-anomaly-detection` | Identifier used by the agent. |
+| `NUM_STREAMS` | (RT-CV only — see below) | `16` | Concurrent stream count target for the whole pipeline. |
+| `RTVI_EMBED_NUM_VLM_PROCS` | `NUM_VLM_PROCS` | `10` | Parallel embedding workers. More procs = more throughput, more VRAM per process. |
+| `VLM_BATCH_SIZE` | `VLM_BATCH_SIZE` | auto (3 / 16 / 64 / 128 by GPU mem) | Batch size for inference. Auto-clamps to GPU capacity. |
+| `RTVI_EMBED_NUM_GPUS` / `VSS_NUM_GPUS_PER_VLM_PROC` | `NUM_GPUS` | empty (1) | Multi-GPU distribution per embed process. |
+| `RT_EMBED_DEVICE_ID` | (compose `device_ids`) | `1` | Which GPU RT-Embed pins to. |
+| `RTVI_EMBED_TAG` | (image tag) | `3.2.0-26.04.2` | x86 / iGPU. For DGX Spark: `3.2.0-sbsa-26.04.3`. |
 
-| Device | Role |
+**Default Cosmos-Embed1 deployment runs on Triton (ONNX), not vLLM.** From `start_rtvi_embed.sh:47-49` and `src/models/custom/samples/cosmos-embed1/inference.py:55-56`, the default `VLM_MODEL_TO_USE=custom` loads Cosmos-Embed1 via Triton-served ONNX models (`text_embeddings`, `video_embeddings`). For that path:
+
+- **No KV cache** — embedding inference is single-pass through an encoder; there's no autoregressive generation, so vLLM's KV-cache concepts don't apply. There is nothing to disable.
+- **`VLLM_GPU_MEMORY_UTILIZATION` is a no-op** when serving the default Cosmos-Embed1. The start script sets it to 0.7 for ≤50 GB GPUs and the Python wrapper's fallback is also 0.7, but the Triton/ONNX path doesn't read it.
+- **Memory is governed by Triton runtime + ONNX weights + per-stream activation buffers**, scaling with `NUM_STREAMS`, `NUM_VLM_PROCS`, and `VLM_BATCH_SIZE`. Cosmos-Embed1 (~1 B params at FP16 ≈ 2 GB weights) is small; the dominant cost on big concurrency is per-stream buffers and the decoder workers.
+
+**`VLLM_GPU_MEMORY_UTILIZATION` IS relevant** only when `VLM_MODEL_TO_USE=vllm-compatible` is set — i.e. when RT-Embed is loading a vLLM-served model instead of Cosmos-Embed1 (uncommon for Search; relevant for the LVS Nemotron Omni path). In that case the same `weights + KV + activations` semantics as [`base.md`](base.md#nim_kvcache_percent--gb-on-common-gpus) apply, and the shared-GPU override discussion in [Worked example](#worked-example--llm--rt-embed-on-gpu-1) below applies.
+
+**For the default search shared layout (LLM + Cosmos-Embed1 on GPU 1)**, **budget 10 GB for RT-Embed and give the LLM the rest** — `NIM_KVCACHE_PERCENT = (GPU_VRAM - 10) / GPU_VRAM - 0.15`. See the [worked example](#worked-example--llm--rt-embed-on-gpu-1) for the per-GPU table. No RT-Embed util override is needed; the env var is a no-op for the default Cosmos-Embed1 model.
+
+### RT-CV sizing
+
+Image: `nvcr.io/nvstaging/vss-core/vss-rt-cv:3.2.0-26.04.2` (SBSA: `3.2.0-sbsa-26.04.3`). Compose: `deploy/docker/services/rtvi/rtvi-cv/compose.yaml`.
+
+RT-CV is a **DeepStream perception pipeline**, not a vLLM container. It has no `--gpu-memory-utilization`-style knob. Memory scales with stream count and the active model family.
+
+Knobs (in `dev-profile-search/.env`):
+
+| Var | Default | Effect |
+|---|---|---|
+| `NUM_STREAMS` | `16` | Concurrent video streams in the perception pipeline. Single biggest VRAM driver. |
+| `DS_MODEL_FAMILY` | `rtdetr-warehouse` | Detection model family. Other variants change weight footprint. |
+| `DS_MODE_FLAG` | `1` | DeepStream mode. |
+| `DS_MESSAGE_RATE` | `1` | Inference messages per second per stream. |
+| `DS_TRACKER_REID` | `false` | Enable re-identification (extra VRAM). |
+| `VISION_ENCODER_MODEL` | `siglip_v2` | Vision encoder downloaded by `perception-2d-init`. |
+| `RT_CV_DEVICE_ID` | `0` | Which GPU RT-CV pins to. |
+| `PERCEPTION_TAG` | `3.2.0-26.04.2` | Image tag (use `-sbsa-` variant on DGX Spark). |
+
+The upstream perf guide doesn't publish a single GB number — it publishes per-GPU max stream counts (consistent with the table above for RT-Embed). Treat **`NUM_STREAMS=16`** as a starting point on H100 / RTX PRO 6000 / L40S; lower it on smaller GPUs or when co-locating with a VLM.
+
+## Worked example — LLM + RT-Embed on GPU 1
+
+Default layout, Nano 9B v2 LLM + Cosmos-Embed1 on GPU 1.
+
+**RT-Embed budget rule of thumb: 10 GB.** Cosmos-Embed1 weights are ~2 GB (1 B params at FP16); the rest is per-stream activation buffers, decoder workers, and Triton/ONNX runtime overhead. 10 GB is a comfortable budget for `NUM_STREAMS=16` on any GPU. Reserve those 10 GB and give the LLM the rest, leaving the standard 15% framework headroom.
+
+| GPU | VRAM | RT-Embed reserved | Framework (15%) | LLM gets | `NIM_KVCACHE_PERCENT` |
+|---|---|---|---|---|---|
+| H100 / A100-80 | 80 GB | 10 GB | 12 GB | 58 GB | **0.72** |
+| H200 | 141 GB | 10 GB | 21 GB | 110 GB | **0.78** |
+| RTX PRO 6000 (Blackwell) | 96 GB | 10 GB | 14 GB | 72 GB | **0.75** |
+| L40S | 48 GB | 10 GB | 7 GB | 31 GB | **0.65** (tight — verify under load) |
+
+Formula: `NIM_KVCACHE_PERCENT = (GPU_VRAM - 10) / GPU_VRAM - 0.15`, rounded to 2 decimals.
+
+Two writes:
+
+```bash
+# 1. In deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/hw-H100-shared.env
+NIM_KVCACHE_PERCENT=0.72             # LLM gets ~58 GB; leaves 10 GB for RT-Embed + 12 GB framework
+
+# 2. In deploy/docker/developer-profiles/dev-profile-search/.env
+RT_EMBED_DEVICE_ID=1
+LLM_DEVICE_ID=1
+LLM_MODE=local_shared
+NUM_STREAMS=16
+RTVI_EMBED_NUM_VLM_PROCS=            # leave default (10)
+# No VLLM_GPU_MEMORY_UTILIZATION override needed — Cosmos-Embed1 uses Triton/ONNX
+# (the env var is a no-op for the default model). Override only if you switch
+# RT-Embed to VLM_MODEL_TO_USE=vllm-compatible.
+```
+
+That's it. No compose-file tweak required for the default Cosmos-Embed1 deployment.
+
+**If you've switched RT-Embed to a vllm-compatible model** (rare — would happen if you load a vLLM-served embedding model instead of Cosmos-Embed1), then you also need to cap RT-Embed's `VLLM_GPU_MEMORY_UTILIZATION`. Compute it from the 10 GB budget: `10 / GPU_VRAM` ≈ `0.13` on H100. Add a passthrough to `rtvi-embed-docker-compose.yml`'s `environment:` block (`VLLM_GPU_MEMORY_UTILIZATION: "${RTVI_EMBED_VLLM_GPU_MEMORY_UTILIZATION:-}"`) and set `RTVI_EMBED_VLLM_GPU_MEMORY_UTILIZATION=0.13` in the profile env.
+
+> **Verifying under load.** Watch `docker logs vss-rtvi-embed` and `nvidia-smi -l 5` on GPU 1 while pushing `NUM_STREAMS=16` of test video. If RT-Embed's resident memory exceeds ~12 GB, raise the budget (e.g. 12 → 15 GB → recompute LLM `NIM_KVCACHE_PERCENT`). If the LLM OOMs at startup, it usually means RT-Embed grabbed more than 10 GB before the LLM allocated; constrain RT-Embed by lowering `NUM_STREAMS` or `RTVI_EMBED_NUM_VLM_PROCS` (10 → 4).
+
+For Path B (default — VLM on GPU 0 with RT-CV), the math is on GPU 0 instead: budget the VLM via [`base.md`](base.md#sizing-math), set its `NIM_KVCACHE_PERCENT` to `VLM_total / GPU_VRAM` rounded up, and let RT-CV consume the rest at the per-GPU `NUM_STREAMS` (16 on H100/RTX PRO 6000, 8 on L40S/A40/Thor/GB10). See [Path B](#path-b--default-co-locate-vlm-on-gpu-0-with-rt-cv) above.
+
+## Hard rules
+
+- **Critique enabled ⇒ a VLM endpoint must be reachable.** UI default is `use_critic=true`; the agent will fail at query time if no VLM is configured. Either set up Path A/B/C, or document with the user that they need to disable Critique in the UI.
+- **L40S (48 GB) cannot host LLM + RT-Embed shared at FP16.** Move to a 2-GPU host (LLM on its own GPU) or pick FP8 LLM. Then the VLM placement question still applies; on 2× L40S, both GPUs are taken by RT-Embed and LLM/VLM, so RT-CV gets a 3rd GPU — escalate per Path A if not available.
+- **Edge platforms (DGX Spark / Thor) are not supported for `search` yet** — track upstream blueprint for support. Use SBSA image tags (`-sbsa-`) when they land.
+- **`RESERVED_DEVICE_IDS` and `FIXED_SHARED_DEVICE_IDS` come from defaults** in `dev-profile-search/.env` (`'0'` and `'1'` respectively). They tell `dev-profile.sh` which devices not to reassign — the skill works at the env-file level, so leave them as-is unless changing the layout meaningfully (e.g. swapping which GPU hosts RT-CV vs RT-Embed).
+- **`/v1` quirk** — `LLM_BASE_URL` / `VLM_BASE_URL` no `/v1` (agent appends). RT-VLM-style `RTVI_VLM_ENDPOINT` (only relevant if you use RT-VLM as the critique VLM) yes `/v1`.
+
+## Key capabilities
+
+- Upload videos; embeddings are generated automatically by RT-Embed.
+- Natural language queries (e.g. "find all instances of forklifts") use Cosmos-Embed1's joint video/text embedding space.
+- Filter results by similarity score, time range, video name, description, source.
+- Timestamped results with clip playback in the UI.
+- Critique agent re-checks top retrieval results via the VLM (default-on; toggle in the UI sidebar).
+
+## Endpoints (after deploy)
+
+| Service | URL |
 |---|---|
-| 0 | RTVI-Embed (Cosmos Embed1) — embedding generation |
-| 1 | LLM (`local_shared`) |
+| Agent UI | `http://<HOST_IP>:3000/` |
+| Agent REST API | `http://<HOST_IP>:8000/` |
+| RT-Embed | `http://<HOST_IP>:8017/` |
+| Elasticsearch | `http://<HOST_IP>:9200/` |
+| Kibana | `http://<HOST_IP>:5601/` |
+| VLM (Path B/C) | `http://<HOST_IP>:30082/v1/` (NIM) or `http://<HOST_IP>:8018/v1/` (RT-VLM) |
+| Phoenix | `http://<HOST_IP>:6006/` |
 
-## Key Capabilities
+## Env file location
 
-- Upload videos; embeddings are generated automatically
-- Natural language queries (e.g., "find all instances of forklifts")
-- Filter results by similarity score, time range, video name, description, source
-- Timestamped results with clip playback
+```
+deploy/docker/developer-profiles/dev-profile-search/.env
+```
 
-## First Run Note
+## First-run note
 
-Downloads Cosmos Embed1 models from NGC — this can take extra time depending on network speed.
+RT-Embed downloads Cosmos-Embed1 weights from Hugging Face on first start; RT-CV's `perception-2d-init` downloads `siglip_v2` from NGC. Expect 10–20 min extra on the first deploy.
+
+## Debugging
+
+- **`docker logs vss-rtvi-embed`** — confirms model load and `Maximum concurrency for X tokens per GPU: Y x` line. If it OOMs, lower `RTVI_EMBED_NUM_VLM_PROCS` (10 → 4) or `NUM_STREAMS`.
+- **`docker logs vss-rtvi-cv`** — DeepStream perception pipeline logs. If GPU 0 OOMs in Path B (default, VLM co-located), drop `NUM_STREAMS` first (with user confirmation if going below 8), then revisit VLM `NIM_KVCACHE_PERCENT`.
+- **Embedding queries return zero hits** — check `lvs-logstash` is consuming `vision-embed-messages` (default Kafka topic) and that the ES index `mdx-embed-filtered-2025-01-01` exists.
+- **Critique returns "no VLM configured"** — confirm `VLM_BASE_URL` resolves and the resolved compose includes a VLM service or `VLM_MODE=remote` is set.

--- a/skills/deploy/references/teardown.md
+++ b/skills/deploy/references/teardown.md
@@ -2,7 +2,7 @@
 
 ### Step 0 — Tear down any existing deployment
 
-Ask user to confirm to tear down the deployment.
+Ask user to confirm to tear down the deployment before you proceed.
 
 Before every deploy, **always** stop any prior VSS stack. This is
 mandatory even if you think the host is clean, and especially when
@@ -39,7 +39,7 @@ docker ps -a --format '{{.Names}}' \
 
 # Step 0b - Cleanup previous stale state and local logs, data.
 
-Ask user to confirm to clean up.
+Ask user to confirm to clean up before you proceed.
 
 Use the bundled cleanup helper. It clears every directory whose stale state can poison a fresh deploy: kafka logs, elasticsearch data + logs, redis data + log, behavior-learning data, video-analytics API state, calibration toolkit, VST/nvstreamer recordings, and any blueprint-configurator backup files. The same logic `dev-profile.sh` runs internally between deploys.
 

--- a/skills/deploy/references/teardown.md
+++ b/skills/deploy/references/teardown.md
@@ -2,6 +2,8 @@
 
 ### Step 0 — Tear down any existing deployment
 
+Ask user to confirm to tear down the deployment.
+
 Before every deploy, **always** stop any prior VSS stack. This is
 mandatory even if you think the host is clean, and especially when
 switching profiles (`base` → `search`, `alerts` verification →
@@ -35,6 +37,13 @@ docker ps -a --format '{{.Names}}' \
   | xargs -r docker rm -f
 ```
 
-If this is the host's first deploy, the `docker compose down`
-line is a no-op (exit 0 with no containers to stop) — safe to run
-unconditionally.
+# Step 0b - Cleanup previous stale state and local logs, data.
+
+Ask user to confirm to clean up.
+
+Use the bundled cleanup helper. It clears every directory whose stale state can poison a fresh deploy: kafka logs, elasticsearch data + logs, redis data + log, behavior-learning data, video-analytics API state, calibration toolkit, VST/nvstreamer recordings, and any blueprint-configurator backup files. The same logic `dev-profile.sh` runs internally between deploys.
+
+```bash
+sudo bash "$REPO/deploy/docker/scripts/cleanup_all_datalog.sh" \
+    --env-file "$REPO/deploy/docker/developer-profiles/dev-profile-<profile>/.env"
+```

--- a/skills/deploy/references/teardown.md
+++ b/skills/deploy/references/teardown.md
@@ -1,0 +1,40 @@
+# Tear down an existing VSS deployment
+
+### Step 0 — Tear down any existing deployment
+
+Before every deploy, **always** stop any prior VSS stack. This is
+mandatory even if you think the host is clean, and especially when
+switching profiles (`base` → `search`, `alerts` verification →
+`alerts` real-time, etc.). Compose profile flags only *start* the
+services listed under the selected profile — they do NOT stop
+services from a previously-active profile, so containers from the
+prior deploy linger and pass unrelated container-name checks,
+contaminate results, and can bind ports the new deploy needs.
+
+```bash
+# If a resolved.yml from a prior deploy exists, prefer it — it
+# knows about all compose-profile services that were brought up.
+if [ -f "$REPO/deployments/resolved.yml" ]; then
+  docker compose -f "$REPO/deployments/resolved.yml" down --remove-orphans
+fi
+
+# Catch-all: remove every VSS-stack container the dev-profile compose
+# files bring up. Without this, leftovers from a prior deploy linger
+# (especially the *-smc set, which the alerts compose profile shares
+# with the *-dev set on host networking and port 30000) and either:
+#   - bind ports the new deploy needs → second sensor-ms fails to bind
+#     → /sensor/list returns 502 (issue #151), or
+#   - pass the new deploy's container-name health checks while serving
+#     stale data from the prior deploy's DB.
+# The patterns below cover everything declared in
+# deployments/vst/{2d,3d,smc,developer,ps}/, deployments/foundational/,
+# deployments/agents/, deployments/proxy/, and the dev-profile-*
+# compose files.
+docker ps -a --format '{{.Names}}' \
+  | grep -E '^(vss-|mdx-|perception-|rtvi-|alert-|nvstreamer-|sensor-ms-|vst-ingress-|vst-mcp-|vst-file-proxy|centralizedb-|storage-ms-|streamprocessing-ms-|sdr-(http|streamprocessing)-|envoy-(http|streamprocessing)-|rtspserver-ms-|recorder-ms-|replaystream-ms-|livestream-ms-|metropolis-vss-ui|phoenix)' \
+  | xargs -r docker rm -f
+```
+
+If this is the host's first deploy, the `docker compose down`
+line is a no-op (exit 0 with no containers to stop) — safe to run
+unconditionally.

--- a/skills/deploy/references/troubleshooting.md
+++ b/skills/deploy/references/troubleshooting.md
@@ -1,0 +1,24 @@
+# Deploy troubleshooting
+
+### Step 3b — Verify resolved.yml has no unexpanded ${...} tokens
+
+**Skipping this is the #1 cause of "I deployed `search` but it brought
+up `base` + `lvs` + `search` services."** The `.env` line near 90 is
+literal `COMPOSE_PROFILES=${BP_PROFILE}_${MODE},...` — docker compose
+expands it at `config` time using the same env file. If any upstream
+var (`BP_PROFILE`, `MODE`, `HARDWARE_PROFILE`, `LLM_MODE`,
+`VLM_MODE`) is missing from the env, the rendered profile list
+collapses to the empty string, and compose then includes **every**
+service from **every** profile.
+
+```bash
+if grep -q '\${' "$REPO/deployments/resolved.yml"; then
+  echo "FAIL: resolved.yml has unexpanded variables:"
+  grep -n '\${' "$REPO/deployments/resolved.yml" | head -5
+  exit 1
+fi
+```
+
+If this check fails, re-apply the Step 2 env overrides directly to
+the `.env` file at the path above, regenerate `resolved.yml` (Step 3),
+and re-run this check before continuing.

--- a/skills/deploy/scripts/normalize_resolved_yml.py
+++ b/skills/deploy/scripts/normalize_resolved_yml.py
@@ -1,6 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --quiet --script
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["pyyaml"]
+# ///
 """Strip dangling optional depends_on entries from a resolved compose file.
 
 Why this exists
@@ -28,8 +32,10 @@ calls this as part of every deploy.
 
 Usage
 -----
-    python3 normalize_resolved_yml.py [path/to/resolved.yml]
+    uv run skills/deploy/scripts/normalize_resolved_yml.py [path/to/resolved.yml]
         # default path: ./resolved.yml in CWD
+        # PEP 723 inline metadata declares pyyaml; uv pulls it into an
+        # ephemeral env on demand, so no `pip install` on the host is needed.
 
 Exit codes
 ----------

--- a/skills/deploy/scripts/normalize_resolved_yml.py
+++ b/skills/deploy/scripts/normalize_resolved_yml.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Strip dangling optional depends_on entries from a resolved compose file.
+
+Why this exists
+---------------
+`docker compose --env-file .env config > resolved.yml` filters out services
+that don't match the active COMPOSE_PROFILES, but leaves depends_on: entries
+pointing at those filtered-out services. Compose's schema validator rejects
+any depends_on target that isn't a defined service in the file — even when
+the entry is `required: false` — so `docker compose -f resolved.yml up -d`
+aborts with:
+
+    service "X" depends on undefined service "Y": invalid compose project
+
+before any container starts. This script normalizes the generated artifact
+by dropping only the dangling depends_on entries; required active deps
+(kafka, redis, rtvi-vlm, sensor-ms, streamprocessing-ms, etc.) are preserved.
+
+The script edits ONLY the generated resolved.yml — never the source compose
+files. The dependencies are correctly marked optional in the source; profile
+filtering is what creates the dangling references in the resolved artifact.
+
+This MUST run after `docker compose ... config > resolved.yml` and before
+`docker compose -f resolved.yml up -d`. The deploy skill (SKILL.md Step 3c)
+calls this as part of every deploy.
+
+Usage
+-----
+    python3 normalize_resolved_yml.py [path/to/resolved.yml]
+        # default path: ./resolved.yml in CWD
+
+Exit codes
+----------
+    0   normalized successfully (or already clean)
+    1   file not found / parse error
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def normalize(path: Path) -> int:
+    """Strip dangling depends_on entries in resolved compose at *path*.
+
+    Returns the number of entries removed.
+    """
+    try:
+        with path.open() as f:
+            doc = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        print(f"ERROR: {path} not found", file=sys.stderr)
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        print(f"ERROR: failed to parse {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    services = doc.get("services") or {}
+    defined = set(services.keys())
+
+    removed: list[tuple[str, str]] = []
+
+    for name, svc in services.items():
+        if not isinstance(svc, dict):
+            continue
+        deps = svc.get("depends_on")
+        if not deps:
+            continue
+
+        if isinstance(deps, dict):
+            kept = {k: v for k, v in deps.items() if k in defined}
+            for k in deps:
+                if k not in defined:
+                    removed.append((name, k))
+            if kept:
+                svc["depends_on"] = kept
+            else:
+                svc.pop("depends_on", None)
+        elif isinstance(deps, list):
+            kept_list = [k for k in deps if k in defined]
+            for k in deps:
+                if k not in defined:
+                    removed.append((name, k))
+            if kept_list:
+                svc["depends_on"] = kept_list
+            else:
+                svc.pop("depends_on", None)
+
+    if removed:
+        with path.open("w") as f:
+            yaml.safe_dump(doc, f, sort_keys=False)
+        print(f"Normalized {path}: dropped {len(removed)} dangling depends_on entries:")
+        for svc_name, target in removed:
+            print(f"  - {svc_name} -> {target}")
+    else:
+        print(f"{path} already clean (0 dangling depends_on entries)")
+
+    return len(removed)
+
+
+def main() -> None:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("resolved.yml")
+    normalize(path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`SKILL.md` slimmed** to cross-profile concerns (routing, prerequisites, NGC, GPU setup, deploy/teardown flow). Per-profile detail moved into reference docs that load conditionally based on the user's intent. New `EXTERNAL_IP` / `VSS_PUBLIC_HOST` callout in Step 1 + Step 1c (Brev) documents the haproxy ingress chain and the Brev secure-link footgun.
- **Per-profile sizing rewritten** around the UCF blueprint-builder methodology. `base.md` carries the canonical `weights × 1.3` math, `NIM_KVCACHE_PERCENT ↔ GB` tuning table, and the swap-a-model decision tree (in-tree slug → build.nvidia.com NIM → DLFW vLLM compose). `lvs.md` and `alerts.md` document the **integrated RT-VLM default** (PR #347) — no standalone Cosmos NIM service, supported integrated checkpoints (CR2 / CR1 / Nemotron Omni 30B-A3B FP8), and the `VLM_NAME=nim_…` quirk that alert-bridge enforces. `search.md` adds the VLM-placement decision tree (remote → co-locate on GPU 0 with RT-CV at per-GPU `NUM_STREAMS` defaults → dedicated 3rd GPU), 10 GB RT-Embed budget rule of thumb, and the Triton/ONNX-vs-vLLM clarification (Cosmos-Embed1 has no KV cache to disable).
- **Skill workflow is purely compose+env** — never invokes `dev-profile.sh`. The agent writes overrides directly to `dev-profile-<profile>/.env`, runs `docker compose --env-file .env config > resolved.yml`, reviews, then `up -d`. Two-trigger remote rule across all profiles: user supplied an endpoint OR sizing math doesn't fit → stop and ask the user (no silent fallback to a smaller local model). Four ancillary refs (`data-directory.md`, `env-overrides.md`, `teardown.md`, `troubleshooting.md`) extracted from the prior monolithic SKILL.md.


🤖 Generated with [Claude Code](https://claude.com/claude-code)