### PR TITLE
feat(skill-eval): run manual sweeps through the matrix (per-spec legs), not one agent

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -164,6 +164,9 @@ The canonical harbor command is in § Harbor invocation.
        it, and the commit + the re-run's per-spec result comments (with
        trace/artifact links) are the review trail. **Fork PRs are the one
        exception**: the bot can't push to a fork, so it comments + BLOCKs.
+       (On a **manual sweep**, `PR_NUMBER` is empty — there is no PR/branch
+       to commit to either; record the adapter trouble in
+       `$GITHUB_STEP_SUMMARY` and `BLOCKED:`, per § "Manual full-sweep mode".)
 
        ```bash
        # Resolve the PR head repo + branch. A fork = head-repo owner differs
@@ -801,6 +804,11 @@ wait for or aggregate the spec's other platforms: those run as separate
 parallel legs this job cannot see. A two-platform spec therefore yields
 two independent comments, one per platform.
 
+**Where the comment goes:** on a PR run (`PR_NUMBER` set) post it with
+`gh pr comment`. On a **manual sweep** (`PR_NUMBER` empty —
+`workflow_dispatch`) there is no PR: append the exact same markdown to
+`$GITHUB_STEP_SUMMARY` instead (see § "Manual full-sweep mode").
+
 ```markdown
 ## Harbor Eval — `skills/<skill>/<eval-dir>/<spec>.json`
 
@@ -967,55 +975,28 @@ harbor invocation, result format, failure modes, the DONE/BLOCKED marker
 
 ## Manual full-sweep mode
 
-The workflow also exposes a `workflow_dispatch` trigger that fires this
-agent against the **current head of whatever branch the operator dispatched
-from** (typically `develop`), with no diff and no PR. The wrapper sets
-`MANUAL_FULL_SWEEP=1`, blanks `PR_NUMBER`/`PR_BASE`, and passes a single
-skill filter:
+The `workflow_dispatch` trigger runs the **same matrix as a push** — the
+`plan` job enumerates the picked skill's specs (`MANUAL_SKILLS_FILTER`, a
+skill-dir name or `*` for every skill) instead of diffing, and the `eval`
+job fans them per `(spec, platform)`. So there is no separate sweep agent:
+each leg runs **Single-spec mode** exactly as on a push, with one
+difference — there is no PR (`PR_NUMBER` is empty). That means:
 
-  - `MANUAL_SKILLS_FILTER` — one skill name from the `type: choice`
-    dispatch dropdown, or `*` for every skill. There is intentionally no
-    spec-level filter — once a skill is picked, every spec under
-    `skills/<skill>/evals/*.json` runs.
-
-When you see `MANUAL_FULL_SWEEP=1` in the env (the user prompt also says so
-explicitly), apply these step overrides — everything else in this file
-applies unchanged:
-
-- **Step 1 (override):** skip the diff. Enumerate `skills/*/evals/*.json` on
-  the checked-out workspace, then drop any skill not matching the filter
-  (`*` keeps all). Skills with no `eval/` dir remain runtime libraries and
-  are skipped as in the normal path. Every spec on the kept skill(s) runs.
-
-- **Step 3 (override):** the adapter auto-commit flow in §§ 3c/3d is **off**
-  — there is no contributor branch to target. If an adapter is missing or stale for a
-  given spec, record that spec as `BLOCKED:<reason>` in the results table
-  and move on. Do NOT push branches, do NOT open PRs. (The hard rule
-  against `skills/` writes still applies in full.)
-
-- **Step 6 (override):** there is no PR to comment on. For each completed
-  `(skill, spec)` batch, append the same markdown you would have posted
-  via `gh pr comment` (per § Result comment format) to the file at
-  `$GITHUB_STEP_SUMMARY`:
-
-  ```bash
-  cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
-  ## Harbor Eval — `skills/<skill>/evals/<spec>.json`
-  ... table + failing checks + suggestions, exactly as in PR-comment mode ...
-  MD
-  ```
-
-  Append per-spec — don't buffer everything for the end. If
-  `$GITHUB_STEP_SUMMARY` is empty/unset (running locally for a smoke
-  test), print the same markdown to stdout and note the fallback. The
-  rendered Actions run summary is the operator's primary view; the Harbor
-  viewer URLs in each row are still per-trial trace links.
+- **Output → job summary, not a PR comment.** Append your result table
+  (the same § Result comment format markdown) to `$GITHUB_STEP_SUMMARY`
+  instead of `gh pr comment`. Each leg is its own job, so its summary is
+  that leg's view; the run page aggregates them and the per-leg artifact +
+  Harbor trace links carry the rest. (If `$GITHUB_STEP_SUMMARY` is unset —
+  a local smoke test — print the markdown to stdout and note the fallback.)
+- **No adapter auto-commit.** § 3c needs a contributor branch; a manual
+  sweep has none. A missing/stale adapter → record it in
+  `$GITHUB_STEP_SUMMARY` and `BLOCKED:` (never push; the hard rule against
+  `skills/` writes still applies in full).
 
 Everything else — startup hygiene, fleet selection (§ 5a), per-box flock
