### PR TITLE
feat(search): route HF_TOKEN to rt-embed via search profile .env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+/Users/zacw/Documents/obsidian-nv/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-/Users/zacw/Documents/obsidian-nv/CLAUDE.md

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -245,6 +245,12 @@ MODEL_PATH=git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detectio
 RTVI_EMBED_PORT=8017
 RTVI_CV_PORT=9000
 
+# HuggingFace token for rt-embed's MODEL_PATH download. Leave empty for the
+# default public Cosmos-Embed1 checkpoint; set to a token
+# (https://huggingface.co/settings/tokens) when MODEL_PATH points to a gated/
+# private repo or when anonymous rate limits cause the model download to fail.
+HF_TOKEN=
+
 # =============================================================================
 # VST (VIDEO STORAGE TOOL) CONFIGURATION
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -245,10 +245,9 @@ MODEL_PATH=git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detectio
 RTVI_EMBED_PORT=8017
 RTVI_CV_PORT=9000
 
-# HuggingFace token for rt-embed's MODEL_PATH download. Leave empty for the
-# default public Cosmos-Embed1 checkpoint; set to a token
-# (https://huggingface.co/settings/tokens) when MODEL_PATH points to a gated/
-# private repo or when anonymous rate limits cause the model download to fail.
+# HuggingFace token for rt-embed's MODEL_PATH download. Optional — fill in
+# (https://huggingface.co/settings/tokens) for faster first-run download of
+# the Cosmos-Embed1 model. Anonymous downloads work but are noticeably slower.
 HF_TOKEN=
 
 # =============================================================================

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -311,6 +311,17 @@ After RT-CV starts, it builds a TensorRT engine from this ONNX (3–5 min on fir
 
 RT-Embed downloads Cosmos-Embed1 weights from Hugging Face on first start; RT-CV's `perception-2d-init` downloads `siglip_v2` from NGC, then builds a TensorRT engine from the ONNX staged in [Stage perception models](#stage-perception-models-rt-detr-warehouse) above. Expect 15–25 min extra on the first deploy.
 
+### HuggingFace token for RT-Embed
+
+RT-Embed downloads the model named in `MODEL_PATH` (default `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection`) via Hugging Face. The default checkpoint is public, so leaving `HF_TOKEN` empty works.
+
+Set `HF_TOKEN` in `deploy/docker/developer-profiles/dev-profile-search/.env` (default is empty) when:
+
+- `MODEL_PATH` is repointed at a **gated or private** HF repo (e.g. a custom fine-tune you've uploaded to a private org).
+- The first-run download fails with an HF **403** or **429** — anonymous downloads share a low rate limit, and a personal token (https://huggingface.co/settings/tokens, "read" scope is enough) raises it dramatically.
+
+The token wires through to the `rtvi-embed` container's `HF_TOKEN` environment variable via the search profile's `.env` (see `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml`). Restart the container after changing it.
+
 ## Debugging
 
 - **`docker logs vss-rtvi-embed`** — confirms model load and `Maximum concurrency for X tokens per GPU: Y x` line. If it OOMs, lower `RTVI_EMBED_NUM_VLM_PROCS` (10 → 4) or `NUM_STREAMS`.

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -313,9 +313,12 @@ RT-Embed downloads Cosmos-Embed1 weights from Hugging Face on first start; RT-CV
 
 ### HuggingFace token for RT-Embed
 
-RT-Embed downloads the model named in `MODEL_PATH` (default `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection`) from Hugging Face on first start. A token is **required** when `MODEL_PATH` points to a gated or private HF repo (anonymous requests return HTTP 403) or when the anonymous rate limit is reached (HTTP 429). It also speeds up the default public Cosmos-Embed1 download.
+RT-Embed downloads the model named in `MODEL_PATH` (default `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection`) from Hugging Face on first start. Setting `HF_TOKEN`:
 
-Set `HF_TOKEN` in `deploy/docker/developer-profiles/dev-profile-search/.env` (default empty) to a token from https://huggingface.co/settings/tokens (a `read`-scope token is enough). The value wires through to the `rtvi-embed` container's `HF_TOKEN` environment variable via the search profile's `.env` (see `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml` line 64: `HF_TOKEN: "${HF_TOKEN:-}"`). Restart the container after changing it.
+- **speeds up the first-run download** of the default public Cosmos-Embed1 checkpoint, and
+- **enables using private or gated HF models** when you repoint `MODEL_PATH` at, e.g., a custom fine-tune hosted in a private org.
+
+Set `HF_TOKEN` in `deploy/docker/developer-profiles/dev-profile-search/.env` (default empty) to a token from https://huggingface.co/settings/tokens — a `read`-scope token is enough. The value wires through to the `rtvi-embed` container's `HF_TOKEN` environment variable via the search profile's `.env` (see `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml` line 64: `HF_TOKEN: "${HF_TOKEN:-}"`). Restart the container after changing it.
 
 ## Debugging
 

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -311,9 +311,9 @@ After RT-CV starts, it builds a TensorRT engine from this ONNX (3–5 min on fir
 
 RT-Embed downloads Cosmos-Embed1 weights from Hugging Face on first start; RT-CV's `perception-2d-init` downloads `siglip_v2` from NGC, then builds a TensorRT engine from the ONNX staged in [Stage perception models](#stage-perception-models-rt-detr-warehouse) above. Expect 15–25 min extra on the first deploy.
 
-### HuggingFace token for RT-Embed (optional, for faster downloads)
+### HuggingFace token for RT-Embed
 
-RT-Embed downloads the model named in `MODEL_PATH` (default `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection`) from Hugging Face on first start. Anonymous downloads work, but a personal token noticeably speeds up that first-run pull.
+RT-Embed downloads the model named in `MODEL_PATH` (default `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection`) from Hugging Face on first start. A token is **required** when `MODEL_PATH` points to a gated or private HF repo (anonymous requests return HTTP 403) or when the anonymous rate limit is reached (HTTP 429). It also speeds up the default public Cosmos-Embed1 download.
 
 Set `HF_TOKEN` in `deploy/docker/developer-profiles/dev-profile-search/.env` (default empty) to a token from https://huggingface.co/settings/tokens (a `read`-scope token is enough). The value wires through to the `rtvi-embed` container's `HF_TOKEN` environment variable via the search profile's `.env` (see `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml` line 64: `HF_TOKEN: "${HF_TOKEN:-}"`). Restart the container after changing it.
 

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -311,16 +311,11 @@ After RT-CV starts, it builds a TensorRT engine from this ONNX (3–5 min on fir
 
 RT-Embed downloads Cosmos-Embed1 weights from Hugging Face on first start; RT-CV's `perception-2d-init` downloads `siglip_v2` from NGC, then builds a TensorRT engine from the ONNX staged in [Stage perception models](#stage-perception-models-rt-detr-warehouse) above. Expect 15–25 min extra on the first deploy.
 
-### HuggingFace token for RT-Embed
+### HuggingFace token for RT-Embed (optional, for faster downloads)
 
-RT-Embed downloads the model named in `MODEL_PATH` (default `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection`) via Hugging Face. The default checkpoint is public, so leaving `HF_TOKEN` empty works.
+RT-Embed downloads the model named in `MODEL_PATH` (default `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection`) from Hugging Face on first start. Anonymous downloads work, but a personal token noticeably speeds up that first-run pull.
 
-Set `HF_TOKEN` in `deploy/docker/developer-profiles/dev-profile-search/.env` (default is empty) when:
-
-- `MODEL_PATH` is repointed at a **gated or private** HF repo (e.g. a custom fine-tune you've uploaded to a private org).
-- The first-run download fails with an HF **403** or **429** — anonymous downloads share a low rate limit, and a personal token (https://huggingface.co/settings/tokens, "read" scope is enough) raises it dramatically.
-
-The token wires through to the `rtvi-embed` container's `HF_TOKEN` environment variable via the search profile's `.env` (see `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml`). Restart the container after changing it.
+Set `HF_TOKEN` in `deploy/docker/developer-profiles/dev-profile-search/.env` (default empty) to a token from https://huggingface.co/settings/tokens (a `read`-scope token is enough). The value wires through to the `rtvi-embed` container's `HF_TOKEN` environment variable via the search profile's `.env` (see `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml` line 64: `HF_TOKEN: "${HF_TOKEN:-}"`). Restart the container after changing it.
 
 ## Debugging
 


### PR DESCRIPTION
## Summary

- Adds `HF_TOKEN=` (default empty) to `deploy/docker/developer-profiles/dev-profile-search/.env`, immediately after the RTVI Embed / `MODEL_PATH` block where it is contextually relevant.
- Documents when/why/how to set it in `skills/vss-deploy-profile/references/search.md` under the existing **First-run note** section.

## Why

The rt-embed compose service already consumes `HF_TOKEN` (`HF_TOKEN: "${HF_TOKEN:-}"` in `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml`), but the search profile's `.env` never declared the variable. Operators who need to:

- repoint `MODEL_PATH` at a **gated/private** HF repo (e.g. a custom fine-tune in a private org), or
- recover from a Hugging Face **403/429** when the anonymous rate limit hits during the first-run Cosmos-Embed1 download,

had no documented place to set the token for the search profile. base and lvs profiles already declared it; this PR brings search in line.

## What

```diff
--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ RTVI Embed block
 RTVI_CV_PORT=9000
+
+# HuggingFace token for rt-embed's MODEL_PATH download. Leave empty for the
+# default public Cosmos-Embed1 checkpoint; set to a token
+# (https://huggingface.co/settings/tokens) when MODEL_PATH points to a gated/
+# private repo or when anonymous rate limits cause the model download to fail.
+HF_TOKEN=
```

Plus a corresponding **HuggingFace token for RT-Embed** subsection in `skills/vss-deploy-profile/references/search.md` explaining the two operator cases and pointing at this `.env` location.

The dev-profile.sh `--env-file generated.env` pipeline picks `HF_TOKEN` up automatically; no compose changes needed, and the helm chart side already wires `HF_TOKEN` via a Kubernetes secret (`deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml:189` and `values.yaml:79-82`), so this is a docker-only gap.

## Behaviour

Unchanged for the default deployment — `HF_TOKEN` stays empty, anonymous HF download path continues to work for the public default model.

## Test plan

- [ ] `docker compose --env-file deploy/docker/developer-profiles/dev-profile-search/generated.env config` includes `HF_TOKEN=` (empty) on the `vss-rtvi-embed` service env.
- [ ] Set `HF_TOKEN=hf_xxx` in `.env`, restart, verify it shows up inside the container with `docker exec vss-rtvi-embed env | grep HF_TOKEN`.
- [ ] Repoint `MODEL_PATH` at a known-gated HF repo, confirm rt-embed pulls only when token is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)