### PR TITLE
backport(develop → dev/3.2.0): summarize+report skills, LVS-availability routing

### DIFF
--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -51,6 +51,8 @@ If the probe fails, hand off to `/vss-deploy-profile` with `-p base` (Mode A) or
 
 ## Mode A — Report on a recorded video clip
 
+**If the VSS `lvs` profile is deployed** — `curl -sf --max-time 5 "http://${HOST_IP}:38111/v1/ready"` returns HTTP 200 — run `/vss-summarize-video` to produce the summary, then paste its output into the report template in Step 4 and skip Steps 1–3 (the VLM-direct path). Run Steps 1–3 only when `/v1/ready` is non-200.
+
 ### Step 1 — Resolve the clip URL
 
 Hand off to `/vss-manage-video-io-storage` to:
@@ -239,4 +241,4 @@ If `get_incidents` returns zero results, return a one-line report stating the ra
 - **`/vss-manage-video-io-storage`** — sensor list, timelines, and clip URL for Mode A Step 1.
 - **`/vss-query-analytics`** — incident retrieval (and verdict / reasoning enrichment) for Mode B Step 2.
 - **`/vss-ask-video`** — ad-hoc VLM Q&A on a single clip (not a structured report).
-- **`/vss-summarize-video`** — long-video summary via LVS (different backend; use for hours-long footage).
+- **`/vss-summarize-video`** — used by Mode A to produce the summary body when the `lvs` profile is deployed; the report template (Step 4) is still filled here.

--- a/skills/vss-summarize-video/SKILL.md
+++ b/skills/vss-summarize-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vss-summarize-video
-description: Summarize a video by calling the VLM NIM or the Long Video Summarization (LVS) microservice directly. For short videos (under 60s) call the VLM's OpenAI-compatible chat completions endpoint; for long videos (60s or longer) call the LVS microservice. Use when asked to summarize a video, describe what happens in a video, analyze a recording, call or debug LVS summarize/model/health/recommended-config/metrics endpoints, or configure and troubleshoot the LVS service that backs long-video summarization.
+description: Summarize a video by calling the video summarization microservice when available, falling back to a direct VLM NIM call when not. The microservice path is mandatory whenever it is reachable and is always preceded by a HITL scenario/events confirmation; the VLM fallback uses a fixed default prompt with no HITL. Use when asked to summarize a video, describe what happens in a video, analyze a recording, call or debug video summarization summarize/model/health/recommended-config/metrics endpoints, or configure and troubleshoot the video summarization service and its Elasticsearch, Neo4j, or ArangoDB database backend.
 license: Apache-2.0
 metadata:
   version: "3.2.0"
@@ -8,91 +8,100 @@ metadata:
   tags: "nvidia blueprint operational"
 ---
 
-You are a video summarization assistant. You call the VLM NIM or the LVS
+You are a video summarization assistant. You call the VLM NIM or the video summarization
 microservice **directly**. Always run `curl` commands yourself; never instruct the user to run them.
 
-Primary video workflow query type: **"Summarize this video."** Direct LVS API
+Primary video workflow query type: **"Summarize this video."** Direct video summarization API
 and service-ops requests are handled by the reference-routed sections below.
 
 ## Reference Map
 
 Use these references only when the user asks for the relevant detail, or when
-the core workflow below needs deeper LVS information:
+the core workflow below needs deeper video summarization information:
 
-- **LVS API details**: [`references/lvs-api.md`](references/lvs-api.md) for
+- **video summarization API details**: [`references/video-summarization-api.md`](references/video-summarization-api.md) for
   `/v1/summarize`, `/summarize`, `/v1/generate_captions`,
   `/v1/stream_summarize`, health probes, `/models`, `/recommended_config`,
   `/metrics`, request fields, response shapes, and API gotchas.
-- **LVS service configuration and ops**:
-  [`references/deploy-lvs-service.md`](references/deploy-lvs-service.md) for
+- **video summarization service configuration and ops**:
+  [`references/video-summarization-deployment.md`](references/video-summarization-deployment.md) for
   the VSS `lvs` profile, ports, required env vars, logs, status, dry-runs,
-  teardown, model/backend swaps, and service-level troubleshooting.
-- **Extended LVS ops references**:
-  [`references/lvs-environment-variables.md`](references/lvs-environment-variables.md),
-  [`references/lvs-debugging.md`](references/lvs-debugging.md), and
-  [`references/lvs.env.example`](references/lvs.env.example).
+  teardown, model/backend swaps, Elasticsearch/Neo4j/ArangoDB backend
+  selection, and service-level troubleshooting.
+- **Extended video summarization ops references**:
+  [`references/video-summarization-environment-variables.md`](references/video-summarization-environment-variables.md),
+  [`references/video-summarization-debugging.md`](references/video-summarization-debugging.md), and
+  [`references/video-summarization.env.example`](references/video-summarization.env.example).
 
-Do not load these references for routine short-video VLM summaries. Load
-`lvs-api.md` for long-video LVS request details or direct LVS API requests.
-Load `deploy-lvs-service.md` only for deployment, configuration, or service
-operations.
+Load `video-summarization-api.md` only when you need a request field, response shape, or
+endpoint that is not already covered by the Step 2 LVS or fallback VLM
+example below, or when handling a direct video summarization API
+request. Load `video-summarization-deployment.md` only for deployment,
+configuration, or service operations.
 
