### PR TITLE
Fix launchable Docker prereq pin flow

### DIFF
--- a/deploy/docker/scripts/deploy_vss_launchable.ipynb
+++ b/deploy/docker/scripts/deploy_vss_launchable.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "- Linux instance with a supported hardware profile (`H100`, `L40S`, `RTXPRO4500BW`, `RTXPRO6000BW`, `DGX-SPARK`, `IGX-THOR`, `AGX-THOR`, or `OTHER`)\n",
     "- NVIDIA driver 550+ with CUDA 12.x-compatible runtime support\n",
-    "- Docker Engine 28.3.3+ and <29.5.0 with Docker Compose v2.39.1+\n",
+    "- Docker Engine 28.3.3+ and <29.5.0 with Docker Compose v2.39.1+. If your launchable image starts with a newer Docker Engine, Section 4.1 pins it before deployment.\n",
     "- NGC API key from [ngc.nvidia.com](https://ngc.nvidia.com)\n",
     "- **500GB+ disk space** for Docker images and models. Most GPU cloud instances have a small root disk (~200-250GB) plus a large ephemeral NVMe. Section 4 will auto-detect this and move Docker/containerd storage to the NVMe."
    ]
@@ -132,7 +132,7 @@
    "source": [
     "## 2. Prerequisites Check\n",
     "\n",
-    "Validate that the NVIDIA driver, CUDA, Docker, Docker Compose, and NVIDIA container runtime meet the deployment prerequisites."
+    "Validate that the NVIDIA driver, CUDA, Docker, Docker Compose, and NVIDIA container runtime meet the deployment prerequisites. Docker versions newer than the supported range are reported here, then pinned in Section 4.1 before deployment."
    ]
   },
   {
@@ -199,9 +199,12 @@
     "DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')\n",
     "version_ge \"$DOCKER_VERSION\" \"$MIN_DOCKER_VERSION\" \\\n",
     "    || fail \"Docker Engine $DOCKER_VERSION is older than required $MIN_DOCKER_VERSION\"\n",
-    "version_lt \"$DOCKER_VERSION\" \"$MAX_DOCKER_VERSION\" \\\n",
-    "    || fail \"Docker Engine $DOCKER_VERSION is not supported; use a version below $MAX_DOCKER_VERSION\"\n",
-    "echo \"Docker Engine: OK ($DOCKER_VERSION >= $MIN_DOCKER_VERSION and < $MAX_DOCKER_VERSION)\"\n",
+    "if version_lt \"$DOCKER_VERSION\" \"$MAX_DOCKER_VERSION\"; then\n",
+    "    echo \"Docker Engine: OK ($DOCKER_VERSION >= $MIN_DOCKER_VERSION and < $MAX_DOCKER_VERSION)\"\n",
+    "else\n",
+    "    echo \"WARNING: Docker Engine $DOCKER_VERSION is newer than the supported range (< $MAX_DOCKER_VERSION).\"\n",
+    "    echo \"Section 4.1 will pin Docker before deployment image pulls. Continue through the notebook in order.\"\n",
+    "fi\n",
     "\n",
     "COMPOSE_VERSION=$(docker compose version --short 2>/dev/null | sed 's/^v//')\n",
     "[ -n \"$COMPOSE_VERSION\" ] || fail \"Docker Compose plugin is not installed\"\n",


### PR DESCRIPTION
## Summary
- Fixes NVBug 6244624 by allowing the launchable prerequisite cell to continue when Docker is newer than the supported range.
- Keeps the lower-bound Docker failure, but reports Docker >=29.5.0 as a warning because Section 4.1 pins Docker before deployment image pulls.
- Updates prerequisite text to document the supported range and pinning flow.

## Validation
- jq empty deploy/docker/scripts/deploy_vss_launchable.ipynb
- jq -r '.cells[5].source|join("")' deploy/docker/scripts/deploy_vss_launchable.ipynb | bash -n
- git diff --check