### PR TITLE
fix: route stream vs uploaded video by `media_type` from `vst_video_list`

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -395,7 +395,9 @@ workflow:
       - If the response status is "not_configured", surface the response message VERBATIM to the user and STOP. Do NOT auto-call lvs_config_media — caption generation must be confirmed by the user first.
       - Examples: "Summarize stream CAM_1 from 0 to 45 seconds"
       **lvs_config_media** - Start LVS caption generation for a live stream (HITL collects scenario/events/objects).
-      - Use ONLY when the user explicitly asks to start caption generation for a stream. Trigger phrases include: "start summarizing the stream <name>", "start captioning <name>", "set up stream <name>", "configure stream <name>".
+      - Use ONLY when the user explicitly asks to start caption generation for a stream. Trigger phrases include: "start captioning <name>", "set up stream <name>", "configure stream <name>".
+      - "summarize <name>" or "summarize <name> from X to Y" is NOT a trigger — it must be routed by `media_type` from `vst_video_list` to `lvs_stream_understanding` (stream) or `lvs_video_understanding` (video).
+      - "generate a report for <name>" or "generate a report for <name> from X to Y" is NOT a trigger — it must be routed to `report_agent`.
       - Do NOT call this tool just because a previous tool's response said the stream is "not configured" — surface that response to the user and wait for an explicit start request.
       - Do NOT call speculatively or as a pre-check.
       - After this tool returns, do NOT chain into lvs_stream_understanding/report_agent in the same turn — captions take time to accumulate. Tell the user captioning has started and to ask again later for a summary or report.
@@ -409,7 +411,7 @@ workflow:
       - CRITICAL: Always call vst_snapshot to get the URL even though the snapshot for the same video and at the same timestamp has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_snapshot.
     ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, you MUST identify its media_type before routing.
       - If you previously added/uploaded `<name>` in this conversation and know its type, use that.
-      - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='stream'` (live RTSP — route to lvs_stream_understanding / lvs_config_media) or `media_type='video'` (uploaded — route to lvs_video_understanding). Do NOT guess from the name; `sample_warehouse` etc. can be either.
+      - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='stream'` (live RTSP) or `media_type='video'` (uploaded) — use this to pick the right tool per the routing rules above. Do NOT guess from the name.
       - If `<name>` is not in `vst_video_list`, tell the user it isn't available and ask them to add or upload it.
     ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
 

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -407,7 +407,10 @@ workflow:
       - CRITICAL: Always call vst_video_clip to get the URL even though the video clip for the same video has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_video_clip.
       **vst_snapshot** - For queries asking for a snapshot of a video at a specific timestamp.
       - CRITICAL: Always call vst_snapshot to get the URL even though the snapshot for the same video and at the same timestamp has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_snapshot.
