### PR TITLE
fix(launchable): fail search critic on 2-GPU Brev

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -955,6 +955,18 @@ function process_args() {
         fi
       fi
 
+      # Search critic requires a local VLM unless --use-remote-vlm is provided.
+      # On 2-GPU Brev launchables the configured local VLM device is unavailable,
+      # so fail fast instead of silently deploying without the critic service.
+      if [[ "${profile}" == "search" ]] && [[ -n "${BREV_ENV_ID:-}" ]] && [[ "${vlm_mode}" != "remote" ]] && ! ([[ "${ENABLE_CRITIC+set}" == "set" ]] && [[ "${ENABLE_CRITIC,,}" == "false" ]]); then
+        local _brev_gpu_count
+        _brev_gpu_count="$(get_nvidia_smi_gpu_count)"
+        if [[ "${_brev_gpu_count}" =~ ^[0-9]+$ ]] && [[ "${_brev_gpu_count}" -gt 0 ]] && [[ "${_brev_gpu_count}" -le 2 ]]; then
+          echo "[ERROR] Search critic requires a local VLM GPU, but this Brev environment has ${_brev_gpu_count} GPU(s). Set ENABLE_CRITIC=false to deploy search without critic, or pass --use-remote-vlm with VLM_ENDPOINT_URL."
+          ((_all_good++))
+        fi
+      fi
+
       # Fail fast: VLM_CUSTOM_WEIGHTS must be an absolute path and the directory must exist (even in dry-run)
       if [[ "${vlm_mode}" != "remote" ]]; then
         if [[ -n "${vlm_custom_weights}" ]]; then
@@ -1284,22 +1296,12 @@ function state_up() {
   fi
 
   # Search profile: critic agent is enabled by default. Host ENABLE_CRITIC case-insensitive false → write ENABLE_CRITIC=false and force VLM_NAME_SLUG=none (skip local VLM).
-  # Brev 2-GPU launchables do not have enough local devices for the Search critic VLM assignment, so disable critic there as well.
   # Otherwise write ENABLE_CRITIC=true (VLM_NAME_SLUG is not overridden here; remote VLM block already sets it to none when --use-remote-vlm is passed).
+  # Brev 2-GPU local-VLM critic deployments are rejected during argument validation.
   if [[ "${profile}" == "search" ]]; then
     if [[ "${ENABLE_CRITIC+set}" == "set" ]] && [[ "${ENABLE_CRITIC,,}" == "false" ]]; then
       set_env_var "ENABLE_CRITIC" "false"
       set_env_var "VLM_NAME_SLUG" "none"
-    elif [[ -n "${BREV_ENV_ID:-}" ]] && [[ "${vlm_mode}" != "remote" ]]; then
-      local _brev_gpu_count
-      _brev_gpu_count="$(get_nvidia_smi_gpu_count)"
-      if [[ "${_brev_gpu_count}" =~ ^[0-9]+$ ]] && [[ "${_brev_gpu_count}" -gt 0 ]] && [[ "${_brev_gpu_count}" -le 2 ]]; then
-        echo "[WARN] Brev environment has ${_brev_gpu_count} GPU(s). Disabling Search critic to avoid starting the local VLM on GPU ${vlm_device_id}."
-        set_env_var "ENABLE_CRITIC" "false"
-        set_env_var "VLM_NAME_SLUG" "none"
-      else
-        set_env_var "ENABLE_CRITIC" "true"
-      fi
     else
       set_env_var "ENABLE_CRITIC" "true"
     fi

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -691,9 +691,14 @@ else
 fi
 EOF
 chmod +x "${_mock_brev_two_gpu_dir}/nvidia-smi"
-PATH="${_mock_brev_two_gpu_dir}:${PATH}" BREV_ENV_ID=test-env ENABLE_CRITIC=true run_dry_run_up_and_check_generated_env "generated.env search Brev 2 GPU disables ENABLE_CRITIC" "search" \
+PATH="${_mock_brev_two_gpu_dir}:${PATH}" BREV_ENV_ID=test-env run_negative_test "search Brev 2 GPU rejects default local critic" 1 up -p search -i 127.0.0.1 -d
+PATH="${_mock_brev_two_gpu_dir}:${PATH}" BREV_ENV_ID=test-env ENABLE_CRITIC=true run_negative_test "search Brev 2 GPU rejects explicitly enabled local critic" 1 up -p search -i 127.0.0.1 -d
+PATH="${_mock_brev_two_gpu_dir}:${PATH}" BREV_ENV_ID=test-env ENABLE_CRITIC=false run_dry_run_up_and_check_generated_env "generated.env search Brev 2 GPU allows explicit ENABLE_CRITIC=false" "search" \
   -i 127.0.0.1 -d -- \
   "ENABLE_CRITIC" "false" "VLM_NAME_SLUG" "none" "VLM_DEVICE_ID" "2"
+PATH="${_mock_brev_two_gpu_dir}:${PATH}" BREV_ENV_ID=test-env ENABLE_CRITIC=true VLM_ENDPOINT_URL=http://127.0.0.1:9998 run_dry_run_up_and_check_generated_env "generated.env search Brev 2 GPU allows remote critic VLM" "search" \
+  -i 127.0.0.1 --use-remote-vlm --vlm my-remote-vlm -d -- \
+  "ENABLE_CRITIC" "true" "VLM_MODE" "remote" "VLM_NAME_SLUG" "none" "VLM_BASE_URL" "http://127.0.0.1:9998"
 _mock_brev_three_gpu_dir="$(mktemp -d)"
 CLEANUP_DIRS+=("${_mock_brev_three_gpu_dir}")
 cat > "${_mock_brev_three_gpu_dir}/nvidia-smi" <<'EOF'


### PR DESCRIPTION
## Summary
- fail fast when Search critic is requested on a 2-GPU Brev launchable with local VLM
- keep ENABLE_CRITIC=false as the explicit search-without-critic path
- keep --use-remote-vlm/VLM_ENDPOINT_URL as the supported critic path for 2-GPU Brev
- update dev-profile dry-run coverage for all three cases

## Related
- NVBug 6268708

## Validation
- bash -n deploy/docker/scripts/dev-profile.sh deploy/docker/test-scripts/test-dev-profile.sh
- git diff --check -- deploy/docker/scripts/dev-profile.sh deploy/docker/test-scripts/test-dev-profile.sh
- docker run --rm -v "$PWD:/repo" -w /repo ubuntu:24.04 bash -lc '... TEST_TIMEOUT=20 bash deploy/docker/test-scripts/test-dev-profile.sh'
  - 167 passed, 0 failed; 1 optional skip because the minimal container lacks python3/jq