### PR TITLE
eval(vss-deploy-profile): update stale container names in 4 specs

### DIFF
--- a/skills/vss-deploy-profile/eval/alerts_cv.json
+++ b/skills/vss-deploy-profile/eval/alerts_cv.json
@@ -16,11 +16,11 @@
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0 (shared message bus)",
-        "`docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (RT-CV perception — the 'CV' in this mode)",
-        "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics-alerts` returns exit 0 (rule-based alert generation on CV output)",
-        "`docker ps --format '{{.Names}}' | grep -qx alert-bridge` returns exit 0 (routes CV-generated alerts to VLM verifier)",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (video ingestion source)"
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared message bus)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (RT-CV perception — the 'CV' in this mode)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics` returns exit 0 (rule-based alert generation on CV output)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-alert-bridge` returns exit 0 (routes CV-generated alerts to VLM verifier)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-vios-nvstreamer` returns exit 0 (video ingestion source)"
       ]
     }
   ]

--- a/skills/vss-deploy-profile/eval/alerts_vlm.json
+++ b/skills/vss-deploy-profile/eval/alerts_vlm.json
@@ -16,10 +16,10 @@
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0 (shared message bus)",
-        "`docker ps --format '{{.Names}}' | grep -qx rtvi-vlm` returns exit 0 (continuous VLM processor — the 'VLM' in this mode)",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-nvstreamer-alerts` returns exit 0 (video ingestion source)",
-        "`! docker ps --format '{{.Names}}' | grep -qx perception-alerts` returns exit 0 (real-time mode does NOT run the CV perception pipeline)"
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared message bus)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0 (continuous VLM processor — the 'VLM' in this mode)",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-vios-nvstreamer` returns exit 0 (video ingestion source)",
+        "`! docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (real-time mode does NOT run the CV perception pipeline)"
       ]
     }
   ]

--- a/skills/vss-deploy-profile/eval/lvs.json
+++ b/skills/vss-deploy-profile/eval/lvs.json
@@ -17,9 +17,8 @@
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
-        "`docker ps --format '{{.Names}}' | grep -qx metropolis-vss-ui` returns exit 0",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0",
-        "`docker ps --format '{{.Names}}' | grep -qx centralizedb-dev` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx phoenix` returns exit 0"
       ]
     }

--- a/skills/vss-deploy-profile/eval/search.json
+++ b/skills/vss-deploy-profile/eval/search.json
@@ -17,9 +17,8 @@
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
-        "`docker ps --format '{{.Names}}' | grep -qx metropolis-vss-ui` returns exit 0",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-redis` returns exit 0",
-        "`docker ps --format '{{.Names}}' | grep -qx centralizedb-dev` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",
+        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx phoenix` returns exit 0"
       ]
     }


### PR DESCRIPTION
## Summary

Cross-referenced each \`docker ps | grep -qx <name>\` check in the 5 \`vss-deploy-profile/eval/*.json\` specs against the actual \`container_name:\` declarations under \`deploy/docker/\`. \`base.json\` was already updated during the GA rename — the other 4 weren't. This PR fixes them.

Surfaced by run 26070411681 (alerts_vlm trial, reward 0.167 = 1/6) where 3 of 5 fails were pure name mismatches, not real deploy bugs.

## Renames applied

| Spec | Stale name | Actual (per compose) |
|---|---|---|
| alerts_cv | \`mdx-redis\` | \`redis\` (\`services/infra/compose.yml:180\`) |
| alerts_cv | \`perception-alerts\` | \`vss-rtvi-cv\` (\`developer-profiles/dev-profile-alerts/compose.yml:80\`) |
| alerts_cv | \`vss-behavior-analytics-alerts\` | \`vss-behavior-analytics\` (\`developer-profiles/dev-profile-alerts/compose.yml:25\`) |
| alerts_cv | \`alert-bridge\` | \`vss-alert-bridge\` (\`services/alert/compose.yml:19\`) |
| alerts_cv | \`mdx-nvstreamer-alerts\` | \`vss-vios-nvstreamer\` (\`developer-profiles/dev-profile-alerts/compose.yml:45\`) |
| alerts_vlm | \`mdx-redis\` | \`redis\` |
| alerts_vlm | \`rtvi-vlm\` | \`vss-rtvi-vlm\` (\`services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml:22\`) |
| alerts_vlm | \`mdx-nvstreamer-alerts\` | \`vss-vios-nvstreamer\` |
| alerts_vlm (negative) | \`! perception-alerts\` | \`! vss-rtvi-cv\` |
| lvs | \`metropolis-vss-ui\` | \`vss-agent-ui\` (\`services/ui/compose.yml:21\`) |
| lvs | \`mdx-redis\` | \`redis\` |
| lvs | \`centralizedb-dev\` | **defunct** — \`grep -rn centralizedb deploy/docker/\` returns 0 hits. Check removed. |
| search | (same as lvs) | (same as lvs) |

## Test plan

- [ ] After merge, re-run \`vss-deploy-profile\` eval. The 3 stale-name fails per alerts_vlm trial should flip to passes (expected reward ~3/6 → ~5/6 if the deploy completes; alerts_cv similar lift).
- [ ] The remaining \`vss-agent\` + \`curl :8000/docs\` failures point at a separate deploy-correctness bug (agent declaring done before containers are healthy) — out of scope for this PR.