### PR TITLE
Update mv3dt max_streams_supported values and remove unused image tag…

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -236,7 +236,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-b0ba77ae135d
+VSS_AGENT_VERSION=3.2.0-26.05.2-e45835c52c4a
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -178,7 +178,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-b0ba77ae135d
+VSS_AGENT_VERSION=3.2.0-26.05.2-e45835c52c4a
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -183,7 +183,7 @@ EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-b0ba77ae135d
+VSS_AGENT_VERSION=3.2.0-26.05.2-e45835c52c4a
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -230,7 +230,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-b0ba77ae135d
+VSS_AGENT_VERSION=3.2.0-26.05.2-e45835c52c4a
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -193,10 +193,7 @@ PERCEPTION_TAG="3.2.0-26.05.1"
 
 # BEV Fusion container used by mv3dt mode
 BEV_FUSION_MV3DT_IMAGE="nvcr.io/nvstaging/vss-core/vss-rt-cv-mv3dt-bev-fusion"
-# For multi-arch: 3.2.0-<version>
 BEV_FUSION_MV3DT_TAG="3.2.0-26.05.3"
-# For DGX-SPARK (SBSA): 3.2.0-<version>-sbsa Uncomment below and comment above
-# BEV_FUSION_MV3DT_TAG="3.2.0-26.05.3-sbsa"
 
 # MQTT broker (used by mv3dt mode for cross-camera messaging)
 MQTT_HOST=localhost

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -253,7 +253,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.2-b0ba77ae135d
+VSS_AGENT_VERSION=3.2.0-26.05.2-e45835c52c4a
 VSS_AGENT_CONFIG_FILE=./deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/industry-profiles/warehouse-operations/blueprint-configurator/blueprint_config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/blueprint-configurator/blueprint_config.yml
@@ -595,7 +595,7 @@ H100:
   3d:
     max_streams_supported: 16
   mv3dt:
-    max_streams_supported: 13
+    max_streams_supported: 61
 
 L4:
   2d:
@@ -603,7 +603,7 @@ L4:
   3d:
     max_streams_supported: 2
   mv3dt:
-    max_streams_supported: 2
+    max_streams_supported: 7
 
 L40S:
   2d:
@@ -611,7 +611,7 @@ L40S:
   3d:
     max_streams_supported: 6
   mv3dt:
-    max_streams_supported: 7
+    max_streams_supported: 23
 
 RTXA6000:
   2d:
@@ -619,7 +619,7 @@ RTXA6000:
   3d:
     max_streams_supported: 2
   mv3dt:
-    max_streams_supported: 2
+    max_streams_supported: 4
 
 RTXA6000ADA:
   2d:
@@ -627,7 +627,7 @@ RTXA6000ADA:
   3d:
     max_streams_supported: 6
   mv3dt:
-    max_streams_supported: 6
+    max_streams_supported: 22
 
 RTXPRO6000BW:
   2d:
@@ -635,7 +635,7 @@ RTXPRO6000BW:
   3d:
     max_streams_supported: 19
   mv3dt:
-    max_streams_supported: 18
+    max_streams_supported: 39
 
 IGX-THOR:
   2d:
@@ -683,7 +683,7 @@ IGX-THOR:
           onvif.max_devices_supported: ${max_streams_supported}
           overlay.enable_overlay_skip_frame: true
   mv3dt:
-    max_streams_supported: 4
+    max_streams_supported: 7
     file_operations:
       # Update DeepStream main config
       - operation_type: "text_config_update"
@@ -735,7 +735,7 @@ DGX-SPARK:
           onvif.max_devices_supported: ${max_streams_supported}
           overlay.enable_overlay_skip_frame: true
   mv3dt:
-    max_streams_supported: 4
+    max_streams_supported: 7
     file_operations:
       # Update DeepStream main config
       - operation_type: "text_config_update"

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -301,7 +301,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-b0ba77ae135d" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-e45835c52c4a" }}'
     waitForDependencies:
       enabled: true
   vss-va-mcp:

--- a/deploy/helm/developer-profiles/dev-profile-base/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/values.yaml
@@ -251,7 +251,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-b0ba77ae135d" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-e45835c52c4a" }}'
 vss-agent-ui:
   enabled: true
   # Empty URL fields: deployment uses global.external* then in-cluster defaults.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -199,7 +199,7 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`agent.vss-agent.vstInternalUrl`** | **`""`** | In-cluster **VST** URL for the agent when the default wiring is insufficient. |
 | **`agent.vss-agent.vstInternalIp`** | **`""`** | In-cluster **VST** host/IP override when defaults are insufficient. |
 | **`agent.vss-agent.vssAgentExternalUrl`** | **`""`** | External **vss-agent** URL override for browser / callbacks when **`global.external*`** is not enough. |
-| **`agent.vss-agent.vssAgentVersion`** | **`3.2.0-26.05.2-b0ba77ae135d`** | Optional version label / env; adjust per release. |
+| **`agent.vss-agent.vssAgentVersion`** | **`3.2.0-26.05.2-e45835c52c4a`** | Optional version label / env; adjust per release. |
 | **`agent.vss-agent.llmName`** | **`""`** | Optional **vss-agent-only** override of **`global.llmName`** (**`LLM_NAME`**). |
 | **`agent.vss-agent.vlmName`** | **`""`** | Optional **vss-agent-only** override of **`global.vlmName`** (**`VLM_NAME`**). |
 | **`agent.vss-agent.llmBaseUrl`** | **`""`** | Optional **vss-agent-only** override of **`global.llmBaseUrl`**. |

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -207,7 +207,7 @@ agent:
     vstInternalUrl: ""
     vstInternalIp: ""
     vssAgentExternalUrl: ""
