### PR TITLE
fix(agent/eval): add http_connection kwarg to patched_run_workflow_local

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -236,7 +236,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-220a0fdacdd2
+VSS_AGENT_VERSION=3.2.0-26.05.5-8ad30888571b
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -178,7 +178,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-220a0fdacdd2
+VSS_AGENT_VERSION=3.2.0-26.05.5-8ad30888571b
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -183,7 +183,7 @@ EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-220a0fdacdd2
+VSS_AGENT_VERSION=3.2.0-26.05.5-8ad30888571b
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -230,7 +230,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-220a0fdacdd2
+VSS_AGENT_VERSION=3.2.0-26.05.5-8ad30888571b
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -253,7 +253,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.0-26.05.5-220a0fdacdd2
+VSS_AGENT_VERSION=3.2.0-26.05.5-8ad30888571b
 VSS_AGENT_CONFIG_FILE=./deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -301,7 +301,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-220a0fdacdd2" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-8ad30888571b" }}'
     waitForDependencies:
       enabled: true
   vss-va-mcp:

--- a/deploy/helm/developer-profiles/dev-profile-base/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/values.yaml
@@ -251,7 +251,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-220a0fdacdd2" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-8ad30888571b" }}'
 vss-agent-ui:
   enabled: true
   # Empty URL fields: deployment uses global.external* then in-cluster defaults.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -252,7 +252,7 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`agent.vss-agent.vstInternalUrl`** | **`""`** | In-cluster **VST** URL for the agent when the default wiring is insufficient. |
 | **`agent.vss-agent.vstInternalIp`** | **`""`** | In-cluster **VST** host/IP override when defaults are insufficient. |
 | **`agent.vss-agent.vssAgentExternalUrl`** | **`""`** | External **vss-agent** URL override for browser / callbacks when **`global.external*`** is not enough. |
-| **`agent.vss-agent.vssAgentVersion`** | **`3.2.0-26.05.5-220a0fdacdd2`** | Optional version label / env; adjust per release. |
+| **`agent.vss-agent.vssAgentVersion`** | **`3.2.0-26.05.5-8ad30888571b`** | Optional version label / env; adjust per release. |
 | **`agent.vss-agent.llmName`** | **`""`** | Optional **vss-agent-only** override of **`global.llmName`** (**`LLM_NAME`**). |
 | **`agent.vss-agent.vlmName`** | **`""`** | Optional **vss-agent-only** override of **`global.vlmName`** (**`VLM_NAME`**). |
 | **`agent.vss-agent.llmBaseUrl`** | **`""`** | Optional **vss-agent-only** override of **`global.llmBaseUrl`**. |

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -207,7 +207,7 @@ agent:
     vstInternalUrl: ""
     vstInternalIp: ""
     vssAgentExternalUrl: ""
-    vssAgentVersion: "3.2.0-26.05.5-220a0fdacdd2"
+    vssAgentVersion: "3.2.0-26.05.5-8ad30888571b"
     evalLlmJudgeName: ""
     evalLlmJudgeBaseUrl: ""
     reportsBaseUrl: ""
@@ -290,7 +290,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-220a0fdacdd2" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-8ad30888571b" }}'
       # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
       # Set enableAudio=true for Nemotron Nano Omni audio-aware VLM.
       - name: ENABLE_AUDIO

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -478,7 +478,7 @@ agent:
     videoAnalysisMcpUrl: ''
     template:
       name: ''
-    vssAgentVersion: 3.2.0-26.05.5-220a0fdacdd2
+    vssAgentVersion: 3.2.0-26.05.5-8ad30888571b
     # Copied from rtvi.* defaults (vss-agent subchart env tpl only sees agent.vss-agent; keep in sync with rtvi.vss-rtvi-embed.port / vss-rtvi-cv.httpPort).
     rtviEmbedPort: '8000'
     rtviCvPort: '9000'
@@ -578,7 +578,7 @@ agent:
       - name: RTVI_EMBED_MODEL
         value: '{{ .Values.rtviEmbedModelName | default "cosmos-embed1-448p-anomaly-detection" }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-220a0fdacdd2" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-8ad30888571b" }}'
 
 vss-agent-ui:
   enabled: true

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -23,7 +23,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.0-26.05.5-220a0fdacdd2"
+  tag: "3.2.0-26.05.5-8ad30888571b"
   pullPolicy: IfNotPresent
 replicas: 1
 service:
@@ -90,7 +90,7 @@ reportsBaseUrl: ""
 vssAgentExternalUrl: ""
 externalIp: ""
 vstInternalIp: ""
-vssAgentVersion: "3.2.0-26.05.5-220a0fdacdd2"
+vssAgentVersion: "3.2.0-26.05.5-8ad30888571b"
 lvsBackendService: ""
 
 # [Optional] HTTP-client timeouts (seconds) for the post-upload pipeline in
