### PR TITLE
chore(skills): touch all SKILL.md to trigger full nvskills CI

### DIFF
--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -96,3 +96,4 @@ curl -s -X POST "${VSS_AGENT_BASE_URL}/generate" \
 - **vss-manage-video-io-storage** — VST storage/replay URLs so **`VIDEO_URL`** is valid for the VLM.
 - **vss-generate-video-report** — timestamped **reports** via the **VSS agent** (`/generate`); this skill is **direct VLM** for ad-hoc **video Q&A**.
 
+

--- a/skills/vss-deploy-dense-captioning/SKILL.md
+++ b/skills/vss-deploy-dense-captioning/SKILL.md
@@ -328,3 +328,4 @@ Dense captioning with alerts on an RTSP stream and the HTTP-vs-Kafka response mo
 - **File upload is multipart, not JSON.** Use `-F file=@path -F purpose=vision -F media_type=video`; a `-d` body returns 422.
 - **Live-stream lifecycle cleanup must unregister the stream:** `DELETE /v1/streams/delete/{stream_id}` removes the RTSP source. If the live schema also exposes `DELETE /v1/generate_captions/{stream_id}`, call it first to stop inference explicitly.
 
+

--- a/skills/vss-deploy-detection-tracking-2d/SKILL.md
+++ b/skills/vss-deploy-detection-tracking-2d/SKILL.md
@@ -275,3 +275,4 @@ corresponding step.
 | `generate text embeddings via rtvi-cv` | API USAGE |
 
 bump:1
+

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -312,3 +312,4 @@ After the quick checks above pass, drive a real query through the agent — e.g.
 Start with [`references/agent-failure-modes.md`](references/agent-failure-modes.md) for cross-profile failures such as NIM cold-start timeouts, OOM, remote endpoint 5xx responses, missing `NGC_CLI_API_KEY` / `HF_TOKEN`, unexpanded values in `resolved.yml` etc.
 
 bump:1
+

--- a/skills/vss-deploy-video-embedding/SKILL.md
+++ b/skills/vss-deploy-video-embedding/SKILL.md
@@ -196,3 +196,4 @@ docker compose -f rtvi-embed-docker-compose.yml down -v
 | [references/environment.md](references/environment.md) | Complete environment-variable matrix, including host-to-container renames and secret-sensitive variables. |
 | [references/troubleshooting.md](references/troubleshooting.md) | Operational diagnostics for startup, model/cache, runtime, and observability issues. |
 
+

--- a/skills/vss-generate-video-calibration/SKILL.md
+++ b/skills/vss-generate-video-calibration/SKILL.md
@@ -225,3 +225,4 @@ Downstream skill flow:
 Root `README.md` "Custom Dataset" and "Calibration Workflow (UI)" sections document input-video guidelines and the UI-driven alternative to this API flow.
 
 bump:1
+

--- a/skills/vss-generate-video-report-rag/SKILL.md
+++ b/skills/vss-generate-video-report-rag/SKILL.md
@@ -254,3 +254,4 @@ curl -sS -X POST "http://${HOST_IP}:${VSS_AGENT_PORT:-8000}/v1/chat" \
 - `enable_interactive_extensions: true` must be set in the frag config for HTTP HITL to work
 - See also: `video-summarization`, `video-understanding`, `report`, `vios`, `deploy`
 
+

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -257,3 +257,4 @@ If `get_incidents` returns zero results, return a one-line report stating the ra
 - **`/vss-ask-video`** — ad-hoc VLM Q&A on a single clip (not a structured report).
 - **`/vss-summarize-video`** — used by Mode A to produce the summary body when the `lvs` profile is deployed; the report template (Step 4) is still filled here.
 
+

--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -332,3 +332,4 @@ natural-language detection description.
 - **Prompt changes to `alert_type_config.json` need an `alert-bridge` restart.** `alert_agent.enrichment.enabled: true` is required for the `enrichment` prompt to fire.
 
 bump:1