-    vssAgentVersion: "3.2.0-26.05.2-b0ba77ae135d"
+    vssAgentVersion: "3.2.0-26.05.2-e45835c52c4a"
     evalLlmJudgeName: ""
     evalLlmJudgeBaseUrl: ""
     reportsBaseUrl: ""
@@ -290,7 +290,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-b0ba77ae135d" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-e45835c52c4a" }}'
       # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
       # Set enableAudio=true for Nemotron Nano Omni audio-aware VLM.
       - name: ENABLE_AUDIO

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -441,7 +441,7 @@ agent:
     videoAnalysisMcpUrl: ''
     template:
       name: ''
-    vssAgentVersion: 3.2.0-26.05.2-b0ba77ae135d
+    vssAgentVersion: 3.2.0-26.05.2-e45835c52c4a
     # Copied from rtvi.* defaults (vss-agent subchart env tpl only sees agent.vss-agent; keep in sync with rtvi.vss-rtvi-embed.port / vss-rtvi-cv.httpPort).
     rtviEmbedPort: '8000'
     rtviCvPort: '9000'
@@ -541,7 +541,7 @@ agent:
       - name: RTVI_EMBED_MODEL
         value: '{{ .Values.rtviEmbedModelName | default "cosmos-embed1-448p-anomaly-detection" }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-b0ba77ae135d" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-e45835c52c4a" }}'
 
 vss-agent-ui:
   enabled: true

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -23,7 +23,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.0-26.05.2-b0ba77ae135d"
+  tag: "3.2.0-26.05.2-e45835c52c4a"
   pullPolicy: IfNotPresent
 replicas: 1
 service:
@@ -90,7 +90,7 @@ reportsBaseUrl: ""
 vssAgentExternalUrl: ""
 externalIp: ""
 vstInternalIp: ""
-vssAgentVersion: "3.2.0-26.05.2-b0ba77ae135d"
+vssAgentVersion: "3.2.0-26.05.2-e45835c52c4a"
 lvsBackendService: ""
 
 # [Optional] HTTP-client timeouts (seconds) for the post-upload pipeline in
@@ -203,7 +203,7 @@ env:
 - name: AGENT_BASE_URL
   value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
 - name: VSS_AGENT_VERSION
-  value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-b0ba77ae135d" }}'
+  value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.2-e45835c52c4a" }}'
 # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
 # Set ENABLE_AUDIO=true for Nemotron Nano Omni audio-aware VLM.
 - name: ENABLE_AUDIO

--- a/deploy/helm/services/agent/charts/va-mcp/values.yaml
+++ b/deploy/helm/services/agent/charts/va-mcp/values.yaml
@@ -18,7 +18,7 @@ global: {}
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.0-26.05.2-b0ba77ae135d"
+  tag: "3.2.0-26.05.2-e45835c52c4a"
   pullPolicy: IfNotPresent
 # Image must have mcp[cli] (typer) installed for `mcp serve` (same as Docker Compose).
 replicas: 1

--- a/tools/rtvi-cv-mv3dt-utils/README.md
+++ b/tools/rtvi-cv-mv3dt-utils/README.md
@@ -31,14 +31,14 @@ Create a virtual environment and install the pinned dependencies:
 ```bash
 python -m venv ~/venv
 source ~/venv/bin/activate
-pip install -r utils/requirements.txt
+pip install -r requirements.txt
 ```
 
 ## Sample commands
 
 ```bash
 # 1. Generate per-camera YAMLs from an Omniverse-style calibration.json
-python utils/generate_cam_info_configs.py \
+python generate_cam_info_configs.py \
     --calibration-json /path/to/calibration.json \
     --output-dir       ./camInfo \
     --class 0 1.60 0.3 \
@@ -49,7 +49,7 @@ python utils/generate_cam_info_configs.py \
     --class 5 2.2  0.9
 
 # 2. Generate the MQTT pub/sub topology from those camInfo files
-python utils/generate_pub_sub_configs.py \
+python generate_pub_sub_configs.py \
     --cam_info_path ./camInfo \
     --mqtt_brokers  localhost:1883 \
     --output_path   .
@@ -80,7 +80,7 @@ once per class.
 **Usage**
 
 ```bash
-python utils/generate_cam_info_configs.py \
+python generate_cam_info_configs.py \
     --calibration-json CALIBRATION_JSON \
     --output-dir       OUTPUT_DIR \
     --class CLASS_ID HEIGHT RADIUS [--class ...]