-    ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, treat it as a stream if the name contains "stream"/"cam"/"rtsp" or you previously added a stream by that name, treat it as an uploaded video if you previously uploaded/listed a video by that name, otherwise ask the user once.
+    ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, you MUST identify its media_type before routing.
+      - If you previously added/uploaded `<name>` in this conversation and know its type, use that.
+      - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='stream'` (live RTSP — route to lvs_stream_understanding / lvs_config_media) or `media_type='video'` (uploaded — route to lvs_video_understanding). Do NOT guess from the name; `sample_warehouse` etc. can be either.
+      - If `<name>` is not in `vst_video_list`, tell the user it isn't available and ask them to add or upload it.
     ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
 
 

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -396,7 +396,9 @@ workflow:
       - If the response status is "not_configured", surface the response message VERBATIM to the user and STOP. Do NOT auto-call lvs_config_media — caption generation must be confirmed by the user first.
       - Examples: "Summarize stream CAM_1 from 0 to 45 seconds"
       **lvs_config_media** - Start LVS caption generation for a live stream (HITL collects scenario/events/objects).
-      - Use ONLY when the user explicitly asks to start caption generation for a stream. Trigger phrases include: "start summarizing the stream <name>", "start captioning <name>", "set up stream <name>", "configure stream <name>".
+      - Use ONLY when the user explicitly asks to start caption generation for a stream. Trigger phrases include: "start captioning <name>", "set up stream <name>", "configure stream <name>".
+      - "summarize <name>" or "summarize <name> from X to Y" is NOT a trigger — it must be routed by `media_type` from `vst_video_list` to `lvs_stream_understanding` (stream) or `lvs_video_understanding` (video).
+      - "generate a report for <name>" or "generate a report for <name> from X to Y" is NOT a trigger — it must be routed to `report_agent`.
       - Do NOT call this tool just because a previous tool's response said the stream is "not configured" — surface that response to the user and wait for an explicit start request.
       - Do NOT call speculatively or as a pre-check.
       - After this tool returns, do NOT chain into lvs_stream_understanding/report_agent in the same turn — captions take time to accumulate. Tell the user captioning has started and to ask again later for a summary or report.
@@ -410,7 +412,7 @@ workflow:
       - CRITICAL: Always call vst_snapshot to get the URL even though the snapshot for the same video and at the same timestamp has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_snapshot.
     ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, you MUST identify its media_type before routing.
       - If you previously added/uploaded `<name>` in this conversation and know its type, use that.
-      - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='stream'` (live RTSP — route to lvs_stream_understanding / lvs_config_media) or `media_type='video'` (uploaded — route to lvs_video_understanding). Do NOT guess from the name; `sample_warehouse` etc. can be either.
+      - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='stream'` (live RTSP) or `media_type='video'` (uploaded) — use this to pick the right tool per the routing rules above. Do NOT guess from the name.
       - If `<name>` is not in `vst_video_list`, tell the user it isn't available and ask them to add or upload it.
     ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
 

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -408,7 +408,10 @@ workflow:
       - CRITICAL: Always call vst_video_clip to get the URL even though the video clip for the same video has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_video_clip.
       **vst_snapshot** - For queries asking for a snapshot of a video at a specific timestamp.
       - CRITICAL: Always call vst_snapshot to get the URL even though the snapshot for the same video and at the same timestamp has already been generated from previous interactions. DO NOT generate the URL yourself without calling vst_snapshot.
-    ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, treat it as a stream if the name contains "stream"/"cam"/"rtsp" or you previously added a stream by that name, treat it as an uploaded video if you previously uploaded/listed a video by that name, otherwise ask the user once.
+    ## Stream vs uploaded video: when a request mentions a `<name>` that could be either, you MUST identify its media_type before routing.
+      - If you previously added/uploaded `<name>` in this conversation and know its type, use that.
+      - Otherwise call `vst_video_list` and look up `<name>` in the result. Each entry has `media_type='stream'` (live RTSP — route to lvs_stream_understanding / lvs_config_media) or `media_type='video'` (uploaded — route to lvs_video_understanding). Do NOT guess from the name; `sample_warehouse` etc. can be either.
+      - If `<name>` is not in `vst_video_list`, tell the user it isn't available and ask them to add or upload it.
     ## Context: If user doesn't specify the video name, you should use the most recently uploaded video.
 
 

--- a/services/agent/src/vss_agents/agents/report_agent.py
+++ b/services/agent/src/vss_agents/agents/report_agent.py
@@ -754,7 +754,7 @@ async def report_agent(config: ReportAgentConfig, builder: Builder) -> AsyncGene
                 "For live streams (media_type='stream'): analyzes a configured stream over a "
                 "[start_time, end_time] window in seconds (use end_time=0 for 'until now'); requires a single "
                 "sensor_id (stream name). If the stream has no captions yet, the response will instruct the "
-                "user to confirm caption generation by saying 'start summarizing the stream <name>'. The "
+                "user to confirm caption generation by saying 'start captioning <name>'. The "
                 "caller MUST surface that message verbatim and STOP — do NOT auto-call lvs_config_media. "
                 "Returns AgentOutput with messages, side_effects (reports, URLs), and metadata."
             ),

--- a/services/agent/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/src/vss_agents/tools/lvs_config_media.py
@@ -278,10 +278,10 @@ async def lvs_config_media(config: LVSConfigMediaConfig, _: Builder) -> AsyncGen
         Set up a live stream for LVS caption generation.
 
         Trigger: call this tool ONLY when the user explicitly asks to start caption
-        generation for a stream (e.g. "start summarizing the stream <name>",
-        "start captioning <name>", "set up stream <name>"). Do NOT call this tool
-        speculatively or in response to another tool's "not_configured" message —
-        the user must confirm first.
+        generation for a stream (e.g. "start captioning <name>", "set up stream <name>",
+        "configure stream <name>"). Do NOT call this tool speculatively
+        or in response to another tool's "not_configured" message — the user must
+        confirm first.
 
         For streams, this tool resolves the stream in VST, collects scenario,
         events, and objects_of_interest through HITL, calls LVS

--- a/services/agent/src/vss_agents/tools/lvs_stream_understanding.py
+++ b/services/agent/src/vss_agents/tools/lvs_stream_understanding.py
@@ -171,7 +171,7 @@ async def lvs_stream_understanding(config: LVSStreamUnderstandingConfig, _: Buil
         generating captions. The agent MUST surface that message verbatim to the user
         and STOP — do NOT auto-call `lvs_config_media`. Caption generation is only
         triggered when the user explicitly replies with
-        "start summarizing the stream <stream_name>".
+        "start captioning <stream_name>".
         """
         configured = configured_media("stream", lvs_input.stream_name)
         if configured is None:
@@ -182,7 +182,7 @@ async def lvs_stream_understanding(config: LVSStreamUnderstandingConfig, _: Buil
                 message=(
                     f"There are no captions stored for stream '{lvs_input.stream_name}'. "
                     "Do you want me to start generating captions for the stream? "
-                    f'If yes, please reply with: "start summarizing the stream {lvs_input.stream_name}".'
+                    f'If yes, please reply with: "start captioning {lvs_input.stream_name}".'
                 ),
             )
 

--- a/services/agent/src/vss_agents/tools/vst/video_list.py
+++ b/services/agent/src/vss_agents/tools/vst/video_list.py
@@ -26,7 +26,8 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from vss_agents.tools.vst.timeline import get_timeline
-from vss_agents.tools.vst.utils import get_name_to_stream_id_map
+from vss_agents.tools.vst.utils import VSTError
+from vss_agents.tools.vst.utils import get_streams_info
 
 logger = logging.getLogger(__name__)
 
@@ -51,23 +52,38 @@ class VSTVideoListOutput(BaseModel):
 
     video_list: list[dict[str, str | float]] = Field(
         ...,
-        description="List of available video names and their durations",
+        description=(
+            "List of available media entries. Each entry has 'name' (str), "
+            "'media_type' ('stream' for live RTSP, 'video' for uploaded files), "
+            "and 'duration' (float seconds; 0 for streams with no captioned timeline yet)."
+        ),
     )
 
 
 @register_function(config_type=VSTVideoListConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def _vst_video_list(config: VSTVideoListConfig, _builder: Builder) -> AsyncGenerator[FunctionInfo]:
     async def _vst_video_list(vst_video_list_input: VSTVideoListInput) -> VSTVideoListOutput:  # noqa: ARG001
-        """Get the list of available video names from VST."""
-        name_to_stream_id = await get_name_to_stream_id_map(config.vst_internal_url)
+        """Get the list of available media (uploaded videos and live streams) from VST.
+
+        Each entry includes a `media_type` field: 'stream' for live RTSP sources,
+        'video' for uploaded files.
+        """
+        streams_info = await get_streams_info(config.vst_internal_url)
         output: list[dict[str, str | float]] = []
-        for name, stream_id in name_to_stream_id.items():
-            start_timestamp, end_timestamp = await get_timeline(stream_id, config.vst_internal_url)
-            duration = (
-                datetime.datetime.fromisoformat(end_timestamp.replace("Z", "+00:00"))
-                - datetime.datetime.fromisoformat(start_timestamp.replace("Z", "+00:00"))
-            ).total_seconds()
-            output.append({"name": name, "duration": duration})
+        for stream_id, info in streams_info.items():
+            name = info.get("name", "")
+            url = info.get("url", "")
+            media_type = "stream" if isinstance(url, str) and url.startswith("rtsp://") else "video"
+            try:
+                start_timestamp, end_timestamp = await get_timeline(stream_id, config.vst_internal_url)
+                duration = (
+                    datetime.datetime.fromisoformat(end_timestamp.replace("Z", "+00:00"))
+                    - datetime.datetime.fromisoformat(start_timestamp.replace("Z", "+00:00"))
+                ).total_seconds()
+            except VSTError:
+                # Live streams without a captioned timeline yet have no duration to report.
+                duration = 0.0
+            output.append({"name": name, "media_type": media_type, "duration": duration})
         return VSTVideoListOutput(video_list=output)
 
     yield FunctionInfo.create(

--- a/services/agent/tests/unit_test/tools/test_lvs_stream_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_lvs_stream_understanding.py
@@ -143,7 +143,7 @@ class TestLVSStreamUnderstandingInner:
         # start caption generation. The agent prompt requires this phrasing
         # so it surfaces verbatim and does NOT auto-call lvs_config_media.
         assert "no captions stored" in result.message.lower()
-        assert "start summarizing the stream CAM_1" in result.message
+        assert "start captioning CAM_1" in result.message
 
     @pytest.mark.asyncio
     async def test_configured_stream_calls_stream_summarize(self):

--- a/services/agent/tests/unit_test/tools/vst/test_video_list_coverage.py
+++ b/services/agent/tests/unit_test/tools/vst/test_video_list_coverage.py
@@ -48,12 +48,15 @@ class TestVSTVideoListOutput:
     def test_valid(self):
         output = VSTVideoListOutput(
             video_list=[
-                {"name": "video1.mp4", "duration": 60.0},
-                {"name": "video2.mp4", "duration": 120.0},
+                {"name": "video1.mp4", "media_type": "video", "duration": 60.0},
+                {"name": "video2.mp4", "media_type": "video", "duration": 120.0},
+                {"name": "warehouse_cam", "media_type": "stream", "duration": 0.0},
             ]
         )
-        assert len(output.video_list) == 2
+        assert len(output.video_list) == 3
         assert output.video_list[0]["name"] == "video1.mp4"
+        assert output.video_list[0]["media_type"] == "video"
+        assert output.video_list[2]["media_type"] == "stream"
 
     def test_empty_list(self):
         output = VSTVideoListOutput(video_list=[])


### PR DESCRIPTION
## Description
- `vst_video_list` now returns a `media_type` field (`'stream'` for live RTSP, `'video'` for uploaded files) by reading stream info from VST and classifying by URL scheme.
- Live streams without a captioned timeline yet return `duration=0.0` instead of erroring.
- Updates the LVS workflow prompt (docker + helm configs) so the top agent routes by `media_type` from `vst_video_list` instead of guessing from name substrings like "stream"/"cam".

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
