### PR TITLE
revert(vss-deploy-dense-captioning): undo #766 behavior changes

### DIFF
--- a/skills/vss-deploy-dense-captioning/SKILL.md
+++ b/skills/vss-deploy-dense-captioning/SKILL.md
@@ -1,42 +1,18 @@
 ---
 name: vss-deploy-dense-captioning
-description: Use to deploy standalone RT-VLM dense captioning and call its REST API (uploads, captions, streams, chat-completions, Kafka). Not for VSS profile deploy or video-search ingestion.
+description: >
+  Deploy and call the VSS 3.2 RT-VLM dense captioning microservice. Use this skill
+  to deploy standalone RT-VLM when needed, generate dense captions and alerts for
+  stored video files and live RTSP streams via `/v1/generate_captions`, upload media
+  via `/v1/files`, add and remove live streams with `/v1/streams/add` and
+  `/v1/streams/delete/{stream_id}`, call OpenAI-compatible `/v1/chat/completions`,
+  consume Kafka caption, incident, and error topics, or debug rtvi-vlm responses.
 license: Apache-2.0
 metadata:
-  author: "NVIDIA Video Search and Summarization team"
   version: "3.2.0"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational deployment"
 ---
-## Purpose
-
-Stand up the RT-VLM dense-captioning microservice on its own and exercise every endpoint it exposes (file upload, generate_captions, stream add/delete, chat-completions, Kafka topics).
-
-## Prerequisites
-
-- Active VSS deployment reachable on `$HOST_IP` (see `vss-deploy-profile` and `references/`).
-- NGC credentials in `$NGC_CLI_API_KEY` and `$NVIDIA_API_KEY` for any image pulls.
-- `curl`, `jq`, and Docker available on the caller.
-
-## Instructions
-
-Follow the routing tables and step-by-step workflows below. Each section that ends in *workflow*, *quick start*, or *flow* is intended to be executed top-to-bottom. Detailed reference material lives in `references/` and helper scripts live in `scripts/` — call them via `run_script` when the skill points to a script by name.
-
-## Examples
-
-Worked end-to-end examples are kept under `evals/` (each `*.json` manifest contains a runnable scenario) and inline in the per-workflow `curl` blocks below. Run a Tier-3 evaluation with `nv-base validate <this-skill-dir> --agent-eval` to replay them.
-
-## Limitations
-
-- Requires the matching VSS profile / microservice to be deployed and reachable from the caller.
-- NGC-hosted models and NIMs may be subject to rate-limits, GPU memory requirements, and license restrictions.
-- Concurrency, GPU memory, and storage limits depend on the host hardware and the profile's compose file.
-
-## Troubleshooting
-
-- **Error**: REST call returns connection refused. **Cause**: target microservice not running. **Solution**: probe `/docs` or `/health`; redeploy via `vss-deploy-profile` or the matching `vss-deploy-*` skill.
-- **Error**: HTTP 401/403 from NGC pulls. **Cause**: missing/expired `NGC_CLI_API_KEY`. **Solution**: `docker login nvcr.io` and re-export the key before retrying.
-- **Error**: container OOM or model fails to load. **Cause**: insufficient GPU memory for the selected profile. **Solution**: switch to a smaller variant or free GPUs via `docker compose down`.
 
 # Deploy and Use RT-VLM Dense Captioning (VSS 3.2)
 
@@ -208,17 +184,125 @@ curl -X POST "$BASE_URL/v1/chat/completions" -H "Authorization: Bearer $API_KEY"
 
 ## Common Workflows
 
-| # | Scenario | Where the runbook lives |
-| --- | --- | --- |
-| 1 | Dense captions from a stored video file | `references/file-captions.md` (or follow Quick Start above with `chunk_duration: 10`, `stream: true`, then `DELETE /v1/files/{id}` to free storage). |
-| 2 | Dense captions from an RTSP live stream | `references/rtsp-captions.md` — `POST /v1/streams/add` → `POST /v1/generate_captions` with `chunk_duration` + `num_frames_per_second_or_fixed_frames_chunk` → `DELETE /v1/streams/delete/{id}` on teardown. |
-| 3 | Dense captions + alerts on an RTSP stream | `references/alerts-captions.md` — same as (2) but with an `Anomaly Detected: Yes/No` prompt + `RTVI_VLM_KAFKA_*` env vars; alerts land on `KAFKA_INCIDENT_TOPIC`. |
-| 4 | Kafka message-bus integration | `references/kafka-workflows.md` (alerts + HTTP-vs-Kafka response model + protobuf field list). |
+The four standard dense-captioning scenarios.
 
