### PR TITLE
fix(dev-profile-search): treat HAProxy ingress controller as cluster prerequisite

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-search/Chart.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/Chart.yaml
@@ -120,16 +120,3 @@ dependencies:
     version: 26.04.2
     repository: "file://../../services/nims"
     condition: nims.enabled
-
-  # ---------------------------------------------------------------------------
-  # HAProxy Kubernetes Ingress controller (optional, in-cluster RTVI affinity)
-  # Pulled in only when rtviInternalIngress.enabled=true so a fresh single-node
-  # cluster gets the controller automatically. Assumes no other ingress
-  # controller is already running in the cluster — if there is one, leave
-  # rtviInternalIngress.enabled=false and use the existing controller.
-  # ---------------------------------------------------------------------------
-  - name: kubernetes-ingress
-    alias: haproxy-ingress
-    version: "1.44.1"
-    repository: "https://haproxytech.github.io/helm-charts"
-    condition: global.rtviInternalIngress.enabled

--- a/deploy/helm/developer-profiles/dev-profile-search/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-search/README.md
@@ -150,12 +150,7 @@ If **`local-path`** is listed but is **not** the default (no **`(default)`** mar
 
 ## Step 2: Install Ingress Controller (HAProxy)
 
-This profile uses the HAProxy Kubernetes Ingress controller for two distinct paths:
-
-1. **External traffic** (browser → VSS UI / agent / Kibana / Phoenix) — uses the controller's host ports `80`/`443` exposed by a DaemonSet.
-2. **In-cluster RTVI affinity** (vss-agent → rtvi-cv / rtvi-embed, when `global.rtviInternalIngress.enabled=true`) — uses the controller's **ClusterIP Service** at `haproxy-kubernetes-ingress.haproxy-controller:80`.
-
-Both paths share the same controller install. Keep the Service enabled (`controller.service.type=ClusterIP`) so the in-cluster path works:
+This profile uses the HAProxy Kubernetes Ingress controller for **external traffic** (browser → VSS UI / agent / Kibana / Phoenix) via the controller's host ports `80`/`443` exposed by a DaemonSet. Install it once as a cluster prerequisite:
 
 ```bash
 helm repo add haproxytech https://haproxytech.github.io/helm-charts
@@ -167,19 +162,25 @@ helm upgrade --install haproxy-kubernetes-ingress haproxytech/kubernetes-ingress
   --set controller.kind=DaemonSet \
   --set controller.daemonset.useHostPort=true \
   --set controller.daemonset.hostPorts.http=80 \
-  --set controller.daemonset.hostPorts.https=443 \
-  --set controller.service.type=ClusterIP
+  --set controller.daemonset.hostPorts.https=443
 ```
 
-Verify the controller is running and the in-cluster Service is created:
+> **In-cluster RTVI affinity (optional).** Only needed when you deploy the Search profile with `global.rtviInternalIngress.enabled=true` (default `false`). That path routes vss-agent → rtvi-cv / rtvi-embed through the controller's **ClusterIP Service** at `haproxy-kubernetes-ingress.haproxy-controller:80`. To enable it, append `--set controller.service.type=ClusterIP` to the install command above. If you only need external traffic, leave it off.
+
+Verify the controller is running:
 
 ```bash
 kubectl get pods -n haproxy-controller
 kubectl get ingressclass
+```
+
+You should see an IngressClass named `haproxy`. If you enabled the ClusterIP Service for RTVI affinity, also confirm it exists:
+
+```bash
 kubectl get svc -n haproxy-controller haproxy-kubernetes-ingress
 ```
 
-You should see an IngressClass named `haproxy` and a ClusterIP Service `haproxy-kubernetes-ingress` in namespace `haproxy-controller`. The `global.rtviInternalIngress.controllerService` default (`haproxy-kubernetes-ingress.haproxy-controller`) and `controllerPort` default (`80`) match this install; override only if you used a different release name or namespace.
+The `global.rtviInternalIngress.controllerService` default (`haproxy-kubernetes-ingress.haproxy-controller`) and `controllerPort` default (`80`) match this install; override only if you used a different release name or namespace.
 
 ## Step 3: Deploy the Search Profile
 

--- a/deploy/helm/developer-profiles/dev-profile-search/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-search/README.md
@@ -150,6 +150,13 @@ If **`local-path`** is listed but is **not** the default (no **`(default)`** mar
 
 ## Step 2: Install Ingress Controller (HAProxy)
 
+This profile uses the HAProxy Kubernetes Ingress controller for two distinct paths:
+
+1. **External traffic** (browser → VSS UI / agent / Kibana / Phoenix) — uses the controller's host ports `80`/`443` exposed by a DaemonSet.
+2. **In-cluster RTVI affinity** (vss-agent → rtvi-cv / rtvi-embed, when `global.rtviInternalIngress.enabled=true`) — uses the controller's **ClusterIP Service** at `haproxy-kubernetes-ingress.haproxy-controller:80`.
+
+Both paths share the same controller install. Keep the Service enabled (`controller.service.type=ClusterIP`) so the in-cluster path works:
+
 ```bash
 helm repo add haproxytech https://haproxytech.github.io/helm-charts
 helm repo update
@@ -158,20 +165,21 @@ helm upgrade --install haproxy-kubernetes-ingress haproxytech/kubernetes-ingress
   --version 1.49.0 \
   -n haproxy-controller --create-namespace \
   --set controller.kind=DaemonSet \
-  --set controller.service.enabled=false \
   --set controller.daemonset.useHostPort=true \
   --set controller.daemonset.hostPorts.http=80 \
-  --set controller.daemonset.hostPorts.https=443
+  --set controller.daemonset.hostPorts.https=443 \
+  --set controller.service.type=ClusterIP
 ```
 
-Verify the controller is running:
+Verify the controller is running and the in-cluster Service is created:
 
 ```bash
 kubectl get pods -n haproxy-controller
 kubectl get ingressclass
+kubectl get svc -n haproxy-controller haproxy-kubernetes-ingress
 ```
 
-You should see an IngressClass named `haproxy`.
+You should see an IngressClass named `haproxy` and a ClusterIP Service `haproxy-kubernetes-ingress` in namespace `haproxy-controller`. The `global.rtviInternalIngress.controllerService` default (`haproxy-kubernetes-ingress.haproxy-controller`) and `controllerPort` default (`80`) match this install; override only if you used a different release name or namespace.
 
 ## Step 3: Deploy the Search Profile
 

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -43,9 +43,10 @@ global:
   #
   # Install command is in this profile's README ("Step 2: Install Ingress
   # Controller (HAProxy)"). It uses DaemonSet + hostPort for external
-  # traffic AND a ClusterIP Service for in-cluster RTVI routing — the
-  # ClusterIP piece (`--set controller.service.type=ClusterIP`) is what
-  # makes `controllerService` below addressable.
+  # traffic; enabling THIS option additionally requires the controller's
+  # ClusterIP Service (`--set controller.service.type=ClusterIP`), which is
+  # what makes `controllerService` below addressable. With rtviInternalIngress
+  # disabled (the default) the ClusterIP Service is not needed.
   #
   # The defaults `haproxy-kubernetes-ingress.haproxy-controller:80` match
   # the README's install. Override only if you used a different release
@@ -57,8 +58,9 @@ global:
     hashHeader: x-stream-id
     rtviCvPath: /rtvi-cv
     rtviEmbedPath: /rtvi-embed
-    # Fully-qualified in-cluster DNS of the HAProxy ingress controller
-    # Service: `<svc-name>.<namespace>` (k8s resolves to FQDN).
+    # In-cluster DNS short name of the HAProxy ingress controller Service:
+    # `<svc-name>.<namespace>` — resolved to the FQDN via the pod search
+    # domain (haproxy-kubernetes-ingress.haproxy-controller.svc.cluster.local).
     controllerService: "haproxy-kubernetes-ingress.haproxy-controller"
     controllerPort: 80
     annotations: {}

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -30,11 +30,26 @@ global:
     streamerHost: ''
   # rtviInternalIngress lives under `global` so the agent sub-chart's env-var
   # templates (rendered via `tpl` in the agent context) can read it — only
-  # `global.*` propagates across sub-charts. The toggle drives three things:
-  # (a) Chart.yaml dependency condition pulls in the haproxy-ingress sub-chart;
-  # (b) templates/rtvi-internal-ingress.yaml renders the Ingress object;
-  # (c) RTVI_*_BASE_URL / COSMOS_EMBED_ENDPOINT env vars below get rewritten
+  # `global.*` propagates across sub-charts. When enabled, this drives:
+  # (a) templates/rtvi-internal-ingress.yaml renders the Ingress object;
+  # (b) RTVI_*_BASE_URL / COSMOS_EMBED_ENDPOINT env vars below get rewritten
   # to go through the controller Service instead of the rtvi ClusterIPs.
+  #
+  # PREREQUISITE — the HAProxy Technologies kubernetes-ingress controller
+  # must already be installed in the cluster. The IngressClass `haproxy` is
+  # a cluster-scoped resource, so VSS does NOT bundle the controller —
+  # bundling collides with any existing HAProxy install (Nam Nguyen hit
+  # this when the controller was already installed via a separate release).
+  #
+  # Install command is in this profile's README ("Step 2: Install Ingress
+  # Controller (HAProxy)"). It uses DaemonSet + hostPort for external
+  # traffic AND a ClusterIP Service for in-cluster RTVI routing — the
+  # ClusterIP piece (`--set controller.service.type=ClusterIP`) is what
+  # makes `controllerService` below addressable.
+  #
+  # The defaults `haproxy-kubernetes-ingress.haproxy-controller:80` match
+  # the README's install. Override only if you used a different release
+  # name or namespace.
   rtviInternalIngress:
     enabled: false
     className: haproxy
@@ -42,9 +57,9 @@ global:
     hashHeader: x-stream-id
     rtviCvPath: /rtvi-cv
     rtviEmbedPath: /rtvi-embed
-    # Empty => defaults to `<release>-haproxy-ingress` (the haproxytech
-    # sub-chart Service, named after the dependency alias in Chart.yaml).
-    controllerService: ""
+    # Fully-qualified in-cluster DNS of the HAProxy ingress controller
+    # Service: `<svc-name>.<namespace>` (k8s resolves to FQDN).
+    controllerService: "haproxy-kubernetes-ingress.haproxy-controller"
     controllerPort: 80
     annotations: {}
     tls: []
@@ -63,19 +78,6 @@ ingress:
     phoenix: ''
   tls: []
 
-# HAProxy Kubernetes Ingress sub-chart values. Only rendered when
-# global.rtviInternalIngress.enabled=true (see Chart.yaml condition).
-# Minimal config for a single-node dev cluster — ClusterIP Service is
-# enough because the agent talks to it in-cluster (no external traffic).
-haproxy-ingress:
-  controller:
-    kind: Deployment
-    replicaCount: 1
-    ingressClassResource:
-      name: haproxy
-      default: false
-    service:
-      type: ClusterIP
 sharedStorage:
   streamerVideos:
     # Disabled: same role as vios.vstStorage + streamprocessing persistence.streamerVideos (matches dev-profile-alerts; avoids a second PVC).
@@ -530,7 +532,7 @@ agent:
       - name: LVS_BACKEND_URL
         value: ''
       - name: RTVI_CV_BASE_URL
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-cv" $rii.rtviCvPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $cvPort := (.Values.rtviCvPort | default "9000") | toString -}}{{- $cvHost := ternary (printf "%s-vss-rtvi-cv" .Release.Name) "vss-rtvi-cv" $pfx -}}{{- printf "http://%s:%s" $cvHost $cvPort -}}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-cv" $rii.rtviCvPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $cvPort := (.Values.rtviCvPort | default "9000") | toString -}}{{- $cvHost := ternary (printf "%s-vss-rtvi-cv" .Release.Name) "vss-rtvi-cv" $pfx -}}{{- printf "http://%s:%s" $cvHost $cvPort -}}{{- end -}}'
       - name: VSS_ES_PORT
         value: ''
       - name: VST_BASE_URL
@@ -542,9 +544,9 @@ agent:
       - name: OPENAI_API_KEY
         value: ''
       - name: RTVI_EMBED_BASE_URL
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.rtviEmbedBaseUrl $def }}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.rtviEmbedBaseUrl $def }}{{- end -}}'
       - name: COSMOS_EMBED_ENDPOINT
