### PR TITLE
feat(skills/vss-deploy-detection-tracking-2d): publish in catalog and expose FPS via /api/v1/metrics

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -26,6 +26,7 @@ The VSS 3.2 GA skill names replaced the pre-GA slash-command names:
 | [vss-manage-alerts](vss-manage-alerts/SKILL.md) | Skill to add, manage, and monitor alerts on streamed video. |
 | [vss-deploy-profile](vss-deploy-profile/SKILL.md) | Skills to deploy, debug, or tear down any VSS profile using a docker compose-centric workflow. |
 | [vss-deploy-dense-captioning](vss-deploy-dense-captioning/SKILL.md) | Skill for deploying and calling the RT-VLM dense captioning microservice API. |
+| [vss-deploy-detection-tracking-2d](vss-deploy-detection-tracking-2d/SKILL.md) | Skill for deploying, operating, and calling the RTVI-CV perception microservice for 2D detection and tracking (warehouse 2d/3d, sparse4d, smartcity rtdetr/gdino). |
 | [vss-generate-video-report](vss-generate-video-report/SKILL.md) | Skill to produce video analysis reports by querying the VSS agent's `/generate` endpoint. |
 | [vss-generate-video-report-rag](vss-generate-video-report-rag/SKILL.md) | Skill to generate video summary reports with Enterprise RAG using the VSS frag/RAG pipeline. |
 | [vss-query-analytics](vss-query-analytics/SKILL.md) | Skill for querying video analytics data and metrics from Elasticsearch via the VA-MCP server. |

--- a/skills/vss-deploy-detection-tracking-2d/references/apply-config.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/apply-config.md
@@ -113,16 +113,17 @@ per-use-case table below, given the user's chosen settings.
 
 | Use case + settings                                     | Section row counts                                                              |
 |---------------------------------------------------------|---------------------------------------------------------------------------------|
-| `warehouse-2d` + eglsink + static + N=4 + cache HIT     | Model 1 · Batch 6 · Sink 4 · Sources 6 · Engine 2 · Backups 1                   |
-| `warehouse-2d` + filedump + static + N=4 + cache HIT    | Model 1 · Batch 6 · Sink 10 (4 base + 6 filedump-only) · Sources 6 · Engine 2   |
-| `warehouse-3d` + eglsink + static + N=4 + cache HIT     | Model 4 · Batch 6 (incl. `num_sensors`, `network-input-shape`) · Sink 6 (4 base + 2 `generate_3d_bbox`) · Sources 6 · Engine 2 · Backups 1 |
-| `smartcity-rtdetr` + eglsink + static + N=4 + cache HIT | Model 1 · Batch 7 · Sink 4 · Sources 6 · Engine 2 · Backups 1                   |
-| `smartcity-gdino` + eglsink + static + N=4 + cache HIT  | Model 2 (Triton `model.onnx` + `model.plan`) · Batch 10 (incl. 4 Triton pbtxts) · Sink 4 · Sources 6 · Engine 2 · Backups 1 |
+| `warehouse-2d` + eglsink + static + N=4 + cache HIT     | Model 1 · Batch 6 · Sink 5 · Sources 6 · Engine 2 · Backups 1                   |
+| `warehouse-2d` + filedump + static + N=4 + cache HIT    | Model 1 · Batch 6 · Sink 11 (5 base + 6 filedump-only) · Sources 6 · Engine 2   |
+| `warehouse-3d` + eglsink + static + N=4 + cache HIT     | Model 4 · Batch 6 (incl. `num_sensors`, `network-input-shape`) · Sink 7 (5 base + 2 `generate_3d_bbox`) · Sources 6 · Engine 2 · Backups 1 |
+| `smartcity-rtdetr` + eglsink + static + N=4 + cache HIT | Model 1 · Batch 7 · Sink 5 · Sources 6 · Engine 2 · Backups 1                   |
+| `smartcity-gdino` + eglsink + static + N=4 + cache HIT  | Model 2 (Triton `model.onnx` + `model.plan`) · Batch 10 (incl. 4 Triton pbtxts) · Sink 5 · Sources 6 · Engine 2 · Backups 1 |
 
 (Sink count assumes the warehouse-2d / smartcity table below where
 `[sink0]` enable + type are folded into one row when both are written
-together. Either form is fine — the agent picks one row per logical
-edit.)
+together, and `[sink0] nvdslogger=1` is rendered as its own row since
+it's a perf-measurement signal, not part of the sink-mode triple.
+Either form is fine — the agent picks one row per logical edit.)
 
 If the agent's box doesn't have the exact row count, it collapsed —
 re-render with one row per key.
