### PR TITLE
docs(skill-eval): align Brev secure-link prefix

### DIFF
--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -137,7 +137,7 @@ Three-step thread against a deployed VSS base: upload video → snapshot URL →
 {
   "skills": ["vss-manage-video-io-storage"],
   "resources": {"platforms": {"L40S": {"modes": ["remote-all"]}}},
-  "env": "A **full-remote deployed VSS base profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs). Run on ONE platform only — the vss-manage-video-io-storage skill exercises VIOS / VST which is GPU-independent, so there's no benefit to fanning out. Required: VST reachable at http://localhost:30888/vst/api/v1 AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 77770). Without BREV_ENV_ID the returned media URLs will be raw http://localhost:... and the Brev-link checks will fail.",
+  "env": "A **full-remote deployed VSS base profile** (deploy mode = `remote-all` — LLM and VLM both via remote launchpad endpoints, no local NIMs). Run on ONE platform only — the vss-manage-video-io-storage skill exercises VIOS / VST which is GPU-independent, so there's no benefit to fanning out. Required: VST reachable at http://localhost:30888/vst/api/v1 AND the Brev secure-link env vars set (BREV_ENV_ID from /etc/environment, BREV_LINK_PREFIX defaulting to 7777). Without BREV_ENV_ID the returned media URLs will be raw http://localhost:... and the Brev-link checks will fail.",
   "expects": [
     {
       "query": "Upload the sample warehouse video to VIOS with timestamp 2025-01-01T00:00:00.000Z.",


### PR DESCRIPTION
## Summary
- update the skill-eval Brev secure-link default from legacy `77770` to current `7777`
- keep the eval expectation aligned with `deploy_vss_launchable.ipynb` and `dev-profile.sh`
- drop the nginx streamId header change after live Brev validation showed current `develop` VST ingress already returns replay thumbnails correctly

## Validation
- `git diff --check origin/develop...HEAD`
- Brev search profile deployed on `nemoclaw-ci-0521-vhbg-host`
- uploaded `dev_base_001.mp4` through `/api/v1/videos-for-search/dev_base_001`
- verified VST replay thumbnail through ingress: `GET /vst/api/v1/replay/stream/dd007ea7-17db-4ad6-81c7-e0f891edeb84/picture?startTime=2025-01-01T00:00:05Z` returned `200 image/jpeg` (180324 bytes)
- verified `/picture/url` through ingress returned `200 text/plain`
- verified HAProxy path with Brev-style Host header returned `200 image/jpeg`