### PR TITLE
docs(skills): Introduced new SKILL.md for deploying the `vss-video-an…

### DIFF
--- a/skills/vss-setup-video-analytics-api/SKILL.md
+++ b/skills/vss-setup-video-analytics-api/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: vss-setup-video-analytics-api
+description: >
+  Deploy the `vss-video-analytics-api` service standalone — no perception, no behavior-analytics, no UI.
+  Use when the user says "deploy video analytics api", "run video-analytics-api standalone",
+  "set up the REST API service", "change the API config", "swap the video-analytics-api config",
+  "run the API against my own Elasticsearch", "point the API at a different broker", or wants to
+  bring up the REST API layer without redeploying the full warehouse blueprint. Walks the user
+  through config selection, data-log volume, infrastructure dependencies (Elasticsearch / Kafka),
+  and deploy + verify.
+license: Apache-2.0
+metadata:
+  version: "3.2.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
+  tags: "nvidia blueprint operational deployment video-analytics-api rest-api"
+---
+
+# VSS Setup Video Analytics API — Standalone
+
+Deploy **just** the `vss-video-analytics-api` container (the Node.js REST API from the upstream `web-apis` repo), not as part of the full warehouse blueprint stack.
+
+The full operational walkthrough — config options, infrastructure dependencies, REST API endpoints, deploy + verify, troubleshooting — is [`references/deploy-video-analytics-api-service.md`](references/deploy-video-analytics-api-service.md). This SKILL.md only handles routing and prerequisites.
+
+## When to use
+
+- "Deploy video analytics api" / "run video-analytics-api standalone"
+- "I just want to run the REST API, not the full stack"
+- "Use my own video-analytics-api config"
+- "Point the API at a different Elasticsearch / Kafka"
+- "Start the API without Kafka" / "run the API broker-less"
+- "Check what REST endpoints are available"
+
+## Prerequisites
+
+1. **Repo checkout** with `$VSS_APPS_DIR` pointing at `<repo>/deploy/docker/`. Required by the service compose's volume binds.
+2. **NGC credentials** — `$NGC_CLI_API_KEY` set so docker can pull the image. See [`../vss-deploy-profile/references/ngc.md`](../vss-deploy-profile/references/ngc.md).
+3. **Elasticsearch** — must be reachable at the URL configured in `elasticsearch.node`. The server pings ES on startup; if unreachable, it exits (and `restart: always` brings it back). If you need to bring up ES too, use the infra compose: `docker compose -f services/infra/compose.yml up -d elasticsearch`.
+4. **Optional Kafka broker**. The API starts fine without Kafka — Kafka-dependent features (dynamic config, dynamic calibration, RTLS/AMR) are simply unavailable.
+5. **Optional `$VSS_DATA_DIR`** for file upload endpoints (sensor images, calibration files uploaded via REST).
+
+If #1 or #2 fails, surface the gap before going further.
+
+## Workflow
+
+Hand the user [`references/deploy-video-analytics-api-service.md`](references/deploy-video-analytics-api-service.md) and walk them through its steps in order:
+
+1. Choose a config — image-baked default, service-shipped, or custom.
+2. Decide whether a data-log volume is needed for file uploads.
+3. Confirm infrastructure dependencies — Elasticsearch (required), Kafka (optional).
+4. Deploy + verify with `docker compose up` and health check.
+
+The compose-file edits, config options, deploy + verify commands, REST API endpoint table, and troubleshooting table all live in that reference — don't duplicate them here.
+
+## REST API capabilities
+
+Once the container is up and Elasticsearch is reachable, the API serves these endpoint groups:
+
+| Endpoint | What it does |
+|---|---|
+| `/livez` | Health check — returns 200 when routes are registered and ES ping succeeded. |
+| `/sensor` | CRUD for sensor metadata (GET / POST / DELETE), supports file uploads. |
+| `/config` | Dynamic config management — GET retrieves current config; POST publishes config updates to Kafka. |
+| `/behavior` | Query behavior data from Elasticsearch. |
+| `/alerts` | Query alert data with time-range and sensor filters. |
+| `/events` | Query event data from Elasticsearch. |
+| `/incidents` | Query incident data from Elasticsearch. |
+| `/frames` | Query frame-level data from Elasticsearch. |
+| `/metrics` | Aggregation / computation metrics (occupancy, behavior metrics). |
+| `/tracker` | Tracker data queries. |
+| `/clustering` | Clustering analysis queries. |
+
+All endpoints except `/livez` require Elasticsearch. Endpoints that publish notifications (config, calibration) also require Kafka.
+
+## Kafka-dependent features (runtime, requires broker)
+
+Once the container is up **and a Kafka broker is reachable**, three additional capabilities are available:
+
+### Dynamic config
+
+The API acts as the **producer** for dynamic config updates. When an operator POSTs to `/config`, the API publishes an `upsert` message to the `mdx-notification` topic with Kafka key `behavior-analytics-config`. The downstream `behavior-analytics` container consumes this and ACKs back. The API also handles the bootstrap flow — when `behavior-analytics` starts, it publishes a `request-config` message, and the API replies with `upsert-all` containing the latest verified config from Elasticsearch.
+
+### Dynamic calibration
+
+The API produces calibration update notifications on `mdx-notification` with Kafka key `calibration`. Supports `upsert-all` (full snapshot), `upsert` (per-sensor merge), and `delete` (per-sensor removal). The downstream `behavior-analytics` container consumes these and applies them to the live calibration.
+
+### RTLS / AMR
+
+The API consumes real-time location (`mdx-rtls`) and AMR (`mdx-amr`) messages from Kafka and exposes them via REST endpoints.
+
+## Routing rules
+
+- If the user wants "the full stack" (UI / agent / perception): hand off to [`vss-deploy-profile`](../vss-deploy-profile/SKILL.md) with profile `warehouse` (or `alerts`). Don't run this skill in parallel.
+- If the user wants to deploy the analytics pipeline (behavior creation, incident detection): hand off to [`vss-setup-behavior-analytics`](../vss-setup-behavior-analytics/SKILL.md).
+- If the user wants to understand the dynamic config / dynamic calibration wire contract from the **consumer** (behavior-analytics) side: point them at [`../vss-setup-behavior-analytics/references/dynamic-config.md`](../vss-setup-behavior-analytics/references/dynamic-config.md) and [`../vss-setup-behavior-analytics/references/dynamic-calibration.md`](../vss-setup-behavior-analytics/references/dynamic-calibration.md).
+- If the user wants to query or interact with the REST API endpoints: the endpoint table above and the deploy reference cover what's available. For the full OpenAPI spec, see `src/app/specification/openapi.json` in the `web-apis` repo.

--- a/skills/vss-setup-video-analytics-api/SKILL.md
+++ b/skills/vss-setup-video-analytics-api/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 
 # VSS Setup Video Analytics API — Standalone
 
-Deploy **just** the `vss-video-analytics-api` container (the Node.js REST API from the upstream `web-apis` repo), not as part of the full warehouse blueprint stack.
+Deploy **just** the `vss-video-analytics-api` container (the Node.js REST API from the upstream `video-analytics-api` repo), not as part of the full warehouse blueprint stack.
 
 The full operational walkthrough — config options, infrastructure dependencies, REST API endpoints, deploy + verify, troubleshooting — is [`references/deploy-video-analytics-api-service.md`](references/deploy-video-analytics-api-service.md). This SKILL.md only handles routing and prerequisites.
 
@@ -92,4 +92,4 @@ The API consumes real-time location (`mdx-rtls`) and AMR (`mdx-amr`) messages fr
 - If the user wants "the full stack" (UI / agent / perception): hand off to [`vss-deploy-profile`](../vss-deploy-profile/SKILL.md) with profile `warehouse` (or `alerts`). Don't run this skill in parallel.
 - If the user wants to deploy the analytics pipeline (behavior creation, incident detection): hand off to [`vss-setup-behavior-analytics`](../vss-setup-behavior-analytics/SKILL.md).
 - If the user wants to understand the dynamic config / dynamic calibration wire contract from the **consumer** (behavior-analytics) side: point them at [`../vss-setup-behavior-analytics/references/dynamic-config.md`](../vss-setup-behavior-analytics/references/dynamic-config.md) and [`../vss-setup-behavior-analytics/references/dynamic-calibration.md`](../vss-setup-behavior-analytics/references/dynamic-calibration.md).
-- If the user wants to query or interact with the REST API endpoints: the endpoint table above and the deploy reference cover what's available. For the full OpenAPI spec, see `src/app/specification/openapi.json` in the `web-apis` repo.
+- If the user wants to query or interact with the REST API endpoints: the endpoint table above and the deploy reference cover what's available. For the full OpenAPI spec, see `src/app/specification/openapi.json` in the `video-analytics-api` repo.

--- a/skills/vss-setup-video-analytics-api/references/configuration.md
+++ b/skills/vss-setup-video-analytics-api/references/configuration.md
@@ -1,0 +1,112 @@
+# Configuration Guide
+
+## Overview
+
+The video-analytics-api server loads a JSON config file at startup via the `--config <path>` CLI flag. The config controls server port, Elasticsearch connection, Kafka connection, and application-level tuning.
+
+## Structure
+
+```json
+{
+  "server": {
+    "port": 8081,
+    "configs": [...]
+  },
+  "elasticsearch": {
+    "node": "http://localhost:9200",
+    "indexPrefix": "mdx-",
+    "rawIndex": "mdx-raw-*",
+    "retries": 15
+  },
+  "kafka": {
+    "brokers": ["localhost:9092"],
+    "retries": null
+  }
+}
+```
+
+## Sections
+
+### `server`
+
+| Field | Type | Default | What it controls |
+|---|---|---|---|
+| `port` | number | `8081` | HTTP port the API listens on. |
+| `configs[]` | array of `{name, value}` | see below | Application-level tuning knobs. |
+
+#### `server.configs[]` keys
+
+| Key | Type | Default (service-shipped) | Default (image-baked) | What it controls |
+|---|---|---|---|---|
+| `postBodySizeLimit` | string | `"50mb"` | `"50mb"` | Maximum POST body size accepted by Express. |
+| `amrRetentionInSec` | string | `"3"` | `"300"` | How long AMR data is retained in memory (seconds). Profiles use `"3"`; the image default uses `"300"`. |
+| `inSimulationMode` | string | `"false"` | `"false"` | Whether the server runs in simulation mode. |
+| `configStatusTimeoutMs` | string | `"30000"` | `"30000"` | How long to wait for an ACK from behavior-analytics after publishing a config update (milliseconds). |
+| `configStatusTimeoutCheckFrequencyMs` | string | `"900000"` | `"900000"` | How often the server checks for timed-out config update ACKs (milliseconds). |
+
+### `elasticsearch`
+
+| Field | Type | Default | What it controls |
+|---|---|---|---|
+| `node` | string | `"http://localhost:9200"` | Elasticsearch URL. The server pings this on startup; if unreachable, the server exits. |
+| `indexPrefix` | string | `"mdx-"` | Prefix for all Elasticsearch index names. |
+| `rawIndex` | string | `"mdx-raw-*"` | Raw data index pattern. |
+| `retries` | number | `15` | Number of Elasticsearch connection retries before giving up. |
+
+### `kafka`
+
+| Field | Type | Default | What it controls |
+|---|---|---|---|
+| `brokers` | array of strings | `["localhost:9092"]` (service-shipped) / `[]` (image-baked) | Kafka broker addresses. Empty array or `null` disables Kafka entirely — no error, no retry loop. |
+| `retries` | number or null | `null` | KafkaJS retry count. `null` uses KafkaJS defaults. |
+
+## Config sources
+
+Three viable sources, in order of increasing customization:
+
+### Image-baked default
+
+Path inside container: `/configs/default-configs/config.json`
+
+Assumes Elasticsearch at `http://localhost:9200`, index prefix `mdx-`, Kafka **disabled** (empty brokers list), server port **8081**.
+
+### Service-shipped config (default in compose)
+
+Path on host: `services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json`
+
+Identical to the image-baked default except Kafka is **enabled** (`brokers: ["localhost:9092"]`). This is the right choice when you have a local Kafka broker running.
+
+### Custom config
+
+Any absolute host path. Copy one of the above as a starting point and edit. Bind-mount it into the container via the compose `volumes:` section.
+
+## Minimal example
+
+```json
+{
+  "server": {
+    "port": 8081,
+    "configs": [
+      { "name": "postBodySizeLimit", "value": "50mb" },
+      { "name": "inSimulationMode", "value": "false" }
+    ]
+  },
+  "elasticsearch": {
+    "node": "http://localhost:9200",
+    "indexPrefix": "mdx-",
+    "rawIndex": "mdx-raw-*",
+    "retries": 15
+  },
+  "kafka": {
+    "brokers": ["localhost:9092"],
+    "retries": null
+  }
+}
+```
+
+## Tips
+
+- Keep `server.configs[].value` as strings — the server parses types internally.
+- When running with `network_mode: "host"`, Elasticsearch and Kafka must also be on the host network.
+- Set `kafka.brokers` to an empty array `[]` to run without Kafka. The server starts normally; Kafka-dependent endpoints (dynamic config, dynamic calibration, RTLS/AMR) are simply unavailable.
+- The `amrRetentionInSec` default differs between the service-shipped config (`"3"`) and the image-baked default (`"300"`). Use the shorter retention in production to reduce memory usage.

