### PR TITLE
feat(search): route HF_TOKEN to rt-embed via search profile .env (cherry-pick of #610 to dev/3.2.0)

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -245,6 +245,11 @@ MODEL_PATH=git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detectio
 RTVI_EMBED_PORT=8017
 RTVI_CV_PORT=9000
 
+# HuggingFace token for rt-embed's MODEL_PATH download. Optional — fill in
+# (https://huggingface.co/settings/tokens) for faster first-run download of
+# the Cosmos-Embed1 model. Anonymous downloads work but are noticeably slower.
+HF_TOKEN=
+
 # =============================================================================
 # VST (VIDEO STORAGE TOOL) CONFIGURATION
 # =============================================================================

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -311,6 +311,15 @@ After RT-CV starts, it builds a TensorRT engine from this ONNX (3–5 min on fir
 
 RT-Embed downloads Cosmos-Embed1 weights from Hugging Face on first start; RT-CV's `perception-2d-init` downloads `siglip_v2` from NGC, then builds a TensorRT engine from the ONNX staged in [Stage perception models](#stage-perception-models-rt-detr-warehouse) above. Expect 15–25 min extra on the first deploy.
 
+### HuggingFace token for RT-Embed
+
+RT-Embed downloads the model named in `MODEL_PATH` (default `git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection`) from Hugging Face on first start. Setting `HF_TOKEN`:
+
+- **speeds up the first-run download** of the default public Cosmos-Embed1 checkpoint, and
+- **enables using private or gated HF models** when you repoint `MODEL_PATH` at, e.g., a custom fine-tune hosted in a private org.
+
+Set `HF_TOKEN` in `deploy/docker/developer-profiles/dev-profile-search/.env` (default empty) to a token from https://huggingface.co/settings/tokens — a `read`-scope token is enough. The value wires through to the `rtvi-embed` container's `HF_TOKEN` environment variable via the search profile's `.env` (see `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml` line 64: `HF_TOKEN: "${HF_TOKEN:-}"`). Restart the container after changing it.
+
 ## Debugging
 
 - **`docker logs vss-rtvi-embed`** — confirms model load and `Maximum concurrency for X tokens per GPU: Y x` line. If it OOMs, lower `RTVI_EMBED_NUM_VLM_PROCS` (10 → 4) or `NUM_STREAMS`.


### PR DESCRIPTION
Cherry-pick of #610 onto `dev/3.2.0` for the 3.2.0 GA release.

## Summary

- Adds `HF_TOKEN=` (default empty) to `deploy/docker/developer-profiles/dev-profile-search/.env`, right after the RTVI Embed / `MODEL_PATH` block.
- Adds an *HuggingFace token for RT-Embed* subsection in `skills/vss-deploy-profile/references/search.md` framing the token as:
  - **speeds up the first-run download** of the default public Cosmos-Embed1 checkpoint, and
  - **enables using private or gated HF models** when `MODEL_PATH` is repointed.

The rt-embed compose already consumes `${HF_TOKEN:-}` (line 64 of `deploy/docker/services/rtvi/rtvi-embed/rtvi-embed-docker-compose.yml`), so this PR just adds the missing operator-facing declaration in the search profile's `.env` plus matching docs. base and lvs profiles already declared it; this brings search in line.

## Behaviour

Unchanged for the default deployment — `HF_TOKEN` stays empty, anonymous HF download path for the public Cosmos-Embed1 checkpoint continues to work.

## Origin

- develop PR: https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/610
- develop squash commit: `b5c041151c307d68c1f09f219f494dfa3054a2bf`

Clean cherry-pick (one trivial auto-merge in the `.env` block, no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)