### PR TITLE
docs: add sudo guard for RT-VLM skill deploy

### DIFF
--- a/.github/skill-eval/adapters/vss-deploy-dense-captioning/generate.py
+++ b/.github/skill-eval/adapters/vss-deploy-dense-captioning/generate.py
@@ -35,8 +35,9 @@ GENERIC_JUDGE = Path(__file__).resolve().parents[2] / "verifiers" / "generic_jud
 
 PREAMBLE = (
     "You are running inside a non-interactive evaluation harness. "
-    "You are pre-authorized to run required setup actions autonomously — "
-    "do not pause to ask for confirmation on setup actions the trial requires."
+    "You are pre-authorized to deploy prerequisites autonomously — "
+    "do not pause to ask for confirmation on `/vss-deploy-profile` or any other "
+    "setup action the trial requires."
 )
 
 

--- a/skills/vss-deploy-dense-captioning/SKILL.md
+++ b/skills/vss-deploy-dense-captioning/SKILL.md
@@ -84,6 +84,8 @@ Always follow this sequence. Never skip the dry-run.
 # 3. Strip the standalone-only dangling depends_on block from the copy.
 # 4. Create a gitignored .env with the required RT-VLM values.
 # 5. Prepare host bind paths such as $VSS_DATA_DIR/data_log/vst/clip_storage.
+#    Use `sudo -n` for ownership fixes; if passwordless sudo is unavailable,
+#    stop and ask the host owner to run the printed command manually.
 # 6. docker compose --env-file .env -f rtvi-vlm-docker-compose.yml config --quiet
 # 7. docker pull the exact RT-VLM image tag.
 # 8. docker compose ... up -d rtvi-vlm, wait for ready, then smoke test.
@@ -105,6 +107,13 @@ contains `depends_on` references to sibling VLM/NIM services that are only
 defined in the full VSS/met-blueprints compose project. The standalone reference
 shows how to copy the compose file, derive the current image tag from it, strip
 the `depends_on` block, and validate the result before `up`.
+
+For agent-driven validation, never let `sudo` prompt interactively. Before any
+privileged ownership or Docker operation, use the non-interactive guard in
+[`references/deploy-rt-vlm-service.md`](references/deploy-rt-vlm-service.md):
+prefer plain `docker`; otherwise use `sudo -n docker`; if `sudo -n` fails, stop
+with the exact manual command for the host owner instead of retrying with
+interactive sudo or weakening permissions.
 
 If `docker pull` fails with a containerd snapshotter/unpack error on Docker 28+,
 apply the `/etc/docker/daemon.json` `containerd-snapshotter=false` fix in the

--- a/skills/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
+++ b/skills/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
@@ -107,7 +107,10 @@ merge this feature setting into `/etc/docker/daemon.json`, then restart Docker
 ```
 
 ```bash
-sudo systemctl restart docker
+sudo -n systemctl restart docker || {
+  echo "Passwordless sudo is unavailable; ask the host owner to run: sudo systemctl restart docker" >&2
+  exit 1
+}
 ```
 
 ## 5. Required Secrets & Credentials
@@ -163,10 +166,18 @@ prepare the VST clip-storage host directory.
 Optional host-path overrides:
 
 ```bash
-mkdir -p ./rtvi-assets && sudo chown 1001:1001 ./rtvi-assets
+mkdir -p ./rtvi-assets
+sudo -n chown 1001:1001 ./rtvi-assets || {
+  echo "Ask the host owner to run: sudo chown 1001:1001 $(pwd)/rtvi-assets" >&2
+  exit 1
+}
 # .env: ASSET_STORAGE_DIR=$(pwd)/rtvi-assets
 
-mkdir -p ./rtvi-logs && sudo chown 1001:1001 ./rtvi-logs
+mkdir -p ./rtvi-logs
+sudo -n chown 1001:1001 ./rtvi-logs || {
+  echo "Ask the host owner to run: sudo chown 1001:1001 $(pwd)/rtvi-logs" >&2
+  exit 1
+}
 # .env: RTVI_VLM_LOG_DIR=$(pwd)/rtvi-logs
 ```
 
@@ -246,9 +257,12 @@ Kafka and Redis are **not bundled** — expected on host or in a sibling compose
 Set `RTVI_VLM_MODEL_TO_USE` in `.env` to select the backend. After any change:
 
 ```bash
-sudo docker compose --env-file .env -f rtvi-vlm-docker-compose.yml \
+docker compose --env-file .env -f rtvi-vlm-docker-compose.yml \
   --profile bp_developer_alerts_2d_vlm up -d --force-recreate rtvi-vlm
 ```
+
+If Docker requires elevated privileges, use `sudo -n docker compose ...` and
+fail fast if `sudo -n` reports that a password is required.
 
 Verify what loaded:
 ```bash
@@ -487,35 +501,53 @@ EOF
 chmod 600 .env
 grep -qxF .env .gitignore 2>/dev/null || printf '.env\n' >> .gitignore
 
