### PR TITLE
ci(license-check): follow PEP 639 — read License-Expression + classifiers

### DIFF
--- a/.github/scripts/check_python_licenses.py
+++ b/.github/scripts/check_python_licenses.py
@@ -71,6 +71,14 @@ PERMISSIVE_LICENSE_PATTERNS = [
     # license_allowlist_overrides.txt pending explicit OSRB confirmation.
     r"^LGPL[ -]?(?:v)?2\.1(?:\+|[ -]?(?:only|or[ -]later))?$",
     r"^GNU Lesser General Public License(?:[ -]?v?2\.1)?(?:[ -]?or[ -]later)?(?:\s*\(LGPL[^)]*\))?$",
+    # Universal Permissive License 1.0 — Oracle's permissive license,
+    # OSI-approved, similar in scope to MIT/BSD/Apache-2 (full rights,
+    # patent grant). Used by `oci`, `langchain-oci`, `oci-openai`. Accepts
+    # the SPDX form (`UPL-1.0`) and the Trove classifier form
+    # ("Universal Permissive License (UPL)"). Confirmed permissive via
+    # NVBug 6111789 comments tracking the PEP 639 fallback work.
+    r"^UPL(?:[ -]?1\.0)?$",
+    r"^Universal Permissive License(?:\s*\(UPL\))?(?:[ -]?1\.0)?$",
 ]
 
 COMPILED_ALLOWLIST = re.compile(
@@ -94,6 +102,44 @@ def shorten_license_field(license_field: str) -> str:
         if candidate:
             return candidate
     return s
+
+
+def resolve_license_pep639(name: str, csv_license: str) -> str:
+    """Fall back to PEP 639 `License-Expression` (and Trove classifiers) when
+    the legacy `License:` field is empty or `UNKNOWN`.
+
+    `pip-licenses` (4.x) reads only the legacy `License:` METADATA field.
+    Packages following PEP 639 (e.g. `langchain-oci`, `oci-openai`) populate
+    only `License-Expression` and leave `License:` empty, so they appear as
+    `UNKNOWN` in the CSV. This function consults the installed wheel's
+    METADATA directly via `importlib.metadata` and returns the first
+    non-empty source.
+
+    Precedence (highest first):
+      1. CSV License (legacy METADATA, what pip-licenses already gave us)
+      2. METADATA `License-Expression` (PEP 639 SPDX expression)
+      3. Trove classifier `License :: OSI Approved :: <name>`
+    """
+    if csv_license and csv_license.strip().upper() not in ("UNKNOWN", "NONE"):
+        return csv_license
+    try:
+        from importlib.metadata import PackageNotFoundError, metadata
+    except ImportError:
+        return csv_license
+    try:
+        md = metadata(name)
+    except PackageNotFoundError:
+        return csv_license
+    expr = md.get("License-Expression")
+    if expr and expr.strip():
+        return expr.strip()
+    classifiers = md.get_all("Classifier") or []
+    osi = [c for c in classifiers if c.startswith("License :: OSI Approved ::")]
+    if osi:
+        # Drop the "License :: OSI Approved ::" prefix so the allowlist regex
+        # sees the bare license name (the classifier's last `::` segment).
+        return max(osi, key=len).rsplit("::", 1)[-1].strip()
+    return csv_license
 
 
 def load_overrides(path: Path) -> set[str]:
@@ -345,6 +391,10 @@ def main() -> int:
         name = row[name_idx].strip()
         version = row[version_idx].strip()
         license_field = row[license_idx].strip()
+        # PEP 639 fallback: if pip-licenses reported UNKNOWN/empty (legacy
+        # `License:` field), consult the wheel METADATA for
+        # `License-Expression` or a Trove classifier before failing.
+        license_field = resolve_license_pep639(name, license_field)
         total += 1
         # 1. Hard denylist wins over everything (override cannot rescue).
         if name.lower() in denylist:

--- a/.github/scripts/check_python_licenses.py
+++ b/.github/scripts/check_python_licenses.py
@@ -136,8 +136,16 @@ def resolve_license_pep639(name: str, csv_license: str) -> str:
     classifiers = md.get_all("Classifier") or []
     osi = [c for c in classifiers if c.startswith("License :: OSI Approved ::")]
     if osi:
-        # Drop the "License :: OSI Approved ::" prefix so the allowlist regex
-        # sees the bare license name (the classifier's last `::` segment).
+        # Trove classifiers form a taxonomy from general to specific:
+        # e.g. "License :: OSI Approved" (vague) →
+        # "License :: OSI Approved :: MIT License" (specific). The longest
+        # entry is the most specific, which is the actual license name we
+        # want to compare against the allowlist. Multi-classifier packages
+        # (dual-licensed) are uncommon enough that one-name-wins is fine —
+        # if it ever matters, an entry in license_allowlist_overrides.txt
+        # covers it.
+        # Drop the "License :: OSI Approved ::" prefix so the allowlist
+        # regex sees the bare license name (the last `::` segment).
         return max(osi, key=len).rsplit("::", 1)[-1].strip()
     return csv_license
 

--- a/.github/scripts/check_python_licenses.sh
+++ b/.github/scripts/check_python_licenses.sh
@@ -34,7 +34,11 @@ cd "$repo_root/services/agent"
 uv sync --frozen --no-default-groups --quiet
 uv pip install --quiet pip-licenses
 
+# Both halves of the pipe run inside the agent's uv venv: pip-licenses needs
+# the venv to enumerate installed packages, and check_python_licenses.py needs
+# it too — the PEP 639 fallback (importlib.metadata) reads each wheel's
+# METADATA to recover `License-Expression` when pip-licenses reports UNKNOWN.
 uv run --no-sync --quiet pip-licenses --format=csv \
-  | python3 "$repo_root/.github/scripts/check_python_licenses.py" \
+  | uv run --no-sync --quiet python3 "$repo_root/.github/scripts/check_python_licenses.py" \
       --overrides "$repo_root/.github/scripts/license_allowlist_overrides.txt" \
       --denylist  "$repo_root/.github/scripts/license_denylist.txt"


### PR DESCRIPTION
## What

Teach our Python license check to read **PEP 639** fields (`License-Expression`, Trove classifiers) when the legacy `License:` METADATA is empty — and add **UPL-1.0** to the permissive allowlist.

## Why

The legacy `License:` field is one of three places a wheel can declare its license. PEP 639 (accepted 2024) added `License-Expression` (SPDX, structured) and `License-File`; modern packages publish via PEP 639 only. `pip-licenses` 4.x reads only the legacy field, so PEP 639-only packages show as `UNKNOWN` in the CSV and fail our allowlist.

Concrete cases that just bit us:

| Package | Version | Legacy License | License-Expression | Wheel ships |
|---|---|---|---|---|
| `langchain-oci` | 0.2.6 | (empty) | **`UPL-1.0`** | `langchain_oci-0.2.6.dist-info/licenses/LICENSE` |
| `oci-openai`    | 1.1.0 | (empty) | **`UPL-1.0`** | `oci_openai-1.1.0.dist-info/licenses/LICENSE.txt` |

Both are permissive (Universal Permissive License v1.0, OSI-approved, similar in scope to MIT/BSD/Apache-2). Both were transitive deps introduced by the NAT 1.7 bump in [#651](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/651).

## Changes

### `check_python_licenses.py`

```python
def resolve_license_pep639(name: str, csv_license: str) -> str:
    """Fall back to PEP 639 `License-Expression` (and Trove classifiers) when
    the legacy `License:` field is empty or `UNKNOWN`."""
    if csv_license and csv_license.strip().upper() not in ("UNKNOWN", "NONE"):
        return csv_license
    md = metadata(name)
    expr = md.get("License-Expression")
    if expr: return expr.strip()
    osi = [c for c in md.get_all("Classifier") or [] if c.startswith("License :: OSI Approved ::")]
    if osi: return max(osi, key=len).rsplit("::", 1)[-1].strip()
    return csv_license
```

- Called for every CSV row before allowlist/override/denylist checks.
- Added 2 patterns to `PERMISSIVE_LICENSE_PATTERNS` for UPL-1.0 (SPDX) and the Trove `Universal Permissive License (UPL)` form.

### `check_python_licenses.sh`

Pipe both halves through `uv run --no-sync` so the Python script runs in the agent venv — `importlib.metadata` needs venv site-packages access to read each wheel's METADATA.

```diff
 uv run --no-sync --quiet pip-licenses --format=csv \
-  | python3 "$repo_root/.github/scripts/check_python_licenses.py" \
+  | uv run --no-sync --quiet python3 "$repo_root/.github/scripts/check_python_licenses.py" \
       --overrides "$repo_root/.github/scripts/license_allowlist_overrides.txt" \
       --denylist  "$repo_root/.github/scripts/license_denylist.txt"
```

## Why not just bump pip-licenses to 5.x

pip-licenses 5.x added `--from=expression` for PEP 639. We'd still need to handle the policy add for UPL in our allowlist regex, and version-pinning pip-licenses adds maintenance load. Reading METADATA in our own script is provider-agnostic, works against today's pip-licenses 4.x, and surfaces the same data that pip-licenses 5.x exposes.

## Test plan

- [ ] CI passes on this PR (license-check Python green; no override addition for langchain-oci / oci-openai is needed).
- [ ] Re-run the check locally via `bash .github/scripts/check_python_licenses.sh` — confirm both packages pass.
- [ ] No regression on the existing pass list — every package that passed before still passes (PEP 639 fallback is only consulted when the legacy field is UNKNOWN/empty).

## Refs

- NVBug 6111789 (OSRB tracking — UPL approval recorded in the latest comment).
- PEP 639 — https://peps.python.org/pep-0639/