### PR TITLE
Add Helm LVS Logstash pipeline support

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -78,15 +78,18 @@ infra:
     init:
       enabled: true
       objectsBundle: lvs
+  logstash:
+    enabled: true
+    lvsPipeline:
+      enabled: true
   kafka:
     enabled: true
     topicJob:
       enabled: true
-    # Compose parity: deploy/docker/services/video-summarization/compose.yml
-    # `lvs-kafka-topic-init` creates `raw-vlm-events-response` (rtvi-vlm →
-    # lvs-logstash) and `structured-events-summary` (vss-summarization
-    # publishes structured summaries). Kept the kafka subchart defaults so
-    # Kibana dashboards + rtvi-vlm incident topics continue to exist.
+    # Shared Logstash consumes the LVS RTVI caption and structured-summary
+    # topics through its optional LVS pipeline. Kept the kafka subchart
+    # defaults so Kibana dashboards + rtvi-vlm incident topics continue to
+    # exist.
     topics:
       - name: mdx-raw
       - name: mdx-bev
@@ -108,9 +111,8 @@ infra:
       - name: mdx-vlm
       - name: mdx-embed
       - name: mdx-embed-filtered
-      # LVS streams support (PR #196)
-      - name: raw-vlm-events-response
-      - name: structured-events-summary
+      - name: mdx-vlm-captions
+      - name: mdx-structured-events-summary
     persistence:
       size: 10Gi
       storageClass: ''
@@ -451,6 +453,9 @@ rtvi:
     # Wait for the LVS Kafka broker and RTVI topics created by infra.kafka.topicJob.
     waitForKafka:
       enabled: true
+      topics:
+        - mdx-vlm-captions
+        - mdx-vlm-incidents
     # Docker parity: shape from services/rtvi/charts/rtvi-vlm/values.yaml.
     # Full list is required because the subchart replaces `env` rather than merging.
     env:
@@ -466,11 +471,10 @@ rtvi:
         value: "cosmos-reason2"
       - name: KAFKA_ENABLED
         value: "true"
-      # Raw VLM event topic produced by rtvi-vlm; consumed by lvs-logstash.
-      # Compose parity: RTVI_VLM_KAFKA_TOPIC in dev-profile-lvs/.env. The
-      # previous value `mdx-vlm` had no consumer in the LVS profile.
+      # Raw VLM event topic produced by rtvi-vlm; consumed by the shared
+      # Logstash LVS pipeline.
       - name: KAFKA_TOPIC
-        value: "raw-vlm-events-response"
+        value: "mdx-vlm-captions"
       - name: KAFKA_INCIDENT_TOPIC
         value: "mdx-vlm-incidents"
       - name: ERROR_MESSAGE_TOPIC

