### PR TITLE
fix(alerts): align realtime alert labeling

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -89,7 +89,7 @@ LLM_MODEL_TYPE=nim
 # vss-rt-vlm image. dev-profile.sh applies the same override
 # (scripts/dev-profile.sh, alerts + vlm_mode != remote branch).
 # Override here for any non-remote VLM deploy.
-VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208
+VLM_NAME=nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8
 VLM_NAME_SLUG=cosmos-reason2-8b
 VLM_ENV_FILE=''
 VLM_BASE_URL=''
@@ -236,7 +236,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-c777a8d34f70
+VSS_AGENT_VERSION=dev-bbeb18a8d01c
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000
@@ -281,7 +281,7 @@ ALERT_BRIDGE_URL=http://${HOST_IP}:${ALERT_BRIDGE_PORT}
 RTVI_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${VLM_NAME}
 RTVI_VLM_MODEL_TO_USE=cosmos-reason2
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
-RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos-reason2-8b:hf-1208'
+RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8'
 
 # RTVI VLM Kafka Configuration
 RTVI_VLM_KAFKA_BOOTSTRAP_SERVERS=${HOST_IP}:9092

--- a/deploy/docker/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/alert_type_config.json
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/alert_type_config.json
@@ -6,7 +6,7 @@
       "output_category": "Ladder PPE Violation",
       "prompts": {
         "system": "You are a helpful assistant.",
-        "user": "Is anyone on the ladder without a hardhat and safety vest? \nAnswer yes or no."
+        "user": "Is anyone on the ladder without a hardhat and safety vest?\n\nWhich category best describes the situation:\n(Yes) Safety hazard present\n(No) No safety hazard observed\n\nAnswer yes or no.\n\nAnswer the question using the following format:\n\n<think>\nYour reasoning.\n</think>\n\nWrite your final answer immediately after the </think> tag."
       }
     }
   ]

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -76,7 +76,7 @@ LLM_MODEL_TYPE=nim
 #   VLM_NAME_SLUG: cosmos-reason2-8b
 # - VLM_NAME: Qwen/Qwen3-VL-8B-Instruct
 #   VLM_NAME_SLUG: qwen3-vl-8b-instruct
-# - VLM_NAME: nvidia/cosmos3-reasoner        # set NIM_MODEL_SIZE below
+# - VLM_NAME: nvidia/cosmos3-reasoner        # staging RC — set NIM_MODEL_SIZE below
 #   VLM_NAME_SLUG: cosmos3-reasoner
 VLM_NAME=nvidia/cosmos-reason2-8b
 VLM_NAME_SLUG=cosmos-reason2-8b
@@ -84,7 +84,7 @@ VLM_ENV_FILE=''
 VLM_BASE_URL=''
 VLM_MODEL_TYPE=nim
 
-# Cosmos3 Reasoner only. Selects model size baked into the NIM:
+# Cosmos3 Reasoner RC only. Selects model size baked into the staging NIM:
 #   nano  — default; fits on shared GPU layouts
 #   super — needs a dedicated VLM GPU
 #NIM_MODEL_SIZE=nano
@@ -178,7 +178,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-c777a8d34f70
+VSS_AGENT_VERSION=dev-bbeb18a8d01c
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -72,7 +72,7 @@ LLM_MODEL_TYPE=nim
 # VLM is served by the RT-VLM container in the LVS profile. For local and
 # local_shared deployments, RT-VLM loads the integrated NGC checkpoint below
 # instead of a separate Cosmos NIM container.
-VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208
+VLM_NAME=nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8
 # Use the following VLM_NAME for Nemotron Nano Omni
 #VLM_NAME=Nemotron-Nano-V3-Omni-GA0420-FP8
 VLM_NAME_SLUG=none
@@ -183,7 +183,7 @@ EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-c777a8d34f70
+VSS_AGENT_VERSION=dev-bbeb18a8d01c
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000
@@ -211,7 +211,7 @@ RTVI_VLM_ENDPOINT=''
 RTVI_VLM_URL=http://${HOST_IP}:${RTVI_VLM_PORT}
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
 RTVI_VLM_MODEL_TO_USE=cosmos-reason2
-RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos-reason2-8b:hf-1208'
+RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8'
 
 # -----------------------------------------------------------------------------
 # Optional: Configuration for Nemotron Nano Omni
@@ -297,10 +297,10 @@ NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE=true
 LVS_IMAGE="nvcr.io/nvstaging/vss-core/vss-video-summarization"
 
 # LVS Image tags for x86 and DGX-THOR
-LVS_TAG="3.2.0"
+LVS_TAG="3.2.0-rc11-d65196a"
 
 # Uncomment below LVS Image tags for DGX-SPARK
-# LVS_TAG="3.2.0-arm64-sbsa"
+# LVS_TAG="3.2.0-rc11-d65196a-arm64-sbsa"
 
 # Kafka integration: route LVS structured summaries through Kafka
 KAFKA_ENABLED=true

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -230,7 +230,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-c777a8d34f70
+VSS_AGENT_VERSION=dev-bbeb18a8d01c
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -253,7 +253,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-c777a8d34f70
+VSS_AGENT_VERSION=dev-bbeb18a8d01c
 VSS_AGENT_CONFIG_FILE=./deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -17,7 +17,7 @@
 
 services:
   vss-va-mcp:
-    image: nvcr.io/nvstaging/vss-core/vss-agent:${VSS_AGENT_VERSION}
+    image: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent:${VSS_AGENT_VERSION}
     container_name: vss-va-mcp
     network_mode: host
     profiles:
@@ -61,7 +61,7 @@ services:
 
   vss-agent:
     # for release, change this to the versioned image from the registry
-    image: nvcr.io/nvstaging/vss-core/vss-agent:${VSS_AGENT_VERSION}
+    image: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent:${VSS_AGENT_VERSION}
     container_name: vss-agent
     network_mode: host
     profiles:

