### PR TITLE
refactor: updated health check configuration for 2D, 3D and mv3dt war…

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
@@ -100,9 +100,10 @@ services:
   #       condition: service_completed_successfully
 
   bp-configurator-2d-init:
-    extends:
-      file: ${VSS_APPS_DIR}/services/infra/compose.yml
-      service: broker-health-check
+    build:
+      context: $VSS_APPS_DIR/services/infra
+      dockerfile: Dockerfiles/${STREAM_TYPE}-health-check.Dockerfile
+      network: host
     profiles: ["bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_2d", "bp_wh_auto_calib_2d"]
     container_name: vss-configurator-2d-init
     network_mode: "host"

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
@@ -97,9 +97,10 @@ services:
   #       condition: service_completed_successfully
 
   bp-configurator-3d-init:
-    extends:
-      file: ${VSS_APPS_DIR}/services/infra/compose.yml
-      service: broker-health-check
+    build:
+      context: $VSS_APPS_DIR/services/infra
+      dockerfile: Dockerfiles/${STREAM_TYPE}-health-check.Dockerfile
+      network: host
     profiles: ["bp_wh_kafka_3d","bp_wh_redis_3d", "bp_wh_auto_calib_3d"]
     container_name: vss-configurator-3d-init
     network_mode: "host"

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
@@ -74,9 +74,10 @@ services:
         condition: service_healthy
 
   bp-configurator-mv3dt-init:
-    extends:
-      file: ${VSS_APPS_DIR}/services/infra/compose.yml
-      service: broker-health-check
+    build:
+      context: $VSS_APPS_DIR/services/infra
+      dockerfile: Dockerfiles/${STREAM_TYPE}-health-check.Dockerfile
+      network: host
     profiles: ["bp_wh_kafka_mv3dt", "bp_wh_redis_mv3dt", "bp_wh_auto_calib_mv3dt"]
     container_name: vss-configurator-mv3dt-init
     network_mode: "host"

--- a/deploy/docker/services/analytics/video-analytics-api/compose.yml
+++ b/deploy/docker/services/analytics/video-analytics-api/compose.yml
@@ -15,7 +15,7 @@
 
 services:
   vss-video-analytics-api:
-    image: nvcr.io/nvstaging/vss-core/vss-video-analytics-api:3.2-26.05.17
+    image: nvcr.io/nvstaging/vss-core/vss-video-analytics-api:3.2-26.05.18
     network_mode: "host"
     command: node index.js --config /opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
     restart: always

--- a/deploy/docker/services/analytics/video-analytics-api/compose.yml
+++ b/deploy/docker/services/analytics/video-analytics-api/compose.yml
@@ -15,7 +15,7 @@
 
 services:
   vss-video-analytics-api:
-    image: nvcr.io/nvstaging/vss-core/vss-video-analytics-api:3.2-26.05.18
+    image: nvcr.io/nvstaging/vss-core/vss-video-analytics-api:3.2-26.05.19
     network_mode: "host"
     command: node index.js --config /opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
     restart: always

--- a/skills/vss-deploy-profile/references/warehouse-debug.md
+++ b/skills/vss-deploy-profile/references/warehouse-debug.md
@@ -571,7 +571,7 @@ After completing Phases 1–5, state the root cause clearly before proposing any
 | Disk < 10 GB | Write failures / container OOM | Free disk space; redeploy |
 | `vss-configurator` failing after 60 s | Misconfigured streams or hardware profile | Verify `.env` values; redeploy |
 | `vss-haproxy-ingress` up but UI 502 / report links broken | `EXTERNAL_IP` / `HAPROXY_PORT` not browser-reachable | Set `EXTERNAL_IP` to a real reachable hostname (see `warehouse.md` Phase 5); redeploy |
-| `error from registry: Incorrect Repository Format` during `docker compose up` | Docker 29.x multi-arch pull regression | Downgrade to Docker 27.2.0 / containerd 2.2.2 (warehouse.md §2.2). |
+| `error from registry: Incorrect Repository Format` during `docker compose up` | Docker 29.x multi-arch pull regression | Pin to Docker 28.3.3 and Docker Compose v2.39.1+ (warehouse.md §2.2). |
 
 Present the summary in this format:
 

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -476,58 +476,71 @@ If that exact apt version is unavailable, use the NVIDIA archive for 580.105.08:
 
 #### 2.2 Docker
 
