### PR TITLE
refactor(behavior-analytics): enhance compose file and documentation

### DIFF
--- a/deploy/docker/services/analytics/behavior-analytics/compose.yml
+++ b/deploy/docker/services/analytics/behavior-analytics/compose.yml
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Shared base for the vss-behavior-analytics image. Default entrypoint is 2D warehouse;
-# extending services set `command`, profiles, container_name, and volumes as needed.
+# Shared base for the vss-behavior-analytics image. Default entrypoint is 2D warehouse.
 #
-# Mount `/resources/vss-behavior-analytics-config.json` in each app compose file (warehouse,
-# dev-profile-alerts, etc.) so it overrides cleanly — do not duplicate that mount here, or Compose
-# `extends` would merge two binds to the same path. Do not `include` this file — use `extends` only.
+# The base ships a working default mount + command so this file is runnable standalone
+# (e.g. via `docker compose -f .../compose.yml up -d vss-behavior-analytics-base`)
+# Extending services override `command`, profiles, container_name, and the volume target at the same path
+# Compose `extends` deduplicates bind targets by container-side path, so the child's mount wins cleanly.
+# Do not `include` this file — use `extends` only.
 
 services:
 
@@ -28,4 +29,4 @@ services:
     restart: always
     volumes:
       - $VSS_APPS_DIR/services/analytics/behavior-analytics/configs/vss-behavior-analytics-config.json:/resources/vss-behavior-analytics-config.json
-    command: python3 apps/analytics/main_analytics_2d_app.py --config resources/warehouse_2d_config.json
+    command: python3 apps/analytics/main_analytics_2d_app.py --config /resources/vss-behavior-analytics-config.json

--- a/skills/README.md
+++ b/skills/README.md
@@ -109,7 +109,7 @@ Match the user's intent to a skill. Start here before opening any individual `SK
 | Skill | Description |
 |---|---|
 | [vss-manage-alerts](vss-manage-alerts/SKILL.md) | Add, manage, and monitor alerts on streamed video — CV verification mode or VLM real-time mode, Alert-Bridge subscriptions, Slack notifications, camera onboarding. |
-| [vss-setup-behavior-analytics](vss-setup-behavior-analytics/SKILL.md) | Deploy the `vss-behavior-analytics` service standalone (events, incidents, violation rules) without the full warehouse stack. |
+| [vss-setup-behavior-analytics](vss-setup-behavior-analytics/SKILL.md) | Deploy the `vss-behavior-analytics` service standalone — pick the entrypoint (Analytics 2D / 3D / mv3dt, dev_example, fusion_search), point it at a profile-shipped or custom config and optional calibration, and (with a Kafka / Redis Streams / MQTT broker reachable) push dynamic-config and dynamic-calibration updates over the `mdx-notification` topic — all without bringing up the full warehouse stack. |
 | [vss-setup-video-analytics-api](vss-setup-video-analytics-api/SKILL.md) | Deploy the `vss-video-analytics-api` REST service standalone against custom Elasticsearch and Kafka infrastructure. |
 
 ### Layer 3 — Agent & offline processing

--- a/skills/vss-setup-behavior-analytics/SKILL.md
+++ b/skills/vss-setup-behavior-analytics/SKILL.md
@@ -14,7 +14,7 @@ Deploy the behavior-analytics service standalone with the user's chosen entrypoi
 
 ## Instructions
 
-Follow the routing tables and step-by-step workflows below. Each section that ends in *workflow*, *quick start*, or *flow* is intended to be executed top-to-bottom. Detailed reference material lives in `references/` and helper scripts live in `scripts/` — call them via `run_script` when the skill points to a script by name.
+Follow the routing tables and step-by-step workflows below. Each section that ends in *workflow*, *quick start*, or *flow* is intended to be executed top-to-bottom. Detailed reference material lives in `references/`.
 
 ## Examples
 