-(§ 5b), canonical harbor invocation (§ Harbor invocation), no
-trial-supervision polling, the artifact-tarball collection step in the
-workflow — is identical to the PR-driven path. The DONE/BLOCKED final
-marker (§ Output requirements) is also unchanged.
+(§ 5b), canonical harbor invocation, no trial-supervision polling, the
+artifact collection step, the DONE/BLOCKED final marker — is identical to
+the PR-driven path.
 
 ## Output requirements
 

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -1012,9 +1012,11 @@ the PR-driven path.
     - `DONE: 2/3 specs passed; 1 spec failed (vss-deploy-dense-captioning/step-2 reward=0.83)`
     - `BLOCKED: anthropic rate limit after 3 retries`
     - `BLOCKED: lock timeout on vss-eval-l40s`
-  If you ran trials, you MUST also have called `gh pr comment
-  $PR_NUMBER` with the per-batch results before printing
-  `DONE:` — otherwise the contributor sees no signal on their PR.
+  If you ran trials, you MUST also have posted the per-spec result before
+  printing `DONE:` — via `gh pr comment $PR_NUMBER` on a PR run, or, on a
+  manual sweep (`PR_NUMBER` empty), appended to `$GITHUB_STEP_SUMMARY`
+  (§ "Result comment format" / "Manual full-sweep mode") — otherwise the
+  result is invisible.
 - Don't tear down or `brev stop` / `brev delete` any instance. The
   `vss-eval-*` pool is operator-managed and stays warm across runs.
 

--- a/.github/skill-eval/docs/matrix-dispatch-design.md
+++ b/.github/skill-eval/docs/matrix-dispatch-design.md
@@ -123,8 +123,8 @@ failing leg doesn't cancel the others.
 
 | Component | Change |
 |---|---|
-| `.github/skill-eval/plan_matrix.py` | **new.** Pure-Python, no LLM. Reads the diff (via `gh api …/compare`), applies the rules above, prints `matrix` JSON + `has_targets` to `$GITHUB_OUTPUT`. Unit-testable offline. |
-| `.github/workflows/skills-eval.yml` | **rewrite.** `plan` job → `eval` matrix job. `workflow_dispatch` manual-sweep path retained (still single-agent full sweep to `$GITHUB_STEP_SUMMARY`). |
+| `.github/skill-eval/plan_matrix.py` | **new.** Pure-Python, no LLM. Reads the diff (local `git diff`) — or, on a manual sweep, enumerates the picked skill's specs — applies the rules above, prints `matrix` JSON + `has_targets` to `$GITHUB_OUTPUT`. Unit-testable offline. |
+| `.github/workflows/skills-eval.yml` | **rewrite.** `plan` job → `eval` matrix job, on push AND `workflow_dispatch` (a manual sweep feeds the picked skill's specs into the same matrix; legs write to `$GITHUB_STEP_SUMMARY` since there's no PR). |
 | `.github/skill-eval/skills_eval_agent.py` | **small add.** New single-spec mode keyed on `EVAL_SKILL`/`EVAL_SPEC`: skip the diff/detection (plan already decided), build a user prompt scoped to one spec, otherwise reuse the existing SDK session, options, hardening, and DONE/BLOCKED enforcement verbatim. |
 | `.github/skill-eval/AGENTS.md` | **add a "Single-spec mode" section** (parallel to "Manual full-sweep mode"): when `EVAL_SPEC` is set, skip step 1's diff — you are handed exactly one `(skill, spec)`; run steps 2–7 for it only, post the one comment, emit the marker. Everything else (hard rules, fleet selection § 5a, flock § 5b, harbor invocation, result format, failure modes) applies unchanged. |
 

--- a/.github/skill-eval/plan_matrix.py
+++ b/.github/skill-eval/plan_matrix.py
@@ -26,6 +26,9 @@ of an adapterless skill don't race to commit it N times.
 
 Env:
     PR_BASE        base branch, e.g. develop (diffed as FETCH_HEAD...HEAD)
