### PR TITLE
fix: route dep-manifest changes to VSS_OSRB_Approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,3 +23,19 @@ Cargo.lock              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 go.sum                  @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 Gemfile.lock            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 LICENSE-3rd-party.txt   @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+
+# Dependency manifests.
+# A manifest can change without an accompanying lockfile update (version-range
+# bumps, new direct deps, removed deps), and the next time the lock regenerates
+# it can pull in new transitive packages and licenses. Gate the manifests too
+# so OSRB sees the change at the point it is introduced, not weeks later when
+# someone else regenerates the lock.
+pyproject.toml          @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+requirements*.txt       @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+setup.py                @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+setup.cfg               @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+Pipfile                 @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+package.json            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+go.mod                  @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+Cargo.toml              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+Gemfile                 @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers


### PR DESCRIPTION
## Summary

- Extends `.github/CODEOWNERS` to route dependency-manifest files (not just lockfiles) to `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers`.
- Closes a gap where a PR can change `pyproject.toml` / `package.json` / etc. without touching the corresponding lockfile, landing new declared dependencies in `develop` without OSRB ever seeing them. The next lock regen (potentially weeks later, by a different dev) is the first time OSRB is auto-requested.

## Files now gated

Added on top of the existing lockfile rules:

```
pyproject.toml          @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
requirements*.txt       @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
setup.py                @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
setup.cfg               @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
Pipfile                 @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
package.json            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
go.mod                  @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
Cargo.toml              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
Gemfile                 @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
```

CODEOWNERS is last-match-wins, so these override the default `* @VSS-developers` only for the listed paths. Pattern style matches the existing lockfile section (bare filename → matches anywhere in the tree, so `agent/pyproject.toml`, `agent/app/video_search_frag/pyproject.toml`, and `ui/**/package.json` are all covered).

The `develop` ruleset already has `require_code_owner_review: true`, so this immediately enforces an OSRB approval on any PR that touches a dep manifest.

## Test plan

- [ ] After merge: open a draft PR that bumps a dependency in any `pyproject.toml` (e.g. `agent/pyproject.toml`) and confirm GitHub auto-requests review from `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers`.
- [ ] Same check for a `package.json` change under `ui/`.
- [ ] Confirm the merge button stays disabled until an OSRB approval lands.