### PR TITLE
helm: sync rtvi-vlm image tag with deploy/docker changes (PR #375)

### DIFF
--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/values.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/values.yaml
@@ -19,7 +19,7 @@ global: {}
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-rt-vlm
-  tag: "3.2.0-26.04.3"
+  tag: "3.2.0-26.05.1"
   pullPolicy: IfNotPresent
 replicas: 1
 


### PR DESCRIPTION
PR #375 bumps RTVI_VLM_IMAGE_TAG in dev-profile-lvs/.env from 3.2.0-26.04.1 to 3.2.0-26.05.1, but leaves the helm chart at 3.2.0-26.04.3. Mirror the docker bump in helm so the rtvi-vlm chart pulls the same Cosmos-Reason2 image as the LVS docker profile.

Note: docker (.env) and helm (image.tag) were already on different patch versions before PR #375 (.04.1 vs .04.3), so the contributor may want to pick a different patch on the .05 line.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