+    MANUAL_SKILLS_FILTER  workflow_dispatch sweep: a skill-dir name or `*`
+                   (all skills) — enumerates those specs instead of diffing,
+                   so the matrix fans per-(spec, platform) like a push
     CHANGED_FILES  optional newline-separated override (tests / local)
     GITHUB_OUTPUT  optional; when set, key=value lines are appended here
 """
@@ -72,6 +75,25 @@ def list_changed_files() -> list[str]:
     override = os.environ.get("CHANGED_FILES")
     if override is not None:
         return [ln.strip() for ln in override.splitlines() if ln.strip()]
+
+    # Manual full-sweep (workflow_dispatch): there's no diff. Enumerate the
+    # chosen skill(s)' specs so build_matrix fans them per-(spec,platform)
+    # exactly like a push — this replaces the legacy single-agent sweep.
+    # `*` sweeps every skill; otherwise a bare skill-dir name.
+    manual = os.environ.get("MANUAL_SKILLS_FILTER")
+    if manual:
+        # workflow_dispatch input — guard against path escape before it
+        # reaches specs_for_skill (which globs REPO_ROOT/skills/<filter>/…).
+        if manual != "*" and not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_-]*", manual):
+            raise ValueError(
+                f"unsafe MANUAL_SKILLS_FILTER {manual!r}: expected a skill-dir "
+                f"name ([A-Za-z0-9_-]) or '*'"
+            )
+        skills = (
+            sorted(p.name for p in (REPO_ROOT / "skills").iterdir() if p.is_dir())
+            if manual == "*" else [manual]
+        )
+        return [sp for sk in skills for sp, _, _ in specs_for_skill(sk)]
 
     base = os.environ["PR_BASE"]
     subprocess.run(

--- a/.github/skill-eval/plan_matrix.py
+++ b/.github/skill-eval/plan_matrix.py
@@ -89,6 +89,14 @@ def list_changed_files() -> list[str]:
                 f"unsafe MANUAL_SKILLS_FILTER {manual!r}: expected a skill-dir "
                 f"name ([A-Za-z0-9_-]) or '*'"
             )
+        # Fail loud on a typo'd / renamed skill rather than emitting an empty
+        # matrix that the eval job silently skips (the removed manual-sweep
+        # job errored here too).
+        if manual != "*" and not (REPO_ROOT / "skills" / manual).is_dir():
+            raise ValueError(
+                f"MANUAL_SKILLS_FILTER {manual!r}: skills/{manual}/ does not "
+                f"exist on this ref — check the skill name"
+            )
         skills = (
             sorted(p.name for p in (REPO_ROOT / "skills").iterdir() if p.is_dir())
             if manual == "*" else [manual]

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -31,8 +31,10 @@ Env (set by the workflow step):
     EVAL_SPEC_PATH        Single-spec mode: skills/<skill>/evals/<spec>.json.
     EVAL_SPEC_STEM        Single-spec mode: the spec filename without .json.
     EVAL_PLATFORM         Single-spec mode: the one platform this leg runs.
-    MANUAL_FULL_SWEEP     "1" on workflow_dispatch: full-sweep mode (see above).
-    MANUAL_SKILLS_FILTER  Skill name from the dispatch input, or "*" for all.
+    MANUAL_SKILLS_FILTER  Skill name from the dispatch input, or "*" for all —
+                          consumed by plan_matrix.py to build the manual-sweep
+                          matrix; manual legs run as single-spec with an empty
+                          PR_NUMBER (results go to the job summary).
     ANTHROPIC_*           Agent SDK credentials (sourced from coordinator .env)
     GH_TOKEN              PR comment posting (push mode only)
     NGC_CLI_API_KEY       Local NIM pulls in trials
@@ -206,12 +208,10 @@ def build_benchmark_md(out_path: Path = BENCHMARK_OUT_PATH) -> Path | None:
               flush=True)
         return None
 
-    manual_sweep = os.environ.get("MANUAL_FULL_SWEEP") == "1"
     generated = datetime.datetime.now(datetime.timezone.utc).strftime(
         "%Y-%m-%d %H:%M:%S UTC")
 
-    title = ("Skills Eval Benchmark — Manual full-sweep" if manual_sweep
-             else "Skills Eval Benchmark")
+    title = "Skills Eval Benchmark"
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("w") as fp:
@@ -291,37 +291,26 @@ async def run_agent() -> int:
         HookMatcher, ResultMessage, TextBlock, ToolUseBlock,
     )
 
-    manual_sweep = os.environ.get("MANUAL_FULL_SWEEP") == "1"
     pr_head = _require("PR_HEAD_SHA")
     pr_repo = _require("PR_REPO")
     run_id = os.environ.get("GITHUB_RUN_ID", f"local-{int(time.time())}")
 
-    if manual_sweep:
-        # workflow_dispatch path: no PR, no diff. PR_NUMBER/PR_BASE may be
-        # blank — keep them as empty strings so any downstream prompt
-        # interpolation still works.
-        pr_number = os.environ.get("PR_NUMBER", "") or f"manual-{run_id}"
-        pr_base = os.environ.get("PR_BASE", "") or "(manual)"
-        # `type: choice` already constrains the value server-side, but
-        # strip whitespace + newlines defensively before splicing into
-        # the agent's user prompt. The agent runs with bypassPermissions
-        # and full filesystem tools, so any prompt-templated user data is
-        # worth scrubbing regardless of the upstream guard.
-        skills_filter = os.environ.get("MANUAL_SKILLS_FILTER", "*").strip().splitlines()[0] if os.environ.get("MANUAL_SKILLS_FILTER", "").strip() else "*"
-        step_summary = os.environ.get("GITHUB_STEP_SUMMARY", "")
-    else:
-        # Single-spec mode (push path): the `plan` job already resolved the
-        # diff into one matrix leg, so this run evaluates exactly one
-        # (skill, spec) — no diff, no looping. EVAL_KIND distinguishes a
-        # normal eval leg from a missing-adapter leg (which only commits the
-        # adapter, no trial). The legacy whole-PR-diff loop is gone; the matrix owns
-        # fan-out now.
-        pr_number = _require("PR_NUMBER")
-        pr_base = _require("PR_BASE")
-        eval_kind = os.environ.get("EVAL_KIND", "eval")
-        eval_skill = _require("EVAL_SKILL")
-        eval_spec_path = os.environ.get("EVAL_SPEC_PATH", "")
-        eval_platform = os.environ.get("EVAL_PLATFORM", "")
+    # Single-spec mode (push AND manual sweep): the `plan` job resolved a diff
+    # (push) or the picked skill's specs (workflow_dispatch) into one matrix
+    # leg, so this run evaluates exactly one (skill, spec, platform) — no diff,
+    # no looping. EVAL_KIND distinguishes a normal eval leg from a
+    # missing-adapter leg (which only commits the adapter). PR_NUMBER is empty
+    # on a manual sweep — the leg then writes its result to its job summary
+    # ($GITHUB_STEP_SUMMARY) instead of a PR comment, and cannot auto-commit an
+    # adapter (no contributor branch). The legacy single-agent sweep is gone;
+    # the matrix owns fan-out for both push and manual now.
+    pr_number = os.environ.get("PR_NUMBER", "")   # empty ⇒ manual sweep
+    pr_base = os.environ.get("PR_BASE", "")
+    eval_kind = os.environ.get("EVAL_KIND", "eval")
+    eval_skill = _require("EVAL_SKILL")
+    eval_spec_path = os.environ.get("EVAL_SPEC_PATH", "")
+    eval_platform = os.environ.get("EVAL_PLATFORM", "")
+    manual = not pr_number
 
     if not AGENTS_MD.exists():
         print(f"FATAL: {AGENTS_MD} not found", file=sys.stderr)
@@ -329,56 +318,7 @@ async def run_agent() -> int:
 
     system_prompt = AGENTS_MD.read_text()
 
-    if manual_sweep:
-        user_prompt = f"""
-**Manual full-sweep run** — `workflow_dispatch` fired (no PR, no diff).
-
-Context:
-  repo                = {pr_repo}
-  head SHA            = {pr_head}
-  workflow run        = {run_id}
-  working dir         = {REPO_ROOT}
-  skills filter       = {skills_filter}   (single skill name from the dispatch dropdown, or `*` = all)
-  GITHUB_STEP_SUMMARY = {step_summary or '(unset — fall back to stdout)'}
-
-Per AGENTS.md § "Manual full-sweep mode" — overrides apply to steps 1, 3, 6:
-
-  Step 1 (override): skip the diff entirely. Enumerate `skills/*/evals/*.json`
-    on the checked-out workspace. Keep only the skill named in `skills filter`
-    (the dispatch dropdown is single-select; `*` matches all). All specs on the
-    chosen skill(s) run — there is no spec-level filter. Skills with no eval/
-    dir are runtime libraries and are skipped as in the normal path.
-
-  Step 3 (override): the adapter auto-commit flow is OFF in manual mode
-    (there's no contributor branch to target). If an adapter is missing or
-    stale for a spec, record that spec as BLOCKED with the trigger that fired
-    (missing / stale / spec drift) and a one-line reason in the results
-    table — DO NOT push anything. Keep processing the
-    remaining (skill, spec) pairs.
-
-  Step 6 (override): there is no PR to comment on. For each completed
-    `(skill, spec)` batch, append the same markdown table you would have
-    posted via `gh pr comment` to the path in `$GITHUB_STEP_SUMMARY`. Use:
-
-      cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
-      ## Harbor Eval — `skills/<skill>/evals/<spec>.json`
-      ... (table + failing checks + suggestions, identical to § Result comment format) ...
-      MD
-
-    Append per-spec — don't buffer everything for the end. If
-    `$GITHUB_STEP_SUMMARY` is empty/unset (smoke-test locally), print the
-    same markdown to stdout instead and note the fallback.
-
-Everything else in AGENTS.md applies unchanged: startup hygiene, fleet
-selection (§ 5a), per-box flock (§ 5b), canonical harbor invocation, no
-trial-supervision polling, no writes under `skills/`, no instance lifecycle
-calls.
-
-When done, emit `DONE: <n>/<total> specs passed; <m> blockers` on the final
-line. If the sweep couldn't proceed at all (e.g. pool exhausted before the
-first trial), emit `BLOCKED: <reason>` instead.
-"""
-    elif eval_kind == "missing_adapter":
+    if eval_kind == "missing_adapter":
         user_prompt = f"""
 PR #{pr_number}: skill `{eval_skill}` ships eval specs but has NO adapter at
 `.github/skill-eval/adapters/{eval_skill}/generate.py`. The `plan` job
