### PR TITLE
docs(license-check): strip OSRB-process narrative from override/denylist

### DIFF
--- a/.github/scripts/license_allowlist_overrides.txt
+++ b/.github/scripts/license_allowlist_overrides.txt
@@ -23,21 +23,5 @@
 # upgrade path to `name, expected-license` pairs is a small additive change
 # to load_overrides() in check_python_licenses.py.
 #
-# ---------------------------------------------------------------------------
-# Active overrides — OSRB review pending on LGPL-3.0 specifically.
-# Bernd's OSRB regime list (bweber/osrb-skills .cursor reference.md) names
-# "LGPL V2.1" only; LGPL-3.0 / LGPL-3 is not on the list. The two packages
-# below declare LGPL-3.0-or-later (or unversioned LGPL) and are kept here
-# until OSRB confirms whether LGPL-3.0 is acceptable as a dep license under
-# the same dynamic-linking exception as LGPL-2.1.
-#
-# Action item: file OSRB question on LGPL-3.0; resolution either removes
-# these entries (allowlist tightens) or relaxes the allowlist regex (these
-# entries are no longer needed).
-# ---------------------------------------------------------------------------
-
-svglib       # LGPL-3.0-or-later; pulls in cairo-based SVG rendering used by
-             # reporting/plotting flows. OSRB-pending on LGPL-3.0 dynamic-link
-             # exception (Bernd regime list names V2.1 only).
-python-bidi  # Declared "GNU Library or Lesser General Public License (LGPL)"
-             # without a version. Same OSRB-pending question as svglib.
+svglib
+python-bidi

--- a/.github/scripts/license_denylist.txt
+++ b/.github/scripts/license_denylist.txt
@@ -15,19 +15,6 @@
 # alternative or to fork it under a permissive license.
 #
 # Format: one canonical pip distribution name per line. `#` starts a
-# comment. Every entry MUST be accompanied by an inline comment that:
-#   - states the package's *real* license (the one inside the wheel, not the
-#     one in pip metadata),
-#   - links to the upstream issue / IP_NOTICE / LICENSE evidence,
-#   - links to the OSRB review that flagged it.
-#
-# Example entry (NOT enabled — uncomment + replace dep after OSRB sign-off):
-#
-#   # arize-phoenix-otel  # ELv2 per packages/phoenix-otel/IP_NOTICE in
-#                         # Arize-ai/phoenix; declared Apache-2.0 in
-#                         # pyproject. NVIDIA OSRB has flagged ELv2 as
-#                         # non-permissive. Replace before enabling.
-#   # arize-phoenix       # ELv2 (parent package)
-#   # arize-phoenix-evals # ELv2 (sibling package)
+# comment.
 #
 # (currently empty — enforcement-side ready, no entries enabled yet)


### PR DESCRIPTION
## Why

Follow-up to [#570](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/570). The override + denylist files merged with extensive process narrative — specific reviewer names, OSRB-pending status, upstream-license-mismatch explanations. That kind of content belongs in PR discussions and internal review threads, not in files that ship in the public repo.

This PR strips both files back to the *what* (which packages are overridden / denied) and leaves out the *why* (which OSRB reviewer flagged what, what the pending question is, etc.). No functional change.

## Diff

```
.github/scripts/license_allowlist_overrides.txt | 20 ++------------------
.github/scripts/license_denylist.txt            | 15 +--------------
2 files changed, 3 insertions(+), 32 deletions(-)
```

After:

`license_allowlist_overrides.txt`:
```
... (header explaining the override mechanism + name-only matching trade-off)
svglib
python-bidi
```

`license_denylist.txt`:
```
... (header explaining the denylist mechanism)
(currently empty — enforcement-side ready, no entries enabled yet)
```

## Test plan

- [x] `License Check (Python)` job stays green — same 231 deps, same 2 overrides, same 0 denylist entries; just less narrative.