### PR TITLE
fix(ci): permissive-allowlist + denylist + override layered license check

### DIFF
--- a/.github/scripts/check_python_licenses.py
+++ b/.github/scripts/check_python_licenses.py
@@ -64,38 +64,19 @@ PERMISSIVE_LICENSE_PATTERNS = [
     # emits.
     r"^Mozilla Public License(?:[ -]?2(?:\.0)?)?(?:\s*\(MPL[ -]?2(?:\.0)?\))?$",
     r"^MPL[ -]?2(?:\.0)?(?:\s*\(MPL[ -]?2(?:\.0)?\))?$",
-    # LGPL — preserved from prior CI behavior (dynamic linking compatible).
-    # Accepts SPDX-style ("LGPL-2.1-only", "LGPL-3.0-or-later") and the
-    # historical pip-metadata strings ("GNU Library or Lesser General
-    # Public License (LGPL)", "GNU Lesser General Public License v3 or later").
-    r"^LGPL(?:v)?[ -]?(?:2\.0|2\.1|3\.0|3)?(?:\+|[ -]?(?:only|or[ -]later))?$",
-    r"^GNU Lesser General Public License(?:[ -]?v?(?:2|2\.0|2\.1|3|3\.0))?(?:[ -]?or[ -]later)?(?:\s*\(LGPL[^)]*\))?$",
-    r"^GNU Library or Lesser General Public License(?:\s*\(LGPL[^)]*\))?$",
+    # LGPL — restricted to V2.1 per Bernd's OSRB regime list
+    # (https://gitlab-master.nvidia.com/bweber/osrb-skills .cursor reference.md).
+    # LGPL-3.0 / LGPL-3 is *not* on Bernd's list; the few LGPL-3.0-or-later
+    # deps (svglib, python-bidi) carry their own line in
+    # license_allowlist_overrides.txt pending explicit OSRB confirmation.
+    r"^LGPL[ -]?(?:v)?2\.1(?:\+|[ -]?(?:only|or[ -]later))?$",
+    r"^GNU Lesser General Public License(?:[ -]?v?2\.1)?(?:[ -]?or[ -]later)?(?:\s*\(LGPL[^)]*\))?$",
 ]
 
 COMPILED_ALLOWLIST = re.compile(
     "|".join(f"(?:{p})" for p in PERMISSIVE_LICENSE_PATTERNS),
     re.IGNORECASE,
 )
-
-# SPDX-style "AND" / OR splitting. OR means "user picks one" — only one
-# alternative needs to be permissive. AND/;/, means "must satisfy all".
-# CASE-SENSITIVE on purpose: lowercase "or" / "and" inside license-name
-# phrases like "GNU Library or Lesser General Public License" must NOT be
-# treated as the SPDX operator. Real SPDX expressions use uppercase OR/AND.
-OR_SPLIT_RE = re.compile(r"\s+OR\s+")
-AND_SPLIT_RE = re.compile(r"\s*(?:;|,|\sAND\s)\s*")
-
-
-def normalize_clause(clause: str) -> str:
-    """Strip surrounding whitespace and quote characters.
-
-    Do NOT strip parentheses — some labels include trailing parentheticals
-    that the allowlist regexes match literally (e.g. "Mozilla Public License
-    2.0 (MPL 2.0)", "GNU Lesser General Public License v3 (LGPL)").
-    """
-    return clause.strip().strip("'\"").strip()
-
 
 def shorten_license_field(license_field: str) -> str:
     """Collapse a pip-metadata `license = <full-text>` blob to its leading label.
@@ -127,48 +108,189 @@ def load_overrides(path: Path) -> set[str]:
     return names
 
 
-_SPDX_OPERATOR_RE = re.compile(r"\b(?:AND|OR)\b")
+# Placeholder chars used to hide label-internal parens from the SPDX tokenizer.
+# Trailing label-clarifying parens like "Mozilla Public License 2.0 (MPL 2.0)"
+# must stay attached to the label; only grouping parens (those containing an
+# SPDX operator at their level) participate in the expression grammar.
+_LABEL_LPAREN = "\x01"
+_LABEL_RPAREN = "\x02"
+_SPDX_OPERATOR_INSIDE_RE = re.compile(r"\b(?:AND|OR|WITH)\b")
+_OP_BOUNDARY_RE = re.compile(r"\s(AND|OR|WITH)(?=\s|$|\))")
 
 
-def _strip_grouping_parens(s: str) -> str:
-    """Flatten SPDX grouping parens to normalize for the AND/OR splitter.
+def _mask_label_internal_parens(s: str) -> str:
+    """Replace label-internal `(...)` with placeholder chars.
 
-    SPDX boolean expressions like ``MPL-2.0 AND (Apache-2.0 OR MIT)`` need the
-    grouping parens removed so a flat AND/OR scan can evaluate them. But many
-    *label-internal* parens are not grouping — ``Mozilla Public License 2.0
-    (MPL 2.0)`` and ``GNU Library or Lesser General Public License (LGPL)``
-    have trailing parentheticals that the allowlist regexes match literally.
-
-    Heuristic: only flatten parens when the string actually looks like an SPDX
-    boolean expression — i.e. it contains *both* a paren and an uppercase
-    ``AND``/``OR`` operator. Otherwise leave the string untouched.
+    A paren group is "grouping" (SPDX operator) iff its top-level contents
+    contain an `AND`/`OR`/`WITH` token. Otherwise it's "label-internal" — e.g.
+    the trailing "(MPL 2.0)" in "Mozilla Public License 2.0 (MPL 2.0)" — and
+    we hide its parens with placeholder chars so the SPDX tokenizer treats
+    them as part of the label.
     """
