### PR TITLE
feat(agent ui): Alerts Tab: change alert rule thumbnail fetching logic

### DIFF
--- a/deploy/docker/services/ui/compose.yml
+++ b/deploy/docker/services/ui/compose.yml
@@ -16,7 +16,7 @@
 services:
 
   vss-ui:
-    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-6d16cb9d880e
+    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-8a526e97fea1
     profiles: ["bp_wh_2d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     container_name: vss-agent-ui
     ports:

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -562,7 +562,7 @@ vss-agent-ui:
     imagePullPolicy: IfNotPresent
   image:
     repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-    tag: "3.2.0-26.05.2-6d16cb9d880e"
+    tag: "3.2.0-26.05.2-8a526e97fea1"
   replicas: 1
   fillAlertBridgeUrlFromGlobal: false
   agentApiUrlBase: ''

--- a/deploy/helm/services/ui/values.yaml
+++ b/deploy/helm/services/ui/values.yaml
@@ -19,7 +19,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-  tag: "3.2.0-26.05.2-6d16cb9d880e"
+  tag: "3.2.0-26.05.2-8a526e97fea1"
   pullPolicy: IfNotPresent
 replicas: 1
 service:

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/VstStreamThumbnail.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/VstStreamThumbnail.test.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  VstStreamThumbnail,
+  clearSensorListCache,
+} from '../../lib-src/components/VstStreamThumbnail';
+
+const jsonResponse = (body: unknown) =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+
+describe('VstStreamThumbnail picture URL', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    clearSensorListCache();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    clearSensorListCache();
+  });
+
+  it('builds /v1/replay/stream/{id}/picture with startTime 5s before now, URL-encoded', async () => {
+    // Pin Date.now so the computed startTime is deterministic.
+    const fixedNow = Date.UTC(2026, 0, 15, 12, 0, 0); // 2026-01-15T12:00:00.000Z
+    jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse([{ name: 'sample.mp4', sensorId: 'id-1', state: 'online' }]),
+    );
+
+    render(
+      <VstStreamThumbnail
+        vstApiUrl="http://vst.test"
+        sensorName="sample.mp4"
+        isDark={false}
+      />,
+    );
+
+    const img = await screen.findByTestId('vst-stream-thumbnail');
+    const src = img.getAttribute('src') ?? '';
+    const url = new URL(src);
+
+    // Endpoint change introduced by this PR: replay (not live).
+    expect(url.pathname).toBe('/v1/replay/stream/id-1/picture');
+
+    // Decoded value is exactly 5s before the pinned now.
+    expect(url.searchParams.get('startTime')).toBe('2026-01-15T11:59:55.000Z');
+
+    // Raw query string is percent-encoded (colons must be %3A).
+    expect(url.search).toBe('?startTime=2026-01-15T11%3A59%3A55.000Z');
+  });
+
+  it('percent-encodes the sensorId path segment', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse([
+        { name: 'cam', sensorId: 'id with space/slash', state: 'online' },
+      ]),
+    );
+
+    render(
+      <VstStreamThumbnail
+        vstApiUrl="http://vst.test"
+        sensorName="cam"
+        isDark={false}
+      />,
+    );
+
+    const img = await screen.findByTestId('vst-stream-thumbnail');
+    expect(img.getAttribute('src')).toContain(
+      '/v1/replay/stream/id%20with%20space%2Fslash/picture',
+    );
+  });
+
+  it('strips trailing slashes from vstApiUrl before assembling the URL', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse([{ name: 'cam', sensorId: 'id-1', state: 'online' }]),
+    );
+
+    render(
+      <VstStreamThumbnail
+        vstApiUrl="http://vst.test///"
+        sensorName="cam"
+        isDark={false}
+      />,
+    );
+
+    const img = await screen.findByTestId('vst-stream-thumbnail');
+    const src = img.getAttribute('src') ?? '';
+    expect(src.startsWith('http://vst.test/v1/replay/stream/id-1/picture?')).toBe(true);
+    expect(src).not.toContain('vst.test//v1');
+  });
+});

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/VstStreamThumbnail.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/VstStreamThumbnail.tsx
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 /**
- * Live still frame for a registered VST sensor. Resolves `sensorName` to a
+ * Recent still frame for a registered VST sensor. Resolves `sensorName` to a
  * VST stream id via `/v1/sensor/list` (cached per `vstApiUrl`), then renders
- * `/v1/live/stream/{id}/picture` as an `<img>`.
+ * `/v1/replay/stream/{id}/picture` with a short lookback as an `<img>`. The
+ * replay endpoint is used instead of `/v1/live/...` to avoid hitting the live
+ * pipeline for what is effectively a preview.
  */
 
 import React, { useEffect, useState } from 'react';
@@ -20,6 +22,14 @@ interface VstStreamThumbnailProps {
 }
 
 const THUMBNAIL_BOX_STYLE: React.CSSProperties = { width: '128px', height: '72px' };
+
+// Short lookback for the replay snapshot. Far enough back that the segment is
+// reliably written to storage, short enough that the preview still looks fresh.
+// NOTE: startTime is computed once per effect invocation (i.e., per prop change).
+// The thumbnail does not auto-refresh; it always shows the frame from ~5 s
+// before the sensor-list fetch resolved. Re-mount or a prop change is required
+// to get a newer frame.
+const THUMBNAIL_LOOKBACK_MS = 5_000;
 
 const Placeholder: React.FC<{
   isDark: boolean;
@@ -99,9 +109,12 @@ export const VstStreamThumbnail: React.FC<VstStreamThumbnailProps> = ({
           });
           return;
         }
-        const pictureUrl = `${vstApiUrl.replace(/\/+$/, '')}/v1/live/stream/${encodeURIComponent(
+        const startTime = new Date(Date.now() - THUMBNAIL_LOOKBACK_MS).toISOString();
+        let baseUrl = vstApiUrl;
+        while (baseUrl.endsWith('/')) baseUrl = baseUrl.slice(0, -1);
+        const pictureUrl = `${baseUrl}/v1/replay/stream/${encodeURIComponent(
           sensorId,
-        )}/picture`;
+        )}/picture?startTime=${encodeURIComponent(startTime)}`;
         setState({ kind: 'ready', pictureUrl });
       })
       .catch((err) => {
@@ -135,7 +148,7 @@ export const VstStreamThumbnail: React.FC<VstStreamThumbnailProps> = ({
     <img
       data-testid="vst-stream-thumbnail"
       src={state.pictureUrl}
-      alt={`Live VST thumbnail for ${sensorName}`}
+      alt={`Recent thumbnail for ${sensorName}`}
       style={THUMBNAIL_BOX_STYLE}
       className={`object-cover rounded border ${
         isDark ? 'border-neutral-700' : 'border-gray-300'


### PR DESCRIPTION
## Description
The VST `/v1/live/stream/{id}/picture` endpoint was
  returning unreliable results for the alerts management
  thumbnails, sometimes failing outright. Switched the
  thumbnail fetch to `/v1/replay/stream/{id}/picture` with
   a 5-second lookback, which pulls from VST's recorded
  segments and reliably returns a recent frame for the
  preview.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<img width="1356" height="788" alt="image" src="https://github.com/user-attachments/assets/ea89c614-7a62-4f75-af80-dc4cbef18f09" />

---

_Supersedes #590 (mirror bot failed to create `pull-request/590` after a close/reopen — opening a fresh PR so required CI checks can run)._