### PR TITLE
fix(agent ui): Alerts Tab: Modify sensor input logic for Alert rule creation to match with the logic via Agentic Chat

### DIFF
--- a/deploy/docker/services/ui/compose.yml
+++ b/deploy/docker/services/ui/compose.yml
@@ -16,7 +16,7 @@
 services:
 
   vss-ui:
-    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-3ab18ca37ffb
+    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-0ab9d94a7fb9
     profiles: ["bp_wh_2d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     container_name: vss-agent-ui
     ports:

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -562,7 +562,7 @@ vss-agent-ui:
     imagePullPolicy: IfNotPresent
   image:
     repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-    tag: "3.2.0-26.05.2-3ab18ca37ffb"
+    tag: "3.2.0-26.05.2-0ab9d94a7fb9"
   replicas: 1
   fillAlertBridgeUrlFromGlobal: false
   agentApiUrlBase: ''

--- a/deploy/helm/services/ui/values.yaml
+++ b/deploy/helm/services/ui/values.yaml
@@ -19,7 +19,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-  tag: "3.2.0-26.05.2-3ab18ca37ffb"
+  tag: "3.2.0-26.05.2-0ab9d94a7fb9"
   pullPolicy: IfNotPresent
 replicas: 1
 service:

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/CreateAlertRulesView.test.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/components/CreateAlertRulesView.test.tsx
@@ -29,17 +29,29 @@ describe('CreateAlertRulesView realtime rules', () => {
     global.fetch = originalFetch;
   });
 
-  it('creates a realtime alert rule using the alert API spec fields', async () => {
+  it('creates a realtime alert rule by picking a sensor from VST live streams', async () => {
+    const liveRtspUrl =
+      'rtsp://10.24.142.82:30554/live/8c7338ec-2266-4eea-aeb4-c568d8944b05';
     let rules: RealtimeAlertRule[] = [];
     global.fetch = jest.fn().mockImplementation((url: string, init?: RequestInit) => {
-      if (url.includes('/v1/sensor/list')) {
-        return jsonResponse([
-          {
-            name: 'sample-warehouse-ladder.mp4',
-            sensorId: 'vst-sensor-abc',
-            state: 'online',
-          },
-        ]);
+      if (url.includes('/v1/live/streams')) {
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify([
+                {
+                  'stream-key-1': [
+                    {
+                      name: 'warehouse-cam-1',
+                      url: liveRtspUrl,
+                      streamId: '8c7338ec-2266-4eea-aeb4-c568d8944b05',
+                    },
+                  ],
+                },
+              ]),
+            ),
+        } as Response);
       }
       if (init?.method === 'POST') {
         const body = JSON.parse(init.body as string);
@@ -82,12 +94,19 @@ describe('CreateAlertRulesView realtime rules', () => {
     );
 
     fireEvent.click(screen.getByTestId('add-new-alert-button-inline'));
-    fireEvent.change(screen.getByPlaceholderText('rtsp://host:port/path'), {
-      target: {
-        value:
-          '  rtsp://10.86.5.74:31554/nvstream/home/vst/vst_release/streamer_videos/sample-warehouse-ladder.mp4?token=abc  ',
-      },
-    });
+
+    // Wait for the live-streams catalog fetch, then focus the combobox so its
+    // listbox renders and pick the suggestion by clicking it.
+    await waitFor(() =>
+      expect(
+        (global.fetch as jest.Mock).mock.calls.some((call) =>
+          String(call[0]).includes('/v1/live/streams'),
+        ),
+      ).toBe(true),
+    );
+    fireEvent.focus(screen.getByTestId('realtime-alert-draft-sensor'));
+    const option = await screen.findByRole('option', { name: 'warehouse-cam-1' });
+    fireEvent.mouseDown(option);
     fireEvent.change(screen.getByPlaceholderText('e.g. collision'), {
       target: { value: '  collision  ' },
     });
@@ -108,17 +127,93 @@ describe('CreateAlertRulesView realtime rules', () => {
     );
     expect(postCall[0]).toBe('http://alerts.test/api/v1/realtime');
     expect(JSON.parse(postCall[1].body as string)).toEqual({
-      live_stream_url:
-        'rtsp://10.86.5.74:31554/nvstream/home/vst/vst_release/streamer_videos/sample-warehouse-ladder.mp4?token=abc',
+      live_stream_url: liveRtspUrl,
       alert_type: 'collision',
       prompt: 'Detect safety violations with ladder',
-      sensor_name: 'sample-warehouse-ladder.mp4',
-      sensor_id: 'vst-sensor-abc',
+      sensor_name: 'warehouse-cam-1',
     });
 
     expect(await screen.findByText('collision')).toBeInTheDocument();
     expect(screen.getByText('Detect safety violations with ladder')).toBeInTheDocument();
-    expect(screen.getByText('sample-warehouse-ladder.mp4')).toBeInTheDocument();
+    expect(screen.getAllByText('warehouse-cam-1').length).toBeGreaterThan(0);
+  });
+
+  it('forwards a custom sensor name that is not in the VST catalog', async () => {
+    let rules: RealtimeAlertRule[] = [];
+    global.fetch = jest.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/v1/live/streams')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify([])),
+        } as Response);
+      }
+      if (init?.method === 'POST') {
+        const body = JSON.parse(init.body as string);
+        rules = [
+          {
+            id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            ...body,
+            status: 'active',
+            created_at: '2026-04-12T10:30:00+00:00',
+          },
+        ];
+        return jsonResponse(
+          {
+            status: 'success',
+            id: rules[0].id,
+            created_at: rules[0].created_at,
+            message: 'Realtime alert rule created',
+          },
+          true,
+          201,
+          'Created',
+        );
+      }
+      return jsonResponse({ status: 'success', rules, count: rules.length });
+    });
+
+    render(
+      <CreateAlertRulesView
+        isDark={false}
+        activeKind="real-time"
+        onAddNew={jest.fn()}
+        alertsApiUrl="http://alerts.test/api/v1"
+        vstApiUrl="http://vst.test"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/No real-time alert rules/i)).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId('add-new-alert-button-inline'));
+    fireEvent.change(screen.getByTestId('realtime-alert-draft-sensor'), {
+      target: { value: 'future-cam-1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g. collision'), {
+      target: { value: 'collision' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Detect any vehicle collisions'), {
+      target: { value: 'Detect collisions' },
+    });
+    fireEvent.click(screen.getByTestId('realtime-alert-draft-save'));
+
+    await waitFor(() => {
+      const postCall = (global.fetch as jest.Mock).mock.calls.find(
+        (call: [string, RequestInit?]) => call[1]?.method === 'POST',
+      );
+      expect(postCall).toBeTruthy();
+    });
+
+    const postCall = (global.fetch as jest.Mock).mock.calls.find(
+      (call: [string, RequestInit?]) => call[1]?.method === 'POST',
+    );
+    expect(JSON.parse(postCall[1].body as string)).toEqual({
+      live_stream_url: '',
+      alert_type: 'collision',
+      prompt: 'Detect collisions',
+      sensor_name: 'future-cam-1',
+    });
   });
 
   it('deletes realtime alert rules by alert rule id after confirmation', async () => {

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/hooks/useRealtimeAlertRules.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/hooks/useRealtimeAlertRules.test.ts
@@ -74,7 +74,6 @@ describe('useRealtimeAlertRules', () => {
           alert_type: 'collision',
           prompt: 'Detect any vehicle collisions',
           sensor_name: 'video1',
-          sensor_id: 'vst-sensor-1',
         });
         return jsonResponse({
           status: 'success',
@@ -99,7 +98,6 @@ describe('useRealtimeAlertRules', () => {
         alert_type: 'collision',
         prompt: 'Detect any vehicle collisions',
         sensor_name: 'video1',
-        sensor_id: 'vst-sensor-1',
       });
     });
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/utils/vstSensorList.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/utils/vstSensorList.test.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 import {
-  clearLiveStreamCatalogCache,
   clearSensorListCache,
   deriveSensorNameFromLiveStreamUrl,
   fetchVstLiveStreamCatalog,
@@ -19,13 +18,11 @@ describe('vstSensorList', () => {
   beforeEach(() => {
     originalFetch = global.fetch;
     clearSensorListCache();
-    clearLiveStreamCatalogCache();
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
     clearSensorListCache();
-    clearLiveStreamCatalogCache();
   });
 
   it('derives sensor name from the last RTSP path segment', () => {
@@ -79,6 +76,15 @@ describe('vstSensorList', () => {
         streamId: 'mp4-stream-id',
       },
     ]);
+  });
+
+  it('does not cache the live-stream catalog — back-to-back calls each hit VST', async () => {
+    global.fetch = jest.fn().mockResolvedValue(textResponse([]));
+
+    await fetchVstLiveStreamCatalog('http://vst.test');
+    await fetchVstLiveStreamCatalog('http://vst.test');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
   it('resolves sensor_name and live_stream_url by sensor name', async () => {

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/utils/vstSensorList.test.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/__tests__/utils/vstSensorList.test.ts
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: MIT
 import {
+  clearLiveStreamCatalogCache,
   clearSensorListCache,
   deriveSensorNameFromLiveStreamUrl,
-  resolveSensorForLiveStreamUrl,
+  fetchVstLiveStreamCatalog,
+  resolveSensorByName,
 } from '../../lib-src/utils/vstSensorList';
 
-const jsonResponse = (body: unknown) =>
+const textResponse = (body: unknown) =>
   Promise.resolve({
     ok: true,
-    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
   } as Response);
 
 describe('vstSensorList', () => {
@@ -17,11 +19,13 @@ describe('vstSensorList', () => {
   beforeEach(() => {
     originalFetch = global.fetch;
     clearSensorListCache();
+    clearLiveStreamCatalogCache();
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
     clearSensorListCache();
+    clearLiveStreamCatalogCache();
   });
 
   it('derives sensor name from the last RTSP path segment', () => {
@@ -37,26 +41,75 @@ describe('vstSensorList', () => {
     ).toBe('sample.mp4');
   });
 
-  it('resolves sensor_id from VST sensor list for an online sensor', async () => {
+  it('flattens the nested VST /v1/live/streams payload', async () => {
     global.fetch = jest.fn().mockResolvedValue(
-      jsonResponse([
-        { name: 'sample.mp4', sensorId: 'id-1', state: 'online' },
-        { name: 'offline.mp4', sensorId: 'id-2', state: 'offline' },
+      textResponse([
+        {
+          'stream-key-1': [
+            {
+              name: 'warehouse-cam-1',
+              url: 'rtsp://10.24.142.82:30554/live/8c7338ec-2266-4eea-aeb4-c568d8944b05',
+              streamId: '8c7338ec-2266-4eea-aeb4-c568d8944b05',
+            },
+          ],
+        },
+        {
+          'stream-key-2': [
+            {
+              name: 'sample.mp4',
+              url: 'rtsp://10.24.142.82:30554/sample.mp4',
+              streamId: 'mp4-stream-id',
+            },
+          ],
+        },
+      ]),
+    );
+
+    const catalog = await fetchVstLiveStreamCatalog('http://vst.test');
+    expect(global.fetch).toHaveBeenCalledWith('http://vst.test/v1/live/streams');
+    expect(catalog).toEqual([
+      {
+        name: 'warehouse-cam-1',
+        url: 'rtsp://10.24.142.82:30554/live/8c7338ec-2266-4eea-aeb4-c568d8944b05',
+        streamId: '8c7338ec-2266-4eea-aeb4-c568d8944b05',
+      },
+      {
+        name: 'sample.mp4',
+        url: 'rtsp://10.24.142.82:30554/sample.mp4',
+        streamId: 'mp4-stream-id',
+      },
+    ]);
+  });
+
+  it('resolves sensor_name and live_stream_url by sensor name', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      textResponse([
+        {
+          'stream-key-1': [
+            {
+              name: 'warehouse-cam-1',
+              url: 'rtsp://10.24.142.82:30554/live/8c7338ec-2266-4eea-aeb4-c568d8944b05',
+              streamId: '8c7338ec-2266-4eea-aeb4-c568d8944b05',
+            },
+          ],
+        },
       ]),
     );
 
     await expect(
-      resolveSensorForLiveStreamUrl('http://vst.test', 'rtsp://host/sample.mp4'),
-    ).resolves.toEqual({ sensor_name: 'sample.mp4', sensor_id: 'id-1' });
-
-    expect(global.fetch).toHaveBeenCalledWith('http://vst.test/v1/sensor/list');
+      resolveSensorByName('http://vst.test', 'warehouse-cam-1'),
+    ).resolves.toEqual({
+      sensor_name: 'warehouse-cam-1',
+      live_stream_url:
+        'rtsp://10.24.142.82:30554/live/8c7338ec-2266-4eea-aeb4-c568d8944b05',
+    });
   });
 
-  it('rejects when the sensor is not registered online', async () => {
-    global.fetch = jest.fn().mockResolvedValue(jsonResponse([]));
+  it('returns undefined when the sensor is not in the VST live-stream catalog', async () => {
+    global.fetch = jest.fn().mockResolvedValue(textResponse([]));
 
     await expect(
-      resolveSensorForLiveStreamUrl('http://vst.test', 'rtsp://host/unknown.mp4'),
-    ).rejects.toThrow(/not registered with VST/i);
+      resolveSensorByName('http://vst.test', 'unknown-sensor'),
+    ).resolves.toBeUndefined();
   });
 });

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/CreateAlertRulesView.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/CreateAlertRulesView.tsx
@@ -244,7 +244,7 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
   };
 
   const loadLiveStreams = useCallback(
-    async (options?: { forceRefresh?: boolean }) => {
+    async () => {
       if (!vstApiUrl) {
         setLiveStreams([]);
         setLiveStreamsError('VST API URL is not configured');
@@ -253,7 +253,7 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
       setLiveStreamsLoading(true);
       setLiveStreamsError(null);
       try {
-        const catalog = await fetchVstLiveStreamCatalog(vstApiUrl, options);
+        const catalog = await fetchVstLiveStreamCatalog(vstApiUrl);
         setLiveStreams(catalog);
       } catch (err) {
         setLiveStreams([]);
@@ -813,7 +813,7 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
                           liveStreams={liveStreams}
                           loading={liveStreamsLoading}
                           errorMessage={liveStreamsError}
-                          onRetry={() => loadLiveStreams({ forceRefresh: true })}
+                          onRetry={() => loadLiveStreams()}
                         />
                       </td>
                       <td className="py-2 px-3 align-top">

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/CreateAlertRulesView.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/components/CreateAlertRulesView.tsx
@@ -34,7 +34,9 @@ import { useRealtimeAlertRules } from '../hooks/useRealtimeAlertRules';
 import { VstStreamThumbnail } from './VstStreamThumbnail';
 import {
   deriveSensorNameFromLiveStreamUrl,
-  resolveSensorForLiveStreamUrl,
+  fetchVstLiveStreamCatalog,
+  resolveSensorByName,
+  VstLiveStream,
 } from '../utils/vstSensorList';
 
 interface CreateAlertRulesViewProps {
@@ -201,6 +203,11 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
     useRealtimeAlertRules({ alertsApiUrl });
 
   const [drafts, setDrafts] = useState<RealtimeAlertRuleDraft[]>([]);
+  // VST live-stream catalog used to populate the sensor picker in draft rows.
+  // Fetched lazily the first time a draft exists; refetched on demand.
+  const [liveStreams, setLiveStreams] = useState<VstLiveStream[]>([]);
+  const [liveStreamsLoading, setLiveStreamsLoading] = useState(false);
+  const [liveStreamsError, setLiveStreamsError] = useState<string | null>(null);
   const [streamFilter, setStreamFilter] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -236,31 +243,58 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
     );
   };
 
+  const loadLiveStreams = useCallback(
+    async (options?: { forceRefresh?: boolean }) => {
+      if (!vstApiUrl) {
+        setLiveStreams([]);
+        setLiveStreamsError('VST API URL is not configured');
+        return;
+      }
+      setLiveStreamsLoading(true);
+      setLiveStreamsError(null);
+      try {
+        const catalog = await fetchVstLiveStreamCatalog(vstApiUrl, options);
+        setLiveStreams(catalog);
+      } catch (err) {
+        setLiveStreams([]);
+        setLiveStreamsError(
+          err instanceof Error ? err.message : 'Failed to load VST live streams',
+        );
+      } finally {
+        setLiveStreamsLoading(false);
+      }
+    },
+    [vstApiUrl],
+  );
+
   const addDraft = useCallback(() => {
     setDrafts((prev) => [
       ...prev,
       {
         draftId: generateDraftId(),
-        live_stream_url: '',
+        sensor_name: '',
         alert_type: '',
         prompt: '',
       },
     ]);
-  }, []);
+    // Fire-and-forget; the picker shows a loading hint while it resolves.
+    void loadLiveStreams();
+  }, [loadLiveStreams]);
 
   const duplicateAsDraft = useCallback(
-    (source: { live_stream_url: string; alert_type: string; prompt: string }) => {
+    (source: { sensor_name: string; alert_type: string; prompt: string }) => {
       setDrafts((prev) => [
         ...prev,
         {
           draftId: generateDraftId(),
-          live_stream_url: source.live_stream_url,
+          sensor_name: source.sensor_name,
           alert_type: source.alert_type,
           prompt: source.prompt,
         },
       ]);
+      void loadLiveStreams();
     },
-    [],
+    [loadLiveStreams],
   );
 
   // Expose `addDraft` to the rest of the app via a module-level ref so the
@@ -287,33 +321,33 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
     async (draftId: string) => {
       const draft = drafts.find((d) => d.draftId === draftId);
       if (!draft) return;
-      const live_stream_url = draft.live_stream_url.trim();
+      const sensorName = draft.sensor_name.trim();
       const alert_type = draft.alert_type.trim();
       const prompt = draft.prompt.trim();
-      if (!live_stream_url || !alert_type || !prompt) {
+      if (!sensorName || !alert_type || !prompt) {
         updateDraft(draftId, {
-          error: 'live_stream_url, alert_type, and prompt are required.',
+          error: 'sensor, alert_type, and prompt are required.',
         });
         return;
       }
       if (!vstApiUrl) {
         updateDraft(draftId, {
-          error: 'VST API URL is not configured; cannot resolve sensor_id and sensor_name.',
+          error: 'VST API URL is not configured; cannot resolve live stream URL.',
         });
         return;
       }
       updateDraft(draftId, { saving: true, error: undefined });
       try {
-        const { sensor_name, sensor_id } = await resolveSensorForLiveStreamUrl(
-          vstApiUrl,
-          live_stream_url,
-        );
+        // Resolver returns undefined if the sensor isn't in VST's live-stream
+        // catalog yet — we still forward the name so users can create alert
+        // rules for streams that will be registered later. Alert Bridge is the
+        // source of truth on whether that's accepted.
+        const resolved = await resolveSensorByName(vstApiUrl, sensorName);
         await createRule({
-          live_stream_url,
+          live_stream_url: resolved?.live_stream_url ?? '',
           alert_type,
           prompt,
-          sensor_name,
-          sensor_id,
+          sensor_name: resolved?.sensor_name ?? sensorName,
         });
         // Drop the draft on success — the rule shows up in the rules list.
         setDrafts((prev) => prev.filter((d) => d.draftId !== draftId));
@@ -588,7 +622,13 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
                           type="button"
                           onClick={() =>
                             duplicateAsDraft({
-                              live_stream_url: rule.live_stream_url,
+                              // Prefer the server-side `sensor_name`. Fall back
+                              // to deriving from the URL for older rules that
+                              // pre-date the sensor_name field.
+                              sensor_name:
+                                rule.sensor_name ??
+                                deriveSensorNameFromLiveStreamUrl(rule.live_stream_url) ??
+                                '',
                               alert_type: rule.alert_type,
                               prompt: rule.prompt,
                             })
@@ -724,7 +764,7 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
                             type="button"
                             onClick={() =>
                               duplicateAsDraft({
-                                live_stream_url: draft.live_stream_url,
+                                sensor_name: draft.sensor_name,
                                 alert_type: draft.alert_type,
                                 prompt: draft.prompt,
                               })
@@ -759,20 +799,21 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
                         <VstStreamThumbnail
                           isDark={isDark}
                           vstApiUrl={vstApiUrl}
-                          sensorName={
-                            deriveSensorNameFromLiveStreamUrl(draft.live_stream_url) ?? ''
-                          }
+                          sensorName={draft.sensor_name}
                         />
                       </td>
                       <td className="py-2 px-3 align-top">
-                        <input
-                          type="text"
-                          placeholder="rtsp://host:port/path"
-                          value={draft.live_stream_url}
-                          onChange={(e) =>
-                            updateDraft(draft.draftId, { live_stream_url: e.target.value })
+                        <SensorPicker
+                          isDark={isDark}
+                          inputClass={inputClass}
+                          value={draft.sensor_name}
+                          onChange={(name) =>
+                            updateDraft(draft.draftId, { sensor_name: name })
                           }
-                          className={inputClass}
+                          liveStreams={liveStreams}
+                          loading={liveStreamsLoading}
+                          errorMessage={liveStreamsError}
+                          onRetry={() => loadLiveStreams({ forceRefresh: true })}
                         />
                       </td>
                       <td className="py-2 px-3 align-top">
@@ -858,6 +899,187 @@ const RealtimeAlertsTab: React.FC<RealtimeAlertsTabProps> = ({
         </div>
       </div>
     </>
+  );
+};
+
+// =============================================================================
+// SensorPicker — sensor dropdown for draft rows
+// =============================================================================
+// Mirrors the chat flow (services/agent/.../rtvi_vlm_alert.py): the user picks
+// a friendly sensor name, and the live-stream URL is resolved from VST at save
+// time. Removes the URL-parsing path that broke for `rtsp://host:port/live/<uuid>`
+// inputs where the last path segment is a UUID, not the sensor name.
+
+interface SensorPickerProps {
+  isDark: boolean;
+  inputClass: string;
+  value: string;
+  onChange: (sensorName: string) => void;
+  liveStreams: VstLiveStream[];
+  loading: boolean;
+  errorMessage: string | null;
+  onRetry: () => void;
+}
+
+const SensorPicker: React.FC<SensorPickerProps> = ({
+  isDark,
+  inputClass,
+  value,
+  onChange,
+  liveStreams,
+  loading,
+  errorMessage,
+  onRetry,
+}) => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(-1);
+
+  const selectedStream = liveStreams.find((s) => s.name === value);
+  const trimmed = value.trim();
+  const isCustom = trimmed.length > 0 && !selectedStream;
+
+  // Filter suggestions by substring match. If the input matches a catalog entry
+  // exactly, don't filter — show the full list so the user can pick a different
+  // sensor without having to clear first.
+  const suggestions = useMemo(() => {
+    if (!trimmed || selectedStream) return liveStreams;
+    const needle = trimmed.toLowerCase();
+    return liveStreams.filter((s) => s.name.toLowerCase().includes(needle));
+  }, [liveStreams, trimmed, selectedStream]);
+
+  // Close on outside click. Bound on `open` so we don't keep a listener around
+  // when the panel is hidden.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  const commit = (name: string) => {
+    onChange(name);
+    setOpen(false);
+    setHighlight(-1);
+  };
+
+  const panelClass = isDark
+    ? 'bg-neutral-900 border border-neutral-700 text-neutral-100'
+    : 'bg-white border border-gray-300 text-gray-800';
+  const itemBaseClass = 'px-3 py-1.5 text-sm cursor-pointer truncate';
+  const itemHoverClass = isDark ? 'hover:bg-neutral-800' : 'hover:bg-gray-100';
+  const itemActiveClass = isDark ? 'bg-neutral-800' : 'bg-gray-100';
+
+  return (
+    <div ref={containerRef} className="relative flex flex-col gap-1">
+      <input
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+        data-testid="realtime-alert-draft-sensor"
+        placeholder={
+          loading
+            ? 'Loading sensors…'
+            : liveStreams.length === 0
+            ? 'Type sensor name'
+            : 'Pick or type a sensor name'
+        }
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+          setHighlight(-1);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setOpen(true);
+            setHighlight((h) => Math.min(h + 1, suggestions.length - 1));
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setHighlight((h) => Math.max(h - 1, 0));
+          } else if (e.key === 'Enter') {
+            if (open && highlight >= 0 && suggestions[highlight]) {
+              e.preventDefault();
+              commit(suggestions[highlight].name);
+            }
+          } else if (e.key === 'Escape') {
+            setOpen(false);
+          }
+        }}
+        className={inputClass}
+        autoComplete="off"
+        spellCheck={false}
+      />
+      {open && suggestions.length > 0 && (
+        <ul
+          role="listbox"
+          data-testid="realtime-alert-draft-sensor-list"
+          className={`absolute z-20 top-full left-0 right-0 mt-1 max-h-56 overflow-auto rounded-md shadow-lg ${panelClass}`}
+        >
+          {suggestions.map((stream, i) => (
+            <li
+              key={stream.streamId}
+              role="option"
+              aria-selected={i === highlight}
+              // onMouseDown fires before input blur, so the click registers
+              // before the panel closes itself.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                commit(stream.name);
+              }}
+              onMouseEnter={() => setHighlight(i)}
+              className={`${itemBaseClass} ${
+                i === highlight ? itemActiveClass : itemHoverClass
+              }`}
+              title={stream.url}
+            >
+              {stream.name}
+            </li>
+          ))}
+        </ul>
+      )}
+      {selectedStream && (
+        <span
+          className={`text-xs break-all ${
+            isDark ? 'text-neutral-400' : 'text-gray-500'
+          }`}
+          title={selectedStream.url}
+        >
+          {selectedStream.url}
+        </span>
+      )}
+      {isCustom && (
+        <span
+          className={`text-xs ${isDark ? 'text-neutral-400' : 'text-gray-500'}`}
+        >
+          Not in VST catalog — will be created against this sensor name.
+        </span>
+      )}
+      {errorMessage && (
+        <span
+          className={`text-xs flex items-start gap-1 ${
+            isDark ? 'text-red-300' : 'text-red-600'
+          }`}
+        >
+          <IconAlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+          <span className="flex-1 break-all">{errorMessage}</span>
+          <button
+            type="button"
+            onClick={onRetry}
+            className={`underline ${isDark ? 'text-red-200' : 'text-red-700'}`}
+          >
+            Retry
+          </button>
+        </span>
+      )}
+    </div>
   );
 };
 

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useRealtimeAlertRules.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/hooks/useRealtimeAlertRules.ts
@@ -22,10 +22,8 @@ export interface CreateRealtimeRuleInput {
   live_stream_url: string;
   alert_type: string;
   prompt: string;
-  /** VST sensor name (`name` in `/v1/sensor/list`). */
+  /** Friendly sensor name (VST `name`). Alert Bridge resolves the stream from this. */
   sensor_name: string;
-  /** VST sensor id (`sensorId` in `/v1/sensor/list`). */
-  sensor_id: string;
 }
 
 const REALTIME_PATH = '/realtime';
@@ -146,7 +144,6 @@ export const useRealtimeAlertRules = ({
           alert_type: input.alert_type,
           prompt: input.prompt,
           sensor_name: input.sensor_name,
-          sensor_id: input.sensor_id,
           status: 'active',
           created_at: body?.created_at,
         };

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/types.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/types.ts
@@ -74,10 +74,14 @@ export interface RealtimeAlertRule {
  * Local draft used by the Create Alert Rules editor before a real-time rule has
  * been saved to the server. Once persisted via `POST /realtime` it is
  * replaced by a {@link RealtimeAlertRule} carrying a server-assigned `id`.
+ *
+ * The draft carries `sensor_name` (chosen from the VST live-stream catalog).
+ * `live_stream_url` and `sensor_id` are resolved from VST at save time so the
+ * user never has to paste an RTSP URL.
  */
 export interface RealtimeAlertRuleDraft {
   draftId: string; // local-only id; not sent to the server
-  live_stream_url: string;
+  sensor_name: string;
   alert_type: string;
   prompt: string;
   saving?: boolean;

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/utils/vstSensorList.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/utils/vstSensorList.ts
@@ -35,13 +35,7 @@ interface SensorMapCacheEntry {
   createdAt: number;
 }
 
-interface LiveStreamCatalogCacheEntry {
-  promise: Promise<VstLiveStream[]>;
-  createdAt: number;
-}
-
 const sensorListCache = new Map<string, SensorMapCacheEntry>();
-const liveStreamCatalogCache = new Map<string, LiveStreamCatalogCacheEntry>();
 
 /** Strip trailing `/` characters in O(n) without regex (Sonar S5852). */
 const stripTrailingSlashes = (value: string): string => {
@@ -71,14 +65,6 @@ export const clearSensorListCache = (vstApiUrl?: string): void => {
     sensorListCache.delete(vstApiUrl);
   } else {
     sensorListCache.clear();
-  }
-};
-
-export const clearLiveStreamCatalogCache = (vstApiUrl?: string): void => {
-  if (vstApiUrl) {
-    liveStreamCatalogCache.delete(vstApiUrl);
-  } else {
-    liveStreamCatalogCache.clear();
   }
 };
 
@@ -151,64 +137,39 @@ export const deriveSensorNameFromLiveStreamUrl = (
 };
 
 /**
- * Live-stream catalog from `GET /v1/live/streams`. The wire shape nests one
- * entry per stream key — `[{<key>: [{name, url, streamId}]}, …]` — so we
- * flatten to a plain `VstLiveStream[]` for callers.
+ * Live-stream catalog from `GET /v1/live/streams`. Not cached — sensors can
+ * be added/removed in VST from another window, and the picker needs to reflect
+ * those changes immediately. The wire shape nests one entry per stream key —
+ * `[{<key>: [{name, url, streamId}]}, …]` — so we flatten to `VstLiveStream[]`.
  */
-export const fetchVstLiveStreamCatalog = (
+export const fetchVstLiveStreamCatalog = async (
   vstApiUrl: string,
-  options?: { forceRefresh?: boolean },
 ): Promise<VstLiveStream[]> => {
-  const now = Date.now();
-  const cached = liveStreamCatalogCache.get(vstApiUrl);
-  if (
-    cached &&
-    !options?.forceRefresh &&
-    now - cached.createdAt < SENSOR_LIST_TTL_MS
-  ) {
-    return cached.promise;
+  const response = await fetch(`${stripTrailingSlashes(vstApiUrl)}/v1/live/streams`);
+  if (!response.ok) {
+    throw new Error(`VST /v1/live/streams returned ${response.status}`);
   }
-
-  const promise = fetch(`${stripTrailingSlashes(vstApiUrl)}/v1/live/streams`)
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`VST /v1/live/streams returned ${response.status}`);
-      }
-      // VST returns text/plain content-type but the body is JSON.
-      return response.text();
-    })
-    .then((text) => {
-      const data = JSON.parse(text) as unknown;
-      const result: VstLiveStream[] = [];
-      if (Array.isArray(data)) {
-        for (const item of data) {
-          if (!item || typeof item !== 'object') continue;
-          for (const streams of Object.values(item) as unknown[]) {
-            if (!Array.isArray(streams) || streams.length === 0) continue;
-            const info = streams[0] as Record<string, unknown>;
-            const name = typeof info.name === 'string' ? info.name : undefined;
-            const url = typeof info.url === 'string' ? info.url : undefined;
-            const streamId =
-              typeof info.streamId === 'string' ? info.streamId : undefined;
-            if (name && url && streamId) {
-              result.push({ name, url, streamId });
-            }
-          }
+  // VST returns text/plain content-type but the body is JSON.
+  const text = await response.text();
+  const data = JSON.parse(text) as unknown;
+  const result: VstLiveStream[] = [];
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      if (!item || typeof item !== 'object') continue;
+      for (const streams of Object.values(item) as unknown[]) {
+        if (!Array.isArray(streams) || streams.length === 0) continue;
+        const info = streams[0] as Record<string, unknown>;
+        const name = typeof info.name === 'string' ? info.name : undefined;
+        const url = typeof info.url === 'string' ? info.url : undefined;
+        const streamId =
+          typeof info.streamId === 'string' ? info.streamId : undefined;
+        if (name && url && streamId) {
+          result.push({ name, url, streamId });
         }
       }
-      return result;
-    })
-    .catch((err) => {
-      // Evict failed entry so subsequent renders can retry before TTL.
-      const existing = liveStreamCatalogCache.get(vstApiUrl);
-      if (existing && existing.promise === promise) {
-        liveStreamCatalogCache.delete(vstApiUrl);
-      }
-      throw err;
-    });
-
-  liveStreamCatalogCache.set(vstApiUrl, { promise, createdAt: now });
-  return promise;
+    }
+  }
+  return result;
 };
 
 /**

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/utils/vstSensorList.ts
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/alerts/lib-src/utils/vstSensorList.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 /**
- * VST (VIOS) sensor list helpers — `GET /v1/sensor/list` maps friendly sensor
- * `name` → `sensorId` for online sensors. Shared by thumbnails and realtime alerts.
+ * VST (VIOS) sensor helpers.
+ *
+ *  - `GET /v1/sensor/list` maps friendly sensor `name` → `sensorId` for online
+ *    sensors. Used by the thumbnail component.
+ *  - `GET /v1/live/streams` returns the live-stream catalog — each entry
+ *    carries `name`, RTSP `url`, and `streamId`. Used by the realtime alert
+ *    creator so users can pick a sensor by name (matching the chat flow in
+ *    `services/agent/.../rtvi_vlm_alert.py`) instead of pasting an RTSP URL.
  */
 
 export interface VstSensorListEntry {
@@ -10,9 +16,15 @@ export interface VstSensorListEntry {
   state?: string;
 }
 
-export interface ResolvedVstSensor {
+export interface VstLiveStream {
+  name: string;
+  url: string;
+  streamId: string;
+}
+
+export interface ResolvedVstStream {
   sensor_name: string;
-  sensor_id: string;
+  live_stream_url: string;
 }
 
 // TTL ensures sensors registered elsewhere appear without a hard reload.
@@ -23,7 +35,13 @@ interface SensorMapCacheEntry {
   createdAt: number;
 }
 
+interface LiveStreamCatalogCacheEntry {
+  promise: Promise<VstLiveStream[]>;
+  createdAt: number;
+}
+
 const sensorListCache = new Map<string, SensorMapCacheEntry>();
+const liveStreamCatalogCache = new Map<string, LiveStreamCatalogCacheEntry>();
 
 /** Strip trailing `/` characters in O(n) without regex (Sonar S5852). */
 const stripTrailingSlashes = (value: string): string => {
@@ -53,6 +71,14 @@ export const clearSensorListCache = (vstApiUrl?: string): void => {
     sensorListCache.delete(vstApiUrl);
   } else {
     sensorListCache.clear();
+  }
+};
+
+export const clearLiveStreamCatalogCache = (vstApiUrl?: string): void => {
+  if (vstApiUrl) {
+    liveStreamCatalogCache.delete(vstApiUrl);
+  } else {
+    liveStreamCatalogCache.clear();
   }
 };
 
@@ -108,8 +134,10 @@ export const fetchSensorMap = (
 /**
  * Last path segment of the RTSP URL, e.g.
  * `rtsp://.../sample-warehouse-ladder.mp4` → `sample-warehouse-ladder.mp4`.
- * Extension is kept — NVStreamer registers sensors with the full filename and
- * VST/alert-bridge lookups match by exact name.
+ * Used only as a thumbnail fallback for legacy rules saved before the server
+ * began returning `sensor_name`. Not safe for live-stream URLs with UUID paths
+ * (`rtsp://host:port/live/<uuid>`) — that's why rule creation goes through the
+ * live-stream catalog instead.
  */
 export const deriveSensorNameFromLiveStreamUrl = (
   liveStreamUrl: string,
@@ -123,26 +151,85 @@ export const deriveSensorNameFromLiveStreamUrl = (
 };
 
 /**
- * Resolve `sensor_name` and `sensor_id` for a live stream URL via VST sensor list.
+ * Live-stream catalog from `GET /v1/live/streams`. The wire shape nests one
+ * entry per stream key — `[{<key>: [{name, url, streamId}]}, …]` — so we
+ * flatten to a plain `VstLiveStream[]` for callers.
  */
-export const resolveSensorForLiveStreamUrl = async (
+export const fetchVstLiveStreamCatalog = (
   vstApiUrl: string,
-  liveStreamUrl: string,
-): Promise<ResolvedVstSensor> => {
-  const sensor_name = deriveSensorNameFromLiveStreamUrl(liveStreamUrl);
-  if (!sensor_name) {
-    throw new Error(
-      'Could not derive sensor name from live_stream_url; check the RTSP path.',
-    );
+  options?: { forceRefresh?: boolean },
+): Promise<VstLiveStream[]> => {
+  const now = Date.now();
+  const cached = liveStreamCatalogCache.get(vstApiUrl);
+  if (
+    cached &&
+    !options?.forceRefresh &&
+    now - cached.createdAt < SENSOR_LIST_TTL_MS
+  ) {
+    return cached.promise;
   }
 
-  const map = await fetchSensorMap(vstApiUrl);
-  const sensor_id = map.get(sensor_name);
-  if (!sensor_id) {
-    throw new Error(
-      `Sensor "${sensor_name}" is not registered with VST (online). Register the stream first.`,
-    );
-  }
+  const promise = fetch(`${stripTrailingSlashes(vstApiUrl)}/v1/live/streams`)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`VST /v1/live/streams returned ${response.status}`);
+      }
+      // VST returns text/plain content-type but the body is JSON.
+      return response.text();
+    })
+    .then((text) => {
+      const data = JSON.parse(text) as unknown;
+      const result: VstLiveStream[] = [];
+      if (Array.isArray(data)) {
+        for (const item of data) {
+          if (!item || typeof item !== 'object') continue;
+          for (const streams of Object.values(item) as unknown[]) {
+            if (!Array.isArray(streams) || streams.length === 0) continue;
+            const info = streams[0] as Record<string, unknown>;
+            const name = typeof info.name === 'string' ? info.name : undefined;
+            const url = typeof info.url === 'string' ? info.url : undefined;
+            const streamId =
+              typeof info.streamId === 'string' ? info.streamId : undefined;
+            if (name && url && streamId) {
+              result.push({ name, url, streamId });
+            }
+          }
+        }
+      }
+      return result;
+    })
+    .catch((err) => {
+      // Evict failed entry so subsequent renders can retry before TTL.
+      const existing = liveStreamCatalogCache.get(vstApiUrl);
+      if (existing && existing.promise === promise) {
+        liveStreamCatalogCache.delete(vstApiUrl);
+      }
+      throw err;
+    });
 
-  return { sensor_name, sensor_id };
+  liveStreamCatalogCache.set(vstApiUrl, { promise, createdAt: now });
+  return promise;
+};
+
+/**
+ * Look up a sensor name in the VST live-stream catalog. Returns `undefined`
+ * when the catalog has no matching entry — callers can decide whether to
+ * forward the name to Alert Bridge anyway (e.g. for a stream that hasn't been
+ * registered yet).
+ */
+export const resolveSensorByName = async (
+  vstApiUrl: string,
+  sensorName: string,
+): Promise<ResolvedVstStream | undefined> => {
+  const trimmed = sensorName.trim();
+  if (!trimmed) return undefined;
+
+  const catalog = await fetchVstLiveStreamCatalog(vstApiUrl);
+  const match = catalog.find((entry) => entry.name === trimmed);
+  if (!match) return undefined;
+
+  return {
+    sensor_name: match.name,
+    live_stream_url: match.url,
+  };
 };


### PR DESCRIPTION
## Description

Fix for https://nvbugspro.nvidia.com/bug/6200965

 ####  The bug

  Creating an alert rule from the UI worked when you pasted a URL like rtsp://host/sample.mp4, but failed for a real live stream URL like rtsp://host/live/<uuid>. The chat could create alerts for either.

   ####  Why one worked and the other didn't

  The old UI tried to figure out the sensor name from the URL by grabbing the last path segment. Then it looked that name up in VST's sensor list to get the sensor's ID.

  - For rtsp://host/sample.mp4, the last segment is sample.mp4. NVStreamer happens to register file-backed streams under their filename, so VST's sensor list had an entry named sample.mp4. Match — worked by coincidence.
  - For rtsp://host/live/<uuid>, the last segment is the UUID. VST's sensor list is keyed by the friendly name (e.g. warehouse-cam-1), not by the UUID. No match — failed.

  The chat avoided this entirely: you give it the friendly name, and it asks VST /v1/live/streams for the URL.

 #### What we did

  Made the UI work like the chat. Instead of pasting a URL, you pick a sensor from a dropdown populated by VST's live-stream catalog. The URL comes straight from VST. No more parsing.

  Two follow-on tweaks:
  - Allowed typing a custom name (for streams not yet registered).
  - Dropped sensor_id from the request payload to exactly match what chat sends, since including it pushed Alert Bridge down a code path that produced an "orphaned rule" warning.


https://github.com/user-attachments/assets/33efb7c7-166c-4bfe-a180-3f57623d729d




## Checklist
- [ X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ X] New or existing tests cover these changes.
- [ X] The documentation is up to date with these changes.