-Every scenario uses the endpoint contracts in the Endpoints table above; only
-the orchestration around them differs. Consume Kafka alerts with the standard
-NvSchema protobuf flow — `print.value=false` is recommended to avoid
-binary-payload spam in console output.
+### 1. Dense captions from a stored video file
+
+```bash
+# Upload → capture file id → generate captions (SSE stream)
+FILE_ID=$(curl -fsS -X POST "$BASE_URL/v1/files" \
+  -H "Authorization: Bearer $API_KEY" \
+  -F "file=@warehouse.mp4" -F "purpose=vision" -F "media_type=video" | jq -r '.id')
+
+curl -N -X POST "$BASE_URL/v1/generate_captions" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -d "{
+    \"id\": \"$FILE_ID\",
+    \"prompt\": \"Describe warehouse events in 1 sentence per 10s chunk.\",
+    \"model\": \"cosmos-reason1\",
+    \"chunk_duration\": 10,
+    \"stream\": true
+  }"
+
+# When done, free storage:
+curl -X DELETE "$BASE_URL/v1/files/$FILE_ID" -H "Authorization: Bearer $API_KEY"
+```
+
+### 2. Dense captions from an RTSP live stream
+
+```bash
+# Register the stream
+STREAM_ID=$(curl -fsS -X POST "$BASE_URL/v1/streams/add" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -d '{"streams":[{"liveStreamUrl":"rtsp://10.0.0.5:8554/warehouse","description":"warehouse cam"}]}' \
+  | jq -r '.results[0].id')
+
+# Start continuous caption generation
+curl -N -X POST "$BASE_URL/v1/generate_captions" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -d "{
+    \"id\": \"$STREAM_ID\",
+    \"prompt\": \"Describe each event; start each sentence with a timestamp.\",
+    \"model\": \"cosmos-reason1\",
+    \"chunk_duration\": 10,
+    \"num_frames_per_second_or_fixed_frames_chunk\": 2,
+    \"use_fps_for_chunking\": true,
+    \"stream\": true
+  }" &
+
+# Tear down when finished. If the live OpenAPI exposes
+# DELETE /v1/generate_captions/{stream_id}, call it before unregistering.
+curl -X DELETE "$BASE_URL/v1/streams/delete/$STREAM_ID"  -H "Authorization: Bearer $API_KEY"
+```
+
+### 3. Dense captions with alerts from an RTSP stream
+
+```bash
+# Pre-req: the container was started with:
+#   RTVI_VLM_KAFKA_ENABLED=true
+#   RTVI_VLM_KAFKA_TOPIC=vision-llm-messages  # or mdx-vlm if your deployment overrides it
+#   RTVI_VLM_KAFKA_INCIDENT_TOPIC=mdx-vlm-incidents
+#   RTVI_VLM_ERROR_MESSAGE_TOPIC=vision-llm-errors
+#   HOST_IP=<kafka-host>
+
+STREAM_ID=$(curl -fsS -X POST "$BASE_URL/v1/streams/add" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -d '{"streams":[{"liveStreamUrl":"rtsp://10.0.0.5:8554/warehouse","description":"warehouse cam"}]}' \
+  | jq -r '.results[0].id')
+
+curl -N -X POST "$BASE_URL/v1/generate_captions" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -d "{
+    \"id\": \"$STREAM_ID\",
+    \"prompt\": \"You are a warehouse monitoring system. Describe the scene in one sentence, then on a new line output exactly:\\nAnomaly Detected: Yes/No\\nReason: <one sentence>\\nFlag an anomaly if any worker is missing a hard hat or high-vis vest.\",
+    \"system_prompt\": \"Answer the user's question correctly in yes or no.\",
+    \"model\": \"cosmos-reason2\",
+    \"chunk_duration\": 60,
+    \"chunk_overlap_duration\": 10,
+    \"stream\": true
+  }"
+```
+
+**Consume alerts from Kafka** (when using the VSS foundational Kafka container).
+Kafka values are NvSchema protobuf payloads, so use `print.value=false` for a
+clean validation pass that shows timestamp, key, and headers without dumping
+binary payload bytes:
+```bash
+docker exec mdx-kafka kafka-console-consumer \
+  --bootstrap-server 127.0.0.1:9092 \
+  --topic mdx-vlm-incidents \
+  --from-beginning \
+  --timeout-ms 5000 \
+  --max-messages 10 \
+  --property print.timestamp=true \
+  --property print.key=true \
+  --property print.headers=true \
+  --property print.value=false
+```
+
+If Kafka is not running in the VSS `mdx-kafka` container, use the Kafka CLI from
+the host running the broker:
+```bash
+kafka-console-consumer \
+  --bootstrap-server "$HOST_IP:9092" \
+  --topic mdx-vlm-incidents \
+  --from-beginning \
+  --timeout-ms 5000 \
+  --max-messages 10 \
+  --property print.timestamp=true \
+  --property print.key=true \
+  --property print.headers=true \
+  --property print.value=false
+```
+Incident protobuf (`ext.proto :: Incident`) key fields: `sensorId`, `timestamp`, `end`,
+`objectIds`, `frameIds`, `place`, `analyticsModule`, `category`, `isAnomaly` (`true` for
+alerts), `llm` (nested VisionLLM), `info` map including `triggerPhrase`, `verdict`,
+`requestId`, `chunkIdx`, `streamId`, `alertCategory` (if the deployment supports the
+`alert_category` query field — post-3.1).
+
+### 4. Kafka workflows (alerts + message bus)
+
+Dense captioning with alerts on an RTSP stream and the HTTP-vs-Kafka response model are documented in [`references/kafka-workflows.md`](references/kafka-workflows.md).
 
 ## Error Reference
 
