### PR TITLE
Fix helm chart issues in download job (search rtvi cv)

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/download-vision-encoder.sh
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/download-vision-encoder.sh
@@ -110,8 +110,8 @@ STORAGE_GID="${STORAGE_GID:-1001}"
 # UID/GID are baked into the vss-rt-cv image and cannot be changed.
 # Since we cannot align UIDs or inject supplementary groups, "other"
 # bits are the only access channel:
-#   - directories: o+rwx  (TensorRT writes engine plans here at runtime)
-#   - files:       o+r    (read-only model artifacts)
+#   - directories: o+rwx   (TensorRT writes engine plans here at runtime)
+#   - files:       o+r     (read-only model artifacts)
 chown -R "${STORAGE_UID}:${STORAGE_GID}" "${DEST}"
 find "${DEST}" -type d -exec chmod 0777 {} +
 find "${DEST}" -type f -exec chmod 0644 {} +

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/job-download-models.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/job-download-models.yaml
@@ -63,8 +63,9 @@ spec:
               mv {{ .sourcePath | quote }} "${DEST}/{{ .destPath }}"
               rm -rf $(dirname {{ .sourcePath | quote }})
               {{- end }}
-              {{- $veModel := dig "models" "visionEncoder" "model" "siglip_v2" .Values }}
-              {{- $veVersion := dig "models" "visionEncoder" "version" "v1.1" .Values }}
+              {{- $vals := .Values | toYaml | fromYaml }}
+              {{- $veModel := dig "models" "visionEncoder" "model" "siglip_v2" $vals }}
+              {{- $veVersion := dig "models" "visionEncoder" "version" "v1.1" $vals }}
               # Workaround: DeepStream expects "siglip2_*" but NGC ships "siglip_v2_*".
               WEIGHTS_FILE="{{ $veModel }}_{{ $veVersion }}_weights.bin"
               COMPAT_LINK="{{ $veModel | replace "_v2" "2" }}_{{ $veVersion }}_weights.bin"


### PR DESCRIPTION
## Description

Fixes the issue - 
```
Error: template: dev-profile-search/charts/rtvi/charts/vss-rtvi-cv/templates/job-download-models.yaml:66:30: executing "dev-profile-search/charts/rtvi/charts/vss-rtvi-cv/templates/job-download-models.yaml" at <dig "models" "visionEncoder" "model" "siglip_v2" .Values>: error calling dig: interface conversion: interface {} is common.Values, not map[string]interface {}
```

Caused by: subchart values lose their plain-map type during the merg…e with parent chart overrides. The toYaml | fromYaml idiom is the standard workaround.

Ref: https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/566

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