--- a/skills/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
+++ b/skills/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
@@ -1,0 +1,233 @@
+# Deploy Video Analytics API — Standalone Service
+
+Deploy **just** `vss-video-analytics-api` (no perception, no behavior-analytics, no UI) — useful when you want to:
+
+- Run the REST API against an existing Elasticsearch cluster (and optionally Kafka).
+- Serve calibration, sensor, behavior, alerts, events, tracking, incident, and metrics endpoints.
+
+---
+
+## What you edit
+
+You only edit the existing service compose:
+
+```
+<repo>/deploy/docker/services/analytics/video-analytics-api/compose.yml
+```
+
+1. **`command:`** — which config file the Node server loads at startup.
+2. **`volumes:`** — what config (required) and what data-log directory (optional) to mount.
+
+After editing, deploy with:
+
+```bash
+cd <repo>/deploy/docker
+export VSS_APPS_DIR=$(pwd)
+export VSS_DATA_DIR=<path-to-data-directory>
+docker compose -f services/analytics/video-analytics-api/compose.yml \
+    up -d vss-video-analytics-api
+```
+
+---
+
+## Step 1 — Choose a config (required)
+
+Every startup requires `--config <path>`. The container has three viable sources:
+
+### Option A — Use the image-baked default
+
+Cheapest path. The image ships a default config at `/configs/default-configs/config.json`. To use it, change the `command:` and drop the config volume mount:
+
+```yaml
+command: node index.js --config /configs/default-configs/config.json
+```
+
+The defaults assume:
+- Elasticsearch at `http://localhost:9200`
+- Index prefix `mdx-`
+- Kafka **disabled** (empty brokers list)
+- Server port **8081**
+
+### Option B — Use the service-shipped config (default in compose)
+
+The base compose already mounts the config from the services directory:
+
+```
+services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json
+```
+
+This config is identical to the image-baked default except Kafka is **enabled** (`brokers: ["localhost:9092"]`). This is the right choice when you have a local Kafka broker running.
+
+No compose change needed — this is the default:
+
+```yaml
+services:
+  vss-video-analytics-api:
+    volumes:
+      - $VSS_APPS_DIR/services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json:/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
+    command: node index.js --config /opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
+```
+
+### Option C — Use your own custom config
+
+Drop in any absolute host path; copy one of the above as a starting point and edit. Compose change:
+
+```yaml
+volumes:
+  - /abs/path/to/my-config.json:/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
+command: node index.js --config /opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
+```
+
+### Config — what's in it
+
+Top-level shape:
+
+| Section | What it controls |
+|---|---|
+| `server.port` | HTTP port the API listens on. Default **8081**. |
+| `server.configs[]` | List of `{name, value}` pairs. Knobs like `postBodySizeLimit` (max POST body, default `50mb`), `amrRetentionInSec` (AMR data retention, default `3`s in profiles / `300`s in image default), `inSimulationMode` (default `false`), `configStatusTimeoutMs` (config update ACK timeout, default `30000`ms), `configStatusTimeoutCheckFrequencyMs` (how often to check for timed-out config updates, default `900000`ms). |
+| `elasticsearch` | `node` (ES URL), `indexPrefix` (default `mdx-`), `rawIndex` (default `mdx-raw-*`), `retries` (default `15`). |
+| `kafka` | `brokers` (array of `"host:port"` strings; empty = Kafka disabled), `retries` (KafkaJS retry count; `null` = KafkaJS default). |
+
+---
+
+## Step 2 — Data log volume (optional)
+
+The compose mounts a data-log directory for file uploads (sensor images, calibration files uploaded via the REST API):
+
+```yaml
+volumes:
+  - $VSS_DATA_DIR/data_log/vss_video_analytics_api:/web-api-app/files
+```
+
+If you don't need file upload endpoints, you can drop this mount — the container will still start, but uploads will write to the container's ephemeral filesystem.
+
+---
+
+## Step 3 — Infrastructure dependencies
+
+### Elasticsearch (required)
+
+The server pings Elasticsearch on startup. If ES is unreachable, the server logs `[APP ERROR] Server initialization failed` and exits. The `restart: always` policy in the base compose will bring it back, and it retries with `[ELASTICSEARCH RETRY] attempt=N` log lines.
+
+Make sure the `elasticsearch.node` in your config matches the running ES instance. With `network_mode: "host"`, ES must also be on the host network.
+
+If you need to bring up Elasticsearch too, use the infra compose:
+
+```bash
+docker compose -f services/infra/compose.yml up -d elasticsearch
+```
+
+Wait for ES to be healthy before starting the API:
+
+```bash
+curl -sf http://localhost:9200/_cluster/health
+```
+
+### Kafka (optional)
+
+Kafka is **optional**. If `kafka.brokers` is empty or null in the config, the server skips Kafka entirely — no error, no retry loop.
+
+When brokers are configured and reachable, the API gains:
+- **Dynamic config** — produces/consumes config update notifications on `mdx-notification` (Kafka key `behavior-analytics-config`). This is how the UI pushes config changes to `behavior-analytics` through the API.
+- **Dynamic calibration** — produces calibration update notifications on `mdx-notification` (Kafka key `calibration`).
+- **RTLS / AMR** — consumes real-time location and AMR messages from `mdx-rtls` / `mdx-amr` topics and exposes them via REST.
+
+If brokers are configured but unreachable, the server still starts (ES must be up), but Kafka-dependent endpoints will fail.
+
+---
+
+## How profiles use this service
+
+Every profile extends the same base service and adds its own `depends_on` and `profiles` constraints. The config is always the same service-shipped config — no profile overrides it:
+
+| Profile compose | Service name | Container name | `depends_on` |
+|---|---|---|---|
+| `warehouse-2d-app/warehouse-2d-app.yml` | `vss-video-analytics-api-2d` | `vss-video-analytics-api` | `broker-health-check`, `elasticsearch-init-container` |
+| `warehouse-3d-app/warehouse-3d-app.yml` | `vss-video-analytics-api-3d` | `vss-video-analytics-api` | `broker-health-check`, `elasticsearch-init-container` |
+| `warehouse-mv3dt-app/warehouse-mv3dt-app.yml` | `vss-video-analytics-api-mv3dt` | `vss-video-analytics-api-mv3dt` | `broker-health-check`, `elasticsearch-init-container` |
+| `dev-profile-alerts/compose.yml` | `vss-video-analytics-api-alerts` | `vss-video-analytics-api` | `broker-health-check`, `elasticsearch-init-container` |
+| `dev-profile-search/video-analytics-2d-app/compose.yml` | `vss-video-analytics-api-fusion` | `vss-video-analytics-api` | `broker-health-check`, `elasticsearch-init-container` |
+
+The `import-calibration-output-container` in warehouse profiles depends on the video-analytics-api service — it POSTs calibration data to the API after startup.
+
+---
+
+## REST API endpoints
+
+The server auto-discovers controllers from `src/app/controllers/rest-apis/` and mounts them as routes. Available endpoints:
+
+| Endpoint | What it does |
+|---|---|
+| `/livez` | Health check. Returns 200 when routes are registered and ES ping succeeded. |
+| `/sensor` | CRUD for sensor metadata (GET / POST / DELETE). Supports file uploads (images). |
+| `/config` | Dynamic config management. GET retrieves current config; POST publishes config updates to Kafka. |
+| `/behavior` | Query behavior data from Elasticsearch. |
+| `/alerts` | Query alert data with time-range and sensor filters. |
+| `/events` | Query event data from Elasticsearch. |
+| `/incidents` | Query incident data from Elasticsearch. |
+| `/frames` | Query frame-level data from Elasticsearch. |
+| `/metrics` | Aggregation / computation metrics (occupancy, behavior metrics). |
+| `/tracker` | Tracker data queries. |
+| `/clustering` | Clustering analysis queries. |
+
+All endpoints except `/livez` require Elasticsearch. Endpoints that publish notifications (config, calibration) also require Kafka.
+
+---
+
+## Deploy + verify
+
+```bash
+cd <repo>/deploy/docker
+export VSS_APPS_DIR=$(pwd)
+export VSS_DATA_DIR=<path-to-data-directory>  # e.g. /opt/vss/data
+
+# (one-time) edit services/analytics/video-analytics-api/configs/vss-video-analytics-api-config.json if needed.
+
+docker compose -f services/analytics/video-analytics-api/compose.yml up -d vss-video-analytics-api
+
+docker ps --filter "name=vss-video-analytics-api" --format '{{.Names}}\t{{.Status}}'
+docker logs -f vss-video-analytics-api
+```
+
+Healthy log lines include:
+
+```
+{"timestamp":"...","level":"info","message":"[SERVER] Listening on port: 8081"}
+```
+
+Verify the health endpoint:
+
+```bash
+curl -sf http://localhost:8081/livez && echo "OK" || echo "DOWN"
+```
+
+If Elasticsearch is not yet up, you'll see:
+
+```
+{"timestamp":"...","level":"error","message":"[ELASTICSEARCH RETRY] attempt=1"}
+```
+
+The container will keep retrying until ES is reachable (up to the configured `retries` count, then it exits and `restart: always` brings it back).
+
+## Teardown
+
+```bash
+docker compose -f services/analytics/video-analytics-api/compose.yml down
+```
+
+For a multi-service teardown (broker, ES, etc.) see [`teardown.md`](teardown.md).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `[APP ERROR] Server initialization failed` on startup | Elasticsearch unreachable. The server pings ES during bootstrap; if it fails, the server exits. | Check `elasticsearch.node` in your config matches the running ES instance. Verify with `curl -sf http://localhost:9200/_cluster/health`. |
+| `[INPUT ERROR] Invalid path for bootstrap config file.` | The `--config` path doesn't exist inside the container. | Verify the volume mount target matches the `--config` flag path. Use an absolute path. |
+| `EADDRINUSE` | Port 8081 (or your configured port) is already in use. | Check with `ss -tlnp | grep :8081`. Stop the conflicting process or change `server.port` in the config. |
+| Container alive but Kafka-dependent endpoints return errors | Kafka brokers configured but unreachable. | Verify brokers are reachable: `nc -zv <broker-host> <broker-port>`. Check `kafka.brokers` is a proper array of `"host:port"` strings. |
+| `/livez` returns 200 but data endpoints return empty results | Elasticsearch indices don't exist or have no data. | Check indices: `curl -s http://localhost:9200/_cat/indices?v \| grep mdx`. If empty, the upstream pipeline (behavior-analytics, perception) hasn't produced data yet. |
+| Config update via POST `/config` times out | The ACK from behavior-analytics didn't arrive within `configStatusTimeoutMs`. | Check that behavior-analytics is running and consuming from `mdx-notification`. Check the `configStatusTimeoutMs` value (default `30000`ms). |
+| Image won't run `docker exec -it ... sh` | The runtime image is distroless (`nvcr.io/nvidia/distroless/node:22`) — no shell. | Debug via `docker logs <container>` only. |

--- a/skills/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
+++ b/skills/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
@@ -216,7 +216,7 @@ The container will keep retrying until ES is reachable (up to the configured `re
 docker compose -f services/analytics/video-analytics-api/compose.yml down
 ```
 
-For a multi-service teardown (broker, ES, etc.) see [`teardown.md`](teardown.md).
+For a multi-service teardown (broker, ES, etc.) see [`teardown.md`](../../vss-deploy-profile/references/teardown.md).
 
 ---
 


### PR DESCRIPTION
…alytics-api` as a standalone service, detailing configuration options and prerequisites

- Introduced new SKILL.md for deploying the `vss-video-analytics-api` as a standalone service, detailing configuration options and prerequisites.
- Added configuration.md to outline the structure and settings for the API's JSON config file.
- Created deploy-video-analytics-api-service.md to provide step-by-step instructions for deployment, including infrastructure dependencies and REST API capabilities.

These additions enhance user guidance for deploying and configuring the Video Analytics API independently from the full warehouse stack.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
