### PR TITLE
ci(dco): exclude dev/* branches from sign-off walk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,13 +435,16 @@ jobs:
               git fetch --no-tags --quiet origin \
                 "+refs/heads/$ref:refs/remotes/origin/$ref" 2>/dev/null || true
           done
-          for pattern in 'release/*' 'hotfix/*'; do
+          for pattern in 'release/*' 'hotfix/*' 'dev/*'; do
             git fetch --no-tags --quiet origin \
               "+refs/heads/$pattern:refs/remotes/origin/$pattern" 2>/dev/null || true
           done
 
           # Build the exclusion set from every long-lived upstream branch we know
           # about. A commit reachable from any of these is inherited history.
+          # dev/* covers integration / release-prep branches (e.g. dev/3.2.0)
+          # which carry squash-merged history from develop and shouldn't have
+          # each historical commit re-checked.
           EXCLUDES=()
           while IFS= read -r ref; do
             [ -n "$ref" ] && EXCLUDES+=("^$ref")
@@ -449,7 +452,8 @@ jobs:
               refs/remotes/origin/main \
               refs/remotes/origin/develop \
               'refs/remotes/origin/release/*' \
-              'refs/remotes/origin/hotfix/*' 2>/dev/null)
+              'refs/remotes/origin/hotfix/*' \
+              'refs/remotes/origin/dev/*' 2>/dev/null)
 
           # --no-merges: skip auto-generated merge commits (e.g. from "Update branch" /
           # `git merge develop` into a feature branch). They have no Signed-off-by and


### PR DESCRIPTION
## Summary

`dev/*` integration / release-prep branches (e.g. `dev/3.2.0`) accumulate squash-merged history from `develop` via sync PRs. The DCO walker excludes `main`/`develop`/`release/*`/`hotfix/*` from its history walk, but **not** `dev/*`. So any PR targeting `dev/3.2.0` re-checks every commit unique to `dev/3.2.0` vs `develop` — including squashed sync commits whose body has hundreds of Signed-off-by lines but which the runner can't always grep correctly.

## Symptom

[#621](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/621) (cherry-pick of #585 onto `dev/3.2.0`) fails DCO on commit `906659f9` (`release: align dev/3.2.0 with develop (strict-identity, 3.2.0 GA cut) (#612)`), a squash sync commit. Locally that commit has **873** `Signed-off-by:` lines (`grep -q` matches trivially), but the runner reports it as missing — likely an interaction between deeply-nested squash bodies and the runner's checkout / log output. Independent of the false-negative root cause, the right semantic fix is to treat `dev/*` the same as `release/*` and `hotfix/*`: an upstream long-lived branch whose history is owned by its own merge process, not the PR under review.

## Fix

Add `dev/*` to both the fetch loop and the `git for-each-ref` exclusion set in the DCO step of `.github/workflows/ci.yml`. Mirrors the existing pattern for `release/*` and `hotfix/*`.

```diff
-          for pattern in 'release/*' 'hotfix/*'; do
+          for pattern in 'release/*' 'hotfix/*' 'dev/*'; do
…
           done < <(git for-each-ref --format='%(refname:short)' \
               refs/remotes/origin/main \
               refs/remotes/origin/develop \
               'refs/remotes/origin/release/*' \
-              'refs/remotes/origin/hotfix/*' 2>/dev/null)
+              'refs/remotes/origin/hotfix/*' \
+              'refs/remotes/origin/dev/*' 2>/dev/null)
```

## Test plan

- [ ] PRs to `develop` keep the same exclusion set in practice (no `dev/*` refs exist on develop's exclusion path, so behavior is unchanged)
- [ ] After this lands + is cherry-picked to `dev/3.2.0`, PR #621's DCO check goes green
- [ ] Future cherry-pick / hotfix PRs against `dev/*` benefit from the same exclusion

## Notes

- This is a CI-side fix. Once merged on develop, the same fix needs cherry-picking to `dev/3.2.0` (and any other `dev/*` that hosts open PRs) for the immediate unblock. Filed as a separate effort.