-## LVS API And Service Ops Requests
+## Video Summarization API And Service Ops Requests
 
-If the user asks to call or debug LVS endpoints directly, answer from
-[`references/lvs-api.md`](references/lvs-api.md) instead of running the
-end-to-end video summarization workflow. Examples: list LVS models, check
+If the user asks to call or debug video summarization endpoints directly, answer from
+[`references/video-summarization-api.md`](references/video-summarization-api.md) instead of running the
+end-to-end video summarization workflow. Examples: list video summarization models, check
 readiness, get recommended chunking config, inspect metrics, explain a 422
 response, or build a `/v1/summarize` request body.
 
 If the user asks to configure, deploy, restart, tear down, or troubleshoot the
-LVS service, prefer the `vss-deploy-profile` skill for full VSS profile
-deployment and use [`references/deploy-lvs-service.md`](references/deploy-lvs-service.md)
-for LVS-specific service details.
+video summarization service, prefer the `vss-deploy-profile` skill for full VSS profile
+deployment and use [`references/video-summarization-deployment.md`](references/video-summarization-deployment.md)
+for video summarization-specific service details.
 
 ## Routing
 
-Decide purely from video duration (fetch the timeline via the `vss-manage-video-io-storage`
-skill, then do the math — see Step 1):
+Decide purely from video summarization service availability (probed in
+*Setup → Availability checks* below). **Duration does not drive routing.**
 
-| Video duration | Backend | Endpoint |
+| Video summarization service `/v1/ready` | Backend | Endpoint |
 |---|---|---|
-| `< 60s` (short) | **VLM / RT-VLM** (OpenAI-compatible) | `POST ${VLM_BASE_URL}/v1/chat/completions` |
-| `>= 60s` (long), LVS available | **LVS microservice** | `POST ${LVS_BACKEND_URL}/v1/summarize` |
-| `>= 60s`, LVS **not** reachable | **VLM / RT-VLM** + tell the user | `POST ${VLM_BASE_URL}/v1/chat/completions` |
+| HTTP 200 (reachable) | **video summarization microservice** with HITL scenario/events | `POST ${LVS_BACKEND_URL}/v1/summarize` |
+| Any other status (not reachable) | **VLM / RT-VLM** with the default prompt + fallback note | `POST ${VLM_BASE_URL}/v1/chat/completions` |
 
-Fallback message when LVS is unreachable for a long video (copy verbatim
-into the response, before the summary):
+The video summarization microservice is the primary backend for **all**
+videos, short or long, whenever it is reachable. The VLM is a
+lower-quality fallback for the case where the `lvs` profile is not
+deployed.
+
+Fallback message when the video summarization service is unreachable
+(copy verbatim into the response, before the summary):
 
 > ⚠️ **Note:** Input video `<name>` is `<N>`s long.
-> Long Video Summarization (LVS) is not deployed, so this summary was
-> produced by the VLM alone. Deploy the `lvs` profile for higher-quality
-> long-video summaries.
+> The video summarization service is not deployed, so this summary was
+> produced by the VLM alone with a generic default prompt. Deploy the
+> `lvs` profile for higher-quality summaries with scenario/events
+> targeting.
 
 ## Deployment prerequisite
 
 This skill requires the VSS **lvs** profile running on the host at `$HOST_IP`. Before any request:
 
-1. Probe the LVS microservice:
+1. Probe the video summarization microservice:
    ```bash
-   LVS=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
-   curl -sf --max-time 5 "$LVS/v1/ready" >/dev/null
+   VIDEO_SUMMARIZATION_URL=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
+   curl -sf --max-time 5 "$VIDEO_SUMMARIZATION_URL/v1/ready" >/dev/null
    ```
-   (Port 38111 is LVS. HTTP 200 → ready; 503 → still warming, retry in a moment.)
+   (Port 38111 is the video summarization service. HTTP 200 → ready; 503 → still warming, retry in a moment.)
 
 2. **If the probe fails**, ask the user:
-   > *"The VSS `lvs` profile isn't running on `$HOST_IP`. Shall I deploy it now using the `/vss-deploy-profile` skill with `-p lvs`?"*
+   > *"The VSS `lvs` profile isn't running on `$HOST_IP`. Shall I deploy it now using the `/vss-deploy-profile` skill with `-p lvs`? Reply `no` to summarize with the VLM-only fallback instead (lower quality, no scenario/events targeting)."*
 
    - If yes → hand off to the `/vss-deploy-profile` skill. Return here once it succeeds.
-   - If no → stop. Long-video summarization without LVS falls back to VLM-only, which is a different (lower-quality) path — confirm with the user before substituting.
+   - If no → proceed directly to **Step 2 fallback (VLM with default prompt)**. Do not ask again, and do not run scenario/events HITL — the user already chose the fallback. Prepend the Routing fallback note to the response so they see what they got.
 
    (If your caller has granted explicit pre-authorization to deploy
    autonomously — e.g. the request says "pre-authorized to deploy
    prerequisites", or you are running in a non-interactive evaluation
    harness with that permission — skip the confirmation and invoke
-   `/vss-deploy-profile` directly.)
+   `/vss-deploy-profile` directly. If the caller has explicitly
+   pre-authorized the VLM fallback instead — e.g. "skip lvs, just use
+   the VLM" — go straight to Step 2 fallback without prompting.)
 