@@ -398,20 +338,28 @@ the adapter and COMMIT it directly to the source PR's `headRefName` (NOT the
 mirror) so the eval re-runs against it on the next sync. Do NOT run any trial
 in this leg (the re-run evaluates the committed adapter), and do NOT post a
 results comment. For an external-fork PR (the bot can't push to a fork),
-comment that the contributor must add the adapter and BLOCK instead.
+comment that the contributor must add the adapter and BLOCK instead. If this
+is a manual sweep (`PR number` above is blank) there is no branch to commit
+to — record the missing adapter in `$GITHUB_STEP_SUMMARY` and BLOCK.
 
 End with `BLOCKED: missing adapter for {eval_skill} auto-committed (<sha>)`
 once pushed, `BLOCKED: fork PR — adapter must be added by the contributor`
-for a fork, or `BLOCKED: <reason>` if you could not commit.
+for a fork, `BLOCKED: missing adapter for {eval_skill} (manual sweep)` for a
+manual run, or `BLOCKED: <reason>` if you could not commit.
 """
     else:
+        target = f"PR #{pr_number}" if pr_number else "Manual sweep"
+        post_step = (
+            "append the result table to `$GITHUB_STEP_SUMMARY` (no PR to comment on)"
+            if manual else "post ONE PR comment for this spec"
+        )
         user_prompt = f"""
-PR #{pr_number}: evaluate exactly ONE spec on ONE platform —
+{target}: evaluate exactly ONE spec on ONE platform —
 `{eval_spec_path}` (skill `{eval_skill}`, platform `{eval_platform or "see spec"}`).
 
 Context:
   repo         = {pr_repo}
-  PR number    = {pr_number}
+  PR number    = {pr_number or "(manual sweep — no PR)"}
   base branch  = {pr_base}
   mirror head  = {pr_head}
   workflow run = {run_id}
@@ -423,16 +371,14 @@ Context:
 Per AGENTS.md § "Single-spec mode": SKIP step 1's diff — the `plan` job
 already selected this (spec, platform). Run steps 2–7 for it only:
 ensure/refresh its adapter under `.github/skill-eval/adapters/{eval_skill}/`
-(missing/stale → commit it to the PR branch per § 3c, then exit BLOCKED;
-the eval re-runs on sync — never run a locally-patched adapter in this leg)
-→ generate the dataset → acquire a per-box flock
-on a `vss-eval-*` member matching `{eval_platform or "the spec's platform"}` →
-run harbor synchronously for this platform (§ Harbor invocation; never
-background it) → gather results →
-post ONE PR comment for this spec (§ Result comment format). Do NOT touch
-any other spec or skill.
+(missing/stale → handle per § 3c, then exit BLOCKED — never run a
+locally-patched adapter in this leg) → generate the dataset → acquire a
+per-box flock on a `vss-eval-*` member matching
+`{eval_platform or "the spec's platform"}` → run harbor synchronously for
+this platform (§ Harbor invocation; never background it) → gather results →
+{post_step} (§ Result comment format). Do NOT touch any other spec or skill.
 
-End with `DONE: <reward summary>` after posting the comment, or
+End with `DONE: <reward summary>` after posting the result, or
 `BLOCKED: <reason>` (e.g. stale adapter auto-committed, pool exhausted).
 """
 

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -319,15 +319,16 @@ async def run_agent() -> int:
     system_prompt = AGENTS_MD.read_text()
 
     if eval_kind == "missing_adapter":
+        target = f"PR #{pr_number}" if pr_number else "Manual sweep"
         user_prompt = f"""
-PR #{pr_number}: skill `{eval_skill}` ships eval specs but has NO adapter at
+{target}: skill `{eval_skill}` ships eval specs but has NO adapter at
 `.github/skill-eval/adapters/{eval_skill}/generate.py`. The `plan` job
 collapsed every spec on this skill into this one leg so the adapter is
 committed exactly once.
 
 Context:
   repo         = {pr_repo}
-  PR number    = {pr_number}
+  PR number    = {pr_number or "(manual sweep — no PR)"}
   base branch  = {pr_base}
   mirror head  = {pr_head}
   workflow run = {run_id}

--- a/.github/skill-eval/tests/test_plan_matrix.py
+++ b/.github/skill-eval/tests/test_plan_matrix.py
@@ -176,6 +176,43 @@ class ListChangedFiles(unittest.TestCase):
         self.assertIn("FETCH_HEAD...HEAD", flat)
         self.assertNotIn("compare", flat)
 
+    def test_manual_filter_enumerates_specs_without_git(self):
+        """Manual sweep (MANUAL_SKILLS_FILTER set) enumerates the chosen
+        skill's specs instead of diffing, so build_matrix fans them per
+        (spec, platform) like a push — and no git diff is run."""
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *a, **k):
+            calls.append(list(cmd))
+
+            class _R:
+                stdout = ""
+
+            return _R()
+
+        orig_run = plan_matrix.subprocess.run
+        orig_specs = plan_matrix.specs_for_skill
+        orig_changed = os.environ.pop("CHANGED_FILES", None)
+        plan_matrix.subprocess.run = fake_run  # type: ignore[assignment]
+        plan_matrix.specs_for_skill = lambda s: (
+            [("skills/vss-foo/evals/a.json", "evals", "a"),
+             ("skills/vss-foo/evals/b.json", "evals", "b")]
+            if s == "vss-foo" else []
+        )
+        os.environ["MANUAL_SKILLS_FILTER"] = "vss-foo"
+        try:
+            files = plan_matrix.list_changed_files()
+        finally:
+            plan_matrix.subprocess.run = orig_run  # type: ignore[assignment]
+            plan_matrix.specs_for_skill = orig_specs
+            os.environ.pop("MANUAL_SKILLS_FILTER", None)
+            if orig_changed is not None:
+                os.environ["CHANGED_FILES"] = orig_changed
+
+        self.assertEqual(files, ["skills/vss-foo/evals/a.json",
+                                 "skills/vss-foo/evals/b.json"])
+        self.assertEqual(calls, [])  # manual mode never invokes git
+
 
 class EmitSlugSafety(unittest.TestCase):
     def test_emit_rejects_unsafe_slug(self):

