### PR TITLE
chore: update vss-video-analytics-api version to 3.2-26.05.27 in Helm…

### DIFF
--- a/deploy/docker/services/analytics/video-analytics-api/compose.yml
+++ b/deploy/docker/services/analytics/video-analytics-api/compose.yml
@@ -15,7 +15,7 @@
 
 services:
   vss-video-analytics-api:
-    image: nvcr.io/nvstaging/vss-core/vss-video-analytics-api:3.2-26.05.26
+    image: nvcr.io/nvstaging/vss-core/vss-video-analytics-api:3.2-26.05.27
     network_mode: "host"
     command: node index.js --config /opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
     restart: always

--- a/deploy/helm/services/analytics/Chart.lock
+++ b/deploy/helm/services/analytics/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 26.04.2
 - name: vss-video-analytics-api
   repository: file://./charts/video-analytics-api
-  version: 26.05.26
+  version: 26.05.27
 - name: video-analytics-ui
   repository: file://./charts/video-analytics-ui
   version: 26.04.2
-digest: sha256:e8dcc6729c008744c5030a238961668a8dc2282c32db2484fdd1e1f912ca6213
-generated: "2026-05-27T09:46:56.816059346Z"
+digest: sha256:c664912a025d2f087a7e099282cd632c7a46a7c0cd757bad1eff280abfc57d03
+generated: "2026-05-28T09:11:26.151254587Z"

--- a/deploy/helm/services/analytics/Chart.yaml
+++ b/deploy/helm/services/analytics/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     repository: "file://./charts/behavior-analytics"
     condition: vss-behavior-analytics.enabled
   - name: vss-video-analytics-api
-    version: 26.05.26
+    version: 26.05.27
     repository: "file://./charts/video-analytics-api"
     condition: vss-video-analytics-api.enabled
   - name: video-analytics-ui

--- a/deploy/helm/services/analytics/charts/video-analytics-api/Chart.yaml
+++ b/deploy/helm/services/analytics/charts/video-analytics-api/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v2
 name: vss-video-analytics-api
-version: 26.05.26
-appVersion: "3.2-26.05.26"
+version: 26.05.27
+appVersion: "3.2-26.05.27"
 description: Video analytics API (Helm subchart under deploy/helm/services/analytics/charts)
 maintainers: []

--- a/deploy/helm/services/analytics/charts/video-analytics-api/values.yaml
+++ b/deploy/helm/services/analytics/charts/video-analytics-api/values.yaml
@@ -18,7 +18,7 @@ global: {}
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-video-analytics-api
-  tag: "3.2-26.05.26"
+  tag: "3.2-26.05.27"
   pullPolicy: IfNotPresent
 replicas: 1
 


### PR DESCRIPTION
… and Docker configurations

- Bumped version in compose.yml, Chart.yaml, and values.yaml files.
- Updated Chart.lock to reflect new version and digest.

This change ensures the deployment uses the latest version of the video analytics API.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
