### PR TITLE
rtvi cv workaround for siglip v2 weights file name issue

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/download-vision-encoder.sh
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/download-vision-encoder.sh
@@ -116,6 +116,20 @@ chown -R "${STORAGE_UID}:${STORAGE_GID}" "${DEST}"
 find "${DEST}" -type d -exec chmod 0777 {} +
 find "${DEST}" -type f -exec chmod 0644 {} +
 
+# ---------------------------------------------------------------------------
+# Workaround: DeepStream expects "siglip2_*" file names but NGC ships
+# "siglip_v2_*".  Create a compatibility symlink for the weights file.
+# ---------------------------------------------------------------------------
+if [[ "${MODEL}" == "siglip_v2" ]]; then
+  COMPAT_LINK="${DEST}/siglip2_${VERSION}_weights.bin"
+  COMPAT_TARGET="siglip_v2_${VERSION}_weights.bin"
+  if [[ ! -e "${COMPAT_LINK}" ]]; then
+    ln -s "${COMPAT_TARGET}" "${COMPAT_LINK}"
+    chown -h "${STORAGE_UID}:${STORAGE_GID}" "${COMPAT_LINK}"
+    echo "##### Created compatibility symlink: ${COMPAT_LINK} -> ${COMPAT_TARGET} #####"
+  fi
+fi
+
 touch "${MARKER}"
 chown "${STORAGE_UID}:${STORAGE_GID}" "${MARKER}"
 echo "##### Vision encoder ${MODEL}:${VERSION} downloaded to ${DEST} #####"

--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/ds-search-start.sh
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/ds-search-start.sh
@@ -27,7 +27,6 @@ VISION_ENCODER_VERSION="${VISION_ENCODER_VERSION:?must be set}"
 
 VISION_ENCODER_ONNX_FILE="${VISION_ENCODER_MODEL}_${VISION_ENCODER_VERSION}.onnx"
 VISION_ENCODER_TOKENIZER_DIR="${VISION_ENCODER_MODEL}_${VISION_ENCODER_VERSION}_tokenizer"
-VISION_ENCODER_DS_MODEL_NAME="${VISION_ENCODER_MODEL}-onnx"
 VISION_ENCODER_STORAGE="/opt/storage"
 DS_APP_DIR="/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app"
 
@@ -72,8 +71,8 @@ for cfg in "${DS_APP_DIR}/configs/ds-main-config.txt" \
   [[ -f "$cfg" ]] || continue
   echo "##### Patching vision encoder paths in $(basename "$cfg") #####"
 
-  # [text-embedder] section
-  sed -i "/^\[text-embedder\]/,/^\[/{s|^model-name=.*|model-name=${VISION_ENCODER_DS_MODEL_NAME}|;}" "$cfg"
+  # [text-embedder] section — model-name is fixed in the config (siglip2-onnx);
+  # only patch file paths which depend on the NGC package naming convention.
   sed -i "/^\[text-embedder\]/,/^\[/{s|^onnx-model-path=.*|onnx-model-path=${VISION_ENCODER_STORAGE}/${VISION_ENCODER_ONNX_FILE}|;}" "$cfg"
   sed -i "/^\[text-embedder\]/,/^\[/{s|^tokenizer-dir=.*|tokenizer-dir=${VISION_ENCODER_STORAGE}/${VISION_ENCODER_TOKENIZER_DIR}/|;}" "$cfg"
 

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/vss-rtvi-cv-configmap.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/vss-rtvi-cv-configmap.yaml
@@ -265,10 +265,9 @@ data:
 
     {{- $veModel := dig "models" "visionEncoder" "model" "siglip_v2" $rtvi }}
     {{- $veVersion := dig "models" "visionEncoder" "version" "v1.1" $rtvi }}
-    {{- $veDsName := dig "models" "visionEncoder" "dsModelName" (printf "%s-onnx" ($veModel | replace "_v2" "2")) $rtvi }}
     [text-embedder]
     enable=1
-    model-name={{ $veDsName }}
+    model-name=siglip2-onnx
     onnx-model-path=/opt/storage/{{ $veModel }}_{{ $veVersion }}.onnx
     tokenizer-dir=/opt/storage/{{ $veModel }}_{{ $veVersion }}_tokenizer/
 

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/vss-rtvi-cv-configmap.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/vss-rtvi-cv-configmap.yaml
@@ -265,9 +265,10 @@ data:
 
     {{- $veModel := dig "models" "visionEncoder" "model" "siglip_v2" $rtvi }}
     {{- $veVersion := dig "models" "visionEncoder" "version" "v1.1" $rtvi }}
+    {{- $veDsName := dig "models" "visionEncoder" "dsModelName" (printf "%s-onnx" ($veModel | replace "_v2" "2")) $rtvi }}
     [text-embedder]
     enable=1