--- a/skills/vss-setup-behavior-analytics/references/configuration.md
+++ b/skills/vss-setup-behavior-analytics/references/configuration.md
@@ -1,8 +1,8 @@
-> Part of behavior-analytics docs. See `../README.md` for the overview.
+> See [`../SKILL.md`](../SKILL.md) for the overview.
 # Configuration Guide
 
 ## Overview
-Configurations are JSON files consumed by `AppConfig` (`src/mdx/analytics/core/schema/config.py`).
+Configurations are JSON files consumed by `AppConfig` (`video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/schema/config.py`).
 
 ## Structure
 ```json
@@ -29,7 +29,7 @@ Configurations are JSON files consumed by `AppConfig` (`src/mdx/analytics/core/s
 - `sourceType` / `sinkType`: typically "kafka" (also supports `redisStream`, `mqtt`)
 - `spaceAnalyticsIntervalSec`: "5.0"
 - Playback: `playbackLoop`, `playbackSensors`, `playbackInSimulationMode`, etc.
-- Trajectory/space: `traj*`, `spaceAnalytics*`, see `config.py` for full list.
+- Trajectory/space: `traj*`, `spaceAnalytics*`, see `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/schema/config.py` for full list.
 
 ## Common sensor keys (examples)
 - `tripwireMinPoints`: "5"
@@ -63,15 +63,18 @@ Configurations are JSON files consumed by `AppConfig` (`src/mdx/analytics/core/s
 - All incident types (proximity, restricted area, confined area, FOV count) default to disabled (`...IncidentEnable = "false"`). Set the corresponding `...IncidentEnable = "true"` to turn them on.
 - Each type has its own `...Threshold` (duration in sec) and `...ExpirationWindow` (gap tolerance in sec); both default to `"1"`.
 - FOV count additionally requires `fovCountViolationIncidentObjectThreshold` — the object type being counted.
-- Details and timing: `readmes/incident-detection.md`.
+- Details and timing: `video-search-and-summarization/services/analytics/behavior-analytics/docs/incident-detection.md`.
 
 ## Examples directory
-- `configs/smart_city_config*.json`
-- `configs/warehouse_2d_config.json`
-- `configs/warehouse_3d_config.json`
-- `configs/public_safety_config.json`
-- `configs/frame_playback_config.json`
-- `configs/rtls_amr_playback_config.json`
+
+Under `video-search-and-summarization/services/analytics/behavior-analytics/configs/`:
+
+- `smart_city_config*.json`
+- `warehouse_2d_config.json`
+- `warehouse_3d_config.json`
+- `public_safety_config.json`
+- `frame_playback_config.json`
+- `rtls_amr_playback_config.json`
 
 ## Messaging blocks
 - Kafka: brokers, group, topics under `kafka`.

--- a/skills/vss-setup-behavior-analytics/references/dynamic-calibration.md
+++ b/skills/vss-setup-behavior-analytics/references/dynamic-calibration.md
@@ -1,7 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-> Part of behavior-analytics docs. See `../README.md` for the project overview.
+> See [`../SKILL.md`](../SKILL.md) for the project overview.
 
 # Dynamic Calibration
 
@@ -65,6 +62,8 @@ The action prefix is parsed by `reload_data` (`os.path.basename(file_path).split
 
 ## Component map
 
+Under `video-search-and-summarization/services/analytics/behavior-analytics/`:
+
 ```
 src/mdx/analytics/core/transform/calibration/
 ├── calibration_listener.py    # Main-process consumer thread: drain mdx-notification
@@ -78,11 +77,11 @@ src/mdx/analytics/core/transform/calibration/
 ├── calibration_dynamic.py     # Wrapper that one-time-switches from
 │                              # no-file to a typed calibration when the
 │                              # first event lands
-└── schemas/calibration.schema.json  # Vendored from video-analytics-api/src/web-api-core/
-                                     # schemas/ajv/calibration.json
+└── schemas/calibration.schema.json  # Vendored from
+                                     # video-search-and-summarization/services/analytics/video-analytics-api/src/web-api-core/schemas/ajv/calibration.json
 ```
 
-Wired up in `src/mdx/analytics/core/app/app_runner.py` (one `CalibrationListener` and one `CalibrationBase`-derived instance per main process). Unlike dynamic config, calibration is **not** per-worker — workers pickle the parent's calibration at fork time and the live updates happen in the parent's watcher. Workers see the new sensor map by reading at use-time via the parent's `CalibrationBase` reference.
+Wired up in `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_runner.py` (one `CalibrationListener` and one `CalibrationBase`-derived instance per main process). Unlike dynamic config, calibration is **not** per-worker — workers pickle the parent's calibration at fork time and the live updates happen in the parent's watcher. Workers see the new sensor map by reading at use-time via the parent's `CalibrationBase` reference.
 
 ---
 
@@ -123,7 +122,7 @@ it locally to drop the notification, the watcher relies on the outer
 
 ### Schema vendoring
 
-The vendored `calibration.schema.json` is a one-way mirror of `video-analytics-api/src/web-api-core/schemas/ajv/calibration.json` with two normalizations:
+The vendored `calibration.schema.json` is a one-way mirror of `video-search-and-summarization/services/analytics/video-analytics-api/src/web-api-core/schemas/ajv/calibration.json` with two normalizations:
 
 1. AJV's non-standard `errorMessage` keyword stripped (Python's `jsonschema` ignores it; removing keeps the file readable).
 2. Top-level `additionalProperties` relaxed from `false` to `true` for forward-compatibility with any new top-level field video analytics api may add. Nested `additionalProperties: false` is preserved.
