### PR TITLE
VDR: docs(skills): address VDR deploy feedback

### DIFF
--- a/deploy/docker/scripts/nemoclaw/update_openclaw_config.py
+++ b/deploy/docker/scripts/nemoclaw/update_openclaw_config.py
@@ -305,7 +305,7 @@ def main() -> int:
         changed = True
 
     # Set agents.defaults.workspace so the VSS plugin's register hook can locate the
-    # workspace dir and copy AGENTS.md / BOOTSTRAP.md / IDENTITY.md / SOUL.md / TOOLS.md.
+    # workspace dir and copy workspace bootstrap files.
     agents_defaults = data.setdefault("agents", {}).setdefault("defaults", {})
     if agents_defaults.get("workspace") != DEFAULT_WORKSPACE_DIR:
         agents_defaults["workspace"] = DEFAULT_WORKSPACE_DIR

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -21,7 +21,7 @@ AI-powered video search, summarization, and incident analysis agent built on
 [NVIDIA AIQ Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest/index.html).
 
 For deployment instructions (Docker Compose, Helm, cloud), refer to the
-[repository root](../README.md) and [`deploy/docker/`](../deploy/docker/).
+[repository root](../../README.md) and [`deploy/docker/`](../../deploy/docker/).
 
 ## Overview
 
@@ -68,8 +68,8 @@ source .venv/bin/activate
 ### Docker
 
 ```bash
-cd .. # Be at repo root level
-docker buildx build --platform linux/amd64 -f agent/docker/Dockerfile -t vss-agent:latest --load .
+cd ../.. # Be at repo root level
+docker buildx build --platform linux/amd64 -f services/agent/docker/Dockerfile -t vss-agent:latest --load .
 ```
 
 ## Quick Start
@@ -77,7 +77,7 @@ docker buildx build --platform linux/amd64 -f agent/docker/Dockerfile -t vss-age
 The instructions below use the **dev-profile-base** profile as an example.
 The same pattern applies to other profiles (search, alerts, LVS) — substitute the
 corresponding `.env` and `config.yml` from