@@ -161,9 +162,10 @@ that row.
 | `ds-main-config.txt`               | `[sink0] enable=1 type=2`  (eglsink — display)        | turn on EGL display sink       |
 | `ds-main-config.txt`               | `[sink0] enable=1 type=1`  (fakesink — bench)         | turn on fakesink (no output)   |
 | `ds-main-config.txt`               | `[sink0] enable=0`         (filedump — disable sink0) | sink0 off — file-dump owns out |
+| `ds-main-config.txt`               | `[sink0] nvdslogger=1`     (all sink modes)           | make /api/v1/metrics report FPS (dormant when sink0 disabled) |
 | `ds-main-config.txt`               | `[sink2] enable=0`         (fakesink/eglsink)         | disable file-dump sink         |
 | `ds-main-config.txt`               | `[sink2] enable=1`         (filedump)                 | enable file-dump sink          |
-| `ds-main-config.txt`               | `[tiled-display] enable=<0\|1>`                       | show / hide tile grid          |
+| `ds-main-config.txt`               | `[tiled-display] enable=<3\|1\|1>` (fakesink / eglsink / filedump) | fakesink: perf-only tiler (per-source FPS to metrics, no compositing); eglsink/filedump: composite the tile grid |
 | `ds-main-config.txt`               | `[osd] enable=<0\|1>`                                 | draw / hide bbox + labels      |
 
 For `filedump` ALSO (6 extra rows):
@@ -295,8 +297,9 @@ flow goes through `setup_gdino.sh` (file copy + engine build):
 │  Output sink  (eglsink — display)                                                                                            │
 │     ds-main-config.txt                                                                                                       │
 │         ✔ [sink0]  enable=1   type=2                       — turn on EGL display sink                                        │
+│         ✔ [sink0]  nvdslogger=1                            — emit per-stream FPS to /api/v1/metrics                          │
 │         ✔ [sink2]  enable=0                                — disable file-dump sink                                          │
-│         ✔ [tiled-display] enable=1                         — show tile grid                                                  │
+│         ✔ [tiled-display] enable=1                         — show tile grid (composite)                                      │
 │         ✔ [osd]    enable=1                                — draw bbox / labels                                              │
 │                                                                                                                              │
 │  Stream sources  (static, 3)                                                                                                 │
