### PR TITLE
fix(skills): make deploy readiness gate POSIX-portable (drop mapfile)

### DIFF
--- a/skills/vss-deploy-profile/references/readiness.md
+++ b/skills/vss-deploy-profile/references/readiness.md
@@ -26,14 +26,15 @@ fi
 # `ps --format json`, not a JSON array — so no `.[]` here; jq's default
 # input loop already iterates each line. The filter accepts only
 # `running` and `exited 0`; everything else (restarting, unhealthy,
-# exited with non-zero code) is a failure.
-mapfile -t bad < <(
-  docker compose -f resolved.yml ps --format json \
-    | jq -r 'select((.State == "running" or (.State == "exited" and .ExitCode == 0)) | not)
-             | "\(.Name)\t\(.State)\texit=\(.ExitCode // "?")\t\(.Status)"'
-)
-if [ "${#bad[@]}" -gt 0 ]; then
-  printf 'FAIL: %s\n' "${bad[@]}" >&2
+# exited with non-zero code) is a failure. Capture into a string and test
+# non-empty (not `mapfile`/arrays): `mapfile` is a bash 4+ builtin, absent
+# on macOS's bash 3.2, zsh, and /bin/sh — where it would error and let this
+# gate pass *vacuously*. `bad=$(…)` + `[ -n ]` is POSIX and aborts everywhere.
+bad=$(docker compose -f resolved.yml ps --format json \
+  | jq -r 'select((.State == "running" or (.State == "exited" and .ExitCode == 0)) | not)
+           | "\(.Name)\t\(.State)\texit=\(.ExitCode // "?")\t\(.Status)"')
+if [ -n "$bad" ]; then
+  printf 'FAIL:\n%s\n' "$bad" >&2
   exit 1
 fi
 ```


### PR DESCRIPTION
## Description

The `vss-deploy-profile` Step 1 readiness gate (`references/readiness.md`) detected non-healthy containers with `mapfile -t bad < <(…)` + `${#bad[@]}`. **`mapfile` is a bash 4+ builtin** — absent on macOS's default **bash 3.2**, on **zsh**, and on **`/bin/sh`/dash** (where `< <()` is also a syntax error). On those shells `mapfile` errors, `bad` stays empty, the `[ ${#bad[@]} -gt 0 ]` test is false, and **the gate passes vacuously** — green-lighting a deploy with `restarting` / `unhealthy` / `exited≠0` containers, i.e. the exact failure the gate exists to catch.

This swaps it for a POSIX string capture + non-empty test (`bad=$(…)`; `[ -n "$bad" ]`) — no arrays, no process substitution, identical logic.

### Verification

Ran the new state-check across all three shells, for a bad container and a clean deploy:

| shell | bad container | clean deploy |
|---|---|---|
| `/bin/sh` (dash/POSIX) | `exit 1` + FAIL ✅ | `exit 0` ✅ |
| `/bin/bash` 3.2.57 (macOS) | `exit 1` + FAIL ✅ | `exit 0` ✅ |
| `zsh` | `exit 1` + FAIL ✅ | `exit 0` ✅ |

The old `mapfile` form returned `exit 0` (vacuous pass) under zsh and bash 3.2.

Scope is the one readiness gate only; the count-guard above it (`wc -l`, `[ -gt ]`) was already POSIX-clean. Follow-up to the readiness gate added in #908 / #915 / #924.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (manual shell-portability verification across bash 3.2 / zsh / sh)
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
