### PR TITLE
fix(vss-generate-video-report): rewrite VST clip URLs to HAProxy ingress (Brev-aware)

### DIFF
--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -49,6 +49,57 @@ If the probe fails, hand off to `/vss-deploy-profile` with `-p base` (Mode A) or
 
 ---
 
+## Browser-playable clip URL (always do this before embedding any clip in the report)
+
+VST returns clip URLs of the form `http://${HOST_IP}:30888/vst/storage/temp_files/<name>.mp4` and incidents from `/vss-query-analytics` carry the same shape. **Those URLs use the agent-internal host:port** — they are reachable from in-cluster services (VLM, RT-VLM) but **not** from the user's browser, where they time out (`ERR_CONNECTION_TIMED_OUT`). Every clip URL surfaced **in the rendered report** must be rewritten to the HAProxy ingress (port 7777, the single browser-facing front door — `deploy/docker/services/infra/haproxy/haproxy.cfg.template` routes `/vst/*` → `bk_vst_ingress`).
+
+On Brev, the HAProxy port is further exposed as the secure-link domain `7777-<BREV_ENV_ID>.brevlab.com` over HTTPS — same convention `vss-deploy-profile` uses for `EXTERNAL_IP` (see `vss-deploy-profile/references/brev.md`).
+
+### Rewrite recipe
+
+```bash
+# Convert any VST URL ("http://<host>:<port>/vst/..." or "/storage/...") into a
+# browser-playable URL for the current deployment. Brev-aware.
+to_browser_clip_url() {
+  local raw="$1"
+
+  # Path: VST sometimes returns /storage/... (HAProxy backwards-compat rewrites
+  # that to /vst/storage/...). Normalize to /vst/storage/... up-front so the
+  # output works regardless of which path VST emitted.
+  local path
+  path=$(printf '%s' "$raw" | sed -E 's|^https?://[^/]+||; s|^/storage/|/vst/storage/|; s|^/storage$|/vst/storage|')
+
+  # Pick the browser-facing host:port for this deploy.
+  local brev_env_id
+  brev_env_id=$(awk -F= '/^BREV_ENV_ID=/ {gsub(/"/, "", $2); print $2; exit}' /etc/environment 2>/dev/null)
+  if [ -n "$brev_env_id" ]; then
+    printf 'https://7777-%s.brevlab.com%s\n' "$brev_env_id" "$path"
+  elif [ -n "${EXTERNAL_IP:-}" ]; then
+    # EXTERNAL_IP may already contain a port (e.g. "7777-<id>.brevlab.com")
+    # or be a bare host — handle both.
+    case "$EXTERNAL_IP" in
+      *.brevlab.com) printf 'https://%s%s\n' "$EXTERNAL_IP" "$path" ;;
+      *:*)           printf 'http://%s%s\n'  "$EXTERNAL_IP" "$path" ;;
+      *)             printf 'http://%s:7777%s\n' "$EXTERNAL_IP" "$path" ;;
+    esac
+  else
+    printf 'http://%s:7777%s\n' "${HOST_IP:-localhost}" "$path"
+  fi
+}
+```
+
+### When to apply
+
+| Surface | Internal URL (input) | Action |
+|---|---|---|
+| **VLM `video_url` content block in Mode A Step 3** | VST URL with `HOST_IP:30888` | **Leave as-is** — the VLM is in-cluster and fetches frames from the internal URL. |
+| **Mode A Step 4 "Video Source" / "Clip URL" template field** | Same internal URL | `to_browser_clip_url "$VIDEO_URL"` — the report is for the user's browser. |
+| **Mode B incident clip URL** (the `clip_url` / equivalent field returned with each incident) | Same shape | `to_browser_clip_url "$INCIDENT_CLIP_URL"` before pasting into the per-incident bullet. |
+
+If `to_browser_clip_url` produces the same value as the input (no rewrite needed because the URL is already external), pass it through unchanged.
+
+---
+
 ## Mode A — Report on a recorded video clip
 
 **If the VSS `lvs` profile is deployed** — `curl -sf --max-time 5 "http://${HOST_IP}:38111/v1/ready"` returns HTTP 200 — run `/vss-summarize-video` to produce the summary, then paste its output into the report template in Step 4 and skip Steps 1–3 (the VLM-direct path). Run Steps 1–3 only when `/v1/ready` is non-200.