@@ -203,7 +203,7 @@ env:
 - name: AGENT_BASE_URL
   value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
 - name: VSS_AGENT_VERSION
-  value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-220a0fdacdd2" }}'
+  value: '{{ .Values.vssAgentVersion | default "3.2.0-26.05.5-8ad30888571b" }}'
 # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
 # Set ENABLE_AUDIO=true for Nemotron Nano Omni audio-aware VLM.
 - name: ENABLE_AUDIO

--- a/deploy/helm/services/agent/charts/va-mcp/values.yaml
+++ b/deploy/helm/services/agent/charts/va-mcp/values.yaml
@@ -18,7 +18,7 @@ global: {}
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.0-26.05.5-220a0fdacdd2"
+  tag: "3.2.0-26.05.5-8ad30888571b"
   pullPolicy: IfNotPresent
 # Image must have mcp[cli] (typer) installed for `mcp serve` (same as Docker Compose).
 replicas: 1

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -21,7 +21,7 @@ AI-powered video search, summarization, and incident analysis agent built on
 [NVIDIA AIQ Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest/index.html).
 
 For deployment instructions (Docker Compose, Helm, cloud), refer to the
-[repository root](../README.md) and [`deployments/`](../deployments/).
+[repository root](../README.md) and [`deploy/docker/`](../deploy/docker/).
 
 ## Overview
 
@@ -77,7 +77,7 @@ docker buildx build --platform linux/amd64 -f agent/docker/Dockerfile -t vss-age
 The instructions below use the **dev-profile-base** profile as an example.
 The same pattern applies to other profiles (search, alerts, LVS) — substitute the
 corresponding `.env` and `config.yml` from
