### PR TITLE
fix(skill-eval): reset box docker runtime + wipe stale /logs before each spec

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -425,9 +425,19 @@ The canonical harbor command is in § Harbor invocation.
    `start()` is what cleans up, on every exit path (happy, `BLOCKED`, cancel,
    max-turns, crash, SIGKILL, reboot). One consequence: wiping all volumes
    drops the `rtvi-hf-cache` / `rtvi-ngc-model-cache` model-weight volumes, so
-   a spec's first deploy is cold (~20 min weight download vs ~55 s warm) — the
-   per-trial harbor timeout already budgets for it. The deploy runbook may
-   still `docker compose down` defensively, but it no longer has to.
+   a spec's first deploy is cold (~20 min weight download vs ~55 s warm) under
+   the canonical `-n 1 --max-retries 0` invocation — paid once per spec; an
+   `-n>1` rollout or a harbor retry re-wipes the caches and re-pays it. The
+   per-trial harbor timeout already budgets for a cold deploy. The deploy
+   runbook may still `docker compose down` defensively, but it no longer has to.
+
+   ⚠️ **`start()` is now destructive on a spec's first trial — never run
+   `harbor` manually against a box another run currently holds.** The wipe is
+   not structurally gated by the per-box flock (that's orchestrator discipline,
+   § 5b); a manual `uvx harbor run` with `BREV_INSTANCE` set (README "Run one
+   trial by hand") will `docker rm -f` the holder's containers and volumes
+   mid-trial. Acquire the flock — or pick a demonstrably idle box — before any
+   manual run.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -396,23 +396,38 @@ The canonical harbor command is in § Harbor invocation.
 
 7. **Release all locks. DO NOT tear down any Brev instance.** The
    `vss-eval-*` boxes are a long-running pool managed by the
-   operator; instances stay up across runs, and so do the slow
-   caches (docker image layers, repo clone, sample-data extract).
+   operator; instances stay up across runs, and so do the slow caches
+   that survive a volume wipe (docker **image** layers, the repo clone, the
+   `data/` sample-data extract — but NOT the model-weight *volumes*, which
+   the per-trial reset drops; see § 7).
    Close each lock FD (`exec {LFD}>&-`) so the next worker can
    grab the box. You never `brev stop` / `brev delete`. Pool
    lifecycle is strictly an operator concern.
 
-   **You do NOT reset deployment state on exit.** Each box's
-   running containers and named volumes stay as you left them;
-   cleanup is the *next* trial's first agent
-   turn — each spec's leading `expects[]` query invokes
-   `/vss-deploy-profile` (or a standalone deploy runbook), which is
-   responsible for `docker compose down` of any leftover containers
-   before bringing its own stack up. No `atexit`, no signal handler,
-   no harness-side reconcile — every exit path (happy, `BLOCKED`,
-   cancel-in-progress, max-turns, agent crash, SIGKILL, host reboot)
-   leaves the same possibly-dirty box, and the next trial's deploy
-   step handles it the same way.
+   **The box's docker runtime is reset for you at the *start* of each spec,
+   not on exit.** On a spec's first trial — a single-step spec, or `step-1`
+   of a multi-step one — `BrevEnvironment.start()` (the env provider, before
+   the agent runs) wipes the docker runtime to a clean slate: it force-removes
+   **all** containers, **all** user-defined networks, and **all** volumes
+   (images are preserved — re-pulling them is slow). So a spec always begins
+   from a deterministic, leak-free runtime regardless of what the previous
+   spec left — a leftover container from a *different* compose project used to
+   port-conflict the new deploy (observed: a stuck `phoenix` + missing init
+   containers because a prior base-profile deploy still held the ports).
+   **Multi-step step-2+ deliberately skip the reset** — their checks build on
+   the deployment step N-1 established, so wiping it would destroy the state
+   under test. Separately, *every* trial (each step included) clears the stale
+   `/logs/artifacts` + `/logs/verifier` working dirs, so a prior run's
+   arbitrarily-named files are never re-collected as this trial's output
+   (observed: 3-day-old `nemoclaw/` artifacts surfacing in an unrelated trial).
+   You still do **not** tear anything down on *exit* — no `atexit`, no signal
+   handler — and you never `brev stop` / `brev delete`; the *next* spec's
+   `start()` is what cleans up, on every exit path (happy, `BLOCKED`, cancel,
+   max-turns, crash, SIGKILL, reboot). One consequence: wiping all volumes
+   drops the `rtvi-hf-cache` / `rtvi-ngc-model-cache` model-weight volumes, so
+   a spec's first deploy is cold (~20 min weight download vs ~55 s warm) — the
+   per-trial harbor timeout already budgets for it. The deploy runbook may
+   still `docker compose down` defensively, but it no longer has to.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -171,6 +171,12 @@ python3 .github/skill-eval/adapters/vss-manage-video-io-storage/generate.py \
 
 # 2. Make sure you have a Brev instance for the target platform
 #    (or let the skills-eval agent manage it).
+#
+# ⚠️ On a spec's first trial the env provider WIPES the box's docker runtime
+#    (all containers, user-defined networks, and volumes; images are kept).
+#    NEVER point a manual run at a box a CI run currently holds — it will
+#    `docker rm -f` that run's deployment mid-trial. Use a demonstrably idle
+#    box, or hold the per-box flock (see AGENTS.md § 5b).
 export BREV_INSTANCE=vss-eval-l40s
 
 # 3. Run one trial. The flags here mirror the canonical invocation in

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -191,13 +191,23 @@ class BrevEnvironment(BaseEnvironment):
         # in an unrelated profile_in_1 trial's artifact tarball). /logs/agent is
         # left intact here — its prior-trial session JSONLs are handled by the
         # archive step just below (move-not-delete, for forensic SSH access).
-        await _run_brev_exec(
+        setup_dirs_result = await _run_brev_exec(
             self._instance_name,
             "sudo rm -rf /logs/artifacts /logs/verifier && "
             "sudo mkdir -p /logs/agent /logs/verifier /logs/artifacts /tests /solution /skills && "
             "sudo chown -R $(whoami):$(id -gn) /logs /tests /solution /skills",
             timeout=30,
         )
+        # Fail loud: this is the load-bearing artifacts wipe. A silent failure
+        # would leave the prior trial's /logs/artifacts in place and re-collect
+        # it as this trial's output — the exact contamination being fixed —
+        # so it gets the same exit-code guard as the docker reset / repo sync.
+        if setup_dirs_result.return_code != 0:
+            tail = (setup_dirs_result.stderr or setup_dirs_result.stdout or "")[-500:]
+            raise RuntimeError(
+                f"log-dir reset/setup failed on {self._instance_name}: "
+                f"exit {setup_dirs_result.return_code}; tail:\n{tail}"
+            )
 
         # Archive any session JSONLs left by prior trials on this warm-pool
         # box. Without this, harbor's claude-code mapper merges every
@@ -378,8 +388,8 @@ class BrevEnvironment(BaseEnvironment):
         trial's deploy uses; no sudo. `network prune` leaves the built-in
         bridge/host/none networks, which is correct. Fails loud (`set -u`,
         explicit `exit 1`) if the daemon is unreachable or any container /
-        volume survives, so a half-reset box surfaces as a trial error rather
-        than silent cross-trial contamination.
+        volume, or user-defined network survives, so a half-reset box surfaces
+        as a trial error rather than silent cross-trial contamination.
         """
         cmd = r"""set -uo pipefail
 docker info >/dev/null 2>&1 || { echo "docker daemon unreachable" >&2; exit 1; }
@@ -388,8 +398,13 @@ vols=$(docker volume ls -q); [ -n "$vols" ] && docker volume rm -f $vols >/dev/n
 docker network prune -f >/dev/null 2>&1 || true
 rc=$(docker ps -aq | wc -l | tr -d ' ')
 rv=$(docker volume ls -q | wc -l | tr -d ' ')
-if [ "$rc" != "0" ] || [ "$rv" != "0" ]; then
-  echo "docker runtime reset incomplete: ${rc} containers, ${rv} volumes remain" >&2
+# Only user-defined networks should be gone; the built-in bridge/host/none
+# are never removable, so filter to type=custom. A surviving user network
+# would collide ("network already exists" / address-range clash) on the next
+# `compose up`, so it must fail the reset like a surviving container/volume.
+rn=$(docker network ls --filter type=custom -q | wc -l | tr -d ' ')
+if [ "$rc" != "0" ] || [ "$rv" != "0" ] || [ "$rn" != "0" ]; then
+  echo "docker runtime reset incomplete: ${rc} containers, ${rv} volumes, ${rn} user-defined networks remain" >&2
   exit 1
 fi
 echo "docker runtime reset OK; images preserved ($(docker images -q | wc -l | tr -d ' ') layers)"

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -334,6 +334,10 @@ class BrevEnvironment(BaseEnvironment):
         # would destroy the very state under test. step-1 gets the clean box;
         # later steps build on it. (`environment_dir.parent` is the task dir —
         # named `step-N` for multi-step, the platform for single-step.)
+        # Caveat: a manual `harbor run` targeting only `step-2+` in isolation
+        # skips the reset and inherits whatever is on the box — run `step-1`
+        # first, or reset by hand. Normal CI always runs `step-1` first on a
+        # freshly reset box, so the gate is correct there.
         task_dir_name = self.environment_dir.parent.name
         if task_dir_name.startswith("step-") and task_dir_name != "step-1":
             logger.info(
@@ -380,22 +384,31 @@ class BrevEnvironment(BaseEnvironment):
         (`rtvi-hf-cache`, `rtvi-ngc-model-cache`), so the next deploy pays the
         full cold model-weight download (~20 min vs ~55 s warm). The caller
         gates this to a spec's first trial only (single-step, or step-1 of a
-        multi-step spec — later steps reuse step-1's deployment), so that cost
-        is paid once per spec, not once per step; the per-trial harbor timeout
-        already budgets for a cold deploy.
+        multi-step spec — later steps reuse step-1's deployment), so under the
+        canonical `-n 1 --max-retries 0` invocation (one trial per spec) the
+        cost is paid once per spec, not once per step. An `-n>1` rollout, a
+        harbor retry, or a repeated manual run on the same warm box each
+        re-wipes the caches and re-pays the cold start. The per-trial harbor
+        timeout already budgets for a cold deploy.
 
         Runs as the normal (docker-group) user — the same identity the
         trial's deploy uses; no sudo. `network prune` leaves the built-in
         bridge/host/none networks, which is correct. Fails loud (`set -u`,
-        explicit `exit 1`) if the daemon is unreachable or any container /
-        volume, or user-defined network survives, so a half-reset box surfaces
-        as a trial error rather than silent cross-trial contamination.
+        explicit `exit 1`) if the daemon is unreachable or dies mid-reset, or
+        if any container, volume, or user-defined network survives, so a
+        half-reset box surfaces as a trial error rather than silent cross-trial
+        contamination.
         """
         cmd = r"""set -uo pipefail
 docker info >/dev/null 2>&1 || { echo "docker daemon unreachable" >&2; exit 1; }
 cids=$(docker ps -aq); [ -n "$cids" ] && docker rm -f $cids >/dev/null 2>&1 || true
 vols=$(docker volume ls -q); [ -n "$vols" ] && docker volume rm -f $vols >/dev/null 2>&1 || true
 docker network prune -f >/dev/null 2>&1 || true
+# Re-confirm the daemon survived the reset. Without `set -e`, a daemon that
+# died mid-script would make the count commands below print nothing and the
+# guard read 0/0/0 -- faking a clean reset. The counts run microseconds after
+# this check, so the remaining TOCTOU window is negligible.
+docker info >/dev/null 2>&1 || { echo "docker daemon died during reset" >&2; exit 1; }
 rc=$(docker ps -aq | wc -l | tr -d ' ')
 rv=$(docker volume ls -q | wc -l | tr -d ' ')
 # Only user-defined networks should be gone; the built-in bridge/host/none

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -182,8 +182,18 @@ class BrevEnvironment(BaseEnvironment):
 
         # Pre-create harbor's expected directories with correct ownership
         # so that agent and verifier processes can write to them.
+        #
+        # Wipe /logs/artifacts and /logs/verifier FIRST: harbor's
+        # Trial._download_artifacts() does a blanket download_dir(/logs/artifacts)
+        # and nothing on a warm-pool box ever clears that dir, so a prior
+        # trial's arbitrarily-named files get collected as THIS trial's
+        # artifacts (observed: 3-day-old `nemoclaw/` base-deploy logs surfacing
+        # in an unrelated profile_in_1 trial's artifact tarball). /logs/agent is
+        # left intact here — its prior-trial session JSONLs are handled by the
+        # archive step just below (move-not-delete, for forensic SSH access).
         await _run_brev_exec(
             self._instance_name,
+            "sudo rm -rf /logs/artifacts /logs/verifier && "
             "sudo mkdir -p /logs/agent /logs/verifier /logs/artifacts /tests /solution /skills && "
             "sudo chown -R $(whoami):$(id -gn) /logs /tests /solution /skills",
             timeout=30,
@@ -300,6 +310,30 @@ class BrevEnvironment(BaseEnvironment):
         # PR_HEAD_SHA forwarded above never actually lands on disk.
         await self._sync_repo_to_pr_head()
 
+        # Wipe the warm-pool box's docker runtime to a clean slate so no
+        # prior trial's deployment state can contaminate this one. Images are
+        # preserved (re-pulling the image set is slow); all containers,
+        # user-defined networks, and volumes are removed. See
+        # _reset_docker_runtime for why this is blanket, not VSS-scoped.
+        #
+        # Gate: ONLY on a spec's first trial — a single-step spec (task dir is
+        # the platform, e.g. `rtxpro6000bw`) or `step-1` of a multi-step spec.
+        # Multi-step checks for step N assume the deployment state established
+        # by step N-1 (AGENTS.md § "Multi-step specs"), and each step is a
+        # separate `harbor run` → separate start(); resetting before step-2+
+        # would destroy the very state under test. step-1 gets the clean box;
+        # later steps build on it. (`environment_dir.parent` is the task dir —
+        # named `step-N` for multi-step, the platform for single-step.)
+        task_dir_name = self.environment_dir.parent.name
+        if task_dir_name.startswith("step-") and task_dir_name != "step-1":
+            logger.info(
+                "Skipping docker runtime reset on %s — %s of a multi-step spec "
+                "must preserve step-1's deployment state",
+                self._instance_name, task_dir_name,
+            )
+        else:
+            await self._reset_docker_runtime()
+
         # The harness intentionally does NOT pre-deploy any VSS profile
         # here. Each eval spec's first `expects[]` query is responsible
         # for invoking `/vss-deploy-profile` (or the appropriate
@@ -310,6 +344,72 @@ class BrevEnvironment(BaseEnvironment):
 
         self._started = True
         logger.info("Brev instance %s is reachable", self._instance_name)
+
+    async def _reset_docker_runtime(self) -> None:
+        """Wipe the warm-pool box's docker runtime before the trial.
+
+        Removes **all** containers (running + stopped), **all** volumes
+        (named + anonymous), and **all** user-defined networks, while
+        **preserving images** — re-pulling the multi-GB VSS/NIM image set on
+        every trial would dominate wall-clock.
+
+        Why blanket, not VSS-project-scoped: trials reach a deploy through
+        heterogeneous paths — direct `docker compose --profile …`, the
+        `/vss-deploy-profile` runbook, an MCP-orchestrator base deploy — under
+        different compose project names. A project- or label-scoped
+        `compose down` from the incoming trial therefore cannot reach a
+        *predecessor's* stack, so a leftover container port-conflicts the new
+        deploy (observed: a profile_in_1 trial where `phoenix` was stuck
+        `Created` and several init containers were missing because a prior
+        base-profile deploy's containers still held the ports). Removing
+        everything is the only reset that doesn't depend on knowing what the
+        last trial deployed. Safe because `vss-eval-*` boxes are a dedicated,
+        flock-serialised eval pool — nothing else runs on them.
+
+        NOTE: wiping all volumes also drops the model-weight caches
+        (`rtvi-hf-cache`, `rtvi-ngc-model-cache`), so the next deploy pays the
+        full cold model-weight download (~20 min vs ~55 s warm). The caller
+        gates this to a spec's first trial only (single-step, or step-1 of a
+        multi-step spec — later steps reuse step-1's deployment), so that cost
+        is paid once per spec, not once per step; the per-trial harbor timeout
+        already budgets for a cold deploy.
+
+        Runs as the normal (docker-group) user — the same identity the
+        trial's deploy uses; no sudo. `network prune` leaves the built-in
+        bridge/host/none networks, which is correct. Fails loud (`set -u`,
+        explicit `exit 1`) if the daemon is unreachable or any container /
+        volume survives, so a half-reset box surfaces as a trial error rather
+        than silent cross-trial contamination.
+        """
+        cmd = r"""set -uo pipefail
+docker info >/dev/null 2>&1 || { echo "docker daemon unreachable" >&2; exit 1; }
+cids=$(docker ps -aq); [ -n "$cids" ] && docker rm -f $cids >/dev/null 2>&1 || true
+vols=$(docker volume ls -q); [ -n "$vols" ] && docker volume rm -f $vols >/dev/null 2>&1 || true
+docker network prune -f >/dev/null 2>&1 || true
+rc=$(docker ps -aq | wc -l | tr -d ' ')
+rv=$(docker volume ls -q | wc -l | tr -d ' ')
+if [ "$rc" != "0" ] || [ "$rv" != "0" ]; then
+  echo "docker runtime reset incomplete: ${rc} containers, ${rv} volumes remain" >&2
+  exit 1
+fi
+echo "docker runtime reset OK; images preserved ($(docker images -q | wc -l | tr -d ' ') layers)"
+"""
+        logger.info(
+            "Resetting docker runtime (all containers/networks/volumes; images kept) on %s",
+            self._instance_name,
+        )
+        result = await _run_brev_exec(self._instance_name, cmd, timeout=300)
+        if result.return_code != 0:
+            tail = (result.stderr or result.stdout or "")[-500:]
+            raise RuntimeError(
+                f"docker runtime reset failed on {self._instance_name}: "
+                f"exit {result.return_code}; tail:\n{tail}"
+            )
+        logger.info(
+            "Docker reset on %s: %s",
+            self._instance_name,
+            (result.stdout or "").strip().splitlines()[-1] if result.stdout else "<no output>",
+        )
 
     async def _sync_repo_to_pr_head(self) -> None:
         """Reset `~/video-search-and-summarization` on the Brev box to the


### PR DESCRIPTION
## Problem

Warm-pool eval boxes are reused across runs and accumulate prior-trial state that contaminates later trials. Two concrete leaks, both surfacing in PR #900's `profile_in_1_streaming_dense_captions` / RTXPRO6000BW trial (reward 0.7, 14/20):

1. **Leftover deployment.** A prior deploy from a *different* compose project (a base-profile / MCP-orchestrator deploy) left containers running. The incoming trial's `docker compose up` then port-conflicted — `phoenix` stuck `Created`; init containers (`vss-broker-health-check`, `vss-kafka-topics`, `sdrc-wait-for-docker-workloads`) missing. The §7 model — *"the next trial's `docker compose down` cleans up"* — cannot reach a predecessor's stack when the compose **project name** differs.
2. **Stale artifacts.** harbor's `Trial._download_artifacts()` blanket-downloads `/logs/artifacts`, and nothing on a warm box ever cleared it. A **3-day-old** `nemoclaw/` base-deploy artifact set (mtime 2026-05-30; internal `t=1780098597`) was collected as the 2026-06-02 `profile_in_1` trial's output.

Source/git state was *already* reset by `_sync_repo_to_pr_head`, so the compose-modification check failures in that trial were genuine this-trial behavior — only the **runtime** and **artifacts** were leaking.

## Fix

`BrevEnvironment.start()`, on a spec's **first trial** (single-step, or `step-1` of a multi-step spec):

- **`_reset_docker_runtime()`** — force-removes **all** containers, **all** user-defined networks, and **all** volumes; **images preserved** (re-pulling is slow). Blanket by design: it cannot depend on knowing the prior trial's compose project. Fails loud (`set -u`, explicit `exit 1`) if the docker daemon is unreachable or any container/volume survives, so a half-reset box surfaces as a trial error rather than silent contamination.
- **`/logs/artifacts` + `/logs/verifier` wipe** — on every trial (each step included), so stale files are never re-collected.

### Multi-step safety
`step-2+` **skip** the docker reset — their checks assume the deployment `step N-1` established (AGENTS.md § "Multi-step specs"); resetting would destroy the state under test. Gated on the task-dir name (`step-N` vs the platform dir).

### Trade-off (accepted)
Wiping all volumes drops the `rtvi-hf-cache` / `rtvi-ngc-model-cache` model-weight volumes → a spec's **first deploy is cold** (~20 min weight download vs ~55 s warm). Paid **once per spec**, not per step; the per-trial harbor timeout already budgets for a cold deploy. Chosen over a cache-volume allow-list for maximum determinism / VSS-agnosticism.

## Validation
- `python3 -m py_compile` (brev_env.py) + `bash -n` on the embedded reset script. ✅
- Live read-only `docker ps -a` on `vss-eval-l40s-1g`: **9 leftover VSS containers "Up 13 hours"** (exactly the contamination this fixes) + 9 volumes; **no brev/shadeform management container** → blanket `docker rm -f` is safe, and SSH connectivity (host `sshd`, not docker) survives the wipe. ✅
- Exercised end-to-end on the next eval run.

## Notes
- No unit test: importing `brev_env` requires `harbor`, matching why #819's brev_env changes shipped without unit tests; this is operational shell, validated live.
- Touches only `brev_env.py` (env provider) + `AGENTS.md` §7 docs. No skill content; no pool lifecycle (`brev create/stop/delete`) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
