### PR TITLE
fix(skill-eval): exclude agent/ trajectories from public artifact (keep on-disk for Harbor viewer)

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -208,10 +208,27 @@ jobs:
             echo "no results dir — agent blocked before running trials (expected for blocker outcomes)"
             exit 0
           fi
+          # Strip per-trial agent/ subdirs before tarring. The trajectory
+          # files inside (claude-code.txt, trajectory.json, sessions/)
+          # capture every tool_use → tool_result pair verbatim — so when
+          # the agent reads a `.env` file, runs `docker compose config`,
+          # or cats a resolved compose YAML, the secret env values land
+          # in the trajectory and then ride along into the public
+          # artifact. PR #516's artifact carried NGC_CLI_API_KEY for ~2
+          # days before deletion + rotation; this strip prevents the
+          # next occurrence regardless of whether downstream agents /
+          # skills tighten their own logging. The reward, judge, and
+          # result.json files that the report builder actually consumes
+          # are kept; trajectories remain on the runner-local
+          # `/home/ubuntu/eval-sweep/` tree for live debugging via the
+          # Harbor viewer.
+          STRIPPED=$(find /tmp/skill-eval/results -type d -name agent | wc -l | tr -d ' ')
+          find /tmp/skill-eval/results -type d -name agent -prune -exec rm -rf {} + 2>/dev/null || true
+          echo "stripped $STRIPPED agent/ subdir(s) from results tree before tarring"
           RESULTS=$(find /tmp/skill-eval/results -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
           if [ -n "$RESULTS" ]; then
             tar czf /tmp/skills-eval-results.tar.gz -C /tmp/skill-eval results
-            echo "archived $(echo "$RESULTS" | wc -l) result.json files"
+            echo "archived $(echo "$RESULTS" | wc -l) result.json files (trajectories excluded)"
           else
             echo "results dir exists but empty — nothing to archive"
           fi

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -208,27 +208,31 @@ jobs:
             echo "no results dir — agent blocked before running trials (expected for blocker outcomes)"
             exit 0
           fi
-          # Strip per-trial agent/ subdirs before tarring. The trajectory
-          # files inside (claude-code.txt, trajectory.json, sessions/)
-          # capture every tool_use → tool_result pair verbatim — so when
-          # the agent reads a `.env` file, runs `docker compose config`,
-          # or cats a resolved compose YAML, the secret env values land
-          # in the trajectory and then ride along into the public
-          # artifact. PR #516's artifact carried NGC_CLI_API_KEY for ~2
-          # days before deletion + rotation; this strip prevents the
-          # next occurrence regardless of whether downstream agents /
-          # skills tighten their own logging. The reward, judge, and
-          # result.json files that the report builder actually consumes
-          # are kept; trajectories remain on the runner-local
-          # `/home/ubuntu/eval-sweep/` tree for live debugging via the
-          # Harbor viewer.
-          STRIPPED=$(find /tmp/skill-eval/results -type d -name agent | wc -l | tr -d ' ')
-          find /tmp/skill-eval/results -type d -name agent -prune -exec rm -rf {} + 2>/dev/null || true
-          echo "stripped $STRIPPED agent/ subdir(s) from results tree before tarring"
+          # Exclude per-trial agent/ subdirs from the artifact tarball
+          # (NOT from the runner-local tree). The trajectory files
+          # inside (claude-code.txt, trajectory.json, sessions/) capture
+          # every tool_use → tool_result pair verbatim — so when the
+          # agent reads a `.env` file, runs `docker compose config`, or
+          # cats a resolved compose YAML, the secret env values land in
+          # the trajectory and then ride along into the public artifact.
+          # PR #516's artifact carried NGC_CLI_API_KEY for ~2 days
+          # before deletion + rotation; this exclusion prevents the next
+          # occurrence regardless of whether downstream agents / skills
+          # tighten their own logging.
+          #
+          # `tar --exclude='agent'` removes those subdirs from the
+          # archive only — the on-disk `/tmp/skill-eval/results/` tree
+          # is left intact, so the harbor-view systemd unit serving
+          # `/tmp/skill-eval/results/_viewer/` keeps rendering the full
+          # trajectory (`Trace` tab) for operators who hit
+          # `https://harbor-<BREV_ENV_ID>.brevlab.com/jobs/...`.
+          # Reward, judge, and result.json — which the report builder
+          # actually consumes — stay in the artifact.
           RESULTS=$(find /tmp/skill-eval/results -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
           if [ -n "$RESULTS" ]; then
-            tar czf /tmp/skills-eval-results.tar.gz -C /tmp/skill-eval results
-            echo "archived $(echo "$RESULTS" | wc -l) result.json files (trajectories excluded)"
+            tar czf /tmp/skills-eval-results.tar.gz \
+              -C /tmp/skill-eval --exclude='agent' results
+            echo "archived $(echo "$RESULTS" | wc -l) result.json files (agent/ trajectories excluded; on-disk tree preserved for harbor view)"
           else
             echo "results dir exists but empty — nothing to archive"
           fi


### PR DESCRIPTION
## Summary

Closes a public-artifact secret-leak class. PR #516's eval artifact (`skills-eval-results-pr-516-26053007355.tar.gz`) carried `NGC_CLI_API_KEY` in `agent/claude-code.txt` for ~2 days before it was caught. The key has been rotated and the artifact deleted, but the **leak surface is generic** — any future skill that reads or expands env-containing files reproduces the same pattern, and today's workflow uploads the trajectory regardless.

## Root cause (short)

`skill-eval`'s **"Collect results for workflow artifact"** step tars the entire `/tmp/skill-eval/results/` tree, including every trial's `agent/` subdir. Harbor populates that subdir with the full Claude Code trajectory: `claude-code.txt` (JSONL of every `tool_use` → `tool_result` pair), `trajectory.json`, and a `sessions/` snapshot. The trajectory captures any text the agent ever read or rendered — including:

- buggy diagnostics like `echo "${NGC_CLI_API_KEY:+SET}${NGC_CLI_API_KEY:-NOT SET}"` (when the var is set, **both** expansions fire and the output is `SET<literal-key>`)
- normal flows like `docker compose config` / `cat resolved.yml` whose `environment:` block has secret values inlined

The public-artifact upload then publishes that trajectory to anyone who can guess the URL.

## Fix

One change: strip per-trial `agent/` subdirs from the results tree **before tarring**:

```bash
STRIPPED=$(find /tmp/skill-eval/results -type d -name agent | wc -l | tr -d ' ')
find /tmp/skill-eval/results -type d -name agent -prune -exec rm -rf {} + 2>/dev/null || true
echo "stripped $STRIPPED agent/ subdir(s) from results tree before tarring"
```

The artifact keeps:
- `result.json` (trial metadata)
- `verifier/reward.txt` (score)
- `verifier/judge.json` (per-check pass/fail + rationale)
- `verifier/test-stdout.txt` / `test-stderr.txt`

Which is exactly what the v2 report builder (`build_report_v2.py`) reads. Token-count stats are derived from `agent/claude-code.txt`; the report builder will still find those on the runner-local `/home/ubuntu/eval-sweep/results-<skill>-v2/` tree since that path is untouched. Only the public artifact is slimmed.

## Why this is defense-in-depth

Two upstream issues should still be fixed independently (see "Out of scope" below):

1. The buggy `${VAR:+SET}${VAR:-NOT SET}` diagnostic that re-emits the key value.
2. The agent dumping fully-resolved compose YAMLs with env values inlined.

But both of those leave **runner-local trajectories** containing secrets, and the next person who broadens this workflow's audience could reintroduce a similar artifact path. Stripping the trajectory at the artifact boundary makes the leak resistant to upstream regressions: even if a skill misbehaves, the secret never reaches the public artifact.

## What was leaked + remediation done

- **Artifact**: `skills-eval-results-pr-516-26053007355` (1.32 GB) — deleted via `gh api -X DELETE ...artifacts/7067098862` before this PR was drafted.
- **Key**: `NGC_CLI_API_KEY` — operator-side rotation required (treat the prior value as compromised regardless of whether anyone downloaded it).

## Test plan

- [ ] Merge → next push-driven skills-eval run uploads an artifact; check that `tar tzf <artifact>` shows no `agent/` paths.
- [ ] Confirm the local `/home/ubuntu/eval-sweep/results-*/` tree still has the trajectories (live debugging via Harbor viewer should be unaffected).
- [ ] Confirm `build_report_v2.py` still produces per-skill cost / token / reward rows when run on the box (its data sources — `result.json`, `reward.txt`, `judge.json`, plus on-box `claude-code.txt` — are all intact).

## Out of scope (separate follow-ups)

- Fix the buggy `${VAR:+SET}${VAR:-NOT SET}` diagnostic in the `ngc` skill.
- Tighten the agent / skill instructions so resolved compose YAMLs aren't cat'd verbatim into trajectories on the runner.