### PR TITLE
fix(alerts): Update default org to nvidia for VSS deployment notebook

### DIFF
--- a/deploy/docker/scripts/deploy_vss_launchable.ipynb
+++ b/deploy/docker/scripts/deploy_vss_launchable.ipynb
@@ -53,7 +53,7 @@
     "# ============================================================\n",
     "\n",
     "NGC_CLI_API_KEY = \"\"          # Your NGC API key — get one at https://ngc.nvidia.com\n",
-    "NGC_CLI_ORG = \"\"              # Optional NGC org. Leave empty to use your account default.\n",
+    "NGC_CLI_ORG = \"nvidia\"        # change NGC org as needed based on your model source\n",
     "\n",
     "PROFILE = \"base\"              # Deployment profile: base, search, alerts, lvs\n",
     "\n",


### PR DESCRIPTION
## Description
Update default org to nvidia for VSS deployment notebook

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
