### PR TITLE
skill-eval: pool hygiene — reset deploy state between runs + drop auto-provision

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -347,13 +347,32 @@ template is in § Harbor invocation below.
    --body-file …`. Do NOT post a planning / "refresh" comment up
    front — comments carry results, not intent.
 
-7. **Release all locks. DO NOT tear down any Brev instance.** The
-   `vss-eval-*` boxes are a long-running pool managed by the operator;
-   they stay up across runs (warm caches, pre-deployed VSS profiles,
-   docker layer reuse). You release the per-box flock so the next
-   worker can grab it; you never `brev stop` / `brev delete`. The
-   wrapper script no longer runs cleanup either — pool lifecycle is
-   strictly an operator concern.
+7. **Reset each locked box, then release its lock. DO NOT tear down
+   any Brev instance.** The `vss-eval-*` boxes are a long-running
+   pool managed by the operator; instances stay up across runs, and
+   so do the slow caches (docker image layers, named volumes —
+   postgres / ES / kafka data, repo clone, sample-data extract). But
+   the *deployment state* — running containers plus the
+   `/tmp/skill-eval/active-deploy.txt` marker — is per-CI-run: warm
+   reuse within a run amortises deploy across `(spec, task, trial)`
+   tuples on the same box, but between runs each PR must redeploy
+   from its own `PR_HEAD_SHA` so it doesn't inherit a stale stack.
+   So for each `vss-eval-*` box you held a flock on, BEFORE releasing
+   that flock, reset its deployment state:
+
+   ```bash
+   brev exec "$INSTANCE_NAME" 'docker rm -f $(docker ps -aq) 2>/dev/null; \
+                               docker network prune -f; \
+                               rm -f /tmp/skill-eval/active-deploy.txt'
+   ```
+
+   Run this once per locked box at the end of the run (after § 6
+   posts the final comment), regardless of trial outcome — `DONE`,
+   `BLOCKED`, or partial. The image cache, named volumes, repo
+   clone, and sample-data extract survive; only live containers and
+   the marker are dropped. Then close the lock FD (or `flock -u
+   $LFD`) so the next worker can grab the box. You never `brev stop`
+   / `brev delete`. Pool lifecycle is strictly an operator concern.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec
@@ -385,12 +404,13 @@ template is in § Harbor invocation below.
 - **Never touch pool-instance lifecycle.** No `brev create`,
   `brev start`, `brev stop`, `brev reset`, or `brev delete` against
   any `vss-eval-*` box. The pool is operator-managed; instances stay
-  running across runs. The agent only reads (`brev ls`, `brev exec
-  -- cat …`) and acquires the per-box flock. If no hardware-matching
-  pool member exists for the trial's platform, follow the wait-for-
-  pool path in § 5a (5-min `brev ls` poll, 28800s budget, then
-  `BLOCKED: pool exhausted for <platform>`) — provisioning is the
-  operator's job.
+  running across runs. The agent's `brev` surface is limited to
+  `brev ls`, `brev exec` (reads + the end-of-run deployment-state
+  reset documented in § 7), and acquiring/releasing the per-box
+  flock. If no hardware-matching pool member exists for the trial's
+  platform, follow the wait-for-pool path in § 5a (5-min `brev ls`
+  poll, 28800s budget, then `BLOCKED: pool exhausted for
+  <platform>`) — provisioning is the operator's job.
 - **Never dispatch code from non-mirror branches.** You only ever
   process `pull-request/<N>` SHAs; those are CPR-bot vetted. If you
   notice the PR head on github.com is ahead of the mirror, note it
@@ -436,8 +456,12 @@ runner-side **flock** on `/tmp/brev/<INSTANCE_NAME>.lock`,
 checked separately via `flock -n` in step 5a. The two together
 let the scoring pick a warm-and-free box first, then fall back
 to warm-but-busy (queue on `flock -w`) or cold-and-free (redeploy).
-See `specs/stale-marker.spec` for verifying the marker against
-the actual running containers.
+The marker is *per-CI-run state*, not per-pool-instance state:
+§ 7's end-of-run cleanup wipes it (along with all containers)
+before releasing the flock, so the next run on the same box
+starts with an empty marker and redeploys from its own
+`PR_HEAD_SHA`. See `specs/stale-marker.spec` for verifying the
+marker against the actual running containers.
 
 With fleet=1, selection collapses to a single candidate. With
 fleet>1, two concurrent workflow runs land on different boxes

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -350,29 +350,33 @@ template is in § Harbor invocation below.
 7. **Reset each locked box, then release its lock. DO NOT tear down
    any Brev instance.** The `vss-eval-*` boxes are a long-running
    pool managed by the operator; instances stay up across runs, and
-   so do the slow caches (docker image layers, named volumes —
-   postgres / ES / kafka data, repo clone, sample-data extract). But
-   the *deployment state* — running containers plus the
-   `/tmp/skill-eval/active-deploy.txt` marker — is per-CI-run: warm
-   reuse within a run amortises deploy across `(spec, task, trial)`
-   tuples on the same box, but between runs each PR must redeploy
-   from its own `PR_HEAD_SHA` so it doesn't inherit a stale stack.
-   So for each `vss-eval-*` box you held a flock on, BEFORE releasing
-   that flock, reset its deployment state:
+   so do the bandwidth-expensive caches (docker image layers, the
+   repo clone, the sample-data extract on the host filesystem). But
+   the *deployment state* — running containers, the named volumes
+   that hold their data (postgres / ES / kafka), the docker networks
+   that wire them, and the `/tmp/skill-eval/active-deploy.txt`
+   marker — is per-CI-run: warm reuse within a run amortises deploy
+   across `(spec, task, trial)` tuples on the same box, but between
+   runs each PR must redeploy from its own `PR_HEAD_SHA` against
+   empty data stores so it doesn't inherit a stale stack OR stale
+   row state. So for each `vss-eval-*` box you held a flock on,
+   BEFORE releasing that flock, reset its deployment state:
 
    ```bash
    brev exec "$INSTANCE_NAME" 'docker rm -f $(docker ps -aq) 2>/dev/null; \
                                docker network prune -f; \
+                               docker volume prune -af; \
                                rm -f /tmp/skill-eval/active-deploy.txt'
    ```
 
    Run this once per locked box at the end of the run (after § 6
    posts the final comment), regardless of trial outcome — `DONE`,
-   `BLOCKED`, or partial. The image cache, named volumes, repo
-   clone, and sample-data extract survive; only live containers and
-   the marker are dropped. Then close the lock FD (or `flock -u
-   $LFD`) so the next worker can grab the box. You never `brev stop`
-   / `brev delete`. Pool lifecycle is strictly an operator concern.
+   `BLOCKED`, or partial. The docker image cache, repo clone, and
+   sample-data extract survive (they're slow to rebuild and carry
+   no trial state); containers, volumes, networks, and the marker
+   are dropped. Then close the lock FD (or `flock -u $LFD`) so the
+   next worker can grab the box. You never `brev stop` / `brev
+   delete`. Pool lifecycle is strictly an operator concern.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec
@@ -457,11 +461,12 @@ checked separately via `flock -n` in step 5a. The two together
 let the scoring pick a warm-and-free box first, then fall back
 to warm-but-busy (queue on `flock -w`) or cold-and-free (redeploy).
 The marker is *per-CI-run state*, not per-pool-instance state:
-§ 7's end-of-run cleanup wipes it (along with all containers)
-before releasing the flock, so the next run on the same box
-starts with an empty marker and redeploys from its own
-`PR_HEAD_SHA`. See `specs/stale-marker.spec` for verifying the
-marker against the actual running containers.
+§ 7's end-of-run cleanup wipes it (along with all containers,
+volumes, and networks) before releasing the flock, so the next
+run on the same box starts with an empty marker, empty data
+stores, and redeploys from its own `PR_HEAD_SHA`. See
+`specs/stale-marker.spec` for verifying the marker against the
+actual running containers.
 
 With fleet=1, selection collapses to a single candidate. With
 fleet>1, two concurrent workflow runs land on different boxes

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -328,8 +328,9 @@ template is in § Harbor invocation below.
       below — **do not improvise flags**. Before the `uvx harbor run`
       call, `export BREV_INSTANCE=<name>` to the instance you
       resolved in step 5a; the canonical snippet has the line —
-      omitting it causes a fresh `harbor-*` to be provisioned per
-      trial and wastes the pre-warmed box. If a trial fails, read the
+      omitting it makes `BrevEnvironment.start()` raise immediately
+      ("no instance resolved, harness does not auto-provision") and
+      the trial fails before harbor invokes the agent. If a trial fails, read the
       trial log, fix the adapter (not the flags), rerun. While a
       trial is running, do NOT babysit the remote box (no
       `brev exec` polling, no `Monitor` on remote logs); harbor has
@@ -447,8 +448,12 @@ even though it shows up in `brev ls`.
 matching the trial's platform; score by (active-deploy marker match,
 free-lock, name) per § 5a; pick the best free candidate; export
 `BREV_INSTANCE` to it before the `uvx harbor run` call (§ Harbor
-invocation). Without the export, BrevEnvironment auto-provisions a
-fresh `harbor-*` per trial regardless of what the snapshot showed.
+invocation). The export is mandatory: BrevEnvironment no longer
+auto-provisions, so without `BREV_INSTANCE` set (or `brev_instance`
+in the task's `task.toml [metadata]`) the harness raises at
+`start()` and the trial fails before harbor runs. If no
+hardware-matching `^vss-eval-*` candidate exists, follow the
+wait-for-pool path in § 5a — do not `brev create` one yourself.
 
 The marker file (`/tmp/skill-eval/active-deploy.txt` on each box)
 records the box's *deployment state* — what VSS profile is
@@ -520,11 +525,11 @@ a file path).
 export PYTHONPATH="${GITHUB_WORKSPACE}/.github/skill-eval:${PYTHONPATH:-}"
 
 # CRITICAL: point the environment at the box you selected in step 5a.
-# BrevEnvironment reads BREV_INSTANCE at module import time; without
-# this export it falls through to the auto-provision branch and spawns
-# a fresh harbor-* per trial (≈20 min provision overhead each, wastes
-# the pre-warmed box, and — on massedcompute L40S — may run multiple
-# harbor-* in parallel on the same lock).
+# BrevEnvironment reads BREV_INSTANCE at module import time; if it's
+# unset and task.toml [metadata].brev_instance is also absent,
+# BrevEnvironment.start() raises immediately — the harness no longer
+# auto-provisions, so the trial fails before harbor invokes the
+# agent. The export is the only path to a successful run.
 #
 # $INSTANCE_NAME comes from the fleet-selection algorithm in step 5a:
 # the chosen ^vss-eval-* candidate scored by (active-deploy marker

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -316,16 +316,10 @@ template is in § Harbor invocation below.
       ```bash
       exec {LFD}>/tmp/brev/"$INSTANCE_NAME".lock
       flock -w 28800 "$LFD" || { echo "BLOCKED: lock timeout"; exit 1; }
