### PR TITLE
skill-nv-base: add workflow_dispatch trigger with skills picker

### DIFF
--- a/.github/skills-nv-base/post_comment.py
+++ b/.github/skills-nv-base/post_comment.py
@@ -12,10 +12,15 @@ match it across runs. If a previous comment with the same marker exists,
 PATCH it in place; otherwise POST a new one. Always posts, even when both
 inputs report zero findings (the green check is useful signal).
 
-Env vars required:
+Env vars required (push mode):
   GITHUB_TOKEN           - auth (provided by Actions)
   GITHUB_REPOSITORY      - owner/repo
   PR_NUMBER              - PR to comment on
+
+Manual-mode fallback (workflow_dispatch):
+  When PR_NUMBER is empty (no PR to comment on), the same composed
+  markdown is appended to $GITHUB_STEP_SUMMARY instead. The Actions run
+  summary page is then the operator's single place to see findings.
 
 Optional:
   GITHUB_SHA             - commit SHA (for the comment footer)
@@ -236,17 +241,59 @@ def compose_body(nv: Optional[dict], pb: Optional[dict]) -> str:
     )
 
 
+def _write_step_summary(body: str) -> bool:
+    """Append the findings body to $GITHUB_STEP_SUMMARY.
+
+    Returns True on success. Renders an ::warning annotation and returns
+    False on any I/O failure — the gate should not fail on a summary
+    write error.
+    """
+    path = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+    if not path:
+        return False
+    try:
+        # The trailing blank line keeps successive summary blocks from
+        # collapsing into one paragraph if other steps also append.
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(body)
+            if not body.endswith("\n"):
+                fh.write("\n")
+            fh.write("\n")
+        return True
+    except OSError as exc:
+        print(f"::warning::Could not write GITHUB_STEP_SUMMARY ({path}): "
+              f"{exc}", flush=True)
+        return False
+
+
 def main() -> None:
     pr = os.environ.get("PR_NUMBER", "").strip()
     repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
-    if not pr or not repo or not os.environ.get("GITHUB_TOKEN"):
-        print("::warning::PR_NUMBER, GITHUB_REPOSITORY, or GITHUB_TOKEN "
-              "missing; cannot post comment", flush=True)
-        sys.exit(0)  # don't fail the gate
+    token = os.environ.get("GITHUB_TOKEN", "")
 
     nv = _load_json("NVBASE_FINDINGS_JSON")
     pb = _load_json("PLAYBOOK_FINDINGS_JSON")
     body = compose_body(nv, pb)
+
+    # Manual-mode (workflow_dispatch): PR_NUMBER is empty. Route findings
+    # to the Actions run summary page so the operator has a single place
+    # to read results without a PR thread. Repo / token may still be
+    # populated by Actions but are unused in this path.
+    if not pr:
+        if _write_step_summary(body):
+            print("Manual mode: findings appended to $GITHUB_STEP_SUMMARY",
+                  flush=True)
+        else:
+            print("::warning::PR_NUMBER unset and GITHUB_STEP_SUMMARY "
+                  "unavailable; findings printed to stdout only",
+                  flush=True)
+            print(body, flush=True)
+        return
+
+    if not repo or not token:
+        print("::warning::GITHUB_REPOSITORY or GITHUB_TOKEN missing; "
+              "cannot post comment", flush=True)
+        sys.exit(0)  # don't fail the gate
 
     try:
         upsert_comment(repo, pr, body)

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -136,7 +136,7 @@ jobs:
           set -euo pipefail
           if [ "${INPUT_SKILLS}" = "*" ] || [ -z "${INPUT_SKILLS}" ]; then
             SKILL_ROOT="skills/"
-            SKILL_FLAG=""
+            SKILL_NAME=""
             echo "manual: scanning entire skills/ tree"
           else
             # The dropdown is server-validated against the choice enum;
@@ -148,12 +148,15 @@ jobs:
               exit 1
             fi
             SKILL_ROOT="skills/${INPUT_SKILLS}"
-            SKILL_FLAG="--skill ${INPUT_SKILLS}"
+            SKILL_NAME="${INPUT_SKILLS}"
             echo "manual: scoping to ${SKILL_ROOT}"
           fi