-Minimum required: **Docker Engine ≥ 27.2.0** and **Compose plugin ≥ v2.29.1**. If both are already installed and at or above those versions, **leave them alone** — proceed to §2.3.
+Reference versions: **Docker Engine 28.3.3** and **Docker Compose plugin v2.39.1+**. If Docker Engine is already **28.3.3** and the Compose plugin is **v2.39.1 or newer**, proceed to §2.3.
 
 ```bash
-docker --version        # need 27.2.0+
-docker compose version  # need v2.29.1+
+docker --version        # need 28.3.3
+docker compose version  # need v2.39.1+
 docker ps               # must run without sudo
 ```
 
-**Install Docker (if missing):**
+**Install / pin Docker (Ubuntu 24.04):**
+
+The pinned Docker CE packages come from Docker's official apt repository. If `apt` says `docker-ce` or `containerd.io` is unavailable, the Docker apt source is missing; add it first, then install the pinned versions.
+
 ```bash
+# Remove conflicting distro packages if present. It is okay if apt says none are installed.
+sudo apt-get remove -y docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc || true
+
+# Add Docker's official apt repository.
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl gnupg lsb-release
+sudo apt-get install -y ca-certificates curl
 sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-  | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-sudo chmod a+r /etc/apt/keyrings/docker.gpg
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-  https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" \
-  | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo rm -f /etc/apt/sources.list.d/docker.list
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+sudo tee /etc/apt/sources.list.d/docker.sources > /dev/null <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
 sudo apt-get update
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Optional sanity check: these should print available Docker repo versions.
+apt-cache madison docker-ce | grep '28.3.3'
+apt-cache madison docker-compose-plugin | grep '2.39.1'
+apt-cache madison docker-ce-rootless-extras | grep '28.3.3'
+
+# Install or downgrade to the known-good reference versions.
+sudo systemctl stop docker docker.socket 2>/dev/null || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades \
+  docker-ce=5:28.3.3-1~ubuntu.24.04~noble \
+  docker-ce-cli=5:28.3.3-1~ubuntu.24.04~noble \
+  containerd.io=2.2.2-1~ubuntu.24.04~noble \
+  docker-buildx-plugin \
+  docker-compose-plugin=2.39.1-1~ubuntu.24.04~noble \
+  docker-ce-rootless-extras=5:28.3.3-1~ubuntu.24.04~noble
+sudo systemctl enable --now docker
+
+# Optional: hold so unattended-upgrades doesn't move them back
+sudo apt-mark hold docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras
+
+docker version --format '{{.Server.Version}}'   # -> 28.3.3
+docker compose version --short                  # -> 2.39.1+
 ```
 
-##### When to downgrade to exactly 27.2.0 / 2.29.x
+##### When to pin to Docker 28.3.3 / Compose v2.39.1+
 
-**Only downgrade if you hit this specific failure during `docker compose up --pull always`:**
+Pin Docker if you hit this specific failure during `docker compose up --pull always`:
 
 ```
 error from registry: Incorrect Repository Format
 ```
 
