### PR TITLE
fix(vss-deploy-profile): backport #648 cache-cleaner edge prerequisite to develop

### DIFF
--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -63,9 +63,40 @@ docker info 2>/dev/null | grep -i "runtimes"
 
 # 3. NVIDIA runtime works end-to-end
 docker run --rm --gpus all ubuntu:22.04 nvidia-smi 2>&1 | head -5
+
+# 4. Edge platforms only — cache cleaner running (auto-start if missing).
+#    DGX-Spark / IGX-Thor / AGX-Thor share unified memory; without
+#    periodic drop_caches the first inference frame OOMs.
+gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -1)
+if echo "$gpu_name" | grep -qiE 'GB10|Thor'; then
+    if pgrep -f sys-cache-cleaner.sh >/dev/null; then
+        echo "cache cleaner OK"
+    else
+        echo "cache cleaner not running — starting it now"
+        # Install the script if it's missing (idempotent — no-op if already installed).
+        if [ ! -x /usr/local/bin/sys-cache-cleaner.sh ]; then
+            sudo tee /usr/local/bin/sys-cache-cleaner.sh >/dev/null << 'EOF'
+#!/bin/bash
+set -e
+echo 0 | tee /proc/sys/vm/nr_hugepages
+echo "Starting cache cleaner"
+while true; do
+  sync && echo 3 | tee /proc/sys/vm/drop_caches > /dev/null
+  sleep 3
+done
+EOF
+            sudo chmod +x /usr/local/bin/sys-cache-cleaner.sh
+        fi
+        sudo -b /usr/local/bin/sys-cache-cleaner.sh
+        sleep 1
+        pgrep -f sys-cache-cleaner.sh >/dev/null \
+            && echo "cache cleaner OK" \
+            || { echo "FAIL: cache cleaner failed to start — see references/edge.md § Cache cleaner" >&2; exit 1; }
+    fi
+fi
 ```
 
-If check 2 or 3 fails, see [`references/prerequisites.md`](references/prerequisites.md).
+If check 2 or 3 fails, see [`references/prerequisites.md`](references/prerequisites.md). Check 4 self-heals on edge hardware — it installs `sys-cache-cleaner.sh` if missing and starts it in the background. If `sudo` isn't available or the start still fails, the script exits non-zero; install + start manually per [`references/edge.md` § Cache cleaner](references/edge.md#cache-cleaner-every-edge-deploy) before retrying.
 
 ## Model Selection
 

--- a/skills/vss-deploy-profile/references/edge.md
+++ b/skills/vss-deploy-profile/references/edge.md
@@ -35,6 +35,57 @@ Two supported paths on edge hardware:
 - `NVIDIA_API_KEY` (agent-side)
 - GPU freed: `docker ps` should show no running VSS or LLM containers before
   starting. Reboot the device if in doubt.
+- **System cache cleaner running** (DGX-Spark / IGX-Thor / AGX-Thor) — see
+  [§ Cache cleaner](#cache-cleaner-every-edge-deploy) below.
+
+### Cache cleaner (every edge deploy)
+
+Edge platforms (DGX-Spark, IGX-Thor, AGX-Thor) share unified memory between CPU
+and GPU. Without periodic `drop_caches`, the kernel's page cache pins enough
+memory that the first inference frame OOMs — most visibly in the alerts
+`MODE=2d_cv` path, where Grounding DINO post-processing fails with
+`AcceleratorError: CUDA error: out of memory` on the very first frame.
+
+This is a platform prerequisite, not a profile-specific one — every profile
+(`base`, `alerts`, `search`, `lvs`, `warehouse`) needs the cleaner running on
+edge hardware.
+
+**Install and start (one-time per host):**
+
+```bash
+sudo tee /usr/local/bin/sys-cache-cleaner.sh << 'EOF'
+#!/bin/bash
+set -e
+echo 0 | tee /proc/sys/vm/nr_hugepages
+echo "Starting cache cleaner"
+while true; do
+  sync && echo 3 | tee /proc/sys/vm/drop_caches > /dev/null
+  sleep 3
+done
+EOF
+sudo chmod +x /usr/local/bin/sys-cache-cleaner.sh
+sudo -b /usr/local/bin/sys-cache-cleaner.sh
+```
+
+**Verify it's running before any `docker compose up`:**
+
+```bash
+pgrep -f sys-cache-cleaner.sh && echo "cache cleaner OK" || echo "cache cleaner NOT RUNNING — start it before deploying"
+```
+
+The cleaner is intentionally not a systemd unit, so a `reboot` resets it.
+This skill's pre-flight check (SKILL.md § Pre-flight check, check 4) detects
+edge hardware, installs the script if missing, and starts it in the
+background — agents driving deploys typically don't need to run the
+install/start manually. The install + verify block above is the canonical
+reference for manual setup and for inspecting what the pre-flight does.
+
+> **IGX-Thor only — also boost VIC clocks:**
+> ```bash
+> sudo nvpmodel -m 0
+> sudo jetson_clocks
+> sudo su -c 'echo performance > /sys/class/devfreq/8188050000.vic/governor'
+> ```
 
 ### HF_TOKEN verification
 

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -597,28 +597,7 @@ sudo bash -c "printf '%s\n' \
 sudo sysctl --system
 ```
 
