### PR TITLE
feat(license-diff): fail and post PR comment when diff is non-empty

### DIFF
--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -59,6 +59,7 @@ jobs:
           head -n 30 license-diff.csv || true
 
       - name: Upload CSV artifact
+        id: upload
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
@@ -117,6 +118,7 @@ jobs:
           ROWS: ${{ steps.gen.outputs.rows }}
           BASE: ${{ steps.ctx.outputs.base }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
         run: |
           set -euo pipefail
           marker='<!-- license-diff-osrb -->'
@@ -125,9 +127,16 @@ jobs:
             echo "## License Diff for OSRB"
             echo
             echo "**${ROWS}** changed packages require OSRB review (vs \`${BASE}\`)."
-            echo "Download the full CSV from the [workflow run](${RUN_URL}) (artifact: \`license-diff\`)."
+            echo "Download the full CSV directly: [\`license-diff.csv\`](${ARTIFACT_URL}) (or browse the [workflow run](${RUN_URL}))."
             echo
             cat diff-table.md
+            echo
+            echo "<details><summary>Raw CSV (inline)</summary>"
+            echo
+            echo '```csv'
+            cat license-diff.csv
+            echo '```'
+            echo "</details>"
             echo
             echo "_This check is informational. CODEOWNERS still gates merge — get approval from \`@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers\` for the touched lockfile/manifest paths._"
           } > comment.md

--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 defaults:
   run:
@@ -31,25 +32,30 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Resolve base ref
-        id: base
+      - name: Resolve base ref and PR number
+        id: ctx
         env:
           DEFAULT_BRANCH: develop
         run: |
           set -euo pipefail
           git fetch --no-tags origin "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
           merge_base=$(git merge-base HEAD "origin/${DEFAULT_BRANCH}" || git rev-parse "origin/${DEFAULT_BRANCH}")
-          echo "ref=${merge_base}" >> "$GITHUB_OUTPUT"
-          echo "Comparing HEAD against ${merge_base}"
+          pr_number="${GITHUB_REF##*/pull-request/}"
+          echo "base=${merge_base}" >> "$GITHUB_OUTPUT"
+          echo "pr=${pr_number}" >> "$GITHUB_OUTPUT"
+          echo "Comparing HEAD against ${merge_base} for PR #${pr_number}"
 
       - name: Generate license diff CSV
+        id: gen
         run: |
           set -euo pipefail
           python scripts/licensing/license_diff_csv.py \
-            --base-ref "${{ steps.base.outputs.ref }}" \
+            --base-ref "${{ steps.ctx.outputs.base }}" \
             --head-ref HEAD \
             --output license-diff.csv
-          echo "--- csv preview ---"
+          row_count=$(($(wc -l < license-diff.csv) - 1))
+          echo "rows=${row_count}" >> "$GITHUB_OUTPUT"
+          echo "--- csv preview (rows=${row_count}) ---"
           head -n 30 license-diff.csv || true
 
       - name: Upload CSV artifact
@@ -60,8 +66,31 @@ jobs:
           path: license-diff.csv
           if-no-files-found: warn
 
+      - name: Render markdown table
+        id: render
+        if: always() && steps.gen.outputs.rows != ''
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' > diff-table.md
+          import csv
+          rows = list(csv.DictReader(open("license-diff.csv")))
+          print("| language | package | change | old_version | new_version | old_license | new_license | repository_url |")
+          print("|----------|---------|--------|-------------|-------------|-------------|-------------|----------------|")
+          for row in rows:
+              cells = [
+                  row["language"], row["package"], row["change"],
+                  row["old_version"], row["new_version"],
+                  row["old_license"], row["new_license"],
+                  row["repository_url"],
+              ]
+              print("| " + " | ".join(c.replace("|", "\\|") for c in cells) + " |")
+          PY
+
       - name: Write step summary
         if: always()