-[`deployments/developer-workflow/`](../deployments/developer-workflow/).
+[`deploy/docker/developer-profiles/`](../deploy/docker/developer-profiles/).
 See [Configuration](#configuration) for the full list of profiles.
 
 ### 1. Set Environment Variables
@@ -86,7 +86,7 @@ Create a `.env_file` that points to the profile's `.env` so the agent auto-loads
 environment variables on startup (one-time per profile):
 
 ```bash
-echo "../deployments/developer-workflow/dev-profile-base/.env" > .env_file
+echo "../deploy/docker/developer-profiles/dev-profile-base/.env" > .env_file
 ```
 
 Then source the same `.env` in your shell and override the placeholders.
@@ -97,7 +97,7 @@ must be re-evaluated — that is what the remaining lines do.
 
 ```bash
 set -a
-source ../deployments/developer-workflow/dev-profile-base/.env
+source ../deploy/docker/developer-profiles/dev-profile-base/.env
 
 HOST_IP=<YOUR_HOST_IP>                 # placeholder in .env
 LLM_BASE_URL=http://${HOST_IP}:${LLM_PORT}   # empty in .env
@@ -119,7 +119,7 @@ set +a
 
 ```bash
 nat serve \
-  --config_file ../deployments/developer-workflow/dev-profile-base/vss-agent/configs/config.yml \
+  --config_file ../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml \
   --host 0.0.0.0 --port 8000
 ```
 
@@ -157,14 +157,14 @@ Agent behavior is defined in YAML config files with four top-level sections:
 Config values support `${ENV_VAR}` substitution with optional defaults (`${VAR:-default}`).
 
 Ready-to-use configurations are provided under
-[`deployments/developer-workflow/`](../deployments/developer-workflow/):
+[`deploy/docker/developer-profiles/`](../deploy/docker/developer-profiles/):
 
 | Profile | Path | Description |
 |---------|------|-------------|
-| Base | [`dev-profile-base/.../config.yml`](../deployments/developer-workflow/dev-profile-base/vss-agent/configs/config.yml) | Video understanding and report generation |
-| Search | [`dev-profile-search/.../config.yml`](../deployments/developer-workflow/dev-profile-search/vss-agent/configs/config.yml) | Search and RAG workflow |
-| LVS | [`dev-profile-lvs/.../config.yml`](../deployments/developer-workflow/dev-profile-lvs/vss-agent/configs/config.yml) | LVS video understanding |
-| Alerts | [`dev-profile-alerts/.../config.yml`](../deployments/developer-workflow/dev-profile-alerts/vss-agent/configs/config.yml) | Incident analysis and alerting |
+| Base | [`dev-profile-base/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml) | Video understanding and report generation |
+| Search | [`dev-profile-search/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml) | Search and RAG workflow |
+| LVS | [`dev-profile-lvs/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml) | LVS video understanding |
+| Alerts | [`dev-profile-alerts/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml) | Incident analysis and alerting |
 
 Each profile has a companion `.env` file in the same directory with all deployment variables
 pre-configured.

--- a/services/agent/docker/Dockerfile
+++ b/services/agent/docker/Dockerfile
@@ -36,17 +36,19 @@ ENV GIT_LFS_SKIP_SMUDGE=1
 WORKDIR /vss-agent
 
 # Copy project files
-COPY --chown=${USER_ID}:${GROUP_ID} agent/pyproject.toml /vss-agent
-COPY --chown=${USER_ID}:${GROUP_ID} agent/LICENSE-3rd-party.txt /vss-agent
-COPY --chown=${USER_ID}:${GROUP_ID} agent/uv.lock /vss-agent
-COPY --chown=${USER_ID}:${GROUP_ID} agent/src/vss_agents /vss-agent/src/vss_agents
+# Own as root:root and copy read-only (0444 files, 0555 dirs) so the non-root
+# runtime user can read/execute but not own or modify the copied resources.
+COPY --chown=root:root --chmod=0444 agent/pyproject.toml /vss-agent
+COPY --chown=root:root --chmod=0444 agent/LICENSE-3rd-party.txt /vss-agent
+COPY --chown=root:root --chmod=0444 agent/uv.lock /vss-agent
+COPY --chown=root:root --chmod=0555 agent/src/vss_agents /vss-agent/src/vss_agents
 # `lib/` is a sibling top-level package shipped in the same wheel
 # (see pyproject.toml `packages = ["src/vss_agents", "src/lib"]`); without
 # this copy, lib.knowledge would be missing from the built image.
-COPY --chown=${USER_ID}:${GROUP_ID} agent/src/lib /vss-agent/src/lib
-COPY --chown=${USER_ID}:${GROUP_ID} agent/docker/cleanup_vulnerabilities.py /vss-agent/cleanup_vulnerabilities.py
-COPY --chown=${USER_ID}:${GROUP_ID} agent/docker/verify_ffmpeg_tarball.py /vss-agent/verify_ffmpeg_tarball.py
-COPY --chown=${USER_ID}:${GROUP_ID} agent/3rdparty/ffmpeg /vss-agent/third_party/ffmpeg
+COPY --chown=root:root --chmod=0555 agent/src/lib /vss-agent/src/lib
+COPY --chown=root:root --chmod=0444 agent/docker/cleanup_vulnerabilities.py /vss-agent/cleanup_vulnerabilities.py
+COPY --chown=root:root --chmod=0444 agent/docker/verify_ffmpeg_tarball.py /vss-agent/verify_ffmpeg_tarball.py
+COPY --chown=root:root --chmod=0555 agent/3rdparty/ffmpeg /vss-agent/third_party/ffmpeg
 
 # Fail early if FFmpeg source tarball is missing or invalid (required for LGPL compliance)
 RUN python3 /vss-agent/verify_ffmpeg_tarball.py
@@ -129,9 +131,9 @@ COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/lib
 COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/libcrypto.so.* /usr/lib/aarch64-linux-gnu/
 
 # Copy application without any dev needs
-COPY --from=builder --chown=${USER_ID}:${GROUP_ID} /vss-agent/.venv /vss-agent/.venv
-COPY --from=builder --chown=${USER_ID}:${GROUP_ID} /vss-agent/third_party/ffmpeg /vss-agent/third_party/ffmpeg
-COPY --from=builder --chown=${USER_ID}:${GROUP_ID} /vss-agent/LICENSE-3rd-party.txt /vss-agent/LICENSE-3rd-party.txt
+COPY --from=builder --chown=root:root --chmod=0555 /vss-agent/.venv /vss-agent/.venv
+COPY --from=builder --chown=root:root --chmod=0555 /vss-agent/third_party/ffmpeg /vss-agent/third_party/ffmpeg
+COPY --from=builder --chown=root:root --chmod=0444 /vss-agent/LICENSE-3rd-party.txt /vss-agent/LICENSE-3rd-party.txt
 FROM runtime AS agent-runtime
 ARG TARGETARCH
 

--- a/services/agent/docker/Dockerfile
+++ b/services/agent/docker/Dockerfile
@@ -103,6 +103,8 @@ ARG USER_ID=1000
 ARG GROUP_ID=1000
 ARG TARGETPLATFORM
 ARG TARGETARCH
+ENV VSS_RUNTIME_UID=${USER_ID}
+ENV VSS_RUNTIME_GID=${GROUP_ID}
 
 # Copy cleanup script (as root to ensure proper permissions)
 COPY --from=builder /vss-agent/cleanup_vulnerabilities.py /tmp/cleanup_vulnerabilities.py
@@ -134,6 +136,10 @@ COPY --from=security-patches /patches/libssl3-extracted/usr/lib/*-linux-gnu*/lib
 COPY --from=builder --chown=root:root --chmod=0555 /vss-agent/.venv /vss-agent/.venv
 COPY --from=builder --chown=root:root --chmod=0555 /vss-agent/third_party/ffmpeg /vss-agent/third_party/ffmpeg
 COPY --from=builder --chown=root:root --chmod=0444 /vss-agent/LICENSE-3rd-party.txt /vss-agent/LICENSE-3rd-party.txt
+
+# NAT writes transient workflow state here at startup. Keep app resources
+# immutable, but provide a narrowly scoped writable scratch directory.
+RUN ["/usr/local/bin/python3", "-c", "import os; os.makedirs('/vss-agent/.tmp', exist_ok=True); os.chown('/vss-agent/.tmp', int(os.environ['VSS_RUNTIME_UID']), int(os.environ['VSS_RUNTIME_GID'])); os.chmod('/vss-agent/.tmp', 0o700)"]
 FROM runtime AS agent-runtime
 ARG TARGETARCH
 

--- a/services/agent/src/vss_agents/evaluators/evaluate_patch.py
+++ b/services/agent/src/vss_agents/evaluators/evaluate_patch.py
@@ -360,12 +360,12 @@ def apply_patch() -> None:
             # Restore all items for result collection
             self.eval_input.eval_input_items = expanded_items
 
-    # Patch publish_output to also write latency_summary.json alongside other output files
-    _original_publish_output = EvaluationRun.publish_output
+    # Patch _on_eval_complete to also write latency_summary.json alongside other output files
+    _original_on_eval_complete = EvaluationRun._on_eval_complete
 
-    def patched_publish_output(self: Any, *args: Any, **kwargs: Any) -> None:
+    def patched_on_eval_complete(self: Any, *args: Any, **kwargs: Any) -> None:
         global _last_avg_latency
-        _original_publish_output(self, *args, **kwargs)
+        _original_on_eval_complete(self, *args, **kwargs)
         _last_avg_latency = _write_latency_summary(self, self.eval_input.eval_input_items)
 
     # Patch write_tabular_output to print average latency
@@ -381,7 +381,7 @@ def apply_patch() -> None:
             click.echo(f"Average Latency: {_last_avg_latency:.2f}s")
 
     EvaluationRun.run_workflow_local = patched_run_workflow_local
-    EvaluationRun.publish_output = patched_publish_output
+    EvaluationRun._on_eval_complete = patched_on_eval_complete
     _nat_cli_eval.write_tabular_output = patched_write_tabular_output
     _patched = True
     logger.info("Evaluation patch applied")

--- a/services/agent/src/vss_agents/evaluators/evaluate_patch.py
+++ b/services/agent/src/vss_agents/evaluators/evaluate_patch.py
@@ -249,7 +249,7 @@ def apply_patch() -> None:
 
     _original_run_workflow_local = EvaluationRun.run_workflow_local
 
-    async def patched_run_workflow_local(self: Any, session_manager: Any) -> None:
+    async def patched_run_workflow_local(self: Any, session_manager: Any, http_connection: Any = None) -> None:
         """Expand multi-turn items, then run turns sequentially within each conversation."""
         from nat.builder.context import ContextState
 
@@ -319,7 +319,7 @@ def apply_patch() -> None:
                 logger.info(f"[Multi-turn] Set conversation_id={conv_id} for {item.id}")
 
                 self.eval_input.eval_input_items = [item]
-                await _original_run_workflow_local(self, session_manager)
+                await _original_run_workflow_local(self, session_manager, http_connection=http_connection)
                 pbar.update(1)
 
                 turn_id = item.full_dataset_entry.get("turn_id", f"turn_{len(conversation_history) + 1}")
@@ -338,7 +338,7 @@ def apply_patch() -> None:
         async def run_non_multi_turn() -> None:
             """Run non-multi-turn items."""
             self.eval_input.eval_input_items = non_multi_turn_items
-            await _original_run_workflow_local(self, session_manager)
+            await _original_run_workflow_local(self, session_manager, http_connection=http_connection)
             pbar.update(len(non_multi_turn_items))
 
         try:

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -267,10 +267,6 @@ per-profile `curl` checks + slow-container triage) lives in
 for that profile. **Never declare the deploy done after `up -d`
 returns** — only after every documented endpoint succeeds.
 
-### Step 6 — 
-Fron
-
-
 ## Tear Down
 
 ```bash


### PR DESCRIPTION
## Description
  - `EvaluationRun.run_workflow_local` gained an `http_connection` parameter in nvidia-nat 1.6.0 (bumped in #451).
  - The monkey-patched override in `evaluate_patch.py` still used the old signature, so `nat eval` failed with a `TypeError` before any workflow could run.
  - Accept the new kwarg and forward it through to the wrapped original.
  
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
