### PR TITLE
revert(vss-deploy-video-embedding): undo #766 behavior changes

### DIFF
--- a/skills/vss-deploy-video-embedding/SKILL.md
+++ b/skills/vss-deploy-video-embedding/SKILL.md
@@ -1,30 +1,17 @@
 ---
 name: vss-deploy-video-embedding
-description: Use to deploy and operate the RT-Embed video-embedding microservice (Compose bring-up, /v1 REST, Redis/Kafka/OTel). Not for dense captioning or search.
+description: >
+  Deploy, operate, and integrate the VSS 3.2 GA RT-Embed Video Embedding
+  microservice. Covers Docker Compose bring-up, 
+  GPU and storage prerequisites, the `/v1` REST API (file uploads,
+  text and video embeddings, live RTSP streams, health and metrics),
+  Redis/Kafka/OTel integration, common failure modes, and teardown.
 license: Apache-2.0
 metadata:
-  author: "NVIDIA Video Search and Summarization team"
   version: "3.2.0"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational deployment"
 ---
-## Purpose
-
-Stand up the RT-Embed video-embedding microservice, exercise its REST surface, and integrate it with Redis/Kafka/OTel.
-
-## Instructions
-
-Follow the routing tables and step-by-step workflows below. Each section that ends in *workflow*, *quick start*, or *flow* is intended to be executed top-to-bottom. Detailed reference material lives in `references/` and helper scripts live in `scripts/` — call them via `run_script` when the skill points to a script by name.
-
-## Examples
-
-Worked end-to-end examples are kept under `evals/` (each `*.json` manifest contains a runnable scenario) and inline in the per-workflow `curl` blocks below. Run a Tier-3 evaluation with `nv-base validate <this-skill-dir> --agent-eval` to replay them.
-
-## Limitations
-
-- Requires the matching VSS profile / microservice to be deployed and reachable from the caller.
-- NGC-hosted models and NIMs may be subject to rate-limits, GPU memory requirements, and license restrictions.
-- Concurrency, GPU memory, and storage limits depend on the host hardware and the profile's compose file.
 
 # VSS Video Embedding (RT-Embed)
 
@@ -148,7 +135,7 @@ curl -fsS "$BASE_URL/v1/streams/get-stream-info"
 curl -fsS -X DELETE "$BASE_URL/v1/generate_video_embeddings/$STREAM_ID"
 ```
 
-See `references/rest-api.md` for the full endpoint catalog, SSE streaming, and single-stream control-plane patterns.
+See `references/api.md` for the full endpoint catalog, SSE streaming, and single-stream control-plane patterns.
 
 ## Logs, Metrics, And Status
 
@@ -181,20 +168,31 @@ For common failure patterns and resolutions, see `references/troubleshooting.md`
 
 ## Upgrade And Rollback
 
-See [Upgrade & Rollback](references/deploy-vss-deploy-video-embedding.md#upgrade--rollback)
-in the deployment reference for the full image-swap and rollback steps; named
-volumes persist across the swap.
+1. Update `RTVI_EMBED_IMAGE` and `RTVI_EMBED_TAG` to the target build.
+2. `docker compose -f rtvi-embed-docker-compose.yml pull rtvi-embed`.
+3. `docker compose -f rtvi-embed-docker-compose.yml --profile bp_developer_search_2d up -d rtvi-embed`.
+4. Watch `/v1/ready` until it returns 200.
+5. To roll back, re-pin `RTVI_EMBED_TAG` to the previous build and repeat. Named volumes persist across the swap.
 
 ## Tear Down
 
 ```bash
