### PR TITLE
ci: skip unchanged SonarQube service scans

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -35,18 +35,21 @@ jobs:
             project_key: TEGRASW_metropolis_video-search-and-summarization-agent_video-search-and-summarization
             project_name: video-search-and-summarization-agent
             sources: services/agent
+            paths: services/agent/
             tests: services/agent/tests
             python_version: "3.13"
           - name: ui
             project_key: TEGRASW_metropolis_video-search-and-summarization-ui_video-search-and-summarization
             project_name: video-search-and-summarization-ui
             sources: services/ui
+            paths: services/ui/
             tests: ""
             python_version: ""
           - name: skills
             project_key: TEGRASW_metropolis_video-search-and-summarization-skills_video-search-and-summarization
             project_name: video-search-and-summarization-skills
             sources: skills
+            paths: skills/
             tests: ""
             python_version: ""
 
@@ -57,7 +60,39 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Detect service changes
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SERVICE_PATHS: ${{ matrix.paths }}
+        run: |
+          should_scan=true
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            should_scan=false
+            git diff --name-only "$(git merge-base "$BASE_SHA" "$HEAD_SHA")" "$HEAD_SHA" > changed-files.txt
+
+            if awk -v prefix="$SERVICE_PATHS" '
+              index($0, prefix) == 1 || $0 == ".github/workflows/sonarqube.yml" {
+                found = 1
+              }
+              END { exit found ? 0 : 1 }
+            ' changed-files.txt; then
+              should_scan=true
+            fi
+          fi
+
+          echo "should_scan=${should_scan}" >> "$GITHUB_OUTPUT"
+          if [ "$should_scan" = "true" ]; then
+            echo "Scanning ${{ matrix.name }}."
+          else
+            echo "Skipping ${{ matrix.name }}; no matching service changes."
+          fi
+
       - name: Validate SonarQube secrets
+        if: steps.changes.outputs.should_scan == 'true'
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -71,7 +106,19 @@ jobs:
             exit 1
           fi
 
+      - name: Prepare SonarQube cache and temp directories
+        if: steps.changes.outputs.should_scan == 'true'
+        env:
+          SONAR_USER_HOME: ${{ runner.temp }}/sonar/${{ matrix.name }}
+          SONAR_JAVA_TMPDIR: ${{ runner.temp }}/sonar-tmp/${{ matrix.name }}
+        run: |
+          : "${SONAR_USER_HOME:?SONAR_USER_HOME is required}"
+          : "${SONAR_JAVA_TMPDIR:?SONAR_JAVA_TMPDIR is required}"
+          rm -rf "$SONAR_USER_HOME" "$SONAR_JAVA_TMPDIR"
+          mkdir -p "$SONAR_USER_HOME" "$SONAR_JAVA_TMPDIR"
+
       - name: Write SonarQube configuration
+        if: steps.changes.outputs.should_scan == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -119,7 +166,10 @@ jobs:
           sed -E 's/(sonar.token|SONAR_TOKEN).*/[REDACTED]/g' sonar-project.properties
 
       - name: Run SonarQube scanner
+        if: steps.changes.outputs.should_scan == 'true'
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_USER_HOME: ${{ runner.temp }}/sonar/${{ matrix.name }}
+          SONAR_SCANNER_JAVA_OPTS: -Djava.io.tmpdir=${{ runner.temp }}/sonar-tmp/${{ matrix.name }}


### PR DESCRIPTION
## Summary
- Add per-service path detection to the SonarQube matrix
- On pull requests, scan only the service whose owned paths changed
- Keep push and workflow_dispatch runs scanning all services
- Always scan all services when `.github/workflows/sonarqube.yml` changes so workflow edits are exercised

Closes #512.