--- a/.github/skill-eval/tests/test_plan_matrix.py
+++ b/.github/skill-eval/tests/test_plan_matrix.py
@@ -194,12 +194,14 @@ class ListChangedFiles(unittest.TestCase):
         orig_specs = plan_matrix.specs_for_skill
         orig_changed = os.environ.pop("CHANGED_FILES", None)
         plan_matrix.subprocess.run = fake_run  # type: ignore[assignment]
+        # Use a real skill dir so the existence guard passes; specs_for_skill
+        # is stubbed so the assertion stays stable as the tree changes.
         plan_matrix.specs_for_skill = lambda s: (
-            [("skills/vss-foo/evals/a.json", "evals", "a"),
-             ("skills/vss-foo/evals/b.json", "evals", "b")]
-            if s == "vss-foo" else []
+            [("skills/vss-manage-alerts/evals/a.json", "evals", "a"),
+             ("skills/vss-manage-alerts/evals/b.json", "evals", "b")]
+            if s == "vss-manage-alerts" else []
         )
-        os.environ["MANUAL_SKILLS_FILTER"] = "vss-foo"
+        os.environ["MANUAL_SKILLS_FILTER"] = "vss-manage-alerts"
         try:
             files = plan_matrix.list_changed_files()
         finally:
@@ -209,9 +211,22 @@ class ListChangedFiles(unittest.TestCase):
             if orig_changed is not None:
                 os.environ["CHANGED_FILES"] = orig_changed
 
