### PR TITLE
VDR: vss-deploy-profile: credentials gate + --env-file Step 5 + service-count gate

### DIFF
--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -38,7 +38,7 @@ Match the user's request to a profile, then load that profile's reference for si
 # 2. Apply env overrides to generated.env  (source .env stays untouched)
 # 3. docker compose --env-file generated.env config > resolved.yml      (dry-run)
 # 4. Review resolved.yml
-# 5. docker compose -f resolved.yml up -d
+# 5. docker compose --env-file generated.env -f resolved.yml up -d
 ```
 
 The source `.env` is treated as **read-only defaults** committed to the repo. The skill's per-deploy working copy is `generated.env` — same pattern `dev-profile.sh` uses internally. This keeps the checked-in `.env` clean across iterations.
@@ -120,28 +120,47 @@ ask the user *"Use NGC account `${org}/${team}` for the deploy?"*
 before exporting. Same pattern for `$HF_TOKEN` via
 `~/.cache/huggingface/token`.
 
-**Probes (fail fast on 401/403):**
+**Probes (fail fast on 401/403).** Each probe runs only when its key is
+set; an unset key prints `skip` (it may simply not be required for the
+chosen mode — see the gate below).
 
 ```bash
 # NGC — local NIM image pulls
-[ -n "$NGC_CLI_API_KEY" ] && curl -sf -u "\$oauthtoken:$NGC_CLI_API_KEY" \
-  "https://authn.nvidia.com/token?service=ngc" >/dev/null \
-  && echo "NGC_CLI_API_KEY ok" || echo "NGC_CLI_API_KEY missing/invalid"
+if [ -n "$NGC_CLI_API_KEY" ]; then
+  curl -sf -u "\$oauthtoken:$NGC_CLI_API_KEY" \
+    "https://authn.nvidia.com/token?service=ngc" >/dev/null \
+    && echo "NGC_CLI_API_KEY ok" || echo "NGC_CLI_API_KEY invalid (401/403)"
+else
+  echo "NGC_CLI_API_KEY not set — skip (required for any local NIM)"
+fi
 
 # build.nvidia.com — remote NIM endpoints
-[ -n "$NVIDIA_API_KEY" ] && curl -sf -H "Authorization: Bearer $NVIDIA_API_KEY" \
-  "https://integrate.api.nvidia.com/v1/models" >/dev/null \
-  && echo "NVIDIA_API_KEY ok" || echo "NVIDIA_API_KEY missing/invalid"
+if [ -n "$NVIDIA_API_KEY" ]; then
+  curl -sf -H "Authorization: Bearer $NVIDIA_API_KEY" \
+    "https://integrate.api.nvidia.com/v1/models" >/dev/null \
+    && echo "NVIDIA_API_KEY ok" || echo "NVIDIA_API_KEY invalid (401/403)"
+else
+  echo "NVIDIA_API_KEY not set — skip (required only for remote NIM)"
+fi
 
 # HF — edge only (gated Edge 4B)
-[ -n "$HF_TOKEN" ] && [ "$(curl -sf -o /dev/null -w '%{http_code}' \
+if [ -n "$HF_TOKEN" ]; then
+  status=$(curl -sf -o /dev/null -w '%{http_code}' \
     -H "Authorization: Bearer $HF_TOKEN" \
-    "https://huggingface.co/api/models/nvidia/NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8")" = "200" ] \
-  && echo "HF_TOKEN ok" || echo "HF_TOKEN missing/invalid or no access"
+    "https://huggingface.co/api/models/nvidia/NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8")
+  [ "$status" = "200" ] \
+    && echo "HF_TOKEN ok" \
+    || echo "HF_TOKEN invalid or no access to gated Edge 4B (HTTP $status)"
+else
+  echo "HF_TOKEN not set — skip (required only on edge with Edge 4B)"
+fi
 ```
 
-On any failure — prompt the user for the missing key and re-probe.
-Do **not** proceed to Step 1 with a missing or 401-ing credential.
+Map the results against what the chosen mode needs (Required-by-mode
+list above): a key reported `invalid` that the mode needs, or a `skip`
+for a key the mode **requires**, is a blocker — prompt the user, re-probe,
+and do **not** proceed to Step 1 until it resolves. A `skip` for a key the
+mode does not use is fine.
 
 ### Step 1 — Gather context
 
@@ -300,7 +319,7 @@ proceed past `up -d` until at least one container exists:
 
 ```bash
 expected=$(docker compose --env-file $ENV_GEN -f resolved.yml config --services | wc -l)
