### PR TITLE
ci: narrow skills smoke paths

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -2,9 +2,8 @@
 
 You are the VSS skills-eval agent, invoked by
 `.github/workflows/skills-eval.yml` on every push to a
-`pull-request/<N>` mirror branch whose diff touches `skills/`,
-`.github/skill-eval/adapters/`, `.github/skill-eval/verifiers/`, or
-`.github/skill-eval/envs/`.
+`pull-request/<N>` mirror branch whose cumulative PR diff touches
+`skills/team-skills/`, `rules/team-rules/`, or `plugins/`.
 
 You run **once per push**, from start to finish, on the
 `vss-skill-validator` self-hosted runner. Your workspace is already
@@ -48,8 +47,9 @@ template is in § Harbor invocation below.
      --jq '.files[].filename'
    ```
 
-   If nothing under `skills/` changed, emit `BLOCKED: no files under skills/`
-   and exit cleanly. No PR comment.
+   If nothing under `skills/` changed, emit
+   `DONE: no changed skills; watched rules/plugins path validated` and exit
+   cleanly. No PR comment.
 
 2. **For each changed skill, decide whether it has a dispatchable
    eval spec** — any `skills/<skill>/eval/<name>.json`. The filename

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -2,7 +2,7 @@
 
 Evaluate VSS skills (deploy, alerts, vios, video-analytics, video-search, video-summarization, incident-report, report) against a live GPU deployment using [Harbor](https://github.com/laude-institute/harbor).
 
-Evaluation is **fully CI-driven**. [`.github/workflows/skills-eval.yml`](../workflows/skills-eval.yml) fires on every push to a `pull-request/<N>` mirror branch whose diff touches `skills/` or `.github/skill-eval/`, and runs a single claude-agent-sdk session ([`skills_eval_agent.py`](skills_eval_agent.py)) that:
+Evaluation is **fully CI-driven**. [`.github/workflows/skills-eval.yml`](../workflows/skills-eval.yml) runs on every push to a `pull-request/<N>` mirror branch whose cumulative PR diff touches `skills/team-skills/`, `rules/team-rules/`, or `plugins/`, and runs a single claude-agent-sdk session ([`skills_eval_agent.py`](skills_eval_agent.py)) that:
 
 1. Diffs the PR against its base branch and picks out changed skills with an eval spec at `skills/<skill>/eval/<profile>.json`.
 2. Generates Harbor datasets per `(skill, profile, platform, mode)` via the adapter at [`adapters/<skill>/generate.py`](adapters/).
@@ -241,7 +241,7 @@ disown
 
 ## Troubleshooting
 
-**CI didn't fire after a push.** The workflow only triggers on pushes to `pull-request/<N>` mirror branches, created by copy-pr-bot after a maintainer comments `/ok to test <sha>` on the source PR. Check that the comment was posted on the correct head SHA.
+**CI didn't fire after a push.** The workflow only evaluates pushes to `pull-request/<N>` mirror branches whose cumulative PR diff touches `skills/team-skills/`, `rules/team-rules/`, or `plugins/`. Those mirror branches are created by copy-pr-bot after a maintainer comments `/ok to test <sha>` on the source PR. Check that the comment was posted on the correct head SHA.
 
 **"missing_platforms_declaration" blocker on a spec.** The spec has no `resources.platforms`. Add one — see the worked example above.
 

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -4,7 +4,8 @@
 """Skills eval agent — single-shot CI-driven runner.
 
 Called by .github/workflows/skills-eval.yml on push to `pull-request/<N>`
-when files under `skills/` (or the harness itself) change. Spawns one
+when files under `skills/team-skills/`, `rules/team-rules/`, or `plugins/`
+change. Spawns one
 `claude-agent-sdk` agent with `.github/skill-eval/AGENTS.md` as its
 system prompt and lets it drive the eval end-to-end: diff →
 adapter/dataset → Brev lock → harbor run → results comment → cleanup.
@@ -121,7 +122,7 @@ async def run_agent() -> int:
     system_prompt = AGENTS_MD.read_text()
 
     user_prompt = f"""
-PR #{pr_number} just pushed new commits touching `skills/` (or eval harness code).
+PR #{pr_number} just pushed new commits touching team skills, team rules, or plugins.
 
 Context:
   repo          = {pr_repo}
@@ -141,8 +142,9 @@ post ONE comment per (PR, spec) batch → release the lock → stop/delete any B
 instance you brought online.
 
 When done, emit a one-line final summary starting with `DONE:` so the workflow
-can grep for it. On blocker (missing_probe, env issue, nothing to eval), emit a
-line starting with `BLOCKED:` followed by the reason.
+can grep for it. On blocker (missing_probe, env issue), emit a line starting
+with `BLOCKED:` followed by the reason. For rules/plugins-only smoke changes
+with no changed skills, emit `DONE: no changed skills; watched path validated`.
 """
 
     model = os.environ.get("ANTHROPIC_MODEL") or "claude-sonnet-4-6"

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Runs the skills eval agent (.github/skill-eval/skills_eval_agent.py) on
-# every push to a pull-request/<N> mirror branch that touches anything
-# under skills/ or the eval harness. See .github/skill-eval/AGENTS.md
+# every push to a pull-request/<N> mirror branch whose cumulative PR diff
+# touches team skills, team rules, or plugins. See .github/skill-eval/AGENTS.md
 # for the agent's system prompt and behaviour.
 
 name: Skills Eval
@@ -13,7 +13,7 @@ on:
   # diff of the *pushed commits*, not the cumulative PR diff against
   # base. That silently skipped the workflow when CPR-bot updated a
   # mirror branch with a merge commit that didn't itself touch
-  # skills/** (observed on PR #188: 16 skills/ files in the PR, but
+  # watched paths (observed on PR #188: 16 skills/ files in the PR, but
   # the latest mirror push was a develop-merge carrying only 2 RTVI
   # files). The path gate is now done inside the job by
   # `dorny/paths-filter`, which diffs the cumulative head...base range.
@@ -33,13 +33,17 @@ concurrency:
   group: skills-eval-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 defaults:
   run:
     shell: bash
 
 jobs:
   eval:
-    name: Eval changed skills against PR
+    name: Eval changed team content against PR
     runs-on: [self-hosted, vss-eval]
 
     # 8-hour hard cap on the whole job. A full PR touching every skill
@@ -85,9 +89,9 @@ jobs:
           base: ${{ steps.pr.outputs.base }}
           filters: |
             relevant:
-              - 'skills/**'
-              - '.github/skill-eval/**'
-              - '.github/workflows/skills-eval.yml'
+              - 'skills/team-skills/**'
+              - 'rules/team-rules/**'
+              - 'plugins/**'
 
       - name: Load coordinator env (Anthropic, NGC, Brev, remote endpoints)
         if: steps.changes.outputs.relevant == 'true'

--- a/plugins/smoke-test.md
+++ b/plugins/smoke-test.md
@@ -1,0 +1,4 @@
+# Skills Smoke Test Marker
+
+This file is intentionally small. It exercises the GitHub Actions path gate for
+plugin changes without altering runtime behavior.


### PR DESCRIPTION
Prepared by Codex.

## Description
- Narrows the Skills Eval path gate to `skills/team-skills/**`, `rules/team-rules/**`, and `plugins/**`.
- Adds a least-privilege permissions block for the workflow's built-in GitHub token.
- Adds `plugins/smoke-test.md` so this PR exercises the watched path for the 3S signing smoke flow.
- Updates nearby skill-eval docs/prompts to match the new watched paths and handle rules/plugins-only smoke changes as a clean `DONE` outcome.

## Validation
- `git diff --check`
- `python3 -m py_compile .github/skill-eval/skills_eval_agent.py`
- Parsed `.github/workflows/skills-eval.yml` with PyYAML `BaseLoader`
- `python3 .github/scripts/check_copyright_headers.py`

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