@@ -250,4 +334,3 @@ binary-payload spam in console output.
 - **File upload is multipart, not JSON.** Use `-F file=@path -F purpose=vision -F media_type=video`; a `-d` body returns 422.
 - **Live-stream lifecycle cleanup must unregister the stream:** `DELETE /v1/streams/delete/{stream_id}` removes the RTSP source. If the live schema also exposes `DELETE /v1/generate_captions/{stream_id}`, call it first to stop inference explicitly.
 
-bump:1

--- a/skills/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
+++ b/skills/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
@@ -42,7 +42,7 @@ live-authoritative schema — see §16.
 - **Free port**: `${RTVI_VLM_PORT}` (whatever you pick)
 - **Outbound**: `nvcr.io`, `huggingface.co`, any remote NIM/OpenAI endpoints
 
-> ⚠ **Profiles are mandatory.** Service declares **6 blueprint profiles**
+> ⚠️ **Profiles are mandatory.** Service declares **6 blueprint profiles**
 > (§12). Plain `docker compose up` starts **nothing** — pass `--profile <name>`.
 
 ## 4. NGC / Registry Preflight
@@ -56,7 +56,7 @@ echo "$NGC_CLI_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
 docker pull "nvcr.io/nvstaging/vss-core/vss-rt-vlm:${RTVI_VLM_IMAGE_TAG:-3.2.0-26.04.1}"
 ```
 
-> ⚠ **`docker compose pull` fails on standalone deployments** (recent Docker
+> ⚠️ **`docker compose pull` fails on standalone deployments** (recent Docker
 > Compose): the compose file's `depends_on` references sibling NIM services
 > that are not defined in this single-file project. Compose rejects this as
 > `invalid compose project` at project-load time even when every reference is
@@ -81,7 +81,7 @@ rewrite to canonical container-side names at the compose boundary.
 | `VLM_NAME` | `VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME` | Remote model name | Your backend |
 | `REDIS_PASSWORD` | `REDIS_PASSWORD` | Only when `ENABLE_REDIS_ERROR_MESSAGES=true` | Your Redis |
 
-> ⚠ **Minimum to boot**: `NGC_CLI_API_KEY` + whatever the sibling NIM needs.
+> ⚠️ **Minimum to boot**: `NGC_CLI_API_KEY` + whatever the sibling NIM needs.
 
 Use the `.env` block in §12 as the starting point.
 
@@ -95,9 +95,17 @@ Use the `.env` block in §12 as the starting point.
 | 111 | `${NGC_MODEL_CACHE:-rtvi-ngc-model-cache}:/opt/nvidia/rtvi/.rtvi/ngc_model_cache` (named) | **yes** | **YES — re-download weights** |
 | 112 | `${RTVI_VLM_LOG_DIR:-/dummy}${RTVI_VLM_LOG_DIR:+:/opt/nvidia/rtvi/log/rtvi/}` (optional bind) | no | no |
 
-**Required host-path setup** — `VSS_DATA_DIR` is not optional. See **Step 2** in the
-Quick-Start section below for the exact commands to prepare the VST clip-storage
-host directory.
+**Required host-path setup** — `VSS_DATA_DIR` is not optional:
+
+```bash
+# Container runs as UID 1001; host dir must be writable by that UID
+export VSS_DATA_DIR=/abs/path/to/vss-data
+mkdir -p "$VSS_DATA_DIR/data_log/vst/clip_storage"
+sudo chown -R 1001:1001 "$VSS_DATA_DIR/data_log/vst/clip_storage"
+# No sudo? Grant UID 1001 via ACL:
+#   sudo setfacl -R -m u:1001:rwx "$VSS_DATA_DIR/data_log/vst/clip_storage"
+# Avoid `chmod 777` — exposes clip storage to every user on the host.
+```
 
 Optional host-path overrides:
 
@@ -109,7 +117,7 @@ mkdir -p ./rtvi-logs && sudo chown 1001:1001 ./rtvi-logs
 # .env: RTVI_VLM_LOG_DIR=$(pwd)/rtvi-logs
 ```
 