-3. If the probe passes, proceed.
+3. If the probe passes, proceed to **Step 2 (LVS + HITL)**.
 
 ---
 
@@ -102,7 +111,7 @@ This skill requires the VSS **lvs** profile running on the host at `$HOST_IP`. B
 
 - VLM / RT-VLM: `${VLM_BASE_URL}` — default
   `${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}` for the `lvs` profile
-- LVS MS: `${LVS_BACKEND_URL}` — default `http://${HOST_IP:-localhost}:38111`
+- Video summarization service: `${LVS_BACKEND_URL}` — default `http://${HOST_IP:-localhost}:38111`
 - VIOS: owned by the `vss-manage-video-io-storage` skill; refer there.
 
 **Endpoint resolution order:**
@@ -119,13 +128,13 @@ This skill requires the VSS **lvs** profile running on the host at `$HOST_IP`. B
 by RT-VLM's `/v1/models`. Do not substitute the friendly model name
 `nvidia/cosmos-reason2-8b` unless the endpoint actually advertises that id.
 
-For full LVS endpoint schemas, optional request fields, response envelopes, and
-error handling, read [`references/lvs-api.md`](references/lvs-api.md).
+For full video summarization endpoint schemas, optional request fields, response envelopes, and
+error handling, read [`references/video-summarization-api.md`](references/video-summarization-api.md).
 
 **Availability checks** (run both before routing):
 
 **Readiness is determined by the HTTP status code only.** Do not parse
-or inspect the response body — LVS's `/v1/ready` can legitimately return
+or inspect the response body — the video summarization service's `/v1/ready` can legitimately return
 `200` with an empty body. Do not treat empty stdout from `curl` as
 "unavailable."
 
@@ -138,30 +147,32 @@ vlm_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 \
   "$VLM/v1/models")
 [ "$vlm_code" = "200" ] && echo "VLM OK" || echo "VLM not reachable (HTTP $vlm_code)"
 
-# LVS: 200 on /v1/ready, with retry on 503 (warmup) for up to ~30s
-LVS=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
-lvs_code=000
+# Video summarization service: 200 on /v1/ready, with retry on 503 (warmup) for up to ~30s
+VIDEO_SUMMARIZATION_URL=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
+video_sum_code=000
 for i in $(seq 1 10); do
-  lvs_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 "$LVS/v1/ready")
-  case "$lvs_code" in
-    200) echo "LVS OK"; break ;;
+  video_sum_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 "$VIDEO_SUMMARIZATION_URL/v1/ready")
+  case "$video_sum_code" in
+    200) echo "video summarization OK"; break ;;
     503) sleep 3 ;;                 # warming up; keep polling
     *)   break ;;                   # any other code = not reachable, stop retrying
   esac
 done
