### PR TITLE
skill(vss-generate-video-report): lead description with outcome + trigger phrases

### DIFF
--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vss-generate-video-report
-description: Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as the standard Video Analysis Report markdown.
+description: Produce a timestamped video analysis report from a clip. Use when the user says "generate a report", "give me a report", or "create a report on this video".
 license: Apache-2.0
 metadata:
   version: "3.2.0"


### PR DESCRIPTION
## Summary

`vss-generate-video-report/SKILL.md`'s frontmatter `description` led with implementation detail and shipped no explicit trigger guidance, so `skill_compliance_check.py` flagged it under **FM-009** (no `Use when…` / `trigger when…` / `load when…` clause). This is one of the 11 remaining warnings surfaced by the NV-BASE checker on `develop` after [#531](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/531).

### Before

> Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as the standard Video Analysis Report markdown.

- Leads with mechanism ("discovering the deployed VSS agent, querying POST /generate…"), not user outcome.
- No `Use when…` clause → FM-009 fires.

### After

> Produce a timestamped video analysis report from a clip. Use when the user says "generate a report", "give me a report", or "create a report on this video".

- Opens with the user outcome (timestamped report from a clip).
- Three explicit trigger phrases an operator typically uses.
- Trigger set kept **tight** — a generic "structured summary" fallback was considered and dropped because that ground is already covered by `vss-summarize-video`; keeping the phrases narrow prevents this skill from shadowing summarize on summary-style requests.
- The body of `SKILL.md` is unchanged; the `POST /generate` + VSS agent implementation notes are already documented further down.

## Verification

Re-ran the checker locally:

```
$ python3 .github/skills-nv-base/skill_compliance_check.py \
    --skills-dir skills/ --skill vss-generate-video-report --no-color
  Skill: vss-generate-video-report  [PASS]
    ✓ No issues found
  Errors         : 0
  Warnings       : 0
  ✓  All checks passed.
```

Before: 1 WARNING (FM-009). After: zero findings.

## Test plan

- [ ] CI green on `Skills NV-BASE` (workflow runs `skill_compliance_check.py` on push to `pull-request/<N>`).
- [ ] PR comment shows `vss-generate-video-report` no longer on the findings list.
- [ ] Manually triggering Claude with `generate a report on this video` continues to load this skill (no regression in routing).