### PR TITLE
ci: scope container-source SHA to build inputs (root-cause fix for docs re-spins)

### DIFF
--- a/.github/scripts/check_container_tag_source.py
+++ b/.github/scripts/check_container_tag_source.py
@@ -29,6 +29,9 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# Sibling module in .github/scripts/ (sys.path[0] when run as a script).
+from source_tree_hash import build_input_tree_sha
+
 
 SOURCE_TREE_SHA_LABEL = "com.nvidia.vss.source_tree_sha"
 SOURCE_PATH_LABEL = "com.nvidia.vss.source_path"
@@ -522,6 +525,7 @@ def check_resolved_image(
     item: ResolvedImage,
     current_commit: str,
     current_tree: str,
+    current_build_inputs: str,
     idx: int,
     total: int,
 ) -> bool:
@@ -556,16 +560,28 @@ def check_resolved_image(
             return False
         print(f"  manifest:      {SOURCE_TREE_SHA_LABEL}={labels.source_tree_sha}")
         print(f"  comparing {src}/:")
-        print(f"    at HEAD ({current_commit[:12]}):  {current_tree}")
-        print(f"    in image manifest:              {labels.source_tree_sha}")
+        print(f"    at HEAD ({current_commit[:12]}):")
+        print(f"      build-input hash:  {current_build_inputs}")
+        print(f"      full-tree   hash:  {current_tree}  (legacy)")
+        print(f"    in image manifest:   {labels.source_tree_sha}")
+        # Accept either hash: the build-input hash (new stamps, ignores
+        # non-shipped files like docs/tests) or the legacy full-tree SHA (images
+        # built before ci-vss-oss adopted build-input hashing). Both guarantee
+        # the shipped source matches; the build-input form additionally lets
+        # docs/tests-only changes pass without a re-spin.
+        if labels.source_tree_sha == current_build_inputs:
+            print("    → identical (build-input hash)")
+            print("  [PASS]")
+            return True
         if labels.source_tree_sha == current_tree:
-            print("    → identical")
+            print("    → identical (legacy full-tree hash)")
             print("  [PASS]")
             return True
         print("    → DIFFERENT")
         print(f"  [FAIL] {config.image_name} container does NOT match the current {src}/ source.")
         print(f"         Image's source tree SHA at build time: {labels.source_tree_sha}")
-        print(f"         Current {src}/ tree SHA:               {current_tree}")
+        print(f"         Current {src}/ build-input hash:        {current_build_inputs}")
+        print(f"         Current {src}/ full-tree hash:          {current_tree}")
         _print_fix_hint(config)
         return False
 
@@ -614,12 +630,19 @@ def check_resolved_image(
     if not tag_tree:
         print(f"  [FAIL] could not read {src}/ at commit {tag_commit[:12]}.")
         return False
+    tag_build_inputs = build_input_tree_sha(repo_root, tag_commit, src)
 
     print(f"  comparing {src}/:")
     print(f"    at HEAD              ({current_commit[:12]}):  {current_tree}")
     print(f"    at container commit  ({tag_commit[:12]}):  {tag_tree}")
+    # Identical full tree, or identical build inputs (docs/tests-only drift
+    # between the two commits) — either means the shipped source matches.
     if tag_tree == current_tree:
         print("    → identical")
+        print("  [PASS]")
+        return True
+    if tag_build_inputs == current_build_inputs:
+        print("    → build inputs identical (only non-shipped files differ)")
         print("  [PASS]")
         return True
     print("    → DIFFERENT")
@@ -656,11 +679,14 @@ def verify(repo_root: Path, config: ImageConfig) -> int:
     if not current_tree:
         print(f"ERROR: could not resolve HEAD:{src}", file=sys.stderr)
         return 1
+    current_build_inputs = build_input_tree_sha(repo_root, "HEAD", src)
 
     print("Current source (HEAD)")
     print(f"  branch:  {current_branch}")
     print(f"  commit:  {current_commit}")
-    print(f"  folder:  {src}/  (content hash: {current_tree})")
+    print(f"  folder:  {src}/")
+    print(f"    build-input hash:  {current_build_inputs}")
+    print(f"    full-tree   hash:  {current_tree}  (legacy)")
     print()
 
     compose_files = discover_compose_files(repo_root)
@@ -691,7 +717,7 @@ def verify(repo_root: Path, config: ImageConfig) -> int:
 
     failures = 0
     for idx, item in enumerate(images, start=1):
-        if not check_resolved_image(repo_root, config, item, current_commit, current_tree, idx, len(images)):
+        if not check_resolved_image(repo_root, config, item, current_commit, current_tree, current_build_inputs, idx, len(images)):
             failures += 1
         print()
 

--- a/.github/scripts/source_tree_hash.py
+++ b/.github/scripts/source_tree_hash.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compute a *build-input-scoped* content hash for a service source folder.
+
+The container-source gate compares a folder's tree SHA against the image's
+``com.nvidia.vss.source_tree_sha``. Historically that SHA was the raw git tree
+object of the whole folder (``git rev-parse <commit>:services/agent``), so any
+change to a non-shipped file — README, AGENTS.md, tests, CI metadata — changed
+the SHA and forced a needless container re-spin.
+
+``build_input_tree_sha`` instead hashes only the files that actually influence
+the image: the git-tracked files under the folder, **minus** anything excluded
+by that folder's ``.dockerignore`` (mirroring the docker build context), but
+**always** including the Dockerfile (it shapes the image even though docker
+strips it from the context). The result is a sha256 over the sorted
+``<blob_sha> <path>`` lines, so it depends only on tracked content + paths and
+is reproducible identically at build time and check time.
+
+IMPORTANT: the build-stamp side (ci-vss-oss ``ci/tools/create_manifest.py``)
+must compute the stamp with this exact algorithm for the two to agree. Vendor
+this module there, or reimplement it byte-for-byte.
+
+The ``.dockerignore`` matcher implements the subset of docker's syntax used in
+this repo: ``#`` comments, blank lines, ``**`` (any depth), ``*`` / ``?``
+(within a path segment), leading ``/`` anchoring, trailing ``/`` directory
+patterns, and ``!`` negation (last match wins).
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+
+
+# A compiled ignore rule is a ``(negated, regex)`` pair.
+
+def _pattern_to_regex(pattern):
+    """Translate a single .dockerignore pattern to an anchored full-path regex."""
+    anchored = pattern.startswith("/")
+    body = pattern[1:] if anchored else pattern
+    dir_only = body.endswith("/")
+    body = body.rstrip("/")
+
+    # Tokenize into path segments and translate each.
+    segments = body.split("/")
+    parts: list[str] = []
+    for seg in segments:
+        if seg == "**":
+            parts.append("(?:.*/)?")  # zero or more path components
+            continue
+        out = []
+        i = 0
+        while i < len(seg):
+            ch = seg[i]
+            if ch == "*":
+                out.append("[^/]*")
+            elif ch == "?":
+                out.append("[^/]")
+            else:
+                out.append(re.escape(ch))
+            i += 1
+        parts.append("".join(out) + "/")
+
+    regex = "".join(parts).rstrip("/")
+    # Collapse the artifact of a leading "**" segment producing "(?:.*/)?/...".
+    regex = regex.replace("(?:.*/)?/", "(?:.*/)?")
+
+    prefix = "" if anchored else r"(?:.*/)?"
+    # A non-anchored, single-segment pattern (e.g. "Dockerfile", "*.md") may
+    # match at any depth; an anchored one only at the folder root.
+    if anchored:
+        prefix = ""
+    suffix = "(?:/.*)?$" if dir_only else r"(?:/.*)?$"
+    return re.compile("^" + prefix + regex + suffix)
+
+
+def load_dockerignore(text):
+    """Parse .dockerignore text into a list of ``(negated, regex)`` rules."""
+    rules = []
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        negated = line.startswith("!")
+        if negated:
+            line = line[1:]
+        line = line.strip()
+        if not line:
+            continue
+        rules.append((negated, _pattern_to_regex(line)))
+    return rules
+
+
+def is_ignored(rel, rules):
+    """Return True if ``rel`` is excluded, honoring negation (last match wins)."""
+    ignored = False
+    for negated, regex in rules:
+        if regex.match(rel):
+            ignored = not negated
+    return ignored
+
+
+def is_dockerfile(rel: str) -> bool:
+    base = rel.rsplit("/", 1)[-1]
+    return base == "Dockerfile" or base.endswith(".Dockerfile") or base.startswith("Dockerfile.")
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout
+
+
+def _read_dockerignore(repo: Path, commit: str, source_path: str) -> list[IgnoreRule]:
+    show = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{commit}:{source_path}/.dockerignore"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if show.returncode != 0:
+        return []
+    return load_dockerignore(show.stdout)
+
+
+def build_input_files(repo: Path, commit: str, source_path: str) -> dict[str, str]:
+    """Return ``{path: blob_sha}`` for the files that influence the image."""
+    rules = _read_dockerignore(repo, commit, source_path)
+    listing = _git(repo, "ls-tree", "-r", commit, "--", f"{source_path}/")
+    kept: dict[str, str] = {}
+    for line in listing.splitlines():
+        if not line.strip():
+            continue
+        meta, _, path = line.partition("\t")
+        fields = meta.split()
+        if len(fields) < 3 or fields[1] != "blob":
+            continue  # skip submodules/trees
+        blob_sha = fields[2]
+        rel = path[len(source_path) + 1 :]
+        if rel == ".dockerignore":
+            continue  # the ignore file itself is not part of the image
+        if is_dockerfile(rel):
+            kept[path] = blob_sha  # always influences the image
+            continue
+        if is_ignored(rel, rules):
+            continue
+        kept[path] = blob_sha
+    return kept
+
+
+def build_input_tree_sha(repo: Path, commit: str, source_path: str) -> str:
+    """Deterministic sha256 over the build-input file set of ``source_path``."""
+    kept = build_input_files(repo, commit, source_path)
+    blob = "\n".join(f"{kept[p]} {p}" for p in sorted(kept))
+    return hashlib.sha256(blob.encode()).hexdigest()

--- a/services/agent/.dockerignore
+++ b/services/agent/.dockerignore
@@ -1,0 +1,19 @@
+# Files under services/agent that the container build does not consume.
+#
+# docker/Dockerfile uses selective COPY (pyproject.toml, uv.lock, src/,
+# 3rdparty/, docker/*.py, license files), so none of the entries below ever
+# enter the image. Listing them here keeps the build context lean AND scopes
+# the container-source-SHA gate to real build inputs, so docs/tests-only edits
+# don't force a needless re-spin.
+#
+# Anchored to the service root on purpose: source under src/ — including its
+# README.md files — IS shipped and must NOT be ignored.
+/AGENTS.md
+/README.md
+/LICENSE.md
+/tests/
+/stubs/
+/.gitattributes
+/.gitleaks.toml
+/.secrets.baseline
+/gitleaks-baseline.json


### PR DESCRIPTION
> **Draft — do not merge until the companion `ci-vss-oss` change lands (see below).** This PR is non-breaking on its own, but its benefit only activates once images are stamped with the new hash.

## Problem

The **Check Agent/UI Container Source** gates compared the *entire* `services/agent` / `services/ui` git tree (`git rev-parse <commit>:services/agent`) against the image's `com.nvidia.vss.source_tree_sha`. Any change to a file that the image build never consumes — `README.md`, `AGENTS.md`, `tests/`, CI metadata — changes that tree SHA and trips the gate, forcing a needless container re-spin or NGC manifest re-stamp (e.g. #902). PR #906 is the stop-gap; this is the root-cause fix.

## Change

**`source_tree_hash.py`** — `build_input_tree_sha()` hashes only the files that influence the image:
- git-tracked files under the service folder,
- **minus** anything matched by that folder's `.dockerignore` (mirrors the docker build context),
- **plus** the Dockerfile (docker strips it from the context, but it shapes the image),
- as a `sha256` over sorted `<blob_sha> <path>` lines — deterministic and reproducible identically at build time and check time.

Includes a stdlib `.dockerignore` matcher (`**`, `*`, `?`, leading `/`, trailing-`/` dirs, `!` negation). No third-party deps.

**`services/agent/.dockerignore`** — lists the service-root docs/tests/CI files the agent Dockerfile's *selective* `COPY` never consumes. Anchored to the service root so shipped `src/**/README.md` still counts. (`services/ui` already has a `.dockerignore` excluding `**/*.md` and test/spec files.) This also trims the agent build context.

**`check_container_tag_source.py`** — now accepts **either** the build-input hash (new stamps) **or** the legacy full-tree SHA (existing images). Backward-compatible by construction.

## Why this is safe to merge early

- On `develop` today, the agent image's stamp matches via the **legacy full-tree** branch → still PASS. Verified by running the script locally against the live `nvstaging` image.
- No image carries a build-input stamp yet, so the new branch is inert until `ci-vss-oss` produces one. Behavior is identical to today until then.
- Validated locally:
  - agent docs (`README.md`+`AGENTS.md`) edit → build-input hash unchanged; `src/*.py` edit → changed; shipped `src/vss_agents/orchestrator/README.md` edit → changed (correctly).
  - UI `README.md` edit → unchanged; UI `Dockerfile` edit → changed (force-included).
  - dual-accept: build-input match → PASS; legacy full-tree match → PASS; neither → FAIL.

## Required companion change (separate, `ci-vss-oss`)

`ci/tools/create_manifest.py` must stamp `com.nvidia.vss.source_tree_sha` using **this exact algorithm** — vendor `source_tree_hash.py` or reimplement it byte-for-byte. Once it does, newly promoted images carry the build-input hash and docs/tests-only PRs stop tripping the gate without a re-spin. Existing images continue to pass via the legacy path until re-promoted.

## Relationship to #906
#906 (path-filter stop-gap) gives immediate relief now; this PR makes the gate correct at the source. Once this is fully rolled out, #906's helper can be removed.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
