### PR TITLE
fix(skill-eval): clear stale Claude task scratch

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -734,15 +734,24 @@ slashes in `<model>` and `<task>` must be URL-encoded (`%2F`).
 
 ### Per-trial trajectory isolation
 
-`BrevEnvironment.start()` archives prior-trial session JSONLs
-(`mv /logs/agent/sessions/projects/* $HOME/.claude-archive/<ts>/`)
-before this trial's `claude --print` runs, because harbor's mapper
-merges **every** `*.jsonl` under `sessions/projects/<project>/` into one
-trajectory.json — on a warm box that would otherwise splice in every
-prior trial (observed: 7549 steps spanning 50 h). So when debugging:
-each trial's copy-back at `$RES/<date>/<trial>/agent/` is clean and
-independently visitable in the viewer; box-side history is at
-`$HOME/.claude-archive/<ts>/` (`ssh <box> "ls .claude-archive/"`).
+`BrevEnvironment.start()` performs two cleanups before this trial's
+`claude --print` runs:
+
+- archives prior-trial session JSONLs (`mv
+  /logs/agent/sessions/projects/* $HOME/.claude-archive/<ts>/`), because
+  harbor's mapper merges **every** `*.jsonl` under
+  `sessions/projects/<project>/` into one `trajectory.json` — on a warm box
+  that would otherwise splice in every prior trial (observed: 7549 steps
+  spanning 50 h).
+- removes stale Claude Code background-task scratch under
+  `/tmp/claude-<uid>/.../tasks`, because completed background command
+  markers can be replayed as fresh `<task-notification>` messages before
+  the eval prompt even when old session JSONLs were archived.
+
+So when debugging: each trial's copy-back at
+`$RES/<date>/<trial>/agent/` is clean and independently visitable in the
+viewer; box-side session history is at `$HOME/.claude-archive/<ts>/`
+(`ssh <box> "ls .claude-archive/"`).
 
 ## Result comment format
 

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -242,6 +242,28 @@ class BrevEnvironment(BaseEnvironment):
         )
         await _run_brev_exec(self._instance_name, archive_cmd, timeout=30)
 
+        # Clear Claude Code's background-task scratch before the new
+        # `claude --print` starts. Session JSONL archival above handles stale
+        # `/logs/agent/sessions/projects/*`, but completed background tasks
+        # can also leave markers under `/tmp/claude-<uid>/.../tasks`. Claude
+        # Code may surface those as fresh `<task-notification>` messages in
+        # the next session, polluting the trajectory before the eval prompt.
+        claude_task_cleanup_result = await _run_brev_exec(
+            self._instance_name,
+            _claude_task_scratch_cleanup_command(),
+            timeout=30,
+        )
+        if claude_task_cleanup_result.return_code != 0:
+            tail = (
+                claude_task_cleanup_result.stderr
+                or claude_task_cleanup_result.stdout
+                or ""
+            )[-500:]
+            raise RuntimeError(
+                f"claude task scratch cleanup failed on {self._instance_name}: "
+                f"exit {claude_task_cleanup_result.return_code}; tail:\n{tail}"
+            )
+
         # Forward task-critical env vars from the local shell into the
         # instance's ~/.eval_env (sourced by ~/.profile, which every
         # brev exec then sources).  Harbor's claude-code agent only
@@ -731,6 +753,28 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
 def _which(cmd: str) -> bool:
     import shutil
     return shutil.which(cmd) is not None
+
+
+def _claude_task_scratch_cleanup_command() -> str:
+    """Remove stale Claude Code background-task markers for this user.
+
+    Claude Code keys temp scratch by effective UID, e.g.
+    `/tmp/claude-1002/-home-shadeform/<session>/tasks/<id>.output`. Removing
+    the old `tasks/` dirs prevents completed background-command notifications
+    from being replayed into the next Harbor trial.
+    """
+    return (
+        "UID_NUM=$(id -u); "
+        'BASE="/tmp/claude-${UID_NUM}"; '
+        'if [ -d "$BASE" ]; then '
+        '  BEFORE=$(find "$BASE" -type d -name tasks -prune 2>/dev/null | wc -l); '
+        '  find "$BASE" -type d -name tasks -prune -exec rm -rf {} + 2>/dev/null || exit 1; '
+        '  AFTER=$(find "$BASE" -type d -name tasks -prune 2>/dev/null | wc -l); '
+        '  echo "[claude-task-scratch] removed task dirs before=$BEFORE after=$AFTER base=$BASE"; '
+        'else '
+        '  echo "[claude-task-scratch] no scratch base $BASE"; '
+        "fi"
+    )
 
 
 def _kill_proc_group(proc: asyncio.subprocess.Process) -> None:
