### PR TITLE
fix(nim): escape $elapsed in LLM-NIM healthcheck shell (NVBug 6158918)

### DIFF
--- a/deploy/docker/services/nim/gpt-oss-20b/compose.yml
+++ b/deploy/docker/services/nim/gpt-oss-20b/compose.yml
@@ -52,7 +52,7 @@ services:
               - "${LLM_DEVICE_ID:-0}"
     restart: always
     healthcheck:
-      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $elapsed"; elapsed=$((elapsed + 5)); if [ $elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
+      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $$elapsed"; elapsed=$$((elapsed + 5)); if [ $$elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
       interval: 60s
       timeout: 650s
       retries: 2
@@ -88,7 +88,7 @@ services:
               - "${SHARED_LLM_VLM_DEVICE_ID:-${LLM_DEVICE_ID:-0}}"
     restart: always
     healthcheck:
-      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $elapsed"; elapsed=$((elapsed + 5)); if [ $elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
+      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $$elapsed"; elapsed=$$((elapsed + 5)); if [ $$elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
       interval: 60s
       timeout: 650s
       retries: 2

--- a/deploy/docker/services/nim/llama-3.3-nemotron-super-49b-v1.5/compose.yml
+++ b/deploy/docker/services/nim/llama-3.3-nemotron-super-49b-v1.5/compose.yml
@@ -42,7 +42,7 @@ services:
               - "${LLM_DEVICE_ID:-0}"
     restart: always
     healthcheck:
-      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $elapsed"; elapsed=$((elapsed + 5)); if [ $elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
+      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $$elapsed"; elapsed=$$((elapsed + 5)); if [ $$elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
       interval: 60s
       timeout: 650s
       retries: 2
@@ -74,7 +74,7 @@ services:
               - "${SHARED_LLM_VLM_DEVICE_ID:-${LLM_DEVICE_ID:-0}}"
     restart: always
     healthcheck:
-      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $elapsed"; elapsed=$((elapsed + 5)); if [ $elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
+      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $$elapsed"; elapsed=$$((elapsed + 5)); if [ $$elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
       interval: 60s
       timeout: 650s
       retries: 2

--- a/deploy/docker/services/nim/nemotron-3-nano/compose.yml
+++ b/deploy/docker/services/nim/nemotron-3-nano/compose.yml
@@ -53,7 +53,7 @@ services:
               - "${LLM_DEVICE_ID:-0}"
     restart: always
     healthcheck:
-      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $elapsed"; elapsed=$((elapsed + 5)); if [ $elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
+      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $$elapsed"; elapsed=$$((elapsed + 5)); if [ $$elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
       interval: 60s
       timeout: 650s
       retries: 2
@@ -108,7 +108,7 @@ services:
         required: false
     restart: always
     healthcheck:
-      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $elapsed"; elapsed=$((elapsed + 5)); if [ $elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
+      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $$elapsed"; elapsed=$$((elapsed + 5)); if [ $$elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
       interval: 60s
       timeout: 650s
       retries: 2

--- a/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/compose.yml
+++ b/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/compose.yml
@@ -43,7 +43,7 @@ services:
               - "${LLM_DEVICE_ID:-0}"
     restart: always
     healthcheck:
-      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $elapsed"; elapsed=$((elapsed + 5)); if [ $elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
+      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $$elapsed"; elapsed=$$((elapsed + 5)); if [ $$elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
       interval: 60s
       timeout: 650s
       retries: 2
@@ -76,7 +76,7 @@ services:
               - "${SHARED_LLM_VLM_DEVICE_ID:-${LLM_DEVICE_ID:-0}}"
     restart: always
     healthcheck:
-      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $elapsed"; elapsed=$((elapsed + 5)); if [ $elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
+      test: ['CMD-SHELL', 'if [ -f /tmp/ready_done ]; then curl --max-time 30 -f http://localhost:8000/v1/health/live; else elapsed=0; while ! curl -fs http://localhost:8000/v1/health/ready > /dev/null 2>&1; do sleep 5; echo "elapsed $$elapsed"; elapsed=$$((elapsed + 5)); if [ $$elapsed -ge 600 ]; then echo "Service did not become ready within 10 minutes"; exit 1; fi; done; touch /tmp/ready_done && curl --max-time 30 -f http://localhost:8000/v1/health/live; fi']
       interval: 60s
       timeout: 650s
       retries: 2


### PR DESCRIPTION
## Summary

`docker compose config` expands unescaped `$elapsed` at config-rendering time, turning the runtime shell variable into an empty string in `resolved.yml`. The NIM healthcheck busy-wait then becomes invalid shell:

```
echo "elapsed "; elapsed=$((elapsed + 5)); if [  -ge 600 ]; then …
```

producing a `[ -ge 600 ]` syntax error and broken NIM readiness/warmup. Fix is the standard Compose escape (`$$` → literal `$` at runtime), matching the existing correct healthcheck in `nvidia-nemotron-nano-9b-v2-fp8/compose.yml`. Three substitutions per service block × two service blocks (dedicated + `-shared-gpu`) per NIM compose × four affected LLM NIM files.

**Affected** (LLM NIMs):
- `deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/compose.yml`
- `deploy/docker/services/nim/nemotron-3-nano/compose.yml`
- `deploy/docker/services/nim/gpt-oss-20b/compose.yml`
- `deploy/docker/services/nim/llama-3.3-nemotron-super-49b-v1.5/compose.yml`

**Already correct** (no changes): the 4 VLM NIMs (`cosmos-reason1-7b`, `cosmos-reason2-8b`, `qwen3-vl-8b-instruct`) and the FP8 vLLM compose (`nvidia-nemotron-nano-9b-v2-fp8`).

**Relationship to PR #353:** the `$elapsed` bug was masked previously by the dangling-`depends_on` issue (`#353` Step 3c + `normalize_resolved_yml.py`) that aborted `resolved.yml` deploys before the healthcheck could run. As `#353`'s lands, this fix becomes load-bearing — the NIM container starts but its readiness loop is broken without the escape.

Fixes NVBug 6158918.

## Test plan

- [ ] **Render the rendered healthcheck**: `cd deploy/docker && docker compose --env-file developer-profiles/dev-profile-base/.env config | grep -B1 -A1 'elapsed'` — every match should show `$elapsed` (preserved for runtime), not empty.
- [ ] **End-to-end NIM warmup**: deploy `base` profile with the default Nano 9B v2 NIM; `docker logs nvidia-nemotron-nano-9b-v2-shared-gpu | grep elapsed` should show counting like `elapsed 5`, `elapsed 10`, … instead of `elapsed ` (blank).
- [ ] **Reproduce on the host that filed the bug** (RTX PRO 6000 Blackwell, search profile) — confirm NIM now reaches healthy after warmup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)