### PR TITLE
Fix/udpate all skills to use host ip and whitelist additional ports in nemoclaw

### DIFF
--- a/.openclaw/workspace/_nemoclaw/AGENTS.md
+++ b/.openclaw/workspace/_nemoclaw/AGENTS.md
@@ -10,10 +10,11 @@ If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out w
 
 Before doing anything else:
 
-1. Read `SOUL.md` — this is who you are
-2. Read `USER.md` — this is who you're helping
-3. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
-4. **If in MAIN SESSION** (direct chat with your human): Also read `MEMORY.md`
+1. Run every `export` in `ENV.md` to set the sandbox environment. The sandbox's `/sandbox/.bashrc` is root-owned read-only, so these can't be persisted to a shell init file — re-run every session. `ENV.md` is the single source of truth for these values; do not hardcode them anywhere else.
+2. Read `SOUL.md` — this is who you are
+3. Read `USER.md` — this is who you're helping
+4. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
+5. **If in MAIN SESSION** (direct chat with your human): Also read `MEMORY.md`
 
 Don't ask permission. Just do it.
 

--- a/.openclaw/workspace/_nemoclaw/BOOTSTRAP.md
+++ b/.openclaw/workspace/_nemoclaw/BOOTSTRAP.md
@@ -10,21 +10,16 @@ through the VSS Orchestrator MCP server.
 
 ---
 
-## Step 1: Pin HOST_IP to the sandbox host alias
+## Step 1: Run AGENTS.md "Every Session" first
 
-In the nemoclaw / openshell sandbox the egress policy only whitelists the VSS backend ports on the hostname `host.openshell.internal`. Direct curls to a LAN IP or `localhost` are blocked with `policy_denied`. Skills curl `${HOST_IP}` for every runtime call, so override `HOST_IP` once here and persist it — every skill then works without modification.
+Complete the `AGENTS.md` "Every Session" checklist before continuing. In particular, Step 1 there runs the exports in `ENV.md`, which the rest of this bootstrap and every skill depends on. The nemoclaw egress policy blocks direct curls to a LAN IP or `localhost` with `policy_denied`, so `${HOST_IP}` must be set first. `ENV.md` is the single source of truth for the value — read it there.
 
-```bash
-export HOST_IP=host.openshell.internal
-grep -q '^export HOST_IP=' ~/.bashrc \
-  && sed -i 's|^export HOST_IP=.*|export HOST_IP=host.openshell.internal|' ~/.bashrc \
-  || echo 'export HOST_IP=host.openshell.internal' >> ~/.bashrc
-```
+`/sandbox/.bashrc` is root-owned (mode `444`) in this sandbox — we cannot persist these exports to a shell init file, so the "Every Session" re-export is the persistence mechanism. See `ENV.md` and `TOOLS.md` "Sandbox host alias" for the full reasoning.
 
-Verify reachability before moving on:
+Then verify reachability:
 
 ```bash
-getent hosts host.openshell.internal && \
+getent hosts "${HOST_IP}" && \
   curl -sf --max-time 5 "http://${HOST_IP}:9988/" >/dev/null && echo "host alias reachable"
 ```
 

--- a/.openclaw/workspace/_nemoclaw/BOOTSTRAP.md
+++ b/.openclaw/workspace/_nemoclaw/BOOTSTRAP.md
@@ -10,7 +10,29 @@ through the VSS Orchestrator MCP server.
 
 ---
 
-## Step 1: Confirm the MCP server
+## Step 1: Pin HOST_IP to the sandbox host alias
+
+In the nemoclaw / openshell sandbox the egress policy only whitelists the VSS backend ports on the hostname `host.openshell.internal`. Direct curls to a LAN IP or `localhost` are blocked with `policy_denied`. Skills curl `${HOST_IP}` for every runtime call, so override `HOST_IP` once here and persist it — every skill then works without modification.
+
+```bash
+export HOST_IP=host.openshell.internal
+grep -q '^export HOST_IP=' ~/.bashrc \
+  && sed -i 's|^export HOST_IP=.*|export HOST_IP=host.openshell.internal|' ~/.bashrc \
+  || echo 'export HOST_IP=host.openshell.internal' >> ~/.bashrc
+```
+
+Verify reachability before moving on:
+
+```bash
+getent hosts host.openshell.internal && \
+  curl -sf --max-time 5 "http://${HOST_IP}:9988/" >/dev/null && echo "host alias reachable"
+```
+
+If `getent` fails or curl returns `policy_denied`, stop and tell the user the `vss-backend` network policy isn't applied to this sandbox.
+
+---
+
+## Step 2: Confirm the MCP server
 
 Follow the handshake-and-discover procedure in `TOOLS.md` (initialize →
 `notifications/initialized` → `tools/list`), then call the prerequisite-check
