### PR TITLE
Allow CI to disable Brev proxy URL fallback

### DIFF
--- a/services/agent/src/vss_agents/orchestrator/docker_compose_util.py
+++ b/services/agent/src/vss_agents/orchestrator/docker_compose_util.py
@@ -577,13 +577,21 @@ def build_resolved_env(config: DryRunRecipe) -> dict[str, str]:
     if external_ip != host_ip:
         merged["EXTERNAL_IP"] = external_ip
 
-    brev_env_id = first_non_placeholder(
+    disable_brev_proxy_env = first_non_placeholder(
         [
-            config.env_overrides.get("BREV_ENV_ID", ""),
-            os.environ.get("BREV_ENV_ID", ""),
-            read_etc_environment().get("BREV_ENV_ID", ""),
+            config.env_overrides.get("VSS_DISABLE_BREV_PROXY_ENV", ""),
+            os.environ.get("VSS_DISABLE_BREV_PROXY_ENV", ""),
         ]
-    )
+    ).lower() in {"1", "true", "yes"}
+    brev_env_id = ""
+    if not disable_brev_proxy_env:
+        brev_env_id = first_non_placeholder(
+            [
+                config.env_overrides.get("BREV_ENV_ID", ""),
+                os.environ.get("BREV_ENV_ID", ""),
+                read_etc_environment().get("BREV_ENV_ID", ""),
+            ]
+        )
     if brev_env_id:
         apply_brev_proxy_env(merged, brev_env_id)
 

--- a/services/agent/tests/unit_test/orchestrator/test_docker_compose_util.py
+++ b/services/agent/tests/unit_test/orchestrator/test_docker_compose_util.py
@@ -413,6 +413,7 @@ class TestBuildResolvedEnv:
 
         brev_calls: list[tuple[str, str]] = []
         monkeypatch.delenv("BREV_ENV_ID", raising=False)
+        monkeypatch.delenv("VSS_DISABLE_BREV_PROXY_ENV", raising=False)
         monkeypatch.setattr(dcu, "detect_internal_ip", lambda: pytest.fail("HOST_IP override should win"))
         monkeypatch.setattr(dcu, "detect_external_ip", lambda: "44.55.66.77")
         monkeypatch.setattr(dcu, "read_etc_environment", lambda: {"BREV_ENV_ID": "brev-from-etc"})
@@ -440,6 +441,45 @@ class TestBuildResolvedEnv:
         assert "SHARED_LLM_VLM_DEVICE_ID" not in resolved
         assert resolved["COMPOSE_PROFILES"] == "search_local,llm_local_llm-a-slug,vlm_local_vlm-a-slug"
         assert brev_calls == [("10.0.0.5", "brev-from-etc")]
+
+    def test_build_resolved_env_can_disable_brev_proxy_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recipe = _make_recipe(
+            tmp_path,
+            _env_text(
+                "MODE=local",
+                "BP_PROFILE=search",
+                "HARDWARE_PROFILE=igx",
+                "LLM_MODE=local_shared",
+                "LLM_NAME=llm-a",
+                "LLM_NAME_SLUG=llm-a-slug",
+                "VLM_MODE=local_shared",
+                "VLM_NAME=vlm-a",
+                "VLM_NAME_SLUG=vlm-a-slug",
+                "HOST_IP=<HOST_IP>",
+                "VSS_APPS_DIR=/path/to/deploy/docker",
+                "COMPOSE_PROFILES=${BP_PROFILE}_${MODE},llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}",
+            ),
+            profile=dcu.PROFILE_SEARCH,
+            env_overrides={"HOST_IP": "10.0.0.5", "VSS_DISABLE_BREV_PROXY_ENV": "true"},
+        )
+
+        monkeypatch.delenv("BREV_ENV_ID", raising=False)
+        monkeypatch.setattr(dcu, "detect_internal_ip", lambda: pytest.fail("HOST_IP override should win"))
+        monkeypatch.setattr(dcu, "detect_external_ip", lambda: "44.55.66.77")
+        monkeypatch.setattr(dcu, "read_etc_environment", lambda: {"BREV_ENV_ID": "brev-from-etc"})
+        monkeypatch.setattr(
+            dcu,
+            "apply_brev_proxy_env",
+            lambda _merged, _brev_env_id: pytest.fail("Brev proxy env should be disabled"),
+        )
+
+        resolved = dcu.build_resolved_env(recipe)
+
+        assert resolved["HOST_IP"] == "10.0.0.5"
+        assert resolved["EXTERNAL_IP"] == "44.55.66.77"
+        assert resolved["COMPOSE_PROFILES"] == "search_local,llm_local_llm-a-slug,vlm_local_vlm-a-slug"
 
     def test_build_resolved_env_uses_recipe_hardware_profile_when_not_overridden(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Description
Adds a VSS orchestrator opt-out for the automatic Brev proxy URL rewrite so CI can keep browser-facing URLs on loopback when Playwright runs in a host-networked container. This prevents `/etc/environment` `BREV_ENV_ID` from rewriting generated VST/chat URLs to `*.brevlab.com`, which is not resolvable from the CI browser container and causes upload failures.

Validated live on the NemoClaw Brev instance by redeploying base with `VSS_DISABLE_BREV_PROXY_ENV=true` and `EXTERNAL_IP=127.0.0.1`; UI E2E completed with 11 passed, including chat upload/playback on retry.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

Tests:
- `SETUPTOOLS_SCM_PRETEND_VERSION=3.2.0 uv run pytest tests/unit_test/orchestrator/test_docker_compose_util.py::TestBuildResolvedEnv::test_build_resolved_env_merges_defaults_and_overrides tests/unit_test/orchestrator/test_docker_compose_util.py::TestBuildResolvedEnv::test_build_resolved_env_can_disable_brev_proxy_env`
- `SETUPTOOLS_SCM_PRETEND_VERSION=3.2.0 uv run ruff check src/vss_agents/orchestrator/docker_compose_util.py tests/unit_test/orchestrator/test_docker_compose_util.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=3.2.0 uv run ruff format --check src/vss_agents/orchestrator/docker_compose_util.py tests/unit_test/orchestrator/test_docker_compose_util.py`
- Live Brev base UI E2E: `11 passed`