### PR TITLE
feat(video-ingest): make HTTP timeouts configurable

### DIFF
--- a/deploy/helm/services/agent/charts/agent/templates/deployment.yaml
+++ b/deploy/helm/services/agent/charts/agent/templates/deployment.yaml
@@ -115,6 +115,15 @@ spec:
             - name: {{ .name }}
               value: {{ tpl (.value | default "" | toString) $ | quote }}
             {{- end }}
+            {{- $videoIngestTimeouts := .Values.videoIngestTimeouts | default dict }}
+            - name: VIDEO_INGEST_VST_UPLOAD_TIMEOUT_SECONDS
+              value: {{ tpl (get $videoIngestTimeouts "vstUploadSeconds" | default "" | toString) $ | quote }}
+            - name: VIDEO_INGEST_VST_STORAGE_TIMEOUT_SECONDS
+              value: {{ tpl (get $videoIngestTimeouts "vstStorageSeconds" | default "" | toString) $ | quote }}
+            - name: VIDEO_INGEST_RTVI_CV_TIMEOUT_SECONDS
+              value: {{ tpl (get $videoIngestTimeouts "rtviCvSeconds" | default "" | toString) $ | quote }}
+            - name: VIDEO_INGEST_RTVI_EMBED_TIMEOUT_SECONDS
+              value: {{ tpl (get $videoIngestTimeouts "rtviEmbedSeconds" | default "" | toString) $ | quote }}
             {{- range (.Values.extraEnv | default list) }}
             - name: {{ .name }}
               value: {{ tpl (.value | default "" | toString) $ | quote }}

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -93,6 +93,15 @@ vstInternalIp: ""
 vssAgentVersion: "3.2.0-26.05.2-2b9b7127c0bb"
 lvsBackendService: ""
 
+# [Optional] VSS Agent service configs for video ingest HTTP call timeouts, in
+# seconds. Leave blank to preserve the service defaults: VST upload 300,
+# VST storage 60, RTVI-CV 60, RTVI-Embed 600.
+videoIngestTimeouts:
+  vstUploadSeconds: ""
+  vstStorageSeconds: ""
+  rtviCvSeconds: ""
+  rtviEmbedSeconds: ""
+
 # Block startup until Kafka, Redis, and Elasticsearch accept TCP (optional).
 waitForDependencies:
   enabled: false