-        self.assertEqual(files, ["skills/vss-foo/evals/a.json",
-                                 "skills/vss-foo/evals/b.json"])
+        self.assertEqual(files, ["skills/vss-manage-alerts/evals/a.json",
+                                 "skills/vss-manage-alerts/evals/b.json"])
         self.assertEqual(calls, [])  # manual mode never invokes git
+
+    def test_manual_filter_unknown_skill_raises(self):
+        """A typo'd / non-existent skill filter fails the plan loudly instead
+        of emitting a silent empty matrix the eval job skips."""
+        orig_changed = os.environ.pop("CHANGED_FILES", None)
+        os.environ["MANUAL_SKILLS_FILTER"] = "vss-this-skill-does-not-exist-xyz"
+        try:
+            with self.assertRaises(ValueError):
+                plan_matrix.list_changed_files()
+        finally:
+            os.environ.pop("MANUAL_SKILLS_FILTER", None)
+            if orig_changed is not None:
+                os.environ["CHANGED_FILES"] = orig_changed
 
 
 class EmitSlugSafety(unittest.TestCase):

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -9,8 +9,9 @@
 #            in single-spec mode (foreground agent, one synchronous harbor
 #            run), posts its own PR comment per AGENTS.md.
 # workflow_dispatch:
-#   manual-sweep -> the legacy single-agent full sweep (no matrix),
-#                   writing per-spec tables to $GITHUB_STEP_SUMMARY.
+#   plan + eval -> manual full sweep, fanned per (spec, platform) just like
+#                  a push; each leg writes its result to its job summary
+#                  (no PR to comment on). Scoped by the `skills` input.
 
 name: Skills Eval
 
@@ -24,16 +25,16 @@ on:
   push:
     branches:
       - "pull-request/[0-9]+"
-  # Manual full-sweep trigger. Runs every eval spec on the picked skill
-  # (or all skills) regardless of diff. No PR to comment on, so the agent
-  # writes per-spec tables to $GITHUB_STEP_SUMMARY. See AGENTS.md
-  # § "Manual full-sweep mode".
+  # Manual full-sweep trigger. The `plan` job enumerates the picked skill's
+  # specs (or all skills) instead of diffing, and the `eval` matrix fans them
+  # per (spec, platform) like a push. No PR to comment on, so each leg writes
+  # its result to its own job summary.
   workflow_dispatch:
     inputs:
       skills:
         # `type: string` rather than `type: choice` because the skills/