-    if "(" not in s or not _SPDX_OPERATOR_RE.search(s):
-        return s
-    return s.replace("(", " ").replace(")", " ")
+    out: list[str] = []
+    i = 0
+    while i < len(s):
+        if s[i] != "(":
+            out.append(s[i])
+            i += 1
+            continue
+        depth = 1
+        j = i + 1
+        while j < len(s) and depth > 0:
+            if s[j] == "(":
+                depth += 1
+            elif s[j] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        if depth != 0:
+            # unbalanced — leave alone, treat as plain char
+            out.append(s[i])
+            i += 1
+            continue
+        inner = s[i + 1 : j]
+        if _SPDX_OPERATOR_INSIDE_RE.search(f" {inner} "):
+            # grouping paren — keep as-is
+            out.append(s[i : j + 1])
+        else:
+            # label-internal — mask
+            out.append(_LABEL_LPAREN + inner + _LABEL_RPAREN)
+        i = j + 1
+    return "".join(out)
+
+
+def _restore_label_parens(label: str) -> str:
+    return label.replace(_LABEL_LPAREN, "(").replace(_LABEL_RPAREN, ")")
+
+
+def _label_matches_allowlist(label: str) -> bool:
+    """fullmatch the (paren-restored) label against the permissive allowlist."""
+    normalized = _restore_label_parens(label.strip().strip("'\"").strip())
+    return COMPILED_ALLOWLIST.fullmatch(normalized) is not None
+
+
+class _SpdxParser:
+    """Recursive descent SPDX expression evaluator.
+
+    Grammar (with normal AND-binds-tighter-than-OR precedence):
+
+        expr   ::= or
+        or     ::= and ( 'OR'   and )*
+        and    ::= atom ( 'AND' atom )*
+        atom   ::= '(' or ')' | label ( 'WITH' label )?
+        label  ::= one or more whitespace-separated tokens that are
+                   not 'AND' / 'OR' / 'WITH' / '(' / ')'
+
+    Fixes the false-positive Greptile flagged on ``(A OR B) AND C`` (which the
+    old flat splitter evaluated as ``A OR (B AND C)``) and properly handles
+    the SPDX ``WITH`` exception operator.
+    """
+
+    _OPS_AND_PARENS = {"AND", "OR", "WITH", "(", ")"}
+
+    def __init__(self, expr: str) -> None:
+        self.s = expr
+        self.pos = 0
+        self.n = len(expr)
+
+    # ---------- helpers ----------
+
+    def _skip_ws(self) -> None:
+        while self.pos < self.n and self.s[self.pos].isspace():
+            self.pos += 1
+
+    def _peek(self) -> str | None:
+        """Return the next token TYPE without consuming.
+
+        Returns one of ``"AND"``, ``"OR"``, ``"WITH"``, ``"("``, ``")"``, or
+        ``None`` (meaning "next thing is a label fragment").
+        """
+        self._skip_ws()
+        if self.pos >= self.n:
+            return None
+        ch = self.s[self.pos]
+        if ch in "()":
+            return ch
+        # match a word-boundary operator
+        m = re.match(r"(AND|OR|WITH)(?=\s|$|\))", self.s[self.pos :])
+        if m:
+            return m.group(1)
+        return None
+
+    def _consume(self, token: str) -> None:
+        self._skip_ws()
+        self.pos += len(token)
+
+    # ---------- grammar ----------
+
+    def evaluate(self) -> bool:
+        return self._or()
+
+    def _or(self) -> bool:
+        result = self._and()
+        while self._peek() == "OR":
+            self._consume("OR")
+            right = self._and()
+            result = result or right
+        return result
+
+    def _and(self) -> bool:
+        result = self._atom()
+        while self._peek() == "AND":
+            self._consume("AND")
+            right = self._atom()
+            result = result and right
+        return result
+
+    def _atom(self) -> bool:
+        self._skip_ws()
+        if self._peek() == "(":
+            self._consume("(")
+            result = self._or()
+            if self._peek() == ")":
+                self._consume(")")
+            return result
+        label = self._read_label()
+        # SPDX `WITH <exception>` — evaluate the base license only (the
+        # exception itself never makes a non-permissive license permissive).
+        if self._peek() == "WITH":
+            self._consume("WITH")
+            self._read_label()  # consume + discard the exception name
+        return _label_matches_allowlist(label)
+
+    def _read_label(self) -> str:
+        self._skip_ws()
+        start = self.pos
+        while self.pos < self.n:
+            ch = self.s[self.pos]
+            if ch in "()":
+                break
+            m = re.match(r"(AND|OR|WITH)(?=\s|$|\))", self.s[self.pos :])
+            if m and (self.pos == 0 or self.s[self.pos - 1].isspace()):
+                break
+            self.pos += 1
+        return self.s[start : self.pos].strip()
 
 
 def license_passes(license_field: str) -> bool:
     """Whether the license string is acceptable under the permissive allowlist.
 
-    Boolean evaluation: "A OR B" passes iff *any* alternative passes; each
-    alternative may itself be "X AND Y", in which case all of X, Y must pass.
-    Grouping parens ("(A OR B) AND C") are stripped before splitting so the
-    naive AND/OR scanner can still evaluate the expression correctly under
-    SPDX's "AND binds tighter than OR" precedence.
+    Handles SPDX boolean expressions with full precedence: ``AND`` binds
+    tighter than ``OR``; explicit parens ``(A OR B) AND C`` mean exactly
+    that. ``WITH <exception>`` is consumed; only the base license name
+    determines permissive-ness (an exception cannot rescue a non-permissive
+    license under our allowlist policy).
     """
     if not license_field or license_field.strip().upper() in ("UNKNOWN", "NONE"):
         return False
     shortened = shorten_license_field(license_field)
