### PR TITLE
ci: run container-source gate only on build-relevant or tag changes

### DIFF
--- a/.github/scripts/check_container_tag_source.py
+++ b/.github/scripts/check_container_tag_source.py
@@ -76,12 +76,12 @@ def strip_quotes(value: str) -> str:
     return value
 
 
-def read_env_file(path: Path) -> dict[str, str]:
+def parse_env_text(text: str) -> dict[str, str]:
+    """Parse ``KEY=value`` lines from .env content. Shared with the gate helper
+    so both resolve the same way regardless of which revision the text is read
+    from (working tree vs ``git show``)."""
     values: dict[str, str] = {}
-    if not path.exists():
-        return values
-
-    for raw_line in path.read_text().splitlines():
+    for raw_line in text.splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
@@ -94,6 +94,12 @@ def read_env_file(path: Path) -> dict[str, str]:
         if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
             values[key] = strip_quotes(value)
     return values
+
+
+def read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    return parse_env_text(path.read_text())
 
 
 def image_name(ref: str) -> str:
@@ -120,9 +126,11 @@ def commit_prefix_from_tag(tag: str | None) -> str | None:
     return matches[-1].group("sha").lower()
 
 
-def find_image_refs(compose_file: Path, expected_image_name: str) -> list[str]:
+def image_refs_in_text(text: str, expected_image_name: str) -> list[str]:
+    """Extract ``image:`` refs matching ``expected_image_name`` from compose
+    content. Shared with the gate helper (see ``parse_env_text``)."""
     refs: list[str] = []
-    for line in compose_file.read_text().splitlines():
+    for line in text.splitlines():
         match = IMAGE_LINE_RE.match(line)
         if not match:
             continue
@@ -130,6 +138,10 @@ def find_image_refs(compose_file: Path, expected_image_name: str) -> list[str]:
         if image_name(ref) == expected_image_name and ref not in refs:
             refs.append(ref)
     return refs
+
+
+def find_image_refs(compose_file: Path, expected_image_name: str) -> list[str]:
+    return image_refs_in_text(compose_file.read_text(), expected_image_name)
 
 
 def resolve_compose_vars(text: str, env: dict[str, str]) -> tuple[str, tuple[str, ...]]:

--- a/.github/scripts/source_check_only_nonbuild.py
+++ b/.github/scripts/source_check_only_nonbuild.py
@@ -1,24 +1,33 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Decide whether a PR touches only non-build files under a service folder.
+"""Decide whether the container-source SHA check is relevant to this PR.
 
 The ``Check {Agent,UI} Container Source`` gates compare the git tree SHA of
 ``services/agent`` / ``services/ui`` against the ``com.nvidia.vss.source_tree_sha``
-baked into the deployed image. That tree SHA covers the *whole* folder, so a
-docs- or tests-only change (which never enters the image — the Dockerfiles use
-selective ``COPY`` / a ``.dockerignore``) still trips the gate and forces a
-needless container re-spin or manifest re-stamp.
+baked into the deployed image. Because that tree SHA covers the *whole* folder,
+once an allowed docs change merges to ``develop`` the folder drifts from the
+promoted image — and then the check fails on **every** later PR, even ones that
+touch neither the service nor the image tag (it re-evaluates HEAD's drifted
+folder). The gate is also a required status check, so it must always run and
+report a conclusion; we can't skip it at the workflow trigger or the PR hangs.
 
-This helper is the stop-gap: it prints ``true`` when **every** file the PR
-changed under the service folder is one the image build provably does not
-consume, so the caller can skip the SHA comparison for that run. It prints
-``false`` (run the real check) whenever it is unsure — unknown base, an
-integration-branch push, or any build-relevant file in the diff.
+So the gate runs the SHA comparison only when the PR could actually affect the
+match, i.e. it changed either:
 
-The durable fix is to make the source_tree_sha cover only build inputs (honor
-the ``.dockerignore`` / COPY set) on both the build-stamp and check sides; once
-that lands this helper can be removed.
+  * a **build-relevant** file under the service folder (anything the image
+    build consumes — i.e. not the allowlisted docs/tests/metadata below), or
+  * the service's **resolved deployable image tag** (a tag bump in
+    ``deploy/docker`` compose/.env).
+
+Otherwise it prints ``true`` (skip — this PR can't have broken the match), so a
+predecessor's docs-drift doesn't red-flag unrelated PRs. It prints ``false``
+(run the real check) whenever a build-relevant file or this service's tag
+changed, on integration-branch pushes, or whenever it is unsure.
+
+The tag comparison is per-service and value-based (resolve the image ref at
+HEAD vs the merge-base), so a UI tag bump in a shared ``.env`` does not trip the
+agent gate and vice-versa.
 
 Output: a single ``true``/``false`` token on stdout. Diagnostics go to stderr.
 """
