### PR TITLE
ci: partition runner pools — vss-skill-eval-runner + vss-brev-runner

### DIFF
--- a/.github/skills-nv-base/README.md
+++ b/.github/skills-nv-base/README.md
@@ -46,10 +46,10 @@ VSS-flavored). Adjust by PR review when the playbook updates.
 
 ## Where it runs
 
-Self-hosted runner labelled **`nv-base`**. NV-BASE is not publicly
-distributed, so Step 1 needs the binary pre-installed; Step 2 is
-stdlib-only and would also run on `ubuntu-latest`, but is kept on the
-same runner to share the checkout.
+Shared brev-CI runner pool labelled **`vss-brev-runner`**. NV-BASE is
+not publicly distributed, so Step 1 needs the binary pre-installed on
+every pool member; Step 2 is stdlib-only and would also run on
+`ubuntu-latest`, but is kept on the same pool to share the checkout.
 
 ## Runner bootstrap (one-time, by operator)
 

--- a/.github/workflows/helm-sync.yml
+++ b/.github/workflows/helm-sync.yml
@@ -58,19 +58,16 @@ defaults:
 jobs:
   sync-check:
     name: Check helm parity for deploy/docker changes
-    # Self-hosted runner labelled `helm-sync`, registered on the
-    # vss-skill-validator-v2 coordinator host as a SECOND runner process
-    # alongside the existing `vss-eval` runner. We tried ubuntu-latest
-    # first but `inference-api.nvidia.com` is IP-allowlisted to NVIDIA
-    # infra and refused TCP from Azure runners (run 25220887217
-    # attempt 2: `API Error: Unable to connect to API
-    # (ConnectionRefused)`). The vss-skill-validator-v2 host IS allowlisted
-    # since it's where the coordinator already runs, and adding a
-    # second runner there is $0 incremental cost. The two runner
-    # processes share the box but pick up jobs by label, so a long
-    # skills-eval batch on `vss-eval` doesn't block helm-sync (and
-    # vice versa).
-    runs-on: [self-hosted, helm-sync]
+    # Shared brev-CI runner pool on the original vss-skill-validator
+    # coordinator host. We tried ubuntu-latest first but
+    # `inference-api.nvidia.com` is IP-allowlisted to NVIDIA infra and
+    # refused TCP from Azure runners (run 25220887217 attempt 2:
+    # `API Error: Unable to connect to API (ConnectionRefused)`). The
+    # `vss-brev-runner` pool sits on the original coordinator host,
+    # which IS allowlisted. Skills-eval workflow lives on its own
+    # `vss-skill-eval-runner` pool (vss-skill-validator-v2 host) so a
+    # long eval doesn't block helm-sync and vice versa.
+    runs-on: [self-hosted, vss-brev-runner]
 
     # 60 min cap. The agent does pure file comparison + at most one
     # bot-PR push. Order-of-magnitude shorter than skills-eval (480m).

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -74,7 +74,7 @@ defaults:
 jobs:
   eval:
     name: Eval changed skills against PR
-    runs-on: [self-hosted, vss-eval]
+    runs-on: [self-hosted, vss-skill-eval-runner]
 
     # 8-hour hard cap on the whole job. A full PR touching every currently
     # evaluable skill queues ~14 trials (5 vss-deploy-profile +

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -9,7 +9,7 @@
 #
 # Step 1 — nv-base validate (schema, secrets, PII, unicode)
 #   NVIDIA-internal Tier 1 checker. Not distributed publicly, so this
-#   workflow targets a self-hosted runner labelled `nv-base` where the
+#   workflow targets the shared `vss-brev-runner` pool where the
 #   binary is pre-installed into /opt/nvbase-venv/. Uses --profile
 #   external so author_missing is demoted from HIGH to MEDIUM by the
 #   bundled external.yaml policy (no env-var allow-list needed).
@@ -52,10 +52,10 @@ defaults:
 jobs:
   skills-check:
     name: skills-check
-    # Dedicated self-hosted runner — nv-base is pre-installed; the
-    # workflow does not install or refresh it at run time. See
-    # .github/skills-nv-base/README.md.
-    runs-on: [self-hosted, nv-base]
+    # Shared brev-CI runner pool — nv-base is pre-installed on each
+    # member, and the workflow does not install or refresh it at run
+    # time. See .github/skills-nv-base/README.md.
+    runs-on: [self-hosted, vss-brev-runner]
 
     timeout-minutes: 20
 


### PR DESCRIPTION
## Summary

Partitions the self-hosted runner fleet into two role-based pools so the heavy Skills Eval workload can't starve helm-sync / nv-base, and vice versa:

| Pool label | Host | Purpose | Pool size |
|---|---|---|---|
| \`vss-skill-eval-runner\` | \`vss-skill-validator-v2\` (n2d-standard-8) | Skills Eval workflow | 12 runners |
| \`vss-brev-runner\` | \`vss-skill-validator\` (n2d-standard-4) | helm-sync + skills-nv-base | 11 runners |

Workflow updates:
- \`skills-eval.yml\`: \`runs-on: [self-hosted, vss-eval]\` → \`[self-hosted, vss-skill-eval-runner]\`
- \`helm-sync.yml\`: \`runs-on: [self-hosted, helm-sync]\` → \`[self-hosted, vss-brev-runner]\`
- \`skills-nv-base.yml\`: \`runs-on: [self-hosted, nv-base]\` → \`[self-hosted, vss-brev-runner]\`

Stale comments in \`helm-sync.yml\`, \`skills-nv-base.yml\`, and \`skills-nv-base/README.md\` refreshed to describe the new topology.

## Runner-side state

New labels added additively to all 23 runners via the GitHub API before this PR (old labels — \`helm-sync\`, \`nv-base\`, \`vss-eval\`, \`brev\`, \`vss\` — kept on the runners so any in-flight job that already dispatched to the old labels can complete). Once this PR merges and the next push of each affected workflow runs cleanly, the old labels can be removed in a follow-up.

## Test plan

- [ ] Next Skills Eval run dispatches to a \`vss-skill-validator-v2-*\` runner.
- [ ] Next helm-sync run dispatches to one of the \`vss-skill-validator*\` runners (not v2).
- [ ] Next nv-base run dispatches to one of the \`vss-skill-validator*\` runners (not v2) and finds \`/opt/nvbase-venv/bin/nv-base\` on the host.