### PR TITLE
fix(agent-ui): Alerts Tabs: split alert type and triggered filter options by VLM verdict

### DIFF
--- a/deploy/docker/services/ui/compose.yml
+++ b/deploy/docker/services/ui/compose.yml
@@ -16,7 +16,7 @@
 services:
 
   vss-ui:
-    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-8a526e97fea1
+    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-3ab18ca37ffb
     profiles: ["bp_wh_2d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     container_name: vss-agent-ui
     ports:

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -562,7 +562,7 @@ vss-agent-ui:
     imagePullPolicy: IfNotPresent
   image:
     repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-    tag: "3.2.0-26.05.2-8a526e97fea1"
+    tag: "3.2.0-26.05.2-3ab18ca37ffb"
   replicas: 1
   fillAlertBridgeUrlFromGlobal: false
   agentApiUrlBase: ''

--- a/deploy/helm/services/ui/values.yaml
+++ b/deploy/helm/services/ui/values.yaml
@@ -19,7 +19,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-  tag: "3.2.0-26.05.2-8a526e97fea1"
+  tag: "3.2.0-26.05.2-3ab18ca37ffb"
   pullPolicy: IfNotPresent
 replicas: 1
 service:

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/AlertsComponent.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/AlertsComponent.test.tsx
@@ -91,6 +91,10 @@ jest.mock('../../lib-src/hooks/useFilters', () => ({
       sensors: [],
       alertTypes: [],
       alertTriggered: [],
+      byVlmVerified: {
+        enabled: { alertTypes: [], alertTriggered: [] },
+        disabled: { alertTypes: [], alertTriggered: [] },
+      },
     },
   })),
   createEmptyFilterState: jest.fn(() => ({

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/FilterControls.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/FilterControls.test.tsx
@@ -60,6 +60,10 @@ const defaultProps = {
     sensors: ['Cam-A', 'Cam-B'],
     alertTypes: ['Tailgating', 'Loitering'],
     alertTriggered: ['Motion', 'Zone'],
+    byVlmVerified: {
+      enabled: { alertTypes: ['Tailgating', 'Loitering'], alertTriggered: ['Motion', 'Zone'] },
+      disabled: { alertTypes: ['Tailgating'], alertTriggered: ['Motion'] },
+    },
   },
   loading: false,
   autoRefreshEnabled: false,

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/FilterControls.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/FilterControls.test.tsx
@@ -62,7 +62,7 @@ const defaultProps = {
     alertTriggered: ['Motion', 'Zone'],
     byVlmVerified: {
       enabled: { alertTypes: ['Tailgating', 'Loitering'], alertTriggered: ['Motion', 'Zone'] },
-      disabled: { alertTypes: ['Tailgating'], alertTriggered: ['Motion'] },
+      disabled: { alertTypes: ['Intrusion'], alertTriggered: ['Thermal'] },
     },
   },
   loading: false,

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/hooks/useFilters.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/hooks/useFilters.test.ts
@@ -196,7 +196,7 @@ describe('useFilters', () => {
     expect(result.current.uniqueValues.alertTypes).toEqual(['Apple', 'Mango', 'Zebra']);
   });
 
-  it('splits alertTypes by vlmVerified state', () => {
+  it('keeps separate alert type cache per vlmVerified state', () => {
     const vlmOnAlerts = [
       makeAlert({ id: '1', alertType: 'Tailgating', alertTriggered: 'Motion' }),
       makeAlert({ id: '2', alertType: 'Loitering', alertTriggered: 'Zone' }),
@@ -207,9 +207,8 @@ describe('useFilters', () => {
       { initialProps: { alerts: vlmOnAlerts, vlmVerified: true } }
     );
 
-    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(
-      expect.arrayContaining(['Tailgating', 'Loitering'])
-    );
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(['Loitering', 'Tailgating']);
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTriggered).toEqual(['Motion', 'Zone']);
     expect(result.current.uniqueValues.byVlmVerified.disabled.alertTypes).toEqual([]);
 
     const vlmOffAlerts = [
@@ -217,36 +216,58 @@ describe('useFilters', () => {
     ];
     rerender({ alerts: vlmOffAlerts, vlmVerified: false });
 
-    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(
-      expect.arrayContaining(['Tailgating', 'Loitering'])
-    );
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(['Loitering', 'Tailgating']);
     expect(result.current.uniqueValues.byVlmVerified.disabled.alertTypes).toEqual(['Intrusion']);
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTriggered).toEqual(['Thermal']);
   });
 
-  it('splits alertTriggered by vlmVerified state', () => {
-    const vlmOnAlerts = [
-      makeAlert({ id: '1', alertType: 'Tailgating', alertTriggered: 'Motion' }),
-      makeAlert({ id: '2', alertType: 'Loitering', alertTriggered: 'Zone' }),
-    ];
+  it('does not clear current bucket when alerts change', () => {
+    const firstBatch = [makeAlert({ id: '1', alertType: 'Type-A', alertTriggered: 'Trig-A' })];
+    const secondBatch = [makeAlert({ id: '2', alertType: 'Type-B', alertTriggered: 'Trig-B' })];
 
     const { result, rerender } = renderHook(
       ({ alerts: a, vlmVerified: v }) => useFilters({ alerts: a, vlmVerified: v }),
-      { initialProps: { alerts: vlmOnAlerts, vlmVerified: true } }
+      { initialProps: { alerts: firstBatch, vlmVerified: true } }
     );
 
-    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTriggered).toEqual(
-      expect.arrayContaining(['Motion', 'Zone'])
-    );
-    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTriggered).toEqual([]);
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(['Type-A']);
 
-    const vlmOffAlerts = [
-      makeAlert({ id: '3', alertType: 'Intrusion', alertTriggered: 'Thermal' }),
-    ];
-    rerender({ alerts: vlmOffAlerts, vlmVerified: false });
+    rerender({ alerts: secondBatch, vlmVerified: true });
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(['Type-A', 'Type-B']);
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTriggered).toEqual(['Trig-A', 'Trig-B']);
+  });
 
-    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTriggered).toEqual(
-      expect.arrayContaining(['Motion', 'Zone'])
+  it('switching vlmVerified does not leak between buckets', () => {
+    const falseAlerts = [makeAlert({ id: '1', alertType: 'False-Type', alertTriggered: 'False-Trig' })];
+    const trueAlerts = [makeAlert({ id: '2', alertType: 'True-Type', alertTriggered: 'True-Trig' })];
+
+    const { result, rerender } = renderHook(
+      ({ alerts: a, vlmVerified: v }) => useFilters({ alerts: a, vlmVerified: v }),
+      { initialProps: { alerts: falseAlerts, vlmVerified: false } }
     );
-    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTriggered).toEqual(['Thermal']);
+
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTypes).toEqual(['False-Type']);
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual([]);
+
+    rerender({ alerts: trueAlerts, vlmVerified: true });
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(['True-Type']);
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTypes).toEqual(['False-Type']);
+  });
+
+  it('toggle alone does not add old alerts into new bucket', () => {
+    const falseAlerts = [makeAlert({ id: '1', alertType: 'False-Type', alertTriggered: 'False-Trig' })];
+
+    const { result, rerender } = renderHook(
+      ({ alerts: a, vlmVerified: v }) => useFilters({ alerts: a, vlmVerified: v }),
+      { initialProps: { alerts: falseAlerts, vlmVerified: false } }
+    );
+
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTypes).toEqual(['False-Type']);
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual([]);
+
+    // Toggle vlmVerified, but keep the same alerts reference.
+    rerender({ alerts: falseAlerts, vlmVerified: true });
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTypes).toEqual(['False-Type']);
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual([]);
   });
 });

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/hooks/useFilters.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/hooks/useFilters.test.ts
@@ -195,4 +195,58 @@ describe('useFilters', () => {
     const { result } = renderHook(() => useFilters({ alerts: unsortedAlerts }));
     expect(result.current.uniqueValues.alertTypes).toEqual(['Apple', 'Mango', 'Zebra']);
   });