@@ -1353,5 +1397,3 @@ async def _check_live_resources(instance_name: str, req: dict) -> None:
             "Instance '%s' driver: %s (>= required %s)",
             instance_name, actual, min_driver,
         )
-
-

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -768,7 +768,10 @@ def _claude_task_scratch_cleanup_command() -> str:
         'BASE="/tmp/claude-${UID_NUM}"; '
         'if [ -d "$BASE" ]; then '
         '  BEFORE=$(find "$BASE" -type d -name tasks -prune 2>/dev/null | wc -l); '
-        '  find "$BASE" -type d -name tasks -prune -exec rm -rf {} + 2>/dev/null || exit 1; '
+        # No `2>/dev/null` on the rm step: a real cleanup failure's stderr must
+        # reach claude_task_cleanup_result.stderr so the RuntimeError tail isn't
+        # empty (the BEFORE/AFTER count-finds keep theirs — that noise is benign).
+        '  find "$BASE" -type d -name tasks -prune -exec rm -rf {} + || exit 1; '
         '  AFTER=$(find "$BASE" -type d -name tasks -prune 2>/dev/null | wc -l); '
         '  echo "[claude-task-scratch] removed task dirs before=$BEFORE after=$AFTER base=$BASE"; '
         'else '

--- a/.github/skill-eval/envs/tests/test_registered_node.py
+++ b/.github/skill-eval/envs/tests/test_registered_node.py
@@ -248,6 +248,9 @@ class ClaudeTaskScratchCleanup(unittest.TestCase):
         self.assertIn("-exec rm -rf {} +", cmd)
         self.assertIn("[claude-task-scratch]", cmd)
         self.assertNotIn("sudo rm -rf /tmp/claude-", cmd)
+        # The rm step must not swallow stderr — a real cleanup failure has to
+        # surface its error to the caller, not raise an empty-tail RuntimeError.
+        self.assertNotIn("rm -rf {} + 2>/dev/null", cmd)
 
 
 if __name__ == "__main__":

--- a/.github/skill-eval/envs/tests/test_registered_node.py
+++ b/.github/skill-eval/envs/tests/test_registered_node.py
@@ -239,5 +239,16 @@ class VersionCompareSanity(unittest.TestCase):
         self.assertFalse(brev_env._version_lt("580.95", "580.95"))
 
 
+class ClaudeTaskScratchCleanup(unittest.TestCase):
+    def test_cleanup_command_targets_current_user_task_dirs(self):
+        cmd = brev_env._claude_task_scratch_cleanup_command()
+
+        self.assertIn('BASE="/tmp/claude-${UID_NUM}"', cmd)
+        self.assertIn("-name tasks", cmd)
+        self.assertIn("-exec rm -rf {} +", cmd)
+        self.assertIn("[claude-task-scratch]", cmd)
+        self.assertNotIn("sudo rm -rf /tmp/claude-", cmd)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- clear current-user `/tmp/claude-<uid>/.../tasks` directories before each Harbor trial
- fail loudly if the pre-trial cleanup cannot run
- document the cleanup alongside session JSONL archival

## Why
A polluted `vss-ask-video` trace started with a stale Claude Code `<task-notification>` sourced from `/tmp/claude-1002/.../tasks/<id>.output` before the real eval instruction. Archiving `/logs/agent/sessions/projects/*` does not remove that task scratch.

## Testing
- python3 -m py_compile .github/skill-eval/envs/brev_env.py .github/skill-eval/run_leg.py .github/skill-eval/skills_eval_agent.py .github/skill-eval/plan_matrix.py
- python3 .github/skill-eval/envs/tests/test_registered_node.py
- python3 .github/skill-eval/tests/test_run_leg.py
- python3 .github/skill-eval/tests/test_plan_matrix.py