### PR TITLE
docs(skills): sync VIOS skill references with new vios folder layout

### DIFF
--- a/skills/vss-deploy-profile/references/data-directory.md
+++ b/skills/vss-deploy-profile/references/data-directory.md
@@ -43,7 +43,7 @@ chmod -R 777 "$DATA/data_log" "$DATA/agent_eval"
 | Container | Image | Runs as | Mount path | Symptom if permissions wrong |
 |---|---|---|---|---|
 | `centralizedb-dev` | postgres:17.9-alpine | uid **70** | `$DATA/data_log/vst/postgres/db` | Can't read own PGDATA → VST `sensor_details` query fails → uploaded videos never appear in `/vst/api/v1/sensor/streams` → warehouse E2E check returns empty |
-| `mdx-redis` | redis:8.2.2-alpine | uid **999** | `$DATA/data_log/redis/log`, `/redis/data` | "Can't open the log file: Permission denied" → redis dies → `envoy-streamprocessing` dies (needs Redis Lua script) → stream pipeline broken |
+| `mdx-redis` | redis:8.2.2-alpine | uid **999** | `$DATA/data_log/redis/log`, `/redis/data` | "Can't open the log file: Permission denied" → redis dies → `sdr-controller` can't reach `WDM_WL_REDIS_SERVER` → SDRC never registers `vss-vios-streamprocessing` on the `:10000` Envoy listener → stream pipeline broken (legacy `envoy-streamprocessing` no longer exists; SDR + Envoy are now consolidated in `sdr-controller` from `services/infra/sdrc/`) |
 | `elasticsearch` | elasticsearch | uid **1000** | `$DATA/data_log/elastic/{data,logs}` | "AccessDeniedException" on startup → ES refuses to start |
 | `vst` / `sensor-ms-dev` | vst | uid **1000** | `$DATA/data_log/vst/*` (videos, clips) | 403 on ingest or stream write |
 

--- a/skills/vss-deploy-profile/references/warehouse-debug.md
+++ b/skills/vss-deploy-profile/references/warehouse-debug.md
@@ -38,7 +38,10 @@ Warehouse Auto-Calibration (BP_PROFILE=bp_wh_auto_calib) — minimal footprint:
 
 VST (VIOS) stack — independent of perception, feeds RTSP into it:
   vss-vios-postgres → vss-vios-sensor / vss-vios-streamprocessing
-                    → vss-vios-sdr / vss-vios-mcp / vss-vios-ingress / vss-vios-envoy
+                    → vss-vios-ingress
+                    → sdr-controller  (from services/infra/sdrc/ — combined WDM controller + Envoy
+                                       router on :10000; replaces the deprecated vss-vios-sdr +
+                                       vss-vios-envoy pair. vss-vios-mcp was also removed.)
 
 elasticsearch — deployed when: BP_PROFILE=bp_wh (always; vss-agent storage), OR kafka/redis with MINIMAL_PROFILE="" (extended; ELK + bounding-box overlays + analytics API; any mode).
 NOTE: minimal does NOT deploy ES — so the mdx-bev index isn't persisted and Phase 5 BEV-sync check has no data to read (applies to 3D and MV3DT).