-      # Record the box in the touched-boxes ledger so the Python
-      # harness's failsafe (atexit + SIGTERM handler) can reset its
-      # deployment state if the agent never reaches § 7 (max-turns
-      # exit, crash, cancel-in-progress, etc.). Append (not
-      # overwrite) — multiple locked boxes per run are normal across
-      # spec×platform tuples.
-      mkdir -p /tmp/skill-eval
-      echo "$INSTANCE_NAME" >> /tmp/skill-eval/touched-boxes-"${GITHUB_RUN_ID}".txt
       # ... trials ...
-      exec {LFD}>&-        # release on exit; trap so SIGINT doesn't strand it
+      exec {LFD}>&-        # release on exit; the kernel also releases
+                           # automatically on process death (no userspace
+                           # trap needed for cancel-in-progress / SIGKILL).
       ```
       8-hour max hold (matches the job timeout). If another worker
       already holds the lock for this box, wait up to 8 h; beyond
@@ -356,61 +350,27 @@ template is in § Harbor invocation below.
    --body-file …`. Do NOT post a planning / "refresh" comment up
    front — comments carry results, not intent.
 
-7. **Reset each locked box, then release its lock. DO NOT tear down
-   any Brev instance.** The `vss-eval-*` boxes are a long-running
-   pool managed by the operator; instances stay up across runs, and
-   so do the bandwidth-expensive caches (docker image layers, the
-   repo clone, the sample-data extract on the host filesystem). But
-   the *deployment state* — running containers, the named volumes
-   that hold their data (postgres / ES / kafka), the docker networks
-   that wire them, and the `/tmp/skill-eval/active-deploy.txt`
-   marker — is per-CI-run: warm reuse within a run amortises deploy
-   across `(spec, task, trial)` tuples on the same box, but between
-   runs each PR must redeploy from its own `PR_HEAD_SHA` against
-   empty data stores so it doesn't inherit a stale stack OR stale
-   row state. So for each `vss-eval-*` box you held a flock on,
-   BEFORE releasing that flock, reset its deployment state:
+7. **Release all locks. DO NOT tear down any Brev instance.** The
+   `vss-eval-*` boxes are a long-running pool managed by the
+   operator; instances stay up across runs, and so do the slow
+   caches (docker image layers, repo clone, sample-data extract).
+   Close each lock FD (`exec {LFD}>&-`) so the next worker can
+   grab the box. You never `brev stop` / `brev delete`. Pool
+   lifecycle is strictly an operator concern.
 
-   ```bash
-   brev exec "$INSTANCE_NAME" 'docker ps -aq | xargs -r docker rm -f >/dev/null && \
-                               docker network prune -f >/dev/null && \
-                               docker volume prune -af >/dev/null && \
-                               rm -f /tmp/skill-eval/active-deploy.txt'
-   ```
-
-   `&&` chaining is load-bearing: if any prune step exits non-zero
-   (daemon hiccup, a container still holding a volume from an
-   incomplete `docker rm`, pre-23.0 Docker without `volume prune
-   -a`), the chain short-circuits and the marker is left intact,
-   so the next worker sees the stale-deploy state instead of an
-   empty marker that lies about a partially-dirty box. `xargs -r`
-   makes the "no containers" case a clean no-op (vs. `docker rm -f`
-   with empty argv). Same idiom as the in-process reconcile path
-   at `envs/brev_env.py::_ensure_prerequisite_deployed`.
-
-   Run this once per locked box at the end of the run (after § 6
-   posts the final comment), regardless of trial outcome — `DONE`,
-   `BLOCKED`, or partial. The docker image cache, repo clone, and
-   sample-data extract survive (they're slow to rebuild and carry
-   no trial state); containers, volumes, networks, and the marker
-   are dropped. If the chain exits non-zero, the box stays flagged
-   for operator attention (marker still set, containers / volumes
-   partially live) — log the failure but do not retry. Then close
-   the lock FD (or `flock -u $LFD`) so the next worker can grab the
-   box. You never `brev stop` / `brev delete`. Pool lifecycle is
-   strictly an operator concern.
-
-   **You are the primary path; the harness is the backstop.** The
-   Python harness (`skills_eval_agent.py`) reads the touched-boxes
-   ledger you appended to in § 5b and runs this same reset chain
-   from `atexit` + a SIGTERM/SIGINT handler. That covers the cases
-   where you never reach § 7 — max-turns exit, crash,
-   `cancel-in-progress` on a fresh push — but it does NOT cover
-   SIGKILL (the 8h `timeout-minutes` terminator). Running § 7
-   yourself on every locked box is still required: it executes
-   while the trials' results are fresh and lets you log a per-box
-   failure into the run summary, which the post-mortem failsafe
-   only logs to stderr.
+   **You do NOT reset deployment state on exit.** Each box's
+   running containers, named volumes, and the active-deploy marker
+   stay as you left them; cleanup is the *next* run's job. The
+   active-deploy marker is tagged `<profile_tag>|<run_id>`, so the
+   next run's `BrevEnvironment._ensure_prerequisite_deployed` sees
+   a run-id mismatch and always reconciles (tear-down + redeploy
+   from its own `PR_HEAD_SHA`) — regardless of how this run ended
+   (happy path, `BLOCKED`, cancel-in-progress, max-turns, agent
+   crash, SIGKILL, host reboot). No `atexit`, no signal handler,
+   no end-of-run docker cleanup — the pull-side reconcile handles
+   every exit path uniformly. Within this run, multiple trials with
+   the same profile still hot-skip because both profile and run id
+   match.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec
@@ -443,9 +403,11 @@ template is in § Harbor invocation below.
   `brev start`, `brev stop`, `brev reset`, or `brev delete` against
   any `vss-eval-*` box. The pool is operator-managed; instances stay
   running across runs. The agent's `brev` surface is limited to
-  `brev ls`, `brev exec` (reads + the end-of-run deployment-state
-  reset documented in § 7), and acquiring/releasing the per-box
-  flock. If no hardware-matching pool member exists for the trial's
+  `brev ls`, `brev exec` (read-only — inspecting markers, peeking
+  at containers; deployment-state reset is the pull-side
+  reconcile in `_ensure_prerequisite_deployed`, not anything you
+  run from this agent), and acquiring/releasing the per-box flock.
+  If no hardware-matching pool member exists for the trial's
   platform, follow the wait-for-pool path in § 5a (5-min `brev ls`
   poll, 28800s budget, then `BLOCKED: pool exhausted for
   <platform>`) — provisioning is the operator's job.
@@ -489,22 +451,26 @@ hardware-matching `^vss-eval-*` candidate exists, follow the
 wait-for-pool path in § 5a — do not `brev create` one yourself.
 
 The marker file (`/tmp/skill-eval/active-deploy.txt` on each box)
-records the box's *deployment state* — what VSS profile is
-currently up and live on that box. It is NOT an occupancy
-signal — a marker can read `base` whether or not a
+records the box's *deployment state* + *owning run* in the form
+`<profile_tag>|<run_id>` — what VSS profile is currently up on
+that box and which CI run deployed it. It is NOT an occupancy
+signal — a marker can read `base|26500001234` whether or not a
 trial is currently driving traffic against the stack. Occupancy
 (is some other worker using this box right now?) is the
 runner-side **flock** on `/tmp/brev/<INSTANCE_NAME>.lock`,
 checked separately via `flock -n` in step 5a. The two together
 let the scoring pick a warm-and-free box first, then fall back
 to warm-but-busy (queue on `flock -w`) or cold-and-free (redeploy).
