### PR TITLE
fix(nim/cosmos-reason-3): set NIM_GPU_MEMORY_UTILIZATION for shared-GPU profiles

### DIFF
--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-H100-shared.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-H100-shared.env
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 NIM_KVCACHE_PERCENT=0.4
+NIM_GPU_MEMORY_UTILIZATION=0.4
 NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization 0.4"
 NIM_MAX_MODEL_LEN=32768
 NIM_MAX_NUM_SEQS=4

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-RTXPRO6000BW-shared.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-RTXPRO6000BW-shared.env
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 NIM_KVCACHE_PERCENT=0.4
+NIM_GPU_MEMORY_UTILIZATION=0.4
 NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization 0.4"
 NIM_MAX_MODEL_LEN=32768
 NIM_MAX_NUM_SEQS=4

--- a/deploy/helm/services/nims/charts/cosmos3-reasoner/values.yaml
+++ b/deploy/helm/services/nims/charts/cosmos3-reasoner/values.yaml
@@ -55,6 +55,7 @@ nimModelSize: "nano"
 # GPU-specific env vars. Populated by the umbrella chart via gpuProfiles lookup.
 env:
   NIM_KVCACHE_PERCENT: "0.7"
+  NIM_GPU_MEMORY_UTILIZATION: "0.7"
   NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.7"
   NIM_MAX_MODEL_LEN: ""
   NIM_MAX_NUM_SEQS: ""
@@ -63,6 +64,7 @@ env:
 # Missing keys are skipped due to optional: true.
 envConfigMapKeys:
   - NIM_KVCACHE_PERCENT
+  - NIM_GPU_MEMORY_UTILIZATION
   - NIM_PASSTHROUGH_ARGS
   - NIM_DISABLE_MM_PREPROCESSOR_CACHE
 

--- a/deploy/helm/services/nims/values.yaml
+++ b/deploy/helm/services/nims/values.yaml
@@ -62,6 +62,7 @@ gpuProfiles:
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
     cosmos3:
       NIM_KVCACHE_PERCENT: "0.7"
+      NIM_GPU_MEMORY_UTILIZATION: "0.7"
       NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.7"
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
 
@@ -81,6 +82,7 @@ gpuProfiles:
       MAX_JOBS: "4"
     cosmos3:
       NIM_KVCACHE_PERCENT: "0.8"
+      NIM_GPU_MEMORY_UTILIZATION: "0.8"
       NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.8"
       NIM_MAX_MODEL_LEN: "32768"
       NIM_MAX_NUM_SEQS: "4"
@@ -101,6 +103,7 @@ gpuProfiles:
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
     cosmos3:
       NIM_KVCACHE_PERCENT: "0.7"
+      NIM_GPU_MEMORY_UTILIZATION: "0.7"
       NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.7"
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
 
@@ -254,6 +257,7 @@ cosmos3:
   # Missing keys are ignored (optional: true).
   envConfigMapKeys:
     - NIM_KVCACHE_PERCENT
+    - NIM_GPU_MEMORY_UTILIZATION
     - NIM_PASSTHROUGH_ARGS
     - NIM_DISABLE_MM_PREPROCESSOR_CACHE
   


### PR DESCRIPTION
## Summary

Need to control GPU memory utilization. For reasoner: use `NIM_GPU_MEMORY_UTILIZATION` as an env var when running the container, e.g. `-e NIM_GPU_MEMORY_UTILIZATION=0.85`.

This PR sets it to `0.4` in `hw-H100-shared.env` and `hw-RTXPRO6000BW-shared.env` so the shared-GPU deployment fits alongside the co-located LLM.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
