### PR TITLE
fix for https://litmus.nvidia.com/vdr-prep-agent/e45339c6-5611-40dd-b…

### DIFF
--- a/.openclaw/README.md
+++ b/.openclaw/README.md
@@ -1,5 +1,7 @@
 # VSS Claw — OpenClaw Plugin
 
+> **Note:** OpenClaw is the upstream framework name; the NemoClaw branding refers to the NVIDIA-curated skill bundle on top of OpenClaw.
+
 NVIDIA Video Search & Summarization agent for [OpenClaw](https://github.com/openclaw/openclaw). Provides 6 skills covering the full VSS lifecycle: NGC setup, prerequisites, base deployment, live video streams, semantic search, and alerts.
 
 ---


### PR DESCRIPTION
…d2e-518cb20c77b5

## Description
Quote:NVIDIA Video Search & Summarization agent for [OpenClaw](https://github.com/openclaw/openclaw). Provides 6 skills covering the full VSS lifecycle...
Fix:Either (a) rename the plugin and CLI surface to NemoClaw consistently across.openclaw/README.md,.openclaw/openclaw.plugin.json, the npm package name@nvidia/openclaw-vss, and the dir.openclaw/; or (b) add a one-paragraph "OpenClaw is the upstream framework name; the NemoClaw branding refers to the NVIDIA-curated skill bundle on top of OpenClaw" note at the top of.openclaw/README.md. Right now a scope-doc reader looking for "NemoClaw" in the repo will find only "OpenClaw" and conclude the artifact is missing.

https://litmus.nvidia.com/vdr-prep-agent/e45339c6-5611-40dd-bd2e-518cb20c77b5

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