--- a/deploy/helm/developer-profiles/dev-profile-alerts/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/README.md
@@ -171,7 +171,7 @@ In **Description**, **Real-time (`values-realtime.yaml`)** notes which subcharts
 | **`agent.vss-agent.profile`** | **`alerts`** | Passed to the **vss-agent** subchart so it mounts **report-templates** and sets template env for the **alerts** UX. ConfigMap data is read from **`configs/vss-agent/config.yml`** (and **`incident_report_template.md`**) in this chart — flat paths, no profile subfolders. |
 | **`agent.vss-agent.mountEvalOutput`** | **`false`** | Shared **vss-agent** chart defaults **`mountEvalOutput: true`** (eval **emptyDir**); alerts sets **`false`** because this profile does not use the eval-output volume. |
 | **`agent.vss-agent.llmName`** | NGC model id (e.g. **`nvidia/nvidia-nemotron-nano-9b-v2`**) | NGC catalog id for the LLM; must match the model deployed under **`nims`**. |
-| **`agent.vss-agent.vlmName`** | NGC model id (e.g. **`nim_nvidia_cosmos-reason2-8b_hf-1208`**) | NGC catalog id for the RTVI-VLM; must match the model deployed with rtvi-vlm. |
+| **`agent.vss-agent.vlmName`** | NGC model id (e.g. **`nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8`**) | NGC catalog id for the RTVI-VLM; must match the model deployed with rtvi-vlm. |
 | **`agent.vss-agent.evalLlmJudgeName`** | **`""`** | Optional eval judge model id. When empty, the **vss-agent** subchart defaults to **`llmName`**. |
 | **`agent.vss-agent.evalLlmJudgeBaseUrl`** | **`""`** | Optional base URL for the eval judge endpoint. When empty, the subchart defaults alongside **`llmBaseUrl`**. |
 | **`agent.vss-agent.reportsBaseUrl`** | **`""`** | Base URL for report links. When empty, templates derive a value from **`global.external*`** and in-cluster defaults. |
@@ -197,7 +197,7 @@ In **Description**, **Real-time (`values-realtime.yaml`)** notes which subcharts
 | **`vss-alert-bridge.redisPort`** | **`6379`** | Redis port for source/sink streams in **`config.yml`**. |
 | **`vss-alert-bridge.elasticHosts`** | **`""`** | Elasticsearch HTTP URL for **`elastic.hosts`** in **`config.yml`**. When empty, defaults to **`http://<release>-elasticsearch:9200`**. |
 | **`vss-alert-bridge.vlmBaseUrl`** | **`""`** | Base URL of the **rtviVLM** NIM HTTP service (no **`/v1`** suffix here; **`config.yml`** appends **`/v1`** for **`vlm.base_url`**). When empty, defaults to **`http://<release>-nvidia-cosmos-reason2-8b:8000`**; align with the **VLM** you deploy under **`nims`** and with **`vlmName`**. |
-| **`vss-alert-bridge.vlmName`** | **`nim_nvidia_cosmos-reason2-8b_hf-1208`** | NGC model id passed to **`vlm.model`**; must match the **RTVI-VLM** NIM you run (same idea as **`agent.vss-agent.vlmName`**). |
+| **`vss-alert-bridge.vlmName`** | **`nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8`** | NGC model id passed to **`vlm.model`**; must match the **RTVI-VLM** NIM you run (same idea as **`agent.vss-agent.vlmName`**). |
 | **`vss-alert-bridge.vstBaseUrl`** | **`""`** | **VST** ingress base URL for **`vst_config`** and storage paths in **`config.yml`**. When empty, defaults to **`http://<release>-vss-vios-ingress:30888`**. |
 | **`vss-alert-bridge.alertReviewMediaBaseDir`** | **`""`** | Optional **`ALERT_REVIEW_MEDIA_BASE_DIR`** in **`config.yml`** for alert-review media; leave empty if unused. |
 | **`vss-alert-bridge.configVariant`** | **`""`** | **`""`:** default **`config.yml`**. |

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values-realtime.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values-realtime.yaml
@@ -21,7 +21,7 @@
 
 profile: alerts
 mode: real-time
-vlmName: "nim_nvidia_cosmos-reason2-8b_hf-1208"
+vlmName: "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8"
 
 ngc:
   createSecrets: true
@@ -53,7 +53,7 @@ agent:
     rtviVlmEnabled: true
     rtviVlmServiceName: "vss-rtvi-vlm"
     cosmosEmbedEnabled: false
-    vlmName: "nim_nvidia_cosmos-reason2-8b_hf-1208"
+    vlmName: "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8"
 
 # No alert-bridge; do not set NEXT_PUBLIC_ALERTS_API_URL
 vss-agent-ui:

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values-realtime.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values-realtime.yaml
@@ -71,6 +71,7 @@ rtvi:
   vss-rtvi-vlm:
     enabled: true
     useSharedNim: false
+    modelPath: "ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8"
     env:
       - name: OPENAI_API_KEY
         value: "NOAPIKEYSET"

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values-verification.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values-verification.yaml
@@ -22,7 +22,7 @@
 
 profile: alerts
 mode: verification
-vlmName: "nim_nvidia_cosmos-reason2-8b_hf-1208"
+vlmName: "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8"
 
 ngc:
   createSecrets: true
@@ -55,7 +55,7 @@ agent:
   vss-agent:
     rtviVlmEnabled: true
     cosmosEmbedEnabled: false
-    vlmName: "nim_nvidia_cosmos-reason2-8b_hf-1208"
+    vlmName: "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8"
 
 vssIngress:
   enabled: true

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values-verification.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values-verification.yaml
@@ -74,6 +74,7 @@ rtvi:
   vss-rtvi-vlm:
     enabled: true
     useSharedNim: false