-The marker is *per-CI-run state*, not per-pool-instance state:
-§ 7's end-of-run cleanup wipes it (along with all containers,
-volumes, and networks) before releasing the flock, so the next
-run on the same box starts with an empty marker, empty data
-stores, and redeploys from its own `PR_HEAD_SHA`. See
-`specs/stale-marker.spec` for verifying the marker against the
-actual running containers.
+Tagging the marker with `<run_id>` (`$GITHUB_RUN_ID`) is what
+makes between-run isolation a pull-side reconcile rather than a
+push-side cleanup: a marker left by a prior run never matches
+the current run's desired `<profile_tag>|<this_run_id>`, so
+`BrevEnvironment._ensure_prerequisite_deployed` always
+tears down + redeploys from the current run's `PR_HEAD_SHA`
+regardless of how the prior run ended. Within one run, multiple
+trials with the same profile still hot-skip (same profile, same
+run id, full match). See `specs/stale-marker.spec` for verifying
+the marker against the actual running containers.
 
 With fleet=1, selection collapses to a single candidate. With
 fleet>1, two concurrent workflow runs land on different boxes

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -316,6 +316,14 @@ template is in § Harbor invocation below.
       ```bash
       exec {LFD}>/tmp/brev/"$INSTANCE_NAME".lock
       flock -w 28800 "$LFD" || { echo "BLOCKED: lock timeout"; exit 1; }
+      # Record the box in the touched-boxes ledger so the Python
+      # harness's failsafe (atexit + SIGTERM handler) can reset its
+      # deployment state if the agent never reaches § 7 (max-turns
+      # exit, crash, cancel-in-progress, etc.). Append (not
+      # overwrite) — multiple locked boxes per run are normal across
+      # spec×platform tuples.
+      mkdir -p /tmp/skill-eval
+      echo "$INSTANCE_NAME" >> /tmp/skill-eval/touched-boxes-"${GITHUB_RUN_ID}".txt
       # ... trials ...
       exec {LFD}>&-        # release on exit; trap so SIGINT doesn't strand it
       ```
@@ -391,6 +399,18 @@ template is in § Harbor invocation below.
    the lock FD (or `flock -u $LFD`) so the next worker can grab the
    box. You never `brev stop` / `brev delete`. Pool lifecycle is
    strictly an operator concern.
+
+   **You are the primary path; the harness is the backstop.** The
+   Python harness (`skills_eval_agent.py`) reads the touched-boxes
+   ledger you appended to in § 5b and runs this same reset chain
+   from `atexit` + a SIGTERM/SIGINT handler. That covers the cases
+   where you never reach § 7 — max-turns exit, crash,
+   `cancel-in-progress` on a fresh push — but it does NOT cover
+   SIGKILL (the 8h `timeout-minutes` terminator). Running § 7
+   yourself on every locked box is still required: it executes
+   while the trials' results are fresh and lets you log a per-box
+   failure into the run summary, which the post-mortem failsafe
+   only logs to stderr.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -364,20 +364,33 @@ template is in § Harbor invocation below.
    BEFORE releasing that flock, reset its deployment state:
 
    ```bash
-   brev exec "$INSTANCE_NAME" 'docker rm -f $(docker ps -aq) 2>/dev/null; \
-                               docker network prune -f; \
-                               docker volume prune -af; \
+   brev exec "$INSTANCE_NAME" 'docker ps -aq | xargs -r docker rm -f >/dev/null && \
+                               docker network prune -f >/dev/null && \
+                               docker volume prune -af >/dev/null && \
                                rm -f /tmp/skill-eval/active-deploy.txt'
    ```
+
+   `&&` chaining is load-bearing: if any prune step exits non-zero
+   (daemon hiccup, a container still holding a volume from an
+   incomplete `docker rm`, pre-23.0 Docker without `volume prune
+   -a`), the chain short-circuits and the marker is left intact,
+   so the next worker sees the stale-deploy state instead of an
+   empty marker that lies about a partially-dirty box. `xargs -r`
+   makes the "no containers" case a clean no-op (vs. `docker rm -f`
+   with empty argv). Same idiom as the in-process reconcile path
+   at `envs/brev_env.py::_ensure_prerequisite_deployed`.
 
    Run this once per locked box at the end of the run (after § 6
    posts the final comment), regardless of trial outcome — `DONE`,
    `BLOCKED`, or partial. The docker image cache, repo clone, and
    sample-data extract survive (they're slow to rebuild and carry
    no trial state); containers, volumes, networks, and the marker