@@ -22,7 +44,7 @@ yourself.
 
 ---
 
-## Step 2: Offer Next Steps
+## Step 3: Offer Next Steps
 
 > "Ready. I can bring up one of the VSS Blueprint profiles — base, search, lvs,
 > or alerts — via the orchestrator. Which would you like?"

--- a/.openclaw/workspace/_nemoclaw/BOOTSTRAP.md
+++ b/.openclaw/workspace/_nemoclaw/BOOTSTRAP.md
@@ -10,20 +10,12 @@ through the VSS Orchestrator MCP server.
 
 ---
 
-## Step 1: Run AGENTS.md "Every Session" first
+## Step 1: Run AGENTS.md "Every Session", then verify reachability
 
-Complete the `AGENTS.md` "Every Session" checklist before continuing. In particular, Step 1 there runs the exports in `ENV.md`, which the rest of this bootstrap and every skill depends on. The nemoclaw egress policy blocks direct curls to a LAN IP or `localhost` with `policy_denied`, so `${HOST_IP}` must be set first. `ENV.md` is the single source of truth for the value — read it there.
+1. Complete the `AGENTS.md` "Every Session" checklist. In particular Step 1 there runs the exports in `ENV.md`, which the rest of this bootstrap and every skill depends on.
+2. Run the **Orchestrator reachability check** from `TOOLS.md` ("Sandbox host alias" → "HTTP-response curl checks" → "Orchestrator reachability check"). It must print `host alias reachable` before you continue.
 
-`/sandbox/.bashrc` is root-owned (mode `444`) in this sandbox — we cannot persist these exports to a shell init file, so the "Every Session" re-export is the persistence mechanism. See `ENV.md` and `TOOLS.md` "Sandbox host alias" for the full reasoning.
-
-Then verify reachability:
-
-```bash
-getent hosts "${HOST_IP}" && \
-  curl -sf --max-time 5 "http://${HOST_IP}:9988/" >/dev/null && echo "host alias reachable"
-```
-
-If `getent` fails or curl returns `policy_denied`, stop and tell the user the `vss-backend` network policy isn't applied to this sandbox.
+`TOOLS.md` also documents the harmless warnings you may see during this step (`oom_score_adj`, `http_proxy` preset) — read it once if you haven't already. Do not re-document any of that here.
 
 ---
 

--- a/.openclaw/workspace/_nemoclaw/ENV.md
+++ b/.openclaw/workspace/_nemoclaw/ENV.md
@@ -1,0 +1,21 @@
+# ENV.md — Sandbox Environment
+
+Environment variables that must be set every session. Single source of
+truth — `AGENTS.md`, `BOOTSTRAP.md`, and `TOOLS.md` all reference this
+file rather than duplicating the values.
+
+`/sandbox/.bashrc` is root-owned (mode `444`) in the nemoclaw sandbox,
+so these cannot be persisted to a shell init file. `AGENTS.md` "Every
+Session" Step 1 runs the block below at session start; if `$HOST_IP`
+is ever empty (new shell, fresh connect, gateway restart), run it
+again.
+
+## Exports
+
+```bash
+# Sandbox host alias — the only hostname the nemoclaw egress policy
+# whitelists for VSS backend ports. Skills curl ${HOST_IP} for every
+# runtime call (never localhost, never a literal IP) so the same skill
+# works in-sandbox and on bare metal.
+export HOST_IP=host.openshell.internal
+```

--- a/.openclaw/workspace/_nemoclaw/TOOLS.md
+++ b/.openclaw/workspace/_nemoclaw/TOOLS.md
@@ -61,10 +61,17 @@ Used by `BOOTSTRAP.md` Step 1 and any time you want to confirm the
 sandbox can reach the host:
 
 ```bash
-getent hosts "${HOST_IP}" >/dev/null \
-  && curl -s -o /dev/null --max-time 5 "http://${HOST_IP}:9988/" \
+curl -s -o /dev/null --max-time 5 "http://${HOST_IP}:9988/" \
   && echo "host alias reachable"
 ```
+
+Do **not** add a `getent hosts "${HOST_IP}"` precondition. In this
+sandbox all VSS backend traffic goes through `http_proxy`; the proxy
+resolves the hostname remotely, and the sandbox itself often has no
+local `/etc/hosts` or DNS entry for `host.openshell.internal`. `getent`
+would fail even when the path is fully healthy, producing false
+negatives. The curl alone is sufficient — it exercises the same proxied
+path skills use.
 
 If it doesn't print `host alias reachable`, the `vss-backend` egress
 policy isn't applied to this sandbox or the orchestrator isn't running