@@ -156,7 +155,7 @@ DynamicCalibration(config, calibration_path=None)
 
 After the one-time switch, the inherited `CalibrationBase` watcher continues to drive `reload_data`, which now delegates to the typed `_calibrator`. The switch is guarded by `_switch_lock` so a burst of file events can't double-switch.
 
-See `src/mdx/analytics/core/transform/calibration/calibration_dynamic.py` and the unit tests in `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_dynamic.py` for the contract.
+See `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/transform/calibration/calibration_dynamic.py` and the unit tests in `video-search-and-summarization/services/analytics/behavior-analytics/tests/unit/mdx/analytics/core/transform/calibration/test_calibration_dynamic.py` for the contract.
 
 ---
 
@@ -167,11 +166,13 @@ See `src/mdx/analytics/core/transform/calibration/calibration_dynamic.py` and th
 3. **Stale-timestamp filter is monotone.** `CalibrationListener` rejects any notification whose `timestamp` is `<= last_insert_timestamp`. After a Kafka offset reset (or replay from offset 0), old notifications are silently skipped. This is intentional — out-of-order deliveries would otherwise corrupt the in-memory map.
 4. **`globalROIs` is not read.** Legacy test fixtures use `globalROIs` (CamelCase). Production code reads `rois` (lowercase). The vendored schema follows `rois`. Migration of legacy data is operator-owned.
 5. **No ACK back to video analytics api.** The dynamic-config flow publishes `ack` after applying; the calibration flow does not. A worker-side validation failure is observable only via container logs (`calibration schema violation (...)`).
-6. **No schema-sync automation between repos.** The vendored `calibration.schema.json` must be manually re-synced when `video-analytics-api/src/web-api-core/schemas/ajv/calibration.json` changes.
+6. **No schema-sync automation between repos.** The vendored `calibration.schema.json` must be manually re-synced when `video-search-and-summarization/services/analytics/video-analytics-api/src/web-api-core/schemas/ajv/calibration.json` changes.
 
 ---
 
 ## Testing approach
+
+Test files live under `video-search-and-summarization/services/analytics/behavior-analytics/`:
 
 | Layer | Test file | What to add |
 |---|---|---|