-If you see that, downgrade to the known-good combination matching the reference rig (Docker 27.2.0):
-
-```bash
-sudo systemctl stop docker docker.socket 2>/dev/null || true
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades \
-  docker-ce=5:27.2.0-1~ubuntu.24.04~noble \
-  docker-ce-cli=5:27.2.0-1~ubuntu.24.04~noble \
-  containerd.io=2.2.2-1~ubuntu.24.04~noble \
-  docker-compose-plugin=2.29.2-1~ubuntu.24.04~noble
-sudo systemctl start docker
-
-# Optional: hold so unattended-upgrades doesn't move them back
-sudo apt-mark hold docker-ce docker-ce-cli containerd.io docker-compose-plugin
-
-docker version --format '{{.Server.Version}}'   # → 27.2.0
-docker compose version --short                  # → 2.29.2
-```
-
-Then re-run `docker compose up --pull always` — the tag-pull will succeed.
+Then re-run `docker compose up --pull always` after the pinned install succeeds.
 
 **Non-root Docker:**
 ```bash

--- a/skills/vss-setup-behavior-analytics/SKILL.md
+++ b/skills/vss-setup-behavior-analytics/SKILL.md
@@ -35,10 +35,11 @@ The full operational walkthrough — entrypoint table, config-source options, ca
 
 1. **Repo checkout** with `$VSS_APPS_DIR` pointing at `<repo>/deploy/docker/`. Required by the service compose's volume binds.
 2. **NGC credentials** — `$NGC_CLI_API_KEY` set so docker can pull the image. See [`../vss-deploy-profile/references/ngc.md`](../vss-deploy-profile/references/ngc.md).
-3. **Optional broker** (Kafka / Redis Streams / MQTT). The container starts fine **without** one — the Kafka client retries a bounded number of times, then the app exits and `restart: always` cycles the container. Status will show `Restarting (N)` in `docker ps` until a broker is reachable. With a broker, dynamic config / dynamic calibration over `mdx-notification` become available.
-4. **Optional config / calibration files on disk** if the user is bringing their own.
+3. **Docker runtime** — Docker Engine **28.3.3** with Docker Compose plugin **v2.39.1+**. Verify with `docker --version` and `docker compose version`.
+4. **Optional broker** (Kafka / Redis Streams / MQTT). The container starts fine **without** one — the Kafka client retries a bounded number of times, then the app exits and `restart: always` cycles the container. Status will show `Restarting (N)` in `docker ps` until a broker is reachable. With a broker, dynamic config / dynamic calibration over `mdx-notification` become available.
+5. **Optional config / calibration files on disk** if the user is bringing their own.
 
-If $1 or $2 fails, surface the gap before going further.
+If any required prerequisite fails, surface the gap before going further.
 
 ## Workflow
 

--- a/skills/vss-setup-behavior-analytics/references/deploy-behavior-analytics-service.md
+++ b/skills/vss-setup-behavior-analytics/references/deploy-behavior-analytics-service.md
@@ -5,6 +5,8 @@ Deploy **just** `vss-behavior-analytics` (no agent, no perception, no UI) — us
 - Run a behavior-analytics pipeline against an existing broker (or no broker at all).
 - Pick a different entrypoint (analytics 2D / 3D, dev_example, fusion_search) without modifying the image.
 
+Required host runtime: **Docker Engine 28.3.3** with **Docker Compose plugin v2.39.1+**.
+
 ---
 
 ## What you edit
@@ -159,6 +161,9 @@ Practical implication: a broker-less analytics container is **not** sitting idle
 
 ```bash
 cd <repo>/deploy/docker
+docker --version        # need 28.3.3
+docker compose version  # need v2.39.1+
+
 export VSS_APPS_DIR=$(pwd)
 
 # (one-time) edit services/analytics/behavior-analytics/compose.yml — entrypoint, config volume, optional calibration volume.

--- a/skills/vss-setup-video-analytics-api/SKILL.md
+++ b/skills/vss-setup-video-analytics-api/SKILL.md
@@ -34,11 +34,12 @@ The full operational walkthrough — config options, infrastructure dependencies
 
 1. **Repo checkout** with `$VSS_APPS_DIR` pointing at `<repo>/deploy/docker/`. Required by the service compose's volume binds.
 2. **NGC credentials** — `$NGC_CLI_API_KEY` set so docker can pull the image. See [`../vss-deploy-profile/references/ngc.md`](../vss-deploy-profile/references/ngc.md).
-3. **Elasticsearch** — must be reachable at the URL configured in `elasticsearch.node`. The server pings ES on startup; if unreachable, it exits (and `restart: always` brings it back). If you need to bring up ES too, use the infra compose: `docker compose -f services/infra/compose.yml up -d elasticsearch`.
-4. **Optional Kafka broker**. The API starts fine without Kafka — Kafka-dependent features (dynamic config, dynamic calibration, RTLS/AMR) are simply unavailable.
-5. **Optional `$VSS_DATA_DIR`** for file upload endpoints (sensor images, calibration files uploaded via REST).
+3. **Docker runtime** — Docker Engine **28.3.3** with Docker Compose plugin **v2.39.1+**. Verify with `docker --version` and `docker compose version`.
+4. **Elasticsearch** — must be reachable at the URL configured in `elasticsearch.node`. The server pings ES on startup; if unreachable, it exits (and `restart: always` brings it back). If you need to bring up ES too, use the infra compose: `docker compose -f services/infra/compose.yml up -d elasticsearch`.
+5. **Optional Kafka broker**. The API starts fine without Kafka — Kafka-dependent features (dynamic config, dynamic calibration, RTLS/AMR) are simply unavailable.
+6. **Optional `$VSS_DATA_DIR`** for file upload endpoints (sensor images, calibration files uploaded via REST).
 
