### PR TITLE
skills(develop): metadata block migration + port skills/README.md from main

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,54 @@
+# VSS Skills
+
+Skills for working with NVIDIA Video Search & Summarization (VSS). Each subdirectory under `skills/` is a self-contained skill following the [agentskills.io](https://agentskills.io/specification) specification, with `name`, `description`, `version`, and `license` declared in its `SKILL.md` frontmatter.
+
+## Catalog
+
+| Skill | Description |
+|---|---|
+| [alerts](alerts/SKILL.md) | Skill to add, manage, and monitor alerts on streamed video. |
+| [deploy](deploy/SKILL.md) | Skills to deploy, debug, or tear down any VSS profile using a docker compose-centric workflow. |
+| [report](report/SKILL.md) | Skill to produce video analysis reports by querying the VSS agent's `/generate` endpoint. |
+| [video-analytics](video-analytics/SKILL.md) | Skill for querying video analytics data and metrics from Elasticsearch via the VA-MCP server. |
+| [video-search](video-search/SKILL.md) | Skills for searching video archives using natural language, multi-embedding fusion, and VLM critique. |
+| [video-summarization](video-summarization/SKILL.md) | Skill for summarizing a video through chunking, dense captioning, and aggregation functions using the Long Video Summarization (LVS) microservice. |
+| [video-understanding](video-understanding/SKILL.md) | Skill for using video understanding tool to answer text questions about video content using a VLM. |
+| [vios](vios/SKILL.md) | Skill for video and stream management, recording timelines, clip extraction, snapshots (and more) using the Video IO and Storage microservices. |
+
+Skills with `eval/*.json` specs are exercised automatically by the Skills Eval CI workflow on every PR that touches `skills/**` — see [`.github/skill-eval/AGENTS.md`](../.github/skill-eval/AGENTS.md) for harness behavior.
+
+## Install (recommended: ask your coding agent)
+
+Open this repository in your coding agent (Claude Code, Codex, Cursor, or any other agentskills.io-compatible host) and paste the following prompt:
+
+> Read `skills/README.md` and every `SKILL.md` file under `skills/`. For each skill in the catalog, install it for this host so I can invoke it from a shell or chat session. Use the host's standard skills directory:
+>
+> - Claude Code: `~/.claude/skills/<name>/`
+> - Codex: `~/.codex/skills/<name>/`
+> - Hosts that follow the agentskills.io universal path: `~/.agents/skills/<name>/`
+>
+> Symlink each skill folder rather than copying it so a `git pull` here keeps every install up to date. Skip skills that are already installed and pointing at this checkout. When you're done, list the skills you registered and which directory you used.
+
+The agent will read the frontmatter of each `SKILL.md`, create the symlinks, and confirm what's installed. The skills become invokable in the next agent session.
+
+### Single-skill install
+
+To install skills individually, paste the following prompt:
+
+> Install only `skills/<name>/` for this host the same way.
+
+### Update
+
+After `git pull`, the symlinks already point at the updated content — nothing to do unless skills were added or renamed. To pick up new skills use the following prompt:
+
+> Re-read `skills/README.md` and add any new skills missing from this host's skills directory.
+
+### Uninstall
+
+To uninstall skills, paste the following prompt:
+
+> Remove every VSS skill symlink you previously created under this host's skills directory.
+
+## Source of truth
+
+This `skills/` directory is the canonical source. Skills published to the public catalog at `github.com/nvidia/skills` are mirrored from here at sync time per [`components.yml`](https://github.com/NVIDIA/skills/blob/main/components.yml).

--- a/skills/alerts/SKILL.md
+++ b/skills/alerts/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: alerts
 description: Manage and monitor VSS alerts after the alerts profile is deployed. The deployment's mode (CV vs VLM real-time) is fixed at deploy time and determines the workflow — start/stop real-time alerts via the VSS Agent on a VLM deployment, onboard CV alerts by adding RTSP streams to VIOS on a CV deployment, query incidents, customize verifier prompts. Use when asked to start/stop a real-time alert, check or list alerts, add a camera, customize alert prompts, or view verdicts.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # VSS Alert Management

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: deploy
 description: Load when the user says "configure vss", "deploy vss", "deploy <profile>", "debug deploy", "verify deployment", or "why is my vss deploy broken".
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint deployment"
 ---
 
 # VSS Deploy

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: report
 description: Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as the standard Video Analysis Report markdown.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # Report

--- a/skills/video-analytics/SKILL.md
+++ b/skills/video-analytics/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: video-analytics
 description: Query video analytics data and metrics from Elastic search via the VA-MCP server (port 9901). This includes incidents, alerts, sensor data, and metrics. Use for any question about violations, alerts, incidents, object counts, speeds, occupancy, or anything that requires looking up recorded events. This is the primary way to answer a question that requires incidents, alerts and other metrics such as people counts and violations.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # Video Analytics (VA-MCP)

--- a/skills/video-search/SKILL.md
+++ b/skills/video-search/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: video-search
 description: Search video archives using natural language — find events, objects, actions, and people across recorded video using fusion search (Cosmos Embed1 semantic search + CV attribute search). Use when asked to search for something in video, find actions and events, locate objects and people, or query video archives. For these types of questions, default to this top-level fusion search unless user specifies otherwise. Requires the search profile to be deployed.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # Video Search Workflows

--- a/skills/video-summarization/SKILL.md
+++ b/skills/video-summarization/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: video-summarization
 description: Summarize a video by calling the VLM NIM or the Long Video Summarization (LVS) microservice directly. For short videos (<60s) call the VLM's OpenAI-compatible chat completions endpoint; for long videos (>=60s) call the LVS microservice. Use when asked to summarize a video, describe what happens in a video, or analyze a recording.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 You are a video summarization assistant. You call the VLM NIM or the LVS

--- a/skills/video-understanding/SKILL.md
+++ b/skills/video-understanding/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: video-understanding
 description: Call the vss agent to run video understanding on video to answer a text question. Use when the user asks about video content, or about visual details that cannot be answered from conversation history, search hits, or metadata alone.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # Video QnA using VLM through VSS Agent

--- a/skills/vios/SKILL.md
+++ b/skills/vios/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: vios
 description: "Query VIOS REST APIs: sensor list, recording timelines, video clip extraction, snapshot capture, add/delete sensors and streams"
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 You are a VIOS API assistant. Interact with the VIOS microservice to manage cameras/sensors, RTSP streams, recordings, snapshots, and storage. Use when asked to: add a camera, add an RTSP stream, list sensors, show configured sensors/cameras/streams, check stream status, get a snapshot, download a clip, upload a video file, or manage video storage. Always query the VIOS API directly using curl — do not navigate the UI.


### PR DESCRIPTION
## Summary

Apply the metadata-block migration that landed on \`main\` (via PRs #294 and #330) to the same skills on \`develop\`, and port \`skills/README.md\` from \`main\` so the catalog table is present on this branch too. Skills schema only — no content rewrites, no procedural changes.

## Frontmatter changes (every SKILL.md)

\`\`\`yaml
# Before
---
name: <skill>
description: ...
version: "3.2.0"
license: "Apache License 2.0"
---

# After
---
name: <skill>
description: ...
license: Apache-2.0
metadata:
  version: "3.2.0"
  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
  tags: "nvidia blueprint <kind>"
---
\`\`\`

## Tag categorization

| Skill | Tag |
|---|---|
| alerts | \`nvidia blueprint operational\` |
| deploy | \`nvidia blueprint deployment\` |
| report | \`nvidia blueprint operational\` |
| video-analytics | \`nvidia blueprint operational\` |
| video-search | \`nvidia blueprint operational\` |
| video-summarization | \`nvidia blueprint operational\` |
| video-understanding | \`nvidia blueprint operational\` |
| vios | \`nvidia blueprint operational\` |

## skills/README.md

Ported from \`main\` with two rows dropped: \`rt-vlm\` and \`vss-frag\` (those skills don't exist on develop yet — main is ahead). The 8-skill catalog table matches the 8 directories present on develop today.

## Out of scope

The XML-tag and token-budget cleanups that landed on main via PR #330 are **not** applied here:

- \`deploy\` description on develop still contains the literal \`<profile>\` placeholder (NV-BASE \`quality_correctness\` will flag it).
- Several SKILL.md files on develop are near or over the agentskills.io 5000-token recommendation.

Those clean up in a follow-up PR once we have an NV-BASE baseline against \`develop\`.

## Validation

- Each SKILL.md parses as YAML.
- Every file contains \`metadata.{version,github-url,tags}\` and SPDX \`license: Apache-2.0\`.
- No top-level \`version:\` key remains.

## Test plan

- [ ] CI green (Lint, Pytest, Mypy, Secret scan, Folder structure, DCO).
- [ ] \`grep -nE "^version:" skills/*/SKILL.md\` returns no matches.
- [ ] \`grep -nE "license: \"Apache License 2.0\"" skills/*/SKILL.md\` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)