### PR TITLE
fix(lvs): override per-chunk frame count for stream captioning

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -159,6 +159,7 @@ functions:
     read_timeout_ms: 600000
     chunk_duration: 10
     num_frames_per_chunk: 10
+    use_fps_for_chunking: false
     vlm_input_width: 1280
     vlm_input_height: 720
     # Nemotron Nano Omni: set ENABLE_AUDIO=true so the agent forwards audio to the VLM.

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -158,6 +158,7 @@ functions:
     conn_timeout_ms: 5000
     read_timeout_ms: 600000
     chunk_duration: 10
+    num_frames_per_chunk: 10
     vlm_input_width: 1280
     vlm_input_height: 720
     # Nemotron Nano Omni: set ENABLE_AUDIO=true so the agent forwards audio to the VLM.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -159,6 +159,7 @@ functions:
     conn_timeout_ms: 5000
     read_timeout_ms: 600000
     chunk_duration: 10
+    num_frames_per_chunk: 10
     vlm_input_width: 1280
     vlm_input_height: 720
     # Nemotron Nano Omni: set ENABLE_AUDIO=true so the agent forwards audio to the VLM.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -160,6 +160,7 @@ functions:
     read_timeout_ms: 600000
     chunk_duration: 10
     num_frames_per_chunk: 10
+    use_fps_for_chunking: false
     vlm_input_width: 1280
     vlm_input_height: 720
     # Nemotron Nano Omni: set ENABLE_AUDIO=true so the agent forwards audio to the VLM.

--- a/services/agent/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/src/vss_agents/tools/lvs_config_media.py
@@ -124,6 +124,10 @@ class LVSConfigMediaConfig(FunctionBaseConfig, name="lvs_config_media"):
         default=10,
         description="Frames per chunk sent to the VLM. Forwarded as `num_frames_per_second_or_fixed_frames_chunk`.",
     )
+    use_fps_for_chunking: bool = Field(
+        default=False,
+        description="If True, interpret `num_frames_per_chunk` as FPS instead of fixed frames per chunk.",
+    )
     seed: int | None = Field(default=None, description="Random seed for LVS media processing.")
     vlm_input_width: int | None = Field(
         default=None,
@@ -348,6 +352,7 @@ async def lvs_config_media(config: LVSConfigMediaConfig, _: Builder) -> AsyncGen
             "events": events,
             "chunk_duration": config.chunk_duration,
             "num_frames_per_second_or_fixed_frames_chunk": config.num_frames_per_chunk,
+            "use_fps_for_chunking": config.use_fps_for_chunking,
         }
         if config.seed is not None:
             payload["seed"] = config.seed

--- a/services/agent/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/src/vss_agents/tools/lvs_config_media.py
@@ -120,6 +120,10 @@ class LVSConfigMediaConfig(FunctionBaseConfig, name="lvs_config_media"):
     conn_timeout_ms: int = Field(default=5000, description="Connection timeout in milliseconds.")
     read_timeout_ms: int = Field(default=600000, description="Read timeout in milliseconds.")
     chunk_duration: int = Field(default=10, description="Duration of each stream chunk in seconds.")
+    num_frames_per_chunk: int = Field(
+        default=10,
+        description="Frames per chunk sent to the VLM. Forwarded as `num_frames_per_second_or_fixed_frames_chunk`.",
+    )
     seed: int | None = Field(default=None, description="Random seed for LVS media processing.")
     vlm_input_width: int | None = Field(
         default=None,
@@ -343,6 +347,7 @@ async def lvs_config_media(config: LVSConfigMediaConfig, _: Builder) -> AsyncGen
             "scenario": scenario,
             "events": events,
             "chunk_duration": config.chunk_duration,
+            "num_frames_per_second_or_fixed_frames_chunk": config.num_frames_per_chunk,
         }
         if config.seed is not None:
             payload["seed"] = config.seed

--- a/services/agent/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/tests/unit_test/tools/test_lvs_config_media.py
@@ -145,6 +145,7 @@ class TestLVSConfigMediaInner:
                 "events": ["accident"],
                 "chunk_duration": 10,
                 "num_frames_per_second_or_fixed_frames_chunk": 10,
+                "use_fps_for_chunking": False,
             },
         )
 
