### PR TITLE
feat: add lianqiann to copy-pr-bot vetters

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -16,6 +16,7 @@ additional_vetters:
   - huyprowow
   - jiayin-nvidia
   - kaushikc-nvidia
+  - lianqiann
   - liamy-nv
   - mansiigo
   - munjalp6


### PR DESCRIPTION
## Summary

Add `lianqiann` to `additional_vetters` in `.github/copy-pr-bot.yaml` so they can approve external PRs for CI.

## Test plan

- [x] YAML parse succeeded
- [x] `git diff --check` passed