### PR TITLE
fix(nemoclaw): remove ngc sandbox setup

### DIFF
--- a/assets/vss_nemoclaw_policy.yaml
+++ b/assets/vss_nemoclaw_policy.yaml
@@ -65,26 +65,6 @@ network_policies:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/node }
 
-  ngc:
-    # Hosts verified by `ngc --debug registry resource download-version
-    # nvidia/vss-developer/dev-profile-sample-data:3.1.0` — only api.ngc and
-    # authn.nvidia are contacted; file payloads stream over api.ngc.nvidia.com.
-    # curl is needed because deploy_nemoclaw_vss.ipynb bootstraps the NGC CLI
-    # itself via `curl -fL -o ngc_cli.zip
-    # https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/...`
-    # before /usr/local/bin/ngc exists in the sandbox.
-    name: ngc
-    endpoints:
-      - host: api.ngc.nvidia.com
-        port: 443
-        access: full
-      - host: authn.nvidia.com
-        port: 443
-        access: full
-    binaries:
-      - { path: /usr/bin/curl }
-      - { path: /usr/local/bin/ngc }
-
   github:
     name: github
     endpoints:

--- a/deploy/docker/scripts/nemoclaw/init_nemoclaw.sh
+++ b/deploy/docker/scripts/nemoclaw/init_nemoclaw.sh
@@ -256,80 +256,6 @@ configure_openshell_provider() {
   openshell inference get || true
 }
 
-# Inject NGC_CLI_API_KEY into the sandbox env so `ngc registry resource
-# download-version nvidia/vss-developer/dev-profile-sample-data:3.1.0` (and
-# the equivalent TAO model downloads) can authenticate from inside the
-# sandbox. Uses `--type generic` (the catch-all in the
-# `claude/opencode/codex/copilot/generic/openai/anthropic/nvidia/gitlab/github/outlook`
-# list) so the credential is exposed as a plain env var without binding to
-# an inference-provider semantic.
-configure_ngc_credential_provider() {
-  if ! have openshell; then
-    log "OpenShell not available yet; skipping NGC credential provider setup"
-    return
-  fi
-
-  local ngc_api_key="${NGC_CLI_API_KEY:-}"
-  if [ -z "$ngc_api_key" ]; then
-    log "NGC_CLI_API_KEY not set in operator env; skipping NGC credential provider setup. Sandbox-side `ngc registry …` calls will fail until this is exported and init re-run."
-    return
-  fi
-
-  local action provider_args
-  if openshell provider get ngc >/dev/null 2>&1; then
-    action="update"
-    provider_args=(provider update --credential NGC_CLI_API_KEY ngc)
-  else
-    action="create"
-    provider_args=(provider create --name ngc --type generic --credential NGC_CLI_API_KEY)
-  fi
-  log "Configuring NGC credential provider (action=${action})"
-  if ! NGC_CLI_API_KEY="$ngc_api_key" openshell "${provider_args[@]}"; then
-    log "NGC provider ${action} failed; sandbox-side ngc calls will be missing NGC_CLI_API_KEY"
-  fi
-}
-
-# Install the NGC CLI inside the running sandbox so `ngc registry resource
-# download-version …` works from openclaw. Uses `pip3 install --user ngcsdk`,
-# which fits the existing `pypi` policy block (binaries=/usr/bin/pip3,
-# hosts=pypi.org + files.pythonhosted.org). After install, copies the binary
-# to /usr/local/bin/ngc to match the path the `ngc` policy block allows.
-# Best-effort: logs and continues on failure rather than aborting the deploy.
-configure_ngc_cli_in_sandbox() {
-  if ! have openshell; then
-    log "openshell not available; skipping in-sandbox NGC CLI install"
-    return
-  fi
-  log "Installing NGC CLI inside sandbox ${NEMOCLAW_SANDBOX_NAME} (pip3 install --user ngcsdk)"
-  # Feed the install script over stdin via `bash -s` rather than as a
-  # `bash -c <script>` argument: the sandbox-exec gRPC API rejects any single
-  # argument containing newlines ("command argument N contains newline or
-  # carriage return characters"), so a multi-line inline script cannot be passed
-  # positionally. Use `openshell` to match every other in-sandbox exec here; the
-  # earlier `nemoclaw sandbox exec -n …` form failed twice over — `nemoclaw` takes
-  # the sandbox name positionally with no `-n` flag, and then rejected the
-  # multi-line `bash -c` body.
-  if ! openshell sandbox exec -n "$NEMOCLAW_SANDBOX_NAME" -- bash -s <<'NGC_INSTALL'
-set -e
-if command -v ngc >/dev/null 2>&1 && ngc --version >/dev/null 2>&1; then
-  echo "ngc already installed: $(ngc --version 2>&1 | head -1)"
-  exit 0
-fi
-python3 -m pip install --user --quiet --break-system-packages ngcsdk 2>/dev/null \
-  || python3 -m pip install --user --quiet ngcsdk
-if [ ! -e /usr/local/bin/ngc ] && [ -e "$HOME/.local/bin/ngc" ]; then
-  sudo install -m 0755 "$HOME/.local/bin/ngc" /usr/local/bin/ngc 2>/dev/null \
-    || cp "$HOME/.local/bin/ngc" /usr/local/bin/ngc 2>/dev/null \
-    || true
-fi
-/usr/local/bin/ngc --version 2>/dev/null \
-  || "$HOME/.local/bin/ngc" --version
-NGC_INSTALL
-  then
-    log "In-sandbox NGC CLI install failed; ngc registry calls inside the sandbox will not work"
-  fi
-}
-
 # `nemoclaw onboard` creates the dashboard port-forward (default 18789) that exposes the in-pod
 # openclaw-gateway (and its /hooks endpoint) to the host. When the sandbox already exists we skip
 # onboard, and the forward can also die independently between runs — so refresh it unconditionally.
