### PR TITLE
Adding index resolver to fix the index issue w.r.t source type

### DIFF
--- a/services/agent/src/vss_agents/tools/attribute_search.py
+++ b/services/agent/src/vss_agents/tools/attribute_search.py
@@ -20,6 +20,7 @@ from datetime import timedelta
 import logging
 import re
 from typing import Any
+from typing import Literal
 from typing import cast
 
 from elasticsearch import AsyncElasticsearch
@@ -51,6 +52,37 @@ MIN_CLIP_DURATION_SECONDS = 1.0
 
 # Default behavior index name — shared across SearchConfig, SearchAgentConfig, AttributeSearchConfig
 DEFAULT_BEHAVIOR_INDEX = "mdx-behavior-2025-01-01"
+
+
+def resolve_index_by_source_type(
+    base_index: str,
+    source_type: Literal["video_file", "rtsp"],
+    wildcard_pattern: str,
+) -> str | list[str]:
+    """Resolve the ES index(es) to query for the given ``source_type``.
+
+    Uploaded ``video_file`` content lives in a single fixed, date-stamped index
+    (the configured default, e.g. ``mdx-behavior-2025-01-01``). Live ``rtsp``
+    sources write to date-based indexes created at ingestion time
+    (e.g. ``mdx-behavior-2026-05-19``), so the search must span the wildcard
+    pattern for the family while excluding the video_file index.
+
+    - ``video_file`` -> ``base_index`` unchanged.
+    - ``rtsp``       -> ``[wildcard_pattern, "-" + base_index]``.
+
+    Args:
+        base_index: The configured video_file index (e.g. ``mdx-behavior-2025-01-01``).
+        source_type: ``"video_file"`` or ``"rtsp"``.
+        wildcard_pattern: Family-wide wildcard, e.g. ``"mdx-behavior-*"``,
+            ``"mdx-embed-filtered-*"``, ``"mdx-raw-*"``.
+
+    Returns:
+        Either ``base_index`` (str) or a two-element index expression list
+        suitable for ``AsyncElasticsearch.search(index=...)``.
+    """
+    if source_type == "video_file":
+        return base_index
+    return [wildcard_pattern, "-" + base_index]
 
 
 class AttributeSearchInput(BaseModel):