-actual=$(docker compose -f resolved.yml ps --services --format '{{.Name}}' | wc -l)
+actual=$(docker compose -f resolved.yml ps -q | wc -l)
 [ "$actual" -gt 0 ] && [ "$actual" -ge "$expected" ] \
   || { echo "FAIL: expected $expected services, got $actual — re-check Step 5 --env-file"; exit 1; }
 ```

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -7,40 +7,11 @@ metadata:
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint deployment"
 ---
-## Purpose
-
-Configure, deploy, verify, and tear down a complete VSS profile end-to-end (model selection, prerequisites, debugging).
-
-## Instructions
-
-Follow the routing tables and step-by-step workflows below. Each section that ends in *workflow*, *quick start*, or *flow* is intended to be executed top-to-bottom. Detailed reference material lives in `references/` and helper scripts live in `scripts/` — call them via `run_script` when the skill points to a script by name.
-
-## Available Scripts
-
-| Script | Purpose | Arguments |
-| --- | --- | --- |
-| `normalize_resolved_yml.py` | Normalize a `docker compose config` dry-run dump (`resolved.yml`) for diff-friendly review during the configure → deploy step. | `<resolved.yml>` (positional) |
-
-Invoke via `run_script("scripts/normalize_resolved_yml.py", "<resolved.yml>")`
-once the dry-run dump exists. All other deployment work is performed
-through compose / `dev-profile.sh` invocations documented per profile in
-`references/`.
-
-## Examples
-
-Worked end-to-end examples are kept under `evals/` (each `*.json` manifest contains a runnable scenario) and inline in the per-workflow `curl` blocks below. Run a Tier-3 evaluation with `nv-base validate <this-skill-dir> --agent-eval` to replay them.
-
-## Limitations
-
-- Requires the matching VSS profile / microservice to be deployed and reachable from the caller.
-- NGC-hosted models and NIMs may be subject to rate-limits, GPU memory requirements, and license restrictions.
-- Concurrency, GPU memory, and storage limits depend on the host hardware and the profile's compose file.
-
 # VSS Deploy
 
-Deploy any VSS profile using a compose-centric workflow: build env overrides, generate resolved compose (dry-run), review, then deploy.
+Deploy any VSS profile (`base`, `search`, `lvs`, `warehouse`, `alerts`, `edge`) using a compose-centric workflow: build env overrides, generate resolved compose (dry-run), review, then deploy. This SKILL.md covers the cross-profile concerns (**profile routing**, **prerequisites**, **NGC**, **GPU setup**, and the deploy/teardown flow). Profile-specific service lists, sizing, env recipes, endpoints, and debugging live in per-profile reference docs — load the one that matches the user's intent.
 
-This SKILL.md covers the cross-profile concerns (**profile routing**, **prerequisites**, **NGC**, **GPU setup**, and the deploy/teardown flow). Profile-specific service lists, sizing, env recipes, endpoints, and debugging live in per-profile reference docs — load the one that matches the user's intent.
+Helper script: `run_script("scripts/normalize_resolved_yml.py", "<resolved.yml>")` normalizes a `docker compose config` dry-run dump for diff-friendly review during Step 3c. All other deployment work goes through `compose` / `dev-profile.sh`.
 
 ## Profile Routing
 
@@ -141,57 +112,36 @@ Validate every credential the chosen profile needs **before** Step 1c
 copies `.env` to `generated.env`. A 401 here is a 30-second failure;
 the same 401 inside a NIM cold-start is a 10–20 min failure.
 
-**Required by profile:**
+Required by mode: `NGC_CLI_API_KEY` for any local NIM (`LLM_MODE`/`VLM_MODE` ∈ `local`,`local_shared`); `NVIDIA_API_KEY` for any remote NIM; add `HF_TOKEN` on edge (DGX Spark / IGX-Thor / AGX-Thor with Edge 4B — gated model).
 
-| Profile / mode | Required credentials |
-|---|---|
-| Any local NIM (`LLM_MODE=local`/`local_shared`, `VLM_MODE=local`/`local_shared`) | `NGC_CLI_API_KEY` |
-| Any remote NIM (`LLM_MODE=remote` or `VLM_MODE=remote`) | `NVIDIA_API_KEY` |
-| Edge — DGX Spark / IGX-Thor / AGX-Thor with Edge 4B | add `HF_TOKEN` (gated model) |
-
-**Discovery — never auto-source; confirm with the user first.**
-
-1. **Env vars** — if `$NGC_CLI_API_KEY` / `$NVIDIA_API_KEY` / `$HF_TOKEN` are already exported, skip to the probes below.
-2. **NGC fallback — `~/.ngc/config`.** If `$NGC_CLI_API_KEY` is unset but `~/.ngc/config` exists, surface the discovered identity to the user instead of silently sourcing it:
-   ```bash
-   ngc_key=$(awk -F'= ' '/^apikey/{print $2}' ~/.ngc/config)
-   ngc_org=$(awk -F'= ' '/^org/{print $2}' ~/.ngc/config)
-   ngc_team=$(awk -F'= ' '/^team/{print $2}' ~/.ngc/config)
-   echo "Found NGC key in ~/.ngc/config (org=${ngc_org}, team=${ngc_team})."
-   ```
-   Ask the user (`AskUserQuestion` or equivalent): *"Use this NGC account for the deploy?"*  Only export `NGC_CLI_API_KEY` after explicit confirmation.
-3. **HF fallback — `~/.cache/huggingface/token`.** Same pattern. Surface the file location and prompt before use.
+**Discovery — surface, do not auto-source.** If `$NGC_CLI_API_KEY` is
+unset but `~/.ngc/config` exists, extract `apikey`/`org`/`team` and
+ask the user *"Use NGC account `${org}/${team}` for the deploy?"*
+before exporting. Same pattern for `$HF_TOKEN` via
+`~/.cache/huggingface/token`.
 
 **Probes (fail fast on 401/403):**
 
 ```bash
 # NGC — local NIM image pulls
-[ -n "$NGC_CLI_API_KEY" ] && \
-  curl -sf -u "\$oauthtoken:$NGC_CLI_API_KEY" \
-    "https://authn.nvidia.com/token?service=ngc" >/dev/null \
-  && echo "NGC_CLI_API_KEY ok" \
-  || echo "NGC_CLI_API_KEY missing or invalid"
+[ -n "$NGC_CLI_API_KEY" ] && curl -sf -u "\$oauthtoken:$NGC_CLI_API_KEY" \
+  "https://authn.nvidia.com/token?service=ngc" >/dev/null \
+  && echo "NGC_CLI_API_KEY ok" || echo "NGC_CLI_API_KEY missing/invalid"
 
 # build.nvidia.com — remote NIM endpoints
-[ -n "$NVIDIA_API_KEY" ] && \
-  curl -sf -H "Authorization: Bearer $NVIDIA_API_KEY" \
-    "https://integrate.api.nvidia.com/v1/models" >/dev/null \
-  && echo "NVIDIA_API_KEY ok" \
-  || echo "NVIDIA_API_KEY missing or invalid"
+[ -n "$NVIDIA_API_KEY" ] && curl -sf -H "Authorization: Bearer $NVIDIA_API_KEY" \
+  "https://integrate.api.nvidia.com/v1/models" >/dev/null \
+  && echo "NVIDIA_API_KEY ok" || echo "NVIDIA_API_KEY missing/invalid"
 
