### PR TITLE
Munjalp/fix sdr init config

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1020,6 +1020,13 @@ function state_up() {
   cp "${_source_env}" "${_generated_env}"
   echo "[INFO] Copied ${_source_env} to ${_generated_env}"
 
+  ensure_generated_env_trailing_newline() {
+    if [[ -s "${_generated_env}" ]] && [[ "$(tail -c 1 "${_generated_env}" | wc -l)" -eq 0 ]]; then
+      printf '\n' >> "${_generated_env}"
+    fi
+  }
+  ensure_generated_env_trailing_newline
+
   # Append compose-wide defaults for variables not already defined in the profile
   local _compose_defaults="${deployment_directory}/vst/compose-defaults.env"
   if [[ -f "${_compose_defaults}" ]]; then

--- a/deploy/docker/services/infra/sdrc/render-config.sh
+++ b/deploy/docker/services/infra/sdrc/render-config.sh
@@ -7,9 +7,9 @@
 # 'render-config' service in docker-compose.yaml). POSIX sh on purpose.
 #
 # Usage (host):
-#   HOST_IP=10.57.202.234 ./render-config.sh
-#   HOST_IP=10.57.202.234 NUM_STREAMS=8 ./render-config.sh path/to/tmpl path/to/out
-#   HOST_IP=10.57.202.234 NUM_SENSORS=8 ./render-config.sh path/to/tmpl path/to/out
+#   HOST_IP=127.0.0.1 ./render-config.sh
+#   HOST_IP=127.0.0.1 NUM_STREAMS=8 ./render-config.sh path/to/tmpl path/to/out
+#   HOST_IP=127.0.0.1 NUM_SENSORS=8 ./render-config.sh path/to/tmpl path/to/out
 #
 # Usage (init container):
 #   sh /render-config.sh /tmpl/config.yml.tmpl /out/config.yml

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -729,6 +729,19 @@ run_dry_run_up_and_check_generated_env "generated.env alerts UI subtitle follows
   "MODE" "2d_vlm" \
   "NEXT_PUBLIC_APP_SUBTITLE" '"Vision (Alerts - VLM)"'
 
+_alerts_env="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-alerts/.env"
+_alerts_env_backup="$(mktemp)"
+cp "${_alerts_env}" "${_alerts_env_backup}"
+CLEANUP_RESTORES+=("${_alerts_env_backup}|${_alerts_env}")
+_alerts_env_without_newline="$(mktemp)"
+printf '%s' "$(cat "${_alerts_env}")" > "${_alerts_env_without_newline}"
+mv "${_alerts_env_without_newline}" "${_alerts_env}"
+LLM_ENDPOINT_URL=http://127.0.0.1:9999 VLM_ENDPOINT_URL=http://127.0.0.1:9998 run_dry_run_up_and_check_generated_env "generated.env appends vars after profile .env without trailing newline" "alerts" \
+ -i 127.0.0.1 -H RTXPRO6000BW -m verification --use-remote-llm --llm my-llm --use-remote-vlm --vlm my-vlm -d -- \
+  "SDR_CONTROLLER_CONFIG_PATH" '${VSS_APPS_DIR}/developer-profiles/dev-profile-alerts/sdrc/${MODE}' \
+  "VST_CONFIG_PATH" "${REPO_ROOT}/deploy/docker/services/vios/configs"
+mv "${_alerts_env_backup}" "${_alerts_env}"
+
 # Base profile: when LLM_DEVICE_ID and VLM_DEVICE_ID match (e.g. both 0), derived modes are local_shared for both; when they differ, both are local
 run_dry_run_up_and_check_generated_env "generated.env LLM_MODE VLM_MODE HOST_IP (base defaults)" "base" \
  -i 127.0.0.1 -d -- \


### PR DESCRIPTION
This PR fixes an issue where dev-profile.sh generates an invalid generated.env when the source profile .env file does not end with a newline.

For the alerts profile, SDR_CONTROLLER_CONFIG_PATH was the final line in .env. When dev-profile.sh appended VST_CONFIG_PATH, the two variables would be concatenated into one malformed line, causing sdrc-render-config to mount the wrong config path and fail with:

`render-config: no *.tmpl files found in /tmpl`

The fix normalizes generated.env immediately after copying the profile .env, ensuring future appended variables always start on a new line.

Additionally this PR updates SDRC's ender-config.sh usage instructions to reflect localhost IP