### PR TITLE
helm: sync chart with deploy/docker changes (PR #375)

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -28,6 +28,8 @@ general:
       # `disabled` is a non-empty placeholder that satisfies the boot-time must be set guard.
       rtvi_embed_base_url: disabled
       rtvi_cv_base_url: disabled
+      # Nemotron Omni: set VST_DISABLE_AUDIO=false so post-upload transcoding preserves audio.
+      disable_audio: ${VST_DISABLE_AUDIO:-true}
     endpoints:
     - path: /api/v1/videos
       method: POST
@@ -116,6 +118,8 @@ functions:
     num_frames_per_chunk: 20  # Sample 20 frames per chunk
     vlm_input_width: 1280
     vlm_input_height: 720
+    # Nemotron Nano Omni: set ENABLE_AUDIO=true on the vss-agent container to forward audio to the VLM.
+    enable_audio: ${ENABLE_AUDIO:-false}
     # HITL Templates (shown each for each query to the user during interaction)
     hitl_scenario_template: |
       Scenario (REQUIRED):
@@ -169,6 +173,8 @@ functions:
     chunk_duration: 10
     vlm_input_width: 1280
     vlm_input_height: 720
+    # Nemotron Nano Omni: set ENABLE_AUDIO=true on the vss-agent container to forward audio to the VLM.
+    enable_audio: ${ENABLE_AUDIO:-false}
     hitl_scenario_template: |
       Scenario (REQUIRED):
       Please provide a scenario description for the stream analysis.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -282,6 +282,12 @@ agent:
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
         value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-55f5cd1d7a59" }}'
+      # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
+      # Set ENABLE_AUDIO=true and VST_DISABLE_AUDIO=false for Nemotron Nano Omni audio-aware VLM.
+      - name: ENABLE_AUDIO
+        value: "false"
+      - name: VST_DISABLE_AUDIO
+        value: "true"
 vss-agent-ui:
   enabled: true
   # NEXT_PUBLIC_* defaults aligned with dev-profile-base; LVS deltas: subtitle + dashboard tab.

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -187,6 +187,12 @@ env:
   value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
 - name: VSS_AGENT_VERSION
   value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-55f5cd1d7a59" }}'
+# Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
+# Set ENABLE_AUDIO=true and VST_DISABLE_AUDIO=false for Nemotron Nano Omni audio-aware VLM.
+- name: ENABLE_AUDIO
+  value: "false"
+- name: VST_DISABLE_AUDIO
+  value: "true"
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Mirror the Nemotron Nano Omni audio-aware VLM plumbing from #375 into the helm charts so compose and helm stay at parity:

- deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml: add disable_audio (streaming_ingest) and enable_audio (lvs_video_understanding, lvs_config_media) to match the docker-side vss-agent config.
- deploy/helm/services/agent/charts/agent/values.yaml and deploy/helm/developer-profiles/dev-profile-lvs/values.yaml: add ENABLE_AUDIO and VST_DISABLE_AUDIO to the vss-agent container env list (the LVS profile overrides the subchart env, so both need the entries) to match deploy/docker/services/agent/compose.yml.

rtvi-vlm (VLM_MODEL_SUPPORTS_AUDIO, VLM_TRUST_REMOTE_CODE) and video-summarization (ENABLE_AUDIO) were already synced.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