@@ -691,12 +617,10 @@ main() {
   wait_for_sandbox_ready
   refresh_path
   ensure_dashboard_forward
-  configure_ngc_credential_provider
   apply_vss_policy
   update_openclaw_allowed_origin
   # Policy/config updates can briefly flap gateway readiness before plugin install.
   wait_for_sandbox_ready "${NEMOCLAW_POST_CONFIG_READY_TIMEOUT:-60}"
-  configure_ngc_cli_in_sandbox
   install_vss_openclaw_plugin
 
   log "To use nemoclaw in your current shell, run:"

--- a/deploy/docker/scripts/nemoclaw/init_nemoclaw.sh
+++ b/deploy/docker/scripts/nemoclaw/init_nemoclaw.sh
@@ -296,27 +296,36 @@ configure_ngc_credential_provider() {
 # to /usr/local/bin/ngc to match the path the `ngc` policy block allows.
 # Best-effort: logs and continues on failure rather than aborting the deploy.
 configure_ngc_cli_in_sandbox() {
-  if ! have nemoclaw; then
-    log "nemoclaw not available; skipping in-sandbox NGC CLI install"
+  if ! have openshell; then
+    log "openshell not available; skipping in-sandbox NGC CLI install"
     return
   fi
   log "Installing NGC CLI inside sandbox ${NEMOCLAW_SANDBOX_NAME} (pip3 install --user ngcsdk)"
-  if ! nemoclaw sandbox exec -n "$NEMOCLAW_SANDBOX_NAME" --no-tty -- bash -c '
-    set -e
-    if command -v ngc >/dev/null 2>&1 && ngc --version >/dev/null 2>&1; then
-      echo "ngc already installed: $(ngc --version 2>&1 | head -1)"
-      exit 0
-    fi
-    python3 -m pip install --user --quiet --break-system-packages ngcsdk 2>/dev/null \
-      || python3 -m pip install --user --quiet ngcsdk
-    if [ ! -e /usr/local/bin/ngc ] && [ -e "$HOME/.local/bin/ngc" ]; then
-      sudo install -m 0755 "$HOME/.local/bin/ngc" /usr/local/bin/ngc 2>/dev/null \
-        || cp "$HOME/.local/bin/ngc" /usr/local/bin/ngc 2>/dev/null \
-        || true
-    fi
-    /usr/local/bin/ngc --version 2>/dev/null \
-      || "$HOME/.local/bin/ngc" --version
-  '; then
+  # Feed the install script over stdin via `bash -s` rather than as a
+  # `bash -c <script>` argument: the sandbox-exec gRPC API rejects any single
+  # argument containing newlines ("command argument N contains newline or
+  # carriage return characters"), so a multi-line inline script cannot be passed
+  # positionally. Use `openshell` to match every other in-sandbox exec here; the
+  # earlier `nemoclaw sandbox exec -n …` form failed twice over — `nemoclaw` takes
+  # the sandbox name positionally with no `-n` flag, and then rejected the
+  # multi-line `bash -c` body.
+  if ! openshell sandbox exec -n "$NEMOCLAW_SANDBOX_NAME" -- bash -s <<'NGC_INSTALL'
+set -e
+if command -v ngc >/dev/null 2>&1 && ngc --version >/dev/null 2>&1; then
+  echo "ngc already installed: $(ngc --version 2>&1 | head -1)"
+  exit 0
+fi
+python3 -m pip install --user --quiet --break-system-packages ngcsdk 2>/dev/null \
+  || python3 -m pip install --user --quiet ngcsdk
+if [ ! -e /usr/local/bin/ngc ] && [ -e "$HOME/.local/bin/ngc" ]; then
+  sudo install -m 0755 "$HOME/.local/bin/ngc" /usr/local/bin/ngc 2>/dev/null \
+    || cp "$HOME/.local/bin/ngc" /usr/local/bin/ngc 2>/dev/null \
+    || true
+fi
+/usr/local/bin/ngc --version 2>/dev/null \
+  || "$HOME/.local/bin/ngc" --version
+NGC_INSTALL
+  then
     log "In-sandbox NGC CLI install failed; ngc registry calls inside the sandbox will not work"
   fi
 }


### PR DESCRIPTION
## Problem

The NemoClaw launchable init path previously tried to prepare NGC inside the OpenClaw sandbox:

- create/update an `ngc` OpenShell credential provider from `NGC_CLI_API_KEY`
- install an in-sandbox `ngc` binary
- allow sandbox egress to NGC endpoints for `/usr/local/bin/ngc` and `/usr/bin/curl`

That setup was broken on NemoClaw v0.0.48 / OpenShell 0.0.39: the install helper used an invalid `nemoclaw sandbox exec -n` form, and a follow-up attempt with a multi-line `bash -c` body hits the sandbox-exec gRPC newline-in-argument rejection.

## Decision

Do not install or configure NGC from the NemoClaw launchable init flow.

The current VSS NemoClaw deploy path should not depend on in-sandbox NGC CLI setup. Keeping a best-effort install path adds deploy noise, requires extra egress policy, and makes the launchable look like it supports NGC operations that are not part of this profile's required startup path.

## Fix

This PR removes the NGC setup path entirely:

- delete `configure_ngc_credential_provider()` from `init_nemoclaw.sh`
- delete `configure_ngc_cli_in_sandbox()` from `init_nemoclaw.sh`
- remove both calls from `main()`
- remove the `ngc` network-policy block from `assets/vss_nemoclaw_policy.yaml`

No replacement NGC install code is added by design.

## Impact

The NemoClaw deploy flow no longer attempts to install `ngc`, inject `NGC_CLI_API_KEY`, or allow NGC endpoint egress inside the sandbox.

Any future feature that truly needs in-sandbox NGC must add that requirement back explicitly, including both a working CLI provisioning path and the matching sandbox egress policy.

## Testing

- `bash -n deploy/docker/scripts/nemoclaw/init_nemoclaw.sh`
- `git diff --check`
- YAML parse check for `assets/vss_nemoclaw_policy.yaml`

Related nvbug: 6263489