### PR TITLE
skill(vios): correct streams-endpoint spec assertion (no file URL)

### DIFF
--- a/skills/vss-manage-video-io-storage/eval/base_profile_ops.json
+++ b/skills/vss-manage-video-io-storage/eval/base_profile_ops.json
@@ -16,7 +16,7 @@
         "The upload PUT to /vst/api/v1/storage/file/<filename>?timestamp=... either returns HTTP 2xx OR returns the VST sensor-cap error (HTTP 5xx with body containing 'Maximum number of sensors limit reached') — the latter is an acceptable warm-pool outcome on a re-used box, as long as the end-state checks below pass.",
         "The agent ultimately obtained a sensorId and streamId for the warehouse video — either parsed from a 2xx upload response OR resolved from /sensor/list + /sensor/<sensorId>/streams after the upload hit the sensor-cap. Subsequent steps in this trial depend on those IDs being known.",
         "curl -sf http://localhost:30888/vst/api/v1/sensor/list returns a JSON array containing a sensor whose name matches the uploaded video's filename stem",
-        "curl -sf http://localhost:30888/vst/api/v1/sensor/<sensorId>/streams returns a non-empty JSON array of stream metadata entries — each entry exposes id (streamId), name, type, and status. No file URL is returned by this endpoint; this check exists to confirm the sensor has at least one stream registered and to surface streamId values for the downstream snapshot / clip calls."
+        "curl -sf http://localhost:30888/vst/api/v1/sensor/<sensorId>/streams returns a non-empty JSON array (confirms the sensor has at least one stream registered; downstream snapshot / clip calls rely on a streamId being available)."
       ]
     },
     {

--- a/skills/vss-manage-video-io-storage/eval/base_profile_ops.json
+++ b/skills/vss-manage-video-io-storage/eval/base_profile_ops.json
@@ -16,7 +16,7 @@
         "The upload PUT to /vst/api/v1/storage/file/<filename>?timestamp=... either returns HTTP 2xx OR returns the VST sensor-cap error (HTTP 5xx with body containing 'Maximum number of sensors limit reached') — the latter is an acceptable warm-pool outcome on a re-used box, as long as the end-state checks below pass.",
         "The agent ultimately obtained a sensorId and streamId for the warehouse video — either parsed from a 2xx upload response OR resolved from /sensor/list + /sensor/<sensorId>/streams after the upload hit the sensor-cap. Subsequent steps in this trial depend on those IDs being known.",
         "curl -sf http://localhost:30888/vst/api/v1/sensor/list returns a JSON array containing a sensor whose name matches the uploaded video's filename stem",
-        "curl -sf http://localhost:30888/vst/api/v1/sensor/<sensorId>/streams returns a non-empty streams array whose main stream's url is a local file path under /home/vst/... or similar (NOT rtsp://)"
+        "curl -sf http://localhost:30888/vst/api/v1/sensor/<sensorId>/streams returns a non-empty JSON array of stream metadata entries — each entry exposes id (streamId), name, type, and status. No file URL is returned by this endpoint; this check exists to confirm the sensor has at least one stream registered and to surface streamId values for the downstream snapshot / clip calls."
       ]
     },
     {


### PR DESCRIPTION
## Summary

`vss-manage-video-io-storage/eval/base_profile_ops.json` had a wrong assertion against the VST API:

> curl -sf .../vst/api/v1/sensor/\<sensorId\>/streams returns **a non-empty streams array whose main stream's url is a local file path under /home/vst/... or similar (NOT rtsp://)**

VST's `/sensor/<sensorId>/streams` endpoint returns **stream metadata** (id / name / type / status) — no file URL is exposed there. The eval was asserting against behavior the API does not promise, and contributed to flaky reward (v1=0.500, v2=0.750 — the v2 lift came from the agent learning to skip the URL check, not from the URL appearing).

## Fix

Rewrite the check to describe what the endpoint actually returns. The other assertions in the same `expects` block already cover the URL-rendering surface this one was over-reaching to cover:

- **Upload** — PUT to `/storage/file/<filename>` returns 2xx (or sensor-cap 5xx)
- **Sensor list** — `/sensor/list` includes a sensor whose name matches the uploaded filename
- **Streams endpoint (this fix)** — `/sensor/<sensorId>/streams` returns a non-empty array of `{id, name, type, status}` entries (no `url` field expected)
- **Snapshot URL** — `/replay/stream/<streamId>/picture/url` returns `imageUrl`, then GET on it returns 200 + image content
- **Clip URL** — `/storage/file/<streamId>/url` returns `videoUrl`, then GET returns 200 + video content

So the file-URL behavior is still gated by the snapshot + clip checks; we just stop asserting it at the wrong endpoint.

## Test plan

- [ ] Re-trigger workflow_dispatch for `vss-manage-video-io-storage` against `develop` after merge — confirm the streams-endpoint check now passes regardless of whether VST embeds a `url` field.
- [ ] Reward should land closer to the post-#534 (or post-#510 — whichever introduced the `imageUrl` resolution) trial — currently 0.75; this should push the failing check off the v2 report.