-   are dropped. Then close the lock FD (or `flock -u $LFD`) so the
-   next worker can grab the box. You never `brev stop` / `brev
-   delete`. Pool lifecycle is strictly an operator concern.
+   are dropped. If the chain exits non-zero, the box stays flagged
+   for operator attention (marker still set, containers / volumes
+   partially live) — log the failure but do not retry. Then close
+   the lock FD (or `flock -u $LFD`) so the next worker can grab the
+   box. You never `brev stop` / `brev delete`. Pool lifecycle is
+   strictly an operator concern.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -6,11 +6,10 @@ Evaluation is **fully CI-driven**. [`.github/workflows/skills-eval.yml`](../work
 
 1. Diffs the PR against its base branch and picks out changed skills with an eval spec at `skills/<skill>/evals/<name>.json` or legacy `skills/<skill>/eval/<name>.json`.
 2. Generates Harbor datasets per `(skill, profile, platform, mode)` via the adapter at [`adapters/<skill>/generate.py`](adapters/).
-3. Acquires a per-instance `flock` on a Brev GPU host, reusing one that matches the target platform or creating one via the fallback chain in [`AGENTS.md`](AGENTS.md).
+3. Acquires a per-instance `flock` on an operator-managed `vss-eval-*` pool member matching the target platform, per the fleet-selection algorithm in [`AGENTS.md`](AGENTS.md) § 5a. The harness does **not** auto-provision — if no pool member matches, the run blocks until one appears (or times out).
 4. Runs `uvx harbor run` against each dataset, one trial at a time, with the canonical invocation captured in [`AGENTS.md § Harbor invocation`](AGENTS.md).
 5. Verifies each trial (containers running, endpoints healthy, trajectory / response / rubric checks — see `verifiers/generic_judge.py`) and scores 0.0–1.0.
 6. Posts one Markdown results summary per `(PR, eval-spec)` batch as a PR comment, with trace URLs served by `harbor view`.
-7. Leaves instance IDs in `/tmp/brev/started-by-<run_id>.txt`; the workflow wrapper deletes / stops them after a 5-min cooldown.
 
 The whole thing runs inside the 8-hour GitHub Actions job timeout. The `.github/skill-eval/AGENTS.md` file **is** the agent's system prompt — keep it readable.
 
@@ -257,4 +256,4 @@ disown
 
 **Agent deployment fails with "pull access denied".** `NGC_CLI_API_KEY` missing or invalid — the agent needs it to pull VSS NIM containers from `nvcr.io`.
 
-**Cancelled run leaves orphan Brev instances.** A cancelled CI job never gets to the cooldown teardown step. Clean up by listing owned instances in `/tmp/brev/started-by-<run_id>.txt` on the runner host and `brev delete` them manually.
+**Orphan `harbor-*` Brev instances.** The harness no longer auto-provisions — every trial must use a `vss-eval-*` pool member. If you see `harbor-*` instances in `brev ls`, they're stragglers from before this change (or from someone running `uvx harbor` manually without `BREV_INSTANCE` set). Clean them up with `brev delete <name>`.

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -34,7 +34,7 @@ The runner has no GPU. Eval trials run on a long-lived pool of `vss-eval-*` Brev
 | `rtx` | `vss-eval-rtx-1g`, `vss-eval-rtx-1g-2`, `vss-eval-rtx-2g` | AWS `g7e.4xlarge` / `g7e.12xlarge` (RTX PRO Server 6000) |
 | `spark` | BYOH DGX Spark node registered via `brev register` | n/a |
 
-Per-CI-run hygiene (containers, named volumes, and the deploy marker are wiped on every locked box at the end of each run, while image cache / repo clone / sample-data extract survive) is documented in [`AGENTS.md § 7`](AGENTS.md). Fleet-selection scoring + the wait-for-pool path on exhaustion live in [`AGENTS.md § Platform topology`](AGENTS.md).
+Per-CI-run hygiene is pull-side: the active-deploy marker on each box carries `<profile_tag>|<run_id>`, and each new run's `BrevEnvironment._ensure_prerequisite_deployed` reconciles by tearing down + redeploying whenever the marker's run id doesn't match its own — so a prior run's leftover state (containers, named volumes, marker) is wiped on the next run's lock acquisition, not on the prior run's exit. That handles every exit path uniformly (happy path, cancel-in-progress, max-turns, SIGKILL, host reboot). Fleet-selection scoring + the wait-for-pool path on exhaustion live in [`AGENTS.md § Platform topology`](AGENTS.md).
 
 ### API keys (`/home/ubuntu/eval-coordinator/.env` on the runner)
 

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -23,18 +23,18 @@ The workflow runs on a self-hosted GitHub Actions runner installed on `vss-skill
 - **Python 3** — for the adapters.
 - **A `.env` at `/home/ubuntu/eval-coordinator/.env`** with the keys below — the workflow step `Load coordinator env` sources this file.
 
-### GPU targets (provisioned on demand, not on the runner)
+### GPU targets (operator-managed `vss-eval-*` pool)
 
-The runner has no GPU. Eval trials run on per-platform Brev instances the agent provisions (and the workflow tears down):
+The runner has no GPU. Eval trials run on a long-lived pool of `vss-eval-*` Brev instances that the **operator** provisions ahead of time with `brev create`; the skill-eval agent only locks, drives, and resets them — never creates, stops, or deletes pool members. Default pool today:
 
-| Platform | Instance type | Lifecycle |
+| Platform | Pool member(s) | Instance type |
 |---|---|---|
-| `l40s` | `massedcompute_L40Sx2` (2× L40S 48 GB) | `brev delete` after trials complete (MC is non-stoppable) |
-| `h100` | `dmz.h100x2.pcie` (2× H100 80 GB) | `brev delete` after trials complete |
-| `rtx` | `g7e.12xlarge` (RTX PRO 6000) | `brev stop` after trials complete |
-| `spark` | BYOH DGX Spark node | no-op — stays online across runs |
+| `l40s` | `vss-eval-l40s`, `vss-eval-l40s-1g`, `vss-eval-l40s-2` | `massedcompute_L40S` / `massedcompute_L40Sx2` |
+| `h100` | `vss-eval-h100` (when needed) | launchpad `dmz.h100x2.pcie` preferred |
+| `rtx` | `vss-eval-rtx-1g`, `vss-eval-rtx-1g-2`, `vss-eval-rtx-2g` | AWS `g7e.4xlarge` / `g7e.12xlarge` (RTX PRO Server 6000) |
+| `spark` | BYOH DGX Spark node registered via `brev register` | n/a |
 
-Fallback chains and matrix constraints live in [`AGENTS.md § Platform topology`](AGENTS.md).
+Per-CI-run hygiene (containers, named volumes, and the deploy marker are wiped on every locked box at the end of each run, while image cache / repo clone / sample-data extract survive) is documented in [`AGENTS.md § 7`](AGENTS.md). Fleet-selection scoring + the wait-for-pool path on exhaustion live in [`AGENTS.md § Platform topology`](AGENTS.md).
 
 ### API keys (`/home/ubuntu/eval-coordinator/.env` on the runner)
 
@@ -250,7 +250,7 @@ disown
 
 **`AddTestsDirError` / `DownloadVerifierDirError`.** File upload/download to the Brev instance failed. Check `brev exec <instance> "echo ok"` works manually. Clear `/tests /logs /skills` on the instance and retry.
 
-**Instance creation fails.** Some Brev providers have capacity issues. Harbor's fallback chain (see [`AGENTS.md § Platform topology`](AGENTS.md)) cycles through alternatives. If all are exhausted, the agent posts a `csp_unavailable` blocker.
+**Pool exhausted for `<platform>`.** No `vss-eval-*` pool member matches the trial's `gpu_type` after the 28800s wait window (`brev ls` polled every 5 min). The agent emits `BLOCKED: pool exhausted for <platform>` and exits. Provisioning new pool members is the operator's job — `brev create vss-eval-<name>` with the matching instance type, then bring it online; the next CI run picks it up automatically via the `^vss-eval-*` fleet scan.
 
 **Brev auth expired mid-run.** The CI run emits `BLOCKED: brev auth expired`. The `brev-keepalive.timer` systemd user unit keeps the access token warm, but only an interactive `brev login --auth nvidia` can refresh a fully-expired refresh token.
 

--- a/.github/skill-eval/adapters/vss-deploy-profile/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-profile/generate.py
@@ -170,11 +170,11 @@ def deploy_profile(eval_profile: str) -> str:
 _DEFAULT_MIN_ROOT_DISK_GB = 220        # base stack ~80GB + 2 local NIMs ~70GB each
 _DEFAULT_MIN_DRIVER_VERSION = "580.95" # cosmos-reason2-8b:1.6.0 floor
 # Caveats — both defaults are enforced unconditionally by
-# `envs/brev_env.py::_check_live_resources` / `_find_cheapest_matching_type`:
+# `envs/brev_env.py::_check_live_resources` on the resolved pool box:
 # - The disk default would reject otherwise-eligible smaller-root
-#   providers (e.g. some launchpad boxes) for trials that end up
-#   running fully remote and would actually fit on <220GB. Acceptable
-#   today because every `vss-eval-*` pool member has ≥220GB.
+#   pool members for trials that end up running fully remote and would
+#   actually fit on <220GB. Acceptable today because every `vss-eval-*`
+#   pool member has ≥220GB.
 # - The driver default is skipped when `nvidia-smi` is absent (the
 #   resource check warns instead of erroring), so CPU-only boxes still
 #   pass; don't tighten that branch to a hard error without revisiting

--- a/.github/skill-eval/adapters/vss-deploy-profile/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-profile/generate.py
@@ -270,27 +270,26 @@ def generate_test_script(spec_name: str, profile: str) -> str:
     /logs/verifier/reward.txt.
 
     On a full-pass (reward == 1.0), OVERWRITES the canonical active
-    marker `/tmp/skill-eval/active-deploy.txt` with this trial's
-    `<underlying_profile>` (plus `-<deploy_mode>` only for alerts) so
-    dependent trials (vss-manage-video-io-storage, video-*) reading the marker via
+    marker `/tmp/skill-eval/active-deploy.txt` with
+    `<profile_tag>|<run_id>` so dependent trials reading the marker via
     `BrevEnvironment._ensure_prerequisite_deployed` see what is currently
-    RUNNING on the box. See specs/stale-marker.spec.
+    RUNNING on the box AND which CI run owns it. See specs/stale-marker.spec.
 
-    Marker format:
-      - `base`, `lvs`, `search` — profile name only (placement is
-        env-driven, not a marker dimension).
-      - `alerts-verification`, `alerts-real-time` — alerts has two
-        distinct stacks (`/vss-deploy-profile -m verification` vs `-m real-time`)
-        so the mode is part of the marker.
+    Marker format is `<profile_tag>|<run_id>`:
+      - `<profile_tag>` is the profile (`base`, `lvs`, `search`) or
+        `<profile>-<deploy_mode>` for alerts (`alerts-verification`,
+        `alerts-real-time` — alerts has two distinct stacks).
+      - `<run_id>` is `$GITHUB_RUN_ID` (forwarded by brev_env.py into
+        ~/.eval_env; falls back to `local-<pid>` outside CI).
 
-    Consumer (`_ensure_prerequisite_deployed`) builds its desired
-    marker the same way: `profile + ("-" + prerequisite_deploy_mode if
-    set else "")`. Non-alerts downstream adapters declare just
-    `profile`; the alerts downstream case additionally declares
-    `prerequisite_deploy_mode`."""
+    Consumer (`_ensure_prerequisite_deployed`) builds its desired marker
+    the same way. A marker from a prior run never matches the current
+    run's desired marker, so the next worker always reconciles
+    (tear-down + redeploy from its own `PR_HEAD_SHA`) regardless of how
+    the prior run ended."""
     underlying_profile = deploy_profile(profile)
     deploy_mode_token = PROFILES[profile].get("deploy_mode")
-    marker_token = (
+    profile_tag = (
         f"{underlying_profile}-{deploy_mode_token}"
         if deploy_mode_token
         else underlying_profile
@@ -310,13 +309,16 @@ def generate_test_script(spec_name: str, profile: str) -> str:
         f'    --spec "$TEST_DIR/{spec_name}" --step 1\n'
         "\n"
         "# On full pass, overwrite the canonical active-deploy marker so\n"
-        "# downstream trials (vss-manage-video-io-storage/vss-*) reuse the running deployment\n"
-        "# instead of re-running /vss-deploy-profile. Overwrite, never append — the\n"
-        "# marker is what is currently RUNNING, not a deploy log.\n"
+        "# downstream trials (vss-manage-video-io-storage/vss-*) in THIS run\n"
+        "# reuse the running deployment instead of re-running /vss-deploy-profile.\n"
+        "# Marker format is `<profile_tag>|<run_id>` — `<run_id>` (from\n"
+        "# $GITHUB_RUN_ID, forwarded by brev_env.py) is what makes the\n"
+        "# next run's reconcile always tear down and redeploy regardless\n"
+        "# of how this run ended.\n"
         'reward="$(cat /logs/verifier/reward.txt 2>/dev/null || echo 0)"\n'
         f'if [ "$reward" = "1.0" ] || [ "$reward" = "1" ]; then\n'
         f'  mkdir -p /tmp/skill-eval && '
-        f"printf '%s\\n' '{marker_token}' "
+        f"printf '%s|%s\\n' '{profile_tag}' \"${{GITHUB_RUN_ID:-local-$$}}\" "
         f"> /tmp/skill-eval/active-deploy.txt\n"
         "fi\n"
         "exit 0\n"

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -50,23 +50,6 @@ BREV_EXEC_TIMEOUT = int(os.environ.get("BREV_EXEC_TIMEOUT", "1800"))
 BREV_COPY_TIMEOUT = int(os.environ.get("BREV_COPY_TIMEOUT", "300"))
 
 
-def _record_started_instance(name: str) -> None:
-    """Append an auto-provisioned instance name to the wrapper's
-    cleanup marker (`/tmp/brev/started-by-<run_id>.txt`) so
-    skills_eval_agent.cleanup_instances() tears it down even if the
-    agent never observes the name. No-op outside CI (no GITHUB_RUN_ID)."""
-    run_id = os.environ.get("GITHUB_RUN_ID")
-    if not run_id:
-        return
-    try:
-        marker = Path(f"/tmp/brev/started-by-{run_id}.txt")
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        with marker.open("a") as fh:
-            fh.write(f"{name}\n")
-    except OSError as exc:
-        logger.warning("failed to record %s in started-by marker: %s", name, exc)
-
-
 class BrevEnvironmentType(str, Enum):
     BREV = "brev"
 
@@ -122,7 +105,7 @@ class BrevEnvironment(BaseEnvironment):
         return tomllib.loads(task_toml.read_text()).get("metadata", {}) or {}
 
     def _resolve_instance_name(self) -> str | None:
-        """Resolve instance name: env var > task.toml > None (auto-provision)."""
+        """Resolve instance name: env var > task.toml > None (error)."""
         if DEFAULT_INSTANCE:
             return DEFAULT_INSTANCE
         meta = self._read_task_metadata()
@@ -131,7 +114,9 @@ class BrevEnvironment(BaseEnvironment):
         return None
 
     async def start(self, force_build: bool) -> None:
-        """Validate or provision a Brev instance matching task GPU requirements."""
+        """Validate that the resolved Brev instance is reachable and matches
+        the task's GPU requirements. Errors if no instance is resolved —
+        the harness does not auto-provision."""
         if self._started:
             return
 
@@ -159,61 +144,15 @@ class BrevEnvironment(BaseEnvironment):
                 )
             await _check_instance_matches(instance, requirements)
         else:
-            # Mode 2: auto-provision via brev search + create.
-            # Some platforms (DGX-SPARK, IGX-THOR) aren't provisionable as
-            # cloud instance types — they're physical devices registered via
-            # `brev register`.  Check there first and give a helpful error.
-            if not requirements["brev_search"]:
-                raise RuntimeError(
-                    "No BREV_INSTANCE set and no GPU requirements in task.toml "
-                    "[metadata] — cannot auto-provision."
-                )
-            logger.info("Auto-provisioning Brev instance for %s", requirements)
-            instance_type = await _find_cheapest_matching_type(requirements)
-            if not instance_type:
-                # Before failing, list any registered nodes that might fit.
-                suggestions = await _suggest_registered_devices(requirements)
-                msg = [
-                    f"Cannot auto-provision: no Brev cloud instance type matches",
-                    f"  requirements: {requirements}",
-                ]
-                if suggestions:
-                    msg.append("")
-                    msg.append("Registered device(s) matching (or partially matching) these requirements:")
-                    for s in suggestions:
-                        msg.append(f"  - {s}")
-                    msg.append("")
-                    msg.append(
-                        "Set `BREV_INSTANCE=<name>` or add `brev_instance = \"<name>\"` "
-                        "to task.toml [metadata] to use one of these."
-                    )
-                else:
-                    msg.append("")
-                    msg.append(
-                        "No registered devices match either. Options:\n"
-                        "  1. Register a physical device via `brev register` "
-                        "(DGX Spark / IGX Thor are typically registered, not provisioned).\n"
-                        "  2. Adjust gpu_type / brev_search in the task to a provisionable "
-                        "platform (e.g. H100, L40S, RTX PRO 6000)."
-                    )
-                full_msg = "\n".join(msg)
-                logger.error(full_msg)
-                raise RuntimeError(full_msg)
-            self._instance_name = f"harbor-{uuid.uuid4().hex[:8]}"
-            logger.info("Creating %s as %s", self._instance_name, instance_type)
-            create_result = await _run_brev(
-                "create", self._instance_name, "--detached",
-                stdin_data=instance_type,
-                timeout=120,
+            raise RuntimeError(
+                "No BREV_INSTANCE set and no `brev_instance` in task.toml "
+                "[metadata]. The harness no longer auto-provisions — every "
+                "trial must run on an operator-managed `vss-eval-*` pool "
+                "member. The skill-eval agent picks one per AGENTS.md § 5a "
+                "and exports BREV_INSTANCE before invoking `uvx harbor run`. "
+                "If you're running harbor manually, export "
+                "BREV_INSTANCE=<vss-eval-*-name> first."
             )
-            if create_result.return_code != 0:
-                raise RuntimeError(f"brev create failed: {create_result.stderr}")
-            # Record the harbor-* instance in the wrapper's cleanup marker
-            # so skills_eval_agent.cleanup_instances() tears it down even if
-            # the trial fails before the agent tracks it. Append before
-            # _wait_for_running so a timeout there doesn't leak an orphan.
-            _record_started_instance(self._instance_name)
-            await _wait_for_running(self._instance_name)
 
         # Quick smoke test — ensure exec works
         result = await _run_brev_exec(
@@ -231,11 +170,11 @@ class BrevEnvironment(BaseEnvironment):
                 f"{(result.stdout or '')[:200]!r}"
             )
 
-        # Post-provision resource checks: root disk + GPU driver.
-        # These catch provider quirks that brev search doesn't surface
-        # (e.g. hyperstack_H100x2 lists disk_min_gb=1600 but mounts the
-        # big volume on /ephemeral — / is only ~100 GB, which OOMs on
-        # local NIM pulls).
+        # Live resource checks: root disk + GPU driver. The pool box was
+        # provisioned by the operator and is expected to meet these, but
+        # the checks catch silent regressions (e.g. a driver downgrade or
+        # a box where the big volume mounts on /ephemeral and / is only
+        # ~100 GB — which OOMs on local NIM pulls).
         await _check_live_resources(self._instance_name, requirements)
 
         # Pre-create harbor's expected directories with correct ownership
@@ -1316,40 +1255,6 @@ async def _check_instance_matches(instance: dict, req: dict) -> None:
     )
 
 
