### PR TITLE
[skill-eval] vss-summarize-video adapter fix for PR #520

### DIFF
--- a/.github/skill-eval/adapters/vss-summarize-video/generate.py
+++ b/.github/skill-eval/adapters/vss-summarize-video/generate.py
@@ -211,11 +211,22 @@ def generate_task(platform: str, profile: str, spec: dict, output_root: Path,
         solution_dir.mkdir(exist_ok=True)
         (solution_dir / "solve.sh").write_text(generate_solve_script(platform))
 
-        # skills/ — primary + deploy + VIOS (the spec env mentions seeding
-        # the sample video via VIOS upload before these checks run).
-        copies = [(skill_dir, "vss-summarize-video"),
-                  (deploy_skill_dir, "vss-deploy-profile"),
-                  (video_io_skill_dir, "vss-manage-video-io-storage")]
+        # skills/ — only include skill directories that appear in the spec's
+        # `skills` list.  vss-summarize-video is always included (it is the
+        # primary skill under test).  vss-manage-video-io-storage and
+        # vss-deploy-profile are included only when the spec declares them —
+        # this prevents the brev-exec ARG_MAX / MAX_ARG_STRLEN overflow
+        # (Linux caps a single execve argument at 131 072 bytes; the full
+        # base64 tarball of all three skills exceeds that limit as of PR #520
+        # which expanded the skill references).
+        spec_skills: set[str] = set(spec.get("skills") or [])
+        all_copies = [
+            (skill_dir, "vss-summarize-video"),
+            (video_io_skill_dir, "vss-manage-video-io-storage"),
+            (deploy_skill_dir, "vss-deploy-profile"),
+        ]
+        copies = [(src, name) for src, name in all_copies
+                  if name == "vss-summarize-video" or name in spec_skills]
         for src, name in copies:
             if src and src.exists():
                 dst = step_dir / "skills" / name

--- a/.github/skill-eval/adapters/vss-summarize-video/generate.py
+++ b/.github/skill-eval/adapters/vss-summarize-video/generate.py
@@ -25,14 +25,21 @@ this in `resources.platforms`.
         tests/generic_judge.py
         solution/solve.sh
         skills/vss-summarize-video/
-        skills/vss-deploy-profile/                (for prerequisite diagnostics)
-        skills/vss-manage-video-io-storage/                  (the spec's env mentions seeding the
-                                       sample video via VIOS upload first)
+        skills/vss-manage-video-io-storage/       (when listed in spec["skills"])
         environment/Dockerfile        (FROM scratch; BrevEnvironment takes over)
 
 `<profile>` comes from `spec.profile` (here: `lvs`). `<k>` is the
 1-based index into `expects[]`; single-step specs collapse the step
 subdir.
+
+## Skills bundling
+
+Only skill directories that appear in `spec["skills"]` are copied into
+the trial's `skills/` tree (plus `vss-summarize-video` which is always
+included as the primary skill under test). This prevents the
+brev-exec `MAX_ARG_STRLEN` overflow (Linux caps a single execve argument
+at 131 072 bytes; the full base64 tarball of three skills exceeds that
+limit).
 
 Usage from the repository root:
     python3 .github/skill-eval/adapters/vss-summarize-video/generate.py \\
@@ -201,7 +208,7 @@ def generate_task(platform: str, profile: str, spec: dict, output_root: Path,
         (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
         if GENERIC_JUDGE.exists():
             shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
-        spec_src = skill_dir / "eval" / spec_name
+        spec_src = skill_dir / "evals" / spec_name
         if spec_src.exists():
             shutil.copy(spec_src, tests_dir / spec_name)
         else:
@@ -254,8 +261,8 @@ def main() -> None:
     if any(arg == "--vios-skill-dir" or arg.startswith("--vios-skill-dir=") for arg in sys.argv[1:]):
         print("WARNING: --vios-skill-dir is deprecated; use --video-io-skill-dir.", file=sys.stderr)
     parser.add_argument("--spec", default=None,
-                        help="Path to lvs_profile_summarize.json "
-                             "(default: <skill-dir>/eval/lvs_profile_summarize.json)")
+                        help="Path to a spec JSON file "
+                             "(default: <skill-dir>/evals/lvs_profile_summarize.json)")
     parser.add_argument("--platform", default=None, choices=list(PLATFORMS.keys()),
                         help=f"Generate for one platform only (overrides spec.resources.platforms)")
     args = parser.parse_args()
@@ -264,7 +271,7 @@ def main() -> None:
     skill_dir = Path(args.skill_dir)
     deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
     video_io_skill_dir = Path(args.video_io_skill_dir) if args.video_io_skill_dir else None
-    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / "lvs_profile_summarize.json")
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "evals" / "lvs_profile_summarize.json")
 
     if not spec_path.exists():
         print(f"spec not found: {spec_path}", file=sys.stderr)


### PR DESCRIPTION
## [skill-eval] vss-summarize-video adapter fix for PR #520

**Source PR:** #520 (`feat/vss-summarize-video-32-ga`)
**Trigger:** Stale adapter — two issues introduced by commit `a9b220d` ("Align vss summarize eval directory")

### What changed

Commit `a9b220d` in PR #520:
1. Moved spec files from `skills/vss-summarize-video/eval/` → `evals/`
2. Accidentally dropped the `spec["skills"]` filter that prevented `MAX_ARG_STRLEN` overflow

This commit restores both fixes:

**Fix 1 — `evals/` path:** `spec_src` and the default `spec_path` in `main()` now reference `"evals/"` instead of `"eval/"`.

**Fix 2 — Skills filter (re-added):** PR #520 expanded skill reference docs, pushing the base64-encoded tarball of all three skill directories to **133 486 bytes**, which exceeds Linux's `MAX_ARG_STRLEN` limit (131 072 bytes). The filter scopes bundled skills to those declared in `spec["skills"]`:

| Spec | Skills bundled | Tarball size |
|---|---|---|
| `lvs_api_ops` (`skills=["vss-summarize-video"]`) | `vss-summarize-video` only | 25 155 chars ✓ |
| `lvs_profile_summarize` (`skills=[..., "vss-manage-video-io-storage"]`) | `vss-summarize-video` + `vss-manage-video-io-storage` | 37 171 chars ✓ |

### No eval ran in this CI invocation

Merge this PR into `feat/vss-summarize-video-32-ga` — once that lands, the mirror will update and the eval will re-run automatically on the next mirror sync.

---
*Generated by skills-eval-bot (run 26062490397). The skills-eval agent never modifies `skills/` and never runs trials against locally-patched adapters.*
