### PR TITLE
fix(skill-eval): hold box lock during harbor run

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -326,13 +326,16 @@ The canonical harbor command is in § Harbor invocation.
       # Score (PREFER an exact gpu_count match so the pool stays partitioned
       # — don't tie up a 2-GPU box with 1-GPU work):
       #   1. exact gpu_count match               (prefer over over-provisioned)
-      #   2. lock free (try flock -n)            (free)
+      #   2. lock appears free (advisory try flock -n)  (free)
       #   3. instance name asc                   (tiebreak)
-      # Pick the best-scoring candidate whose flock -n succeeds. Use an
+      # Pick the best-scoring candidate whose advisory flock -n succeeds.
+      # This is only a scoring hint; run_leg.py below is the only code that
+      # actually reserves the box. Use an
       # OVER-provisioned box (more GPUs than required) only as a fallback,
       # when no exact-count match is lock-free/reachable — brev_env accepts
       # it (>= check) and start() wipes it clean before the trial. If none
-      # free, block on flock -w 21000 of the best candidate.
+      # free, hand the best candidate to run_leg.py and let its structural
+      # lock wait arbitrate.
       INSTANCE_NAME=<picked>
       ```
 
@@ -350,8 +353,8 @@ The canonical harbor command is in § Harbor invocation.
       With fleet=1, this collapses to today's behaviour — the single
       `vss-eval-<short>` candidate is picked and locked. With fleet>1
       (operator manually `brev create`s `vss-eval-l40s-2`, etc.), two
-      concurrent CI runs land on different boxes naturally; the per-box
-      flock arbitrates within-fleet contention.
+      concurrent CI runs land on different boxes naturally; the wrapper-held
+      per-box lock arbitrates within-fleet contention.
 
       Selection priority is **hardware-hard, software-free**: the
       candidate's `gpu_type` MUST match the platform (hard); the box's
@@ -369,17 +372,22 @@ The canonical harbor command is in § Harbor invocation.
       polling forbidden in § "No polling", which watches in-flight work
       the synchronous harbor call already blocks on.
 
-   b. **Acquire the per-box lock** before running anything on the
-      chosen instance (filename keys off `$INSTANCE_NAME`):
+   b. **Run the structural leg wrapper**. Do not acquire or release
+      `flock` manually in a separate Bash call. `run_leg.py` opens
+      `/tmp/brev/$INSTANCE_NAME.lock`, holds that file descriptor for
+      the entire Harbor run (including all step-1..N invocations), and
+      releases it only when the wrapper exits or dies:
       ```bash
