### PR TITLE
fix(ci): add package-name denylist to license-check-python

### DIFF
--- a/.github/scripts/check_python_licenses.py
+++ b/.github/scripts/check_python_licenses.py
@@ -171,17 +171,33 @@ def license_passes(license_field: str) -> bool:
     return False
 
 
+def load_denylist(path: Path) -> set[str]:
+    """Parse the package-name denylist (one canonical pip name per line)."""
+    return load_overrides(path)  # same `#`-comment + per-line format
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--overrides",
         type=Path,
         required=True,
-        help="Path to the package-name override file.",
+        help="Path to the package-name override file (OSRB-cleared exceptions).",
+    )
+    parser.add_argument(
+        "--denylist",
+        type=Path,
+        required=True,
+        help=(
+            "Path to the package-name denylist (always fails, regardless of "
+            "license metadata — for packages whose declared license is known "
+            "to misrepresent the wheel's actual terms)."
+        ),
     )
     args = parser.parse_args()
 
     overrides = load_overrides(args.overrides)
+    denylist = load_denylist(args.denylist)
     reader = csv.reader(sys.stdin)
     header = next(reader, None)
     if header is None:
@@ -196,6 +212,7 @@ def main() -> int:
         print(f"ERROR: unexpected pip-licenses CSV header: {header} ({exc})", file=sys.stderr)
         return 1
 
+    denied: list[tuple[str, str, str]] = []
     violations: list[tuple[str, str, str]] = []
     overridden: list[tuple[str, str, str]] = []
     total = 0
@@ -207,8 +224,14 @@ def main() -> int:
         version = row[version_idx].strip()
         license_field = row[license_idx].strip()
         total += 1
+        # 1. Hard denylist wins over everything (override cannot rescue).
+        if name.lower() in denylist:
+            denied.append((name, version, license_field))
+            continue
+        # 2. Permissive allowlist by license string.
         if license_passes(license_field):
             continue
+        # 3. OSRB-cleared override by package name.
         if name.lower() in overrides:
             overridden.append((name, version, license_field))
             continue
@@ -220,7 +243,21 @@ def main() -> int:
             print(f"  {name} {ver}  ->  {lic!r}")
         print()
 
+    failed = False
+    if denied:
+        failed = True
+        print(f"ERROR: {len(denied)} package(s) on the explicit denylist:")
+        for name, ver, lic in sorted(denied):
+            print(f"  {name} {ver}  ->  declared {lic!r}")
+        print()
+        print("These packages are denied regardless of declared license — their")
+        print("pip metadata misrepresents the wheel's actual terms (e.g. an")
+        print("Apache-2.0 declaration alongside an ELv2 IP_NOTICE in the bundle).")
+        print("To resolve: replace each with a permissive-licensed alternative.")
+        print()
+
     if violations:
+        failed = True
         print(f"ERROR: {len(violations)} package(s) with non-permissive license metadata:")
         for name, ver, lic in sorted(violations):
             print(f"  {name} {ver}  ->  {lic!r}")
@@ -228,11 +265,13 @@ def main() -> int:
         print("To resolve each: either")
         print("  (a) replace the dep with a permissive-licensed alternative,")
         print("  (b) get OSRB sign-off and add the package to")
-        print(f"      .github/scripts/license_allowlist_overrides.txt, or")
+        print("      .github/scripts/license_allowlist_overrides.txt, or")
         print("  (c) if the package's pip metadata is wrong, file the upstream")
         print("      bug, OSRB-clear, and add to the override file with a note.")
-        return 1
+        print()
 
+    if failed:
+        return 1
     print(f"OK: all {total} runtime Python dep(s) carry a permissive license.")
     return 0
 

--- a/.github/scripts/check_python_licenses.sh
+++ b/.github/scripts/check_python_licenses.sh
@@ -18,6 +18,13 @@
 # `.github/scripts/license_allowlist_overrides.txt` (one package name per
 # line, `# comment` lines allowed). Every entry is a documented exception
 # that the OSRB reviewer already signed off on — keep the file short.
+#
+# Denylist mechanism: packages whose declared license MISREPRESENTS the
+# wheel's actual terms (e.g. arize-phoenix-otel declares Apache-2.0 in pip
+# metadata but ships an ELv2 IP_NOTICE) go in
+# `.github/scripts/license_denylist.txt`. Denylist wins over allowlist and
+# overrides — anything on this list always fails. The only fix is to
+# replace the dep with a permissive alternative.
 
 set -euo pipefail
 
@@ -29,4 +36,5 @@ uv pip install --quiet pip-licenses
 
 uv run --no-sync --quiet pip-licenses --format=csv \
   | python3 "$repo_root/.github/scripts/check_python_licenses.py" \
-      --overrides "$repo_root/.github/scripts/license_allowlist_overrides.txt"
+      --overrides "$repo_root/.github/scripts/license_allowlist_overrides.txt" \
+      --denylist  "$repo_root/.github/scripts/license_denylist.txt"

