### PR TITLE
bump MV3DT vss-configurator to 3.2-2026.05.12

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/sdr/docker_cluster_config.json
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/sdr/docker_cluster_config.json
@@ -1,6 +1,0 @@
-{
-    "vss-rtvi-cv-mv3dt": {
-      "provisioning_address": "localhost:9000",
-      "process_type": "docker"
-    }
-}

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
@@ -120,7 +120,7 @@ services:
         fi
 
   bp-configurator-mv3dt:
-    image: nvcr.io/nvstaging/vss-core/vss-configurator:3.2-2026.05.04
+    image: nvcr.io/nvstaging/vss-core/vss-configurator:3.2-2026.05.12
     container_name: vss-configurator-mv3dt
     network_mode: "host"
     profiles: ["bp_wh_kafka_mv3dt", "bp_wh_redis_mv3dt", "bp_wh_auto_calib_mv3dt"]


### PR DESCRIPTION
## Summary

Aligns the warehouse MV3DT profile with the other warehouse profiles by updating the `vss-configurator` image tag and removing a leftover SDR cluster config file that is no longer used.

- Bump `bp-configurator-mv3dt` image from `vss-configurator:3.2-2026.05.04` → `3.2-2026.05.12` in `warehouse-mv3dt-app.yml` (matches `warehouse-2d-app` and `warehouse-3d-app` on develop)
- Delete obsolete `warehouse-mv3dt-app/sdr/docker_cluster_config.json` — SDRC now uses workload-specific configs (`docker_cluster_config-rtvi-cv-mv3dt.json`, `docker_cluster_config-streamprocessing.json`) per `sdrc/configs/config.yml.tmpl`

## Files changed

| File | Change |
|------|--------|
| `deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml` | Update configurator image tag |
| `deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/sdr/docker_cluster_config.json` | Removed (obsolete) |