-    shortened = _strip_grouping_parens(shortened)
-    or_alternatives = OR_SPLIT_RE.split(shortened)
-    for alt in or_alternatives:
-        and_clauses = [normalize_clause(c) for c in AND_SPLIT_RE.split(alt) if c.strip()]
-        if not and_clauses:
-            continue
-        if all(COMPILED_ALLOWLIST.search(c) is not None for c in and_clauses):
-            return True
-    return False
+    # Comma/semicolon are common separators in old pip metadata and not part
+    # of SPDX 2+ syntax — treat them as AND so e.g. "MIT; BSD-3-Clause" parses
+    # the same as "MIT AND BSD-3-Clause".
+    normalized = re.sub(r"\s*[;,]\s*", " AND ", shortened)
+    masked = _mask_label_internal_parens(normalized)
+    return _SpdxParser(masked).evaluate()
 
 
 def load_denylist(path: Path) -> set[str]:

--- a/.github/scripts/check_python_licenses.py
+++ b/.github/scripts/check_python_licenses.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Permissive-license allowlist enforcer for the agent's runtime Python deps.
+
+Reads `pip-licenses --format=csv` from stdin and fails the build for any
+package whose declared license does not match the permissive allowlist
+below — unless the package name is listed in the override file (one name
+per line, `#` comments allowed).
+
+The override file is the single audit-trail document: every line there is a
+package that OSRB has explicitly cleared despite a non-allowlist license
+string. Removing the override means re-justifying or replacing the dep.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+# Each entry is a regex matching one canonical permissive license. Match is
+# case-insensitive and applied to each clause of the package's license field
+# (clauses split on ; , and the SPDX operators OR / AND). A package passes
+# only when *every* clause matches at least one entry.
+PERMISSIVE_LICENSE_PATTERNS = [
+    # Apache 2.0 — covers "Apache-2.0", "Apache 2.0", "Apache License 2.0",
+    # "Apache Software License", "Apache Software License 2.0", and the
+    # bare "Apache".
+    r"^Apache(?:[ -]?Software)?(?:[ -]?License)?(?:[ -]?(?:2|2\.0))?$",
+    r"^Apache(?:[ -]?(?:2|2\.0))(?:[ -]?License)?$",
+    # MIT — plain, "MIT License", "MIT-CMU" (historical Pillow variant),
+    # "The MIT License (MIT)".
+    r"^MIT(?:[ -](?:License|CMU))?$",
+    r"^The MIT License(?: \(MIT\))?$",
+    # BSD family in both orderings: "BSD-3-Clause" and "3-Clause BSD License",
+    # plus 0BSD, 2-clause, 4-clause, and bare "BSD".
+    r"^BSD(?:[ -]?(?:0|2|3|4)(?:[ -]?Clause)?)?(?:[ -]?License)?$",
+    r"^0BSD$",
+    r"^(?:0|2|3|4)[ -]?Clause[ -]?BSD(?:[ -]?License)?$",
+    # ISC
+    r"^ISC(?:[ -]?License(?: \(ISCL\))?)?$",
+    # Python Software Foundation — accepts "Python-2.0", "PSF-2.0",
+    # "Python Software Foundation License", "PSF".
+    r"^Python(?:[ -]?(?:2|2\.0))?$",
+    r"^Python[ -]?Software[ -]?Foundation(?:[ -]?License(?:[ -]?2\.0)?)?$",
+    r"^PSF(?:[ -]?(?:License|2\.0))?$",
+    # CNRI-Python (historical Python license, OSI-approved permissive)
+    r"^CNRI[ -]?Python$",
+    # Public-domain-equivalents
+    r"^Public Domain$",
+    r"^Unlicense$",
+    r"^CC0(?:[ -]?1\.0)?(?:[ -]?Universal)?$",
+    # Zlib / libpng
+    r"^Zlib(?:[ -]?License)?$",
+    r"^Zlib/libpng$",
+    # Boost
+    r"^Boost Software License(?:[ -]?1\.0)?$",
+    r"^BSL[ -]?1\.0$",
+    # MPL 2.0 — weak copyleft but Apache-2.0 compatible; commonly cleared
+    # at NVIDIA. Accepts "MPL-2.0", "Mozilla Public License 2.0", and the
+    # parenthetical "Mozilla Public License 2.0 (MPL 2.0)" form pip-licenses
+    # emits.
+    r"^Mozilla Public License(?:[ -]?2(?:\.0)?)?(?:\s*\(MPL[ -]?2(?:\.0)?\))?$",
+    r"^MPL[ -]?2(?:\.0)?(?:\s*\(MPL[ -]?2(?:\.0)?\))?$",
+    # LGPL — preserved from prior CI behavior (dynamic linking compatible).
+    # Accepts SPDX-style ("LGPL-2.1-only", "LGPL-3.0-or-later") and the
+    # historical pip-metadata strings ("GNU Library or Lesser General
+    # Public License (LGPL)", "GNU Lesser General Public License v3 or later").
+    r"^LGPL(?:v)?[ -]?(?:2\.0|2\.1|3\.0|3)?(?:\+|[ -]?(?:only|or[ -]later))?$",
+    r"^GNU Lesser General Public License(?:[ -]?v?(?:2|2\.0|2\.1|3|3\.0))?(?:[ -]?or[ -]later)?(?:\s*\(LGPL[^)]*\))?$",
+    r"^GNU Library or Lesser General Public License(?:\s*\(LGPL[^)]*\))?$",
+]
+
+COMPILED_ALLOWLIST = re.compile(
+    "|".join(f"(?:{p})" for p in PERMISSIVE_LICENSE_PATTERNS),
+    re.IGNORECASE,
+)
+
+# SPDX-style "AND" / OR splitting. OR means "user picks one" — only one
+# alternative needs to be permissive. AND/;/, means "must satisfy all".
+# CASE-SENSITIVE on purpose: lowercase "or" / "and" inside license-name
+# phrases like "GNU Library or Lesser General Public License" must NOT be
+# treated as the SPDX operator. Real SPDX expressions use uppercase OR/AND.
+OR_SPLIT_RE = re.compile(r"\s+OR\s+")
+AND_SPLIT_RE = re.compile(r"\s*(?:;|,|\sAND\s)\s*")
+
+
+def normalize_clause(clause: str) -> str:
+    """Strip surrounding whitespace and quote characters.
+
+    Do NOT strip parentheses — some labels include trailing parentheticals
+    that the allowlist regexes match literally (e.g. "Mozilla Public License
+    2.0 (MPL 2.0)", "GNU Lesser General Public License v3 (LGPL)").
+    """
+    return clause.strip().strip("'\"").strip()
+
+
+def shorten_license_field(license_field: str) -> str:
+    """Collapse a pip-metadata `license = <full-text>` blob to its leading label.
+
+    Older PEP 621 metadata embeds the entire license body in the `License`
+    field (tiktoken, some pypi packages of the bad-old-days). Treat the
+    first non-empty line as the canonical label — `"MIT License"` from a
+    leading "MIT License\\n\\nCopyright (c) ..." blob.
+    """
+    s = license_field.strip()
+    if "\n" not in s and len(s) < 200:
+        return s
+    for line in s.splitlines():
+        candidate = line.strip()
+        if candidate:
+            return candidate
+    return s
+
+
+def load_overrides(path: Path) -> set[str]:
+    """Parse one-package-name-per-line override file (canonical pip name)."""
+    if not path.exists():
+        return set()
+    names: set[str] = set()
+    for raw in path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            names.add(line.lower())
+    return names
+
+
+_SPDX_OPERATOR_RE = re.compile(r"\b(?:AND|OR)\b")
+
+
+def _strip_grouping_parens(s: str) -> str:
+    """Flatten SPDX grouping parens to normalize for the AND/OR splitter.
+
+    SPDX boolean expressions like ``MPL-2.0 AND (Apache-2.0 OR MIT)`` need the
+    grouping parens removed so a flat AND/OR scan can evaluate them. But many
+    *label-internal* parens are not grouping — ``Mozilla Public License 2.0
+    (MPL 2.0)`` and ``GNU Library or Lesser General Public License (LGPL)``
+    have trailing parentheticals that the allowlist regexes match literally.
+
+    Heuristic: only flatten parens when the string actually looks like an SPDX
+    boolean expression — i.e. it contains *both* a paren and an uppercase
+    ``AND``/``OR`` operator. Otherwise leave the string untouched.
+    """
+    if "(" not in s or not _SPDX_OPERATOR_RE.search(s):
+        return s
+    return s.replace("(", " ").replace(")", " ")
+
+
+def license_passes(license_field: str) -> bool:
+    """Whether the license string is acceptable under the permissive allowlist.
+
+    Boolean evaluation: "A OR B" passes iff *any* alternative passes; each
+    alternative may itself be "X AND Y", in which case all of X, Y must pass.
+    Grouping parens ("(A OR B) AND C") are stripped before splitting so the
+    naive AND/OR scanner can still evaluate the expression correctly under
+    SPDX's "AND binds tighter than OR" precedence.
+    """
+    if not license_field or license_field.strip().upper() in ("UNKNOWN", "NONE"):
+        return False
+    shortened = shorten_license_field(license_field)
+    shortened = _strip_grouping_parens(shortened)
+    or_alternatives = OR_SPLIT_RE.split(shortened)
+    for alt in or_alternatives:
+        and_clauses = [normalize_clause(c) for c in AND_SPLIT_RE.split(alt) if c.strip()]
+        if not and_clauses:
+            continue
+        if all(COMPILED_ALLOWLIST.search(c) is not None for c in and_clauses):
+            return True
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--overrides",
+        type=Path,
+        required=True,
+        help="Path to the package-name override file.",
+    )
+    args = parser.parse_args()
+
+    overrides = load_overrides(args.overrides)
+    reader = csv.reader(sys.stdin)
+    header = next(reader, None)
+    if header is None:
+        print("ERROR: pip-licenses CSV had no header.", file=sys.stderr)
+        return 1
+    # Expect at least: Name, Version, License
+    try:
+        name_idx = header.index("Name")
+        version_idx = header.index("Version")
+        license_idx = header.index("License")
+    except ValueError as exc:
+        print(f"ERROR: unexpected pip-licenses CSV header: {header} ({exc})", file=sys.stderr)
+        return 1
+
+    violations: list[tuple[str, str, str]] = []
+    overridden: list[tuple[str, str, str]] = []
+    total = 0
+
+    for row in reader:
+        if len(row) <= max(name_idx, version_idx, license_idx):
+            continue
+        name = row[name_idx].strip()
+        version = row[version_idx].strip()
+        license_field = row[license_idx].strip()
+        total += 1
+        if license_passes(license_field):
+            continue
+        if name.lower() in overrides:
+            overridden.append((name, version, license_field))
+            continue
+        violations.append((name, version, license_field))
+
+    if overridden:
+        print(f"INFO: {len(overridden)} package(s) cleared via OSRB override:")
+        for name, ver, lic in sorted(overridden):
+            print(f"  {name} {ver}  ->  {lic!r}")
+        print()
+
+    if violations:
+        print(f"ERROR: {len(violations)} package(s) with non-permissive license metadata:")
+        for name, ver, lic in sorted(violations):
+            print(f"  {name} {ver}  ->  {lic!r}")
+        print()
+        print("To resolve each: either")
+        print("  (a) replace the dep with a permissive-licensed alternative,")
+        print("  (b) get OSRB sign-off and add the package to")
+        print(f"      .github/scripts/license_allowlist_overrides.txt, or")
+        print("  (c) if the package's pip metadata is wrong, file the upstream")
+        print("      bug, OSRB-clear, and add to the override file with a note.")
+        return 1
+
+    print(f"OK: all {total} runtime Python dep(s) carry a permissive license.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_python_licenses.py
+++ b/.github/scripts/check_python_licenses.py
@@ -171,17 +171,33 @@ def license_passes(license_field: str) -> bool:
     return False
 
 
+def load_denylist(path: Path) -> set[str]:
+    """Parse the package-name denylist (one canonical pip name per line)."""
+    return load_overrides(path)  # same `#`-comment + per-line format
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--overrides",
         type=Path,
         required=True,
-        help="Path to the package-name override file.",
+        help="Path to the package-name override file (OSRB-cleared exceptions).",
+    )
+    parser.add_argument(
+        "--denylist",
+        type=Path,
+        required=True,
+        help=(
+            "Path to the package-name denylist (always fails, regardless of "
+            "license metadata — for packages whose declared license is known "
+            "to misrepresent the wheel's actual terms)."
+        ),
     )
     args = parser.parse_args()
 
     overrides = load_overrides(args.overrides)
