### PR TITLE
skill-eval/verifier: retry once when judge omits verdict JSON

### DIFF
--- a/.github/skill-eval/verifiers/generic_judge.py
+++ b/.github/skill-eval/verifiers/generic_judge.py
@@ -286,10 +286,14 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
     collected_text: list[str] = []
     cost_usd = 0.0
     saw_result = False
+    result_is_error = False
+    result_subtype: str | None = None
+    result_stop_reason: str | None = None
     retry_attempted = False
 
     async def _run() -> None:
         nonlocal cost_usd, saw_result, retry_attempted
+        nonlocal result_is_error, result_subtype, result_stop_reason
         async with ClaudeSDKClient(options=options) as client:
             await client.query(_assemble_judge_prompt(check, traj_path))
             async for message in client.receive_response():
@@ -298,8 +302,16 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
                         if isinstance(block, TextBlock) and block.text:
                             collected_text.append(block.text)
                 elif isinstance(message, ResultMessage):
-                    cost_usd += getattr(message, "total_cost_usd", 0.0) or 0.0
+                    # `total_cost_usd` on ResultMessage is cumulative for
+                    # the SDK session (same field that carries cumulative
+                    # `num_turns`), so re-assign on every ResultMessage
+                    # rather than accumulating — the last value is the
+                    # whole-session total.
+                    cost_usd = getattr(message, "total_cost_usd", 0.0) or 0.0
                     saw_result = True
+                    result_is_error = bool(getattr(message, "is_error", False))
+                    result_subtype = getattr(message, "subtype", None)
+                    result_stop_reason = getattr(message, "stop_reason", None)
                     break
 
             # Retry once if the first response ended cleanly but didn't
@@ -310,8 +322,15 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
             # the right evidence but never emitted the {"pass": ...} JSON.
             # The follow-up uses the same session so prior tool results
             # stay in context — no re-investigation cost.
+            #
+            # Gate retry on `not result_is_error`: when the SDK flagged the
+            # first response as an error (rate limit, content policy,
+            # tool-use abort, max-turns exhaustion surfaced via is_error),
+            # re-prompting in the same session won't recover and just
+            # buries the real failure cause under a second-pass rationale.
             if (
                 saw_result
+                and not result_is_error
                 and collected_text
                 and _parse_verdict_json("\n".join(collected_text)) is None
             ):
@@ -323,7 +342,10 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
                             if isinstance(block, TextBlock) and block.text:
                                 collected_text.append(block.text)
                     elif isinstance(message, ResultMessage):
-                        cost_usd += getattr(message, "total_cost_usd", 0.0) or 0.0
+                        cost_usd = getattr(message, "total_cost_usd", 0.0) or 0.0
+                        result_is_error = bool(getattr(message, "is_error", False))
+                        result_subtype = getattr(message, "subtype", None)
+                        result_stop_reason = getattr(message, "stop_reason", None)
                         break
 
     try:
@@ -352,13 +374,21 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
         # Common causes: ran out of turns mid-analysis without emitting the
         # final {"pass": ...} object; SDK closed the stream early
         # (saw_result=False); or the agent returned only tool-use blocks.