-> ⚠ `docker compose down -v` wipes `rtvi-hf-cache` + `rtvi-ngc-model-cache` →
+> ⚠️ `docker compose down -v` wipes `rtvi-hf-cache` + `rtvi-ngc-model-cache` →
 > **20–80 GB re-download** on next up.
 
 ## 7. Required Environment Variables
@@ -356,26 +364,6 @@ fi
 grep -c 'depends_on' rtvi-vlm-docker-compose.yml
 
 # 1. Config — set model vars per §11 (Options A–E)
-#
-# SECURITY NOTE: Writing API keys to `.env` via the shell (`cat > .env`)
-# puts the secret into the shell process for the duration of the heredoc.
-# To minimise exposure, prefer ONE of:
-#
-#   (a) `printf` from an already-set env var that you exported with
-#       `read -rs NGC_CLI_API_KEY`, so the key is never on the
-#       command-line and never echoed.
-#   (b) Render the file from a templated source with an external secret
-#       manager (HashiCorp Vault, AWS Secrets Manager, sealed-secrets).
-#   (c) Manage `.env` with `chmod 600` and `chown $(id -u):$(id -g)`
-#       immediately after writing it, and add the path to `.gitignore`
-#       (it already is — keep it that way).
-#
-# In all cases, NEVER commit `.env` to a repository, NEVER leave it in
-# `/tmp`, NEVER paste the value into chat history, and clear the shell
-# history for the writing shell (`history -c && history -w`) before
-# leaving the host. Rotate `NGC_CLI_API_KEY` if it ever leaves this
-# host's trust boundary.
-umask 077  # ensure the file is created mode 0600
 cat > .env <<EOF
 NGC_CLI_API_KEY=<your-ngc-key>
 RTVI_VLM_PORT=8100
@@ -387,9 +375,8 @@ RT_VLM_DEVICE_ID=0
 RTVI_VLM_MODEL_TO_USE=cosmos-reason2
 RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:1208-fp8-static-kv8
 EOF
-chmod 600 .env
 
-# 2. Prepare VST clip-storage host dir (required per §6 above)
+# 2. Prepare VST clip-storage host dir (required)
 mkdir -p "$VSS_DATA_DIR/data_log/vst/clip_storage"
 sudo chown -R 1001:1001 "$VSS_DATA_DIR/data_log/vst/clip_storage"
 
@@ -398,7 +385,7 @@ echo "<your-ngc-key>" | sudo docker login nvcr.io -u '$oauthtoken' --password-st
 # Or preserve env: sudo --preserve-env=NGC_CLI_API_KEY bash -c \
 #   'echo "$NGC_CLI_API_KEY" | docker login nvcr.io -u $oauthtoken --password-stdin'
 
-# 4. Pull image directly (as described in §4 above)
+# 4. Pull image directly (docker compose pull fails on standalone — see §4)
 sudo docker pull "nvcr.io/nvstaging/vss-core/vss-rt-vlm:${VLM_TAG}"
 
 # 5. Bring up — plain `up` (no profile) starts nothing
@@ -503,7 +490,7 @@ once the service is up):
 | Metadata | Service metadata and version info |
 | NIM Compatible | OpenAI-compatible endpoints for interop |
 
-> ⚠ **Docs API page is a landing page only** — concrete paths, request/response
+> ⚠️ **Docs API page is a landing page only** — concrete paths, request/response
 > schemas, and error codes were not retrievable from the upstream HTML.
 > `GET /openapi.json` on the running service is authoritative for specifics.
 


### PR DESCRIPTION
## Summary

Reverts the behavior-affecting changes that PR #766 made to `vss-deploy-dense-captioning`. Packaging additions from #766 (`skill-card.md`, `skill.oms.sig`, `evals/` rename) are preserved.

## Files reverted to pre-#766 state

- `skills/vss-deploy-dense-captioning/SKILL.md`
- `skills/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md`

## What this rolls back

- **Description**: re-narrowed scope ("Use to deploy standalone RT-VLM dense captioning…")
- **Frontmatter `author` field** added
- **New structural sections** (Purpose / Prerequisites / Instructions / Examples / Limitations / Troubleshooting)
- **Inline workflow examples** replaced by a reference-table routing
- **`deploy-rt-vlm-service.md` security guidance**: mandatory `chmod 600 .env`, `umask 077`, and the host-path setup moved into Quick-Start

## Test plan

- [ ] CI nvskills validation stays green (packaging files untouched).
- [ ] Re-deploy RT-VLM standalone end-to-end against the pre-revert workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)