### PR TITLE
ci(skills-nv-base): post warnings as a sticky PR comment

### DIFF
--- a/.github/skills-nv-base/README.md
+++ b/.github/skills-nv-base/README.md
@@ -1,15 +1,18 @@
 # Skills NV-BASE CI
 
-Two-step Tier-1 skill gate that runs on every PR touching `skills/` or
-this harness. Fails the check if either step reports a blocking finding.
+Three-step Tier-1 skill gate that runs on every PR touching `skills/` or
+this harness. Fails the check if Step 1 or Step 2 reports a blocking
+finding. Step 3 posts a sticky PR comment summarising all findings (kept
+in sync across pushes by a hidden marker).
 
 ## Files
 
 | File | Role |
 |---|---|
 | [`../workflows/skills-nv-base.yml`](../workflows/skills-nv-base.yml) | GitHub Actions workflow definition |
-| [`run_check.py`](run_check.py) | Step 1 — driver for `nv-base validate` (parses JSON report, emits annotations) |
-| [`skill_compliance_check.py`](skill_compliance_check.py) | Step 2 — vendored playbook compliance checker (NAM / FM / STR / SEC) |
+| [`run_check.py`](run_check.py) | Step 1 — driver for `nv-base validate` (parses JSON report, emits annotations, dumps findings to `$NVBASE_FINDINGS_JSON`) |
+| [`skill_compliance_check.py`](skill_compliance_check.py) | Step 2 — vendored playbook compliance checker (NAM / FM / STR / SEC). `--json-out` dumps findings for the comment poster |
+| [`post_comment.py`](post_comment.py) | Step 3 — composes a markdown summary from both JSON inputs and posts/updates a sticky PR comment via REST API |
 | `README.md` | this file |
 
 ## What each step covers
@@ -109,8 +112,22 @@ as a required status check on `develop` (and `main`, once synced) under
 Settings → Branches / Rulesets. Without that, a failing finding shows a
 red X but doesn't prevent merge.
 
+## PR comment poster (Step 3)
+
+`post_comment.py` walks the two JSON inputs from Steps 1 and 2, builds a
+markdown summary, and posts a sticky comment on the PR. Subsequent runs
+update the same comment in place (matched by the hidden HTML marker
+`<!-- skills-nv-base-bot:v1 -->`). The comment has two sections (one per
+step), each with a count summary and a table of findings (capped at 30
+rows per table; the full list remains in the job annotations + log).
+
+Failures inside the poster (network errors, missing token, etc.) surface
+as `::warning` annotations and the script exits 0 — the comment is best-
+effort and should never block the gate. Requires `pull-requests: write`
+in the workflow permissions; the GHA-issued `${{ github.token }}` is
+enough, no PAT.
+
 ## What's NOT in v1
 
