### PR TITLE
feat(launchable): pin Docker CE to 29.4.3 in VSS + NemoClaw notebooks

### DIFF
--- a/deploy/docker/scripts/deploy_nemoclaw_vss.ipynb
+++ b/deploy/docker/scripts/deploy_nemoclaw_vss.ipynb
@@ -660,6 +660,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "39abb4d8-0794-4404-820f-6297a71f77c0",
+   "metadata": {},
+   "source": [
+    "### 5.0 Pin Docker version\n",
+    "\n",
+    "Some Brev launchables ship a newer Docker CE than the VSS deploy profiles are tested against. Pin to **29.4.3** (downgrading if needed) so the steps below — Docker login, compose, the orchestrator MCP server — run against a known-good combination. Safe to re-run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dadca3b8-a6fd-4e96-85fa-ae5d66f637a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# Pin Docker CE to a known-good version (currently 29.4.3). Some Brev launchables\n",
+    "# ship a newer Docker that introduces compose/buildx incompatibilities with the\n",
+    "# VSS deploy profiles; explicitly install + downgrade to this version so the\n",
+    "# rest of the notebook runs against a tested combination. Idempotent — safe\n",
+    "# to re-run.\n",
+    "\n",
+    "VER=\"5:29.4.3-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)\"\n",
+    "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \\\n",
+    "  --allow-downgrades \\\n",
+    "  -o Dpkg::Options::=--force-confdef \\\n",
+    "  -o Dpkg::Options::=--force-confold \\\n",
+    "  docker-ce=$VER \\\n",
+    "  docker-ce-cli=$VER \\\n",
+    "  docker-buildx-plugin \\\n",
+    "  docker-compose-plugin \\\n",
+    "  containerd.io\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f6ba326b",
    "metadata": {},
    "source": [

--- a/deploy/docker/scripts/deploy_nemoclaw_vss.ipynb
+++ b/deploy/docker/scripts/deploy_nemoclaw_vss.ipynb
@@ -253,6 +253,66 @@
   },
   {
    "cell_type": "markdown",
+   "id": "18fe5334-049a-4cf2-899d-06ffa5feb16a",
+   "metadata": {},
+   "source": [
+    "### 2.1 Pin Docker version\n",
+    "\n",
+    "Pin Docker CE + plugins + containerd.io to a known-good combination (CE **29.4.3**, buildx **0.33.0**, compose **5.1.3**, containerd **2.2.3**) **before** section 3 brings up the OpenClaw sandbox — a docker-ce downgrade restarts dockerd and would disrupt live sandbox containers if it ran later in the notebook. `apt-mark hold` prevents drift back to newer versions before section 6 runs. Safe to re-run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb782286-f0bd-401e-9056-39a81821e3c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# Pin Docker CE + plugins + containerd.io to a known-good combination. Some\n",
+    "# Brev launchables ship a newer Docker than the VSS deploy profiles are\n",
+    "# tested against; pin explicitly so compose/buildx incompatibilities don't\n",
+    "# surface mid-deployment. Idempotent — safe to re-run.\n",
+    "\n",
+    "set -euo pipefail\n",
+    "\n",
+    "# Read distro info from /etc/os-release (always present on Ubuntu; minimal\n",
+    "# images don't ship `lsb_release`).\n",
+    ". /etc/os-release\n",
+    "DISTRO=\"${VERSION_ID}\"\n",
+    "CODENAME=\"${UBUNTU_CODENAME:-${VERSION_CODENAME}}\"\n",
+    "\n",
+    "# Versions hard-coded to what shipped alongside docker-ce 29.4.3 on the\n",
+    "# Docker apt repo (verified against download.docker.com + upstream GitHub\n",
+    "# release timestamps). When bumping DOCKER_CE_VER, bump these four together.\n",
+    "DOCKER_CE_VER=\"5:29.4.3-1~ubuntu.${DISTRO}~${CODENAME}\"\n",
+    "BUILDX_VER=\"0.33.0-1~ubuntu.${DISTRO}~${CODENAME}\"\n",
+    "COMPOSE_VER=\"5.1.3-1~ubuntu.${DISTRO}~${CODENAME}\"\n",
+    "CONTAINERD_VER=\"2.2.3-1~ubuntu.${DISTRO}~${CODENAME}\"\n",
+    "\n",
+    "# Refresh the APT cache first — without this, the specific epoch-versioned\n",
+    "# package may not be in the local index and the install would fail with\n",
+    "# version-not-found before any pinning takes effect.\n",
+    "sudo apt-get update -qq\n",
+    "\n",
+    "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \\\n",
+    "  --allow-downgrades \\\n",
+    "  -o Dpkg::Options::=--force-confdef \\\n",
+    "  -o Dpkg::Options::=--force-confold \\\n",
+    "  docker-ce=\"$DOCKER_CE_VER\" \\\n",
+    "  docker-ce-cli=\"$DOCKER_CE_VER\" \\\n",
+    "  docker-buildx-plugin=\"$BUILDX_VER\" \\\n",
+    "  docker-compose-plugin=\"$COMPOSE_VER\" \\\n",
+    "  containerd.io=\"$CONTAINERD_VER\"\n",
+    "\n",
+    "# Hold so unattended-upgrades / later `apt-get install` calls don't drift\n",
+    "# the box back to newer versions before the rest of the notebook runs.\n",
+    "sudo apt-mark hold \\\n",
+    "  docker-ce docker-ce-cli docker-buildx-plugin docker-compose-plugin containerd.io\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "run-md",
    "metadata": {},
    "source": [
@@ -656,42 +716,6 @@
     "\n",
     "print(\"NGC CLI configured.\")\n",
     "print(run(\"ngc config current\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "39abb4d8-0794-4404-820f-6297a71f77c0",
-   "metadata": {},
-   "source": [
-    "### 5.0 Pin Docker version\n",
-    "\n",
-    "Some Brev launchables ship a newer Docker CE than the VSS deploy profiles are tested against. Pin to **29.4.3** (downgrading if needed) so the steps below — Docker login, compose, the orchestrator MCP server — run against a known-good combination. Safe to re-run."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dadca3b8-a6fd-4e96-85fa-ae5d66f637a6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "# Pin Docker CE to a known-good version (currently 29.4.3). Some Brev launchables\n",
-    "# ship a newer Docker that introduces compose/buildx incompatibilities with the\n",
-    "# VSS deploy profiles; explicitly install + downgrade to this version so the\n",
-    "# rest of the notebook runs against a tested combination. Idempotent — safe\n",
-    "# to re-run.\n",
-    "\n",
-    "VER=\"5:29.4.3-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)\"\n",
-    "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \\\n",
-    "  --allow-downgrades \\\n",
-    "  -o Dpkg::Options::=--force-confdef \\\n",
-    "  -o Dpkg::Options::=--force-confold \\\n",
-    "  docker-ce=$VER \\\n",
-    "  docker-ce-cli=$VER \\\n",
-    "  docker-buildx-plugin \\\n",
-    "  docker-compose-plugin \\\n",
-    "  containerd.io\n"
    ]
   },
   {

--- a/deploy/docker/scripts/deploy_vss_launchable.ipynb
+++ b/deploy/docker/scripts/deploy_vss_launchable.ipynb
@@ -264,42 +264,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dce694f7-143b-4bfa-8091-1b9c0727fca6",
-   "metadata": {},
-   "source": [
-    "### 4.0 Pin Docker version\n",
-    "\n",
-    "Brev launchables sometimes ship a newer Docker CE than the VSS deploy profiles are tested against. Pin to **29.4.3** (downgrading if needed) so the rest of this notebook runs against a known-good combination. Safe to re-run."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a914851a-aaae-4f3c-81cf-a2b18d04dacd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "# Pin Docker CE to a known-good version (currently 29.4.3). Some Brev launchables\n",
-    "# ship a newer Docker that introduces compose/buildx incompatibilities with the\n",
-    "# VSS deploy profiles; explicitly install + downgrade to this version so the\n",
-    "# rest of the notebook runs against a tested combination. Idempotent — safe\n",
-    "# to re-run.\n",
-    "\n",
-    "VER=\"5:29.4.3-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)\"\n",
-    "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \\\n",
-    "  --allow-downgrades \\\n",
-    "  -o Dpkg::Options::=--force-confdef \\\n",
-    "  -o Dpkg::Options::=--force-confold \\\n",
-    "  docker-ce=$VER \\\n",
-    "  docker-ce-cli=$VER \\\n",
-    "  docker-buildx-plugin \\\n",
-    "  docker-compose-plugin \\\n",
-    "  containerd.io\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 4. Docker & Containerd Storage\n",
@@ -534,6 +498,68 @@
     "else:\n",
     "    if not STORAGE_ROOT and root_free >= MIN_ROOT_FREE_GB:\n",
     "        print(\"Skipping storage move.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "737a4711-8616-4d8e-81f1-dad62c9301b0",
+   "metadata": {},
+   "source": [
+    "### 4.1 Pin Docker version\n",
+    "\n",
+    "Pin Docker CE + plugins + containerd.io to a known-good combination (CE **29.4.3**, buildx **0.33.0**, compose **5.1.3**, containerd **2.2.3**). Some Brev launchables ship newer versions than the VSS deploy profiles are tested against; pin explicitly so compose/buildx incompatibilities don't surface in later sections. `apt-mark hold` prevents unattended-upgrades or later cells from drifting the box back. Safe to re-run.\n",
+    "\n",
+    "Runs *after* the section 4 storage relocation so the APT download lands on the relocated volume and the dockerd restart triggered by the downgrade picks up the new data-root."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbb3b970-81f7-4afa-941b-b2c85dbf25df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# Pin Docker CE + plugins + containerd.io to a known-good combination. Some\n",
+    "# Brev launchables ship a newer Docker than the VSS deploy profiles are\n",
+    "# tested against; pin explicitly so compose/buildx incompatibilities don't\n",
+    "# surface mid-deployment. Idempotent — safe to re-run.\n",
+    "\n",
+    "set -euo pipefail\n",
+    "\n",
+    "# Read distro info from /etc/os-release (always present on Ubuntu; minimal\n",
+    "# images don't ship `lsb_release`).\n",
+    ". /etc/os-release\n",
+    "DISTRO=\"${VERSION_ID}\"\n",
+    "CODENAME=\"${UBUNTU_CODENAME:-${VERSION_CODENAME}}\"\n",
+    "\n",
+    "# Versions hard-coded to what shipped alongside docker-ce 29.4.3 on the\n",
+    "# Docker apt repo (verified against download.docker.com + upstream GitHub\n",
+    "# release timestamps). When bumping DOCKER_CE_VER, bump these four together.\n",
+    "DOCKER_CE_VER=\"5:29.4.3-1~ubuntu.${DISTRO}~${CODENAME}\"\n",
+    "BUILDX_VER=\"0.33.0-1~ubuntu.${DISTRO}~${CODENAME}\"\n",
+    "COMPOSE_VER=\"5.1.3-1~ubuntu.${DISTRO}~${CODENAME}\"\n",
+    "CONTAINERD_VER=\"2.2.3-1~ubuntu.${DISTRO}~${CODENAME}\"\n",
+    "\n",
+    "# Refresh the APT cache first — without this, the specific epoch-versioned\n",
+    "# package may not be in the local index and the install would fail with\n",
+    "# version-not-found before any pinning takes effect.\n",
+    "sudo apt-get update -qq\n",
+    "\n",
+    "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \\\n",
+    "  --allow-downgrades \\\n",
+    "  -o Dpkg::Options::=--force-confdef \\\n",
+    "  -o Dpkg::Options::=--force-confold \\\n",
+    "  docker-ce=\"$DOCKER_CE_VER\" \\\n",
+    "  docker-ce-cli=\"$DOCKER_CE_VER\" \\\n",
+    "  docker-buildx-plugin=\"$BUILDX_VER\" \\\n",
+    "  docker-compose-plugin=\"$COMPOSE_VER\" \\\n",
+    "  containerd.io=\"$CONTAINERD_VER\"\n",
+    "\n",
+    "# Hold so unattended-upgrades / later `apt-get install` calls don't drift\n",
+    "# the box back to newer versions before the rest of the notebook runs.\n",
+    "sudo apt-mark hold \\\n",
+    "  docker-ce docker-ce-cli docker-buildx-plugin docker-compose-plugin containerd.io\n"
    ]
   },
   {

--- a/deploy/docker/scripts/deploy_vss_launchable.ipynb
+++ b/deploy/docker/scripts/deploy_vss_launchable.ipynb
@@ -264,6 +264,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dce694f7-143b-4bfa-8091-1b9c0727fca6",
+   "metadata": {},
+   "source": [
+    "### 4.0 Pin Docker version\n",
+    "\n",
+    "Brev launchables sometimes ship a newer Docker CE than the VSS deploy profiles are tested against. Pin to **29.4.3** (downgrading if needed) so the rest of this notebook runs against a known-good combination. Safe to re-run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a914851a-aaae-4f3c-81cf-a2b18d04dacd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# Pin Docker CE to a known-good version (currently 29.4.3). Some Brev launchables\n",
+    "# ship a newer Docker that introduces compose/buildx incompatibilities with the\n",
+    "# VSS deploy profiles; explicitly install + downgrade to this version so the\n",
+    "# rest of the notebook runs against a tested combination. Idempotent — safe\n",
+    "# to re-run.\n",
+    "\n",
+    "VER=\"5:29.4.3-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)\"\n",
+    "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \\\n",
+    "  --allow-downgrades \\\n",
+    "  -o Dpkg::Options::=--force-confdef \\\n",
+    "  -o Dpkg::Options::=--force-confold \\\n",
+    "  docker-ce=$VER \\\n",
+    "  docker-ce-cli=$VER \\\n",
+    "  docker-buildx-plugin \\\n",
+    "  docker-compose-plugin \\\n",
+    "  containerd.io\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 4. Docker & Containerd Storage\n",
@@ -1502,5 +1538,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Why

Brev launchables sometimes ship a newer Docker CE than the VSS deploy profiles are tested against. That's surfaced as compose / buildx incompatibilities mid-deployment in launchable runs. Pinning Docker to a known-good version up front sidesteps the class of problem entirely.

## What changes

Adds two new cells (markdown explainer + `%%bash` code) to each of:

- `deploy/docker/scripts/deploy_vss_launchable.ipynb` — new sub-section **4.0 Pin Docker version**, inserted at the start of section 4 (*Docker & Containerd Storage*).
- `deploy/docker/scripts/deploy_nemoclaw_vss.ipynb` — new sub-section **5.0 Pin Docker version**, inserted before section 5.2 (*Docker login to nvcr.io*).

The `%%bash` cell installs / downgrades Docker CE + CLI + buildx + compose plugins + containerd.io to **29.4.3** via apt-get, with `--allow-downgrades` and the standard `Dpkg::Options` for non-interactive runs. Idempotent — safe to re-run from the top of the notebook.

```bash
%%bash
VER="5:29.4.3-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)"
sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
  --allow-downgrades \
  -o Dpkg::Options::=--force-confdef \
  -o Dpkg::Options::=--force-confold \
  docker-ce=$VER \
  docker-ce-cli=$VER \
  docker-buildx-plugin \
  docker-compose-plugin \
  containerd.io
```

## Diff

```
deploy/docker/scripts/deploy_nemoclaw_vss.ipynb   | 38 ++++++++++++++-
deploy/docker/scripts/deploy_vss_launchable.ipynb | 38 ++++++++++++++-
2 files changed, 74 insertions(+), 2 deletions(-)
```

Pure insertion — no existing cells touched. Both notebooks parse as valid JSON; cell counts go from 30 → 32 (vss_launchable) and 25 → 27 (nemoclaw).

## Test plan

- [ ] Run `deploy_vss_launchable.ipynb` on a fresh Brev instance whose Docker version differs from `29.4.3` and confirm: section 4.0 installs / downgrades cleanly, sections 4+ then proceed normally.
- [ ] Run `deploy_nemoclaw_vss.ipynb` on a similar fresh instance; section 5.0 succeeds, Docker login in 5.2 then works.
- [ ] Re-run both notebooks top-to-bottom; section 4.0 / 5.0 are no-ops on the second pass (idempotency check).