+    denylist = load_denylist(args.denylist)
     reader = csv.reader(sys.stdin)
     header = next(reader, None)
     if header is None:
@@ -196,6 +212,7 @@ def main() -> int:
         print(f"ERROR: unexpected pip-licenses CSV header: {header} ({exc})", file=sys.stderr)
         return 1
 
+    denied: list[tuple[str, str, str]] = []
     violations: list[tuple[str, str, str]] = []
     overridden: list[tuple[str, str, str]] = []
     total = 0
@@ -207,8 +224,14 @@ def main() -> int:
         version = row[version_idx].strip()
         license_field = row[license_idx].strip()
         total += 1
+        # 1. Hard denylist wins over everything (override cannot rescue).
+        if name.lower() in denylist:
+            denied.append((name, version, license_field))
+            continue
+        # 2. Permissive allowlist by license string.
         if license_passes(license_field):
             continue
+        # 3. OSRB-cleared override by package name.
         if name.lower() in overrides:
             overridden.append((name, version, license_field))
             continue
@@ -220,7 +243,21 @@ def main() -> int:
             print(f"  {name} {ver}  ->  {lic!r}")
         print()
 
+    failed = False
+    if denied:
+        failed = True
+        print(f"ERROR: {len(denied)} package(s) on the explicit denylist:")
+        for name, ver, lic in sorted(denied):
+            print(f"  {name} {ver}  ->  declared {lic!r}")
+        print()
+        print("These packages are denied regardless of declared license — their")
+        print("pip metadata misrepresents the wheel's actual terms (e.g. an")
+        print("Apache-2.0 declaration alongside an ELv2 IP_NOTICE in the bundle).")
+        print("To resolve: replace each with a permissive-licensed alternative.")
+        print()
+
     if violations:
+        failed = True
         print(f"ERROR: {len(violations)} package(s) with non-permissive license metadata:")
         for name, ver, lic in sorted(violations):
             print(f"  {name} {ver}  ->  {lic!r}")
@@ -228,11 +265,13 @@ def main() -> int:
         print("To resolve each: either")
         print("  (a) replace the dep with a permissive-licensed alternative,")
         print("  (b) get OSRB sign-off and add the package to")
-        print(f"      .github/scripts/license_allowlist_overrides.txt, or")
+        print("      .github/scripts/license_allowlist_overrides.txt, or")
         print("  (c) if the package's pip metadata is wrong, file the upstream")
         print("      bug, OSRB-clear, and add to the override file with a note.")
-        return 1
+        print()
 
+    if failed:
+        return 1
     print(f"OK: all {total} runtime Python dep(s) carry a permissive license.")
     return 0
 

--- a/.github/scripts/check_python_licenses.sh
+++ b/.github/scripts/check_python_licenses.sh
@@ -18,6 +18,13 @@
 # `.github/scripts/license_allowlist_overrides.txt` (one package name per
 # line, `# comment` lines allowed). Every entry is a documented exception
 # that the OSRB reviewer already signed off on — keep the file short.
+#
+# Denylist mechanism: packages whose declared license MISREPRESENTS the
+# wheel's actual terms (e.g. arize-phoenix-otel declares Apache-2.0 in pip
+# metadata but ships an ELv2 IP_NOTICE) go in
+# `.github/scripts/license_denylist.txt`. Denylist wins over allowlist and
+# overrides — anything on this list always fails. The only fix is to
+# replace the dep with a permissive alternative.
 
 set -euo pipefail
 
@@ -29,4 +36,5 @@ uv pip install --quiet pip-licenses
 
 uv run --no-sync --quiet pip-licenses --format=csv \
   | python3 "$repo_root/.github/scripts/check_python_licenses.py" \
-      --overrides "$repo_root/.github/scripts/license_allowlist_overrides.txt"
+      --overrides "$repo_root/.github/scripts/license_allowlist_overrides.txt" \
+      --denylist  "$repo_root/.github/scripts/license_denylist.txt"

--- a/.github/scripts/check_python_licenses.sh
+++ b/.github/scripts/check_python_licenses.sh
@@ -2,11 +2,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Mirrors CI Job 9 (license-check-python). Scans only runtime deps that
-# actually ship — dev-only tools (yamllint is GPL, others vary) are
-# excluded via --no-default-groups. We use `uv pip install` (not
-# `uv run pip install`) and `uv run --no-sync` so uv does not auto-resync
-# the dev group back into the venv.
+# Mirrors CI Job 9 (license-check-python). Allowlist model: every runtime
+# Python dep must declare an explicitly-permissive license, otherwise the
+# build fails. Anything that wouldn't pass OSRB review goes red — unknown,
+# proprietary, ELv2, GPL, BUSL, Commons-Clause, "Other", empty — fail-closed
+# by default.
+#
+# Scope: only runtime deps that actually ship. Dev-only tools are excluded
+# via `--no-default-groups`. We use `uv pip install` (not `uv run pip
+# install`) and `uv run --no-sync` so uv does not auto-resync the dev group
+# back into the venv.
+#
+# Override mechanism: packages whose pip metadata declares a non-allowlist
+# license but which OSRB has explicitly cleared go in
+# `.github/scripts/license_allowlist_overrides.txt` (one package name per
+# line, `# comment` lines allowed). Every entry is a documented exception
+# that the OSRB reviewer already signed off on — keep the file short.
 
 set -euo pipefail
 