@@ -179,18 +180,20 @@ See `src/mdx/analytics/core/transform/calibration/calibration_dynamic.py` and th
 | Listener | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_listener.py` | Test new notification shapes, atomic-write behavior, pruning. |
 | Watcher | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_base.py` (`CalibrationFileMonitor`) | Test new event-handling paths in `on_moved`. |
 | Base reload | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_base.py` | Test new `update_calibration_info` branches, `_load_sensors` extraction. |
-| Typed subclasses | `test_calibration.py` / `test_calibration_e.py` / `test_calibration_i.py` | Test sensor-type-specific logic. |
-| DynamicCalibration | `test_calibration_dynamic.py` | Test the one-time switch and `reload_data` override. |
+| Typed subclasses | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration.py` / `test_calibration_e.py` / `test_calibration_i.py` | Test sensor-type-specific logic. |
+| DynamicCalibration | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_dynamic.py` | Test the one-time switch and `reload_data` override. |
 | End-to-end | `tests/integration/dynamic_calibration/dynamic_calibration_e2e.py` | Add a scenario for new wire-level behavior. See its README. |
 
-Aim for 100% line + branch coverage on new code under `transform/calibration/`. Keep parity with the dynamic-config side.
+Aim for 100% line + branch coverage on new code under `src/mdx/analytics/core/transform/calibration/`. Keep parity with the dynamic-config side.
 
 ---
 
 ## Where to find canonical examples
 
+Consumer-side paths are under `video-search-and-summarization/services/analytics/behavior-analytics/`; the producer-side path is under `video-search-and-summarization/services/analytics/video-analytics-api/`.
+
 - Listener (atomic-write contract): `src/mdx/analytics/core/transform/calibration/calibration_listener.py`.
 - Watcher (`on_moved` + dotfile filter): `src/mdx/analytics/core/transform/calibration/calibration_base.py::CalibrationFileMonitor`.
 - Validator (per-action dispatch + minimal delete schema): `src/mdx/analytics/core/transform/calibration/calibration_validator.py`.
 - One-time switch on `DynamicCalibration`: `src/mdx/analytics/core/transform/calibration/calibration_dynamic.py::reload_data`.
-- Producer side (for reference): `video-analytics-api/src/web-api-core/Services/Calibration.js::upsert`, `::deleteSensors`, plus `Services/NotificationManager.js::produceCalibrationNotification`.
+- Producer side (for reference, in `video-analytics-api/`): `src/web-api-core/Services/Calibration.js::upsert`, `::deleteSensors`, plus `src/web-api-core/Services/NotificationManager.js::produceCalibrationNotification`.

--- a/skills/vss-setup-behavior-analytics/references/dynamic-calibration.md
+++ b/skills/vss-setup-behavior-analytics/references/dynamic-calibration.md
@@ -180,7 +180,7 @@ Test files live under `video-search-and-summarization/services/analytics/behavio
 | Listener | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_listener.py` | Test new notification shapes, atomic-write behavior, pruning. |
 | Watcher | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_base.py` (`CalibrationFileMonitor`) | Test new event-handling paths in `on_moved`. |
 | Base reload | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_base.py` | Test new `update_calibration_info` branches, `_load_sensors` extraction. |
-| Typed subclasses | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration.py` / `test_calibration_e.py` / `test_calibration_i.py` | Test sensor-type-specific logic. |
+| Typed subclasses | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration.py`, `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_e.py`, `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_i.py` | Test sensor-type-specific logic. |
 | DynamicCalibration | `tests/unit/mdx/analytics/core/transform/calibration/test_calibration_dynamic.py` | Test the one-time switch and `reload_data` override. |
 | End-to-end | `tests/integration/dynamic_calibration/dynamic_calibration_e2e.py` | Add a scenario for new wire-level behavior. See its README. |
 

--- a/skills/vss-setup-behavior-analytics/references/dynamic-config.md
+++ b/skills/vss-setup-behavior-analytics/references/dynamic-config.md
@@ -1,4 +1,4 @@
-> Part of behavior-analytics docs. See `../README.md` for the project overview.
+> See [`../SKILL.md`](../SKILL.md) for the project overview.
 
 # Dynamic Configuration
 
@@ -196,6 +196,8 @@ Read-only sections (`kafka`, `redisStream`, `mqtt`, `coordinateReferenceSystem`,
 
 ## Component map
 
+Under `video-search-and-summarization/services/analytics/behavior-analytics/`:
+
 ```
 src/mdx/analytics/core/transform/config/
 ├── config_validator.py        # Stateless validation: shape -> scope -> allowlist -> per-key value