+

--- a/skills/vss-manage-video-io-storage/SKILL.md
+++ b/skills/vss-manage-video-io-storage/SKILL.md
@@ -253,3 +253,4 @@ If you see double-`http://` prefixes in `imageUrl` or `videoUrl` fields on `/url
 - **Endpoint resolution:** The VST endpoint is provided by the VSS deployment context. Do not attempt manual IP/port discovery. If unavailable, ask the user. All curl examples use `<VST_ENDPOINT>` as a placeholder — substitute the resolved endpoint before executing.
 
 bump:1
+

--- a/skills/vss-query-analytics/SKILL.md
+++ b/skills/vss-query-analytics/SKILL.md
@@ -211,3 +211,4 @@ and speaks JSON-RPC 2.0 over Server-Sent Events.
    are idempotent.
 
 bump:1
+

--- a/skills/vss-search-archive/SKILL.md
+++ b/skills/vss-search-archive/SKILL.md
@@ -263,3 +263,4 @@ find someone wearing a red jacket
 Results include timestamped clips with similarity scores.
 
 bump:1
+

--- a/skills/vss-setup-behavior-analytics/SKILL.md
+++ b/skills/vss-setup-behavior-analytics/SKILL.md
@@ -123,3 +123,4 @@ Both flows live entirely on the broker — the producer can be `video-analytics-
 - If the user describes a behavior-analytics behavior change they want to validate (new incident type, new ROI rule, new sensor): point them at [`references/configuration.md`](references/configuration.md), [`references/dynamic-config.md`](references/dynamic-config.md), or [`references/dynamic-calibration.md`](references/dynamic-calibration.md) before editing the JSON.
 
 bump:1
+

--- a/skills/vss-setup-video-analytics-api/SKILL.md
+++ b/skills/vss-setup-video-analytics-api/SKILL.md
@@ -130,3 +130,4 @@ The API consumes real-time location (`mdx-rtls`) and AMR (`mdx-amr`) messages fr
 - If the user wants to query or interact with the REST API endpoints: the endpoint table above and the deploy reference cover what's available. For the full OpenAPI spec, see `src/app/specification/openapi.json` in the `video-analytics-api` repo.
 
 bump:1
+

--- a/skills/vss-summarize-video/SKILL.md
+++ b/skills/vss-summarize-video/SKILL.md
@@ -382,3 +382,4 @@ mixed into it.
 - **video summarization service ops reference** — [`references/video-summarization-deployment.md`](references/video-summarization-deployment.md)
 
 bump:1
+


### PR DESCRIPTION
## Summary

Append a single trailing blank line to every skill's `SKILL.md` so nvskills-ci picks up all 15 skill folders as changed dirs. Full catalog validation + signing exercised in one pass.

## Files touched (+1 line each)

- `skills/vss-ask-video/SKILL.md`
- `skills/vss-deploy-dense-captioning/SKILL.md`
- `skills/vss-deploy-detection-tracking-2d/SKILL.md`
- `skills/vss-deploy-profile/SKILL.md`
- `skills/vss-deploy-video-embedding/SKILL.md`
- `skills/vss-generate-video-calibration/SKILL.md`
- `skills/vss-generate-video-report/SKILL.md`
- `skills/vss-generate-video-report-rag/SKILL.md`
- `skills/vss-manage-alerts/SKILL.md`
- `skills/vss-manage-video-io-storage/SKILL.md`
- `skills/vss-query-analytics/SKILL.md`
- `skills/vss-search-archive/SKILL.md`
- `skills/vss-setup-behavior-analytics/SKILL.md`
- `skills/vss-setup-video-analytics-api/SKILL.md`
- `skills/vss-summarize-video/SKILL.md`

## Test plan

- [ ] nvskills-ci runs `validate:content` against all 15 skills.
- [ ] `sign:attach-signatures-to-upstream` pushes a signature commit covering every changed folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)