+    modelPath: "ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8"
     kafkaBootstrapServers: ""
     redisHost: ""
     env:

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -301,7 +301,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-c777a8d34f70" }}'
+        value: '{{ .Values.vssAgentVersion | default "dev-bbeb18a8d01c" }}'
     waitForDependencies:
       enabled: true
   vss-va-mcp:
@@ -348,7 +348,7 @@ vss-alert-bridge:
   redisPort: "6379"
   elasticHosts: ""
   vlmBaseUrl: '{{- if (trim (.Values.rtviVlmBaseUrl | default "")) }}{{ trim .Values.rtviVlmBaseUrl }}{{- else }}{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $svc := trim (.Values.rtviVlmServiceName | default "vss-rtvi-vlm") }}{{- printf "http://%s:8000" (ternary (printf "%s-%s" .Release.Name $svc) $svc $pfx) -}}{{- end }}'
-  vlmName: "nim_nvidia_cosmos-reason2-8b_hf-1208"
+  vlmName: "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8"
   vstBaseUrl: ""
   alertReviewMediaBaseDir: ""
   configVariant: ""

--- a/deploy/helm/developer-profiles/dev-profile-base/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/values.yaml
@@ -251,7 +251,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-c777a8d34f70" }}'
+        value: '{{ .Values.vssAgentVersion | default "dev-bbeb18a8d01c" }}'
 vss-agent-ui:
   enabled: true
   # Empty URL fields: deployment uses global.external* then in-cluster defaults.
@@ -272,7 +272,7 @@ vss-agent-ui:
     - name: NEXT_PUBLIC_ALERTS_TAB_MAX_SEARCH_TIME_LIMIT
       value: "0"
     - name: NEXT_PUBLIC_ALERTS_TAB_MEDIA_WITH_OBJECTS_BBOX
-      value: "false"
+      value: "true"
     - name: NEXT_PUBLIC_ALERTS_TAB_VERIFIED_FLAG_DEFAULT
       value: "false"
     - name: NEXT_PUBLIC_APP_TITLE

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -26,7 +26,7 @@ By default this profile is an **in-cluster** deployment:
 | Component | Default behavior | Default model name |
 |-----------|------------------|--------------------|
 | LLM | Deploys the **`nvidia-nemotron-nano-9b-v2`** NIM through the **`nims`** umbrella chart (`NIMCache` / `NIMService`). | `nvidia/nvidia-nemotron-nano-9b-v2` |
-| VLM / RT-VLM | Deploys **`vss-rtvi-vlm`** in this release. The RT-VLM pod loads the integrated Cosmos Reason2 checkpoint; the profile does **not** deploy a separate Cosmos VLM NIM by default. | `nim_nvidia_cosmos-reason2-8b_hf-1208` |
+| VLM / RT-VLM | Deploys **`vss-rtvi-vlm`** in this release. The RT-VLM pod loads the integrated Cosmos Reason2 checkpoint; the profile does **not** deploy a separate Cosmos VLM NIM by default. | `nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8` |
 
 Switch to **external-service mode** only when the model endpoints already run outside this release. Setting **`global.llmBaseUrl`** or **`global.vlmBaseUrl`** (or the matching **`agent.vss-agent.*BaseUrl`** / **`vss-summarization.*BaseUrl`** overrides) makes those workloads call the supplied external service instead of the default in-cluster service. When both LLM and VLM are external, set **`nims.enabled=false`** and set **`rtvi.vss-rtvi-vlm.useSharedNim=true`** so RT-VLM proxies the external VLM instead of loading the integrated checkpoint.
 