@@ -65,7 +116,7 @@ Hand off to `/vss-manage-video-io-storage` to:
    curl -s "http://${HOST_IP}:30888/vst/api/v1/storage/file/<streamId>/url?startTime=<startTime>&endTime=<endTime>&container=mp4&disableAudio=true" | jq -r .videoUrl
    ```
 
-   That gives a direct `mp4` URL that the VLM can pull frames from. Bind it to `VIDEO_URL`.
+   That gives a direct `mp4` URL that the VLM can pull frames from. Bind it to `VIDEO_URL` (used in-cluster by the VLM in Step 3) **and** compute `BROWSER_CLIP_URL=$(to_browser_clip_url "$VIDEO_URL")` for the Step 4 report template — the user's browser cannot reach `$VIDEO_URL` directly.
    Mode A requires the selected VLM endpoint to be able to fetch `VIDEO_URL`.
    Local NIM/RT-VLM deployments normally can; remote endpoints generally cannot
    fetch `localhost`, private `HOST_IP`, or VST-internal URLs. If the live
@@ -162,6 +213,7 @@ If the VLM returns a `<think>…</think>` block (Cosmos Reason reasoning mode), 
 | **Time of Analysis** | <HH:MM:SS> |
 | **Video Source** | <sensor_id or filename> |
 | **Clip Range** | <startTime> – <endTime> |
+| **Clip URL** | `<BROWSER_CLIP_URL>` (from `to_browser_clip_url "$VIDEO_URL"` — NEVER paste the raw `HOST_IP:30888` URL here) |
 | **VLM** | <VLM_MODEL (NIM or RT-VLM)> |
 | **Analysis Request** | <user's request> |
 
@@ -199,7 +251,7 @@ Hand off to `/vss-query-analytics` (initialize → `tools/call`) with:
 }
 ```
 
-For each incident keep: `id`, `sensorId`, `timestamp`, `end`, `category`, `place.name`, `info.verdict`, `info.reasoning`, `objectIds`.
+For each incident keep: `id`, `sensorId`, `timestamp`, `end`, `category`, `place.name`, `info.verdict`, `info.reasoning`, `objectIds`, and the clip URL (commonly `info.clip_url`, `clip_url`, or whichever clip-pointer field the response carries). **Run every clip URL through `to_browser_clip_url` (see *Browser-playable clip URL* above) before pasting it into the report.** The raw value is a `HOST_IP:30888` URL the user's browser cannot reach.
 
 ### Step 3 — Fill the Incident Range Report template
 
@@ -224,6 +276,7 @@ Group by sensor (or by category if no sensor scope), tally verdicts, list each i
 
 - **<timestamp>** — <category> — verdict: **<confirmed|rejected|unverified>**
   - <info.reasoning (1–2 lines)>
+  - clip: `<to_browser_clip_url result>` (omit row when the incident carries no clip URL — never paste a raw `HOST_IP:30888` URL)
   - objects: <objectIds joined>
 - …
 


### PR DESCRIPTION
## Summary

`vss-generate-video-report` was pasting VST's internal clip URL — `http://${HOST_IP}:30888/vst/storage/temp_files/<name>.mp4` — directly into the rendered report. That URL is reachable from in-cluster services (VLM frame pulls, agent backend) but the user's browser hits `ERR_CONNECTION_TIMED_OUT` because the host IP is agent-internal and port 30888 isn't on the Brev secure-link front door.