--- a/deploy/helm/services/infra/charts/logstash/files/mdx-lvs-logstash.conf
+++ b/deploy/helm/services/infra/charts/logstash/files/mdx-lvs-logstash.conf
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Streaming RTVI-VLM Kafka -> Elasticsearch pipeline.
+#
+# Decodes nv.VisionLLM protobuf messages from two topics
+# (mdx-vlm-captions and mdx-structured-events-summary) and writes
+# documents into Elasticsearch in the EXACT shape that
+# via-ctx-rag's ElasticsearchDBTool.add_summary produces.
+
+input {
+  kafka {
+    bootstrap_servers        => "{{ include "logstash.kafkaBootstrap" . }}"
+    topics                   => ["mdx-vlm-captions", "mdx-structured-events-summary"]
+    group_id                 => "logstash-vlm-es-writer"
+    client_id                => "logstash-visionllm-1"
+    auto_offset_reset        => "earliest"
+    enable_auto_commit       => true
+    decorate_events          => "basic"
+    key_deserializer_class   => "org.apache.kafka.common.serialization.StringDeserializer"
+    value_deserializer_class => "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+
+    codec => protobuf {
+      class_name              => "nv.VisionLLM"
+      class_file              => "/opt/logstash-data-libs/logstash/pb_definitions/schema_pb.rb"
+      protobuf_root_directory => "/opt/logstash-data-libs/logstash/pb_definitions/"
+      protobuf_version        => 3
+      stop_on_error           => false
+    }
+  }
+}
+
+filter {
+  if [llm][queries] {
+    mutate {
+      add_field => { "text" => "%{[llm][queries][0][response]}" }
+    }
+  }
+
+  ruby {
+    init => '
+      require "digest"
+
+      def null_embedding(text, dim, seed)
+        digest_hex = Digest::SHA256.hexdigest(text.to_s)
+        text_seed  = digest_hex[0, 16].to_i(16)
+        rng        = Random.new(seed + text_seed)
+        Array.new(dim) { rng.rand }
+      end
+    '
+    code => '
+      info = event.get("info") || {}
+      cm   = info.dup
+
+      raw_sid = (cm["streamId"] || "unknown").to_s
+      safe_sid = raw_sid.gsub(/[-\/\\ ]/, "_")
+      coll = cm.delete("collection_name") || "default_#{safe_sid}"
+
+      cm["doc_type"] ||= "raw_events"
+      q = (event.get("[llm][queries]") || [])[0]
+      q_id = (q && q["id"]).to_s
+      cm["doc_i"] ||= (q_id =~ /\A\d+\z/ ? q_id : cm["chunkIdx"] || "")
+
+      cm["uuid"] ||= raw_sid
+
+      ts = event.get("timestamp")
+      if ts && !cm["start_ntp_float"]
+        cm["start_ntp_float"] = ts["seconds"].to_f + (ts["nanos"] || 0).to_f / 1_000_000_000.0
+      end
+      end_ts = event.get("end")
+      if end_ts && !cm["end_ntp_float"]
+        cm["end_ntp_float"] = end_ts["seconds"].to_f + (end_ts["nanos"] || 0).to_f / 1_000_000_000.0
+      end
+
+      source = cm.delete("source") || cm["file"] || "N/A"
+
+      cm.each_pair do |k, v|
+        cm[k] = nil if v == ""
+      end
+
+      event.set("[metadata][source]", source)
+      event.set("[metadata][content_metadata]", cm)
+      event.set("[@metadata][collection]", coll)
+      event.set("[@metadata][es_id]",
+        "#{coll}:#{cm["uuid"] || ""}:#{cm["doc_type"]}:" \
+        "#{cm["chunkIdx"] || cm["batch_i"] || cm["doc_i"] || ""}")
+
+      event.set("vector", null_embedding(event.get("text"), 1024, 42))
+    '
+  }
+
+  mutate {
+    convert => {
+      "[metadata][content_metadata][doc_i]"           => "integer"
+      "[metadata][content_metadata][chunkIdx]"        => "integer"
+      "[metadata][content_metadata][batch_i]"         => "integer"
+      "[metadata][content_metadata][event_count]"     => "integer"
+      "[metadata][content_metadata][total_events]"    => "integer"
+      "[metadata][content_metadata][pts_offset_ns]"   => "integer"
+      "[metadata][content_metadata][start_pts]"       => "integer"
+      "[metadata][content_metadata][end_pts]"         => "integer"
+      "[metadata][content_metadata][start_ntp_float]" => "float"
+      "[metadata][content_metadata][end_ntp_float]"   => "float"
+      "[metadata][content_metadata][is_first]"        => "boolean"
+      "[metadata][content_metadata][is_last]"         => "boolean"
+    }
+  }
+
+  mutate {
+    remove_field => ["info", "llm", "@version", "event"]
+  }
+}
+
+output {
+  elasticsearch {
+    hosts           => ["{{ include "logstash.elasticsearchUrl" . }}"]
+    index           => "%{[@metadata][collection]}"
+    document_id     => "%{[@metadata][es_id]}"
+    action          => "index"
+    manage_template => false
+  }
+}

