### PR TITLE
docs(license-index): add 2 missing 3rd-party inventories to root index

### DIFF
--- a/LICENSE-3rd-party.txt
+++ b/LICENSE-3rd-party.txt
@@ -3,5 +3,7 @@ This file contains the list of third party software with their licenses used in 
 See below files for the licenses:
 - services/agent/LICENSE-3rd-party.txt
 - services/ui/LICENSE-3rd-party.txt
+- services/analytics/video-analytics-api/src/app/3rdParty_Licenses.md
 - deploy/docker/scripts/LICENSE-3rd-party-dev-profile.txt
+- deploy/docker/services/infra/3rdParty_Licenses
 - deploy/LICENSE-3rd-party.txt


### PR DESCRIPTION
## What

Updates the root [`LICENSE-3rd-party.txt`](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/develop/LICENSE-3rd-party.txt) index to reference 2 component-level 3rd-party license inventories that were committed earlier without being added to the index.

```diff
- services/agent/LICENSE-3rd-party.txt
- services/ui/LICENSE-3rd-party.txt
+ services/analytics/video-analytics-api/src/app/3rdParty_Licenses.md
- deploy/docker/scripts/LICENSE-3rd-party-dev-profile.txt
+ deploy/docker/services/infra/3rdParty_Licenses
- deploy/LICENSE-3rd-party.txt
```

## Why

Root file is the discoverable entry point for OSRB / downstream consumers asking "what 3rd-party software ships in VSS?" — drift between the index and the actual files means an auditor reading the root file misses ~10K lines of declared 3rd-party content (the analytics-api inventory alone is 9,777 lines).

## Scope

- **No** new license content. Both files already exist in the repo.
- **No** filename normalization. Two pre-existing naming conventions remain:
  - `LICENSE-3rd-party.txt` (hyphen + `.txt`) — agent, ui, deploy, dev-profile
  - `3rdParty_Licenses[.md]` (CamelCase + underscore) — video-analytics-api, infra
  Cleanup tracked separately.
- **Not included**: `services/rtvi/rt-embed/LICENSE.3rdparty` (third naming variant; landing via [PR #649](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/649)). Will follow up once #649 merges.

## Diff stat

```
LICENSE-3rd-party.txt | 2 ++
1 file changed, 2 insertions(+)
```