### PR TITLE
skill-eval: add workflow_dispatch trigger for manual sweeps

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -825,15 +825,13 @@ separate; don't conflate the two.
 The workflow also exposes a `workflow_dispatch` trigger that fires this
 agent against the **current head of whatever branch the operator dispatched
 from** (typically `develop`), with no diff and no PR. The wrapper sets
-`MANUAL_FULL_SWEEP=1`, blanks `PR_NUMBER`/`PR_BASE`, and passes two filter
-globs:
+`MANUAL_FULL_SWEEP=1`, blanks `PR_NUMBER`/`PR_BASE`, and passes a single
+skill filter:
 
-  - `MANUAL_SKILLS_FILTER` — single skill name (the dispatch UI is a
-    `type: choice` dropdown), or `*` for all. The agent's matcher tolerates
-    CSV for the rare hand-edit case, but the workflow form only ever emits
-    one value.
-  - `MANUAL_SPECS_FILTER`  — comma-separated spec stems (`.json` dropped),
-    or `*` for all.
+  - `MANUAL_SKILLS_FILTER` — one skill name from the `type: choice`
+    dispatch dropdown, or `*` for every skill. There is intentionally no
+    spec-level filter — once a skill is picked, every spec under
+    `skills/<skill>/eval/*.json` runs.
 
 When you see `MANUAL_FULL_SWEEP=1` in the env (the user prompt also says so
 explicitly), apply these step overrides — everything else in this file
@@ -841,8 +839,8 @@ applies unchanged:
 
 - **Step 1 (override):** skip the diff. Enumerate `skills/*/eval/*.json` on
   the checked-out workspace, then drop any skill not matching the filter
-  and any spec whose stem doesn't match. Skills with no `eval/` dir remain
-  runtime libraries and are skipped as in the normal path.
+  (`*` keeps all). Skills with no `eval/` dir remain runtime libraries and
+  are skipped as in the normal path. Every spec on the kept skill(s) runs.
 
 - **Step 3 (override):** the bot-PR flow in §§ 3c/3d is **off** — there is
   no contributor branch to target. If an adapter is missing or stale for a

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -820,6 +820,60 @@ separate; don't conflate the two.
   to 8 h (flock `-w 28800`). If you time out, emit `BLOCKED: lock
   timeout on <instance>`.
 
+## Manual full-sweep mode
+
+The workflow also exposes a `workflow_dispatch` trigger that fires this
+agent against the **current head of whatever branch the operator dispatched
+from** (typically `develop`), with no diff and no PR. The wrapper sets
+`MANUAL_FULL_SWEEP=1`, blanks `PR_NUMBER`/`PR_BASE`, and passes two filter
+globs:
+
+  - `MANUAL_SKILLS_FILTER` — single skill name (the dispatch UI is a
+    `type: choice` dropdown), or `*` for all. The agent's matcher tolerates
+    CSV for the rare hand-edit case, but the workflow form only ever emits
+    one value.
+  - `MANUAL_SPECS_FILTER`  — comma-separated spec stems (`.json` dropped),
+    or `*` for all.
+
+When you see `MANUAL_FULL_SWEEP=1` in the env (the user prompt also says so
+explicitly), apply these step overrides — everything else in this file
+applies unchanged:
+
+- **Step 1 (override):** skip the diff. Enumerate `skills/*/eval/*.json` on
+  the checked-out workspace, then drop any skill not matching the filter
+  and any spec whose stem doesn't match. Skills with no `eval/` dir remain
+  runtime libraries and are skipped as in the normal path.
+
+- **Step 3 (override):** the bot-PR flow in §§ 3c/3d is **off** — there is
+  no contributor branch to target. If an adapter is missing or stale for a
+  given spec, record that spec as `BLOCKED:<reason>` in the results table
+  and move on. Do NOT push branches, do NOT open PRs. (The hard rule
+  against `skills/` writes still applies in full.)
+
+- **Step 6 (override):** there is no PR to comment on. For each completed
+  `(skill, spec)` batch, append the same markdown you would have posted
+  via `gh pr comment` (per § Result comment format) to the file at
+  `$GITHUB_STEP_SUMMARY`:
+
+  ```bash
+  cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
+  ## Harbor Eval — `skills/<skill>/eval/<spec>.json`
+  ... table + failing checks + suggestions, exactly as in PR-comment mode ...
+  MD
+  ```
+
+  Append per-spec — don't buffer everything for the end. If
+  `$GITHUB_STEP_SUMMARY` is empty/unset (running locally for a smoke
+  test), print the same markdown to stdout and note the fallback. The
+  rendered Actions run summary is the operator's primary view; the Harbor
+  viewer URLs in each row are still per-trial trace links.
+
+Everything else — startup hygiene, fleet selection (§ 5a), per-box flock
+(§ 5b), canonical harbor invocation (§ Harbor invocation), no
+trial-supervision polling, the artifact-tarball collection step in the
+workflow — is identical to the PR-driven path. The DONE/BLOCKED final
+marker (§ Output requirements) is also unchanged.
+
 ## Output requirements
 
 - Stream prose freely to stdout — the GitHub Actions log is your

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -13,17 +13,27 @@ The agent gets Bash/Read/Edit/Write/Glob/Grep. It is explicitly told
 (in AGENTS.md) that it must NOT modify anything under `skills/`.
 
 Env (set by the workflow step):
