### PR TITLE
fix(helm,lvs): dedupe vss-summarization env to support profile overrides

### DIFF
--- a/deploy/helm/services/video-summarization/templates/deployment.yaml
+++ b/deploy/helm/services/video-summarization/templates/deployment.yaml
@@ -135,9 +135,15 @@ spec:
             {{- range (.Values.extraEnv | default list) }}
             {{- $_ := set $envMap .name (tpl (.value | default "" | toString) $) }}
             {{- end }}
-            {{- range $k, $v := $envMap }}
+            {{- /*
+              Emit alphabetically. Go's text/template already sorts map keys
+              implicitly when ranging, but pinning the order explicitly with
+              sortAlpha documents the intent and prevents accidental
+              re-ordering if the template is refactored to a helper later.
+            */}}
+            {{- range $k := (keys $envMap | sortAlpha) }}
             - name: {{ $k }}
-              value: {{ $v | quote }}
+              value: {{ index $envMap $k | quote }}
             {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:

--- a/deploy/helm/services/video-summarization/templates/deployment.yaml
+++ b/deploy/helm/services/video-summarization/templates/deployment.yaml
@@ -109,31 +109,35 @@ spec:
               mountPath: /tmp/model_cache
             {{- end }}
           env:
+            {{- /*
+              Merge env from three sources, deduplicating by name.
+              Precedence (later sources override earlier ones):
+                1. .Values.env                  — service-chart defaults
+                2. hardcoded computed values    — wired-in template values
+                3. .Values.extraEnv             — profile-chart overrides
+              Without this dedup, a profile that overlays a base key (e.g.
+              LVS_ENABLE_LLM_MERGING) produces a Deployment with two entries
+              for the same name, which kubectl server-side apply rejects.
+            */}}
+            {{- $envMap := dict }}
             {{- range .Values.env }}
-            - name: {{ .name }}
-              value: {{ .value | quote }}
+            {{- $_ := set $envMap .name (.value | default "" | toString) }}
             {{- end }}
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: {{ $kafkaBootstrap | quote }}
-            - name: ES_HOST
-              value: {{ $esHost | quote }}
-            - name: ES_PORT
-              value: {{ $esPort | quote }}
-            - name: ES_TRANSPORT_PORT
-              value: {{ $esTransportPort | quote }}
-            - name: LVS_LLM_BASE_URL
-              value: {{ $llmBaseUrl | quote }}
-            - name: LVS_LLM_MODEL_NAME
-              value: {{ $llmModelName | quote }}
-            - name: VIA_VLM_ENDPOINT
-              value: {{ $vlmBaseUrl | quote }}
-            - name: VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME
-              value: {{ $vlmModelName | quote }}
-            - name: VST_INTERNAL_URL
-              value: {{ $vstInternalUrl | quote }}
+            {{- $_ := set $envMap "KAFKA_BOOTSTRAP_SERVERS"              ($kafkaBootstrap  | toString) }}
+            {{- $_ := set $envMap "ES_HOST"                              ($esHost          | toString) }}
+            {{- $_ := set $envMap "ES_PORT"                              ($esPort          | toString) }}
+            {{- $_ := set $envMap "ES_TRANSPORT_PORT"                    ($esTransportPort | toString) }}
+            {{- $_ := set $envMap "LVS_LLM_BASE_URL"                     ($llmBaseUrl      | toString) }}
+            {{- $_ := set $envMap "LVS_LLM_MODEL_NAME"                   ($llmModelName    | toString) }}
+            {{- $_ := set $envMap "VIA_VLM_ENDPOINT"                     ($vlmBaseUrl      | toString) }}
+            {{- $_ := set $envMap "VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME" ($vlmModelName    | toString) }}
+            {{- $_ := set $envMap "VST_INTERNAL_URL"                     ($vstInternalUrl  | toString) }}
             {{- range (.Values.extraEnv | default list) }}
-            - name: {{ .name }}
-              value: {{ tpl (.value | default "" | toString) $ | quote }}
+            {{- $_ := set $envMap .name (tpl (.value | default "" | toString) $) }}
+            {{- end }}
+            {{- range $k, $v := $envMap }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
             {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:


### PR DESCRIPTION
## Summary

Server-side apply rejects the rendered Deployment when a profile chart overlays an env key already defined by the service chart:

```
Error: server-side apply failed for object .../vss-summarization apps/v1, Kind=Deployment:
failed to create typed patch object: .spec.template.spec.containers[name="vss-summarization"].env:
duplicate entries for key [name="LVS_ENABLE_LLM_MERGING"]
```

`dev-profile-lvs/values.yaml` sets `LVS_ENABLE_LLM_MERGING="true"` via `extraEnv` to override the service chart's default of `"false"`, but the old template concatenated `.Values.env` + hardcoded computed values + `.Values.extraEnv` into the container env list without deduplication, producing two entries for the same name.

## Fix

Replace the concat in `deploy/helm/services/video-summarization/templates/deployment.yaml` with a dict-based merge. Precedence (later overrides earlier):

1. `.Values.env` — service-chart defaults
2. hardcoded computed values (`KAFKA_BOOTSTRAP_SERVERS`, `ES_HOST`, `LVS_LLM_*`, `VIA_VLM_*`, `VST_INTERNAL_URL`)
3. `.Values.extraEnv` — profile-chart overrides

Profiles can now safely override any env value (including the hardcoded ones) without colliding with the service-chart defaults. The service chart remains deployable standalone — defaults stay in `.Values.env`.

## Repro / verify

```bash
helm template lvs deploy/helm/developer-profiles/dev-profile-lvs/ \
  | grep -c LVS_ENABLE_LLM_MERGING   # was 2 (duplicate), now 1
```

## Notes

- Same class of failure could surface for any other profile that overlays a base env key; this fix is per-template (only vss-summarization) — sibling charts not touched in this PR.
- Stable env ordering across renders is out of scope for this PR.