### PR TITLE
Update video analytics API version and Helm chart dependencies to 26.…

### DIFF
--- a/deploy/docker/services/analytics/video-analytics-api/compose.yml
+++ b/deploy/docker/services/analytics/video-analytics-api/compose.yml
@@ -15,7 +15,7 @@
 
 services:
   vss-video-analytics-api:
-    image: nvcr.io/nvstaging/vss-core/vss-video-analytics-api:3.2-26.05.29
+    image: nvcr.io/nvstaging/vss-core/vss-video-analytics-api:3.2-26.05.30
     network_mode: "host"
     command: node index.js --config /opt/mdx/vss-video-analytics-api/configs/vss-video-analytics-api-config.json
     restart: always

--- a/deploy/helm/services/analytics/Chart.lock
+++ b/deploy/helm/services/analytics/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 26.04.2
 - name: vss-video-analytics-api
   repository: file://./charts/video-analytics-api
-  version: 26.05.29
+  version: 26.05.4
 - name: video-analytics-ui
   repository: file://./charts/video-analytics-ui
   version: 26.04.2
-digest: sha256:be981bff69a41040d6f41a66c2796e6472153381492f3ba8c65f3ad4e981d107
-generated: "2026-05-28T18:59:34.460557561Z"
+digest: sha256:173a8cd0d7c2d3145d17e04689bb6ebe4f57ac4142b1444321c0ff739d789e51
+generated: "2026-05-30T19:38:57.212772806Z"

--- a/deploy/helm/services/analytics/Chart.yaml
+++ b/deploy/helm/services/analytics/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     repository: "file://./charts/behavior-analytics"
     condition: vss-behavior-analytics.enabled
   - name: vss-video-analytics-api
-    version: 26.05.29
+    version: 26.05.4
     repository: "file://./charts/video-analytics-api"
     condition: vss-video-analytics-api.enabled
   - name: video-analytics-ui

--- a/deploy/helm/services/analytics/charts/behavior-analytics/Chart.yaml
+++ b/deploy/helm/services/analytics/charts/behavior-analytics/Chart.yaml
@@ -18,6 +18,6 @@ name: vss-behavior-analytics
 description: VSS behavior analytics — parent charts must set command and config.kafkaConfigJson when enabled
 type: application
 version: 26.04.2
-appVersion: "3.2-26.05.27"
+appVersion: "3.2-26.05.30"
 maintainers:
   - name: NVIDIA

--- a/deploy/helm/services/analytics/charts/video-analytics-api/Chart.yaml
+++ b/deploy/helm/services/analytics/charts/video-analytics-api/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v2
 name: vss-video-analytics-api
-version: 26.05.29
-appVersion: "3.2-26.05.29"
+version: 26.05.4
+appVersion: "3.2-26.05.30"
 description: Video analytics API (Helm subchart under deploy/helm/services/analytics/charts)
 maintainers: []

--- a/deploy/helm/services/analytics/charts/video-analytics-api/values.yaml
+++ b/deploy/helm/services/analytics/charts/video-analytics-api/values.yaml
@@ -18,7 +18,7 @@ global: {}
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-video-analytics-api
-  tag: "3.2-26.05.29"
+  tag: "3.2-26.05.30"
   pullPolicy: IfNotPresent
 replicas: 1
 

--- a/services/analytics/video-analytics-api/src/web-api-core/Utils/Validator.js
+++ b/services/analytics/video-analytics-api/src/web-api-core/Utils/Validator.js
@@ -102,7 +102,7 @@ class Validator {
      * @static
      * @param {string} fromTimestamp - fromTimestamp to validate.
      * @param {string} toTimestamp - toTimestamp to validate.
-     * @returns {boolean} Returns a boolean signifying whether the input time range was valid
+     * @returns {Object} Returns an object containing the validity of the time range and the reason for the invalidity if any.
      * @example
      * const mdx = require("@nvidia-mdx/web-api-core");
      * let result = mdx.Utils.Validator.isValidTimeRange("2023-01-12T11:20:10.000Z","2023-01-12T14:20:10.000Z");
@@ -126,7 +126,7 @@ class Validator {
      * @param {Object} jsonInput - JSON input object to validate.
      * @param {Object} schema - JSON schema used for validation.
      * @param {boolean} [coerceTypes=true] - Whether to coerce input types during validation.
-     * @returns {{valid:boolean,reason:?string}} Returns the validity of the json input.
+     * @returns {Object} Returns an object containing the validity of the json input and the reason for the invalidity if any.
      * @example
      * const mdx = require("@nvidia-mdx/web-api-core");
      * let result = mdx.Utils.Validator.validateJsonSchema(jsonInput,schema);


### PR DESCRIPTION
…05.30 and 26.05.4 respectively. Modify Validator.js documentation to clarify return types for time range and JSON input validation methods.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
