### PR TITLE
fix(helm/lvs): sync vss-agent config with docker

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -98,7 +98,6 @@ functions:
     lvs_backend_url: ${LVS_BACKEND_URL}
     model: ${VLM_NAME}
     video_url_tool: vst_video_clip
-    vlm_mode: ${VLM_MODE}
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
     conn_timeout_ms: 5000

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
@@ -94,7 +94,6 @@ functions:
     lvs_backend_url: ${LVS_BACKEND_URL}
     model: ${VLM_NAME}
     video_url_tool: vst_video_clip
-    vlm_mode: ${VLM_MODE}
     vst_internal_url: ${VST_INTERNAL_URL}
     # Connection and timeout configuration
     conn_timeout_ms: 5000


### PR DESCRIPTION
## Description
The `lvs_video_understanding` schema rejects `vlm_mode`; the docker source already omits it but the helm copy was out of sync, so vss-agent on deployment raised an error "Extra inputs are not permitted".

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
