### PR TITLE
docs: clarify container license terms

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -238,5 +238,21 @@ uv run mypy src/vss_agents/
 
 ## License
 
-[Apache-2.0](LICENSE.md). Third-party licenses: [LICENSE-3rd-party.txt](LICENSE-3rd-party.txt).
+This module is governed by **two separate licenses**, depending on what you use:
 
+- **The source code in this directory and its subdirectories is licensed under the Apache License,
+  Version 2.0.** The full license text is at the repository root: [`LICENSE`](../../LICENSE). If you
+  clone, build, modify, or redistribute the source, Apache 2.0 terms apply.
+
+- **The pre-built VSS Agent container images distributed by NVIDIA via NGC**
+  (`nvcr.io/nvidia/blueprint/vss-agent` and related tags) **are licensed under the NVIDIA Software
+  License Agreement.** The full agreement is included in this directory as
+  [`NVIDIA-Software-License-Agreement.pdf`](./NVIDIA-Software-License-Agreement.pdf). If you pull and
+  use NVIDIA's pre-built container images, the NVIDIA Software License Agreement governs your use.
+
+Third-party open-source components bundled in the container image are attributed in
+[`LICENSE-3rd-party.txt`](./LICENSE-3rd-party.txt).
+
+The presence of `NVIDIA-Software-License-Agreement.pdf` in this directory does **not** modify the
+Apache 2.0 license that governs the source code in this repository. It is included here so that the
+pre-built container images carry the license they ship under.

--- a/services/alert/README.md
+++ b/services/alert/README.md
@@ -137,6 +137,21 @@ required SPDX license headers, and the DCO sign-off requirement.
 
 ## License
 
-The Alerts Microservice is licensed under the Apache License, Version 2.0 — see
-the repository root [`LICENSE`](../../LICENSE). Third-party dependency licenses
-are listed in [`LICENSE-3rd-party.txt`](LICENSE-3rd-party.txt).
+This module is governed by **two separate licenses**, depending on what you use:
+
+- **The source code in this directory and its subdirectories is licensed under the Apache License,
+  Version 2.0.** The full license text is at the repository root: [`LICENSE`](../../LICENSE). If you
+  clone, build, modify, or redistribute the source, Apache 2.0 terms apply.
+
+- **The pre-built VSS Alert container images distributed by NVIDIA via NGC**
+  (`nvcr.io/nvidia/blueprint/vss-alert-verification` and related tags) **are licensed under the
+  NVIDIA Software License Agreement.** The full agreement is included in this directory as
+  [`NVIDIA-Software-License-Agreement.pdf`](./NVIDIA-Software-License-Agreement.pdf). If you pull and
+  use NVIDIA's pre-built container images, the NVIDIA Software License Agreement governs your use.
+
+Third-party open-source components bundled in the container image are attributed in
+[`LICENSE-3rd-party.txt`](./LICENSE-3rd-party.txt).
+
+The presence of `NVIDIA-Software-License-Agreement.pdf` in this directory does **not** modify the
+Apache 2.0 license that governs the source code in this repository. It is included here so that the
+pre-built container images carry the license they ship under.

--- a/services/ui/README.md
+++ b/services/ui/README.md
@@ -178,3 +178,24 @@ services/ui/create-third-party-deps-tar.sh
 ```
 
 Requires Docker. The script reads the Node version from `services/ui/.nvmrc` and runs in a matching `node:<version>` container (override with `NODE_IMAGE` if needed). It runs `npm ci` (devDependencies are build-only tools), then `turbo run build bundle`, then archives only standalone traced `node_modules` and `custom-server.js` runtime deps—not the full workspace `node_modules` and not a plain `npm ci --omit=dev` tree (which omits some runtime packages and still includes unused production installs). Output is `services/ui/third-party-deps-sources-YYYYMMDD-HHMMSS.tar.gz`.
+
+## License
+
+This module is governed by **two separate licenses**, depending on what you use:
+
+- **The source code in this directory and its subdirectories is licensed under the MIT License.** The
+  full license text is included in this directory: [`LICENSE`](./LICENSE). If you clone, build, modify,
+  or redistribute the source, MIT License terms apply.
+
+- **The pre-built VSS Agent UI container images distributed by NVIDIA via NGC**
+  (`nvcr.io/nvidia/blueprint/vss-agent-ui` and related tags) **are licensed under the NVIDIA Software
+  License Agreement.** The full agreement is included in this directory as
+  [`NVIDIA-Software-License-Agreement.pdf`](./NVIDIA-Software-License-Agreement.pdf). If you pull and
+  use NVIDIA's pre-built container images, the NVIDIA Software License Agreement governs your use.
+
+Third-party open-source components bundled in the container image are attributed in
+[`LICENSE-3rd-party.txt`](./LICENSE-3rd-party.txt).
+
+The presence of `NVIDIA-Software-License-Agreement.pdf` in this directory does **not** modify the MIT
+License that governs the source code in this directory. It is included here so that the pre-built
+container images carry the license they ship under.


### PR DESCRIPTION
## Summary
- Clarifies that source code and NVIDIA-distributed pre-built container images are governed by separate license terms.
- Adds the container license notice to `services/agent`, `services/alert`, and `services/ui`, which carry `NVIDIA-Software-License-Agreement.pdf`.
- Preserves the UI source license as MIT while documenting NVIDIA Software License Agreement terms for the UI container image.

## Test plan
- Pre-commit hooks ran during commit: TruffleHog, SPDX header check, and relevant lint/test hooks.
- Ran `git diff --check`.
- Checked IDE markdown diagnostics; remaining markdownlint warnings are pre-existing style issues in the edited README files.
