### PR TITLE
skill-eval: add workflow_dispatch trigger on main so UI button appears

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -26,9 +26,24 @@ on:
   push:
     branches:
       - "pull-request/[0-9]+"
+  # The "Run workflow" button in the Actions UI only appears when
+  # `workflow_dispatch:` is configured on the repo's default branch
+  # (`main`). The full manual-sweep harness — skills dropdown input,
+  # agent prompt overrides, $GITHUB_STEP_SUMMARY result table — lives
+  # on `develop` (PR #524). When the operator clicks "Run workflow"
+  # and picks `develop` in the ref dropdown, GitHub runs develop's
+  # version of this file (inputs, env passthrough, agent invocation
+  # all come from develop). No other harness state needs to be ported
+  # back to main; the skills/ tree, adapter names, and agent script
+  # have diverged enough that a full backport would create more churn
+  # than value. If anyone accidentally dispatches against `main`
+  # itself, the job's `if:` guard below (only true for
+  # `pull-request/<N>` refs) makes the job a clean no-op.
+  workflow_dispatch:
 
-# Only one eval runs per PR at a time. A fresh push cancels the in-flight
-# run (lock on /tmp/brev/<id>.lock will be released by the agent's trap).
+# Only one eval runs per PR (or per manual sweep) at a time. A fresh push
+# cancels the in-flight run (lock on /tmp/brev/<id>.lock will be released
+# by the agent's trap).
 concurrency:
   group: skills-eval-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Adds **only** the `workflow_dispatch:` trigger to `.github/workflows/skills-eval.yml` on `main`. No body changes.

### Why this trivial-looking change is needed

The full manual-sweep harness landed via #524 on `develop` — single-select skills dropdown, agent-prompt overrides, `\$GITHUB_STEP_SUMMARY` results table. But GitHub only renders the **Run workflow** button in the Actions UI when `workflow_dispatch:` is configured on the **default branch** (this repo's default is \`main\`). With our change only on develop, the button never appears.

Adding just the trigger here is enough to unlock the button. When the operator clicks **Run workflow** and switches the ref dropdown to \`develop\`, GitHub uses **develop's** version of the workflow file — so all the input plumbing and agent prompt overrides come from develop, not from this PR.

A full backport of the harness to main would conflict on every renamed skill/adapter (\`deploy/\` → \`vss-deploy-profile/\`, \`vios/\` → \`vss-ask-video/\`, etc.) and is intentionally out of scope.

### Safety: accidental dispatch against main

If anyone picks \`main\` in the ref dropdown by mistake, main's older agent script (no \`MANUAL_FULL_SWEEP\` support) would crash on a missing PR_NUMBER. The job's existing guard
\`\`\`yaml
if: startsWith(github.ref, 'refs/heads/pull-request/')
\`\`\`
evaluates false for a workflow_dispatch against main → the job is a clean no-op. No execution against the stale harness, no zombie state.

## Test plan

- [ ] Merge → confirm the "Run workflow" button appears at https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/workflows/skills-eval.yml
- [ ] Open the form, switch ref dropdown to \`develop\` → confirm the \`skills\` single-select dropdown appears (proves the UI is reading develop's file).
- [ ] Pick a skill (e.g. \`vss-deploy-profile\`) → click Run → confirm the run starts against develop's harness.
- [ ] Dispatch against \`main\` itself → confirm the job is skipped cleanly (no Eval step runs).