--- a/deploy/helm/services/infra/charts/logstash/templates/configmap.yaml
+++ b/deploy/helm/services/infra/charts/logstash/templates/configmap.yaml
@@ -25,6 +25,13 @@ data:
     pipeline.ordered: true
     pipeline.ecs_compatibility: disabled
     api.http.host: "0.0.0.0"
+  pipelines.yml: |
+    - pipeline.id: mdx-kafka
+      path.config: "/usr/share/logstash/pipeline/mdx-kafka-logstash.conf"
+{{- if .Values.lvsPipeline.enabled }}
+    - pipeline.id: mdx-lvs
+      path.config: "/usr/share/logstash/pipeline/mdx-lvs-logstash.conf"
+{{- end }}
   mdx-kafka-logstash.conf: |
     input {
       kafka {
@@ -411,3 +418,7 @@ data:
         }
       }
     }
+{{- if .Values.lvsPipeline.enabled }}
+  mdx-lvs-logstash.conf: |
+{{ tpl (.Files.Get "files/mdx-lvs-logstash.conf") . | indent 4 }}
+{{- end }}

--- a/deploy/helm/services/infra/charts/logstash/templates/deployment.yaml
+++ b/deploy/helm/services/infra/charts/logstash/templates/deployment.yaml
@@ -99,9 +99,19 @@ spec:
               subPath: logstash.yml
               readOnly: true
             - name: logstash-config
-              mountPath: /usr/share/logstash/pipeline/logstash.conf
+              mountPath: /usr/share/logstash/config/pipelines.yml
+              subPath: pipelines.yml
+              readOnly: true
+            - name: logstash-config
+              mountPath: /usr/share/logstash/pipeline/mdx-kafka-logstash.conf
               subPath: mdx-kafka-logstash.conf
               readOnly: true
+            {{- if .Values.lvsPipeline.enabled }}
+            - name: logstash-config
+              mountPath: /usr/share/logstash/pipeline/mdx-lvs-logstash.conf
+              subPath: mdx-lvs-logstash.conf
+              readOnly: true
+            {{- end }}
             - name: logstash-libs
               mountPath: /opt/logstash-data-libs
             - name: pb-definitions

--- a/deploy/helm/services/infra/charts/logstash/values.yaml
+++ b/deploy/helm/services/infra/charts/logstash/values.yaml
@@ -24,6 +24,8 @@ kafka:
   bootstrapServers: ""
 elasticsearch:
   host: ""
+lvsPipeline:
+  enabled: false
 service:
   port: 5044
 persistence:

--- a/deploy/helm/services/video-summarization/templates/deployment.yaml
+++ b/deploy/helm/services/video-summarization/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
       {{- $esHost := .Values.elasticsearchHost | default (ternary (printf "%s-elasticsearch" $release) "elasticsearch" $pfx) }}
       {{- $esPort := .Values.elasticsearchPort | default "9200" }}
       {{- $esTransportPort := .Values.elasticsearchTransportPort | default "9300" }}
+      {{- $kafkaHost := ternary (printf "%s-kafka-kafka" $release) "kafka-kafka" $pfx }}
+      {{- $kafkaBootstrap := .Values.kafkaBootstrapServers | default (printf "%s:9092" $kafkaHost) }}
       {{- $llmSvc := .Values.llmService | default "nvidia-nemotron-nano-9b-v2" }}
       {{- $vlmSvc := .Values.vlmService | default "nvidia-cosmos-reason2-8b" }}
       {{- /* Same base URL as vss-agent (global / subchart); LVS OpenAI paths need /v1 — append when missing */}}
@@ -111,6 +113,8 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ $kafkaBootstrap | quote }}
             - name: ES_HOST
               value: {{ $esHost | quote }}
             - name: ES_PORT