-[`deploy/docker/developer-profiles/`](../deploy/docker/developer-profiles/).
+[`deploy/docker/developer-profiles/`](../../deploy/docker/developer-profiles/).
 See [Configuration](#configuration) for the full list of profiles.
 
 ### 1. Set Environment Variables
@@ -86,7 +86,7 @@ Create a `.env_file` that points to the profile's `.env` so the agent auto-loads
 environment variables on startup (one-time per profile):
 
 ```bash
-echo "../deploy/docker/developer-profiles/dev-profile-base/.env" > .env_file
+echo "../../deploy/docker/developer-profiles/dev-profile-base/.env" > .env_file
 ```
 
 Then source the same `.env` in your shell and override the placeholders.
@@ -97,7 +97,7 @@ must be re-evaluated — that is what the remaining lines do.
 
 ```bash
 set -a
-source ../deploy/docker/developer-profiles/dev-profile-base/.env
+source ../../deploy/docker/developer-profiles/dev-profile-base/.env
 
 HOST_IP=<YOUR_HOST_IP>                 # placeholder in .env
 LLM_BASE_URL=http://${HOST_IP}:${LLM_PORT}   # empty in .env
@@ -119,7 +119,7 @@ set +a
 
 ```bash
 nat serve \
-  --config_file ../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml \
+  --config_file ../../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml \
   --host 0.0.0.0 --port 8000
 ```
 
@@ -157,14 +157,14 @@ Agent behavior is defined in YAML config files with four top-level sections:
 Config values support `${ENV_VAR}` substitution with optional defaults (`${VAR:-default}`).
 
 Ready-to-use configurations are provided under
-[`deploy/docker/developer-profiles/`](../deploy/docker/developer-profiles/):
+[`deploy/docker/developer-profiles/`](../../deploy/docker/developer-profiles/):
 
 | Profile | Path | Description |
 |---------|------|-------------|
-| Base | [`dev-profile-base/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml) | Video understanding and report generation |
-| Search | [`dev-profile-search/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml) | Search and RAG workflow |
-| LVS | [`dev-profile-lvs/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml) | LVS video understanding |
-| Alerts | [`dev-profile-alerts/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml) | Incident analysis and alerting |
+| Base | [`dev-profile-base/.../config.yml`](../../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml) | Video understanding and report generation |
+| Search | [`dev-profile-search/.../config.yml`](../../deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml) | Search and RAG workflow |
+| LVS | [`dev-profile-lvs/.../config.yml`](../../deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml) | LVS video understanding |
+| Alerts | [`dev-profile-alerts/.../config.yml`](../../deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml) | Incident analysis and alerting |
 
 Each profile has a companion `.env` file in the same directory with all deployment variables
 pre-configured.
@@ -232,4 +232,3 @@ uv run mypy src/vss_agents/
 ## License
 
 [Apache-2.0](LICENSE.md). Third-party licenses: [LICENSE-3rd-party.txt](LICENSE-3rd-party.txt).
-

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -21,7 +21,7 @@ AI-powered video search, summarization, and incident analysis agent built on
 [NVIDIA AIQ Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest/index.html).
 
 For deployment instructions (Docker Compose, Helm, cloud), refer to the
-[repository root](../../README.md) and [`deploy/docker/`](../../deploy/docker/).
+[repository root](../README.md) and [`deploy/docker/`](../deploy/docker/).
 
 ## Overview
 
@@ -68,8 +68,8 @@ source .venv/bin/activate
 ### Docker
 
 ```bash
-cd ../.. # Be at repo root level
-docker buildx build --platform linux/amd64 -f services/agent/docker/Dockerfile -t vss-agent:latest --load .
+cd .. # Be at repo root level
+docker buildx build --platform linux/amd64 -f agent/docker/Dockerfile -t vss-agent:latest --load .
 ```
 
 ## Quick Start
@@ -77,7 +77,7 @@ docker buildx build --platform linux/amd64 -f services/agent/docker/Dockerfile -
 The instructions below use the **dev-profile-base** profile as an example.
 The same pattern applies to other profiles (search, alerts, LVS) — substitute the
 corresponding `.env` and `config.yml` from
-[`deploy/docker/developer-profiles/`](../../deploy/docker/developer-profiles/).
+[`deploy/docker/developer-profiles/`](../deploy/docker/developer-profiles/).
 See [Configuration](#configuration) for the full list of profiles.
 
 ### 1. Set Environment Variables
@@ -86,7 +86,7 @@ Create a `.env_file` that points to the profile's `.env` so the agent auto-loads
 environment variables on startup (one-time per profile):
 
 ```bash
-echo "../../deploy/docker/developer-profiles/dev-profile-base/.env" > .env_file
+echo "../deploy/docker/developer-profiles/dev-profile-base/.env" > .env_file
 ```
 
 Then source the same `.env` in your shell and override the placeholders.
@@ -97,7 +97,7 @@ must be re-evaluated — that is what the remaining lines do.
 
 ```bash
 set -a
-source ../../deploy/docker/developer-profiles/dev-profile-base/.env
+source ../deploy/docker/developer-profiles/dev-profile-base/.env
 
 HOST_IP=<YOUR_HOST_IP>                 # placeholder in .env
 LLM_BASE_URL=http://${HOST_IP}:${LLM_PORT}   # empty in .env
@@ -119,7 +119,7 @@ set +a
 
 ```bash
 nat serve \
-  --config_file ../../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml \
+  --config_file ../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml \
   --host 0.0.0.0 --port 8000
 ```
 
@@ -157,14 +157,14 @@ Agent behavior is defined in YAML config files with four top-level sections:
 Config values support `${ENV_VAR}` substitution with optional defaults (`${VAR:-default}`).
 
 Ready-to-use configurations are provided under
-[`deploy/docker/developer-profiles/`](../../deploy/docker/developer-profiles/):
+[`deploy/docker/developer-profiles/`](../deploy/docker/developer-profiles/):
 
 | Profile | Path | Description |
 |---------|------|-------------|
-| Base | [`dev-profile-base/.../config.yml`](../../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml) | Video understanding and report generation |
-| Search | [`dev-profile-search/.../config.yml`](../../deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml) | Search and RAG workflow |
-| LVS | [`dev-profile-lvs/.../config.yml`](../../deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml) | LVS video understanding |
-| Alerts | [`dev-profile-alerts/.../config.yml`](../../deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml) | Incident analysis and alerting |
+| Base | [`dev-profile-base/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml) | Video understanding and report generation |
+| Search | [`dev-profile-search/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml) | Search and RAG workflow |
+| LVS | [`dev-profile-lvs/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml) | LVS video understanding |
+| Alerts | [`dev-profile-alerts/.../config.yml`](../deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml) | Incident analysis and alerting |
 
 Each profile has a companion `.env` file in the same directory with all deployment variables
 pre-configured.
@@ -232,3 +232,4 @@ uv run mypy src/vss_agents/
 ## License
 
 [Apache-2.0](LICENSE.md). Third-party licenses: [LICENSE-3rd-party.txt](LICENSE-3rd-party.txt).
+

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -58,9 +58,45 @@ The source `.env` is treated as **read-only defaults** committed to the repo. Th
 
 ## Prerequisites
 
-1. **Repo path** — find `video-search-and-summarization/` on disk.
+1. **Repo path** — auto-detect `video-search-and-summarization/` before
+   asking the user. Use the detected path as `$REPO` for all subsequent
+   commands.
 2. **Credential gates** — see [`references/credentials.md`](references/credentials.md): `NGC_CLI_API_KEY` for local/local_shared NIM pulls, `NVIDIA_API_KEY` for remote NIM endpoints, and `HF_TOKEN` for edge recipes that use gated HF models.
 3. **System prerequisites (GPU driver, Docker, NVIDIA Container Toolkit, kernel sysctls)** — full checks in [`references/prerequisites.md`](references/prerequisites.md). Canonical hardware/driver matrix is the [VSS prerequisites page](https://docs.nvidia.com/vss/3.2.0/prerequisites.html).
+
+```bash
+REPO="${REPO:-}"
+if [ -z "$REPO" ]; then
+  git_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  candidates=()
+  [ -n "$git_root" ] && candidates+=("$git_root")
+  candidates+=(
+    "$PWD"
+    "$PWD/.."
+    "$PWD/../.."
+    "$HOME/video-search-and-summarization"
+    "$HOME/VSS/vss-oss/video-search-and-summarization"
+    "$HOME/VSS/video-search-and-summarization"
+  )
+
+  for candidate in "${candidates[@]}"; do
+    candidate="$(cd "$candidate" 2>/dev/null && pwd -P || true)"
+    if [ -n "$candidate" ] \
+      && [ -f "$candidate/deploy/docker/compose.yml" ] \
+      && [ -x "$candidate/deploy/docker/scripts/dev-profile.sh" ] \
+      && [ -d "$candidate/skills/vss-deploy-profile" ]; then
+      REPO="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$REPO" ]; then
+  echo "Could not auto-detect video-search-and-summarization; ask the user for the checkout path."
+else
+  echo "REPO=$REPO"
+fi
+```
 
 ### Pre-flight check
 
@@ -153,7 +189,7 @@ Before building env overrides, confirm:
 | Value | How to determine |
 |---|---|
 | **Profile** | Match user intent to the routing table above. Default: `base` |
-| **Repo path** | Find `video-search-and-summarization/` on disk |
+| **Repo path** | Use the `$REPO` value auto-detected in prerequisites. If auto-detect failed, ask the user for the checkout path before continuing. |
 | **Hardware** | `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader` |
 | **LLM/VLM placement** | Explicitly decide local / local_shared / remote. Cross-reference available GPUs against the chosen profile's **Minimum GPU count** table. If endpoint env vars are present but the user did not request remote, ask whether to use or ignore them. |
 | **API keys** | `NGC_CLI_API_KEY` for local NIMs, `NVIDIA_API_KEY` for remote |
@@ -326,11 +362,36 @@ docker ps --format 'table {{.Names}}\t{{.Status}}'
 curl -sf http://localhost:8000/docs >/dev/null && echo "agent OK"
 curl -sf http://localhost:3000/ >/dev/null && echo "ui OK"
 
+if [ -n "${ENV_GEN:-}" ] && [ -f "$ENV_GEN" ]; then
+  LLM_MODE="${LLM_MODE:-$(awk -F= '$1=="LLM_MODE"{print $2}' "$ENV_GEN" | tail -1)}"
+  VLM_MODE="${VLM_MODE:-$(awk -F= '$1=="VLM_MODE"{print $2}' "$ENV_GEN" | tail -1)}"
+  LLM_BASE_URL="${LLM_BASE_URL:-$(awk -F= '$1=="LLM_BASE_URL"{print $2}' "$ENV_GEN" | tail -1)}"
+  VLM_BASE_URL="${VLM_BASE_URL:-$(awk -F= '$1=="VLM_BASE_URL"{print $2}' "$ENV_GEN" | tail -1)}"
+  LLM_NAME="${LLM_NAME:-$(awk -F= '$1=="LLM_NAME"{print $2}' "$ENV_GEN" | tail -1)}"
+  VLM_NAME="${VLM_NAME:-$(awk -F= '$1=="VLM_NAME"{print $2}' "$ENV_GEN" | tail -1)}"
+fi
+
 # 3. VLM NIM responding (base/lvs profiles)
-curl -sf http://localhost:30082/v1/models | python3 -m json.tool
+# Skip localhost:30082 when VLM_MODE=remote; HTTP 000/connection refused is expected.
+# Probe the selected VLM_BASE_URL /v1/models endpoint instead.
+if [ "${VLM_MODE:-}" = "remote" ]; then
+  echo "VLM_MODE=remote — skip localhost:30082; probing ${VLM_BASE_URL:-<remote-vlm-base-url>}/v1/models"
+  REMOTE_API_KEY="${NVIDIA_API_KEY:-}" \
+    "$REPO/skills/vss-deploy-profile/scripts/probe_remote_models.sh" "$VLM_BASE_URL" "${VLM_NAME:-}"
+else
+  curl -sf http://localhost:30082/v1/models | python3 -m json.tool
+fi
 
 # 4. LLM NIM responding
-curl -sf http://localhost:30081/v1/models | python3 -m json.tool
+# Skip localhost:30081 when LLM_MODE=remote; HTTP 000/connection refused is expected.
+# Probe the selected LLM_BASE_URL /v1/models endpoint instead.
+if [ "${LLM_MODE:-}" = "remote" ]; then
+  echo "LLM_MODE=remote — skip localhost:30081; probing ${LLM_BASE_URL:-<remote-llm-base-url>}/v1/models"
+  REMOTE_API_KEY="${NVIDIA_API_KEY:-}" \
+    "$REPO/skills/vss-deploy-profile/scripts/probe_remote_models.sh" "$LLM_BASE_URL" "${LLM_NAME:-}"
+else
+  curl -sf http://localhost:30081/v1/models | python3 -m json.tool
+fi
 ```
 
 ### End-to-end video sanity check

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -13,13 +13,16 @@ metadata:
 
 Deploy any VSS profile (`base`, `search`, `lvs`, `warehouse`, `alerts`, `edge`) using a compose-centric workflow: build env overrides, generate resolved compose (dry-run), review, then deploy. This SKILL.md covers the cross-profile concerns (**profile routing**, **prerequisites**, **NGC**, **GPU setup**, and the deploy/teardown flow). Profile-specific service lists, sizing, env recipes, endpoints, and debugging live in per-profile reference docs — load the one that matches the user's intent.
 
-Helper script: `run_script("scripts/normalize_resolved_yml.py", "<resolved.yml>")` normalizes a `docker compose config` dry-run dump for diff-friendly review during Step 3c. All other deployment work goes through `compose` / `dev-profile.sh`.
+Helper scripts normalize `docker compose config` output and probe selected
+remote model endpoints before env mutation. All other deployment work goes
+through `compose` / `dev-profile.sh`.
 
 ## Available Scripts
 
 | Script | Purpose | Arguments |
 |---|---|---|
 | `scripts/normalize_resolved_yml.py` | Strip optional `depends_on` entries for services filtered out of `resolved.yml` before deploy. | Path to `resolved.yml` |
+| `scripts/probe_remote_models.sh` | Probe an OpenAI-compatible remote LLM/VLM endpoint and verify the selected model id. | Base URL, optional expected model id |
 
 ## Profile Routing
 
@@ -56,7 +59,7 @@ The source `.env` is treated as **read-only defaults** committed to the repo. Th
 ## Prerequisites
 
 1. **Repo path** — find `video-search-and-summarization/` on disk.
-2. **NGC CLI & API key** — see [`references/ngc.md`](references/ngc.md). Confirm `$NGC_CLI_API_KEY` is set.
+2. **Credential gates** — see [`references/credentials.md`](references/credentials.md): `NGC_CLI_API_KEY` for local/local_shared NIM pulls, `NVIDIA_API_KEY` for remote NIM endpoints, and `HF_TOKEN` for edge recipes that use gated HF models.
 3. **System prerequisites (GPU driver, Docker, NVIDIA Container Toolkit, kernel sysctls)** — full checks in [`references/prerequisites.md`](references/prerequisites.md). Canonical hardware/driver matrix is the [VSS prerequisites page](https://docs.nvidia.com/vss/3.2.0/prerequisites.html).
 
 ### Pre-flight check
@@ -137,9 +140,9 @@ Validate every credential and selected remote endpoint the chosen profile
 needs **before** Step 1c copies `.env` to `generated.env`. A 401 here is a
 30-second failure; the same 401 inside a NIM cold-start is a 10–20 min
 failure. Run the discovery and probe flow in
-[`references/credentials.md`](references/credentials.md), including the
-customer endpoint `/v1/models` probe for any LLM/VLM endpoint you plan to
-write into `generated.env`. Map the result against the chosen mode: missing
+[`references/credentials.md`](references/credentials.md), including
+`scripts/probe_remote_models.sh` for any LLM/VLM endpoint you plan to write
+into `generated.env`. Map the result against the chosen mode: missing
 or invalid required credentials/endpoints are blockers, optional credentials
 are not.
 

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -55,7 +55,7 @@ The source `.env` is treated as **read-only defaults** committed to the repo. Th
 
 ## Prerequisites
 
-1. **Repo path** — find `video-search-and-summarization/` on disk. Check `TOOLS.md` if available.
+1. **Repo path** — find `video-search-and-summarization/` on disk.
 2. **NGC CLI & API key** — see [`references/ngc.md`](references/ngc.md). Confirm `$NGC_CLI_API_KEY` is set.
 3. **System prerequisites (GPU driver, Docker, NVIDIA Container Toolkit, kernel sysctls)** — full checks in [`references/prerequisites.md`](references/prerequisites.md). Canonical hardware/driver matrix is the [VSS prerequisites page](https://docs.nvidia.com/vss/3.2.0/prerequisites.html).
 
@@ -102,6 +102,21 @@ for the remediation tree.
 - `$LLM_REMOTE_URL` / `$VLM_REMOTE_URL` if the user asks for remote
 - `$NGC_CLI_API_KEY` (local NIMs) or `$NVIDIA_API_KEY` (remote)
 
+**Endpoint intent gate.** Do not infer remote placement from stray host
+environment variables alone. `LLM_ENDPOINT_URL`, `VLM_ENDPOINT_URL`,
+`LLM_BASE_URL`, or `VLM_BASE_URL` may be leftovers from an earlier run.
+Use remote LLM/VLM only when:
+
+1. the user explicitly requested a remote endpoint or supplied one,
+2. local sizing cannot satisfy the selected models and the user agrees to
+   remote placement, or
+3. an edge recipe requires a standalone local service that VSS treats as
+   `remote` (for example DGX Spark Nano 9B on `localhost:30081`).
+
+If any endpoint env var is already set but the user did not ask for remote,
+surface it in Step 1 and ask whether to use it or ignore it. Never silently
+deploy remote because an env var happened to exist.
+
 If no combination on this host satisfies the profile's sizing requirements, **stop and report the blocker** — don't silently pick another shape.
 
 > **Edge shared mode is platform-specific.** On DGX Spark, run `nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark:1.0.0-variant` as a standalone local NIM on port `30081` and point the agent at it with `LLM_MODE=remote`. On AGX/IGX Thor, keep using the Edge 4B standalone vLLM fallback with `HF_TOKEN`. Full recipes are in [`references/edge.md`](references/edge.md).
@@ -118,7 +133,15 @@ Full procedure lives in [`references/teardown.md`](references/teardown.md).
 
 ### Step 0a — Credentials gate (run before any env mutation)
 
-Validate every credential the chosen profile needs **before** Step 1c copies `.env` to `generated.env`. A 401 here is a 30-second failure; the same 401 inside a NIM cold-start is a 10–20 min failure. Run the discovery and probe flow in [`references/credentials.md`](references/credentials.md), then map the result against the chosen mode: missing or invalid required credentials are blockers, optional credentials are not.
+Validate every credential and selected remote endpoint the chosen profile
+needs **before** Step 1c copies `.env` to `generated.env`. A 401 here is a
+30-second failure; the same 401 inside a NIM cold-start is a 10–20 min
+failure. Run the discovery and probe flow in
+[`references/credentials.md`](references/credentials.md), including the
+customer endpoint `/v1/models` probe for any LLM/VLM endpoint you plan to
+write into `generated.env`. Map the result against the chosen mode: missing
+or invalid required credentials/endpoints are blockers, optional credentials
+are not.
 
 ### Step 1 — Gather context
 
@@ -129,7 +152,7 @@ Before building env overrides, confirm:
 | **Profile** | Match user intent to the routing table above. Default: `base` |
 | **Repo path** | Find `video-search-and-summarization/` on disk |
 | **Hardware** | `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader` |
-| **LLM/VLM placement** | Cross-reference available GPUs against the chosen profile's **Minimum GPU count** table |
+| **LLM/VLM placement** | Explicitly decide local / local_shared / remote. Cross-reference available GPUs against the chosen profile's **Minimum GPU count** table. If endpoint env vars are present but the user did not request remote, ask whether to use or ignore them. |
 | **API keys** | `NGC_CLI_API_KEY` for local NIMs, `NVIDIA_API_KEY` for remote |
 | **`HOST_IP`** | `hostname -I \| awk '{print $1}'` — the host's primary internal IP |
 | **`EXTERNAL_IP`** | Browser-reachable host/IP. On Brev, use the secure-link domain (see [`references/brev.md`](references/brev.md)). |
@@ -170,7 +193,14 @@ sed -i "s|^EXTERNAL_IP=.*|EXTERNAL_IP=7777-${brev_env_id}.brevlab.com|" "$ENV_GE
 
 ### Step 2 — Build env_overrides
 
-Produce an `env_overrides` dict from the user request and the gathered context: choose remote/local LLM/VLM, set credentials, point at endpoints, set platform-specific flags. The full mapping (every override key, when it applies, defaults, profile-specific differences) lives in [`references/env-overrides.md`](references/env-overrides.md). Each profile reference has worked examples for that profile's common scenarios.
+Produce an `env_overrides` dict from the user request and the gathered
+context: explicitly choose remote/local LLM/VLM, set credentials, point at
+endpoints, set platform-specific flags. Do not let existing shell env vars
+silently pick placement; write the selected `LLM_MODE` / `VLM_MODE` and
+matching endpoint/model fields into `generated.env`. The full mapping (every
+override key, when it applies, defaults, profile-specific differences) lives
+in [`references/env-overrides.md`](references/env-overrides.md). Each profile
+reference has worked examples for that profile's common scenarios.
 
 ### Step 3 — Apply overrides + dry-run
 
@@ -244,7 +274,14 @@ docker compose --env-file $ENV_GEN -f resolved.yml up -d
 
 > **`--env-file` is mandatory.** Without the same `generated.env` used in Step 3, `COMPOSE_PROFILES` may be unset and `up -d` can exit 0 with zero selected services.
 
-> **Do NOT use `--force-recreate` on retries.** It destroys already-warm NIM containers, forcing another 3–5 min torch.compile + CUDA-graph capture per NIM. If the previous `up -d` partially failed, fix the root cause (usually perms or an env typo) and just re-run `up -d` — Docker will re-create only the containers whose config changed or that are down.
+> **Avoid broad `--force-recreate` on ordinary retries.** It destroys
+> already-warm NIM containers, forcing another 3–5 min torch.compile +
+> CUDA-graph capture per NIM. If the previous `up -d` partially failed, fix
+> the root cause (usually perms or an env typo) and just re-run `up -d` —
+> Docker will re-create only containers whose config changed or that are
+> down. Use targeted `--force-recreate --no-deps <service...>` only when a
+> profile reference documents it as the recovery path for a specific stale
+> service/config issue.
 
 `docker compose up -d` only creates containers; it does not wait for internal services to finish warming. Never declare deploy success until the readiness gates pass.
 
@@ -312,4 +349,3 @@ After the quick checks above pass, drive a real query through the agent — e.g.
 ## Troubleshooting
 
 Start with [`references/agent-failure-modes.md`](references/agent-failure-modes.md) for cross-profile failures such as NIM cold-start timeouts, OOM, remote endpoint 5xx responses, missing `NGC_CLI_API_KEY` / `HF_TOKEN`, unexpanded values in `resolved.yml` etc.
-

--- a/skills/vss-deploy-profile/references/credentials.md
+++ b/skills/vss-deploy-profile/references/credentials.md
@@ -61,50 +61,23 @@ it into `generated.env`. Do this even when the endpoint is on localhost; it
 catches wrong ports, stale tunnels, missing auth, and model-name mismatches
 before the deploy flow spends time generating compose or warming containers.
 
-Use the base URL without a trailing `/v1`; if the user supplied `/v1`, strip it
-first. If the endpoint requires auth, set `REMOTE_API_KEY` to the key that the
-agent will use for that endpoint.
+Use the base URL without a trailing `/v1`; the script strips `/v1` and
+`/v1/models` if the user supplied them. If the endpoint requires auth, set
+`REMOTE_API_KEY` to the key that the agent will use for that endpoint.
 
 Aggregate endpoints such as `https://integrate.api.nvidia.com` can advertise
 many LLM and VLM models. Do not auto-select the first returned model from such
 endpoints. If the endpoint lists multiple models and the user has not selected
 an exact model id, stop and ask which model to use.
 
+Run the skill script:
+
 ```bash
-probe_remote_models() {
-  base_url="${1%/}"
-  base_url="${base_url%/v1}"
-  expected_model="${2:-}"
-  model_count=""
-  auth_header=()
-  if [ -n "${REMOTE_API_KEY:-}" ]; then
-    auth_header=(-H "Authorization: Bearer ${REMOTE_API_KEY}")
-  fi
+REMOTE_API_KEY="$NVIDIA_API_KEY" \
+  skills/vss-deploy-profile/scripts/probe_remote_models.sh "$LLM_BASE_URL" "$LLM_NAME"
 
-  models_json="$(curl -sf "${auth_header[@]}" "${base_url}/v1/models")" \
-    || { echo "remote endpoint failed: ${base_url}/v1/models"; return 1; }
-
-  model_count="$(echo "$models_json" | jq -r \
-    'if (.data? | type) == "array" then (.data | length) elif (.id? != null) then 1 else 0 end')"
-
-  if [ -z "$expected_model" ] && [ "${model_count:-0}" -gt 1 ]; then
-    echo "remote endpoint advertises multiple models; ask the user to choose one:" >&2
-    echo "$models_json" | jq -r '.data[]?.id' | sed 's/^/  /' >&2
-    return 1
-  fi
-
-  if [ -n "$expected_model" ]; then
-    echo "$models_json" | jq -e --arg model "$expected_model" \
-      '(.id == $model) or any(.data[]?; .id == $model)' >/dev/null \
-      || { echo "remote endpoint does not advertise model: $expected_model"; return 1; }
-  fi
-
-  echo "remote endpoint OK: ${base_url}"
-}
-
-# Examples:
-# REMOTE_API_KEY="$NVIDIA_API_KEY" probe_remote_models "$LLM_BASE_URL" "$LLM_NAME"
-# probe_remote_models "http://localhost:30081" "nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark"
+skills/vss-deploy-profile/scripts/probe_remote_models.sh \
+  "http://localhost:30081" "nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark"
 ```
 
 If `/v1/models` fails or does not advertise the selected model, stop and ask

--- a/skills/vss-deploy-profile/references/credentials.md
+++ b/skills/vss-deploy-profile/references/credentials.md
@@ -7,6 +7,9 @@ Run this before mutating `generated.env` or starting any image pull. Validate cr
 - `NGC_CLI_API_KEY`: required for any local NIM image pull (`LLM_MODE` or `VLM_MODE` set to `local` / `local_shared`).
 - `NVIDIA_API_KEY`: required for remote NIM endpoints.
 - `HF_TOKEN`: required on edge targets that use the gated Edge 4B model.
+- Customer LLM/VLM endpoint URL + model name: required for any selected
+  remote endpoint. This includes build.nvidia.com / NVIDIA API catalog
+  endpoints because their `/v1/models` response can list many models.
 
 ## Discovery
 
@@ -51,8 +54,67 @@ else
 fi
 ```
 
+## Remote Endpoint Probes
+
+For every selected remote LLM/VLM endpoint, probe the endpoint before writing
+it into `generated.env`. Do this even when the endpoint is on localhost; it
+catches wrong ports, stale tunnels, missing auth, and model-name mismatches
+before the deploy flow spends time generating compose or warming containers.
+
+Use the base URL without a trailing `/v1`; if the user supplied `/v1`, strip it
+first. If the endpoint requires auth, set `REMOTE_API_KEY` to the key that the
+agent will use for that endpoint.
+
+Aggregate endpoints such as `https://integrate.api.nvidia.com` can advertise
+many LLM and VLM models. Do not auto-select the first returned model from such
+endpoints. If the endpoint lists multiple models and the user has not selected
+an exact model id, stop and ask which model to use.
+
+```bash
+probe_remote_models() {
+  base_url="${1%/}"
+  base_url="${base_url%/v1}"
+  expected_model="${2:-}"
+  model_count=""
+  auth_header=()
+  if [ -n "${REMOTE_API_KEY:-}" ]; then
+    auth_header=(-H "Authorization: Bearer ${REMOTE_API_KEY}")
+  fi
+
+  models_json="$(curl -sf "${auth_header[@]}" "${base_url}/v1/models")" \
+    || { echo "remote endpoint failed: ${base_url}/v1/models"; return 1; }
+
+  model_count="$(echo "$models_json" | jq -r \
+    'if (.data? | type) == "array" then (.data | length) elif (.id? != null) then 1 else 0 end')"
+
+  if [ -z "$expected_model" ] && [ "${model_count:-0}" -gt 1 ]; then
+    echo "remote endpoint advertises multiple models; ask the user to choose one:" >&2
+    echo "$models_json" | jq -r '.data[]?.id' | sed 's/^/  /' >&2
+    return 1
+  fi
+
+  if [ -n "$expected_model" ]; then
+    echo "$models_json" | jq -e --arg model "$expected_model" \
+      '(.id == $model) or any(.data[]?; .id == $model)' >/dev/null \
+      || { echo "remote endpoint does not advertise model: $expected_model"; return 1; }
+  fi
+
+  echo "remote endpoint OK: ${base_url}"
+}
+
+# Examples:
+# REMOTE_API_KEY="$NVIDIA_API_KEY" probe_remote_models "$LLM_BASE_URL" "$LLM_NAME"
+# probe_remote_models "http://localhost:30081" "nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark"
+```
+
+If `/v1/models` fails or does not advertise the selected model, stop and ask
+the user for the correct endpoint/model before mutating `generated.env`.
+
 ## Decision Rule
 
-A key reported `invalid` that the chosen mode needs, or a `skip` for a key the mode requires, is a blocker. Prompt the user, re-probe, and do not proceed to env mutation until it resolves.
+A key reported `invalid` that the chosen mode needs, a `skip` for a key the
+mode requires, or a selected remote endpoint that fails `/v1/models` is a
+blocker. Prompt the user, re-probe, and do not proceed to env mutation until it
+resolves.
 
 A `skip` for a key the mode does not use is fine.

--- a/skills/vss-deploy-profile/references/env-overrides.md
+++ b/skills/vss-deploy-profile/references/env-overrides.md
@@ -4,7 +4,7 @@
 
 Build a dictionary of env var overrides based on user intent. Only include vars that differ from the profile's `.env` defaults.
 
-**Always set (they have placeholder defaults in the template):**
+**Always set (non-secret deployment values with placeholder defaults in the template):**
 
 | Var | Value |
 |---|---|
@@ -12,7 +12,12 @@ Build a dictionary of env var overrides based on user intent. Only include vars 
 | `VSS_APPS_DIR` | `<repo>/deployments` |
 | `VSS_DATA_DIR` | `<repo>/data` (or user-specified) |
 | `HOST_IP` | Detected host IP |
-| `NGC_CLI_API_KEY` | From environment or user |
+
+Credential env vars are mode-scoped. Set `NGC_CLI_API_KEY` only when
+local/local_shared NIM pulls are selected, `NVIDIA_API_KEY` only when the
+selected remote endpoint requires it, and `HF_TOKEN` only for edge recipes that
+use gated HF models. Validate them through
+[`credentials.md`](credentials.md) before writing them to `generated.env`.
 
 **Placement selection rules.**
 
@@ -31,8 +36,9 @@ Build a dictionary of env var overrides based on user intent. Only include vars 
   exact model id for each selected side. The catalog `/v1/models` endpoint can
   return many LLM/VLM models, so never use the first returned model as a
   default.
-- Before writing any selected remote endpoint to `generated.env`, run the
-  `/v1/models` probe in [`credentials.md`](credentials.md#remote-endpoint-probes).
+- Before writing any selected remote endpoint to `generated.env`, run
+  `scripts/probe_remote_models.sh` as described in
+  [`credentials.md`](credentials.md#remote-endpoint-probes).
 - In `dev-profile.sh`, the host input variable is `LLM_ENDPOINT_URL` /
   `VLM_ENDPOINT_URL`; in `generated.env`, the deployed agent keys are
   `LLM_BASE_URL` / `VLM_BASE_URL`.
@@ -67,7 +73,8 @@ all of the following before `docker compose up`:
    If the endpoint is `https://integrate.api.nvidia.com`, this is mandatory
    even though `/v1/models` is reachable: that endpoint is an aggregate catalog
    and may list many models.
-3. Probe `<endpoint>/v1/models` using
+3. Probe `<endpoint>/v1/models` with
+   `scripts/probe_remote_models.sh` as described in
    [`credentials.md`](credentials.md#remote-endpoint-probes). The selected
    model must appear in the response before you mutate `generated.env`.
 4. Write `LLM_MODE=remote` + `LLM_NAME_SLUG=none` + `LLM_BASE_URL=<url>` +

--- a/skills/vss-deploy-profile/references/env-overrides.md
+++ b/skills/vss-deploy-profile/references/env-overrides.md
@@ -14,6 +14,29 @@ Build a dictionary of env var overrides based on user intent. Only include vars 
 | `HOST_IP` | Detected host IP |
 | `NGC_CLI_API_KEY` | From environment or user |
 
+**Placement selection rules.**
+
+- Treat host env vars such as `LLM_ENDPOINT_URL`, `VLM_ENDPOINT_URL`,
+  `LLM_BASE_URL`, and `VLM_BASE_URL` as candidate values, not user intent.
+  They may be leftovers from a previous deploy.
+- Default to local/local_shared placement only when the selected models fit
+  the host and the user did not request remote placement.
+- Use remote placement only when the user asked for it, supplied an endpoint,
+  approved remote placement after a sizing blocker, or the profile reference
+  documents a standalone local service that VSS consumes as remote.
+- If the user only says "use build.nvidia.com", "use NVIDIA API catalog", or
+  provides `https://integrate.api.nvidia.com` without saying which side is
+  remote, stop and ask whether to use remote LLM, remote VLM, or both.
+- For build.nvidia.com / NVIDIA API catalog remote endpoints, require the
+  exact model id for each selected side. The catalog `/v1/models` endpoint can
+  return many LLM/VLM models, so never use the first returned model as a
+  default.
+- Before writing any selected remote endpoint to `generated.env`, run the
+  `/v1/models` probe in [`credentials.md`](credentials.md#remote-endpoint-probes).
+- In `dev-profile.sh`, the host input variable is `LLM_ENDPOINT_URL` /
+  `VLM_ENDPOINT_URL`; in `generated.env`, the deployed agent keys are
+  `LLM_BASE_URL` / `VLM_BASE_URL`.
+
 **Common overrides by user intent:**
 
 | User intent | Env overrides |
@@ -41,7 +64,13 @@ all of the following before `docker compose up`:
    - The LLM model name served there
    - (same pair for VLM if they also said "remote VLM")
    - An `NVIDIA_API_KEY` if the endpoint requires one
-3. Write `LLM_MODE=remote` + `LLM_NAME_SLUG=none` + `LLM_BASE_URL=<url>` +
+   If the endpoint is `https://integrate.api.nvidia.com`, this is mandatory
+   even though `/v1/models` is reachable: that endpoint is an aggregate catalog
+   and may list many models.
+3. Probe `<endpoint>/v1/models` using
+   [`credentials.md`](credentials.md#remote-endpoint-probes). The selected
+   model must appear in the response before you mutate `generated.env`.
+4. Write `LLM_MODE=remote` + `LLM_NAME_SLUG=none` + `LLM_BASE_URL=<url>` +
    `LLM_NAME=<model>` into
    `deploy/docker/developer-profiles/dev-profile-<profile>/generated.env`
    (the skill's per-deploy working copy — see ``SKILL.md`` (see `../SKILL.md`)
@@ -49,7 +78,7 @@ all of the following before `docker compose up`:
    `sed -i "s|^KEY=.*|KEY=VALUE|"` — the source `.env` template ships
    with placeholder rows for these keys, which `cp` to `generated.env`
    so the same `sed` patterns work.
-4. After writing, `grep -E '^(HARDWARE_PROFILE|LLM_MODE|VLM_MODE|LLM_NAME_SLUG|VLM_NAME_SLUG|LLM_BASE_URL|VLM_BASE_URL)=' <env-file>`
+5. After writing, `grep -E '^(HARDWARE_PROFILE|LLM_MODE|VLM_MODE|LLM_NAME_SLUG|VLM_NAME_SLUG|LLM_BASE_URL|VLM_BASE_URL)=' <env-file>`
    and verify every line shows the value you intended. A silent miss on
    `LLM_MODE` / `VLM_MODE` is the #1 cause of deployments coming up with
    wrong compose profiles.

--- a/skills/vss-deploy-profile/references/ngc.md
+++ b/skills/vss-deploy-profile/references/ngc.md
@@ -70,7 +70,7 @@ export NGC_CLI_API_KEY='<key>'
 echo "export NGC_CLI_API_KEY='<key>'" >> ~/.bashrc
 ```
 
-> Do not store the raw key in `TOOLS.md` or any workspace file.
+> Do not store the raw key in any workspace file.
 
 ---
 

--- a/skills/vss-deploy-profile/references/prerequisites.md
+++ b/skills/vss-deploy-profile/references/prerequisites.md
@@ -25,10 +25,6 @@ Use this skill when:
 - After a driver or Docker update
 - Called from BOOTSTRAP during first-time setup
 
-## Read TOOLS.md First
-
-Check `TOOLS.md` for the VSS section. If missing, the environment isn't configured yet — run BOOTSTRAP first.
-
 ---
 
 ## Sudo Access

--- a/skills/vss-deploy-profile/scripts/probe_remote_models.sh
+++ b/skills/vss-deploy-profile/scripts/probe_remote_models.sh
@@ -21,12 +21,12 @@ Examples:
 EOF
 }
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0
 fi
 
-if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
   usage
   exit 1
 fi
@@ -44,7 +44,7 @@ base_url="${base_url%/v1}"
 expected_model="${2:-}"
 curl_args=(-sf)
 
-if [ -n "${REMOTE_API_KEY:-}" ]; then
+if [[ -n "${REMOTE_API_KEY:-}" ]]; then
   curl_args+=(-H "Authorization: Bearer ${REMOTE_API_KEY}")
 fi
 
@@ -54,7 +54,7 @@ models_json="$(curl "${curl_args[@]}" "${base_url}/v1/models")" \
 model_count="$(echo "$models_json" | jq -r \
   'if (.data? | type) == "array" then (.data | length) elif (.id? != null) then 1 else 0 end')"
 
-if [ -z "$expected_model" ] && [ "${model_count:-0}" -gt 1 ]; then
+if [[ -z "$expected_model" && "${model_count:-0}" -gt 1 ]]; then
   echo "ERROR: remote endpoint advertises multiple models; ask the user to choose one:" >&2
   echo "$models_json" | jq -r \
     'if (.data? | type) == "array" then .data[]?.id elif .id? != null then .id else empty end' \
@@ -62,7 +62,7 @@ if [ -z "$expected_model" ] && [ "${model_count:-0}" -gt 1 ]; then
   exit 2
 fi
 
-if [ -n "$expected_model" ]; then
+if [[ -n "$expected_model" ]]; then
   echo "$models_json" | jq -e --arg model "$expected_model" \
     '(.id == $model) or any(.data[]?; .id == $model)' >/dev/null \
     || {

--- a/skills/vss-deploy-profile/scripts/probe_remote_models.sh
+++ b/skills/vss-deploy-profile/scripts/probe_remote_models.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  probe_remote_models.sh <base-url> [expected-model-id]
+
+Probes <base-url>/v1/models for an OpenAI-compatible remote LLM/VLM endpoint.
+If REMOTE_API_KEY is set, it is sent as a Bearer token.
+
+Examples:
+  REMOTE_API_KEY="$NVIDIA_API_KEY" probe_remote_models.sh \
+    https://integrate.api.nvidia.com nvidia/llama-3.3-nemotron-super-49b-v1
+
+  probe_remote_models.sh \
+    http://localhost:30081 nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  usage
+  exit 1
+fi
+
+for dep in curl jq; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $dep" >&2
+    exit 1
+  fi
+done
+
+base_url="${1%/}"
+base_url="${base_url%/v1/models}"
+base_url="${base_url%/v1}"
+expected_model="${2:-}"
+curl_args=(-sf)
+
+if [ -n "${REMOTE_API_KEY:-}" ]; then
+  curl_args+=(-H "Authorization: Bearer ${REMOTE_API_KEY}")
+fi
+
+models_json="$(curl "${curl_args[@]}" "${base_url}/v1/models")" \
+  || { echo "ERROR: remote endpoint failed: ${base_url}/v1/models" >&2; exit 1; }
+
+model_count="$(echo "$models_json" | jq -r \
+  'if (.data? | type) == "array" then (.data | length) elif (.id? != null) then 1 else 0 end')"
+
+if [ -z "$expected_model" ] && [ "${model_count:-0}" -gt 1 ]; then
+  echo "ERROR: remote endpoint advertises multiple models; ask the user to choose one:" >&2
+  echo "$models_json" | jq -r \
+    'if (.data? | type) == "array" then .data[]?.id elif .id? != null then .id else empty end' \
+    | sed 's/^/  /' >&2
+  exit 2
+fi
+
+if [ -n "$expected_model" ]; then
+  echo "$models_json" | jq -e --arg model "$expected_model" \
+    '(.id == $model) or any(.data[]?; .id == $model)' >/dev/null \
+    || {
+      echo "ERROR: remote endpoint does not advertise model: $expected_model" >&2
+      echo "Advertised models:" >&2
+      echo "$models_json" | jq -r \
+        'if (.data? | type) == "array" then .data[]?.id elif .id? != null then .id else empty end' \
+        | sed 's/^/  /' >&2
+      exit 1
+    }
+fi
+
+echo "remote endpoint OK: ${base_url}"

--- a/skills/vss-deploy-profile/scripts/probe_remote_models.sh
+++ b/skills/vss-deploy-profile/scripts/probe_remote_models.sh
@@ -19,6 +19,8 @@ Examples:
   probe_remote_models.sh \
     http://localhost:30081 nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark
 EOF
+
+  return 0
 }
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then

--- a/skills/vss-deploy-profile/scripts/probe_remote_models.sh
+++ b/skills/vss-deploy-profile/scripts/probe_remote_models.sh
@@ -51,8 +51,17 @@ fi
 models_json="$(curl "${curl_args[@]}" "${base_url}/v1/models")" \
   || { echo "ERROR: remote endpoint failed: ${base_url}/v1/models" >&2; exit 1; }
 
-model_count="$(echo "$models_json" | jq -r \
-  'if (.data? | type) == "array" then (.data | length) elif (.id? != null) then 1 else 0 end')"
+model_count="$(printf '%s\n' "$models_json" | jq -r \
+  'if type == "object" and ((.data? | type) == "array") then ([.data[]? | select(.id? != null)] | length) elif type == "object" and (.id? != null) then 1 else 0 end' 2>/dev/null)" \
+  || {
+    echo "ERROR: remote endpoint did not return JSON from: ${base_url}/v1/models" >&2
+    exit 1
+  }
+
+if [[ ! "$model_count" =~ ^[0-9]+$ || "$model_count" -lt 1 ]]; then
+  echo "ERROR: remote endpoint did not advertise any models: ${base_url}/v1/models" >&2
+  exit 1
+fi
 
 if [[ -z "$expected_model" && "${model_count:-0}" -gt 1 ]]; then
   echo "ERROR: remote endpoint advertises multiple models; ask the user to choose one:" >&2

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -121,7 +121,9 @@ If the probe fails or the listed ids don't include `${VLM_MODEL}`, fall back to 
 
 ### Step 3 — Call the VLM directly
 
-Use the OpenAI-compatible `chat/completions` endpoint with a `video_url` content block — the same payload shape `video_understanding` builds in `src/vss_agents/tools/video_understanding.py` (`_build_vlm_messages`):
+Use the OpenAI-compatible `chat/completions` endpoint with a `video_url` content block — the same payload shape **and multimodal settings** `video_understanding` builds in `src/vss_agents/tools/video_understanding.py` (`_build_vlm_messages` + the Cosmos `base_vlm.bind(...)` call).
+
+The frame sampling and visual-token (pixel) budget below mirror the **base profile** `video_understanding` config (`deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml`): `max_fps=2`, `max_frames=30`, `min_pixels=3136`, `max_pixels=8388608`. **Always send `mm_processor_kwargs` and `media_io_kwargs`** — omitting them lets the VLM fall back to its own frame/pixel defaults, which on Cosmos Reason 2 (e.g. DGX Spark) yields garbage output (repeated tokens, stray characters, off-topic answers).
 
 ```bash
 PROMPT='Describe in detail what happens in the video, with timestamps (start–end in seconds from clip start) for each segment or event. Cover scenes, objects, people, vehicles, and notable actions.'
@@ -138,6 +140,14 @@ Your reasoning.
 
 Write your final answer immediately after the </think> tag."
 
+# Multimodal settings — mirror the base-profile video_understanding config (config.yml).
+# num_frames = min(clip_seconds * max_fps, max_frames); clip_seconds = Step 1 endTime - startTime.
+MAX_FPS=2; MAX_FRAMES=30; MIN_PIXELS=3136; MAX_PIXELS=8388608
+CLIP_SECONDS=${CLIP_SECONDS:-15}   # from the Step 1 clip range; a >=15s clip caps at MAX_FRAMES anyway
+NUM_FRAMES=$(( CLIP_SECONDS * MAX_FPS ))
+[ "$NUM_FRAMES" -gt "$MAX_FRAMES" ] && NUM_FRAMES=$MAX_FRAMES
+[ "$NUM_FRAMES" -lt 1 ] && NUM_FRAMES=1
+
 curl -s -X POST "${VLM_ENDPOINT}/chat/completions" \
   -H "Content-Type: application/json" \
   -d @- <<EOF | jq -r '.choices[0].message.content'
@@ -153,10 +163,14 @@ curl -s -X POST "${VLM_ENDPOINT}/chat/completions" \
     }
   ],
   "max_tokens": 1024,
-  "temperature": 0.0
+  "temperature": 0.0,
+  "mm_processor_kwargs": {"size": {"shortest_edge": ${MIN_PIXELS}, "longest_edge": ${MAX_PIXELS}}},
+  "media_io_kwargs": {"video": {"num_frames": ${NUM_FRAMES}}}
 }
 EOF
 ```
+
+> **`mm_processor_kwargs` shape is model-specific** (matches `video_understanding.py`): Cosmos Reason 2 uses `{"size": {"shortest_edge": <min_pixels>, "longest_edge": <max_pixels>}}` (above); Cosmos Reason 1 and other Cosmos VLMs use `{"videos_kwargs": {"min_pixels": <min_pixels>, "max_pixels": <max_pixels>}}`. Use the form that matches the live `${VLM_MODEL}`.
 
 If the VLM returns a `<think>…</think>` block (Cosmos Reason reasoning mode), keep only the text after `</think>` as the report body.
 

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -155,12 +155,14 @@ NUM_FRAMES=$(( CLIP_SECONDS * MAX_FPS ))
 [ "$NUM_FRAMES" -gt "$MAX_FRAMES" ] && NUM_FRAMES=$MAX_FRAMES
 [ "$NUM_FRAMES" -lt 1 ] && NUM_FRAMES=1
 
-# mm kwargs are Cosmos-only and the shape differs by model (matches video_understanding.py bind()):
-#   cosmos-reason2 -> size:{shortest_edge,longest_edge}; other cosmos (e.g. reason1) -> videos_kwargs:{min_pixels,max_pixels}.
-# Non-Cosmos VLMs get no extra kwargs. Build the trailing JSON fragment for the live ${VLM_MODEL}.
+# num_frames (media_io_kwargs) applies to any Cosmos VLM. The pixel budget (mm_processor_kwargs) below is
+# Cosmos Reason 2-SPECIFIC: both the size{shortest_edge,longest_edge} shape and the 3136/8388608 values come
+# from the CR2 base config. Do NOT reuse these for Cosmos Reason 1 — CR1 takes videos_kwargs{min_pixels,
+# max_pixels}, whose max_pixels is a different quantity than CR2's longest_edge (see the Cosmos Reason NIM
+# docs). For CR1/other VLMs, add that model's own mm_processor_kwargs per its docs. Build the JSON fragment:
 case "$VLM_MODEL" in
   *cosmos-reason2*) MM_KWARGS=", \"mm_processor_kwargs\": {\"size\": {\"shortest_edge\": ${MIN_PIXELS}, \"longest_edge\": ${MAX_PIXELS}}}, \"media_io_kwargs\": {\"video\": {\"num_frames\": ${NUM_FRAMES}}}" ;;
-  *cosmos*)         MM_KWARGS=", \"mm_processor_kwargs\": {\"videos_kwargs\": {\"min_pixels\": ${MIN_PIXELS}, \"max_pixels\": ${MAX_PIXELS}}}, \"media_io_kwargs\": {\"video\": {\"num_frames\": ${NUM_FRAMES}}}" ;;
+  *cosmos*)         MM_KWARGS=", \"media_io_kwargs\": {\"video\": {\"num_frames\": ${NUM_FRAMES}}}" ;;  # CR1/other Cosmos: also add mm_processor_kwargs per the model's NIM docs
   *)                MM_KWARGS="" ;;
 esac
 
@@ -184,7 +186,7 @@ curl -s -X POST "${VLM_ENDPOINT}/chat/completions" \
 EOF
 ```
 
-> The `case "$VLM_MODEL"` block above sends the **model-specific** `mm_processor_kwargs` shape (matches `video_understanding.py`): `size:{shortest_edge,longest_edge}` for Cosmos Reason 2, `videos_kwargs:{min_pixels,max_pixels}` for Cosmos Reason 1 / other Cosmos, and **no** extra kwargs for non-Cosmos VLMs.
+> The `case "$VLM_MODEL"` block sends the Cosmos Reason 2 pixel budget (`size:{shortest_edge:3136, longest_edge:8388608}`, from `config.yml`) **only for Cosmos Reason 2**, plus `num_frames` for any Cosmos VLM. **Do not reuse these pixel values for other VLMs:** Cosmos Reason 1 takes `videos_kwargs:{min_pixels, max_pixels}`, and its `max_pixels` is **not** the same quantity as CR2's `longest_edge` — set CR1/other-VLM `mm_processor_kwargs` per that model's [Cosmos Reason NIM docs](https://docs.nvidia.com/nim/vision-language-models/1.6.0/introduction.html). Non-Cosmos VLMs need no extra kwargs.
 
 If the VLM returns a `<think>…</think>` block (Cosmos Reason reasoning mode), keep only the text after `</think>` as the report body.
 

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -128,8 +128,11 @@ The frame sampling and visual-token (pixel) budget below mirror the **base profi
 ```bash
 PROMPT='Describe in detail what happens in the video, with timestamps (start–end in seconds from clip start) for each segment or event. Cover scenes, objects, people, vehicles, and notable actions.'
 
-# Cosmos Reason 2 reasoning prompt suffix — matches video_understanding.py for is_cosmos_reason2 + reasoning=true.
-# Drop this suffix for non-cosmos-reason2 VLMs.
+# Reasoning is OFF by default — matches the base-profile video_understanding config (`reasoning: false`).
+# video_understanding.py uses config.reasoning unless the caller overrides it, so default to non-reasoning.
+# Append the Cosmos Reason 2 reasoning suffix ONLY when the user explicitly asks for reasoning
+# (drop it for non-cosmos-reason2 VLMs). With reasoning off, the response has no <think> block.
+if [ "${REASONING:-false}" = "true" ]; then
 PROMPT="${PROMPT}
 
 Answer the question using the following format:
@@ -139,6 +142,7 @@ Your reasoning.
 </think>
 
 Write your final answer immediately after the </think> tag."
+fi
 
 # Multimodal settings — mirror the base-profile video_understanding config (config.yml).
 # num_frames = min(clip_seconds * max_fps, max_frames); clip_seconds = Step 1 endTime - startTime.

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -123,7 +123,7 @@ If the probe fails or the listed ids don't include `${VLM_MODEL}`, fall back to 
 
 Use the OpenAI-compatible `chat/completions` endpoint with a `video_url` content block — the same payload shape **and multimodal settings** `video_understanding` builds in `src/vss_agents/tools/video_understanding.py` (`_build_vlm_messages` + the Cosmos `base_vlm.bind(...)` call).
 
-The frame sampling and visual-token (pixel) budget below mirror the **base profile** `video_understanding` config (`deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml`): `max_fps=2`, `max_frames=30`, `min_pixels=3136`, `max_pixels=8388608`. **Always send `mm_processor_kwargs` and `media_io_kwargs`** — omitting them lets the VLM fall back to its own frame/pixel defaults, which on Cosmos Reason 2 (e.g. DGX Spark) yields garbage output (repeated tokens, stray characters, off-topic answers).
+The frame sampling and visual-token (pixel) budget below mirror the **base profile** `video_understanding` config (`deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml`): `max_fps=2`, `max_frames=30`, `min_pixels=3136`, `max_pixels=8388608`. **Send `mm_processor_kwargs` and `media_io_kwargs`** so the direct call uses the same frame sampling and pixel budget as the in-agent `video_understanding` tool — omitting them lets the VLM apply its own defaults, so the output diverges from the agent path.
 
 ```bash
 PROMPT='Describe in detail what happens in the video, with timestamps (start–end in seconds from clip start) for each segment or event. Cover scenes, objects, people, vehicles, and notable actions.'

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -145,12 +145,24 @@ Write your final answer immediately after the </think> tag."
 fi
 
 # Multimodal settings — mirror the base-profile video_understanding config (config.yml).
-# num_frames = min(clip_seconds * max_fps, max_frames); clip_seconds = Step 1 endTime - startTime.
 MAX_FPS=2; MAX_FRAMES=30; MIN_PIXELS=3136; MAX_PIXELS=8388608
-CLIP_SECONDS=${CLIP_SECONDS:-15}   # from the Step 1 clip range; a >=15s clip caps at MAX_FRAMES anyway
+
+# num_frames = min(int(clip_seconds) * max_fps, max_frames), min 1 — matches video_understanding.py.
+# clip_seconds (Step 1 endTime-startTime) may be fractional; truncate to integer seconds — bash $((...))
+# is integer-only and errors on "15.0"/"1.5". Default 15s -> caps at MAX_FRAMES.
+CLIP_SECONDS=$(awk -v s="${CLIP_SECONDS:-15}" 'BEGIN{printf "%d", s}')
 NUM_FRAMES=$(( CLIP_SECONDS * MAX_FPS ))
 [ "$NUM_FRAMES" -gt "$MAX_FRAMES" ] && NUM_FRAMES=$MAX_FRAMES
 [ "$NUM_FRAMES" -lt 1 ] && NUM_FRAMES=1
+
+# mm kwargs are Cosmos-only and the shape differs by model (matches video_understanding.py bind()):
+#   cosmos-reason2 -> size:{shortest_edge,longest_edge}; other cosmos (e.g. reason1) -> videos_kwargs:{min_pixels,max_pixels}.
+# Non-Cosmos VLMs get no extra kwargs. Build the trailing JSON fragment for the live ${VLM_MODEL}.
+case "$VLM_MODEL" in
+  *cosmos-reason2*) MM_KWARGS=", \"mm_processor_kwargs\": {\"size\": {\"shortest_edge\": ${MIN_PIXELS}, \"longest_edge\": ${MAX_PIXELS}}}, \"media_io_kwargs\": {\"video\": {\"num_frames\": ${NUM_FRAMES}}}" ;;
+  *cosmos*)         MM_KWARGS=", \"mm_processor_kwargs\": {\"videos_kwargs\": {\"min_pixels\": ${MIN_PIXELS}, \"max_pixels\": ${MAX_PIXELS}}}, \"media_io_kwargs\": {\"video\": {\"num_frames\": ${NUM_FRAMES}}}" ;;
+  *)                MM_KWARGS="" ;;
+esac
 
 curl -s -X POST "${VLM_ENDPOINT}/chat/completions" \
   -H "Content-Type: application/json" \
@@ -167,14 +179,12 @@ curl -s -X POST "${VLM_ENDPOINT}/chat/completions" \
     }
   ],
   "max_tokens": 1024,
-  "temperature": 0.0,
-  "mm_processor_kwargs": {"size": {"shortest_edge": ${MIN_PIXELS}, "longest_edge": ${MAX_PIXELS}}},
-  "media_io_kwargs": {"video": {"num_frames": ${NUM_FRAMES}}}
+  "temperature": 0.0${MM_KWARGS}
 }
 EOF
 ```
 
-> **`mm_processor_kwargs` shape is model-specific** (matches `video_understanding.py`): Cosmos Reason 2 uses `{"size": {"shortest_edge": <min_pixels>, "longest_edge": <max_pixels>}}` (above); Cosmos Reason 1 and other Cosmos VLMs use `{"videos_kwargs": {"min_pixels": <min_pixels>, "max_pixels": <max_pixels>}}`. Use the form that matches the live `${VLM_MODEL}`.
+> The `case "$VLM_MODEL"` block above sends the **model-specific** `mm_processor_kwargs` shape (matches `video_understanding.py`): `size:{shortest_edge,longest_edge}` for Cosmos Reason 2, `videos_kwargs:{min_pixels,max_pixels}` for Cosmos Reason 1 / other Cosmos, and **no** extra kwargs for non-Cosmos VLMs.
 
 If the VLM returns a `<think>…</think>` block (Cosmos Reason reasoning mode), keep only the text after `</think>` as the report body.
 


### PR DESCRIPTION
## Summary
- add missing skill catalog entries for behavior analytics and video analytics API
- add upfront credential and remote endpoint gates, including explicit local vs remote LLM/VLM selection and `/v1/models` probing
- move the remote model probe into `skills/vss-deploy-profile/scripts/probe_remote_models.sh`
- address Sonar S7688 by using `[[ ... ]]` conditionals in the shell probe script
- address Sonar S7682 by ending the shell function with an explicit `return 0`
- harden the remote model probe so non-JSON, wrong-schema JSON, and zero-model responses fail before reporting OK
- add repo auto-detect before asking the user for the checkout path
- make all-profile quick checks skip local NIM ports in remote mode and probe selected remote endpoints instead
- clarify doc ownership: prerequisites = host/tool readiness, credentials = keys/endpoints, env-overrides = selected values written to `generated.env`
- relax the broad `--force-recreate` prohibition to allow documented targeted recovery, and remove stale `TOOLS.md` references

## Validation
- `git diff --check origin/develop...HEAD`
- `bash -n skills/vss-deploy-profile/scripts/probe_remote_models.sh`
- `skills/vss-deploy-profile/scripts/probe_remote_models.sh --help`
- local mock `/v1/models` test: expected model exits `0`, missing model on multi-model endpoint exits `2`
- negative mock endpoint tests: empty model list, wrong-schema JSON, and HTML all exit non-zero
- remote quick-check branch with temporary `generated.env`: probes mock LLM and VLM endpoints successfully
- repo auto-detect snippet resolves this checkout
- no `if [` conditionals remain in `skills/vss-deploy-profile/scripts/probe_remote_models.sh`
- `services/agent/README.md` is no longer in the PR diff
- `rg -n "TOOLS\.md|TOOLS.md" .` returned no matches
- skills catalog checker reports `missing: []`, `extra: []`, `skill_dirs: 16`, `catalog_entries: 16`