### PR TITLE
ci(dco): exclude dev/* branches from sign-off walk (cherry-pick of #623)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,13 +435,16 @@ jobs:
               git fetch --no-tags --quiet origin \
                 "+refs/heads/$ref:refs/remotes/origin/$ref" 2>/dev/null || true
           done
-          for pattern in 'release/*' 'hotfix/*'; do
+          for pattern in 'release/*' 'hotfix/*' 'dev/*'; do
             git fetch --no-tags --quiet origin \
               "+refs/heads/$pattern:refs/remotes/origin/$pattern" 2>/dev/null || true
           done
 
           # Build the exclusion set from every long-lived upstream branch we know
           # about. A commit reachable from any of these is inherited history.
+          # dev/* covers integration / release-prep branches (e.g. dev/3.2.0)
+          # which carry squash-merged history from develop and shouldn't have
+          # each historical commit re-checked.
           EXCLUDES=()
           while IFS= read -r ref; do
             [ -n "$ref" ] && EXCLUDES+=("^$ref")
@@ -449,7 +452,8 @@ jobs:
               refs/remotes/origin/main \
               refs/remotes/origin/develop \
               'refs/remotes/origin/release/*' \
-              'refs/remotes/origin/hotfix/*' 2>/dev/null)
+              'refs/remotes/origin/hotfix/*' \
+              'refs/remotes/origin/dev/*' 2>/dev/null)
 
           # --no-merges: skip auto-generated merge commits (e.g. from "Update branch" /
           # `git merge develop` into a feature branch). They have no Signed-off-by and


### PR DESCRIPTION
Cherry-pick of [#623](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/623) to `dev/3.2.0` so the immediate DCO false-positive on [#621](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/621) is unblocked without waiting for #623 to merge + sync back.

Adds `dev/*` to the DCO exclusion set in `.github/workflows/ci.yml`. Same rationale as #623 — `dev/3.2.0` is a long-lived integration branch carrying squash-merged history, and the DCO walker should treat it like `release/*` and `hotfix/*`.

Once merged, PR #621 will re-run and pass the DCO check (the squashed sync commit `906659f9` falls into the exclusion set instead of being walked).