### PR TITLE
chore(deploy): update vss-behavior-analytics image tag and remove unu…

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/vss-behavior-analytics/configs/vss-behavior-analytics-config.json
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/vss-behavior-analytics/configs/vss-behavior-analytics-config.json
@@ -116,10 +116,6 @@
 			"value": "1.0"
 		},
 		{
-			"name": "spaceAnalyticsCalibSensorsOnly",
-			"value": "false"
-		},
-		{
 			"name": "spaceAnalyticsGridSize",
 			"value": "0.2"
 		},

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/vss-behavior-analytics/configs/vss-behavior-analytics-config.json
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/vss-behavior-analytics/configs/vss-behavior-analytics-config.json
@@ -116,10 +116,6 @@
 			"value": "1.0"
 		},
 		{
-			"name": "spaceAnalyticsCalibSensorsOnly",
-			"value": "false"
-		},
-		{
 			"name": "spaceAnalyticsGridSize",
 			"value": "0.2"
 		},

--- a/deploy/docker/services/analytics/behavior-analytics/compose.yml
+++ b/deploy/docker/services/analytics/behavior-analytics/compose.yml
@@ -23,7 +23,7 @@
 services:
 
   vss-behavior-analytics-base:
-    image: nvcr.io/nvstaging/vss-core/vss-behavior-analytics:3.2-26.05.17
+    image: nvcr.io/nvstaging/vss-core/vss-behavior-analytics:3.2-26.05.23
     network_mode: "host"
     restart: always
     volumes:

--- a/deploy/helm/services/analytics/charts/behavior-analytics/Chart.yaml
+++ b/deploy/helm/services/analytics/charts/behavior-analytics/Chart.yaml
@@ -18,6 +18,6 @@ name: vss-behavior-analytics
 description: VSS behavior analytics — parent charts must set command and config.kafkaConfigJson when enabled
 type: application
 version: 26.04.2
-appVersion: "3.2-26.05.17"
+appVersion: "3.2-26.05.23"
 maintainers:
   - name: NVIDIA

--- a/deploy/helm/services/analytics/charts/behavior-analytics/values.yaml
+++ b/deploy/helm/services/analytics/charts/behavior-analytics/values.yaml
@@ -23,7 +23,7 @@ replicas: 1
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-behavior-analytics
-  tag: "3.2-26.05.17"
+  tag: "3.2-26.05.23"
   pullPolicy: IfNotPresent
 
 port: 8080


### PR DESCRIPTION
…sed config parameter

- Updated the Docker Compose configuration to use the latest vss-behavior-analytics image tag (3.2-26.05.23).
- Removed the unused configuration parameter `spaceAnalyticsCalibSensorsOnly` from the vss-behavior-analytics config files for both warehouse-3d-app and warehouse-mv3dt-app.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