-async def _find_cheapest_matching_type(req: dict) -> str | None:
-    """Find the cheapest `brev search` instance type matching GPU requirements."""
-    result = await _run_brev("search", "--json", timeout=30)
-    search = (req.get("brev_search") or "").lower()
-    required_count = req.get("gpu_count", 1)
-    required_vram = req.get("min_vram_gb_per_gpu", 0)
-    required_disk = req.get("min_root_disk_gb", 0)
-
-    candidates = []
-    for inst in _parse_brev_json(result.stdout):
-        gpu_name = (inst.get("gpu_name") or "").lower()
-        gpu_count = int(inst.get("gpu_count", 0) or 0)
-        total_vram = float(inst.get("total_vram_gb", 0) or 0)
-        disk_min_gb = int(inst.get("disk_min_gb", 0) or 0)
-        if search and search not in gpu_name:
-            continue
-        if gpu_count < required_count:
-            continue
-        if required_vram and (total_vram / max(gpu_count, 1)) < required_vram:
-            continue
-        # Pre-filter by disk_min_gb.  Some providers misreport this (e.g.
-        # hyperstack lists ephemeral-disk size not root), so the live check
-        # in _check_live_resources is authoritative; this filter just prunes
-        # candidates that are obviously undersized.
-        if required_disk and disk_min_gb and disk_min_gb < required_disk:
-            continue
-        candidates.append(inst)
-
-    if not candidates:
-        return None
-    candidates.sort(key=lambda x: float(x.get("price_per_hour", 0) or 0))
-    return candidates[0].get("type")
-
-
 def _version_lt(a: str, b: str) -> bool:
     """Return True if NVIDIA driver version `a` is older than `b`.
 
@@ -1417,56 +1322,3 @@ async def _check_live_resources(instance_name: str, req: dict) -> None:
         )
 
 
-async def _suggest_registered_devices(req: dict) -> list[str]:
-    """Query `brev ls nodes --json` for registered physical devices that
-    match the task's requirements (best-effort, by name substring).
-    Returns human-readable strings for error messages."""
-    result = await _run_brev("ls", "nodes", "--json", timeout=15)
-    nodes = _parse_brev_json(result.stdout)
-    if not nodes:
-        return []
-    search = (req.get("brev_search") or req.get("gpu_type") or "").lower()
-    suggestions = []
-    for n in nodes:
-        name = n.get("name") or ""
-        status = n.get("status") or "?"
-        # Node entries don't include GPU specs; fall back to name matching.
-        # If search term appears in node name, it's a likely fit.
-        if search and search in name.lower():
-            suggestions.append(f"{name}  (status={status})  [name matches '{search}']")
-    # Also include all connected nodes as fallback suggestions.
-    if not suggestions:
-        for n in nodes:
-            if n.get("status") == "Connected":
-                suggestions.append(
-                    f"{n.get('name')}  (status=Connected)  "
-                    f"[GPU unknown — verify manually]"
-                )
-    return suggestions
-
-
-async def _wait_for_running(
-    name: str,
-    timeout_sec: int = 2400,
-    poll_interval: int = 15,
-) -> None:
-    """Poll `brev ls` until the named instance reaches RUNNING + shell READY."""
-    elapsed = 0
-    while elapsed < timeout_sec:
-        inst = await _find_brev_instance(name)
-        if inst:
-            status = inst.get("status")
-            shell = inst.get("shell_status")
-            if status == "FAILURE":
-                raise RuntimeError(f"Brev instance {name} creation FAILED")
-            if status == "RUNNING" and shell == "READY":
-                return
-            logger.info(
-                "Waiting for %s (status=%s shell=%s, %ds/%ds)",
-                name, status, shell, elapsed, timeout_sec,
-            )
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
-    raise TimeoutError(
-        f"Brev instance {name} did not become ready within {timeout_sec}s"
-    )

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -2,23 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 """Harbor environment provider for Brev GPU instances.
 
-Two modes:
-
-1. **Reuse an existing instance** (BREV_INSTANCE env var):
-   Validate the instance's GPU meets the task's requirements
-   (gpu_type, gpu_count, min_vram_gb_per_gpu from task.toml [metadata])
-   and fail early if not.
-
-2. **Auto-provision** (no BREV_INSTANCE):
-   Query `brev search --json` for a matching instance type, create
-   one, wait for ready.  The instance is stopped (not deleted) on
-   trial completion so subsequent trials can reuse it.
+Connects to a pre-existing operator-managed `vss-eval-*` pool member
+resolved via the `BREV_INSTANCE` env var (or `brev_instance` in
+task.toml [metadata]). Validates that the resolved instance is
+reachable and that its GPU meets the task's requirements; raises if
+no instance is resolved. The harness does NOT auto-provision — see
+AGENTS.md § 5a for the fleet-selection algorithm the skill-eval
+agent uses to pick a pool member.
 
 Task.toml [metadata] fields consumed:
     gpu_type              — e.g. "L40S", "H100", "RTX PRO 6000"
     gpu_count             — 1 or 2
     min_vram_gb_per_gpu   — e.g. 48, 80
