### PR TITLE
skill-eval: include token usage / agent turns / duration per trial in result comment

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -767,26 +767,81 @@ One comment per `(PR, eval_spec)` batch, posted only after every
 Head: `<short-sha>` · N platforms · spec `<spec-sha>`
 First started: `<utc>` · Last finished: `<utc>` · Total: `<Ahr Bmin>`
 
-| Platform | Result | Reward | Duration | Trace |
-|---|---|---|---|---|
-| L40S | ✅ 1.0 (7/7) | 1.0 | 9m 40s | [trace](…) |
-| RTXPRO6000BW | ❌ 0.57 (4/7) | 0.571 | 14m 42s | [trace](…) |
-| …    | …     | …    | … | … |
+| Platform | Result | Reward | Duration | Turns | Prompt tok | Cached tok | Trace |
+|---|---|---|---|---|---|---|---|
+| L40S | ✅ 1.0 (7/7) | 1.0 | 9m 40s | 23 | 8.4k | 156k | [trace](…) |
+| RTXPRO6000BW | ❌ 0.57 (4/7) | 0.571 | 14m 42s | 41 | 31k | 412k | [trace](…) |
+| …    | …     | …    | … | … | … | … | … |
 
 For multi-step specs, render one row per step and mark
 prior-fail-skips explicitly:
 
-| Platform | Step | Query | Result | Reward | Trace |
-|---|---|---|---|---|---|
-| L40S | step-1 | Deploy alerts (VLM real-time) | ✅ 1.0 (6/6) | 1.0 | [trace](…) |
-| L40S | step-2 | Add warehouse_sample via NVStreamer | ❌ 0.2 (1/5) | 0.2 | [trace](…) |
-| L40S | step-3 | Query incidents | ⏭️ skipped (prior-step fail, step-2 reward=0.2) | — | — |
-| L40S | step-4 | … | ⏭️ skipped | — | — |
+| Platform | Step | Query | Result | Reward | Duration | Turns | Prompt tok | Cached tok | Trace |
+|---|---|---|---|---|---|---|---|---|---|
+| L40S | step-1 | Deploy alerts (VLM real-time) | ✅ 1.0 (6/6) | 1.0 | 11m 12s | 18 | 6.1k | 98k | [trace](…) |
+| L40S | step-2 | Add warehouse_sample via NVStreamer | ❌ 0.2 (1/5) | 0.2 | 3m 04s | 12 | 4.2k | 41k | [trace](…) |
+| L40S | step-3 | Query incidents | ⏭️ skipped (prior-step fail, step-2 reward=0.2) | — | — | — | — | — | — |
+| L40S | step-4 | … | ⏭️ skipped | — | — | — | — | — | — |
 
 A `⏭️ skipped` row means the dispatch loop short-circuited after
 the previous step's reward < 1.0. The step was not run — its
 checks would have asserted state that was never set up. Read the
 prior step's trace to see the actual failure.
