### PR TITLE
ci(skill-eval, skill-nv-base): add vss-deploy-video-embedding to dispatch dropdown

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -43,6 +43,7 @@ on:
           - vss-ask-video
           - vss-deploy-dense-captioning
           - vss-deploy-profile
+          - vss-deploy-video-embedding
           - vss-generate-video-report
           - vss-manage-alerts
           - vss-manage-video-io-storage

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -55,6 +55,7 @@ on:
           - vss-ask-video
           - vss-deploy-dense-captioning
           - vss-deploy-profile
+          - vss-deploy-video-embedding
           - vss-generate-video-report
           - vss-manage-alerts
           - vss-manage-video-io-storage


### PR DESCRIPTION
## Summary

Manual `workflow_dispatch` on both **Skills Eval** and **Skills NV-BASE** exposes a `type: choice` skills dropdown. The list was hardcoded in PR #524 / #528 against the 8 adapters that existed at the time and hasn't been bumped since.

**`vss-deploy-video-embedding`** landed on develop more recently with a complete `eval/` spec + adapter, so it's eval-ready today — but operators couldn't trigger it through the UI.

## Audit

Comparing `skills/` on develop (14 skills) vs. the dropdown options (8 + `*`):

| Skill | eval/ spec? | Adapter? | Status |
|---|---|---|---|
| **vss-deploy-video-embedding** | ✅ | ✅ | **adding in this PR** |
| vss-generate-video-calibration | ✅ | ❌ | left off — would trigger bot-PR adapter flow |
| vss-generate-video-report-rag | ❌ | ❌ | left off — not eval-ready |
| vss-query-analytics | ❌ | ❌ | same |
| vss-setup-behavior-analytics | ❌ | ❌ | same |
| vss-setup-video-analytics-api | ❌ | ❌ | same |

## Heads-up — choice cap

GitHub Actions `type: choice` is soft-capped at 10 options. After this PR we sit at exactly **10** (`*` + 9 skills). The next skill to come online will need either:
- `type: string` (loses dropdown validation but unlimited), or
- Two split dropdowns (deploy / use), each <10 options.

Documenting now so the next maintainer doesn't get caught by the limit.

## Test plan

- [ ] Merge → Actions → Skills Eval → "Run workflow": confirm `vss-deploy-video-embedding` is selectable in the dropdown.
- [ ] Same on Skills NV-BASE.
- [ ] Dispatch the new option against `develop` and confirm the eval picks up the adapter + spec.