### PR TITLE
docs(skills): document DGX Spark -sbsa container caveat in edge.md

### DIFF
--- a/skills/vss-deploy-profile/references/edge.md
+++ b/skills/vss-deploy-profile/references/edge.md
@@ -252,6 +252,13 @@ Then follow `SKILL.md` Steps 3-5. Thor uses the default 35% GPU budget for
 
 ## Caveats
 
+- **DGX Spark needs the `-sbsa` container images.** GB10/DGX Spark runs the dGPU/SBSA
+  driver (not Tegra/L4T); the default image tags pull the Tegra DeepStream build, which
+  crash-loops on missing `libnvbufsurface.so.1.0.0` / `libnvrm_mem.so`. `dev-profile.sh`
+  auto-swaps the `-sbsa` variants for `HARDWARE_PROFILE=DGX-SPARK`. When writing
+  `generated.env` directly, set each image tag to its `-sbsa` variant (the commented
+  `# …-sbsa` line in the profile's `.env`): `RTVI_VLM_IMAGE_TAG` (RT-VLM),
+  `PERCEPTION_TAG` (RT-CV), and `LVS_TAG` (LVS).
 - **DGX Spark NIM is local but configured as remote in VSS.** This is only
   because the image is not wired into compose yet. `LLM_MODE=remote` skips the
   local LLM compose service and points the agent at `localhost:30081`.


### PR DESCRIPTION
## Summary

Document the DGX Spark `-sbsa` container-image requirement as an edge deployment caveat in `edge.md`.

On GB10/DGX Spark (dGPU/**SBSA** driver, **not** Tegra/L4T), the default image tags pull the **Tegra** DeepStream build, which crash-loops on missing `libnvbufsurface.so.1.0.0` / `libnvrm_mem.so` (RT-VLM / RT-CV never reach `healthy`, and the services gated on them stay stuck). `dev-profile.sh` already auto-swaps the `-sbsa` variants for `HARDWARE_PROFILE=DGX-SPARK`, but the skill's compose-centric path (writing `generated.env` directly) does not run that script — so the caveat documents the image-tag keys to set manually:

- `RTVI_VLM_IMAGE_TAG` (RT-VLM) — base / alerts / lvs
- `PERCEPTION_TAG` (RT-CV) — alerts / search
- `LVS_TAG` (LVS) — lvs

Each profile's `.env` carries the `-sbsa` value as a commented line (the same source `dev-profile.sh`'s DGX-SPARK swap reads).

Ref: NVBug 6257334.

## Validation

- Caveat added under `## Caveats` in `skills/vss-deploy-profile/references/edge.md` (docs-only, +7 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