-        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default (printf "%s-haproxy-ingress" .Release.Name) $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.cosmosEmbedEndpoint $def }}{{- end -}}'
+        value: '{{- $g := .Values.global | default dict -}}{{- $rii := (index $g "rtviInternalIngress") | default dict -}}{{- if $rii.enabled -}}{{- $svc := default "haproxy-kubernetes-ingress.haproxy-controller" $rii.controllerService -}}{{- $port := $rii.controllerPort | default 80 -}}{{- $path := default "/rtvi-embed" $rii.rtviEmbedPath -}}{{- printf "http://%s:%v%s" $svc $port $path -}}{{- else -}}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) -}}{{- $embedPort := (.Values.rtviEmbedPort | default "8000") | toString -}}{{- $embedHost := ternary (printf "%s-vss-rtvi-embed" .Release.Name) "vss-rtvi-embed" $pfx -}}{{- $def := printf "http://%s:%s" $embedHost $embedPort -}}{{ coalesce .Values.cosmosEmbedEndpoint $def }}{{- end -}}'
       - name: ELASTIC_SEARCH_ENDPOINT
         value: '{{- if (trim (.Values.elasticsearchUrl | default "")) }}{{ trim .Values.elasticsearchUrl }}{{- else }}{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $h := ternary (printf "%s-elasticsearch" .Release.Name) "elasticsearch" $pfx }}{{- printf "http://%s:9200" $h -}}{{- end }}'
       - name: ELASTIC_SEARCH_INDEX