@@ -27,9 +36,15 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
+
+# Sibling module in .github/scripts/ (sys.path[0] when run as a script). We
+# reuse its compose/.env discovery + variable resolution so the gate's notion
+# of "the service's image tag" is identical to the check's.
+import check_container_tag_source as chk
 
 
 # Image name -> source folder (must match check_container_tag_source.py).
@@ -105,6 +120,103 @@ def git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+# --- resolved image-tag comparison (per service, value-based) ---------------
+#
+# Mirror check_container_tag_source's compose/.env resolution but read file
+# contents through a pluggable reader so we can resolve at HEAD (working tree)
+# and at the merge-base (git show) and compare the resolved ref sets.
+
+def _image_refs_in_compose(text: str, expected_name: str) -> list[str]:
+    refs: list[str] = []
+    for line in text.splitlines():
+        m = chk.IMAGE_LINE_RE.match(line)
+        if not m:
+            continue
+        ref = chk.strip_quotes(m.group("ref"))
+        if chk.image_name(ref) == expected_name and ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def _env_from_text(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            values[key] = chk.strip_quotes(value)
+    return values
+
+
+def resolve_service_refs(repo: Path, read_text, image_name: str) -> set[str]:
+    """Set of fully-resolved deployable image refs for ``image_name``.
+
+    ``read_text(relpath)`` returns the file's content (or None if absent) at the
+    revision being inspected. Returns an empty set if nothing resolves.
+    """
+    config = chk.IMAGE_CONFIGS[image_name]
+    compose_files = chk.discover_compose_files(repo)
+    env_files = chk.discover_env_files(repo)
+
+    env_caches: dict[Path, dict[str, str]] = {}
+    for ef in env_files:
+        env_caches[ef] = _env_from_text(read_text(str(ef.relative_to(repo))) or "")
+
+    refs: set[str] = set()
+    for cf in compose_files:
+        text = read_text(str(cf.relative_to(repo)))
+        if not text:
+            continue
+        for raw in _image_refs_in_compose(text, config.image_name):
+            _, needed = chk.resolve_compose_vars(raw, {})
+            if not needed:
+                resolved, _ = chk.resolve_compose_vars(raw, dict(os.environ))
+                refs.add(resolved)
+                continue
+            for ef in env_files:
+                env_values = env_caches[ef]
+                if all(name in env_values for name in needed):
+                    resolved, missing = chk.resolve_compose_vars(
+                        raw, {**env_values, **os.environ}
+                    )
+                    if not missing:
+                        refs.add(resolved)
+    return refs
+
+
+def service_tag_changed(repo: Path, base: str, image_name: str) -> bool:
+    """True if the service's resolved image ref(s) differ between base and HEAD."""
+    def head_reader(rel: str):
+        path = repo / rel
+        return path.read_text() if path.exists() else None
+
+    def base_reader(rel: str):
+        result = git(repo, "show", f"{base}:{rel}")
+        return result.stdout if result.returncode == 0 else None
+
+    head_refs = resolve_service_refs(repo, head_reader, image_name)
+    if not head_refs:
+        # Couldn't resolve anything at HEAD — be conservative and run the check.
+        log("could not resolve any image refs at HEAD; running full source check.")
+        return True
+    base_refs = resolve_service_refs(repo, base_reader, image_name)
+    if head_refs != base_refs:
+        log(f"image tag changed vs {base[:12]}:")
+        for r in sorted(head_refs - base_refs):
+            log(f"  + {r}")
+        for r in sorted(base_refs - head_refs):
+            log(f"  - {r}")
+        return True
+    return False
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--image-name", choices=sorted(SOURCE_PATHS), required=True)
@@ -134,27 +246,25 @@ def main() -> int:
         return 0
     base = mb.stdout.strip()
 
+    # (1) Did the PR change a build-relevant file under the service folder?
     diff = git(repo, "diff", "--name-only", base, "HEAD", "--", f"{source_path}/")
     if diff.returncode != 0:
         log(f"git diff failed ({diff.stderr.strip()}); running full source check.")
         print("false")
         return 0
-
     changed = [line for line in diff.stdout.splitlines() if line.strip()]
-    if not changed:
-        log(f"no changes under {source_path}/ vs {base[:12]}; running full source check.")
-        print("false")
-        return 0
-
-    log(f"changed files under {source_path}/ (vs {base[:12]}):")
     build_relevant = []
-    for path in changed:
-        rel = path[len(source_path) + 1 :]
-        if is_nonbuild(rel, patterns):
-            log(f"  non-build : {path}")
-        else:
-            log(f"  BUILD-REL : {path}")
-            build_relevant.append(path)
+    if changed:
+        log(f"changed files under {source_path}/ (vs {base[:12]}):")
+        for path in changed:
+            rel = path[len(source_path) + 1 :]
+            if is_nonbuild(rel, patterns):
+                log(f"  non-build : {path}")
+            else:
+                log(f"  BUILD-REL : {path}")
+                build_relevant.append(path)
+    else:
+        log(f"no changes under {source_path}/ vs {base[:12]}.")
 
     if build_relevant:
         log(
@@ -164,9 +274,15 @@ def main() -> int:
         print("false")
         return 0
 
+    # (2) Did the PR bump this service's deployable image tag?
+    if service_tag_changed(repo, base, args.image_name):
+        log("image tag changed; running full source check.")
+        print("false")
+        return 0
+
     log(
-        f"only non-build files changed under {source_path}/; "
-        "skipping the container-source SHA check for this run."
+        f"neither build-relevant source nor the {args.image_name} image tag "
+        "changed; skipping the container-source SHA check for this run."
     )
     print("true")
     return 0

--- a/.github/scripts/source_check_only_nonbuild.py
+++ b/.github/scripts/source_check_only_nonbuild.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -47,10 +46,10 @@ from pathlib import Path
 import check_container_tag_source as chk
 
 
-# Image name -> source folder (must match check_container_tag_source.py).
+# Image name -> source folder, derived from the check's own config so the two
+# can't drift.
 SOURCE_PATHS = {
-    "vss-agent": "services/agent",
-    "vss-agent-ui": "services/ui",
+    name: cfg.source_path.as_posix() for name, cfg in chk.IMAGE_CONFIGS.items()
 }
 
 # Paths (relative to the service folder) the image build does NOT consume.
@@ -122,44 +121,19 @@ def git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 # --- resolved image-tag comparison (per service, value-based) ---------------
 #
-# Mirror check_container_tag_source's compose/.env resolution but read file
-# contents through a pluggable reader so we can resolve at HEAD (working tree)
-# and at the merge-base (git show) and compare the resolved ref sets.
+# Reuse check_container_tag_source's compose/.env discovery + variable
+# expansion, but feed file contents through a pluggable reader so we can
+# resolve at HEAD (working tree) and at the merge-base (git show) and compare
+# the resolved ref sets. We reuse chk.parse_env_text / chk.image_refs_in_text
+# so the gate resolves identically to the check (no parallel parsers to drift).
 
-def _image_refs_in_compose(text: str, expected_name: str) -> list[str]:
-    refs: list[str] = []
-    for line in text.splitlines():
-        m = chk.IMAGE_LINE_RE.match(line)
-        if not m:
-            continue
-        ref = chk.strip_quotes(m.group("ref"))
-        if chk.image_name(ref) == expected_name and ref not in refs:
-            refs.append(ref)
-    return refs
-
-
-def _env_from_text(text: str) -> dict[str, str]:
-    values: dict[str, str] = {}
-    for raw in text.splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("export "):
-            line = line[len("export ") :].strip()
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        key = key.strip()
-        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
-            values[key] = chk.strip_quotes(value)
-    return values
-
-
-def resolve_service_refs(repo: Path, read_text, image_name: str) -> set[str]:
-    """Set of fully-resolved deployable image refs for ``image_name``.
+def resolve_service_refs(repo: Path, read_text, image_name: str) -> tuple[set[str], set[str]]:
+    """Return ``(resolved, unresolved)`` deployable image refs for ``image_name``.
 
     ``read_text(relpath)`` returns the file's content (or None if absent) at the
-    revision being inspected. Returns an empty set if nothing resolves.
+    revision being inspected. ``unresolved`` holds raw refs that match the
+    image name but that no ``.env`` could fully expand — the check treats those
+    as a hard failure, so the gate must run when one is newly introduced.
     """
     config = chk.IMAGE_CONFIGS[image_name]
     compose_files = chk.discover_compose_files(repo)
@@ -167,32 +141,40 @@ def resolve_service_refs(repo: Path, read_text, image_name: str) -> set[str]:
 
     env_caches: dict[Path, dict[str, str]] = {}
     for ef in env_files:
-        env_caches[ef] = _env_from_text(read_text(str(ef.relative_to(repo))) or "")
+        env_caches[ef] = chk.parse_env_text(read_text(str(ef.relative_to(repo))) or "")
 
-    refs: set[str] = set()
+    resolved: set[str] = set()
+    unresolved: set[str] = set()
     for cf in compose_files:
         text = read_text(str(cf.relative_to(repo)))
         if not text:
             continue
-        for raw in _image_refs_in_compose(text, config.image_name):
+        for raw in chk.image_refs_in_text(text, config.image_name):
             _, needed = chk.resolve_compose_vars(raw, {})
             if not needed:
-                resolved, _ = chk.resolve_compose_vars(raw, dict(os.environ))
-                refs.add(resolved)
+                expanded, _ = chk.resolve_compose_vars(raw, dict(os.environ))
+                resolved.add(expanded)
                 continue
+            applied = False
             for ef in env_files:
                 env_values = env_caches[ef]
                 if all(name in env_values for name in needed):
-                    resolved, missing = chk.resolve_compose_vars(
+                    expanded, missing = chk.resolve_compose_vars(
                         raw, {**env_values, **os.environ}
                     )
                     if not missing:
-                        refs.add(resolved)
-    return refs
+                        resolved.add(expanded)
+                        applied = True
+            if not applied:
+                # No env file supplies the needed vars — the check would record
+                # this as an unresolved image and fail.
+                unresolved.add(raw)
+    return resolved, unresolved
 
 
 def service_tag_changed(repo: Path, base: str, image_name: str) -> bool:
-    """True if the service's resolved image ref(s) differ between base and HEAD."""
+    """True if the service's image ref(s) differ between base and HEAD, or HEAD
+    introduces a ref the check would treat as unresolved."""
     def head_reader(rel: str):
         path = repo / rel
         return path.read_text() if path.exists() else None
@@ -201,19 +183,31 @@ def service_tag_changed(repo: Path, base: str, image_name: str) -> bool:
         result = git(repo, "show", f"{base}:{rel}")
         return result.stdout if result.returncode == 0 else None
 
-    head_refs = resolve_service_refs(repo, head_reader, image_name)
-    if not head_refs:
-        # Couldn't resolve anything at HEAD — be conservative and run the check.
-        log("could not resolve any image refs at HEAD; running full source check.")
+    head_resolved, head_unresolved = resolve_service_refs(repo, head_reader, image_name)
+    if not head_resolved and not head_unresolved:
+        # No deployable ref for this service at HEAD — be conservative and run.
+        log("found no image refs at HEAD; running full source check.")
         return True
-    base_refs = resolve_service_refs(repo, base_reader, image_name)
-    if head_refs != base_refs:
+
+    base_resolved, base_unresolved = resolve_service_refs(repo, base_reader, image_name)
+
+    if head_resolved != base_resolved:
         log(f"image tag changed vs {base[:12]}:")
-        for r in sorted(head_refs - base_refs):
+        for r in sorted(head_resolved - base_resolved):
             log(f"  + {r}")
-        for r in sorted(base_refs - head_refs):
+        for r in sorted(base_resolved - head_resolved):
             log(f"  - {r}")
         return True
+
+    # A ref that resolves at HEAD nowhere it didn't at base would make the real
+    # check fail (unresolved image); don't let the gate mask that.
+    new_unresolved = head_unresolved - base_unresolved
+    if new_unresolved:
+        log("PR introduces image ref(s) that no .env resolves; running full source check:")
+        for r in sorted(new_unresolved):
+            log(f"  ? {r}")
+        return True
+
     return False
 
 

--- a/.github/scripts/test_source_check_only_nonbuild.py
+++ b/.github/scripts/test_source_check_only_nonbuild.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the container-source gate helper.
+
+Run directly (no pytest dependency): ``python3 .github/scripts/test_source_check_only_nonbuild.py``.
+The repo's pytest job runs from services/agent, so it won't collect this; the
+container-source workflows run it as a step instead, so a helper regression
+fails the required gate it powers.
+"""
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_container_tag_source as chk  # noqa: E402
+import source_check_only_nonbuild as gate  # noqa: E402
+
+
+class TestIsNonbuild(unittest.TestCase):
+    def nb(self, image, rel):
+        return gate.is_nonbuild(rel, gate.NONBUILD_PATTERNS[image])
+
+    def test_agent_docs_and_tests_are_nonbuild(self):
+        self.assertTrue(self.nb("vss-agent", "README.md"))
+        self.assertTrue(self.nb("vss-agent", "AGENTS.md"))
+        self.assertTrue(self.nb("vss-agent", "tests/test_x.py"))
+        self.assertTrue(self.nb("vss-agent", "stubs/nat/__init__.pyi"))
+
+    def test_agent_shipped_src_md_is_build_relevant(self):
+        # COPY agent/src/vss_agents wholesale ships these — must NOT be skipped.
+        self.assertFalse(self.nb("vss-agent", "src/vss_agents/orchestrator/README.md"))
+        self.assertFalse(self.nb("vss-agent", "pyproject.toml"))
+        self.assertFalse(self.nb("vss-agent", "uv.lock"))
+
+    def test_ui_markdown_and_ts_tests_are_nonbuild(self):
+        self.assertTrue(self.nb("vss-agent-ui", "README.md"))
+        self.assertTrue(self.nb("vss-agent-ui", "apps/x/notes.md"))
+        self.assertTrue(self.nb("vss-agent-ui", "apps/x/Button.test.tsx"))
+        self.assertTrue(self.nb("vss-agent-ui", "apps/x/util.spec.ts"))
+
+    def test_ui_nonjs_test_and_source_are_build_relevant(self):
+        # .dockerignore only drops the .js/.ts/.tsx test/spec variants.
+        self.assertFalse(self.nb("vss-agent-ui", "scripts/gen.test.py"))
+        self.assertFalse(self.nb("vss-agent-ui", "apps/x/Button.tsx"))
+        self.assertFalse(self.nb("vss-agent-ui", "package.json"))
+
+
+class TestResolveServiceRefs(unittest.TestCase):
+    def setUp(self):
+        self.repo = Path("/repo")
+        self.compose = self.repo / "deploy/docker/services/agent/compose.yml"
+        self.env = self.repo / "deploy/docker/dev/.env"
+
+    def resolve(self, contents, image="vss-agent"):
+        def read(rel):
+            return contents.get(rel)
+
+        with mock.patch.object(chk, "discover_compose_files", return_value=[self.compose]), \
+             mock.patch.object(chk, "discover_env_files", return_value=[self.env]):
+            return gate.resolve_service_refs(self.repo, read, image)
+
+    def test_resolves_via_env(self):
+        resolved, unresolved = self.resolve({
+            "deploy/docker/services/agent/compose.yml":
+                "    image: nvcr.io/x/vss-agent:${VSS_AGENT_VERSION}\n",
+            "deploy/docker/dev/.env": "VSS_AGENT_VERSION=1.2.3\n",
+        })
+        self.assertEqual(resolved, {"nvcr.io/x/vss-agent:1.2.3"})
+        self.assertEqual(unresolved, set())
+
+    def test_unresolvable_ref_is_recorded(self):
+        resolved, unresolved = self.resolve({
+            "deploy/docker/services/agent/compose.yml":
+                "    image: nvcr.io/x/vss-agent:${UNDEFINED_XYZ}\n",
+            "deploy/docker/dev/.env": "VSS_AGENT_VERSION=1.2.3\n",
+        })
+        self.assertEqual(resolved, set())
+        self.assertTrue(any("UNDEFINED_XYZ" in r for r in unresolved))
+
+    def test_other_service_ref_ignored(self):
+        # A ui ref must not appear when resolving for vss-agent.
+        resolved, unresolved = self.resolve({
+            "deploy/docker/services/agent/compose.yml":
+                "    image: nvcr.io/x/vss-agent-ui:9.9.9\n",
+            "deploy/docker/dev/.env": "",
+        })
+        self.assertEqual(resolved, set())
+        self.assertEqual(unresolved, set())
+
+
+class TestServiceTagChanged(unittest.TestCase):
+    def run_with(self, head, base):
+        with mock.patch.object(gate, "resolve_service_refs", side_effect=[head, base]):
+            return gate.service_tag_changed(Path("/repo"), "deadbeef", "vss-agent")
+
+    def test_no_change_skips(self):
+        self.assertFalse(self.run_with(({"a:1"}, set()), ({"a:1"}, set())))
+
+    def test_tag_bump_runs(self):
+        self.assertTrue(self.run_with(({"a:2"}, set()), ({"a:1"}, set())))
+
+    def test_no_refs_at_head_is_conservative(self):
+        self.assertTrue(self.run_with((set(), set()), ({"a:1"}, set())))
+
+    def test_newly_unresolvable_runs(self):
+        self.assertTrue(self.run_with(({"a:1"}, {"x:${NOPE}"}), ({"a:1"}, set())))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/check-agent-container-source.yml
+++ b/.github/workflows/check-agent-container-source.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Validate the gate helper itself — a regression here would silently
+      # block every PR or skip a genuinely-drifted container, so fail loudly.
+      - name: Unit-test the gate helper
+        run: python3 .github/scripts/test_source_check_only_nonbuild.py
+
       # Docs/tests-only PRs never change what enters the agent image — the
       # Dockerfile uses selective COPY — yet they change the services/agent
       # tree SHA and would trip the gate below. Detect that case and skip the

--- a/.github/workflows/check-ui-container-source.yml
+++ b/.github/workflows/check-ui-container-source.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Validate the gate helper itself — a regression here would silently
+      # block every PR or skip a genuinely-drifted container, so fail loudly.
+      - name: Unit-test the gate helper
+        run: python3 .github/scripts/test_source_check_only_nonbuild.py
+
       # Docs/tests-only PRs never change what enters the UI image — the build
       # context honors services/ui/.dockerignore, which excludes **/*.md and
       # test/spec files — yet they change the services/ui tree SHA and would


### PR DESCRIPTION
## Problem

The **Check Agent/UI Container Source** gates compare the full `services/agent` / `services/ui` git subtree SHA against the image's `com.nvidia.vss.source_tree_sha`. Once an allowed docs change merges to `develop` (via the #906 skip), the folder's subtree SHA drifts from the promoted image — and because the check re-evaluates HEAD's (drifted) folder, it then **fails on every later PR, even ones that touch neither the service nor the image tag** (e.g. #911, which only changes `.github/skill-eval/`). These are **ruleset-required** checks ("Protect develop"), so a red/missing status blocks the PR.

> Note: because they're required, we can't gate them with a workflow-level `on: push: paths:` filter — a required check that never runs leaves the PR hanging. So this is done **in-job**: the job always runs and reports success; it just skips the SHA comparison when it isn't relevant.

## Change

Extend the gate helper so a service's check **runs the SHA comparison only when the PR changed**:

1. a **build-relevant** file under that service folder (anything the image build consumes — not the allowlisted docs/tests/metadata), **or**
2. that service's **resolved deployable image tag** (a tag bump in `deploy/docker` compose/`.env`).

Otherwise it skips (passes) — a predecessor's docs-drift can no longer red-flag unrelated PRs.

The tag check is **per-service and value-based**: it resolves the image ref at HEAD vs the merge-base (reusing `check_container_tag_source.py`'s own compose/`.env` resolution), so an agent tag bump in a shared `.env` doesn't trip the UI gate and vice-versa.

The existing SHA comparison in `check_container_tag_source.py` is **untouched** — no custom hash, no `.dockerignore` parsing. This is purely about *when* the (unchanged) check runs.

## Verified locally (merge-base vs HEAD)

| PR touches | agent gate | ui gate |
|---|---|---|
| only `.github/skill-eval/` (#911) | skip | skip |
| `services/agent/README.md` (docs) | skip | skip |
| `services/agent/tests/…` | skip | skip |
| `services/agent/src/**` | **run** | skip |
| agent tag bump (`VSS_AGENT_VERSION`) | **run** | skip |
| ui tag bump (`services/ui/compose.yml`) | skip | **run** |

The job still always runs (required-status-safe; `continue-on-error` + fail-safe default from #906 retained).

## Relationship to #906 / #907
- Supersedes the one gap in #906 (it ran the full check when a PR touched *no* service files → the source of the #911-style failures).
- Makes #907 (build-input/`.dockerignore` SHA filtering) unnecessary — we no longer need the check to *ignore* docs; we just don't *run* it for docs/unrelated PRs. Closing #907.

## Unblocking already-open PRs
A PR picks up this logic from its own branch's workflow, so already-open PRs (#911) need to merge/rebase `develop` after this lands (or re-promote the images to clear the current drift).

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