-docker compose -f rtvi-embed-docker-compose.yml down       # keeps caches
-docker compose -f rtvi-embed-docker-compose.yml down -v    # also removes the named caches; first re-start re-downloads the model and rebuilds the Triton repo (20+ min)
+# Preserve caches (named volumes survive).
+docker compose -f rtvi-embed-docker-compose.yml down
+
+# WARNING: removes rtvi-hf-cache, rtvi-ngc-model-cache, rtvi-triton-model-repo.
+# Next start will re-download the model and rebuild the Triton repo (20+ min).
+docker compose -f rtvi-embed-docker-compose.yml down -v
 ```
 
 ## References
 
-See [`references/README.md`](references/README.md) for the full reference index
-(deploy, integrate, API catalog, environment matrix, troubleshooting).
+| File | When to read |
+|---|---|
+| [references/README.md](references/README.md) | Table of contents for all reference files. |
+| [references/deploy-vss-deploy-video-embedding.md](references/deploy-vss-deploy-video-embedding.md) | Build Vision Agent deployment reference: image, GPU, storage, startup, prerequisites, known issues. |
+| [references/integrate-vss-deploy-video-embedding.md](references/integrate-vss-deploy-video-embedding.md) | Build Vision Agent integration reference: peers, inputs/outputs, env vars, network, example Compose snippet. |
+| [references/api.md](references/api.md) | Full REST endpoint catalog with worked `curl` examples for file uploads, video/text embeddings, live streams, and health/metrics. |
+| [references/environment.md](references/environment.md) | Complete environment-variable matrix, including host-to-container renames and secret-sensitive variables. |
+| [references/troubleshooting.md](references/troubleshooting.md) | Operational diagnostics for startup, model/cache, runtime, and observability issues. |
 
-bump:1

--- a/skills/vss-deploy-video-embedding/references/README.md
+++ b/skills/vss-deploy-video-embedding/references/README.md
@@ -4,8 +4,8 @@ Reference files for the `vss-deploy-video-embedding` skill (VSS 3.2 GA Video Emb
 
 | File | Description | When to read |
 |---|---|---|
-| `deploy-vss-deploy-video-embedding.md` | Build Vision Agent deployment reference: container image, GPU/CPU/memory, storage, startup behavior, known deployment issues, prerequisites, verify/teardown commands. | When deploying, sizing, upgrading, or tearing down the service. |
-| `integrate-vss-deploy-video-embedding.md` | Build Vision Agent integration reference: peer services, inputs/outputs, environment variables, network requirements, integration constraints, example Compose snippet. | When wiring the service into a VSS deployment or another microservice's workflow. |
-| `rest-api.md` | Full REST endpoint catalog grouped by tag, with worked `curl` examples for uploads, text/video embeddings, live RTSP streams, health, and metrics. | When calling the API or building a client. |
-| `environment.md` | Complete environment-variable matrix, host-to-container rewrites, volume override variables, and the list of secret-sensitive variables. | When wiring `.env` files, configuring orchestrators, or tuning the runtime. |
-| `troubleshooting.md` | Operational diagnostics tables for startup, model/cache, runtime, and observability problems. | When `/v1/ready` is stuck, embeddings fail, or caches misbehave. |
+| [deploy-vss-deploy-video-embedding.md](deploy-vss-deploy-video-embedding.md) | Build Vision Agent deployment reference: container image, GPU/CPU/memory, storage, startup behavior, known deployment issues, prerequisites, verify/teardown commands. | When deploying, sizing, upgrading, or tearing down the service. |
+| [integrate-vss-deploy-video-embedding.md](integrate-vss-deploy-video-embedding.md) | Build Vision Agent integration reference: peer services, inputs/outputs, environment variables, network requirements, integration constraints, example Compose snippet. | When wiring the service into a VSS deployment or another microservice's workflow. |
+| [api.md](api.md) | Full REST endpoint catalog grouped by tag, with worked `curl` examples for uploads, text/video embeddings, live RTSP streams, health, and metrics. | When calling the API or building a client. |
+| [environment.md](environment.md) | Complete environment-variable matrix, host-to-container rewrites, volume override variables, and the list of secret-sensitive variables. | When wiring `.env` files, configuring orchestrators, or tuning the runtime. |
+| [troubleshooting.md](troubleshooting.md) | Operational diagnostics tables for startup, model/cache, runtime, and observability problems. | When `/v1/ready` is stuck, embeddings fail, or caches misbehave. |

--- a/skills/vss-deploy-video-embedding/references/api.md
+++ b/skills/vss-deploy-video-embedding/references/api.md
@@ -2,7 +2,7 @@
 
 The service exposes a v1 REST API on container port `8000`. The OpenAPI spec uses a relative server URL, so callers must set `BASE_URL` to the deployed host and port (for example, `http://localhost:${RTVI_EMBED_PORT}`).
 