-[ "$lvs_code" = "200" ] || echo "LVS not reachable (HTTP $lvs_code)"
+[ "$video_sum_code" = "200" ] || echo "video summarization service not reachable (HTTP $video_sum_code)"
 ```
 
 **How to interpret the results:**
 
-- `vlm_code = 200` and `lvs_code = 200` → normal routing (Step 2a for
-  `<60s`, Step 2b for `>=60s`).
-- `vlm_code != 200` → fail; summarization cannot run without the VLM.
-- `vlm_code = 200`, `lvs_code != 200` → LVS is truly unavailable; use
-  the VLM fallback path described above for long videos.
-- A non-200 LVS code after the retry loop is the ONLY signal that LVS
-  is unavailable. Empty stdout, missing JSON fields, or a "weird"
-  response body are NOT "unavailable."
+- `video_sum_code = 200` → primary path: **Step 2 (LVS with HITL)** for
+  every video, regardless of duration.
+- `video_sum_code != 200`, `vlm_code = 200` → the video summarization
+  service is truly unavailable; use **Step 2 fallback (VLM with default
+  prompt)** below and prepend the fallback note to the response.
+- `vlm_code != 200` → fail; summarization cannot run without at least
+  one backend reachable.
+- A non-200 video summarization service code after the retry loop is
+  the ONLY signal that the service is unavailable. Empty stdout,
+  missing JSON fields, or a "weird" response body are NOT "unavailable."
 
 ---
 
@@ -182,10 +193,12 @@ From `vss-manage-video-io-storage`, collect exactly three values:
 1. **`streamId`** for the video (via `sensor/list` -> `sensor/<id>/streams`,
    or directly from an upload response).
 2. **Timeline** - `{startTime, endTime}` for the stream, ISO 8601 UTC.
-   `endTime - startTime` is the duration that drives the routing decision
-   below. Always compute; never assume.
+   `endTime - startTime` is the duration. It is not used to pick a
+   backend — that decision is made from the video summarization
+   service's readiness probe — but you still need it for the
+   user-facing header (`Ns` or `Mm Ss`).
 3. **Temporary MP4 clip URL** - the `/storage/file/<streamId>/url` variant
-   with `container=mp4`. The VLM and LVS both need an HTTP(S) URL they can
+   with `container=mp4`. The VLM and video summarization service both need an HTTP(S) URL they can
    `GET`; the `/url` variant is preferred over streaming bytes through the
    summarization client. Response field: `.videoUrl`.
 
@@ -193,69 +206,23 @@ Everything else (auth, error handling, upload, `disableAudio`, expiry, etc.)
 is covered in the `vss-manage-video-io-storage` skill - refer users there if the VIOS step
 fails.
 
-**Once you have these three values, proceed immediately to Step 2a (`<60s`)
-or Step 2b (`>=60s`) below. The deliverable is the rendered summary from
-Step 2, not the clip URL from Step 1.**
+**Once you have these three values, proceed immediately to Step 2 below.
+The deliverable is the rendered summary from Step 2, not the clip URL
+from Step 1.**
 
 ---
 
-## Step 2a — Short video (< 60s) → VLM direct
+## Step 2 — Primary: video summarization microservice with HITL
 
-### HITL: confirm the VLM prompt first (REQUIRED — do not skip)
+Use this path **whenever** the video summarization service `/v1/ready` returned 200 in Setup. Duration is irrelevant — the service handles short and long videos alike.
 
-Full prompt-confirmation walk-through (questions to ask the user, examples, refusal handling) lives in [`references/hitl-prompts.md`](references/hitl-prompts.md). Always run this step before calling the VLM.
-### Call the VLM
-
-Once the user confirms a prompt, send it as the `text` part of the VLM
-message. OpenAI-compatible chat completions with the video URL embedded in
-the message content:
-
-```bash
-VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
-VLM="${VLM%/v1}"
-PROMPT='<confirmed_prompt_from_hitl>'
-
-curl -s -X POST "$VLM/v1/chat/completions" \
-  -H "Content-Type: application/json" \
-  -d "$(jq -n \
-        --arg model "${VLM_NAME:-nim_nvidia_cosmos-reason2-8b_hf-1208}" \
-        --arg text "$PROMPT" \
-        --arg url "<clip_url_from_vss_manage_video_io_storage>" \
-        '{
-          model: $model,
-          temperature: 0.0,
-          max_tokens: 1024,
-          messages: [{
-            role: "user",
-            content: [
-              {type: "text", text: $text},
-              {type: "video_url", video_url: {url: $url}}
-            ]
-          }]
-        }')" | jq -r '.choices[0].message.content'
-```
-
-**Response:** standard OpenAI chat-completion envelope. The summary is in
-`choices[0].message.content`.
-
-**Cosmos-model notes:** Cosmos Reason 2 supports reasoning via
-`<think>...</think><answer>...</answer>` blocks. Omit the reasoning
-instructions if you want a plain summary. Frame sampling and pixel limits
-are applied server-side; no client-side prep is required when you pass a
-`video_url`.
-
----
-
-## Step 2b — Long video (>= 60s) → LVS microservice direct
-
-This section contains the narrow long-video summarization path. For advanced
-LVS fields such as `media_info`, `schema`, structured output, stream
+For advanced video summarization fields such as `media_info`, `schema`, structured output, stream
 captioning, metrics, or recommended config, read
-[`references/lvs-api.md`](references/lvs-api.md).
+[`references/video-summarization-api.md`](references/video-summarization-api.md).
 
 ### HITL: collect scenario and events first (REQUIRED — do not skip)
 
-Full scenario/events collection walk-through lives in [`references/hitl-prompts.md`](references/hitl-prompts.md). Always run this step before calling LVS.
+Full scenario/events collection walk-through lives in [`references/hitl-prompts.md`](references/hitl-prompts.md). Always run this step before calling the video summarization service.
 
 **Autonomous-mode defaults.** When HITL is bypassed (caller said "run
 autonomously without prompting for confirmation") and the original
@@ -267,19 +234,22 @@ defaults and offer to redo with more specific parameters. See
 [`references/hitl-prompts.md`](references/hitl-prompts.md) for the
 canonical defaults rule.
 
+This is the ONLY supported reason to skip HITL. "The video is short" or
+"the user seems in a hurry" are not valid reasons.
+
 Prefer the 3.2 GA versioned route `POST /v1/summarize`. The OpenAPI spec also
 exposes `/summarize` as a compatibility alias, but new examples should use
 `/v1/summarize`.
 
 ```bash
-LVS=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
+VIDEO_SUMMARIZATION_URL=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
 
 # From HITL reply:
 SCENARIO='warehouse monitoring'
 EVENTS_JSON='["notable activity"]'
 OBJECTS_JSON=''  # '' to omit, else '["forklifts","pallets","workers"]'
 
-curl -s -X POST "$LVS/v1/summarize" \
+curl -s -X POST "$VIDEO_SUMMARIZATION_URL/v1/summarize" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg url "<clip_url_from_vss_manage_video_io_storage>" \
         --arg model "${VLM_NAME:-nim_nvidia_cosmos-reason2-8b_hf-1208}" \
@@ -316,18 +286,13 @@ broader `scenario` rather than reporting "no content."
 
 ---
 
-## End-to-end examples
+## Step 2 fallback — VLM direct with default prompt
 
