### PR TITLE
skill-eval(adapters): read specs from skills/<x>/evals/ (was eval/)

### DIFF
--- a/.github/skill-eval/adapters/vss-ask-video/generate.py
+++ b/.github/skill-eval/adapters/vss-ask-video/generate.py
@@ -33,7 +33,7 @@ Usage from the repository root:
         --skill-dir skills/vss-ask-video \\
         --deploy-skill-dir skills/vss-deploy-profile \\
         --video-io-skill-dir skills/vss-manage-video-io-storage \\
-        --spec skills/vss-ask-video/eval/base_profile_video_understanding.json
+        --spec skills/vss-ask-video/evals/base_profile_video_understanding.json
 """
 from __future__ import annotations
 
@@ -229,7 +229,7 @@ def generate_task(
         (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
         if GENERIC_JUDGE.exists():
             shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
-        spec_src = skill_dir / "eval" / spec_name
+        spec_src = skill_dir / "evals" / spec_name
         if spec_src.exists():
             shutil.copy(spec_src, tests_dir / spec_name)
         else:
@@ -287,7 +287,7 @@ def main() -> None:
     parser.add_argument(
         "--spec", default=None,
         help="Path to spec JSON "
-             "(default: <skill-dir>/eval/base_profile_video_understanding.json)",
+             "(default: <skill-dir>/evals/base_profile_video_understanding.json)",
     )
     parser.add_argument(
         "--platform", default=None, choices=list(PLATFORMS.keys()),
@@ -303,7 +303,7 @@ def main() -> None:
     spec_path = (
         Path(args.spec)
         if args.spec
-        else (skill_dir / "eval" / "base_profile_video_understanding.json")
+        else (skill_dir / "evals" / "base_profile_video_understanding.json")
     )
 
     if not spec_path.exists():

--- a/.github/skill-eval/adapters/vss-deploy-dense-captioning/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-dense-captioning/generate.py
@@ -273,7 +273,7 @@ def main() -> None:
     output_root = Path(args.output_dir)
     skill_dir = Path(args.skill_dir)
     deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
-    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / DEFAULT_SPEC)
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "evals" / DEFAULT_SPEC)
 
     if not spec_path.exists():
         print(f"spec not found: {spec_path}", file=sys.stderr)

--- a/.github/skill-eval/adapters/vss-deploy-detection-tracking-2d/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-detection-tracking-2d/generate.py
@@ -24,7 +24,7 @@ Usage from the repository root:
     python3 .github/skill-eval/adapters/vss-deploy-detection-tracking-2d/generate.py \\
         --output-dir .github/skill-eval/datasets/vss-deploy-detection-tracking-2d \\
         --skill-dir skills/vss-deploy-detection-tracking-2d \\
-        --spec skills/vss-deploy-detection-tracking-2d/eval/deploy-evals.json
+        --spec skills/vss-deploy-detection-tracking-2d/evals/deploy-evals.json
 """
 from __future__ import annotations
 
@@ -316,14 +316,14 @@ def main() -> None:
     parser.add_argument(
         "--spec",
         default=None,
-        help=f"Path to spec file (default: <skill-dir>/eval/{DEFAULT_SPEC})",
+        help=f"Path to spec file (default: <skill-dir>/evals/{DEFAULT_SPEC})",
     )
     parser.add_argument("--platform", default=None, choices=list(PLATFORMS.keys()))
     args = parser.parse_args()
 
     output_root = Path(args.output_dir)
     skill_dir = Path(args.skill_dir)
-    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / DEFAULT_SPEC)
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "evals" / DEFAULT_SPEC)
 
     if not spec_path.exists():
         print(f"spec not found: {spec_path}", file=sys.stderr)

