### PR TITLE
ci(codeowners): route compose files + LICENSE.3rdparty variants to OSRB

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,3 +54,23 @@ Gemfile                 @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 Dockerfile              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 *.Dockerfile            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 Dockerfile.*            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+
+# Compose files.
+# A compose file pins service image tags — a tag change can swap the
+# underlying base image (different bundled packages, different licenses)
+# without any language-level manifest change. Same OSRB concern as a
+# Dockerfile bump.
+compose.yaml            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+compose.yml             @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+docker-compose.yaml     @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+docker-compose.yml      @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+
+# 3rd-party license inventories — filename variants.
+# Some components ship the inventory as `LICENSE.3rdparty` (no hyphen,
+# no .txt) or `3rdParty_Licenses[.md]`. The `LICENSE-3rd-party.txt` rule
+# in the lockfile section above covers the hyphenated form; the patterns
+# below cover the remaining variants so every flavor routes to OSRB.
+LICENSE.3rdparty        @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+LICENSE.3rdParty        @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+3rdParty_Licenses       @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+3rdParty_Licenses.md    @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers


### PR DESCRIPTION
## What

Two follow-ups to [#654](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/654) (Dockerfile OSRB routing), surfaced by [#672](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/672) (rt-vlm) and [#649](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/649) (rt-embed):

```diff
+# Compose files.
+compose.yaml            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+compose.yml             @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+docker-compose.yaml     @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+docker-compose.yml      @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers

+# 3rd-party license inventories — filename variants.
+LICENSE.3rdparty        @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+LICENSE.3rdParty        @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+3rdParty_Licenses       @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+3rdParty_Licenses.md    @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
```

## Why

### Compose files

A `compose.yaml` pins **service image tags**. A tag bump (e.g. `nvcr.io/.../vss-rt-vlm:1.5 → :2.0`) can swap the underlying base image, change bundled packages, and change licenses — **without any language-level manifest change**. Same OSRB concern as a Dockerfile `FROM` bump. Per the PLC tracker (sheet "14 - Github folder tracker"), `docker/compose.yaml` is listed alongside `docker/Dockerfile` in the dep-files-to-track column for RTVI Embed MS.

### `LICENSE.3rdparty` / `3rdParty_Licenses` filename variants

The repo today has three naming conventions for component-level 3rd-party license inventories:

| Filename | Used by |
|---|---|
| `LICENSE-3rd-party.txt` | agent, ui, deploy, dev-profile (already routed) |
| `LICENSE.3rdparty` | rt-vlm, rt-embed (new in #672, #649) |
| `3rdParty_Licenses[.md]` | video-analytics-api, infra |

Only the first form was routed. This PR adds patterns for the other two.

Filename normalization is real tech debt — a future cleanup could standardize on a single form across the repo. This change just closes the routing gap today.

## What this covers immediately

After merge, OSRB review will be auto-requested on:

- `services/rtvi/rt-vlm/docker/compose.yaml` (#672)
- `services/rtvi/rt-vlm/LICENSE.3rdparty` (#672)
- `services/rtvi/rt-embed/docker/compose.yaml` (#649)
- `services/rtvi/rt-embed/LICENSE.3rdparty` (#649)
- `services/analytics/video-analytics-api/src/app/3rdParty_Licenses.md` (already merged via #637)
- `deploy/docker/services/infra/3rdParty_Licenses`
- All future `compose.yaml` / `docker-compose.yaml` files in the repo

## Test plan

- [ ] After merge, push a no-op commit to PR #672 or #649 — verify `VSS_OSRB_Approvers` appears as required reviewer on the compose + LICENSE.3rdparty files in the PR's Reviewers panel.