### PR TITLE
Update the GitHub README to match 28.3.3 <= Docker Engine < 29.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,11 @@ Follow the steps from the [documentation](https://docs.nvidia.com/vss/latest/clo
     - 580.95.05 (DGX-SPARK)
     - 580.00 (IGX-THOR and AGX-THOR)
 - NVIDIA Container Toolkit: 1.17.8+
-- Docker: 28.3.3+
+- Docker Engine: 28.3.3 <= Docker Engine < 29.5.0
 - Docker Compose: v2.39.1+
 - NGC CLI: 4.10.0+
+
+> **Docker upper bound:** Docker Engine 29.5.0+ may fail pulling NGC-hosted images. Use Docker Engine 28.3.3 or another supported version below 29.5.0.
 
 Please refer to [Prerequisites section here for installation details](https://docs.nvidia.com/vss/latest/prerequisites.html).
 


### PR DESCRIPTION
## Description
https://litmus.nvidia.com/vdr-prep-agent/0731930d-c277-4cf0-b187-ec1d285b0242

[P0] GitHub README states Docker 28.3.3+ with no upper bound; doc site caps at < 29.5.0 — Users installing Docker per the README's stated requirement on a current host get Docker 29.5+, which fails on NGC image pulls per the doc site's own warning.

Quote: Docker 28.3.3+
Fix: Update the GitHub README to match 28.3.3 <= Docker Engine < 29.5.0 and add the same callout that exists in Quickstart and release-notes ("Docker Engine 29.5.0+ may fail pulling NGC-hosted images"). The README is the first contact surface for OSS-style adoption and for the Brev Launchable's repo link; the version pin needs to live there too.
Location: docs/github-readme.md, "System Requirements" — conflicts with docs/quickstart.md ("Use 28.3.3 <= Docker Engine < 29.5.0") and docs/prerequisites.md and docs/release-notes.md.
Source: 01-doc-audit §3, §4

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