--- a/.openclaw/workspace/_nemoclaw/TOOLS.md
+++ b/.openclaw/workspace/_nemoclaw/TOOLS.md
@@ -1,5 +1,20 @@
 # TOOLS.md
 
+## Sandbox host alias
+
+Inside the openshell/nemoclaw sandbox, `HOST_IP` is pinned to
+`host.openshell.internal` by `BOOTSTRAP.md` Step 1 (and persisted in
+`~/.bashrc`). Skills should curl `${HOST_IP}` for every runtime call —
+never `localhost` and never a literal IP — so the same skill works
+in-sandbox and on bare metal.
+
+The sandbox's egress policy whitelists `host.openshell.internal` on a
+fixed set of VSS backend ports. The policy file lives on the host
+(outside the sandbox), so you can't grep it from here. A LAN IP,
+`localhost`, or a port not on the whitelist returns `policy_denied`. If a
+curl fails that way, tell the user the port needs to be added to the
+host-side policy and re-applied. Do not try to bypass.
+
 ## Deployment
 
 Deployment is delegated to the VSS Orchestrator MCP server at

--- a/.openclaw/workspace/_nemoclaw/TOOLS.md
+++ b/.openclaw/workspace/_nemoclaw/TOOLS.md
@@ -23,6 +23,53 @@ the whitelist returns `policy_denied`. If a curl fails that way, tell
 the user the port needs to be added to the host-side policy and
 re-applied. Do not try to bypass.
 
+## Preset proxy and harmless warnings
+
+Two things you will see in this sandbox that are **not** problems:
+
+- **`http_proxy=http://10.200.0.1:3128`** is preset in the sandbox env.
+  `no_proxy` covers `localhost,127.0.0.1,::1,10.200.0.1` but **not**
+  `host.openshell.internal`, so every VSS backend curl is proxied
+  through `10.200.0.1:3128`. This is the expected path and works with
+  the egress policy. Do not unset `http_proxy` or add `host.openshell.internal`
+  to `no_proxy` — the proxy is how traffic legitimately exits the sandbox.
+
+- **`/bin/bash: cannot create /proc/self/oom_score_adj: Permission denied`**
+  appears at bash startup. The sandbox restricts `/proc/self/*` writes;
+  bash tries to set its OOM priority, fails, and continues normally.
+  Cosmetic only — ignore it.
+
+## HTTP-response curl checks
+
+When testing whether a VSS backend port is reachable, do **not** use
+`curl -f`. Several VSS endpoints (orchestrator MCP, agent API) only
+expose specific routes and return `404` from `GET /` even when fully
+healthy — `-f` treats that as failure. Use:
+
+```bash
+curl -s -o /dev/null --max-time 5 "http://${HOST_IP}:<port>/"
+```
+
+curl exits 0 when *any* HTTP response is received (network/DNS/policy
+all work) and non-zero only on real failures (DNS miss, connection
+refused, `policy_denied`, timeout). For health endpoints that promise
+a 2xx, use `-f`; for "is the server up at all", omit it.
+
+### Orchestrator reachability check
+
+Used by `BOOTSTRAP.md` Step 1 and any time you want to confirm the
+sandbox can reach the host:
+
+```bash
+getent hosts "${HOST_IP}" >/dev/null \
+  && curl -s -o /dev/null --max-time 5 "http://${HOST_IP}:9988/" \
+  && echo "host alias reachable"
+```
+
+If it doesn't print `host alias reachable`, the `vss-backend` egress
+policy isn't applied to this sandbox or the orchestrator isn't running
+on the host. Stop and tell the user.
+
 ## Deployment
 
 Deployment is delegated to the VSS Orchestrator MCP server at

--- a/.openclaw/workspace/_nemoclaw/TOOLS.md
+++ b/.openclaw/workspace/_nemoclaw/TOOLS.md
@@ -2,18 +2,26 @@
 
 ## Sandbox host alias
 
-Inside the openshell/nemoclaw sandbox, `HOST_IP` is pinned to
-`host.openshell.internal` by `BOOTSTRAP.md` Step 1 (and persisted in
-`~/.bashrc`). Skills should curl `${HOST_IP}` for every runtime call —
-never `localhost` and never a literal IP — so the same skill works
-in-sandbox and on bare metal.
+Inside the openshell/nemoclaw sandbox, `HOST_IP` is the sandbox host
+alias — the only hostname the egress policy whitelists for VSS backend
+ports. Skills should curl `${HOST_IP}` for every runtime call — never
+`localhost` and never a literal IP — so the same skill works in-sandbox
+and on bare metal.
 
