### PR TITLE
chore: fix CR3 VLM model names in .env

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -76,7 +76,10 @@ LLM_MODEL_TYPE=nim
 #   VLM_NAME_SLUG: cosmos-reason2-8b
 # - VLM_NAME: Qwen/Qwen3-VL-8B-Instruct
 #   VLM_NAME_SLUG: qwen3-vl-8b-instruct
-# - VLM_NAME: nvidia/cosmos3-reasoner        # set NIM_MODEL_SIZE below
+# Cosmos3 Reasoner: set VLM_NAME/VLM_NAME_SLUG here, and set matching NIM_MODEL_SIZE below:
+# - VLM_NAME: nvidia/cosmos3-nano-reasoner -> NIM_MODEL_SIZE=nano
+#   VLM_NAME_SLUG: cosmos3-reasoner
+# - VLM_NAME: nvidia/cosmos3-super-reasoner -> NIM_MODEL_SIZE=super
 #   VLM_NAME_SLUG: cosmos3-reasoner
 VLM_NAME=nvidia/cosmos-reason2-8b
 VLM_NAME_SLUG=cosmos-reason2-8b

--- a/deploy/docker/services/nim/cosmos3-reasoner/compose.yml
+++ b/deploy/docker/services/nim/cosmos3-reasoner/compose.yml
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 # Cosmos3 Reasoner NIM image. Opt in via
-#   VLM_NAME=nvidia/cosmos3-reasoner
+#   VLM_NAME=nvidia/cosmos3-nano-reasoner (for nano) or
+#   VLM_NAME=nvidia/cosmos3-super-reasoner (for super)
 #   VLM_NAME_SLUG=cosmos3-reasoner
 # in dev-profile-base/.env. NIM_MODEL_SIZE selects nano (default) or super.
 


### PR DESCRIPTION
## Description

- CR3 has different model names depending on the size instead of `cosmos3-reasoner`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