--- a/services/agent/src/vss_agents/api/video_ingest.py
+++ b/services/agent/src/vss_agents/api/video_ingest.py
@@ -61,6 +61,16 @@ from vss_agents.utils.url_translation import rewrite_url_host
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_RTVI_CV_TIMEOUT_SECONDS = 60.0
+DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS = 600.0
+DEFAULT_VST_STORAGE_TIMEOUT_SECONDS = 60.0
+DEFAULT_VST_UPLOAD_TIMEOUT_SECONDS = 300.0
+
+ENV_RTVI_CV_TIMEOUT_SECONDS = "VIDEO_INGEST_RTVI_CV_TIMEOUT_SECONDS"
+ENV_RTVI_EMBED_TIMEOUT_SECONDS = "VIDEO_INGEST_RTVI_EMBED_TIMEOUT_SECONDS"
+ENV_VST_STORAGE_TIMEOUT_SECONDS = "VIDEO_INGEST_VST_STORAGE_TIMEOUT_SECONDS"
+ENV_VST_UPLOAD_TIMEOUT_SECONDS = "VIDEO_INGEST_VST_UPLOAD_TIMEOUT_SECONDS"
+
 
 def _parse_optional_http_url(url: str | None) -> urllib.parse.ParseResult | None:
     """
@@ -90,6 +100,36 @@ def _parse_optional_http_url(url: str | None) -> urllib.parse.ParseResult | None
     if parsed.netloc.endswith(":"):
         return None
     return parsed
+
+
+def _parse_timeout_seconds(raw_value: Any, *, default: float, setting_name: str) -> float:
+    """Parse an optional timeout value, preserving the old hard-coded default."""
+    if raw_value is None or raw_value == "":
+        return default
+    try:
+        timeout_seconds = float(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; falling back to %.1fs", setting_name, raw_value, default)
+        return default
+    if timeout_seconds <= 0:
+        logger.warning("Invalid %s=%r; timeout must be > 0, falling back to %.1fs", setting_name, raw_value, default)
+        return default
+    return timeout_seconds
+
+
+def _resolve_timeout_seconds(
+    streaming_config: Any,
+    *,
+    attr_name: str,
+    env_name: str,
+    default: float,
+) -> float:
+    raw_value = getattr(streaming_config, attr_name, None) if streaming_config else None
+    if raw_value is not None and raw_value.__class__.__module__ == "unittest.mock":
+        raw_value = None
+    if raw_value is None or raw_value == "":
+        raw_value = os.getenv(env_name, "")
+    return _parse_timeout_seconds(raw_value, default=default, setting_name=attr_name)
 
 
 class VideoIngestResponse(BaseModel):
@@ -154,6 +194,10 @@ class _VideoUploadConfig(BaseModel):
     rtvi_cv_base_url: str = ""
     rtvi_embed_model: str = "cosmos-embed1-448p"
     rtvi_embed_chunk_duration: int = 5
+    rtvi_cv_timeout_seconds: float = DEFAULT_RTVI_CV_TIMEOUT_SECONDS
+    rtvi_embed_timeout_seconds: float = DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS
+    vst_storage_timeout_seconds: float = DEFAULT_VST_STORAGE_TIMEOUT_SECONDS
+    vst_upload_timeout_seconds: float = DEFAULT_VST_UPLOAD_TIMEOUT_SECONDS
 
 
 def _resolve_video_upload_config(config: "Any") -> _VideoUploadConfig | None:
@@ -189,6 +233,31 @@ def _resolve_video_upload_config(config: "Any") -> _VideoUploadConfig | None:
     if not vst_internal_url:
         return None
 
+    rtvi_cv_timeout_seconds = _resolve_timeout_seconds(
+        streaming_config,
+        attr_name="rtvi_cv_timeout_seconds",
+        env_name=ENV_RTVI_CV_TIMEOUT_SECONDS,
+        default=DEFAULT_RTVI_CV_TIMEOUT_SECONDS,
+    )
+    rtvi_embed_timeout_seconds = _resolve_timeout_seconds(
+        streaming_config,
+        attr_name="rtvi_embed_timeout_seconds",
+        env_name=ENV_RTVI_EMBED_TIMEOUT_SECONDS,
+        default=DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS,
+    )
+    vst_storage_timeout_seconds = _resolve_timeout_seconds(
+        streaming_config,
+        attr_name="vst_storage_timeout_seconds",
+        env_name=ENV_VST_STORAGE_TIMEOUT_SECONDS,
+        default=DEFAULT_VST_STORAGE_TIMEOUT_SECONDS,
+    )
+    vst_upload_timeout_seconds = _resolve_timeout_seconds(
+        streaming_config,
+        attr_name="vst_upload_timeout_seconds",
+        env_name=ENV_VST_UPLOAD_TIMEOUT_SECONDS,
+        default=DEFAULT_VST_UPLOAD_TIMEOUT_SECONDS,
+    )
+
     return _VideoUploadConfig(
         vst_internal_url=vst_internal_url,
         vst_external_url=vst_external_url or vst_internal_url,
@@ -196,6 +265,10 @@ def _resolve_video_upload_config(config: "Any") -> _VideoUploadConfig | None:
         rtvi_cv_base_url=rtvi_cv_base_url,
         rtvi_embed_model=rtvi_embed_model,
         rtvi_embed_chunk_duration=rtvi_embed_chunk_duration,
+        rtvi_cv_timeout_seconds=rtvi_cv_timeout_seconds,
+        rtvi_embed_timeout_seconds=rtvi_embed_timeout_seconds,
+        vst_storage_timeout_seconds=vst_storage_timeout_seconds,
+        vst_upload_timeout_seconds=vst_upload_timeout_seconds,
     )
 
 
@@ -206,6 +279,7 @@ async def _register_with_rtvi_cv(
     camera_name: str,
     vst_file_path: str,
     start_timestamp: str,
+    timeout_seconds: float = DEFAULT_RTVI_CV_TIMEOUT_SECONDS,
 ) -> None:
     """POST ``/api/v1/stream/add`` to RTVI-CV. Best-effort (tolerates network errors).
 
