### PR TITLE
skill-nv-base: stub workflow on main so dispatch button appears

### DIFF
--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Stub workflow on `main` whose only purpose is to surface the
+# "Run workflow" button in the Actions UI. The full Skills NV-BASE
+# harness — push trigger on `pull-request/<N>` mirrors, the two
+# Tier-1 checker steps, sticky PR comment, etc. — lives on `develop`
+# (PR #528). GitHub Actions only renders the workflow_dispatch button
+# when `workflow_dispatch:` is configured on the repo's default
+# branch; if the harness only existed on develop, the button would
+# never appear.
+#
+# When the operator clicks "Run workflow" and switches the ref
+# dropdown to `develop`, GitHub re-reads this file from develop and
+# runs **develop's** version — including the checker steps, the
+# `.github/skills-nv-base/*.py` scripts, and the runner-pool label.
+# None of that is needed on main.
+#
+# If anyone dispatches against `main` itself, the job below is gated
+# with `if: false` so nothing runs — main doesn't carry the harness
+# scripts and the runner-pool label isn't guaranteed to exist here
+# either. The job is a clean no-op rather than a red ✗.
+#
+# Mirrors the pattern established by PR #525 for skills-eval.yml.
+
+name: Skills NV-BASE
+
+on:
+  workflow_dispatch:
+    inputs:
+      skills:
+        description: >-
+          Which skill to check (single-select). Pick `*` for the whole
+          skills/ tree. Schema mirrors develop so the dispatch form
+          renders correctly even when `main` is the selected ref; the
+          real workflow body runs from develop.
+        required: false
+        default: "*"
+        type: choice
+        options:
+          - "*"
+          - vss-ask-video
+          - vss-deploy-dense-captioning
+          - vss-deploy-profile
+          - vss-generate-video-report
+          - vss-manage-alerts
+          - vss-manage-video-io-storage
+          - vss-search-archive
+          - vss-summarize-video
+
+jobs:
+  noop:
+    # Hard-gated off. The real job lives in develop's copy of this
+    # file. See header comment for the rationale.
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Never runs
+        run: |
+          echo "Skills NV-BASE runs from develop's workflow file."
+          echo "Switch the ref dropdown to 'develop' and try again."


### PR DESCRIPTION
## Summary

Introduces a **minimal stub** of `.github/workflows/skills-nv-base.yml` on `main` so the **Run workflow** button shows up in the Actions UI for Skills NV-BASE. Mirrors PR #525 (the equivalent dispatch-trigger backport for skills-eval).

### Why this differs slightly from #525

`skills-eval.yml` already existed on main — that PR just added the `workflow_dispatch:` line to the existing on: block. **`skills-nv-base.yml` does not exist on main at all** (the harness landed on develop only). So this PR introduces the full file, but with the job body deliberately stubbed.

The stub:
- declares `workflow_dispatch:` with the same `skills` choice input as develop, so the dispatch form renders correctly even when `main` is the selected ref;
- carries a single job hard-gated with `if: false` so dispatching against main never actually executes anything (the harness scripts under `.github/skills-nv-base/` aren't on main, and the `vss-brev-runner` label isn't guaranteed to exist here either);
- when the operator switches the ref dropdown to `develop`, GitHub runs **develop's** version of this file — checker steps, scripts, runner label all come from develop (per PR #528).

No harness backport — develop is the source of truth for skill-eval and skill-nv-base alike.

## Test plan

- [ ] Merge → confirm the **Run workflow** button appears at https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/workflows/skills-nv-base.yml
- [ ] Open the form, leave ref as `main` → expect the `skills` dropdown is visible (because schema is mirrored) but submitting against main is a clean no-op (no Eval step runs; job skipped on `if: false`).
- [ ] Switch the ref dropdown to `develop` → expect the form to re-load the (identical) inputs from develop's file and the run to proceed against the real checker steps.
- [ ] Dispatch against `develop` with `skills=vss-deploy-profile` → confirm the run summary page shows the markdown body from `post_comment.py`'s manual-mode fallback.