### PR TITLE
fix(skill-eval): accept over-provisioned boxes (gpu_count >=) + reset the fallback box

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -336,6 +336,17 @@ The canonical harbor command is in § Harbor invocation.
       INSTANCE_NAME=<picked>
       ```
 
+      Resolving a candidate's gpu_count for the exact-match preference:
+      `brev ls --json` does **not** carry `gpu_count` (only `name`, `gpu`,
+      `instance_type`, `status`), so cross-reference each candidate's
+      `instance_type` against `brev search gpu --json` — the same catalog
+      `brev_env._get_instance_gpu_count_from_catalog` validates against. The
+      `vss-eval-*` fleet naming is a fallback hint (`*-1g` → 1 GPU; bare or
+      `*-2` → 2 GPU). If you can't resolve a count, just pick any
+      `gpu_type`-matching box and let `brev_env` enforce `gpu_count >=
+      required` post-selection — exact-match is a partitioning *optimisation*,
+      not a correctness gate (the box is reset either way).
+
       With fleet=1, this collapses to today's behaviour — the single
       `vss-eval-<short>` candidate is picked and locked. With fleet>1
       (operator manually `brev create`s `vss-eval-l40s-2`, etc.), two

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -318,16 +318,21 @@ The canonical harbor command is in § Harbor invocation.
       score and pick:
 
       ```bash
-      # Candidates: RUNNING+READY ^vss-eval-* boxes whose gpu/platform
-      # matches the trial. (envs/brev_env.py validates the pick post-
-      # selection; this step just narrows the field.)
+      # Candidates: RUNNING+READY ^vss-eval-* boxes whose gpu_type matches
+      # the trial AND whose gpu_count >= the spec's required count.
+      # (envs/brev_env.py validates the pick post-selection; this step
+      # just narrows the field.)
       brev ls --json > "/tmp/skill-eval/brev-snapshot-${LEG}.json"
-      # Score:
-      #   1. lock free (try flock -n)            (free)
-      #   2. instance name asc                   (tiebreak)
-      # Pick the first candidate that scores best AND whose flock -n
-      # succeeds. If none free, block on flock -w 21000 of the
-      # first hardware-matching candidate.
+      # Score (PREFER an exact gpu_count match so the pool stays partitioned
+      # — don't tie up a 2-GPU box with 1-GPU work):
+      #   1. exact gpu_count match               (prefer over over-provisioned)
+      #   2. lock free (try flock -n)            (free)
+      #   3. instance name asc                   (tiebreak)
+      # Pick the best-scoring candidate whose flock -n succeeds. Use an
+      # OVER-provisioned box (more GPUs than required) only as a fallback,
+      # when no exact-count match is lock-free/reachable — brev_env accepts
+      # it (>= check) and start() wipes it clean before the trial. If none
+      # free, block on flock -w 21000 of the best candidate.
       INSTANCE_NAME=<picked>
       ```
 
@@ -546,6 +551,14 @@ Match rules enforced by `envs/brev_env.py::_check_instance_matches`
   of 'L40S' in 'L4'`. Treat the candidate as not eligible and wait
   for a hardware-matching pool member per § 5a — the operator
   provisions matching capacity, not the agent.
+- **gpu_count is `>=`, not exact.** `_check_instance_matches` accepts any
+  box with **at least** the spec's `gpu_count` — a 1-GPU spec runs fine on
+  a 2-GPU box (2nd GPU idles); only an *under*-provisioned box is rejected.
+  **Prefer** an exact match at selection time (§ 5a scoring) so the pool
+  stays partitioned, but an over-provisioned box is a valid fallback when
+  no exact match is free/reachable. Because the `>=` check passes (rather
+  than raising), `start()` runs `_reset_docker_runtime` on the fallback
+  box, so it never inherits a prior trial's containers.
 
 ## Harbor invocation
 

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -1128,16 +1128,21 @@ async def _check_live_gpu_count(instance_name: str, required_count: int) -> None
             instance_name, result.stdout,
         )
         return
-    if actual != required_count:
+    # Over-provisioning is fine — a 1-GPU spec runs on a 2-GPU box with the
+    # 2nd GPU idle. Only UNDER-provisioning is fatal (a 2-GPU spec can't
+    # launch its second model on a 1-GPU box). The orchestrator still PREFERS
+    # an exact match for pool partitioning (AGENTS.md § 5a); this is the
+    # fallback gate. Returning (not raising) lets start() proceed to
+    # _reset_docker_runtime, so a fallback over-provisioned box still gets
+    # wiped before the trial deploys onto it.
+    if actual < required_count:
         raise RuntimeError(
             f"Brev instance '{instance_name}' has {actual} GPU(s) (live "
-            f"nvidia-smi); task requires exactly {required_count}. Pool "
-            f"partition mismatch — pick a fleet member with the matching "
-            f"GPU count (e.g. vss-eval-l40s-1g for 1-GPU, vss-eval-l40s* "
-            f"for 2-GPU)."
+            f"nvidia-smi); task requires at least {required_count}. Pick a "
+            f"fleet member with >= the required GPU count."
         )
     logger.info(
-        "Instance '%s' live gpu_count: %d (matches required %d)",
+        "Instance '%s' live gpu_count: %d (satisfies required >= %d)",
         instance_name, actual, required_count,
     )
 