@@ -238,7 +312,7 @@ async def _register_with_rtvi_cv(
     logger.info(f"Adding video to RTVI-CV: POST {rtvi_cv_add_url}")
 
     try:
-        async with httpx.AsyncClient(timeout=60.0) as client:
+        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             with TimeMeasure("video_ingest: register with RTVI-CV"):
                 response = await client.post(
                     rtvi_cv_add_url,
@@ -265,6 +339,7 @@ async def _run_rtvi_embedding(
     rtvi_embed_model: str,
     rtvi_embed_chunk_duration: int,
     start_timestamp: str,
+    timeout_seconds: float = DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS,
 ) -> int:
     """POST ``/v1/generate_video_embeddings``. Returns ``total_chunks_processed``.
 
@@ -290,7 +365,7 @@ async def _run_rtvi_embedding(
 
     logger.info(f"Calling RTVI Embedding API: POST {embedding_url}")
 
-    async with httpx.AsyncClient(timeout=600.0) as client:
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
         with TimeMeasure("video_ingest: generate embeddings (RTVI)"):
             response = await client.post(
                 embedding_url,
@@ -304,9 +379,7 @@ async def _run_rtvi_embedding(
             )
 
         if response.status_code != 200:
-            error_msg = (
-                f"Embedding generation failed with status {response.status_code}: {response.text}"
-            )
+            error_msg = f"Embedding generation failed with status {response.status_code}: {response.text}"
             logger.error(error_msg)
             raise HTTPException(status_code=502, detail=f"Embedding generation failed: {error_msg}")
 
@@ -326,6 +399,9 @@ async def _run_post_upload_processing(
     rtvi_cv_base_url: str = "",
     rtvi_embed_model: str = "cosmos-embed1-448p",
     rtvi_embed_chunk_duration: int = 5,
+    rtvi_cv_timeout_seconds: float = DEFAULT_RTVI_CV_TIMEOUT_SECONDS,
+    rtvi_embed_timeout_seconds: float = DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS,
+    vst_storage_timeout_seconds: float = DEFAULT_VST_STORAGE_TIMEOUT_SECONDS,
 ) -> VideoIngestResponse:
     """
     Run post-upload processing: get timeline, get video URL, add to RTVI-CV, generate embeddings.
@@ -377,7 +453,7 @@ async def _run_post_upload_processing(
     }
     logger.info(f"Calling Storage API: GET {storage_url}")
 
-    async with httpx.AsyncClient(timeout=60.0) as client:
+    async with httpx.AsyncClient(timeout=vst_storage_timeout_seconds) as client:
         with TimeMeasure("video_ingest: get storage URL from VST"):
             storage_response = await client.get(storage_url, params=storage_params)
 
@@ -416,6 +492,7 @@ async def _run_post_upload_processing(
                     camera_name=camera_name,
                     vst_file_path=vst_file_path,
                     start_timestamp=start_timestamp,
+                    timeout_seconds=rtvi_cv_timeout_seconds,
                 ),
             )
         )
@@ -435,6 +512,7 @@ async def _run_post_upload_processing(
                     rtvi_embed_model=rtvi_embed_model,
                     rtvi_embed_chunk_duration=rtvi_embed_chunk_duration,
                     start_timestamp=start_timestamp,
+                    timeout_seconds=rtvi_embed_timeout_seconds,
                 ),
             )
         )