-    model-name={{ $veModel }}-onnx
+    model-name={{ $veDsName }}
     onnx-model-path=/opt/storage/{{ $veModel }}_{{ $veVersion }}.onnx
     tokenizer-dir=/opt/storage/{{ $veModel }}_{{ $veVersion }}_tokenizer/
 

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/job-download-models.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/job-download-models.yaml
@@ -63,6 +63,11 @@ spec:
               mv {{ .sourcePath | quote }} "${DEST}/{{ .destPath }}"
               rm -rf $(dirname {{ .sourcePath | quote }})
               {{- end }}
+              # Workaround: DeepStream expects "siglip2_*" but NGC ships "siglip_v2_*".
+              if [[ -f "${DEST}/siglip_v2_v1.1_weights.bin" && ! -e "${DEST}/siglip2_v1.1_weights.bin" ]]; then
+                ln -s "siglip_v2_v1.1_weights.bin" "${DEST}/siglip2_v1.1_weights.bin"
+                echo "[INFO] Created compatibility symlink: siglip2_v1.1_weights.bin -> siglip_v2_v1.1_weights.bin"
+              fi
               chmod -R a+rX "${DEST}"
               echo "[INFO] Models downloaded to ${DEST}"
           volumeMounts:

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/job-download-models.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/job-download-models.yaml
@@ -63,10 +63,14 @@ spec:
               mv {{ .sourcePath | quote }} "${DEST}/{{ .destPath }}"
               rm -rf $(dirname {{ .sourcePath | quote }})
               {{- end }}
+              {{- $veModel := dig "models" "visionEncoder" "model" "siglip_v2" .Values }}
+              {{- $veVersion := dig "models" "visionEncoder" "version" "v1.1" .Values }}
               # Workaround: DeepStream expects "siglip2_*" but NGC ships "siglip_v2_*".
-              if [[ -f "${DEST}/siglip_v2_v1.1_weights.bin" && ! -e "${DEST}/siglip2_v1.1_weights.bin" ]]; then
-                ln -s "siglip_v2_v1.1_weights.bin" "${DEST}/siglip2_v1.1_weights.bin"
-                echo "[INFO] Created compatibility symlink: siglip2_v1.1_weights.bin -> siglip_v2_v1.1_weights.bin"
+              WEIGHTS_FILE="{{ $veModel }}_{{ $veVersion }}_weights.bin"
+              COMPAT_LINK="{{ $veModel | replace "_v2" "2" }}_{{ $veVersion }}_weights.bin"
+              if [[ -f "${DEST}/${WEIGHTS_FILE}" && ! -e "${DEST}/${COMPAT_LINK}" ]]; then
+                ln -s "${WEIGHTS_FILE}" "${DEST}/${COMPAT_LINK}"
+                echo "[INFO] Created compatibility symlink: ${COMPAT_LINK} -> ${WEIGHTS_FILE}"
               fi
               chmod -R a+rX "${DEST}"
               echo "[INFO] Models downloaded to ${DEST}"


### PR DESCRIPTION
## Description

### Summary
The siglip v2 onnx file refers to the wrong `weights.bin` after the file names were changed in the model card; the name is hardcoded (re-exporting the model is expected to fix it).


### Context
The vision encoder model siglip v2 on NGC underwent a few file name changes for adhere to a consistent naming convention so that the onnx, weights and tokenizer file names could be derived from the base model name.
The file name changes are:
```
siglip2_v1.1.onnx  ->  siglip_v2_v1.1.onnx
siglip2_v1.1_tokenizer  ->  siglip_v2_v1.1_tokenizer
siglip2_v1.1_weights.bin  ->  siglip_v2_v1.1_weights.bin
```
The same was adapted in dev-search profile with the PR - https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/545.


### Details
RTVI-CV container fails to start with the following error - 
```
[TRT-1] WeightsContext.cpp:190: Failed to open file: /opt/storage/siglip2_v1.1_weights.bin
```

The `weights.bin` file name for siglip v2 is hardcoded in the onnx file as `siglip2_v1.1_weights.bin`. With the recent file name changes, RTVI-CV fails to find the file and crashes.

While the long term fix is to remove the hardcoded value (re-export model), this PR provides a work around - **create a compatibility  symlink from the downloaded file `siglip_v2_v1.1_weights.bin` to the old/expected file name** `siglip2_v1.1_weights.bin`:
```
1 1001 1001   26 May 20 08:36 siglip2_v1.1_weights.bin -> siglip_v2_v1.1_weights.bin
```

**Fix in the PR alleviates the issue for now.**

**NOTE:** The changes can be reverted once the file reference is fixed in the model onnx file; the work around, though redundant, is compatible with the long term fix.


### Later (TODO)
Remove the hardcoding and follow the file naming conventions to derive the model file names from the base model name - 
```
# Convention (org=nvstaging or nvidia, team=tao):
#   NGC model:  nvstaging/tao/{MODEL}:deployable_{VERSION}
#   ONNX file:  {MODEL}_{VERSION}.onnx
#   Weights:    {MODEL}_{VERSION}_weights.bin
#   Tokenizer:  {MODEL}_{VERSION}_tokenizer
```


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