@@ -229,6 +230,47 @@ class TestLVSConfigMediaInner:
         mock_session.post.assert_called_once()
         _, kwargs = mock_session.post.call_args
         assert kwargs["json"]["num_frames_per_second_or_fixed_frames_chunk"] == 20
+
+    @pytest.mark.asyncio
+    async def test_use_fps_for_chunking_is_configurable(self):
+        config = LVSConfigMediaConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+            model="nvidia/cosmos-reason2-8b",
+            hitl_scenario_template="Scenario",
+            hitl_events_template="Events",
+            hitl_objects_template="Objects",
+            default_scenario="warehouse monitoring",
+            default_events=["accident"],
+            use_fps_for_chunking=True,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status = 202
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("vss_agents.tools.lvs_config_media.get_stream_info_by_name", new_callable=AsyncMock) as mock_stream:
+            mock_stream.return_value = ("stream-uuid", "rtsp://example/stream")
+            with patch(
+                "vss_agents.tools.lvs_config_media._prompt_user_input",
+                new_callable=AsyncMock,
+            ) as mock_prompt:
+                mock_prompt.side_effect = ["", "", "forklifts, workers", ""]
+                with patch("vss_agents.tools.lvs_config_media.aiohttp.ClientSession", return_value=mock_session):
+                    with patch("vss_agents.tools.lvs_config_media.aiohttp.ClientTimeout"):
+                        inner_fn = await self._get_inner_fn(config)
+                        await inner_fn(LVSConfigMediaInput(stream_name="CAM_1"))
+
+        mock_session.post.assert_called_once()
+        _, kwargs = mock_session.post.call_args
+        assert kwargs["json"]["use_fps_for_chunking"] is True
 
     @pytest.mark.asyncio
     async def test_config_media_stream_not_found(self):

--- a/services/agent/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/tests/unit_test/tools/test_lvs_config_media.py
@@ -144,6 +144,7 @@ class TestLVSConfigMediaInner:
                 "scenario": "warehouse monitoring",
                 "events": ["accident"],
                 "chunk_duration": 10,
+                "num_frames_per_second_or_fixed_frames_chunk": 10,
             },
         )
 
@@ -187,6 +188,47 @@ class TestLVSConfigMediaInner:
         mock_session.post.assert_called_once()
         _, kwargs = mock_session.post.call_args
         assert kwargs["json"].get("enable_audio") is True
+
+    @pytest.mark.asyncio
+    async def test_num_frames_per_chunk_is_configurable(self):
+        config = LVSConfigMediaConfig(
+            lvs_backend_url="http://localhost:38111",
+            vst_internal_url="http://localhost:30888",
+            model="nvidia/cosmos-reason2-8b",
+            hitl_scenario_template="Scenario",
+            hitl_events_template="Events",
+            hitl_objects_template="Objects",
+            default_scenario="warehouse monitoring",
+            default_events=["accident"],
+            num_frames_per_chunk=20,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status = 202
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("vss_agents.tools.lvs_config_media.get_stream_info_by_name", new_callable=AsyncMock) as mock_stream:
+            mock_stream.return_value = ("stream-uuid", "rtsp://example/stream")
+            with patch(
+                "vss_agents.tools.lvs_config_media._prompt_user_input",
+                new_callable=AsyncMock,
+            ) as mock_prompt:
+                mock_prompt.side_effect = ["", "", "forklifts, workers", ""]
+                with patch("vss_agents.tools.lvs_config_media.aiohttp.ClientSession", return_value=mock_session):
+                    with patch("vss_agents.tools.lvs_config_media.aiohttp.ClientTimeout"):
+                        inner_fn = await self._get_inner_fn(config)
+                        await inner_fn(LVSConfigMediaInput(stream_name="CAM_1"))
+
+        mock_session.post.assert_called_once()
+        _, kwargs = mock_session.post.call_args
+        assert kwargs["json"]["num_frames_per_second_or_fixed_frames_chunk"] == 20
 
     @pytest.mark.asyncio
     async def test_config_media_stream_not_found(self):


### PR DESCRIPTION
## Description
- The LVS-side default of 1 frame per chunk made the VLM emit ~1 ms event durations on stream-mode reports.
- Pass `num_frames_per_second_or_fixed_frames_chunk` (default 10) in the `/v1/generate_captions` payload via a new `num_frames_per_chunk` config field on `lvs_config_media`. 
- Include `num_frames_per_chunk: 10` in the `dev-profile-lvs` agent config (docker + helm).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