+          # Emit skill_name (not a pre-built `--skill <name>` string) so
+          # downstream steps can build the flag with proper quoting —
+          # avoids bash word-splitting an unquoted multi-token output.
           {
             echo "skill_root=${SKILL_ROOT}"
-            echo "skill_flag=${SKILL_FLAG}"
+            echo "skill_name=${SKILL_NAME}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Step 1 — nv-base validate (schema + security)
@@ -164,11 +167,12 @@ jobs:
           # Tells run_check.py to dump structured findings here; consumed
           # by Step 3 to compose the sticky PR comment.
           NVBASE_FINDINGS_JSON: ${{ runner.temp }}/nvbase-findings.json
-        run: |
           # Push runs scan the whole skills/ tree; manual runs scan the
-          # dispatch-selected scope resolved in the scope step.
-          SKILL_ROOT="${{ steps.scope.outputs.skill_root }}"
-          SKILL_ROOT="${SKILL_ROOT:-skills/}"
+          # dispatch-selected scope. Routed via env: rather than
+          # templated into the run: body — same defense-in-depth pattern
+          # used for INPUT_SKILLS above.
+          SKILL_ROOT: ${{ steps.scope.outputs.skill_root || 'skills/' }}
+        run: |
           python3 .github/skills-nv-base/run_check.py "$SKILL_ROOT"
 
       - name: Step 2 — playbook compliance (naming + frontmatter + structure)
@@ -176,13 +180,23 @@ jobs:
         # runs when Step 1 fails — both gates should surface findings in
         # the same CI run, not block each other.
         if: ((github.event_name == 'push' && steps.changes.outputs.relevant == 'true') || github.event_name == 'workflow_dispatch') && !cancelled()
+        env:
+          # Empty in push mode (and in manual `*` mode); otherwise the
+          # picked skill name. Routed via env: for the same reason
+          # SKILL_ROOT above is.
+          SKILL_NAME: ${{ steps.scope.outputs.skill_name }}
         run: |
           # skill_compliance_check.py supports an optional `--skill <name>`
-          # filter; when set in manual mode it scopes the playbook scan
-          # to that single skill folder.
-          SKILL_FLAG="${{ steps.scope.outputs.skill_flag }}"
+          # filter; when set in manual mode it scopes the playbook scan to
+          # that single skill folder. Build the flag as an array so the
+          # value stays quoted and we never depend on bash word-splitting
+          # of an unquoted variable.
+          SKILL_FLAGS=()
+          if [ -n "$SKILL_NAME" ]; then
+            SKILL_FLAGS=(--skill "$SKILL_NAME")
+          fi
           python3 .github/skills-nv-base/skill_compliance_check.py \
-            --skills-dir skills/ $SKILL_FLAG --no-color \
+            --skills-dir skills/ "${SKILL_FLAGS[@]}" --no-color \
             --json-out "${{ runner.temp }}/playbook-findings.json"
 
       - name: Step 3 — post findings (PR comment on push, step summary on dispatch)

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -36,6 +36,30 @@ on:
   push:
     branches:
       - "pull-request/[0-9]+"
+  # Manual trigger. Same shape as skills-eval.yml's dispatch: a single
+  # `skills` dropdown (the 8 adapters under .github/skill-eval/adapters/
+  # plus `*` for the whole `skills/` tree). No diff-gate is applied —
+  # the operator is explicitly asking for the checks to run. Without a
+  # PR to comment on, Step 3 writes the same findings markdown to
+  # $GITHUB_STEP_SUMMARY (rendered on the Actions run summary page);
+  # see post_comment.py's manual-mode branch.
+  workflow_dispatch:
+    inputs:
+      skills:
+        description: "Which skill to check (single-select). Pick `*` for the whole skills/ tree. Keep this list in sync with the skills-eval dispatch input."
+        required: false
+        default: "*"
+        type: choice
+        options:
+          - "*"
+          - vss-ask-video
+          - vss-deploy-dense-captioning
+          - vss-deploy-profile
+          - vss-generate-video-report
+          - vss-manage-alerts
+          - vss-manage-video-io-storage
+          - vss-search-archive
+          - vss-summarize-video
 
 permissions:
   contents: read
@@ -59,7 +83,8 @@ jobs:
 
     timeout-minutes: 20
 
-    if: startsWith(github.ref, 'refs/heads/pull-request/')
+    # Allow mirror-branch pushes OR manual full-sweep dispatch.
+    if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout mirror head
@@ -74,6 +99,7 @@ jobs:
 
       - name: Extract PR number + base
         id: pr
+        if: github.event_name == 'push'
         run: |
           REF="${{ github.ref_name }}"
           PR="${REF##pull-request/}"
@@ -86,6 +112,7 @@ jobs:
 
       - name: Detect skills/ changes vs PR base
         id: changes
+        if: github.event_name == 'push'
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           base: ${{ steps.pr.outputs.base }}
@@ -95,8 +122,42 @@ jobs:
               - '.github/skills-nv-base/**'
               - '.github/workflows/skills-nv-base.yml'
 
+      - name: Resolve target skill scope (manual mode)
+        id: scope
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          # Route the dispatch input through env: so it isn't templated
+          # directly into the run: script body. `type: choice` already
+          # enum-validates the value (no free-form input), but this
+          # matches the defense-in-depth pattern used in skills-eval.yml
+          # and keeps the run: body free of templated user data.
+          INPUT_SKILLS: ${{ inputs.skills }}
+        run: |
+          set -euo pipefail
+          if [ "${INPUT_SKILLS}" = "*" ] || [ -z "${INPUT_SKILLS}" ]; then
+            SKILL_ROOT="skills/"
+            SKILL_FLAG=""
+            echo "manual: scanning entire skills/ tree"
+          else
+            # The dropdown is server-validated against the choice enum;
+            # path-traversal is impossible. Verify the dir exists so we
+            # fail loudly on stale options rather than silently scanning
+            # nothing.
+            if [ ! -d "skills/${INPUT_SKILLS}" ]; then
+              echo "::error::skills/${INPUT_SKILLS}/ does not exist on this ref. Update the workflow_dispatch options to match the current skills/ tree."
+              exit 1
+            fi
+            SKILL_ROOT="skills/${INPUT_SKILLS}"
+            SKILL_FLAG="--skill ${INPUT_SKILLS}"
+            echo "manual: scoping to ${SKILL_ROOT}"
+          fi
+          {
+            echo "skill_root=${SKILL_ROOT}"
+            echo "skill_flag=${SKILL_FLAG}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Step 1 — nv-base validate (schema + security)
-        if: steps.changes.outputs.relevant == 'true'
+        if: (github.event_name == 'push' && steps.changes.outputs.relevant == 'true') || github.event_name == 'workflow_dispatch'
         env:
           # Path to the pre-installed nv-base binary on the runner.
           NVBASE_BIN: /opt/nvbase-venv/bin/nv-base
@@ -104,23 +165,34 @@ jobs:
           # by Step 3 to compose the sticky PR comment.
           NVBASE_FINDINGS_JSON: ${{ runner.temp }}/nvbase-findings.json
         run: |
-          python3 .github/skills-nv-base/run_check.py skills/
+          # Push runs scan the whole skills/ tree; manual runs scan the
+          # dispatch-selected scope resolved in the scope step.
+          SKILL_ROOT="${{ steps.scope.outputs.skill_root }}"
+          SKILL_ROOT="${SKILL_ROOT:-skills/}"
+          python3 .github/skills-nv-base/run_check.py "$SKILL_ROOT"
 
       - name: Step 2 — playbook compliance (naming + frontmatter + structure)
         # `!cancelled()` overrides the implicit `success()` so Step 2 still
         # runs when Step 1 fails — both gates should surface findings in
         # the same CI run, not block each other.
-        if: steps.changes.outputs.relevant == 'true' && !cancelled()
+        if: ((github.event_name == 'push' && steps.changes.outputs.relevant == 'true') || github.event_name == 'workflow_dispatch') && !cancelled()
         run: |
+          # skill_compliance_check.py supports an optional `--skill <name>`
+          # filter; when set in manual mode it scopes the playbook scan
+          # to that single skill folder.
+          SKILL_FLAG="${{ steps.scope.outputs.skill_flag }}"
           python3 .github/skills-nv-base/skill_compliance_check.py \
-            --skills-dir skills/ --no-color \
+            --skills-dir skills/ $SKILL_FLAG --no-color \
             --json-out "${{ runner.temp }}/playbook-findings.json"
 
-      - name: Step 3 — post sticky PR comment with findings
+      - name: Step 3 — post findings (PR comment on push, step summary on dispatch)
         # Always run (even when prior steps failed) so warnings surface
-        # alongside any blocking findings. Comment poster swallows its own
-        # errors via ::warning so it never fails the gate.
-        if: steps.changes.outputs.relevant == 'true' && !cancelled()
+        # alongside any blocking findings. The poster swallows its own
+        # errors via ::warning so it never fails the gate. In manual
+        # mode PR_NUMBER is empty; post_comment.py detects that and
+        # appends the same markdown to $GITHUB_STEP_SUMMARY instead of
+        # bailing.
+        if: ((github.event_name == 'push' && steps.changes.outputs.relevant == 'true') || github.event_name == 'workflow_dispatch') && !cancelled()
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -130,6 +202,6 @@ jobs:
           python3 .github/skills-nv-base/post_comment.py
 
       - name: Skip note when no skills/ changes
-        if: steps.changes.outputs.relevant != 'true'
+        if: github.event_name == 'push' && steps.changes.outputs.relevant != 'true'
         run: |
           echo "::notice::No skills/ changes in this PR; NV-BASE check skipped."


### PR DESCRIPTION
## Summary

Brings the same operator-driven manual trigger landed on `skills-eval.yml` ([PR #524](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/524)) to the **Skills NV-BASE** workflow.

- New `workflow_dispatch` input on `.github/workflows/skills-nv-base.yml` — a `skills` single-select dropdown with the same 8 adapter names as the skills-eval dispatch, plus `*` for the whole `skills/` tree.
- Input is routed through the step `env:` block as `INPUT_SKILLS` (same defense-in-depth pattern from #524 — `type: choice` already enum-validates, but env-passthrough keeps the run: body free of templated user data).
- A `Resolve target skill scope` step turns the input into `SKILL_ROOT=skills/` (when `*`) or `SKILL_ROOT=skills/<picked>/` (when a single skill is chosen) and a `--skill <name>` flag for `skill_compliance_check.py`. The directory is `[ -d ... ]` verified so a stale dropdown option fails loudly instead of scanning nothing.
- `post_comment.py` gains a manual-mode fallback: when `PR_NUMBER` is empty, the **same composed markdown body** is appended to `$GITHUB_STEP_SUMMARY` instead of bailing silently. Push-mode behaviour (sticky PR comment with the existing HTML marker) is unchanged.

### Where results land

| Trigger | Where findings show up |
|---|---|
| `push` to `pull-request/<N>` (existing) | Sticky PR comment, same marker as today |
| `workflow_dispatch` (new) | Actions run summary page (`/actions/runs/<run_id>`) — rendered markdown |

## Test plan

- [ ] **UI form renders correctly.** Open `.../actions/workflows/skills-nv-base.yml` → click **Run workflow** → confirm the `skills` dropdown lists `*` + the 8 adapter names.
- [ ] **Whole-tree manual run.** Dispatch with `skills=*` against `develop`. Expect both checkers to scan the whole `skills/` tree, and the same markdown body (Step 1 + Step 2 findings tables) to render on the run summary page.
- [ ] **Single-skill manual run.** Dispatch with `skills=vss-deploy-profile`. Expect Step 1 to scan only `skills/vss-deploy-profile/`, Step 2 to apply `--skill vss-deploy-profile`, and the run summary to reflect a narrower body.
- [ ] **Stale-option guard.** Temporarily mis-pick a name not present in `skills/` (or imagine a future rename); expect the `Resolve target skill scope` step to fail fast with `::error::skills/<name>/ does not exist on this ref...` rather than scanning nothing.
- [ ] **Push regression check.** Push to any open `pull-request/<N>` mirror and confirm the sticky PR comment still posts as before (no GH step summary leakage, no double-posting).

## Notes

- Dropdown options are hard-coded, just like #524 — the input description tells the next maintainer to keep this list in sync with `.github/skill-eval/adapters/`. A future PR could DRY this against the skills-eval dispatch via a shared composite action, but that's overkill for two workflows.
- `post_comment.py` is stdlib-only and remains so; the new helper is 15 lines of `open(..., "a") as fh: fh.write(body)`.