-# HF — only required on edge platforms with Edge 4B
-[ -n "$HF_TOKEN" ] && \
-  status=$(curl -sf -o /dev/null -w '%{http_code}' \
+# HF — edge only (gated Edge 4B)
+[ -n "$HF_TOKEN" ] && [ "$(curl -sf -o /dev/null -w '%{http_code}' \
     -H "Authorization: Bearer $HF_TOKEN" \
-    "https://huggingface.co/api/models/nvidia/NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8") \
-  && [ "$status" = "200" ] && echo "HF_TOKEN ok" \
-  || echo "HF_TOKEN missing/invalid or no access to gated Edge 4B"
+    "https://huggingface.co/api/models/nvidia/NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8")" = "200" ] \
+  && echo "HF_TOKEN ok" || echo "HF_TOKEN missing/invalid or no access"
 ```
 
-**On any failure** — prompt the user for the missing key and re-probe.
-Do **not** proceed to Step 1 with a missing or 401-ing credential; the
-deploy will fail mid-way (NIM image pull or remote chat call) after
-generating env mutations and starting containers.
+On any failure — prompt the user for the missing key and re-probe.
+Do **not** proceed to Step 1 with a missing or 401-ing credential.
 
 ### Step 1 — Gather context
 
@@ -364,10 +314,6 @@ per-profile `curl` checks + slow-container triage) lives in
 for that profile. **Never declare the deploy done after `up -d`
 returns** — only after every documented endpoint succeeds.
 
-### Step 6 — 
-Fron
-
-
 ## Tear Down
 
 ```bash
@@ -407,5 +353,3 @@ After the quick checks above pass, drive a real query through the agent — e.g.
 ## Troubleshooting
 
 Start with [`references/agent-failure-modes.md`](references/agent-failure-modes.md) for cross-profile failures such as NIM cold-start timeouts, OOM, remote endpoint 5xx responses, missing `NGC_CLI_API_KEY` / `HF_TOKEN`, unexpanded values in `resolved.yml` etc.
-
-bump:1

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -85,6 +85,24 @@ auto-install snippet for DGX-Spark / IGX-Thor / AGX-Thor, and the
 remediation steps for each failure live in
 [`references/prerequisites.md`](references/prerequisites.md#preflight).
 
+**Detect sudo mode first.** Several pre-flight remediations and the
+edge cache-cleaner installer call `sudo`. If the host requires a
+sudo password, those steps will silently no-op under `sudo -n` and
+leave the deploy in a half-prepared state.
+
+```bash
+if sudo -n true 2>/dev/null; then
+  echo "passwordless sudo — pre-flight will auto-install missing pieces"
+else
+  echo "sudo requires password — pre-flight will NOT auto-install; hand commands to the user"
+fi
+```
+
+When sudo needs a password, the skill **must not** run privileged
+installers itself. Surface the copy-pasteable command block from
+`references/prerequisites.md` to the user with a *"run this once and
+confirm"* handoff, then resume after the user replies.
+
 Minimum smoke test (must succeed):
 
 ```bash
@@ -116,6 +134,64 @@ Always follow this sequence. Never skip the dry-run.
 If a deployment already exists, tear it down AND clear stale data volumes before redeploying. 
 
 Full procedure lives in [`references/teardown.md`](references/teardown.md).
+
+### Step 0a — Credentials gate (run before any env mutation)
+
+Validate every credential the chosen profile needs **before** Step 1c
+copies `.env` to `generated.env`. A 401 here is a 30-second failure;
+the same 401 inside a NIM cold-start is a 10–20 min failure.
+
+**Required by profile:**
+
+| Profile / mode | Required credentials |
+|---|---|
+| Any local NIM (`LLM_MODE=local`/`local_shared`, `VLM_MODE=local`/`local_shared`) | `NGC_CLI_API_KEY` |
+| Any remote NIM (`LLM_MODE=remote` or `VLM_MODE=remote`) | `NVIDIA_API_KEY` |
+| Edge — DGX Spark / IGX-Thor / AGX-Thor with Edge 4B | add `HF_TOKEN` (gated model) |
+
+**Discovery — never auto-source; confirm with the user first.**
+
+1. **Env vars** — if `$NGC_CLI_API_KEY` / `$NVIDIA_API_KEY` / `$HF_TOKEN` are already exported, skip to the probes below.
+2. **NGC fallback — `~/.ngc/config`.** If `$NGC_CLI_API_KEY` is unset but `~/.ngc/config` exists, surface the discovered identity to the user instead of silently sourcing it:
+   ```bash
+   ngc_key=$(awk -F'= ' '/^apikey/{print $2}' ~/.ngc/config)
+   ngc_org=$(awk -F'= ' '/^org/{print $2}' ~/.ngc/config)
+   ngc_team=$(awk -F'= ' '/^team/{print $2}' ~/.ngc/config)
+   echo "Found NGC key in ~/.ngc/config (org=${ngc_org}, team=${ngc_team})."
+   ```
+   Ask the user (`AskUserQuestion` or equivalent): *"Use this NGC account for the deploy?"*  Only export `NGC_CLI_API_KEY` after explicit confirmation.
+3. **HF fallback — `~/.cache/huggingface/token`.** Same pattern. Surface the file location and prompt before use.
+
+**Probes (fail fast on 401/403):**
+
+```bash
+# NGC — local NIM image pulls
+[ -n "$NGC_CLI_API_KEY" ] && \
+  curl -sf -u "\$oauthtoken:$NGC_CLI_API_KEY" \
+    "https://authn.nvidia.com/token?service=ngc" >/dev/null \
+  && echo "NGC_CLI_API_KEY ok" \
+  || echo "NGC_CLI_API_KEY missing or invalid"
+
+# build.nvidia.com — remote NIM endpoints
+[ -n "$NVIDIA_API_KEY" ] && \
+  curl -sf -H "Authorization: Bearer $NVIDIA_API_KEY" \
+    "https://integrate.api.nvidia.com/v1/models" >/dev/null \
+  && echo "NVIDIA_API_KEY ok" \
+  || echo "NVIDIA_API_KEY missing or invalid"
+
+# HF — only required on edge platforms with Edge 4B
+[ -n "$HF_TOKEN" ] && \
+  status=$(curl -sf -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer $HF_TOKEN" \
+    "https://huggingface.co/api/models/nvidia/NVIDIA-Nemotron-Edge-4B-v2.1-EA-020126_FP8") \
+  && [ "$status" = "200" ] && echo "HF_TOKEN ok" \
+  || echo "HF_TOKEN missing/invalid or no access to gated Edge 4B"
+```
+
+**On any failure** — prompt the user for the missing key and re-probe.
+Do **not** proceed to Step 1 with a missing or 401-ing credential; the
+deploy will fail mid-way (NIM image pull or remote chat call) after
+generating env mutations and starting containers.
 
 ### Step 1 — Gather context
 
@@ -249,14 +325,35 @@ Ask: **"Looks good — deploy now?"** and wait for confirmation before Step 5.
 
 ```bash
 cd $REPO/deploy/docker
-docker compose -f resolved.yml up -d
+docker compose --env-file $ENV_GEN -f resolved.yml up -d
 ```
+
+> **`--env-file` is mandatory.** `resolved.yml` resolves variable
+> substitutions at config time but the per-service `profiles:` keys
+> are still active filters at `up` time. Without `--env-file`,
+> `COMPOSE_PROFILES` is unset, every service gets filtered out, and
+> `up -d` exits **0** with `no service selected` and an empty
+> container set — a silent zero-container "success". Always pass the
+> same `generated.env` here that was used in Step 3.
 
 > **Do NOT use `--force-recreate` on retries.** It destroys already-warm NIM containers, forcing another 3–5 min torch.compile + CUDA-graph capture per NIM. If the previous `up -d` partially failed, fix the root cause (usually perms or an env typo) and just re-run `up -d` — Docker will re-create only the containers whose config changed or that are down.
 
 `docker compose up -d` returns as soon as the daemon has **created** the containers — it does **not** wait for the processes inside to finish initializing. Polling `docker ps | grep -qx <name>` immediately after returns 0 (container exists) while `curl :8000/docs` returns exit 7 (Python process inside is still importing modules, loading models, binding the port). Eval verifiers and humans both regularly trip on this — declaring "deploy done" right after `up -d` returns probes a half-warm stack, and `vss-agent` / `:8000/docs` / `vss-agent-ui` checks all spuriously fail before the agent has actually bound its ports.
 
 ### Step 5b — Wait until the stack is actually healthy
+
+**Gate 0 — container count must be > 0.** `docker compose up -d` can
+return 0 while starting **zero** containers (see the `--env-file`
+warning in Step 5). The readiness probes in `readiness.md` walk an
+empty container list and incorrectly report success. Refuse to
+proceed past `up -d` until at least one container exists:
+
+```bash
+expected=$(docker compose --env-file $ENV_GEN -f resolved.yml config --services | wc -l)
+actual=$(docker compose -f resolved.yml ps --services --format '{{.Name}}' | wc -l)
+[ "$actual" -gt 0 ] && [ "$actual" -ge "$expected" ] \
+  || { echo "FAIL: expected $expected services, got $actual — re-check Step 5 --env-file"; exit 1; }
+```
 
 `docker compose up -d` returns once containers are *created*, not when
 the processes inside are *ready*. Cold deploys can legitimately take

--- a/skills/vss-deploy-profile/references/alerts.md
+++ b/skills/vss-deploy-profile/references/alerts.md
@@ -23,21 +23,23 @@ Switch modes by editing `MODE` in `dev-profile-alerts/generated.env` (`MODE=2d_c
 
 ## What gets deployed
 
+Container names below are the actual `container_name:` keys from `deploy/docker/services/**/compose.yml`. LLM/VLM NIM containers are named after the selected model (default shown; varies with `LLM_NAME_SLUG`).
+
 | Service | Container | Port | Purpose | Mode |
 |---|---|---|---|---|
-| RT-CV (DeepStream perception) | vss-rtvi-cv | — (host net) | Object detection (Grounding DINO via `MODEL_NAME_2D=GDINO`) | **2d_cv only** |
-| Behavior analytics | vss-behavior-analytics | — | Rule-based alerts from RT-CV metadata | **2d_cv only** |
-| RT-VLM | vss-rtvi-vlm | 8018 | VLM runner (Cosmos Reason 2 by default) | both |
-| Alert-bridge | (alert-bridge) | 9080 | Realtime alerting API; drives `POST/DELETE /api/v1/realtime` on the agent | both |
-| LLM NIM | mdx-nim-llm-1 | 30081 | Same options as `base` (Nano 9B v2 default) | both |
-| nvstreamer-alerts | vss-vios-nvstreamer | 31000 | Plays back dataset video to simulate live cameras | both |
-| VST | mdx-vst-1 | 30888 | Video storage + ingest | both |
-| VSS Agent | mdx-vss-agent-1 | 8000 | Orchestrates alert verification and incident reports | both |
-| VSS UI | mdx-vss-ui-1 | 3000 | Alerts tab | both |
-| Video-Analytics MCP | vss-va-mcp | 9901 | Analytics API for the agent | both |
-| Elasticsearch + Kibana | mdx-elasticsearch-1, kibana | 9200, 5601 | Alert/event storage | both |
-| Kafka | mdx-kafka-1 | 9092 | Message bus | both |
-| Phoenix | mdx-phoenix-1 | 6006 | Observability | both |
+| RT-CV (DeepStream perception) | `vss-rtvi-cv` | — (host net) | Object detection (Grounding DINO via `MODEL_NAME_2D=GDINO`) | **2d_cv only** |
+| Behavior analytics | `vss-behavior-analytics` | — | Rule-based alerts from RT-CV metadata | **2d_cv only** |
+| RT-VLM | `vss-rtvi-vlm` | 8018 | VLM runner (Cosmos Reason 2 by default) | both |
+| Alert-bridge | `vss-alert-bridge` | 9080 | Realtime alerting API; drives `POST/DELETE /api/v1/realtime` on the agent | both |
+| LLM NIM (default) | `nvidia-nemotron-nano-9b-v2` | 30081 | Same options as `base` (Nano 9B v2 default). Container name = `${LLM_NAME_SLUG}`. | both |
+| nvstreamer-alerts | `vss-vios-nvstreamer` | 31000 | Plays back dataset video to simulate live cameras | both |
+| VST Ingress | `vss-vios-ingress` | 30888 | Video storage + ingest | both |
+| VSS Agent | `vss-agent` | 8000 | Orchestrates alert verification and incident reports | both |
+| VSS Agent UI | `vss-agent-ui` | 3000 | Alerts tab | both |
+| Video-Analytics MCP | `vss-va-mcp` | 9901 | Analytics API for the agent | both |
+| Elasticsearch + Kibana | `elasticsearch`, `kibana` | 9200, 5601 | Alert/event storage | both |
+| Kafka | `kafka` | 9092 | Message bus | both |
+| Phoenix | `phoenix` | 6006 | Observability | both |
 
 ## Default models
 

--- a/skills/vss-deploy-profile/references/alerts.md
+++ b/skills/vss-deploy-profile/references/alerts.md
@@ -233,6 +233,43 @@ Formula: `NIM_KVCACHE_PERCENT = 1 - 0.35 - 0.15 = 0.50`. Same fraction across GP
 | nvstreamer | `http://<HOST_IP>:31000/` |
 | Phoenix | `http://<HOST_IP>:6006/` |
 
+## Readiness checks (per mode)
+
+The two modes deploy **different service sets**, so the readiness checks differ. Run the generic compose-ps gate from [`readiness.md`](readiness.md) first, then the per-mode checks below. Follow [`SKILL.md`](../SKILL.md) Step 5b — `up -d` returning is not readiness.
+
+> **Expected container count differs by mode.** `2d_vlm` does **not** start `vss-rtvi-cv` or `vss-behavior-analytics` (both are `bp_developer_alerts_2d_cv`-only — see [What gets deployed](#what-gets-deployed)), so `docker compose -f resolved.yml config --services` yields a smaller set than `2d_cv`. A smaller container count in real-time mode is correct, not a partial deploy — the Gate 0 check in [`SKILL.md`](../SKILL.md) Step 5b derives `expected` from the resolved compose, so it self-adjusts.
+
+**Both modes — these must be reachable:**
+
+```bash
+curl -sf http://${HOST_IP}:8000/health            && echo "agent ok"      # VSS Agent
+curl -sf http://${HOST_IP}:8018/v1/models         && echo "rt-vlm ok"     # RT-VLM (skip if VLM_MODE=remote; probe the remote /v1/models instead)
+curl -sf http://${HOST_IP}:9901/                  && echo "va-mcp ok"     # Video-Analytics MCP
+curl -sf http://${HOST_IP}:3000/                  && echo "ui ok"         # Agent UI
+```
+
+**`MODE=2d_cv` (verification) — also check the perception path:**
+
+```bash
+docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv            && echo "rt-cv up"
+docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics && echo "behavior-analytics up"
+curl -sf http://${HOST_IP}:9000/v1/health                        && echo "rt-cv health ok"
+```
+
+RT-CV builds TensorRT engines on first start (3–5 min) — `:9000/v1/health` won't answer until that finishes. See [Stage perception models](#stage-perception-models-rtdetr-its--gdino); if the ONNX files weren't staged, RT-CV never becomes healthy.
+
+**`MODE=2d_vlm` (real-time) — RT-CV / behavior-analytics are intentionally absent:**
+
+```bash
+# Confirm the 2d_cv-only services are NOT running (their absence is expected):
+docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv && echo "UNEXPECTED: rt-cv running in 2d_vlm" || echo "rt-cv absent (correct)"
+# Confirm RT-VLM is processing the live stream and emitting to the alert-bridge:
+docker logs vss-rtvi-vlm  2>&1 | tail -20   # expect continuous VLM inference over the nvstreamer feed
+docker logs vss-alert-bridge 2>&1 | tail -20 # expect realtime session active, no HTTP 400 "No such model"
+```
+
+In real-time mode the readiness signal is **RT-VLM continuously inspecting the live feed**, not a per-alert verification trigger — there is no RT-CV health endpoint to gate on. Confirm `MODE=2d_vlm` in `resolved.yml` and that `vss-vios-nvstreamer` (`:31000`) is publishing streams.
+
 ## Env file location
 
 ```

--- a/skills/vss-deploy-profile/references/base.md
+++ b/skills/vss-deploy-profile/references/base.md
@@ -8,18 +8,21 @@ Video upload, Q&A, and report generation with HITL (Human-in-the-Loop) feedback.
 
 Profile `bp_developer_base_2d` activates only the services below. Elasticsearch, Kafka, and VST MCP are **not** part of `base` — they ship with `search`, `lvs`, and `alerts` (see those profile references). If you see `VST_MCP_URL` / `VSS_VA_MCP_PORT` warnings during `docker compose config`, that's expected on `base` and not an error.
 
+Container names below are exactly what `docker ps` reports (sourced from the `container_name:` keys in `deploy/docker/services/**/compose.yml`). LLM/VLM NIM containers are named after the selected model — the row shows the **default**; swapping `LLM_NAME_SLUG` / `VLM_NAME_SLUG` in `generated.env` selects a different per-model compose with its own `container_name`.
+
 | Service | Container | Port | Purpose |
 |---|---|---|---|
-| VSS Agent | vss-agent | 8000 | Orchestrates tool calls and model inference |
-| VSS UI | vss-ui | 3000 | Web UI — chat, video upload, views |
-| HAProxy Ingress | vss-haproxy-ingress | 7777 | Browser-facing entry point — proxies UI + Agent API + VST |
-| VST Ingress | vst-ingress | 30888 | Video Storage Tool — ingest, record, playback |
-| Sensor MS | sensor-ms | — | VIOS sensor management |
-| Stream Processing MS | streamprocessing-ms | — | VIOS stream processing |
-| LLM NIM | mdx-nim-llm-1 | 30081 | Nemotron LLM for reasoning (activated by `llm_local*` / `llm_local_shared*` COMPOSE_PROFILES) |
-| VLM NIM | mdx-nim-vlm-1 | 30082 | Cosmos Reason VLM for vision (activated by `vlm_local*` / `vlm_local_shared*` COMPOSE_PROFILES) |
-| Redis | redis | 6379 | Cache |
-| Phoenix | phoenix | 6006 | Observability / telemetry |
+| VSS Agent | `vss-agent` | 8000 | Orchestrates tool calls and model inference |
+| VSS Agent UI | `vss-agent-ui` | 3000 | Web UI — chat, video upload, views |
+| HAProxy Ingress | `vss-haproxy-ingress` | 7777 | Browser-facing entry point — proxies UI + Agent API + VST |
+| VIOS Ingress (VST) | `vss-vios-ingress` | 30888 | Video Storage Tool — ingest, record, playback |
+| VIOS Postgres | `vss-vios-postgres` | — | VIOS metadata store |
+| VIOS Sensor MS | `vss-vios-sensor` | — | VIOS sensor management |
+| VIOS Stream Processing | `vss-vios-streamprocessing` | — | VIOS stream processing |
+| LLM NIM (default) | `nvidia-nemotron-nano-9b-v2` | 30081 | Nemotron LLM for reasoning. Activated by `llm_<mode>_<slug>` COMPOSE_PROFILES; container name = `${LLM_NAME_SLUG}` (e.g. `nvidia-nemotron-nano-9b-v2-fp8`, `nemotron-3-nano`, `gpt-oss-20b`, `llama-3.3-nemotron-super-49b-v1.5`). |
+| VLM NIM (default) | `nvidia-cosmos-reason2-8b` | 30082 | Cosmos Reason VLM for vision. Activated by `vlm_<mode>_<slug>`; container name = `${VLM_NAME_SLUG}` (e.g. `cosmos-reason1-7b`, `qwen3-vl-8b-instruct`). |
+| Redis | `redis` | 6379 | Cache |
+| Phoenix | `phoenix` | 6006 | Observability / telemetry |
 
 ## Default Models
 

--- a/skills/vss-deploy-profile/references/base.md
+++ b/skills/vss-deploy-profile/references/base.md
@@ -6,18 +6,20 @@ Video upload, Q&A, and report generation with HITL (Human-in-the-Loop) feedback.
 
 ## Services Deployed
 
+Profile `bp_developer_base_2d` activates only the services below. Elasticsearch, Kafka, and VST MCP are **not** part of `base` — they ship with `search`, `lvs`, and `alerts` (see those profile references). If you see `VST_MCP_URL` / `VSS_VA_MCP_PORT` warnings during `docker compose config`, that's expected on `base` and not an error.
+
 | Service | Container | Port | Purpose |
 |---|---|---|---|
-| VSS Agent | mdx-vss-agent-1 | 8000 | Orchestrates tool calls and model inference |
-| VSS UI | mdx-vss-ui-1 | 3000 | Web UI — chat, video upload, views |
-| VST | mdx-vst-1 | 30888 | Video Storage Tool — ingest, record, playback |
-| VST MCP | mdx-vst-mcp-1 | 8001 | VST management API |
-| LLM NIM | mdx-nim-llm-1 | 30081 | Nemotron LLM for reasoning |
-| VLM NIM | mdx-nim-vlm-1 | 30082 | Cosmos Reason VLM for vision |
-| Elasticsearch | mdx-elasticsearch-1 | 9200 | Analytics data store |
-| Kafka | mdx-kafka-1 | 9092 | Message broker |
-| Redis | mdx-redis-1 | 6379 | Cache |
-| Phoenix | mdx-phoenix-1 | 6006 | Observability / telemetry |
+| VSS Agent | vss-agent | 8000 | Orchestrates tool calls and model inference |
+| VSS UI | vss-ui | 3000 | Web UI — chat, video upload, views |
+| HAProxy Ingress | vss-haproxy-ingress | 7777 | Browser-facing entry point — proxies UI + Agent API + VST |
+| VST Ingress | vst-ingress | 30888 | Video Storage Tool — ingest, record, playback |
+| Sensor MS | sensor-ms | — | VIOS sensor management |
+| Stream Processing MS | streamprocessing-ms | — | VIOS stream processing |
+| LLM NIM | mdx-nim-llm-1 | 30081 | Nemotron LLM for reasoning (activated by `llm_local*` / `llm_local_shared*` COMPOSE_PROFILES) |
+| VLM NIM | mdx-nim-vlm-1 | 30082 | Cosmos Reason VLM for vision (activated by `vlm_local*` / `vlm_local_shared*` COMPOSE_PROFILES) |
+| Redis | redis | 6379 | Cache |
+| Phoenix | phoenix | 6006 | Observability / telemetry |
 
 ## Default Models
 

--- a/skills/vss-deploy-profile/references/data-directory.md
+++ b/skills/vss-deploy-profile/references/data-directory.md
@@ -42,10 +42,10 @@ chmod -R 777 "$DATA/data_log" "$DATA/agent_eval"
 
 | Container | Image | Runs as | Mount path | Symptom if permissions wrong |
 |---|---|---|---|---|
-| `centralizedb-dev` | postgres:17.9-alpine | uid **70** | `$DATA/data_log/vst/postgres/db` | Can't read own PGDATA → VST `sensor_details` query fails → uploaded videos never appear in `/vst/api/v1/sensor/streams` → warehouse E2E check returns empty |
-| `mdx-redis` | redis:8.2.2-alpine | uid **999** | `$DATA/data_log/redis/log`, `/redis/data` | "Can't open the log file: Permission denied" → redis dies → `sdr-controller` can't reach `WDM_WL_REDIS_SERVER` → SDRC never registers `vss-vios-streamprocessing` on the `:10000` Envoy listener → stream pipeline broken (legacy `envoy-streamprocessing` no longer exists; SDR + Envoy are now consolidated in `sdr-controller` from `services/infra/sdrc/`) |
+| `vss-vios-postgres` | postgres:17.9-alpine | uid **70** | `$DATA/data_log/vst/postgres/db` | Can't read own PGDATA → VST `sensor_details` query fails → uploaded videos never appear in `/vst/api/v1/sensor/streams` → warehouse E2E check returns empty |
+| `redis` | redis:8.2.2-alpine | uid **999** | `$DATA/data_log/redis/log`, `/redis/data` | "Can't open the log file: Permission denied" → redis dies → `sdr-controller` can't reach `WDM_WL_REDIS_SERVER` → SDRC never registers `vss-vios-streamprocessing` on the `:10000` Envoy listener → stream pipeline broken (legacy `envoy-streamprocessing` no longer exists; SDR + Envoy are now consolidated in `sdr-controller` from `services/infra/sdrc/`) |
 | `elasticsearch` | elasticsearch | uid **1000** | `$DATA/data_log/elastic/{data,logs}` | "AccessDeniedException" on startup → ES refuses to start |
-| `vst` / `sensor-ms-dev` | vst | uid **1000** | `$DATA/data_log/vst/*` (videos, clips) | 403 on ingest or stream write |
+| `vss-vios-ingress` / `vss-vios-sensor` | vst | uid **1000** | `$DATA/data_log/vst/*` (videos, clips) | 403 on ingest or stream write |
 
 `chmod -R 777 $DATA/data_log` covers all of these. Do NOT chown them to
 individual uids — containers that init their own dirs on first start (like

--- a/skills/vss-deploy-profile/references/lvs-profile.md
+++ b/skills/vss-deploy-profile/references/lvs-profile.md
@@ -15,19 +15,21 @@ Long-video summarization. The LLM stack is identical to `base` (`base.md`) — s
 
 ## What gets deployed
 
+Container names below are the actual `container_name:` keys from `deploy/docker/services/**/compose.yml`. LLM NIM container is named after the selected model (default shown; varies with `LLM_NAME_SLUG`).
+
 | Service | Container | Port | Purpose |
 |---|---|---|---|
-| VSS Agent | mdx-vss-agent-1 | 8000 | Orchestrates tool calls and model inference |
-| VSS UI | mdx-vss-ui-1 | 3000 | Web UI — chat, video upload, views |
-| VST | mdx-vst-1 | 30888 | Video storage + ingest |
-| LLM NIM | mdx-nim-llm-1 | 30081 | Same options as `base` (Nano 9B v2 default) |
-| **RT-VLM** | **vss-rtvi-vlm** | **8018** | **VLM runner — loads `MODEL_PATH` or proxies remote** |
-| LVS service | vss-lvs | 38111, 38112 | Long-video segmentation + summarization |
-| Shared Logstash | logstash | 9600 | Loads the `mdx-lvs` RTVI → Kafka → ES pipeline |
-| Elasticsearch + Kibana | mdx-elasticsearch-1, kibana | 9200, 5601 | Log/event storage |
-| Kafka | mdx-kafka-1 | 9092 | Message broker (VLM captions topic: `mdx-vlm-captions`) |
-| Redis | mdx-redis-1 | 6379 | Cache |
-| Phoenix | mdx-phoenix-1 | 6006 | Observability |
+| VSS Agent | `vss-agent` | 8000 | Orchestrates tool calls and model inference |
+| VSS Agent UI | `vss-agent-ui` | 3000 | Web UI — chat, video upload, views |
+| VST Ingress | `vss-vios-ingress` | 30888 | Video storage + ingest |
+| LLM NIM (default) | `nvidia-nemotron-nano-9b-v2` | 30081 | Same options as `base` (Nano 9B v2 default). Container name = `${LLM_NAME_SLUG}`. |
+| **RT-VLM** | **`vss-rtvi-vlm`** | **8018** | **VLM runner — loads `MODEL_PATH` or proxies remote** |
+| LVS service | `vss-lvs` | 38111, 38112 | Long-video segmentation + summarization |
+| Shared Logstash | `logstash` | 9600 | Loads the `mdx-lvs` RTVI → Kafka → ES pipeline |
+| Elasticsearch + Kibana | `elasticsearch`, `kibana` | 9200, 5601 | Log/event storage |
+| Kafka | `kafka` | 9092 | Message broker (VLM captions topic: `mdx-vlm-captions`) |
+| Redis | `redis` | 6379 | Cache |
+| Phoenix | `phoenix` | 6006 | Observability |
 
 Post-deploy readiness probe: `curl -sf http://${HOST_IP}:38111/v1/ready` should return exit 0 once `vss-lvs` is serving. The VSS Agent at `http://${HOST_IP}:8000/docs` is the cross-profile readiness signal; this one confirms the LVS-specific microservice.
 
@@ -204,6 +206,6 @@ deploy/docker/developer-profiles/dev-profile-lvs/generated.env   # skill's worki
 
 - **`docker logs vss-rtvi-vlm`** — startup takes up to 20 min on first run (model download from NGC). Look for `Maximum concurrency for X tokens per GPU: Y x` to confirm vLLM is up and the KV-cache budget is what you set.
 - **`vss-lvs` returns `400 BadParameters: No such model '<id>'`** (summarization fails in the UI) — `VLM_NAME` doesn't match what RT-VLM advertises. Verify with `curl http://${HOST_IP}:8018/v1/models | jq`; the `id` field must equal `VLM_NAME` in `dev-profile-lvs/generated.env` (the deployed values). For the default integrated path that's `nim_nvidia_cosmos-reason2-8b_hf-1208` (NOT `nvidia/cosmos-reason2-8b`). Fix → `docker compose -f resolved.yml up -d --no-deps --force-recreate vss-lvs vss-agent`. If the same UI chat thread is stuck in the failed-tool loop, refresh or start a fresh prompt.
-- **VLM never produces summaries** — check that the topic `mdx-vlm-captions` is being written. `docker exec mdx-kafka-1 kafka-console-consumer --bootstrap-server localhost:9092 --topic mdx-vlm-captions --max-messages 1`.
+- **VLM never produces summaries** — check that the topic `mdx-vlm-captions` is being written. `docker exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic mdx-vlm-captions --max-messages 1`.
 - **Empty Kibana dashboards** — shared `logstash` may have failed to load the `mdx-lvs` pipeline or protobuf codec; `docker logs logstash` should show pipeline startup for `mdx-lvs-logstash.conf`.
 - **OOM in RT-VLM under load** — lower `RTVI_VLLM_GPU_MEMORY_UTILIZATION` by 0.05; if that doesn't help, drop `RTVI_VLM_MAX_MODEL_LEN` to `16384` and `RTVI_VLLM_MAX_NUM_SEQS` to `64`.

--- a/skills/vss-deploy-profile/references/prerequisites.md
+++ b/skills/vss-deploy-profile/references/prerequisites.md
@@ -33,15 +33,36 @@ Check `TOOLS.md` for the VSS section. If missing, the environment isn't configur
 
 ## Sudo Access
 
-Most prerequisite steps require `sudo` (Docker install, NVIDIA toolkit, kernel settings, systemctl). On cloud instances (Brev, Colossus, DGX Cloud) the default user typically has passwordless sudo. On bare-metal machines, the user may need to enter a password or be in the `sudo` group.
+Most prerequisite steps require `sudo` (Docker install, NVIDIA toolkit, kernel settings, systemctl, edge cache-cleaner). On cloud instances (Brev, Colossus, DGX Cloud) the default user typically has passwordless sudo. On bare-metal machines, the user may need to enter a password or be in the `sudo` group.
 
-Check before proceeding:
+Check first — every subsequent step branches on this result:
 
 ```bash
-sudo -n true 2>/dev/null && echo "passwordless sudo" || echo "sudo requires password"
+sudo -n true 2>/dev/null && SUDO_NOPASSWD=1 || SUDO_NOPASSWD=0
+echo "SUDO_NOPASSWD=${SUDO_NOPASSWD}"
 ```
 
-If sudo requires a password, ask the user to run privileged commands manually or configure passwordless sudo for the session.
+**Branch — passwordless sudo (`SUDO_NOPASSWD=1`):** the skill can run
+the install snippets in this document directly (`sudo modprobe`,
+`sudo apt-get install`, `sudo tee`, `sudo -b`, etc.).
+
+**Branch — password-required sudo (`SUDO_NOPASSWD=0`):** **do not**
+attempt `sudo -n` installs. They will fail silently (exit 1, no
+`askpass`) and leave the host half-configured — most visibly with the
+edge cache-cleaner (`sudo -b /usr/local/bin/sys-cache-cleaner.sh`):
+the install no-ops, deploy proceeds, and first-frame inference OOMs
+on edge platforms with no obvious cause.
+
+Instead, surface the failing command block verbatim to the user with
+a handoff like:
+
+> *"Sudo requires a password on this host. Please run the block
+> below in your shell, then confirm so I can continue."*
+> *(then paste the relevant install snippet from this doc)*
+
+Resume only after the user confirms the command succeeded. Do not
+re-run `sudo -n` checks in a loop — they won't change without user
+action.
 
 ## Kernel Settings
 

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -14,18 +14,20 @@ Semantic video search via Cosmos Embed1 embeddings indexed in Elasticsearch. The
 
 ## What gets deployed
 
+Container names below are the actual `container_name:` keys from `deploy/docker/services/**/compose.yml`. LLM/VLM NIM containers are named after the selected model (default shown; varies with `LLM_NAME_SLUG` / `VLM_NAME_SLUG`).
+
 | Service | Container | Port | Purpose |
 |---|---|---|---|
-| RT-CV (DeepStream perception) | vss-rtvi-cv | — (host net) | Object detection / tracking on incoming streams; default model family `rtdetr-warehouse` |
-| RT-Embed (Cosmos Embed1) | vss-rtvi-embed | 8017 | Video + text embedding generation |
-| LLM NIM | mdx-nim-llm-1 | 30081 | Same options as `base` (Nano 9B v2 default) |
-| VLM | (depends on placement) | 30082 (NIM) / 8018 (RT-VLM) | **Only if Critique enabled** — see [VLM placement](#vlm-placement) |
-| VSS Agent | mdx-vss-agent-1 | 8000 | Orchestrates tool calls, embed search, critique |
-| VSS UI | mdx-vss-ui-1 | 3000 | Search tab |
-| VST | mdx-vst-1 | 30888 | Video storage + ingest |
-| Elasticsearch + Logstash + Kibana | mdx-elasticsearch-1, logstash, kibana | 9200, 5601 | Index, ingest pipeline, dashboards |
-| Kafka | mdx-kafka-1 | 9092 | Embedding pipeline message bus |
-| Phoenix | mdx-phoenix-1 | 6006 | Observability |
+| RT-CV (DeepStream perception) | `vss-rtvi-cv` | — (host net) | Object detection / tracking on incoming streams; default model family `rtdetr-warehouse` |
+| RT-Embed (Cosmos Embed1) | `vss-rtvi-embed` | 8017 | Video + text embedding generation |
+| LLM NIM (default) | `nvidia-nemotron-nano-9b-v2` | 30081 | Same options as `base` (Nano 9B v2 default). Container name = `${LLM_NAME_SLUG}`. |
+| VLM | depends on placement; default `nvidia-cosmos-reason2-8b` (NIM) or `vss-rtvi-vlm` (RT-VLM) | 30082 (NIM) / 8018 (RT-VLM) | **Only if Critique enabled** — see [VLM placement](#vlm-placement) |
+| VSS Agent | `vss-agent` | 8000 | Orchestrates tool calls, embed search, critique |
+| VSS Agent UI | `vss-agent-ui` | 3000 | Search tab |
+| VST Ingress | `vss-vios-ingress` | 30888 | Video storage + ingest |
+| Elasticsearch + Logstash + Kibana | `elasticsearch`, `logstash`, `kibana` | 9200, 5601 | Index, ingest pipeline, dashboards |
+| Kafka | `kafka` | 9092 | Embedding pipeline message bus |
+| Phoenix | `phoenix` | 6006 | Observability |
 
 ## Default models
 

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -562,21 +562,7 @@ sudo systemctl daemon-reload && sudo systemctl restart docker
 
 #### 2.3 NVIDIA Container Toolkit
 
-```bash
-docker run --rm --gpus all ubuntu:24.04 nvidia-smi 2>&1 | head -8
-```
-
-If it fails:
-```bash
-curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
-  | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
-  | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
-  | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
-sudo nvidia-ctk runtime configure --runtime=docker
-sudo systemctl restart docker
-```
+Canonical install + verify lives in [`prerequisites.md` § 3 NVIDIA Container Toolkit](prerequisites.md#3-nvidia-container-toolkit). Run that block and re-verify with `docker run --rm --gpus all ubuntu:24.04 nvidia-smi` before continuing.
 
 #### 2.4 Linux Kernel Settings
 


### PR DESCRIPTION
## Summary

Close five silent-failure modes in `vss-deploy-profile` surfaced in review:

1. **Credentials gate (new Step 0a)** — validate `NGC_CLI_API_KEY`, `NVIDIA_API_KEY`, and (on edge) `HF_TOKEN` **before** any env mutation, with fail-fast 401 probes against `authn.nvidia.com`, `integrate.api.nvidia.com`, and the gated Edge 4B HF repo. Discovers keys in `~/.ngc/config` and `~/.cache/huggingface/token` but surfaces them with org/team identity for explicit user confirmation — no silent auto-source.

2. **Sudo-password detection up front** — pre-flight now sets `SUDO_NOPASSWD=0/1` and branches: passwordless hosts auto-install, password-required hosts get a copy-pasteable handoff to the user instead of silently failing under `sudo -n`. Mirrored in `references/prerequisites.md § Sudo Access`. Closes the silent edge cache-cleaner installer no-op.

3. **Step 5 mandates `--env-file $ENV_GEN`** — without it `COMPOSE_PROFILES` is unset, every profile-gated service is filtered out, and `up -d` exits 0 with zero containers. Inline warning added.

4. **Step 5b "Gate 0" — service-count check** — compares actual container count to `docker compose config --services` output before running the readiness probes; fails fast if zero. Closes the empty-result false-success in the readiness loop.

5. **`references/base.md` service table sync** — drops Elasticsearch, Kafka, VST MCP (not in `bp_developer_base_2d`); adds HAProxy ingress and VIOS `sensor-ms` / `streamprocessing-ms`; notes that the `VST_MCP_URL` / `VSS_VA_MCP_PORT` `compose config` warnings are expected on `base`.

## Files

- `skills/vss-deploy-profile/SKILL.md` (+92/-7)
- `skills/vss-deploy-profile/references/base.md` (+11/-11) — service table only
- `skills/vss-deploy-profile/references/prerequisites.md` (+27/-5) — Sudo Access section

## Test plan

- [ ] Run `/vss-deploy-profile -p base` from a host without `NGC_CLI_API_KEY` → Step 0a halts and prompts.
- [ ] Run from a host with only `~/.ngc/config` → Step 0a surfaces org/team and asks before exporting.
- [ ] Run on a passwordless-sudo host → pre-flight auto-installs as today.
- [ ] Run on a password-sudo host → pre-flight surfaces install commands to the user instead of silently failing.
- [ ] Deploy `base`, confirm `docker compose ps` lists the services in the updated `base.md` table; confirm Step 5b service-count gate passes.
- [ ] Reproduce the original bug: omit `--env-file` from Step 5 manually → confirm new gate in Step 5b fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)