### PR TITLE
ci(codeowners): add Skill and Agent team directory owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,14 @@
 # Default — all files
 * @NVIDIA-AI-Blueprints/VSS-developers
 
+# Component ownership — per-directory owners.
+# Placed BEFORE the OSRB block below so dependency/license files (lockfiles,
+# manifests, Dockerfiles) inside these directories still route to
+# VSS_OSRB_Approvers — CODEOWNERS is last-match-wins, so the OSRB rules that
+# follow take precedence over these directory rules for those specific files.
+/skills/                @NVIDIA-AI-Blueprints/VSS-Skill-Developers
+/services/agent/        @NVIDIA-AI-Blueprints/VSS-Agent-Developers
+
 # Lockfiles and 3rd-party license inventory.
 # Resolved-dependency state is the authoritative record of which packages
 # (and which licenses) ship in VSS, so OSRB must approve any change.


### PR DESCRIPTION
## What

Add per-directory CODEOWNERS entries for two component teams:

| Path | Owner |
|------|-------|
| `/skills/` | `@NVIDIA-AI-Blueprints/VSS-Skill-Developers` |
| `/services/agent/` | `@NVIDIA-AI-Blueprints/VSS-Agent-Developers` |

## Why the placement matters

CODEOWNERS is **last-match-wins**. The existing OSRB block routes dependency/license files (lockfiles, manifests, `Dockerfile*`) to `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers` regardless of directory.

These two directory rules are inserted **before** the OSRB block, so OSRB review is preserved for those files even when they live under `/skills/` or `/services/agent/` (e.g. `services/agent/Dockerfile`, `skills/**/pyproject.toml`). For every other file in those directories, the component team becomes the code owner.

Both team handles were verified to exist in the org (`vss-skill-developers`, `vss-agent-developers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)