### PR TITLE
skill(vss-search-archive): add ingest triggers + agent-backend ingestion prereq

### DIFF
--- a/skills/vss-search-archive/SKILL.md
+++ b/skills/vss-search-archive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vss-search-archive
-description: Search video archives using natural language — find events, objects, actions, and people across recorded video using fusion search (Cosmos Embed1 semantic search + CV attribute search). Use when asked to search for something in video, find actions and events, locate objects and people, or query video archives. For these types of questions, default to this top-level fusion search unless user specifies otherwise. Requires the search profile to be deployed.
+description: Search video archives using natural language — find events, objects, actions, and people across recorded video using fusion search (Cosmos Embed1 semantic search + CV attribute search). Also handles ingestion for search — uploading a video file or adding an RTSP stream through the agent backend so it ends up in the search index. Use when asked to search for something in video, find actions and events, locate objects and people, query video archives, ingest a video for search, or add an RTSP stream for search. For search questions, default to this top-level fusion search unless user specifies otherwise. Requires the search profile to be deployed.
 license: Apache-2.0
 metadata:
   version: "3.2.0"
@@ -21,6 +21,8 @@ Search video archives by natural language using Cosmos Embed1 embeddings. Requir
 - "Show me people near the loading dock"
 - "Search for vehicles between 8am and noon"
 - Any natural-language search across video archives
+- "Ingest `<file>` for search" / "upload this video for search"
+- "Add this RTSP stream for search" / "register `<rtsp_url>` for search"
 
 ---
 
@@ -51,9 +53,57 @@ This skill requires the VSS **search** profile running on the host at `$HOST_IP`
 
 ---
 
+## Ingestion prerequisite (required before any `/generate`)
+
+For a source to be searchable it must be ingested **through the VSS agent backend**, not through VIOS alone. The agent's ingest routes own the VIOS upload + RTVI-CV register + RTVI-embed pipeline as one transaction; a bare VIOS PUT only stores the bytes and never wires them into Elasticsearch.
+
+Confirm the source exists in VIOS first (Mandatory workflow Step 2). If it is missing, ingest it with one of the recipes below before firing `/generate`. Reuse the registered `sensorId` you get back for the search query.
+
+### File upload — universal three-step flow
+
+```bash
+# 1. Ask the agent for the chunked-upload URL
+URL=$(curl -s -X POST "http://${HOST_IP}:8000/api/v1/videos" \
+  -H "Content-Type: application/json" \
+  -d '{"filename": "<filename.mp4>"}' | jq -r .url)
+
+# 2. Chunked POST the file to that VST URL (the UI streams chunks; from a shell,
+#    a single multipart POST is fine). The final-chunk response carries sensorId.
+SENSOR=$(curl -s -X POST "$URL" \
+  -F "file=@/path/to/<filename.mp4>;type=video/mp4" | jq -r .sensorId)
+
+# 3. Tell the agent the upload finished — this fans out to RTVI-CV + RTVI-embed
+curl -s -X POST "http://${HOST_IP}:8000/api/v1/videos/${SENSOR}/complete" \
+  -H "Content-Type: application/json" \
+  -d '{"filename": "<filename.mp4>"}' | jq .
+```
+
+Wait for the `/complete` response (it returns `chunks_processed > 0` once embeddings land). Only then is the video searchable.
+
+> The deprecated `PUT /api/v1/videos-for-search/{filename}` route is also wired in for legacy callers (single-shot, agent-driven), but its OpenAPI entry is flagged `deprecated`. Prefer the three-step flow above for new work.
+
+### RTSP stream — single endpoint
+
+```bash
+curl -s -X POST "http://${HOST_IP}:8000/api/v1/rtsp-streams/add" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sensor_url": "rtsp://<host>:<port>/<path>",
+    "name": "<sensor-name>",
+    "username": "",
+    "password": "",
+    "location": "",
+    "tags": ""
+  }' | jq .
+```
+
+The endpoint adds the stream to VST, registers it with RTVI-CV and RTVI-embed, and kicks off embedding generation in one shot. On any step's failure earlier steps roll back, so a 2xx is the green light to search the stream.
+
+---
+
 ## How Search Works
 
-1. **Ingest** — Videos are uploaded or streamed via VIOS. The RTVI-Embed service (Cosmos Embed1) generates vector embeddings for video segments.
+1. **Ingest** — Files come in through the agent's three-step universal flow; RTSP streams through `/api/v1/rtsp-streams/add`. Both routes hand the source to RTVI-CV (attribute detection) and RTVI-Embed (Cosmos Embed1) which generates vector embeddings for video segments.
 2. **Index** — Embeddings are stored in Elasticsearch via the Kafka pipeline.
 3. **Query** — Natural-language queries are embedded and matched against stored vectors by similarity.
 4. **Results** — Timestamped video segments ranked by relevance, with clip playback links.
