### PR TITLE
skill-eval: enforce sequential per-step dispatch + skip-on-prior-fail

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -521,15 +521,63 @@ Notes that have burned prior runs:
   the adapter (usually `<platform>`, e.g. `l40s`).
   `-i` / `--include` is a different flag and will silently match
   nothing or everything.
-- For multi-step specs (e.g. `vios`, `video-search`,
-  `video-summarization`), `-p` points at the **platform directory**
-  (`.../<spec_stem>/<platform>/`) and harbor auto-discovers
-  the `step-1/ step-2/ ...` subdirs beneath it, each as its own
-  task. To run a specific step, pass
-  `--include-task-name "<platform>-step-<N>"`. Do NOT point
-  `-p` at a single `step-N/` dir — harbor then can't see sibling
-  steps and chaining breaks. This matches how
-  `adapters/vios/generate.py` lays out step dirs.
+- **Multi-step specs MUST be dispatched one step at a time, in
+  order, with skip-on-prior-fail.** Harbor's default scheduler
+  treats every `step-*/` subdir as an independent task and runs them
+  unordered (observed on PR #440: alerts ran step-1 → step-4 → step-2,
+  step-3 never dispatched at all). Spec checks for step N assume
+  the state established by step N-1; running them out of order
+  silently produces bogus failures. Use this dispatch loop instead
+  of a single `harbor run -p <platform_dir>` invocation:
+
+  ```bash
+  # Pre-condition: the spec lays out step_count subdirs under
+  # /tmp/skill-eval/datasets/<skill>/<spec_stem>/<platform>/ named
+  # step-1, step-2, ..., step-<step_count>. Read step_count from
+  # any step's task.toml [metadata] (it's the same on every step).
+  STEP_COUNT=$(grep -oP '^step_count\s*=\s*\K\d+' \
+    /tmp/skill-eval/datasets/<skill>/<spec_stem>/<platform>/step-1/task.toml)
+  RESULTS=/tmp/skill-eval/results/"$GITHUB_RUN_ID"
+
+  for STEP in $(seq 1 "$STEP_COUNT"); do
+    uvx harbor run \
+      --environment-import-path "envs.brev_env:BrevEnvironment" \
+      -p /tmp/skill-eval/datasets/<skill>/<spec_stem>/<platform> \
+      --include-task-name "<platform>-step-${STEP}" \
+      -a claude-code \
+      --model "$ANTHROPIC_MODEL" \
+      --ak api_base="$ANTHROPIC_BASE_URL/v1" \
+      --ae CLAUDE_CODE_DISABLE_THINKING=1 \
+      --environment-build-timeout-multiplier 3.0 \
+      --agent-timeout-multiplier 3.0 \
+      --verifier-timeout-multiplier 3.0 \
+      --max-retries 0 -n 1 --yes \
+      -o "$RESULTS"
+
+    # Read the just-completed step's reward. The trial dir is
+    # named step-<N>__<rand6>, so glob it.
+    REWARD=$(cat "$RESULTS"/*/*/step-${STEP}__*/verifier/reward.txt \
+      2>/dev/null | tail -n 1)
+    REWARD="${REWARD:-0}"
+
+    # Skip-on-prior-fail: if this step didn't fully pass, do not
+    # dispatch the remaining steps. Their checks assume this step's
+    # state was set up; running them produces noise, not signal.
+    # Record "skipped (prior-step fail)" in the result table.
+    awk -v r="$REWARD" 'BEGIN { exit !(r+0 < 1.0) }' && {
+      for SKIP in $(seq $((STEP + 1)) "$STEP_COUNT"); do
+        printf '%s\n' "skipped (prior-step fail, step=$STEP reward=$REWARD)" \
+          > /tmp/skill-eval/skipped-<spec_stem>-<platform>-step-${SKIP}.txt
+      done
+      break
+    }
+  done
+  ```
+
+  Single-step specs (most deploy/* specs) skip this loop entirely
+  and use the simpler one-shot invocation pattern. Detect by
+  reading `step_count` from `task.toml`: if 1, dispatch once
+  with `--include-task-name "<platform>"`; if N, use the loop.
 - `--environment-import-path` is a **Python module spec**
   (`envs.brev_env:BrevEnvironment`), not a filesystem path. Do not
   prepend `.github.skill-eval.` — `.github` isn't a valid Python
@@ -709,6 +757,21 @@ First started: `<utc>` · Last finished: `<utc>` · Total: `<Ahr Bmin>`
 | L40S | ✅ 1.0 (7/7) | 1.0 | 9m 40s | [trace](…) |
 | RTXPRO6000BW | ❌ 0.57 (4/7) | 0.571 | 14m 42s | [trace](…) |
 | …    | …     | …    | … | … |
+
+For multi-step specs, render one row per step and mark
+prior-fail-skips explicitly:
+
+| Platform | Step | Query | Result | Reward | Trace |
+|---|---|---|---|---|---|
+| L40S | step-1 | Deploy alerts (VLM real-time) | ✅ 1.0 (6/6) | 1.0 | [trace](…) |
+| L40S | step-2 | Add warehouse_sample via NVStreamer | ❌ 0.2 (1/5) | 0.2 | [trace](…) |
+| L40S | step-3 | Query incidents | ⏭️ skipped (prior-step fail, step-2 reward=0.2) | — | — |
+| L40S | step-4 | … | ⏭️ skipped | — | — |
+
+A `⏭️ skipped` row means the dispatch loop short-circuited after
+the previous step's reward < 1.0. The step was not run — its
+checks would have asserted state that was never set up. Read the
+prior step's trace to see the actual failure.
 
 ### Failing checks
 


### PR DESCRIPTION
## Summary

Multi-step specs (`alerts/alerts_vlm_real_time`, `vios`, `video-search`, `video-summarization`) lay out N `step-*/` subdirs under a single platform dir. The prior canonical invocation was `harbor run -p <platform_dir>`, which lets harbor's scheduler treat every step as independent and run them **out of order or skip some**.

Observed on PR #440's alerts batch:
- step-1 ran (deploy)
- step-4 ran (incident query) — but its setup state from step-2/step-3 was never built, so it failed 0/4
- step-2 ran (NVStreamer upload + start alert)
- **step-3 never dispatched at all**

Step checks written assuming sequential 1→2→3→4 setup state produce noise instead of signal.

## Fix (AGENTS.md only)

The harness driver is the LLM agent reading AGENTS.md, so the dispatch policy lives there. Two changes:

1. **Harbor invocation block** — replace the "harbor auto-discovers `step-*/`" note with a bash loop that dispatches one step at a time, in order, via `--include-task-name "<platform>-step-<N>"`. After each step, read `verifier/reward.txt`; if reward < 1.0, write skip-marker files for the remaining steps and `break`.

2. **Result-comment template** — added a multi-step variant table with one row per step, including explicit `⏭️ skipped` rows + the prior-fail reason inlined.

Single-step specs (most deploy/*) keep the one-shot invocation; detection is `step_count == 1` in task.toml.

## No adapter changes needed

All adapters already emit `step_index` and `step_count` in task.toml `[metadata]`. The harness was just ignoring them.

## Test plan

- [x] Markdown renders
- [x] After merge: re-run alerts/alerts_vlm_real_time spec; trial.log should show one `uvx harbor run` per step, in 1→2→3→4 order; if any earlier step fails, remaining `step-N/` dirs are not dispatched and the comment shows `⏭️ skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)