### PR TITLE
feat(skills): gate deploy readiness on agent :8000/health (was /docs)

### DIFF
--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -359,7 +359,7 @@ Each profile reference has a **Debugging** section listing the exact commands an
 docker ps --format 'table {{.Names}}\t{{.Status}}'
 
 # 2. Agent API + UI responding
-curl -sf http://localhost:8000/docs >/dev/null && echo "agent OK"
+curl -sf http://localhost:8000/health >/dev/null && echo "agent OK"
 curl -sf http://localhost:3000/ >/dev/null && echo "ui OK"
 
 if [ -n "${ENV_GEN:-}" ] && [ -f "$ENV_GEN" ]; then

--- a/skills/vss-deploy-profile/evals/alerts_cv.json
+++ b/skills/vss-deploy-profile/evals/alerts_cv.json
@@ -13,7 +13,7 @@
     {
       "query": "Deploy the VSS **alerts** profile on {{platform}} for CV-driven alert generation with VLM-as-verifier. Run end-to-end and autonomously.",
       "checks": [
-        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
         "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared message bus)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (RT-CV perception \u2014 the 'CV' in this mode)",

--- a/skills/vss-deploy-profile/evals/alerts_vlm.json
+++ b/skills/vss-deploy-profile/evals/alerts_vlm.json
@@ -13,7 +13,7 @@
     {
       "query": "Deploy the VSS **alerts** profile on {{platform}} for continuous VLM-driven alert generation. Run end-to-end and autonomously.",
       "checks": [
-        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
         "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared message bus)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0 (continuous VLM processor \u2014 the 'VLM' in this mode)",

--- a/skills/vss-deploy-profile/evals/base.json
+++ b/skills/vss-deploy-profile/evals/base.json
@@ -13,7 +13,7 @@
     {
       "query": "Deploy the VSS **base** profile on {{platform}}, using the `/vss-deploy-profile` skill end-to-end and autonomously.",
       "checks": [
-        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",

--- a/skills/vss-deploy-profile/evals/lvs.json
+++ b/skills/vss-deploy-profile/evals/lvs.json
@@ -13,7 +13,7 @@
     {
       "query": "Deploy the VSS **lvs** profile on {{platform}}, using the `/vss-deploy-profile` skill end-to-end and autonomously.",
       "checks": [
-        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",

--- a/skills/vss-deploy-profile/evals/search.json
+++ b/skills/vss-deploy-profile/evals/search.json
@@ -13,7 +13,7 @@
     {
       "query": "Deploy the VSS **search** profile on {{platform}}, using the `/vss-deploy-profile` skill end-to-end and autonomously.",
       "checks": [
-        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",

--- a/skills/vss-deploy-profile/evals/warehouse.json
+++ b/skills/vss-deploy-profile/evals/warehouse.json
@@ -13,7 +13,7 @@
     {
       "query": "Deploy the VSS **warehouse** profile in 2D mode (`bp_wh_2d`, the agents variant) on {{platform}}. Set LLM_REMOTE_URL and LLM_REMOTE_MODEL. Get the App Data from ngc registry resource download-version nvstaging/vss-warehouse/vss-warehouse-app-data:v3.2.0-05212026. Use the `/vss-deploy-profile` skill end-to-end and autonomously.",
       "checks": [
-        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
+        "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
         "`curl -sf --max-time 15 http://localhost:8081/livez` returns exit 0 (Video Analytics API health endpoint responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",

--- a/skills/vss-deploy-profile/references/lvs-profile.md
+++ b/skills/vss-deploy-profile/references/lvs-profile.md
@@ -32,7 +32,7 @@ Container names below are the actual `container_name:` keys from `deploy/docker/
 | Redis | `redis` | 6379 | Cache |
 | Phoenix | `phoenix` | 6006 | Observability |
 
-Post-deploy readiness probe: `curl -sf http://${HOST_IP}:38111/v1/ready` should return exit 0 once `vss-lvs` is serving. The VSS Agent at `http://${HOST_IP}:8000/docs` is the cross-profile readiness signal; this one confirms the LVS-specific microservice.
+Post-deploy readiness probe: `curl -sf http://${HOST_IP}:38111/v1/ready` should return exit 0 once `vss-lvs` is serving. The VSS Agent at `http://${HOST_IP}:8000/health` is the cross-profile readiness signal; this one confirms the LVS-specific microservice.
 
 ## Default models
 

--- a/skills/vss-deploy-profile/references/readiness.md
+++ b/skills/vss-deploy-profile/references/readiness.md
@@ -48,12 +48,6 @@ endpoint), and Step 1 would still pass:
 curl -sf --max-time 15 http://localhost:8000/health >/dev/null && echo "agent OK"
 ```
 
-A non-zero exit here is a deploy failure even when Step 1 passed. Use
-`/health` (the agent's liveness endpoint), not `/docs`. On Brev the browser
-reaches the agent through the `:7777` HAProxy ingress under `/api/*`; this
-`:8000/health` probe is the on-host process-liveness check — see
-[`brev.md`](brev.md) for validating the secure-link path.
-
 ## Step 3 — triage slow containers
 
 If any probe times out, dump `docker compose ps` and

--- a/skills/vss-deploy-profile/references/readiness.md
+++ b/skills/vss-deploy-profile/references/readiness.md
@@ -38,6 +38,22 @@ inference NIMs, etc., on the ports the profile actually opens). Run those
 warmup) and only declare the deploy done once every documented endpoint
 returns the expected success exit code.
 
+**Cross-profile gate — the VSS Agent must answer on `:8000/health`.** Every
+profile runs the agent, so this probe is required regardless of profile. A
+`running` agent container does not mean the NAT-serve process is listening —
+it can be up while `:8000` never bound (config error, unreachable model
+endpoint), and Step 1 would still pass:
+
+```bash
+curl -sf --max-time 15 http://localhost:8000/health >/dev/null && echo "agent OK"
+```
+
+A non-zero exit here is a deploy failure even when Step 1 passed. Use
+`/health` (the agent's liveness endpoint), not `/docs`. On Brev the browser
+reaches the agent through the `:7777` HAProxy ingress under `/api/*`; this
+`:8000/health` probe is the on-host process-liveness check — see
+[`brev.md`](brev.md) for validating the secure-link path.
+
 ## Step 3 — triage slow containers
 
 If any probe times out, dump `docker compose ps` and


### PR DESCRIPTION
## Summary

Harden the deploy readiness gate so an unresponsive VSS Agent `:8000` can't pass as "deploy done", and switch the agent check to `/health`.

- **`readiness.md`** — add an explicit **cross-profile `:8000/health` gate**. A `running` agent container does not mean the NAT-serve process bound `:8000` (config error / unreachable model endpoint), and `vss-agent` has no container healthcheck — so Step 1 (container state) alone passes an up-but-dead agent. A non-zero `:8000/health` is now a deploy failure even when Step 1 passes.
- **Switch the agent-responsiveness check from `/docs` → `/health`** (the agent's liveness endpoint, registered in `custom_fastapi_worker.py`): `SKILL.md` quick-checks, `references/lvs-profile.md`, and the 6 `vss-deploy-profile` eval specs.
- **Kept `/docs`** in `base.md` — that's the Swagger UI URL (documentation), not a check. `alerts.md` already used `/health`.

The `readiness.md` note also points to `brev.md` for the Brev secure-link path (the browser reaches the agent via the `:7777` HAProxy ingress under `/api/*`; `:8000/health` is the on-host process-liveness probe).

## Validation
- `git grep 8000/docs` → only the Swagger-UI doc reference in `base.md` remains; every check is `/health`.
- The 6 eval spec JSONs still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
