### PR TITLE
eval(vss-summarize-video): drop total_events / uuid from response-shape check

### DIFF
--- a/skills/vss-summarize-video/evals/lvs_profile_summarize.json
+++ b/skills/vss-summarize-video/evals/lvs_profile_summarize.json
@@ -19,7 +19,7 @@
         "The agent issues exactly one POST http://localhost:38111/v1/summarize call \u2014 not zero, not two, no parallel hedging",
         "The POST /v1/summarize request body is application/json and contains the keys {url, model, scenario, events, chunk_duration, num_frames_per_second_or_fixed_frames_chunk, use_fps_for_chunking}; scenario equals 'warehouse monitoring' and events equals the three user-supplied strings verbatim",
         "The LVS response is HTTP 200 and the body is an OpenAI-style envelope with choices[0].message.content populated as a JSON-encoded string",
-        "Parsing choices[0].message.content as JSON yields an object with non-empty fields {video_summary, events, total_events, uuid}",
+        "Parsing choices[0].message.content as JSON yields an object with non-empty fields {video_summary, events}",
         "events is a non-empty array and every element has the keys {id, start_time, end_time, type, description}",
         "The agent renders the video_summary field verbatim in its final reply \u2014 no paraphrasing, no added emojis, no re-voicing",
         "The agent renders every event returned by LVS (not a subset), preserving the description field in full",


### PR DESCRIPTION
## Description

Removes two phantom fields from the `lvs_profile_summarize` response-shape check. The spec asserted that `choices[0].message.content` parses to an object with `{video_summary, events, total_events, uuid}`, but the live LVS `/v1/summarize` response only returns `{video_summary, events}` - `total_events` and `uuid` are not part of the GA API surface and the skill docs never reference them. The check was unreachable by design.

Verified against a live VSS lvs deployment: the LVS response keys are `video_summary`, `events`, and inside each event `{id, start_time, end_time, type, description}` - no `total_events`, no top-level `uuid`.

Expected impact: `lvs_profile_summarize` step-1 reward 0.875 (7/8) -> 1.0 (8/8). The PR that fixed the agent-flow bug (#574) raised the reward from 0.125 to 0.875; this PR clears the last failing check.

The other 7 checks (POST count, request body shape, HTTP 200, event keys, verbatim rendering, etc.) are untouched.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.