-- **No PR comment.** Findings surface as inline annotations only.
 - **No Tier-2/3 nv-base checks** (`quality`, `inter-skill`, `lint`, dedup, agent-eval). Those need an Anthropic / inference-api credential on the runner and are a separate decision. The existing `skills-eval` workflow handles agent-eval.
 - **No gitleaks / bandit / pip-audit** (the playbook's GitLab pipeline runs those separately). Step 1's `secrets` check covers the credential-scan surface.

--- a/.github/skills-nv-base/post_comment.py
+++ b/.github/skills-nv-base/post_comment.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Post or update a sticky PR comment summarising the Skills NV-BASE gate.
+
+Reads two JSON inputs:
+  - $NVBASE_FINDINGS_JSON     (written by run_check.py)
+  - $PLAYBOOK_FINDINGS_JSON   (written by skill_compliance_check.py --json-out)
+
+Composes a single markdown comment carrying a hidden HTML marker so we can
+match it across runs. If a previous comment with the same marker exists,
+PATCH it in place; otherwise POST a new one. Always posts, even when both
+inputs report zero findings (the green check is useful signal).
+
+Env vars required:
+  GITHUB_TOKEN           - auth (provided by Actions)
+  GITHUB_REPOSITORY      - owner/repo
+  PR_NUMBER              - PR to comment on
+
+Optional:
+  GITHUB_SHA             - commit SHA (for the comment footer)
+  GITHUB_RUN_ID          - workflow run id (for the "view log" link)
+  GITHUB_SERVER_URL      - usually https://github.com
+
+Stdlib only. Errors are surfaced as ::warning annotations and the script
+exits 0 — failing here should not fail the gate.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+MARKER = "<!-- skills-nv-base-bot:v1 -->"
+MAX_ROWS_PER_TABLE = 30
+
+
+# ── GitHub REST helpers ────────────────────────────────────────────────
+
+
+def _gh_request(method: str, url: str, body: Optional[dict] = None) -> dict:
+    token = os.environ["GITHUB_TOKEN"]
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        if resp.status == 204:
+            return {}
+        return json.loads(resp.read())
+
+
+def find_sticky_comment(repo: str, pr: str) -> Optional[int]:
+    """Return the id of the existing sticky comment, or None."""
+    url = f"https://api.github.com/repos/{repo}/issues/{pr}/comments?per_page=100"
+    while url:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(req) as resp:
+            comments = json.loads(resp.read())
+            link = resp.headers.get("Link") or ""
+        for c in comments:
+            if MARKER in (c.get("body") or ""):
+                return c["id"]
+        url = None
+        # rfc5988 link header; pick rel="next" if present
+        for piece in link.split(","):
+            if 'rel="next"' in piece:
+                start = piece.find("<") + 1
+                end = piece.find(">", start)
+                if start > 0 and end > start:
+                    url = piece[start:end]
+                break
+    return None
+
+
+def upsert_comment(repo: str, pr: str, body: str) -> None:
+    existing = find_sticky_comment(repo, pr)
+    if existing is not None:
+        _gh_request(
+            "PATCH",
+            f"https://api.github.com/repos/{repo}/issues/comments/{existing}",
+            {"body": body},
+        )
+        print(f"::notice::Updated sticky comment id={existing}", flush=True)
+    else:
+        _gh_request(
+            "POST",
+            f"https://api.github.com/repos/{repo}/issues/{pr}/comments",
+            {"body": body},
+        )
+        print("::notice::Posted new sticky comment", flush=True)
+
+
+# ── Markdown composition ───────────────────────────────────────────────
+
+SEV_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4,
+             "ERROR": 0, "WARNING": 1, "INFO": 2, "PASS": 3}
+SEV_EMOJI = {
+    "critical": "🔴", "high": "🟠", "medium": "🟡", "low": "🔵", "info": "ℹ️",
+    "ERROR": "🔴", "WARNING": "🟡", "INFO": "ℹ️",
+}
+
+
+def _md_escape(s: str) -> str:
+    return (s or "").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _load_json(path_env: str) -> Optional[dict]:
+    p = os.environ.get(path_env, "").strip()
+    if not p:
+        return None
+    pth = Path(p)
+    if not pth.is_file():
+        print(f"::notice::{path_env}={p} not found; treating as no findings",
+              flush=True)
+        return None
+    try:
+        return json.loads(pth.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"::warning::Could not parse {path_env}={p}: {exc}", flush=True)
+        return None
+
+
+def _section_nvbase(data: Optional[dict]) -> str:
+    if data is None:
+        return "### Step 1 — nv-base validate\n\n_Step did not run or no JSON output captured._\n"
+    counts = data.get("counts", {})
+    findings = data.get("findings", [])
+    blocking = data.get("blocking", 0)
+
+    summary = (
+        f"**critical={counts.get('critical', 0)} · "
+        f"high={counts.get('high', 0)} · "
+        f"medium={counts.get('medium', 0)} · "
+        f"low={counts.get('low', 0)}**"
+    )
+    status = "✅ no blocking findings" if blocking == 0 else f"❌ {blocking} blocking finding(s)"
+    out = [f"### Step 1 — nv-base validate", "", f"{status} — {summary}", ""]
+    if findings:
+        findings = sorted(findings, key=lambda f: SEV_ORDER.get(f.get("severity", "info"), 9))
+        out += [
+            "| Sev | Check | File | Line | Message |",
+            "|---|---|---|---:|---|",
+        ]
+        for f in findings[:MAX_ROWS_PER_TABLE]:
+            sev = f.get("severity", "info")
+            emoji = SEV_EMOJI.get(sev, "")
+            out.append(
+                f"| {emoji} {sev} "
+                f"| `{_md_escape(f.get('validator', '') + '/' + f.get('check', ''))}` "
+                f"| `{_md_escape(f.get('file', ''))}` "
+                f"| {f.get('line', 0) or ''} "
+                f"| {_md_escape(f.get('message', ''))} |"
+            )
+        if len(findings) > MAX_ROWS_PER_TABLE:
+            out.append(f"\n_…and {len(findings) - MAX_ROWS_PER_TABLE} more (truncated; see job annotations for the full list)._")
+    return "\n".join(out) + "\n"
+
+
+def _section_playbook(data: Optional[dict]) -> str:
+    if data is None:
+        return "### Step 2 — playbook compliance\n\n_Step did not run or no JSON output captured._\n"
+    findings = data.get("findings", [])
+    skills_checked = data.get("skills_checked", 0)
+    errors = [f for f in findings if f.get("severity") == "ERROR"]
+    warnings = [f for f in findings if f.get("severity") == "WARNING"]
+
+    status = "✅ no errors" if not errors else f"❌ {len(errors)} error(s)"
+    summary = (
+        f"**errors={len(errors)} · warnings={len(warnings)} · "
+        f"skills_checked={skills_checked}**"
+    )
+    out = [f"### Step 2 — playbook compliance", "", f"{status} — {summary}", ""]
+    if findings:
+        findings = sorted(findings, key=lambda f: (
+            SEV_ORDER.get(f.get("severity", "INFO"), 9),
+            f.get("skill", ""), f.get("rule", ""),
+        ))
+        out += [
+            "| Sev | Rule | Skill | File | Message |",
+            "|---|---|---|---|---|",
+        ]
+        for f in findings[:MAX_ROWS_PER_TABLE]:
+            sev = f.get("severity", "INFO")
+            emoji = SEV_EMOJI.get(sev, "")
+            file_field = _md_escape(f.get("file", "") or "")
+            out.append(
+                f"| {emoji} {sev} "
+                f"| `{_md_escape(f.get('rule', ''))}` "
+                f"| `{_md_escape(f.get('skill', ''))}` "
+                f"| {('`' + file_field + '`') if file_field else ''} "
+                f"| {_md_escape(f.get('message', ''))} |"
+            )
+        if len(findings) > MAX_ROWS_PER_TABLE:
+            out.append(f"\n_…and {len(findings) - MAX_ROWS_PER_TABLE} more (truncated; see job log for the full list)._")
+    return "\n".join(out) + "\n"
+
+
+def _footer() -> str:
+    sha = os.environ.get("GITHUB_SHA", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    bits = []
+    if sha:
+        bits.append(f"commit `{sha[:7]}`")
+    if repo and run_id:
+        bits.append(f"[view full log]({server}/{repo}/actions/runs/{run_id})")
+    if not bits:
+        return ""
+    return "\n---\n_Skills NV-BASE — " + " · ".join(bits) + "._\n"
+
+
+def compose_body(nv: Optional[dict], pb: Optional[dict]) -> str:
+    return (
+        f"{MARKER}\n"
+        f"## 🤖 Skills NV-BASE\n\n"
+        f"{_section_nvbase(nv)}\n"
+        f"{_section_playbook(pb)}"
+        f"{_footer()}"
+    )
+
+
+def main() -> None:
+    pr = os.environ.get("PR_NUMBER", "").strip()
+    repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if not pr or not repo or not os.environ.get("GITHUB_TOKEN"):
+        print("::warning::PR_NUMBER, GITHUB_REPOSITORY, or GITHUB_TOKEN "
+              "missing; cannot post comment", flush=True)
+        sys.exit(0)  # don't fail the gate
+
+    nv = _load_json("NVBASE_FINDINGS_JSON")
+    pb = _load_json("PLAYBOOK_FINDINGS_JSON")
+    body = compose_body(nv, pb)
+
+    try:
+        upsert_comment(repo, pr, body)
+    except urllib.error.HTTPError as exc:
+        print(f"::warning::Could not post/update comment ({exc.code} "
+              f"{exc.reason}): {exc.read().decode(errors='replace')[:200]}",
+              flush=True)
+    except Exception as exc:
+        print(f"::warning::Comment poster failed: {exc!r}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills-nv-base/run_check.py
+++ b/.github/skills-nv-base/run_check.py
@@ -124,9 +124,14 @@ def annotate_finding(validator: str, f: dict) -> str:
 
 
 def emit_from_report(report: dict) -> int:
-    """Walk the report and emit annotations. Return blocking count."""
+    """Walk the report and emit annotations. Return blocking count.
+
+    If $NVBASE_FINDINGS_JSON is set, also dump a per-finding JSON list to
+    that path for downstream consumption (PR comment poster).
+    """
     blocking = 0
     counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
+    out_findings: list[dict] = []
 
     for v in report.get("results", []) or []:
         validator = v.get("validator") or "?"
@@ -135,6 +140,15 @@ def emit_from_report(report: dict) -> int:
             counts[sev] = counts.get(sev, 0) + 1
             if sev in ("critical", "high"):
                 blocking += 1
+            out_findings.append({
+                "validator": validator,
+                "check": f.get("check_name") or f.get("check") or "unknown",
+                "severity": sev,
+                "file": _normalize_path(f.get("file_path") or ""),
+                "line": f.get("line_number") or 0,
+                "message": f.get("message") or "",
+                "suggestion": f.get("suggestion") or "",
+            })
 
     print(
         f"\nNV-BASE summary: critical={counts['critical']} "
@@ -142,6 +156,21 @@ def emit_from_report(report: dict) -> int:
         f"low={counts['low']}  blocking={blocking}",
         flush=True,
     )
+
+    findings_path = os.environ.get("NVBASE_FINDINGS_JSON", "").strip()
+    if findings_path:
+        try:
+            Path(findings_path).write_text(json.dumps({
+                "counts": counts,
+                "blocking": blocking,
+                "findings": out_findings,
+            }, indent=2))
+            print(f"::notice::Wrote findings JSON to {findings_path}",
+                  flush=True)
+        except OSError as exc:
+            print(f"::warning::Could not write NVBASE_FINDINGS_JSON "
+                  f"({findings_path}): {exc}", flush=True)
+
     return blocking
 
 

--- a/.github/skills-nv-base/skill_compliance_check.py
+++ b/.github/skills-nv-base/skill_compliance_check.py
@@ -908,6 +908,11 @@ def main() -> None:
         "--no-color", action="store_true",
         help="Disable ANSI color (auto-disabled when stdout is not a TTY)",
     )
+    parser.add_argument(
+        "--json-out", metavar="PATH",
+        help="Write all findings to PATH as JSON for downstream consumers "
+             "(e.g. PR-comment poster). The text report still prints to stdout.",
+    )
     args = parser.parse_args()
 
     use_color = not args.no_color and sys.stdout.isatty()
@@ -941,6 +946,30 @@ def main() -> None:
     # Cross-skill rules run once over the full result set.
     check_collisions(results)
     exit_code = print_report(results, use_color=use_color, strict=args.strict)
+
+    if args.json_out:
+        import json as _json
+        out = []
+        for r in results:
+            for f in r.findings:
+                out.append({
+                    "skill": r.skill_name,
+                    "rule": f.rule,
+                    "severity": f.severity,
+                    "message": f.message,
+                    "file": f.file or "",
+                    "line": f.line or 0,
+                })
+        try:
+            Path(args.json_out).write_text(_json.dumps({
+                "skills_checked": len(results),
+                "findings": out,
+            }, indent=2))
+            print(f"\nWrote findings JSON to {args.json_out}")
+        except OSError as exc:
+            print(f"WARNING: could not write --json-out {args.json_out}: {exc}",
+                  file=sys.stderr)
+
     sys.exit(exit_code)
 
 

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -39,6 +39,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write   # Step 3 posts/updates a sticky comment
 
 concurrency:
   group: skills-nv-base-${{ github.ref }}
@@ -99,6 +100,9 @@ jobs:
         env:
           # Path to the pre-installed nv-base binary on the runner.
           NVBASE_BIN: /opt/nvbase-venv/bin/nv-base
+          # Tells run_check.py to dump structured findings here; consumed
+          # by Step 3 to compose the sticky PR comment.
+          NVBASE_FINDINGS_JSON: ${{ runner.temp }}/nvbase-findings.json
         run: |
           python3 .github/skills-nv-base/run_check.py skills/
 
@@ -109,7 +113,21 @@ jobs:
         if: steps.changes.outputs.relevant == 'true' && !cancelled()
         run: |
           python3 .github/skills-nv-base/skill_compliance_check.py \
-            --skills-dir skills/ --no-color
+            --skills-dir skills/ --no-color \
+            --json-out "${{ runner.temp }}/playbook-findings.json"
+
+      - name: Step 3 — post sticky PR comment with findings
+        # Always run (even when prior steps failed) so warnings surface
+        # alongside any blocking findings. Comment poster swallows its own
+        # errors via ::warning so it never fails the gate.
+        if: steps.changes.outputs.relevant == 'true' && !cancelled()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          NVBASE_FINDINGS_JSON: ${{ runner.temp }}/nvbase-findings.json
+          PLAYBOOK_FINDINGS_JSON: ${{ runner.temp }}/playbook-findings.json
+        run: |
+          python3 .github/skills-nv-base/post_comment.py
 
       - name: Skip note when no skills/ changes
         if: steps.changes.outputs.relevant != 'true'


### PR DESCRIPTION
## Summary

Add a Step 3 to the Skills NV-BASE workflow that posts/updates a sticky markdown comment on the PR summarizing both Step 1 (`nv-base validate`) and Step 2 (playbook compliance) findings. The comment is matched across pushes by a hidden HTML marker and updated in place — no comment spam.

Why: inline `::warning` annotations are easy to miss when the gate passes overall. Reviewers don't open the diff-annotations panel on a green check, so a non-blocking PII/STR-003/NAM-004 finding goes unseen. A sticky comment surfaces all warnings alongside any blocking findings without adding noise.

## Files

| File | Change |
|---|---|
| `.github/skills-nv-base/post_comment.py` | New stdlib script; reads both finding JSONs and POSTs/PATCHes a sticky comment via REST. Failures emit `::warning` and exit 0 — never fails the gate. |
| `.github/skills-nv-base/run_check.py` | Adds optional `$NVBASE_FINDINGS_JSON` dump (per-finding JSON). |
| `.github/skills-nv-base/skill_compliance_check.py` | Adds `--json-out PATH` flag. |
| `.github/workflows/skills-nv-base.yml` | Re-grants `pull-requests: write`; wires Step 3 with `!cancelled()` so it runs even when Step 1 fails. |
| `.github/skills-nv-base/README.md` | Documents the comment poster + how to tune it. |

## Comment shape

````markdown
<!-- skills-nv-base-bot:v1 -->
## 🤖 Skills NV-BASE

### Step 1 — nv-base validate

✅ no blocking findings — **critical=0 · high=0 · medium=1 · low=0**

| Sev | Check | File | Line | Message |
|---|---|---|---:|---|
| 🟡 medium | `PII/phone_numbers` | `skills/vss-deploy-profile/references/warehouse.md` | 569 | US phone number pattern |

### Step 2 — playbook compliance

✅ no errors — **errors=0 · warnings=18 · skills_checked=11**

| Sev | Rule | Skill | File | Message |
|---|---|---|---|---|
| 🟡 WARNING | `STR-003` | `vss-ask-video` | | evals/ directory not found … |
| … 17 more rows … |

---
*Skills NV-BASE — commit `abc1234` · [view full log](…).*
````

Tables are capped at 30 rows each (job log + GHA annotations remain the source of truth for the full list).

## Permissions

The workflow regains `pull-requests: write`, which was dropped earlier per a review comment when no step needed it. Now Step 3 needs it. Auth is the GHA-issued `${{ github.token }}`, no PAT.

## Test plan

- [ ] CI green on this PR (the workflow path filter includes `.github/skills-nv-base/**` and `.github/workflows/skills-nv-base.yml`, so the gate runs on itself).
- [ ] Verify the comment appears on this PR's conversation tab after Step 3 runs.
- [ ] Push a dummy commit; verify the comment is updated in place (no second comment appears).
- [ ] Verify the gate still fails on a deliberate blocking finding (e.g., add `<xml>` to a description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)