-Assume the `vss-manage-video-io-storage` skill has already given you `$CLIP` (clip URL) and
-`$DURATION` (seconds) for the target video — those two values are the
-contract from Step 1.
-
-### Short video (`$DURATION < 60`)
-
-**HITL (required, before the curl):** post the Step 2a message, wait for
-`Submit` (or a `/generate` / `/refine` round-trip that ends in `Submit`),
-then set `PROMPT` to the confirmed text. Do not run the curl below until
-that confirmation has arrived.
+Use this path **only** when Setup's `/v1/ready` probe did not return 200
+after the warmup retries. Do NOT run HITL on this path — the user did
+not opt into the lower-quality VLM-only summary, you fell back to it
+because the service was missing. Prepend the fallback note from the
+Routing section to the response so the user knows.
 
 ```bash
 VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
@@ -343,43 +308,65 @@ EXAMPLE:
 
 curl -s -X POST "$VLM/v1/chat/completions" \
   -H "Content-Type: application/json" \
-  -d "$(jq -n --arg url "$CLIP" --arg text "$PROMPT" \
-        --arg model "${VLM_NAME:-nim_nvidia_cosmos-reason2-8b_hf-1208}" '{
-    model: $model,
-    temperature: 0.0,
-    max_tokens: 1024,
-    messages: [{role:"user", content:[
-      {type:"text", text:$text},
-      {type:"video_url", video_url:{url:$url}}
-    ]}]
-  }')" | jq -r '.choices[0].message.content'
+  -d "$(jq -n \
+        --arg model "${VLM_NAME:-nim_nvidia_cosmos-reason2-8b_hf-1208}" \
+        --arg text "$PROMPT" \
+        --arg url "<clip_url_from_vss_manage_video_io_storage>" \
+        '{
+          model: $model,
+          temperature: 0.0,
+          max_tokens: 1024,
+          messages: [{
+            role: "user",
+            content: [
+              {type: "text", text: $text},
+              {type: "video_url", video_url: {url: $url}}
+            ]
+          }]
+        }')" | jq -r '.choices[0].message.content'
 ```
 
-### Long video (`$DURATION >= 60`)
+**Response:** standard OpenAI chat-completion envelope. The summary is in
+`choices[0].message.content`.
 
-**HITL (required, before the curl):** post the Step 2b message and wait
-for the user's reply. Substitute their values (or the `defaults` opt-in)
-into `$SCENARIO`, `$EVENTS_JSON`, and `$OBJECTS_JSON` below. Do not run
-the curl without that reply.
+**Cosmos-model notes:** Cosmos Reason 2 supports reasoning via
+`<think>...</think><answer>...</answer>` blocks. Omit the reasoning
+instructions if you want a plain summary. Frame sampling and pixel limits
+are applied server-side; no client-side prep is required when you pass a
+`video_url`.
+
+---
+
+## End-to-end example
+
+Assume the `vss-manage-video-io-storage` skill has already given you
+`$CLIP` (clip URL) and `$DURATION` (seconds, for the user-facing
+header). The flow probes the video summarization service once, runs
+HITL + LVS when it is up, and falls back to the VLM with the default
+prompt only when it is not.
 
 ```bash
-LVS=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
-
-# From HITL reply:
-SCENARIO='warehouse monitoring'            # or whatever the user gave
-EVENTS_JSON='["notable activity"]'         # jq-compatible JSON array
-OBJECTS_JSON=''                            # '' to omit, else '["cars","trucks"]'
+VIDEO_SUMMARIZATION_URL=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
 
 # Readiness = HTTP 200 on /v1/ready. Body may be empty — do not inspect it.
-# Retry on 503 (warmup) for up to ~30s before concluding LVS is unavailable.
-lvs_code=000
+# Retry on 503 (warmup) for up to ~30s before concluding the service is unavailable.
+video_sum_code=000
 for i in $(seq 1 10); do
-  lvs_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 "$LVS/v1/ready")
-  case "$lvs_code" in 200) break ;; 503) sleep 3 ;; *) break ;; esac
+  video_sum_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 "$VIDEO_SUMMARIZATION_URL/v1/ready")
+  case "$video_sum_code" in 200) break ;; 503) sleep 3 ;; *) break ;; esac
 done
 
-if [ "$lvs_code" = "200" ]; then
-  curl -s -X POST "$LVS/v1/summarize" \
+if [ "$video_sum_code" = "200" ]; then
+  # ── Primary path: video summarization microservice with HITL ──
+  # HITL (required, before the curl): post the Step 2 scenario/events message and
+  # wait for the user's reply. Substitute their values (or the `defaults` opt-in)
+  # into $SCENARIO, $EVENTS_JSON, and $OBJECTS_JSON below. Do not run the curl
+  # without that reply.
+  SCENARIO='warehouse monitoring'            # or whatever the user gave
+  EVENTS_JSON='["notable activity"]'         # jq-compatible JSON array
+  OBJECTS_JSON=''                            # '' to omit, else '["cars","trucks"]'
+
+  curl -s -X POST "$VIDEO_SUMMARIZATION_URL/v1/summarize" \
     -H "Content-Type: application/json" \
     -d "$(jq -n --arg url "$CLIP" \
           --arg model "${VLM_NAME:-nim_nvidia_cosmos-reason2-8b_hf-1208}" \
@@ -397,9 +384,32 @@ if [ "$lvs_code" = "200" ]; then
     } + (if $objects == null then {} else {objects_of_interest: $objects} end)')" \
     | jq -r '.choices[0].message.content' | jq '{video_summary, events}'
 else
-  echo "⚠️ Note: video is ${DURATION}s long. LVS returned HTTP $lvs_code; falling back to VLM."
-  # Fall back to the short-video VLM flow above (which itself requires
-  # the Step 2a HITL confirmation before calling the VLM).
+  # ── Fallback path: VLM with the default prompt, no HITL ──
+  # Prepend the Routing fallback note to the response so the user knows.
+  echo "⚠️ Note: the video summarization service returned HTTP $video_sum_code; falling back to VLM with the default prompt."
+  VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
+  VLM="${VLM%/v1}"
+  PROMPT='Describe in detail what is happening in this video,
+including all visible people, vehicles, equipments, objects,
+actions, and environmental conditions.
+OUTPUT REQUIREMENTS:
+[timestamp-timestamp] Description of what is happening.
+EXAMPLE:
+[0.0s-4.0s] <description of the first event>
+[4.0s-12.0s] <description of the second event>'
+
+  curl -s -X POST "$VLM/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg url "$CLIP" --arg text "$PROMPT" \
+          --arg model "${VLM_NAME:-nim_nvidia_cosmos-reason2-8b_hf-1208}" '{
+      model: $model,
+      temperature: 0.0,
+      max_tokens: 1024,
+      messages: [{role:"user", content:[
+        {type:"text", text:$text},
+        {type:"video_url", video_url:{url:$url}}
+      ]}]
+    }')" | jq -r '.choices[0].message.content'
 fi
 ```
 
