### PR TITLE
skill-eval: fix adapter platform key for vss-build-vision-agent (PR #…

### DIFF
--- a/.github/skill-eval/adapters/vss-build-vision-agent/generate.py
+++ b/.github/skill-eval/adapters/vss-build-vision-agent/generate.py
@@ -62,8 +62,10 @@ from pathlib import Path
 
 PLATFORMS: dict[str, dict] = {
     # Primary target for vss-build-vision-agent IN-1
-    "2xRTXPro": {
-        "short_name":       "2xrtxpro",
+    # Key matches the spec's resources.platforms declaration ("RTXPRO6000BW")
+    # and the cross-adapter convention (see vss-manage-video-io-storage, vss-deploy-profile, etc.)
+    "RTXPRO6000BW": {
+        "short_name":       "rtxpro6000bw",
         "gpu_type":         "RTX PRO 6000",
         "gpu_count":        2,
         "min_vram_per_gpu": 96,
@@ -89,7 +91,7 @@ PLATFORMS: dict[str, dict] = {
     },
 }
 
-DEFAULT_PLATFORM = "2xRTXPro"
+DEFAULT_PLATFORM = "RTXPRO6000BW"
 
 # Prepended to every instruction.md so the skill's own HITL bypass clause fires.
 # The skill's SKILL.md "Autonomous mode" branch triggers on exactly this wording;


### PR DESCRIPTION
…727)

The adapter's PLATFORMS table used a non-standard key '2xRTXPro' (short_name '2xrtxpro') while the spec's resources.platforms declares 'RTXPRO6000BW'. This mismatch caused the adapter to fall through to a default, generating the dataset under the wrong platform directory and with wrong metadata.

Fix: rename the primary key to 'RTXPRO6000BW' with short_name 'rtxpro6000bw' — matching the spec declaration and the cross-adapter convention used by all other adapters (vss-manage-video-io-storage, vss-deploy-profile, vss-deploy-dense-captioning, etc.).

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
