### PR TITLE
feat(agent ui): Alerts Tab: change alerts thumbnail fetching logic

### DIFF
--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/VstStreamThumbnail.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/VstStreamThumbnail.tsx
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 /**
- * Live still frame for a registered VST sensor. Resolves `sensorName` to a
+ * Recent still frame for a registered VST sensor. Resolves `sensorName` to a
  * VST stream id via `/v1/sensor/list` (cached per `vstApiUrl`), then renders
- * `/v1/live/stream/{id}/picture` as an `<img>`.
+ * `/v1/replay/stream/{id}/picture` with a short lookback as an `<img>`. The
+ * replay endpoint is used instead of `/v1/live/...` to avoid hitting the live
+ * pipeline for what is effectively a preview.
  */
 
 import React, { useEffect, useState } from 'react';
@@ -20,6 +22,14 @@ interface VstStreamThumbnailProps {
 }
 
 const THUMBNAIL_BOX_STYLE: React.CSSProperties = { width: '128px', height: '72px' };
+
+// Short lookback for the replay snapshot. Far enough back that the segment is
+// reliably written to storage, short enough that the preview still looks fresh.
+// NOTE: startTime is computed once per effect invocation (i.e., per prop change).
+// The thumbnail does not auto-refresh; it always shows the frame from ~5 s
+// before the sensor-list fetch resolved. Re-mount or a prop change is required
+// to get a newer frame.
+const THUMBNAIL_LOOKBACK_MS = 5_000;
 
 const Placeholder: React.FC<{
   isDark: boolean;
@@ -99,9 +109,12 @@ export const VstStreamThumbnail: React.FC<VstStreamThumbnailProps> = ({
           });
           return;
         }
-        const pictureUrl = `${vstApiUrl.replace(/\/+$/, '')}/v1/live/stream/${encodeURIComponent(
+        const startTime = new Date(Date.now() - THUMBNAIL_LOOKBACK_MS).toISOString();
+        let baseUrl = vstApiUrl;
+        while (baseUrl.endsWith('/')) baseUrl = baseUrl.slice(0, -1);
+        const pictureUrl = `${baseUrl}/v1/replay/stream/${encodeURIComponent(
           sensorId,
-        )}/picture`;
+        )}/picture?startTime=${encodeURIComponent(startTime)}`;
         setState({ kind: 'ready', pictureUrl });
       })
       .catch((err) => {
@@ -135,7 +148,7 @@ export const VstStreamThumbnail: React.FC<VstStreamThumbnailProps> = ({
     <img
       data-testid="vst-stream-thumbnail"
       src={state.pictureUrl}
-      alt={`Live VST thumbnail for ${sensorName}`}
+      alt={`Recent thumbnail for ${sensorName}`}
       style={THUMBNAIL_BOX_STYLE}
       className={`object-cover rounded border ${
         isDark ? 'border-neutral-700' : 'border-gray-300'


### PR DESCRIPTION
## Description
The VST `/v1/live/stream/{id}/picture` endpoint was
  returning unreliable results for the alerts management
  thumbnails, sometimes failing outright. Switched the
  thumbnail fetch to `/v1/replay/stream/{id}/picture` with
   a 5-second lookback, which pulls from VST's recorded
  segments and reliably returns a recent frame for the
  preview.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<img width="1356" height="788" alt="image" src="https://github.com/user-attachments/assets/ea89c614-7a62-4f75-af80-dc4cbef18f09" />
