### PR TITLE
skill(vss-summarize-video): apply canonical defaults in autonomous mode

### DIFF
--- a/skills/vss-summarize-video/SKILL.md
+++ b/skills/vss-summarize-video/SKILL.md
@@ -257,6 +257,16 @@ captioning, metrics, or recommended config, read
 
 Full scenario/events collection walk-through lives in [`references/hitl-prompts.md`](references/hitl-prompts.md). Always run this step before calling LVS.
 
+**Autonomous-mode defaults.** When HITL is bypassed (caller said "run
+autonomously without prompting for confirmation") and the original
+query asks for `default` / `defaults` scenario/events - or gives none -
+use `scenario="activity monitoring"` and `events=["notable activity"]`
+**verbatim**. Do not infer the scenario from the video filename or
+sensor name. In the final reply, note that you used the generic
+defaults and offer to redo with more specific parameters. See
+[`references/hitl-prompts.md`](references/hitl-prompts.md) for the
+canonical defaults rule.
+
 Prefer the 3.2 GA versioned route `POST /v1/summarize`. The OpenAPI spec also
 exposes `/summarize` as a compatibility alias, but new examples should use
 `/v1/summarize`.

--- a/skills/vss-summarize-video/references/hitl-prompts.md
+++ b/skills/vss-summarize-video/references/hitl-prompts.md
@@ -109,6 +109,18 @@ mention in your response that you used generic defaults (offer to redo
 with more specific parameters). **Do not apply defaults without that
 explicit opt-in** — the HITL message is the gate.
 
+**Defaults opt-in via the original query (autonomous mode).** When HITL
+is bypassed (e.g. the caller said "run autonomously without prompting
+for confirmation") and the original query contains the word `default`
+or `defaults` for scenario/events, treat that as the same opt-in as a
+HITL `defaults` reply: use `scenario="activity monitoring"` and
+`events=["notable activity"]` **verbatim** - do not infer the scenario
+from the video filename, sensor name, or any other context. In the
+final reply, note that you used the generic defaults and offer to redo
+with more specific parameters. The same rule applies if the original
+query gives no scenario/events at all and HITL is bypassed - use the
+canonical defaults rather than guessing.
+
 **Request:**
 
 ```bash


### PR DESCRIPTION
## Description

Fixes the `lvs_profile_summarize` step-2 failure (1/3 -> 3/3 expected) where the agent, running with HITL bypassed via "run autonomously without prompting for confirmation," used the wrong scenario value and never mentioned defaults in its reply.

## Root cause

The skill recognized only the literal HITL reply `defaults` as the opt-in for the canonical defaults (`scenario="activity monitoring"`, `events=["notable activity"]`). When HITL is bypassed and the original query says *"using default scenario and events"*, the agent had no skill-level guidance for how to resolve "default", fell through the HITL gate, inferred `scenario='warehouse monitoring'` from the video filename, and skipped the "I used generic defaults, want to redo?" framing.

This is a coverage gap in the skill (would have failed before PR #574 too), not a regression.

## Fix

Add an "Autonomous-mode defaults" carve-out:
- `skills/vss-summarize-video/SKILL.md` (Step 2b)
- `skills/vss-summarize-video/references/hitl-prompts.md` (scenario/events section)

When HITL is bypassed and the original query asks for `default` / `defaults` scenario/events (or supplies none at all), use `scenario="activity monitoring"` and `events=["notable activity"]` verbatim. Do not infer scenario from the video filename or sensor name. In the final reply, note that you used the generic defaults and offer to redo with more specific parameters.

Anchored in both files so the agent finds the rule whichever it reads first.

## Test plan

Verified locally against a live VSS lvs deployment with the verbatim step-2 query *"Summarize the uploaded warehouse video using default scenario and events."*:

| Check | Result |
|---|---|
| POST `/v1/summarize` body has `scenario='activity monitoring'` AND `events=['notable activity']` | PASS - sent exactly those values verbatim |
| LVS returns 200 with non-empty `video_summary` and `events` | PASS |
| Final reply notes defaults were used + offers to redo with specifics | PASS - *"Note: This run used the autonomous-mode generic defaults ... Let me know if you'd like to rerun with a warehouse-specific scenario (e.g. `warehouse safety monitoring`) or targeted events ..."* |

Confirmed the agent did NOT pick `warehouse monitoring` from the video name (`sample_warehouse`), which was the previous failure mode.

Combined effect of the three related PRs:
- PR #574 (merged): step-1 1/8 -> 7/8 (agent reaches POST /v1/summarize)
- PR #576 (merged): step-1 7/8 -> 8/8 (spec matches real LVS response shape)
- This PR: step-2 1/3 -> 3/3 (canonical defaults in autonomous mode)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.