--- a/deploy/helm/services/video-summarization/values.yaml
+++ b/deploy/helm/services/video-summarization/values.yaml
@@ -42,6 +42,9 @@ vlmName: ""  # optional: overrides global.vlmName for VIA_VLM_OPENAI_MODEL_DEPLO
 elasticsearchHost: ""
 elasticsearchPort: "9200"
 elasticsearchTransportPort: "9300"
+# Leave empty for the in-cluster Kafka service. Defaults to kafka-kafka:9092,
+# or <release>-kafka-kafka:9092 when global.useReleaseNamePrefix is enabled.
+kafkaBootstrapServers: ""
 env:
   - name: ARANGO_DB_HOST
     value: arango-db
@@ -78,14 +81,11 @@ env:
   - name: GRAPH_DB_USERNAME
     value: neo4j
   # Kafka integration: consume RTVI captions / publish structured summaries.
-  # Compose parity: deploy/docker/services/video-summarization/compose.yml
-  # `lvs-server` environment block + dev-profile-lvs/.env.
+  # Helm LVS uses the infra Kafka service name; Compose uses kafka:9092.
   - name: KAFKA_ENABLED
-    value: "false"
-  - name: KAFKA_BOOTSTRAP_SERVERS
-    value: "kafka:9092"
+    value: "true"
   - name: KAFKA_STRUCTURED_SUMMARY_TOPIC
-    value: structured-events-summary
+    value: mdx-structured-events-summary
   - name: LVS_DATABASE_BACKEND
     value: elasticsearch_db
   - name: LVS_DISABLE_DB_RESET_ON_REQUEST_DONE
@@ -125,9 +125,9 @@ env:
   - name: VSS_LOG_LEVEL
     value: INFO
 
-# extraEnv: appended after the computed env block (duplicate names: last wins). Each value is rendered with `tpl`, so
-# expressions like `http://{{ .Release.Name }}-vss-rtvi-vlm:8000` are supported. Use this for LVS → RTVI-VLM wiring
-# (RTVI_VLM_URL, RTVI_VLM_URL_PASSTHROUGH) without duplicating the full `env` list.
+# extraEnv: appended after the computed env block. Each value is rendered with `tpl`, so expressions like
+# `http://{{ .Release.Name }}-vss-rtvi-vlm:8000` are supported. Use this for LVS -> RTVI-VLM wiring
+# (RTVI_VLM_URL, RTVI_VLM_URL_PASSTHROUGH) or truly additional env vars.
 extraEnv: []
 
 # VST_INTERNAL_URL: used by LVS to rewrite video download URLs (e.g. from 127.0.0.1 or external host to in-cluster VST).


### PR DESCRIPTION
## Summary

- Add an optional `mdx-lvs` pipeline to the shared Helm Logstash chart, gated by `logstash.lvsPipeline.enabled` and disabled by default.
- Enable the shared Logstash pipeline in `dev-profile-lvs`, add the LVS Kafka topics, and point RT-VLM at `mdx-vlm-captions`.
- Enable LVS Kafka publishing in Helm with release-prefix-aware Kafka bootstrap rendering, and publish structured summaries to `mdx-structured-events-summary`.

## Why

Docker compose now uses the shared Logstash service for LVS. Helm still needed the matching LVS pipeline file and topic wiring, without adding a dedicated LVS Logstash service or changing shared Logstash volumes.

## Validation

- Rendered Logstash chart with `lvsPipeline.enabled=false`.
- Rendered Logstash chart with `lvsPipeline.enabled=true`.
- Built a temporary `dev-profile-lvs` dependency tree and rendered the full profile.
- Verified the rendered profile includes `mdx-lvs`, `mdx-vlm-captions`, `mdx-structured-events-summary`, `KAFKA_ENABLED=true`, and release-prefix-aware Kafka bootstrap output.
- Parsed rendered YAML and edited values files with Ruby YAML.
- Ran `git diff --check`.
- Completed expert subagent review with no blockers.