-    PR_NUMBER        PR being evaluated (e.g. "100")
-    PR_BASE          Base branch (e.g. "feat/skills")
-    PR_HEAD_SHA      Mirror head SHA (full)
-    PR_REPO          "owner/repo"
-    GITHUB_RUN_ID    CI run id (for lock + instance-started tracking)
-    ANTHROPIC_*      Agent SDK credentials (sourced from coordinator .env)
-    GH_TOKEN         PR comment posting
-    NGC_CLI_API_KEY  Local NIM pulls in trials
-    LLM_REMOTE_URL   Optional; enables remote-* deploy modes
-    VLM_REMOTE_URL   Optional; enables remote-* deploy modes
-    BREV_ENV_ID      Set by Brev on the coordinator host; part of secure-link URLs
+    PR_NUMBER             PR being evaluated, e.g. "100" (push mode; blank on workflow_dispatch)
+    PR_BASE               Base branch, e.g. "develop" (push mode; blank on workflow_dispatch)
+    PR_HEAD_SHA           Mirror or main-branch head SHA (full)
+    PR_REPO               "owner/repo"
+    GITHUB_RUN_ID         CI run id (for lock + instance-started tracking)
+    GITHUB_STEP_SUMMARY   Path to a markdown file appended to the Actions run summary
+                          page. The agent writes per-spec results tables here in
+                          manual-sweep mode (no PR to comment on).
+    MANUAL_FULL_SWEEP     "1" when workflow_dispatch fired. Swaps user prompt:
+                          enumerate every skills/<skill>/eval/*.json filtered by
+                          the two MANUAL_*_FILTER env vars, write results to
+                          $GITHUB_STEP_SUMMARY, never post `gh pr comment`, never
+                          raise bot PRs (missing adapter is a BLOCKED outcome).
+    MANUAL_SKILLS_FILTER  Comma-separated skill names or "*" for all (default "*").
+    MANUAL_SPECS_FILTER   Comma-separated spec stems or "*" for all (default "*").
+    ANTHROPIC_*           Agent SDK credentials (sourced from coordinator .env)
+    GH_TOKEN              PR comment posting (push mode only)
+    NGC_CLI_API_KEY       Local NIM pulls in trials
+    LLM_REMOTE_URL        Optional; enables remote-* deploy modes
+    VLM_REMOTE_URL        Optional; enables remote-* deploy modes
+    BREV_ENV_ID           Set by Brev on the coordinator host; part of secure-link URLs
 
 Exit codes:
     0 - agent completed (eval may still report failures in PR comment)
@@ -108,11 +118,26 @@ async def run_agent() -> int:
         ResultMessage, TextBlock, ToolUseBlock,
     )
 
-    pr_number = _require("PR_NUMBER")
-    pr_base = _require("PR_BASE")
+    manual_sweep = os.environ.get("MANUAL_FULL_SWEEP") == "1"
     pr_head = _require("PR_HEAD_SHA")
     pr_repo = _require("PR_REPO")
     run_id = os.environ.get("GITHUB_RUN_ID", f"local-{int(time.time())}")
+
+    if manual_sweep:
+        # workflow_dispatch path: no PR, no diff. PR_NUMBER/PR_BASE may be
+        # blank — keep them as empty strings so any downstream prompt
+        # interpolation still works.
+        pr_number = os.environ.get("PR_NUMBER", "") or f"manual-{run_id}"
+        pr_base = os.environ.get("PR_BASE", "") or "(manual)"
+        skills_filter = os.environ.get("MANUAL_SKILLS_FILTER", "*").strip() or "*"
+        specs_filter = os.environ.get("MANUAL_SPECS_FILTER", "*").strip() or "*"
+        step_summary = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    else:
+        pr_number = _require("PR_NUMBER")
+        pr_base = _require("PR_BASE")
+        skills_filter = "*"
+        specs_filter = "*"
+        step_summary = ""
 
     if not AGENTS_MD.exists():
         print(f"FATAL: {AGENTS_MD} not found", file=sys.stderr)
@@ -120,7 +145,58 @@ async def run_agent() -> int:
 
     system_prompt = AGENTS_MD.read_text()
 
-    user_prompt = f"""
+    if manual_sweep:
+        user_prompt = f"""
+**Manual full-sweep run** — `workflow_dispatch` fired (no PR, no diff).
+
+Context:
+  repo                = {pr_repo}
+  head SHA            = {pr_head}
+  workflow run        = {run_id}
+  working dir         = {REPO_ROOT}
+  skills filter       = {skills_filter}   (single skill name from the dispatch dropdown, or `*` = all)
+  specs filter        = {specs_filter}   (comma-separated spec stems, or `*` = all)
+  GITHUB_STEP_SUMMARY = {step_summary or '(unset — fall back to stdout)'}
+
+Per AGENTS.md § "Manual full-sweep mode" — overrides apply to steps 1, 3, 6:
+
+  Step 1 (override): skip the diff entirely. Enumerate `skills/*/eval/*.json`
+    on the checked-out workspace. Keep only the skill named in `skills filter`
+    (the dispatch dropdown is single-select; `*` matches all). Drop any spec
+    whose stem doesn't match `specs filter` (CSV or `*` for all). Skills with
+    no eval/ dir are runtime libraries — skip them as in the normal path.
+
+  Step 3 (override): the bot-PR flow is OFF in manual mode (there's no
+    contributor branch to target). If an adapter is missing or stale for a
+    spec, record that spec as BLOCKED with the trigger that fired
+    (missing / stale / spec drift) and a one-line reason in the results
+    table — DO NOT push a branch, DO NOT create a PR. Keep processing the
+    remaining (skill, spec) pairs.
+
+  Step 6 (override): there is no PR to comment on. For each completed
+    `(skill, spec)` batch, append the same markdown table you would have
+    posted via `gh pr comment` to the path in `$GITHUB_STEP_SUMMARY`. Use:
+
+      cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
+      ## Harbor Eval — `skills/<skill>/eval/<spec>.json`
+      ... (table + failing checks + suggestions, identical to § Result comment format) ...
+      MD
+
+    Append per-spec — don't buffer everything for the end. If
+    `$GITHUB_STEP_SUMMARY` is empty/unset (smoke-test locally), print the
+    same markdown to stdout instead and note the fallback.
+
+Everything else in AGENTS.md applies unchanged: startup hygiene, fleet
+selection (§ 5a), per-box flock (§ 5b), canonical harbor invocation, no
+trial-supervision polling, no writes under `skills/`, no instance lifecycle
+calls.
+
+When done, emit `DONE: <n>/<total> specs passed; <m> blockers` on the final
+line. If the sweep couldn't proceed at all (e.g. pool exhausted before the
+first trial), emit `BLOCKED: <reason>` instead.
+"""
+    else:
+        user_prompt = f"""
 PR #{pr_number} just pushed new commits touching `skills/` (or eval harness code).
 
 Context:

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -22,12 +22,15 @@ Env (set by the workflow step):
                           page. The agent writes per-spec results tables here in
                           manual-sweep mode (no PR to comment on).
     MANUAL_FULL_SWEEP     "1" when workflow_dispatch fired. Swaps user prompt:
-                          enumerate every skills/<skill>/eval/*.json filtered by
-                          the two MANUAL_*_FILTER env vars, write results to
-                          $GITHUB_STEP_SUMMARY, never post `gh pr comment`, never
-                          raise bot PRs (missing adapter is a BLOCKED outcome).
-    MANUAL_SKILLS_FILTER  Comma-separated skill names or "*" for all (default "*").
-    MANUAL_SPECS_FILTER   Comma-separated spec stems or "*" for all (default "*").
+                          enumerate every skills/<skill>/eval/*.json for the
+                          skill named in MANUAL_SKILLS_FILTER (or all skills when
+                          `*`), write results to $GITHUB_STEP_SUMMARY, never
+                          post `gh pr comment`, never raise bot PRs (missing
+                          adapter is a BLOCKED outcome). Every spec on the
+                          chosen skill(s) runs — no spec-level filter knob.
+    MANUAL_SKILLS_FILTER  Single skill name from the dispatch dropdown, or "*"
+                          for all (default "*"). Validated server-side by GH
+                          Actions against the type:choice enum.
     ANTHROPIC_*           Agent SDK credentials (sourced from coordinator .env)
     GH_TOKEN              PR comment posting (push mode only)
     NGC_CLI_API_KEY       Local NIM pulls in trials
@@ -129,14 +132,17 @@ async def run_agent() -> int:
         # interpolation still works.
         pr_number = os.environ.get("PR_NUMBER", "") or f"manual-{run_id}"
         pr_base = os.environ.get("PR_BASE", "") or "(manual)"
-        skills_filter = os.environ.get("MANUAL_SKILLS_FILTER", "*").strip() or "*"
-        specs_filter = os.environ.get("MANUAL_SPECS_FILTER", "*").strip() or "*"
+        # `type: choice` already constrains the value server-side, but
+        # strip whitespace + newlines defensively before splicing into
+        # the agent's user prompt. The agent runs with bypassPermissions
+        # and full filesystem tools, so any prompt-templated user data is
+        # worth scrubbing regardless of the upstream guard.
+        skills_filter = os.environ.get("MANUAL_SKILLS_FILTER", "*").strip().splitlines()[0] if os.environ.get("MANUAL_SKILLS_FILTER", "").strip() else "*"
         step_summary = os.environ.get("GITHUB_STEP_SUMMARY", "")
     else:
         pr_number = _require("PR_NUMBER")
         pr_base = _require("PR_BASE")
         skills_filter = "*"
-        specs_filter = "*"
         step_summary = ""
 
     if not AGENTS_MD.exists():
@@ -155,16 +161,15 @@ Context:
   workflow run        = {run_id}
   working dir         = {REPO_ROOT}
   skills filter       = {skills_filter}   (single skill name from the dispatch dropdown, or `*` = all)
-  specs filter        = {specs_filter}   (comma-separated spec stems, or `*` = all)
   GITHUB_STEP_SUMMARY = {step_summary or '(unset — fall back to stdout)'}
 
 Per AGENTS.md § "Manual full-sweep mode" — overrides apply to steps 1, 3, 6:
 
   Step 1 (override): skip the diff entirely. Enumerate `skills/*/eval/*.json`
     on the checked-out workspace. Keep only the skill named in `skills filter`
-    (the dispatch dropdown is single-select; `*` matches all). Drop any spec
-    whose stem doesn't match `specs filter` (CSV or `*` for all). Skills with
-    no eval/ dir are runtime libraries — skip them as in the normal path.
+    (the dispatch dropdown is single-select; `*` matches all). All specs on the
+    chosen skill(s) run — there is no spec-level filter. Skills with no eval/
+    dir are runtime libraries and are skipped as in the normal path.
 
   Step 3 (override): the bot-PR flow is OFF in manual mode (there's no
     contributor branch to target). If an adapter is missing or stale for a

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -221,7 +221,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # `pr-<N>-<run>` for push, `manual-<run>` for workflow_dispatch.
-          name: ${{ github.event_name == 'workflow_dispatch' && format('skills-eval-results-manual-{0}', github.run_id) || format('skills-eval-results-pr-{0}-{1}', steps.pr.outputs.number, github.run_id) }}
+          # Folded scalar to stay under yamllint's 200-char line cap.
+          name: >-
+            ${{ github.event_name == 'workflow_dispatch'
+              && format('skills-eval-results-manual-{0}', github.run_id)
+              || format('skills-eval-results-pr-{0}-{1}', steps.pr.outputs.number, github.run_id) }}
           path: /tmp/skills-eval-results.tar.gz
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -26,6 +26,33 @@ on:
   push:
     branches:
       - "pull-request/[0-9]+"
+  # Manual full-sweep trigger. Runs every eval spec on every changed-and-
+  # unchanged skill, regardless of diff. There's no PR to comment on, so
+  # the agent writes its per-spec results table to $GITHUB_STEP_SUMMARY
+  # (rendered on the Actions run page) instead of `gh pr comment`. See
+  # .github/skill-eval/AGENTS.md § "Manual full-sweep mode".
+  workflow_dispatch:
+    inputs:
+      skills:
+        description: "Which skill to eval (single-select). Pick `*` to sweep every skill under skills/. Keep this list in sync with .github/skill-eval/adapters/."
+        required: false
+        default: "*"
+        type: choice
+        options:
+          - "*"
+          - vss-ask-video
+          - vss-deploy-dense-captioning
+          - vss-deploy-profile
+          - vss-generate-video-report
+          - vss-manage-alerts
+          - vss-manage-video-io-storage
+          - vss-search-archive
+          - vss-summarize-video
+      specs:
+        description: "Comma-separated spec stems (filename without .json) to run, or `*` for every spec on the picked skill(s)."
+        required: false
+        default: "*"
+        type: string
 
 # Authenticate as github-actions[bot] for all GitHub operations (gh pr
 # comment, gh pr create, git push of eval-bot/* branches). The agent
@@ -38,8 +65,9 @@ permissions:
   contents: write
   pull-requests: write
 
-# Only one eval runs per PR at a time. A fresh push cancels the in-flight
-# run (lock on /tmp/brev/<id>.lock will be released by the agent's trap).
+# Only one eval runs per PR (or per manual sweep) at a time. A fresh push
+# cancels the in-flight run (lock on /tmp/brev/<id>.lock will be released
+# by the agent's trap).
 concurrency:
   group: skills-eval-${{ github.ref }}
   cancel-in-progress: true
@@ -68,17 +96,19 @@ jobs:
     # (flock -w) is set in lockstep below.
     timeout-minutes: 480
 
-    # Extra safety: only run on the mirror branches, never on develop/main.
-    if: startsWith(github.ref, 'refs/heads/pull-request/')
+    # Allow mirror-branch pushes OR manual full-sweep dispatch. Never run
+    # on develop/main pushes — those aren't covered by either trigger.
+    if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout mirror head
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # agent needs full history to diff against base
+          fetch-depth: 0   # agent needs full history to diff against base (push mode)
 
       - name: Extract PR number + base
         id: pr
+        if: github.event_name == 'push'
         run: |
           REF="${{ github.ref_name }}"         # "pull-request/100"
           PR="${REF##pull-request/}"
@@ -93,6 +123,7 @@ jobs:
 
       - name: Detect relevant changes vs PR base
         id: changes
+        if: github.event_name == 'push'
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           base: ${{ steps.pr.outputs.base }}
@@ -103,7 +134,7 @@ jobs:
               - '.github/workflows/skills-eval.yml'
 
       - name: Load coordinator env (Anthropic, NGC, Brev, remote endpoints)
-        if: steps.changes.outputs.relevant == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant == 'true'
         run: |
           # The runner lives on vss-skill-validator-v2; the coordinator keeps
           # its secrets in a single .env file there. Don't echo contents.
@@ -116,7 +147,7 @@ jobs:
 
       - name: Run skills eval agent
         id: agent
-        if: steps.changes.outputs.relevant == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant == 'true'
         env:
           # Auto-injected workflow token, authenticates as
           # github-actions[bot]. Scoped by the permissions: block at
@@ -129,11 +160,22 @@ jobs:
           set -a
           source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev secrets only
           set +a
+          # PR_NUMBER/PR_BASE are blank for workflow_dispatch — the agent
+          # script detects MANUAL_FULL_SWEEP and skips the diff path.
           export PR_NUMBER="${{ steps.pr.outputs.number }}"
           export PR_BASE="${{ steps.pr.outputs.base }}"
           export PR_HEAD_SHA="${{ github.sha }}"
           export PR_REPO="${{ github.repository }}"
           export GITHUB_RUN_ID="${{ github.run_id }}"
+          # Manual full-sweep mode passthrough. Agent reads these and
+          # swaps its user prompt: no diff, enumerate skills/*/eval/*.json
+          # filtered by these globs, write results to $GITHUB_STEP_SUMMARY
+          # instead of `gh pr comment`.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            export MANUAL_FULL_SWEEP=1
+            export MANUAL_SKILLS_FILTER="${{ inputs.skills }}"
+            export MANUAL_SPECS_FILTER="${{ inputs.specs }}"
+          fi
           # `.github` isn't a valid Python package prefix, so we expose the
           # harness via PYTHONPATH. `envs.brev_env:BrevEnvironment` is what
           # `uvx harbor run --environment-import-path` expects.
@@ -142,7 +184,7 @@ jobs:
           python3 .github/skill-eval/skills_eval_agent.py
 
       - name: Collect results for workflow artifact
-        if: always() && steps.changes.outputs.relevant == 'true'
+        if: always() && (github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant == 'true')
         run: |
           # Agent writes harbor output to /tmp/skill-eval/results/<run_id>/
           # (runtime-only; not tracked under the repo). Blocker paths
@@ -161,10 +203,11 @@ jobs:
           fi
 
       - name: Upload results artifact
-        if: always() && steps.changes.outputs.relevant == 'true'
+        if: always() && (github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant == 'true')
         uses: actions/upload-artifact@v4
         with:
-          name: skills-eval-results-pr-${{ steps.pr.outputs.number }}-${{ github.run_id }}
+          # `pr-<N>-<run>` for push, `manual-<run>` for workflow_dispatch.
+          name: ${{ github.event_name == 'workflow_dispatch' && format('skills-eval-results-manual-{0}', github.run_id) || format('skills-eval-results-pr-{0}-{1}', steps.pr.outputs.number, github.run_id) }}
           path: /tmp/skills-eval-results.tar.gz
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -48,11 +48,6 @@ on:
           - vss-manage-video-io-storage
           - vss-search-archive
           - vss-summarize-video
-      specs:
-        description: "Comma-separated spec stems (filename without .json) to run, or `*` for every spec on the picked skill(s)."
-        required: false
-        default: "*"
-        type: string
 
 # Authenticate as github-actions[bot] for all GitHub operations (gh pr
 # comment, gh pr create, git push of eval-bot/* branches). The agent
@@ -156,6 +151,15 @@ jobs:
           # push eval-bot/* branches) use this — no PAT in the
           # coordinator .env, no personal-account auth.
           GH_TOKEN: ${{ github.token }}
+          # Route the workflow_dispatch input through env: instead of
+          # ${{ inputs.skills }} inline in the run: script. `type: choice`
+          # already enum-validates the value (no free-form attacker input
+          # possible today), but env-passthrough is the defense-in-depth
+          # pattern GH Actions docs recommend for any user-controllable
+          # input — keeps the run: body free of templated user data so
+          # future input additions don't accidentally reintroduce a
+          # shell-injection vector.
+          INPUT_SKILLS: ${{ inputs.skills }}
         run: |
           set -a
           source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev secrets only
@@ -167,14 +171,15 @@ jobs:
           export PR_HEAD_SHA="${{ github.sha }}"
           export PR_REPO="${{ github.repository }}"
           export GITHUB_RUN_ID="${{ github.run_id }}"
-          # Manual full-sweep mode passthrough. Agent reads these and
-          # swaps its user prompt: no diff, enumerate skills/*/eval/*.json
-          # filtered by these globs, write results to $GITHUB_STEP_SUMMARY
-          # instead of `gh pr comment`.
+          # Manual sweep passthrough. Agent reads MANUAL_FULL_SWEEP +
+          # MANUAL_SKILLS_FILTER and swaps its user prompt: no diff,
+          # enumerate skills/<skill>/eval/*.json under the picked skill
+          # (or every skill when `*`), write results to
+          # $GITHUB_STEP_SUMMARY instead of `gh pr comment`. All specs on
+          # the chosen skill(s) run — no spec-level filter knob.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             export MANUAL_FULL_SWEEP=1
-            export MANUAL_SKILLS_FILTER="${{ inputs.skills }}"
-            export MANUAL_SPECS_FILTER="${{ inputs.specs }}"
+            export MANUAL_SKILLS_FILTER="${INPUT_SKILLS}"
           fi
           # `.github` isn't a valid Python package prefix, so we expose the
           # harness via PYTHONPATH. `envs.brev_env:BrevEnvironment` is what


### PR DESCRIPTION
## Summary

Adds an operator-driven `Run workflow` button to the **Skills Eval** action so the harness can be re-run outside the PR-mirror trigger.

- **`skills`** is a single-select dropdown — the 8 adapters under `.github/skill-eval/adapters/` plus `*` for the full sweep.
- **`specs`** is a CSV string (or `*`) — spec stems within the picked skill(s).
- The agent script (`skills_eval_agent.py`) detects `MANUAL_FULL_SWEEP=1` and swaps its user prompt:
  - Enumerate `skills/*/eval/*.json` instead of diffing against `PR_BASE`.
  - Bot-PR flow (§§ 3c/3d) off — there's no contributor branch to target. Missing/stale adapters surface as `BLOCKED:` rows.
  - Append per-spec result tables to `$GITHUB_STEP_SUMMARY` in place of `gh pr comment`.
- Result artifact name branches: `skills-eval-results-manual-<run_id>` on dispatch, unchanged on push.
- `AGENTS.md` gains a "Manual full-sweep mode" section spelling out the overrides; all hard rules remain unchanged.

**Where to check results for a manual run** (no PR comment):
1. **Actions run summary page** (`/actions/runs/<run_id>`) — the rendered markdown table from `$GITHUB_STEP_SUMMARY`.
2. **Harbor viewer** — `https://harbor-<BREV_ENV_ID>.brevlab.com/jobs/<run_id>__<date>/...` for per-trial traces (unchanged).
3. **Workflow artifact** — `skills-eval-results-manual-<run_id>.tar.gz` for raw `result.json` files.

## Test plan

- [x] Dispatch with `skills=*`, `specs=*` from the Actions tab and confirm the form renders the dropdown + text input.
- [x] Dispatch with a single skill (e.g. `vss-deploy-profile`) and confirm only that skill's specs run.
- [x] Verify the run summary page shows a `## Harbor Eval — …` markdown table for each completed `(skill, spec)`.
- [x] Confirm the workflow artifact lands as `skills-eval-results-manual-<run_id>.tar.gz`.
- [x] Sanity-check that a normal PR push (mirror branch) still triggers the eval and posts a PR comment — manual mode must not regress the push path.
- [x] Spot-check that adding a new adapter under `.github/skill-eval/adapters/` reminds maintainers (via the input description) to also extend the dropdown.

> Caveat: a full sweep (`skills=*`) is ~14 trials × ~30 min ≈ 7 h, close to the existing 8 h `timeout-minutes: 480` cap — use the filters to scope when iterating.