### PR TITLE
skill-nv-base: STR-003 — check `eval/` not `evals/` (repo convention)

### DIFF
--- a/.github/skills-nv-base/skill_compliance_check.py
+++ b/.github/skills-nv-base/skill_compliance_check.py
@@ -12,9 +12,12 @@ Modifications vs upstream
 -------------------------
 - STR-004 (references/README.md required) removed — not part of the
   agentskills.io spec and not used by Anthropic's reference skills.
-- STR-003 softened to WARN: "evals/ directory not found" only.
+- STR-003 softened to WARN: "eval/ directory not found" only.
   No filename restriction (upstream required `evals/evals.json`, which
-  is one community runner's convention, not a standard).
+  is one community runner's convention, not a standard). This repo's
+  skills ship eval specs at `skills/<skill>/eval/<spec>.json` (singular
+  directory name — matches the skill-eval workflow + skills_eval_agent.py
+  conventions).
 - EVAL-001..005 family removed entirely. The repo's existing
   `skills-eval` workflow is the source of truth for actual eval
   execution; this script stays Tier-1 schema/static only.
@@ -561,19 +564,24 @@ def check_structure(skill_path: Path, result: SkillResult) -> None:
             "Move domain detail into references/ and link to it from SKILL.md.",
         ))
 
-    # STR-003: nudge — `evals/` directory present. No filename or format
+    # STR-003: nudge — `eval/` directory present. No filename or format
     # restriction; the actual eval runner (skills-eval workflow) owns shape.
-    evals_dir = skill_path / "evals"
-    if not evals_dir.is_dir():
+    # This repo's convention is `eval/` (singular) — matches the path
+    # skills_eval_agent.py walks (`skills/<skill>/eval/*.json`) and the
+    # skill-eval adapter layout. Earlier versions of this rule checked for
+    # `evals/` (plural, an upstream playbook convention) and false-flagged
+    # every skill in this repo.
+    eval_dir = skill_path / "eval"
+    if not eval_dir.is_dir():
         result.findings.append(Finding(
             WARNING, "STR-003",
-            "evals/ directory not found. Ship at least one eval scenario "
+            "eval/ directory not found. Ship at least one eval scenario "
             "(any filename / format) so the skill can be regression-tested.",
         ))
-    elif not any(evals_dir.iterdir()):
+    elif not any(eval_dir.iterdir()):
         result.findings.append(Finding(
             WARNING, "STR-003",
-            "evals/ directory exists but is empty.",
+            "eval/ directory exists but is empty.",
         ))
 
 


### PR DESCRIPTION
## Summary

`STR-003` was checking for `<skill>/evals/` (plural — upstream `agent_skills_playbook` convention). Every skill in this repo actually ships eval specs under `<skill>/eval/` (singular) — matches the path `.github/skill-eval/skills_eval_agent.py` walks at the top of its diff loop, and the skill-eval adapter layout.

**Result:** the warning was firing on **13/13 skills**, including ones with rich `eval/` content like `vss-deploy-profile` (5 specs). Operators learned to ignore it; the rule was devalued. After the fix, STR-003 fires only on the 4 skills that **genuinely** have no `eval/` folder:

| Skill | Reason |
|---|---|
| `vss-query-analytics` | only `SKILL.md` exists |
| `vss-setup-behavior-analytics` | only `SKILL.md` + `references/` |
| `vss-setup-video-analytics-api` | no `eval/` (also flagged NAM-004) |
| `vss-generate-video-report-rag` | no `eval/` (also flagged NAM-004) |

## What changed

`.github/skills-nv-base/skill_compliance_check.py`:
- Header doc-comment: "evals/ directory not found" → "eval/ directory not found", plus a short note that this repo's convention is singular.
- Rule body: `evals_dir = skill_path / "evals"` → `eval_dir = skill_path / "eval"`.
- Both finding-message strings (`"evals/ directory not found..."`, `"evals/ directory exists but is empty."`) now say `eval/`.
- A short comment in the rule body documents the rename + why (so future readers don't re-introduce the pluralization).
- Upstream-history mentions of `evals/` are intentionally kept where they explain the rename context.

## Verification

Ran the script locally on `develop`'s `skills/` tree:

| Before | After |
|---|---|
| 20 WARNINGs (13× STR-003) | **11 WARNINGs (4× STR-003)** |

```
Before: by rule: STR-003: 13, FM-009: 3, NAM-004: 3, FM-011: 1
After:  by rule: STR-003: 4,  FM-009: 3, NAM-004: 3, FM-011: 1
```

## Test plan

- [ ] CI green on `Skills NV-BASE` (workflow runs `skill_compliance_check.py` on push to `pull-request/<N>`).
- [ ] PR comment from `post_comment.py` shows the 4 expected STR-003 hits, not 13.
- [ ] Spot-check `vss-deploy-profile` (5 eval specs) no longer flagged STR-003.