+
+### Extracting per-trial metrics
+
+For each completed trial under `/tmp/skill-eval/results/<run_id>/<date>/<trial>/`,
+populate the new columns by reading the trajectory's `final_metrics`
+block (or falling back to the streaming usage blocks if `final_metrics`
+is missing because the trial crashed mid-run):
+
+```bash
+TRAJ=/tmp/skill-eval/results/<run>/<date>/<trial>/agent/trajectory.json
+
+# Turns = count of assistant messages (one per agent reasoning step)
+jq '[.steps[].message | fromjson | select(.type=="assistant")] | length' "$TRAJ"
+
+# Prompt tokens (uncached input) — read final_metrics first, fall back
+# to per-message sum. Both keys may exist; sum the cache-miss portion.
+jq -r '.final_metrics.modelUsage | to_entries[0].value.inputTokens // 0' "$TRAJ"
+
+# Cached tokens (cache read + cache creation are both "cached" for our
+# purposes — they're the warm context the prompt reused).
+jq -r '
+  .final_metrics.modelUsage | to_entries[0].value
+  | (.cacheReadInputTokens // 0) + (.cacheCreationInputTokens // 0)
+' "$TRAJ"
+
+# Duration: trial start/end times — use Harbor's result.json which has
+# `trial_started_at` / `trial_finished_at` (ISO 8601). Compute the diff
+# in seconds; render as `<m>m <s>s` for under an hour, `<h>h <m>m` for
+# over.
+jq -r '[.trial_started_at, .trial_finished_at] | @tsv' \
+  /tmp/skill-eval/results/<run>/<date>/<trial>/result.json
+```
+
+Render tokens with k/M suffixes — `8400` → `8.4k`, `5_178_086` → `5.2M`.
+Round to 1 decimal. Output tokens are intentionally not shown per
+trial (almost always a small fraction of input + cached; if you need
+the breakdown, look at the trace). The "Prompt tok" column is the
+uncached input — what's actually billed at the full input rate. The
+"Cached tok" column is read + creation combined — what the cache hit
+on, billed at the much lower cache rate.
+
+If a trial crashed before writing `final_metrics`, sum per-message
+usage from the stream instead:
+
+```bash
+jq -r '
+  [.steps[].message | fromjson | select(.type=="assistant") | .message.usage]
+  | { inputTokens:           map(.input_tokens // 0)              | add,
+      cacheReadInputTokens:  map(.cache_read_input_tokens // 0)   | add,
+      cacheCreationInputTokens: map(.cache_creation_input_tokens // 0) | add }
+' "$TRAJ"
+```
+
+For a `⏭️ skipped` step, write `—` (em-dash) in all four metric
+columns — there's no trial to extract from.
 
 ### Failing checks
 

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -801,19 +801,37 @@ TRAJ=/tmp/skill-eval/results/<run>/<date>/<trial>/agent/trajectory.json
 # Turns = count of assistant messages (one per agent reasoning step)
 jq '[.steps[].message | fromjson | select(.type=="assistant")] | length' "$TRAJ"
 
-# Prompt tokens (uncached input) — read final_metrics first, fall back
-# to per-message sum. Sum across every model entry; some trials
-# exercise more than one (e.g. a vision model alongside the main
-# reasoning model), and `to_entries[0]` would silently drop them.
-jq -r '[.final_metrics.modelUsage | to_entries[].value.inputTokens // 0] | add // 0' "$TRAJ"
+# Step 1 — decide which extraction path to use. `final_metrics`
+# is written when the trial completes cleanly; crashed-mid-run
+# trials have it missing or null. Branch explicitly so a missing
+# block doesn't silently render as "0 tokens" (indistinguishable
+# from a clean trial that happened to have zero uncached input,
+# which is technically possible).
+if jq -e 'has("final_metrics") and (.final_metrics.modelUsage != null)' "$TRAJ" >/dev/null; then
+  # Step 2a — canonical path: sum across every model entry.
+  # Some trials exercise more than one model (e.g. a vision model
+  # alongside the main reasoning model); `to_entries[0]` would
+  # silently drop them.
+  PROMPT_TOK=$(jq -r '[.final_metrics.modelUsage | to_entries[].value.inputTokens // 0] | add // 0' "$TRAJ")
 