@@ -155,7 +155,7 @@ stem.
 **Usage**
 
 ```bash
-python utils/generate_pub_sub_configs.py \
+python generate_pub_sub_configs.py \
     [--cam_info_path        CAM_INFO_PATH] \
     [--mqtt_brokers         HOST:PORT[,HOST:PORT,...]] \
     [--minimum_object_size  PIXELS] \

--- a/tools/rtvi-cv-mv3dt-utils/README.md
+++ b/tools/rtvi-cv-mv3dt-utils/README.md
@@ -1,0 +1,191 @@
+# Utility scripts for MV3DT RTVI-CV Pipeline
+
+Two offline utility scripts for pre-generating `warehouse-mv3dt-app` configs on
+custom datasets
+(`deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/`).
+
+Two configuration artifacts are produced:
+
+1. `camInfo/<sensor_id>.yml` — one per camera, containing the flattened 3x4
+   projection matrix that maps a 3D world point to a 2D image point, plus
+   per-class object-model dimensions used by SV3DT back-projection. Mounted
+   into the DeepStream container at `/tmp/camInfo/` and referenced by
+   `ds-mv3dt-tracker-config.yml` under `ObjectModelProjection.cameraModelFilepath`.
+   Place the generated directory at
+   `warehouse-mv3dt-app/calibration/sample-data/<DATASET_NAME>/camInfo/`.
+2. `pub_sub_info_config.yml` — the MQTT publish/subscribe graph used by MV3DT
+   to exchange 3D tracklets across cameras. The recommended topology is a
+   *vision-neighbor* graph in which each camera subscribes only to peers whose
+   FOVs overlap with its own. Mounted into the container at
+   `/tmp/generated/pub_sub_info_config.yml` and read by the tracker's
+   `Communicator` block. Place the generated file at
+   `warehouse-mv3dt-app/deepstream/configs/pub_sub_info_config.yml`.
+
+## Requirements
+
+- Python 3.8+
+- `numpy`, `opencv-python`, `PyYAML`, `tqdm` (pinned versions in [`requirements.txt`](./requirements.txt))
+
+Create a virtual environment and install the pinned dependencies:
+
+```bash
+python -m venv ~/venv
+source ~/venv/bin/activate
+pip install -r utils/requirements.txt
+```
+
+## Sample commands
+
+```bash
+# 1. Generate per-camera YAMLs from an Omniverse-style calibration.json
+python utils/generate_cam_info_configs.py \
+    --calibration-json /path/to/calibration.json \
+    --output-dir       ./camInfo \
+    --class 0 1.60 0.3 \
+    --class 1 1.60 0.3 \
+    --class 2 1.60 0.3 \
+    --class 3 0.48 0.3 \
+    --class 4 0.2  0.52 \
+    --class 5 2.2  0.9
+
+# 2. Generate the MQTT pub/sub topology from those camInfo files
+python utils/generate_pub_sub_configs.py \
+    --cam_info_path ./camInfo \
+    --output_path   .
+```
+
+Notes on the sample commands:
+
+- The `--class` priors above match the RT-DETR detector's class set. If you
+  are using a custom detector, adjust the `--class` flags (and add/remove
+  classes) accordingly — see the per-script reference below.
+- The `generate_pub_sub_configs.py` invocation above emits a dense
+  publish/subscribe graph that connects every pair of cameras whose
+  field-of-view masks overlap on the world plane. If you want a sparser graph
+  (e.g. only the top-K most-overlapping neighbours) or only care about a
+  specific world-plane region, use `--neighbor_criteria` and/or
+  `--range_of_interest` as documented in the per-script reference below.
+
+## Script reference for advanced usage
+
+### `generate_cam_info_configs.py`
+
+Convert a single calibration JSON (with a top-level `sensors` array of camera
+entries, each containing a 3x4 `cameraMatrix`) into one `camInfo/<sensor_id>.yml`
+file per camera sensor. Object-class priors (`classID`, `height` in meters,
+`radius` in meters) are appended to every generated file and may be repeated
+once per class.
+
+**Usage**
+
+```bash
+python utils/generate_cam_info_configs.py \
+    --calibration-json CALIBRATION_JSON \
+    --output-dir       OUTPUT_DIR \
+    --class CLASS_ID HEIGHT RADIUS [--class ...]
+```
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--calibration-json` | yes | Path to the input `calibration.json`. |
+| `--output-dir` | yes | Directory where one `<sensor_id>.yml` is written per camera sensor. Created if missing. |
+| `--class CLASS_ID HEIGHT RADIUS` | yes (repeatable) | One object class per flag. `CLASS_ID` is an integer; `HEIGHT` and `RADIUS` are numeric (meters). |
+
+**Input `calibration.json` shape**
+
+```json
+{
+  "sensors": [
+    { "id": "Camera_01", "type": "camera",
+      "cameraMatrix": [[...4 floats...], [...4 floats...], [...4 floats...]] },
+    ...
+  ]
+}
+```
+
+Non-camera sensors and sensors without `cameraMatrix` are skipped; the script
+errors out if no camera sensors are found.
+
+**Output `<sensor_id>.yml` shape**
+
+```yaml
+projectionMatrix_3x4_w2p:
+- <p00>
+- <p01>
+  ...
+- <p23>
+
+modelInfo:
+  - classID: 0
+    height: 1.60
+    radius: 0.3
+  - classID: 1
+    height: 1.60
+    radius: 0.3
+  - classID: 2
+    height: 1.60
+    radius: 0.3
+  - classID: 3
+    height: 0.48
+    radius: 0.3
+  - classID: 4
+    height: 0.2
+    radius: 0.52
+  - classID: 5
+    height: 2.2
+    radius: 0.9
+```
+
+### `generate_pub_sub_configs.py`
+
+Compute pairwise field-of-view overlap between every camera in a `camInfo/`
+directory on the world (ground) plane, decide which neighbours each camera
+should subscribe to, and emit a single `pub_sub_info_config.yml` listing
+publish/subscribe MQTT broker+topic strings.
+
+For each camera, the script projects a grid of world-plane samples through its
+intrinsics/extrinsics (decomposed from `projectionMatrix_3x4_w2p`) to build an
+FOV mask, then ranks other cameras by the overlap fraction of their masks.
+Topics are named `/trck/<cam_name>` where `<cam_name>` is the camInfo file
+stem.
+
+**Usage**
+
+```bash
+python utils/generate_pub_sub_configs.py \
+    [--cam_info_path        CAM_INFO_PATH] \
+    [--mqtt_brokers         HOST:PORT[,HOST:PORT,...]] \
+    [--minimum_object_size  PIXELS] \
+    [--neighbor_criteria    {top_N:K | overlap_threshold:T}] \
+    [--output_path          OUTPUT_DIR] \
+    [--range_of_interest    "x1,y1,x2,y2"]
+```
+
+**Arguments**
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--cam_info_path` | `$PWD/camInfo` | Directory of `*.yml` / `*.yaml` files produced by `generate_cam_info_configs.py`. |
+| `--mqtt_brokers` | `127.0.0.1:1883` | Comma-separated broker `host:port` list. For a Docker Compose deployment a single entry is sufficient; if multiple entries are provided, cameras (sorted by filename) are distributed evenly across the brokers. |
+| `--minimum_object_size` | `50` | Minimum projected object height in pixels for a world-plane sample to count as visible (used when building per-camera FOV masks). Smaller values make masks broader (more neighbours); larger values make them stricter (fewer, more confidently overlapping neighbours). |
+| `--neighbor_criteria` | `overlap_threshold:<2/(1920*1080)>` | Either `top_N:K` (keep the K cameras with the largest overlap) or `overlap_threshold:T` (keep cameras whose overlap fraction is ≥ T). |
+| `--output_path` | `./peer_configs` | Output directory; the script writes `pub_sub_info_config.yml` inside it (created if missing). |
+| `--range_of_interest` | bounding box of camera positions, padded by 20 units | World-plane sampling region `x1,y1,x2,y2` in the same units as `projectionMatrix_3x4_w2p`. |
+
+**Output `pub_sub_info_config.yml` shape**
+
+```yaml
+pubBrokerTopicStr:
+  Camera_01: 127.0.0.1:1883;/trck/Camera_01
+  Camera_02: 127.0.0.1:1883;/trck/Camera_02
+subPeerBrokerTopicStrs:
+  Camera_01:
+  - 127.0.0.1:1883;/trck/Camera_02
+  Camera_02:
+  - 127.0.0.1:1883;/trck/Camera_01
+```
+
+When multiple brokers are supplied, the `host:port` prefix of each entry
+reflects the instance the corresponding camera was assigned to.

--- a/tools/rtvi-cv-mv3dt-utils/README.md
+++ b/tools/rtvi-cv-mv3dt-utils/README.md
@@ -51,6 +51,7 @@ python utils/generate_cam_info_configs.py \
 # 2. Generate the MQTT pub/sub topology from those camInfo files
 python utils/generate_pub_sub_configs.py \
     --cam_info_path ./camInfo \
+    --mqtt_brokers  localhost:1883 \
     --output_path   .
 ```
 

