### PR TITLE
ci(codeowners): route Dockerfile changes to VSS_OSRB_Approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,3 +39,18 @@ package.json            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 go.mod                  @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 Cargo.toml              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 Gemfile                 @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+
+# Dockerfiles.
+# A Dockerfile pins the base image, installs system packages (apt/yum), and
+# pulls in toolchain components that don't show up in language-level manifests.
+# Each of those is a dependency from OSRB's perspective — base-image licenses,
+# distro-package licenses, embedded binaries — so route Dockerfile changes
+# through OSRB the same way language manifests are routed.
+#
+# Patterns cover the three naming variants seen in-tree:
+#   Dockerfile                       (services/{agent,ui,video-analytics-api}/...)
+#   *.Dockerfile                     (deploy/.../Dockerfiles/*.Dockerfile, aarch64.Dockerfile)
+#   Dockerfile.*                     (Dockerfile.base, Dockerfile.dev, etc.)
+Dockerfile              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+*.Dockerfile            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+Dockerfile.*            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers


### PR DESCRIPTION
## What

Adds Dockerfile patterns to `.github/CODEOWNERS` so changes to any Dockerfile in the repo require approval from `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers` — same pattern already used for `package.json`, `pyproject.toml`, etc.

## Why

A Dockerfile is a dependency manifest from OSRB's perspective:

- Pins the **base image** (license, embedded packages, vulnerabilities).
- Installs **system packages** via `apt-get`, `yum`, `apk` — none of which show up in language-level manifests.
- Embeds **toolchain binaries** (ffmpeg tarballs, CUDA runtimes, etc.) via `COPY` / `wget`.

Today, `package.json` changes route to OSRB but a Dockerfile that bumps `FROM nvcr.io/...:1.5` → `:2.0` (different distro, different bundled packages, different licenses) doesn't. This closes that gap.

## Patterns

```diff
+Dockerfile              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+*.Dockerfile            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+Dockerfile.*            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
```

Covers the three naming variants in-tree:

| Pattern | Example | Count |
|---|---|---|
| `Dockerfile` | `services/agent/docker/Dockerfile`, `services/ui/Dockerfile`, `services/video-analytics-api/docker/Dockerfile` | 3 |
| `*.Dockerfile` | `deploy/docker/.../Dockerfiles/kibana-dashboard.Dockerfile`, `elastic-init.Dockerfile`, etc. | 13 |
| `Dockerfile.*` | `Dockerfile.base`, `Dockerfile.dev`, etc. (none in-tree yet, future-proofing) | 0 |

## Triggered by

[PR #637](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/637) (Video Analytics API open-sourcing) adds the first new Dockerfile to a service since CODEOWNERS was set up — the `services/video-analytics-api/docker/Dockerfile` it introduces would otherwise merge without an OSRB sign-off, even though the spreadsheet [VSS 3.2.0 Release PLC Tracker](https://docs.google.com/spreadsheets/d/1vo6rybSB6Lr0vHEn2Wr9Tp3khikbhEmM/edit?gid=1544950807#gid=1544950807) (sheet "14 - Github folder tracker") explicitly lists `docker/Dockerfile` as a dependency file to track for this module (and several others).

Doing the global fix avoids needing one CODEOWNERS PR per module.

## Test plan

- [ ] Linting / CODEOWNERS-syntax check passes.
- [ ] After merge, verify on PR #637 that the agent VSS_OSRB_Approvers review is now required (the `Code owners` panel on the PR should list them next to the Dockerfile entry).
- [ ] Spot-check on a follow-up PR that touches `services/agent/docker/Dockerfile` — confirm `VSS_OSRB_Approvers` is added as a reviewer.