@@ -409,27 +419,29 @@ fi
 
 - **VLM** returns an OpenAI chat-completion envelope; the summary string is
   `choices[0].message.content`.
-- **LVS** returns the same envelope but `content` is a JSON string — run
+- **Video summarization service** returns the same envelope but `content` is a JSON string — run
   `jq -r '.choices[0].message.content' | jq` to reach `{video_summary, events}`.
-- **Errors** from VLM/LVS surface as HTTP non-2xx plus JSON `{error: ...}`.
-  `503` from LVS typically means it is still warming up — wait and retry
+- **Errors** from VLM/video summarization service surface as HTTP non-2xx plus JSON `{error: ...}`.
+  `503` from video summarization service typically means it is still warming up — wait and retry
   `v1/ready`.
 
 ### Presenting the output to the user (IMPORTANT — do not rewrite)
 
-The VLM and LVS responses are the final user-facing product. Surface
+The VLM and video summarization responses are the final user-facing product. Surface
 them with minimal transformation; do not paraphrase, re-voice, add
 emojis, or re-format into bullets/tables that weren't in the source.
 
 **Exactly one backend call, exactly one rendering.** A single confirmed
-prompt (Step 2a) or a single confirmed scenario/events set (Step 2b)
-corresponds to exactly one `POST /v1/chat/completions` or `POST
-/v1/summarize` request, and exactly one block of output to the user. Do
-NOT fan out parallel calls to hedge (e.g., one call for "full scene"
-plus another for "anomalies"), and do NOT render the same response
-twice with different headers. If the user wants a second pass (e.g.,
-"now with a safety-incident focus"), that's a new HITL round → a new
-single call → a new single rendering.
+scenario/events set for Step 2 (LVS) — or a single VLM call on the
+fallback path — corresponds to exactly one `POST /v1/summarize` or
+`POST /v1/chat/completions` request, and exactly one block of output to
+the user. Do NOT fan out parallel calls to hedge (e.g., one call for
+"full scene" plus another for "anomalies"), and do NOT render the same
+response twice with different headers. If the user wants a second pass
+(e.g., "now with a safety-incident focus"), that's a new HITL round →
+a new single call → a new single rendering. Never call both the LVS
+and the VLM for the same video; the VLM is reached only when the LVS
+probe failed.
 
 **Header line format.** Start the response with exactly one header:
 
@@ -441,7 +453,7 @@ Use `<duration>` formatted as `Ns` for durations under 60 seconds (e.g.
 `25s`) and `Mm Ss` for durations ≥60 seconds (e.g. `3m 30s`). Never
 include the same header twice in different formats.
 
-**LVS output:**
+**Video summarization output:**
 
 - **`video_summary`** (string) — render **verbatim** as the narrative
   summary. It is already a polished, tone-controlled "Observational
@@ -464,15 +476,25 @@ assistant reply — render it verbatim. If the model produced
 block and show the `<answer>` content (or the whole content if the
 tags are absent).
 
-**Fallback warning**, when applicable, goes **above** the LVS/VLM
+**Fallback warning**, when applicable, goes **above** the video summarization/VLM
 output, not mixed into it.
 
 ## Tips
 