### PR DESCRIPTION
## Summary

After PR #723 landed, Nam Nguyen reported a Helm install failure when `--set global.rtviInternalIngress.enabled=true`:

```
Error: ... IngressClass "haproxy" ... cannot be imported into the current release:
invalid ownership metadata; key "meta.helm.sh/release-name" must equal "vss-search":
current value is "haproxy-kubernetes-ingress"; key "meta.helm.sh/release-namespace"
must equal "vss-search": current value is "haproxy-controller"
```

The bundled `haproxytech/kubernetes-ingress` sub-chart introduced in #723 tried to install a second HAProxy controller under the `vss-search` release, colliding with the controller that was already installed separately as the cluster's ingress controller. **IngressClass is cluster-scoped**, so two controllers fight over ownership — there's no `name`-mangling that gets around it.

This PR moves HAProxy back to a one-time cluster prerequisite — matching the existing precedent already documented in [`dev-profile-lvs/Chart.yaml`](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/develop/deploy/helm/developer-profiles/dev-profile-lvs/Chart.yaml#L51-L58) (which made the same decision earlier for the same reason).

## Changes

- **`Chart.yaml`** — drop the `kubernetes-ingress` (aliased `haproxy-ingress`) sub-chart dependency.
- **`values.yaml`** — drop the corresponding `haproxy-ingress:` sub-chart values block. Change `global.rtviInternalIngress.controllerService` default to `haproxy-kubernetes-ingress.haproxy-controller` and `controllerPort` to `80` — the in-cluster Service produced by the documented install.
- **`README.md` — "Step 2: Install Ingress Controller (HAProxy)"** — keep DaemonSet + hostPort for external traffic but enable a ClusterIP Service alongside (`--set controller.service.type=ClusterIP`, replacing the prior `controller.service.enabled=false`) so the in-cluster RTVI affinity path has a Service to route through. Added a `kubectl get svc` verify step.

## Behavior after this PR

When `global.rtviInternalIngress.enabled=true` on a cluster where the README's prerequisite HAProxy install has been run, `vss-agent`'s env vars auto-rewrite to the controller Service:

```
RTVI_CV_BASE_URL    = http://haproxy-kubernetes-ingress.haproxy-controller:80/rtvi-cv
RTVI_EMBED_BASE_URL = http://haproxy-kubernetes-ingress.haproxy-controller:80/rtvi-embed
COSMOS_EMBED_ENDPOINT = http://haproxy-kubernetes-ingress.haproxy-controller:80/rtvi-embed
```

If you used a different release name / namespace for the controller, override `controllerService` and `controllerPort` accordingly.

## Test plan

- [x] `helm template vss-search ./dev-profile-search --set global.rtviInternalIngress.enabled=true` renders 0 haproxy-ingress sub-chart objects, 1 `rtvi-internal` Ingress, and rewrites the three RTVI env vars to point at `haproxy-kubernetes-ingress.haproxy-controller:80`. Verified ✓
- [ ] On Nam's cluster (HAProxy already installed via separate release): re-run `helm install vss-search ./dev-profile-search --set global.rtviInternalIngress.enabled=true` — no IngressClass collision; agent reaches RTVI through the existing controller.

## Refs

- Closes the regression from PR #275-era bundling
- Same pattern as `dev-profile-lvs/Chart.yaml` lines 51–58 (HAProxy ingress controller previously vendored, moved cluster-wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)