### PR TITLE
ci: dummy PR to trigger downstream pipeline against dev/3.2.0

### DIFF
--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,0 +1,13 @@
+# CI trigger file — no-op
+#
+# Touched solely to force a CI run against the current dev/3.2.0 HEAD.
+# The downstream pipeline (gitlab-master:metromind/ci-vss-oss) only
+# fires on push to develop/main or on copy-pr-bot's pull-request/<N>
+# mirror branches, so a PR against dev/3.2.0 is the path to exercise it.
+#
+# This file is intentionally inert and can be removed once the workflow
+# learns to trigger directly off release branches.
+#
+last_triggered: 2026-05-21T21:08:32Z
+target_branch:  dev/3.2.0
+target_sha:     fe3ecfc7344349cf5a0c5327c578479aebfd41b8


### PR DESCRIPTION
## What

Trivial PR to force the downstream CI pipeline to run against the current `dev/3.2.0` HEAD.

## Why

`.github/workflows/ci.yml` only fires on push to `main`, `develop`, or `pull-request/[0-9]+`. Direct merges to `dev/3.2.0` don't trigger CI or the downstream gitlab-master pipeline. Opening this PR routes the dev/3.2.0 HEAD through copy-pr-bot's `pull-request/<N>` mirror, which matches the trigger.

## Change

A single inert marker file `.ci-trigger` — no consumer reads it.

## Disposition

**Do not merge.** Close after the downstream pipeline reports back. Once `ci.yml` learns to trigger directly off release branches (separate PR against develop), this pattern goes away.

## Test plan

- [ ] `Trigger Downstream Pipeline` job starts.
- [ ] Downstream pipeline completes (alerts/search/lvs/base profiles green).
- [ ] Close PR; delete branch.