-    brev_search           — (optional) substring override for brev search
+    min_root_disk_gb      — root-disk floor enforced post-resolve
+    min_gpu_driver_version — driver floor enforced post-resolve
     brev_instance         — (optional) explicit instance name override
 """
 
@@ -125,7 +122,6 @@ class BrevEnvironment(BaseEnvironment):
             "gpu_type": meta.get("gpu_type"),
             "gpu_count": int(meta.get("gpu_count", 1)),
             "min_vram_gb_per_gpu": int(meta.get("min_vram_gb_per_gpu", 0)),
-            "brev_search": meta.get("brev_search") or meta.get("gpu_type"),
             "min_root_disk_gb": int(meta.get("min_root_disk_gb", 0)),
             "min_gpu_driver_version": meta.get("min_gpu_driver_version"),
         }

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -245,6 +245,13 @@ class BrevEnvironment(BaseEnvironment):
             # the renamed release/3.2.0 container names while the eval
             # deployed feat/skills's old names).
             "PR_HEAD_SHA", "PR_REPO",
+            # Tag the active-deploy marker with the run id so the next
+            # run's `_ensure_prerequisite_deployed` always reconciles
+            # against a prior run's leftover state, regardless of how
+            # the prior run ended. Consumed by the vss-deploy-profile
+            # adapter's test.sh when it writes the marker on
+            # reward=1.0.
+            "GITHUB_RUN_ID",
         ):
             val = os.environ.get(key)
             if val:
@@ -298,43 +305,57 @@ class BrevEnvironment(BaseEnvironment):
     async def _ensure_prerequisite_deployed(self, meta: dict) -> None:
         """Reconcile the Brev box's deployment state with what this
         trial's task.toml [metadata] declares. Reads a single canonical
-        marker that records what is currently RUNNING on the box — not
-        a deploy log. See specs/stale-marker.spec.
+        marker that records what is currently RUNNING on the box AND
+        which CI run owns it — not a deploy log. See
+        specs/stale-marker.spec.
+
+        Marker format is `<profile_tag>|<run_id>`:
+          - `<profile_tag>` is `<profile>` or `<profile>-<deploy_mode>`
+            (only alerts splits this way: `alerts-verification`,
+            `alerts-real-time`).
+          - `<run_id>` is `$GITHUB_RUN_ID` (or `local-<pid>` outside CI).
+
+        Tagging the marker with the run id makes "fresh between runs"
+        a pull-side reconcile rather than a push-side cleanup: a
+        marker from a prior run NEVER matches the current run's
+        desired marker, so the next worker always reconciles
+        (tear-down + redeploy from its own `PR_HEAD_SHA`) regardless
+        of how the prior run ended — happy path, cancel-in-progress,
+        max-turns, SIGKILL, host reboot. Within a single run, multiple
+        trials with the same profile still hot-skip because both
+        profile and run id match.
 
         Three regimes, derived from `profile` + `prerequisite_deploy_mode`:
 
         1. `profile` set (downstream needs a deployed VSS stack):
