### PR TITLE
skill-eval: remove BrevEnvironment auto-provisioning

### DIFF
--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -6,11 +6,10 @@ Evaluation is **fully CI-driven**. [`.github/workflows/skills-eval.yml`](../work
 
 1. Diffs the PR against its base branch and picks out changed skills with an eval spec at `skills/<skill>/evals/<name>.json` or legacy `skills/<skill>/eval/<name>.json`.
 2. Generates Harbor datasets per `(skill, profile, platform, mode)` via the adapter at [`adapters/<skill>/generate.py`](adapters/).
-3. Acquires a per-instance `flock` on a Brev GPU host, reusing one that matches the target platform or creating one via the fallback chain in [`AGENTS.md`](AGENTS.md).
+3. Acquires a per-instance `flock` on an operator-managed `vss-eval-*` pool member matching the target platform, per the fleet-selection algorithm in [`AGENTS.md`](AGENTS.md) § 5a. The harness does **not** auto-provision — if no pool member matches, the run blocks until one appears (or times out).
 4. Runs `uvx harbor run` against each dataset, one trial at a time, with the canonical invocation captured in [`AGENTS.md § Harbor invocation`](AGENTS.md).
 5. Verifies each trial (containers running, endpoints healthy, trajectory / response / rubric checks — see `verifiers/generic_judge.py`) and scores 0.0–1.0.
 6. Posts one Markdown results summary per `(PR, eval-spec)` batch as a PR comment, with trace URLs served by `harbor view`.
-7. Leaves instance IDs in `/tmp/brev/started-by-<run_id>.txt`; the workflow wrapper deletes / stops them after a 5-min cooldown.
 
 The whole thing runs inside the 8-hour GitHub Actions job timeout. The `.github/skill-eval/AGENTS.md` file **is** the agent's system prompt — keep it readable.
 
@@ -257,4 +256,4 @@ disown
 
 **Agent deployment fails with "pull access denied".** `NGC_CLI_API_KEY` missing or invalid — the agent needs it to pull VSS NIM containers from `nvcr.io`.
 
-**Cancelled run leaves orphan Brev instances.** A cancelled CI job never gets to the cooldown teardown step. Clean up by listing owned instances in `/tmp/brev/started-by-<run_id>.txt` on the runner host and `brev delete` them manually.
+**Orphan `harbor-*` Brev instances.** The harness no longer auto-provisions — every trial must use a `vss-eval-*` pool member. If you see `harbor-*` instances in `brev ls`, they're stragglers from before this change (or from someone running `uvx harbor` manually without `BREV_INSTANCE` set). Clean them up with `brev delete <name>`.

--- a/.github/skill-eval/adapters/vss-deploy-profile/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-profile/generate.py
@@ -170,11 +170,11 @@ def deploy_profile(eval_profile: str) -> str:
 _DEFAULT_MIN_ROOT_DISK_GB = 220        # base stack ~80GB + 2 local NIMs ~70GB each
 _DEFAULT_MIN_DRIVER_VERSION = "580.95" # cosmos-reason2-8b:1.6.0 floor
 # Caveats — both defaults are enforced unconditionally by
-# `envs/brev_env.py::_check_live_resources` / `_find_cheapest_matching_type`:
+# `envs/brev_env.py::_check_live_resources` on the resolved pool box:
 # - The disk default would reject otherwise-eligible smaller-root
-#   providers (e.g. some launchpad boxes) for trials that end up
-#   running fully remote and would actually fit on <220GB. Acceptable
-#   today because every `vss-eval-*` pool member has ≥220GB.
+#   pool members for trials that end up running fully remote and would
+#   actually fit on <220GB. Acceptable today because every `vss-eval-*`
+#   pool member has ≥220GB.
 # - The driver default is skipped when `nvidia-smi` is absent (the
 #   resource check warns instead of erroring), so CPU-only boxes still
 #   pass; don't tighten that branch to a hard error without revisiting

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -48,23 +48,6 @@ BREV_EXEC_TIMEOUT = int(os.environ.get("BREV_EXEC_TIMEOUT", "1800"))
 BREV_COPY_TIMEOUT = int(os.environ.get("BREV_COPY_TIMEOUT", "300"))
 
 
-def _record_started_instance(name: str) -> None:
-    """Append an auto-provisioned instance name to the wrapper's
-    cleanup marker (`/tmp/brev/started-by-<run_id>.txt`) so
-    skills_eval_agent.cleanup_instances() tears it down even if the
-    agent never observes the name. No-op outside CI (no GITHUB_RUN_ID)."""
-    run_id = os.environ.get("GITHUB_RUN_ID")
-    if not run_id:
-        return
-    try:
-        marker = Path(f"/tmp/brev/started-by-{run_id}.txt")
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        with marker.open("a") as fh:
-            fh.write(f"{name}\n")
-    except OSError as exc:
-        logger.warning("failed to record %s in started-by marker: %s", name, exc)
-
-
 class BrevEnvironmentType(str, Enum):
     BREV = "brev"
 
@@ -120,7 +103,7 @@ class BrevEnvironment(BaseEnvironment):
         return tomllib.loads(task_toml.read_text()).get("metadata", {}) or {}
 
     def _resolve_instance_name(self) -> str | None:
-        """Resolve instance name: env var > task.toml > None (auto-provision)."""
+        """Resolve instance name: env var > task.toml > None (error)."""
         if DEFAULT_INSTANCE:
             return DEFAULT_INSTANCE
         meta = self._read_task_metadata()
@@ -129,7 +112,9 @@ class BrevEnvironment(BaseEnvironment):
         return None
 
     async def start(self, force_build: bool) -> None:
-        """Validate or provision a Brev instance matching task GPU requirements."""
+        """Validate that the resolved Brev instance is reachable and matches
+        the task's GPU requirements. Errors if no instance is resolved —
+        the harness does not auto-provision."""
         if self._started:
             return
 
@@ -157,61 +142,15 @@ class BrevEnvironment(BaseEnvironment):
                 )
             await _check_instance_matches(instance, requirements)
         else:
-            # Mode 2: auto-provision via brev search + create.
-            # Some platforms (DGX-SPARK, IGX-THOR) aren't provisionable as
-            # cloud instance types — they're physical devices registered via
-            # `brev register`.  Check there first and give a helpful error.
-            if not requirements["brev_search"]:
-                raise RuntimeError(
-                    "No BREV_INSTANCE set and no GPU requirements in task.toml "
-                    "[metadata] — cannot auto-provision."
-                )
-            logger.info("Auto-provisioning Brev instance for %s", requirements)
-            instance_type = await _find_cheapest_matching_type(requirements)
-            if not instance_type:
-                # Before failing, list any registered nodes that might fit.
-                suggestions = await _suggest_registered_devices(requirements)
-                msg = [
-                    f"Cannot auto-provision: no Brev cloud instance type matches",
-                    f"  requirements: {requirements}",
-                ]
-                if suggestions:
-                    msg.append("")
-                    msg.append("Registered device(s) matching (or partially matching) these requirements:")
-                    for s in suggestions:
-                        msg.append(f"  - {s}")
-                    msg.append("")
-                    msg.append(
-                        "Set `BREV_INSTANCE=<name>` or add `brev_instance = \"<name>\"` "
-                        "to task.toml [metadata] to use one of these."
-                    )
-                else:
-                    msg.append("")
-                    msg.append(
-                        "No registered devices match either. Options:\n"
-                        "  1. Register a physical device via `brev register` "
-                        "(DGX Spark / IGX Thor are typically registered, not provisioned).\n"
-                        "  2. Adjust gpu_type / brev_search in the task to a provisionable "
-                        "platform (e.g. H100, L40S, RTX PRO 6000)."
-                    )
-                full_msg = "\n".join(msg)
-                logger.error(full_msg)
-                raise RuntimeError(full_msg)
-            self._instance_name = f"harbor-{uuid.uuid4().hex[:8]}"
-            logger.info("Creating %s as %s", self._instance_name, instance_type)
-            create_result = await _run_brev(
-                "create", self._instance_name, "--detached",
-                stdin_data=instance_type,
-                timeout=120,
+            raise RuntimeError(
+                "No BREV_INSTANCE set and no `brev_instance` in task.toml "
+                "[metadata]. The harness no longer auto-provisions — every "
+                "trial must run on an operator-managed `vss-eval-*` pool "
+                "member. The skill-eval agent picks one per AGENTS.md § 5a "
+                "and exports BREV_INSTANCE before invoking `uvx harbor run`. "
+                "If you're running harbor manually, export "
+                "BREV_INSTANCE=<vss-eval-*-name> first."
             )
-            if create_result.return_code != 0:
-                raise RuntimeError(f"brev create failed: {create_result.stderr}")
-            # Record the harbor-* instance in the wrapper's cleanup marker
-            # so skills_eval_agent.cleanup_instances() tears it down even if
-            # the trial fails before the agent tracks it. Append before
-            # _wait_for_running so a timeout there doesn't leak an orphan.
-            _record_started_instance(self._instance_name)
-            await _wait_for_running(self._instance_name)
 
         # Quick smoke test — ensure exec works
         result = await _run_brev_exec(
@@ -229,11 +168,11 @@ class BrevEnvironment(BaseEnvironment):
                 f"{(result.stdout or '')[:200]!r}"
             )
 
-        # Post-provision resource checks: root disk + GPU driver.
-        # These catch provider quirks that brev search doesn't surface
-        # (e.g. hyperstack_H100x2 lists disk_min_gb=1600 but mounts the
-        # big volume on /ephemeral — / is only ~100 GB, which OOMs on
-        # local NIM pulls).
+        # Live resource checks: root disk + GPU driver. The pool box was
+        # provisioned by the operator and is expected to meet these, but
+        # the checks catch silent regressions (e.g. a driver downgrade or
+        # a box where the big volume mounts on /ephemeral and / is only
+        # ~100 GB — which OOMs on local NIM pulls).
         await _check_live_resources(self._instance_name, requirements)
 
         # Pre-create harbor's expected directories with correct ownership
@@ -1279,40 +1218,6 @@ async def _check_instance_matches(instance: dict, req: dict) -> None:
     )
 
 
