### PR TITLE
docs(skill-eval): clarify --include-task-name is a glob suffix match

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -518,8 +518,20 @@ uvx harbor run \
 ```
 
 Notes that have burned prior runs:
-- `--include-task-name` takes the full trial task name as emitted by
-  the adapter (usually `<platform>`, e.g. `l40s`).
+- `--include-task-name` is an **fnmatch glob** against the full task
+  name. Adapters emit task names of the form
+  `nvidia-vss/<skill>-<spec>-<platform>[-step-<N>]`, so the
+  templates above (`<platform>` for single-step, `<platform>-step-${STEP}`
+  for multi-step) work as **suffix matches** — `l40s` matches
+  `nvidia-vss/vss-generate-video-report-base-l40s`, and
+  `l40s-step-1` matches
+  `nvidia-vss/vss-generate-video-report-base-l40s-step-1`. Do **not**
+  paste the full task name into this flag and do **not** prefix it
+  with `*` — the suffix template is sufficient. Observed failure
+  mode (PR #532): an agent unfamiliar with the glob semantics treats
+  `<platform>` as a placeholder for the full name, gets stuck
+  spelunking the codebase, and exhausts its turn budget before
+  dispatching the first trial.
   `-i` / `--include` is a different flag and will silently match
   nothing or everything.
 - **Multi-step specs MUST be dispatched one step at a time, in

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -532,7 +532,7 @@ Notes that have burned prior runs:
   `<platform>` as a placeholder for the full name, gets stuck
   spelunking the codebase, and exhausts its turn budget before
   dispatching the first trial.
-  `-i` / `--include` is a different flag and will silently match
+- `-i` / `--include` is a different flag and will silently match
   nothing or everything.
 - **Multi-step specs MUST be dispatched one step at a time, in
   order, with skip-on-prior-fail.** Harbor's default scheduler


### PR DESCRIPTION
## Summary

Fixes the misleading sentence in \`AGENTS.md\` § Harbor invocation that caused [PR #532's Skills Eval run](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/26071831780/job/76654687216) to exit with code 4 (no \`DONE:\` / \`BLOCKED:\` marker).

## Bug

\`AGENTS.md\` previously said:

> \`--include-task-name\` takes the full trial task name as emitted by the adapter (usually \`<platform>\`, e.g. \`l40s\`).

This conflates two things. The flag is an **fnmatch glob**, and the actual task names emitted by adapters look like \`nvidia-vss/<skill>-<spec>-<platform>[-step-<N>]\`. \`l40s\` works because it's a suffix of that name — not because it IS the full name. An agent reading this cold can't tell whether \`<platform>\` is literal or a placeholder; on PR #532 the eval agent burned 30 turns grep-ing the codebase trying to reconcile the template against the actual task names it found, then exhausted its \`max_turns\` budget without ever dispatching a trial. \$0.74 spent, zero signal.

## Fix

Replace the misleading sentence with explicit fnmatch-glob semantics, including:
- Show the actual task name shape adapters emit.
- Tell agents NOT to paste the full name and NOT to prefix with \`*\` — the suffix template is enough.
- Name the failure mode + PR reference so a future cold reader gets the context.

## Test plan

- [ ] Next multi-step Skills Eval dispatch on a fresh runner reaches \`harbor run\` within a few turns rather than grep-spelunking.