@@ -1210,11 +1215,15 @@ async def _check_instance_matches(instance: dict, req: dict) -> None:
                 f"gpu_type: want tokens of {required_type!r} in {gpu!r}"
             )
 
-    # gpu_count check — strict equality so pool partitioning works.
-    # A 1-GPU task on a 2-GPU box wastes capacity (the other GPU could
-    # serve a sibling 1-GPU trial in parallel); a 2-GPU task on a 1-GPU
-    # box can't even launch the second LLM/VLM. Strict match makes both
-    # cases loud at validate time instead of mid-trial.
+    # gpu_count check — require >= (over-provisioned OK), NOT strict equality.
+    # A 1-GPU spec runs fine on a 2-GPU box (2nd GPU idles); only an
+    # UNDER-provisioned box (fewer GPUs than required) can't launch the spec's
+    # second model and must be rejected. Pool partitioning is preserved by the
+    # orchestrator PREFERRING an exact match (AGENTS.md § 5a) — this is the
+    # validate-time gate for the fallback case. Crucially, because we no longer
+    # raise here for an over-provisioned box, start() proceeds to
+    # _reset_docker_runtime, so a fallback 2-GPU box is wiped clean before the
+    # trial deploys onto it.
     required_count = int(req.get("gpu_count", 1) or 0)
     if required_count > 0:
         catalog_count = await _get_instance_gpu_count_from_catalog(
@@ -1231,9 +1240,9 @@ async def _check_instance_matches(instance: dict, req: dict) -> None:
                 await _check_live_gpu_count(instance.get("name"), required_count)
             except RuntimeError as exc:
                 errors.append(str(exc))
-        elif catalog_count != required_count:
+        elif catalog_count < required_count:
             errors.append(
-                f"gpu_count: want exactly {required_count}, instance has "
+                f"gpu_count: want at least {required_count}, instance has "
                 f"{catalog_count} (instance_type={instance.get('instance_type')})"
             )
 
@@ -1250,7 +1259,7 @@ async def _check_instance_matches(instance: dict, req: dict) -> None:
         require_clauses = []
         if required_type:
             require_clauses.append(f"gpu_type={required_type!r}")
-        require_clauses.append(f"gpu_count={required_count}")
+        require_clauses.append(f"gpu_count>={required_count}")
         require_phrase = " + ".join(require_clauses)
         hint = (
             f"\n\nTo find a matching pool member, scan vss-eval-* "

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -1107,7 +1107,8 @@ async def _get_instance_gpu_count_from_catalog(instance_type: str) -> int | None
 
 
 async def _check_live_gpu_count(instance_name: str, required_count: int) -> None:
-    """SSH in and count GPUs via nvidia-smi. Raises on mismatch."""
+    """SSH in and count GPUs via nvidia-smi. Raises only if the box has
+    FEWER GPUs than required — over-provisioned boxes are accepted (>=)."""
     result = await _run_brev_exec(
         instance_name,
         "nvidia-smi --query-gpu=name --format=csv,noheader | wc -l",


### PR DESCRIPTION
## Problem

The orchestrator (AGENTS.md §5a) and `brev_env` disagreed on gpu_count eligibility:
- §5a treated **any** gpu_type-matching box as eligible (*"gpu_count: 1, so all are eligible"*) and locked the first alphabetically.
- `brev_env._check_instance_matches` enforced **strict equality** and rejected over-provisioned boxes.

Observed on run `26859586477` (vss-ask-video `base` / L40S): the orchestrator locked `vss-eval-l40s` (2-GPU) for a 1-GPU spec, `start()` rejected it on gpu_count, and it bounced to `vss-eval-l40s-1g`. Two consequences:

1. **The 2-GPU box it bounced off was never reset.** `_check_instance_matches` raises *before* `_reset_docker_runtime` runs, so a locked-then-rejected box keeps its leftover containers (the user-reported "leftover containers after the reset PR").
2. **Spurious BLOCKs on fallback.** When exact-count boxes are unreachable (the flaky `rtx-1g` pool), a 1-GPU spec couldn't use a reachable 2-GPU box.

## Fix — prefer exact, allow over-provisioned fallback

- **`brev_env`**: `_check_instance_matches` + `_check_live_gpu_count` now require `actual >= required` (reject only *under*-provisioned). Since the check no longer raises for an over-provisioned box, `start()` flows through to `_reset_docker_runtime` — **so a fallback 2-GPU box gets wiped clean before the trial deploys onto it** (the specific guarantee requested in review).
- **AGENTS.md §5a**: candidate scoring now **prefers** an exact gpu_count match (pool stays partitioned in the common case) and falls back to an over-provisioned box only when no exact match is lock-free/reachable; the match-rules section documents the `>=` enforcement + the reset guarantee.

## Result
- No more lock→reject→relock bounce — the orchestrator scores the exact-match box first and picks it directly.
- The box that actually runs the trial is **always** reset, whether exact-match or fallback.
- 1-GPU specs can fall back to 2-GPU boxes when the 1-GPU pool is unreachable, instead of BLOCKing.

## Validation
- `python3 -m py_compile` on `brev_env.py`. ✅
- No unit test: importing `brev_env` requires `harbor` (matches #819/#911 convention — operational shell, validated live).
- Touches only `brev_env.py` + `AGENTS.md §5a`. No skill content; no pool-lifecycle changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