--- a/.github/skill-eval/adapters/vss-deploy-profile/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-profile/generate.py
@@ -473,7 +473,7 @@ def generate_task(
         "",
         "[metadata]",
         # Intentionally NOT emitting `profile = "{profile}"` here. For
-        # vss-deploy-profile/eval/<X>.json the trial IS the deploy — it
+        # vss-deploy-profile/evals/<X>.json the trial IS the deploy — it
         # invokes /vss-deploy-profile -p X via its own prompt. Setting
         # `profile` in [metadata] would trick BrevEnvironment's
         # _ensure_prerequisite_deployed into running an extra sub-claude
@@ -526,7 +526,7 @@ def generate_task(
     # -- tests/: wrapper + generic judge + rendered eval spec --
     tests_dir = task_dir / "tests"
     tests_dir.mkdir(exist_ok=True)
-    spec_path = skill_dir / "eval" / f"{profile}.json" if skill_dir else None
+    spec_path = skill_dir / "evals" / f"{profile}.json" if skill_dir else None
     if spec_path and spec_path.exists():
         raw_spec = json.loads(spec_path.read_text())
         rendered = _render_eval_spec(raw_spec, profile, platform)
@@ -538,7 +538,7 @@ def generate_task(
     else:
         (tests_dir / "test.sh").write_text(
             "#!/bin/bash\n"
-            f"echo 'FAIL: no eval spec at skills/vss-deploy-profile/eval/{profile}.json' >&2\n"
+            f"echo 'FAIL: no eval spec at skills/vss-deploy-profile/evals/{profile}.json' >&2\n"
             "mkdir -p /logs/verifier\n"
             "echo 0 > /logs/verifier/reward.txt\n"
             "exit 0\n"
@@ -574,7 +574,7 @@ def _spec_platforms_for(profile: str, skill_dir: Path | None) -> dict[str, int] 
     A warning is printed so authors notice the dead field."""
     if skill_dir is None:
         return None
-    spec_path = skill_dir / "eval" / f"{profile}.json"
+    spec_path = skill_dir / "evals" / f"{profile}.json"
     if not spec_path.exists():
         return None
     try:
@@ -623,7 +623,7 @@ def expand_matrix(
             continue
         spec_matrix = _spec_platforms_for(profile, skill_dir)
         if spec_matrix is None:
-            skipped.append((profile, "-", "no spec at skills/vss-deploy-profile/eval/"
+            skipped.append((profile, "-", "no spec at skills/vss-deploy-profile/evals/"
                                           f"{profile}.json with resources.platforms"))
             continue
         for platform, spec_gpu_count in spec_matrix.items():

--- a/.github/skill-eval/adapters/vss-deploy-video-embedding/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-video-embedding/generate.py
@@ -20,7 +20,7 @@ budget without exercising new code paths.
 
 ## Spec shape
 
-`skills/vss-deploy-video-embedding/eval/standalone_deploy.json` has a
+`skills/vss-deploy-video-embedding/evals/standalone_deploy.json` has a
 single `expects` entry (one bring-up query + 9 checks). The adapter
 therefore emits a flat `base/<platform_short>/` task directory rather
 than a step-chain.
@@ -283,7 +283,7 @@ def generate_task(platform: str, spec: dict, output_root: Path,
     (tests_dir / "test.sh").write_text(generate_test_script(1, spec_name))
     if GENERIC_JUDGE.exists():
         shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
-    spec_src = skill_dir / "eval" / spec_name
+    spec_src = skill_dir / "evals" / spec_name
     if spec_src.exists():
         shutil.copy(spec_src, tests_dir / spec_name)
     else:
@@ -317,7 +317,7 @@ def main() -> None:
                         help="Path to skills/vss-deploy-video-embedding")
     parser.add_argument("--spec", default=None,
                         help="Path to standalone_deploy.json "
-                             "(default: <skill-dir>/eval/standalone_deploy.json)")
+                             "(default: <skill-dir>/evals/standalone_deploy.json)")
     parser.add_argument("--platform", default=None,
                         choices=list(PLATFORMS.keys()),
                         help=f"Generate for this platform only "
@@ -326,7 +326,7 @@ def main() -> None:
 
     output_root = Path(args.output_dir)
     skill_dir = Path(args.skill_dir)
-    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / "standalone_deploy.json")
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "evals" / "standalone_deploy.json")
 
     if not spec_path.exists():
         print(f"spec not found: {spec_path}", file=sys.stderr)

--- a/.github/skill-eval/adapters/vss-generate-video-report/generate.py
+++ b/.github/skill-eval/adapters/vss-generate-video-report/generate.py
@@ -37,7 +37,7 @@ Usage from the repository root:
         --skill-dir skills/vss-generate-video-report \\
         --deploy-skill-dir skills/vss-deploy-profile \\
         --video-io-skill-dir skills/vss-manage-video-io-storage \\
-        --spec skills/vss-generate-video-report/eval/base_profile_report.json
+        --spec skills/vss-generate-video-report/evals/base_profile_report.json
 """
 from __future__ import annotations
 
@@ -233,7 +233,7 @@ def generate_task(
         (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
         if GENERIC_JUDGE.exists():
             shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
-        spec_src = skill_dir / "eval" / spec_name
+        spec_src = skill_dir / "evals" / spec_name
         if spec_src.exists():
             shutil.copy(spec_src, tests_dir / spec_name)
         else:
@@ -290,7 +290,7 @@ def main() -> None:
         print("WARNING: --vios-skill-dir is deprecated; use --video-io-skill-dir.", file=sys.stderr)
     parser.add_argument(
         "--spec", default=None,
-        help="Path to spec JSON (default: <skill-dir>/eval/base_profile_report.json)",
+        help="Path to spec JSON (default: <skill-dir>/evals/base_profile_report.json)",
     )
     parser.add_argument(
         "--platform", default=None, choices=list(PLATFORMS.keys()),
@@ -306,7 +306,7 @@ def main() -> None:
     spec_path = (
         Path(args.spec)
         if args.spec
-        else (skill_dir / "eval" / "base_profile_report.json")
+        else (skill_dir / "evals" / "base_profile_report.json")
     )
 
     if not spec_path.exists():

--- a/.github/skill-eval/adapters/vss-manage-alerts/generate.py
+++ b/.github/skill-eval/adapters/vss-manage-alerts/generate.py
@@ -36,7 +36,7 @@ Usage from the repository root:
         --output-dir /tmp/skill-eval/datasets/vss-manage-alerts \\
         --skill-dir   skills/vss-manage-alerts \\
         --deploy-skill-dir skills/vss-deploy-profile \\
-        --spec        skills/vss-manage-alerts/eval/alerts_vlm_real_time.json
+        --spec        skills/vss-manage-alerts/evals/alerts_vlm_real_time.json
 """
 from __future__ import annotations
 
@@ -349,7 +349,7 @@ def main() -> None:
     parser.add_argument("--deploy-skill-dir", default=None,
                         help="Path to skills/vss-deploy-profile (included so agent can diagnose issues)")
     parser.add_argument("--spec", default=None,
-                        help=f"Path to spec JSON (default: <skill-dir>/eval/{DEFAULT_SPEC})")
+                        help=f"Path to spec JSON (default: <skill-dir>/evals/{DEFAULT_SPEC})")
     parser.add_argument("--platform", default=None,
                         choices=list(PLATFORMS.keys()),
                         help="Generate for this platform only")
@@ -360,7 +360,7 @@ def main() -> None:
     deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
     spec_path = (
         Path(args.spec) if args.spec
-        else (skill_dir / "eval" / DEFAULT_SPEC)
+        else (skill_dir / "evals" / DEFAULT_SPEC)
     )
 
     if not spec_path.exists():

--- a/.github/skill-eval/adapters/vss-manage-video-io-storage/generate.py
+++ b/.github/skill-eval/adapters/vss-manage-video-io-storage/generate.py
@@ -5,7 +5,7 @@
 
 The vss-manage-video-io-storage skill exercises VIOS (VST) API calls — upload video, extract
 snapshot URL, extract clip URL, etc. The current spec
-([`skills/vss-manage-video-io-storage/eval/vios_ops.json`]) **omits the `profile` field
+([`skills/vss-manage-video-io-storage/evals/vios_ops.json`]) **omits the `profile` field
 by design** — the agent is expected to stand VIOS up standalone via the
 skill's bundled `references/deploy-vios-service.md` runbook before
 exercising the API. Per `.github/skill-eval/AGENTS.md` § 2, an absent
@@ -282,7 +282,7 @@ def generate_task(platform: str, spec: dict, output_root: Path,
         (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
         if GENERIC_JUDGE.exists():
             shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
-        spec_src = skill_dir / "eval" / spec_name
+        spec_src = skill_dir / "evals" / spec_name
         if spec_src.exists():
             shutil.copy(spec_src, tests_dir / spec_name)
         else:
@@ -321,7 +321,7 @@ def main() -> None:
                         help="Path to skills/vss-deploy-profile (optional — included for agent debug)")
     parser.add_argument("--spec", default=None,
                         help="Path to vios_ops.json "
-                             "(default: <skill-dir>/eval/vios_ops.json)")
+                             "(default: <skill-dir>/evals/vios_ops.json)")
     parser.add_argument("--platform", default=None,
                         choices=list(PLATFORMS.keys()),
                         help=f"Generate for this platform only "
@@ -341,7 +341,7 @@ def main() -> None:
     output_root = Path(args.output_dir)
     skill_dir = Path(args.skill_dir)
     deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
-    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / "vios_ops.json")
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "evals" / "vios_ops.json")
 
     if not spec_path.exists():
         print(f"spec not found: {spec_path}", file=sys.stderr)

--- a/.github/skill-eval/adapters/vss-search-archive/generate.py
+++ b/.github/skill-eval/adapters/vss-search-archive/generate.py
@@ -224,7 +224,7 @@ def generate_task(platform: str, profile: str, spec: dict, output_root: Path,
         (tests_dir / "test.sh").write_text(generate_test_script(idx, spec_name))
         if GENERIC_JUDGE.exists():
             shutil.copy(GENERIC_JUDGE, tests_dir / "generic_judge.py")
-        spec_src = skill_dir / "eval" / spec_name
+        spec_src = skill_dir / "evals" / spec_name
         if spec_src.exists():
             shutil.copy(spec_src, tests_dir / spec_name)
         else:
@@ -267,7 +267,7 @@ def main() -> None:
     if any(arg == "--vios-skill-dir" or arg.startswith("--vios-skill-dir=") for arg in sys.argv[1:]):
         print("WARNING: --vios-skill-dir is deprecated; use --video-io-skill-dir.", file=sys.stderr)
     parser.add_argument("--spec", default=None,
-                        help="Path to search.json (default: <skill-dir>/eval/search.json)")
+                        help="Path to search.json (default: <skill-dir>/evals/search.json)")
     parser.add_argument("--platform", default=None, choices=list(PLATFORMS.keys()),
                         help=f"Generate for one platform only (overrides spec.resources.platforms)")
     args = parser.parse_args()
@@ -276,7 +276,7 @@ def main() -> None:
     skill_dir = Path(args.skill_dir)
     deploy_skill_dir = Path(args.deploy_skill_dir) if args.deploy_skill_dir else None
     video_io_skill_dir = Path(args.video_io_skill_dir) if args.video_io_skill_dir else None
-    spec_path = Path(args.spec) if args.spec else (skill_dir / "eval" / "search.json")
+    spec_path = Path(args.spec) if args.spec else (skill_dir / "evals" / "search.json")
 
     if not spec_path.exists():
         print(f"spec not found: {spec_path}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Develop already renamed every `skills/<skill>/eval/` directory to `skills/<skill>/evals/`, but the adapters under `.github/skill-eval/adapters/<skill>/generate.py` still hard-coded `"eval"` as the spec subdir.
- Each adapter's default `--spec <skill-dir>/eval/...` path missed the file and the harness fell into the "no eval spec at …" failure branch.
- Replaces `skill_dir / "eval" / ...` with `skill_dir / "evals" / ...` across all nine adapters that still pointed at the old name, and updates the matching docstrings/help text/error messages so they print the real path.
- `vss-summarize-video` was already on the new convention and is unchanged.

## Test plan
- [ ] `workflow_dispatch` with `*` finds and runs every spec (no "no eval spec at …" failures).
- [ ] Per-skill `workflow_dispatch` resolves the correct default spec path for adapters with no `--spec` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)