@@ -69,8 +69,8 @@ Key values (see `values.yaml` for defaults and the full `rtvi.vss-rtvi-vlm.env` 
 |-----|---------|-------|
 | `rtvi.enabled` | `true` | Umbrella switch; set `false` only if you intentionally bypass RT-VLM. Also configure `vss-agent` `VLM_MODEL_TYPE=nim` and remove `vss-summarization.extraEnv` entries that target the RTVI service. |
 | `rtvi.vss-rtvi-vlm.enabled` | `true` | Deploy the RTVI-VLM pod. |
-| `rtvi.vss-rtvi-vlm.useSharedNim` | `false` | Load the integrated checkpoint in the RT-VLM pod. Sets `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` and `VLM_MODEL_TO_USE=cosmos-reason2`. |
-| `rtvi.vss-rtvi-vlm.modelPath` | `ngc:nim/nvidia/cosmos-reason2-8b:hf-1208` | Integrated RT-VLM checkpoint path used when `useSharedNim=false`. |
+| `rtvi.vss-rtvi-vlm.useSharedNim` | `false` | Load the integrated checkpoint in the RT-VLM pod. Sets `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8` and `VLM_MODEL_TO_USE=cosmos-reason2`. |
+| `rtvi.vss-rtvi-vlm.modelPath` | `ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8` | Integrated RT-VLM checkpoint path used when `useSharedNim=false`. |
 | `infra.kafka.enabled` | `true` | Deploy Kafka for RTVI-VLM event publishing and create the default VSS topics, including `mdx-vlm` and `mdx-vlm-incidents`. |
 | `rtvi.vss-rtvi-vlm.waitForKafka.enabled` | `true` | The RTVI-VLM init container waits for Kafka and required RTVI topics before startup. |
 | `rtvi.vss-rtvi-vlm.env` | full list | Replaces the subchart default `env`. Override individual values (e.g. edge `VLM_INPUT_*`) by editing the list in your overlay. |
@@ -196,7 +196,7 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`global.llmBaseUrl`** | **`""`** | **Single place** for remote LLM base URL shared by **vss-agent** and **vss-summarization** ( **`LLM_BASE_URL`**, **`LVS_LLM_BASE_URL`** ). Use the service root without trailing **`/v1`** (e.g. **`http://host:31081`**): **vss-agent** appends **`/v1`** in its config, and **vss-summarization** adds **`/v1`** when missing. Subchart **`agent.vss-agent.llmBaseUrl`** or **`vss-summarization.llmBaseUrl`** overrides when set. |
 | **`global.vlmBaseUrl`** | **`""`** | Same for VLM (**`VLM_BASE_URL`**, **`VIA_VLM_ENDPOINT`**). Use the same service-root convention without trailing **`/v1`** for compatibility with **vss-agent** and RT-VLM proxying. |
 | **`global.llmName`** | **`nvidia/nvidia-nemotron-nano-9b-v2`** | NGC model id for **both** **vss-agent** (**`LLM_NAME`**) and **vss-summarization** (**`LVS_LLM_MODEL_NAME`**). Override with **`agent.vss-agent.llmName`** or **`vss-summarization.llmName`** when a workload needs a different id (e.g. remote NIM). |
-| **`global.vlmName`** | **`nim_nvidia_cosmos-reason2-8b_hf-1208`** | Same for VLM (**`VLM_NAME`**, **`VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME`**). |
+| **`global.vlmName`** | **`nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8`** | Same for VLM (**`VLM_NAME`**, **`VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME`**). |
 | **`global.storageClass`** | unset in repo **`values.yaml`** | Set in **`values-lvs.yaml`**; used for **Elasticsearch**, **`vios.vstStorage`** PVCs, and other subcharts that inherit **`global.storageClass`**. |
 | **`vios.vstStorage.createSharedPvcs`** | **`true`** | **`true`:** the **`vios`** umbrella creates **PersistentVolumeClaims** so **sensor** and **streamprocessing** share on-disk folders for VST data and video; data survives pod restarts but your cluster must have a working **StorageClass** (see **`global.storageClass`**). **`false`:** no shared PVCs from **`vios`**; behavior depends on **`vios.vss-vios-*`** persistence settings. |
 | **`vios.vstStorage.accessMode`** | **`ReadWriteOnce`** | Access mode for the three shared VST PVCs (see **`helm/services/vios/templates/vst-storage-pvc.yaml`**). |
@@ -252,7 +252,7 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`agent.vss-agent.vstInternalUrl`** | **`""`** | In-cluster **VST** URL for the agent when the default wiring is insufficient. |
 | **`agent.vss-agent.vstInternalIp`** | **`""`** | In-cluster **VST** host/IP override when defaults are insufficient. |
 | **`agent.vss-agent.vssAgentExternalUrl`** | **`""`** | External **vss-agent** URL override for browser / callbacks when **`global.external*`** is not enough. |
-| **`agent.vss-agent.vssAgentVersion`** | **`3.2.0-26.05.5-c777a8d34f70`** | Optional version label / env; adjust per release. |
+| **`agent.vss-agent.vssAgentVersion`** | **`dev-bbeb18a8d01c`** | Optional version label / env; adjust per release. |
 | **`agent.vss-agent.llmName`** | **`""`** | Optional **vss-agent-only** override of **`global.llmName`** (**`LLM_NAME`**). |
 | **`agent.vss-agent.vlmName`** | **`""`** | Optional **vss-agent-only** override of **`global.vlmName`** (**`VLM_NAME`**). |
 | **`agent.vss-agent.llmBaseUrl`** | **`""`** | Optional **vss-agent-only** override of **`global.llmBaseUrl`**. |
@@ -323,7 +323,7 @@ helm upgrade --install vss-lvs ./dev-profile-lvs \
   --set-string global.llmBaseUrl="$LLM_BASE_URL" \
   --set-string global.vlmBaseUrl="$VLM_BASE_URL" \
   --set-string global.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
-  --set-string global.vlmName="nim_nvidia_cosmos-reason2-8b_hf-1208" \
+  --set-string global.vlmName="nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8" \
   --set rtvi.vss-rtvi-vlm.useSharedNim=true
 ```
 

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
@@ -23,7 +23,7 @@ profile: lvs
 mode: ""
 llmNameSlug: <replace-with-llm-name> # e.g. nvidia-nemotron-nano-9b-v2, nvidia-nemotron-nano-9b-v2-mini, nvidia-nemotron-nano-9b-v2-mini-2
 vlmNameSlug: none # LVS uses the integrated RT-VLM checkpoint, not a VLM NIM subchart.
-vlmName: "nim_nvidia_cosmos-reason2-8b_hf-1208"
+vlmName: "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8"
 
 ngc:
   createSecrets: true
@@ -40,7 +40,7 @@ global:
   llmBaseUrl: ""
   vlmBaseUrl: ""
   llmName: "nvidia/nvidia-nemotron-nano-9b-v2"
-  vlmName: "nim_nvidia_cosmos-reason2-8b_hf-1208"
+  vlmName: "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8"
 
 
 # Shared umbrella helm/services/nims — override gpuType here (see dev-profile-lvs/values.yaml for full nims.* defaults).

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -44,7 +44,7 @@ global:
   vlmBaseUrl: ""
   # NGC model ids — shared by vss-agent (LLM_NAME / VLM_NAME) and vss-summarization (LVS_LLM_MODEL_NAME, VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME). Override per subchart if needed.
   llmName: "nvidia/nvidia-nemotron-nano-9b-v2"
-  vlmName: "nim_nvidia_cosmos-reason2-8b_hf-1208"
+  vlmName: "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8"
 
 # Set global.external* and optional global.kibanaPublicUrl in values-lvs.yaml. Images/replicas: charts/<name>/values.yaml.
 
@@ -207,7 +207,7 @@ agent:
     vstInternalUrl: ""
     vstInternalIp: ""
     vssAgentExternalUrl: ""
-    vssAgentVersion: "3.2.0-26.05.5-c777a8d34f70"
+    vssAgentVersion: "dev-bbeb18a8d01c"
     evalLlmJudgeName: ""
     evalLlmJudgeBaseUrl: ""
     reportsBaseUrl: ""
@@ -278,7 +278,7 @@ agent:
       - name: LLM_NAME
         value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.llmName ((index $g "llmName") | default "") "nvidia/nvidia-nemotron-nano-9b-v2") }}'
       - name: VLM_NAME
-        value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.vlmName ((index $g "vlmName") | default "") "nim_nvidia_cosmos-reason2-8b_hf-1208") }}'
+        value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.vlmName ((index $g "vlmName") | default "") "nim_nvidia_cosmos-reason2-8b_0303-fp8-dynamic-kv8") }}'
       - name: EVAL_LLM_JUDGE_NAME
         value: '{{- $g := .Values.global | default dict }}{{- $ln := trim (coalesce .Values.llmName ((index $g "llmName") | default "") "nvidia/nvidia-nemotron-nano-9b-v2") }}{{ coalesce .Values.evalLlmJudgeName $ln }}'
       - name: EVAL_LLM_JUDGE_BASE_URL
@@ -290,7 +290,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-c777a8d34f70" }}'
+        value: '{{ .Values.vssAgentVersion | default "dev-bbeb18a8d01c" }}'
       # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
       # Set enableAudio=true for Nemotron Nano Omni audio-aware VLM.
       - name: ENABLE_AUDIO
@@ -315,7 +315,7 @@ vss-agent-ui:
     - name: NEXT_PUBLIC_ALERTS_TAB_MAX_SEARCH_TIME_LIMIT
       value: "0"
     - name: NEXT_PUBLIC_ALERTS_TAB_MEDIA_WITH_OBJECTS_BBOX
-      value: "false"
+      value: "true"
     - name: NEXT_PUBLIC_ALERTS_TAB_VERIFIED_FLAG_DEFAULT
       value: "false"
     - name: NEXT_PUBLIC_APP_TITLE
@@ -458,7 +458,7 @@ rtvi:
   vss-rtvi-vlm:
     enabled: true
     useSharedNim: false
-    modelPath: "ngc:nim/nvidia/cosmos-reason2-8b:hf-1208"
+    modelPath: "ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8"
     sharedNimPort: "8000"
     # Wait for the LVS Kafka broker and RTVI topics created by infra.kafka.topicJob.
     waitForKafka:

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/ingress.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/ingress.yaml
@@ -155,7 +155,8 @@ spec:
                 port:
                   number: {{ $ing.vssUiPort | default 3000 }}
           {{- end }}
-    {{- if (index $vios "vss-vios-nvstreamer").enabled }}
+    {{- $nvstreamer := index $vios "vss-vios-nvstreamer" | default dict }}
+    {{- if $nvstreamer.enabled }}
     # ── Streamer host: NVStreamer HTTP API ─────────────────────────────
     - host: {{ $streamerHost }}
       http:
@@ -166,9 +167,10 @@ spec:
               service:
                 name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-vios-nvstreamer") }}
                 port:
-                  number: {{ (index $vios "vss-vios-nvstreamer").service.port }}
+                  number: {{ (index $nvstreamer "service" | default dict).port | default 31000 }}
     {{- end }}
-    {{- if (index (.Values.infra | default dict) "kibana" | default dict).enabled }}
+    {{- $kibana := index (.Values.infra | default dict) "kibana" | default dict }}
+    {{- if $kibana.enabled }}
     # ── Kibana host: dashboards ───────────────────────────────────────
     - host: {{ $kibanaHost }}
       http:
@@ -179,7 +181,7 @@ spec:
               service:
                 name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "kibana") }}
                 port:
-                  number: {{ (index (.Values.infra | default dict) "kibana" | default dict).service.port | default 5601 }}
+                  number: {{ (index $kibana "service" | default dict).port | default 5601 }}
     {{- end }}
     {{- $fp := index (.Values.infra | default dict) "phoenix" | default dict }}
     {{- if and $fp (default true $fp.enabled) (ne $phoenixHost "") }}

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -30,11 +30,25 @@ global:
     streamerHost: ''
   # rtviInternalIngress lives under `global` so the agent sub-chart's env-var
   # templates (rendered via `tpl` in the agent context) can read it — only
-  # `global.*` propagates across sub-charts. The toggle drives three things:
-  # (a) Chart.yaml dependency condition pulls in the haproxy-ingress sub-chart;
-  # (b) templates/rtvi-internal-ingress.yaml renders the Ingress object;
-  # (c) RTVI_*_BASE_URL / COSMOS_EMBED_ENDPOINT env vars below get rewritten
+  # `global.*` propagates across sub-charts. When enabled, this drives:
+  # (a) templates/rtvi-internal-ingress.yaml renders the Ingress object;
+  # (b) RTVI_*_BASE_URL / COSMOS_EMBED_ENDPOINT env vars below get rewritten
   # to go through the controller Service instead of the rtvi ClusterIPs.
+  #
+  # PREREQUISITE - the HAProxy Technologies kubernetes-ingress controller
+  # must already be installed in the cluster. The IngressClass `haproxy` is
+  # a cluster-scoped resource, so VSS does not bundle the controller.
+  #
+  # Install command is in this profile's README ("Step 2: Install Ingress
+  # Controller (HAProxy)"). It uses DaemonSet + hostPort for external
+  # traffic; enabling THIS option additionally requires the controller's
+  # ClusterIP Service (`--set controller.service.type=ClusterIP`), which is
+  # what makes `controllerService` below addressable. With rtviInternalIngress
+  # disabled (the default) the ClusterIP Service is not needed.
+  #
+  # The defaults `haproxy-kubernetes-ingress.haproxy-controller:80` match
+  # the README's install. Override only if you used a different release
+  # name or namespace.
   rtviInternalIngress:
     enabled: false
     className: haproxy
@@ -42,9 +56,10 @@ global:
     hashHeader: x-stream-id
     rtviCvPath: /rtvi-cv
     rtviEmbedPath: /rtvi-embed
-    # Empty => defaults to `<release>-haproxy-ingress` (the haproxytech
-    # sub-chart Service, named after the dependency alias in Chart.yaml).
-    controllerService: ""
+    # In-cluster DNS short name of the HAProxy ingress controller Service:
+    # `<svc-name>.<namespace>` - resolved to the FQDN via the pod search
+    # domain (haproxy-kubernetes-ingress.haproxy-controller.svc.cluster.local).
+    controllerService: "haproxy-kubernetes-ingress.haproxy-controller"
     controllerPort: 80
     annotations: {}
     tls: []
@@ -63,19 +78,6 @@ ingress:
     phoenix: ''
   tls: []
 
-# HAProxy Kubernetes Ingress sub-chart values. Only rendered when
-# global.rtviInternalIngress.enabled=true (see Chart.yaml condition).
-# Minimal config for a single-node dev cluster — ClusterIP Service is
-# enough because the agent talks to it in-cluster (no external traffic).
-haproxy-ingress:
-  controller:
-    kind: Deployment
-    replicaCount: 1
-    ingressClassResource:
-      name: haproxy
-      default: false
-    service:
-      type: ClusterIP
 sharedStorage:
   streamerVideos:
     # Disabled: same role as vios.vstStorage + streamprocessing persistence.streamerVideos (matches dev-profile-alerts; avoids a second PVC).
@@ -530,7 +532,7 @@ agent:
       - name: LVS_BACKEND_URL
         value: ''
       - name: RTVI_CV_BASE_URL
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-cv" $rii.rtviCvPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $cvPort := (.Values.rtviCvPort | default "9000") | toString -}}{{- $cvHost := ternary (printf "%s-vss-rtvi-cv" .Release.Name) "vss-rtvi-cv" $pfx -}}{{- printf "http://%s:%s" $cvHost $cvPort -}}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-cv" $rii.rtviCvPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $cvPort := (.Values.rtviCvPort | default "9000") | toString -}}{{- $cvHost := ternary (printf "%s-vss-rtvi-cv" .Release.Name) "vss-rtvi-cv" $pfx -}}{{- printf "http://%s:%s" $cvHost $cvPort -}}{{- end -}}'
       - name: VSS_ES_PORT
         value: ''
       - name: VST_BASE_URL
@@ -542,9 +544,9 @@ agent:
       - name: OPENAI_API_KEY
         value: ''
       - name: RTVI_EMBED_BASE_URL
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.rtviEmbedBaseUrl $def }}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.rtviEmbedBaseUrl $def }}{{- end -}}'
       - name: COSMOS_EMBED_ENDPOINT
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.cosmosEmbedEndpoint $def }}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.cosmosEmbedEndpoint $def }}{{- end -}}'
       - name: ELASTIC_SEARCH_ENDPOINT
         value: '{{- if (trim (.Values.elasticsearchUrl | default "")) }}{{ trim .Values.elasticsearchUrl }}{{- else }}{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $h := ternary (printf "%s-elasticsearch" .Release.Name) "elasticsearch" $pfx }}{{- printf "http://%s:9200" $h -}}{{- end }}'
       - name: ELASTIC_SEARCH_INDEX

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -30,27 +30,11 @@ global:
     streamerHost: ''
   # rtviInternalIngress lives under `global` so the agent sub-chart's env-var
   # templates (rendered via `tpl` in the agent context) can read it — only
-  # `global.*` propagates across sub-charts. When enabled, this drives:
-  # (a) templates/rtvi-internal-ingress.yaml renders the Ingress object;
-  # (b) RTVI_*_BASE_URL / COSMOS_EMBED_ENDPOINT env vars below get rewritten
+  # `global.*` propagates across sub-charts. The toggle drives three things:
+  # (a) Chart.yaml dependency condition pulls in the haproxy-ingress sub-chart;
+  # (b) templates/rtvi-internal-ingress.yaml renders the Ingress object;
+  # (c) RTVI_*_BASE_URL / COSMOS_EMBED_ENDPOINT env vars below get rewritten
   # to go through the controller Service instead of the rtvi ClusterIPs.
-  #
-  # PREREQUISITE — the HAProxy Technologies kubernetes-ingress controller
-  # must already be installed in the cluster. The IngressClass `haproxy` is
-  # a cluster-scoped resource, so VSS does NOT bundle the controller —
-  # bundling collides with any existing HAProxy install (Nam Nguyen hit
-  # this when the controller was already installed via a separate release).
-  #
-  # Install command is in this profile's README ("Step 2: Install Ingress
-  # Controller (HAProxy)"). It uses DaemonSet + hostPort for external
-  # traffic; enabling THIS option additionally requires the controller's
-  # ClusterIP Service (`--set controller.service.type=ClusterIP`), which is
-  # what makes `controllerService` below addressable. With rtviInternalIngress
-  # disabled (the default) the ClusterIP Service is not needed.
-  #
-  # The defaults `haproxy-kubernetes-ingress.haproxy-controller:80` match
-  # the README's install. Override only if you used a different release
-  # name or namespace.
   rtviInternalIngress:
     enabled: false
     className: haproxy
@@ -58,10 +42,9 @@ global:
     hashHeader: x-stream-id
     rtviCvPath: /rtvi-cv
     rtviEmbedPath: /rtvi-embed
-    # In-cluster DNS short name of the HAProxy ingress controller Service:
-    # `<svc-name>.<namespace>` — resolved to the FQDN via the pod search
-    # domain (haproxy-kubernetes-ingress.haproxy-controller.svc.cluster.local).
-    controllerService: "haproxy-kubernetes-ingress.haproxy-controller"
+    # Empty => defaults to `<release>-haproxy-ingress` (the haproxytech
+    # sub-chart Service, named after the dependency alias in Chart.yaml).
+    controllerService: ""
     controllerPort: 80
     annotations: {}
     tls: []
@@ -80,6 +63,19 @@ ingress:
     phoenix: ''
   tls: []
 
+# HAProxy Kubernetes Ingress sub-chart values. Only rendered when
+# global.rtviInternalIngress.enabled=true (see Chart.yaml condition).
+# Minimal config for a single-node dev cluster — ClusterIP Service is
+# enough because the agent talks to it in-cluster (no external traffic).
+haproxy-ingress:
+  controller:
+    kind: Deployment
+    replicaCount: 1
+    ingressClassResource:
+      name: haproxy
+      default: false
+    service:
+      type: ClusterIP
 sharedStorage:
   streamerVideos:
     # Disabled: same role as vios.vstStorage + streamprocessing persistence.streamerVideos (matches dev-profile-alerts; avoids a second PVC).
@@ -482,7 +478,7 @@ agent:
     videoAnalysisMcpUrl: ''
     template:
       name: ''
-    vssAgentVersion: 3.2.0-26.05.5-c777a8d34f70
+    vssAgentVersion: dev-bbeb18a8d01c
     # Copied from rtvi.* defaults (vss-agent subchart env tpl only sees agent.vss-agent; keep in sync with rtvi.vss-rtvi-embed.port / vss-rtvi-cv.httpPort).
     rtviEmbedPort: '8000'
     rtviCvPort: '9000'
@@ -534,7 +530,7 @@ agent:
       - name: LVS_BACKEND_URL
         value: ''
       - name: RTVI_CV_BASE_URL
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-cv" $rii.rtviCvPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $cvPort := (.Values.rtviCvPort | default "9000") | toString -}}{{- $cvHost := ternary (printf "%s-vss-rtvi-cv" .Release.Name) "vss-rtvi-cv" $pfx -}}{{- printf "http://%s:%s" $cvHost $cvPort -}}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-cv" $rii.rtviCvPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $cvPort := (.Values.rtviCvPort | default "9000") | toString -}}{{- $cvHost := ternary (printf "%s-vss-rtvi-cv" .Release.Name) "vss-rtvi-cv" $pfx -}}{{- printf "http://%s:%s" $cvHost $cvPort -}}{{- end -}}'
       - name: VSS_ES_PORT
         value: ''
       - name: VST_BASE_URL
@@ -546,9 +542,9 @@ agent:
       - name: OPENAI_API_KEY
         value: ''
       - name: RTVI_EMBED_BASE_URL
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.rtviEmbedBaseUrl $def }}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.rtviEmbedBaseUrl $def }}{{- end -}}'
       - name: COSMOS_EMBED_ENDPOINT
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.cosmosEmbedEndpoint $def }}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.cosmosEmbedEndpoint $def }}{{- end -}}'
       - name: ELASTIC_SEARCH_ENDPOINT
         value: '{{- if (trim (.Values.elasticsearchUrl | default "")) }}{{ trim .Values.elasticsearchUrl }}{{- else }}{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $h := ternary (printf "%s-elasticsearch" .Release.Name) "elasticsearch" $pfx }}{{- printf "http://%s:9200" $h -}}{{- end }}'
       - name: ELASTIC_SEARCH_INDEX
@@ -582,7 +578,7 @@ agent:
       - name: RTVI_EMBED_MODEL
         value: '{{ .Values.rtviEmbedModelName | default "cosmos-embed1-448p-anomaly-detection" }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-c777a8d34f70" }}'
+        value: '{{ .Values.vssAgentVersion | default "dev-bbeb18a8d01c" }}'
 
 vss-agent-ui:
   enabled: true
@@ -594,7 +590,7 @@ vss-agent-ui:
     imagePullPolicy: IfNotPresent
   image:
     repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-    tag: "3.2.0-26.05.5-c777a8d34f70"
+    tag: "3.2.0-26.05.2-794e57d82d0e"
   replicas: 1
   fillAlertBridgeUrlFromGlobal: false
   agentApiUrlBase: ''
@@ -626,7 +622,7 @@ vss-agent-ui:
     - name: NEXT_PUBLIC_ALERTS_TAB_MAX_SEARCH_TIME_LIMIT
       value: "0"
     - name: NEXT_PUBLIC_ALERTS_TAB_MEDIA_WITH_OBJECTS_BBOX
-      value: "false"
+      value: "true"
     - name: NEXT_PUBLIC_ALERTS_TAB_VERIFIED_FLAG_DEFAULT
       value: "false"
     - name: NEXT_PUBLIC_APP_TITLE

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -22,8 +22,8 @@ global: {}
 serviceAccount:
   create: false
 image:
-  repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.0-26.05.5-c777a8d34f70"
+  repository: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent
+  tag: "dev-bbeb18a8d01c"
   pullPolicy: IfNotPresent
 replicas: 1
 service:
@@ -90,7 +90,7 @@ reportsBaseUrl: ""
 vssAgentExternalUrl: ""
 externalIp: ""
 vstInternalIp: ""
-vssAgentVersion: "3.2.0-26.05.5-c777a8d34f70"
+vssAgentVersion: "dev-bbeb18a8d01c"
 lvsBackendService: ""
 
 # [Optional] HTTP-client timeouts (seconds) for the post-upload pipeline in
@@ -203,7 +203,7 @@ env:
 - name: AGENT_BASE_URL
   value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
 - name: VSS_AGENT_VERSION
-  value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-c777a8d34f70" }}'
+  value: '{{ .Values.vssAgentVersion | default "dev-bbeb18a8d01c" }}'
 # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
 # Set ENABLE_AUDIO=true for Nemotron Nano Omni audio-aware VLM.
 - name: ENABLE_AUDIO

--- a/deploy/helm/services/agent/charts/va-mcp/values.yaml
+++ b/deploy/helm/services/agent/charts/va-mcp/values.yaml
@@ -17,8 +17,8 @@ enabled: false
 global: {}
 
 image:
-  repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.0-26.05.5-c777a8d34f70"
+  repository: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent
+  tag: "dev-bbeb18a8d01c"
   pullPolicy: IfNotPresent
 # Image must have mcp[cli] (typer) installed for `mcp serve` (same as Docker Compose).
 replicas: 1

--- a/deploy/helm/services/video-summarization/values.yaml
+++ b/deploy/helm/services/video-summarization/values.yaml
@@ -17,7 +17,7 @@ enabled: false
 global: {}
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-video-summarization
-  tag: "3.2.0"
+  tag: "3.2.0-rc11-d65196a"
   pullPolicy: IfNotPresent
 replicas: 1
 # Backend (API), MCP ports — match Compose

--- a/services/agent/src/vss_agents/tools/rtvi_vlm_alert.py
+++ b/services/agent/src/vss_agents/tools/rtvi_vlm_alert.py
@@ -53,7 +53,7 @@ class RTVIVLMAlertConfig(FunctionBaseConfig, name="rtvi_vlm_alert"):
         description="Default VLM model for caption/alert generation",
     )
     default_alert_type: str = Field(
-        "alert",
+        "vlm-alert",
         description="Default alert_type label assigned to created rules when not provided",
     )
     default_prompt: str | None = Field(

--- a/services/agent/tests/unit_test/tools/test_rtvi_vlm_alert.py
+++ b/services/agent/tests/unit_test/tools/test_rtvi_vlm_alert.py
@@ -34,7 +34,7 @@ class TestRTVIVLMAlertConfig:
         assert config.alert_bridge_url == "http://localhost:9080"
         assert config.vst_internal_url == "http://10.0.0.1:30888"
         assert config.default_model == "nvidia/cosmos-reason1-7b"
-        assert config.default_alert_type == "alert"
+        assert config.default_alert_type == "vlm-alert"
         assert config.timeout == 180
 
     def test_custom_defaults(self):

--- a/services/agent/tests/unit_test/tools/test_rtvi_vlm_alert_inner.py
+++ b/services/agent/tests/unit_test/tools/test_rtvi_vlm_alert_inner.py
@@ -161,6 +161,44 @@ class TestRTVIVLMAlertInner:
         assert "not found" in result.message.lower()
 
     @pytest.mark.asyncio
+    async def test_start_posts_default_vlm_alert_type(self, config, mock_builder):
+        _sensor_to_alert_rule_id.pop("HWY_20", None)
+
+        mock_get_resp = AsyncMock()
+        mock_get_resp.status = 200
+        mock_get_resp.raise_for_status = MagicMock()
+        mock_get_resp.text = AsyncMock(
+            return_value=json.dumps([{"stream-uuid-1": [{"name": "HWY_20", "url": "rtsp://ip/stream"}]}])
+        )
+        mock_get_resp.__aenter__ = AsyncMock(return_value=mock_get_resp)
+        mock_get_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_post_resp = MagicMock()
+        mock_post_resp.status = 201
+        mock_post_resp.text = AsyncMock(return_value=json.dumps({"id": "rule-uuid-1"}))
+        mock_post_cm = AsyncMock()
+        mock_post_cm.__aenter__ = AsyncMock(return_value=mock_post_resp)
+        mock_post_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_get_resp
+        mock_session.post.return_value = mock_post_cm
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("vss_agents.tools.rtvi_vlm_alert.aiohttp.ClientSession", return_value=mock_session):
+            with patch("vss_agents.tools.rtvi_vlm_alert.aiohttp.ClientTimeout"):
+                inner_fn = await self._get_inner_fn(config, mock_builder)
+                inp = RTVIVLMAlertInput(action="start", sensor_name="HWY_20")
+                result = await inner_fn(inp)
+
+        assert result.success is True
+        assert result.alert_rule_id == "rule-uuid-1"
+        assert mock_session.post.call_args.kwargs["json"]["alert_type"] == "vlm-alert"
+        assert _sensor_to_alert_rule_id["HWY_20"] == "rule-uuid-1"
+        _sensor_to_alert_rule_id.pop("HWY_20", None)
+
+    @pytest.mark.asyncio
     async def test_stop_404_response(self, config, mock_builder):
         """Stop returns success when Alert Bridge reports rule already gone."""
         _sensor_to_alert_rule_id["SENSOR_404"] = "rule-uuid-404"


### PR DESCRIPTION
## Summary
- change the default realtime VLM alert type from `alert` to `vlm-alert`
- add unit coverage asserting the default POST payload uses `vlm-alert`
- align the Docker PPE verifier prompt with the stricter Helm prompt already on develop

## Validation
- `jq empty deploy/docker/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/alert_type_config.json`
- `git diff --check HEAD~1 HEAD`
- `uv run ruff check services/agent/src/vss_agents/tools/rtvi_vlm_alert.py services/agent/tests/unit_test/tools/test_rtvi_vlm_alert.py services/agent/tests/unit_test/tools/test_rtvi_vlm_alert_inner.py`
- `uv run ruff format --check services/agent/src/vss_agents/tools/rtvi_vlm_alert.py services/agent/tests/unit_test/tools/test_rtvi_vlm_alert.py services/agent/tests/unit_test/tools/test_rtvi_vlm_alert_inner.py`
- from `services/agent`: `SETUPTOOLS_SCM_PRETEND_VERSION=3.2.0 uv run pytest tests/unit_test/tools/test_rtvi_vlm_alert.py tests/unit_test/tools/test_rtvi_vlm_alert_inner.py -v` -> 29 passed

## NVBugs
- 6187330
- 6186227: prompt quality aligned; rejected-to-confirmed transition appears expected continuous VLM evaluation behavior per bug comments.