-async def _find_cheapest_matching_type(req: dict) -> str | None:
-    """Find the cheapest `brev search` instance type matching GPU requirements."""
-    result = await _run_brev("search", "--json", timeout=30)
-    search = (req.get("brev_search") or "").lower()
-    required_count = req.get("gpu_count", 1)
-    required_vram = req.get("min_vram_gb_per_gpu", 0)
-    required_disk = req.get("min_root_disk_gb", 0)
-
-    candidates = []
-    for inst in _parse_brev_json(result.stdout):
-        gpu_name = (inst.get("gpu_name") or "").lower()
-        gpu_count = int(inst.get("gpu_count", 0) or 0)
-        total_vram = float(inst.get("total_vram_gb", 0) or 0)
-        disk_min_gb = int(inst.get("disk_min_gb", 0) or 0)
-        if search and search not in gpu_name:
-            continue
-        if gpu_count < required_count:
-            continue
-        if required_vram and (total_vram / max(gpu_count, 1)) < required_vram:
-            continue
-        # Pre-filter by disk_min_gb.  Some providers misreport this (e.g.
-        # hyperstack lists ephemeral-disk size not root), so the live check
-        # in _check_live_resources is authoritative; this filter just prunes
-        # candidates that are obviously undersized.
-        if required_disk and disk_min_gb and disk_min_gb < required_disk:
-            continue
-        candidates.append(inst)
-
-    if not candidates:
-        return None
-    candidates.sort(key=lambda x: float(x.get("price_per_hour", 0) or 0))
-    return candidates[0].get("type")
-
-
 def _version_lt(a: str, b: str) -> bool:
     """Return True if NVIDIA driver version `a` is older than `b`.
 
@@ -1380,56 +1285,3 @@ async def _check_live_resources(instance_name: str, req: dict) -> None:
         )
 
 
-async def _suggest_registered_devices(req: dict) -> list[str]:
-    """Query `brev ls nodes --json` for registered physical devices that
-    match the task's requirements (best-effort, by name substring).
-    Returns human-readable strings for error messages."""
-    result = await _run_brev("ls", "nodes", "--json", timeout=15)
-    nodes = _parse_brev_json(result.stdout)
-    if not nodes:
-        return []
-    search = (req.get("brev_search") or req.get("gpu_type") or "").lower()
-    suggestions = []
-    for n in nodes:
-        name = n.get("name") or ""
-        status = n.get("status") or "?"
-        # Node entries don't include GPU specs; fall back to name matching.
-        # If search term appears in node name, it's a likely fit.
-        if search and search in name.lower():
-            suggestions.append(f"{name}  (status={status})  [name matches '{search}']")
-    # Also include all connected nodes as fallback suggestions.
-    if not suggestions:
-        for n in nodes:
-            if n.get("status") == "Connected":
-                suggestions.append(
-                    f"{n.get('name')}  (status=Connected)  "
-                    f"[GPU unknown — verify manually]"
-                )
-    return suggestions
-
-
-async def _wait_for_running(
-    name: str,
-    timeout_sec: int = 2400,
-    poll_interval: int = 15,
-) -> None:
-    """Poll `brev ls` until the named instance reaches RUNNING + shell READY."""
-    elapsed = 0
-    while elapsed < timeout_sec:
-        inst = await _find_brev_instance(name)
-        if inst:
-            status = inst.get("status")
-            shell = inst.get("shell_status")
-            if status == "FAILURE":
-                raise RuntimeError(f"Brev instance {name} creation FAILED")
-            if status == "RUNNING" and shell == "READY":
-                return
-            logger.info(
-                "Waiting for %s (status=%s shell=%s, %ds/%ds)",
-                name, status, shell, elapsed, timeout_sec,
-            )
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
-    raise TimeoutError(
-        f"Brev instance {name} did not become ready within {timeout_sec}s"
-    )


### PR DESCRIPTION
## Summary

Remove the Mode 2 auto-provision fallback in `BrevEnvironment.start()`. Trials must now run on an operator-managed `vss-eval-*` pool member (resolved via `BREV_INSTANCE` env var or `task.toml [metadata].brev_instance`); if neither is set, the harness fails loud instead of silently `brev create`-ing a fresh `harbor-<uuid8>`.

## Why

The auto-provision path was designed as a fallback for the pre-pool world, but in the long-running pool model it had three failure modes:

1. **Silent paid leaks.** `uvx harbor` invoked outside the CI agent (or in any code path that forgets to `export BREV_INSTANCE`) would spin up a fresh GPU and leave it running. The wrapper-side cleanup that used to delete these on a 5-min cooldown was removed when the pool went long-lived, so the `/tmp/brev/started-by-<run_id>.txt` markers are still written but never read.
2. **Concrete cost today.** Three orphan `harbor-*` were running on this org (2× `g7e.2xlarge`, 1× `massedcompute_L40S`) — ~\$9/hr combined. Deleted out-of-band before this PR.
3. **Hides operator intent.** AGENTS.md is explicit that the pool is operator-managed and the agent must select+export `BREV_INSTANCE`; the auto-provision fallback gave the agent (and any other caller) a way to bypass that without an error.

## What changed

`envs/brev_env.py`:
- `BrevEnvironment.start()`'s `else:` branch is now a `RuntimeError` pointing the caller at the pool model.
- Removed the now-unreachable helpers: `_record_started_instance`, `_find_cheapest_matching_type`, `_suggest_registered_devices`, `_wait_for_running`.
- Docstring + `_resolve_instance_name` doc + post-validation comment updated to reflect "validate, don't provision."

`adapters/vss-deploy-profile/generate.py`:
- Comment dropped its dangling reference to `_find_cheapest_matching_type`.

`README.md`:
- Step 7 of the run lifecycle (about `started-by-<run_id>.txt` + wrapper cleanup) removed.
- Troubleshooting entry "Cancelled run leaves orphan Brev instances" rewritten to reflect the post-removal world.

## Test plan

- [ ] Run a normal CI eval (e.g. trigger skills-eval on an open PR). Confirm the agent sets `BREV_INSTANCE` and the trials run as before — no `harbor-*` instances appear in `brev ls`.
- [ ] Manually run `uvx harbor run` against a fresh dataset *without* `BREV_INSTANCE` set. Confirm it errors at startup with the new pointer message instead of `brev create`-ing.
- [ ] Confirm `mypy` / `ruff` still pass on `envs/brev_env.py` (no dangling references to removed names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)