### PR TITLE
skill-eval(adapter): drop self-test prereq from vss-deploy-profile

### DIFF
--- a/.github/skill-eval/adapters/vss-deploy-profile/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-profile/generate.py
@@ -470,11 +470,26 @@ def generate_task(
         'skills_dir = "/skills"',
         "",
         "[metadata]",
-        f'profile = "{profile}"',
+        # Intentionally NOT emitting `profile = "{profile}"` here. For
+        # vss-deploy-profile/eval/<X>.json the trial IS the deploy — it
+        # invokes /vss-deploy-profile -p X via its own prompt. Setting
+        # `profile` in [metadata] would trick BrevEnvironment's
+        # _ensure_prerequisite_deployed into running an extra sub-claude
+        # `claude --print /vss-deploy-profile -p X` BEFORE the trial agent,
+        # which is both redundant and (observed on run 26066279318) prone
+        # to picking the wrong profile when the box's stale active-deploy
+        # marker points at a different profile. Per the spec authors:
+        # absent `profile` → BrevEnvironment runs its box-clean path
+        # (`desired=""`) which wipes containers/networks/volumes and
+        # clears the marker, then the trial runs from a guaranteed-clean
+        # state. The `platform` key below is purely informational.
         f'platform = "{platform}"',
     ]
     deploy_flag_m = profile_def.get("deploy_mode")
     if deploy_flag_m:
+        # Informational — does NOT match BrevEnvironment's
+        # `prerequisite_deploy_mode` field used by downstream consumers,
+        # so this is safe to emit here without triggering prereq logic.
         meta_lines.append(f'deploy_mode = "{deploy_flag_m}"')
     meta_lines += [
         "# GPU requirements — BrevEnvironment checks these against the",

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -390,9 +390,14 @@ class BrevEnvironment(BaseEnvironment):
                   the reconcile instead of running against a
                   partially-dirty box that pretends to be clean.
 
-        vss-deploy-profile/* trials themselves set `profile` but don't request a
-        prereq — their test.sh writes the marker on reward=1.0. They
-        never call this hook.
+        vss-deploy-profile/* trials don't set `profile` in their task.toml
+        [metadata], so they fall into the `desired=""` box-clean branch
+        above — wipes containers/networks/volumes and clears the marker
+        before the trial deploys from scratch. Their test.sh writes the
+        marker on reward=1.0 for downstream warm-reuse. (Earlier the
+        adapter emitted `profile = "<X>"` here, which mistakenly fired
+        the prereq reconcile below before the trial — see commit
+        history on `adapters/vss-deploy-profile/generate.py`.)
 
         claude-code is expected on the box from a prior vss-deploy-profile/* trial's
         harbor agent setup; persists across trials on the reused


### PR DESCRIPTION
## Summary

Fixes a redundant-and-wrong sub-agent deploy that fires before every \`vss-deploy-profile/eval/<X>.json\` trial.

## Bug

The adapter emits this into the generated \`task.toml\`:

\`\`\`toml
[metadata]
profile = "{profile}"
platform = "{platform}"
\`\`\`

\`BrevEnvironment._ensure_prerequisite_deployed\` (envs/brev_env.py) reads \`profile\` from metadata. If the box's marker (\`/tmp/skill-eval/active-deploy.txt\`) doesn't match, it runs

\`\`\`bash
claude --print /vss-deploy-profile -p <profile>
\`\`\`

as a sub-agent on the box, BEFORE the trial's own \`claude --print\` starts. For \`vss-deploy-profile\` specs this is redundant — the trial *is* the deploy.

## Observed failure mode

Run [26066279318](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/26066279318) on develop dispatched the \`search\` trial to \`vss-eval-rtx-2g\`. The box still had \`alerts_vlm\` in its marker (left over from PR #508's successful \`alerts_vlm\` trial). Sequence:

1. Trial dispatched 23:24 UTC.
2. \`_ensure_prerequisite_deployed\` saw \`desired=search\`, \`current=alerts_vlm\`, mismatch → fired the sub-agent \`claude --print /vss-deploy-profile -p search\`.
3. The sub-agent invoked the skill with \`"Deploy the **alerts** profile in real-time mode on RTXPRO6000BW"\` instead of search — likely pattern-matching the stale marker. Burned ~1 hour.
4. At 00:26:40 the marker was overwritten to \`alerts_vlm\` again (sub-agent's deploy outcome).
5. At 00:27:15 the **actual trial agent** finally started its \`claude --print\` — onto a box already running alerts containers.
6. Verifier (search-specific checks) will see no search containers → reward 0.

Two compounding harms: a wasted hour of sub-agent compute, and a polluted box state for the real trial.

## Fix

Stop emitting \`profile\` in the \`[metadata]\` block. With \`profile\` absent, \`_ensure_prerequisite_deployed\` falls into its \`desired=""\` branch — which wipes containers/networks/volumes + clears the marker (per the volume-prune change in #440), then the trial's own \`/vss-deploy-profile -p X\` starts from a guaranteed-clean state.

\`deploy_mode\` is kept; it's informational, and \`BrevEnvironment\` reads \`prerequisite_deploy_mode\` (different field name), so emitting \`deploy_mode\` here doesn't trigger the prereq path.

## Test plan

- [ ] Re-run the manual Skills Eval dispatch for \`vss-deploy-profile\`. Trials should start almost immediately (no 1-hour pre-deploy). Each trial completes near its historical baseline (base 22m, alerts_cv 24m, alerts_vlm 16m, lvs 1h11m, search 58m on RTXPRO6000BW per PR #508).
- [ ] After the run, \`/tmp/skill-eval/active-deploy.txt\` on the box matches the **last successful trial's** profile (verifier writes it on full pass).
- [ ] No "Deploy the alerts profile" sub-agent invocation appears inside a search-trial's \`/logs/agent/claude-code.txt\`.