--- a/.github/scripts/license_denylist.txt
+++ b/.github/scripts/license_denylist.txt
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Package-name denylist for the license-check-python job
+# (`.github/scripts/check_python_licenses.py`).
+#
+# Purpose: explicitly fail the build for packages whose declared pip
+# license metadata MISREPRESENTS the wheel's actual terms. The permissive
+# allowlist alone cannot catch these — they pass the allowlist via a fake
+# "Apache-2.0"/"MIT" label while shipping a non-permissive IP_NOTICE /
+# LICENSE-text in the wheel.
+#
+# Denylist wins over allowlist AND over the override file. Anything on this
+# list always fails. The only fix is to replace the dep with a permissive
+# alternative or to fork it under a permissive license.
+#
+# Format: one canonical pip distribution name per line. `#` starts a
+# comment. Every entry MUST be accompanied by an inline comment that:
+#   - states the package's *real* license (the one inside the wheel, not the
+#     one in pip metadata),
+#   - links to the upstream issue / IP_NOTICE / LICENSE evidence,
+#   - links to the OSRB review that flagged it.
+#
+# Example entry (NOT enabled — uncomment + replace dep after OSRB sign-off):
+#
+#   # arize-phoenix-otel  # ELv2 per packages/phoenix-otel/IP_NOTICE in
+#                         # Arize-ai/phoenix; declared Apache-2.0 in
+#                         # pyproject. NVIDIA OSRB has flagged ELv2 as
+#                         # non-permissive. Replace before enabling.
+#   # arize-phoenix       # ELv2 (parent package)
+#   # arize-phoenix-evals # ELv2 (sibling package)
+#
+# (currently empty — enforcement-side ready, no entries enabled yet)


### PR DESCRIPTION
## Why

Stacks on [#570](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/570). The permissive allowlist there catches packages that *honestly declare* a non-permissive license — but not packages whose pip metadata lies about the wheel's actual terms.

Canonical example: `arize-phoenix-otel`.

| | What it says | What's actually in the wheel |
|---|---|---|
| `pyproject.toml` license field | `Apache-2.0` | (the same) |
| PyPI metadata | `Apache-2.0` | (the same) |
| `packages/phoenix-otel/LICENSE` (shipped in wheel) | Apache 2.0 license text | (the same) |
| `packages/phoenix-otel/IP_NOTICE` (shipped in wheel) | **"This software is licensed under the terms of the Elastic License 2.0 (ELv2)"** | (the same — the contradiction) |

The allowlist sees Apache-2.0 and passes. Without a separate catch, ELv2 silently lands in the agent container.

## What changes

Adds a third layer to `.github/scripts/check_python_licenses.py`: `--denylist <file>`. Anything on that list **always fails**, regardless of declared license or override-file membership.

| Layer | Wins over |
|---|---|
| **Denylist** (package name) | everything — there is no override |
| **Allowlist** (license string) | violations |
| **Override** (package name) | the violations the allowlist alone produced |

Files:

- `.github/scripts/check_python_licenses.py` — adds `--denylist` arg + denylist-first ordering in the main loop
- `.github/scripts/check_python_licenses.sh` — passes the new flag
- `.github/scripts/license_denylist.txt` — **empty entries, documented format**; `arize-phoenix-otel` shown commented out as the canonical example

## Why ship empty

If we enable `arize-phoenix-otel` on the denylist today, this PR's CI goes red — because `arize-phoenix-otel` is in `services/agent/uv.lock` (pulled in by `nvidia-nat[phoenix]`). Enabling enforcement requires replacing the dep first.

Shipping the **mechanism** now, with the canonical example commented out, lets OSRB / VSS-team decide the dep-replacement timeline separately from getting the gate live.

## Local verification

Empty denylist (PR state) — all 231 runtime deps pass:

```
$ uv run pip-licenses --format=csv \
    | python3 .github/scripts/check_python_licenses.py \
        --overrides .github/scripts/license_allowlist_overrides.txt \
        --denylist  .github/scripts/license_denylist.txt
OK: all 231 runtime Python dep(s) carry a permissive license.
```

Simulated denylist hit (one-line `arize-phoenix-otel`):

```
$ printf 'arize-phoenix-otel\n' > /tmp/test-denylist.txt
$ uv run pip-licenses --format=csv \
    | python3 .github/scripts/check_python_licenses.py \
        --overrides /tmp/empty.txt --denylist /tmp/test-denylist.txt
ERROR: 1 package(s) on the explicit denylist:
  arize-phoenix-otel 0.14.0  ->  declared 'Apache-2.0'

These packages are denied regardless of declared license — their
pip metadata misrepresents the wheel's actual terms ...
To resolve: replace each with a permissive-licensed alternative.
```

## Test plan

- [ ] CI on this PR's mirror: `License Check (Python)` job remains green (empty denylist).
- [ ] Follow-up: once OSRB clears removal of `arize-phoenix-otel`, uncomment the line in `license_denylist.txt` in a separate PR (will go red until the dep is removed from `services/agent/pyproject.toml` + uv.lock).

> ⚠️  Merge order: #570 first, then this. (PR base is `fix/license-check-python-allowlist`; will auto-retarget to `develop` once #570 merges.)