@@ -71,7 +74,7 @@ vss-haproxy-ingress — bp_wh OR kafka/redis extended (front-door on HAPROXY_POR
 | `vss-rtvi-cv-config-adaptor` | DeepStream config adaptor (3D only) |
 | `vss-configurator` | Stream and hardware config |
 | `vss-behavior-analytics` | ROI / tripwire / proximity analytics |
-| `vss-vios-postgres` / `-sensor` / `-streamprocessing` / `-sdr` / `-mcp` / `-ingress` / `-envoy` | VST stack |
+| `vss-vios-postgres` / `-sensor` / `-streamprocessing` / `-ingress` + `sdr-controller` (from `services/infra/sdrc/`) | VST stack (legacy `-sdr` / `-mcp` / `-envoy` removed; SDR + Envoy roles now consolidated in `sdr-controller`) |
 
 ### MV3DT CV core (`bp_wh_kafka_mv3dt` / `bp_wh_redis_mv3dt`)
 
@@ -85,7 +88,7 @@ vss-haproxy-ingress — bp_wh OR kafka/redis extended (front-door on HAPROXY_POR
 | `mosquitto` | MQTT broker for cross-camera messaging |
 | `vss-configurator-mv3dt` | Stream and hardware config |
 | `vss-behavior-analytics-mv3dt` | 3D spatial analytics |
-| `vss-vios-postgres` / `sensor-ms-mv3dt` / `-streamprocessing` / `-sdr` / `-mcp` / `-ingress` / `-envoy` | VST stack |
+| `vss-vios-postgres` / `sensor-ms-mv3dt` (container `vss-vios-sensor`) / `-streamprocessing` / `-ingress` + `sdr-controller` (from `services/infra/sdrc/`) | VST stack (legacy `-sdr` / `-mcp` / `-envoy` removed; SDR + Envoy roles now consolidated in `sdr-controller`) |
 
 ### Warehouse Auto-Calibration (`bp_wh_auto_calib`)
 
@@ -401,7 +404,7 @@ docker logs --tail 50 vss-behavior-analytics-mv3dt 2>&1 | grep -E "ERROR|error|f
 ### 3.7 VST / VIOS stack
 
 ```bash
-for c in vss-vios-postgres vss-vios-sensor vss-vios-streamprocessing vss-vios-sdr vss-vios-mcp vss-vios-ingress vss-vios-envoy; do
+for c in vss-vios-postgres vss-vios-sensor vss-vios-streamprocessing vss-vios-ingress sdr-controller; do
   echo "=== $c ==="
   docker logs --tail 30 "$c" 2>&1 | grep -E "ERROR|error|fail" | tail -10
 done

--- a/skills/vss-manage-video-io-storage/SKILL.md
+++ b/skills/vss-manage-video-io-storage/SKILL.md
@@ -120,11 +120,11 @@ host without re-deploying and see 502s, re-run `/vss-deploy-profile` to clean.
 >   streamprocessing on `:30001`. The combined WDM controller + Envoy router lives at
 >   [`deploy/docker/services/infra/sdrc/docker-compose.yaml`](../../deploy/docker/services/infra/sdrc/docker-compose.yaml).
 >
-> The legacy `sdr-streamprocessing` + `envoy-streamprocessing` services still
-> exist in the tree (gated to the dead `bp_developer_sdr_envoy_disabled` profile)
-> but are not invoked by any active deploy. The `sdr-*` / `envoy-*` patterns in
-> the teardown grep above are retained to clean up stale hosts that ran an
-> older `develop`.
+> The legacy `sdr-streamprocessing` + `envoy-streamprocessing` services have
+> been removed from the tree along with the `services/vios/sdr/` directory
+> (PR #711, commit `3c9de80e`). The `sdr-*` / `envoy-*` patterns in the
+> teardown grep above are retained to clean up stale hosts that still carry
+> these containers from an older `develop` checkout.
 
 Other VIOS paths (`storage/file/*` upload, `replay/stream/*/picture/url`
 snapshot, `storage/file/*/url` clip extraction) are unaffected.

--- a/skills/vss-manage-video-io-storage/references/integrate-vios-service.md
+++ b/skills/vss-manage-video-io-storage/references/integrate-vios-service.md
@@ -404,7 +404,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
 
-(Full upstream definitions live in `deploy/docker/services/vios/{foundational,initiator}/docker-compose.yaml` + `deploy/docker/services/infra/sdrc/docker-compose.yaml`. Container names use the canonical `vss-vios-*` form, NOT the legacy `*-dev` form. The deprecated `services/vios/sdr/streamprocessing/` tree is no longer referenced.)
+(Full upstream definitions live in `deploy/docker/services/vios/{foundational,initiator,streamprocessing}/docker-compose.yaml` + `deploy/docker/services/infra/sdrc/docker-compose.yaml`. Container names use the canonical `vss-vios-*` form, NOT the legacy `*-dev` form. The deprecated `services/vios/sdr/streamprocessing/` tree has been removed — streamprocessing now lives directly under `services/vios/streamprocessing/`, with the legacy `envoy.yaml` + `sdr-config/` bind sources gone.)
 
 For Topology B (NvStreamer file-driven), use this service shape instead of `vss-vios-sensor`:
 


### PR DESCRIPTION
Update the skill reference docs that still pointed at the old layout/containers:

## Description

- Realign skill docs after PR #711 moved services/vios/sdr/streamprocessing/ → services/vios/streamprocessing/ and replaced vss-vios-{sdr,mcp,envoy} with sdr-controller (services/infra/sdrc/).
- Updates the VST-stack diagram, container tables, and debug loop in vss-deploy-profile, plus the SDR/Envoy migration notes and compose-path list in vss-manage-video-io-storage.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
