### PR TITLE
feat: clarify critic criteria in search results

### DIFF
--- a/skills/vss-search-archive/SKILL.md
+++ b/skills/vss-search-archive/SKILL.md
@@ -94,6 +94,7 @@ When using this skill, ALWAYS follow this high-level workflow:
    — Use clear section headers
    - Organize findings individually with supporting detail, and close with a summary
    - Use tables where comparisons help. Write like a technical report, not a chat message.
+   - If criteria results are non-null, then in addition to a column "Critic result" ("confirmed" | "rejected" | "skipped"), include a column "Criteria" with all the criteria for this search result ({criteria_n}: ✓ | ✗)
 5. CRITICAL: Verify the results and explain this to the user concisely.
    If search fails, or returns unexpected results (i.e. videos that do not appear to match user query, zero matches, zero videos returned, error etc.), STOP. Do not proceed without reading [troubleshooting.md](references/troubleshooting.md) to iterate with feedback loops until proper results are found and presented like a professional inspection report.
 6. Final verifications:

--- a/skills/vss-search-archive/eval/search.json
+++ b/skills/vss-search-archive/eval/search.json
@@ -27,6 +27,7 @@
         "The agent's final reply is formatted as an inspection report titled `Video Search Results` with clear section headers — not a raw JSON dump, not a chat-style bullet list",
         "Every search hit rendered in the report cites its start time, end time, similarity score, screenshot url or clip url verbatim from the /generate response — no fabricated timestamps, no paraphrased similarity scores",
         "Every screenshot_url / clip_url cited in the agent's final report matches the Brev secure-link pattern: https://<BREV_LINK_PREFIX>-<BREV_ENV_ID>.brevlab.com/... (NOT http://localhost:... and NOT http://<internal-ip>:...) — otherwise the user cannot open them from outside the Brev box",
+        "Each search result in the report displays a critic result outcome column, and also a criteria column listing all evaluation criteria relevant to that result (formatted with ✓ for true and ✗ for false).",
         "The agent's final reply includes a `Verification Step` offer at the end of the report, telling the user that screenshots can be downloaded and inspected — it does NOT silently download screenshots without opt-in",
         "The agent did NOT start the video ingest handshake (`POST /api/v1/videos` or `POST /api/v1/videos/{sensorId}/complete`) during this step, it considered the video was in the system already"
       ]


### PR DESCRIPTION
## Description
Clarify and enforce critic results inside video search skill.
Video search already uses critic through the API and usually surfaces the critic outcome and criteria.
In the future, an inspection report template can be enforced in terms of the output of the skill.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