-The sandbox's egress policy whitelists `host.openshell.internal` on a
-fixed set of VSS backend ports. The policy file lives on the host
-(outside the sandbox), so you can't grep it from here. A LAN IP,
-`localhost`, or a port not on the whitelist returns `policy_denied`. If a
-curl fails that way, tell the user the port needs to be added to the
-host-side policy and re-applied. Do not try to bypass.
+`/sandbox/.bashrc` is root-owned and read-only in this sandbox, so
+`HOST_IP` is **not** persisted to a shell init file. Instead, the
+"Every Session" checklist in `AGENTS.md` runs the exports in `ENV.md`
+at session start. If `echo $HOST_IP` is empty in any new shell or after
+a session/connect restart, re-run the exports in `ENV.md`. `ENV.md` is
+the single source of truth for the value — do not hardcode it
+elsewhere.
+
+The sandbox's egress policy whitelists the alias on a fixed set of VSS
+backend ports. The policy file lives on the host (outside the sandbox),
+so you can't grep it from here. A LAN IP, `localhost`, or a port not on
+the whitelist returns `policy_denied`. If a curl fails that way, tell
+the user the port needs to be added to the host-side policy and
+re-applied. Do not try to bypass.
 
 ## Deployment
 

--- a/assets/vss_nemoclaw_policy.yaml
+++ b/assets/vss_nemoclaw_policy.yaml
@@ -257,6 +257,69 @@ network_policies:
       access: full
       allowed_ips:
       - 172.17.0.0/24
+    # Agent UI (3000), Auto-Calibration UI (5000), Phoenix (6006), VST MCP (8001),
+    # Auto-Calibration MS (8010), RT-Embed (8017), RT-VLM (8018), Kafka (9092),
+    # VA-MCP (9901), NvStreamer UI (31000), LVS REST (38111), LVS MCP (38112).
+    - host: host.openshell.internal
+      port: 3000
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 5000
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 6006
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 8001
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 8010
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 8017
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 8018
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 9092
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 9901
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 31000
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 38111
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
+    - host: host.openshell.internal
+      port: 38112
+      access: full
+      allowed_ips:
+      - 172.17.0.0/24
     binaries:
     - {path: /usr/bin/curl}
     - {path: /usr/local/bin/node}

