### PR TITLE
fix(skills): add Tier-3 eval datasets to the 13 skills missing them

### DIFF
--- a/skills/vss-ask-video/evals/evals.json
+++ b/skills/vss-ask-video/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "ask-video-visual-question",
+    "question": "Ask the VSS agent a fresh visual question about a recorded video clip, e.g. \"what colour is the forklift in the warehouse_sample clip?\"",
+    "expected_skill": "vss-ask-video",
+    "ground_truth": "Loads vss-ask-video and routes the question through the VSS agent's video_understanding tool (POST /generate with input_message) against a named recorded clip, not search hits or metadata.",
+    "expected_behavior": [
+      "Loads the vss-ask-video skill and uses the agent's video_understanding tool (not search or metadata).",
+      "Targets a named recorded clip and asks a genuinely visual question via the agent REST API.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-deploy-dense-captioning/evals/evals.json
+++ b/skills/vss-deploy-dense-captioning/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "deploy-dense-captioning",
+    "question": "Deploy the standalone RT-VLM dense-captioning service and verify its REST API.",
+    "expected_skill": "vss-deploy-dense-captioning",
+    "ground_truth": "Loads vss-deploy-dense-captioning, brings up the standalone RT-VLM dense-captioning service (not a full VSS profile), and exercises its REST API (uploads, captions, streams, chat-completions).",
+    "expected_behavior": [
+      "Loads vss-deploy-dense-captioning and deploys the standalone RT-VLM service, not a full VSS profile.",
+      "Verifies the REST API (uploads / captions / streams / chat-completions).",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-deploy-detection-tracking-2d/evals/evals.json
+++ b/skills/vss-deploy-detection-tracking-2d/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "deploy-detection-tracking-2d",
+    "question": "Deploy the RTVI-CV 2D detection/tracking microservice and call its REST API.",
+    "expected_skill": "vss-deploy-detection-tracking-2d",
+    "ground_truth": "Loads vss-deploy-detection-tracking-2d, deploys the standalone RTVI-CV 2D detection/tracking microservice, and calls its REST API; does not route to VLM, embedding, or analytics skills.",
+    "expected_behavior": [
+      "Loads vss-deploy-detection-tracking-2d and deploys the 2D detection/tracking microservice.",
+      "Calls its REST API and does not route to VLM / embedding / analytics skills.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-deploy-video-embedding/evals/evals.json
+++ b/skills/vss-deploy-video-embedding/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "deploy-video-embedding",
+    "question": "Deploy the VSS RT-Embed video-embedding microservice and verify its /v1 embedding API.",
+    "expected_skill": "vss-deploy-video-embedding",
+    "ground_truth": "Loads vss-deploy-video-embedding, brings up the standalone RT-Embed video-embedding microservice via Docker Compose, and verifies its /v1 REST API (health/metrics, text and video embeddings); not a full VSS profile or search ingestion.",
+    "expected_behavior": [
+      "Loads vss-deploy-video-embedding and brings up the standalone RT-Embed microservice via Docker Compose.",
+      "Verifies the /v1 embedding REST API (health, text/video embeddings).",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-generate-video-report-rag/evals/evals.json
+++ b/skills/vss-generate-video-report-rag/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "generate-video-report-rag",
+    "question": "Generate a video summary report using the FRAG/RAG pipeline.",
+    "expected_skill": "vss-generate-video-report-rag",
+    "ground_truth": "Loads vss-generate-video-report-rag and produces a video summary/report/analysis via the frag/RAG pipeline.",
+    "expected_behavior": [
+      "Loads vss-generate-video-report-rag and uses the FRAG/RAG pipeline.",
+      "Produces a video summary / report / analysis from the retrieved context.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-generate-video-report/evals/evals.json
+++ b/skills/vss-generate-video-report/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "generate-video-report",
+    "question": "Generate a VSS analysis report for a recorded video.",
+    "expected_skill": "vss-generate-video-report",
+    "ground_truth": "Loads vss-generate-video-report and produces a VSS analysis report, selecting Mode A (per-clip VLM) or Mode B (incident-range via video-analytics); not real-time alerts or ad-hoc Q&A.",
+    "expected_behavior": [
+      "Loads vss-generate-video-report and selects Mode A (per-clip VLM) or Mode B (incident-range).",
+      "Produces the analysis report and does not route to alerts or ad-hoc Q&A skills.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-manage-alerts/evals/evals.json
+++ b/skills/vss-manage-alerts/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "manage-alerts",
+    "question": "Set up a real-time VSS alert subscription via Alert-Bridge and route its notifications.",
+    "expected_skill": "vss-manage-alerts",
+    "ground_truth": "Loads vss-manage-alerts and drives a real-time alert workflow (Alert-Bridge subscription, notifications such as Slack, incident queries, camera onboarding); not non-alert analytics.",
+    "expected_behavior": [
+      "Loads vss-manage-alerts for the real-time alert workflow (Alert-Bridge / notifications / incident queries).",
+      "Does not route to non-alert analytics skills.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-manage-video-io-storage/evals/evals.json
+++ b/skills/vss-manage-video-io-storage/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "manage-video-io-storage",
+    "question": "List sensors and extract a video clip via the VIOS REST API.",
+    "expected_skill": "vss-manage-video-io-storage",
+    "ground_truth": "Loads vss-manage-video-io-storage and calls the VIOS REST API (sensor list, timelines, clip extraction, snapshots, add/delete sensors and streams); not VLM inference or search.",
+    "expected_behavior": [
+      "Loads vss-manage-video-io-storage and calls the VIOS REST API (sensor list / clip extraction).",
+      "Does not route to VLM or search skills.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-query-analytics/evals/evals.json
+++ b/skills/vss-query-analytics/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "query-analytics",
+    "question": "Query recent video-analytics incidents and metrics via the VA-MCP server.",
+    "expected_skill": "vss-query-analytics",
+    "ground_truth": "Loads vss-query-analytics and reads video-analytics metrics, incidents, alerts, and sensor data via the VA-MCP server (port 9901); not live VLM or incident-range narrative reports.",
+    "expected_behavior": [
+      "Loads vss-query-analytics and queries the VA-MCP server (port 9901) for analytics / incidents / metrics.",
+      "Does not route to live VLM or report-generation skills.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-search-archive/evals/evals.json
+++ b/skills/vss-search-archive/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "search-archive",
+    "question": "Run a natural-language fusion search over archived VSS video, ingesting a clip first if needed.",
+    "expected_skill": "vss-search-archive",
+    "ground_truth": "Loads vss-search-archive and runs top-level VSS fusion search on archived video (or ingests video files / RTSP streams for search); not ad-hoc Q&A or live captioning.",
+    "expected_behavior": [
+      "Loads vss-search-archive and runs fusion search on archived video, ingesting first if needed.",
+      "Does not route to Q&A or live-captioning skills.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-setup-behavior-analytics/evals/evals.json
+++ b/skills/vss-setup-behavior-analytics/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "setup-behavior-analytics",
+    "question": "Deploy the vss-behavior-analytics service standalone.",
+    "expected_skill": "vss-setup-behavior-analytics",
+    "ground_truth": "Loads vss-setup-behavior-analytics and deploys the standalone vss-behavior-analytics service (entrypoint, config-source, optional calibration); not the full warehouse deploy.",
+    "expected_behavior": [
+      "Loads vss-setup-behavior-analytics and deploys the standalone behavior-analytics service.",
+      "Does not run the full warehouse profile deploy.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-setup-video-analytics-api/evals/evals.json
+++ b/skills/vss-setup-video-analytics-api/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "setup-video-analytics-api",
+    "question": "Deploy the vss-video-analytics-api REST service standalone.",
+    "expected_skill": "vss-setup-video-analytics-api",
+    "ground_truth": "Loads vss-setup-video-analytics-api and deploys the standalone vss-video-analytics-api REST service (config-source, data-log bind, Elasticsearch, optional Kafka); not the full warehouse deploy.",
+    "expected_behavior": [
+      "Loads vss-setup-video-analytics-api and deploys the standalone video-analytics-api REST service.",
+      "Wires Elasticsearch (and optional Kafka) and does not run the full warehouse deploy.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]

--- a/skills/vss-summarize-video/evals/evals.json
+++ b/skills/vss-summarize-video/evals/evals.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "summarize-video",
+    "question": "Summarize a recorded video using the LVS summarization microservice.",
+    "expected_skill": "vss-summarize-video",
+    "ground_truth": "Loads vss-summarize-video and summarizes a recorded video via the LVS summarization microservice (HITL-gated) with a VLM fallback; not live RTSP captioning or incident-range reports.",
+    "expected_behavior": [
+      "Loads vss-summarize-video and uses the LVS summarization microservice (HITL-gated, VLM fallback).",
+      "Does not route to live captioning or incident-range report skills.",
+      "Does not print plaintext API tokens or other secrets."
+    ]
+  }
+]


### PR DESCRIPTION
## Problem
NVSkills / CARPS `validate:content` flags **every external-profile skill without a Tier-3 eval dataset**:
> `[AGENT_EVAL-HIGH] External-profile skills must include a valid Tier 3 eval dataset` — `skills/<skill>/evals/evals.json`

(gitlab `nvcarps-ci` job `333651631` flagged vss-ask-video, vss-deploy-dense-captioning, … — one per missing file). **13 skills** lacked the file.

## Fix
Adds a minimal **one-query `evals.json`** to each of the 13, matching the format of the skills that already pass the check (`vss-deploy-detection-tracking-3d`, `vss-deploy-profile`): a top-level array with one `{id, question, expected_skill, ground_truth, expected_behavior}` entry. Each query is a representative skill-activation task derived from that skill's own `description`, plus a "no plaintext secrets" safety expectation.

This clears the **dataset-required** blocker (the Tier-3 *presence* check). The Tier-3 live-agent verdict itself is advisory — NVSkills CI publishes-with-warning and isn't a required check.

**Skills covered (13):** vss-ask-video, vss-deploy-dense-captioning, vss-deploy-detection-tracking-2d, vss-deploy-video-embedding, vss-generate-video-report-rag, vss-generate-video-report, vss-manage-alerts, vss-manage-video-io-storage, vss-query-analytics, vss-search-archive, vss-setup-behavior-analytics, vss-setup-video-analytics-api, vss-summarize-video.

## Scope
- `vss-deploy-profile`'s `evals.json` is added separately in **#934** — excluded here to avoid a conflict.
- One query per skill (as requested); can be expanded later. No skill content changed — only new `evals/evals.json` files.

## Validation
All 13 are valid JSON, exactly one entry each, key-parity with the reference, and `expected_skill` matches the skill dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