-- **HITL is not optional.** Every summarization starts with the HITL
-  message (Step 2a or 2b). Skipping it to "be efficient" is the single
-  most common failure mode of this skill — do not do it.
-- **LVS readiness = HTTP 200 on `/v1/ready`. Nothing else.** The body is
+- **The video summarization service is the primary backend whenever it is reachable.**
+  Probe `/v1/ready` once in Setup; if it returns 200, run Step 2
+  (LVS + HITL) regardless of video duration. The VLM is reached only
+  when the probe failed.
+- **HITL is mandatory on the LVS path.** Every Step 2 (LVS) call starts
+  with the scenario/events HITL message. Skipping it to "be efficient"
+  or because "the video is short" is the single most common failure
+  mode of this skill — do not do it. The autonomous-mode `defaults`
+  opt-in is the only sanctioned bypass.
+- **The VLM fallback is silent (no HITL).** When the LVS probe failed
+  you already had to fall back; do not also gate the fallback summary
+  on a user confirmation round. Use the default prompt and prepend the
+  Routing fallback note so the user knows what happened.
+- **video summarization readiness = HTTP 200 on `/v1/ready`. Nothing else.** The body is
   often empty (`size=0`). Do NOT pipe the readiness check through
   `head`, `jq`, `grep`, or any other command — bash will report the
   pipeline's last exit code, not curl's, and an empty body will look
@@ -482,31 +504,35 @@ output, not mixed into it.
   upload calls here - they'll drift from the canonical recipes.
 - **`vss-manage-video-io-storage` is a sub-task, not the final answer.** Step 1 returns
   ingredients ($CLIP, $DURATION); the deliverable is the Step 2 summary.
-  Do not end your turn after Step 1 - continue to Step 2a / 2b and render
-  the LVS or VLM output. Returning the clip URL as your final answer is
-  the single most common failure mode of the LVS path.
-- **Duration is authoritative.** Don't route on filename or user hints;
-  compute from the timeline returned by `vss-manage-video-io-storage`.
-- **`jq` twice for LVS.** First unwraps the OpenAI-style envelope, second
+  Do not end your turn after Step 1 - continue to Step 2 and render
+  the video summarization service or VLM output. Returning the clip URL
+  as your final answer is the single most common failure mode of this
+  skill.
+- **Routing is by service availability, not by duration.** Do not route
+  on filename, user hints, or video length; route on the `/v1/ready`
+  result from Setup.
+- **`jq` twice for video summarization.** First unwraps the OpenAI-style envelope, second
   parses the JSON string inside `content`.
 - **Prefer `/v1/summarize` for 3.2 GA.** `/summarize` exists as a
   compatibility route but should not be the default in new examples.
 - **Use the exact VLM model id advertised by the serving endpoint.** The
   default VSS `lvs` profile uses `nim_nvidia_cosmos-reason2-8b_hf-1208`.
-- **Do not set or depend on development-only LVS API switches in GA workflows.**
-- **Do not rewrite LVS / VLM output.** The `video_summary` from LVS and
+- **Do not set or depend on development-only video summarization API switches in GA workflows.**
+- **Do not rewrite video summarization / VLM output.** The `video_summary` from the video summarization service and
   `choices[0].message.content` from VLM are the deliverables. Render
   them verbatim; don't paraphrase into your own voice or reformat. See
   *Responses → Presenting the output to the user*.
-- **One call, one render.** One confirmed HITL → one backend request →
-  one block of output. No parallel hedging, no duplicate renderings
-  with different headers.
+- **One call, one render.** Each Step 2 invocation (a confirmed LVS
+  scenario/events round, or a single VLM fallback call) → one backend
+  request → one block of output. No parallel hedging, no duplicate
+  renderings with different headers, no calling both backends for the
+  same video.
 
 ## Cross-reference
 
-- **vss-deploy-profile** — bring up the `base` (VLM only) or `lvs` (VLM + LVS MS) profile
+- **vss-deploy-profile** — bring up the `base` (VLM only) or `lvs` (VLM + video summarization service) profile
 - **vss-manage-video-io-storage** (VIOS API) — upload videos, list streams, get clip URLs
 - **vss-search-archive** — semantic search across the archive (different profile)
 - **vss-query-analytics** — query incidents/events from Elasticsearch
-- **LVS API reference** — [`references/lvs-api.md`](references/lvs-api.md)
-- **LVS service ops reference** — [`references/deploy-lvs-service.md`](references/deploy-lvs-service.md)
+- **video summarization API reference** — [`references/video-summarization-api.md`](references/video-summarization-api.md)
+- **video summarization service ops reference** — [`references/video-summarization-deployment.md`](references/video-summarization-deployment.md)

--- a/skills/vss-summarize-video/references/hitl-prompts.md
+++ b/skills/vss-summarize-video/references/hitl-prompts.md
@@ -1,70 +1,10 @@
 # Video Summarization — HITL Prompt Walkthroughs
 
