### PR TITLE
skill-eval/deploy: drop mode from spec — declare gpu_count directly

### DIFF
--- a/.github/skill-eval/adapters/deploy/generate.py
+++ b/.github/skill-eval/adapters/deploy/generate.py
@@ -565,8 +565,16 @@ def generate_task(
     skill_dir: Path | None,
     llm_remote: dict | None,
     vlm_remote: dict | None,
+    gpu_count_override: int | None = None,
 ) -> None:
-    """Write a single Harbor task directory for <profile>/<platform>-<mode>."""
+    """Write a single Harbor task directory for <profile>/<platform>-<mode>.
+
+    `gpu_count_override` (when not None) is written verbatim to task.toml's
+    `gpu_count` field, bypassing the mode-derived calculation
+    (`MODES[mode].gpus_needed + PROFILES[profile].local_extras`). Spec
+    authors use this to express "this profile needs an N-GPU box" without
+    leaking mode-selection vocabulary into the spec layer.
+    """
     platform_spec = PLATFORMS[platform]
     mode_spec = effective_mode_spec(platform, mode)
 
@@ -598,7 +606,11 @@ def generate_task(
         "# GPU requirements — BrevEnvironment checks these against the",
         "# instance's actual GPU capacity before the trial runs.",
         f'gpu_type = "{platform_spec["gpu_type"]}"',
-        f'gpu_count = {mode_spec["gpus_needed"] + profile_def.get("local_extras", 0)}',
+        (
+            f'gpu_count = {gpu_count_override}'
+            if gpu_count_override is not None
+            else f'gpu_count = {mode_spec["gpus_needed"] + profile_def.get("local_extras", 0)}'
+        ),
         f'min_vram_gb_per_gpu = {platform_spec["min_vram_per_gpu"]}',
         f'brev_search = "{platform_spec["brev_search"]}"',
         "# Disk + driver requirements — BrevEnvironment validates both via",
@@ -694,11 +706,17 @@ def _mode_needs_local_nim(mode_spec: dict) -> bool:
     return mode_spec["llm_mode"] != "remote" or mode_spec["vlm_mode"] != "remote"
 
 
-def _spec_platforms_for(profile: str, skill_dir: Path | None) -> dict[str, list[str]] | None:
+def _spec_platforms_for(profile: str, skill_dir: Path | None) -> dict[str, dict] | None:
     """If the skill's `eval/<profile>.json` declares `resources.platforms`,
-    return {platform: [modes...]}. Else return None (adapter falls back to
-    PLATFORMS defaults below). Gives the spec author control over which
-    platforms/modes to exercise — e.g. `alerts_cv` only on 2-GPU hosts."""
+    return {platform: {"modes": [...], "gpu_count": int | None}}. Else
+    return None (adapter falls back to PLATFORMS defaults below).
+
+    Spec authors can:
+      - declare `modes: [...]` to enumerate LLM/VLM placements to test, or
+      - omit `modes` and declare `gpu_count: N` to test a single
+        platform-shape variant (the adapter picks an internal default mode;
+        only alerts profiles surface a `-m <variant>` flag via PROFILES).
+    """
     if skill_dir is None:
         return None
     spec_path = skill_dir / "eval" / f"{profile}.json"
@@ -711,7 +729,22 @@ def _spec_platforms_for(profile: str, skill_dir: Path | None) -> dict[str, list[
     resources = (spec.get("resources") or {}).get("platforms")
     if not isinstance(resources, dict) or not resources:
         return None
-    return {p: list((v or {}).get("modes") or []) for p, v in resources.items()}
+    out: dict[str, dict] = {}
+    for p, v in resources.items():
+        v = v or {}
+        modes = list(v.get("modes") or [])
+        # No modes declared → single internal iteration. "remote-all" is the
+        # one mode every profile supports (LLM/VLM both remote) so it's the
+        # safe default; spec author isn't asserting LLM placement, they only
+        # care about platform × gpu_count.
+        if not modes:
+            modes = ["remote-all"]
+        gpu_count = v.get("gpu_count")
+        out[p] = {
+            "modes": modes,
+            "gpu_count": int(gpu_count) if gpu_count is not None else None,
+        }
+    return out
 
 
 def expand_matrix(
@@ -722,16 +755,18 @@ def expand_matrix(
     have_vlm_remote: bool,
     have_ngc_key: bool,
     skill_dir: Path | None = None,
-) -> tuple[list[tuple[str, str, str]], list[tuple[str, str, str, str]]]:
+) -> tuple[list[tuple[str, str, str, int | None]], list[tuple[str, str, str, str]]]:
     """Return (included, skipped) where:
-        included = list of (profile, platform, mode) that will be generated
-        skipped  = list of (profile, platform, mode, reason)
+        included = list of (profile, platform, mode, gpu_count_override) tuples
+                   gpu_count_override is None unless the spec declared a value
+                   that should override the mode-derived calculation.
+        skipped  = list of (profile, platform, mode, reason) tuples
     For each profile, the platform × mode matrix comes from:
       - `spec.resources.platforms` if declared in `skills/deploy/eval/<profile>.json`
       - otherwise falls back to the full PLATFORMS × supported_modes defaults
     Also filters: --profile/--platform/--mode CLI, remote URL availability for
     modes that need them, and NGC_CLI_API_KEY for modes that pull local NIMs."""
-    included: list[tuple[str, str, str]] = []
+    included: list[tuple[str, str, str, int | None]] = []
     skipped: list[tuple[str, str, str, str]] = []
     for profile in PROFILES:
         if profile_filter and profile != profile_filter:
@@ -740,20 +775,21 @@ def expand_matrix(
         # Prefer the spec's own declaration; fall back to the adapter defaults.
         spec_matrix = _spec_platforms_for(profile, skill_dir)
         if spec_matrix is not None:
-            platform_modes = spec_matrix
+            platform_entries = spec_matrix
         else:
-            platform_modes = {
-                p: list(pspec["supported_modes"])
+            platform_entries = {
+                p: {"modes": list(pspec["supported_modes"]), "gpu_count": None}
                 for p, pspec in PLATFORMS.items()
             }
 
-        for platform, modes in platform_modes.items():
+        for platform, pinfo in platform_entries.items():
             if platform_filter and platform != platform_filter:
                 continue
             if platform not in PLATFORMS:
                 skipped.append((profile, platform, "-", f"unknown platform {platform!r}"))
                 continue
-            for mode in modes:
+            gpu_count_override = pinfo["gpu_count"]
+            for mode in pinfo["modes"]:
                 if mode_filter and mode != mode_filter:
                     continue
                 if mode not in MODES:
@@ -770,7 +806,7 @@ def expand_matrix(
                 if reason:
                     skipped.append((profile, platform, mode, reason))
                 else:
-                    included.append((profile, platform, mode))
+                    included.append((profile, platform, mode, gpu_count_override))
     return included, skipped
 
 
@@ -890,13 +926,15 @@ def main() -> None:
 
     # --- Generate ---
     print(f"=== Generating ({len(included)}) ===")
-    for profile, platform, mode in included:
+    for profile, platform, mode, gpu_count_override in included:
         task_id = make_task_id(platform, mode)
-        print(f"  GEN  {profile}/{task_id}")
+        suffix = f" (gpu_count={gpu_count_override} from spec)" if gpu_count_override is not None else ""
+        print(f"  GEN  {profile}/{task_id}{suffix}")
         generate_task(
             profile, platform, mode,
             PROFILES[profile], output_root, skill_dir,
             llm_remote, vlm_remote,
+            gpu_count_override=gpu_count_override,
         )
 
     print()
@@ -904,7 +942,7 @@ def main() -> None:
     print()
     print("Coverage:")
     by_profile: dict[str, list[str]] = {}
-    for p, plat, m in included:
+    for p, plat, m, _ in included:
         by_profile.setdefault(p, []).append(make_task_id(plat, m))
     for p, tasks in by_profile.items():
         print(f"  {p}: {', '.join(tasks)}")

--- a/skills/deploy/eval/alerts_cv.json
+++ b/skills/deploy/eval/alerts_cv.json
@@ -4,22 +4,20 @@
   ],
   "resources": {
     "platforms": {
-      "L40S": {
-        "modes": [
-          "remote-all"
-        ]
+      "RTXPRO6000BW": {
+        "gpu_count": 2
       }
     }
   },
-  "env": "Multi-GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must be set. The **alerts-verification (CV)** mode uses `deploy -m verification`: RT-CV perception generates candidate alerts upstream (one dedicated GPU), and the VLM reviews each candidate to reduce false positives. On H100/RTX-PRO-6000 two GPUs are enough (CV on GPU 0, shared LLM+VLM on GPU 1). On L40S 48GB \u00d7 2, LLM+VLM can't fit on one GPU, so only `remote-*` modes are supported. DGX-Spark (single GPU) can't run this mode at all. See `skills/deploy/references/alerts.md` \u00a7 *Two Modes*.",
+  "env": "Multi-GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. Remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`/`LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL`) may also be set. The **alerts-verification (CV)** mode (`deploy -m verification`) runs RT-CV perception locally on one dedicated GPU to generate candidate alerts upstream, and the VLM reviews each candidate to reduce false positives. The adapter selects this variant for `alerts_cv` evaluations. See `skills/deploy/references/alerts.md` § *Two Modes*.",
   "expects": [
     {
-      "query": "Deploy the VSS **alerts** profile on {{platform}} in {{mode}} mode using `/deploy -m verification` (CV-driven alert generation with VLM-as-verifier). Run end-to-end and autonomously.",
+      "query": "Deploy the VSS **alerts** profile on {{platform}} for CV-driven alert generation with VLM-as-verifier. Run end-to-end and autonomously.",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0 (shared message bus)",
-        "`docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (RT-CV perception \u2014 the 'CV' in this mode)",
+        "`docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (RT-CV perception — the 'CV' in this mode)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (rule-based alert generation on CV output)",
         "`docker ps --format '{{.Names}}' | grep -qx alert-bridge` returns exit 0 (routes CV-generated alerts to VLM verifier)",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (video ingestion source)"

--- a/skills/deploy/eval/alerts_vlm.json
+++ b/skills/deploy/eval/alerts_vlm.json
@@ -4,22 +4,20 @@
   ],
   "resources": {
     "platforms": {
-      "L40S": {
-        "modes": [
-          "remote-all"
-        ]
+      "RTXPRO6000BW": {
+        "gpu_count": 2
       }
     }
   },
-  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must be set. The **alerts-real-time (VLM)** mode uses `deploy -m real-time`: the VLM continuously processes live video at periodic intervals, producing alerts directly without upstream CV filtering \u2014 broader coverage, higher GPU load. See `skills/deploy/references/alerts.md` \u00a7 *Two Modes*.",
+  "env": "Multi-GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. Remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`/`LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL`) may also be set. The **alerts-real-time (VLM)** mode (`deploy -m real-time`) runs `rtvi-vlm` locally — a continuous VLM inference loop that processes live video and emits alerts directly, with no upstream CV filtering. The adapter selects this variant for `alerts_vlm` evaluations. See `skills/deploy/references/alerts.md` § *Two Modes*.",
   "expects": [
     {
-      "query": "Deploy the VSS **alerts** profile on {{platform}} in {{mode}} mode using `/deploy -m real-time` (continuous VLM-driven alert generation). Run end-to-end and autonomously.",
+      "query": "Deploy the VSS **alerts** profile on {{platform}} for continuous VLM-driven alert generation. Run end-to-end and autonomously.",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0 (shared message bus)",
-        "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor \u2014 the 'VLM' in this mode)",
+        "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor — the 'VLM' in this mode)",
         "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (video ingestion source)",
         "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (real-time mode does NOT run the CV perception pipeline)"
       ]

--- a/skills/deploy/eval/base.json
+++ b/skills/deploy/eval/base.json
@@ -4,17 +4,15 @@
   ],
   "resources": {
     "platforms": {
-      "L40S": {
-        "modes": [
-          "remote-all"
-        ]
+      "RTXPRO6000BW": {
+        "gpu_count": 1
       }
     }
   },
-  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The `/deploy` skill is responsible for the full deploy workflow \u2014 this spec verifies the resulting state by probing the live stack, not the contents of any `.env` file.",
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. Remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`/`LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL`) may also be set. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack, not the contents of any `.env` file.",
   "expects": [
     {
-      "query": "Deploy the VSS **base** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",
+      "query": "Deploy the VSS **base** profile on {{platform}}, using the `/deploy` skill end-to-end and autonomously.",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",

--- a/skills/deploy/eval/lvs.json
+++ b/skills/deploy/eval/lvs.json
@@ -4,17 +4,15 @@
   ],
   "resources": {
     "platforms": {
-      "L40S": {
-        "modes": [
-          "remote-all"
-        ]
+      "RTXPRO6000BW": {
+        "gpu_count": 1
       }
     }
   },
-  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The LVS profile brings up the full long-video-summarization workflow (agent + UI + NIMs) on top of the base stack. The `/deploy` skill is responsible for the full deploy workflow \u2014 this spec verifies the resulting state by probing the live stack.",
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. Remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`/`LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL`) may also be set. The LVS profile brings up the full long-video-summarization workflow (agent + UI + NIMs) on top of the base stack. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack.",
   "expects": [
     {
-      "query": "Deploy the VSS **lvs** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",
+      "query": "Deploy the VSS **lvs** profile on {{platform}}, using the `/deploy` skill end-to-end and autonomously.",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",

--- a/skills/deploy/eval/search.json
+++ b/skills/deploy/eval/search.json
@@ -4,17 +4,15 @@
   ],
   "resources": {
     "platforms": {
-      "L40S": {
-        "modes": [
-          "remote-all"
-        ]
+      "RTXPRO6000BW": {
+        "gpu_count": 2
       }
     }
   },
-  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. For `remote-*` modes, the corresponding `LLM_REMOTE_URL`/`LLM_REMOTE_MODEL` and/or `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL` must also be set. On DGX-Spark/Thor shared mode, `HF_TOKEN` is required for the Edge 4B vLLM. The search profile adds Cosmos Embed1 semantic search on top of base. The `/deploy` skill is responsible for the full deploy workflow \u2014 this spec verifies the resulting state by probing the live stack.",
+  "env": "A GPU host matching `{{platform}}` with Docker + NVIDIA container toolkit + `NGC_CLI_API_KEY`. Remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`/`LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`/`VLM_REMOTE_MODEL`) may also be set. The search profile adds Cosmos Embed1 semantic search on top of base; Embed1 runs locally and requires a GPU regardless of LLM/VLM placement. The `/deploy` skill is responsible for the full deploy workflow — this spec verifies the resulting state by probing the live stack.",
   "expects": [
     {
-      "query": "Deploy the VSS **search** profile on {{platform}} in {{mode}} mode, using the `/deploy` skill end-to-end and autonomously.",
+      "query": "Deploy the VSS **search** profile on {{platform}}, using the `/deploy` skill end-to-end and autonomously.",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",


### PR DESCRIPTION
## Summary

Demotes `mode` (remote-all / shared / dedicated / remote-llm / remote-vlm) from a user-facing spec field to an adapter-internal detail, and lets spec authors declare resource shape directly via `gpu_count`.

## Before / after

```jsonc
// Before
"resources": {
  "platforms": {
    "L40S": { "modes": ["remote-all"] }
  }
}

// After
"resources": {
  "platforms": {
    "RTXPRO6000BW": { "gpu_count": 1 }
  }
}
```

## What changed

### Adapter — `.github/skill-eval/adapters/deploy/generate.py`
- `resources.platforms.<P>.gpu_count: N` is read directly and written to `task.toml`'s `gpu_count`, bypassing the `MODES[mode].gpus_needed + PROFILES[profile].local_extras` derivation.
- `modes: [...]` is now optional. Absent → adapter iterates once with internal default `remote-all`. Mode stops being user-facing for profiles without an alerts-style variant.
- `/deploy -m <X>` flag behavior unchanged: only emitted when `PROFILES[profile]["deploy_mode"]` is set (`alerts_cv` → `verification`, `alerts_vlm` → `real-time`).
- Existing specs with explicit `modes: [...]` keep working — back-compat preserved.

### Specs — `skills/deploy/eval/*.json` (all 5)
- `resources.platforms.<P>` carries `gpu_count` instead of `modes: [...]`.
- `env` prose no longer references mode names ("remote-all placement", "remote-* modes", "in shared mode", etc.).
- `expects[].query` no longer carries `{{mode}}` template.
- Verifier checks unchanged (no container-name changes — that's a separate concern; develop's alerts specs still carry the pre-PR-#135 names like `mdx-redis`, leaving those alone here).

## Final matrix

| Spec | Platform | `gpu_count` | Pool target |
|---|---|---|---|
| `base.json` | RTXPRO6000BW | 1 | `vss-eval-rtx-1g` |
| `lvs.json` | RTXPRO6000BW | 1 | `vss-eval-rtx-1g` |
| `search.json` | RTXPRO6000BW | 2 | `vss-eval-rtx-2g` |
| `alerts_cv.json` | RTXPRO6000BW | 2 | `vss-eval-rtx-2g` |
| `alerts_vlm.json` | RTXPRO6000BW | 2 | `vss-eval-rtx-2g` |

## Smoke test

```
$ python3 .github/skill-eval/adapters/deploy/generate.py --output-dir /tmp/x \
    --skill-dir skills/deploy --llm-remote-url ... --vlm-remote-url ... \
    --assume-ngc-key
...
=== Generating (5) ===
  GEN  base/rtxpro6000bw-remote-all (gpu_count=1 from spec)
  GEN  alerts_cv/rtxpro6000bw-remote-all (gpu_count=2 from spec)
  GEN  alerts_vlm/rtxpro6000bw-remote-all (gpu_count=2 from spec)
  GEN  lvs/rtxpro6000bw-remote-all (gpu_count=1 from spec)
  GEN  search/rtxpro6000bw-remote-all (gpu_count=2 from spec)
```

## Scheduling note (NOT in this PR)

Eval runs serially per push (one agent, one pool member at a time). With both pool members provisioned (`vss-eval-rtx-1g` + `vss-eval-rtx-2g`), the matcher correctly routes each spec to a same-gpu-count box, but the 5 trials still execute back-to-back, not concurrently across the two boxes. True concurrent dispatch is a workflow-level / agent-architecture change — separate follow-up.

## Test plan

- [x] CI triggers on this PR
- [x] Agent picks `vss-eval-rtx-1g` for base/lvs trials, `vss-eval-rtx-2g` for search/alerts_*
- [x] Eval result comment lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)