### PR TITLE
skill(vss-search-archive): tighten ingest prereq per Greptile + trim description

### DIFF
--- a/skills/vss-search-archive/SKILL.md
+++ b/skills/vss-search-archive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vss-search-archive
-description: Search video archives using natural language — find events, objects, actions, and people across recorded video using fusion search (Cosmos Embed1 semantic search + CV attribute search). Also handles ingestion for search — uploading a video file or adding an RTSP stream through the agent backend so it ends up in the search index. Use when asked to search for something in video, find actions and events, locate objects and people, query video archives, ingest a video for search, or add an RTSP stream for search. For search questions, default to this top-level fusion search unless user specifies otherwise. Requires the search profile to be deployed.
+description: Use when asked to search for something in video, find actions and events, locate objects and people, query video archives, ingest a video for search, or add an RTSP stream for search. For search questions, default to this top-level fusion search unless user specifies otherwise. Requires the search profile to be deployed.
 license: Apache-2.0
 metadata:
   version: "3.2.0"
@@ -57,7 +57,7 @@ This skill requires the VSS **search** profile running on the host at `$HOST_IP`
 
 For a source to be searchable it must be ingested **through the VSS agent backend**, not through VIOS alone. The agent's ingest routes own the VIOS upload + RTVI-CV register + RTVI-embed pipeline as one transaction; a bare VIOS PUT only stores the bytes and never wires them into Elasticsearch.
 
-Confirm the source exists in VIOS first (Mandatory workflow Step 2). If it is missing, ingest it with one of the recipes below before firing `/generate`. Reuse the registered `sensorId` you get back for the search query.
+Confirm the source exists in VIOS first (Mandatory workflow Step 2). If it is missing, ingest it with one of the recipes below before firing `/generate`. After ingest succeeds, the source appears in `sensor/list` under the name you provided and can be referenced from the natural-language query the agent forwards to its search-tool decomposer — you do NOT need to construct a structured `video_sources` payload yourself.
 
 ### File upload — universal three-step flow
 
@@ -97,7 +97,7 @@ curl -s -X POST "http://${HOST_IP}:8000/api/v1/rtsp-streams/add" \
   }' | jq .
 ```
 
-The endpoint adds the stream to VST, registers it with RTVI-CV and RTVI-embed, and kicks off embedding generation in one shot. On any step's failure earlier steps roll back, so a 2xx is the green light to search the stream.
+The response shape is `{status, message, error}` — no `sensorId` (the agent keys the stream by the `name` you provided). On any step's failure earlier steps roll back. The `start_embedding_generation` step is fire-and-verify: a 2xx confirms the request was accepted and the embedding pipeline is running in the background, **not** that the stream is searchable yet. Search hits will start appearing only after enough chunks land in Elasticsearch — poll with a low-`top_k` query a few seconds in if you need a readiness signal.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to [#698](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/698). Two factual errors in the ingestion prereq surfaced by Greptile on the parallel develop backport ([#699](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/699)) — landing the same three-line fix on `dev/3.2.0` so the skill reads identically across branches before the next `dev-26.05.3-N` tag bump.

Clean cherry-pick of develop's `407d236f`.

### What's wrong on the current dev/3.2.0 file

- **"Reuse the registered `sensorId` you get back for the search query"** (lead paragraph) — verified against `services/agent/src/vss_agents/api/rtsp_ingest.py` L132–137: `AddStreamResponse` only carries `{status, message, error}`. No `sensorId` is returned for RTSP. Even on the file path it's imprecise — the agent's search-tool decomposer extracts video sources from the natural-language query, so callers don't construct a structured `video_sources` payload. Replaced with the actual contract (source shows up in `sensor/list` under its `name`; reference it in the NL query).
- **"a 2xx is the green light to search the stream"** (RTSP closing line) — verified against `rtsp_ingest.py` L400–417: `start_embedding_generation` is fire-and-verify (HTTP 200 + close), embedding pipeline runs asynchronously. Reworded to: 2xx = accepted + pipeline running in background; poll a low-`top_k` query for the readiness signal.

### Also bundled

- **Frontmatter description trim** — dropped the verbose "Search video archives using natural language…" / "Also handles ingestion for search…" lead-in. Kept only the trigger-phrase sentence + "default to top-level fusion search" + "requires search profile" notes for a tighter loader signal.

File path's "/complete blocks until embeddings land" claim left as-is — verified accurate against `video_ingest.py:_run_post_upload_processing` (it `asyncio.gather`s the RTVI-embed task).

## Files touched

- `skills/vss-search-archive/SKILL.md` — +3 / −3

## Test plan

- [ ] No regression on existing search queries (search-only intents still default to `/generate`).
- [ ] Ingest triggers still pick up the skill loader after the description trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)