### PR TITLE
skill-eval: allow parallel workflow_dispatch sweeps

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -72,19 +72,34 @@ permissions:
   contents: write
   pull-requests: write
 
-# Only one eval runs per PR (or per manual sweep) at a time. A fresh push
-# cancels the in-flight run; the per-box flocks (/tmp/brev/<INSTANCE_NAME>.lock)
-# release automatically when the agent process dies (POSIX flock(2) semantics —
-# no userspace trap needed). Any stale containers / volumes / marker that the
-# cancelled run left on a box are reconciled by the NEXT run's
-# `BrevEnvironment._ensure_prerequisite_deployed`: the active-deploy marker
-# carries `<profile_tag>|<run_id>`, so a marker from this run never matches
-# the next run's desired marker and the next run always tears down + redeploys.
-# Same path handles SIGKILL (the 12h timeout-minutes terminator) and host reboots
-# — there's no exit-side cleanup machinery to bypass.
+# Push-mode (PR mirror branches): one eval per PR at a time. A fresh
+# push cancels the in-flight run — the previous head's results are
+# stale the moment a new commit lands. The per-box flocks
+# (/tmp/brev/<INSTANCE_NAME>.lock) release automatically when the
+# agent process dies (POSIX flock(2) semantics — no userspace trap
+# needed). Any stale containers / volumes / marker that the cancelled
+# run left on a box are reconciled by the NEXT run's
+# `BrevEnvironment._ensure_prerequisite_deployed`: the active-deploy
+# marker carries `<profile_tag>|<run_id>`, so a marker from this run
+# never matches the next run's desired marker and the next run always
+# tears down + redeploys. Same path handles SIGKILL (the 12h
+# timeout-minutes terminator) and host reboots — there's no exit-side
+# cleanup machinery to bypass.
+#
+# Manual dispatch: each `workflow_dispatch` gets a unique group
+# (keyed on run_id) so two operators dispatching sweeps in parallel
+# don't cancel each other. Contention is handled per-box by the
+# flocks above: a second run picks an idle `vss-eval-*` box, or
+# waits at `flock -w` for one to free up. The validator host runs
+# multiple GH Actions worker processes labeled
+# `vss-skill-eval-runner`, so concurrent jobs actually start in
+# parallel rather than queueing at the runner level.
 concurrency:
-  group: skills-eval-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.event_name == 'workflow_dispatch'
+      && format('skills-eval-manual-{0}', github.run_id)
+      || format('skills-eval-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 defaults:
   run:


### PR DESCRIPTION
## Summary
- Splits the workflow's `concurrency` block by trigger so two `workflow_dispatch` sweeps no longer cancel each other.
- Push (PR mirror branches): unchanged — group keyed on `github.ref`, `cancel-in-progress: true`. A fresh push to `pull-request/<N>` still cancels the prior in-flight run on that PR (previous-head results go stale the moment a new commit lands).
- `workflow_dispatch`: group keyed on `github.run_id` (unique per dispatch), `cancel-in-progress: false`. Two operators dispatching sweeps in parallel get independent group keys.
- Per-box contention is already handled by the existing flocks at `/tmp/brev/<INSTANCE_NAME>.lock` — a second concurrent run picks an idle `vss-eval-*` box or waits at `flock -w` for one to free up. The validator-v2 host runs multiple GH Actions workers labeled `vss-skill-eval-runner`, so concurrent jobs actually start in parallel rather than queueing at the runner level.

## Test plan
- [ ] Dispatch two `workflow_dispatch` runs back-to-back with different `skills` inputs — both should reach the "Run skills eval agent" step (neither canceled).
- [ ] Push a new commit to a `pull-request/<N>` mirror branch while a prior run is in-flight — confirm the prior run is canceled (existing behavior preserved).
- [ ] No regression in the per-box `flock` contention path: two parallel sweeps targeting overlapping platforms should serialize at the box level, not error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)