### PR TITLE
ci: fetch release/develop/main so image-tag SHA check resolves

### DIFF
--- a/.github/workflows/check-agent-container-source.yml
+++ b/.github/workflows/check-agent-container-source.yml
@@ -33,5 +33,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch sibling branches so image-tag SHAs resolve
+        # `fetch-depth: 0` above pulls the full history of the PR's own
+        # branch — but image tags carry SHAs built from `release/*`,
+        # `develop`, or `main` (different branches). Without these refs
+        # in the local object DB, `git cat-file -e <sha>` in the check
+        # script fails and every PR is red. `|| true` keeps the step
+        # green if a branch happens not to exist yet (e.g. very early
+        # in repo history); the next check step still runs and reports
+        # specifically which SHA it can't resolve.
+        run: |
+          git fetch --no-tags --quiet origin \
+            '+refs/heads/release/*:refs/remotes/origin/release/*' \
+            develop main \
+            || true
+
       - name: Check vss-agent tag matches services/agent
         run: python3 .github/scripts/check_container_tag_source.py --image-name vss-agent

--- a/.github/workflows/check-ui-container-source.yml
+++ b/.github/workflows/check-ui-container-source.yml
@@ -33,5 +33,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch sibling branches so image-tag SHAs resolve
+        # See identical step in check-agent-container-source.yml for the
+        # full explanation. TL;DR: `fetch-depth: 0` only pulls the PR's
+        # branch; image-tag SHAs live on release/*, develop, or main.
+        run: |
+          git fetch --no-tags --quiet origin \
+            '+refs/heads/release/*:refs/remotes/origin/release/*' \
+            develop main \
+            || true
+
       - name: Check vss-agent-ui tag matches services/ui
         run: python3 .github/scripts/check_container_tag_source.py --image-name vss-agent-ui


### PR DESCRIPTION
## Summary

Unblocks every open PR — both container-source workflows have been failing on **every** recent PR (#440, #425, #422, #437, #436, …) with the same error.

```
tag:           3.2.0-26.05.2-2b9b7127c0bb
built from:    2b9b7127c0bb  (NOT found in this checkout)
[FAIL] could not resolve this SHA locally.
```

## Root cause

`actions/checkout@v4` with `fetch-depth: 0` fetches the full history of the **checked-out branch only** — sibling branches like `release/3.2.0` aren't in the local object DB, so `git cat-file -e <sha>` in `check_container_tag_source.py` fails for every image whose tag SHA was built off the release branch.

## Fix

Insert one step between checkout and the check, in both workflows:

```yaml
- name: Fetch sibling branches so image-tag SHAs resolve
  run: |
    git fetch --no-tags --quiet origin \
      '+refs/heads/release/*:refs/remotes/origin/release/*' \
      develop main \
      || true
```

`|| true` is intentional — if a branch doesn't exist yet (early repo history or someone renames `develop`), the next step still runs and reports the specific SHA it couldn't resolve, instead of failing with an opaque "unknown revision" from `git fetch`.

Applied symmetrically to:
- `.github/workflows/check-agent-container-source.yml`
- `.github/workflows/check-ui-container-source.yml`

~5–10s extra clone time per run.

## Test plan
- [x] yaml valid
- [ ] After merge: confirm `Check vss-agent tag source` + `Check vss-agent-ui tag source` flip from red to green on the in-flight PRs without any per-PR action

🤖 Generated with [Claude Code](https://claude.com/claude-code)