### PR TITLE
feat: add gous-75 to copy-pr-bot vetters

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -11,6 +11,7 @@ additional_vetters:
   - daviddu0425
   - dineshv
   - freshyjmp
+  - gous-75
   - hugoverjus
   - huyprowow
   - jiayin-nvidia


### PR DESCRIPTION
## Description
Add gous-75 to additional_vetters in .github/copy-pr-bot.yaml so that to trigger CI for PRs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