-        # tree has more than 10 entries — GitHub caps `choice` at 10. The
-        # manual-sweep job sanity-checks the value before use.
+        # tree has more than 10 entries — GitHub caps `choice` at 10.
+        # plan_matrix.py validates the value (skill-dir name or `*`).
         description: "Which skill to eval. `*` sweeps all. Otherwise a bare skill-dir name (e.g. `vss-deploy-profile`)."
         required: false
         default: "*"
@@ -73,7 +74,7 @@ jobs:
   # ---------------------------------------------------------------------
   plan:
     name: Plan eval matrix
-    if: startsWith(github.ref, 'refs/heads/pull-request/')
+    if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, vss-skill-eval-runner]
     timeout-minutes: 15
     outputs:
@@ -92,13 +93,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          REF="${{ github.ref_name }}"          # "pull-request/100"
-          PR="${REF##pull-request/}"
-          echo "number=$PR" >> "$GITHUB_OUTPUT"
-          # Query the source PR for its base branch (never hardcode develop).
-          BASE=$(gh pr view "$PR" --json baseRefName --jq .baseRefName)
-          echo "base=$BASE" >> "$GITHUB_OUTPUT"
-          echo "PR #$PR, base=$BASE"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual sweep: no PR. Leave number empty — the eval legs detect
+            # "manual" and write results to their job summary instead of a PR
+            # comment; base is just this ref, for logging.
+            echo "number=" >> "$GITHUB_OUTPUT"
+            echo "base=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "manual sweep on ${{ github.ref_name }}"
+          else
+            REF="${{ github.ref_name }}"          # "pull-request/100"
+            PR="${REF##pull-request/}"
+            echo "number=$PR" >> "$GITHUB_OUTPUT"
+            # Query the source PR for its base branch (never hardcode develop).
+            BASE=$(gh pr view "$PR" --json baseRefName --jq .baseRefName)
+            echo "base=$BASE" >> "$GITHUB_OUTPUT"
+            echo "PR #$PR, base=$BASE"
+          fi
 
       - name: Compute matrix
         id: plan
@@ -107,6 +117,10 @@ jobs:
           PR_REPO: ${{ github.repository }}
           PR_BASE: ${{ steps.pr.outputs.base }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          # Manual sweep (workflow_dispatch): enumerate the picked skill('s)
+          # specs instead of diffing (plan_matrix validates the value).
+          # Empty on push, so plan diffs as usual.
+          MANUAL_SKILLS_FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.skills || '' }}
         run: python3 .github/skill-eval/plan_matrix.py
 
   # ---------------------------------------------------------------------
@@ -240,101 +254,5 @@ jobs:
         with:
           name: skills-eval-results-pr-${{ needs.plan.outputs.pr_number }}-${{ matrix.slug }}-${{ github.run_id }}
           path: /tmp/skills-eval-results-${{ matrix.slug }}-${{ github.run_id }}.tar.gz
