### PR TITLE
Feat/remove agent browesr skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ __pycache__/
 # vss-deploy-profile skill on every deploy.
 **/generated.env
 deploy/docker/resolved.yml
+
+*.log
+*checkpoint.*
+.orchestrator-artifacts/*

--- a/.openclaw/index.ts
+++ b/.openclaw/index.ts
@@ -15,7 +15,6 @@ export default function register(api: {
 }) {
   copyWorkspaceTemplates(api);
   patchGatewayDockerGroup(api);
-  installAgentBrowserSkill(api);
 }
 
 function resolveVariant(pluginDir: string, logger: Logger): string | undefined {
@@ -75,28 +74,6 @@ function copyWorkspaceTemplates(api: {
     }
   } catch (err) {
     api.logger.warn(`[vss-claw] workspace copy failed: ${err}`);
-  }
-}
-
-function installAgentBrowserSkill(api: {
-  config: { agents?: { defaults?: { workspace?: string } } };
-  logger: Logger;
-}) {
-  const workspaceDir = api.config?.agents?.defaults?.workspace;
-  if (!workspaceDir) return;
-
-  const skillDir = join(workspaceDir, "skills", "agent-browser");
-  if (existsSync(skillDir)) return;
-
-  try {
-    mkdirSync(join(workspaceDir, "skills"), { recursive: true });
-    execSync("npx --yes skills add vercel-labs/agent-browser --yes", {
-      cwd: workspaceDir,
-      stdio: "ignore",
-    });
-    api.logger.info("[vss-claw] installed agent-browser skill into workspace");
-  } catch (err) {
-    api.logger.warn(`[vss-claw] agent-browser skill install failed: ${err}`);
   }
 }
 

--- a/.openclaw/workspace/AGENTS.md
+++ b/.openclaw/workspace/AGENTS.md
@@ -117,32 +117,6 @@ Reactions are lightweight social signals. Humans use them constantly — they sa
 
 Skills provide your tools. When you need one, check its `SKILL.md`. Keep local notes (camera names, SSH details, voice preferences) in `TOOLS.md`.
 
-### VSS Browser Conventions
-
-> **You have `agent-browser` available. When the user asks you to interact with the VSS UI, VIOS dashboard, or any web UI — do it yourself using `agent-browser`. Do NOT give the user click-by-click instructions or ask them to open a browser.**
->
-> **You also have `curl` and shell access. For VSS API operations (adding streams, submitting alerts, querying sensors) — run the curl commands yourself. Do NOT tell the user to run them.**
-
-- Use CDP mode to connect to the user's already-running Chrome — no headless browser needed:
-  ```bash
-  npx agent-browser --auto-connect snapshot -i   # auto-discover running Chrome
-  # or if auto-connect fails:
-  npx agent-browser --cdp 9222 snapshot -i       # connect to Chrome on CDP port 9222
-  ```
-  Chrome must be launched with `--remote-debugging-port=9222` for `--cdp` to work. `--auto-connect` tries to find it automatically.
-- Always snapshot first to get element refs, then interact:
-  ```bash
-  npx agent-browser --auto-connect snapshot -i
-  npx agent-browser --auto-connect fill @e3 "some value"
-  npx agent-browser --auto-connect click @e5
-  npx agent-browser --auto-connect snapshot -i   # re-snapshot after interaction
-  ```
-- If a form field or button ref isn't obvious from the snapshot, take a screenshot:
-  ```bash
-  npx agent-browser --auto-connect screenshot --path /tmp/vss-screen.png
-  ```
-- **Always send screenshots to the user via Slack (or whatever channel this session is on) immediately after taking them.** Never save to disk silently — the user needs to see it.
-- **This also applies to VIOS snapshots** — after saving a snapshot with `curl ... --output /tmp/snapshot.jpg`, immediately upload the file to Slack using the `message` tool. Do NOT just tell the user the file path.
 
 ### VSS Deploy Conventions
 

--- a/.openclaw/workspace/_nemoclaw/AGENTS.md
+++ b/.openclaw/workspace/_nemoclaw/AGENTS.md
@@ -117,32 +117,6 @@ Reactions are lightweight social signals. Humans use them constantly — they sa
 
 Skills provide your tools. When you need one, check its `SKILL.md`. Keep local notes (camera names, SSH details, voice preferences) in `TOOLS.md`.
 
-### VSS Browser Conventions
-
-> **You have `agent-browser` available. When the user asks you to interact with the VSS UI, VIOS dashboard, or any web UI — do it yourself using `agent-browser`. Do NOT give the user click-by-click instructions or ask them to open a browser.**
->
-> **You also have `curl` and shell access. For VSS API operations (adding streams, submitting alerts, querying sensors) — run the curl commands yourself. Do NOT tell the user to run them.**
-
-- Use CDP mode to connect to the user's already-running Chrome — no headless browser needed:
-  ```bash
-  npx agent-browser --auto-connect snapshot -i   # auto-discover running Chrome
-  # or if auto-connect fails:
-  npx agent-browser --cdp 9222 snapshot -i       # connect to Chrome on CDP port 9222
-  ```
-  Chrome must be launched with `--remote-debugging-port=9222` for `--cdp` to work. `--auto-connect` tries to find it automatically.
-- Always snapshot first to get element refs, then interact:
-  ```bash
-  npx agent-browser --auto-connect snapshot -i
-  npx agent-browser --auto-connect fill @e3 "some value"
-  npx agent-browser --auto-connect click @e5
-  npx agent-browser --auto-connect snapshot -i   # re-snapshot after interaction
-  ```
-- If a form field or button ref isn't obvious from the snapshot, take a screenshot:
-  ```bash
-  npx agent-browser --auto-connect screenshot --path /tmp/vss-screen.png
-  ```
-- **Always send screenshots to the user via Slack (or whatever channel this session is on) immediately after taking them.** Never save to disk silently — the user needs to see it.
-- **This also applies to VIOS snapshots** — after saving a snapshot with `curl ... --output /tmp/snapshot.jpg`, immediately upload the file to Slack using the `message` tool. Do NOT just tell the user the file path.
 
 ### VSS Deploy Conventions
 

--- a/skills/vss-search-archive/SKILL.md
+++ b/skills/vss-search-archive/SKILL.md
@@ -167,15 +167,3 @@ find someone wearing a red jacket
 ```
 
 Results include timestamped clips with similarity scores.
-
----
-
-## Interact via Browser (agent-browser)
-
-```bash
-npx agent-browser --auto-connect open http://${HOST_IP}:3000
-npx agent-browser --auto-connect wait --load networkidle
-npx agent-browser --auto-connect snapshot -i
-```
-
-Find the chat input, enter a search query, and snapshot results.


### PR DESCRIPTION
## Description
Remove agent-browser from skills (confirmed with Zac from [slack](https://nvidia.slack.com/archives/C0AKMT8FWP9/p1779300416455679?thread_ts=1779230233.102709&cid=C0AKMT8FWP9) to avoid security error from NemoClaw

`ls] (12/12)
  [sandbox-state 2026-05-20T16:54:50.590Z] Pre-backup audit: checking for symlinks, hard links, and special files
  [sandbox-state 2026-05-20T16:54:50.707Z] SECURITY: Pre-backup audit found 1 unsafe entries: l /sandbox/.openclaw/workspace/skills/agent-browser
  [rebuild 2026-05-20T16:54:50.707Z] Backup result: success=false, backed=, failed=agents,extensions,workspace,skills,hooks,identity,devices,canvas,cron,memory,telegram,credentials
  Failed to back up sandbox state.
  Failed: agents, extensions, workspace, skills, hooks, identity, devices, canvas, cron, memory, telegram, credentials
  Aborting rebuild to prevent data loss.`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
