### PR TITLE
ci(license-diff): skip when PR targets dev/* or release/* branches

### DIFF
--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -52,6 +52,18 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --json baseRefName --jq '.baseRefName // ""' 2>/dev/null || true)"
           target="${target:-${DEFAULT_BRANCH}}"
+          # Release branches (dev/*, release/*) accept only curated content
+          # that already passed License Diff on its develop-targeted PR. Running
+          # the diff again here just floods every cherry-pick / release-train
+          # PR with noise, so short-circuit and skip the rest of the workflow.
+          case "${target}" in
+            dev/*|release/*)
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "Skipping License Diff: PR targets release branch '${target}' — diff already enforced on the develop-targeted PR."
+              exit 0
+              ;;
+          esac
+          echo "skip=false" >> "$GITHUB_OUTPUT"
           git fetch --no-tags origin "+refs/heads/${target}:refs/remotes/origin/${target}"
           merge_base=$(git merge-base HEAD "origin/${target}" || git rev-parse "origin/${target}")
           echo "base=${merge_base}" >> "$GITHUB_OUTPUT"
@@ -60,6 +72,7 @@ jobs:
 
       - name: Generate license diff CSV
         id: gen
+        if: steps.ctx.outputs.skip != 'true'
         run: |
           set -euo pipefail
           python .github/scripts/license_diff_csv.py \
@@ -73,7 +86,7 @@ jobs:
 
       - name: Upload CSV artifact
         id: upload
-        if: always()
+        if: always() && steps.ctx.outputs.skip != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: license-diff
@@ -82,7 +95,7 @@ jobs:
 
       - name: Render markdown table
         id: render
-        if: always() && steps.gen.outputs.rows != ''
+        if: always() && steps.ctx.outputs.skip != 'true' && steps.gen.outputs.rows != ''
         run: |
           set -euo pipefail
           python3 - <<'PY' > diff-table.md
@@ -103,6 +116,7 @@ jobs:
       - name: Write step summary
         if: always()
         env:
+          SKIP: ${{ steps.ctx.outputs.skip }}
           ROWS: ${{ steps.gen.outputs.rows }}
           BASE: ${{ steps.ctx.outputs.base }}
         run: |
@@ -110,7 +124,10 @@ jobs:
           {
             echo "## License Diff for OSRB"
             echo
-            if [[ ! -f license-diff.csv ]]; then
+            if [[ "${SKIP}" == "true" ]]; then
+              echo "Skipped: PR targets a release branch (\`dev/*\` or \`release/*\`)."
+              echo "License Diff already enforced on the develop-targeted PR; running again here only adds noise."
+            elif [[ ! -f license-diff.csv ]]; then
               echo "No CSV produced."
             elif [[ "${ROWS:-0}" -le 0 ]]; then
               echo "No package version or license changes detected."
@@ -123,7 +140,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Post or update PR comment
-        if: always() && steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
+        if: always() && steps.ctx.outputs.skip != 'true' && steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -165,7 +182,7 @@ jobs:
           fi
 
       - name: Fail when license diff is non-empty
-        if: steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
+        if: steps.ctx.outputs.skip != 'true' && steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
         env:
           ROWS: ${{ steps.gen.outputs.rows }}
         run: |


### PR DESCRIPTION
## What

Short-circuits the `License Diff (OSRB CSV)` workflow when a PR targets a release branch (`dev/*` or `release/*`). The workflow still runs and reports a green pass, but skips CSV generation, the PR comment, and the fail-on-non-empty gate.

## Why

License Diff compares the PR head against the merge-base with its target branch. For PRs targeting `dev/3.2.0` / `release/3.2.0`:

- Content on a release branch arrived via a develop-targeted PR that already ran License Diff and got OSRB approval.
- Re-checking the same content against the release branch just floods every cherry-pick / release-train sync with hundreds of "changed packages" that were never actually new — they're approved content rolling forward.

Triggered by [PR #669](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/669) (nemoclaw policy port additions, merged onto `dev/3.2.0`), where the workflow posted a sprawling diff CSV that was entirely content already approved via develop.

## How

One change inside the existing `Resolve base ref and PR number` step: after resolving `target`, classify release-branch targets and exit early with `skip=true` output. All downstream steps gate on `steps.ctx.outputs.skip != 'true'`.

```yaml
case "${target}" in
  dev/*|release/*)
    echo "skip=true" >> "$GITHUB_OUTPUT"
    echo "Skipping License Diff: PR targets release branch '${target}' — ..."
    exit 0
    ;;
esac
echo "skip=false" >> "$GITHUB_OUTPUT"
```

The step-summary section reflects the skip with a clear message; nothing is silent.

## Coverage gap (intentional)

A PR opened **directly** against `dev/3.2.0` that introduces a net-new dep (not via a develop-targeted PR upstream) would not be license-checked here. That's covered separately by [BE-124](https://jirasw.nvidia.com/browse/BE-124) — the proposed OSRB scope-drift check that compares against the approved manifest rather than against branch state. License Diff's job is "did this PR change the lockfile vs base"; BE-124's job is "does the resulting dep set match what OSRB approved." Different signals.

## Propagation to release branches

This change lands on `develop`. PRs whose head branch was forked off `dev/3.2.0` will still pick up the old workflow file from dev/3.2.0 until the next routine develop→dev/3.2.0 sync. Cherry-pick to `dev/3.2.0` if the user wants faster reach.

## Test plan

- [x] CI green on this PR (target = develop, so skip path is NOT taken — workflow runs in full and produces a diff that matches what develop normally produces).
- [x] After merge, open a dummy PR against `dev/3.2.0` — License Diff job is green with a step-summary line `Skipped: PR targets a release branch`, no PR comment posted.
- [x] Verify the normal develop path is unchanged: open a dummy PR against `develop` with a `package.json` bump — License Diff posts the usual CSV comment and fails when non-empty.