### PR TITLE
ci(license-diff): resolve base ref from PR target, not hardcoded develop

### DIFF
--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -45,9 +45,12 @@ jobs:
           # branch so cherry-pick / hotfix PRs against release branches
           # (e.g. dev/3.2.0) get a sensible diff baseline. Fall back to
           # develop only if the lookup fails (e.g. PR closed mid-run).
+          # `// ""` coerces a missing/null baseRefName to an empty string —
+          # bare `.baseRefName` would emit the literal "null" and bypass the
+          # `${target:-DEFAULT_BRANCH}` fallback below.
           target="$(gh pr view "${pr_number}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --json baseRefName --jq '.baseRefName' 2>/dev/null || true)"
+            --json baseRefName --jq '.baseRefName // ""' 2>/dev/null || true)"
           target="${target:-${DEFAULT_BRANCH}}"
           git fetch --no-tags origin "+refs/heads/${target}:refs/remotes/origin/${target}"
           merge_base=$(git merge-base HEAD "origin/${target}" || git rev-parse "origin/${target}")

--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -35,15 +35,25 @@ jobs:
       - name: Resolve base ref and PR number
         id: ctx
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: develop
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
-          merge_base=$(git merge-base HEAD "origin/${DEFAULT_BRANCH}" || git rev-parse "origin/${DEFAULT_BRANCH}")
           pr_number="${GITHUB_REF##*/pull-request/}"
+          # This workflow runs on push-to-mirror (refs/heads/pull-request/<N>),
+          # so github.base_ref is empty. Query the PR API for the real target
+          # branch so cherry-pick / hotfix PRs against release branches
+          # (e.g. dev/3.2.0) get a sensible diff baseline. Fall back to
+          # develop only if the lookup fails (e.g. PR closed mid-run).
+          target="$(gh pr view "${pr_number}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json baseRefName --jq '.baseRefName' 2>/dev/null || true)"
+          target="${target:-${DEFAULT_BRANCH}}"
+          git fetch --no-tags origin "+refs/heads/${target}:refs/remotes/origin/${target}"
+          merge_base=$(git merge-base HEAD "origin/${target}" || git rev-parse "origin/${target}")
           echo "base=${merge_base}" >> "$GITHUB_OUTPUT"
           echo "pr=${pr_number}" >> "$GITHUB_OUTPUT"
-          echo "Comparing HEAD against ${merge_base} for PR #${pr_number}"
+          echo "Comparing HEAD against ${merge_base} (PR target: ${target}) for PR #${pr_number}"
 
       - name: Generate license diff CSV
         id: gen


### PR DESCRIPTION
## Summary

`.github/workflows/license-diff.yml` hardcoded `DEFAULT_BRANCH=develop` because the workflow runs on push-to-mirror (`refs/heads/pull-request/<N>`), where `github.base_ref` is empty. For any PR targeting a branch other than `develop` (cherry-picks to `dev/3.2.0`, hotfixes to `release/*`), the diff baseline became 'the merge-base with develop' — typically weeks of unrelated dependency drift away from the actual PR base.

**Symptom:** [#621](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/621) cherry-picks #585 onto `dev/3.2.0` and adds **zero** lines to `services/agent/pyproject.toml` or `uv.lock`. Yet the License Diff reported **116 changed packages** because it compared against `develop`'s merge-base (`e03d5133`, 2026-05-06) — every agent-dep upgrade that landed on `dev/3.2.0` since then showed up as a 'change in this PR'.

## Fix

Resolve the PR target via `gh pr view <pr_number> --json baseRefName` (the PR number is already extracted from `GITHUB_REF`). The workflow falls back to `develop` only if the lookup fails (e.g. PR closed mid-run). Added `GH_TOKEN` to the step env so `gh` works.

```diff
       - name: Resolve base ref and PR number
         id: ctx
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: develop
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
-          merge_base=$(git merge-base HEAD "origin/${DEFAULT_BRANCH}" || git rev-parse "origin/${DEFAULT_BRANCH}")
           pr_number="${GITHUB_REF##*/pull-request/}"
+          target="$(gh pr view "${pr_number}" --repo "${GITHUB_REPOSITORY}" --json baseRefName --jq '.baseRefName' 2>/dev/null || true)"
+          target="${target:-${DEFAULT_BRANCH}}"
+          git fetch --no-tags origin "+refs/heads/${target}:refs/remotes/origin/${target}"
+          merge_base=$(git merge-base HEAD "origin/${target}" || git rev-parse "origin/${target}")
           echo "base=${merge_base}" >> "$GITHUB_OUTPUT"
           echo "pr=${pr_number}" >> "$GITHUB_OUTPUT"
-          echo "Comparing HEAD against ${merge_base} for PR #${pr_number}"
+          echo "Comparing HEAD against ${merge_base} (PR target: ${target}) for PR #${pr_number}"
```

## Test plan

- [ ] PRs to `develop` keep producing the same diffs (target == develop → same merge-base as before)
- [ ] PR #621 (and any future cherry-pick PRs against `dev/3.2.0`) gets a sensible diff baseline once this lands and the workflow re-runs
- [ ] If the PR API call fails for any reason, the fallback to `develop` keeps the workflow from silently breaking

No effect on already-merged PRs.