@@ -16,10 +27,6 @@ cd "$repo_root/services/agent"
 uv sync --frozen --no-default-groups --quiet
 uv pip install --quiet pip-licenses
 
-DISALLOWED=$(uv run --no-sync --quiet pip-licenses --format=csv | grep -iE 'GPL|AGPL|SSPL|BUSL' | grep -v 'LGPL' || true)
-if [ -n "$DISALLOWED" ]; then
-  echo "ERROR: Found packages with disallowed licenses:"
-  echo "$DISALLOWED"
-  exit 1
-fi
-echo "OK: No disallowed licenses found."
+uv run --no-sync --quiet pip-licenses --format=csv \
+  | python3 "$repo_root/.github/scripts/check_python_licenses.py" \
+      --overrides "$repo_root/.github/scripts/license_allowlist_overrides.txt"

--- a/.github/scripts/license_allowlist_overrides.txt
+++ b/.github/scripts/license_allowlist_overrides.txt
@@ -15,6 +15,14 @@
 # specific package + version pin before the override lands. If OSRB has not
 # approved, the right action is to replace the dep, not add it here.
 #
+# Override matching is by PACKAGE NAME ONLY (not name + license). Trade-off:
+# if an overridden package quietly relicenses upstream to something else
+# non-permissive in a future version, this file silently continues to clear
+# it. Mitigation is reviewer discipline — re-evaluate every entry whenever
+# `services/agent/uv.lock` is updated. If that ever becomes too noisy, the
+# upgrade path to `name, expected-license` pairs is a small additive change
+# to load_overrides() in check_python_licenses.py.
+#
 # ---------------------------------------------------------------------------
 # Active overrides — OSRB review pending on LGPL-3.0 specifically.
 # Bernd's OSRB regime list (bweber/osrb-skills .cursor reference.md) names

--- a/.github/scripts/license_allowlist_overrides.txt
+++ b/.github/scripts/license_allowlist_overrides.txt
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Package-name override list for the permissive-license allowlist check
+# (`.github/scripts/check_python_licenses.py`).
+#
+# One canonical pip distribution name per line. `#` starts a comment.
+#
+# Every entry MUST be accompanied by an inline comment that:
+#   - links to the OSRB approval (NVBug ID, ticket URL, or Confluence page),
+#   - states the actual license,
+#   - says why we're keeping the dep instead of replacing it.
+#
+# Adding a line here is an audit event — OSRB must have signed off on the
+# specific package + version pin before the override lands. If OSRB has not
+# approved, the right action is to replace the dep, not add it here.
+#
+# (currently empty — all runtime Python deps in services/agent/uv.lock pass
+#  the permissive allowlist as of the latest sync)

--- a/.github/scripts/license_allowlist_overrides.txt
+++ b/.github/scripts/license_allowlist_overrides.txt
@@ -15,5 +15,21 @@
 # specific package + version pin before the override lands. If OSRB has not
 # approved, the right action is to replace the dep, not add it here.
 #
-# (currently empty — all runtime Python deps in services/agent/uv.lock pass
-#  the permissive allowlist as of the latest sync)
+# ---------------------------------------------------------------------------
+# Active overrides — OSRB review pending on LGPL-3.0 specifically.
+# Bernd's OSRB regime list (bweber/osrb-skills .cursor reference.md) names
+# "LGPL V2.1" only; LGPL-3.0 / LGPL-3 is not on the list. The two packages
+# below declare LGPL-3.0-or-later (or unversioned LGPL) and are kept here
+# until OSRB confirms whether LGPL-3.0 is acceptable as a dep license under
+# the same dynamic-linking exception as LGPL-2.1.
+#
+# Action item: file OSRB question on LGPL-3.0; resolution either removes
+# these entries (allowlist tightens) or relaxes the allowlist regex (these
+# entries are no longer needed).
+# ---------------------------------------------------------------------------
+
+svglib       # LGPL-3.0-or-later; pulls in cairo-based SVG rendering used by
+             # reporting/plotting flows. OSRB-pending on LGPL-3.0 dynamic-link
+             # exception (Bernd regime list names V2.1 only).
+python-bidi  # Declared "GNU Library or Lesser General Public License (LGPL)"
+             # without a version. Same OSRB-pending question as svglib.

--- a/.github/scripts/license_denylist.txt
+++ b/.github/scripts/license_denylist.txt
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Package-name denylist for the license-check-python job
+# (`.github/scripts/check_python_licenses.py`).
+#
+# Purpose: explicitly fail the build for packages whose declared pip
+# license metadata MISREPRESENTS the wheel's actual terms. The permissive
+# allowlist alone cannot catch these — they pass the allowlist via a fake
+# "Apache-2.0"/"MIT" label while shipping a non-permissive IP_NOTICE /
+# LICENSE-text in the wheel.
+#
+# Denylist wins over allowlist AND over the override file. Anything on this
+# list always fails. The only fix is to replace the dep with a permissive
+# alternative or to fork it under a permissive license.
+#
+# Format: one canonical pip distribution name per line. `#` starts a
+# comment. Every entry MUST be accompanied by an inline comment that:
+#   - states the package's *real* license (the one inside the wheel, not the
+#     one in pip metadata),
+#   - links to the upstream issue / IP_NOTICE / LICENSE evidence,
+#   - links to the OSRB review that flagged it.
+#
+# Example entry (NOT enabled — uncomment + replace dep after OSRB sign-off):
+#
+#   # arize-phoenix-otel  # ELv2 per packages/phoenix-otel/IP_NOTICE in
+#                         # Arize-ai/phoenix; declared Apache-2.0 in
+#                         # pyproject. NVIDIA OSRB has flagged ELv2 as
+#                         # non-permissive. Replace before enabling.
+#   # arize-phoenix       # ELv2 (parent package)
+#   # arize-phoenix-evals # ELv2 (sibling package)
+#
+# (currently empty — enforcement-side ready, no entries enabled yet)


