### PR TITLE
Fix SDRC Helm chart streamprocessing workload port for stream registration

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-alerts/configs/sdrc/config-realtime.yml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/configs/sdrc/config-realtime.yml
@@ -45,3 +45,4 @@ k8s-workload-streamprocessing:
   ENVOY_ROUTE_URL_PREFIX: /
   ENVOY_REQUEST_TIMEOUT: "30"
   ENVOYROUTEHEADER: streamid
+  WDM_WL_CONFIG_PORT: "30001"

--- a/deploy/helm/developer-profiles/dev-profile-alerts/configs/sdrc/config-verification.yml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/configs/sdrc/config-verification.yml
@@ -45,6 +45,7 @@ k8s-workload-streamprocessing:
   ENVOY_ROUTE_URL_PREFIX: /
   ENVOY_REQUEST_TIMEOUT: "30"
   ENVOYROUTEHEADER: streamid
+  WDM_WL_CONFIG_PORT: "30001"
 
 k8s-workload-rtvi-cv:
   wl_obj_name: vss-rtvi-cv
@@ -59,7 +60,6 @@ k8s-workload-rtvi-cv:
   WDM_REDIS_MSG_KEY: vst.event
   REDIS_MSG_KEY: vst.event
   WDM_KFK_ENABLE: false
-  WDM_WL_CONFIG_PORT: "30001"
   WDM_MS_LISTENER_PORT: 10001
   WDM_K8S_HEADLESS_BASE_DOMAIN: vss-rtvi-cv-headless
   WDM_K8S_HEADLESS_DEFAULT_POD_PORT: "9010"


### PR DESCRIPTION
This MR updates the alerts SDRC configuration to explicitly set:

`WDM_WL_CONFIG_PORT: "30001"`
for k8s-workload-streamprocessing.

vss-vios-streamprocessing exposes its HTTP/proxy API on port 30001. Without this value, SDRC falls back to the default workload config port 5000, causing SDRC to send stream add/delete requests to the wrong port and preventing RTSP URLs added in VST from being registered correctly.