### PR TITLE
skill-eval: actionable pool-mismatch hint + bump MAX_TURNS

### DIFF
--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -1239,10 +1239,30 @@ async def _check_instance_matches(instance: dict, req: dict) -> None:
             )
 
     if errors:
+        required_count = int(req.get("gpu_count", 1) or 0)
+        # Actionable hint so the agent doesn't burn its turn budget
+        # re-discovering how to find a matching pool member. Stay
+        # generic — don't name specific pool boxes here, the pool
+        # is operator-managed and naming couples this code to the
+        # current fleet topology.
+        hint = (
+            f"\n\nTo find a matching pool member, scan vss-eval-* "
+            f"candidates and require gpu_type={required_type!r} + "
+            f"gpu_count={required_count}:\n"
+            f"  brev ls --json | jq -r '.[] | select(.name | "
+            f"startswith(\"vss-eval-\")) | \"\\(.name)\\t\\(.instance_type)"
+            f"\\t\\(.gpu)\"'\n"
+            f"Cross-reference each candidate's instance_type against "
+            f"`brev search gpu --json` to confirm gpu_count, then "
+            f"re-export BREV_INSTANCE=<candidate> and retry. Do NOT "
+            f"`brev create` a new instance — the pool is operator-"
+            f"managed (see AGENTS.md § Platform topology)."
+        )
         raise RuntimeError(
             f"Brev instance '{instance.get('name')}' does not meet task "
             f"requirements:\n  - " + "\n  - ".join(errors) +
             f"\n  (instance: type={instance.get('instance_type')}, gpu={gpu})"
+            + hint
         )
 
     logger.info(

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -1239,16 +1239,23 @@ async def _check_instance_matches(instance: dict, req: dict) -> None:
             )
 
     if errors:
-        required_count = int(req.get("gpu_count", 1) or 0)
         # Actionable hint so the agent doesn't burn its turn budget
         # re-discovering how to find a matching pool member. Stay
         # generic — don't name specific pool boxes here, the pool
         # is operator-managed and naming couples this code to the
-        # current fleet topology.
+        # current fleet topology. `required_count` and `required_type`
+        # are already bound above; reuse them. Build the "require …"
+        # phrase conditionally so an empty `gpu_type` (count-only
+        # specs) doesn't render as `gpu_type='' + gpu_count=N` and
+        # mislead the agent into filtering for a literal empty string.
+        require_clauses = []
+        if required_type:
+            require_clauses.append(f"gpu_type={required_type!r}")
+        require_clauses.append(f"gpu_count={required_count}")
+        require_phrase = " + ".join(require_clauses)
         hint = (
             f"\n\nTo find a matching pool member, scan vss-eval-* "
-            f"candidates and require gpu_type={required_type!r} + "
-            f"gpu_count={required_count}:\n"
+            f"candidates and require {require_phrase}:\n"
             f"  brev ls --json | jq -r '.[] | select(.name | "
             f"startswith(\"vss-eval-\")) | \"\\(.name)\\t\\(.instance_type)"
             f"\\t\\(.gpu)\"'\n"

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -67,12 +67,17 @@ AGENTS_MD = Path(__file__).resolve().parent / "AGENTS.md"
 # Hard cap on the agent's tool loop — one trial burns ~20-30 harness
 # turns (startup + brev wait + `uvx harbor run` exec + reading results +
 # migrating to _viewer), so a full-PR fan-out of 10-15 trials plus
-# recon/retry overhead exceeds the previous 300 ceiling. Run
-# 24879743425 burned ~270 turns on only 3 trials before hitting it
-# mid-lvs with 10+ trials unstarted. 600 is a safety valve against
-# runaway loops, not a budget knob — the workflow's 8h wall-clock
-# (skills-eval.yml timeout-minutes: 480) is the real ceiling.
-MAX_TURNS = int(os.environ.get("AGENT_MAX_TURNS", "600"))
+# recon/retry overhead exceeds the previous 300 ceiling. The 600 cap
+# that replaced it was still tight when the agent hit a novel
+# situation it had to discover (e.g. gpu_count selection rejecting
+# the default candidate, or harbor flag semantics from a fresh runner
+# without prior context) — each "discovery" burst is 5-10 turns of
+# Read/Grep/Bash spelunking on top of the steady-state per-trial
+# cost. Bumping to 2000 absorbs that overhead without lifting the
+# real ceiling (skills-eval.yml timeout-minutes: 480 is the wall-
+# clock gate; this knob is just a safety valve against runaway
+# loops).
+MAX_TURNS = int(os.environ.get("AGENT_MAX_TURNS", "2000"))
 
 # ---------------------------------------------------------------------------
 # Pre-flight


### PR DESCRIPTION
## Summary

The skills-eval agent keeps blowing its 600-turn budget on novel situations it has to derive from first principles. Most recent example: vss-manage-alerts dispatch on develop (run [26075507063](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/26075507063)) — agent picked \`vss-eval-l40s\` by default, \`_check_instance_matches\` rejected it (\`gpu_count=1\` vs 2), then spent ~25-30 turns querying \`brev ls\`, \`brev exec nvidia-smi\`, reading \`task.toml\`, comparing against \`envs/brev_env\` logic, and deliberating between candidates. Never dispatched the trial. Workflow exit 4 (no \`DONE:\` / \`BLOCKED:\` marker).

Two surgical changes, no coupling to specific pool member names:

## 1. `envs/brev_env.py` — actionable failure message

When \`_check_instance_matches\` raises, append a hint that tells the agent HOW to find a different candidate using runtime queries (\`brev ls --json\` filtered by \`vss-eval-*\` prefix + cross-reference \`brev search gpu --json\` for \`gpu_count\`). Stays generic — no hardcoded \`vss-eval-l40s-1g\` / \`-2\` names, so the hint survives any future pool topology change.

Old message:
\`\`\`
Brev instance 'vss-eval-l40s' does not meet task requirements:
  - gpu_count: want exactly 1, instance has 2 (instance_type=massedcompute_L40Sx2)
  (instance: type=massedcompute_L40Sx2, gpu=L40S)
\`\`\`

New message adds:
\`\`\`
To find a matching pool member, scan vss-eval-* candidates and require
gpu_type='L40S' + gpu_count=1:
  brev ls --json | jq -r '.[] | select(.name | startswith("vss-eval-")) | "\(.name)\t\(.instance_type)\t\(.gpu)"'
Cross-reference each candidate's instance_type against `brev search gpu --json`
to confirm gpu_count, then re-export BREV_INSTANCE=<candidate> and retry. Do NOT
`brev create` a new instance — the pool is operator-managed (see AGENTS.md §
Platform topology).
\`\`\`

## 2. `skills_eval_agent.py` — bump `MAX_TURNS` default 600 → 2000

Discovery bursts cost 5-10 turns each on top of the ~20-30 per-trial steady-state cost. 600 covered the steady-state, 2000 leaves room for several discovery-heavy runs without tripping the safety valve. Still a safety valve, not a budget knob — the workflow's \`timeout-minutes: 480\` is the real wall-clock gate.

## Test plan

- [ ] Re-dispatch \`vss-manage-alerts\` on develop. Expected: agent reads the hint from the first \`_check_instance_matches\` failure, jumps to \`vss-eval-l40s-1g\` directly (few turns), dispatches the trial successfully.
- [ ] Workflow logs show \`max_turns=2000\` (was 600) in the agent step's stdout.