### PR TITLE
fix(agent ui): Video Management Tab: use full timeline segment for uploaded video playback

### DIFF
--- a/deploy/docker/services/ui/compose.yml
+++ b/deploy/docker/services/ui/compose.yml
@@ -16,7 +16,7 @@
 services:
 
   vss-ui:
-    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-328c2d6eacb9
+    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-e640bf4a6dfc
     profiles: ["bp_wh_2d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     container_name: vss-agent-ui
     ports:

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -548,7 +548,7 @@ vss-agent-ui:
     imagePullPolicy: IfNotPresent
   image:
     repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-    tag: "3.2.0-26.05.2-328c2d6eacb9"
+    tag: "3.2.0-26.05.2-e640bf4a6dfc"
   replicas: 1
   fillAlertBridgeUrlFromGlobal: false
   agentApiUrlBase: ''

--- a/deploy/helm/services/ui/values.yaml
+++ b/deploy/helm/services/ui/values.yaml
@@ -19,7 +19,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-  tag: "3.2.0-26.05.2-328c2d6eacb9"
+  tag: "3.2.0-26.05.2-e640bf4a6dfc"
   pullPolicy: IfNotPresent
 replicas: 1
 service:

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/VideoManagementComponent.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/__tests__/components/VideoManagementComponent.test.tsx
@@ -117,7 +117,7 @@ describe('VideoManagementComponent — video playback', () => {
     });
   });
 
-  it('calls openVideoModal with last timeline segment for uploaded video', async () => {
+  it('calls openVideoModal with full last timeline segment for uploaded video', async () => {
     renderComponent();
 
     await waitFor(() => {
@@ -133,7 +133,7 @@ describe('VideoManagementComponent — video playback', () => {
     expect(callArgs.video_name).toBe('test_video');
     expect(callArgs.sensor_id).toBe('sensor-vid');
     expect(callArgs.start_time).toBe('2025-01-01T01:00:00Z');
-    expect(callArgs.end_time).toBe('2025-01-01T01:00:30.000Z');
+    expect(callArgs.end_time).toBe('2025-01-01T01:03:30Z');
   });
 
   it('calls openVideoModal with recent 30s window for RTSP stream', async () => {

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
@@ -336,12 +336,7 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
       const range = getLastTimelineForStream(stream.streamId);
       if (!range) return;
       startTime = range.startTime;
-      const rangeStart = new Date(range.startTime).getTime();
-      const rangeEnd = new Date(range.endTime).getTime();
-      endTime =
-        rangeEnd - rangeStart > 30000
-          ? new Date(rangeStart + 30000).toISOString()
-          : range.endTime;
+      endTime = range.endTime;
     }
 
     setLoadingStreamId(stream.streamId);


### PR DESCRIPTION
Extract services/ui changes from 207868ba (VSS DevX launchable regressions): stop capping uploaded-video modal playback to 30s and assert the full last timeline segment end time in tests.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