-# Cached tokens (cache read + cache creation are both "cached" for our
-# purposes — they're the warm context the prompt reused). Same
-# multi-model summation as above.
-jq -r '
-  [.final_metrics.modelUsage | to_entries[].value
-   | (.cacheReadInputTokens // 0) + (.cacheCreationInputTokens // 0)] | add // 0
-' "$TRAJ"
+  # Cached tokens (cache read + cache creation are both "cached"
+  # for our purposes — they're the warm context the prompt reused).
+  CACHED_TOK=$(jq -r '
+    [.final_metrics.modelUsage | to_entries[].value
+     | (.cacheReadInputTokens // 0) + (.cacheCreationInputTokens // 0)] | add // 0
+  ' "$TRAJ")
+else
+  # Step 2b — fallback: sum per-message `usage` blocks from the
+  # stream. `| add` on an empty array evaluates to null, not 0;
+  # guard each field with `// 0` so a trial that crashed before
+  # any assistant message renders 0s, not nulls.
+  read PROMPT_TOK CACHED_TOK < <(jq -r '
+    [.steps[].message | fromjson | select(.type=="assistant") | .message.usage] as $u
+    | ($u | map(.input_tokens // 0) | add // 0) as $in
+    | ($u | map((.cache_read_input_tokens // 0) + (.cache_creation_input_tokens // 0)) | add // 0) as $cached
+    | "\($in) \($cached)"
+  ' "$TRAJ")
+fi
 
 # Duration: trial start/end times — use Harbor's result.json which has
 # `trial_started_at` / `trial_finished_at` (ISO 8601). Compute the diff
@@ -830,21 +848,6 @@ the breakdown, look at the trace). The "Prompt tok" column is the
 uncached input — what's actually billed at the full input rate. The
 "Cached tok" column is read + creation combined — what the cache hit
 on, billed at the much lower cache rate.
-
-If a trial crashed before writing `final_metrics`, sum per-message
-usage from the stream instead:
-
-```bash
-# `| add` on an empty array evaluates to null, not 0 — guard each
-# field with `// 0` so a crashed-mid-run trial with zero assistant
-# messages renders blank-safe 0s rather than nulls in the table.
-jq -r '
-  [.steps[].message | fromjson | select(.type=="assistant") | .message.usage]
-  | { inputTokens:           map(.input_tokens // 0)              | add // 0,
-      cacheReadInputTokens:  map(.cache_read_input_tokens // 0)   | add // 0,
-      cacheCreationInputTokens: map(.cache_creation_input_tokens // 0) | add // 0 }
-' "$TRAJ"
-```
 
 For a `⏭️ skipped` step, write `—` (em-dash) in all four metric
 columns — there's no trial to extract from.

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -802,14 +802,17 @@ TRAJ=/tmp/skill-eval/results/<run>/<date>/<trial>/agent/trajectory.json
 jq '[.steps[].message | fromjson | select(.type=="assistant")] | length' "$TRAJ"
 
 # Prompt tokens (uncached input) — read final_metrics first, fall back
-# to per-message sum. Both keys may exist; sum the cache-miss portion.
-jq -r '.final_metrics.modelUsage | to_entries[0].value.inputTokens // 0' "$TRAJ"
+# to per-message sum. Sum across every model entry; some trials
+# exercise more than one (e.g. a vision model alongside the main
+# reasoning model), and `to_entries[0]` would silently drop them.
+jq -r '[.final_metrics.modelUsage | to_entries[].value.inputTokens // 0] | add // 0' "$TRAJ"
 
 # Cached tokens (cache read + cache creation are both "cached" for our
-# purposes — they're the warm context the prompt reused).
+# purposes — they're the warm context the prompt reused). Same
+# multi-model summation as above.
 jq -r '
-  .final_metrics.modelUsage | to_entries[0].value
-  | (.cacheReadInputTokens // 0) + (.cacheCreationInputTokens // 0)
+  [.final_metrics.modelUsage | to_entries[].value
+   | (.cacheReadInputTokens // 0) + (.cacheCreationInputTokens // 0)] | add // 0
 ' "$TRAJ"
 
 # Duration: trial start/end times — use Harbor's result.json which has
@@ -832,11 +835,14 @@ If a trial crashed before writing `final_metrics`, sum per-message
 usage from the stream instead:
 
 ```bash
+# `| add` on an empty array evaluates to null, not 0 — guard each
+# field with `// 0` so a crashed-mid-run trial with zero assistant
+# messages renders blank-safe 0s rather than nulls in the table.
 jq -r '
   [.steps[].message | fromjson | select(.type=="assistant") | .message.usage]
-  | { inputTokens:           map(.input_tokens // 0)              | add,
-      cacheReadInputTokens:  map(.cache_read_input_tokens // 0)   | add,
-      cacheCreationInputTokens: map(.cache_creation_input_tokens // 0) | add }
+  | { inputTokens:           map(.input_tokens // 0)              | add // 0,
+      cacheReadInputTokens:  map(.cache_read_input_tokens // 0)   | add // 0,
+      cacheCreationInputTokens: map(.cache_creation_input_tokens // 0) | add // 0 }
 ' "$TRAJ"
 ```
 

--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -234,7 +234,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-7a4716841a2d
+VSS_AGENT_VERSION=3.2.0-26.05.2-7c361dfd0a51
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -171,7 +171,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-7a4716841a2d
+VSS_AGENT_VERSION=3.2.0-26.05.2-7c361dfd0a51
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -183,7 +183,7 @@ EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-7a4716841a2d
+VSS_AGENT_VERSION=3.2.0-26.05.2-7c361dfd0a51
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -230,7 +230,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-7a4716841a2d
+VSS_AGENT_VERSION=3.2.0-26.05.2-7c361dfd0a51
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -256,7 +256,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-7a4716841a2d
+VSS_AGENT_VERSION=3.2.0-26.05.2-7c361dfd0a51
 VSS_AGENT_CONFIG_FILE=./deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -307,7 +307,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7a4716841a2d" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7c361dfd0a51" }}'
     waitForDependencies:
       enabled: true
   vss-va-mcp:

--- a/deploy/helm/developer-profiles/dev-profile-base/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/values.yaml
@@ -250,7 +250,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7a4716841a2d" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7c361dfd0a51" }}'
 vss-agent-ui:
   enabled: true
   # Empty URL fields: deployment uses global.external* then in-cluster defaults.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -200,7 +200,7 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`agent.vss-agent.vstInternalUrl`** | **`""`** | In-cluster **VST** URL for the agent when the default wiring is insufficient. |
 | **`agent.vss-agent.vstInternalIp`** | **`""`** | In-cluster **VST** host/IP override when defaults are insufficient. |
 | **`agent.vss-agent.vssAgentExternalUrl`** | **`""`** | External **vss-agent** URL override for browser / callbacks when **`global.external*`** is not enough. |
-| **`agent.vss-agent.vssAgentVersion`** | **`3.2.0-26.05.2-7a4716841a2d`** | Optional version label / env; adjust per release. |
+| **`agent.vss-agent.vssAgentVersion`** | **`3.2.0-26.05.2-7c361dfd0a51`** | Optional version label / env; adjust per release. |
 | **`agent.vss-agent.llmName`** | **`""`** | Optional **vss-agent-only** override of **`global.llmName`** (**`LLM_NAME`**). |
 | **`agent.vss-agent.vlmName`** | **`""`** | Optional **vss-agent-only** override of **`global.vlmName`** (**`VLM_NAME`**). |
 | **`agent.vss-agent.llmBaseUrl`** | **`""`** | Optional **vss-agent-only** override of **`global.llmBaseUrl`**. |

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -201,7 +201,7 @@ agent:
     vstInternalUrl: ""
     vstInternalIp: ""
     vssAgentExternalUrl: ""
-    vssAgentVersion: "3.2.0-26.05.2-7a4716841a2d"
+    vssAgentVersion: "3.2.0-26.05.2-7c361dfd0a51"
     evalLlmJudgeName: ""
     evalLlmJudgeBaseUrl: ""
     reportsBaseUrl: ""
@@ -284,7 +284,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7a4716841a2d" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7c361dfd0a51" }}'
       # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
       # Set enableAudio=true for Nemotron Nano Omni audio-aware VLM.
       - name: ENABLE_AUDIO

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -437,7 +437,7 @@ agent:
     videoAnalysisMcpUrl: ''
     template:
       name: ''
-    vssAgentVersion: 3.2.0-26.05.2-7a4716841a2d
+    vssAgentVersion: 3.2.0-26.05.2-7c361dfd0a51
     # Copied from rtvi.* defaults (vss-agent subchart env tpl only sees agent.vss-agent; keep in sync with rtvi.vss-rtvi-embed.port / vss-rtvi-cv.httpPort).
     rtviEmbedPort: '8000'
     rtviCvPort: '9000'
@@ -537,7 +537,7 @@ agent:
       - name: RTVI_EMBED_MODEL
         value: '{{ .Values.rtviEmbedModelName | default "cosmos-embed1-448p-anomaly-detection" }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7a4716841a2d" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7c361dfd0a51" }}'
 
 vss-agent-ui:
   enabled: true

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -23,7 +23,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.0-26.05.2-7a4716841a2d"
+  tag: "3.2.0-26.05.2-7c361dfd0a51"
   pullPolicy: IfNotPresent
 replicas: 1
 service:
@@ -90,7 +90,7 @@ reportsBaseUrl: ""
 vssAgentExternalUrl: ""
 externalIp: ""
 vstInternalIp: ""
-vssAgentVersion: "3.2.0-26.05.2-7a4716841a2d"
+vssAgentVersion: "3.2.0-26.05.2-7c361dfd0a51"
 lvsBackendService: ""
 
 # [Optional] HTTP-client timeouts (seconds) for the post-upload pipeline in
@@ -203,7 +203,7 @@ env:
 - name: AGENT_BASE_URL
   value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
 - name: VSS_AGENT_VERSION
-  value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7a4716841a2d" }}'
+  value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-7c361dfd0a51" }}'
 # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
 # Set ENABLE_AUDIO=true for Nemotron Nano Omni audio-aware VLM.
 - name: ENABLE_AUDIO

--- a/deploy/helm/services/agent/charts/va-mcp/values.yaml
+++ b/deploy/helm/services/agent/charts/va-mcp/values.yaml
@@ -18,7 +18,7 @@ global: {}
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.0-26.05.2-7a4716841a2d"
+  tag: "3.2.0-26.05.2-7c361dfd0a51"
   pullPolicy: IfNotPresent
 # Image must have mcp[cli] (typer) installed for `mcp serve` (same as Docker Compose).
 replicas: 1


### PR DESCRIPTION
## Summary

Eval result comments today report just \`reward\` + \`duration\` per trial. Adds four metric columns the agent extracts from \`trajectory.json\` and surfaces in the table:

- **Duration** — wall-clock from trial start to finish (already partially there; now in the metrics group, not next to Trace)
- **Turns** — count of assistant messages = agent reasoning iterations
- **Prompt tok** — uncached input tokens (billed at full input rate)
- **Cached tok** — cache-read + cache-creation combined (billed at cache rate)

These surface three failure modes that today hide behind the reward number:

1. **High-reward but expensive trials.** A trial scoring 1.0 in 400 turns + \$15 vs another scoring 1.0 in 15 turns + \$0.30 are very different agent behaviours but indistinguishable in current comments.
2. **Cache-ratio regressions.** A trial whose Prompt:Cached ratio is unusually high signals the agent keeps re-uploading the same skill files / references / spec context instead of caching them — useful for catching context-handling regressions.
3. **Thrashing loops.** A low-reward trial paired with a huge token / turn count identifies the \"agent stuck deliberating\" pattern (recently seen on \`vss-manage-alerts\` run 26075507063 — exit 4 after 30+ turns deliberating gpu_count selection). Reward alone says \"failed\"; turn count + cost tells you *why*.

## Table format (after)

\`\`\`
| Platform | Result | Reward | Duration | Turns | Prompt tok | Cached tok | Trace |
|---|---|---|---|---|---|---|---|
| L40S | ✅ 1.0 (7/7) | 1.0 | 9m 40s | 23 | 8.4k | 156k | [trace](…) |
\`\`\`

Multi-step variant adds the same four columns to the per-step rows. Skipped steps render \`—\` across all four metrics.

## Where the data comes from

\`trajectory.json\`'s \`final_metrics.modelUsage\` block carries per-trial totals when the trial completes cleanly. For crashed trials that didn't write \`final_metrics\`, the AGENTS.md update documents a fallback \`jq\` recipe that sums the per-message \`usage\` blocks from the stream.

Tokens render with k/M suffixes (\`8400\` → \`8.4k\`, \`5_178_086\` → \`5.2M\`).

## Why output tokens aren't shown

Almost always a small fraction of input + cached, and rarely the variable that explains a trial's cost. The trace URL still has the full breakdown if anyone wants it.

## Test plan

- [ ] Land this PR. Next Skills Eval run on any PR comments with the new columns.
- [ ] Spot-check on a multi-step skill (\`vss-summarize-video\` is a good one — has \`final_metrics\` reliably). Confirm the agent extracts \`Turns\` / \`Prompt tok\` / \`Cached tok\` and the numbers match \`final_metrics\` from the artifact.
- [ ] Confirm that a known-failed trial (e.g. one that exited 4) renders \`Turns\` from the per-message fallback recipe rather than blank.