-      exec {LFD}>/tmp/brev/"$INSTANCE_NAME".lock
-      flock -w 21000 "$LFD" || { echo "BLOCKED: lock timeout"; exit 1; }
-      # ... trials ...
-      exec {LFD}>&-        # release on exit; the kernel also releases
-                           # automatically on process death (no userspace
-                           # trap needed for cancel-in-progress / SIGKILL).
+      python3 .github/skill-eval/run_leg.py \
+        --instance "$INSTANCE_NAME" \
+        --dataset-root "$DS" \
+        --results-root "$RES" \
+        --scratch "$SCRATCH" \
+        --spec-stem "$EVAL_SPEC_STEM" \
+        --platform "$EVAL_PLATFORM"
       ```
-      The flock wait (21000s ≈ 5.8 h) sits just under the per-leg job
+
+      The wrapper's flock wait (21000s ≈ 5.8 h) sits just under the per-leg job
       timeout (`skills-eval.yml` `timeout-minutes: 360` = 6 h), so the
       agent always reaches the `BLOCKED: lock timeout` line before the
       job-killer fires (the old 12 h / 43200s budget was for the
@@ -387,19 +395,14 @@ The canonical harbor command is in § Harbor invocation.
       mid-wait). If another worker holds the lock past that window,
       fall back to step 5a and rescore — another box may have come
       free. Final fallback: emit `BLOCKED: lock timeout` and exit.
-   c. Drive harbor one trial at a time (they share GPU/ports on the
-      host). Use the canonical invocation in § Harbor invocation
-      below — **do not improvise flags**. Before the `uvx harbor run`
-      call, `export BREV_INSTANCE=<name>` to the instance you
-      resolved in step 5a; the canonical snippet has the line —
-      omitting it makes `BrevEnvironment.start()` raise immediately
-      ("no instance resolved, harness does not auto-provision") and
-      the trial fails before harbor invokes the agent. If a trial fails, read the
-      trial log, fix the adapter (not the flags), rerun. While a
-      trial is running, do NOT poll the remote box from your tool loop
-      — harbor has its own agent-execution timeout and will fail the
-      trial cleanly. Spend turns on the next trial's setup or on
-      reading already-completed trial logs instead.
+   c. The wrapper drives Harbor one trial at a time (they share GPU/ports
+      on the host), exports `BREV_INSTANCE`, discovers single-step vs
+      multi-step task layouts, and uses the canonical flags in
+      § Harbor invocation. If a trial fails, read the trial log, fix the
+      adapter (not the flags), regenerate the dataset, and rerun the
+      wrapper. While a trial is running, do NOT poll the remote box from
+      your tool loop — Harbor has its own agent-execution timeout and
+      will fail the trial cleanly.
    d. After each trial, parse
       `$RES/<date>/<trial>/verifier/reward.txt`
       and `test-stdout.txt`. Record `(spec, platform, reward,
@@ -413,15 +416,15 @@ The canonical harbor command is in § Harbor invocation.
    --body-file …`. Do NOT post a planning / "refresh" comment up
    front — comments carry results, not intent.
 
-7. **Release all locks. DO NOT tear down any Brev instance.** The
+7. **Do not tear down any Brev instance.** The
    `vss-eval-*` boxes are a long-running pool managed by the
    operator; instances stay up across runs, and so do the slow caches
    that survive a volume wipe (docker **image** layers, the repo clone, the
    `data/` sample-data extract — but NOT the model-weight *volumes*, which
    the per-trial reset drops; see § 7).
-   Close each lock FD (`exec {LFD}>&-`) so the next worker can
-   grab the box. You never `brev stop` / `brev delete`. Pool
-   lifecycle is strictly an operator concern.
+   `run_leg.py` releases the per-box lock automatically when its process
+   exits; there is no shell FD for you to close. You never `brev stop` /
+   `brev delete`. Pool lifecycle is strictly an operator concern.
 
    **The box's docker runtime is reset for you at the *start* of each spec,
    not on exit.** On a spec's first trial — a single-step spec, or `step-1`
@@ -452,11 +455,10 @@ The canonical harbor command is in § Harbor invocation.
 
    ⚠️ **`start()` is now destructive on a spec's first trial — never run
    `harbor` manually against a box another run currently holds.** The wipe is
-   not structurally gated by the per-box flock (that's orchestrator discipline,
-   § 5b); a manual `uvx harbor run` with `BREV_INSTANCE` set (README "Run one
-   trial by hand") will `docker rm -f` the holder's containers and volumes
-   mid-trial. Acquire the flock — or pick a demonstrably idle box — before any
-   manual run.
+   structurally gated only when the trial goes through `run_leg.py` (§ 5b);
+   a manual direct `uvx harbor run` with `BREV_INSTANCE` set will
+   `docker rm -f` the holder's containers and volumes mid-trial. Use
+   `run_leg.py` — or pick a demonstrably idle box — before any manual run.
 
 8. **Exit.** Print a last line starting with `DONE:` summarizing
    outcomes (e.g. `DONE: 3/3 specs passed; 0 blockers`). If any spec
@@ -491,8 +493,8 @@ The canonical harbor command is in § Harbor invocation.
   running across runs. The agent's `brev` surface is limited to
   `brev ls`, `brev exec` (read-only — peeking at container state for
   diagnostics; deployment is done by each trial's own first agent
-  turn, not by anything you run from this agent), and acquiring /
-  releasing the per-box flock.
+  turn, not by anything you run from this agent), and invoking
+  `run_leg.py` for the structurally locked Harbor run.
   If no hardware-matching pool member exists for the trial's
   platform, follow the wait-for-pool path in § 5a (5-min `brev ls`
   poll, 21000s budget, then `BLOCKED: pool exhausted for
@@ -524,7 +526,7 @@ Pool naming is operator-managed; the actual fleet is whatever
 `brev ls` reports matching the prefix. Don't hardcode a specific
 instance name — the fleet-selection algorithm in § 5a picks the
 candidate. **Lifecycle is the operator's job**; you only acquire
-the per-box flock, run trials, and release the flock — see Hard
+the per-box lock through `run_leg.py` and run trials — see Hard
 rules about `brev create / start / stop / delete / reset`.
 
 `vss-skill-validator-v2` is the CI runner host — **never** touch it,
@@ -532,13 +534,13 @@ even though it shows up in `brev ls`.
 
 **Fleet selection (worker-pool model).** One matrix leg = one serial
 worker; concurrency comes from sibling legs each grabbing a different
-box. Pick + lock per § 5a, then `export BREV_INSTANCE` before
-`uvx harbor run` (§ Harbor invocation). The export is mandatory —
-BrevEnvironment no longer auto-provisions, so without it (or
-`task.toml [metadata].brev_instance`) `start()` raises before harbor
-runs. The pool is operator-managed: never `brev create / start / stop /
-reset / delete` a member; if none matches the platform, wait per § 5a
-and only then `BLOCKED: pool exhausted for <platform>`.
+box. Pick per § 5a, then run `run_leg.py` (§ Harbor invocation). The
+wrapper exports `BREV_INSTANCE` before Harbor starts; that export is
+mandatory because BrevEnvironment no longer auto-provisions, so without
+it (or `task.toml [metadata].brev_instance`) `start()` raises before
+Harbor runs. The pool is operator-managed: never `brev create / start /
+stop / reset / delete` a member; if none matches the platform, wait per
+§ 5a and only then `BLOCKED: pool exhausted for <platform>`.
 
 **Name prefix is an anchored match, not a substring.** Only instances
 whose name starts with `vss-eval-` are eligible. Ignore everything else
@@ -573,82 +575,33 @@ Match rules enforced by `envs/brev_env.py::_check_instance_matches`
 
 ## Harbor invocation
 
-The one command that drives a trial. Copy this verbatim — harbor's
-flag names have bitten multiple runs (`--include-task-name`, not
-`--include`; the environment import is a Python **module** path, not
-a file path).
+The command that drives a trial is the wrapper from § 5b. Copy this
+shape, substituting only the selected `$INSTANCE_NAME`:
 
 ```bash
-# uvx (and claude) install under ~/.local/bin. A fresh `bash -c` /
-# subshell does NOT source ~/.bashrc, so $HOME/.local/bin is missing
-# from PATH and `uvx` resolves to "command not found" — the trial
-# never starts. Re-export PATH defensively at the top of every Bash
-# call that runs harbor (observed on PR #827: "uvx is not in PATH for
-# subshells", whole sweep stalled).
-export PATH="$HOME/.local/bin:$PATH"
-
-# PYTHONPATH lets uvx harbor resolve envs.brev_env:BrevEnvironment.
-# The workflow step already exports it, but re-export defensively in
-# case you're driving harbor from a subshell.
-export PYTHONPATH="${GITHUB_WORKSPACE}/.github/skill-eval:${PYTHONPATH:-}"
-
-# CRITICAL: point the environment at the box you selected in step 5a.
-# BrevEnvironment reads BREV_INSTANCE at module import time; if it's
-# unset and task.toml [metadata].brev_instance is also absent,
-# BrevEnvironment.start() raises immediately — the harness no longer
-# auto-provisions, so the trial fails before harbor invokes the
-# agent. The export is the only path to a successful run.
-#
-# $INSTANCE_NAME comes from the fleet-selection algorithm in step 5a:
-# the chosen ^vss-eval-* candidate scored by (free-lock, name). Do
-# not hardcode "vss-eval-l40s" — with a multi-box fleet, concurrent
-# workflow runs land on different boxes and that's how parallelism
-# happens.
-export BREV_INSTANCE="$INSTANCE_NAME"
-
-# Per-(spec, platform) output ROOT. This is load-bearing: harbor
-# creates a <date>/<trial> subdir keyed to the *second* under -o, so
-# two harbor runs that share one -o and start in the same second
-# collide with FileExistsError and silently lose a trial (observed on
-# PR #827: base/lvs/alerts_cv vanished when 6 specs fanned out onto a
-# shared -o). Giving every invocation its own root makes serial
-# retries, stale dirs left by a failed attempt, and concurrent
-# fan-out (§ Wait contract #4) all collision-proof. NEVER point two
-# harbor runs at the same -o.
-# `$RES` (this leg's per-leg results root, set in § "Per-leg scratch
-# isolation") IS the harbor -o for a single-step spec — a single-step
-# leg owns its whole `$RES` root, so trials land at `$RES/<date>/<trial>`
-# and the workflow's collector finds them directly. Do NOT prepend an
-# extra `<spec_stem>-<platform>` subdir (a vestige of the retired
-# unscoped `results/<run_id>/` layout): that pushed result.json one
-# level deeper than the collector's `find` looks and silently dropped
-# the artifact.
-
-# Harbor names each task by its path RELATIVE to -p (the dir that holds
-# task.toml), NOT the task.toml `[task] name`. Point -p at the task dir's
-# immediate PARENT so the name collapses to the leaf basename. A single-step
-# spec emits ONE task at $DS/<profile>/<platform>/task.toml; the <profile>
-# middle dir varies per spec, so discover it — never hardcode -p "$DS".
-TASK_DIR=$(dirname "$(find "$DS" -name task.toml -print -quit)")
-
-uvx harbor run \
-  --environment-import-path "envs.brev_env:BrevEnvironment" \
-  -p "$(dirname "$TASK_DIR")" \
-  --include-task-name "$(basename "$TASK_DIR")" \
-  -a claude-code \
-  --model "$ANTHROPIC_MODEL" \
-  --ak api_base="$ANTHROPIC_BASE_URL/v1" \
-  --ae CLAUDE_CODE_DISABLE_THINKING=1 \
-  --environment-build-timeout-multiplier 3.0 \
-  --agent-timeout-multiplier 6.0 \
-  --verifier-timeout-multiplier 3.0 \
-  --max-retries 0 -n 1 --yes \
-  -o "$RES"
+python3 .github/skill-eval/run_leg.py \
+  --instance "$INSTANCE_NAME" \
+  --dataset-root "$DS" \
+  --results-root "$RES" \
+  --scratch "$SCRATCH" \
+  --spec-stem "$EVAL_SPEC_STEM" \
+  --platform "$EVAL_PLATFORM"
 ```
 
-(`$DS` / `$RES` are this leg's per-leg roots — see § "Per-leg scratch
+Do **not** run `uvx harbor run` directly from the agent. The wrapper
+does that inside the same process that holds `/tmp/brev/$INSTANCE_NAME.lock`.
+It exports `PATH`, `PYTHONPATH`, `BREV_INSTANCE`, and
+`CLAUDE_CODE_DISABLE_THINKING=1`; discovers whether `$DS` contains a
+single-step task or ordered `step-1..N` tasks; dispatches one Harbor
+task at a time with the fixed flags below; writes multi-step skip
+markers; and releases the lock when it exits.
+
+`$DS` / `$RES` are this leg's per-leg roots — see § "Per-leg scratch
 isolation". Never write to an unscoped `datasets/` or `results/<run_id>`
-path; concurrent legs share the host.)
+path; concurrent legs share the host. `$RES` is the Harbor `-o` root
+for both single-step and multi-step specs, so trials land at
+`$RES/<date>/<trial>/` where the collector and viewer migration expect
+them.
 
 Notes that have burned prior runs:
 - `--include-task-name` matches a task by its path **relative to `-p`**,
@@ -669,71 +622,16 @@ Notes that have burned prior runs:
 - `-i` / `--include` is a different flag and will silently match
   nothing or everything.
 - **Multi-step specs MUST be dispatched one step at a time, in
-  order, with skip-on-prior-fail.** Harbor's default scheduler
-  treats every `step-*/` subdir as an independent task and runs them
-  unordered (observed on PR #440: alerts ran step-1 → step-4 → step-2,
-  step-3 never dispatched at all). Spec checks for step N assume
-  the state established by step N-1; running them out of order
-  silently produces bogus failures. Use this dispatch loop instead
-  of a single `harbor run -p <platform_dir>` invocation:
-
-  ```bash
-  # Discover the platform dir that holds the step-*/ subdirs. The adapter
-  # nests them under a middle dir that is NOT the platform — it's the
-  # spec's deploy-profile (e.g. summarize emits $DS/lvs/l40s/step-1, whose
-  # stem is `lvs_api_ops`), so never hardcode `$DS/<platform>`. Find it.
-  STEP1_TOML=$(find "$DS" -path '*/step-1/task.toml' -print -quit)
-  PLATFORM_DIR=$(dirname "$(dirname "$STEP1_TOML")")   # the .../<platform> dir
-  # Read step_count from any step's task.toml [metadata] (same on each).
-  STEP_COUNT=$(grep -oP '^step_count\s*=\s*\K\d+' "$STEP1_TOML")
-
-  for STEP in $(seq 1 "$STEP_COUNT"); do
-    # All steps share the per-leg root `-o "$RES"`, same as a single-step
-    # spec — so trials land at `$RES/<date>/<trial>` (depth the collector +
-    # the viewer-migration below both expect). Sharing one -o is safe HERE
-    # because the steps run strictly sequentially, minutes apart (each is a
-    # full deploy+trial), so harbor always writes a distinct `<date>` dir —
-    # the same-second `-o` collision warned about above only happens with
-    # PARALLEL spec fan-out, never sequential steps. `--include-task-name`
-    # pins this invocation to exactly step N's task.
-    uvx harbor run \
-      --environment-import-path "envs.brev_env:BrevEnvironment" \
-      -p "$PLATFORM_DIR" \
-      --include-task-name "step-${STEP}" \
-      -a claude-code \
-      --model "$ANTHROPIC_MODEL" \
-      --ak api_base="$ANTHROPIC_BASE_URL/v1" \
-      --ae CLAUDE_CODE_DISABLE_THINKING=1 \
-      --environment-build-timeout-multiplier 3.0 \
-      --agent-timeout-multiplier 6.0 \
-      --verifier-timeout-multiplier 3.0 \
-      --max-retries 0 -n 1 --yes \
-      -o "$RES"
-
-    # Read the just-completed step's reward. Trial dirs are named
-    # step-<N>__<rand6> under $RES/<date>/, so glob on the step prefix.
-    REWARD=$(cat "$RES"/*/step-${STEP}__*/verifier/reward.txt \
-      2>/dev/null | tail -n 1)
-    REWARD="${REWARD:-0}"
-
-    # Skip-on-prior-fail: if this step didn't fully pass, do not
-    # dispatch the remaining steps. Their checks assume this step's
-    # state was set up; running them produces noise, not signal.
-    # Record "skipped (prior-step fail)" in the result table.
-    awk -v r="$REWARD" 'BEGIN { exit !(r+0 < 1.0) }' && {
-      for SKIP in $(seq $((STEP + 1)) "$STEP_COUNT"); do
-        printf '%s\n' "skipped (prior-step fail, step=$STEP reward=$REWARD)" \
-          > "$SCRATCH/skipped-<spec_stem>-<platform>-step-${SKIP}.txt"
-      done
-      break
-    }
-  done
-  ```
-
-  Single-step specs (most `vss-deploy-profile/*` specs) skip this loop and use
-  the one-shot pattern above (`-p "$(dirname "$TASK_DIR")"`,
-  `--include-task-name "$(basename "$TASK_DIR")"`). Detect by reading
-  `step_count` from `task.toml`: if 1, dispatch once; if N, use the loop.
+  order, with skip-on-prior-fail.** Harbor's default scheduler treats every
+  `step-*/` subdir as an independent task and runs them unordered
+  (observed on PR #440: alerts ran step-1 -> step-4 -> step-2, step-3
+  never dispatched at all). `run_leg.py` implements the ordered loop:
+  it finds every `*/step-1/task.toml` chain under `$DS`, reads
+  `step_count`, runs `step-1..N` sequentially with `--include-task-name
+  step-N`, reads the just-finished step's reward, and writes
+  `$SCRATCH/skipped-<spec_stem>-<platform>-step-<N>.txt` for remaining
+  steps when a prior step's reward is below 1.0. Do not reimplement this
+  loop in Bash.
 - `--environment-import-path` is a **Python module spec**
   (`envs.brev_env:BrevEnvironment`), not a filesystem path. Do not
   prepend `.github.skill-eval.` — `.github` isn't a valid Python
@@ -759,19 +657,20 @@ Notes that have burned prior runs:
 - Output goes to `$RES/<date>/<trial>/`. Migrate to the viewer
   (see § Harbor viewer).
 
-### Wait contract — every harbor invocation is reaped before the Bash tool returns
+### Wait contract — run_leg.py blocks until Harbor exits
 
-`uvx harbor run` MUST block this turn until the trial exits. Do NOT
-background it and poll progress (line counts, `brev exec`, etc.) — each
-poll burns a tool turn and a trial that out-runs the budget exits with
-no comment (a real failure: the wrapper exits 4, see § Output
-requirements).
+`python3 .github/skill-eval/run_leg.py ...` MUST run in the foreground
+until the trial or ordered multi-step chain exits. Do NOT background it
+and poll progress (line counts, `brev exec`, etc.) — each poll burns a
+tool turn and a trial that out-runs the budget exits with no comment (a
+real failure: the wrapper exits 4, see § Output requirements).
 
 Don't background the trial (`run_in_background`, `&`/`nohup`/`disown`):
-the harness blocks those and raises the Bash timeout cap so a long
-foreground run isn't auto-backgrounded into a pollable task. Wrap each
-run as `timeout 7800 uvx harbor run …` (hard backstop, under the cap).
-To peek at a stuck trial, do it ONCE between trials, never in a loop.
+the harness blocks those and raises the Bash timeout cap so the long
+foreground wrapper call is not auto-backgrounded into a pollable task.
+`run_leg.py` applies a 7800s hard backstop to each internal Harbor
+subprocess. To peek at a stuck trial, do it ONCE after the wrapper
+returns, never in a loop while it is running.
 
 If a trial errors out, read `$RES/<date>/<trial>/trial.log` —
 it has the harness + adapter traceback. Fix the adapter
@@ -989,9 +888,9 @@ separate; don't conflate the two.
 - **Claude-agent-sdk / API rate limit.** Back off 60s, retry up to
   3x. If still failing, emit `BLOCKED: anthropic rate limit` and
   exit.
-- **Lock contention** (another CI run holds the Brev lock). Wait up
-  to ~5.8 h (flock `-w 21000`, the per-leg job timeout is 6 h). If you time out, emit `BLOCKED: lock
-  timeout on <instance>`.
+- **Lock contention** (another CI run holds the Brev lock). `run_leg.py`
+  waits up to ~5.8 h (`--lock-timeout-sec 21000`, under the per-leg job
+  timeout). If it times out, emit `BLOCKED: lock timeout on <instance>`.
 
 ## Single-spec mode
 
@@ -1018,7 +917,7 @@ loop. Two leg kinds:
   (fork PR → comment + BLOCK). Run no trial, post no results comment.
   End `BLOCKED: missing adapter for <skill> auto-committed (<sha>)`.
 
-Everything else — hard rules, fleet selection (§ 5a), flock (§ 5b),
+Everything else — hard rules, fleet selection (§ 5a), wrapper-held lock (§ 5b),
 harbor invocation, result format, failure modes, the DONE/BLOCKED marker
 (§ Output requirements) — applies unchanged.
 
@@ -1042,8 +941,8 @@ difference — there is no PR (`PR_NUMBER` is empty). That means:
   `$GITHUB_STEP_SUMMARY` and `BLOCKED:` (never push; the hard rule against
   `skills/` writes still applies in full).
 
-Everything else — startup hygiene, fleet selection (§ 5a), per-box flock
-(§ 5b), canonical harbor invocation, no trial-supervision polling, the
+Everything else — startup hygiene, fleet selection (§ 5a), wrapper-held
+per-box lock (§ 5b), canonical harbor invocation, no trial-supervision polling, the
 artifact collection step, the DONE/BLOCKED final marker — is identical to
 the PR-driven path.
 

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -6,8 +6,8 @@ Evaluation is **fully CI-driven**. [`.github/workflows/skills-eval.yml`](../work
 
 1. Diffs the PR against its base branch and picks out changed skills with an eval spec at `skills/<skill>/evals/<name>.json` (legacy `skills/<skill>/eval/<name>.json` still accepted).
 2. Generates Harbor datasets per `(skill, profile, platform, mode)` via the adapter at [`adapters/<skill>/generate.py`](adapters/).
-3. Acquires a per-instance `flock` on an operator-managed `vss-eval-*` pool member matching the target platform, per the fleet-selection algorithm in [`AGENTS.md`](AGENTS.md) § 5a. The harness does **not** auto-provision — if no pool member matches, the run blocks until one appears (or times out).
-4. Runs `uvx harbor run` against each dataset, one trial at a time, with the canonical invocation captured in [`AGENTS.md § Harbor invocation`](AGENTS.md).
+3. Selects an operator-managed `vss-eval-*` pool member matching the target platform, per the fleet-selection algorithm in [`AGENTS.md`](AGENTS.md) § 5a. The harness does **not** auto-provision — if no pool member matches, the run blocks until one appears (or times out).
+4. Calls [`run_leg.py`](run_leg.py), which acquires the per-instance `flock`, holds it while every Harbor subprocess for this `(spec, platform)` runs, and invokes `uvx harbor run` with the canonical flags from [`AGENTS.md § Harbor invocation`](AGENTS.md).
 5. Verifies each trial (containers running, endpoints healthy, trajectory / response / rubric checks — see `verifiers/generic_judge.py`) and scores 0.0–1.0.
 6. Posts one Markdown results summary per `(PR, eval-spec)` batch as a PR comment, with trace URLs served by `harbor view`.
 
@@ -56,6 +56,7 @@ Per-CI-run hygiene is the trial's own responsibility: each spec's first agent tu
 ├── README.md              ← you are here
 ├── AGENTS.md              ← skills-eval agent's system prompt
 ├── skills_eval_agent.py   ← the CI entrypoint (spawns the agent)
+├── run_leg.py             ← structural per-box lock + Harbor launcher
 ├── adapters/              ← per-skill dataset generators
 │   ├── vss-deploy-profile/            ← profile × platform × mode matrix
 │   │   └── generate.py
@@ -170,29 +171,26 @@ python3 .github/skill-eval/adapters/vss-manage-video-io-storage/generate.py \
   --platform L40S
 
 # 2. Make sure you have a Brev instance for the target platform
-#    (or let the skills-eval agent manage it).
+#    (or let the skills-eval agent select one).
 #
 # ⚠️ On a spec's first trial the env provider WIPES the box's docker runtime
 #    (all containers, user-defined networks, and volumes; images are kept).
 #    NEVER point a manual run at a box a CI run currently holds — it will
-#    `docker rm -f` that run's deployment mid-trial. Use a demonstrably idle
-#    box, or hold the per-box flock (see AGENTS.md § 5b).
-export BREV_INSTANCE=vss-eval-l40s
+#    `docker rm -f` that run's deployment mid-trial. Use run_leg.py so the
+#    same per-box lock contract applies to manual runs.
+INSTANCE_NAME=vss-eval-l40s
 
-# 3. Run one trial. The flags here mirror the canonical invocation in
-#    AGENTS.md § Harbor invocation — don't improvise.
+# 3. Run one trial. run_leg.py discovers single-step vs multi-step task
+#    layouts, holds /tmp/brev/$INSTANCE_NAME.lock, and invokes Harbor.
 export PYTHONPATH="$(pwd)/.github/skill-eval:${PYTHONPATH:-}"
 
-uvx harbor run \
-  --environment-import-path "envs.brev_env:BrevEnvironment" \
-  -p /tmp/skill-eval/datasets/vss-manage-video-io-storage/vios_ops \
-  --include-task-name "l40s" \
-  -a claude-code \
-  --model "$ANTHROPIC_MODEL" \
-  --ak api_base="$ANTHROPIC_BASE_URL/v1" \
-  --ae CLAUDE_CODE_DISABLE_THINKING=1 \
-  --max-retries 0 -n 1 --yes \
-  -o /tmp/skill-eval/results/manual-$(date +%Y%m%d-%H%M%S)
+python3 .github/skill-eval/run_leg.py \
+  --instance "$INSTANCE_NAME" \
+  --dataset-root /tmp/skill-eval/datasets/vss-manage-video-io-storage \
+  --results-root /tmp/skill-eval/results/manual-$(date +%Y%m%d-%H%M%S) \
+  --scratch /tmp/skill-eval/manual \
+  --spec-stem vios_ops \
+  --platform L40S
 ```
 
 `CLAUDE_CODE_DISABLE_THINKING=1` is required when routing through the NVIDIA Anthropic proxy — claude-code ≥ 2.1.x otherwise emits a `context_management` field the proxy rejects with HTTP 400.
@@ -240,7 +238,7 @@ disown
 
 **`AddTestsDirError` / `DownloadVerifierDirError`.** File upload/download to the Brev instance failed. Check `brev exec <instance> "echo ok"` works manually. Clear `/tests /logs /skills` on the instance and retry.
 
-**Pool exhausted for `<platform>`.** No `vss-eval-*` pool member matches the trial's `gpu_type` after the 28800s wait window (`brev ls` polled every 5 min). The agent emits `BLOCKED: pool exhausted for <platform>` and exits. Provisioning new pool members is the operator's job — `brev create vss-eval-<name>` with the matching instance type, then bring it online; the next CI run picks it up automatically via the `^vss-eval-*` fleet scan.
+**Pool exhausted for `<platform>`.** No `vss-eval-*` pool member matches the trial's `gpu_type` after the 21000s wait window (`brev ls` polled every 5 min). The agent emits `BLOCKED: pool exhausted for <platform>` and exits. Provisioning new pool members is the operator's job — `brev create vss-eval-<name>` with the matching instance type, then bring it online; the next CI run picks it up automatically via the `^vss-eval-*` fleet scan.
 
 **Brev auth expired mid-run.** The CI run emits `BLOCKED: brev auth expired`. The `brev-keepalive.timer` systemd user unit keeps the access token warm, but only an interactive `brev login --auth nvidia` can refresh a fully-expired refresh token.
 

--- a/.github/skill-eval/docs/matrix-dispatch-design.md
+++ b/.github/skill-eval/docs/matrix-dispatch-design.md
@@ -34,8 +34,8 @@ gathering, comment posting, and analysis — it is simply **scoped to a
 single `(skill, spec)`** instead of looping over all of them.
 
 Parallelism now comes from the matrix + the brev pool: N legs run
-concurrently and contend for hardware-matching boxes via the existing
-per-box `flock`. No leg ever backgrounds work; the SDK-side hardening
+concurrently and contend for hardware-matching boxes via a `run_leg.py`
+wrapper-held per-box `flock`. No leg ever backgrounds work; the SDK-side hardening
 (`disallowed_tools` for `Task*`/`BashOutput`/`KillShell` + a PreToolUse
 hook rejecting `run_in_background`/`&`/`nohup`) guarantees it.
 
@@ -59,8 +59,8 @@ push to pull-request/<N>
 │                                                                │
 │  each leg:  EVAL_SKILL / EVAL_SPEC set                         │
 │    → foreground agent, single-spec mode (AGENTS.md override)   │
-│    → ensure adapter+dataset → flock a matching box             │
-│    → uvx harbor run (synchronous, this spec only)              │
+│    → ensure adapter+dataset → pick a matching box              │
+│    → run_leg.py (flock + synchronous Harbor, this spec only)   │
 │    → gather results → POST ITS OWN per-spec comment            │
 │    → DONE:/BLOCKED:                                            │
 │    → upload this leg's results artifact                        │
@@ -116,7 +116,7 @@ cleanly to multi-platform specs (each platform parallelizes onto its own
 runner) and makes the per-`(spec,platform)` output root automatic.
 
 `max-parallel` is capped near the `vss-eval-*` box count so legs don't
-all grab runner slots only to block on `flock`. `fail-fast: false` so one
+all grab runner slots only to wait inside `run_leg.py`. `fail-fast: false` so one
 failing leg doesn't cancel the others.
 
 ## What changes in code
@@ -126,11 +126,11 @@ failing leg doesn't cancel the others.
 | `.github/skill-eval/plan_matrix.py` | **new.** Pure-Python, no LLM. Reads the diff (local `git diff`) — or, on a manual sweep, enumerates the picked skill's specs — applies the rules above, prints `matrix` JSON + `has_targets` to `$GITHUB_OUTPUT`. Unit-testable offline. |
 | `.github/workflows/skills-eval.yml` | **rewrite.** `plan` job → `eval` matrix job, on push AND `workflow_dispatch` (a manual sweep feeds the picked skill's specs into the same matrix; legs write to `$GITHUB_STEP_SUMMARY` since there's no PR). |
 | `.github/skill-eval/skills_eval_agent.py` | **small add.** New single-spec mode keyed on `EVAL_SKILL`/`EVAL_SPEC`: skip the diff/detection (plan already decided), build a user prompt scoped to one spec, otherwise reuse the existing SDK session, options, hardening, and DONE/BLOCKED enforcement verbatim. |
-| `.github/skill-eval/AGENTS.md` | **add a "Single-spec mode" section** (parallel to "Manual full-sweep mode"): when `EVAL_SPEC` is set, skip step 1's diff — you are handed exactly one `(skill, spec)`; run steps 2–7 for it only, post the one comment, emit the marker. Everything else (hard rules, fleet selection § 5a, flock § 5b, harbor invocation, result format, failure modes) applies unchanged. |
+| `.github/skill-eval/AGENTS.md` | **add a "Single-spec mode" section** (parallel to "Manual full-sweep mode"): when `EVAL_SPEC` is set, skip step 1's diff — you are handed exactly one `(skill, spec)`; run steps 2–7 for it only, post the one comment, emit the marker. Everything else (hard rules, fleet selection § 5a, wrapper-held lock § 5b, harbor invocation, result format, failure modes) applies unchanged. |
 
 The background-task removal is already in place (`disallowed_tools` +
 PreToolUse hook); each leg's foreground agent therefore *must* drive
-harbor synchronously.
+`run_leg.py` synchronously.
 
 ## Unchanged on purpose
 
@@ -159,13 +159,17 @@ concurrent sibling's live dataset) — each leg cleans only its own scratch
 and age-GCs *other* run_ids. `run_id` is in the key too, so two different
 PRs' runs on the same host don't collide either.
 
-**Box mutex.** The per-box `flock /tmp/brev/<box>.lock` serializes trials
-on a box. This is a valid mutex **only while all eval legs run on one
-host** — flock is host-local. If the `vss-skill-eval-runner` label ever
-spans multiple hosts, two legs could lock their own local files and both
-drive the same brev box (docker/port collision + trajectory corruption
-via `start()`'s archive-on-start racing a live session). Keep the label
-pinned to one host, or move the lock onto the box itself.
+**Box mutex.** `run_leg.py` opens `/tmp/brev/<box>.lock`, takes an
+exclusive `flock`, and keeps that file descriptor open while it launches
+every Harbor subprocess for the leg. This serializes trials on a box and
+avoids the broken pattern where an agent acquires a lock in one shell
+call and runs Harbor in a later shell call after the FD has closed. The
+mutex is still valid **only while all eval legs run on one host** — flock
+is host-local. If the `vss-skill-eval-runner` label ever spans multiple
+hosts, two legs could lock their own local files and both drive the same
+brev box (docker/port collision + trajectory corruption via `start()`'s
+archive-on-start racing a live session). Keep the label pinned to one
+host, or move the lock onto the box itself.
 
 ## Open questions / future
 

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run one skills-eval leg under a process-held Brev box lock.
+
+The LLM selects a vss-eval-* instance, but this wrapper owns the
+per-instance flock and keeps the lock file descriptor open while Harbor
+runs. That makes the mutex a real kernel lock instead of a shell-FD
+convention spread across multiple agent tool calls.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import dataclasses
+import errno
+import fcntl
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STEP_COUNT_RE = re.compile(r"^\s*step_count\s*=\s*(\d+)\s*$", re.MULTILINE)
+SAFE_PART_RE = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+@dataclasses.dataclass(frozen=True)
+class HarborInvocation:
+    """One concrete `uvx harbor run` invocation."""
+
+    harbor_root: Path
+    include_task_name: str
+    chain_key: str
+    step_index: int | None = None
+    step_count: int | None = None
+
+
+class LockTimeoutError(RuntimeError):
+    pass
+
+
+def _read_step_count(task_toml: Path) -> int | None:
+    match = STEP_COUNT_RE.search(task_toml.read_text())
+    return int(match.group(1)) if match else None
+
+
+def _max_step_number(platform_dir: Path) -> int:
+    max_step = 0
+    for child in platform_dir.iterdir():
+        if not child.is_dir():
+            continue
+        match = re.fullmatch(r"step-(\d+)", child.name)
+        if match:
+            max_step = max(max_step, int(match.group(1)))
+    return max_step
+
+
+def _chain_key(dataset_root: Path, harbor_root: Path) -> str:
+    try:
+        rel = harbor_root.relative_to(dataset_root)
+    except ValueError:
+        rel = harbor_root
+    return SAFE_PART_RE.sub("_", rel.as_posix()).strip("_") or harbor_root.name
+
+
+def discover_invocations(dataset_root: Path) -> list[HarborInvocation]:
+    """Discover single-step tasks or ordered multi-step task chains."""
+    dataset_root = dataset_root.resolve()
+    step1_tomls = sorted(dataset_root.rglob("step-1/task.toml"))
+    if step1_tomls:
+        invocations: list[HarborInvocation] = []
+        seen_roots: set[Path] = set()
+        for step1_toml in step1_tomls:
+            platform_dir = step1_toml.parent.parent
+            if platform_dir in seen_roots:
+                continue
+            seen_roots.add(platform_dir)
+            step_count = _read_step_count(step1_toml) or _max_step_number(platform_dir)
+            if step_count < 1:
+                raise ValueError(f"invalid step_count for {platform_dir}")
+            key = _chain_key(dataset_root, platform_dir)
+            for idx in range(1, step_count + 1):
+                task_toml = platform_dir / f"step-{idx}" / "task.toml"
+                if not task_toml.exists():
+                    raise FileNotFoundError(
+                        f"missing task.toml for step-{idx}: {task_toml}"
+                    )
+                invocations.append(
+                    HarborInvocation(
+                        harbor_root=platform_dir,
+                        include_task_name=f"step-{idx}",
+                        chain_key=key,
+                        step_index=idx,
+                        step_count=step_count,
+                    )
+                )
+        return invocations
+
+    task_tomls = sorted(dataset_root.rglob("task.toml"))
+    if not task_tomls:
+        raise FileNotFoundError(f"no task.toml found under {dataset_root}")
+
+    invocations = []
+    for task_toml in task_tomls:
+        task_dir = task_toml.parent
+        invocations.append(
+            HarborInvocation(
+                harbor_root=task_dir.parent,
+                include_task_name=task_dir.name,
+                chain_key=_chain_key(dataset_root, task_dir),
+            )
+        )
+    return invocations
+
+
+def _api_base_v1(base_url: str) -> str:
+    stripped = base_url.rstrip("/")
+    if stripped.endswith("/v1"):
+        return stripped
+    return f"{stripped}/v1"
+
+
+def build_harbor_command(
+    invocation: HarborInvocation,
+    results_root: Path,
+    model: str,
+    anthropic_base_url: str,
+) -> list[str]:
+    return [
+        "uvx",
+        "harbor",
+        "run",
+        "--environment-import-path",
+        "envs.brev_env:BrevEnvironment",
+        "-p",
+        str(invocation.harbor_root),
+        "--include-task-name",
+        invocation.include_task_name,
+        "-a",
+        "claude-code",
+        "--model",
+        model,
+        "--ak",
+        f"api_base={_api_base_v1(anthropic_base_url)}",
+        "--ae",
+        "CLAUDE_CODE_DISABLE_THINKING=1",
+        "--environment-build-timeout-multiplier",
+        "3.0",
+        "--agent-timeout-multiplier",
+        "6.0",
+        "--verifier-timeout-multiplier",
+        "3.0",
+        "--max-retries",
+        "0",
+        "-n",
+        "1",
+        "--yes",
+        "-o",
+        str(results_root),
+    ]
+
+
+def harbor_env(instance: str) -> dict[str, str]:
+    env = os.environ.copy()
+    workspace = env.get("GITHUB_WORKSPACE") or str(REPO_ROOT)
+    skill_eval_path = str(Path(workspace) / ".github" / "skill-eval")
+    pythonpath = env.get("PYTHONPATH", "")
+    if skill_eval_path not in pythonpath.split(":"):
+        pythonpath = f"{skill_eval_path}:{pythonpath}" if pythonpath else skill_eval_path
+    env["PYTHONPATH"] = pythonpath
+    env["PATH"] = f"{Path.home() / '.local' / 'bin'}:{env.get('PATH', '')}"
+    env["BREV_INSTANCE"] = instance
+    env["CLAUDE_CODE_DISABLE_THINKING"] = "1"
+    return env
+
+
+@contextlib.contextmanager
+def hold_box_lock(lock_dir: Path, instance: str, timeout_sec: int):
+    if "/" in instance or instance in {"", ".", ".."}:
+        raise ValueError(f"invalid Brev instance name for lock file: {instance!r}")
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / f"{instance}.lock"
+    deadline = time.monotonic() + timeout_sec
+    with lock_path.open("a+") as fp:
+        while True:
+            try:
+                fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                print(f"[run-leg] lock acquired: {lock_path}", flush=True)
+                break
+            except OSError as exc:
+                if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise LockTimeoutError(f"lock timeout on {instance}") from exc
+                print(
+                    f"[run-leg] waiting for lock {lock_path} "
+                    f"({int(remaining)}s remaining)",
+                    flush=True,
+                )
+                time.sleep(min(60, remaining))
+        try:
+            yield lock_path
+        finally:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+            print(f"[run-leg] lock released: {lock_path}", flush=True)
+
+
+def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
+    print(f"[run-leg] exec: {' '.join(cmd)}", flush=True)
+    proc = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env, start_new_session=True)
+    try:
+        return proc.wait(timeout=timeout_sec)
+    except subprocess.TimeoutExpired:
+        print(f"[run-leg] timeout after {timeout_sec}s; terminating harbor", flush=True)
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+            proc.wait(timeout=30)
+        except (ProcessLookupError, subprocess.TimeoutExpired):
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(proc.pid, signal.SIGKILL)
+            proc.wait()
+        return 124
+
+
+def latest_reward(
+    results_root: Path,
+    include_task_name: str,
+    started_at: float | None = None,
+) -> str | None:
+    matches = list(results_root.glob(f"*/{include_task_name}__*/verifier/reward.txt"))
+    if started_at is not None:
+        matches = [p for p in matches if p.stat().st_mtime >= started_at]
+    if not matches:
+        return None
+    latest = max(matches, key=lambda p: p.stat().st_mtime)
+    return latest.read_text().strip()
+
+
+def _reward_value(reward: str | None) -> float:
+    if reward is None:
+        return 0.0
+    try:
+        return float(reward)
+    except ValueError:
+        return 0.0
+
+
+def _safe_part(value: str) -> str:
+    return SAFE_PART_RE.sub("_", value).strip("_") or "unknown"
+
+
+def write_skip_markers(
+    scratch: Path,
+    spec_stem: str,
+    platform: str,
+    failed_step: int,
+    reward: str | None,
+    step_count: int,
+) -> None:
+    scratch.mkdir(parents=True, exist_ok=True)
+    stem = _safe_part(spec_stem or "spec")
+    plat = _safe_part(platform or "platform")
+    reward_text = reward if reward is not None else "missing"
+    for step in range(failed_step + 1, step_count + 1):
+        marker = scratch / f"skipped-{stem}-{plat}-step-{step}.txt"
+        marker.write_text(
+            f"skipped (prior-step fail, step={failed_step} reward={reward_text})\n"
+        )
+        print(f"[run-leg] wrote skip marker: {marker}", flush=True)
+
+
+def run_invocations(
+    invocations: list[HarborInvocation],
+    instance: str,
+    results_root: Path,
+    scratch: Path,
+    spec_stem: str,
+    platform: str,
+    harbor_timeout_sec: int,
+) -> int:
+    env = harbor_env(instance)
+    model = os.environ.get("ANTHROPIC_MODEL", "")
+    base_url = os.environ.get("ANTHROPIC_BASE_URL", "")
+    if not model:
+        print("FATAL: ANTHROPIC_MODEL not set", file=sys.stderr)
+        return 1
+    if not base_url:
+        print("FATAL: ANTHROPIC_BASE_URL not set", file=sys.stderr)
+        return 1
+
+    results_root.mkdir(parents=True, exist_ok=True)
+    skipped_after: dict[str, int] = {}
+    overall_rc = 0
+
+    for invocation in invocations:
+        if (
+            invocation.step_index is not None
+            and invocation.chain_key in skipped_after
+            and invocation.step_index > skipped_after[invocation.chain_key]
+        ):
+            continue
+
+        cmd = build_harbor_command(invocation, results_root, model, base_url)
+        started_at = time.time() - 1.0
+        rc = run_command(cmd, env, harbor_timeout_sec)
+        if rc != 0 and overall_rc == 0:
+            overall_rc = rc
+
+        if invocation.step_index is not None and invocation.step_count is not None:
+            reward = latest_reward(results_root, invocation.include_task_name, started_at)
+            reward_value = _reward_value(reward)
+            print(
+                f"[run-leg] {invocation.chain_key}/{invocation.include_task_name} "
+                f"rc={rc} reward={reward if reward is not None else 'missing'}",
+                flush=True,
+            )
+            if rc == 124 or reward_value < 1.0:
+                write_skip_markers(
+                    scratch,
+                    spec_stem,
+                    platform or invocation.chain_key,
+                    invocation.step_index,
+                    reward,
+                    invocation.step_count,
+                )
+                skipped_after[invocation.chain_key] = invocation.step_index
+                if rc == 124:
+                    return 124
+
+    return overall_rc
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--instance", required=True, help="Selected vss-eval-* Brev instance")
+    parser.add_argument("--dataset-root", required=True, type=Path, help="Per-leg generated dataset root")
+    parser.add_argument("--results-root", required=True, type=Path, help="Per-leg Harbor results root")
+    parser.add_argument(
+        "--scratch",
+        default=Path(f"/tmp/skill-eval/{run_id}"),
+        type=Path,
+        help="Per-run scratch root for skip marker files",
+    )
+    parser.add_argument("--spec-stem", default=os.environ.get("EVAL_SPEC_STEM", ""))
+    parser.add_argument("--platform", default=os.environ.get("EVAL_PLATFORM", ""))
+    parser.add_argument("--lock-dir", default=Path("/tmp/brev"), type=Path)
+    parser.add_argument("--lock-timeout-sec", default=21000, type=int)
+    parser.add_argument("--harbor-timeout-sec", default=7800, type=int)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        invocations = discover_invocations(args.dataset_root)
+        print(f"[run-leg] discovered {len(invocations)} harbor invocation(s)", flush=True)
+        for invocation in invocations:
+            print(
+                f"[run-leg] target: -p {invocation.harbor_root} "
+                f"--include-task-name {invocation.include_task_name}",
+                flush=True,
+            )
+        with hold_box_lock(args.lock_dir, args.instance, args.lock_timeout_sec):
+            return run_invocations(
+                invocations,
+                args.instance,
+                args.results_root,
+                args.scratch,
+                args.spec_stem,
+                args.platform,
+                args.harbor_timeout_sec,
+            )
+    except LockTimeoutError:
+        print(f"BLOCKED: lock timeout on {args.instance}", flush=True)
+        return 75
+    except Exception as exc:  # noqa: BLE001
+        print(f"FATAL: run_leg failed: {exc!r}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -5,7 +5,7 @@
 
 Spawns one `claude-agent-sdk` agent with `.github/skill-eval/AGENTS.md`
 as its system prompt and lets it drive an eval end-to-end:
-adapter/dataset → Brev lock → harbor run → results comment. Two modes:
+adapter/dataset → Brev box selection → run_leg.py → results comment. Two modes:
 
   - Single-spec (push): the `plan` job in skills-eval.yml resolves the PR
     diff into a matrix of one leg per (spec, platform); each leg invokes
@@ -72,7 +72,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 AGENTS_MD = Path(__file__).resolve().parent / "AGENTS.md"
 
 # Hard cap on the agent's tool loop — one trial burns ~20-30 harness
-# turns (startup + brev wait + `uvx harbor run` exec + reading results +
+# turns (startup + brev wait + `run_leg.py` exec + reading results +
 # migrating to _viewer), so a full-PR fan-out of 10-15 trials plus
 # recon/retry overhead exceeds the previous 300 ceiling. The 600 cap
 # that replaced it was still tight when the agent hit a novel
@@ -81,7 +81,7 @@ AGENTS_MD = Path(__file__).resolve().parent / "AGENTS.md"
 # without prior context) — each "discovery" burst is 5-10 turns of
 # Read/Grep/Bash spelunking on top of the steady-state per-trial
 # cost. Bumping to 2000 absorbs that overhead without lifting the
-# real ceiling (skills-eval.yml timeout-minutes: 480 is the wall-
+# real ceiling (skills-eval.yml timeout-minutes: 360 is the wall-
 # clock gate; this knob is just a safety valve against runaway
 # loops).
 MAX_TURNS = int(os.environ.get("AGENT_MAX_TURNS", "2000"))
@@ -124,25 +124,25 @@ def _disable_server_thinking() -> None:
 
 
 def _set_bash_timeouts() -> None:
-    """Raise the Bash tool's timeout cap above the worst-case single
-    `uvx harbor run` so the runtime never auto-backgrounds the foreground
-    trial call.
+    """Raise the Bash tool's timeout cap above the worst-case `run_leg.py`
+    foreground call.
 
     Claude Code moves a foreground Bash command to a background task once it
     crosses the Bash *max* timeout (default 600000 ms = 10 min), then
     surfaces it as pollable task output. That silently defeats AGENTS.md's
-    "block on harbor — no polling" contract for any trial longer than 10 min
-    (most real deploys: env-build 1800s + agent 3600s + verify 1800s ≈ 2h).
-    Past the cap the foreground call is backgrounded and the agent falls into
-    polling its task .output files. The
+    "block on run_leg.py / Harbor -- no polling" contract. A full leg can
+    include lock contention plus multiple ordered Harbor subprocesses, so the
+    foreground cap must cover the workflow job window, not just one Harbor
+    attempt. Past the cap the foreground call is backgrounded and the agent
+    falls into polling its task .output files. The
     `_block_bash_background` hook can't prevent it: the runtime sets
     run_in_background *after* the timeout, not in the call input the hook
     inspects. Raising the cap is the only structural fix. The CI workflow
     exports these too; set them here defensively so local smoke-tests and any
     non-CI caller get the same guarantee. Both stay under the workflow's
     timeout-minutes so a genuinely hung call is still reaped by the job."""
-    os.environ.setdefault("BASH_DEFAULT_TIMEOUT_MS", "7200000")   # 2h
-    os.environ.setdefault("BASH_MAX_TIMEOUT_MS", "10800000")      # 3h
+    os.environ.setdefault("BASH_DEFAULT_TIMEOUT_MS", "21600000")  # 6h
+    os.environ.setdefault("BASH_MAX_TIMEOUT_MS", "21600000")      # 6h
 
 
 # ---------------------------------------------------------------------------
@@ -248,7 +248,7 @@ def build_benchmark_md(out_path: Path = BENCHMARK_OUT_PATH) -> Path | None:
 async def _block_bash_background(input_data, tool_use_id, context):
     """PreToolUse hook: deny any Bash call that backgrounds work.
 
-    AGENTS.md § "No polling — block on harbor" requires `uvx harbor run`
+    AGENTS.md § "No polling — block on harbor" requires `run_leg.py`
     to be invoked synchronously so the orchestrating agent blocks on
     stdout instead of polling an output file. Enforcing that in prose
     alone is fragile — a drifting agent can still set
@@ -265,7 +265,7 @@ async def _block_bash_background(input_data, tool_use_id, context):
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "deny",
                 "permissionDecisionReason": (
-                    "Backgrounding forbidden — run harbor synchronously "
+                    "Backgrounding forbidden — run run_leg.py synchronously "
                     "(AGENTS.md § No polling — block on harbor)."
                 ),
             }
@@ -373,10 +373,11 @@ Per AGENTS.md § "Single-spec mode": SKIP step 1's diff — the `plan` job
 already selected this (spec, platform). Run steps 2–7 for it only:
 ensure/refresh its adapter under `.github/skill-eval/adapters/{eval_skill}/`
 (missing/stale → handle per § 3c, then exit BLOCKED — never run a
-locally-patched adapter in this leg) → generate the dataset → acquire a
-per-box flock on a `vss-eval-*` member matching
-`{eval_platform or "the spec's platform"}` → run harbor synchronously for
-this platform (§ Harbor invocation; never background it) → gather results →
+locally-patched adapter in this leg) → generate the dataset → select a
+`vss-eval-*` member matching `{eval_platform or "the spec's platform"}` →
+run `.github/skill-eval/run_leg.py` for this platform (§ Harbor invocation;
+never background it; the wrapper holds the per-box lock while Harbor runs)
+→ gather results →
 {post_step} (§ Result comment format). Do NOT touch any other spec or skill.
 
 End with `DONE: <reward summary>` after posting the result, or

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for run_leg.py.
+
+Run:
+    python3 .github/skill-eval/tests/test_run_leg.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "run_leg", Path(__file__).resolve().parents[1] / "run_leg.py"
+)
+run_leg = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = run_leg
+_SPEC.loader.exec_module(run_leg)
+
+
+class DiscoverInvocations(unittest.TestCase):
+    def test_discover_single_step_invocation(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            task_dir = root / "alerts_cv" / "rtxpro6000bw"
+            task_dir.mkdir(parents=True)
+            (task_dir / "task.toml").write_text("step_count = 1\n")
+
+            invocations = run_leg.discover_invocations(root)
+
+        self.assertEqual(len(invocations), 1)
+        self.assertEqual(invocations[0].harbor_root.name, "alerts_cv")
+        self.assertEqual(invocations[0].include_task_name, "rtxpro6000bw")
+        self.assertIsNone(invocations[0].step_index)
+
+    def test_discover_multi_step_invocations(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            platform_dir = root / "foo" / "l40s"
+            for step in (1, 2):
+                step_dir = platform_dir / f"step-{step}"
+                step_dir.mkdir(parents=True)
+                (step_dir / "task.toml").write_text("step_count = 2\n")
+
+            invocations = run_leg.discover_invocations(root)
+
+        self.assertEqual(len(invocations), 2)
+        self.assertEqual([i.include_task_name for i in invocations], ["step-1", "step-2"])
+        self.assertTrue(all(i.harbor_root.name == "l40s" for i in invocations))
+        self.assertEqual([i.step_index for i in invocations], [1, 2])
+        self.assertEqual([i.step_count for i in invocations], [2, 2])
+
+    def test_discover_multi_chain_invocations(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            for mode in ("remote-all", "standalone"):
+                platform_dir = root / "spec" / f"l40s-{mode}"
+                for step in (1, 2):
+                    step_dir = platform_dir / f"step-{step}"
+                    step_dir.mkdir(parents=True)
+                    (step_dir / "task.toml").write_text("step_count = 2\n")
+
+            invocations = run_leg.discover_invocations(root)
+
+        self.assertEqual(len(invocations), 4)
+        self.assertEqual(
+            [(i.chain_key, i.include_task_name) for i in invocations],
+            [
+                ("spec_l40s-remote-all", "step-1"),
+                ("spec_l40s-remote-all", "step-2"),
+                ("spec_l40s-standalone", "step-1"),
+                ("spec_l40s-standalone", "step-2"),
+            ],
+        )
+
+
+class HarborCommand(unittest.TestCase):
+    def test_build_command_uses_env_and_v1_suffix(self):
+        invocation = run_leg.HarborInvocation(
+            harbor_root=Path("/tmp/datasets/alerts_cv"),
+            include_task_name="rtxpro6000bw",
+            chain_key="alerts_cv_rtxpro6000bw",
+        )
+
+        cmd = run_leg.build_harbor_command(
+            invocation,
+            Path("/tmp/results"),
+            "aws/anthropic/bedrock-claude-opus-4-6",
+            "https://inference-api.nvidia.com/v1",
+        )
+
+        self.assertIn("--include-task-name", cmd)
+        self.assertEqual(cmd[cmd.index("--include-task-name") + 1], "rtxpro6000bw")
+        self.assertEqual(cmd[cmd.index("--model") + 1], "aws/anthropic/bedrock-claude-opus-4-6")
+        self.assertEqual(cmd[cmd.index("--ak") + 1], "api_base=https://inference-api.nvidia.com/v1")
+        self.assertEqual(cmd[cmd.index("-o") + 1], "/tmp/results")
+
+
+class SkipMarkers(unittest.TestCase):
+    def test_latest_reward_ignores_prior_chain_reward_when_since_is_set(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            reward = root / "2026-06-04" / "step-1__old" / "verifier" / "reward.txt"
+            reward.parent.mkdir(parents=True)
+            reward.write_text("1.0\n")
+            since = time.time() + 10
+
+            self.assertIsNone(run_leg.latest_reward(root, "step-1", started_at=since))
+
+    def test_write_skip_markers(self):
+        with tempfile.TemporaryDirectory() as td:
+            scratch = Path(td)
+            run_leg.write_skip_markers(
+                scratch,
+                spec_stem="vios_ops",
+                platform="L40S",
+                failed_step=2,
+                reward="0.2",
+                step_count=4,
+            )
+
+            step3 = scratch / "skipped-vios_ops-L40S-step-3.txt"
+            step4 = scratch / "skipped-vios_ops-L40S-step-4.txt"
+            self.assertTrue(step3.exists())
+            self.assertTrue(step4.exists())
+            self.assertEqual(
+                step3.read_text().strip(),
+                "skipped (prior-step fail, step=2 reward=0.2)",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -49,9 +49,10 @@ permissions:
   pull-requests: write
 
 # One eval generation per PR (or manual sweep) at a time. A fresh push
-# cancels every in-flight matrix leg of the prior push for this ref; the
-# per-box flocks (/tmp/brev/<INSTANCE_NAME>.lock) release automatically
-# when each agent process dies (POSIX flock(2) — no userspace trap).
+# cancels every in-flight matrix leg of the prior push for this ref;
+# run_leg.py holds /tmp/brev/<INSTANCE_NAME>.lock while Harbor runs, and
+# the kernel releases it automatically when the wrapper process dies
+# (POSIX flock(2) — no userspace trap).
 # Stale containers/volumes a cancelled leg left on a box are reconciled by
 # the next trial's own deploy step (the harness no longer pre-deploys or
 # tracks an active-deploy marker). Same path handles SIGKILL (the
@@ -138,7 +139,7 @@ jobs:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false
       # Cap concurrent legs near the vss-eval-* box count so legs don't
-      # all grab a runner slot only to block on flock. Excess legs queue.
+      # all grab a runner slot only to wait inside run_leg.py. Excess legs queue.
       max-parallel: 4
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     # Per-leg cap. One spec, but a multi-step spec runs step-1..N as
@@ -146,10 +147,10 @@ jobs:
     # (AGENTS.md `--agent-timeout-multiplier 6.0`). 360m covers a ~4-step
     # cold-box spec plus deploy/dataset/comment overhead without the
     # whole-sweep 12 h cap the single-job design needed. AGENTS.md's
-    # box-lock wait (flock -w 21000 ≈ 5.8 h) is kept strictly under this
+    # box-lock wait (run_leg.py --lock-timeout-sec 21000 ≈ 5.8 h) is kept strictly under this
     # 360 m ceiling so a lock-starved leg emits `BLOCKED: lock timeout`
     # before the job-killer fires (a 43200 s / 12 h wait would be
-    # silently killed mid-flock with no verdict — the exit-4 trap).
+    # silently killed while waiting on a box with no verdict — the exit-4 trap).
     timeout-minutes: 360
     steps:
       - name: Checkout mirror head
@@ -176,16 +177,17 @@ jobs:
           # per-leg scratch dir with no hosts.yml so a stored OAuth on the
           # host can't reauthor bot comments. Same fix helm-sync.yml uses.
           GH_CONFIG_DIR: ${{ runner.temp }}/gh-skill-eval-${{ github.run_id }}-${{ matrix.slug }}
-          # Raise the Bash-tool timeout cap above the worst-case single
-          # `uvx harbor run` (~2h: env-build 1800s + agent 3600s + verify
-          # 1800s). Without this the runtime auto-backgrounds the foreground
-          # harbor call at the 10-min default cap and the agent falls into
-          # polling its task output — silently defeating the "block on
-          # harbor" wait contract (the PreToolUse hook can't catch a
+          # Raise the Bash-tool timeout cap above the worst-case foreground
+          # run_leg.py call. The wrapper can spend most of the job waiting
+          # for a box lock and then run one or more Harbor subprocesses.
+          # Without this the runtime auto-backgrounds the foreground wrapper
+          # call at the default cap and the agent falls into polling its task
+          # output — silently defeating the "block on Harbor" wait contract
+          # (the PreToolUse hook can't catch a
           # runtime-initiated background; it only inspects call input). Both
           # stay under the job's timeout-minutes so the call can't outlive it.
-          BASH_DEFAULT_TIMEOUT_MS: "7200000"
-          BASH_MAX_TIMEOUT_MS: "10800000"
+          BASH_DEFAULT_TIMEOUT_MS: "21600000"
+          BASH_MAX_TIMEOUT_MS: "21600000"
         run: |
           mkdir -p "$GH_CONFIG_DIR"
           set -a


### PR DESCRIPTION
## Summary
- add run_leg.py to hold the per-box flock for the full Harbor run
- update the skills-eval prompt/workflow/docs to route Harbor through the wrapper
- add offline tests for task discovery, command construction, and skip markers

## Testing
- python3 -m py_compile .github/skill-eval/run_leg.py .github/skill-eval/skills_eval_agent.py .github/skill-eval/plan_matrix.py
- python3 .github/skill-eval/tests/test_run_leg.py
- python3 .github/skill-eval/tests/test_plan_matrix.py

Spun out from PR #934 so the harness fix is reviewed independently from the skill changes.