### PR TITLE
Allow Nemoclaw access to developer profile app ports

### DIFF
--- a/assets/vss_nemoclaw_policy.yaml
+++ b/assets/vss_nemoclaw_policy.yaml
@@ -1,4 +1,4 @@
-version: 2
+version: 3
 
 filesystem_policy:
   include_workdir: true
@@ -227,49 +227,12 @@ network_policies:
   vss-backend:
     name: vss-backend-readwrite
     endpoints:
-    - host: host.openshell.internal
-      port: 8000
-      access: full
-      allowed_ips:
-      - 172.17.0.0/24
-    - host: host.openshell.internal
-      port: 30888
-      access: full
-      allowed_ips:
-      - 172.17.0.0/24
-    - host: host.openshell.internal
-      port: 5601
-      access: full
-      allowed_ips:
-      - 172.17.0.0/24
-    - host: host.openshell.internal
-      port: 9200
-      access: full
-      allowed_ips:
-      - 172.17.0.0/24
-    - host: host.openshell.internal
-      port: 8081
-      access: full
-      allowed_ips:
-      - 172.17.0.0/24
-    - host: host.openshell.internal
-      port: 9080
-      access: full
-      allowed_ips:
-      - 172.17.0.0/24
-    - host: host.openshell.internal
-      port: 9988
-      access: full
-      allowed_ips:
-      - 172.17.0.0/24
-    - host: host.openshell.internal
-      port: 18789
-      access: full
-      allowed_ips:
-      - 172.17.0.0/24
-    # Agent UI (3000), Auto-Calibration UI (5000), Phoenix (6006), VST MCP (8001),
-    # Auto-Calibration MS (8010), RT-Embed (8017), RT-VLM (8018), Kafka (9092),
-    # VA-MCP (9901), NvStreamer UI (31000), LVS REST (38111), LVS MCP (38112).
+    # VSS developer-profile app-facing endpoints: Agent UI (3000),
+    # Auto-Calibration UI/MS (5000/8010), Phoenix (6006), GraphRAG UI/API
+    # (30081/30082), VST (30888) and VST MCP (8001), NvStreamer UI (31000),
+    # OpenClaw dashboard/hooks (18789), RT-Embed/RT-VLM (8017/8018), Kafka
+    # (9092), VA-MCP (9901), LVS REST/MCP (38111/38112), plus shared infra
+    # endpoints used by skills.
     - host: host.openshell.internal
       port: 3000
       access: full
@@ -281,7 +244,22 @@ network_policies:
       allowed_ips:
       - 172.17.0.0/24
     - host: host.openshell.internal
+      port: 5601
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
       port: 6006
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 7777
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 8000
       access: full
       allowed_ips:
       - 172.17.0.0/24
@@ -306,12 +284,52 @@ network_policies:
       allowed_ips:
       - 172.17.0.0/24
     - host: host.openshell.internal
+      port: 8081
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 9080
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
       port: 9092
       access: full
       allowed_ips:
       - 172.17.0.0/24
     - host: host.openshell.internal
+      port: 9200
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
       port: 9901
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 9988
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 18789
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 30081
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 30082
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 30888
       access: full
       allowed_ips:
       - 172.17.0.0/24


### PR DESCRIPTION
## Summary
- Bump the Nemoclaw policy version to 3.
- Add app/skill-facing developer-profile endpoints to the `vss-backend` `host.openshell.internal` allow-list.
- Cover UI/ingress/observability, model endpoints, RT-Embed/RT-VLM, LVS REST, nvstreamer, and VA-MCP while leaving internal broker/data-plane ports out of scope.

## Validation
- `python3 -c "import yaml, sys; yaml.safe_load(open('assets/vss_nemoclaw_policy.yaml')); print('yaml ok')"`
- `git diff --check`
- Read-only subagent review: no findings; confirmed internal ports like `9092`, `6379`, `30000`, `30001`