### PR TITLE
Remove outdated references to the dev example walkthrough in document…

### DIFF
--- a/services/analytics/behavior-analytics/CLAUDE.md
+++ b/services/analytics/behavior-analytics/CLAUDE.md
@@ -119,7 +119,6 @@ quick table for common tasks:
 - Configuration guide: `docs/configuration.md`
 - Dynamic configuration (runtime updates): `docs/dynamic-config.md`
 - Modules overview: `docs/modules-overview.md`
-- Dev example walkthrough (Cursor session): `docs/cursor-dev-example-walkthrough.md`
 - Testing: `docs/testing.md`
 - Troubleshooting: `docs/troubleshooting.md`
 

--- a/services/analytics/behavior-analytics/README.md
+++ b/services/analytics/behavior-analytics/README.md
@@ -93,4 +93,3 @@ For the full schema and dynamic-config behavior (runtime updates via Flask endpo
 - [Incident Detection](./docs/incident-detection.md)
 - [Dynamic Configuration](./docs/dynamic-config.md)
 - [Dynamic Calibration](./docs/dynamic-calibration.md)
-- [Dev Example Walkthrough](./docs/cursor-dev-example-walkthrough.md)

--- a/services/analytics/behavior-analytics/docs/building-mdx-analytics-app.md
+++ b/services/analytics/behavior-analytics/docs/building-mdx-analytics-app.md
@@ -1,6 +1,6 @@
 # Building an MDX Analytics App (Warehouse2D example)
 
-> Part of behavior-analytics docs. See `../README.md` for the project overview. For the Cursor case study, see `docs/cursor-dev-example-walkthrough.md`.
+> Part of behavior-analytics docs. See `../README.md` for the project overview.
 
 This guide walks you through creating an analytics application using the MDX `behavior-analytics` library. We'll use the `Analytics2DApp` at `apps/analytics/main_analytics_2d_app.py` as our reference implementation to demonstrate how to build a robust analytics app that processes video frames and generates behaviors and events. Most apps load configuration from JSON via `AppConfig` (see `configs/` examples and defaults in `config.py`).
 

--- a/services/analytics/behavior-analytics/docs/modules-overview.md
+++ b/services/analytics/behavior-analytics/docs/modules-overview.md
@@ -235,5 +235,4 @@ Referenced in `pyrightconfig.json` via `extraPaths`.
 - Configuration details: `docs/configuration.md`
 - Building an app: `docs/building-mdx-analytics-app.md` (and the `new-app` skill)
 - Incident detection: `docs/incident-detection.md` (and the `new-incident` skill)
-- Dev example walkthrough: `docs/cursor-dev-example-walkthrough.md`
 - Repo rules for agents: `../CLAUDE.md`


### PR DESCRIPTION
…ation files

- Deleted mentions of the "Dev example walkthrough" from CLAUDE.md, README.md, and modules-overview.md to streamline documentation and remove outdated content.
- Updated the building-mdx-analytics-app.md file to eliminate the reference to the cursor-dev-example-walkthrough, ensuring consistency across documentation.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
