### PR TITLE
fix(vss-generate-video-report): bypass /generate planner; dispatch by intent

### DIFF
--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -67,16 +67,38 @@ Hand off to `/vss-manage-video-io-storage` to:
 
 ### Step 2 — Resolve VLM endpoint and model
 
-Both come from the agent's `vss_agent/configs/config.yml` (`llms.nim_vlm.base_url` = `${VLM_BASE_URL}/v1`, `llms.nim_vlm.model_name` = `${VLM_NAME}`). Read them off the running container — do not guess:
+The deploy may serve the VLM through either of two stacks. Both expose an OpenAI-compatible `chat/completions` API — pick whichever is live:
+
+| Backend | Env vars | Typical host endpoint | Picked when |
+|---|---|---|---|
+| **NIM Cosmos** | `VLM_BASE_URL`, `VLM_NAME` | `${VLM_BASE_URL}/v1` (no trailing `/v1` on the env var; the agent appends it) | `VLM_MODE` ∈ {`local`, `local_shared`, `remote`} **and** `VLM_BASE_URL` is non-empty |
+| **RT-VLM Cosmos** | `RTVI_VLM_BASE_URL`, `RTVI_VLM_MODEL_TO_USE` (model identifier on the RT-VLM side, e.g. `cosmos-reason2`) | `${RTVI_VLM_BASE_URL}/v1` — alerts default `http://${HOST_IP}:8018/v1`, base default `http://${HOST_IP}:30082/v1` (`RTVI_VLM_ENDPOINT`) | `VLM_MODE=none` **or** `VLM_BASE_URL` empty; also the only path for `warehouse` |
+
+Read the live values off the running agent container — do not guess:
 
 ```bash
-docker exec vss-agent env | grep -E '^(VLM_BASE_URL|VLM_NAME)=' 
-# typical alerts profile defaults:
-#   VLM_BASE_URL=http://${HOST_IP}:8009     (no trailing /v1)
-#   VLM_NAME=nvidia/cosmos-reason2-8b
+docker exec vss-agent env | grep -E '^(VLM_BASE_URL|VLM_NAME|VLM_MODE|RTVI_VLM_BASE_URL|RTVI_VLM_ENDPOINT|RTVI_VLM_MODEL_TO_USE)='
 ```
 
-Bind to `VLM_BASE_URL` and `VLM_NAME`. If `docker exec` is unavailable, fall back to `grep -E '^(VLM_BASE_URL|VLM_NAME)=' .../dev-profile-base/generated.env`.
+Selection rule:
+
+```bash
+if [ -n "${VLM_BASE_URL}" ] && [ "${VLM_MODE}" != "none" ]; then
+  VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
+  VLM_MODEL="${VLM_NAME}"
+else
+  VLM_ENDPOINT="${RTVI_VLM_ENDPOINT:-${RTVI_VLM_BASE_URL%/}/v1}"
+  VLM_MODEL="${RTVI_VLM_MODEL_TO_USE}"
+fi
+```
+
+Probe `/v1/models` before sending a chat request to confirm the chosen endpoint is alive and the model is loaded:
+
+```bash
+curl -sf --max-time 5 "${VLM_ENDPOINT}/models" | jq -r '.data[].id'
+```
+
+If the probe fails or the listed ids don't include `${VLM_MODEL}`, fall back to the other backend (or surface the error — never silently pick a model that isn't on the server).
 
 ### Step 3 — Call the VLM directly
 
@@ -97,11 +119,11 @@ Your reasoning.
 
 Write your final answer immediately after the </think> tag."
 