@@ -206,7 +208,7 @@ src/mdx/analytics/core/transform/config/
 └── config_monitor.py          # Per-worker watchdog: pick up files written by the listener
 ```
 
-Wired up in `src/mdx/analytics/core/app/app_runner.py` (one `ConfigListener` per main process) and `src/mdx/analytics/core/app/app_base.py` (one `ConfigFileMonitor` per worker). The listener writes a JSON file into `CONFIG_DIR` (default `/tmp/checkpoint/config`) on every successful apply; each worker's `ConfigFileMonitor` picks up the file via watchdog `on_moved` and applies through its own local `ConfigApplier`.
+Wired up in `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_runner.py` (one `ConfigListener` per main process) and `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_base.py` (one `ConfigFileMonitor` per worker). The listener writes a JSON file into `CONFIG_DIR` (default `/tmp/checkpoint/config`) on every successful apply; each worker's `ConfigFileMonitor` picks up the file via watchdog `on_moved` and applies through its own local `ConfigApplier`.
 
 ### Why per-worker monitor, not per-process
 
@@ -258,6 +260,8 @@ Note the deliberate split between "zero items in input" (success no-op) and "ite
 
 ## Testing approach
 
+Test files live under `video-search-and-summarization/services/analytics/behavior-analytics/`:
+
 | Layer | Test file | What to add |
 |---|---|---|
 | Cache invalidation | `tests/unit/mdx/analytics/core/schema/test_config.py::TestAppConfig` | Test that mutating + `invalidate_caches()` flips a cached property's value. |
@@ -269,11 +273,13 @@ Note the deliberate split between "zero items in input" (success no-op) and "ite
 | Worker file monitor | `tests/unit/mdx/analytics/core/transform/config/test_config_monitor.py` | Test new file-handling paths. |
 | End-to-end | `tests/integration/dynamic_config/dynamic_config_e2e.py` | Add a scenario for new wire-level behavior. See its README. |
 
-Aim for 100% line + branch coverage on new code under `transform/config/`. The six modules there are at 100% today — keep that bar.
+Aim for 100% line + branch coverage on new code under `src/mdx/analytics/core/transform/config/`. The six modules there are at 100% today — keep that bar.
 
 ---
 
 ## Where to find canonical examples
+
+All paths below are under `video-search-and-summarization/services/analytics/behavior-analytics/`:
 
 - Read-at-use consumer: `src/mdx/analytics/core/stream/state/behavior/state_management_base.py` (just stores the `AppConfig` reference; reads at use-time).
 - Per-call value-capture: `src/mdx/analytics/core/stream/state/behavior/state_management_e.py::_create_trajectory` (passes values into a per-call sub-object).


### PR DESCRIPTION
- Updated the `compose.yml` for the `vss-behavior-analytics` service to clarify the default entrypoint and mount configurations, ensuring it can run standalone.
- Revised the README and SKILL documentation for `vss-setup-behavior-analytics` to provide clearer instructions on deploying the service with customizable entrypoints and configurations.
- Improved references in the configuration and dynamic calibration documentation to point to the correct file paths, enhancing user guidance.

This update aims to streamline the deployment process and improve clarity for users working with the behavior analytics service.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
