### PR TITLE
skill-eval: scope per-run scratch state under /tmp/skill-eval/$GITHUB_RUN_ID

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -14,27 +14,55 @@ workflow runs your invocation with a 12-hour hard timeout.
 
 ## Startup hygiene (do this first, before step 1)
 
-The CI runner host reuses `/tmp/skill-eval/` across runs. Prior
-runs — including cancelled ones — leave datasets and partial results
-behind that will confuse you if you read them as "current". Clean at
-startup, then never look at `<other_run_id>` artifacts again:
+The CI runner host reuses `/tmp/skill-eval/` across runs, and since
+the workflow allows parallel `workflow_dispatch` sweeps you may share
+the host with one or more peer agents holding their own in-flight
+state under `/tmp/skill-eval/`. **Never delete a peer run's subtree.**
+Confine every piece of scratch state this run owns to `$SCRATCH` and
+only ever clean inside that:
 
 ```bash
-# Drop every dataset — you're regenerating in step 4 anyway.
-rm -rf /tmp/skill-eval/datasets/*
+# Every per-run path in this file is rooted here. Export it for every
+# subshell you spawn — adapter generators, harbor invocations, and any
+# helper script all reference $SCRATCH instead of bare /tmp paths.
+export SCRATCH=/tmp/skill-eval/$GITHUB_RUN_ID
+mkdir -p "$SCRATCH"
 
-# Keep your own run's results; drop everything else.
-find /tmp/skill-eval/results -mindepth 1 -maxdepth 1 -type d \
-  ! -name "${GITHUB_RUN_ID}" ! -name "_viewer" -exec rm -rf {} +
+# Drop only THIS run's prior dataset tree (e.g. from a re-attempt).
+# Never `rm -rf /tmp/skill-eval/datasets/*` — that's a peer's data.
+rm -rf "$SCRATCH/datasets"
 
-# One authoritative brev snapshot — don't re-list repeatedly.
-brev ls > /tmp/skill-eval/brev-snapshot.txt
+# Authoritative brev snapshot for this run.
+brev ls > "$SCRATCH/brev-snapshot.txt"
 ```
 
-If you find yourself reading files under `/tmp/skill-eval/results/<other_id>/`
-to figure out what "used to work", stop — that path belongs to a
-different run and its invocation may be stale. The canonical command
-template is in § Harbor invocation below.
+Hard rules:
+
+- **Never delete `/tmp/skill-eval/results/<other_run_id>/`.** A peer
+  in-flight workflow run owns that subtree and an `rm -rf` from your
+  agent will corrupt its trial output mid-flight. Stale-dir cleanup is
+  operator-managed (cron + retention budget on the validator host),
+  not your job.
+- **Never read from `/tmp/skill-eval/results/<other_run_id>/`** to
+  figure out what "used to work" — that path belongs to a different
+  run and its invocation may be different too. The canonical command
+  template is in § Harbor invocation below.
+- **Never write to `/tmp/skill-eval/` outside `$SCRATCH`** for state
+  this run owns. The intentionally shared paths are listed below;
+  everything else is per-run.
+
+Intentionally shared paths (do NOT scope these under `$SCRATCH`):
+
+- `/tmp/skill-eval/results/$GITHUB_RUN_ID/` — harbor's output dir
+  convention; the `<run_id>` is already in the path. Peer runs
+  occupy sibling subdirs and the `_viewer` symlink farm is
+  operator-managed.
+- `/tmp/skill-eval/active-deploy.txt` on each Brev box — per-box
+  marker carrying `<profile_tag>|<run_id>`. Concurrent overwrites
+  from peer runs are by design: the marker exists so the next trial
+  on that box knows whether to redeploy.
+- `/tmp/brev/<INSTANCE_NAME>.lock` — per-box flock, intentionally
+  cross-run; it's the arbiter.
 
 ## Your job, in order
 
@@ -156,7 +184,7 @@ template is in § Harbor invocation below.
          --base "$SOURCE_BRANCH" \
          --head "$BOT_BRANCH" \
          --title "[skill-eval] ${SKILL} adapter for PR #${PR_NUMBER}" \
-         --body-file /tmp/skill-eval/bot-pr-body.md)
+         --body-file "$SCRATCH/bot-pr-body.md")
 
        gh pr comment "$PR_NUMBER" --repo "$PR_REPO" --body "
        The skills-eval bot generated/updated the adapter required to
@@ -235,7 +263,7 @@ template is in § Harbor invocation below.
 
 4. **Regenerate the dataset** for each `(skill, spec, platform)` the
    spec's `resources.platforms` enumerates. Datasets land at
-   `/tmp/skill-eval/datasets/<skill>/<spec_stem>/<platform>/`,
+   `$SCRATCH/datasets/<skill>/<spec_stem>/<platform>/`,
    where `<spec_stem>` is the spec filename with `.json` dropped.
    **Gate**: only run this step for skills that did NOT trigger 3c/3d
    in this run. A skill with an open bot PR is parked until the
@@ -256,7 +284,7 @@ template is in § Harbor invocation below.
       # Candidates: RUNNING+READY ^vss-eval-* boxes whose gpu/platform
       # matches the trial. (envs/brev_env.py validates the pick post-
       # selection; this step just narrows the field.)
-      brev ls --json > /tmp/skill-eval/brev-snapshot.txt
+      brev ls --json > "$SCRATCH/brev-snapshot.txt"
       # For each candidate read /tmp/skill-eval/active-deploy.txt
       # via `brev exec <name> -- cat ...`. Score:
       #   1. marker == "<profile>" desired by trial   (warm)
@@ -294,7 +322,7 @@ template is in § Harbor invocation below.
       # Pseudocode for the wait-for-pool case:
       DEADLINE=$(( $(date +%s) + 43200 ))
       while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-          brev ls --json > /tmp/skill-eval/brev-snapshot.txt
+          brev ls --json > "$SCRATCH/brev-snapshot.txt"
           # Re-evaluate candidates against the snapshot (same scoring
           # as above). If any RUNNING+READY ^vss-eval-* matches the
           # platform's hardware (hard req), break and proceed to flock
@@ -439,7 +467,7 @@ template is in § Harbor invocation below.
 even though it shows up in `brev ls`.
 
 **Fleet selection (worker-pool model).** Scan
-`/tmp/skill-eval/brev-snapshot.txt` for `^vss-eval-*` candidates
+`$SCRATCH/brev-snapshot.txt` for `^vss-eval-*` candidates
 matching the trial's platform; score by (active-deploy marker match,
 free-lock, name) per § 5a; pick the best free candidate; export
 `BREV_INSTANCE` to it before the `uvx harbor run` call (§ Harbor
@@ -539,7 +567,7 @@ export BREV_INSTANCE="$INSTANCE_NAME"
 
 uvx harbor run \
   --environment-import-path "envs.brev_env:BrevEnvironment" \
-  -p /tmp/skill-eval/datasets/<skill>/<spec_stem> \
+  -p "$SCRATCH/datasets/<skill>/<spec_stem>" \
   --include-task-name "<platform>" \
   -a claude-code \
   --model "$ANTHROPIC_MODEL" \
@@ -580,17 +608,17 @@ Notes that have burned prior runs:
 
   ```bash
   # Pre-condition: the spec lays out step_count subdirs under
-  # /tmp/skill-eval/datasets/<skill>/<spec_stem>/<platform>/ named
+  # $SCRATCH/datasets/<skill>/<spec_stem>/<platform>/ named
   # step-1, step-2, ..., step-<step_count>. Read step_count from
   # any step's task.toml [metadata] (it's the same on every step).
   STEP_COUNT=$(grep -oP '^step_count\s*=\s*\K\d+' \
-    /tmp/skill-eval/datasets/<skill>/<spec_stem>/<platform>/step-1/task.toml)
+    "$SCRATCH/datasets/<skill>/<spec_stem>/<platform>/step-1/task.toml")
   RESULTS=/tmp/skill-eval/results/"$GITHUB_RUN_ID"
 
   for STEP in $(seq 1 "$STEP_COUNT"); do
     uvx harbor run \
       --environment-import-path "envs.brev_env:BrevEnvironment" \
-      -p /tmp/skill-eval/datasets/<skill>/<spec_stem>/<platform> \
+      -p "$SCRATCH/datasets/<skill>/<spec_stem>/<platform>" \
       --include-task-name "<platform>-step-${STEP}" \
       -a claude-code \
       --model "$ANTHROPIC_MODEL" \
@@ -615,7 +643,7 @@ Notes that have burned prior runs:
     awk -v r="$REWARD" 'BEGIN { exit !(r+0 < 1.0) }' && {
       for SKIP in $(seq $((STEP + 1)) "$STEP_COUNT"); do
         printf '%s\n' "skipped (prior-step fail, step=$STEP reward=$REWARD)" \
-          > /tmp/skill-eval/skipped-<spec_stem>-<platform>-step-${SKIP}.txt
+          > "$SCRATCH/skipped-<spec_stem>-<platform>-step-${SKIP}.txt"
       done
       break
     }
@@ -905,7 +933,7 @@ the workflow artifact at
 `skills-eval-results-pr-<N>-<run_id>.tar.gz`.</sub>
 ```
 
-Use `gh pr comment $PR_NUMBER --body-file /tmp/pr-<spec>.md`. Never
+Use `gh pr comment $PR_NUMBER --body-file "$SCRATCH/pr-<spec>.md"`. Never
 post a partial batch. If you posted a blocker earlier in the run
 (`missing_probe`, `env_blocker`), the final results comment is still
 separate; don't conflate the two.

--- a/.github/skill-eval/adapters/vss-manage-alerts/generate.py
+++ b/.github/skill-eval/adapters/vss-manage-alerts/generate.py
@@ -33,7 +33,7 @@ Directory layout (one platform × mode per directory):
 
 Usage from the repository root:
     python3 .github/skill-eval/adapters/vss-manage-alerts/generate.py \\
-        --output-dir /tmp/skill-eval/datasets/vss-manage-alerts \\
+        --output-dir "$SCRATCH/datasets/vss-manage-alerts" \\
         --skill-dir   skills/vss-manage-alerts \\
         --deploy-skill-dir skills/vss-deploy-profile \\
         --spec        skills/vss-manage-alerts/evals/alerts_vlm_real_time.json
@@ -343,7 +343,7 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--output-dir", required=True,
-                        help="Dataset output root (e.g. /tmp/skill-eval/datasets/vss-manage-alerts)")
+                        help='Dataset output root (e.g. "$SCRATCH/datasets/vss-manage-alerts")')
     parser.add_argument("--skill-dir", required=True,
                         help="Path to skills/vss-manage-alerts")
     parser.add_argument("--deploy-skill-dir", default=None,

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -123,13 +123,18 @@ def _disable_server_thinking() -> None:
 # Benchmark report
 # ---------------------------------------------------------------------------
 
-# Glob the agent uses for per-spec result comments. AGENTS.md § "Result
-# comment format" mandates `gh pr comment --body-file /tmp/pr-<spec>.md`,
-# so every per-spec markdown body lands here before it's posted. Reading
-# the files back is cheaper and more reliable than re-fetching from the
-# PR (and works in manual-sweep mode too, where there's no PR to read).
-BENCHMARK_INPUT_GLOB = "/tmp/pr-*.md"
-BENCHMARK_OUT_PATH = Path("/tmp/skill-eval/benchmark.md")
+# Per-run scratch root. AGENTS.md § "Startup hygiene" mandates that
+# every piece of state this run owns lives under $SCRATCH so that
+# parallel workflow_dispatch sweeps don't trample each other's
+# in-flight files. The agent writes per-spec result comments to
+# `$SCRATCH/pr-<spec>.md` before posting via `gh pr comment` (per
+# § "Result comment format"); we read them back from the same place
+# rather than re-fetching from the PR — that path also works in
+# manual-sweep mode, where there's no PR to read.
+_RUN_ID = os.environ.get("GITHUB_RUN_ID", "local")
+_SCRATCH = Path(f"/tmp/skill-eval/{_RUN_ID}")
+BENCHMARK_INPUT_GLOB = str(_SCRATCH / "pr-*.md")
+BENCHMARK_OUT_PATH = _SCRATCH / "benchmark.md"
 
 _MD_LINK_RE = re.compile(r"\[([^\]\n]+)\]\([^)\n]*\)")
 _BARE_URL_RE = re.compile(r"https?://\S+")
@@ -158,11 +163,13 @@ def _sanitize_public(text: str) -> str:
 def build_benchmark_md(out_path: Path = BENCHMARK_OUT_PATH) -> Path | None:
     """Concatenate per-spec result comments into one benchmark report.
 
-    Reads every `/tmp/pr-*.md` the agent produced (one per (PR, spec)
-    batch per AGENTS.md § "Result comment format") and writes a single
-    `benchmark.md` with a run-level header followed by each spec body
-    in deterministic order. Output is sanitized for public consumption
-    via `_sanitize_public` — see that docstring for what's stripped.
+    Reads every `$SCRATCH/pr-*.md` the agent produced (one per (PR,
+    spec) batch per AGENTS.md § "Result comment format") and writes a
+    single `benchmark.md` with a run-level header followed by each spec
+    body in deterministic order. Output is sanitized for public
+    consumption via `_sanitize_public` — see that docstring for what's
+    stripped. The glob is run-scoped so a parallel workflow_dispatch
+    peer's per-spec comments never leak into this run's benchmark.
 
     Returns the output path on success, or `None` if no per-spec
     comments were found — that's a valid outcome (blocker before any

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -246,13 +246,21 @@ jobs:
 
       - name: Collect results for workflow artifact
         if: always() && (github.event_name == 'workflow_dispatch' || steps.changes.outputs.relevant == 'true')
+        env:
+          # Scope the tar + find to THIS run's subtree. Parallel
+          # workflow_dispatch sweeps share /tmp/skill-eval/results/ and
+          # archiving the parent dir would splice peer runs' trial
+          # outputs into this run's artifact (and vice versa). The
+          # harbor convention is /tmp/skill-eval/results/<run_id>/ so
+          # the per-run subdir name == github.run_id.
+          RUN_RESULTS: /tmp/skill-eval/results/${{ github.run_id }}
         run: |
-          # Agent writes harbor output to /tmp/skill-eval/results/<run_id>/
-          # (runtime-only; not tracked under the repo). Blocker paths
+          # Agent writes harbor output to $RUN_RESULTS (runtime-only;
+          # not tracked under the repo). Blocker paths
           # (missing_platforms_declaration, missing_probe, etc.) finish
           # without producing a results dir — that's a success, not a failure.
-          if [ ! -d /tmp/skill-eval/results ]; then
-            echo "no results dir — agent blocked before running trials (expected for blocker outcomes)"
+          if [ ! -d "$RUN_RESULTS" ]; then
+            echo "no results dir for this run — agent blocked before running trials (expected for blocker outcomes)"
             exit 0
           fi
           # Exclude per-trial agent/ subdirs from the artifact tarball
@@ -275,10 +283,10 @@ jobs:
           # `https://harbor-<BREV_ENV_ID>.brevlab.com/jobs/...`.
           # Reward, judge, and result.json — which the report builder
           # actually consumes — stay in the artifact.
-          RESULTS=$(find /tmp/skill-eval/results -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
+          RESULTS=$(find "$RUN_RESULTS" -maxdepth 2 -name "result.json" 2>/dev/null | head -50 || true)
           if [ -n "$RESULTS" ]; then
             tar czf /tmp/skills-eval-results.tar.gz \
-              -C /tmp/skill-eval --exclude='agent' results
+              -C /tmp/skill-eval/results --exclude='agent' "${{ github.run_id }}"
             echo "archived $(echo "$RESULTS" | wc -l) result.json files (agent/ trajectories excluded; on-disk tree preserved for harbor view)"
           else
             echo "results dir exists but empty — nothing to archive"
@@ -312,6 +320,6 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch'
               && format('skills-eval-benchmark-manual-{0}', github.run_id)
               || format('skills-eval-benchmark-pr-{0}-{1}', steps.pr.outputs.number, github.run_id) }}
-          path: /tmp/skill-eval/benchmark.md
+          path: /tmp/skill-eval/${{ github.run_id }}/benchmark.md
           if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Summary
Fixes a concurrency bug introduced by PR #800 (parallel `workflow_dispatch` sweeps). The agent's `/tmp/skill-eval/` layout was designed under the "one eval at a time" invariant — several scratch paths were shared across peer runs, and a fresh dispatch's startup-hygiene step would `rm -rf` peer in-flight state.

### Observed failure (2026-05-28)
Three parallel sweeps started against `develop`. The third (26597650709) reached startup hygiene at ~19:36 UTC and ran the documented `find /tmp/skill-eval/results -mindepth 1 -maxdepth 1 ! -name ${GITHUB_RUN_ID} -exec rm -rf {} +`, deleting the in-flight `/tmp/skill-eval/results/<run_id>/` subtrees of the two older sweeps (26596083210, 26596559167) mid-trial.

### Path migration
All per-run scratch state moves under `$SCRATCH=/tmp/skill-eval/$GITHUB_RUN_ID` so every agent only writes to and cleans inside its own subtree:

| Old | New |
|---|---|
| `/tmp/skill-eval/datasets/<skill>/...` | `$SCRATCH/datasets/<skill>/...` |
| `/tmp/skill-eval/brev-snapshot.txt` | `$SCRATCH/brev-snapshot.txt` |
| `/tmp/skill-eval/bot-pr-body.md` | `$SCRATCH/bot-pr-body.md` |
| `/tmp/skill-eval/skipped-<spec>-<plat>-step-N.txt` | `$SCRATCH/skipped-<spec>-<plat>-step-N.txt` |
| `/tmp/pr-<spec>.md` | `$SCRATCH/pr-<spec>.md` |
| benchmark.md | `$SCRATCH/benchmark.md` |

### Intentionally shared paths (unchanged)
- `/tmp/skill-eval/results/$GITHUB_RUN_ID/` — harbor convention; `<run_id>` is already in the path
- `/tmp/skill-eval/active-deploy.txt` on each Brev box — per-box marker; concurrent overwrites are by design
- `/tmp/brev/<INSTANCE_NAME>.lock` — per-box flock arbiter

### Workflow + agent code
- `Collect results` step now archives `/tmp/skill-eval/results/$GITHUB_RUN_ID/` instead of the parent `results/` dir (which would have spliced peer runs' trial outputs into this run's artifact).
- `build_benchmark_md` reads from the run-scoped glob so a parallel peer's per-spec comments never leak into this run's benchmark.
- `Upload benchmark report artifact` step path updated to the new location.

### Documentation
- AGENTS.md startup-hygiene block rewritten with hard rules against touching peer subtrees.
- Every path reference in AGENTS.md uses `$SCRATCH` instead of bare `/tmp/` paths.

## Test plan
- [ ] Dispatch two parallel `workflow_dispatch` sweeps; confirm neither agent's startup hygiene wipes the other's in-flight `results/<run_id>/`.
- [ ] Confirm each run's benchmark.md and results tarball contain only its own specs (no peer-run cross-contamination).
- [ ] `gh pr comment --body-file "$SCRATCH/pr-<spec>.md"` posts correctly for PR-driven runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)