+# Step 1b. Select Docker command without interactive sudo.
+# NOTE: run this quick-start snippet with bash, not POSIX sh. The Docker
+# command wrapper below uses bash arrays.
+# Prefer direct Docker access. If the host requires sudo, use `sudo -n` so
+# agent sessions fail fast instead of hanging on a password prompt.
+if docker ps >/dev/null 2>&1; then
+  DOCKER=(docker)
+elif sudo -n docker ps >/dev/null 2>&1; then
+  DOCKER=(sudo -n docker)
+else
+  echo "ERROR: Docker is not accessible as this user and passwordless sudo is unavailable." >&2
+  echo "Ask the host owner to add this user to the docker group, enable passwordless sudo for Docker, or run the Docker commands manually." >&2
+  exit 1
+fi
+
 # Step 2. Prepare VST clip-storage host dir (required per §6 above).
 # Compose `config` validates schema/interpolation, but it does not prove this
 # host bind path exists or is writable by the container user.
-mkdir -p "$VSS_DATA_DIR/data_log/vst/clip_storage"
-sudo chown -R 1001:1001 "$VSS_DATA_DIR/data_log/vst/clip_storage"
-# If sudo is unavailable in an agent session, stop here and have the host owner
-# run the chown. Do not work around this with world-writable permissions.
+CLIP_STORAGE_DIR="$VSS_DATA_DIR/data_log/vst/clip_storage"
+mkdir -p "$CLIP_STORAGE_DIR"
+if ! sudo -n chown -R 1001:1001 "$CLIP_STORAGE_DIR"; then
+  echo "ERROR: passwordless sudo is unavailable for host-path ownership." >&2
+  echo "Ask the host owner to run: sudo chown -R 1001:1001 \"$CLIP_STORAGE_DIR\"" >&2
+  echo "Do not work around this with chmod 777 or world-writable permissions." >&2
+  exit 1
+fi
 
 # Step 3. Validate the standalone compose before creating containers.
-docker compose --env-file .env -f rtvi-vlm-docker-compose.yml \
+"${DOCKER[@]}" compose --env-file .env -f rtvi-vlm-docker-compose.yml \
   --profile bp_developer_alerts_2d_vlm config --quiet
 
-# Step 4. NGC auth — if running docker via sudo, pass the key inline (sudo drops env vars)
-echo "<your-ngc-key>" | sudo docker login nvcr.io -u '$oauthtoken' --password-stdin
-# Or preserve env: sudo --preserve-env=NGC_CLI_API_KEY bash -c \
-#   'echo "$NGC_CLI_API_KEY" | docker login nvcr.io -u $oauthtoken --password-stdin'
+# Step 4. NGC auth. Pipe the key from the user shell; do not rely on sudo
+# preserving environment variables.
+: "${NGC_CLI_API_KEY:?Set NGC_CLI_API_KEY before docker login}"
+printf '%s' "$NGC_CLI_API_KEY" | "${DOCKER[@]}" login nvcr.io -u '$oauthtoken' --password-stdin
 
 # Step 5. Pull image directly (docker compose pull fails on standalone — see §4)
-sudo docker pull "nvcr.io/nvstaging/vss-core/vss-rt-vlm:${VLM_TAG}"
+"${DOCKER[@]}" pull "nvcr.io/nvstaging/vss-core/vss-rt-vlm:${VLM_TAG}"
 
 # Step 6. Bring up — plain `up` (no profile) starts nothing
-sudo --preserve-env=NGC_CLI_API_KEY \
-  docker compose --env-file .env -f rtvi-vlm-docker-compose.yml \
+"${DOCKER[@]}" compose --env-file .env -f rtvi-vlm-docker-compose.yml \
   --profile bp_developer_alerts_2d_vlm up -d
 
 # Step 7. Wait for healthy — start_period is 1200s (20 MIN) on first boot.
 #         Model weight download + vLLM warmup can take the full window.
 #         Do NOT kill as "stuck" before 20 minutes have elapsed.
-until [ "$(sudo docker compose --env-file .env -f rtvi-vlm-docker-compose.yml ps --format json rtvi-vlm \
+until [ "$("${DOCKER[@]}" compose --env-file .env -f rtvi-vlm-docker-compose.yml ps --format json rtvi-vlm \
   | jq -r '[.[].Health] | all(. == "healthy")')" = "true" ]; do
   echo "waiting for rtvi-vlm… (up to 20 minutes on first run)"
   sleep 15
@@ -626,11 +658,12 @@ once the service is up):
 | `Exited (1)` immediately, logs mention `RTVI_VLM_PORT` | Strict sentinel fired | Set `RTVI_VLM_PORT` in `.env` |
 | Container starts but Kafka errors `:9092 connection refused` or offsets stay at 0 | `HOST_IP` unset, or no broker is reachable at `${HOST_IP}:9092` when RT-VLM starts | Set `HOST_IP` to an address reachable from the container, start Kafka with that advertised listener, then restart/recreate `rtvi-vlm`. Non-fatal for API/inference, but Kafka publishing is broken until fixed. |
 | Volume mount error mentioning `data_log/vst/clip_storage` | `VSS_DATA_DIR` unset → malformed mount | Set `VSS_DATA_DIR`; pre-create the `data_log/vst/clip_storage` subtree |
