### PR TITLE
fix(nemoclaw-policy): open 6 ports referenced by VSS skills

### DIFF
--- a/assets/vss_nemoclaw_policy.yaml
+++ b/assets/vss_nemoclaw_policy.yaml
@@ -352,6 +352,54 @@ network_policies:
           - 172.17.0.0/16
           - 172.18.0.0/16
           - 172.20.0.0/16
+      # HAProxy ingress (7777, browser-facing proxy for Brev / warehouse UI),
+      # RT-CV health (9000, alerts MODE=2d_cv perception probe),
+      # alert-notify webhook relay (9090, local notification fanout server),
+      # Milvus vector DB (19530, vss-generate-video-report-rag knowledge retrieval),
+      # LLM NIM (30081), VLM NIM (30082) — both referenced by the deploy + report
+      # skills for /v1/models probes and RTVI_VLM_BASE_URL defaults.
+      - host: host.openshell.internal
+        port: 7777
+        access: full
+        allowed_ips:
+          - 172.17.0.0/16
+          - 172.18.0.0/16
+          - 172.20.0.0/16
+      - host: host.openshell.internal
+        port: 9000
+        access: full
+        allowed_ips:
+          - 172.17.0.0/16
+          - 172.18.0.0/16
+          - 172.20.0.0/16
+      - host: host.openshell.internal
+        port: 9090
+        access: full
+        allowed_ips:
+          - 172.17.0.0/16
+          - 172.18.0.0/16
+          - 172.20.0.0/16
+      - host: host.openshell.internal
+        port: 19530
+        access: full
+        allowed_ips:
+          - 172.17.0.0/16
+          - 172.18.0.0/16
+          - 172.20.0.0/16
+      - host: host.openshell.internal
+        port: 30081
+        access: full
+        allowed_ips:
+          - 172.17.0.0/16
+          - 172.18.0.0/16
+          - 172.20.0.0/16
+      - host: host.openshell.internal
+        port: 30082
+        access: full
+        allowed_ips:
+          - 172.17.0.0/16
+          - 172.18.0.0/16
+          - 172.20.0.0/16
     binaries:
       - { path: /usr/bin/curl }
       - { path: /usr/local/bin/node }


### PR DESCRIPTION
## Summary

Audit of `assets/vss_nemoclaw_policy.yaml` (the `vss-backend-readwrite` endpoint allowlist) against every `localhost` / `HOST_IP` / `127.0.0.1`:PORT reference across `skills/` on `dev/3.2.0` found **six** ports the policy silently blocks. Closes the gap so NemoClaw-driven skills can actually talk to the services they document.

## Ports added

| Port  | Service | Referenced by | Why it matters |
|------:|---|---|---|
|  7777 | HAProxy ingress (browser-facing proxy) | `vss-deploy-profile`: brev.md, warehouse.md, warehouse-debug.md | Brev secure-link + warehouse UI both terminate here |
|  9000 | RT-CV `/v1/health` (DeepStream perception) | `vss-deploy-profile/references/alerts.md` | alerts `MODE=2d_cv` troubleshooting probe |
|  9090 | `alert-notify` local webhook relay | `vss-manage-alerts/references/alert-notify.md` | local notification fanout server bound here by design |
| 19530 | Milvus vector DB | `vss-deploy-profile/references/knowledge-retrieval.md`, `vss-generate-video-report-rag/SKILL.md` | RAG path won't function without it |
| 30081 | LLM NIM (`LLM_PORT` default) | `vss-deploy-profile/SKILL.md`, `edge.md` | Pre-flight curls `/v1/models`; edge Edge-4B vLLM binds here |
| 30082 | VLM NIM (`RTVI_VLM_BASE_URL` default) | `vss-deploy-profile/SKILL.md`, alerts.md, lvs.md, search.md, **`vss-generate-video-report/SKILL.md`** | **Headline gap** — the report-generate skill's documented default for `RTVI_VLM_BASE_URL` is `http://${HOST_IP}:30082/v1`, which the policy was blocking |

## Implementation

Six new `endpoint` entries appended to the existing `vss-backend.endpoints` block, with the same `host: host.openshell.internal` + Docker bridge CIDR allowlist (`172.17.0.0/16`, `172.18.0.0/16`, `172.20.0.0/16`) used by every other entry. Added a comment header above the block explaining what each port covers so the next reader doesn't have to re-derive the audit.

## Verification

YAML validated post-edit; the file's full distinct port set is now:

```
443, 3000, 5000, 5601, 6006, 7777, 8000, 8001, 8010, 8017,
8018, 8081, 9000, 9080, 9090, 9092, 9200, 9901, 9988, 18789,
19530, 30081, 30082, 30888, 31000, 38111, 38112
```

## Test plan

- [x] Render `assets/vss_nemoclaw_policy.yaml` in the GitHub PR view; confirm the 6 new entries land in the expected block and the YAML structure is consistent.
- [ ] Deploy NemoClaw against a VSS host with one of the new services running (e.g. `vss-rtvi-vlm` on 8018 → `RTVI_VLM_BASE_URL=http://localhost:30082/v1` after a redirect, or the alert-notify relay on 9090), confirm the agent can reach the endpoint without policy denial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)