### PR TITLE
ci(workflow-dispatch): allow any skill name (string input, all 15 skills)

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -34,21 +34,32 @@ on:
   workflow_dispatch:
     inputs:
       skills:
-        description: "Which skill to eval (single-select). Pick `*` to sweep every skill under skills/. Keep this list in sync with .github/skill-eval/adapters/."
+        # `type: string` rather than `type: choice` because the skills/
+        # tree has more than 10 entries — GitHub caps `choice` options
+        # at 10. The scope-resolution step below sanity-checks the value
+        # before passing it to the agent.
+        #
+        # Valid values (skills/<name>/ on develop):
+        #   *  (sweep every skill)
+        #   vss-ask-video
+        #   vss-deploy-dense-captioning
+        #   vss-deploy-detection-tracking-2d
+        #   vss-deploy-profile
+        #   vss-deploy-video-embedding
+        #   vss-generate-video-calibration
+        #   vss-generate-video-report
+        #   vss-generate-video-report-rag
+        #   vss-manage-alerts
+        #   vss-manage-video-io-storage
+        #   vss-query-analytics
+        #   vss-search-archive
+        #   vss-setup-behavior-analytics
+        #   vss-setup-video-analytics-api
+        #   vss-summarize-video
+        description: "Which skill to eval (single-select). `*` sweeps every skill. Otherwise type the bare skill dir name (e.g. `vss-deploy-profile`). Keep aligned with .github/skill-eval/adapters/."
         required: false
         default: "*"
-        type: choice
-        options:
-          - "*"
-          - vss-ask-video
-          - vss-deploy-dense-captioning
-          - vss-deploy-profile
-          - vss-deploy-video-embedding
-          - vss-generate-video-report
-          - vss-manage-alerts
-          - vss-manage-video-io-storage
-          - vss-search-archive
-          - vss-summarize-video
+        type: string
 
 # Authenticate as github-actions[bot] for all GitHub operations (gh pr
 # comment, gh pr create, git push of eval-bot/* branches). The agent
@@ -168,13 +179,11 @@ jobs:
           # by pointing gh at a per-run scratch dir with no hosts.yml.
           GH_CONFIG_DIR: ${{ runner.temp }}/gh-skill-eval-${{ github.run_id }}
           # Route the workflow_dispatch input through env: instead of
-          # ${{ inputs.skills }} inline in the run: script. `type: choice`
-          # already enum-validates the value (no free-form attacker input
-          # possible today), but env-passthrough is the defense-in-depth
-          # pattern GH Actions docs recommend for any user-controllable
-          # input — keeps the run: body free of templated user data so
-          # future input additions don't accidentally reintroduce a
-          # shell-injection vector.
+          # ${{ inputs.skills }} inline in the run: script. The input is
+          # now `type: string` (free-form) so this matters more — the
+          # run: body sanity-checks INPUT_SKILLS below before passing it
+          # to the agent, keeping any user-controllable string out of the
+          # templated shell context.
           INPUT_SKILLS: ${{ inputs.skills }}
         run: |
           mkdir -p "$GH_CONFIG_DIR"
@@ -195,6 +204,20 @@ jobs:
           # $GITHUB_STEP_SUMMARY instead of `gh pr comment`. All specs on
           # the chosen skill(s) run — no spec-level filter knob.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Sanity-check INPUT_SKILLS now that the input is `type: string`
+            # (free-form). Either `*`, blank, or a bare skill-dir name
+            # — reject anything with slashes / dots that could escape the
+            # skills/ scope.
+            if [ "${INPUT_SKILLS}" != "*" ] && [ -n "${INPUT_SKILLS}" ]; then
+              if ! [[ "${INPUT_SKILLS}" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_-]*$ ]]; then
+                echo "::error::skills='${INPUT_SKILLS}' is not a valid skill-dir name. Type a bare name like 'vss-deploy-profile' or '*' to sweep all."
+                exit 1
+              fi
+              if [ ! -d "skills/${INPUT_SKILLS}" ]; then
+                echo "::error::skills/${INPUT_SKILLS}/ does not exist on this ref."
+                exit 1
+              fi
+            fi
             export MANUAL_FULL_SWEEP=1
             export MANUAL_SKILLS_FILTER="${INPUT_SKILLS}"
           fi

--- a/.github/workflows/skills-nv-base.yml
+++ b/.github/workflows/skills-nv-base.yml
@@ -46,21 +46,32 @@ on:
   workflow_dispatch:
     inputs:
       skills:
-        description: "Which skill to check (single-select). Pick `*` for the whole skills/ tree. Keep this list in sync with the skills-eval dispatch input."
+        # `type: string` rather than `type: choice` because the skills/ tree
+        # has more than 10 entries — GitHub caps `choice` options at 10.
+        # The scope-resolution step below sanity-checks the value to reject
+        # path-traversal before passing it to nv-base.
+        #
+        # Valid values (skills/<name>/ on develop):
+        #   *  (sweep entire skills/ tree)
+        #   vss-ask-video
+        #   vss-deploy-dense-captioning
+        #   vss-deploy-detection-tracking-2d
+        #   vss-deploy-profile
+        #   vss-deploy-video-embedding
+        #   vss-generate-video-calibration
+        #   vss-generate-video-report
+        #   vss-generate-video-report-rag
+        #   vss-manage-alerts
+        #   vss-manage-video-io-storage
+        #   vss-query-analytics
+        #   vss-search-archive
+        #   vss-setup-behavior-analytics
+        #   vss-setup-video-analytics-api
+        #   vss-summarize-video
+        description: "Which skill to check (single-select). `*` sweeps every skill. Otherwise type the bare skill dir name (e.g. `vss-deploy-profile`). Keep aligned with skills-eval dispatch input."
         required: false
         default: "*"