-| `sudo chown` prompts for a password or fails in an agent session | Host path ownership requires user privileges | Ask the host owner to run `sudo chown -R 1001:1001 "$VSS_DATA_DIR/data_log/vst/clip_storage"`; do not use `chmod 777` |
+| `sudo -n chown` reports that a password is required or fails in an agent session | Host path ownership requires user privileges and passwordless sudo is unavailable | Ask the host owner to run `sudo chown -R 1001:1001 "$VSS_DATA_DIR/data_log/vst/clip_storage"`; do not use `chmod 777` |
+| `sudo -n docker ...` reports that a password is required | Docker requires elevated privileges, but the agent cannot satisfy an interactive sudo prompt | Prefer adding the user to the docker group, enable passwordless sudo for Docker, or have the host owner run the printed Docker command manually. Do not retry with interactive sudo. |
 | `service "X" depends on undefined service "Y": invalid compose project` | Recent Docker Compose rejects `depends_on` refs to sibling NIM services not defined in this single-file project — even with `required: false`. | Remove the `depends_on` block from the local compose copy (§12 step 0b). Only needed for standalone deploys without the full met-blueprints project. |
 | `docker compose pull` → `invalid compose project` | Same `depends_on` validation runs before pull | Use `docker pull nvcr.io/nvstaging/vss-core/vss-rt-vlm:<tag>` directly (§4) |
 | `docker compose pull --no-deps` → `unknown flag: --no-deps` | Compose 2.38 does not support `--no-deps` on `pull` | Use direct `docker pull` (§4), or strip `depends_on` and validate before `up` (§12 step 0b). |
-| `password is empty` on `sudo docker login` | `sudo` drops the user's environment — `$NGC_CLI_API_KEY` is not set in the sudo shell | Pass the key inline: `echo "<key>" \| sudo docker login nvcr.io -u '$oauthtoken' --password-stdin`, or use `sudo --preserve-env=NGC_CLI_API_KEY` |
+| `password is empty` on Docker login | `$NGC_CLI_API_KEY` is not set in the invoking shell, or a previous sudo shell dropped the environment | Export `NGC_CLI_API_KEY` in the user shell and pipe it through the §12 Docker wrapper: `printf '%s' "$NGC_CLI_API_KEY" \| "${DOCKER[@]}" login nvcr.io -u '$oauthtoken' --password-stdin` |
 | `unauthorized` on `docker compose pull` | Missing NGC auth or no org access | `docker login nvcr.io` with a key that has `nvidia/vss-core` access |
 | `Exited (1)` "Error: No GPUs were found" | Container can't see GPUs | Install NVIDIA Container Toolkit; `docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi` must work |
 | `Exited (137)` OOM | VRAM pressure | Lower `RTVI_VLLM_GPU_MEMORY_UTILIZATION`; drop `RTVI_VLLM_MAX_NUM_SEQS` below 256; bigger GPU via `RT_VLM_DEVICE_ID`; drop `RTVI_VLM_MAX_MODEL_LEN` |
@@ -705,8 +738,10 @@ docker compose --env-file .env -f rtvi-vlm-docker-compose.yml down --rmi local
   the full met-blueprints multi-file project where all sibling services are
   defined.
 - **`sudo docker` drops environment variables**: `NGC_CLI_API_KEY` and other
-  vars set in the user shell are invisible to `sudo docker`. Pass secrets inline
-  (`echo "<key>" | sudo docker login ...`) or use `sudo --preserve-env=VAR_NAME`.
+  vars set in the user shell are invisible to `sudo docker`. Prefer the §12
+  `DOCKER=(docker)` / `DOCKER=(sudo -n docker)` wrapper and pipe secrets through
+  stdin (`printf '%s' "$NGC_CLI_API_KEY" | "${DOCKER[@]}" login ...`). Never let
+  `sudo` prompt interactively in an agent session.
 - **External Kafka required**: `KAFKA_BOOTSTRAP_SERVERS=${HOST_IP}:9092` — if
   `HOST_IP` isn't set, the container tries `:9092` and fails.
   `host.docker.internal` is wired via `extra_hosts` as an alternative value.


### PR DESCRIPTION
## Summary
- address NVBug 6263789 by documenting non-interactive sudo handling in vss-deploy-dense-captioning
- add a Docker command wrapper that uses plain docker when available or sudo -n docker when needed
- add fail-fast fallbacks for host-path chown and Docker commands so agent sessions do not hang on sudo prompts
- update troubleshooting guidance to avoid interactive sudo and chmod 777 workarounds

## Validation
- bash -n on the new quick-start shell fragment
- git diff --check