@@ -510,6 +588,9 @@ def create_video_upload_complete_router(
     rtvi_cv_base_url: str = "",
     rtvi_embed_model: str = "cosmos-embed1-448p",
     rtvi_embed_chunk_duration: int = 5,
+    rtvi_cv_timeout_seconds: float = DEFAULT_RTVI_CV_TIMEOUT_SECONDS,
+    rtvi_embed_timeout_seconds: float = DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS,
+    vst_storage_timeout_seconds: float = DEFAULT_VST_STORAGE_TIMEOUT_SECONDS,
 ) -> APIRouter:
     """Build the universal ``POST /api/v1/videos/{sensor_id}/complete`` router.
 
@@ -553,6 +634,9 @@ def create_video_upload_complete_router(
                 rtvi_cv_base_url=rtvi_cv_base_url,
                 rtvi_embed_model=rtvi_embed_model,
                 rtvi_embed_chunk_duration=rtvi_embed_chunk_duration,
+                rtvi_cv_timeout_seconds=rtvi_cv_timeout_seconds,
+                rtvi_embed_timeout_seconds=rtvi_embed_timeout_seconds,
+                vst_storage_timeout_seconds=vst_storage_timeout_seconds,
             )
         except HTTPException:
             raise
@@ -603,6 +687,9 @@ def register_video_upload_complete(app: "FastAPI", config: "Any") -> None:
                 rtvi_cv_base_url=cfg.rtvi_cv_base_url,
                 rtvi_embed_model=cfg.rtvi_embed_model,
                 rtvi_embed_chunk_duration=cfg.rtvi_embed_chunk_duration,
+                rtvi_cv_timeout_seconds=cfg.rtvi_cv_timeout_seconds,
+                rtvi_embed_timeout_seconds=cfg.rtvi_embed_timeout_seconds,
+                vst_storage_timeout_seconds=cfg.vst_storage_timeout_seconds,
             )
         )
         logger.info("Registered POST /api/v1/videos/{sensor_id}/complete")

--- a/services/agent/src/vss_agents/api/video_search_ingest.py
+++ b/services/agent/src/vss_agents/api/video_search_ingest.py
@@ -40,6 +40,10 @@ from fastapi import HTTPException
 from fastapi import Request
 import httpx
 
+from vss_agents.api.video_ingest import DEFAULT_RTVI_CV_TIMEOUT_SECONDS
+from vss_agents.api.video_ingest import DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS
+from vss_agents.api.video_ingest import DEFAULT_VST_STORAGE_TIMEOUT_SECONDS
+from vss_agents.api.video_ingest import DEFAULT_VST_UPLOAD_TIMEOUT_SECONDS
 from vss_agents.api.video_ingest import VideoIngestResponse
 from vss_agents.api.video_ingest import _resolve_video_upload_config
 from vss_agents.api.video_ingest import _run_post_upload_processing
@@ -60,6 +64,10 @@ def create_video_search_ingest_router(
     rtvi_cv_base_url: str = "",
     rtvi_embed_model: str = "cosmos-embed1-448p",
     rtvi_embed_chunk_duration: int = 5,
+    vst_upload_timeout_seconds: float = DEFAULT_VST_UPLOAD_TIMEOUT_SECONDS,
+    rtvi_cv_timeout_seconds: float = DEFAULT_RTVI_CV_TIMEOUT_SECONDS,
+    rtvi_embed_timeout_seconds: float = DEFAULT_RTVI_EMBED_TIMEOUT_SECONDS,
+    vst_storage_timeout_seconds: float = DEFAULT_VST_STORAGE_TIMEOUT_SECONDS,
 ) -> APIRouter:
     """Build the deprecated ``PUT /api/v1/videos-for-search/{filename}`` router.
 
@@ -121,7 +129,7 @@ def create_video_search_ingest_router(
             raise HTTPException(status_code=400, detail="File is empty.")
 
         try:
-            async with httpx.AsyncClient(timeout=300.0) as client:
+            async with httpx.AsyncClient(timeout=vst_upload_timeout_seconds) as client:
                 logger.info("Streaming PUT upload to VST at %s", vst_upload_url)
                 with TimeMeasure("video_search_ingest: stream upload to VST"):
                     vst_response = await client.put(
@@ -160,6 +168,9 @@ def create_video_search_ingest_router(
                     rtvi_cv_base_url=rtvi_cv_base_url,
                     rtvi_embed_model=rtvi_embed_model,
                     rtvi_embed_chunk_duration=rtvi_embed_chunk_duration,
+                    rtvi_cv_timeout_seconds=rtvi_cv_timeout_seconds,
+                    rtvi_embed_timeout_seconds=rtvi_embed_timeout_seconds,
+                    vst_storage_timeout_seconds=vst_storage_timeout_seconds,
                 )
 
         except HTTPException:
@@ -192,6 +203,10 @@ def register_video_search_ingest_routes(app: "FastAPI", config: "Any") -> None:
                 rtvi_cv_base_url=cfg.rtvi_cv_base_url,
                 rtvi_embed_model=cfg.rtvi_embed_model,
                 rtvi_embed_chunk_duration=cfg.rtvi_embed_chunk_duration,
+                vst_upload_timeout_seconds=cfg.vst_upload_timeout_seconds,
+                rtvi_cv_timeout_seconds=cfg.rtvi_cv_timeout_seconds,
+                rtvi_embed_timeout_seconds=cfg.rtvi_embed_timeout_seconds,
+                vst_storage_timeout_seconds=cfg.vst_storage_timeout_seconds,
             )
         )
         logger.info("Registered deprecated PUT /api/v1/videos-for-search/{filename}")