-            desired = `<profile>` (e.g. `base`, `lvs`, `search`),
-                  or `<profile>-<deploy_mode>` for alerts variants
-                  (`alerts-verification`, `alerts-real-time`).
-            If marker == desired → hot, no-op.
-            Else → run `/vss-deploy-profile -p <profile> [-m <mode>]` via
-                  `claude --print`. On success OVERWRITE marker.
+            desired = `<profile_tag>|<run_id>`.
+            If marker == desired → hot, no-op (same profile, same run).
+            Else → run `/vss-deploy-profile -p <profile> [-m <mode>]`
+                  via `claude --print`. On success OVERWRITE marker
+                  with the new `<profile_tag>|<run_id>`.
 
         2. `profile` absent (trial needs a clean box, no VSS running):
             desired = `""` (empty marker).
             Always tear down all containers (`docker rm -f $(docker
-                  ps -aq)`) + prune networks; OVERWRITE marker to empty.
-                  An empty marker does not prove a prior standalone
-                  profile-less trial cleaned up every container it started.
-                  Preserves anything `docker rm -f` doesn't touch:
-                  docker image cache, named volumes (postgres / ES /
-                  kafka data), repo clone, and sample-data extract —
-                  the slow caches that make warm reuse valuable for
-                  the next deploy trial. Cleanup failures fail loud:
-                  if either docker command exits non-zero the marker
-                  is NOT overwritten, so the next trial re-attempts
-                  the reconcile instead of running against a
-                  partially-dirty box that pretends to be clean.
+                  ps -aq)`) + prune networks + prune volumes;
+                  OVERWRITE marker to empty. An empty marker does not
+                  prove a prior standalone profile-less trial cleaned
+                  up every container it started. Preserves anything
+                  `docker rm -f` doesn't touch: docker image cache,
+                  repo clone, and sample-data extract — the slow
+                  caches that make warm reuse valuable for the next
+                  deploy trial. Cleanup failures fail loud: if any
+                  docker command exits non-zero the marker is NOT
+                  overwritten, so the next trial re-attempts the
+                  reconcile instead of running against a partially-
+                  dirty box that pretends to be clean.
 
         vss-deploy-profile/* trials don't set `profile` in their task.toml
         [metadata], so they fall into the `desired=""` box-clean branch
         above — wipes containers/networks/volumes and clears the marker
         before the trial deploys from scratch. Their test.sh writes the
-        marker on reward=1.0 for downstream warm-reuse. (Earlier the
-        adapter emitted `profile = "<X>"` here, which mistakenly fired
-        the prereq reconcile below before the trial — see commit
-        history on `adapters/vss-deploy-profile/generate.py`.)
+        marker (tagged with the trial's `$GITHUB_RUN_ID`) on reward=1.0
+        for downstream warm-reuse within the same run.
 
         claude-code is expected on the box from a prior vss-deploy-profile/* trial's
         harbor agent setup; persists across trials on the reused
@@ -343,11 +364,14 @@ class BrevEnvironment(BaseEnvironment):
         profile = meta.get("profile")
         deploy_mode = meta.get("prerequisite_deploy_mode")
         if profile and deploy_mode:
-            desired = f"{profile}-{deploy_mode}"
+            profile_tag = f"{profile}-{deploy_mode}"
         elif profile:
-            desired = profile
+            profile_tag = profile
         else:
-            desired = ""
+            profile_tag = ""
+
+        run_id = os.environ.get("GITHUB_RUN_ID") or f"local-{os.getpid()}"
+        desired = f"{profile_tag}|{run_id}" if profile_tag else ""
 
         marker_path = "/tmp/skill-eval/active-deploy.txt"
         probe = await _run_brev_exec(
@@ -357,10 +381,9 @@ class BrevEnvironment(BaseEnvironment):
         )
         current = (probe.stdout or "").strip()
         if current == desired and desired:
-            state = desired or "<clean>"
             logger.info(
-                "prerequisite %s already current on %s; skipping reconcile",
-                state, self._instance_name,
+                "prerequisite %s already current on %s (run %s); skipping reconcile",
+                profile_tag, self._instance_name, run_id,
             )
             return
         logger.info(

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -47,7 +47,9 @@ Exit codes:
 from __future__ import annotations
 
 import asyncio
+import atexit
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -310,8 +312,124 @@ line starting with `BLOCKED:` followed by the reason.
 
 
 # ---------------------------------------------------------------------------
-# Cleanup
+# Failsafe deployment-state reset
 # ---------------------------------------------------------------------------
+#
+# AGENTS.md § 7 commits the agent to reset deployment state on every box it
+# locked before releasing the flock. That covers the happy-path exit, but
+# several CI paths bypass § 7 entirely: max-turns exit (rc=3 before the
+# step runs), agent crash, cancel-in-progress SIGTERM from GitHub when a
+# fresh push lands on the same `concurrency.group`, KeyboardInterrupt
+# (^C in local dev). The kernel releases the flock automatically on
+# process death — but the docker containers / named volumes / marker
+# don't, so the next worker grabs a free lock on a contaminated box.
+#
+# The agent appends each `vss-eval-*` instance it locks (per AGENTS.md
+# § 5b) to a touched-boxes ledger; this module reads the ledger and
+# runs the same § 7 reset command from `atexit` and a SIGTERM/SIGINT
+# handler. Idempotent vs. agent-side cleanup: both run the same
+# `xargs -r docker rm -f && … && rm -f marker` chain, post-reset is a
+# no-op. NOT caught: SIGKILL (the 8h workflow timeout-minutes terminator);
+# that needs an operator-side periodic sweep, out of scope here.
+
+
+def _touched_boxes_path() -> Path:
+    run_id = os.environ.get("GITHUB_RUN_ID") or f"local-{int(time.time())}"
+    return Path(f"/tmp/skill-eval/touched-boxes-{run_id}.txt")
+
+
+# Mirrors AGENTS.md § 7's reset chain verbatim. `xargs -r` makes the
+# "no containers" case a no-op; `&&` chaining ensures the marker is
+# only wiped if every prune step succeeded — so a partial cleanup
+# failure leaves the box flagged for operator attention instead of
+# handing it to the next worker with a lying marker.
+_RESET_CMD = (
+    "docker ps -aq | xargs -r docker rm -f >/dev/null && "
+    "docker network prune -f >/dev/null && "
+    "docker volume prune -af >/dev/null && "
+    "rm -f /tmp/skill-eval/active-deploy.txt"
+)
+
+
+_failsafe_already_ran = False
+
+
+def _failsafe_reset_touched_boxes() -> None:
+    """Read the touched-boxes ledger and run § 7 reset on each box.
+
+    Best-effort and idempotent: per-box failures are logged and the loop
+    continues (a single stuck box must not block cleanup of the others),
+    and the reset command is itself safe to repeat. Re-entry-guarded so
+    atexit + signal-handler firing both is harmless."""
+    global _failsafe_already_ran
+    if _failsafe_already_ran:
+        return
+    _failsafe_already_ran = True
+
+    ledger = _touched_boxes_path()
+    if not ledger.exists():
+        return
+    try:
+        raw = ledger.read_text()
+    except OSError as exc:
+        print(f"[failsafe] cannot read {ledger}: {exc}", file=sys.stderr)
+        return
+
+    boxes = sorted({
+        line.strip() for line in raw.splitlines()
+        if line.strip().startswith("vss-eval-")
+    })
+    if not boxes:
+        return
+
+    print(
+        f"[failsafe] resetting deployment state on {len(boxes)} box(es): "
+        f"{', '.join(boxes)}",
+        file=sys.stderr,
+    )
+    for box in boxes:
+        try:
+            result = subprocess.run(
+                ["brev", "exec", box, "--", _RESET_CMD],
+                timeout=180, capture_output=True, text=True,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"[failsafe] {box}: brev exec timed out after 180s",
+                  file=sys.stderr)
+            continue
+        except OSError as exc:
+            print(f"[failsafe] {box}: brev exec failed to start: {exc}",
+                  file=sys.stderr)
+            continue
+        if result.returncode != 0:
+            stderr_tail = (result.stderr or "")[-300:]
+            print(f"[failsafe] {box}: reset returned rc={result.returncode}; "
+                  f"stderr tail: {stderr_tail!r}", file=sys.stderr)
+        else:
+            print(f"[failsafe] {box}: reset OK", file=sys.stderr)
+
+
+def _install_failsafe() -> None:
+    """Wire `_failsafe_reset_touched_boxes` into `atexit` + SIGTERM +
+    SIGINT. `atexit` catches normal exits and uncaught exceptions;
+    SIGTERM catches GitHub's `concurrency.cancel-in-progress`; SIGINT
+    catches local ^C. SIGKILL (workflow `timeout-minutes` hit) is
+    unreachable from Python and is not covered."""
+    atexit.register(_failsafe_reset_touched_boxes)
+
+    def _handle(signum: int, _frame: object) -> None:
+        # Run cleanup synchronously, then restore the default disposition
+        # and re-raise so the runner records the cancellation with the
+        # correct exit code (128 + signum). Calling `sys.exit()` here
+        # would shadow the signal and make GitHub Actions log the job as
+        # a normal failure instead of a cancellation.
+        _failsafe_reset_touched_boxes()
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
+
 
 # ---------------------------------------------------------------------------
 # Main
@@ -320,6 +438,7 @@ line starting with `BLOCKED:` followed by the reason.
 def main() -> int:
     _disable_server_thinking()
     _ensure_sdk()
+    _install_failsafe()
     try:
         rc = asyncio.run(run_agent())
     except KeyboardInterrupt:

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -47,9 +47,7 @@ Exit codes:
 from __future__ import annotations
 
 import asyncio
-import atexit
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -312,133 +310,22 @@ line starting with `BLOCKED:` followed by the reason.
 
 
 # ---------------------------------------------------------------------------
-# Failsafe deployment-state reset
-# ---------------------------------------------------------------------------
-#
-# AGENTS.md § 7 commits the agent to reset deployment state on every box it
-# locked before releasing the flock. That covers the happy-path exit, but
-# several CI paths bypass § 7 entirely: max-turns exit (rc=3 before the
-# step runs), agent crash, cancel-in-progress SIGTERM from GitHub when a
-# fresh push lands on the same `concurrency.group`, KeyboardInterrupt
-# (^C in local dev). The kernel releases the flock automatically on
-# process death — but the docker containers / named volumes / marker
-# don't, so the next worker grabs a free lock on a contaminated box.
-#
-# The agent appends each `vss-eval-*` instance it locks (per AGENTS.md
-# § 5b) to a touched-boxes ledger; this module reads the ledger and
-# runs the same § 7 reset command from `atexit` and a SIGTERM/SIGINT
-# handler. Idempotent vs. agent-side cleanup: both run the same
-# `xargs -r docker rm -f && … && rm -f marker` chain, post-reset is a
-# no-op. NOT caught: SIGKILL (the 8h workflow timeout-minutes terminator);
-# that needs an operator-side periodic sweep, out of scope here.
-
-
-def _touched_boxes_path() -> Path:
-    run_id = os.environ.get("GITHUB_RUN_ID") or f"local-{int(time.time())}"
-    return Path(f"/tmp/skill-eval/touched-boxes-{run_id}.txt")
-
-
-# Mirrors AGENTS.md § 7's reset chain verbatim. `xargs -r` makes the
-# "no containers" case a no-op; `&&` chaining ensures the marker is
-# only wiped if every prune step succeeded — so a partial cleanup
-# failure leaves the box flagged for operator attention instead of
-# handing it to the next worker with a lying marker.
-_RESET_CMD = (
-    "docker ps -aq | xargs -r docker rm -f >/dev/null && "
-    "docker network prune -f >/dev/null && "
-    "docker volume prune -af >/dev/null && "
-    "rm -f /tmp/skill-eval/active-deploy.txt"
-)
-
-
-_failsafe_already_ran = False
-
-
-def _failsafe_reset_touched_boxes() -> None:
-    """Read the touched-boxes ledger and run § 7 reset on each box.
-
-    Best-effort and idempotent: per-box failures are logged and the loop
-    continues (a single stuck box must not block cleanup of the others),
-    and the reset command is itself safe to repeat. Re-entry-guarded so
-    atexit + signal-handler firing both is harmless."""
-    global _failsafe_already_ran
-    if _failsafe_already_ran:
-        return
-    _failsafe_already_ran = True
-
-    ledger = _touched_boxes_path()
-    if not ledger.exists():
-        return
-    try:
-        raw = ledger.read_text()
-    except OSError as exc:
-        print(f"[failsafe] cannot read {ledger}: {exc}", file=sys.stderr)
-        return
-
-    boxes = sorted({
-        line.strip() for line in raw.splitlines()
-        if line.strip().startswith("vss-eval-")
-    })
-    if not boxes:
-        return
-
-    print(
-        f"[failsafe] resetting deployment state on {len(boxes)} box(es): "
-        f"{', '.join(boxes)}",
-        file=sys.stderr,
-    )
-    for box in boxes:
-        try:
-            result = subprocess.run(
-                ["brev", "exec", box, "--", _RESET_CMD],
-                timeout=180, capture_output=True, text=True,
-            )
-        except subprocess.TimeoutExpired:
-            print(f"[failsafe] {box}: brev exec timed out after 180s",
-                  file=sys.stderr)
-            continue
-        except OSError as exc:
-            print(f"[failsafe] {box}: brev exec failed to start: {exc}",
-                  file=sys.stderr)
-            continue
-        if result.returncode != 0:
-            stderr_tail = (result.stderr or "")[-300:]
-            print(f"[failsafe] {box}: reset returned rc={result.returncode}; "
-                  f"stderr tail: {stderr_tail!r}", file=sys.stderr)
-        else:
-            print(f"[failsafe] {box}: reset OK", file=sys.stderr)
-
-
-def _install_failsafe() -> None:
-    """Wire `_failsafe_reset_touched_boxes` into `atexit` + SIGTERM +
-    SIGINT. `atexit` catches normal exits and uncaught exceptions;
-    SIGTERM catches GitHub's `concurrency.cancel-in-progress`; SIGINT
-    catches local ^C. SIGKILL (workflow `timeout-minutes` hit) is
-    unreachable from Python and is not covered."""
-    atexit.register(_failsafe_reset_touched_boxes)
-
-    def _handle(signum: int, _frame: object) -> None:
-        # Run cleanup synchronously, then restore the default disposition
-        # and re-raise so the runner records the cancellation with the
-        # correct exit code (128 + signum). Calling `sys.exit()` here
-        # would shadow the signal and make GitHub Actions log the job as
-        # a normal failure instead of a cancellation.
-        _failsafe_reset_touched_boxes()
-        signal.signal(signum, signal.SIG_DFL)
-        os.kill(os.getpid(), signum)
-
-    signal.signal(signal.SIGTERM, _handle)
-    signal.signal(signal.SIGINT, _handle)
-
-
-# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+#
+# No process-side cleanup here by design — the box's deployment state is
+# reset on the NEXT run's lock acquisition, not on this run's exit. See
+# `envs/brev_env.py::_ensure_prerequisite_deployed`: the active-deploy
+# marker carries `<profile_tag>|<run_id>`, and a run id mismatch always
+# triggers tear-down + redeploy. That makes every exit path equivalent
+# from the next run's perspective — happy path, max-turns, cancel-in-
+# progress SIGTERM, agent crash, SIGKILL, host reboot — so we don't need
+# atexit / signal handlers / a touched-boxes ledger to chase the cases
+# where end-of-run cleanup might be skipped.
 
 def main() -> int:
     _disable_server_thinking()
     _ensure_sdk()
-    _install_failsafe()
     try:
         rc = asyncio.run(run_agent())
     except KeyboardInterrupt:

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -222,9 +222,10 @@ The coordinator host is vss-skill-validator; Brev CLI is authenticated, Docker i
 
 Process this PR per AGENTS.md: diff → detect changed skills → update or create the
 adapter under `.github/skill-eval/adapters/<skill>/` → generate the dataset → acquire
-a Brev lock for the target platform(s) → run harbor trials → gather results →
-post ONE comment per (PR, spec) batch → release the lock → stop/delete any Brev
-instance you brought online.
+a per-box flock on a `vss-eval-*` pool member matching the target platform(s) →
+run harbor trials → gather results → post ONE comment per (PR, spec) batch →
+reset deployment state on each locked box per § 7 → release the flock. Never
+`brev stop` / `brev delete` any pool member — pool lifecycle is operator-managed.
 
 When done, emit a one-line final summary starting with `DONE:` so the workflow
 can grep for it. On blocker (missing_probe, env issue, nothing to eval), emit a

--- a/.github/skill-eval/specs/stale-marker.spec
+++ b/.github/skill-eval/specs/stale-marker.spec
@@ -44,24 +44,34 @@ concurrency rework — it stays serial.
 
 Replace the per-profile flag fan-out with **one canonical file per Brev
 instance** at `/tmp/skill-eval/active-deploy.txt`. Holds what is
-currently RUNNING on the box. Writes are **overwrite, never append**.
-Empty / missing means "nothing is up."
+currently RUNNING on the box AND which CI run owns it. Writes are
+**overwrite, never append**. Empty / missing means "nothing is up."
 
-Marker format:
-- `base`, `lvs`, `search` — profile name only. Placement (LLM/VLM
-  local vs remote) is decided at deploy time from the env the
-  `/vss-deploy-profile` skill sees; it is NOT part of the marker.
-- `alerts-verification`, `alerts-real-time` — alerts has two distinct
-  stacks (`/vss-deploy-profile -m verification` runs CV + VLM-verifier; `-m
-  real-time` runs continuous-VLM). Downstream trials that need a
-  specific variant cannot share a box running the other one, so the
-  alerts mode is part of the marker.
+Marker format: `<profile_tag>|<run_id>`.
+
+- `<profile_tag>`:
+  - `base`, `lvs`, `search` — profile name only. Placement (LLM/VLM
+    local vs remote) is decided at deploy time from the env the
+    `/vss-deploy-profile` skill sees; it is NOT part of the marker.
+  - `alerts-verification`, `alerts-real-time` — alerts has two distinct
+    stacks (`/vss-deploy-profile -m verification` runs CV + VLM-verifier; `-m
+    real-time` runs continuous-VLM). Downstream trials that need a
+    specific variant cannot share a box running the other one, so the
+    alerts mode is part of the profile tag.
+- `<run_id>`: `$GITHUB_RUN_ID` (or `local-<pid>` outside CI). Tagging
+  the marker with the owning run id is what makes between-run
+  isolation a pull-side reconcile: a marker from a prior run never
+  matches the current run's desired marker, so the next worker
+  always tears down + redeploys regardless of how the prior run
+  ended (happy path, cancel-in-progress, max-turns, SIGKILL, host
+  reboot). Within one run, multiple trials with the same profile
+  still hot-skip on a full match.
 
 Single owner: whoever last successfully ran `/vss-deploy-profile` on the box. Two
 write paths in practice — the harness pre-deploy hook (when called) and
 the vss-deploy-profile/* trial's `test.sh` (its scored task IS running /vss-deploy-profile) —
-both overwrite the same file with the same token. Equivalent semantics;
-pick one or both, just never `touch` per-flag.
+both overwrite the same file with the same `<profile_tag>|<run_id>` token.
+Equivalent semantics; pick one or both, just never `touch` per-flag.
 
 ### 2. Pre-deploy hook reconciles box state with task metadata
 

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -62,8 +62,13 @@ permissions:
   pull-requests: write
 
 # Only one eval runs per PR (or per manual sweep) at a time. A fresh push
-# cancels the in-flight run (lock on /tmp/brev/<id>.lock will be released
-# by the agent's trap).
+# cancels the in-flight run via SIGTERM; the Python harness's signal
+# handler in skills_eval_agent.py runs § 7 deployment-state reset on
+# every box recorded in /tmp/skill-eval/touched-boxes-<run_id>.txt
+# before re-raising the signal, so the next worker on those boxes
+# doesn't inherit stale containers / volumes / marker. The per-box
+# flock (/tmp/brev/<INSTANCE_NAME>.lock) is released by the kernel
+# when the agent process dies — no userspace trap needed for that.
 concurrency:
   group: skills-eval-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -62,13 +62,15 @@ permissions:
   pull-requests: write
 
 # Only one eval runs per PR (or per manual sweep) at a time. A fresh push
-# cancels the in-flight run via SIGTERM; the Python harness's signal
-# handler in skills_eval_agent.py runs § 7 deployment-state reset on
-# every box recorded in /tmp/skill-eval/touched-boxes-<run_id>.txt
-# before re-raising the signal, so the next worker on those boxes
-# doesn't inherit stale containers / volumes / marker. The per-box
-# flock (/tmp/brev/<INSTANCE_NAME>.lock) is released by the kernel
-# when the agent process dies — no userspace trap needed for that.
+# cancels the in-flight run; the per-box flocks (/tmp/brev/<INSTANCE_NAME>.lock)
+# release automatically when the agent process dies (POSIX flock(2) semantics —
+# no userspace trap needed). Any stale containers / volumes / marker that the
+# cancelled run left on a box are reconciled by the NEXT run's
+# `BrevEnvironment._ensure_prerequisite_deployed`: the active-deploy marker
+# carries `<profile_tag>|<run_id>`, so a marker from this run never matches
+# the next run's desired marker and the next run always tears down + redeploys.
+# Same path handles SIGKILL (the 8h timeout-minutes terminator) and host reboots
+# — there's no exit-side cleanup machinery to bypass.
 concurrency:
   group: skills-eval-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Reopen of #615 (closed; GitHub refused `reopen` because the branch was rebased on current develop). Same four commits, replayed on top of develop's current tip — verified no overlap with the meanwhile-merged #652 (`upload_dir()` refactor in `brev_env.py` — different region).

Two related cleanups to the `vss-eval-*` pool model. Independent file-wise (AGENTS.md + brev_env.py + adapter comment + README), bundled in one PR.

## Change 1 — Reset deployment state between CI runs

The per-box marker `/tmp/skill-eval/active-deploy.txt` was treated as per-pool-instance state, so a deploy from one PR persisted across runs and any later PR with the same profile hot-skipped redeploy — inheriting whatever stale image set the prior PR left running. `vss-eval-rtx-1g` was reporting VSS `3.0.0` from `/v1/metadata` while the agent expected `3.2.0`, breaking `vss-search-archive`.

Make the marker per-CI-run: at end-of-run (§ 7), before releasing each box's flock, wipe live containers, networks, named volumes, and the marker while preserving slow caches (image layers, repo clone, sample-data extract on the host fs). Next run sees an empty marker and redeploys from its own `PR_HEAD_SHA` against empty data stores. Warm reuse within a run is unchanged.

`AGENTS.md` updates:
- § 7 (lock release): now requires `docker rm -f $(docker ps -aq); docker network prune -f; docker volume prune -af; rm -f active-deploy.txt` on every locked box before flock release.
- Pool-lifecycle hard rule: explicitly permits `brev exec` for the § 7 cleanup.
- Marker file description, § 5c trial loop, canonical Harbor invocation comment, and fleet-selection paragraph: all aligned with the no-auto-provision reality (three stale "auto-provisions a fresh harbor-*" claims were rewritten as "raises at start()").

No code changes — `brev_env.py::_ensure_prerequisite_deployed` already handles empty/missing marker correctly.

## Change 2 — Remove `BrevEnvironment` auto-provisioning

`BrevEnvironment.start()`'s Mode 2 fallback would `brev create` a fresh `harbor-<uuid8>` whenever no `BREV_INSTANCE` was resolved. The pool was supposed to make this dead code, but:
- `uvx harbor` invoked outside the CI agent (or any code path forgetting to export `BREV_INSTANCE`) silently spun up paid GPUs.
- The wrapper-side cleanup that used to delete these on a 5-min cooldown was removed when the pool became long-running, so leaks were silent.

Three orphan `harbor-*` had accumulated (2× `g7e.2xlarge`, 1× `massedcompute_L40S` — ~\$9/hr combined). Deleted out-of-band before #615.

Make the absence of a resolved instance a hard error pointing at the pool. Drop the now-unreachable helpers: `_record_started_instance`, `_find_cheapest_matching_type`, `_suggest_registered_devices`, `_wait_for_running`. Also drop the stale "wrapper deletes them after 5-min cooldown" claim from `README.md`, and fix a dangling `_find_cheapest_matching_type` reference in `adapters/vss-deploy-profile/generate.py`.

Behaviour for trials with `BREV_INSTANCE` set (i.e. every CI run) is unchanged.

## Test plan

- [x] `vss-eval-rtx-1g` hard-reset out-of-band; first post-merge run on it starts cold.
- [ ] Re-run `vss-search-archive` skill-eval on a PR — confirm the trial does a full `/vss-deploy-profile -p lvs` against the PR's HEAD SHA and `/v1/metadata` returns `3.2.0`.
- [ ] Run two consecutive PRs that target the same platform back-to-back — confirm the second redeploys instead of hot-skipping.
- [ ] Run a multi-spec PR — confirm warm reuse is still in effect across the specs (only one deploy per box per run).
- [ ] Manually run `uvx harbor run` without `BREV_INSTANCE` — confirm it errors at startup with the new pointer message instead of `brev create`-ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)