-The OpenAPI spec annotates every endpoint with a Bearer token security scheme. Compose-based **local** deployments may not enforce Bearer auth on the loopback interface, **but** Bearer auth MUST be enabled before exposing the API on any non-loopback interface, in staging, or in production. Treat the unauthenticated bring-up as a localhost-only debug shortcut: bind only to `127.0.0.1`, never to `0.0.0.0`, never to a publicly routable IP, and never to a shared host without first restoring the Bearer header. Operators who copy the local pattern into staging or prod will expose an unauthenticated embedding API to the network — this is a credential-equivalent disclosure risk for any RAG corpus reachable through it. Always inject `Authorization: Bearer <token>` at the caller boundary the moment the service leaves the developer laptop.
+The OpenAPI spec annotates every endpoint with a Bearer token security scheme. Compose-based local deployments typically do not enforce Bearer auth on the loopback interface; treat the API as deployment-gated and inject an `Authorization: Bearer <token>` header at the caller boundary when exposing it beyond localhost.
 
 All examples below assume:
 
@@ -114,18 +114,7 @@ curl -fsS -X POST "$BASE_URL/v1/generate_video_embeddings" \
   }'
 ```
 
-Supported `url` schemes per the spec: `http://`, `https://`, `s3://`, `file://`, and `data:` URIs.
-
-> **Security warning — `file://`**: this scheme causes the embedding server
-> to read **arbitrary local files** from its own filesystem. It is gated by
-> the `FILE_URL_ALLOWED_DIRS` env var and MUST stay restricted to a
-> narrow allow-list of directories that hold only intended media. An
-> empty / overly broad allow-list combined with an exposed (or
-> unauthenticated) endpoint lets a caller read any file the container
-> process can see — config, secrets, mounted data. Set
-> `FILE_URL_ALLOWED_DIRS` to the smallest dataset directory possible and
-> prefer `https://` / `s3://` whenever the caller can reach the media
-> over the network.
+Supported `url` schemes per the spec: `http://`, `https://`, `s3://`, `file://` (requires server-side `FILE_URL_ALLOWED_DIRS`), and `data:` URIs.
 
 #### Response schema
 
@@ -133,8 +122,8 @@ A synchronous (non-SSE) response looks like:
 
 ```json
 {
-  "id": "<uuid>",
-  "created": "<unix-epoch>",
+  "id": "3a5c1703-717c-47e2-950f-dba57e749826",
+  "created": 1715760000,
   "model": "cosmos-embed1-448p",
   "media_info": { "type": "offset", "start_offset": 0, "end_offset": 130 },
   "usage": {
@@ -145,8 +134,9 @@ A synchronous (non-SSE) response looks like:
     "total_tokens": null
   },
   "chunk_responses": [
-    { "start_time": "0", "end_time": "60",  "embeddings": ["<float>", "<float>", "..."] },
-    { "start_time": "50", "end_time": "110", "embeddings": ["<float>", "<float>", "..."] }
+    { "start_time": "0.0",   "end_time": "60.0",    "embeddings": [0.0282, 0.0331, ...] },
+    { "start_time": "50.0",  "end_time": "110.0",   "embeddings": [0.0594, 0.0294, ...] },
+    { "start_time": "100.0", "end_time": "130.434", "embeddings": [0.0585, 0.0488, ...] }
   ]
 }
 ```
@@ -191,11 +181,11 @@ curl -fsS -X POST "$BASE_URL/v1/generate_text_embeddings" \
 
 ```json
 {
-  "id": "<uuid>",
-  "created": "<unix-epoch>",
+  "id": "...",
+  "created": 1715760000,
   "model": "cosmos-embed1-448p",
   "data": [
-    { "text_input": "a forklift moving pallets", "embeddings": ["<float>", "<float>", "..."] }
+    { "text_input": "a forklift moving pallets", "embeddings": [-0.0712, 0.0065, ...] }
   ]
 }
 ```