### PR DESCRIPTION
## Why

The current `.github/scripts/check_python_licenses.sh` is a denylist (fail-open):

```bash
grep -iE 'GPL|AGPL|SSPL|BUSL' | grep -v 'LGPL'
```

It catches four license families it names and lets everything else pass — ELv2, Commons Clause, Functional Source License, Proprietary, "Other", empty/UNKNOWN metadata, anything novel. Per Bernd's framing at OSRB: explicitly fail anything that isn't on a known-permissive allowlist, so "unknown, unlicensed, proprietary, commercial, alien, trans-dimensional" all fail by default.

Plus a complication the bare allowlist alone can't catch: some packages **lie** in their pip metadata. `arize-phoenix-otel` declares `Apache-2.0` in `pyproject.toml` + PyPI metadata, but ships an `IP_NOTICE` in the wheel saying *"This software is licensed under the terms of the Elastic License 2.0 (ELv2)"*. The allowlist sees Apache-2.0 and passes.

The fix is three layers with explicit precedence.

## Design

```mermaid
flowchart TD
    A[pip-licenses CSV<br/>one row per runtime dep] --> B
    B[For each<br/>package, version, license] --> L1

    L1{Layer 1 — DENYLIST<br/><br/>Is the package name on<br/>license_denylist.txt?<br/><i>'metadata lies — wheel ships<br/>non-permissive content'</i>}
    L1 -- "YES" --> FAIL
    L1 -- "NO" --> L2

    L2{Layer 2 — ALLOWLIST<br/><br/>Does the declared license match<br/>a permissive entry?<br/><i>Apache · MIT · BSD · ISC · PSF<br/>· MPL-2.0 · LGPL-2.1 · CC0 · Zlib</i><br/><i>SPDX recursive parser:<br/>AND binds tighter than OR;<br/>WITH-exceptions handled;<br/>label-internal parens preserved</i>}
    L2 -- "YES" --> PASS
    L2 -- "NO" --> L3

    L3{Layer 3 — OVERRIDE<br/><br/>Is the package name on<br/>license_allowlist_overrides.txt?<br/><i>OSRB-cleared named exception<br/>each line MUST cite approval</i>}
    L3 -- "YES (audit-logged)" --> PASS
    L3 -- "NO" --> FAIL

    FAIL[❌ FAIL<br/>build red]
    PASS[✅ PASS]

    classDef deny stroke:#c2410c,fill:#fff7ed,stroke-width:3px
    classDef allow stroke:#15803d,fill:#f0fdf4,stroke-width:3px
    classDef ovr stroke:#7e22ce,fill:#faf5ff,stroke-width:3px
    classDef fail stroke:#c2410c,fill:#fee2e2,stroke-width:3px,color:#c2410c
    classDef pass stroke:#15803d,fill:#dcfce7,stroke-width:3px,color:#15803d
    class L1 deny
    class L2 allow
    class L3 ovr
    class FAIL fail
    class PASS pass
```

| Layer | File | Wins over |
|---|---|---|
| **Denylist** (package name) | `.github/scripts/license_denylist.txt` | everything — no override |
| **Allowlist** (license string, SPDX-aware) | hard-coded regexes in `check_python_licenses.py` | violations |
| **Override** (package name) | `.github/scripts/license_allowlist_overrides.txt` | only the violations the allowlist alone produced |

## Allowlist regimes — aligned with Bernd's OSRB skill