+
+  it('splits alertTypes by vlmVerified state', () => {
+    const vlmOnAlerts = [
+      makeAlert({ id: '1', alertType: 'Tailgating', alertTriggered: 'Motion' }),
+      makeAlert({ id: '2', alertType: 'Loitering', alertTriggered: 'Zone' }),
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ alerts: a, vlmVerified: v }) => useFilters({ alerts: a, vlmVerified: v }),
+      { initialProps: { alerts: vlmOnAlerts, vlmVerified: true } }
+    );
+
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(
+      expect.arrayContaining(['Tailgating', 'Loitering'])
+    );
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTypes).toEqual([]);
+
+    const vlmOffAlerts = [
+      makeAlert({ id: '3', alertType: 'Intrusion', alertTriggered: 'Thermal' }),
+    ];
+    rerender({ alerts: vlmOffAlerts, vlmVerified: false });
+
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTypes).toEqual(
+      expect.arrayContaining(['Tailgating', 'Loitering'])
+    );
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTypes).toEqual(['Intrusion']);
+  });
+
+  it('splits alertTriggered by vlmVerified state', () => {
+    const vlmOnAlerts = [
+      makeAlert({ id: '1', alertType: 'Tailgating', alertTriggered: 'Motion' }),
+      makeAlert({ id: '2', alertType: 'Loitering', alertTriggered: 'Zone' }),
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ alerts: a, vlmVerified: v }) => useFilters({ alerts: a, vlmVerified: v }),
+      { initialProps: { alerts: vlmOnAlerts, vlmVerified: true } }
+    );
+
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTriggered).toEqual(
+      expect.arrayContaining(['Motion', 'Zone'])
+    );
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTriggered).toEqual([]);
+
+    const vlmOffAlerts = [
+      makeAlert({ id: '3', alertType: 'Intrusion', alertTriggered: 'Thermal' }),
+    ];
+    rerender({ alerts: vlmOffAlerts, vlmVerified: false });
+
+    expect(result.current.uniqueValues.byVlmVerified.enabled.alertTriggered).toEqual(
+      expect.arrayContaining(['Motion', 'Zone'])
+    );
+    expect(result.current.uniqueValues.byVlmVerified.disabled.alertTriggered).toEqual(['Thermal']);
+  });
 });

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/AlertsComponent.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/AlertsComponent.tsx
@@ -196,6 +196,39 @@ export const AlertsComponent: React.FC<AlertsComponentProps> = ({
 
   const [activeFilters, setActiveFilters] = useSessionFilterState(FILTERS_STORAGE_KEY);
 
+  // Maintain separate alertTypes & alertTriggered filter selections per
+  // vlmVerified state. When the toggle flips, the current selections are saved
+  // into the old bucket and the previously saved selections for the new state
+  // are restored, so tags never leak between the two states.
+  // Done via a synchronous callback (not an effect) to avoid an intermediate
+  // render frame where stale tags from the wrong state are briefly visible.
+  const vlmFiltersRef = React.useRef<{
+    enabled: { alertTypes: Set<string>; alertTriggered: Set<string> };
+    disabled: { alertTypes: Set<string>; alertTriggered: Set<string> };
+  }>({
+    enabled: { alertTypes: new Set(), alertTriggered: new Set() },
+    disabled: { alertTypes: new Set(), alertTriggered: new Set() },
+  });
+  const handleVlmVerifiedChange = React.useCallback((next: boolean) => {
+    setActiveFilters(prev => {
+      const curBucket = vlmVerified
+        ? vlmFiltersRef.current.enabled
+        : vlmFiltersRef.current.disabled;
+      curBucket.alertTypes = new Set(prev.alertTypes);
+      curBucket.alertTriggered = new Set(prev.alertTriggered);
+
+      const newBucket = next
+        ? vlmFiltersRef.current.enabled
+        : vlmFiltersRef.current.disabled;
+      return {
+        ...prev,
+        alertTypes: new Set(newBucket.alertTypes),
+        alertTriggered: new Set(newBucket.alertTriggered),
+      };
+    });
+    setVlmVerified(next);
+  }, [vlmVerified, setActiveFilters, setVlmVerified]);
+
   /** Incremented when "Show more" succeeds so AlertsTable resets column sort but keeps current page. */
   const [loadMoreCompletionCount, setLoadMoreCompletionCount] = React.useState(0);
 
@@ -303,7 +336,7 @@ export const AlertsComponent: React.FC<AlertsComponentProps> = ({
         autoRefreshInterval,
         refreshControlsSuspended: false,
         alertsView,
-        onVlmVerifiedChange: setVlmVerified,
+        onVlmVerifiedChange: handleVlmVerifiedChange,
         onTimeWindowChange: setTimeWindow,
         onRefresh: refetch,
         onAutoRefreshToggle: toggleAutoRefresh,
@@ -324,7 +357,7 @@ export const AlertsComponent: React.FC<AlertsComponentProps> = ({
     refetch,
     toggleAutoRefresh,
     handleAddNewAlertRule,
-    setVlmVerified,
+    handleVlmVerifiedChange,
     setTimeWindow,
     setAlertsView,
     controlsComponent,
@@ -374,7 +407,7 @@ export const AlertsComponent: React.FC<AlertsComponentProps> = ({
           loading={loading}
           autoRefreshEnabled={autoRefreshEnabled}
           autoRefreshInterval={autoRefreshInterval}
-          onVlmVerifiedChange={setVlmVerified}
+          onVlmVerifiedChange={handleVlmVerifiedChange}
           onVlmVerdictChange={setVlmVerdict}
           onTimeWindowChange={setTimeWindow}
           onCustomTimeValueChange={handleCustomTimeChange}

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/AlertsComponent.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/AlertsComponent.tsx
@@ -237,6 +237,7 @@ export const AlertsComponent: React.FC<AlertsComponentProps> = ({
   // API-provided sensorList rather than accumulating from data.
   const { addFilter, removeFilter, filteredAlerts, uniqueValues } = useFilters({
     alerts,
+    vlmVerified,
     externalFilters: activeFilters,
     onFiltersChange: setActiveFilters,
     sensorList

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/FilterControls.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/FilterControls.tsx
@@ -33,6 +33,10 @@ interface FilterControlsProps {
     sensors: string[];
     alertTypes: string[];
     alertTriggered: string[];
+    byVlmVerified: {
+      enabled: { alertTypes: string[]; alertTriggered: string[] };
+      disabled: { alertTypes: string[]; alertTriggered: string[] };
+    };
   };
   loading: boolean;
   autoRefreshEnabled: boolean;
@@ -180,7 +184,7 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
         }}
       >
         <option value="">Alert Type...</option>
-        {uniqueValues.alertTypes
+        {uniqueValues.byVlmVerified[vlmVerified ? 'enabled' : 'disabled'].alertTypes
           .filter(type => type && type.trim() !== '')
           .map(type => (
             <option key={type} value={type}>{type}</option>
@@ -200,7 +204,7 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
         }}
       >
         <option value="">Alert Triggered...</option>
-        {uniqueValues.alertTriggered
+        {uniqueValues.byVlmVerified[vlmVerified ? 'enabled' : 'disabled'].alertTriggered
           .filter(triggered => triggered && triggered.trim() !== '')
           .map(triggered => (
             <option key={triggered} value={triggered}>{triggered}</option>

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useAlerts.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useAlerts.ts
@@ -276,6 +276,12 @@ export const useAlerts = ({ apiUrl, vstApiUrl, vlmVerified = true, vlmVerdict = 
   const alertsRef = useRef(alerts);
   alertsRef.current = alerts;
 
+  // Tracks the live vlmVerified value so in-flight fetches (including those
+  // triggered by auto-refresh without an AbortSignal) can detect that the
+  // toggle changed while they were awaiting a response and discard stale data.
+  const currentVlmVerifiedRef = useRef(vlmVerified);
+  currentVlmVerifiedRef.current = vlmVerified;
+
   // Memoize the serialized filters to prevent unnecessary API calls
   // when the filter object reference changes but values remain the same
   const serializedFilters = useMemo(() => serializeFilters(activeFilters), [activeFilters]);
@@ -325,14 +331,19 @@ export const useAlerts = ({ apiUrl, vstApiUrl, vlmVerified = true, vlmVerdict = 
   }, [vstApiUrl]);
 
   /**
-   * Fetches alerts data from the incidents API with time-based filtering
+   * Fetches alerts data from the incidents API with time-based filtering.
+   * Accepts an optional AbortSignal so the automatic effect can cancel
+   * in-flight requests when dependencies change (prevents race conditions
+   * where a stale response overwrites data for the current vlmVerified state).
    */
-  const fetchAlerts = useCallback(async (): Promise<boolean> => {
+  const fetchAlerts = useCallback(async (signal?: AbortSignal): Promise<boolean> => {
     if (!apiUrl) {
       setError('API URL is not configured');
       setLoading(false);
       return false;
     }
+
+    const fetchedForVlmVerified = vlmVerified;
 
     try {
       setLoading(true);
@@ -345,12 +356,15 @@ export const useAlerts = ({ apiUrl, vstApiUrl, vlmVerified = true, vlmVerdict = 
 
       const mdxWebApiIncidents = buildIncidentsUrl(fromTimestamp, toTimestamp);
 
-      const response = await fetch(mdxWebApiIncidents);
+      const response = await fetch(mdxWebApiIncidents, { signal });
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
+
+      // Discard stale results if vlmVerified changed while this fetch was in flight
+      if (fetchedForVlmVerified !== currentVlmVerifiedRef.current) return false;
 
       const transformedAlerts = transformIncidentsPayload(data);
       setLastBatchSize(transformedAlerts.length);
@@ -358,10 +372,14 @@ export const useAlerts = ({ apiUrl, vstApiUrl, vlmVerified = true, vlmVerdict = 
 
       return true;
     } catch (err) {
+      if (signal?.aborted) return false;
+      if (fetchedForVlmVerified !== currentVlmVerifiedRef.current) return false;
       setError(err instanceof Error ? err.message : 'Failed to fetch alerts');
       return false;
     } finally {
-      setLoading(false);
+      if (!signal?.aborted && fetchedForVlmVerified === currentVlmVerifiedRef.current) {
+        setLoading(false);
+      }
     }
   }, [apiUrl, timeWindow, buildIncidentsUrl, vlmVerified, vlmVerdict, maxResults]);
 
@@ -423,9 +441,12 @@ export const useAlerts = ({ apiUrl, vstApiUrl, vlmVerified = true, vlmVerdict = 
     fetchSensorList();
   }, [fetchSensorList]);
 
-  // Fetch alerts when dependencies change
+  // Fetch alerts when dependencies change; abort any in-flight request first
+  // so stale responses never overwrite the current state.
   useEffect(() => {
-    fetchAlerts();
+    const controller = new AbortController();
+    fetchAlerts(controller.signal);
+    return () => controller.abort();
   }, [fetchAlerts]);
 
   // Refetch function - only refetches alerts by default, optionally refetches sensor list too

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useFilters.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useFilters.ts
@@ -26,21 +26,24 @@ import { AlertData, FilterState, FilterType } from '../types';
 
 const sortedArray = (set: Set<string>) => [...set].sort((a, b) => a.localeCompare(b));
 
-interface VlmSpecificValues {
-  alertTypes: Set<string>;
-  alertTriggered: Set<string>;
-}
-
 /**
- * Interface for accumulated unique values
+ * Interface for accumulated unique values (sensors only — alertTypes & alertTriggered
+ * are accumulated for general backwards-compat but the dropdowns use the vlm-aware
+ * values derived directly from the current `alerts` array).
  */
 interface UniqueValuesState {
   sensors: Set<string>;
   alertTypes: Set<string>;
   alertTriggered: Set<string>;
   byVlmVerified: {
-    enabled: VlmSpecificValues;
-    disabled: VlmSpecificValues;
+    enabled: {
+      alertTypes: Set<string>;
+      alertTriggered: Set<string>;
+    };
+    disabled: {
+      alertTypes: Set<string>;
+      alertTriggered: Set<string>;
+    };
   };
 }
 
@@ -53,22 +56,24 @@ export const createEmptyFilterState = (): FilterState => ({
   alertTriggered: new Set()
 });
 
-const createEmptyVlmSpecificValues = (): VlmSpecificValues => ({
+const createEmptyUniqueValuesState = (): UniqueValuesState => ({
+  sensors: new Set(),
   alertTypes: new Set(),
   alertTriggered: new Set(),
-});
-
-const createEmptyUniqueValuesState = (): UniqueValuesState => ({
-  ...createEmptyFilterState(),
   byVlmVerified: {
-    enabled: createEmptyVlmSpecificValues(),
-    disabled: createEmptyVlmSpecificValues(),
+    enabled: {
+      alertTypes: new Set(),
+      alertTriggered: new Set(),
+    },
+    disabled: {
+      alertTypes: new Set(),
+      alertTriggered: new Set(),
+    },
   },
 });
 
 interface UseFiltersOptions {
   alerts: AlertData[];
-  /** Current vlmVerified toggle state - used to split alertTypes/alertTriggered into separate lists */
   vlmVerified?: boolean;
   /** Optional external filter state - if provided, hook won't manage its own state */
   externalFilters?: FilterState;
@@ -79,7 +84,7 @@ interface UseFiltersOptions {
 }
 
 export const useFilters = (options: UseFiltersOptions) => {
-  const { alerts, vlmVerified, externalFilters, onFiltersChange, sensorList } = options;
+  const { alerts, vlmVerified = true, externalFilters, onFiltersChange, sensorList } = options;
 
   // Internal state - only used if external state is not provided
   const [internalFilters, setInternalFilters] = useState<FilterState>(createEmptyFilterState);
@@ -88,59 +93,51 @@ export const useFilters = (options: UseFiltersOptions) => {
   const activeFilters = externalFilters ?? internalFilters;
   const setActiveFilters = onFiltersChange ?? setInternalFilters;
 
-  // Accumulated unique values - persists across filter changes
-  // Using ref to avoid unnecessary re-renders when accumulating
+  // Accumulated unique values - persists across filter changes so dropdown
+  // options don't disappear when server-side filters narrow the result set.
+  // Only used for sensors and the general alertTypes/alertTriggered lists.
   const accumulatedValuesRef = useRef<UniqueValuesState>(createEmptyUniqueValuesState());
   const [uniqueValuesVersion, setUniqueValuesVersion] = useState(0);
+  const prevAlertsRef = useRef<AlertData[] | null>(null);
 
-  // Track previous alerts reference so we only accumulate into vlm-specific
-  // sets when the alerts data actually changes (after refetch), not when only
-  // vlmVerified toggles while stale alerts are still in state.
-  const prevAlertsRef = useRef<AlertData[]>([]);
-
-  // Accumulate unique values from alerts data
-  // This ensures filter options don't disappear when filters are applied
-  // Note: Skip sensor accumulation if sensorList from API is provided
+  // Accumulate unique values without clearing existing options.
+  // For alertType/alertTriggered we keep a dedicated cache per vlmVerified bucket
+  // so each toggle state has an isolated, persistent option list.
   useEffect(() => {
     if (alerts.length === 0) return;
-
     const alertsChanged = alerts !== prevAlertsRef.current;
+    if (!alertsChanged) return;
     prevAlertsRef.current = alerts;
 
     let hasNewValues = false;
     const accumulated = accumulatedValuesRef.current;
     const hasSensorListFromApi = sensorList && sensorList.length > 0;
-
     const vlmBucket = vlmVerified
       ? accumulated.byVlmVerified.enabled
       : accumulated.byVlmVerified.disabled;
 
-    alerts.forEach(alert => {
+    for (const alert of alerts) {
       if (!hasSensorListFromApi && alert.sensor && !accumulated.sensors.has(alert.sensor)) {
         accumulated.sensors.add(alert.sensor);
         hasNewValues = true;
       }
-      if (alert.alertType) {
-        if (!accumulated.alertTypes.has(alert.alertType)) {
-          accumulated.alertTypes.add(alert.alertType);
-          hasNewValues = true;
-        }
-        if (alertsChanged && !vlmBucket.alertTypes.has(alert.alertType)) {
-          vlmBucket.alertTypes.add(alert.alertType);
-          hasNewValues = true;
-        }
+      if (alert.alertType && !accumulated.alertTypes.has(alert.alertType)) {
+        accumulated.alertTypes.add(alert.alertType);
+        hasNewValues = true;
       }
-      if (alert.alertTriggered) {
-        if (!accumulated.alertTriggered.has(alert.alertTriggered)) {
-          accumulated.alertTriggered.add(alert.alertTriggered);
-          hasNewValues = true;
-        }
-        if (alertsChanged && !vlmBucket.alertTriggered.has(alert.alertTriggered)) {
-          vlmBucket.alertTriggered.add(alert.alertTriggered);
-          hasNewValues = true;
-        }
+      if (alert.alertType && !vlmBucket.alertTypes.has(alert.alertType)) {
+        vlmBucket.alertTypes.add(alert.alertType);
+        hasNewValues = true;
       }
-    });
+      if (alert.alertTriggered && !accumulated.alertTriggered.has(alert.alertTriggered)) {
+        accumulated.alertTriggered.add(alert.alertTriggered);
+        hasNewValues = true;
+      }
+      if (alert.alertTriggered && !vlmBucket.alertTriggered.has(alert.alertTriggered)) {
+        vlmBucket.alertTriggered.add(alert.alertTriggered);
+        hasNewValues = true;
+      }
+    }
 
     if (hasNewValues) {
       setUniqueValuesVersion(v => v + 1);
@@ -177,9 +174,8 @@ export const useFilters = (options: UseFiltersOptions) => {
     });
   }, [alerts, activeFilters]);
 
-  // Convert accumulated Sets to sorted arrays for the UI
-  // uniqueValuesVersion ensures this updates when new values are accumulated
-  // sensorList from API takes precedence over accumulated sensors
+  // Convert accumulated Sets to sorted arrays for the UI.
+  // sensorList from API takes precedence over accumulated sensors.
   const uniqueValues = useMemo(() => {
     const accumulated = accumulatedValuesRef.current;
     const { enabled, disabled } = accumulated.byVlmVerified;

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useFilters.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useFilters.ts
@@ -17,11 +17,19 @@
  * - Type-safe filter operations with comprehensive TypeScript support
  * - Support for external state management (for server-side filtering via API)
  * - Accumulated unique values that persist across filter changes
+ * - VLM-verified-aware alert type and trigger lists
  * 
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef, Dispatch, SetStateAction } from 'react';
 import { AlertData, FilterState, FilterType } from '../types';
+
+const sortedArray = (set: Set<string>) => [...set].sort((a, b) => a.localeCompare(b));
+
+interface VlmSpecificValues {
+  alertTypes: Set<string>;
+  alertTriggered: Set<string>;
+}
 
 /**
  * Interface for accumulated unique values
@@ -30,6 +38,10 @@ interface UniqueValuesState {
   sensors: Set<string>;
   alertTypes: Set<string>;
   alertTriggered: Set<string>;
+  byVlmVerified: {
+    enabled: VlmSpecificValues;
+    disabled: VlmSpecificValues;
+  };
 }
 
 /**
@@ -41,10 +53,23 @@ export const createEmptyFilterState = (): FilterState => ({
   alertTriggered: new Set()
 });
 
-const createEmptyUniqueValuesState = (): UniqueValuesState => createEmptyFilterState();
+const createEmptyVlmSpecificValues = (): VlmSpecificValues => ({
+  alertTypes: new Set(),
+  alertTriggered: new Set(),
+});
+
+const createEmptyUniqueValuesState = (): UniqueValuesState => ({
+  ...createEmptyFilterState(),
+  byVlmVerified: {
+    enabled: createEmptyVlmSpecificValues(),
+    disabled: createEmptyVlmSpecificValues(),
+  },
+});
 
 interface UseFiltersOptions {
   alerts: AlertData[];
+  /** Current vlmVerified toggle state - used to split alertTypes/alertTriggered into separate lists */
+  vlmVerified?: boolean;
   /** Optional external filter state - if provided, hook won't manage its own state */
   externalFilters?: FilterState;
   /** Optional external setter for filter state */
@@ -54,7 +79,7 @@ interface UseFiltersOptions {
 }
 
 export const useFilters = (options: UseFiltersOptions) => {
-  const { alerts, externalFilters, onFiltersChange, sensorList } = options;
+  const { alerts, vlmVerified, externalFilters, onFiltersChange, sensorList } = options;
 
   // Internal state - only used if external state is not provided
   const [internalFilters, setInternalFilters] = useState<FilterState>(createEmptyFilterState);
@@ -68,37 +93,59 @@ export const useFilters = (options: UseFiltersOptions) => {
   const accumulatedValuesRef = useRef<UniqueValuesState>(createEmptyUniqueValuesState());
   const [uniqueValuesVersion, setUniqueValuesVersion] = useState(0);
 
+  // Track previous alerts reference so we only accumulate into vlm-specific
+  // sets when the alerts data actually changes (after refetch), not when only
+  // vlmVerified toggles while stale alerts are still in state.
+  const prevAlertsRef = useRef<AlertData[]>([]);
+
   // Accumulate unique values from alerts data
   // This ensures filter options don't disappear when filters are applied
   // Note: Skip sensor accumulation if sensorList from API is provided
   useEffect(() => {
     if (alerts.length === 0) return;
 
+    const alertsChanged = alerts !== prevAlertsRef.current;
+    prevAlertsRef.current = alerts;
+
     let hasNewValues = false;
     const accumulated = accumulatedValuesRef.current;
     const hasSensorListFromApi = sensorList && sensorList.length > 0;
 
+    const vlmBucket = vlmVerified
+      ? accumulated.byVlmVerified.enabled
+      : accumulated.byVlmVerified.disabled;
+
     alerts.forEach(alert => {
-      // Only accumulate sensors if no sensorList from API
       if (!hasSensorListFromApi && alert.sensor && !accumulated.sensors.has(alert.sensor)) {
         accumulated.sensors.add(alert.sensor);
         hasNewValues = true;
       }
-      if (alert.alertType && !accumulated.alertTypes.has(alert.alertType)) {
-        accumulated.alertTypes.add(alert.alertType);
-        hasNewValues = true;
+      if (alert.alertType) {
+        if (!accumulated.alertTypes.has(alert.alertType)) {
+          accumulated.alertTypes.add(alert.alertType);
+          hasNewValues = true;
+        }
+        if (alertsChanged && !vlmBucket.alertTypes.has(alert.alertType)) {
+          vlmBucket.alertTypes.add(alert.alertType);
+          hasNewValues = true;
+        }
       }
-      if (alert.alertTriggered && !accumulated.alertTriggered.has(alert.alertTriggered)) {
-        accumulated.alertTriggered.add(alert.alertTriggered);
-        hasNewValues = true;
+      if (alert.alertTriggered) {
+        if (!accumulated.alertTriggered.has(alert.alertTriggered)) {
+          accumulated.alertTriggered.add(alert.alertTriggered);
+          hasNewValues = true;
+        }
+        if (alertsChanged && !vlmBucket.alertTriggered.has(alert.alertTriggered)) {
+          vlmBucket.alertTriggered.add(alert.alertTriggered);
+          hasNewValues = true;
+        }
       }
     });
 
-    // Only trigger re-render if we found new values
     if (hasNewValues) {
       setUniqueValuesVersion(v => v + 1);
     }
-  }, [alerts, sensorList]);
+  }, [alerts, sensorList, vlmVerified]);
 
   const addFilter = useCallback((type: FilterType, value: string) => {
     setActiveFilters(prev => ({
@@ -135,13 +182,23 @@ export const useFilters = (options: UseFiltersOptions) => {
   // sensorList from API takes precedence over accumulated sensors
   const uniqueValues = useMemo(() => {
     const accumulated = accumulatedValuesRef.current;
+    const { enabled, disabled } = accumulated.byVlmVerified;
     return {
-      // Use sensorList from API if provided, otherwise use accumulated sensors
-      sensors: sensorList && sensorList.length > 0 
-        ? sensorList 
-        : [...accumulated.sensors].sort((a, b) => a.localeCompare(b)),
-      alertTypes: [...accumulated.alertTypes].sort((a, b) => a.localeCompare(b)),
-      alertTriggered: [...accumulated.alertTriggered].sort((a, b) => a.localeCompare(b))
+      sensors: sensorList && sensorList.length > 0
+        ? sensorList
+        : sortedArray(accumulated.sensors),
+      alertTypes: sortedArray(accumulated.alertTypes),
+      alertTriggered: sortedArray(accumulated.alertTriggered),
+      byVlmVerified: {
+        enabled: {
+          alertTypes: sortedArray(enabled.alertTypes),
+          alertTriggered: sortedArray(enabled.alertTriggered),
+        },
+        disabled: {
+          alertTypes: sortedArray(disabled.alertTypes),
+          alertTriggered: sortedArray(disabled.alertTriggered),
+        },
+      },
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uniqueValuesVersion, sensorList]);
@@ -154,4 +211,3 @@ export const useFilters = (options: UseFiltersOptions) => {
     uniqueValues
   };
 };
-


### PR DESCRIPTION
…ified state

Alert Type and Alert Triggered dropdowns now show separate options depending on the VLM Verified toggle, preventing stale values from the opposite state from leaking into the filter lists.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
