### PR TITLE
rtdetr version bumped to rn50_v1.0.2

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/configs/ds-pgie-config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/configs/ds-pgie-config.yml
@@ -48,8 +48,8 @@ property:
   net-scale-factor: 0.00392156862745098
   network-mode: 2
   network-type: 0
-  model-engine-file: /opt/storage/rtdetr_warehouse_v1.0.1.fp16.onnx_b8_gpu0_fp16.engine
-  onnx-file: /opt/storage/rtdetr_warehouse_v1.0.1.fp16.onnx
+  model-engine-file: /opt/storage/rtdetr_warehouse_v1.0.2.fp16.onnx_b8_gpu0_fp16.engine
+  onnx-file: /opt/storage/rtdetr_warehouse_v1.0.2.fp16.onnx
   num-detected-classes: 7
   output-tensor-meta: 1
   output-blob-names: pred_boxes;pred_logits

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1382,9 +1382,9 @@ function state_up() {
 
     if [[ "${dry_run}" == "true" ]]; then
       echo "[DRY-RUN] mkdir -p ${data_directory}/models"
-      echo "[DRY-RUN] NGC_CLI_API_KEY=<ngc-cli-api-key> ngc registry model download-version nvstaging/tao/rtdetr_2d_warehouse:deployable_efficientvit_l2_v1.0.1 --org nvstaging"
-      echo "[DRY-RUN] mv rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1/rtdetr_warehouse_v1.0.1.fp16.onnx ${data_directory}/models/rtdetr_warehouse_v1.0.1.fp16.onnx"
-      echo "[DRY-RUN] rm -rf rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1"
+      echo "[DRY-RUN] NGC_CLI_API_KEY=<ngc-cli-api-key> ngc registry model download-version nvstaging/tao/rtdetr_2d_warehouse:deployable_rn50_v1.0.2 --org nvstaging"
+      echo "[DRY-RUN] mv rtdetr_2d_warehouse_vdeployable_rn50_v1.0.2/rtdetr_warehouse_v1.0.2.fp16.onnx ${data_directory}/models/rtdetr_warehouse_v1.0.2.fp16.onnx"
+      echo "[DRY-RUN] rm -rf rtdetr_2d_warehouse_vdeployable_rn50_v1.0.2"
       echo "[DRY-RUN] chmod -R 777 ${data_directory}/models"
     else
       mkdir -p "${data_directory}/models"
@@ -1393,12 +1393,12 @@ function state_up() {
         registry \
         model \
         download-version \
-        nvstaging/tao/rtdetr_2d_warehouse:deployable_efficientvit_l2_v1.0.1 \
+        nvstaging/tao/rtdetr_2d_warehouse:deployable_rn50_v1.0.2 \
         --org nvstaging
 
-      mv rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1/rtdetr_warehouse_v1.0.1.fp16.onnx "${data_directory}/models/rtdetr_warehouse_v1.0.1.fp16.onnx"
+      mv rtdetr_2d_warehouse_vdeployable_rn50_v1.0.2/rtdetr_warehouse_v1.0.2.fp16.onnx "${data_directory}/models/rtdetr_warehouse_v1.0.2.fp16.onnx"
 
-      rm -rf rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1
+      rm -rf rtdetr_2d_warehouse_vdeployable_rn50_v1.0.2
 
       chmod -R 777 "${data_directory}/models"
       echo "[INFO] RT-DETR model downloaded and installed to ${data_directory}/models"

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -682,11 +682,11 @@ rm -f "${_out_alerts}"
 # Search profile: dry-run must include NGC model download steps (RT-DETR warehouse from nvstaging TAO).
 _out_search="$(mktemp)"
 timeout "${TEST_TIMEOUT}" "$DEV_PROFILE" up -p search -i 127.0.0.1 -d > "${_out_search}" 2>&1
-if grep -q "Downloading RT-DETR model from NGC" "${_out_search}" && grep -q "nvstaging/tao/rtdetr_2d_warehouse" "${_out_search}" && grep -q "rtdetr_warehouse_v1.0.1.fp16.onnx" "${_out_search}" && grep -q -- "--org nvstaging" "${_out_search}" && grep -q "ngc registry model" "${_out_search}"; then
+if grep -q "Downloading RT-DETR model from NGC" "${_out_search}" && grep -q "nvstaging/tao/rtdetr_2d_warehouse" "${_out_search}" && grep -q "rtdetr_warehouse_v1.0.2.fp16.onnx" "${_out_search}" && grep -q -- "--org nvstaging" "${_out_search}" && grep -q "ngc registry model" "${_out_search}"; then
   echo "PASS: search dry-run output includes NGC model download steps"
   ((TESTS_PASSED++)) || true
 else
-  echo "FAIL: search dry-run output missing NGC model download steps (Downloading RT-DETR model from NGC, nvstaging/tao/rtdetr_2d_warehouse, rtdetr_warehouse_v1.0.1.fp16.onnx, --org nvstaging, ngc registry model)"
+  echo "FAIL: search dry-run output missing NGC model download steps (Downloading RT-DETR model from NGC, nvstaging/tao/rtdetr_2d_warehouse, rtdetr_warehouse_v1.0.2.fp16.onnx, --org nvstaging, ngc registry model)"
   ((TESTS_FAILED++)) || true
 fi
 rm -f "${_out_search}"

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -198,9 +198,9 @@ rtvi:
     ngcApiKeySecretKey: NGC_API_KEY
     ngcOrg: nvstaging
     ngcModelsToDownload:
-      - model: nvstaging/tao/rtdetr_2d_warehouse:deployable_efficientvit_l2_v1.0.1
-        sourcePath: rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1/rtdetr_warehouse_v1.0.1.fp16.onnx
-        destPath: rtdetr_warehouse_v1.0.1.fp16.onnx
+      - model: nvstaging/tao/rtdetr_2d_warehouse:deployable_rn50_v1.0.2
+        sourcePath: rtdetr_2d_warehouse_vdeployable_rn50_v1.0.2/rtdetr_warehouse_v1.0.2.fp16.onnx
+        destPath: rtdetr_warehouse_v1.0.2.fp16.onnx
       - model: nvstaging/tao/siglip_v2:deployable_v1.1
         sourcePath: siglip_v2_vdeployable_v1.1/siglip2_v1.1.onnx
         destPath: siglip2_v1.1.onnx
@@ -220,8 +220,8 @@ rtvi:
           org: nvstaging
           team: tao
           model: rtdetr_2d_warehouse
-          version: deployable_efficientvit_l2_v1.0.1
-        onnxFile: rtdetr_warehouse_v1.0.1.fp16.onnx
+          version: deployable_rn50_v1.0.2
+        onnxFile: rtdetr_warehouse_v1.0.2.fp16.onnx
         inferDims: 3;640;640
       visionEncoder:
         ngc:

--- a/services/agent/src/vss_agents/orchestrator/vss_orchestrator_mcp_config.yml
+++ b/services/agent/src/vss_agents/orchestrator/vss_orchestrator_mcp_config.yml
@@ -62,9 +62,9 @@ function_groups:
     # Model artifact definitions keyed by profile name.
     model_artifacts:
       search:
-      - package_ref: "nvidia/tao/rtdetr_2d_warehouse:deployable_efficientvit_l2_v1.0.1"
-        downloaded_relative_path: "rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1/rtdetr_warehouse_v1.0.1.fp16.onnx"  # yamllint disable-line rule:line-length
-        output_name: "rtdetr_warehouse_v1.0.1.fp16.onnx"
+      - package_ref: "nvidia/tao/rtdetr_2d_warehouse:deployable_rn50_v1.0.2"
+        downloaded_relative_path: "rtdetr_2d_warehouse_vdeployable_rn50_v1.0.2/rtdetr_warehouse_v1.0.2.fp16.onnx"  # yamllint disable-line rule:line-length
+        output_name: "rtdetr_warehouse_v1.0.2.fp16.onnx"
         artifact_kind: "file"
       - package_ref: "nvidia/tao/radio-clip:deployable_v1.0"
         downloaded_relative_path: "radio-clip_vdeployable_v1.0/radio-clip_v1.0.onnx"

--- a/skills/deploy/references/search.md
+++ b/skills/deploy/references/search.md
@@ -276,7 +276,7 @@ deploy/docker/developer-profiles/dev-profile-search/.env
 
 **MUST run before `docker compose -f resolved.yml up -d`.** The compose's `perception-2d-init` container only fetches the SigLIP vision encoder. The RT-DETR detector model that RT-CV needs is staged separately by `dev-profile.sh` — and since this skill doesn't run that script, the agent must stage it directly.
 
-Symptom if skipped: RT-CV starts but its TensorRT engine build fails because `${VSS_DATA_DIR}/models/rtdetr_warehouse_v1.0.1.fp16.onnx` is missing. (User-confirmed on 2026-05-10.)
+Symptom if skipped: RT-CV starts but its TensorRT engine build fails because `${VSS_DATA_DIR}/models/rtdetr_warehouse_v1.0.2.fp16.onnx` is missing. (User-confirmed on 2026-05-10.)
 
 ```bash
 # Source: deploy/docker/scripts/dev-profile.sh (search profile, model staging block)
@@ -287,12 +287,12 @@ mkdir -p "$DATA/data_log/vss_video_analytics_api" "$DATA/models"
 
 NGC_CLI_API_KEY="$NGC_CLI_API_KEY" ngc registry model \
     download-version \
-    nvstaging/tao/rtdetr_2d_warehouse:deployable_efficientvit_l2_v1.0.1 \
+    nvstaging/tao/rtdetr_2d_warehouse:deployable_rn50_v1.0.2 \
     --org nvstaging
 
-mv rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1/rtdetr_warehouse_v1.0.1.fp16.onnx \
-    "$DATA/models/rtdetr_warehouse_v1.0.1.fp16.onnx"
-rm -rf rtdetr_2d_warehouse_vdeployable_efficientvit_l2_v1.0.1
+mv rtdetr_2d_warehouse_vdeployable_rn50_v1.0.2/rtdetr_warehouse_v1.0.2.fp16.onnx \
+    "$DATA/models/rtdetr_warehouse_v1.0.2.fp16.onnx"
+rm -rf rtdetr_2d_warehouse_vdeployable_rn50_v1.0.2
 
 chmod -R 777 "$DATA/models"
 ```
@@ -300,7 +300,7 @@ chmod -R 777 "$DATA/models"
 **Verify** before deploying:
 
 ```bash
-ls -l "$VSS_DATA_DIR/models/rtdetr_warehouse_v1.0.1.fp16.onnx"
+ls -l "$VSS_DATA_DIR/models/rtdetr_warehouse_v1.0.2.fp16.onnx"
 # expected: ~30–50 MB onnx file, mode 777
 ```
 


### PR DESCRIPTION
## Description
Search Profile - upgrade RTDETR version to deployable_rn50_v1.0.2


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
