### PR TITLE
ci: skip container-source gate for docs/tests-only changes

### DIFF
--- a/.github/scripts/source_check_only_nonbuild.py
+++ b/.github/scripts/source_check_only_nonbuild.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Decide whether a PR touches only non-build files under a service folder.
+
+The ``Check {Agent,UI} Container Source`` gates compare the git tree SHA of
+``services/agent`` / ``services/ui`` against the ``com.nvidia.vss.source_tree_sha``
+baked into the deployed image. That tree SHA covers the *whole* folder, so a
+docs- or tests-only change (which never enters the image — the Dockerfiles use
+selective ``COPY`` / a ``.dockerignore``) still trips the gate and forces a
+needless container re-spin or manifest re-stamp.
+
+This helper is the stop-gap: it prints ``true`` when **every** file the PR
+changed under the service folder is one the image build provably does not
+consume, so the caller can skip the SHA comparison for that run. It prints
+``false`` (run the real check) whenever it is unsure — unknown base, an
+integration-branch push, or any build-relevant file in the diff.
+
+The durable fix is to make the source_tree_sha cover only build inputs (honor
+the ``.dockerignore`` / COPY set) on both the build-stamp and check sides; once
+that lands this helper can be removed.
+
+Output: a single ``true``/``false`` token on stdout. Diagnostics go to stderr.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+# Image name -> source folder (must match check_container_tag_source.py).
+SOURCE_PATHS = {
+    "vss-agent": "services/agent",
+    "vss-agent-ui": "services/ui",
+}
+
+# Paths (relative to the service folder) the image build does NOT consume.
+#
+# vss-agent: services/agent/docker/Dockerfile uses selective COPY of
+#   pyproject.toml, uv.lock, src/, 3rdparty/, docker/*.py and the license
+#   files — so the service-root docs, tests/, stubs/ and CI-metadata files
+#   below never enter the build context. Note the patterns are anchored to the
+#   service root: src/vss_agents/**/README.md IS copied and must NOT be ignored.
+#
+# vss-agent-ui: services/ui/.dockerignore excludes **/*.md and *.test.*/*.spec.*
+#   from the build context, so markdown and test/spec files never ship.
+NONBUILD_PATTERNS = {
+    "vss-agent": [
+        "AGENTS.md",
+        "README.md",
+        "LICENSE.md",
+        "tests/**",
+        "stubs/**",
+        ".gitattributes",
+        ".gitleaks.toml",
+        ".secrets.baseline",
+        "gitleaks-baseline.json",
+    ],
+    "vss-agent-ui": [
+        "**/*.md",
+        "*.md",
+        "**/*.test.*",
+        "**/*.spec.*",
+        "*.test.*",
+        "*.spec.*",
+    ],
+}
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def matches(rel: str, pattern: str) -> bool:
+    base = rel.rsplit("/", 1)[-1]
+    if pattern.endswith("/**") or pattern.endswith("/*"):
+        directory = pattern.rsplit("/", 1)[0].rstrip("/")
+        return rel == directory or rel.startswith(directory + "/")
+    if pattern.startswith("**/"):
+        return fnmatch.fnmatch(rel, pattern) or fnmatch.fnmatch(base, pattern[3:])
+    if "/" not in pattern and ("*" in pattern or "?" in pattern):
+        return fnmatch.fnmatch(base, pattern)
+    return rel == pattern
+
+
+def is_nonbuild(rel: str, patterns: list[str]) -> bool:
+    return any(matches(rel, p) for p in patterns)
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image-name", choices=sorted(SOURCE_PATHS), required=True)
+    parser.add_argument("--base-ref", default="origin/develop")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    repo = args.repo_root.resolve()
+    source_path = SOURCE_PATHS[args.image_name]
+    patterns = NONBUILD_PATTERNS[args.image_name]
+
+    # Always run the full check on integration-branch pushes — there is no PR
+    # diff to scope against and we want the develop/main health signal.
+    ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    if ref_name in ("develop", "main"):
+        log(f"on integration branch {ref_name!r}; running full source check.")
+        print("false")
+        return 0
+
+    # Make sure the base ref is present, then find the merge-base.
+    remote_base = args.base_ref.split("/", 1)[-1] if "/" in args.base_ref else args.base_ref
+    git(repo, "fetch", "--no-tags", "--quiet", "origin", remote_base)
+    mb = git(repo, "merge-base", "HEAD", args.base_ref)
+    if mb.returncode != 0 or not mb.stdout.strip():
+        log(f"could not find merge-base with {args.base_ref}; running full source check.")
+        print("false")
+        return 0
+    base = mb.stdout.strip()
+
+    diff = git(repo, "diff", "--name-only", base, "HEAD", "--", f"{source_path}/")
+    if diff.returncode != 0:
+        log(f"git diff failed ({diff.stderr.strip()}); running full source check.")
+        print("false")
+        return 0
+
+    changed = [line for line in diff.stdout.splitlines() if line.strip()]
+    if not changed:
+        log(f"no changes under {source_path}/ vs {base[:12]}; running full source check.")
+        print("false")
+        return 0
+
+    log(f"changed files under {source_path}/ (vs {base[:12]}):")
+    build_relevant = []
+    for path in changed:
+        rel = path[len(source_path) + 1 :]
+        if is_nonbuild(rel, patterns):
+            log(f"  non-build : {path}")
+        else:
+            log(f"  BUILD-REL : {path}")
+            build_relevant.append(path)
+
+    if build_relevant:
+        log(
+            f"{len(build_relevant)} build-relevant file(s) changed; "
+            "running full source check."
+        )
+        print("false")
+        return 0
+
+    log(
+        f"only non-build files changed under {source_path}/; "
+        "skipping the container-source SHA check for this run."
+    )
+    print("true")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/source_check_only_nonbuild.py
+++ b/.github/scripts/source_check_only_nonbuild.py
@@ -46,8 +46,9 @@ SOURCE_PATHS = {
 #   below never enter the build context. Note the patterns are anchored to the
 #   service root: src/vss_agents/**/README.md IS copied and must NOT be ignored.
 #
-# vss-agent-ui: services/ui/.dockerignore excludes **/*.md and *.test.*/*.spec.*
-#   from the build context, so markdown and test/spec files never ship.
+# vss-agent-ui: services/ui/.dockerignore excludes **/*.md and the
+#   *.test.{js,ts,tsx} / *.spec.{js,ts,tsx} files from the build context, so
+#   markdown and those test/spec files never ship.
 NONBUILD_PATTERNS = {
     "vss-agent": [
         "AGENTS.md",
@@ -61,12 +62,16 @@ NONBUILD_PATTERNS = {
         "gitleaks-baseline.json",
     ],
     "vss-agent-ui": [
+        # Strict subset of services/ui/.dockerignore's tracked-file exclusions,
+        # so this never skips a file that could ship. (.dockerignore only drops
+        # the .js/.ts/.tsx test/spec variants — not e.g. *.test.py.)
         "**/*.md",
-        "*.md",
-        "**/*.test.*",
-        "**/*.spec.*",
-        "*.test.*",
-        "*.spec.*",
+        "**/*.test.js",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.js",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
     ],
 }
 

--- a/.github/workflows/check-agent-container-source.yml
+++ b/.github/workflows/check-agent-container-source.yml
@@ -40,8 +40,14 @@ jobs:
       # status stays green. Durable fix: scope source_tree_sha to build inputs.
       - name: Detect docs/tests-only change
         id: filter
+        continue-on-error: true  # fail safe: a helper error must not block PRs
         run: |
-          skip=$(python3 .github/scripts/source_check_only_nonbuild.py --image-name vss-agent)
+          # Any failure or non-"true" result falls through to the full check.
+          if ! skip=$(python3 .github/scripts/source_check_only_nonbuild.py --image-name vss-agent); then
+            echo "filter helper failed; running the full source check." >&2
+            skip=false
+          fi
+          [ "$skip" = "true" ] || skip=false
           echo "skip=$skip" >> "$GITHUB_OUTPUT"
 
       # Primary path reads com.nvidia.vss.source_tree_sha from the image's

--- a/.github/workflows/check-agent-container-source.yml
+++ b/.github/workflows/check-agent-container-source.yml
@@ -33,12 +33,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Docs/tests-only PRs never change what enters the agent image — the
+      # Dockerfile uses selective COPY — yet they change the services/agent
+      # tree SHA and would trip the gate below. Detect that case and skip the
+      # SHA comparison. The job still runs and reports success, so the required
+      # status stays green. Durable fix: scope source_tree_sha to build inputs.
+      - name: Detect docs/tests-only change
+        id: filter
+        run: |
+          skip=$(python3 .github/scripts/source_check_only_nonbuild.py --image-name vss-agent)
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+
       # Primary path reads com.nvidia.vss.source_tree_sha from the image's
       # OCI manifest annotations (stamped by ci-vss-oss at build time) via the
       # OCI Distribution HTTP API. NGC_CLI_API_KEY is needed to pull the
       # manifest from nvcr.io/nvstaging; without it the registry returns 401
       # and the script falls back to git-SHA resolution.
       - name: Check vss-agent tag matches services/agent
+        if: steps.filter.outputs.skip != 'true'
         env:
           NGC_CLI_API_KEY: ${{ secrets.NGC_CLI_API_KEY }}
         run: python3 .github/scripts/check_container_tag_source.py --image-name vss-agent

--- a/.github/workflows/check-ui-container-source.yml
+++ b/.github/workflows/check-ui-container-source.yml
@@ -33,12 +33,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Docs/tests-only PRs never change what enters the UI image — the build
+      # context honors services/ui/.dockerignore, which excludes **/*.md and
+      # test/spec files — yet they change the services/ui tree SHA and would
+      # trip the gate below. Detect that case and skip the SHA comparison. The
+      # job still runs and reports success, so the required status stays green.
+      # Durable fix: scope source_tree_sha to build inputs.
+      - name: Detect docs/tests-only change
+        id: filter
+        run: |
+          skip=$(python3 .github/scripts/source_check_only_nonbuild.py --image-name vss-agent-ui)
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+
       # Primary path reads com.nvidia.vss.source_tree_sha from the image's
       # OCI manifest annotations (stamped by ci-vss-oss at build time) via the
       # OCI Distribution HTTP API. NGC_CLI_API_KEY is needed to pull the
       # manifest from nvcr.io/nvstaging; without it the registry returns 401
       # and the script falls back to git-SHA resolution.
       - name: Check vss-agent-ui tag matches services/ui
+        if: steps.filter.outputs.skip != 'true'
         env:
           NGC_CLI_API_KEY: ${{ secrets.NGC_CLI_API_KEY }}
         run: python3 .github/scripts/check_container_tag_source.py --image-name vss-agent-ui

--- a/.github/workflows/check-ui-container-source.yml
+++ b/.github/workflows/check-ui-container-source.yml
@@ -41,8 +41,14 @@ jobs:
       # Durable fix: scope source_tree_sha to build inputs.
       - name: Detect docs/tests-only change
         id: filter
+        continue-on-error: true  # fail safe: a helper error must not block PRs
         run: |
-          skip=$(python3 .github/scripts/source_check_only_nonbuild.py --image-name vss-agent-ui)
+          # Any failure or non-"true" result falls through to the full check.
+          if ! skip=$(python3 .github/scripts/source_check_only_nonbuild.py --image-name vss-agent-ui); then
+            echo "filter helper failed; running the full source check." >&2
+            skip=false
+          fi
+          [ "$skip" = "true" ] || skip=false
           echo "skip=$skip" >> "$GITHUB_OUTPUT"
 
       # Primary path reads com.nvidia.vss.source_tree_sha from the image's


### PR DESCRIPTION
## Description

The **Check Agent Container Source** / **Check UI Container Source** gates hash the *entire* `services/agent` and `services/ui` trees and compare that tree SHA against the `com.nvidia.vss.source_tree_sha` baked into the deployed image. A docs- or tests-only change never alters what the image build consumes, yet it changes the folder's tree SHA and trips the gate — forcing a needless container re-spin or NGC manifest re-stamp for a README edit (e.g. #902).

This PR adds `source_check_only_nonbuild.py`. Before the SHA comparison runs, the gate checks the PR's diff under the service folder: if **every** changed file is one the build provably does not consume, it skips the comparison. The job still runs and reports success, so the required status stays green — no branch-protection change needed.

What counts as "non-build":
- **agent** — `services/agent/docker/Dockerfile` uses *selective* `COPY`, so service-root docs (`README.md`, `AGENTS.md`, `LICENSE.md`), `tests/`, `stubs/`, and CI-metadata files (`.gitleaks.toml`, `.secrets.baseline`, …) never enter the build context. Patterns are anchored to the service root — `src/vss_agents/**/README.md` **is** copied and is correctly treated as build-relevant.
- **ui** — `services/ui/.dockerignore` excludes `**/*.md` and `*.test.*`/`*.spec.*`, so markdown and test/spec files never ship.

Anything build-relevant, an unresolved merge-base, or a push to `develop`/`main` runs the full check exactly as before.

### Scope / safety
- No change to `check_container_tag_source.py` or to the build pipeline.
- The job always executes → the required status always reports (no skipped-required-check hang).
- Verified locally: agent docs-only → skip; agent `src/**/README.md` → run; agent `.py` → run; UI docs-only → skip.

### Follow-up
This is a stop-gap. The durable fix (separate PR, draft) scopes `source_tree_sha` to **build inputs** on both the build-stamp (`ci-vss-oss/ci/tools/create_manifest.py`) and check sides, after which this helper can be removed.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