@@ -549,7 +552,15 @@ Sink configuration spans four config sections (`[sink0]`, `[sink2]`, `[tiled-dis
 
 ### Note on `[tiled-display] enable`
 
-Some shipped reference-configs use `enable=3` as the default, which happens to work for both display and fakesink modes (DeepStream treats non-zero as "enabled"). But the canonical values are **0 (off)** and **1 (on)** — the skill writes these explicit values so the config is readable and predictable, and matches what any human or downstream tool would expect.
+DeepStream's `nvmultistreamtiler` recognizes three meaningful values:
+
+| Value | Meaning                                                                  | Used by skill for |
+|-------|--------------------------------------------------------------------------|-------------------|
+| `0`   | Element absent from the pipeline.                                        | (not used)        |
+| `1`   | Element present, composes all sources into a single tiled buffer.        | `eglsink`, `filedump` (display / file-write paths need the composited buffer) |
+| `3`   | Element present in **perf-only** mode — no compositing, but per-source perf samples still flow to `nvdslogger`. | `fakesink` (benchmark path — want per-stream FPS in `/api/v1/metrics` without paying the compositing cost) |
+
+The skill writes one of these three values explicitly so the config is readable and predictable. Some shipped reference-configs default to `3`; that happens to work for display too (DS treats any non-zero as "enabled"), but it makes the config ambiguous about intent — the explicit `1` for display vs `3` for perf-only path makes the agent's output sink choice legible at a glance.
 
 ### Tile grid (rows × columns)
 

--- a/skills/vss-deploy-detection-tracking-2d/scripts/update_batch_size.sh
+++ b/skills/vss-deploy-detection-tracking-2d/scripts/update_batch_size.sh
@@ -48,7 +48,10 @@ echo ">> Updating batch size to $BATCH for use case: $USECASE"
 
 # ── Compute tile grid once; applied to every use case below. ─────
 # Tile-grid rule: ROW=floor(sqrt(N)), COL=ceil(N/ROW).
-# Ignored by DS when tiled-display is not active (fakesink), harmless to set.
+# rows/columns are honored when the tiler composites (eglsink, filedump:
+# [tiled-display] enable=1) and ignored when the tiler is in perf-only
+# mode (fakesink: [tiled-display] enable=3, no compositing). Harmless to
+# set in either case — see update_output_sink.sh for the enable matrix.
 #
 # Capture the helper's stdout into a variable instead of `read -r ... < <(cmd)`.
 # Process substitution masks the helper's exit code from `set -e`, so a

--- a/skills/vss-deploy-detection-tracking-2d/scripts/update_output_sink.sh
+++ b/skills/vss-deploy-detection-tracking-2d/scripts/update_output_sink.sh
@@ -56,20 +56,21 @@
 # What it writes (all via update_ds_config from common.sh):
 #
 #   fakesink:
-#     [sink0]         enable=1  type=1
+#     [sink0]         enable=1  type=1  nvdslogger=1
 #     [sink2]         enable=0
-#     [tiled-display] enable=0
+#     [tiled-display] enable=3   (perf-only — emits per-source FPS for
+#                                 /api/v1/metrics without rendering)
 #     [osd]           enable=0
 #
 #   eglsink (display):
-#     [sink0]         enable=1  type=2
+#     [sink0]         enable=1  type=2  nvdslogger=1
 #     [sink2]         enable=0
 #     [tiled-display] enable=1  (rows/columns set by update_batch_size.sh)
 #     [osd]           enable=1
 #     (warehouse-3d only) config.yaml generate_3d_bbox: True
 #
 #   filedump (file):
-#     [sink0]         enable=0  (so DS uses sink2 instead)
+#     [sink0]         enable=0  nvdslogger=1  (key written but dormant — sink0 disabled)
 #     [sink2]         enable=1  type=3  enc-type=1  codec=1
 #                     container=<auto-from-extension>  output-file=<output-file>
 #     [tiled-display] enable=1
@@ -83,6 +84,26 @@
 #     /opt/storage/.user_additional_install.done from a previous partial
 #     install cannot cause silent "Failed to create sink_sub_bin_encoder1"
 #     pipeline-build errors. On success the marker is (re)written.
+#
+# Why nvdslogger=1 on [sink0] in every mode:
+#   /api/v1/metrics returns real per-stream FPS only when an `nvdslogger`
+#   element is attached to an enabled sink. None of the shipped reference
+#   configs set this on [sink0] (warehouse-2d/3d have it only on [sink1]
+#   kafka; smartcity-rtdetr has it commented out). Writing it here means
+#   the metrics API works out-of-the-box for fakesink/eglsink (the
+#   common cases) and the log-parse fallback in collect_metrics.sh stays
+#   only as a safety net. For filedump the key is dormant (sink0
+#   enable=0) — no behavior change for that mode.
+#
+# Why [tiled-display] enable=3 for fakesink:
+#   The tiler has three modes — 0=disabled, 1=enabled (composite into a
+#   tiled buffer for display), 3=perf-only (no compositing; just emit
+#   per-source perf samples that nvdslogger picks up). For fakesink
+#   benchmarks there is no display, so we want the perf signals without
+#   paying the compositing cost — enable=3 gives the metrics API real
+#   per-source FPS while keeping the bench path lean. eglsink stays at 1
+#   (compositing required to draw the grid) and filedump stays at 1
+#   (the file-write path consumes the composited buffer).
 #
 # Every edit is verified at the end; the script exits non-zero if any key
 # didn't land. Prints "SINK_UPDATE_OK <usecase> <sink_mode>" on success.
@@ -243,7 +264,9 @@ case "$SINK_MODE" in
     fakesink)
         SINK0_ENABLE=1; SINK0_TYPE=1
         SINK2_ENABLE=0
-        TILE_ENABLE=0
+        # 3 = tiler perf-only: skips compositing but still emits per-source
+        # perf samples that nvdslogger forwards to /api/v1/metrics.
+        TILE_ENABLE=3
         OSD_ENABLE=0
         ;;
     eglsink)
@@ -265,8 +288,12 @@ case "$SINK_MODE" in
 esac
 
 # ── [sink0] ────────────────────────────────────────────────────
-update_ds_config "$MAIN" "[sink0]"         enable "$SINK0_ENABLE"
-update_ds_config "$MAIN" "[sink0]"         type   "$SINK0_TYPE"
+update_ds_config "$MAIN" "[sink0]"         enable     "$SINK0_ENABLE"
+update_ds_config "$MAIN" "[sink0]"         type       "$SINK0_TYPE"
+# nvdslogger=1 is what makes /api/v1/metrics report real FPS. Write
+# unconditionally (idempotent via update_ds_config) — dormant when sink0
+# is disabled (filedump), active for fakesink/eglsink.
+update_ds_config "$MAIN" "[sink0]"         nvdslogger 1
 
 # ── [sink2] (file dump) ────────────────────────────────────────
 update_ds_config "$MAIN" "[sink2]"         enable "$SINK2_ENABLE"
@@ -326,9 +353,10 @@ _check() {
         fail=1
     fi
 }
-_check "sink0.enable"         "[sink0]"         enable "$SINK0_ENABLE"
-_check "sink0.type"           "[sink0]"         type   "$SINK0_TYPE"
-_check "sink2.enable"         "[sink2]"         enable "$SINK2_ENABLE"
+_check "sink0.enable"         "[sink0]"         enable     "$SINK0_ENABLE"
+_check "sink0.type"           "[sink0]"         type       "$SINK0_TYPE"
+_check "sink0.nvdslogger"     "[sink0]"         nvdslogger 1
+_check "sink2.enable"         "[sink2]"         enable     "$SINK2_ENABLE"
 if [[ "$SINK_MODE" == "filedump" ]]; then
     _check "sink2.container"  "[sink2]"         container "$CONTAINER_CODE"
     _check "sink2.enc-type"   "[sink2]"         enc-type  1


### PR DESCRIPTION
## Description

Two small, related improvements to the `vss-deploy-detection-tracking-2d` skill:

**1. Add the skill to the public catalog**

`skills/README.md` lists every shipped skill in a Catalog table, but `vss-deploy-detection-tracking-2d` was never added. This PR adds it next to the other deploy skills with a one-liner description consistent with the table's style.

**2. Surface real per-stream FPS via `/api/v1/metrics`**

Today, when the user runs `collect_metrics.sh`, `/api/v1/metrics` returns `stream-count=0` for static-mode deploys and the script falls back to log-parsing FPS (see `collect_metrics.sh:248-261`). Root cause: the metrics API only reports FPS when an `nvdslogger` element is attached to an enabled sink, and none of the four shipped reference configs (`warehouse-2d`, `warehouse-3d`, `smartcity-rtdetr`, `smartcity-gdino`) have `nvdslogger=1` under `[sink0]` — warehouse-2d/3d have it only on `[sink1]` (kafka), smartcity-rtdetr has it commented out.

`scripts/update_output_sink.sh` is where the skill canonically writes the sink config on every deploy. Two changes there:

- **Always write `nvdslogger=1` to `[sink0]`** — for every use case and every sink mode (`fakesink`, `eglsink`, `filedump`). For filedump (`[sink0] enable=0`) the key is dormant — no behavior change for that mode. For fakesink/eglsink the metrics API now reports real per-stream FPS out-of-the-box; the log-parse fallback in `collect_metrics.sh` stays only as a safety net.
- **Switch `[tiled-display] enable` from `0` to `3` for fakesink** — DS tiler perf-only mode. The element stays in the pipeline but skips compositing, so the bench path stays lean while per-source perf samples still flow to `nvdslogger`. `eglsink`/`filedump` stay at `1` (need the composited buffer to render the grid / feed the file-write path).
- Extend the script's final verification with `_check "sink0.nvdslogger"` so a silent write failure now triggers `SINK_UPDATE_FAIL` instead of a regression.

**3. Docs in sync**

`references/apply-config.md` (edit-list table, per-use-case Sink row counts, worked-example ✔ box, and the existing "Note on `[tiled-display] enable`") and `scripts/update_batch_size.sh`'s tile-grid comment all updated to match the new policy.
