### PR TITLE
agent: Move video understanding parameters to vlm and maintain backwards compatibility

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
@@ -58,10 +58,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 30
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: true
     video_url_tool: vst_video_clip
     vlm_mode: ${VLM_MODE}
     vst_internal_url: ${VST_INTERNAL_URL}
@@ -70,10 +66,6 @@ functions:
   video_understanding_iso:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 30
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: true
     video_url_tool: vst_video_url
     use_base64: true
     vlm_mode: ${VLM_MODE}
@@ -221,6 +213,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 1024
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: true
 
   openai_vlm:
     _type: openai
@@ -228,6 +225,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: true
 
   vllm_vlm:
     _type: openai
@@ -235,6 +237,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: true
 
   # --- Others ---
   prompt_gen_llm:

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
@@ -226,6 +226,7 @@ llms:
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_tokens: 4096
     max_frames: 30
     max_fps: 2  # for CR1, max fps is 2
     min_pixels: 3136

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
@@ -52,11 +52,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm # e.g. nim_vlm, openai_vlm
-    max_frames: 30
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 8388608
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -195,6 +190,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   openai_vlm:
     _type: openai
@@ -202,6 +202,11 @@ llms:
     # uses https://api.openai.com/v1 by default
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -209,6 +214,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   # RTVI pipeline VLM (search/alerts). Endpoint: ${RTVI_VLM_BASE_URL}; model: ${VLM_NAME}. Keep in sync with config_rag.yml.
   rtvi_vlm:
@@ -216,6 +226,11 @@ llms:
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -233,6 +233,7 @@ llms:
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_tokens: 4096
     max_frames: 30
     max_fps: 2  # for CR1, max fps is 2
     min_pixels: 3136

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -49,11 +49,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm # e.g. nim_vlm, openai_vlm
-    max_frames: 30
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 8388608
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -202,6 +197,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   openai_vlm:
     _type: openai
@@ -209,6 +209,11 @@ llms:
     # uses https://api.openai.com/v1 by default
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -216,6 +221,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   # RTVI pipeline VLM (search/alerts). Endpoint: ${RTVI_VLM_BASE_URL}; model: ${VLM_NAME}. Keep in sync with config.yml.
   rtvi_vlm:
@@ -223,6 +233,11 @@ llms:
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -52,11 +52,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 60
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -312,12 +307,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   openai_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -325,12 +330,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   rtvi_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -48,11 +48,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 60
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -252,12 +247,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   openai_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -265,12 +270,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   rtvi_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
@@ -132,11 +132,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 60
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -165,6 +160,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   openai_vlm:
     _type: openai
@@ -172,6 +172,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -179,6 +184,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
 workflow:
   _type: top_agent

--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
@@ -54,10 +54,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 30
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: false
     video_url_tool: vst_video_url
     vlm_mode: ${VLM_MODE}
     vst_internal_url: ${VST_INTERNAL_URL}
@@ -177,12 +173,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 1024
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   openai_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     temperature: 0.0
     max_tokens: 1024
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -190,12 +196,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 1024
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   rtvi_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
@@ -58,10 +58,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 30
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: true
     video_url_tool: vst_video_clip
     vlm_mode: ${VLM_MODE}
     vst_internal_url: ${VST_INTERNAL_URL}
@@ -70,10 +66,6 @@ functions:
   video_understanding_iso:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 30
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: true
     video_url_tool: vst_video_url
     use_base64: true
     vlm_mode: ${VLM_MODE}
@@ -223,6 +215,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 1024
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: true
 
   openai_vlm:
     _type: openai
@@ -230,6 +227,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: true
 
   vllm_vlm:
     _type: openai
@@ -237,6 +239,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: true
 
   # --- Others ---
   prompt_gen_llm:

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
@@ -52,11 +52,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm # e.g. nim_vlm, openai_vlm
-    max_frames: 30
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 8388608
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -195,6 +190,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   openai_vlm:
     _type: openai
@@ -202,6 +202,11 @@ llms:
     # uses https://api.openai.com/v1 by default
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -209,6 +214,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   # RTVI pipeline VLM (search/alerts). Endpoint: ${RTVI_VLM_BASE_URL}; model: ${VLM_NAME}. Keep in sync with config_rag.yml.
   rtvi_vlm:
@@ -216,6 +226,12 @@ llms:
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
@@ -49,11 +49,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm # e.g. nim_vlm, openai_vlm
-    max_frames: 30
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 8388608
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -202,6 +197,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   openai_vlm:
     _type: openai
@@ -209,6 +209,11 @@ llms:
     # uses https://api.openai.com/v1 by default
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -216,6 +221,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
 
   # RTVI pipeline VLM (search/alerts). Endpoint: ${RTVI_VLM_BASE_URL}; model: ${VLM_NAME}. Keep in sync with config.yml.
   rtvi_vlm:
@@ -223,6 +233,12 @@ llms:
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_tokens: 4096
+    max_frames: 30
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 8388608
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -52,11 +52,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 60
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -312,12 +307,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   openai_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -325,12 +330,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   rtvi_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
@@ -48,11 +48,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 60
-    max_fps: 2  # for CR1, max fps is 2
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -252,12 +247,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   openai_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -265,12 +270,22 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   rtvi_vlm:
     _type: openai
     model_name: ${VLM_NAME}
     base_url: ${RTVI_VLM_BASE_URL}/v1
     temperature: 0.0
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
     model_kwargs:
       extra_body:
         num_frames_per_second_or_fixed_frames_chunk: 20

--- a/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
@@ -132,11 +132,6 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm
-    max_frames: 60
-    max_fps: 2
-    min_pixels: 3136
-    max_pixels: 12845056
-    reasoning: false
     video_url_tool: vst_video_clip
     time_format: offset
     vlm_mode: ${VLM_MODE}
@@ -165,6 +160,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   openai_vlm:
     _type: openai
@@ -172,6 +172,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
   vllm_vlm:
     _type: openai
@@ -179,6 +184,11 @@ llms:
     base_url: ${VLM_BASE_URL}/v1
     temperature: 0.0
     max_tokens: 4096
+    max_frames: 60
+    max_fps: 2  # for CR1, max fps is 2
+    min_pixels: 3136
+    max_pixels: 12845056
+    reasoning: false
 
 workflow:
   _type: top_agent