-          if-no-files-found: ignore
-          retention-days: 7
-
-  # ---------------------------------------------------------------------
-  # manual-sweep — legacy single-agent full sweep (workflow_dispatch).
-  # No matrix: one agent enumerates every spec on the picked skill and
-  # writes per-spec tables to the Actions run summary.
-  # ---------------------------------------------------------------------
-  manual-sweep:
-    name: Manual full sweep
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, vss-skill-eval-runner]
-    timeout-minutes: 720
-    steps:
-      - name: Checkout head
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Load coordinator env
-        run: |
-          set -a
-          source /home/ubuntu/eval-coordinator/.env
-          set +a
-          printf "COORDINATOR_ENV=loaded\n" >> "$GITHUB_ENV"
-          printf "CLAUDE_CODE_DISABLE_THINKING=1\n" >> "$GITHUB_ENV"
-
-      - name: Run skills eval agent (full sweep)
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_CONFIG_DIR: ${{ runner.temp }}/gh-skill-eval-${{ github.run_id }}
-          INPUT_SKILLS: ${{ inputs.skills }}
-          # See the single-spec step for the rationale — keep the foreground
-          # `uvx harbor run` from being auto-backgrounded at the 10-min cap.
-          BASH_DEFAULT_TIMEOUT_MS: "7200000"
-          BASH_MAX_TIMEOUT_MS: "10800000"
-        run: |
-          mkdir -p "$GH_CONFIG_DIR"
-          set -a
-          source /home/ubuntu/eval-coordinator/.env
-          set +a
-          export PR_HEAD_SHA="${{ github.sha }}"
-          export PR_REPO="${{ github.repository }}"
-          export GITHUB_RUN_ID="${{ github.run_id }}"
-          # Sanity-check the free-form skill filter: `*`, blank, or a bare
-          # skill-dir name — reject anything with slashes/dots that could
-          # escape skills/.
-          if [ "${INPUT_SKILLS}" != "*" ] && [ -n "${INPUT_SKILLS}" ]; then
-            if ! [[ "${INPUT_SKILLS}" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_-]*$ ]]; then
-              echo "::error::skills='${INPUT_SKILLS}' is not a valid skill-dir name."
-              exit 1
-            fi
-            if [ ! -d "skills/${INPUT_SKILLS}" ]; then
-              echo "::error::skills/${INPUT_SKILLS}/ does not exist on this ref."
-              exit 1
-            fi
-          fi
-          export MANUAL_FULL_SWEEP=1
-          export MANUAL_SKILLS_FILTER="${INPUT_SKILLS}"
-          export PYTHONPATH="${GITHUB_WORKSPACE}/.github/skill-eval:${PYTHONPATH:-}"
-          mkdir -p /tmp/brev /tmp/skill-eval
-          python3 .github/skill-eval/skills_eval_agent.py
-
-      - name: Collect sweep results for workflow artifact
-        if: always()
-        run: |
-          # A sweep runs many (skill,spec,platform) legs, each writing
-          # /tmp/skill-eval/results/<slug>/<run_id>/, plus the assembled
-          # /tmp/skill-eval/<run_id>/benchmark.md. Bundle every result tree
-          # for this run + the benchmark into one artifact so a sweep is as
-          # debuggable as a per-leg push run. Exclude per-trial agent/
-          # trajectories — same secret hygiene as the eval job (they can
-          # carry .env / NGC key values).
-          RUN="${{ github.run_id }}"
-          OUT="/tmp/skills-eval-sweep-${RUN}.tar.gz"
-          MEMBERS=()
-          while IFS= read -r d; do
-            MEMBERS+=("${d#/}")          # tar relative to / (no leading-/ warning)
-          done < <(find /tmp/skill-eval/results -mindepth 2 -maxdepth 2 \
-                     -type d -name "$RUN" 2>/dev/null)
-          if [ -f "/tmp/skill-eval/${RUN}/benchmark.md" ]; then
-            MEMBERS+=("tmp/skill-eval/${RUN}/benchmark.md")
-          fi
-          if [ ${#MEMBERS[@]} -eq 0 ]; then
-            echo "no sweep results or benchmark for run ${RUN} — nothing to archive"
-            exit 0
-          fi
-          tar czf "$OUT" -C / --exclude='agent' "${MEMBERS[@]}"
-          echo "archived ${#MEMBERS[@]} member(s) into $OUT (agent/ trajectories excluded)"
-
-      - name: Upload sweep results artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: skills-eval-sweep-${{ github.run_id }}
-          path: /tmp/skills-eval-sweep-${{ github.run_id }}.tar.gz
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -120,7 +120,10 @@ jobs:
           # Manual sweep (workflow_dispatch): enumerate the picked skill('s)
           # specs instead of diffing (plan_matrix validates the value).
           # Empty on push, so plan diffs as usual.
-          MANUAL_SKILLS_FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.skills || '' }}
+          # Blank input → `*` (sweep all), matching the dropdown default and
+          # the old behavior — never blank, which would fall through to the
+          # diff path and silently produce an empty matrix.
+          MANUAL_SKILLS_FILTER: ${{ github.event_name == 'workflow_dispatch' && (inputs.skills || '*') || '' }}
         run: python3 .github/skill-eval/plan_matrix.py
 
   # ---------------------------------------------------------------------


### PR DESCRIPTION
## What

A `workflow_dispatch` sweep ran **one agent serially over every spec** of the picked skill (the legacy `manual-sweep` job) — no parallelism, no per-leg isolation, and a single 502/crash killed the whole sweep. This unifies manual dispatch onto the **same matrix as a push**:

- **`plan_matrix.py`** — manual mode: when `MANUAL_SKILLS_FILTER` is set, enumerate the chosen skill('s) specs (`*` = all) instead of diffing, so `build_matrix` fans them per `(spec, platform)` like a push. Validates the filter against path escape. **+1 test.**
- **`skills-eval.yml`** — `plan` now also runs on `workflow_dispatch`; `eval`'s `if: has_targets` already fires for any event; the single-agent **`manual-sweep` job is removed**.
- **`skills_eval_agent.py`** — dropped `MANUAL_FULL_SWEEP`. Single-spec mode handles an empty `PR_NUMBER` (manual): appends the result to the leg's `$GITHUB_STEP_SUMMARY` instead of `gh pr comment`; a missing/stale adapter `BLOCKED`s with a note (no branch to auto-commit to).
- **AGENTS.md** — rewrote § "Manual full-sweep mode" to the matrix behavior; § "Result comment format" routes output by `PR_NUMBER`; § 3c notes the manual no-commit case.

## Result
A manual sweep is now **N parallel per-`(spec,platform)` legs** with isolation + per-leg artifacts, identical to a push — a 502/crash fails one leg, not the whole sweep. Trade-off: no single aggregated `benchmark.md`; each leg's result lands in its own job summary + artifact.

## Verification
`py_compile` clean; 16 plan_matrix tests pass (incl. new manual-mode test); workflow YAML parses (jobs: `plan`, `eval`).

Builds on #891 (auto-commit adapters), now merged — rebased onto `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)