@@ -246,19 +236,19 @@ Per-chunk SSE events use the same envelope as the file-mode response, but **time
 
 ```json
 {
-  "id": "<uuid>",
-  "created": "<unix-epoch>",
+  "id": "8183c6fd-f965-4db9-9ff6-b971ea3490f8",
+  "created": 1778739794,
   "model": "cosmos-embed1-448p",
   "media_info": {
     "type": "timestamp",
-    "start_timestamp": "<ISO-8601-UTC>",
-    "end_timestamp":   "<ISO-8601-UTC>"
+    "start_timestamp": "2026-05-14T06:23:18.106Z",
+    "end_timestamp":   "2026-05-14T06:23:26.881Z"
   },
   "chunk_responses": [
     {
-      "start_time": "<ISO-8601-UTC>",
-      "end_time":   "<ISO-8601-UTC>",
-      "embeddings": ["<float>", "<float>", "..."]
+      "start_time": "2026-05-14T06:23:18.106Z",
+      "end_time":   "2026-05-14T06:23:26.881Z",
+      "embeddings": [-0.0074, -0.0539, 0.0281, ...]
     }
   ]
 }

--- a/skills/vss-deploy-video-embedding/references/deploy-vss-deploy-video-embedding.md
+++ b/skills/vss-deploy-video-embedding/references/deploy-vss-deploy-video-embedding.md
@@ -61,9 +61,15 @@ The named volumes `rtvi-hf-cache`, `rtvi-ngc-model-cache`, and `rtvi-triton-mode
 
 ## Known Deployment Issues
 