--- a/services/agent/src/vss_agents/agents/report_agent.py
+++ b/services/agent/src/vss_agents/agents/report_agent.py
@@ -94,7 +94,7 @@ class ReportAgentInput(BaseModel):
 
     vlm_reasoning: bool | None = Field(
         default=None,
-        description="Enable VLM reasoning mode for video analysis. If None, uses video_understanding config default.",
+        description="Enable VLM reasoning mode for video analysis. If None, uses the VLM profile or video_understanding config default.",
     )
 
     llm_reasoning: bool | None = Field(
@@ -139,7 +139,7 @@ class VideoReportAgentInput(BaseModel):
     )
     vlm_reasoning: bool | None = Field(
         default=None,
-        description="Enable VLM reasoning mode for video analysis. If None, uses video_understanding config default. Ignored for RTSP streams.",
+        description="Enable VLM reasoning mode for video analysis. If None, uses the VLM profile or video_understanding config default. Ignored for RTSP streams.",
     )
     media_type: Literal["video", "rtsp"] = Field(
         default="video",

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -54,7 +54,17 @@ _VLM_PROFILE_MEDIA_KEYS = frozenset({"max_frames", "max_fps", "min_pixels", "max
 
 def _vlm_profile_media_overrides(vlm_llm_config: Any) -> dict[str, Any]:
     """Return subset of VLM profile fields that override video_understanding defaults."""
-    dump = vlm_llm_config.model_dump(mode="python")
+    if vlm_llm_config is None:
+        return {}
+    try:
+        dump = vlm_llm_config.model_dump(mode="python")
+    except AttributeError as e:
+        logger.error(
+            "VLM profile config has no model_dump(); expected a NAT LLM config model. "
+            "Check that `vlm_name` points to a registered `llms:` entry. Error: %s",
+            e,
+        )
+        return {}
     return {key: dump[key] for key in _VLM_PROFILE_MEDIA_KEYS if key in dump}
 
 
@@ -361,12 +371,34 @@ async def _build_vlm_messages(
 @register_function(config_type=VideoUnderstandingConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def video_understanding(config: VideoUnderstandingConfig, builder: Builder) -> AsyncGenerator[FunctionInfo]:
     vlm_llm_config = builder.get_llm_config(config.vlm_name)
+    if vlm_llm_config is None:
+        msg = (
+            f"No LLM/VLM profile registered for vlm_name={config.vlm_name!r}. "
+            "Add a matching entry under `llms:` in the workflow config (e.g. nim_vlm, openai_vlm)."
+        )
+        logger.error(msg)
+        raise ValueError(msg)
+
     profile_media = _vlm_profile_media_overrides(vlm_llm_config)
     max_frames = profile_media.get("max_frames", config.max_frames)
     max_fps = profile_media.get("max_fps", config.max_fps)
     min_pixels = profile_media.get("min_pixels", config.min_pixels)
     max_pixels = profile_media.get("max_pixels", config.max_pixels)
     reasoning_default = profile_media.get("reasoning", config.reasoning)
+
+    profile_keys = sorted(profile_media.keys())
+    logger.info(
+        "VLM media effective for profile %s: max_frames=%s max_fps=%s min_pixels=%s max_pixels=%s "
+        "reasoning_default=%s | keys taken from VLM profile YAML/extras: %s "
+        "(any missing key uses VideoUnderstandingConfig / class default)",
+        config.vlm_name,
+        max_frames,
+        max_fps,
+        min_pixels,
+        max_pixels,
+        reasoning_default,
+        profile_keys if profile_keys else "none",
+    )
 
     base_vlm = await builder.get_llm(config.vlm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
     is_nim = config.vlm_name.startswith("nim_")

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -523,9 +523,7 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             if is_cosmos_reason2:
                 mm_processor_kwargs = {"size": {"shortest_edge": min_pixels, "longest_edge": max_pixels}}
             else:
-                mm_processor_kwargs = {
-                    "videos_kwargs": {"min_pixels": min_pixels, "max_pixels": max_pixels}
-                }
+                mm_processor_kwargs = {"videos_kwargs": {"min_pixels": min_pixels, "max_pixels": max_pixels}}
             vlm = base_vlm.bind(
                 mm_processor_kwargs=mm_processor_kwargs,
                 media_io_kwargs=media_io_kwargs,

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -47,6 +47,17 @@ from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
 
 logger = logging.getLogger(__name__)
 
+# Optional VLM media / reasoning knobs configured on each LLM profile in YAML (nim_vlm, openai_vlm, …).
+# NAT NIM/OpenAI configs use `extra="allow"`, so these appear in `model_dump()` when set.
+_VLM_PROFILE_MEDIA_KEYS = frozenset({"max_frames", "max_fps", "min_pixels", "max_pixels", "reasoning"})
+
+
+def _vlm_profile_media_overrides(vlm_llm_config: Any) -> dict[str, Any]:
+    """Return subset of VLM profile fields that override video_understanding defaults."""
+    dump = vlm_llm_config.model_dump(mode="python")
+    return {key: dump[key] for key in _VLM_PROFILE_MEDIA_KEYS if key in dump}
+
+
 # Transient errors worth retrying for VLM calls.
 # Excludes client errors (4xx) like BadRequestError which are not retryable.
 _VLM_RETRYABLE_ERRORS = (
@@ -138,23 +149,28 @@ class VideoUnderstandingConfig(FunctionBaseConfig, name="video_understanding"):
     )
     max_frames: int = Field(
         24,
-        description="The maximum number of frames to sample from the video",
+        description="The maximum number of frames to sample from the video. "
+        "When the same key is set on the VLM LLM profile (e.g. nim_vlm), the profile value wins.",
     )
     max_fps: int = Field(
         default=2,
-        description="Maximum frames per second to sample. num_frames = min(video_length * max_fps, max_frames)",
+        description="Maximum frames per second to sample. num_frames = min(video_length * max_fps, max_frames). "
+        "When set on the VLM LLM profile, the profile value wins.",
     )
     min_pixels: int = Field(
         1568,
-        description="The minimum number of pixels for 2 frames from the video, 28x28=784 will be converted to one video token",
+        description="The minimum number of pixels for 2 frames from the video, 28x28=784 will be converted to one video token. "
+        "When set on the VLM LLM profile, the profile value wins.",
     )
     max_pixels: int = Field(
         345600,
-        description="The maximum number of pixels for 2 frames from the video, 28x28=784 will be converted to one video token",
+        description="The maximum number of pixels for 2 frames from the video, 28x28=784 will be converted to one video token. "
+        "When set on the VLM LLM profile, the profile value wins.",
     )
     reasoning: bool = Field(
         False,
-        description="Only for cosmos reason models, turn on reasoning when you want to let the VLM reason before returning the answer.",
+        description="Only for cosmos reason models, turn on reasoning when you want to let the VLM reason before returning the answer. "
+        "When set on the VLM LLM profile, the profile value wins.",
     )
     filter_thinking: bool = Field(
         False,
@@ -221,7 +237,7 @@ class VideoUnderstandingInput(BaseModel):
     )
     vlm_reasoning: bool | None = Field(
         default=None,
-        description="Enable VLM reasoning mode. If None, uses config.reasoning default.",
+        description="Enable VLM reasoning mode. If None, uses the reasoning default from the VLM profile (or video_understanding config).",
     )
     model_config = {
         "extra": "forbid",
@@ -254,7 +270,7 @@ class VideoUnderstandingOffsetInput(BaseModel):
     )
     vlm_reasoning: bool | None = Field(
         default=None,
-        description="Enable VLM reasoning mode. If None, uses config.reasoning default.",
+        description="Enable VLM reasoning mode. If None, uses the reasoning default from the VLM profile (or video_understanding config).",
     )
     model_config = {
         "extra": "forbid",
@@ -344,6 +360,14 @@ async def _build_vlm_messages(
 
 @register_function(config_type=VideoUnderstandingConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def video_understanding(config: VideoUnderstandingConfig, builder: Builder) -> AsyncGenerator[FunctionInfo]:
+    vlm_llm_config = builder.get_llm_config(config.vlm_name)
+    profile_media = _vlm_profile_media_overrides(vlm_llm_config)
+    max_frames = profile_media.get("max_frames", config.max_frames)
+    max_fps = profile_media.get("max_fps", config.max_fps)
+    min_pixels = profile_media.get("min_pixels", config.min_pixels)
+    max_pixels = profile_media.get("max_pixels", config.max_pixels)
+    reasoning_default = profile_media.get("reasoning", config.reasoning)
+
     base_vlm = await builder.get_llm(config.vlm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
     is_nim = config.vlm_name.startswith("nim_")
     model_name = getattr(base_vlm, "model_name", "") or getattr(base_vlm, "model", "")
@@ -454,21 +478,21 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             start_dt = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
             end_dt = datetime.fromisoformat(end_iso.replace("Z", "+00:00"))
         video_length_seconds = (end_dt - start_dt).total_seconds()
-        num_frames = min(int(video_length_seconds) * config.max_fps, config.max_frames)
+        num_frames = min(int(video_length_seconds) * max_fps, max_frames)
         # Ensure at least 1 frame
         num_frames = max(num_frames, 1)
         logger.info(
-            f"Video length: {video_length_seconds:.1f}s, num_frames: {num_frames} (max_fps={config.max_fps}, max_frames={config.max_frames})"
+            f"Video length: {video_length_seconds:.1f}s, num_frames: {num_frames} (max_fps={max_fps}, max_frames={max_frames})"
         )
 
         # Bind VLM with dynamic num_frames
         if is_cosmos_model:
             media_io_kwargs = {"video": {"num_frames": num_frames}}
             if is_cosmos_reason2:
-                mm_processor_kwargs = {"size": {"shortest_edge": config.min_pixels, "longest_edge": config.max_pixels}}
+                mm_processor_kwargs = {"size": {"shortest_edge": min_pixels, "longest_edge": max_pixels}}
             else:
                 mm_processor_kwargs = {
-                    "videos_kwargs": {"min_pixels": config.min_pixels, "max_pixels": config.max_pixels}
+                    "videos_kwargs": {"min_pixels": min_pixels, "max_pixels": max_pixels}
                 }
             vlm = base_vlm.bind(
                 mm_processor_kwargs=mm_processor_kwargs,
@@ -477,11 +501,11 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
         else:
             vlm = base_vlm
 
-        # Select reasoning mode: default to config.reasoning if not specified in the input
+        # Select reasoning mode: default to VLM profile / video_understanding if not specified in the input
         use_reasoning = (
             video_understanding_input.vlm_reasoning
             if video_understanding_input.vlm_reasoning is not None
-            else config.reasoning
+            else reasoning_default
         )
 
         prompt_template = reasoning_prompt_template if use_reasoning else non_reasoning_prompt_template
@@ -566,7 +590,7 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             use_base64=use_video_base64,
             video_length_seconds=video_length_seconds,
             num_frames=num_frames,
-            max_fps=config.max_fps,
+            max_fps=max_fps,
         )
 
         # Retry logic for VLM call — only retry transient errors (connection/timeout/5xx).
@@ -613,7 +637,7 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             start_timestamp: The start timestamp in offset seconds since beginning of the stream
             end_timestamp: The end timestamp in offset seconds since beginning of the stream
             user_prompt: The prompt that is used to query the VLM to understand the video, mention all search entities in the prompt that is related to the user's query.
-            vlm_reasoning: Enable VLM reasoning mode. If None, uses config.reasoning default.
+            vlm_reasoning: Enable VLM reasoning mode. If None, uses the reasoning default from the VLM profile (or video_understanding config).
             Note: start_timestamp and end_timestamp are optional. If None, then the entire stream is returned.
         """
 
@@ -634,7 +658,7 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             start_timestamp: The start timestamp in UTC ISO 8601 format (e.g., '2025-08-25T03:05:55.752Z')
             end_timestamp: The end timestamp in UTC ISO 8601 format (e.g., '2025-08-25T03:06:15.752Z')
             user_prompt: The prompt that is used to query the VLM to understand the video, mention all search entities in the prompt that is related to the user's query.
-            vlm_reasoning: Enable VLM reasoning mode. If None, uses config.reasoning default.
+            vlm_reasoning: Enable VLM reasoning mode. If None, uses the reasoning default from the VLM profile (or video_understanding config).
         """
 
         yield FunctionInfo.create(

--- a/services/agent/tests/unit_test/tools/test_video_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_video_understanding.py
@@ -219,6 +219,13 @@ class TestVideoUnderstandingConfig:
         overrides = _vlm_profile_media_overrides(cfg)
         assert overrides == {"max_frames": 7}
 
+    def test_vlm_profile_media_overrides_none(self):
+        assert _vlm_profile_media_overrides(None) == {}
+
+    def test_vlm_profile_media_overrides_non_model_returns_empty(self):
+        """Mis-typed config should not crash; overrides fall back to VideoUnderstandingConfig."""
+        assert _vlm_profile_media_overrides(object()) == {}
+
     def test_ip_translation_fields_are_not_exposed(self):
         assert "internal_ip" not in VideoUnderstandingConfig.model_fields
         assert "external_ip" not in VideoUnderstandingConfig.model_fields

--- a/services/agent/tests/unit_test/tools/test_video_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_video_understanding.py
@@ -20,6 +20,7 @@ from vss_agents.tools.video_understanding import VideoUnderstandingConfig
 from vss_agents.tools.video_understanding import _build_vlm_messages
 from vss_agents.tools.video_understanding import _parse_thinking_from_content
 from vss_agents.tools.video_understanding import _should_use_video_base64
+from vss_agents.tools.video_understanding import _vlm_profile_media_overrides
 
 
 class TestParseThinkingFromContent:
@@ -188,6 +189,35 @@ class TestBuildVlmMessages:
 
 class TestVideoUnderstandingConfig:
     """Test video understanding config shape."""
+
+    def test_vlm_profile_media_overrides_from_extras(self):
+        """VLM profile YAML extras should be picked up for video understanding."""
+        from nat.llm.nim_llm import NIMModelConfig
+
+        cfg = NIMModelConfig(
+            model_name="nvidia/test",
+            max_frames=30,
+            max_fps=2,
+            min_pixels=100,
+            max_pixels=200,
+            reasoning=True,
+        )
+        overrides = _vlm_profile_media_overrides(cfg)
+        assert overrides == {
+            "max_frames": 30,
+            "max_fps": 2,
+            "min_pixels": 100,
+            "max_pixels": 200,
+            "reasoning": True,
+        }
+
+    def test_vlm_profile_media_overrides_partial(self):
+        """Only keys present on the profile should appear in overrides."""
+        from nat.llm.nim_llm import NIMModelConfig
+
+        cfg = NIMModelConfig(model_name="nvidia/test", max_frames=7)
+        overrides = _vlm_profile_media_overrides(cfg)
+        assert overrides == {"max_frames": 7}
 
     def test_ip_translation_fields_are_not_exposed(self):
         assert "internal_ip" not in VideoUnderstandingConfig.model_fields


### PR DESCRIPTION
## Description
Moved VLM-specfic parameters from video understanding to VLM in config file

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
