### PR TITLE
docs: add pre-commit hook checkbox to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,6 @@
 
 ## Checklist
 - [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
+- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
 - [ ] New or existing tests cover these changes.
 - [ ] The documentation is up to date with these changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,6 @@
 ## Checklist
 - [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
 - [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
+- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
 - [ ] New or existing tests cover these changes.
 - [ ] The documentation is up to date with these changes.


### PR DESCRIPTION
## Summary

Adds a third item to the **Checklist** in `.github/PULL_REQUEST_TEMPLATE.md`, pointing contributors at the existing pre-commit hook instructions in CONTRIBUTING.md.

## Before

```markdown
## Checklist
- [ ] I am familiar with the Contributing Guidelines.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
```

## After

```markdown
## Checklist
- [ ] I am familiar with the Contributing Guidelines.
- [ ] I have installed and run pre-commit hooks locally (...).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
```

## Why

CONTRIBUTING.md already documents the hooks and the CI `Lint (Python)` job mirrors them exactly. But contributors regularly open PRs without the hooks installed, and the same lint failures surface in CI. Promoting the hook-install step to the visible PR checklist (with a deep link to the install instructions) prompts the one-time setup at the right moment without changing CI or adding any tooling.

## Test plan

- [ ] After merge: open a new draft PR and confirm the description box pre-fills with the four-item checklist including the pre-commit item.