-See `troubleshooting.md` for the consolidated symptom →
-root cause → fix table covering startup, model/cache, runtime, and GPU
-visibility issues.
+| Symptom | Root cause | Fix |
+|---|---|---|
+| Container is marked unhealthy within the first 20 minutes. | Health check `start_period` was shortened below the model warmup time. | Restore `start_period: 1200s` or longer for first boots; keep model and Triton volumes warm to shorten subsequent boots. |
+| `docker compose up` errors that `RTVI_EMBED_PORT` is required. | The `ports:` mapping uses `${RTVI_EMBED_PORT?}`, which fails fast when unset. | Set `RTVI_EMBED_PORT` in the environment or `.env` file before bringing the service up. |
+| Model download fails with HTTP 429 against Hugging Face. | Anonymous Hugging Face downloads are being rate-limited while pulling `nvidia/Cosmos-Embed1-448p`. | Set `HF_TOKEN` to a valid Hugging Face token to lift the rate limit, or pre-populate the `rtvi-hf-cache` volume so first boot does not need to re-fetch the weights. |
+| Model download fails with HTTP 401/403 against NGC. | `NGC_API_KEY` is missing or invalid. | Provide a valid `NGC_API_KEY` and confirm `docker login nvcr.io` succeeded on the host. |
+| Service starts but `/v1/ready` keeps returning 503. | A peer such as Redis or Kafka was enabled but is not reachable. | Either disable the feature on the host (`ENABLE_REDIS_ERROR_MESSAGES=false`, `RTVI_EMBED_KAFKA_ENABLED=false` — the latter maps to the container's `KAFKA_ENABLED`) or fix peer reachability (`REDIS_HOST`, `HOST_IP`/`KAFKA_BOOTSTRAP_SERVERS`). |
+| Process exits with permission errors on `/opt/nvidia/rtvi/.rtvi/ngc_model_cache` or `/tmp/huggingface`. | Host-side bind mount is not writable by UID/GID `1001:1001`. | `chown -R 1001:1001` on the host bind target, or rely on the named volumes which are provisioned with correct permissions. |
+| GPU not visible inside the container. | NVIDIA Container Toolkit not installed or driver too old. | Install/upgrade NVIDIA Container Toolkit and matching driver, then re-pull the image and restart the service. |
 
 ## Prerequisites
 

--- a/skills/vss-deploy-video-embedding/references/integrate-vss-deploy-video-embedding.md
+++ b/skills/vss-deploy-video-embedding/references/integrate-vss-deploy-video-embedding.md
@@ -49,19 +49,39 @@ The service exposes a v1 REST API. Set `BASE_URL=http://<host>:${RTVI_EMBED_PORT
 - **Metadata / NIM-compatible** — `GET /v1/metadata`, `GET /v1/version`, `GET /v1/license`, `GET /v1/manifest`.
 - **Metrics** — `GET /v1/metrics` (Prometheus text format).
 
-**Examples** (all worked `curl` recipes are in `rest-api.md`):
-
-- Embed an uploaded video — see [`rest-api` § Upload + embed](rest-api.md#1-upload).
-- Embed a text query — see `rest-api.md` § Text embeddings.
-- Register and embed a live RTSP stream — see [`rest-api` § Add stream + SSE embed](rest-api.md#add-the-stream).
-  Live-stream requests **require** `stream: true` and `chunk_duration > 0`; a
-  synchronous call returns `400 BadParameters: "Only streaming output is
-  supported for live-streams"` and an unset/zero `chunk_duration` returns
-  `400 BadParameter: "chunk_duration must be greater than 0"`. Use
-  `Accept: text/event-stream` with `curl -N` so SSE events stream immediately.
+Example: embed an uploaded video.
 
 ```bash
-# Start embedding the stream (SSE) — see rest-api.md for the full flow including streams/add.
+# 1. Upload the media file.
+FILE_ID=$(curl -fsS -X POST "$BASE_URL/v1/files" \
+  -F purpose=vision \
+  -F media_type=video \
+  -F file=@/path/to/clip.mp4 | jq -r .id)
+
+# 2. Generate embeddings.
+curl -fsS -X POST "$BASE_URL/v1/generate_video_embeddings" \
+  -H "Content-Type: application/json" \
+  -d "{\"id\": \"$FILE_ID\", \"model\": \"cosmos-embed1-448p\", \"chunk_duration\": 60}"
+```
+
+Example: embed a text query.
+
+```bash
+curl -fsS -X POST "$BASE_URL/v1/generate_text_embeddings" \
+  -H "Content-Type: application/json" \
+  -d '{"text_input": "a forklift moving pallets", "model": "cosmos-embed1-448p"}'
+```
+
+Example: register and embed a live RTSP stream. Live-stream requests **require** `stream: true` and `chunk_duration > 0`; a synchronous call returns `400 BadParameters: "Only streaming output is supported for live-streams"` and an unset/zero `chunk_duration` returns `400 BadParameter: "chunk_duration must be greater than 0"`. Send `Accept: text/event-stream` and use `curl -N` so SSE events stream immediately.
+
+```bash
+# 1. Add the live stream.
+STREAM_ID=$(curl -fsS -X POST "$BASE_URL/v1/streams/add" \
+  -H "Content-Type: application/json" \
+  -d '{"streams":[{"liveStreamUrl":"rtsp://host:port/live/video","description":"camera-001"}]}' \
+  | jq -r '.results[0].id')
+
+# 2. Start embedding for that stream (SSE).
 curl -N -X POST "$BASE_URL/v1/generate_video_embeddings" \
   -H "Content-Type: application/json" \
   -H "Accept: text/event-stream" \


### PR DESCRIPTION
## Summary

Reverts the behavior-affecting changes that PR #766 made to `vss-deploy-video-embedding`. Packaging additions (`skill-card.md`, `skill.oms.sig`, `evals/` rename) are preserved.

## Files reverted to pre-#766 state

- `skills/vss-deploy-video-embedding/SKILL.md`
- `skills/vss-deploy-video-embedding/references/README.md`
- `skills/vss-deploy-video-embedding/references/deploy-vss-deploy-video-embedding.md`
- `skills/vss-deploy-video-embedding/references/integrate-vss-deploy-video-embedding.md`
- `skills/vss-deploy-video-embedding/references/rest-api.md` → renamed back to `api.md`

## What this rolls back

- **Description** retightened to the #766 single-line form
- **New structural sections** (Purpose / Prerequisites / Instructions / Examples / Limitations) and frontmatter `author`
- **`rest-api.md` → `api.md` rename** and the associated security mandates:
  - "Bearer auth MUST be enabled before non-loopback exposure"
  - "`FILE_URL_ALLOWED_DIRS` must stay narrow; overly broad lists expose secrets"
- **Inline curl examples** restored to `integrate-vss-deploy-video-embedding.md` (had been deduped into rest-api.md)
- **Known Issues table** restored to `deploy-vss-deploy-video-embedding.md` (had been delegated to a troubleshooting.md cross-reference)

## Test plan

- [ ] CI nvskills validation stays green.
- [ ] Re-deploy RT-Embed standalone and confirm REST flows still operate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)