### PR TITLE
VDR: retarget stale `deployments/` paths + drop truncated `Step 6` stub

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -21,7 +21,7 @@ AI-powered video search, summarization, and incident analysis agent built on
 [NVIDIA AIQ Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest/index.html).
 
 For deployment instructions (Docker Compose, Helm, cloud), refer to the
-[repository root](../README.md) and [`deployments/`](../deployments/).
+[repository root](../README.md) and [`deploy/docker/`](../deploy/docker/).
 
 ## Overview
 
@@ -77,7 +77,7 @@ docker buildx build --platform linux/amd64 -f agent/docker/Dockerfile -t vss-age
 The instructions below use the **dev-profile-base** profile as an example.
 The same pattern applies to other profiles (search, alerts, LVS) — substitute the
 corresponding `.env` and `config.yml` from
-[`deployments/developer-workflow/`](../deployments/developer-workflow/).
+[`deploy/docker/developer-profiles/`](../deploy/docker/developer-profiles/).
 See [Configuration](#configuration) for the full list of profiles.
 
 ### 1. Set Environment Variables
@@ -86,7 +86,7 @@ Create a `.env_file` that points to the profile's `.env` so the agent auto-loads
 environment variables on startup (one-time per profile):
 
 ```bash
-echo "../deployments/developer-workflow/dev-profile-base/.env" > .env_file
+echo "../deploy/docker/developer-profiles/dev-profile-base/.env" > .env_file
 ```
 
 Then source the same `.env` in your shell and override the placeholders.
@@ -97,7 +97,7 @@ must be re-evaluated — that is what the remaining lines do.
 
 ```bash
 set -a
-source ../deployments/developer-workflow/dev-profile-base/.env
+source ../deploy/docker/developer-profiles/dev-profile-base/.env
 
 HOST_IP=<YOUR_HOST_IP>                 # placeholder in .env
 LLM_BASE_URL=http://${HOST_IP}:${LLM_PORT}   # empty in .env
@@ -119,7 +119,7 @@ set +a
 
 ```bash
 nat serve \
-  --config_file ../deployments/developer-workflow/dev-profile-base/vss-agent/configs/config.yml \
+  --config_file ../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml \
   --host 0.0.0.0 --port 8000
 ```
 
@@ -157,14 +157,14 @@ Agent behavior is defined in YAML config files with four top-level sections:
 Config values support `${ENV_VAR}` substitution with optional defaults (`${VAR:-default}`).
 
 Ready-to-use configurations are provided under
-[`deployments/developer-workflow/`](../deployments/developer-workflow/):
+[`deploy/docker/developer-profiles/`](../deploy/docker/developer-profiles/):
 
 | Profile | Path | Description |
 |---------|------|-------------|
-| Base | [`dev-profile-base/.../config.yml`](../deployments/developer-workflow/dev-profile-base/vss-agent/configs/config.yml) | Video understanding and report generation |
-| Search | [`dev-profile-search/.../config.yml`](../deployments/developer-workflow/dev-profile-search/vss-agent/configs/config.yml) | Search and RAG workflow |
-| LVS | [`dev-profile-lvs/.../config.yml`](../deployments/developer-workflow/dev-profile-lvs/vss-agent/configs/config.yml) | LVS video understanding |
-| Alerts | [`dev-profile-alerts/.../config.yml`](../deployments/developer-workflow/dev-profile-alerts/vss-agent/configs/config.yml) | Incident analysis and alerting |
+| Base | [`dev-profile-base/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml) | Video understanding and report generation |
+| Search | [`dev-profile-search/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml) | Search and RAG workflow |
+| LVS | [`dev-profile-lvs/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml) | LVS video understanding |
+| Alerts | [`dev-profile-alerts/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml) | Incident analysis and alerting |
 
 Each profile has a companion `.env` file in the same directory with all deployment variables
 pre-configured.

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -267,10 +267,6 @@ per-profile `curl` checks + slow-container triage) lives in
 for that profile. **Never declare the deploy done after `up -d`
 returns** — only after every documented endpoint succeeds.
 
-### Step 6 — 
-Fron
-
-
 ## Tear Down
 
 ```bash


### PR DESCRIPTION
## Summary

Two small documentation cleanups bundled in one PR — both are stale-content fixes shipped to develop, both surface as anchor / link breakage.

### 1. `services/agent/README.md` — stale `deployments/` paths

The Quick Start and Configuration sections pointed at the pre-rename `deployments/developer-workflow/...` layout in 10 places. That directory no longer exists on develop; the canonical path is `deploy/docker/developer-profiles/...`. A new contributor following the Quick Start would hit "no such file or directory" on the very first command (`echo ../deployments/... > .env_file`).

Sweep:
- `../deployments/developer-workflow/` → `../deploy/docker/developer-profiles/` (8 occurrences: Quick Start `.env_file`, `.env` source, `nat serve --config_file`, and the Configuration table's 4 profile rows).
- Top-of-file deployment-instructions link: `[deployments/](../deployments/)` → `[deploy/docker/](../deploy/docker/)`.

Verified every rewritten path resolves to a real file (`config.yml`, `.env`, or directory) in develop.

### 2. `skills/vss-deploy-profile/SKILL.md` — truncated Step 6 stub

L270–271 shipped:

```markdown
### Step 6 — 
Fron
```

The heading title is empty after the em-dash, which is why the GitHub anchor degraded to `#step-6-` with a dangling trailing dash. `Fron` looks like the start of "Frontend" / "Front-end" that was never finished.

Culprit (via `git log -L 270,272:.../SKILL.md`): **`1e0519ab` refactor(deploy-skill): restructure for 3.2 — RT-VLM defaults, per-model sizing, EXTERNAL_IP guidance**, which replaced the previous `### Step 6 — Report endpoints` heading with the unfinished form mid-edit. Step 5b "Wait until the stack is actually healthy" already covers post-deploy endpoint verification via `references/readiness.md` and `references/<profile>.md`, so the original "Report endpoints" subsection is redundant in the refactored doc — dropping the stub rather than reviving the former content.

## Files touched

- `services/agent/README.md` — +10 / −10
- `skills/vss-deploy-profile/SKILL.md` — +0 / −4

🤖 Generated with [Claude Code](https://claude.com/claude-code)