+        env:
+          ROWS: ${{ steps.gen.outputs.rows }}
+          BASE: ${{ steps.ctx.outputs.base }}
         run: |
           set -euo pipefail
           {
@@ -69,27 +98,54 @@ jobs:
             echo
             if [[ ! -f license-diff.csv ]]; then
               echo "No CSV produced."
-              exit 0
-            fi
-            row_count=$(($(wc -l < license-diff.csv) - 1))
-            if [[ "$row_count" -le 0 ]]; then
+            elif [[ "${ROWS:-0}" -le 0 ]]; then
               echo "No package version or license changes detected."
-              exit 0
+            else
+              echo "Compared HEAD against \`${BASE}\`."
+              echo "**${ROWS}** changed packages require OSRB review. Full CSV is attached as the **license-diff** artifact."
+              echo
+              cat diff-table.md
             fi
-            echo "Compared HEAD against \`${{ steps.base.outputs.ref }}\`."
-            echo "**$row_count** changed packages require OSRB review. Full CSV is attached as the **license-diff** artifact."
-            echo
-            echo "| language | package | change | old_version | new_version | old_license | new_license |"
-            echo "|----------|---------|--------|-------------|-------------|-------------|-------------|"
-            python3 - <<'PY'
-          import csv
-          with open("license-diff.csv") as f:
-              for row in csv.DictReader(f):
-                  cells = [
-                      row["language"], row["package"], row["change"],
-                      row["old_version"], row["new_version"],
-                      row["old_license"], row["new_license"],
-                  ]
-                  print("| " + " | ".join(c.replace("|", "\\|") for c in cells) + " |")
-          PY
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post or update PR comment
+        if: always() && steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.ctx.outputs.pr }}
+          ROWS: ${{ steps.gen.outputs.rows }}
+          BASE: ${{ steps.ctx.outputs.base }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          marker='<!-- license-diff-osrb -->'
+          {
+            echo "$marker"
+            echo "## License Diff for OSRB"
+            echo
+            echo "**${ROWS}** changed packages require OSRB review (vs \`${BASE}\`)."
+            echo "Download the full CSV from the [workflow run](${RUN_URL}) (artifact: \`license-diff\`)."
+            echo
+            cat diff-table.md
+            echo
+            echo "_This check is informational. CODEOWNERS still gates merge — get approval from \`@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers\` for the touched lockfile/manifest paths._"
+          } > comment.md
+          existing=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id")
+          payload=$(jq -Rsn '{body: input}' < comment.md)
+          if [[ -n "$existing" && "$existing" != "null" ]]; then
+            echo "Updating existing comment $existing"
+            echo "$payload" | gh api -X PATCH "repos/${REPO}/issues/comments/${existing}" --input - > /dev/null
+          else
+            echo "Creating new comment on PR #${PR}"
+            echo "$payload" | gh api -X POST "repos/${REPO}/issues/${PR}/comments" --input - > /dev/null
+          fi
+
+      - name: Fail when license diff is non-empty
+        if: steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
+        env:
+          ROWS: ${{ steps.gen.outputs.rows }}
+        run: |
+          echo "::error title=License diff non-empty::${ROWS} packages changed; requires OSRB review."
+          exit 1


### PR DESCRIPTION
## Summary

Builds on #461. The License Diff job currently always passes (informational only). This change makes it **actively surface attention** when a PR changes packages:

- **Empty diff** → green check, no comment (unchanged).
- **Non-empty diff** → posts (or updates idempotently via a hidden marker) a PR comment with the diff table + artifact link, then **exits non-zero** so the check shows red on the PR.

The job is not in the `develop` ruleset's required-checks list, so the red status surfaces attention without hard-blocking merge — the actual gate remains the CODEOWNERS approval from `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers` added in #455.

## What the PR comment looks like

````markdown
<!-- license-diff-osrb -->
## License Diff for OSRB

**3** changed packages require OSRB review (vs `abcdef0`).
Download the full CSV from the [workflow run](...) (artifact: `license-diff`).

| language | package | change | old_version | new_version | old_license | new_license | repository_url |
|----------|---------|--------|-------------|-------------|-------------|-------------|----------------|
| python   | aiohttp | updated | 3.13.3 | 3.13.4 | Apache-2.0 AND MIT | Apache-2.0 AND MIT | https://github.com/aio-libs/aiohttp |
| python   | click   | updated | 8.3.1  | 8.1.8  |                    | BSD                | https://github.com/pallets/click/   |
| node     | idb     | added   |        | 8.0.3  |                    | ISC                | https://www.npmjs.com/package/idb/v/8.0.3 |

_This check is informational. CODEOWNERS still gates merge — get approval from `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers` for the touched lockfile/manifest paths._
````

## Implementation notes

- The marker `<!-- license-diff-osrb -->` is the first line of every bot comment, used to dedupe on re-runs: a re-push of the same PR updates the existing comment via `PATCH /repos/.../issues/comments/{id}` instead of stacking new ones.
- Comment body is built via `jq -Rsn '{body: input}'` and piped to `gh api --input -` so the markdown is safely JSON-encoded regardless of contents.
- Added `permissions: pull-requests: write` to the workflow so the `GITHUB_TOKEN` can post comments.

## Test plan

- [ ] This PR itself changes only the workflow → diff is empty → job stays green and posts no comment.
- [ ] Manually push a draft PR that bumps a dep in `services/agent/uv.lock` → red check, single PR comment with the bumped row, artifact downloadable.
- [ ] Push a second commit to that same PR → existing comment is updated in-place (no duplicate comments).