### PR TITLE
fix(skill-eval): skip aggregate evals.json from spec discovery

### DIFF
--- a/.github/skill-eval/plan_matrix.py
+++ b/.github/skill-eval/plan_matrix.py
@@ -59,6 +59,14 @@ ADAPTER_RE = re.compile(r"^\.github/skill-eval/adapters/([^/]+)/")
 # corrupting an artifact name or escaping a path.
 SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
+# `evals.json` (plural stem) is a legacy aggregate index — a JSON *array* of
+# scenarios, not a dispatchable spec object. It has no `resources.platforms`,
+# so spec_platforms() would choke on it (list has no .get), and the agent can't
+# run it as a single spec. Real specs are named per scenario (deploy.json,
+# routing.json, …). Skip `evals.json` everywhere a spec is discovered so it
+# never becomes a matrix leg.
+EXCLUDED_SPEC_NAMES = frozenset({"evals.json"})
+
 
 def list_changed_files() -> list[str]:
     """Changed files in the cumulative PR diff (base...mirror head).
@@ -124,6 +132,8 @@ def specs_for_skill(skill: str) -> list[tuple[str, str, str]]:
         if not d.is_dir():
             continue
         for p in sorted(d.glob("*.json")):
+            if p.name in EXCLUDED_SPEC_NAMES:
+                continue
             rel = p.relative_to(REPO_ROOT).as_posix()
             found.append((rel, eval_dir, p.stem))
     return found
@@ -158,7 +168,10 @@ def build_matrix(changed: list[str]) -> list[dict]:
 
     for f in changed:
         m = SPEC_RE.match(f)
-        if m:
+        # A changed `evals.json` is not a spec; let it fall through to the
+        # whole-skill rule below (and specs_for_skill keeps it out of that
+        # expansion too) rather than dispatching it as its own leg.
+        if m and Path(f).name not in EXCLUDED_SPEC_NAMES:
             changed_specs.add(f)
             continue
         m = SKILL_FILE_RE.match(f)

--- a/.github/skill-eval/tests/test_plan_matrix.py
+++ b/.github/skill-eval/tests/test_plan_matrix.py
@@ -87,6 +87,16 @@ class BuildMatrix(unittest.TestCase):
         ])
         self.assertEqual(self._stems(inc), ["a", "b"])  # a appears once
 
+    def test_changed_evals_json_falls_through_to_whole_skill(self):
+        # `evals.json` (plural) is a legacy aggregate index, not a spec, so a
+        # changed evals.json must not dispatch as its own leg. It falls through
+        # to whole-skill scope like any other non-spec file under the skill.
+        inc = plan_matrix.build_matrix(
+            ["skills/vss-summarize-video/evals/evals.json"]
+        )
+        self.assertEqual(self._stems(inc), ["a", "b"])
+        self.assertNotIn("evals", self._stems(inc))
+
     def test_harness_only_change_is_empty(self):
         for f in (
             ".github/skill-eval/skills_eval_agent.py",
@@ -141,6 +151,29 @@ class BuildMatrix(unittest.TestCase):
         inc = plan_matrix.build_matrix(changed)
         self.assertEqual(len(inc), 400)
         self.assertTrue(all(leg["kind"] == "eval" for leg in inc))
+
+
+class SpecsForSkill(unittest.TestCase):
+    """specs_for_skill globs the real tree, so it's tested against a temp
+    skills/ dir (not the stubbed FAKE_SPECS above)."""
+
+    def test_skips_aggregate_evals_json_index(self):
+        import tempfile
+
+        orig_root = plan_matrix.REPO_ROOT
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "skills" / "foo" / "evals"
+            d.mkdir(parents=True)
+            (d / "deploy.json").write_text("{}")        # real spec object
+            (d / "evals.json").write_text("[]")          # legacy array index
+            plan_matrix.REPO_ROOT = Path(td)
+            try:
+                specs = plan_matrix.specs_for_skill("foo")
+            finally:
+                plan_matrix.REPO_ROOT = orig_root
+        stems = sorted(s[2] for s in specs)
+        self.assertEqual(stems, ["deploy"])
+        self.assertNotIn("evals", stems)
 
 
 class ListChangedFiles(unittest.TestCase):


### PR DESCRIPTION
## Problem

`plan_matrix.py` treats every `skills/<skill>/evals/*.json` as a dispatchable eval spec. But two skills ship a **legacy aggregate index** literally named `evals.json`:

- `skills/vss-deploy-detection-tracking-3d/evals/evals.json`
- `skills/vss-generate-video-calibration/evals/evals.json`

Their top level is a JSON **array** of scenarios, not a spec object with `resources.platforms`. When such a skill is pulled into scope — a whole-skill change, or a `MANUAL_SKILLS_FILTER` sweep — `spec_platforms()` runs `data.get("resources", {})` on a `list`:

```python
data = json.loads(...)                       # -> list
platforms = data.get("resources", {})...     # AttributeError: 'list' object has no attribute 'get'
```

`spec_platforms()` only catches `(OSError, ValueError)`, so the `AttributeError` propagates and **crashes the plan job**. (For the two skills above it currently collapses to `missing_adapter`, but `evals.json` is still enumerated as a spec, and any adapter'd skill carrying an `evals.json` crashes the planner outright.)

## Fix

Exclude files named `evals.json` from **both** spec-discovery paths in `plan_matrix.py`:

1. `specs_for_skill()` glob — used by whole-skill expansion and the manual-sweep enumeration.
2. The `SPEC_RE` changed-file branch — a changed `evals.json` now falls through to whole-skill scope (like any other non-spec skill file) instead of dispatching as its own broken leg.

Centralized in a single `EXCLUDED_SPEC_NAMES = frozenset({"evals.json"})`. Real specs are named per scenario (`deploy.json`, `routing.json`, `calibration-chain.json`, …) and are unaffected.

## Tests

Adds two unit tests (all 19 pass, `python3 .github/skill-eval/tests/test_plan_matrix.py`):
- `SpecsForSkill.test_skips_aggregate_evals_json_index` — temp `evals/` dir with `deploy.json` + `evals.json`; only `deploy` is returned.
- `BuildMatrix.test_changed_evals_json_falls_through_to_whole_skill` — a changed `evals.json` dispatches the skill's real specs, never an `evals` leg.

Verified against the live tree: `specs_for_skill("vss-deploy-detection-tracking-3d")` now returns `[calibration-chain, deploy, routing]` (no `evals`), and the manual sweep no longer raises.

> Follow-up (not in this PR): `spec_platforms()` could also harden its `except` to swallow `AttributeError`/`TypeError`, so any future malformed (non-object) spec degrades to a platform-less leg instead of crashing the planner.