Fix: a new top-level *Browser-playable clip URL* section with a `to_browser_clip_url` bash helper that the skill is now instructed to apply before any clip URL lands in the report.

## What the rewrite does

```bash
to_browser_clip_url() {
  # 1. Strip host:port from the raw URL; normalize /storage/… → /vst/storage/…
  # 2. Prepend the right browser-facing host:port for this deploy:
  #    - Brev (BREV_ENV_ID in /etc/environment) → https://7777-<id>.brevlab.com
  #    - bare metal with EXTERNAL_IP → http(s)://$EXTERNAL_IP[:7777]
  #    - otherwise → http://${HOST_IP:-localhost}:7777
}
```

Why port 7777 specifically: `deploy/docker/services/infra/haproxy/haproxy.cfg.template` routes `/vst/*` → `bk_vst_ingress`, with a `replace-path` rule that rewrites bare `/storage/*` → `/vst/storage/*`. So 7777 is the single browser-facing front door for VST in every deployment shape — bare metal, Brev, or anything else that exposes HAProxy.

Why Brev's specific secure-link convention: same one `vss-deploy-profile/references/brev.md` uses for `EXTERNAL_IP` (`7777-<BREV_ENV_ID>.brevlab.com` over https).

## Smoke test

```
$ to_browser_clip_url "http://172.31.40.112:30888/vst/storage/temp_files/sample.mp4"
http://172.31.40.112:7777/vst/storage/temp_files/sample.mp4

$ EXTERNAL_IP=reports.example.com to_browser_clip_url "http://172.31.40.112:30888/vst/storage/temp_files/sample.mp4"
http://reports.example.com:7777/vst/storage/temp_files/sample.mp4

$ to_browser_clip_url "http://172.31.40.112:30888/storage/temp_files/sample.mp4"   # /storage/* path variant
http://172.31.40.112:7777/vst/storage/temp_files/sample.mp4
```

Brev path (with `BREV_ENV_ID=fn030l2bn` in `/etc/environment`) produces `https://7777-fn030l2bn.brevlab.com/vst/storage/temp_files/sample.mp4` — which is the same convention as the bug-reporter's manually-rewritten working URL, just routed through HAProxy rather than directly to VST's secure-link port.

## Call sites updated

| Surface | Before | After |
|---|---|---|
| Mode A Step 1 (clip URL bind) | only binds `$VIDEO_URL` (internal) | also binds `$BROWSER_CLIP_URL=$(to_browser_clip_url "$VIDEO_URL")` |
| Mode A Step 4 template | no Clip URL row | new "Clip URL" row uses `$BROWSER_CLIP_URL` with an explicit "never paste raw HOST_IP:30888" warning |
| Mode B Step 2 incident keep-set | doesn't mention clip URLs | calls out `info.clip_url` / `clip_url` and instructs the rewrite |
| Mode B Step 3 per-incident bullet | no clip row | new "clip:" sub-bullet renders the rewritten URL (omitted when the incident carries none) |

VLM `video_url` content block in Mode A Step 3 is intentionally **not** rewritten — the VLM is in-cluster and the internal URL is what it needs.

## Files touched

- `skills/vss-generate-video-report/SKILL.md` — +55 / −2

## Test plan

- [ ] On a Brev VSS launchable with the Alerts profile deployed, ask the agent to "generate a report for incident #2". The report's Clip URL renders as `https://7777-<BREV_ENV_ID>.brevlab.com/vst/storage/temp_files/<name>.mp4` and the link plays in the browser.
- [ ] On a bare-metal deploy, the same flow produces `http://<host>:7777/vst/storage/temp_files/<name>.mp4` and that resolves through HAProxy.
- [ ] Mode A clip-based report: the VLM still receives the internal `HOST_IP:30888` URL and frame-pulls work; the rendered report shows the rewritten URL.
- [ ] Incidents with no `clip_url` field render without a "clip:" row (no broken link, no synthetic URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)