-        type: choice
-        options:
-          - "*"
-          - vss-ask-video
-          - vss-deploy-dense-captioning
-          - vss-deploy-profile
-          - vss-deploy-video-embedding
-          - vss-generate-video-report
-          - vss-manage-alerts
-          - vss-manage-video-io-storage
-          - vss-search-archive
-          - vss-summarize-video
+        type: string
 
 permissions:
   contents: read
@@ -128,10 +139,10 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           # Route the dispatch input through env: so it isn't templated
-          # directly into the run: script body. `type: choice` already
-          # enum-validates the value (no free-form input), but this
-          # matches the defense-in-depth pattern used in skills-eval.yml
-          # and keeps the run: body free of templated user data.
+          # directly into the run: script body. The input is now
+          # `type: string` (free-form) because skills/ has >10 entries
+          # and `type: choice` is capped at 10 options. Sanitize the
+          # value below before passing it to nv-base.
           INPUT_SKILLS: ${{ inputs.skills }}
         run: |
           set -euo pipefail
@@ -140,12 +151,18 @@ jobs:
             SKILL_NAME=""
             echo "manual: scanning entire skills/ tree"
           else
-            # The dropdown is server-validated against the choice enum;
-            # path-traversal is impossible. Verify the dir exists so we
-            # fail loudly on stale options rather than silently scanning
-            # nothing.
+            # Free-form string input — defense in depth against path
+            # traversal: reject anything that isn't a bare lowercase
+            # skill-dir name (e.g. `vss-deploy-profile`). Allowed chars:
+            # alnum, hyphen, underscore. No `/`, no `..`, no leading dot.
+            if ! [[ "${INPUT_SKILLS}" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_-]*$ ]]; then
+              echo "::error::skills='${INPUT_SKILLS}' is not a valid skill-dir name. Type a bare name like 'vss-deploy-profile' or '*' to sweep all."
+              exit 1
+            fi
+            # Verify the dir exists so we fail loudly on typos rather
+            # than silently scanning nothing.
             if [ ! -d "skills/${INPUT_SKILLS}" ]; then
-              echo "::error::skills/${INPUT_SKILLS}/ does not exist on this ref. Update the workflow_dispatch options to match the current skills/ tree."
+              echo "::error::skills/${INPUT_SKILLS}/ does not exist on this ref. Check skills/ for the current set of valid names."
               exit 1
             fi
             SKILL_ROOT="skills/${INPUT_SKILLS}"


### PR DESCRIPTION
## Summary

- Switch the `skills` input in `.github/workflows/skills-nv-base.yml` and `.github/workflows/skills-eval.yml` from `type: choice` to `type: string`.
- GitHub caps `type: choice` at 10 options. The skills/ tree on develop currently has **15** skills, so 6 of them had no way to be manually triggered.
- Per the latest NV-BASE pipeline ([gitlab job 327597998](https://gitlab-master.nvidia.com/nvcarps/ci-group/nvcarps-ci/-/jobs/327597998)), 12 of 15 skills fail NV-BASE — including the 5 that weren't even in the dropdown. Operators need to be able to re-run those specifically.

## Skills now selectable (was 9, now 15)

| Skill | Previously selectable? | Latest NV-BASE |
|---|---|---|
| vss-ask-video | ✅ | PASS |
| vss-deploy-dense-captioning | ✅ | FAIL |
| **vss-deploy-detection-tracking-2d** | ❌ added | FAIL |
| vss-deploy-profile | ✅ | FAIL |
| vss-deploy-video-embedding | ✅ | FAIL |
| **vss-generate-video-calibration** | ❌ added | FAIL |
| vss-generate-video-report | ✅ | FAIL |
| **vss-generate-video-report-rag** | ❌ added | FAIL |
| vss-manage-alerts | ✅ | FAIL |
| vss-manage-video-io-storage | ✅ | FAIL (partial) |
| **vss-query-analytics** | ❌ added | FAIL (partial) |
| vss-search-archive | ✅ | PASS |
| **vss-setup-behavior-analytics** | ❌ added | PASS |
| **vss-setup-video-analytics-api** | ❌ added | FAIL |
| vss-summarize-video | ✅ | FAIL (partial) |

## Security

The previous `type: choice` enum provided implicit path-traversal protection — only the listed options were possible. Free-form `type: string` removes that guarantee, so both scope-resolution steps now explicitly:

1. Allow only `^[a-zA-Z0-9_][a-zA-Z0-9_-]*$` (rejects `/`, `..`, leading dot, etc.).
2. Confirm the resulting `skills/<name>/` dir exists before passing the name downstream.

Defense-in-depth env-passthrough (`INPUT_SKILLS=${{ inputs.skills }}` → run-step) is preserved.

## Test plan

- [ ] Merge to develop.
- [ ] On the Actions tab, "Run workflow" → Skills NV-BASE → type one of the previously-missing skills (e.g. `vss-query-analytics`). Confirm the run scopes to `skills/vss-query-analytics/` and posts a step summary.
- [ ] Same on Skills Eval.
- [ ] Type a bogus value like `not-a-skill` — should fail at the validation step with the explicit error message.
- [ ] Type `*` (default) — should still sweep the entire tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)