-        # `retry_attempted` distinguishes "judge never tried to format"
-        # from "judge tried twice and still wandered" — the latter is a
-        # spec-prompt issue, the former is an LLM noncompliance flake.
+        # `is_error`/`subtype`/`stop_reason` carry the SDK's own
+        # termination reason: triage `is_error=True` as an SDK/model
+        # failure (rate-limit, content-policy, tool-use abort) rather
+        # than a "judge wandered into prose" issue. `retry_attempted`
+        # distinguishes "judge never tried to format" (`False`) from
+        # "judge tried twice and still wandered" (`True`); the latter
+        # points at a spec-prompt issue, the former at an LLM
+        # noncompliance flake or SDK-side error.
         head = full_text[:600]
         tail = full_text[-400:] if len(full_text) > 1000 else ""
         signals = (
             f"saw_result_message={saw_result} "
+            f"is_error={result_is_error} "
+            f"subtype={result_subtype!r} "
+            f"stop_reason={result_stop_reason!r} "
             f"text_chars={len(full_text)} "
             f"text_blocks={len(collected_text)} "
             f"retry_attempted={retry_attempted}"

--- a/.github/skill-eval/verifiers/generic_judge.py
+++ b/.github/skill-eval/verifiers/generic_judge.py
@@ -182,6 +182,24 @@ When done, output a single JSON object on its own line:
 """
 
 
+# Follow-up nudge for when the judge ran to completion (saw_result=True)
+# but its prose never closed with the required {"pass": ...} JSON. Common
+# enough on rubric-style checks where the model drifts into investigation
+# mode. Re-uses the open session so we don't pay for re-running tool calls;
+# the model still has all prior context. Conservative — one retry only,
+# and only when we've already seen a clean stream end.
+_VERDICT_NUDGE = (
+    "Stop investigating. Based ONLY on the evidence you have already "
+    "gathered above, emit the verdict JSON now. Do not call any tools. "
+    "Do not gather more evidence. Output a single line containing the "
+    "JSON object and nothing else:\n"
+    '{"pass": <true|false>, "matched": "<evidence-snippet-or-null>", '
+    '"rationale": "<one or two sentences>"}\n'
+    "If your prior analysis was inconclusive, emit pass=false with that "
+    "as the rationale."
+)
+
+
 def _assemble_judge_prompt(check: str, traj_path: str | None) -> str:
     if traj_path:
         try:
@@ -268,9 +286,10 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
     collected_text: list[str] = []
     cost_usd = 0.0
     saw_result = False
+    retry_attempted = False
 
     async def _run() -> None:
-        nonlocal cost_usd, saw_result
+        nonlocal cost_usd, saw_result, retry_attempted
         async with ClaudeSDKClient(options=options) as client:
             await client.query(_assemble_judge_prompt(check, traj_path))
             async for message in client.receive_response():
@@ -279,9 +298,33 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
                         if isinstance(block, TextBlock) and block.text:
                             collected_text.append(block.text)
                 elif isinstance(message, ResultMessage):
-                    cost_usd = getattr(message, "total_cost_usd", 0.0) or 0.0
+                    cost_usd += getattr(message, "total_cost_usd", 0.0) or 0.0
                     saw_result = True
                     break
+
+            # Retry once if the first response ended cleanly but didn't
+            # close with a parseable verdict. The judge LLM (sonnet) drifts
+            # into "I'll investigate..." prose surprisingly often on rubric
+            # checks — observed live on vss-generate-video-report
+            # base_profile_report step-1 check 2, where the model gathered
+            # the right evidence but never emitted the {"pass": ...} JSON.
+            # The follow-up uses the same session so prior tool results
+            # stay in context — no re-investigation cost.
+            if (
+                saw_result
+                and collected_text
+                and _parse_verdict_json("\n".join(collected_text)) is None
+            ):
+                retry_attempted = True
+                await client.query(_VERDICT_NUDGE)
+                async for message in client.receive_response():
+                    if isinstance(message, AssistantMessage):
+                        for block in message.content:
+                            if isinstance(block, TextBlock) and block.text:
+                                collected_text.append(block.text)
+                    elif isinstance(message, ResultMessage):
+                        cost_usd += getattr(message, "total_cost_usd", 0.0) or 0.0
+                        break
 
     try:
         await asyncio.wait_for(_run(), timeout=timeout_s)
@@ -309,12 +352,16 @@ async def _judge_llm_agent(check: str, traj_path: str | None, *, timeout_s: int)
         # Common causes: ran out of turns mid-analysis without emitting the
         # final {"pass": ...} object; SDK closed the stream early
         # (saw_result=False); or the agent returned only tool-use blocks.
+        # `retry_attempted` distinguishes "judge never tried to format"
+        # from "judge tried twice and still wandered" — the latter is a
+        # spec-prompt issue, the former is an LLM noncompliance flake.
         head = full_text[:600]
         tail = full_text[-400:] if len(full_text) > 1000 else ""
         signals = (
             f"saw_result_message={saw_result} "
             f"text_chars={len(full_text)} "
-            f"text_blocks={len(collected_text)}"
+            f"text_blocks={len(collected_text)} "
+            f"retry_attempted={retry_attempted}"
         )
         rationale = (
             f"judge returned no compliant verdict ({signals}); "


### PR DESCRIPTION
## Summary

When the agent-style judge in `verifiers/generic_judge.py` runs a check, gathers evidence, and then forgets to close with the required `{\"pass\": ..., \"matched\": ..., \"rationale\": ...}` JSON, send one follow-up turn in the same SDK session asking for the verdict JSON only.

## Why

Live failure on PR #609 run `26297115943`, spec `vss-generate-video-report/base_profile_report` step-1:

| Check | Result | Reason |
|---|---|---|
| 1 — Agent probed VST before uploading | ✅ pass | Trajectory step 274 hit `/vst/api/v1/sensor/list`, no PUT after |
| 2 — `/vst/api/v1/sensor/list` contains the uploaded video's stem | ❌ **fail** | **Judge ran the curl, saw `warehouse_safety_0001` in the response, narrated it — never emitted the verdict JSON** |
| 3 — `/vst/api/v1/sensor/<id>/streams` returns a local-file URL | ✅ pass | Same data; judge produced verdict |

Same trial, same evidence — only check 2 wandered. The `judge.json` for the failure said:

```
"rationale": "judge returned no compliant verdict (saw_result_message=True text_chars=322 text_blocks=2); head: \"I'll investigate this check by first probing the live endpoint and then examining the trajectory...\""
```

Reward dropped to 0.667, blocking steps 2-3 (chained on `requires_previous_passed`). The agent under test did everything right; the judge LLM (sonnet) just forgot the output format. This is a known fragility of agent-style rubric judging, not a spec bug — the same prompt produced a verdict for checks 1 and 3.

## What changed

`verifiers/generic_judge.py::_judge_llm_agent::_run`:

- After the first response loop, if `saw_result_message=True` AND collected text has no parseable verdict, send a second `client.query()` with a strict format-only nudge. Stream the second response into the same `collected_text` buffer.
- Uses the **same** `ClaudeSDKClient` session — prior tool results (Bash curl outputs, trajectory reads) stay in context, so the follow-up costs one short turn instead of a full re-investigation.
- `retry_attempted` is plumbed through to the failure rationale's `signals` block so we can distinguish:
  - `retry_attempted=False` → first response had no text at all or stream didn't end cleanly (different bug class)
  - `retry_attempted=True` → judge tried twice and still couldn't format → spec-prompt issue worth tightening

Cost accounting: changed `cost_usd = …` to `cost_usd += …` on each `ResultMessage`. Equivalent in the single-response case (prior behaviour); additive across the retry.

Scope is intentionally narrow: timeouts, crashes, and empty-text responses are not retried — they're symptoms of larger problems and re-prompting won't help. One retry only, no loop.

## Test plan

- [ ] Re-run `vss-generate-video-report` skill-eval (the spec that exposed this). Confirm check 2 now passes via the retry path (judge.json shows `pass: true` and `signals.retry_attempted=True`).
- [ ] Spot-check a normal run: confirm a check that emits the verdict on the first turn doesn't trigger retry (no extra `ResultMessage`, `retry_attempted=False`).
- [ ] Confirm timeout / crash paths still surface the original error rationale (retry block is conditional on `saw_result` being true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)