--- a/skills/vss-generate-video-calibration/references/sample-dataset.md
+++ b/skills/vss-generate-video-calibration/references/sample-dataset.md
@@ -36,17 +36,18 @@ The shared AMC microservice prereq comes from the SKILL.md [Prerequisites](../SK
 ### Detect Running Backend
 
 ```bash
+MS_HOST="${HOST_IP:-localhost}"
 MS_PORT=""
 for port in {8000..8009}; do
-  if curl -s "http://localhost:$port/v1/ready" | grep -q '"code":0'; then
+  if curl -s "http://${MS_HOST}:$port/v1/ready" | grep -q '"code":0'; then
     MS_PORT=$port; break
   fi
 done
-if [ -z "$MS_PORT" ] && curl -s "http://localhost:8010/v1/ready" | grep -q '"code":0'; then
+if [ -z "$MS_PORT" ] && curl -s "http://${MS_HOST}:8010/v1/ready" | grep -q '"code":0'; then
   MS_PORT=8010
 fi
 [ -z "$MS_PORT" ] && { echo "No running backend. Walk deploy-auto-calibration-service.md first to bring up AMC."; exit 1; }
-echo "Backend on port $MS_PORT"
+echo "Backend on ${MS_HOST}:$MS_PORT"
 ```
 
 ### Obtain the sample zip
@@ -115,7 +116,7 @@ export REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 ENV_FILE="$REPO_ROOT/deploy/docker/industry-profiles/warehouse-operations/.env"
 export MS_PORT="$(grep ^VSS_AUTO_CALIBRATION_PORT "$ENV_FILE" 2>/dev/null | cut -d= -f2)"
 export MS_PORT="${MS_PORT:-8010}"
-export BASE_URL="http://localhost:${MS_PORT}/v1"
+export BASE_URL="http://${HOST_IP:-localhost}:${MS_PORT}/v1"
 # Optional: export SAMPLE_DIR=/abs/path/to/extracted/sample to override autodetection
 
 # Pick a python3 that has `requests`; create a throwaway venv if needed (no repo files written)
@@ -154,7 +155,7 @@ import requests
 # (no `__file__` to lean on when fed via stdin).
 REPO_ROOT = Path(os.environ.get("REPO_ROOT") or Path.cwd())
 MS_PORT = os.environ.get("MS_PORT", "8010")
-BASE_URL = os.environ.get("BASE_URL", f"http://localhost:{MS_PORT}/v1")
+BASE_URL = os.environ.get("BASE_URL", f"http://{os.environ.get('HOST_IP', 'localhost')}:{MS_PORT}/v1")
 
 # Sample zip lives in assets/.
 def _find_sample_dir() -> Path:

--- a/skills/vss-query-analytics/SKILL.md
+++ b/skills/vss-query-analytics/SKILL.md
@@ -49,14 +49,14 @@ This skill reads from the Elasticsearch/VA-MCP stack brought up by the VSS **ale
 
 ```bash
 # Step 1: initialize — get session ID from response HEADER
-SESSION_ID=$(curl -si -X POST http://localhost:9901/mcp \
+SESSION_ID=$(curl -si -X POST http://${HOST_IP:-localhost}:9901/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"cli","version":"1.0"}},"id":0}' \
   | grep -i "mcp-session-id" | awk '{print $2}' | tr -d '\r')
 
 # Step 2: call the tool using the session ID in the header
-curl -s -X POST http://localhost:9901/mcp \
+curl -s -X POST http://${HOST_IP:-localhost}:9901/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -H "mcp-session-id: $SESSION_ID" \

--- a/skills/vss-summarize-video/SKILL.md
+++ b/skills/vss-summarize-video/SKILL.md
@@ -101,8 +101,8 @@ This skill requires the VSS **lvs** profile running on the host at `$HOST_IP`. B
 **Endpoints (defaults for a local VSS `lvs` deployment):**
 
 - VLM / RT-VLM: `${VLM_BASE_URL}` — default
-  `${RTVI_VLM_BASE_URL:-http://localhost:8018}` for the `lvs` profile
-- LVS MS: `${LVS_BACKEND_URL}` — default `http://localhost:38111`
+  `${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}` for the `lvs` profile
+- LVS MS: `${LVS_BACKEND_URL}` — default `http://${HOST_IP:-localhost}:38111`
 - VIOS: owned by the `vss-manage-video-io-storage` skill; refer there.
 
 **Endpoint resolution order:**
@@ -130,7 +130,7 @@ or inspect the response body — LVS's `/v1/ready` can legitimately return
 "unavailable."
 
 ```bash
-VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://localhost:8018}}"
+VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
 VLM="${VLM%/v1}"
 
 # VLM / RT-VLM: 200 on /v1/models
@@ -139,7 +139,7 @@ vlm_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 \
 [ "$vlm_code" = "200" ] && echo "VLM OK" || echo "VLM not reachable (HTTP $vlm_code)"
 
 # LVS: 200 on /v1/ready, with retry on 503 (warmup) for up to ~30s
-LVS=${LVS_BACKEND_URL:-http://localhost:38111}
+LVS=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
 lvs_code=000
 for i in $(seq 1 10); do
   lvs_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 "$LVS/v1/ready")
@@ -211,7 +211,7 @@ message. OpenAI-compatible chat completions with the video URL embedded in
 the message content:
 
 ```bash
-VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://localhost:8018}}"
+VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
 VLM="${VLM%/v1}"
 PROMPT='<confirmed_prompt_from_hitl>'
 
@@ -262,7 +262,7 @@ exposes `/summarize` as a compatibility alias, but new examples should use
 `/v1/summarize`.
 
 ```bash
-LVS=${LVS_BACKEND_URL:-http://localhost:38111}
+LVS=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
 
 # From HITL reply:
 SCENARIO='warehouse monitoring'
@@ -320,7 +320,7 @@ then set `PROMPT` to the confirmed text. Do not run the curl below until
 that confirmation has arrived.
 
 ```bash
-VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://localhost:8018}}"
+VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
 VLM="${VLM%/v1}"
 PROMPT='Describe in detail what is happening in this video,
 including all visible people, vehicles, equipments, objects,
@@ -353,7 +353,7 @@ into `$SCENARIO`, `$EVENTS_JSON`, and `$OBJECTS_JSON` below. Do not run
 the curl without that reply.
 
 ```bash
-LVS=${LVS_BACKEND_URL:-http://localhost:38111}
+LVS=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
 
 # From HITL reply:
 SCENARIO='warehouse monitoring'            # or whatever the user gave


### PR DESCRIPTION
## Description
- whitelisted additional ports from NemoClaw policy for all skills
- remove hardcoded localhost etc. from skills and use ${HOST_IP:- localhost}
- load $HOST_IP from ENV.md
- ignore some harmless errors 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
