### PR TITLE
Update cadvisor to use actively maintained repo source

### DIFF
--- a/deploy/LICENSE-3rd-party.txt
+++ b/deploy/LICENSE-3rd-party.txt
@@ -143,10 +143,10 @@ running developer profiles via scripts/dev-profile.sh or docker compose).
     See: https://curl.se/docs/copyright.html
 
 
-12. gcr.io/cadvisor/cadvisor:v0.52.0
-    Image: gcr.io/cadvisor/cadvisor:v0.52.0
+12. ghcr.io/google/cadvisor:0.56.2
+    Image: ghcr.io/google/cadvisor:0.56.2
     License: Apache License 2.0
-    Registry: https://gcr.io/cadvisor/cadvisor
+    Registry: https://ghcr.io/google/cadvisor
     Source: https://github.com/google/cadvisor
     License URL: https://github.com/google/cadvisor/blob/master/LICENSE
     Description: Container resource usage and performance monitoring (cAdvisor).

--- a/deploy/docker/services/monitoring/compose.yml
+++ b/deploy/docker/services/monitoring/compose.yml
@@ -67,7 +67,7 @@ services:
       - '--path.rootfs=/rootfs'
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.52.0
+    image: ghcr.io/google/cadvisor:0.56.2
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d"]
     ports:
       - "18080:8080"


### PR DESCRIPTION
## Description
Update cadvisor to use image from ghcr.io/google/cadvisor instead of deprecated gcr.io/cadvisor/cadvisor

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