-If #1 or #2 fails, surface the gap before going further.
+If any required prerequisite fails, surface the gap before going further.
 
 ## Workflow
 

--- a/skills/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
+++ b/skills/vss-setup-video-analytics-api/references/deploy-video-analytics-api-service.md
@@ -5,6 +5,8 @@ Deploy **just** `vss-video-analytics-api` (no perception, no behavior-analytics,
 - Run the REST API against an existing Elasticsearch cluster (and optionally Kafka).
 - Serve calibration, sensor, behavior, alerts, events, tracking, incident, and metrics endpoints.
 
+Required host runtime: **Docker Engine 28.3.3** with **Docker Compose plugin v2.39.1+**.
+
 ---
 
 ## What you edit
@@ -22,6 +24,9 @@ After editing, deploy with:
 
 ```bash
 cd <repo>/deploy/docker
+docker --version        # need 28.3.3
+docker compose version  # need v2.39.1+
+
 export VSS_APPS_DIR=$(pwd)
 export VSS_DATA_DIR=<path-to-data-directory>
 docker compose -f services/analytics/video-analytics-api/compose.yml \
@@ -179,6 +184,9 @@ All endpoints except `/livez` require Elasticsearch. Endpoints that publish noti
 
 ```bash
 cd <repo>/deploy/docker
+docker --version        # need 28.3.3
+docker compose version  # need v2.39.1+
+
 export VSS_APPS_DIR=$(pwd)
 export VSS_DATA_DIR=<path-to-data-directory>  # e.g. /opt/vss/data
 
@@ -230,4 +238,19 @@ For a multi-service teardown (broker, ES, etc.) see [`teardown.md`](../../vss-de
 | Container alive but Kafka-dependent endpoints return errors | Kafka brokers configured but unreachable. | Verify brokers are reachable: `nc -zv <broker-host> <broker-port>`. Check `kafka.brokers` is a proper array of `"host:port"` strings. |
 | `/livez` returns 200 but data endpoints return empty results | Elasticsearch indices don't exist or have no data. | Check indices: `curl -s http://localhost:9200/_cat/indices?v \| grep mdx`. If empty, the upstream pipeline (behavior-analytics, perception) hasn't produced data yet. |
 | Config update via POST `/config` times out | The ACK from behavior-analytics didn't arrive within `configStatusTimeoutMs`. | Check that behavior-analytics is running and consuming from `mdx-notification`. Check the `configStatusTimeoutMs` value (default `30000`ms). |
-| Image won't run `docker exec -it ... sh` | The runtime image is distroless (`nvcr.io/nvidia/distroless/node:22`) — no shell. | Debug via `docker logs <container>` only. |
+| Image won't run `docker exec -it ... sh` | Runtime is a **Node** image (`nvcr.io/nvidia/distroless/node:22-v4.0.7`) — no shell, but the `node` binary is present. | Use `docker logs <container>` for runtime output. To print a bind-mounted file (e.g. bootstrap config), use `docker exec <container> node -e '...'` — see below. Prefer reading the host-side mount path when the file is volume-bound. |
+
+**Inspect a mounted config inside the container** (same path as `command: node index.js --config …`):
+
+```bash
+docker exec vss-video-analytics-api node -e \
+  "const fs=require('fs'); const p='/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json'; console.log(JSON.stringify(JSON.parse(fs.readFileSync(p,'utf8')), null, 2))"
+```
+
+With compose (standalone deploy):
+
+```bash
+docker compose -f services/analytics/video-analytics-api/compose.yml \
+  exec vss-video-analytics-api node -e \
+  "const fs=require('fs'); const p='/opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json'; console.log(JSON.stringify(JSON.parse(fs.readFileSync(p,'utf8')), null, 2))"
+```


### PR DESCRIPTION
…ehouse applications

Replaced the `extends` directive with a `build` section in the Docker Compose files for the 2D, 3D, and MV3DT warehouse applications. This change specifies the build context and Dockerfile for the health check service, ensuring a more explicit configuration.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
