### PR TITLE
[skill-eval] video-search + video-summarization adapters for PR #366

### DIFF
--- a/.github/skill-eval/adapters/video-search/__init__.py
+++ b/.github/skill-eval/adapters/video-search/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/.github/skill-eval/adapters/video-search/generate.py
+++ b/.github/skill-eval/adapters/video-search/generate.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the video-search skill.
+
+The video-search skill exercises natural-language video archive search via
+the VSS search profile (Cosmos Embed1 + Elasticsearch). It requires a
+**full-remote deployed VSS search profile** (deploy mode = `remote-all`).
+The coordinator chains a deploy task ahead of each trial.
+
+## Directory layout
+
+    datasets/video-search/<spec_stem>/<platform>-<mode>/
+        step-1/  step-2/  ...   (one per entry in spec["expects"])
+            task.toml
+            instruction.md
+            tests/test.sh
+            tests/generic_judge.py
+            tests/<spec_stem>.json
+            solution/solve.sh
+            skills/video-search/   (full skill copy)
+            skills/deploy/         (for agent diagnostics)
+            environment/Dockerfile
+
+Usage:
+    python3 generate.py --output-dir ../../datasets/video-search \\
+        --skill-dir ../../../../../skills/video-search \\
+        --deploy-skill-dir ../../../../../skills/deploy \\
+        --spec ../../../../../skills/video-search/eval/search.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Preamble — required in every instruction.md so the agent's skill prereq
+# bypass clause fires and the agent doesn't stall waiting for confirmation.
+# ---------------------------------------------------------------------------
+
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness.\n"
+    "You are pre-authorized to deploy prerequisites autonomously —\n"
+    "do not pause to ask for confirmation on `/deploy` or any other\n"
+    "setup action the trial requires.\n"
+)
+
+# ---------------------------------------------------------------------------
+# Platforms
+# ---------------------------------------------------------------------------
+
+PLATFORMS: dict[str, dict] = {
+    "H100":         {"short_name": "h100",         "gpu_type": "H100",         "min_vram_per_gpu": 80,  "brev_search": "H100"},
+    "L40S":         {"short_name": "l40s",         "gpu_type": "L40S",         "min_vram_per_gpu": 48,  "brev_search": "L40S"},
+    "RTXPRO6000BW": {"short_name": "rtxpro6000bw", "gpu_type": "RTX PRO 6000", "min_vram_per_gpu": 96,  "brev_search": "RTX PRO"},
+    "DGX-SPARK":    {"short_name": "spark",        "gpu_type": "GB10",         "min_vram_per_gpu": 96,  "brev_search": "GB10"},
+    "IGX-THOR":     {"short_name": "thor",         "gpu_type": "Thor",         "min_vram_per_gpu": 64,  "brev_search": "Thor"},
+}
+
+DEFAULT_PLATFORM = "L40S"
+
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+
+# ---------------------------------------------------------------------------
+# Script generators
+# ---------------------------------------------------------------------------
+
+def generate_test_script(step: int, spec_name: str) -> str:
+    """Shell wrapper that invokes the generic LLM-as-judge verifier."""
+    return (
+        "#!/bin/bash\n"
+        f"# video-search verifier (step {step}): delegates to the generic\n"
+        "# LLM-as-judge (tools/eval/harbor/verifiers/generic_judge.py).\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def generate_solve_script(platform: str, profile: str) -> str:
+    """Gold solution — asserts the search stack is live."""
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution: video-search ({profile} profile) on {platform}\n"
+        "# The verifier drives the search queries directly — the solution\n"
+        "# script just asserts the required endpoints are live.\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 http://localhost:8000/docs >/dev/null || {\n"
+        "    echo 'VSS Agent API is not reachable — cannot solve video-search task'\n"
+        "    exit 1\n"
+        "}\n"
+        "curl -sf --connect-timeout 5 http://localhost:9200/ >/dev/null || {\n"
+        "    echo 'Elasticsearch is not reachable — cannot solve video-search task'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'VSS search stack is live — verifier will drive the queries.'\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task generation
+# ---------------------------------------------------------------------------
+
+def generate_task(platform: str, spec: dict, output_root: Path,
+                  skill_dir: Path, deploy_skill_dir: Path | None,
+                  spec_stem: str, mode: str) -> None:
+    """Emit one Harbor task directory per entry in spec['expects'] — i.e.
+    step-<k>/ subdirs under `<spec_stem>/<platform_short>-<mode>/`."""
+    pspec = PLATFORMS[platform]
+    platform_short = pspec["short_name"]
+    expects = spec.get("expects") or []
+    spec_name = f"{spec_stem}.json"
+    profile = spec.get("profile", "search")
+    deploy_mode = spec.get("deploy_mode", "remote-all")
+
+    task_dir_root = output_root / spec_stem / f"{platform_short}-{mode}"
+
+    for idx, expect in enumerate(expects, 1):
+        step_dir = task_dir_root
+        if len(expects) > 1:
+            step_dir = task_dir_root / f"step-{idx}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+
+        # instruction.md — begins with PREAMBLE, then step query + env notes
+        step_suffix = f"step {idx}/{len(expects)}: " if len(expects) > 1 else ""
+        lines = [
+            PREAMBLE,
+            f"Use the `/video-search` skill against the VSS **{profile}** profile "
+            f"already running on this `{platform}` host "
+            "(VSS agent must be reachable at `http://localhost:8000/docs` "
+            "and Elasticsearch at `http://localhost:9200/`).",
+            "",
+            f"## {step_suffix}Query",
+            "",
+            expect.get("query", ""),
+            "",
+            "## Environment notes",
+            "",
+            spec.get("env", ""),
+            "",
+        ]
+        (step_dir / "instruction.md").write_text("\n".join(lines) + "\n")
+
+        # task.toml
+        step_suffix_id = f"-step-{idx}" if len(expects) > 1 else ""
+        meta_lines = [
+            "[task]",
+            f'name = "nvidia-vss/video-search-{spec_stem}-{platform_short}-{mode}{step_suffix_id}"',
+            f'description = "video-search {spec_stem} query {idx}/{len(expects)} on {platform}/{mode}"',
+            f'keywords = ["video-search", "{spec_stem}", "{platform}", "{mode}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[verifier.env]",
+            'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+            'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+            'JUDGE_MODEL = "${JUDGE_MODEL:-claude-haiku-4-5}"',
+            "",
+            "[metadata]",
+            'skill = "video-search"',
+            f'profile = "{profile}"',
+            f'platform = "{platform}"',
+            f'gpu_type = "{pspec["gpu_type"]}"',
+            f'brev_search = "{pspec["brev_search"]}"',
+            f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+            "requires_deployed_vss = true",
+            f'prerequisite_deploy_mode = "{deploy_mode}"',
+            f"step_index = {idx}",
+            f"step_count = {len(expects)}",
+            f"check_count = {len(expect.get('checks') or [])}",
+            "",
+        ]
+        (step_dir / "task.toml").write_text("\n".join(meta_lines))
+
+        # environment/
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        # tests/
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        spec_src = skill_dir / "eval" / spec_name
+        if spec_src.exists():
+            shutil.copy(spec_src, tests_dir / spec_name)
+        else:
+            (tests_dir / spec_name).write_text(json.dumps(spec, indent=2))
+
+        # solution/
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(generate_solve_script(platform, profile))
+
+        # skills/
+        for src, name in ((skill_dir, "video-search"), (deploy_skill_dir, "deploy")):
+            if src and src.exists():
+                dst = step_dir / "skills" / name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--output-dir", required=True,
+                        help="Dataset output root (e.g. .github/skill-eval/datasets/video-search)")
+    parser.add_argument("--skill-dir", required=True,
+                        help="Path to skills/video-search")
+    parser.add_argument("--deploy-skill-dir", default=None,
+                        help="Path to skills/deploy (optional — included for agent debug)")
+    parser.add_argument("--spec", default=None,
+                        help="Path to eval spec JSON (default: <skill-dir>/eval/search.json)")
+    parser.add_argument("--platform", default=None, choices=list(PLATFORMS.keys()),
+                        help=f"Generate for this platform only (default: {DEFAULT_PLATFORM})")
+    parser.add_argument("--all-platforms", action="store_true",
+                        help="Fan out across every platform in PLATFORMS")
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / "search.json")
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+
+    spec = json.loads(spec_path.read_text())
+    spec_stem = spec_path.stem
+
+    if args.platform:
+        platforms = [args.platform]
+    elif args.all_platforms:
+        platforms = list(PLATFORMS.keys())
+    else:
+        # Use platforms declared in spec.resources.platforms; fall back to DEFAULT_PLATFORM
+        spec_platforms = list((spec.get("resources") or {}).get("platforms") or {})
+        platforms = spec_platforms if spec_platforms else [DEFAULT_PLATFORM]
+
+    expects = spec.get("expects") or []
+    print("=== Inputs ===")
+    print(f"  output_dir   : {output_root}")
+    print(f"  skill_dir    : {skill_dir}")
+    print(f"  spec         : {spec_path}")
+    print(f"  spec_stem    : {spec_stem}")
+    print(f"  profile      : {spec.get('profile', 'search')}")
+    print(f"  platforms    : {platforms}")
+    print(f"  queries      : {len(expects)}")
+    print(f"  total checks : {sum(len(q.get('checks') or []) for q in expects)}")
+    print()
+
+    for platform in platforms:
+        # Determine modes from spec
+        spec_modes = list(
+            ((spec.get("resources") or {}).get("platforms") or {})
+            .get(platform, {})
+            .get("modes") or ["remote-all"]
+        )
+        for mode in spec_modes:
+            pshort = PLATFORMS[platform]["short_name"]
+            print(f"  GEN  video-search/{spec_stem}/{pshort}-{mode}")
+            generate_task(platform, spec, output_root, skill_dir,
+                          deploy_skill_dir, spec_stem, mode)
+
+    print()
+    print(f"Generated tasks under {output_root}/{spec_stem}/")
+    print()
+    print("Note: these tasks assume VSS search profile is already deployed on the")
+    print("target Brev instance. The coordinator is responsible for injecting a")
+    print("matching deploy task ahead of each video-search task.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skill-eval/adapters/video-summarization/__init__.py
+++ b/.github/skill-eval/adapters/video-summarization/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/.github/skill-eval/adapters/video-summarization/generate.py
+++ b/.github/skill-eval/adapters/video-summarization/generate.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the video-summarization skill.
+
+The video-summarization skill exercises the Long Video Summarization (LVS)
+microservice and the VLM NIM directly. It requires a **full-remote deployed
+VSS lvs profile** (deploy mode = `remote-all`). The coordinator chains a
+deploy task ahead of each trial.
+
+## Directory layout
+
+    datasets/video-summarization/<spec_stem>/<platform>-<mode>/
+        step-1/  step-2/  ...   (one per entry in spec["expects"])
+            task.toml
+            instruction.md
+            tests/test.sh
+            tests/generic_judge.py
+            tests/<spec_stem>.json
+            solution/solve.sh
+            skills/video-summarization/   (full skill copy)
+            skills/deploy/                (for agent diagnostics)
+            environment/Dockerfile
+
+Usage:
+    python3 generate.py --output-dir ../../datasets/video-summarization \\
+        --skill-dir ../../../../../skills/video-summarization \\
+        --deploy-skill-dir ../../../../../skills/deploy \\
+        --spec ../../../../../skills/video-summarization/eval/lvs_profile_summarize.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Preamble — required in every instruction.md so the agent's skill prereq
+# bypass clause fires and the agent doesn't stall waiting for confirmation.
+# ---------------------------------------------------------------------------
+
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness.\n"
+    "You are pre-authorized to deploy prerequisites autonomously —\n"
+    "do not pause to ask for confirmation on `/deploy` or any other\n"
+    "setup action the trial requires.\n"
+)
+
+# ---------------------------------------------------------------------------
+# Platforms
+# ---------------------------------------------------------------------------
+
+PLATFORMS: dict[str, dict] = {
+    "H100":         {"short_name": "h100",         "gpu_type": "H100",         "min_vram_per_gpu": 80,  "brev_search": "H100"},
+    "L40S":         {"short_name": "l40s",         "gpu_type": "L40S",         "min_vram_per_gpu": 48,  "brev_search": "L40S"},
+    "RTXPRO6000BW": {"short_name": "rtxpro6000bw", "gpu_type": "RTX PRO 6000", "min_vram_per_gpu": 96,  "brev_search": "RTX PRO"},
+    "DGX-SPARK":    {"short_name": "spark",        "gpu_type": "GB10",         "min_vram_per_gpu": 96,  "brev_search": "GB10"},
+    "IGX-THOR":     {"short_name": "thor",         "gpu_type": "Thor",         "min_vram_per_gpu": 64,  "brev_search": "Thor"},
+}
+
+DEFAULT_PLATFORM = "L40S"
+
+GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_judge.py"
+
+
+# ---------------------------------------------------------------------------
+# Script generators
+# ---------------------------------------------------------------------------
+
+def generate_test_script(step: int, spec_name: str) -> str:
+    """Shell wrapper that invokes the generic LLM-as-judge verifier."""
+    return (
+        "#!/bin/bash\n"
+        f"# video-summarization verifier (step {step}): delegates to the generic\n"
+        "# LLM-as-judge (tools/eval/harbor/verifiers/generic_judge.py).\n"
+        "set -uo pipefail\n"
+        "\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        "python3 -m pip install --quiet 'anthropic>=0.40.0' >/dev/null 2>&1 || true\n"
+        "\n"
+        'python3 "$TEST_DIR/generic_judge.py" \\\n'
+        f'    --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def generate_solve_script(platform: str, profile: str) -> str:
+    """Gold solution — asserts the LVS + VST stack is live."""
+    return (
+        "#!/bin/bash\n"
+        f"# Gold solution: video-summarization ({profile} profile) on {platform}\n"
+        "# The verifier drives the summarization queries directly — the solution\n"
+        "# script just asserts the required endpoints are live.\n"
+        "set -euo pipefail\n"
+        "\n"
+        "curl -sf --connect-timeout 5 http://localhost:8000/docs >/dev/null || {\n"
+        "    echo 'VSS Agent API is not reachable — cannot solve video-summarization task'\n"
+        "    exit 1\n"
+        "}\n"
+        "curl -sf --connect-timeout 5 http://localhost:38111/v1/ready >/dev/null || {\n"
+        "    echo 'LVS microservice is not reachable — cannot solve video-summarization task'\n"
+        "    exit 1\n"
+        "}\n"
+        "echo 'VSS lvs stack is live — verifier will drive the queries.'\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task generation
+# ---------------------------------------------------------------------------
+
+def generate_task(platform: str, spec: dict, output_root: Path,
+                  skill_dir: Path, deploy_skill_dir: Path | None,
+                  spec_stem: str, mode: str) -> None:
+    """Emit one Harbor task directory per entry in spec['expects'] — i.e.
+    step-<k>/ subdirs under `<spec_stem>/<platform_short>-<mode>/`."""
+    pspec = PLATFORMS[platform]
+    platform_short = pspec["short_name"]
+    expects = spec.get("expects") or []
+    spec_name = f"{spec_stem}.json"
+    profile = spec.get("profile", "lvs")
+    deploy_mode = spec.get("deploy_mode", "remote-all")
+
+    task_dir_root = output_root / spec_stem / f"{platform_short}-{mode}"
+
+    for idx, expect in enumerate(expects, 1):
+        step_dir = task_dir_root
+        if len(expects) > 1:
+            step_dir = task_dir_root / f"step-{idx}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+
+        # instruction.md — begins with PREAMBLE, then step query + env notes
+        step_label = f"step {idx}/{len(expects)}: " if len(expects) > 1 else ""
+        lines = [
+            PREAMBLE,
+            f"Use the `/video-summarization` skill against the VSS **{profile}** profile "
+            f"already running on this `{platform}` host "
+            "(VSS agent must be reachable at `http://localhost:8000/docs` "
+            "and the LVS microservice at `http://localhost:38111/v1/ready`).",
+            "",
+            f"## {step_label}Query",
+            "",
+            expect.get("query", ""),
+            "",
+            "## Environment notes",
+            "",
+            spec.get("env", ""),
+            "",
+        ]
+        (step_dir / "instruction.md").write_text("\n".join(lines) + "\n")
+
+        # task.toml
+        step_suffix_id = f"-step-{idx}" if len(expects) > 1 else ""
+        meta_lines = [
+            "[task]",
+            f'name = "nvidia-vss/video-summarization-{spec_stem}-{platform_short}-{mode}{step_suffix_id}"',
+            f'description = "video-summarization {spec_stem} query {idx}/{len(expects)} on {platform}/{mode}"',
+            f'keywords = ["video-summarization", "{spec_stem}", "{platform}", "{mode}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[verifier.env]",
+            'ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"',
+            'ANTHROPIC_BASE_URL = "${ANTHROPIC_BASE_URL}"',
+            'JUDGE_MODEL = "${JUDGE_MODEL:-claude-haiku-4-5}"',
+            "",
+            "[metadata]",
+            'skill = "video-summarization"',
+            f'profile = "{profile}"',
+            f'platform = "{platform}"',
+            f'gpu_type = "{pspec["gpu_type"]}"',
+            f'brev_search = "{pspec["brev_search"]}"',
+            f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
+            "requires_deployed_vss = true",
+            f'prerequisite_deploy_mode = "{deploy_mode}"',
+            f"step_index = {idx}",
+            f"step_count = {len(expects)}",
+            f"check_count = {len(expect.get('checks') or [])}",
+            "",
+        ]
+        (step_dir / "task.toml").write_text("\n".join(meta_lines))
+
+        # environment/
+        env_dir = step_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+        # tests/
+        tests_dir = step_dir / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
+        if GENERIC_JUDGE.exists():
+            shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
+        spec_src = skill_dir / "eval" / spec_name
+        if spec_src.exists():
+            shutil.copy(spec_src, tests_dir / spec_name)
+        else:
+            (tests_dir / spec_name).write_text(json.dumps(spec, indent=2))
+
+        # solution/
+        solution_dir = step_dir / "solution"
+        solution_dir.mkdir(exist_ok=True)
+        (solution_dir / "solve.sh").write_text(generate_solve_script(platform, profile))
+
+        # skills/
+        for src, name in ((skill_dir, "video-summarization"), (deploy_skill_dir, "deploy")):
+            if src and src.exists():
+                dst = step_dir / "skills" / name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--output-dir", required=True,
+                        help="Dataset output root (e.g. .github/skill-eval/datasets/video-summarization)")
+    parser.add_argument("--skill-dir", required=True,
+                        help="Path to skills/video-summarization")
+    parser.add_argument("--deploy-skill-dir", default=None,
+                        help="Path to skills/deploy (optional — included for agent debug)")
+    parser.add_argument("--spec", default=None,
+                        help="Path to eval spec JSON (default: <skill-dir>/eval/lvs_profile_summarize.json)")
+    parser.add_argument("--platform", default=None, choices=list(PLATFORMS.keys()),
+                        help=f"Generate for this platform only (default: {DEFAULT_PLATFORM})")
+    parser.add_argument("--all-platforms", action="store_true",
+                        help="Fan out across every platform in PLATFORMS")
+    args = parser.parse_args()
+
+    output_root = Path(args.output_dir)
+    skill_dir = Path(args.skill_dir)
+    deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
+
+    spec_path = (
+        Path(args.spec) if args.spec
+        else (skill_dir / "eval" / "lvs_profile_summarize.json")
+    )
+    if not spec_path.exists():
+        print(f"spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+
+    spec = json.loads(spec_path.read_text())
+    spec_stem = spec_path.stem
+
+    if args.platform:
+        platforms = [args.platform]
+    elif args.all_platforms:
+        platforms = list(PLATFORMS.keys())
+    else:
+        # Use platforms declared in spec.resources.platforms; fall back to DEFAULT_PLATFORM
+        spec_platforms = list((spec.get("resources") or {}).get("platforms") or {})
+        platforms = spec_platforms if spec_platforms else [DEFAULT_PLATFORM]
+
+    expects = spec.get("expects") or []
+    print("=== Inputs ===")
+    print(f"  output_dir   : {output_root}")
+    print(f"  skill_dir    : {skill_dir}")
+    print(f"  spec         : {spec_path}")
+    print(f"  spec_stem    : {spec_stem}")
+    print(f"  profile      : {spec.get('profile', 'lvs')}")
+    print(f"  platforms    : {platforms}")
+    print(f"  queries      : {len(expects)}")
+    print(f"  total checks : {sum(len(q.get('checks') or []) for q in expects)}")
+    print()
+
+    for platform in platforms:
+        # Determine modes from spec
+        spec_modes = list(
+            ((spec.get("resources") or {}).get("platforms") or {})
+            .get(platform, {})
+            .get("modes") or ["remote-all"]
+        )
+        for mode in spec_modes:
+            pshort = PLATFORMS[platform]["short_name"]
+            print(f"  GEN  video-summarization/{spec_stem}/{pshort}-{mode}")
+            generate_task(platform, spec, output_root, skill_dir,
+                          deploy_skill_dir, spec_stem, mode)
+
+    print()
+    print(f"Generated tasks under {output_root}/{spec_stem}/")
+    print()
+    print("Note: these tasks assume VSS lvs profile is already deployed on the")
+    print("target Brev instance. The coordinator is responsible for injecting a")
+    print("matching deploy task ahead of each video-summarization task.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,54 @@
+# VSS Skills
+
+Skills for working with NVIDIA Video Search & Summarization (VSS). Each subdirectory under `skills/` is a self-contained skill following the [agentskills.io](https://agentskills.io/specification) specification, with `name`, `description`, `version`, and `license` declared in its `SKILL.md` frontmatter.
+
+## Catalog
+
+| Skill | Description |
+|---|---|
+| [alerts](alerts/SKILL.md) | Skill to add, manage, and monitor alerts on streamed video. |
+| [deploy](deploy/SKILL.md) | Skills to deploy, debug, or tear down any VSS profile using a docker compose-centric workflow. |
+| [report](report/SKILL.md) | Skill to produce video analysis reports by querying the VSS agent's `/generate` endpoint. |
+| [video-analytics](video-analytics/SKILL.md) | Skill for querying video analytics data and metrics from Elasticsearch via the VA-MCP server. |
+| [video-search](video-search/SKILL.md) | Skills for searching video archives using natural language, multi-embedding fusion, and VLM critique. |
+| [video-summarization](video-summarization/SKILL.md) | Skill for summarizing a video through chunking, dense captioning, and aggregation functions using the Long Video Summarization (LVS) microservice. |
+| [video-understanding](video-understanding/SKILL.md) | Skill for using video understanding tool to answer text questions about video content using a VLM. |
+| [vios](vios/SKILL.md) | Skill for video and stream management, recording timelines, clip extraction, snapshots (and more) using the Video IO and Storage microservices. |
+
+Skills with `eval/*.json` specs are exercised automatically by the Skills Eval CI workflow on every PR that touches `skills/**` — see [`.github/skill-eval/AGENTS.md`](../.github/skill-eval/AGENTS.md) for harness behavior.
+
+## Install (recommended: ask your coding agent)
+
+Open this repository in your coding agent (Claude Code, Codex, Cursor, or any other agentskills.io-compatible host) and paste the following prompt:
+
+> Read `skills/README.md` and every `SKILL.md` file under `skills/`. For each skill in the catalog, install it for this host so I can invoke it from a shell or chat session. Use the host's standard skills directory:
+>
+> - Claude Code: `~/.claude/skills/<name>/`
+> - Codex: `~/.codex/skills/<name>/`
+> - Hosts that follow the agentskills.io universal path: `~/.agents/skills/<name>/`
+>
+> Symlink each skill folder rather than copying it so a `git pull` here keeps every install up to date. Skip skills that are already installed and pointing at this checkout. When you're done, list the skills you registered and which directory you used.
+
+The agent will read the frontmatter of each `SKILL.md`, create the symlinks, and confirm what's installed. The skills become invokable in the next agent session.
+
+### Single-skill install
+
+To install skills individually, paste the following prompt:
+
+> Install only `skills/<name>/` for this host the same way.
+
+### Update
+
+After `git pull`, the symlinks already point at the updated content — nothing to do unless skills were added or renamed. To pick up new skills use the following prompt:
+
+> Re-read `skills/README.md` and add any new skills missing from this host's skills directory.
+
+### Uninstall
+
+To uninstall skills, paste the following prompt:
+
+> Remove every VSS skill symlink you previously created under this host's skills directory.
+
+## Source of truth
+
+This `skills/` directory is the canonical source. Skills published to the public catalog at `github.com/nvidia/skills` are mirrored from here at sync time per [`components.yml`](https://github.com/NVIDIA/skills/blob/main/components.yml).

--- a/skills/alerts/SKILL.md
+++ b/skills/alerts/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: alerts
 description: Manage and monitor VSS alerts after the alerts profile is deployed. The deployment's mode (CV vs VLM real-time) is fixed at deploy time and determines the workflow — start/stop real-time alerts via the VSS Agent on a VLM deployment, onboard CV alerts by adding RTSP streams to VIOS on a CV deployment, query incidents, customize verifier prompts. Use when asked to start/stop a real-time alert, check or list alerts, add a camera, customize alert prompts, or view verdicts.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # VSS Alert Management

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: deploy
 description: Load when the user says "configure vss", "deploy vss", "deploy <profile>", "debug deploy", "verify deployment", or "why is my vss deploy broken".
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint deployment"
 ---
 
 # VSS Deploy

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: report
 description: Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as the standard Video Analysis Report markdown.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # Report

--- a/skills/video-analytics/SKILL.md
+++ b/skills/video-analytics/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: video-analytics
 description: Query video analytics data and metrics from Elastic search via the VA-MCP server (port 9901). This includes incidents, alerts, sensor data, and metrics. Use for any question about violations, alerts, incidents, object counts, speeds, occupancy, or anything that requires looking up recorded events. This is the primary way to answer a question that requires incidents, alerts and other metrics such as people counts and violations.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # Video Analytics (VA-MCP)

--- a/skills/video-search/SKILL.md
+++ b/skills/video-search/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: video-search
 description: Search video archives using natural language — find events, objects, actions, and people across recorded video using fusion search (Cosmos Embed1 semantic search + CV attribute search). Use when asked to search for something in video, find actions and events, locate objects and people, or query video archives. For these types of questions, default to this top-level fusion search unless user specifies otherwise. Requires the search profile to be deployed.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # Video Search Workflows

--- a/skills/video-summarization/SKILL.md
+++ b/skills/video-summarization/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: video-summarization
 description: Summarize a video by calling the VLM NIM or the Long Video Summarization (LVS) microservice directly. For short videos (<60s) call the VLM's OpenAI-compatible chat completions endpoint; for long videos (>=60s) call the LVS microservice. Use when asked to summarize a video, describe what happens in a video, or analyze a recording.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 You are a video summarization assistant. You call the VLM NIM or the LVS

--- a/skills/video-understanding/SKILL.md
+++ b/skills/video-understanding/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: video-understanding
 description: Call the vss agent to run video understanding on video to answer a text question. Use when the user asks about video content, or about visual details that cannot be answered from conversation history, search hits, or metadata alone.
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 # Video QnA using VLM through VSS Agent

--- a/skills/vios/SKILL.md
+++ b/skills/vios/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: vios
 description: "Query VIOS REST APIs: sensor list, recording timelines, video clip extraction, snapshot capture, add/delete sensors and streams"
-version: "3.2.0"
-license: "Apache License 2.0"
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational"
 ---
 
 You are a VIOS API assistant. Interact with the VIOS microservice to manage cameras/sensors, RTSP streams, recordings, snapshots, and storage. Use when asked to: add a camera, add an RTSP stream, list sensors, show configured sensors/cameras/streams, check stream status, get a snapshot, download a clip, upload a video file, or manage video storage. Always query the VIOS API directly using curl — do not navigate the UI.


### PR DESCRIPTION
## skill-eval: adapters for `video-search` and `video-summarization` (PR #366)

This bot PR was automatically generated by the skills-eval CI agent to unblock eval of PR #366 (`feat/skills-metadata-develop`).

### Trigger

**Missing adapters** — neither `.github/skill-eval/adapters/video-search/generate.py` nor `.github/skill-eval/adapters/video-summarization/generate.py` existed on the mirror head of PR #366. Two skills with eval specs (`skills/video-search/eval/search.json` and `skills/video-summarization/eval/lvs_profile_summarize.json`) require adapters to run harbor trials.

### What was added

| Adapter | Skill | Spec | Profile | Platform |
|---|---|---|---|---|
| `.github/skill-eval/adapters/video-search/generate.py` | `video-search` | `search.json` | `search` | L40S / remote-all |
| `.github/skill-eval/adapters/video-summarization/generate.py` | `video-summarization` | `lvs_profile_summarize.json` | `lvs` | L40S / remote-all |

Both adapters:
- Follow the `vios` step-chain pattern (one step dir per `expects` entry)
- Read `profile` and `deploy_mode` from the spec JSON (not hardcoded)
- Begin every `instruction.md` with the required `PREAMBLE` constant so the agent's prereq bypass clause fires in CI

### No eval ran in this CI invocation

**No eval ran in this CI invocation** — merge into `feat/skills-metadata-develop` and the eval will re-run automatically on the next mirror sync.

### Verification

To verify locally:
```bash
python3 .github/skill-eval/adapters/video-search/generate.py \
  --output-dir /tmp/datasets/video-search \
  --skill-dir skills/video-search \
  --deploy-skill-dir skills/deploy

python3 .github/skill-eval/adapters/video-summarization/generate.py \
  --output-dir /tmp/datasets/video-summarization \
  --skill-dir skills/video-summarization \
  --deploy-skill-dir skills/deploy
```

Source PR: #366
