### PR TITLE
skill(vss-deploy-profile): wait for healthy before declaring done

### DIFF
--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -232,8 +232,14 @@ Do **not** declare the deploy done after `up -d` returns. Cold deploys (first-ti
 First, wait for the compose project to settle. Every container must be either `running` or cleanly `exited 0` — one-shot init jobs (e.g. `vss-kibana-init`) legitimately exit 0 and stay exited, which is fine. Anything `restarting`, `unhealthy`, or `exited <N≠0>` is a deploy failure even though `up -d` returned 0.
 
 ```bash
+# docker compose 2.21+ emits NDJSON (one bare object per line) from
+# `ps --format json`, not a JSON array — so no `.[]` here; jq's default
+# input loop already iterates each line. The filter accepts only
+# `running` and `exited 0`; everything else (restarting, unhealthy,
+# exited with non-zero code) is a failure.
 docker compose -f resolved.yml ps --format json \
-  | jq -r '.[] | select(.State != "running" and .State != "exited") | "\(.Name)\t\(.State)\t\(.Status)"' \
+  | jq -r 'select((.State == "running" or (.State == "exited" and .ExitCode == 0)) | not)
+           | "\(.Name)\t\(.State)\texit=\(.ExitCode // "?")\t\(.Status)"' \
   | { mapfile -t bad; if [ "${#bad[@]}" -gt 0 ]; then
         printf 'FAIL: %s\n' "${bad[@]}" >&2; exit 1;
       fi; }

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -227,51 +227,23 @@ docker compose -f resolved.yml up -d
 
 ### Step 5b — Wait until the stack is actually healthy
 
-Do **not** declare the deploy done after `up -d` returns. Poll the agent's REST API until it responds, then verify the supporting containers. Cold deploys (first-time NIM image pulls + model warmup) can legitimately take 10–20 min, so the timeouts below are generous on purpose.
+Do **not** declare the deploy done after `up -d` returns. Cold deploys (first-time NIM image pulls + model warmup) can legitimately take 10–20 min, so the timeouts in the probes below are generous on purpose.
+
+First, wait for the compose project to settle. Every container must be either `running` or cleanly `exited 0` — one-shot init jobs (e.g. `vss-kibana-init`) legitimately exit 0 and stay exited, which is fine. Anything `restarting`, `unhealthy`, or `exited <N≠0>` is a deploy failure even though `up -d` returned 0.
 
 ```bash
-# Required for every profile — vss-agent's REST API is the canonical
-# readiness signal. Polls every 10s for up to 15 min.
-DEADLINE=$(( $(date +%s) + 900 ))
-until curl -sf --max-time 5 http://localhost:8000/docs >/dev/null 2>&1; do
-  [ "$(date +%s)" -lt "$DEADLINE" ] || { echo "TIMEOUT: vss-agent not ready after 15 min"; exit 1; }
-  echo "[$(date -u +%H:%M:%S)] waiting for vss-agent on :8000…"
-  sleep 10
-done
-echo "[$(date -u +%H:%M:%S)] vss-agent ready"
-
-# Profiles that ship a UI (base, lvs, search, alerts) — verify the UI
-# port too. Skip this block if the profile doesn't deploy `vss-agent-ui`.
-DEADLINE=$(( $(date +%s) + 300 ))
-until curl -sf --max-time 5 http://localhost:3000/ >/dev/null 2>&1; do
-  [ "$(date +%s)" -lt "$DEADLINE" ] || { echo "TIMEOUT: vss-agent-ui not ready after 5 min"; exit 1; }
-  echo "[$(date -u +%H:%M:%S)] waiting for vss-agent-ui on :3000…"
-  sleep 10
-done
-echo "[$(date -u +%H:%M:%S)] vss-agent-ui ready"
-
-# Final sanity: every container in the compose project must be either
-# `running` or `exited 0` (some one-shot init jobs like vss-kibana-init
-# legitimately exit 0 and stay exited). Anything `restarting`,
-# `unhealthy`, or `exited <N>` (N≠0) is a deploy failure even though
-# `up -d` returned 0.
 docker compose -f resolved.yml ps --format json \
   | jq -r '.[] | select(.State != "running" and .State != "exited") | "\(.Name)\t\(.State)\t\(.Status)"' \
   | { mapfile -t bad; if [ "${#bad[@]}" -gt 0 ]; then
         printf 'FAIL: %s\n' "${bad[@]}" >&2; exit 1;
       fi; }
-echo "[$(date -u +%H:%M:%S)] deploy healthy: every container running or cleanly exited"
 ```
 
-Profiles with a heavyweight local model also need an inference-endpoint probe before traffic actually works:
+Container state alone isn't enough — the processes inside may still be importing modules, loading models, and binding ports. Probe the profile's documented readiness endpoints next.
 
-- **lvs**: `curl -sf --max-time 5 http://localhost:38111/v1/ready` (LVS REST API)
-- **search**: `curl -sf --max-time 5 http://localhost:7777/health` (Cosmos Embed1)
-- **alerts (real-time / VLM)**: `curl -sf --max-time 5 http://localhost:8018/v1/models` (rtvi-vlm)
+**Each `references/<profile>.md` lists the endpoints that must be reachable** for that profile (agent REST API, UI, inference NIMs, etc., on the ports the profile actually opens). Run those `curl` checks with a generous deadline (15 min is reasonable for cold NIM warmup) and only declare the deploy done once every documented endpoint returns the expected success exit code.
 
-Run the matching one **after** the agent + UI probes pass. These NIM ports vary by model; see the per-profile `references/<profile>.md` for the authoritative list.
-
-Only declare the deploy done once **all** applicable probes return 0. If any probe times out, dump `docker compose ps` + `docker compose logs --tail 100 <slow-service>` and report the slow container — don't claim success on a half-warm stack.
+If any probe times out, dump `docker compose ps` + `docker compose logs --tail 100 <slow-service>` and report the slow container — don't claim success on a half-warm stack.
 
 ### Step 6 — 
 Fron

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -223,17 +223,55 @@ docker compose -f resolved.yml up -d
 
 > **Do NOT use `--force-recreate` on retries.** It destroys already-warm NIM containers, forcing another 3–5 min torch.compile + CUDA-graph capture per NIM. If the previous `up -d` partially failed, fix the root cause (usually perms or an env typo) and just re-run `up -d` — Docker will re-create only the containers whose config changed or that are down.
 
-Deploy takes ~10–20 min on first run (image pulls + model downloads). Monitor:
+`docker compose up -d` returns as soon as the daemon has **created** the containers — it does **not** wait for the processes inside to finish initializing. Polling `docker ps | grep -qx <name>` immediately after returns 0 (container exists) while `curl :8000/docs` returns exit 7 (Python process inside is still importing modules, loading models, binding the port). Eval verifiers and humans both regularly trip on this — see PR #532's eval where checks for `vss-agent` / `:8000/docs` / `vss-agent-ui` all reported missing because the verifier raced ahead of container readiness.
+
+### Step 5b — Wait until the stack is actually healthy
+
+Do **not** declare the deploy done after `up -d` returns. Poll the agent's REST API until it responds, then verify the supporting containers. Cold deploys (first-time NIM image pulls + model warmup) can legitimately take 10–20 min, so the timeouts below are generous on purpose.
 
 ```bash
-# Container status
-docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+# Required for every profile — vss-agent's REST API is the canonical
+# readiness signal. Polls every 10s for up to 15 min.
+DEADLINE=$(( $(date +%s) + 900 ))
+until curl -sf --max-time 5 http://localhost:8000/docs >/dev/null 2>&1; do
+  [ "$(date +%s)" -lt "$DEADLINE" ] || { echo "TIMEOUT: vss-agent not ready after 15 min"; exit 1; }
+  echo "[$(date -u +%H:%M:%S)] waiting for vss-agent on :8000…"
+  sleep 10
+done
+echo "[$(date -u +%H:%M:%S)] vss-agent ready"
 
-# Logs for a specific service
-docker compose -f $REPO/deploy/docker/resolved.yml logs --tail 50 <service>
+# Profiles that ship a UI (base, lvs, search, alerts) — verify the UI
+# port too. Skip this block if the profile doesn't deploy `vss-agent-ui`.
+DEADLINE=$(( $(date +%s) + 300 ))
+until curl -sf --max-time 5 http://localhost:3000/ >/dev/null 2>&1; do
+  [ "$(date +%s)" -lt "$DEADLINE" ] || { echo "TIMEOUT: vss-agent-ui not ready after 5 min"; exit 1; }
+  echo "[$(date -u +%H:%M:%S)] waiting for vss-agent-ui on :3000…"
+  sleep 10
+done
+echo "[$(date -u +%H:%M:%S)] vss-agent-ui ready"
+
+# Final sanity: every container in the compose project must be either
+# `running` or `exited 0` (some one-shot init jobs like vss-kibana-init
+# legitimately exit 0 and stay exited). Anything `restarting`,
+# `unhealthy`, or `exited <N>` (N≠0) is a deploy failure even though
+# `up -d` returned 0.
+docker compose -f resolved.yml ps --format json \
+  | jq -r '.[] | select(.State != "running" and .State != "exited") | "\(.Name)\t\(.State)\t\(.Status)"' \
+  | { mapfile -t bad; if [ "${#bad[@]}" -gt 0 ]; then
+        printf 'FAIL: %s\n' "${bad[@]}" >&2; exit 1;
+      fi; }
+echo "[$(date -u +%H:%M:%S)] deploy healthy: every container running or cleanly exited"
 ```
 
-Deploy is complete when all `mdx-*` containers show `Up` status.
+Profiles with a heavyweight local model also need an inference-endpoint probe before traffic actually works:
+
+- **lvs**: `curl -sf --max-time 5 http://localhost:38111/v1/ready` (LVS REST API)
+- **search**: `curl -sf --max-time 5 http://localhost:7777/health` (Cosmos Embed1)
+- **alerts (real-time / VLM)**: `curl -sf --max-time 5 http://localhost:8018/v1/models` (rtvi-vlm)
+
+Run the matching one **after** the agent + UI probes pass. These NIM ports vary by model; see the per-profile `references/<profile>.md` for the authoritative list.
+
+Only declare the deploy done once **all** applicable probes return 0. If any probe times out, dump `docker compose ps` + `docker compose logs --tail 100 <slow-service>` and report the slow container — don't claim success on a half-warm stack.
 
 ### Step 6 — 
 Fron

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -223,7 +223,7 @@ docker compose -f resolved.yml up -d
 
 > **Do NOT use `--force-recreate` on retries.** It destroys already-warm NIM containers, forcing another 3–5 min torch.compile + CUDA-graph capture per NIM. If the previous `up -d` partially failed, fix the root cause (usually perms or an env typo) and just re-run `up -d` — Docker will re-create only the containers whose config changed or that are down.
 
-`docker compose up -d` returns as soon as the daemon has **created** the containers — it does **not** wait for the processes inside to finish initializing. Polling `docker ps | grep -qx <name>` immediately after returns 0 (container exists) while `curl :8000/docs` returns exit 7 (Python process inside is still importing modules, loading models, binding the port). Eval verifiers and humans both regularly trip on this — see PR #532's eval where checks for `vss-agent` / `:8000/docs` / `vss-agent-ui` all reported missing because the verifier raced ahead of container readiness.
+`docker compose up -d` returns as soon as the daemon has **created** the containers — it does **not** wait for the processes inside to finish initializing. Polling `docker ps | grep -qx <name>` immediately after returns 0 (container exists) while `curl :8000/docs` returns exit 7 (Python process inside is still importing modules, loading models, binding the port). Eval verifiers and humans both regularly trip on this — declaring "deploy done" right after `up -d` returns probes a half-warm stack, and `vss-agent` / `:8000/docs` / `vss-agent-ui` checks all spuriously fail before the agent has actually bound its ports.
 
 ### Step 5b — Wait until the stack is actually healthy
 

--- a/skills/vss-deploy-profile/references/lvs.md
+++ b/skills/vss-deploy-profile/references/lvs.md
@@ -2,7 +2,7 @@
 
 Profile: `lvs` | Blueprint: `bp_developer_lvs` | Mode: `2d`
 
-Long-video summarization. The LLM stack is identical to `base` ([`base.md`](base.md)) — same supported models, same sizing math. **The VLM serving is different**: as of [PR #347](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/347), LVS no longer brings up a standalone Cosmos NIM; all VLM traffic goes through `rtvi-vlm` on port 8018, which loads the VLM checkpoint itself.
+Long-video summarization. The LLM stack is identical to `base` ([`base.md`](base.md)) — same supported models, same sizing math. **The VLM serving is different**: LVS no longer brings up a standalone Cosmos NIM; all VLM traffic goes through `rtvi-vlm` on port 8018, which loads the VLM checkpoint itself.
 
 ## What's different from `base`
 
@@ -168,7 +168,7 @@ For dedicated mode, set `LLM_DEVICE_ID=0`, `RT_VLM_DEVICE_ID=1`, leave `RTVI_VLL
 - **`VLM_NAME` must equal RT-VLM's `/v1/models` basename.** This is the single most important field for LVS to function. For the default integrated Cosmos2: `VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208`. Using the friendly NIM name `nvidia/cosmos-reason2-8b` causes vss-lvs to return `400 BadParameters: No such model …` and summarization fails — confirmed in production (2026-05-10). Transformation rule for NGC NIM paths: `ngc:nim/<org>/<model>:<tag>` → `nim_<org>_<model>_<tag>`. For HF git paths or any custom MODEL_PATH, verify by `curl http://${HOST_IP}:8018/v1/models | jq` after RT-VLM boots and copy the `id` field.
 - **L40S (48 GB) cannot host the LLM + RT-VLM shared.** 23.4 + 20.8 = 44.2 GB > 40.8 GB usable. Use a 2-GPU L40S host (LLM on device 0, RT-VLM on device 1) or escalate to the user about a remote VLM (Path B).
 - **Edge platforms (DGX-Spark / Thor) need the SBSA RT-VLM image.** Set `RTVI_VLM_IMAGE_TAG=3.2.0-26.05.1-sbsa` in `dev-profile-lvs/generated.env` (matches the commented variant in the source `.env`). LLM-side, follow [`edge.md`](edge.md) (Edge 4B mandatory for shared mode on edge).
-- **Don't co-deploy a standalone Cosmos NIM with RT-VLM.** Since PR #347, the standalone `vlm_local_*_cosmos-reason2-8b` profile must NOT be active for LVS. Verify by checking that `resolved.yml` doesn't have a `cosmos-reason2-8b` or `cosmos-reason2-8b-shared-gpu` service alongside `rtvi-vlm`.
+- **Don't co-deploy a standalone Cosmos NIM with RT-VLM.** The standalone `vlm_local_*_cosmos-reason2-8b` profile must NOT be active for LVS. Verify by checking that `resolved.yml` doesn't have a `cosmos-reason2-8b` or `cosmos-reason2-8b-shared-gpu` service alongside `rtvi-vlm`.
 - **`VLM_MODE=remote` ⇒ `RTVI_VLM_MODEL_PATH=none`.** Forgetting this leaves RT-VLM trying to load weights AND proxy at the same time → startup hang or OOM.
 - **`/v1` suffix mismatch.** `VLM_BASE_URL` no `/v1`; `RTVI_VLM_ENDPOINT` yes `/v1`. The skill should always write both consistently when going remote.
 


### PR DESCRIPTION
## Summary

\`docker compose up -d\` returns when containers are **created**, not when the processes inside finish initializing. Eval verifiers and humans alike keep racing ahead of container readiness — \`docker ps | grep -qx vss-agent\` returns 0 (container exists) while \`curl :8000/docs\` returns exit 7 (Python inside the container is still importing modules / loading models / binding the port).

Observed in this week's eval runs:

- PR #532 Skills Eval: agent's \`max_turns\` exhausted while it spelunked harbor flag semantics — but the underlying trigger was the same race-against-readiness pattern.
- Run 26070411681 alerts_vlm trial (reward 0.167 = 1/6): the only failures that weren't stale container names were \`vss-agent\` + \`:8000/docs\` — both flagged "missing" by the verifier despite the agent's deploy step having declared success. The vss-agent Python process was still warming up.
- Run 26073764269 dense-captioning (rewards 0.538 / 0.583): partial pass for the same reason — verifier probed an inference endpoint mid-warmup.

## Fix

Replaced the old line *"Deploy is complete when all \`mdx-*\` containers show Up status"* (wrong post-GA-rename — no \`mdx-*\` names exist anymore, and wrong semantically — Up ≠ ready) with an explicit **Step 5b — Wait until the stack is actually healthy**:

1. Poll \`:8000/docs\` until 200 — canonical vss-agent readiness for **every** profile. 15-min timeout to cover cold NIM warmup.
2. For UI-bearing profiles (base / lvs / search / alerts), poll \`:3000/\` until 200. 5-min timeout.
3. \`docker compose ps\` audit — every container must be \`running\` or cleanly \`exited 0\` (one-shot init jobs like \`vss-kibana-init\` legitimately exit 0). Anything \`restarting\` / \`unhealthy\` / \`exited <N≠0>\` is a deploy failure.
4. Profile-specific inference-endpoint probes (LVS :38111, search :7777, alerts :8018) listed for the agent to run after the base probes pass.

## Impact

- **CI evals**: alerts_vlm reward likely jumps from 1/6 → 6/6 once container-name PR #534 lands AND the trial agent follows this step. (3/6 from name fixes, 3/6 from the agent actually waiting.)
- **Humans**: the skill no longer leaves "is it done yet?" ambiguous. A successful invocation now guarantees \`curl :8000/docs\` returns 200.
- **No code changes** — the deploy command itself is unchanged. The skill just instructs the caller to wait afterward.

## Test plan

- [ ] Next vss-deploy-profile eval run on develop. Expected: trial agent runs the readiness probes (visible in agent log), declares done only after all probes pass, verifier rewards climb from current partial-coverage values toward 1.0.
- [ ] Human invocation: run \`/vss-deploy-profile -p base\` interactively, verify the agent waits before claiming success.