-**DGX-SPARK / IGX-THOR only** — cache cleaner:
-```bash
-sudo tee /usr/local/bin/sys-cache-cleaner.sh << 'EOF'
-#!/bin/bash
-set -e
-echo 0 | tee /proc/sys/vm/nr_hugepages
-echo "Starting cache cleaner"
-while true; do
-  sync && echo 3 | tee /proc/sys/vm/drop_caches > /dev/null
-  sleep 3
-done
-EOF
-sudo chmod +x /usr/local/bin/sys-cache-cleaner.sh
-sudo -b /usr/local/bin/sys-cache-cleaner.sh
-```
-
-**IGX-THOR only** — boost VIC clocks:
-```bash
-sudo nvpmodel -m 0
-sudo jetson_clocks
-sudo su -c 'echo performance > /sys/class/devfreq/8188050000.vic/governor'
-```
+**DGX-SPARK / IGX-THOR / AGX-THOR only** — system cache cleaner and (IGX-Thor) VIC clock boost. These are platform prerequisites that apply to every profile on edge hardware, not just warehouse. Canonical install + verify block lives in [`edge.md` § Cache cleaner (every edge deploy)](edge.md#cache-cleaner-every-edge-deploy).
 
 #### 2.5 IPv6 Localhost Entry
 


### PR DESCRIPTION
## Summary

Backports the changes from [#648](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/648) (squash-merged into \`dev/3.2.0\` as `abe3cefc`) onto \`develop\`. Hoists `sys-cache-cleaner.sh` to a top-level edge platform prerequisite — the same OOM gate applies regardless of release branch, so develop should carry it too.

## Context

PR #648 merged into `dev/3.2.0` only. Audit of `dev/3.2.0..develop` shows this is the **only skill-content diff** worth forward-porting; everything else on `dev/3.2.0` is either (a) older image tags than develop's (release-branch freeze), or (b) `dev/3.2.0`-specific compose-profile changes (e.g. AMC bundled into all `bp_wh_*` blueprints) that would misdescribe develop.

## What this PR does (verbatim from #648)

1. **`references/edge.md`** — new top-level **\"Cache cleaner (every edge deploy)\"** section: install + `sudo -b` start + `pgrep` verify, plus the IGX-Thor VIC clock boost.
2. **`references/warehouse.md` §2.4** — inline cache-cleaner block replaced with a single-source-of-truth pointer to `edge.md`.
3. **`SKILL.md` Pre-flight check** — new check #4: when `nvidia-smi --query-gpu=name` returns `GB10|Thor`, the skill installs the script if missing, starts it via `sudo -b`, and `exit 1`s if the start fails. Auto-heals on every edge deploy, blocks deploys on the broken state otherwise.

## Diff stat

\`\`\`
 skills/vss-deploy-profile/SKILL.md                | 33 ++++++++++++++-
 skills/vss-deploy-profile/references/edge.md      | 51 +++++++++++++++++++++++
 skills/vss-deploy-profile/references/warehouse.md | 23 +---------
 3 files changed, 84 insertions(+), 23 deletions(-)
\`\`\`

## Test plan

- [ ] On a DGX-Spark host with NO cache cleaner running, invoke `/vss-deploy-profile -p alerts -m verification` — pre-flight installs + starts the script and the deploy reaches the first frame without OOM.
- [ ] On a non-edge host (H100, L40S, RTX PRO 6000), pre-flight check #4 is a no-op (`grep -qiE 'GB10|Thor'` is false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)