--- a/tools/rtvi-cv-mv3dt-utils/generate_cam_info_configs.py
+++ b/tools/rtvi-cv-mv3dt-utils/generate_cam_info_configs.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List
+
+
+@dataclass(frozen=True)
+class ModelInfoEntry:
+    class_id: int
+    height_raw: str
+    radius_raw: str
+
+
+def _parse_float_token(token: str, field_name: str) -> None:
+    try:
+        float(token)
+    except ValueError as exc:
+        raise ValueError(f"Invalid {field_name} value '{token}'. Must be numeric.") from exc
+
+
+def _parse_model_args(model_args: List[List[str]]) -> List[ModelInfoEntry]:
+    entries: List[ModelInfoEntry] = []
+    for triple in model_args:
+        class_id_raw, height_raw, radius_raw = triple
+        try:
+            class_id = int(class_id_raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid classID value '{class_id_raw}'. classID must be an integer."
+            ) from exc
+
+        _parse_float_token(height_raw, "height")
+        _parse_float_token(radius_raw, "radius")
+        entries.append(
+            ModelInfoEntry(class_id=class_id, height_raw=height_raw, radius_raw=radius_raw)
+        )
+    return entries
+
+
+def _format_number(value: Any) -> str:
+    if isinstance(value, bool):
+        raise ValueError("Boolean value found where numeric projection matrix entry was expected.")
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return repr(value)
+    raise ValueError(f"Unsupported projection matrix entry type: {type(value).__name__}")
+
+
+def _flatten_camera_matrix(camera_matrix: Any, sensor_id: str) -> List[str]:
+    if not isinstance(camera_matrix, list) or len(camera_matrix) != 3:
+        raise ValueError(f"Sensor '{sensor_id}' has invalid cameraMatrix shape; expected 3x4.")
+
+    flattened: List[str] = []
+    for row in camera_matrix:
+        if not isinstance(row, list) or len(row) != 4:
+            raise ValueError(f"Sensor '{sensor_id}' has invalid cameraMatrix shape; expected 3x4.")
+        for value in row:
+            flattened.append(_format_number(value))
+    return flattened
+
+
+def _render_cam_info_yaml(flattened_projection: Iterable[str], model_entries: List[ModelInfoEntry]) -> str:
+    lines = ["projectionMatrix_3x4_w2p:"]
+    for value in flattened_projection:
+        lines.append(f"- {value}")
+
+    lines.append("")
+    lines.append("modelInfo:")
+    for entry in model_entries:
+        lines.append(f"  - classID: {entry.class_id}")
+        lines.append(f"    height: {entry.height_raw}")
+        lines.append(f"    radius: {entry.radius_raw}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def generate_cam_info_files(
+    calibration_json: Path, output_dir: Path, model_entries: List[ModelInfoEntry]
+) -> int:
+    with calibration_json.open("r", encoding="utf-8") as fh:
+        calibration = json.load(fh)
+
+    sensors = calibration.get("sensors")
+    if not isinstance(sensors, list):
+        raise ValueError("calibration.json does not contain a valid 'sensors' list.")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated_count = 0
+    for sensor in sensors:
+        if not isinstance(sensor, dict):
+            continue
+        if sensor.get("type") != "camera":
+            continue
+
+        sensor_id = sensor.get("id")
+        camera_matrix = sensor.get("cameraMatrix")
+        if not isinstance(sensor_id, str) or not sensor_id:
+            raise ValueError("Encountered camera sensor with missing/invalid 'id'.")
+        if camera_matrix is None:
+            raise ValueError(f"Sensor '{sensor_id}' is missing 'cameraMatrix'.")
+
+        flattened_projection = _flatten_camera_matrix(camera_matrix, sensor_id)
+        rendered_yaml = _render_cam_info_yaml(flattened_projection, model_entries)
+
+        out_path = output_dir / f"{sensor_id}.yml"
+        out_path.write_text(rendered_yaml, encoding="utf-8")
+        generated_count += 1
+
+    if generated_count == 0:
+        raise ValueError("No camera sensors found in calibration.json.")
+
+    return generated_count
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate camInfo YAML files from calibration.json and repeated "
+            "(classID height radius) model triples."
+        )
+    )
+    parser.add_argument(
+        "--calibration-json",
+        type=Path,
+        required=True,
+        help="Path to input calibration.json.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory where camera YAML files will be written.",
+    )
+    parser.add_argument(
+        "--class",
+        dest="class_args",
+        action="append",
+        nargs=3,
+        metavar=("CLASS_ID", "HEIGHT", "RADIUS"),
+        required=True,
+        help=(
+            "Class tuple: classID height radius. "
+            "Repeat this argument for each object class."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    model_entries = _parse_model_args(args.class_args)
+    generated_count = generate_cam_info_files(
+        calibration_json=args.calibration_json,
+        output_dir=args.output_dir,
+        model_entries=model_entries,
+    )
+    print(f"Generated {generated_count} camInfo files in: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rtvi-cv-mv3dt-utils/generate_pub_sub_configs.py
+++ b/tools/rtvi-cv-mv3dt-utils/generate_pub_sub_configs.py
@@ -20,7 +20,6 @@ import yaml
 import os
 import cv2
 import glob
-import re
 from os.path import join
 
 def get_camera_fov_mask(cam_calib, num_pix, range_of_interest=None):
@@ -28,7 +27,6 @@ def get_camera_fov_mask(cam_calib, num_pix, range_of_interest=None):
     cx, cy = K[0, 2], K[1, 2]
     cam_h, cam_w = int(cy * 2), int(cx * 2)
     limits_ov = range_of_interest
-    # print ("range_of_interests", limits_ov[0, 0, 0], limits_ov[1, 0, 0], limits_ov[0, 0, 1], limits_ov[1, 0, 1])
     x_ov = np.arange(np.round(limits_ov[0]), np.round(limits_ov[2]))
     y_ov = np.arange(np.round(limits_ov[1]), np.round(limits_ov[3]))
     xy_ov = np.array(np.meshgrid(x_ov, y_ov), dtype=float).reshape(2, -1)
@@ -44,7 +42,7 @@ def get_camera_fov_mask(cam_calib, num_pix, range_of_interest=None):
     mask3 = np.linalg.norm(xyh_cam - xy0_cam, ord=np.inf, axis=0) > num_pix # object size: OK
     mask4 = ((xy_ov.T - pos.T) @ (end - pos)).flatten() > 0                   # direction: OK
     # Update the mask
-    mask = mask1 & mask2 & mask3 & mask4 
+    mask = mask1 & mask2 & mask3 & mask4
     return mask
 
 def load_and_process_camera_matrices(cam_info_path):
@@ -73,8 +71,6 @@ def load_and_process_camera_matrices(cam_info_path):
         # Point 3 world units (meters) in front of the camera, used to define
         # the camera's forward direction for FOV culling.
         end = pos + R[-1:, :2].T * (3 / np.linalg.norm(R[-1, :2]))
-        # pos_px = cv2.perspectiveTransform(pos.reshape(1, 1, 2), T_ov2px).reshape(2)
-        # end_px = cv2.perspectiveTransform(end.reshape(1, 1, 2), T_ov2px).reshape(2)
         cam_matrices[cam] = P, Q, K, R, t, pos, end, height
     return cam_matrices, cam_names
 
@@ -124,25 +120,36 @@ def get_overlap_matrix(cam_matrices, minimum_object_size, range_of_interest, cam
 
 
 def get_subscription_map(overlap_matrix, criteria):
-    criteria_type, value = criteria.split(':')
+    if ':' not in criteria:
+        raise ValueError(
+            f"Unknown --neighbor_criteria '{criteria}'. "
+            f"Expected 'top_N:<int>' or 'overlap_threshold:<float>'."
+        )
+    criteria_type, value = criteria.split(':', 1)
     subscription_map = {}
     if criteria_type == 'top_N':
         N = int(value)
+        if N < 0:
+            raise ValueError(f"top_N must be non-negative, got {N}.")
         for cam in overlap_matrix:
-            subscription_map[cam] = []
             neighbors = list(overlap_matrix[cam].keys())
             k = min(N, len(neighbors))
+            if k == 0:
+                subscription_map[cam] = []
+                continue
             top_cam_idxs = np.argpartition([overlap_matrix[cam][nei] for nei in neighbors], -k)[-k:].tolist()
             top_cams = [neighbors[i] for i in top_cam_idxs]
-            subscription_map[cam] = top_cams
+            # Sort for deterministic output (np.argpartition is not stable).
+            subscription_map[cam] = sorted(top_cams)
 
     elif criteria_type == 'overlap_threshold':
         threshold = float(value)
         for cam in overlap_matrix:
-            subscription_map[cam] = []
-            for neighbor in overlap_matrix[cam]:
-                if overlap_matrix[cam][neighbor] >= threshold:
-                    subscription_map[cam].append(neighbor)
+            subscription_map[cam] = sorted(
+                neighbor
+                for neighbor, ratio in overlap_matrix[cam].items()
+                if ratio >= threshold
+            )
 
     else:
         raise ValueError(
@@ -166,8 +173,8 @@ def parse_args():
         '--mqtt_brokers',
         type=str,
         default='127.0.0.1:1883',
-        help='Comma-separated MQTT broker addresses, one per DS instance (e.g. 127.0.0.1:1884,127.0.0.1:1885). '
-             'Cameras are distributed evenly across instances in sorted order.'
+        help='Comma-separated MQTT broker host:port list. For a Docker Compose deployment a single entry is sufficient; '
+             'if multiple entries are provided, cameras (sorted by filename) are distributed evenly across the brokers.'
     )
 
     parser.add_argument(

--- a/tools/rtvi-cv-mv3dt-utils/generate_pub_sub_configs.py
+++ b/tools/rtvi-cv-mv3dt-utils/generate_pub_sub_configs.py
@@ -81,21 +81,35 @@ def load_and_process_camera_matrices(cam_info_path):
 
 def get_overlap_of_2_masks(mask1, mask2):
     overlap = np.logical_and(mask1, mask2)
-    overlap_count = np.sum(overlap)
-    mask1_ratio = overlap_count / np.sum(mask1)
-    mask2_ratio = overlap_count / np.sum(mask2)
+    overlap_count = int(np.sum(overlap))
+    mask1_size = int(np.sum(mask1))
+    mask2_size = int(np.sum(mask2))
+    # Treat an empty mask as zero overlap (avoids NaN poisoning top_N selection).
+    mask1_ratio = overlap_count / mask1_size if mask1_size > 0 else 0.0
+    mask2_ratio = overlap_count / mask2_size if mask2_size > 0 else 0.0
     return mask1_ratio, mask2_ratio, overlap_count
 
 
-def get_overlap_matrix(cam_matrices, minimum_object_size, range_of_interest):
+def get_overlap_matrix(cam_matrices, minimum_object_size, range_of_interest, cam_names=None):
     overlap_matrix = {}
     masks = {}
-    
+
     # Generate masks for all cameras
     for cam in tqdm.tqdm(cam_matrices, desc="Generating masks"):
         mask = get_camera_fov_mask(cam_matrices[cam], num_pix=minimum_object_size, range_of_interest=range_of_interest)
         masks[cam] = mask
-    
+
+    # Surface empty-mask cameras as misconfiguration (no visible world-plane samples).
+    empty_cams = [cam for cam, m in masks.items() if int(np.sum(m)) == 0]
+    if empty_cams:
+        empty_names = [cam_names[c] if cam_names else str(c) for c in empty_cams]
+        print(
+            f"WARNING: {len(empty_cams)} camera(s) produced an empty FOV mask "
+            f"and will have no vision neighbors: {empty_names}. "
+            f"Check --range_of_interest, --minimum_object_size, and the "
+            f"camInfo projection matrices for these cameras."
+        )
+
     # Calculate overlap ratios for all camera pairs
     for cam1 in tqdm.tqdm(cam_matrices, desc="Calculating overlaps"):
         overlap_matrix[cam1] = {}
@@ -105,7 +119,7 @@ def get_overlap_matrix(cam_matrices, minimum_object_size, range_of_interest):
             mask2 = masks[cam2]
             mask1_ratio, mask2_ratio, _ = get_overlap_of_2_masks(mask1, mask2)
             overlap_matrix[cam1][cam2] = mask1_ratio
-    
+
     return overlap_matrix
 
 
@@ -216,7 +230,7 @@ if __name__ == '__main__':
         max_y = max([pose[1][0] for pose in cam_poses])
         range_of_interest_ov = np.array([min_x - range_padding, min_y - range_padding, max_x + range_padding, max_y + range_padding], dtype=float)
 
-    overlap_matrix = get_overlap_matrix(cam_matrices, args.minimum_object_size, range_of_interest_ov)
+    overlap_matrix = get_overlap_matrix(cam_matrices, args.minimum_object_size, range_of_interest_ov, cam_names=cam_names)
     subscription_map = get_subscription_map(overlap_matrix, args.neighbor_criteria)
 
     num_neighbors = np.mean([len(subscription_map[cam]) for cam in subscription_map])

--- a/tools/rtvi-cv-mv3dt-utils/generate_pub_sub_configs.py
+++ b/tools/rtvi-cv-mv3dt-utils/generate_pub_sub_configs.py
@@ -144,7 +144,7 @@ def parse_args():
     parser.add_argument(
         '--cam_info_path',
         type=str,
-        default=join(os.getenv("PWD"), "camInfo"),
+        default=join(os.getcwd(), "camInfo"),
         help='Directory containing camera calibration info (intrinsic & extrinsic params)'
     )
 

--- a/tools/rtvi-cv-mv3dt-utils/generate_pub_sub_configs.py
+++ b/tools/rtvi-cv-mv3dt-utils/generate_pub_sub_configs.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import numpy as np
+import tqdm
+import yaml
+import os
+import cv2
+import glob
+import re
+from os.path import join
+
+def get_camera_fov_mask(cam_calib, num_pix, range_of_interest=None):
+    P, Q, K, R, _, pos, end, height = cam_calib
+    cx, cy = K[0, 2], K[1, 2]
+    cam_h, cam_w = int(cy * 2), int(cx * 2)
+    limits_ov = range_of_interest
+    # print ("range_of_interests", limits_ov[0, 0, 0], limits_ov[1, 0, 0], limits_ov[0, 0, 1], limits_ov[1, 0, 1])
+    x_ov = np.arange(np.round(limits_ov[0]), np.round(limits_ov[2]))
+    y_ov = np.arange(np.round(limits_ov[1]), np.round(limits_ov[3]))
+    xy_ov = np.array(np.meshgrid(x_ov, y_ov), dtype=float).reshape(2, -1)
+    # Create 3D points in z=0, z=h/2, z=h
+    xyz_0 = np.vstack([xy_ov, np.zeros(xy_ov.shape[1])]).T.reshape(len(x_ov), len(y_ov), 3)
+    xyz_h = np.vstack([xy_ov, height * np.ones(xy_ov.shape[1])]).T.reshape(len(x_ov), len(y_ov), 3)
+    # Project to the image plane
+    xy0_cam = cv2.perspectiveTransform(xyz_0, P).reshape(-1, 2).T
+    xyh_cam = cv2.perspectiveTransform(xyz_h, P).reshape(-1, 2).T
+    # Create the mask
+    mask1 = (xy0_cam[0] > 0) & (xy0_cam[0] < cam_w)
+    mask2 = (xy0_cam[1] > 0) & (xy0_cam[1] < cam_h)
+    mask3 = np.linalg.norm(xyh_cam - xy0_cam, ord=np.inf, axis=0) > num_pix # object size: OK
+    mask4 = ((xy_ov.T - pos.T) @ (end - pos)).flatten() > 0                   # direction: OK
+    # Update the mask
+    mask = mask1 & mask2 & mask3 & mask4 
+    return mask
+
+def load_and_process_camera_matrices(cam_info_path):
+    # Load all .yml and .yaml files
+    cam_files = glob.glob(os.path.join(cam_info_path, "*.yml")) + glob.glob(os.path.join(cam_info_path, "*.yaml"))
+    
+    cam_matrices = {}
+    cam_names = {}  # cam_id -> camInfo filename stem (used as map key in pub/sub configs)
+    for idx, cam_file in enumerate(sorted(cam_files)):
+        cam = idx + 1
+        cam_names[cam] = os.path.splitext(os.path.basename(cam_file))[0]
+
+        with open(cam_file, 'r') as file:
+            yaml_data = yaml.safe_load(file)
+        if isinstance(yaml_data['modelInfo'], list):
+            heights = [yaml_data['modelInfo'][i]['height'] for i in range(len(yaml_data['modelInfo']))]
+            height = max(heights)
+        else:
+            height = yaml_data['modelInfo']["height"]
+        P = np.array(yaml_data["projectionMatrix_3x4_w2p"]).reshape(3, 4)
+        Q = np.linalg.pinv(P)
+        K, R, t, _, _, _, _ = cv2.decomposeProjectionMatrix(P)
+        K = K / K[2, 2]
+        # Camera position on the world plane (-R.t @ t)
+        pos = t[:2] / t[-1]
+        # Point 3 world units (meters) in front of the camera, used to define
+        # the camera's forward direction for FOV culling.
+        end = pos + R[-1:, :2].T * (3 / np.linalg.norm(R[-1, :2]))
+        # pos_px = cv2.perspectiveTransform(pos.reshape(1, 1, 2), T_ov2px).reshape(2)
+        # end_px = cv2.perspectiveTransform(end.reshape(1, 1, 2), T_ov2px).reshape(2)
+        cam_matrices[cam] = P, Q, K, R, t, pos, end, height
+    return cam_matrices, cam_names
+
+
+def get_overlap_of_2_masks(mask1, mask2):
+    overlap = np.logical_and(mask1, mask2)
+    overlap_count = np.sum(overlap)
+    mask1_ratio = overlap_count / np.sum(mask1)
+    mask2_ratio = overlap_count / np.sum(mask2)
+    return mask1_ratio, mask2_ratio, overlap_count
+
+
+def get_overlap_matrix(cam_matrices, minimum_object_size, range_of_interest):
+    overlap_matrix = {}
+    masks = {}
+    
+    # Generate masks for all cameras
+    for cam in tqdm.tqdm(cam_matrices, desc="Generating masks"):
+        mask = get_camera_fov_mask(cam_matrices[cam], num_pix=minimum_object_size, range_of_interest=range_of_interest)
+        masks[cam] = mask
+    
+    # Calculate overlap ratios for all camera pairs
+    for cam1 in tqdm.tqdm(cam_matrices, desc="Calculating overlaps"):
+        overlap_matrix[cam1] = {}
+        mask1 = masks[cam1]
+        for cam2 in cam_matrices:
+            if cam1 == cam2: continue
+            mask2 = masks[cam2]
+            mask1_ratio, mask2_ratio, _ = get_overlap_of_2_masks(mask1, mask2)
+            overlap_matrix[cam1][cam2] = mask1_ratio
+    
+    return overlap_matrix
+
+
+def get_subscription_map(overlap_matrix, criteria):
+    criteria_type, value = criteria.split(':')
+    subscription_map = {}
+    if criteria_type == 'top_N':
+        N = int(value)
+        for cam in overlap_matrix:
+            subscription_map[cam] = []
+            neighbors = list(overlap_matrix[cam].keys())
+            k = min(N, len(neighbors))
+            top_cam_idxs = np.argpartition([overlap_matrix[cam][nei] for nei in neighbors], -k)[-k:].tolist()
+            top_cams = [neighbors[i] for i in top_cam_idxs]
+            subscription_map[cam] = top_cams
+
+    elif criteria_type == 'overlap_threshold':
+        threshold = float(value)
+        for cam in overlap_matrix:
+            subscription_map[cam] = []
+            for neighbor in overlap_matrix[cam]:
+                if overlap_matrix[cam][neighbor] >= threshold:
+                    subscription_map[cam].append(neighbor)
+
+    else:
+        raise ValueError(
+            f"Unknown --neighbor_criteria '{criteria}'. "
+            f"Expected 'top_N:<int>' or 'overlap_threshold:<float>'."
+        )
+
+    return subscription_map
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--cam_info_path',
+        type=str,
+        default=join(os.getenv("PWD"), "camInfo"),
+        help='Directory containing camera calibration info (intrinsic & extrinsic params)'
+    )
+
+    parser.add_argument(
+        '--mqtt_brokers',
+        type=str,
+        default='127.0.0.1:1883',
+        help='Comma-separated MQTT broker addresses, one per DS instance (e.g. 127.0.0.1:1884,127.0.0.1:1885). '
+             'Cameras are distributed evenly across instances in sorted order.'
+    )
+
+    parser.add_argument(
+        '--minimum_object_size',
+        type=int,
+        default=50,
+        help='Number of pixels (in height) to consider an object visible when rendering FOV'
+    )
+
+    parser.add_argument(
+        '--neighbor_criteria',
+        type=str,
+        default='overlap_threshold:%f' % (2 / (1920 * 1080)),
+        help='Format: "top_N:{N}" or "overlap_threshold:{thres}". Determines neighbor selection method'
+    )
+
+    parser.add_argument(
+        '--output_path',
+        type=str,
+        default='./peer_configs',
+        help='Directory to store output pub_sub_info_config.yml'
+    )
+
+    parser.add_argument(
+        '--range_of_interest',
+        type=str,
+        default=None,
+        help='Range of interest of world plane in format "x1,y1,x2,y2" where (x1,y1) is min corner and (x2,y2) is max corner'
+    )
+
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    # Load all cameras from camInfo directory
+    cam_matrices, cam_names = load_and_process_camera_matrices(args.cam_info_path)
+    cam_ids = sorted(cam_matrices.keys())
+    n = len(cam_ids)
+    print(f"Loaded {n} cameras: {[cam_names[c] for c in cam_ids]}")
+
+    # Broker list determines the number of DS instances; cameras are split into
+    # sequential blocks of equal size across instances.
+    mqtt_brokers = [b.strip() for b in args.mqtt_brokers.split(',')]
+    num_instances = len(mqtt_brokers)
+    block_size = (n + num_instances - 1) // num_instances  # ceiling division
+    cam2instance = {cam: min((cam - 1) // block_size, num_instances - 1) for cam in cam_ids}
+    print(f"Distributing {n} cameras across {num_instances} instance(s), ~{block_size} per instance")
+
+    # Parse range of interest
+    if args.range_of_interest:
+        x1, y1, x2, y2 = map(float, args.range_of_interest.split(','))
+        range_of_interest_ov = np.array([x1, y1, x2, y2], dtype=float)
+    else:
+        range_padding = 20
+        cam_poses = [cam_matrices[cam][5] for cam in cam_ids]
+        min_x = min([pose[0][0] for pose in cam_poses])
+        max_x = max([pose[0][0] for pose in cam_poses])
+        min_y = min([pose[1][0] for pose in cam_poses])
+        max_y = max([pose[1][0] for pose in cam_poses])
+        range_of_interest_ov = np.array([min_x - range_padding, min_y - range_padding, max_x + range_padding, max_y + range_padding], dtype=float)
+
+    overlap_matrix = get_overlap_matrix(cam_matrices, args.minimum_object_size, range_of_interest_ov)
+    subscription_map = get_subscription_map(overlap_matrix, args.neighbor_criteria)
+
+    num_neighbors = np.mean([len(subscription_map[cam]) for cam in subscription_map])
+    print(f'Average number of neighbors: {num_neighbors}')
+    for cam in subscription_map:
+        print(f'    {cam_names[cam]}:', [cam_names[nei] for nei in subscription_map[cam]])
+
+    # Generate a single pub_sub_info_config.yml covering all instances.
+    # Topics are named /trck/{cam_name}; broker is determined by the instance the camera belongs to.
+    config = {"pubBrokerTopicStr": {}, "subPeerBrokerTopicStrs": {}}
+    for cam in cam_ids:
+        cam_name = cam_names[cam]
+        cam_broker = mqtt_brokers[cam2instance[cam]]
+        config["pubBrokerTopicStr"][cam_name] = f'{cam_broker};/trck/{cam_name}'
+        config["subPeerBrokerTopicStrs"][cam_name] = []
+        for nei in subscription_map[cam]:
+            nei_name = cam_names[nei]
+            nei_broker = mqtt_brokers[cam2instance[nei]]
+            config["subPeerBrokerTopicStrs"][cam_name].append(f'{nei_broker};/trck/{nei_name}')
+
+    if not os.path.exists(args.output_path):
+        os.makedirs(args.output_path)
+    out_path = os.path.join(args.output_path, 'pub_sub_info_config.yml')
+    with open(out_path, 'w') as f:
+        yaml.dump(config, f, default_flow_style=False)
+    print(f'Written: {out_path}')

--- a/tools/rtvi-cv-mv3dt-utils/requirements.txt
+++ b/tools/rtvi-cv-mv3dt-utils/requirements.txt
@@ -1,0 +1,4 @@
+numpy==2.2.6
+opencv-python~=4.12.0
+PyYAML==6.0.2
+tqdm==4.67.1


### PR DESCRIPTION
… in comments

## Description
This PR has 3 changes:
1. Set `max_streams_supported` for the mv3dt profile in `blueprint_config.yml` to 20% below the corresponding 2d profile values as an extrapolation. MV3DT adds BodyPoseNet3D inference on top of RT-DETR, but it only runs for the first few frames when a new object appears, so the steady-state cost is small. Communication-graph generation utility scripts are also provided (see change 3), which produce a sparse vision-neighbor graph and keep the cross-camera communication overhead manageable. Note that for `RTXA6000` and `DGX-SPARK` the values are set equal to the 2d profile values rather than 20% below — this is intentional, since the 2d values do not seem to be GPU-bound and mv3dt should be able to sustain the same number of streams.
2. Drop SBSA comments for `BEV_FUSION_MV3DT_TAG` in .env. `BEV_FUSION_MV3DT_IMAGE` is a CPU-only container, so a separate SBSA image tag isn't needed. Removed the now-obsolete comments.
3. Add MV3DT config-generation utility scripts under `tools/rtvi-cv-mv3dt-utils/` for adapting the `warehouse-mv3dt-app` profile to custom camera datasets.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
