### PR TITLE
chore(deploy): update vss-agent-ui image tag to 3.2.0-26.05.5-a479b6ae06ab

### DIFF
--- a/deploy/docker/services/ui/compose.yml
+++ b/deploy/docker/services/ui/compose.yml
@@ -16,7 +16,7 @@
 services:
 
   vss-ui:
-    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.2-794e57d82d0e
+    image: nvcr.io/nvstaging/vss-core/vss-agent-ui:3.2.0-26.05.5-a479b6ae06ab
     profiles: ["bp_wh_2d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     container_name: vss-agent-ui
     ports:

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -590,7 +590,7 @@ vss-agent-ui:
     imagePullPolicy: IfNotPresent
   image:
     repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-    tag: "3.2.0-26.05.2-794e57d82d0e"
+    tag: "3.2.0-26.05.5-a479b6ae06ab"
   replicas: 1
   fillAlertBridgeUrlFromGlobal: false
   agentApiUrlBase: ''

--- a/deploy/helm/services/ui/values.yaml
+++ b/deploy/helm/services/ui/values.yaml
@@ -19,7 +19,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-  tag: "3.2.0-26.05.2-794e57d82d0e"
+  tag: "3.2.0-26.05.5-a479b6ae06ab"
   pullPolicy: IfNotPresent
 replicas: 1
 service:


### PR DESCRIPTION
Bumps the pinned `vss-agent-ui` image tag from `3.2.0-26.05.2-794e57d82d0e` to `3.2.0-26.05.5-a479b6ae06ab` (latest published to `nvcr.io/nvstaging/vss-core/vss-agent-ui`, May 28).

The new image's `com.nvidia.vss.source_tree_sha` label is `216377df4a02a62bd3053507df62d6b659ed046b`, which matches the current `services/ui/` tree on `develop`, so `.github/scripts/check_container_tag_source.py` validates cleanly.

Touched in three places:
- `deploy/docker/services/ui/compose.yml`
- `deploy/helm/services/ui/values.yaml`
- `deploy/helm/developer-profiles/dev-profile-search/values.yaml`