-### HITL: confirm the VLM prompt first (REQUIRED — do not skip)
-
-**Before any call to the VLM, you MUST show the default prompt to the
-user verbatim and wait for their response.** Do not proceed on silence
-and do not assume defaults.
-
-You MAY reuse a confirmed prompt from earlier in the same chat **only
-if** the user is asking to re-summarize the **same video** (same
-`streamId` / clip URL) — in that case, remind the user what prompt
-you're about to reuse and offer them the chance to change it before
-calling. For any **different video**, re-run the HITL from scratch.
-
-Post the message as follows (literal template — fill the `{video_name}`
-placeholder):
-
-> I'm about to summarize **{video_name}** with this VLM prompt. Reply
-> `Submit` to use it as-is, paste replacement text, `/generate <desc>`
-> to rewrite it from a description, `/refine <instr>` to tweak it, or
-> `/cancel` to stop.
->
-> ```
-> <default VLM prompt below>
-> ```
-
-**Default VLM prompt** (copy verbatim from the base profile):
-
-```
-Describe in detail what is happening in this video,
-including all visible people, vehicles, equipments, objects,
-actions, and environmental conditions.
-OUTPUT REQUIREMENTS:
-[timestamp-timestamp] Description of what is happening.
-EXAMPLE:
-[0.0s-4.0s] <description of the first event>
-[4.0s-12.0s] <description of the second event>
-```
-
-**User response handling:**
-
-| User input | Effect |
-|---|---|
-| `Submit` (or empty) | Approve the current prompt and call the VLM |
-| Any other free text | Treat as a full replacement prompt; echo it back and ask for `Submit` before calling |
-| `/generate <description>` | You (the assistant) write a new prompt from the description, show it back, and wait for `Submit` |
-| `/refine <instructions>` | You (the assistant) refine the current prompt per the instructions, show it back, and wait for `Submit` |
-| `/cancel` | Cancel summarization |
-
-Rules:
-
-- You MAY call the VLM **only** after receiving `Submit` (or an empty
-  confirmation) on a prompt that is currently visible in the chat.
-- `/generate` and `/refine` are not terminal — they produce a new prompt
-  that itself needs `Submit`.
-- When handling `/generate` and `/refine`, preserve the
-  `[Xs-Ys] <description>` output-format requirement from the default
-  prompt.
-- If the user just says "go" / "ok" / "yes" without having seen the
-  prompt, show the prompt first, then wait for `Submit`.
-
-
 ### HITL: collect scenario and events first (REQUIRED — do not skip)
 
 **Before any call to `POST /v1/summarize`, you MUST ask the user for
 `scenario`, `events`, and `objects_of_interest`, and wait for their
-response.** Do not call LVS with defaults silently — if the user wants
+response.** Do not call the video summarization service with defaults silently — if the user wants
 defaults, they must say so explicitly (e.g., "use the generic
 defaults").
 
@@ -78,7 +18,7 @@ video**, re-run the HITL from scratch.
 Post the message as follows (literal template — fill the `{video_name}`
 and `{duration}` placeholders):
 
-> I'm about to send **{video_name}** ({duration}s) to LVS. I need three
+> I'm about to send **{video_name}** ({duration}s) to the video summarization service. I need three
 > parameters first:
 >
 > 1. **`scenario`** — one-line context, e.g. `"warehouse monitoring"`,
@@ -93,7 +33,7 @@ and `{duration}` placeholders):
 > `events=["notable activity"]`, no objects. Reply `/cancel` to stop.
 
 Only after the user replies with values (or `defaults`) may you build
-and send the LVS request.
+and send the video summarization request.
 
 **Required parameters:**
 


### PR DESCRIPTION
## Summary

Backport of [#692](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/692) (merged 2026-05-26, squash `bf78299a`) to `dev/3.2.0`. A direct cherry-pick conflicts in 10+ places because `dev/3.2.0` is missing five intermediate post-GA documentation refactors that #692 was built on top of. To get a clean end-state, this PR syncs the three affected skill docs to develop's tip in one commit. Net effect: dev/3.2.0 catches up on six PRs at once.

| PR | Description |
|----|----|
| #520 | feat: update vss summarize video skill for LVS 3.2 |
| #574 | skill(vss-summarize-video): keep agent in flow after VIOS sub-skill |
| #581 | Update video summarization skill naming and DB backend docs |
| #582 | skill(vss-summarize-video): apply canonical defaults in autonomous mode |
| #589 | Fix/update all skills to use host ip and whitelist additional ports in nemoclaw |
| #692 | skills(summarize+report): route by LVS availability, always HITL on LVS |

The headline behavioral change is #692: the video summarization microservice (LVS) is the primary backend for every video whenever its `/v1/ready` probe returns 200, regardless of duration, always preceded by scenario/events HITL. The direct VLM call survives only as a fallback when LVS is unreachable, using a fixed default prompt with no HITL. `vss-generate-video-report`'s Mode A produces the summary body via `/vss-summarize-video` when LVS is up and pastes it into the existing Step 4 report template.

The intermediate doc refactors come along for the ride so the skills read identically across branches and the next backport stays small.

## Files touched

- `skills/vss-summarize-video/SKILL.md` — synced verbatim to develop tip.
- `skills/vss-summarize-video/references/hitl-prompts.md` — synced verbatim to develop tip.
- `skills/vss-generate-video-report/SKILL.md` — synced verbatim to develop tip.

## Test plan

- [ ] Eval: short video (`<60s`) flows through LVS+HITL when `lvs` profile is up.
- [ ] Eval: long video (`≥60s`) flow unchanged (still LVS+HITL).
- [ ] Eval: with `lvs` profile down, both short and long videos fall back to VLM with default prompt and prepend the fallback note.
- [ ] Eval: `vss-generate-video-report` Mode A pipes summary through `/vss-summarize-video` when LVS is up; falls back to VLM-direct Steps 1–3 when LVS is down.
- [ ] No regression on the autonomous-mode `defaults` opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)