--- a/services/agent/src/vss_agents/tools/attribute_search.py
+++ b/services/agent/src/vss_agents/tools/attribute_search.py
@@ -79,10 +79,19 @@ def resolve_index_by_source_type(
     Returns:
         Either ``base_index`` (str) or a two-element index expression list
         suitable for ``AsyncElasticsearch.search(index=...)``.
+
+    Raises:
+        ValueError: If ``source_type`` is not one of the supported values.
+            The ``Literal`` annotation guards typed call sites, but a runtime
+            check fails loudly for config-driven or JSON-deserialized inputs
+            that bypass static type checks.
     """
     if source_type == "video_file":
         return base_index
-    return [wildcard_pattern, "-" + base_index]
+    elif source_type == "rtsp":
+        return [wildcard_pattern, "-" + base_index]
+    else:
+        raise ValueError(f"Unsupported source_type {source_type!r}; expected 'video_file' or 'rtsp'.")
 
 
 class AttributeSearchInput(BaseModel):

--- a/services/agent/src/vss_agents/tools/search.py
+++ b/services/agent/src/vss_agents/tools/search.py
@@ -45,6 +45,7 @@ from pydantic import Field
 from vss_agents.agents.data_models import AgentMessageChunk
 from vss_agents.agents.data_models import AgentMessageChunkType
 from vss_agents.tools.attribute_search import DEFAULT_BEHAVIOR_INDEX
+from vss_agents.tools.attribute_search import resolve_index_by_source_type
 from vss_agents.tools.embed_search import EmbedSearchOutput
 from vss_agents.tools.vst.utils import get_streams_info
 from vss_agents.utils.es_client import VSSESClient
@@ -986,11 +987,24 @@ async def execute_core_search(
 
         es = await VSSESClient.get_es_client(es_endpoint=config.behavior_es_endpoint)
 
+        # Resolve the behavior index by source_type so RTSP/live sources hit the
+        # date-based ingestion indexes (e.g. ``mdx-behavior-2026-05-19``) instead
+        # of the fixed video_file default. Mirrors the inline pattern used by
+        # ``search_attributes`` and ``embed_search``.
+        object_search_index = resolve_index_by_source_type(
+            base_index=config.behavior_index,
+            source_type=search_input.source_type,
+            wildcard_pattern="mdx-behavior-*",
+        )
+        logger.info(
+            f"Object-id behavior search index(es): {object_search_index} (source_type={search_input.source_type})"
+        )
+
         async def _safe_object_search(oid: int) -> list[AttributeSearchResult]:
             try:
                 return await search_by_object_embedding(
                     object_id=str(oid),
-                    behavior_index=config.behavior_index,
+                    behavior_index=object_search_index,
                     es=es,
                     top_k=top_k,
                     min_similarity=0.0,

--- a/services/agent/tests/unit_test/tools/test_attribute_search_inner.py
+++ b/services/agent/tests/unit_test/tools/test_attribute_search_inner.py
@@ -23,6 +23,7 @@ from vss_agents.tools.attribute_search import AttributeSearchMetadata
 from vss_agents.tools.attribute_search import AttributeSearchResult
 from vss_agents.tools.attribute_search import _search_behavior
 from vss_agents.tools.attribute_search import enrich_attribute_results
+from vss_agents.tools.attribute_search import resolve_index_by_source_type
 
 
 def _make_result(
@@ -137,3 +138,36 @@ class TestSearchBehaviorFilters:
         assert {"terms": {"sensor.id.keyword": [stream_id]}} not in should_clauses
         assert {"term": {"sensor.id.keyword": stream_id}} in should_clauses
         assert {"wildcard": {"sensor.info.url.keyword": f"*{stream_id}*"}} in should_clauses
+
+
+class TestResolveIndexBySourceType:
+    """Tests for the shared video_file/rtsp index resolver."""
+
+    def test_video_file_returns_base_index_unchanged(self) -> None:
+        assert (
+            resolve_index_by_source_type(
+                base_index="mdx-behavior-2025-01-01",
+                source_type="video_file",
+                wildcard_pattern="mdx-behavior-*",
+            )
+            == "mdx-behavior-2025-01-01"
+        )
+
+    def test_rtsp_returns_wildcard_with_video_file_exclusion(self) -> None:
+        assert resolve_index_by_source_type(
+            base_index="mdx-behavior-2025-01-01",
+            source_type="rtsp",
+            wildcard_pattern="mdx-behavior-*",
+        ) == ["mdx-behavior-*", "-mdx-behavior-2025-01-01"]
+
+    def test_rtsp_works_for_other_index_families(self) -> None:
+        assert resolve_index_by_source_type(
+            base_index="mdx-embed-filtered-2025-01-01",
+            source_type="rtsp",
+            wildcard_pattern="mdx-embed-filtered-*",
+        ) == ["mdx-embed-filtered-*", "-mdx-embed-filtered-2025-01-01"]
+        assert resolve_index_by_source_type(
+            base_index="mdx-raw-2025-01-01",
+            source_type="rtsp",
+            wildcard_pattern="mdx-raw-*",
+        ) == ["mdx-raw-*", "-mdx-raw-2025-01-01"]

--- a/services/agent/tests/unit_test/tools/test_attribute_search_inner.py
+++ b/services/agent/tests/unit_test/tools/test_attribute_search_inner.py
@@ -171,3 +171,19 @@ class TestResolveIndexBySourceType:
             source_type="rtsp",
             wildcard_pattern="mdx-raw-*",
         ) == ["mdx-raw-*", "-mdx-raw-2025-01-01"]
+
+    def test_unsupported_source_type_raises(self) -> None:
+        # Cast to bypass the Literal at type-check time; the guard targets
+        # config-driven or JSON-deserialized inputs that escape static typing.
+        with pytest.raises(ValueError, match="Unsupported source_type"):
+            resolve_index_by_source_type(
+                base_index="mdx-behavior-2025-01-01",
+                source_type="RTSP",  # type: ignore[arg-type]
+                wildcard_pattern="mdx-behavior-*",
+            )
+        with pytest.raises(ValueError, match="Unsupported source_type"):
+            resolve_index_by_source_type(
+                base_index="mdx-behavior-2025-01-01",
+                source_type="",  # type: ignore[arg-type]
+                wildcard_pattern="mdx-behavior-*",
+            )


### PR DESCRIPTION
## Description
Adding index resolver function to resolve the index name w.r.t the source type in object id queries

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