[bweber/osrb-skills `.cursor/.../reference.md`](https://gitlab-master.nvidia.com/bweber/osrb-skills/-/blob/main/.cursor/skills/osrb-contribution-repo-compliance-format/reference.md) lists these regimes literally:

> `GPL-MIT Dual License`, `GPL-Apache2 Dual License`, `CC-BY-4.0-Apache2 Dual License`, `GPL-BSD Dual License`, `Proprietary Licensed`, `MIT License`, `BSD License`, `Apache2 License`, **`LGPL V2.1`**, `GPLv2`, `Creative-Commons-4.0 - Non-commercial`, `Creative-Commons-4.0`

The allowlist permits:

- **MIT / BSD / Apache-2.0 / ISC / PSF / Python-2.0 / CNRI-Python / Zlib / Boost-1.0 / MPL-2.0 / CC0 / Public Domain / Unlicense** — explicit permissive set
- **LGPL-2.1** *only* (per Bernd's regime list; LGPL-3.0 / LGPL-3 deliberately not in regex — see overrides section below)
- **Dual-license OR-expressions** that include a permissive side: `LGPL-2.1-only OR MPL-1.1`, `GPL-3.0 OR Apache-2.0`, etc.

Explicitly NOT on the allowlist: GPL (any), AGPL, SSPL, BUSL, Commons Clause, ELv2, FSL, Proprietary/Other/Unknown, MPL-1.1, NPL, EUPL.

## Override file — current entries

[`license_allowlist_overrides.txt`](.github/scripts/license_allowlist_overrides.txt) has two OSRB-pending entries:

```
svglib       # LGPL-3.0-or-later
python-bidi  # GNU Library or Lesser General Public License (LGPL) — unversioned
```

Both are LGPL-3.0 (or LGPL of unspecified version). Bernd's OSRB regime list names only **LGPL V2.1** — LGPL-3.0 is not explicitly cleared. These overrides are tracked so we can ask OSRB the targeted question (is the LGPL-2.1 dynamic-linking exception extendable to LGPL-3.0?) instead of either pretending it's resolved or silently shipping the deps with the old denylist.

Resolution paths after OSRB answers:
- If OSRB clears LGPL-3.0 generally → the regex relaxes, both override entries drop.
- If OSRB declines LGPL-3.0 → both deps need permissive-licensed replacements.

## Override matching — by package name only

Override entries are keyed on the **package name only**, not on a (name, license) tuple. Once `svglib` is on the override list it stays cleared whether it declares `LGPL-3.0-or-later` today or rev-bumps to something else non-permissive next quarter — the override silently still applies.

Trade-off accepted intentionally:
- **Pros:** simple to maintain; routine version bumps don't churn the override file or re-trigger OSRB review.
- **Cons:** doesn't catch upstream license drift on overridden packages.
- **Mitigation:** reviewer discipline — re-evaluate every entry whenever `services/agent/uv.lock` changes. The set is currently 2 packages, so the cost is small.
- **Upgrade path** (if/when this becomes noisy): change `load_overrides()` to parse `name, expected-license  # comment` lines and require both to match. ~10 lines of additive code; no migration headache since the existing 2-entry file would just need a comma added.

The **denylist** is *correctly* name-only: a denylist entry says "this package is forbidden regardless of what its label claims" — exactly the matching semantics we want, and a future "fixed" version would have to come back in through the override file with explicit OSRB sign-off.

## SPDX expression handling

The evaluator is a recursive descent parser with correct precedence (`AND` binds tighter than `OR`) and explicit handling of `WITH` exceptions. Replaces the previous flat OR/AND splitter that Greptile correctly flagged as soundness-broken on `(A OR B) AND C` patterns.

| Pattern | Result | Why |
|---|---|---|
| `Apache-2.0` | pass | label |
| `Apache-2.0 OR MIT` | pass | user picks either |
| `Apache-2.0 AND MIT` | pass | both permissive |
| `(Apache-2.0 OR MIT) AND GPL-3.0` | **fail** | GPL-3.0 AND clause required — Greptile P1 |
| `MPL-2.0 AND (Apache-2.0 OR MIT)` | pass | both sides satisfiable |
| `Apache-2.0 WITH LLVM-exception` | pass | base is permissive — Greptile P2 |
| `GPL-2.0-only WITH Classpath-exception` | fail | exception cannot rescue non-permissive base |
| `LGPL-2.1-only OR MPL-1.1` | pass | LGPL-2.1 alternative |
| `Mozilla Public License 2.0 (MPL 2.0) AND Apache-2.0` | pass | label-internal parens preserved — Greptile P2 |
| `LGPL-3.0-or-later` | fail | not in allowlist; needs override |
| `GPL-3.0 AND Apache-2.0` | fail | GPL is non-permissive |
| `GPL-3.0 OR Apache-2.0` | pass | user picks Apache-2.0 |

## What this catches

| Surprise case | Old check | New check |
|---|---|---|
| `GPL-3.0` | ✓ fail | ✓ fail |
| `(A OR B) AND GPL-3.0` (Greptile P1) | ⚠ pass | ✓ fail |
| `Apache-2.0 WITH LLVM-exception` (Greptile P2) | ⚠ would have failed pre-parser | ✓ pass |
| `Elastic License 2.0` (honest label) | ⚠ pass | ✓ fail (allowlist) |
| `Commons Clause`, `BUSL-1.1` outside the grep | ⚠ pass | ✓ fail |
| `Other/Proprietary License` | ⚠ pass | ✓ fail |
| Empty / UNKNOWN metadata | ⚠ pass | ✓ fail |
| `arize-phoenix-otel` (lies about Apache-2.0) | ⚠ pass | ✓ fail (denylist) |
| Anything we haven't catalogued yet | ⚠ pass | ✓ fail |

## Files

| File | What |
|---|---|
| `.github/scripts/check_python_licenses.sh` | slim wrapper; pipes `pip-licenses --format=csv` into the Python evaluator |
| `.github/scripts/check_python_licenses.py` (new) | three-layer evaluator + SPDX recursive descent parser (handles `AND`, `OR`, `WITH`, parens, label-internal parens) |
| `.github/scripts/license_allowlist_overrides.txt` (new) | OSRB-cleared named exceptions — currently 2 entries (svglib, python-bidi), OSRB-pending |
| `.github/scripts/license_denylist.txt` (new, empty) | metadata-lies blocklist; `arize-phoenix-otel` documented as the canonical example, commented out until OSRB clears removal |

## Local verification

Final state against `services/agent/uv.lock`:

```
$ uv run pip-licenses --format=csv \
    | python3 .github/scripts/check_python_licenses.py \
        --overrides .github/scripts/license_allowlist_overrides.txt \
        --denylist  .github/scripts/license_denylist.txt
INFO: 2 package(s) cleared via OSRB override:
  python-bidi 0.6.7  ->  'GNU Library or Lesser General Public License (LGPL)'
  svglib 1.6.0  ->  'LGPL-3.0-or-later'

OK: all 231 runtime Python dep(s) carry a permissive license.
```

Unit tests: 37 / 37 pass (regression suite + all Greptile-flagged edge cases).

## Follow-ups (out of scope for this PR)

1. **OSRB question on LGPL-3.0** — clarify whether the V2.1 dynamic-linking exception extends to V3.0. Resolves the two override-file entries one way or the other.
2. **arize-phoenix-otel removal** — replace the dep with `opentelemetry-exporter-otlp` (the wrapper is ~30 LoC) or accept ELv2 explicitly in `LICENSE-3rd-party.txt` + retract the "This project is Apache2 licensed" sweep claim from `LICENSE.md`. Once resolved, the line `arize-phoenix-otel` in `license_denylist.txt` (currently commented out) gets uncommented.

## Test plan

- [ ] CI on this PR's `pull-request/N` mirror: `License Check (Python)` job goes green with the 2 audit-logged overrides.
- [ ] Draft a test PR that adds `gpl-pkg` to a fake compose-only path and confirm the job goes red with the violations message.
- [ ] Same with adding `gpl-pkg` to `license_allowlist_overrides.txt` and confirm it's audit-logged + passes.
- [ ] Same with adding `gpl-pkg` to `license_denylist.txt` and confirm the override no longer rescues it (denylist wins).
