### PR TITLE
fix: eval brev upload

### DIFF
--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -29,6 +29,8 @@ import json
 import logging
 import os
 import shlex
+import subprocess
+import tempfile
 import uuid
 from enum import Enum
 from pathlib import Path
@@ -635,25 +637,60 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
 
     async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
         assert self._instance_name
-        # brev copy has broken directory nesting behaviour.  Use tar
-        # piped over brev exec: tar locally, base64-encode, send via
-        # exec, decode+untar on the remote side.
+        # brev copy has broken directory nesting behaviour. Package the
+        # directory locally, copy one archive, then extract remotely. Do
+        # not embed the archive bytes in a brev exec argv: larger skill
+        # bundles can exceed the OS per-argument limit.
         src = str(source_dir).rstrip("/")
-        import subprocess as _sp, base64 as _b64
-        tar_bytes = _sp.check_output(
-            ["tar", "-czf", "-", "-C", src, "."],
-            timeout=60,
+        fd, tar_path_str = tempfile.mkstemp(
+            prefix="brev-upload-", suffix=".tar.gz",
         )
-        encoded = _b64.b64encode(tar_bytes).decode()
-        result = await _run_brev_exec(
-            self._instance_name,
-            f"sudo mkdir -p {shlex.quote(target_dir)} && "
-            f"sudo chown $(whoami):$(id -gn) {shlex.quote(target_dir)} && "
-            f"echo '{encoded}' | base64 -d | tar -xzf - -C {shlex.quote(target_dir)}",
-            timeout=120,
-        )
-        if result.return_code != 0:
-            raise RuntimeError(f"Upload dir failed: {result.stderr}")
+        os.close(fd)
+        tar_path = Path(tar_path_str)
+        remote_upload_dir = f"/tmp/skill-eval/uploads/{uuid.uuid4().hex}"
+        remote_tar = f"{remote_upload_dir}/archive.tar.gz"
+
+        try:
+            subprocess.check_call(
+                ["tar", "-czf", str(tar_path), "-C", src, "."],
+                timeout=60,
+            )
+
+            result = await _run_brev_exec(
+                self._instance_name,
+                f"mkdir -p {shlex.quote(remote_upload_dir)}",
+                timeout=30,
+            )
+            if result.return_code != 0:
+                raise RuntimeError(f"Upload dir failed: {result.stderr}")
+
+            result = await _run_brev_copy(
+                str(tar_path), f"{self._instance_name}:{remote_tar}",
+            )
+            if result.return_code != 0:
+                raise RuntimeError(f"Upload dir failed: {result.stderr}")
+
+            target = shlex.quote(target_dir)
+            remote_archive = shlex.quote(remote_tar)
+            remote_dir = shlex.quote(remote_upload_dir)
+            result = await _run_brev_exec(
+                self._instance_name,
+                f"sudo mkdir -p {target} && "
+                f"sudo chown $(whoami):$(id -gn) {target}; "
+                "status=$?; "
+                "if [ $status -eq 0 ]; then "
+                f"tar -xzf {remote_archive} -C {target}; "
+                "status=$?; "
+                "fi; "
+                f"rm -f {remote_archive}; "
+                f"rmdir {remote_dir} 2>/dev/null || true; "
+                "exit $status",
+                timeout=120,
+            )
+            if result.return_code != 0:
+                raise RuntimeError(f"Upload dir failed: {result.stderr}")
+        finally:
+            tar_path.unlink(missing_ok=True)
 
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
         assert self._instance_name

--- a/.github/skill-eval/envs/tests/test_registered_node.py
+++ b/.github/skill-eval/envs/tests/test_registered_node.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
@@ -120,13 +121,22 @@ class CheckInstanceMatchesForRegistered(unittest.TestCase):
         """Registered nodes often have empty `gpu` field — shouldn't fail."""
         inst = {"name": "SPARK", "_registered": True, "gpu": ""}
         # Should not raise
-        brev_env._check_instance_matches(inst, {"gpu_type": "GB10"})
+        asyncio.run(brev_env._check_instance_matches(inst, {"gpu_type": "GB10"}))
 
     def test_brev_managed_still_checks_gpu(self):
         """Non-registered instances still enforce GPU-name match."""
-        inst = {"name": "test", "gpu": "L40S"}
-        with self.assertRaises(RuntimeError):
-            brev_env._check_instance_matches(inst, {"gpu_type": "H100"})
+        inst = {"name": "test", "gpu": "L40S", "instance_type": "test-l40s"}
+
+        async def fake_catalog_count(instance_type):
+            return 1
+
+        original = brev_env._get_instance_gpu_count_from_catalog
+        brev_env._get_instance_gpu_count_from_catalog = fake_catalog_count
+        try:
+            with self.assertRaises(RuntimeError):
+                asyncio.run(brev_env._check_instance_matches(inst, {"gpu_type": "H100"}))
+        finally:
+            brev_env._get_instance_gpu_count_from_catalog = original
 
 
 class EnsurePrerequisiteCleanup(unittest.IsolatedAsyncioTestCase):
@@ -174,6 +184,96 @@ class EnsurePrerequisiteCleanup(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(calls), 1)
         self.assertIn("cat /tmp/skill-eval/active-deploy.txt", calls[0][1])
+
+
+class UploadDirTarballCopy(unittest.IsolatedAsyncioTestCase):
+
+    async def test_upload_dir_copies_tarball_and_extracts_with_short_command(self):
+        exec_calls = []
+        copy_calls = []
+
+        async def fake_run_brev_exec(instance, command, timeout=brev_env.BREV_EXEC_TIMEOUT):
+            exec_calls.append((instance, command, timeout))
+            return brev_env.ExecResult(stdout="", stderr=None, return_code=0)
+
+        async def fake_run_brev_copy(src, dst, timeout=brev_env.BREV_COPY_TIMEOUT):
+            copy_calls.append((src, dst, timeout))
+            self.assertTrue(Path(src).is_file())
+            return brev_env.ExecResult(stdout="", stderr=None, return_code=0)
+
+        original_exec = brev_env._run_brev_exec
+        original_copy = brev_env._run_brev_copy
+        brev_env._run_brev_exec = fake_run_brev_exec
+        brev_env._run_brev_copy = fake_run_brev_copy
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                src_dir = Path(td) / "skills"
+                src_dir.mkdir()
+                (src_dir / "SKILL.md").write_text("test skill\n")
+
+                env = brev_env.BrevEnvironment()
+                env._instance_name = "vss-eval-test"
+                await env.upload_dir(src_dir, "/skills")
+        finally:
+            brev_env._run_brev_exec = original_exec
+            brev_env._run_brev_copy = original_copy
+
+        self.assertEqual(len(copy_calls), 1)
+        copied_src, copied_dst, _ = copy_calls[0]
+        self.assertTrue(copied_src.endswith(".tar.gz"))
+        self.assertFalse(Path(copied_src).exists())
+        self.assertRegex(
+            copied_dst,
+            r"^vss-eval-test:/tmp/skill-eval/uploads/[0-9a-f]+/archive\.tar\.gz$",
+        )
+
+        commands = [call[1] for call in exec_calls]
+        self.assertEqual(len(commands), 2)
+        self.assertIn("mkdir -p /tmp/skill-eval/uploads/", commands[0])
+        extract_cmd = commands[1]
+        self.assertIn("tar -xzf", extract_cmd)
+        self.assertIn("-C /skills", extract_cmd)
+        self.assertIn("rm -f /tmp/skill-eval/uploads/", extract_cmd)
+        self.assertIn("rmdir /tmp/skill-eval/uploads/", extract_cmd)
+        self.assertLess(max(len(command) for command in commands), 1000)
+        self.assertNotIn("base64", "\n".join(commands))
+        self.assertNotIn("echo '", "\n".join(commands))
+
+    async def test_upload_dir_raises_when_tarball_copy_fails(self):
+        exec_calls = []
+        copy_calls = []
+
+        async def fake_run_brev_exec(instance, command, timeout=brev_env.BREV_EXEC_TIMEOUT):
+            exec_calls.append((instance, command, timeout))
+            return brev_env.ExecResult(stdout="", stderr=None, return_code=0)
+
+        async def fake_run_brev_copy(src, dst, timeout=brev_env.BREV_COPY_TIMEOUT):
+            copy_calls.append((src, dst, timeout))
+            return brev_env.ExecResult(stdout="", stderr="copy failed", return_code=1)
+
+        original_exec = brev_env._run_brev_exec
+        original_copy = brev_env._run_brev_copy
+        brev_env._run_brev_exec = fake_run_brev_exec
+        brev_env._run_brev_copy = fake_run_brev_copy
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                src_dir = Path(td) / "skills"
+                src_dir.mkdir()
+                (src_dir / "SKILL.md").write_text("test skill\n")
+
+                env = brev_env.BrevEnvironment()
+                env._instance_name = "vss-eval-test"
+                with self.assertRaisesRegex(RuntimeError, "copy failed"):
+                    await env.upload_dir(src_dir, "/skills")
+        finally:
+            brev_env._run_brev_exec = original_exec
+            brev_env._run_brev_copy = original_copy
+
+        self.assertEqual(len(copy_calls), 1)
+        copied_src, _, _ = copy_calls[0]
+        self.assertFalse(Path(copied_src).exists())
+        self.assertEqual(len(exec_calls), 1)
+        self.assertIn("mkdir -p /tmp/skill-eval/uploads/", exec_calls[0][1])
 
 
 class VersionCompareSanity(unittest.TestCase):


### PR DESCRIPTION
## Description
Skill eval setup can fail before the agent runs because BrevEnvironment.upload_dir() sends the entire tarred skills/ bundle as base64 embedded in a single brev exec command argument. Larger bundles, like the search skill eval bundle, can exceed the OS argv limit and raise OSError: [Errno 7] Argument list too long: 'brev'.

```
  [tool] Bash :: # That was the FIRST failed attempt at step-1 (the OSError from skills upload).
```
https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/26293619017/job/77400176534

This PR changes the upload path to copy a tarball with brev copy and extract it remotely with a short brev exec command.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
