### PR TITLE
cherry-pick #614 to dev/3.2.0: default NemoClaw LLM to opus-4-7

### DIFF
--- a/deploy/docker/scripts/deploy_nemoclaw_vss.ipynb
+++ b/deploy/docker/scripts/deploy_nemoclaw_vss.ipynb
@@ -438,7 +438,12 @@
     "else:\n",
     "    print(\"NemoClaw already installed, skipping installer.\", flush=True)\n",
     "run_streamed([\"bash\", str(NEMOCLAW_INIT_SCRIPT_PATH)], label=\"init_nemoclaw.sh\", cwd=str(NEMOCLAW_INIT_SCRIPT_PATH.parent))\n",
-    "print(\"Done.\", flush=True)"
+    "print(\"Done.\", flush=True)\n",
+    "\n",
+    "subprocess.run(\n",
+    "    [\"openshell\", \"forward\", \"start\", \"--background\", \"9090\", NEMOCLAW_SANDBOX_NAME],\n",
+    "    check=True,\n",
+    ")\n"
    ]
   },
   {
@@ -1077,7 +1082,53 @@
    "cell_type": "markdown",
    "id": "next-md",
    "metadata": {},
-   "source": "#### Step 2. Verify the LLM works in chat\n\nStart a chat with the agent and send a simple prompt such as:\n\n- `hello`\n- `what model are you using?`\n- `list your available skills`\n\n![OpenClaw UI chat screenshot](./images/OpenClawUIChat.png)\n\nYou should get a normal model response back. If the UI opens but chat fails, re-check provider setup and the active policy.\n\n#### Step 3. Verify the VSS skills are imported\n\nOpen the **Skills** tab in the UI and confirm the **VSS skills** are present.\n\n![OpenClaw UI skills screenshot](./images/OpenClawUISkills.png)\n\n#### Step 4. Verify the agent sees the `vss_orchestrator` MCP tools\n\nRun the prompts below in order. They progress from *\"can the agent see the tools?\"* → *\"can the agent query a tool?\"* → *\"can the agent invoke deployment tools end-to-end?\"*. If any step fails, re-check that **6.1** completed successfully and that the MCP server is still running on port 9988.\n\n**Prompt A — list available tools:**\n\n> *\"List your available tools.\"*\n\nThe agent should enumerate the nine `vss_orchestrator__*` tools registered by the MCP server.\n\n![OpenClaw UI list tools screenshot](./images/OpenClawUIListTools.png)\n\n**Prompt B — query a tool (list profiles):**\n\n> *\"List the available VSS deployment profiles.\"*\n\nThe agent should invoke `vss_orchestrator__profiles` and return `base`, `search`, `alerts`, `lvs`.\n\n![OpenClaw UI search profiles screenshot](./images/OpenClawUISearch.png)\n\n**Prompt C — invoke a deployment:**\n\n> *\"Deploy the VSS `alerts` profile in `verification` mode.\"*\n\nThe agent should chain `vss_orchestrator__docker_generate` → `docker_up` → `docker_status` and stream progress back into the chat. It will ask before invoking the build, and surface a `docker_compose_id` you can reference later.\n\n![OpenClaw UI deploy VSS screenshot](./images/OpenClawUIDeploy.png)\n"
+   "source": [
+    "#### Step 2. Verify the LLM works in chat\n",
+    "\n",
+    "Start a chat with the agent and send a simple prompt such as:\n",
+    "\n",
+    "- `hello`\n",
+    "- `what model are you using?`\n",
+    "- `list your available skills`\n",
+    "\n",
+    "![OpenClaw UI chat screenshot](./images/OpenClawUIChat.png)\n",
+    "\n",
+    "You should get a normal model response back. If the UI opens but chat fails, re-check provider setup and the active policy.\n",
+    "\n",
+    "#### Step 3. Verify the VSS skills are imported\n",
+    "\n",
+    "Open the **Skills** tab in the UI and confirm the **VSS skills** are present.\n",
+    "\n",
+    "![OpenClaw UI skills screenshot](./images/OpenClawUISkills.png)\n",
+    "\n",
+    "#### Step 4. Verify the agent sees the `vss_orchestrator` MCP tools\n",
+    "\n",
+    "Run the prompts below in order. They progress from *\"can the agent see the tools?\"* → *\"can the agent query a tool?\"* → *\"can the agent invoke deployment tools end-to-end?\"*. If any step fails, re-check that **6.1** completed successfully and that the MCP server is still running on port 9988.\n",
+    "\n",
+    "**Prompt A — list available tools:**\n",
+    "\n",
+    "> *\"List your available tools.\"*\n",
+    "\n",
+    "The agent should enumerate the nine `vss_orchestrator__*` tools registered by the MCP server.\n",
+    "\n",
+    "![OpenClaw UI list tools screenshot](./images/OpenClawUIListTools.png)\n",
+    "\n",
+    "**Prompt B — query a tool (list profiles):**\n",
+    "\n",
+    "> *\"List the available VSS deployment profiles.\"*\n",
+    "\n",
+    "The agent should invoke `vss_orchestrator__profiles` and return `base`, `search`, `alerts`, `lvs`.\n",
+    "\n",
+    "![OpenClaw UI search profiles screenshot](./images/OpenClawUISearch.png)\n",
+    "\n",
+    "**Prompt C — invoke a deployment:**\n",
+    "\n",
+    "> *\"Deploy the VSS `alerts` profile in `verification` mode.\"*\n",
+    "\n",
+    "The agent should chain `vss_orchestrator__docker_generate` → `docker_up` → `docker_status` and stream progress back into the chat. It will ask before invoking the build, and surface a `docker_compose_id` you can reference later.\n",
+    "\n",
+    "![OpenClaw UI deploy VSS screenshot](./images/OpenClawUIDeploy.png)\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1179,7 +1230,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1193,7 +1244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.5"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What

Cherry-picks [#614](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/614) from `develop` (`0b63928d`) onto `dev/3.2.0`. Updates the NemoClaw launchable notebook to default the NemoClaw LLM to opus-4-7 and adds port-forward 9090.

## Scope

Single file change:

```
deploy/docker/scripts/deploy_nemoclaw_vss.ipynb | 55 ++++++++++++++++++--
1 file changed, 55 insertions(+), 4 deletions(-)
```

No agent source change → no container rebuild.

## Why cherry-pick instead of full sync

Targeted: only the NemoClaw LLM default is needed on dev/3.2.0 for the 3.2.0 GA cut. The 8 other develop commits since #612 (auto-calibration refactor, sdrc, helm sync, index resolver, lvs rc11 bump, etc.) are not release-critical and can wait for the next routine sync.

## Test plan

- [ ] CI green.
- [ ] Smoke-test the NemoClaw launchable notebook on a fresh Brev instance — confirm opus-4-7 is the resolved default and the 9090 port-forward is established.