--- a/services/agent/tests/unit_test/api/test_video_ingest.py
+++ b/services/agent/tests/unit_test/api/test_video_ingest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Unit tests for the video_ingest module's three-step chat upload flow."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -23,6 +24,10 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 import pytest
 
+from vss_agents.api.video_ingest import ENV_RTVI_CV_TIMEOUT_SECONDS
+from vss_agents.api.video_ingest import ENV_RTVI_EMBED_TIMEOUT_SECONDS
+from vss_agents.api.video_ingest import ENV_VST_STORAGE_TIMEOUT_SECONDS
+from vss_agents.api.video_ingest import ENV_VST_UPLOAD_TIMEOUT_SECONDS
 from vss_agents.api.video_ingest import VideoIngestResponse
 from vss_agents.api.video_ingest import VideoUploadCompleteInput
 from vss_agents.api.video_ingest import VideoUploadUrlInput
@@ -168,6 +173,7 @@ class TestRunPostUploadProcessing:
         so callbacks may consume the side_effect list in either order. Route by
         URL substring instead of by call order.
         """
+
         def _dispatch(url, *args, **kwargs):
             for substring, response in routes.items():
                 if substring in url:
@@ -188,10 +194,12 @@ class TestRunPostUploadProcessing:
         client.__aenter__ = AsyncMock(return_value=client)
         client.__aexit__ = AsyncMock(return_value=None)
         client.get = AsyncMock(return_value=storage_resp)
-        client.post = self._post_router({
-            "/api/v1/stream/add": cv_resp,
-            "/v1/generate_video_embeddings": embed_resp,
-        })
+        client.post = self._post_router(
+            {
+                "/api/v1/stream/add": cv_resp,
+                "/v1/generate_video_embeddings": embed_resp,
+            }
+        )
 
         with self._timeline_patch(), patch("vss_agents.api.video_ingest.httpx.AsyncClient", return_value=client):
             result = await _run_post_upload_processing(
@@ -218,10 +226,12 @@ class TestRunPostUploadProcessing:
         client.__aenter__ = AsyncMock(return_value=client)
         client.__aexit__ = AsyncMock(return_value=None)
         client.get = AsyncMock(return_value=storage_resp)
-        client.post = self._post_router({
-            "/api/v1/stream/add": httpx.ConnectError("connection refused"),
-            "/v1/generate_video_embeddings": embed_resp,
-        })
+        client.post = self._post_router(
+            {
+                "/api/v1/stream/add": httpx.ConnectError("connection refused"),
+                "/v1/generate_video_embeddings": embed_resp,
+            }
+        )
 
         with self._timeline_patch(), patch("vss_agents.api.video_ingest.httpx.AsyncClient", return_value=client):
             result = await _run_post_upload_processing(
@@ -396,6 +406,26 @@ class TestUploadCompleteRoute:
         assert kwargs["filename"] == "sensor-xyz"
         assert kwargs["camera_name"] == "sensor-xyz"
 
+    @pytest.mark.asyncio
+    async def test_handler_passes_timeout_config_to_processing(self):
+        route = create_video_upload_complete_router(
+            vst_internal_url="http://vst:30888",
+            rtvi_cv_timeout_seconds=12.5,
+            rtvi_embed_timeout_seconds=345.0,
+            vst_storage_timeout_seconds=23.0,
+        ).routes[0]
+
+        with patch(
+            "vss_agents.api.video_ingest._run_post_upload_processing",
+            new=AsyncMock(return_value=VideoIngestResponse(message="ok", sensor_id="sensor-xyz", filename="clip.mp4")),
+        ) as mock_post:
+            await route.endpoint(sensor_id="sensor-xyz", body=VideoUploadCompleteInput(filename="clip.mp4"))
+
+        kwargs = mock_post.call_args.kwargs
+        assert kwargs["rtvi_cv_timeout_seconds"] == 12.5
+        assert kwargs["rtvi_embed_timeout_seconds"] == 345.0
+        assert kwargs["vst_storage_timeout_seconds"] == 23.0
+
 
 class TestResolveVideoUploadConfig:
     """Pin down config resolution: YAML wins, env-var fallback."""
@@ -416,6 +446,40 @@ class TestResolveVideoUploadConfig:
         assert resolved.vst_internal_url == "http://vst:8080"
         assert resolved.vst_external_url == "http://vst.public:8080"
         assert resolved.rtvi_embed_base_url == "http://rtvi-embed:8017"
+        assert resolved.vst_upload_timeout_seconds == 300.0
+        assert resolved.vst_storage_timeout_seconds == 60.0
+        assert resolved.rtvi_cv_timeout_seconds == 60.0
+        assert resolved.rtvi_embed_timeout_seconds == 600.0
+
+    def test_streaming_ingest_timeout_config_wins(self):
+        streaming = SimpleNamespace(
+            vst_internal_url="http://vst:8080",
+            vst_external_url="",
+            rtvi_embed_base_url="",
+            rtvi_cv_base_url="",
+            rtvi_embed_model="cosmos-embed1-448p",
+            rtvi_embed_chunk_duration=5,
+            vst_upload_timeout_seconds="301.5",
+            vst_storage_timeout_seconds=61,
+            rtvi_cv_timeout_seconds="62",
+            rtvi_embed_timeout_seconds=601.0,
+        )
+        config = SimpleNamespace(general=SimpleNamespace(front_end=SimpleNamespace(streaming_ingest=streaming)))
+
+        env = {
+            ENV_VST_UPLOAD_TIMEOUT_SECONDS: "999",
+            ENV_VST_STORAGE_TIMEOUT_SECONDS: "999",
+            ENV_RTVI_CV_TIMEOUT_SECONDS: "999",
+            ENV_RTVI_EMBED_TIMEOUT_SECONDS: "999",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            resolved = _resolve_video_upload_config(config)
+
+        assert resolved is not None
+        assert resolved.vst_upload_timeout_seconds == 301.5
+        assert resolved.vst_storage_timeout_seconds == 61.0
+        assert resolved.rtvi_cv_timeout_seconds == 62.0
+        assert resolved.rtvi_embed_timeout_seconds == 601.0
 
     def test_external_url_falls_back_to_internal_when_unset(self):
         config = MagicMock()
@@ -453,6 +517,26 @@ class TestResolveVideoUploadConfig:
         assert resolved.vst_external_url == "http://vst.public:30888"
         assert resolved.rtvi_embed_base_url == "http://10.0.0.5:8017"
         assert resolved.rtvi_cv_base_url == "http://10.0.0.5:9000"
+
+    def test_falls_back_to_env_timeout_overrides_when_streaming_ingest_missing(self):
+        config = MagicMock()
+        config.general.front_end.streaming_ingest = None
+
+        env = {
+            "VST_INTERNAL_URL": "http://vst:30888",
+            ENV_VST_UPLOAD_TIMEOUT_SECONDS: "444",
+            ENV_VST_STORAGE_TIMEOUT_SECONDS: "45.5",
+            ENV_RTVI_CV_TIMEOUT_SECONDS: "46",
+            ENV_RTVI_EMBED_TIMEOUT_SECONDS: "447.25",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            resolved = _resolve_video_upload_config(config)
+
+        assert resolved is not None
+        assert resolved.vst_upload_timeout_seconds == 444.0
+        assert resolved.vst_storage_timeout_seconds == 45.5
+        assert resolved.rtvi_cv_timeout_seconds == 46.0
+        assert resolved.rtvi_embed_timeout_seconds == 447.25
 
     def test_returns_none_when_vst_url_unavailable(self):
         config = MagicMock()

--- a/services/agent/tests/unit_test/api/test_video_search_ingest.py
+++ b/services/agent/tests/unit_test/api/test_video_search_ingest.py
@@ -14,12 +14,14 @@
 # limitations under the License.
 """Unit tests for the deprecated PUT /api/v1/videos-for-search/{filename} shim."""
 
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from fastapi import FastAPI
 import pytest
 
+from vss_agents.api.video_ingest import VideoIngestResponse
 from vss_agents.api.video_search_ingest import create_video_search_ingest_router
 from vss_agents.api.video_search_ingest import register_video_search_ingest_routes
 
@@ -157,3 +159,45 @@ class TestUploadVideoToVstHeaderValidation:
                 request=self._request({"content-type": "video/mp4", "content-length": "0"}),
             )
         assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_custom_timeouts_apply_to_upload_and_completion(self):
+        route = create_video_search_ingest_router(
+            vst_internal_url="http://vst:30888",
+            rtvi_embed_base_url="",
+            vst_upload_timeout_seconds=123.0,
+            rtvi_cv_timeout_seconds=124.0,
+            rtvi_embed_timeout_seconds=125.0,
+            vst_storage_timeout_seconds=126.0,
+        ).routes[0]
+
+        response = MagicMock()
+        response.status_code = 201
+        response.json.return_value = {"sensorId": "sensor-abc", "filename": "clip.mp4"}
+        response.text = "OK"
+
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.put = AsyncMock(return_value=response)
+
+        request = self._request({"content-type": "video/mp4", "content-length": "10"})
+        request.stream.return_value = "stream-body"
+
+        with (
+            patch("vss_agents.api.video_search_ingest.httpx.AsyncClient", return_value=client) as async_client,
+            patch(
+                "vss_agents.api.video_search_ingest._run_post_upload_processing",
+                new=AsyncMock(
+                    return_value=VideoIngestResponse(message="ok", sensor_id="sensor-abc", filename="clip.mp4")
+                ),
+            ) as mock_post,
+        ):
+            result = await route.endpoint(filename="clip.mp4", request=request)
+
+        assert result.sensor_id == "sensor-abc"
+        async_client.assert_called_once_with(timeout=123.0)
+        kwargs = mock_post.call_args.kwargs
+        assert kwargs["rtvi_cv_timeout_seconds"] == 124.0
+        assert kwargs["rtvi_embed_timeout_seconds"] == 125.0
+        assert kwargs["vst_storage_timeout_seconds"] == 126.0


### PR DESCRIPTION
## Summary
- Adds four configurable HTTP-call timeouts for the video ingest path: RTVI-CV register, RTVI-Embed generation, VST storage GET, and VST upload PUT.
- New `_parse_timeout_seconds` helper warns and falls back to the built-in default on invalid / non-positive values; `_resolve_timeout_seconds` applies precedence YAML → env var → default.
- Helm chart exposes the four timeouts under `videoIngestTimeouts.*` and injects them into the agent as `VIDEO_INGEST_*_TIMEOUT_SECONDS` env vars.
- Both the universal `POST /api/v1/videos/{sensor_id}/complete` route and the deprecated `PUT /api/v1/videos-for-search/{filename}` shim are threaded with the resolved timeouts.
- Unit tests cover YAML-wins-over-env, env fallback when `streaming_ingest` is absent, router threading into `_run_post_upload_processing`, and the deprecated shim applying custom timeouts to both `AsyncClient` and the completion call.

## Motivation
The previous hard-coded `httpx.AsyncClient` timeouts (VST upload 300 s, RTVI-Embed generation 600 s) are too short for long videos and slow embedding runs in real deployments. Tuning them required a code change. This change lets operators adjust the four ingest timeouts via YAML config or env vars at deploy time, with no behavior change for deployments that leave them unset.

## Risk & Blast Radius
Low. All four timeouts default to their previous hard-coded values when no YAML or env override is set, so existing deployments behave identically. The Helm change is additive (new optional values block). Touches only the ingest HTTP paths — no auth, schema, persistence, or public-API contract changes. Reversible by reverting the single commit.

## Test Plan
- [ ] Deploy with no YAML / env overrides — confirm existing ingest behavior is unchanged.
- [ ] Set `videoIngestTimeouts.vstUploadSeconds` in Helm values — confirm the env var is injected and the upload client uses the new value.
- [ ] Set `VIDEO_INGEST_VST_UPLOAD_TIMEOUT_SECONDS=120` env var without a YAML override — confirm 120 s is used.
- [ ] Set both YAML and env for the same timeout — confirm YAML wins.
- [ ] Pass an invalid value (e.g. `"abc"` or `"-1"`) — confirm a warning is logged and the default is used.

## Notes for Reviewer
- The deprecated `PUT /api/v1/videos-for-search/{filename}` shim is updated alongside the universal `POST /api/v1/videos/{sensor_id}/complete` route — both paths needed the same env/YAML wiring.
- `_resolve_timeout_seconds` includes a `unittest.mock` guard so that a `MagicMock`'s default-attribute behavior doesn't mask the env-var fallback path in tests.
- Defaults are exported as module-level constants so `video_search_ingest.py` and the tests can import them without duplication.