### PR TITLE
docs(skills): drop dead components.yml link

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -70,4 +70,4 @@ To uninstall skills, paste the following prompt:
 
 ## Source of truth
 
-This `skills/` directory is the canonical source. Skills published to the public catalog at `github.com/nvidia/skills` are mirrored from here at sync time per [`components.yml`](https://github.com/NVIDIA/skills/blob/main/components.yml).
+This `skills/` directory is the canonical source. Skills published to the public catalog at `github.com/nvidia/skills` are mirrored from here at sync time.


### PR DESCRIPTION
The link to \`https://github.com/NVIDIA/skills/blob/main/components.yml\` in \`skills/README.md\` returns 404. Drop the link from the prose; everything else stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)