@@ -87,7 +137,7 @@ When using this skill, ALWAYS follow this high-level workflow:
 
    Then:
    - **If the named source (or a clearly substring-matching name) IS in the list** → proceed to step 3. Forward the user's natural-language query verbatim — the agent's own search tool decomposer (`services/agent/src/vss_agents/tools/search.py`) extracts `video_sources` from the prose given the available sources, so the skill does NOT need to construct a structured `video sources` payload.
-   - **If the named source is NOT in the list** → STOP. Do NOT fire `/generate` as a probe. Respond to the user with the registered source names and ask whether they meant one of those, want to ingest the missing video, or want to abandon the query. Wait for clarification.
+   - **If the named source is NOT in the list** → STOP. Do NOT fire `/generate` as a probe. Respond to the user with the registered source names and ask whether they meant one of those, want to ingest the missing source (point them at *Ingestion prerequisite* and run the matching file or RTSP recipe through the **agent backend**, not bare VIOS), or want to abandon the query. Wait for clarification.
    - **If the query names no specific source** ("find forklifts in the ingested videos", "search across all sources") → skip the substring check, but `sensor/list` must still return non-empty (otherwise no sources are ingested → HARD STOP).
 3. Run the search(es) via approach chosen
 4. Present the results to the user query. Format response as a professional inspection report but name it `Video Search Results`:
@@ -112,7 +162,7 @@ Infer these inputs only from the conversation or user query (no other files unle
 
 - ALWAYS step into the troubleshooting step of the workflow immediately if anything unexpected happens, read [troubleshooting.md](references/troubleshooting.md)
 - Queries work best with **concrete visual descriptions** (objects, actions, locations). Augment user queries if needed to enhance the quality of the questions, expanding potential details
-- The skill assumes video sources are **already ingested in VIOS**. It is NOT the skill's job to ingest, find local files, or upload. But you also can't assume blindly — workflow step 2 makes confirming "this source exists in VIOS" a hard precondition before `/generate`. If the source isn't there, ask the user; don't search locally on disk and don't trigger an ingest handshake on their behalf.
+- The skill assumes video sources are **already ingested through the agent backend** (see *Ingestion prerequisite*). It MAY run the agent-backed ingest recipes when the user explicitly asks ("ingest `<file>` for search", "add `<rtsp_url>` for search"); it does NOT search the local filesystem for files the user didn't name, and it does NOT use the bare-VIOS PUT path (no embeddings get generated). Workflow step 2 still makes confirming "this source exists in VIOS" a hard precondition before `/generate`.
 - Use `vss-query-analytics` skill to cross-reference search results with incident/alert data
 
 ---


### PR DESCRIPTION
## Summary

Teaches `vss-search-archive` how to handle "ingest video for search" / "add this RTSP stream for search" intents and documents the agent-backed ingestion contract those intents share with `/generate`.

- **Triggers** — frontmatter `description` and the *When to Use* list now name the ingest phrasings explicitly so the loader picks the skill up on ingest requests, not just search ones.
- **Ingestion prerequisite** — new section between *Deployment prerequisite* and *How Search Works*. Pins the contract: ingestion must go through the **agent backend**, not bare VIOS PUT, because the agent owns the VIOS upload + RTVI-CV register + RTVI-embed transaction. A bare-VIOS PUT only stores bytes and never wires the source into Elasticsearch.
- **Recipes** — file uploads use the universal three-step flow `POST /api/v1/videos` → chunked `POST` to the returned VST URL → `POST /api/v1/videos/{sensor_id}/complete`; RTSP uses single-shot `POST /api/v1/rtsp-streams/add`. Noted the deprecated `PUT /api/v1/videos-for-search/{filename}` for awareness only.
- **Workflow + Gotchas** — Mandatory workflow Step 2 ("named source not in VIOS") and the Gotchas bullet on ingestion both reroute the user at the new section instead of the previous "ask the user" dead-end.

Endpoint shapes verified against `services/agent/src/vss_agents/api/{video_ingest,video_search_ingest,rtsp_ingest}.py` on `dev/3.2.0`.

## Files touched

- `skills/vss-search-archive/SKILL.md` — +54 / −4

## Test plan

- [ ] Eval: "ingest `<file>` for search" triggers `vss-search-archive` and walks the three-step flow.
- [ ] Eval: "add `<rtsp_url>` for search" triggers `vss-search-archive` and calls `/api/v1/rtsp-streams/add`.
- [ ] Eval: search query for a named-but-unregistered source no longer dead-ends at "ask the user"; offers the ingest recipe.
- [ ] No regression on existing search queries (search-only intents still default to `/generate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)