-curl -s -X POST "${VLM_BASE_URL}/v1/chat/completions" \
+curl -s -X POST "${VLM_ENDPOINT}/chat/completions" \
   -H "Content-Type: application/json" \
   -d @- <<EOF | jq -r '.choices[0].message.content'
 {
-  "model": "${VLM_NAME}",
+  "model": "${VLM_MODEL}",
   "messages": [
     {
       "role": "user",
@@ -133,7 +155,7 @@ If the VLM returns a `<think>…</think>` block (Cosmos Reason reasoning mode), 
 | **Time of Analysis** | <HH:MM:SS> |
 | **Video Source** | <sensor_id or filename> |
 | **Clip Range** | <startTime> – <endTime> |
-| **VLM** | <VLM_NAME> |
+| **VLM** | <VLM_MODEL (NIM or RT-VLM)> |
 | **Analysis Request** | <user's request> |
 
 ## Analysis Results

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vss-generate-video-report
-description: Produce a timestamped video analysis report from a clip. Use when the user says "generate a report", "give me a report", or "create a report on this video".
+description: Produce a video analysis report. Two modes — (a) report on a recorded video / sensor clip via direct VLM call, (b) report on incidents in a time range via video-analytics. Use when the user says "generate a report", "give me a report", or "create a report".
 license: Apache-2.0
 metadata:
   version: "3.2.0"
@@ -10,101 +10,116 @@ metadata:
 
 # Report
 
-Build **timestamped video analysis reports** by **querying the VSS agent** for a description of the video using `POST …/generate`. The agent runs **`video_understanding`** (and related tools) internally. Take the agent’s **caption-style text with timestamps** and paste it into the **Video Analysis Report** template below.
+Generate a video analysis report by routing to one of two backends — **never via** `POST /generate` on the VSS agent.
+
+| Mode | Trigger | Backend |
+|---|---|---|
+| **A. Video clip** | "report on `<sensor>`", "report on this video", "analyze warehouse_01.mp4" | `/vss-manage-video-io-storage` → clip URL → **VLM chat/completions** |
+| **B. Incident range** | "report on incidents from `<t1>` to `<t2>`", "report on alerts today", "what incidents happened on `<sensor>` last hour" | `/vss-query-analytics` → incident list → narrative report |
+
+If the request is ambiguous (e.g. "report on `<sensor>`" with no time range and no incident wording), default to **Mode A**. Ask only if the user mentions both a sensor and a time range.
 
 ---
 
 ## When to Use
 
-- "Generate a report for this video" / "for `<sensor-id>`"
-- "Create an analysis report"
-- "Report on what happens in the uploaded video"
-- "Give me a report"
+- "Generate a report for this video" / "for `<sensor-id>`" — **Mode A**
+- "Create an analysis report on the uploaded video" — **Mode A**
+- "Report on incidents from 12:31Z to 12:32Z" — **Mode B**
+- "Summarize alerts on `<sensor>` between `<t1>` and `<t2>`" — **Mode B**
 
 ---
 
 ## Deployment prerequisite
 
-This skill requires the VSS **base** profile running on the host at `$HOST_IP`. Before any request:
+**Mode A** needs the VSS **base** profile (VST + VLM NIM).
+**Mode B** needs the VSS **alerts** profile (VA-MCP + Elasticsearch).
 
-1. Probe the VSS agent:
-   ```bash
-   curl -sf --max-time 5 "http://${HOST_IP}:8000/docs" >/dev/null
-   ```
-
-2. **If the probe fails**, ask the user:
-   > *"The VSS `base` profile isn't running on `$HOST_IP`. Shall I deploy it now using the `/vss-deploy-profile` skill with `-p base`?"*
-
-   - If yes → hand off to the `/vss-deploy-profile` skill. Return here once it succeeds.
-   - If no → stop. Do not run this skill against a missing stack.
-
-   (If your caller has granted explicit pre-authorization to deploy
-   autonomously — e.g. the request says "pre-authorized to deploy
-   prerequisites", or you are running in a non-interactive evaluation
-   harness with that permission — skip the confirmation and invoke
-   `/vss-deploy-profile` directly.)
-
-3. If the probe passes, proceed.
-
----
-
-## Sensor prerequisite
-
-**You MUST list VST sensors before any `/generate` call.** This is required even when the user names the sensor explicitly, even when the user asserts the video is already uploaded, and even when a previous turn appeared to use the same video. Do not skip this step.
-
-1. List sensors:
-   ```bash
-   curl -sf --max-time 5 "http://${HOST_IP}:30888/vst/api/v1/sensor/list" | jq '.[].name'
-   ```
-
-2. Compare the returned `name` values against the user-supplied `<sensor-id>` (or **filename stem**, e.g. `warehouse_safety_0001`).
-
-3. **If a matching sensor is present** → proceed to the Agent workflow below.
-
-4. **If no matching sensor is present** — upload the video first, then re-list to confirm the new sensor appears:
-   ```bash
-   # filename: must not contain whitespace
-   # timestamp: ISO 8601 UTC — default 2025-01-01T00:00:00.000Z if user did not specify
-   curl -s -X PUT "http://${HOST_IP}:30888/vst/api/v1/storage/file/<filename>?timestamp=<timestamp>" \
-     -H "Content-Type: application/octet-stream" \
-     -H "Content-Length: <file_size_in_bytes>" \
-     --upload-file /path/to/<filename> | jq .
-   ```
-   See `/vss-manage-video-io-storage` for full upload semantics (v1 vs v2, conflict handling, delete flow). In interactive runs, confirm with the user before uploading. **Never** issue an unconditional PUT without first running the sensor-list check above — that is exactly the failure mode this prerequisite exists to prevent.
-
----
-
-## Agent workflow
-
-The Sensor prerequisite above must have already confirmed (or made) the sensor exist on VST. Then run these steps **in order**:
-
-1. **Sensor / clip** — Confirm which **sensor id** or **video** the user means. If unclear, ask before proceeding. If the sensor or video is not mentioned directly in the user request, the user may be referring to a video they mentioned previously.
-
-2. **VSS agent deployment** — Resolve the agent **HTTP base URL**. Read **`VSS_AGENT_PORT`**, **`EXTERNAL_IP` / `HOST_IP`**, or compose / deployment docs for the machine where the stack runs. Typical pattern: **`http://<host>:<port>`** with port from env (often **`8000`** for the agent API).
-
-3. **Query the agent** — **`POST ${VSS_AGENT_BASE_URL}/generate`** with JSON **`{"input_message": "<prompt>"}`**. Ask for a **captioned summary with timestamps** (chronological segments, seconds from clip start), e.g. describe scenes and events with time ranges. Name the **sensor / file** in the message so the agent has the necessary information.
-   - DO NOT mention a report to vss agent
-
-4. **Report template** — Copy the agent’s final text (timestamped caption/summary) into **Analysis Results** and fill **Basic Information**; **return that markdown** to the user.
-
----
-
-## Query VSS agent (`/generate`)
+Probe:
 
 ```bash
-# Set from deployment (compose / .env / host where vss-agent listens)
-export VSS_AGENT_BASE_URL="http://localhost:8000"
+# Mode A — VST + VLM reachability
+curl -sf --max-time 5 "http://${HOST_IP}:30888/vst/api/v1/sensor/version" >/dev/null
 
-curl -s -X POST "${VSS_AGENT_BASE_URL}/generate" \
-  -H "Content-Type: application/json" \
-  -d '{"input_message": "Describe in detail what happens in the video for sensor <sensor-id>, with timestamps (start–end in seconds from clip start) for each segment or event."}' | jq .
+# Mode B — VA-MCP
+curl -sf --max-time 5 "http://${HOST_IP}:9901/" >/dev/null
 ```
+
+If the probe fails, hand off to `/vss-deploy-profile` with `-p base` (Mode A) or `-p alerts` (Mode B). With pre-authorization to deploy prerequisites, invoke `/vss-deploy-profile` directly; otherwise confirm with the user first.
 
 ---
 
-## Video Analysis Report template
+## Mode A — Report on a recorded video clip
 
-Paste the **agent’s timestamped summary** under **Analysis Results**. Fill the table fields (timestamps, source, request).
+### Step 1 — Resolve the clip URL
+
+Hand off to `/vss-manage-video-io-storage` to:
+
+1. List sensors and confirm the named `<sensor-id>` exists (upload first if not).
+2. Fetch `/storage/<streamId>/timelines` for the recorded range when the user did not supply `startTime` / `endTime`.
+3. Request a clip URL:
+
+   ```bash
+   curl -s "http://${HOST_IP}:30888/vst/api/v1/storage/file/<streamId>/url?startTime=<startTime>&endTime=<endTime>&container=mp4&disableAudio=true" | jq -r .videoUrl
+   ```
+
+   That gives a direct `mp4` URL that the VLM can pull frames from. Bind it to `VIDEO_URL`.
+
+### Step 2 — Resolve VLM endpoint and model
+
+Both come from the agent's `vss_agent/configs/config.yml` (`llms.nim_vlm.base_url` = `${VLM_BASE_URL}/v1`, `llms.nim_vlm.model_name` = `${VLM_NAME}`). Read them off the running container — do not guess:
+
+```bash
+docker exec vss-agent env | grep -E '^(VLM_BASE_URL|VLM_NAME)=' 
+# typical alerts profile defaults:
+#   VLM_BASE_URL=http://${HOST_IP}:8009     (no trailing /v1)
+#   VLM_NAME=nvidia/cosmos-reason2-8b
+```
+
+Bind to `VLM_BASE_URL` and `VLM_NAME`. If `docker exec` is unavailable, fall back to `grep -E '^(VLM_BASE_URL|VLM_NAME)=' .../dev-profile-base/generated.env`.
+
+### Step 3 — Call the VLM directly
+
+Use the OpenAI-compatible `chat/completions` endpoint with a `video_url` content block — the same payload shape `video_understanding` builds in `src/vss_agents/tools/video_understanding.py` (`_build_vlm_messages`):
+
+```bash
+PROMPT='Describe in detail what happens in the video, with timestamps (start–end in seconds from clip start) for each segment or event. Cover scenes, objects, people, vehicles, and notable actions.'
+
+# Cosmos Reason 2 reasoning prompt suffix — matches video_understanding.py for is_cosmos_reason2 + reasoning=true.
+# Drop this suffix for non-cosmos-reason2 VLMs.
+PROMPT="${PROMPT}
+
+Answer the question using the following format:
+
+<think>
+Your reasoning.
+</think>
+
+Write your final answer immediately after the </think> tag."
+
+curl -s -X POST "${VLM_BASE_URL}/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d @- <<EOF | jq -r '.choices[0].message.content'
+{
+  "model": "${VLM_NAME}",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": $(jq -Rs . <<< "${PROMPT}")},
+        {"type": "video_url", "video_url": {"url": "${VIDEO_URL}"}}
+      ]
+    }
+  ],
+  "max_tokens": 1024,
+  "temperature": 0.0
+}
+EOF
+```
+
+If the VLM returns a `<think>…</think>` block (Cosmos Reason reasoning mode), keep only the text after `</think>` as the report body.
+
+### Step 4 — Fill the Video Analysis Report template
 
 ```markdown
 # Video Analysis Report
@@ -116,18 +131,85 @@ Paste the **agent’s timestamped summary** under **Analysis Results**. Fill the
 | **Report Identifier** | vss_report_<YYYYMMDD_HHMMSS> |
 | **Date of Analysis** | <YYYY-MM-DD> |
 | **Time of Analysis** | <HH:MM:SS> |
-| **Reporting AI Agent** | <e.g. your label> |
 | **Video Source** | <sensor_id or filename> |
-| **Analysis Request** | <description of user's request to you> |
+| **Clip Range** | <startTime> – <endTime> |
+| **VLM** | <VLM_NAME> |
+| **Analysis Request** | <user's request> |
 
 ## Analysis Results
 
-<agent output: timestamped caption / summary>
+<VLM output: timestamped caption / summary>
 ```
+
+Return the rendered markdown to the user.
+
+---
+
+## Mode B — Report on incidents in a time range
+
+### Step 1 — Resolve the time range and (optionally) sensor
+
+- `start_time` / `end_time` must be ISO 8601 UTC (`YYYY-MM-DDTHH:MM:SS.sssZ`). Resolve relative phrases ("last hour", "today") against the current host clock.
+- If the user names a sensor, capture it as `source` + `source_type=sensor`. Otherwise leave both unset for an all-sensors query.
+
+### Step 2 — Fetch incidents via `/vss-query-analytics`
+
+Hand off to `/vss-query-analytics` (initialize → `tools/call`) with:
+
+```json
+{
+  "name": "video_analytics__get_incidents",
+  "arguments": {
+    "source": "<sensor-id-or-omit>",
+    "source_type": "sensor",
+    "start_time": "<ISO>",
+    "end_time": "<ISO>",
+    "max_count": 100,
+    "includes": ["objectIds", "info"]
+  }
+}
+```
+
+For each incident keep: `id`, `sensorId`, `timestamp`, `end`, `category`, `place.name`, `info.verdict`, `info.reasoning`, `objectIds`.
+
+### Step 3 — Fill the Incident Range Report template
+
+Group by sensor (or by category if no sensor scope), tally verdicts, list each incident as a bullet with timestamp / category / verdict / reasoning.
+
+```markdown
+# Incident Range Report
+
+## Basic Information
+
+| Field | Value |
+|-------|-------|
+| **Report Identifier** | vss_report_<YYYYMMDD_HHMMSS> |
+| **Range** | <start_time> – <end_time> |
+| **Scope** | <sensor_id> | all sensors |
+| **Total Incidents** | <N> |
+| **Confirmed / Rejected / Unverified** | <c> / <r> / <u> |
+
+## Incidents
+
+### <sensor_id_or_category>
+
+- **<timestamp>** — <category> — verdict: **<confirmed|rejected|unverified>**
+  - <info.reasoning (1–2 lines)>
+  - objects: <objectIds joined>
+- …
+
+## Summary
+
+<2–4 sentences synthesizing what dominates the range — top categories, sensors with the most confirmed incidents, any clusters in time.>
+```
+
+If `get_incidents` returns zero results, return a one-line report stating the range and scope produced no incidents — do not invent content and do not fall back to Mode A.
 
 ---
 
 ## Cross-Reference
 
-- **vss-manage-video-io-storage** — VST sensors, storage, and clip URLs if you need to verify the video exists before calling the agent.
-- **vss-summarize-video** / **vss-manage-alerts** — other **`/generate`** patterns; this skill focuses on **timestamped captions → report template**.
+- **`/vss-manage-video-io-storage`** — sensor list, timelines, and clip URL for Mode A Step 1.
+- **`/vss-query-analytics`** — incident retrieval (and verdict / reasoning enrichment) for Mode B Step 2.
+- **`/vss-ask-video`** — ad-hoc VLM Q&A on a single clip (not a structured report).
+- **`/vss-summarize-video`** — long-video summary via LVS (different backend; use for hours-long footage).

--- a/skills/vss-generate-video-report/eval/base_profile_report.json
+++ b/skills/vss-generate-video-report/eval/base_profile_report.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "env": "VSS **base** profile on the target host: VST reachable at http://localhost:30888/vst/api/v1, VLM endpoint reachable at $VLM_BASE_URL/v1/chat/completions (read VLM_BASE_URL + VLM_NAME off the vss-agent container env). Use **remote-all** (remote LLM + VLM) so no local NIMs are required. Set Brev secure-link vars (`BREV_ENV_ID`, `BREV_LINK_PREFIX`) if checks validate media URLs. (See `skills/vss-generate-video-report/SKILL.md`).",
+  "env": "VSS **base** profile on the target host: VST reachable at http://localhost:30888/vst/api/v1, VLM endpoint reachable at either ${VLM_BASE_URL}/v1 (NIM Cosmos, picked when VLM_BASE_URL non-empty and VLM_MODE != none) or ${RTVI_VLM_ENDPOINT} / ${RTVI_VLM_BASE_URL}/v1 (RT-VLM Cosmos, picked otherwise; base default port 30082, alerts default 8018). Read VLM_BASE_URL / VLM_NAME / VLM_MODE / RTVI_VLM_BASE_URL / RTVI_VLM_ENDPOINT / RTVI_VLM_MODEL_TO_USE off the vss-agent container env. Use **remote-all** (remote LLM + VLM) so no local NIMs are required. Set Brev secure-link vars (`BREV_ENV_ID`, `BREV_LINK_PREFIX`) if checks validate media URLs. (See `skills/vss-generate-video-report/SKILL.md`).",
   "expects": [
     {
       "query": "Check if the warehouse_safety_0001 video is already uploaded on VST. If it doesn't exist, upload the warehouse_safety_0001 video to VIOS with timestamp 2025-01-01T00:00:00.000Z. If it exists, skip the uploading.",
@@ -25,21 +25,21 @@
       "checks": [
         "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:30888/vst/api/v1/sensor/version returns 200",
         "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body",
-        "VLM_BASE_URL and VLM_NAME are resolvable from the vss-agent container environment (e.g. docker exec vss-agent env returns both)"
+        "Either VLM_BASE_URL + VLM_NAME (NIM Cosmos) or RTVI_VLM_BASE_URL/RTVI_VLM_ENDPOINT + RTVI_VLM_MODEL_TO_USE (RT-VLM Cosmos) are resolvable from the vss-agent container environment (e.g. docker exec vss-agent env returns one set), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
       ]
     },
     {
       "query": "Give me a report for warehouse_safety_0001. VSS agent is on http://localhost:8000",
       "checks": [
         "The run performed at least one successful GET to a VST clip-URL endpoint of the form http://localhost:30888/vst/api/v1/storage/file/<streamId>/url with startTime and endTime query params and returned a JSON body containing videoUrl (the clip is sourced through /vss-manage-video-io-storage, NOT via POST /generate).",
-        "The run performed at least one successful POST to ${VLM_BASE_URL}/v1/chat/completions with Content-Type application/json, a JSON body containing model (e.g. nvidia/cosmos-reason2-8b), and a messages array whose first user content list contains both a text block and a video_url block referencing the clip URL from the prior step; HTTP 2xx.",
+        "The run performed at least one successful POST to /v1/chat/completions on the resolved VLM endpoint (either ${VLM_BASE_URL}/v1 for NIM Cosmos or ${RTVI_VLM_BASE_URL}/v1 / ${RTVI_VLM_ENDPOINT} for RT-VLM Cosmos), with Content-Type application/json, a JSON body containing model (e.g. nvidia/cosmos-reason2-8b for NIM, or cosmos-reason2 / openai-compat for RT-VLM matching RTVI_VLM_MODEL_TO_USE), and a messages array whose first user content list contains both a text block and a video_url block referencing the clip URL from the prior step; HTTP 2xx.",
         "The run did NOT POST to http://localhost:8000/generate.",
         "The user-facing markdown has a single top-level title line matching # Video Analysis Report (allows leading whitespace after #).",
         "The markdown contains ## Basic Information followed by a pipe-table (Field | Value) including every row header from the skill template: Report Identifier; Date of Analysis; Time of Analysis; Video Source; Clip Range; VLM; Analysis Request — each paired cell is filled with concrete text (no raw placeholders like literal <sensor_id>, <YYYY-MM-DD>, '<e.g.', or duplicate Field names without values).",
         "The Basic Information Report Identifier row value matches pattern vss_report_ followed by 8-digit date (YYYYMMDD), underscore, and 6-digit time (HHMMSS) as in SKILL (vss_report_<YYYYMMDD_HHMMSS>).",
         "The Basic Information Date of Analysis value looks like calendar date YYYY-MM-DD (four digits-two digits-two digits) not a template stub; Time of Analysis looks like HH:MM:SS.",
         "The Basic Information Video Source row names warehouse_safety_0001",
-        "The Basic Information VLM row names the model returned by the chat/completions call (e.g. nvidia/cosmos-reason2-8b) rather than a placeholder.",
+        "The Basic Information VLM row names the model returned by the chat/completions call (e.g. nvidia/cosmos-reason2-8b for NIM Cosmos, or the RT-VLM model id from RTVI_VLM_MODEL_TO_USE) rather than a placeholder.",
         "The Basic Information Analysis Request row restates or paraphrases the user ask (report about warehouse_safety_0001 context) rather than staying empty.",
         "The markdown contains ## Analysis Results and beneath it substantive content: the VLM caption summary with timestamps or time segments (seconds or ranges), chronological sense, non-empty—not only headings or placeholders. Any <think>...</think> reasoning block from Cosmos Reason VLMs is stripped before insertion.",
         "The Analysis Results content is visibly derived from the VLM response (caption-style description); it is not a single sentence like N/A covering the whole section unless the VLM truly returned that."

--- a/skills/vss-generate-video-report/eval/base_profile_report.json
+++ b/skills/vss-generate-video-report/eval/base_profile_report.json
@@ -10,36 +10,50 @@
       }
     }
   },
-  "env": "VSS **base** profile on the target host: VSS agent HTTP API on **8000** (e.g. `http://localhost:8000/docs`), VST reachable at http://localhost:30888/vst/api/v1. Use **remote-all** (remote LLM + VLM) so no local NIMs are required. Set Brev secure-link vars (`BREV_ENV_ID`, `BREV_LINK_PREFIX`) if checks validate media URLs. (See `skills/vss-generate-video-report/SKILL.md`).",
+  "env": "VSS **base** profile on the target host: VST reachable at http://localhost:30888/vst/api/v1, VLM endpoint reachable at $VLM_BASE_URL/v1/chat/completions (read VLM_BASE_URL + VLM_NAME off the vss-agent container env). Use **remote-all** (remote LLM + VLM) so no local NIMs are required. Set Brev secure-link vars (`BREV_ENV_ID`, `BREV_LINK_PREFIX`) if checks validate media URLs. (See `skills/vss-generate-video-report/SKILL.md`).",
   "expects": [
     {
       "query": "Check if the warehouse_safety_0001 video is already uploaded on VST. If it doesn't exist, upload the warehouse_safety_0001 video to VIOS with timestamp 2025-01-01T00:00:00.000Z. If it exists, skip the uploading.",
       "checks": [
-        "Trajectory or reasoning shows probing VST/VIOS for warehouse_safety_0001 **before** deciding to upload\u2014for example listing sensors/streams via the agent tools (or equivalent REST such as curl /vst/api/v1/sensor/list)\u2014not unconditional PUT-only behavior.",
+        "Trajectory or reasoning shows probing VST/VIOS for warehouse_safety_0001 **before** deciding to upload—for example listing sensors/streams via the agent tools (or equivalent REST such as curl /vst/api/v1/sensor/list)—not unconditional PUT-only behavior.",
         "curl -sf http://localhost:30888/vst/api/v1/sensor/list returns a JSON array containing a sensor whose name matches the uploaded video's filename stem",
         "curl -sf http://localhost:30888/vst/api/v1/sensor/<sensorId>/streams returns a non-empty streams array whose main stream's url is a local file path under /home/vst/... or similar (NOT rtsp://)"
       ]
     },
     {
-      "query": "Verify the VSS stack is ready for the **report** skill. Confirm the agent serves OpenAPI at `/docs` and that VST lists at least one stream.",
+      "query": "Verify the VSS stack is ready for the **report** skill. Confirm VST reachable and at least one stream is registered, and the VLM endpoint resolves.",
       "checks": [
-        "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:8000/docs returns 200",
-        "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body"
+        "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:30888/vst/api/v1/sensor/version returns 200",
+        "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body",
+        "VLM_BASE_URL and VLM_NAME are resolvable from the vss-agent container environment (e.g. docker exec vss-agent env returns both)"
       ]
     },
     {
       "query": "Give me a report for warehouse_safety_0001. VSS agent is on http://localhost:8000",
       "checks": [
-        "The run performed at least one successful POST to http://localhost:8000/generate (or equivalent agent base URL) with Content-Type application/json and a JSON body containing input_message with HTTP 2xx.",
-        "The POST input_message asks the agent for a timestamped captioned summary for sensor or file warehouse_safety_0001 but does NOT use the word report (skill rule DO NOT mention a report to vss agent); if echoed in trajectory or logs this must hold.",
+        "The run performed at least one successful GET to a VST clip-URL endpoint of the form http://localhost:30888/vst/api/v1/storage/file/<streamId>/url with startTime and endTime query params and returned a JSON body containing videoUrl (the clip is sourced through /vss-manage-video-io-storage, NOT via POST /generate).",
+        "The run performed at least one successful POST to ${VLM_BASE_URL}/v1/chat/completions with Content-Type application/json, a JSON body containing model (e.g. nvidia/cosmos-reason2-8b), and a messages array whose first user content list contains both a text block and a video_url block referencing the clip URL from the prior step; HTTP 2xx.",
+        "The run did NOT POST to http://localhost:8000/generate.",
         "The user-facing markdown has a single top-level title line matching # Video Analysis Report (allows leading whitespace after #).",
-        "The markdown contains ## Basic Information followed by a pipe-table (Field | Value) including every row header from the skill template: Report Identifier; Date of Analysis; Time of Analysis; Reporting AI Agent; Video Source; Analysis Request \u2014 each paired cell is filled with concrete text (no raw placeholders like literal <sensor_id>, <YYYY-MM-DD>, '<e.g.', or duplicate Field names without values).",
+        "The markdown contains ## Basic Information followed by a pipe-table (Field | Value) including every row header from the skill template: Report Identifier; Date of Analysis; Time of Analysis; Video Source; Clip Range; VLM; Analysis Request — each paired cell is filled with concrete text (no raw placeholders like literal <sensor_id>, <YYYY-MM-DD>, '<e.g.', or duplicate Field names without values).",
         "The Basic Information Report Identifier row value matches pattern vss_report_ followed by 8-digit date (YYYYMMDD), underscore, and 6-digit time (HHMMSS) as in SKILL (vss_report_<YYYYMMDD_HHMMSS>).",
         "The Basic Information Date of Analysis value looks like calendar date YYYY-MM-DD (four digits-two digits-two digits) not a template stub; Time of Analysis looks like HH:MM:SS.",
         "The Basic Information Video Source row names warehouse_safety_0001",
+        "The Basic Information VLM row names the model returned by the chat/completions call (e.g. nvidia/cosmos-reason2-8b) rather than a placeholder.",
         "The Basic Information Analysis Request row restates or paraphrases the user ask (report about warehouse_safety_0001 context) rather than staying empty.",
-        "The markdown contains ## Analysis Results and beneath it substantive content: the pasted agent caption summary with timestamps or time segments (seconds or ranges), chronological sense, non-empty\u2014not only headings or placeholders.",
-        "The Analysis Results content is visibly derived from the agent response (caption-style description); it is not a single sentence like N/A covering the whole section unless the agent truly returned that."
+        "The markdown contains ## Analysis Results and beneath it substantive content: the VLM caption summary with timestamps or time segments (seconds or ranges), chronological sense, non-empty—not only headings or placeholders. Any <think>...</think> reasoning block from Cosmos Reason VLMs is stripped before insertion.",
+        "The Analysis Results content is visibly derived from the VLM response (caption-style description); it is not a single sentence like N/A covering the whole section unless the VLM truly returned that."
+      ]
+    },
+    {
+      "query": "Give me a report on incidents on warehouse_safety_0001 between 2025-01-01T00:00:00.000Z and 2025-01-01T01:00:00.000Z.",
+      "checks": [
+        "The run initialized a VA-MCP session against http://localhost:9901/mcp (POST with method=initialize) and extracted mcp-session-id from the response header.",
+        "The run issued at least one tools/call POST to http://localhost:9901/mcp with the mcp-session-id header set, calling video_analytics__get_incidents with arguments including start_time and end_time matching the user's range and source=warehouse_safety_0001 source_type=sensor.",
+        "The run did NOT POST to http://localhost:8000/generate and did NOT POST to a VLM chat/completions endpoint for this incident-range query (Mode B routes through analytics, not VLM).",
+        "The user-facing markdown title is # Incident Range Report.",
+        "The markdown ## Basic Information table contains rows Report Identifier, Range, Scope, Total Incidents, Confirmed / Rejected / Unverified — each filled with concrete values consistent with the VA-MCP response (e.g. Range echoes the user's start_time – end_time; Total Incidents is an integer; the verdict triple sums to Total Incidents).",
+        "If get_incidents returned zero results the report is a one-line statement of the empty range and scope and does NOT silently fall back to calling the VLM."
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Rewrites `skills/vss-generate-video-report/SKILL.md` to **bypass `POST /generate`** on the VSS agent and dispatch by intent:
  - **Mode A** (video clip): `/vss-manage-video-io-storage` → clip URL → direct `POST ${VLM_BASE_URL}/v1/chat/completions` with `video_url` content block.
  - **Mode B** (incident time range): `/vss-query-analytics` → `video_analytics__get_incidents` → narrative Incident Range Report.
- Updates `eval/base_profile_report.json` to assert the new call patterns (must NOT POST `/generate`) and the new template fields (`VLM`, `Clip Range`), plus a Mode B incident-range query.
- No other skills touched.

## Why

On the alerts profile (and base, when the planner picks similar tools), `POST /generate` routes through the agent's LangGraph planner. The planner ping-pongs between `video_understanding` (offset) / `video_understanding_iso` (ISO) and `vst_video_clip` variants whose Pydantic schemas don't agree on input shape, eventually hitting `recursion_limit=15` and returning the canned *"Sorry, I wasn't able to complete your request"* reply. Filed as:

- [NVBug 6206496](https://nvbugspro.nvidia.com/bug/6206496) — `video_understanding` planner-vs-tool schema mismatch causes recursion-limit failure
- [NVBug 6206501](https://nvbugspro.nvidia.com/bug/6206501) — `report_agent` (Generate Video Report) fails with HTTP 504 + contradictory clip-time validation

The skill-level fix here sidesteps both. The underlying agent/tool-schema fix in `metromind/surf/deep-search` is separate.

## What changed

| File | Change |
|---|---|
| `skills/vss-generate-video-report/SKILL.md` | Replace single-mode `/generate` flow with two-mode dispatcher (clip-via-VLM vs incidents-via-analytics). VLM curl payload mirrors `src/vss_agents/tools/video_understanding.py:_build_vlm_messages`. |
| `skills/vss-generate-video-report/eval/base_profile_report.json` | Drop `/generate` assertions, add VST-clip-URL + `chat/completions` assertions, add Mode B (incident range) query + checks. |

## Test plan

- [ ] Run `vss-generate-video-report` eval on a `base` profile L40S host with `warehouse_safety_0001` already uploaded — confirm Mode A path (clip URL → VLM) renders the Video Analysis Report.
- [ ] On `alerts` (verification or real-time), run the Mode B query with a known incident range — confirm the Incident Range Report renders verdicts/categories from VA-MCP without touching the VLM.
- [ ] Confirm zero POSTs to `/generate` across both runs.
- [ ] Verify VLM_BASE_URL / VLM_NAME readback from `docker exec vss-agent env` works against the alerts profile defaults (`nvidia/cosmos-reason2-8b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)