### PR TITLE
docs(vss-deploy-profile/lvs): note LVS readiness probe

### DIFF
--- a/skills/vss-deploy-profile/references/lvs.md
+++ b/skills/vss-deploy-profile/references/lvs.md
@@ -28,7 +28,7 @@ Long-video summarization. The LLM stack is identical to `base` ([`base.md`](base
 | Redis | mdx-redis-1 | 6379 | Cache |
 | Phoenix | mdx-phoenix-1 | 6006 | Observability |
 
-Post-deploy readiness probe: `curl -sf http://localhost:38111/v1/ready` should return exit 0 once `vss-lvs` is serving. The VSS Agent at `:8000/docs` is the cross-profile readiness signal; this one confirms the LVS-specific microservice.
+Post-deploy readiness probe: `curl -sf http://${HOST_IP}:38111/v1/ready` should return exit 0 once `vss-lvs` is serving. The VSS Agent at `http://${HOST_IP}:8000/docs` is the cross-profile readiness signal; this one confirms the LVS-specific microservice.
 
 ## Default models
 

--- a/skills/vss-deploy-profile/references/lvs.md
+++ b/skills/vss-deploy-profile/references/lvs.md
@@ -28,6 +28,8 @@ Long-video summarization. The LLM stack is identical to `base` ([`base.md`](base
 | Redis | mdx-redis-1 | 6379 | Cache |
 | Phoenix | mdx-phoenix-1 | 6006 | Observability |
 
+Post-deploy readiness probe: `curl -sf http://localhost:38111/v1/ready` should return exit 0 once `vss-lvs` is serving. The VSS Agent at `:8000/docs` is the cross-profile readiness signal; this one confirms the LVS-specific microservice.
+
 ## Default models
 
 | Role | `*_NAME` (env) | `*_NAME_SLUG` | Served by |


### PR DESCRIPTION
## Summary

Trigger commit for the LVS deployment eval — adds a one-line readiness-probe note to \`references/lvs.md\`.

Pairs with the cross-profile \`:8000/docs\` probe so an agent following the wait-for-healthy guidance has both signals in one place:
- \`:8000/docs\` → cross-profile (vss-agent)
- \`:38111/v1/ready\` → LVS-specific (vss-lvs microservice)

## Test plan

- [ ] Skills Eval workflow fires on the \`pull-request/<N>\` mirror once CPR syncs.
- [ ] All 5 \`vss-deploy-profile/eval/*.json\` specs dispatch (base / lvs / search / alerts_cv / alerts_vlm).
- [ ] LVS spec specifically reaches the verifier and reports a reward rather than BLOCKED/exit-4.