### PR TITLE
feat(skills-review): multi-paradigm skill review CI on main (enable workflow_dispatch)

### DIFF
--- a/.github/skills-review/.gitignore
+++ b/.github/skills-review/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.github/skills-review/README.md
+++ b/.github/skills-review/README.md
@@ -1,0 +1,121 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Skills Review (multi-paradigm, advisory)
+
+A CI pass that reviews **changed skills** with six independent paradigms in
+parallel, consolidates their findings by **cross-paradigm agreement + severity**,
+and posts a **sticky PR comment** + uploads a full **artifact**. It is the CI
+realization of the manual 6-paradigm review. It is **advisory** — it never fails
+the merge and is not a required status check.
+
+Complements, does not replace: `skills-nv-base.yml` (schema/secrets/PII lint) and
+`skills-eval.yml` (GPU behavioral eval). This is static, LLM-only review.
+
+## Flow
+
+```
+plan  (plan_review_matrix.py: changed skills × 6 paradigms → matrix)
+  → review  (matrix, fail-fast:false, max-parallel 12; one Agent-SDK leg per (skill,paradigm))
+       each leg → review-<skill>__<paradigm>.json   (canonical findings schema)
+  → report  (consolidate.py → sticky comment via post_review_comment.py + consolidated.{json,md})
+```
+
+Parallelism is the **Actions matrix**, not in-agent subagents — the Agent-SDK
+substrate disables Task/background tools (one serial agent per leg), exactly as
+`skills-eval` does.
+
+## Paradigms
+
+| Paradigm | Engine | Scope |
+|---|---|---|
+| `review` | Claude Agent SDK + `prompts/review.md` | diff: VSS correctness (stale refs, dead container names, ghost paths) |
+| `gstack-review` | Claude Agent SDK + `prompts/gstack-review.md` | diff: dangerous/non-portable shell, side effects, proxy gates |
+| `codex` | `codex exec` + `prompts/codex.md` | diff: adversarial second opinion, authz-vs-authn, fabricated facts |
+| `ce-code-review` | installed `ce-code-review` skill (`mode:agent`) | diff: multi-persona code review (native JSON) |
+| `ce-doc-review` | installed `ce-doc-review` skill (`mode:headless`) | whole `SKILL.md`: document quality |
+| `best-practices` | Claude Agent SDK + `prompts/best-practices.md` | whole skill: Anthropic authoring rubric |
+
+All legs normalize to one schema (`findings-schema.json`): `{skill, paradigm,
+file, line, title, severity, category, rationale, suggested_fix, confidence}`.
+
+## Runner prerequisites (`vss-brev-runner`)
+
+Runs on `[self-hosted, vss-brev-runner]` — the **original `vss-skill-validator`**
+host (shared CPU brev-CI pool), **not** `vss-skill-validator-v2`
+(`vss-skill-eval-runner`, reserved for GPU eval). Review is LLM-only; no GPU,
+Brev box, or Harbor.
+
+That host must have:
+1. **Anthropic coordinator `.env`** at `/home/ubuntu/eval-coordinator/.env` with
+   `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_MODEL`. The review legs
+   source it and set `CLAUDE_CODE_DISABLE_THINKING=1` (the NVIDIA Anthropic proxy
+   rejects the `context_management` field otherwise). **Confirmed present on
+   `vss-skill-validator`.**
+2. **`claude` CLI** — the Claude Agent SDK *spawns* the `claude` binary, so it is
+   required for **every agentic leg**: `review` / `gstack-review` /
+   `best-practices` (via the SDK) and `ce-code-review` / `ce-doc-review` (which
+   call it directly). The two `ce-*` legs additionally need the
+   **compound-engineering plugin** installed. Missing `claude` → SDK legs record
+   `status: failed`, CE legs `status: skipped`.
+3. **`codex` CLI + auth** (`CODEX_HOME`) for the `codex` leg. If absent, that leg
+   degrades to `status: skipped` — net-new on this pool; install only if the
+   cross-model lens is wanted.
+4. `python3` 3.12 (provided by `actions/setup-python`); `claude-agent-sdk` is
+   `pip install`ed on demand by `review_agent.py` (it still needs the `claude`
+   CLI from item 2 at runtime).
+
+> **Provisioning status (checked via `brev exec vss-skill-validator`):** the
+> `.env` + `ANTHROPIC_*` keys are present, but `claude`, the CE plugin, and
+> `codex` are **not installed** on the pool yet. Until `claude` is installed the
+> report is empty/skipped — the workflow still runs green (advisory). The eval
+> host `vss-skill-validator-v2` already has `claude`, but it is reserved for GPU
+> eval; install `claude` (+ CE plugin, codex) on `vss-skill-validator` to enable
+> the legs.
+
+## Consolidation rules (`review_findings.py`)
+
+- **agreement** = count of **distinct** paradigms that raised a finding (two
+  checks from one paradigm are not corroboration).
+- **severity** = **max** across members (worst-case wins).
+- **needs_verification** = `severity == critical` **or** `agreement == 1` (the
+  "verify criticals and single-lens outliers" rule — e.g. the DGX-Spark trap).
+- dedupe key = `(skill, file, ~title)`; titles merge on token-overlap ≥ 0.6 **or**
+  `SequenceMatcher` ≥ 0.82.
+- ranking = `(severity, -agreement, skill, file)`.
+
+The sticky comment shows critical/high + corroborated (agreement ≥ 2) rows and a
+critical/high **verify** list; the low-confidence long tail stays in the artifact.
+
+## Secret hygiene
+
+Only the JSON **findings** are uploaded — never agent trajectory dirs (the
+`skills-eval` PR #516 lesson, where `NGC_CLI_API_KEY` leaked via trajectories).
+
+## Triggers
+
+- **PR** (push to `pull-request/<N>` mirror): reviews only the **changed** skills
+  (`FETCH_HEAD...HEAD` cumulative diff).
+- **Manual** (`workflow_dispatch` `skills` input): `*` (all), a comma list, or a
+  JSON array of skill dirs.
+
+## Promoting to a gate (later)
+
+Kept advisory until the false-positive rate is understood. To make it blocking,
+add `Skills Review / report` as a required status check and change the leg/report
+exit-code policy — today everything exits 0 by design.
+
+## Cost
+
+A full manual sweep is ~`(#skills) × 6` LLM legs (~100); PR runs review only the
+changed skills. `max-parallel` bounds concurrency against the Anthropic proxy
+rate limit.
+
+## Tests
+
+```
+python3 .github/skills-review/tests/test_plan_review_matrix.py
+python3 .github/skills-review/tests/test_review_findings.py
+python3 .github/skills-review/tests/test_consolidate.py
+python3 .github/skills-review/tests/test_review_agent.py
+python3 .github/skills-review/tests/test_post_review_comment.py
+```

--- a/.github/skills-review/consolidate.py
+++ b/.github/skills-review/consolidate.py
@@ -85,7 +85,11 @@ def _row(f: dict) -> str:
 def build_comment(consolidated: list[dict], run_url: str | None = None) -> str:
     """Compact sticky-comment body — corroborated rows + verify list; tail stays in artifact."""
     cnt = _counts(consolidated)
-    n_verify = sum(1 for f in consolidated if f["needs_verification"])
+    # Count only what the Verify table below actually shows (critical/high). Low
+    # single-lens findings are needs_verification too, but they stay in the
+    # artifact, so counting them here would overstate the displayed list.
+    n_verify = sum(1 for f in consolidated
+                   if f["needs_verification"] and f["severity"] in ("critical", "high"))
     n_skills = len({f["skill"] for f in consolidated})
     lines = [
         "## 🔬 Skills Review — 6-paradigm consolidation",

--- a/.github/skills-review/consolidate.py
+++ b/.github/skills-review/consolidate.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Consolidate per-leg review artifacts into one report (the `report` job).
+
+Reads every per-leg `review-<slug>.json` produced by review_agent.py, merges
+across paradigms via review_findings.consolidate(), and emits three outputs:
+  - skills-review-consolidated.json  (full machine-readable array)
+  - skills-review-consolidated.md    (human triage doc, bucketed by category)
+  - a compact sticky-comment body    (printed / handed to post_review_comment.py)
+
+Stdlib only. The sticky-comment poster (post_review_comment.py) adds the marker
+and upserts; this module only computes content (pure functions are unit-tested).
+
+Env (main()):
+    REVIEW_ARTIFACTS_DIR   dir holding the per-leg review-*.json (default: cwd)
+    CONSOLIDATED_JSON      output path (default: skills-review-consolidated.json)
+    CONSOLIDATED_MD        output path (default: skills-review-consolidated.md)
+    COMMENT_BODY           output path for the comment body (default: review-comment.md)
+    RUN_URL                optional Actions run URL for the comment footer
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import review_findings as rf  # noqa: E402
+
+SEV_EMOJI = {"critical": "🔴", "high": "🟠", "medium": "🟡", "low": "🔵"}
+CATEGORY_ORDER = ["deploy-breaking", "security", "api-contract", "packaging-style", "tone"]
+CATEGORY_LABEL = {
+    "deploy-breaking": "Deploy-breaking",
+    "security": "Security",
+    "api-contract": "API contract",
+    "packaging-style": "Packaging / authoring",
+    "tone": "Tone / voice",
+}
+MAX_ROWS_PER_TABLE = 15
+N_PARADIGMS = len(rf.PARADIGM_DEFAULT_CATEGORY)  # agreement is out of this many lenses
+
+
+def load_legs(artifacts_dir: pathlib.Path) -> list[dict]:
+    """Load + normalize findings from every review-*.json under artifacts_dir.
+
+    A leg's artifact is {skill, paradigm, [status], findings:[...]}. Malformed
+    or unreadable legs are skipped with a warning — one bad leg never sinks the
+    report (advisory posture).
+    """
+    findings: list[dict] = []
+    for path in sorted(artifacts_dir.rglob("review-*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, ValueError) as exc:
+            print(f"::warning::skills-review: skipping unreadable leg {path}: {exc}")
+            continue
+        skill = data.get("skill")
+        paradigm = data.get("paradigm")
+        if not skill or not paradigm:
+            print(f"::warning::skills-review: leg {path} missing skill/paradigm")
+            continue
+        findings.extend(rf.normalize(paradigm, data.get("findings"), skill=skill))
+    return findings
+
+
+def _counts(consolidated: list[dict]) -> dict:
+    c = {s: 0 for s in rf.SEVERITIES}
+    for f in consolidated:
+        c[f["severity"]] += 1
+    return c
+
+
+def _loc(f: dict) -> str:
+    return f"`{f['file']}" + (f":{f['line']}" if f["line"] else "") + "`"
+
+
+def _row(f: dict) -> str:
+    title = f["title"].replace("|", "\\|")  # keep markdown table cells intact
+    return (f"| {SEV_EMOJI[f['severity']]} {f['severity']} | "
+            f"{f['agreement']}/{N_PARADIGMS} | {f['skill']} | {_loc(f)} | {title} |")
+
+
+def build_comment(consolidated: list[dict], run_url: str | None = None) -> str:
+    """Compact sticky-comment body — corroborated rows + verify list; tail stays in artifact."""
+    cnt = _counts(consolidated)
+    n_verify = sum(1 for f in consolidated if f["needs_verification"])
+    n_skills = len({f["skill"] for f in consolidated})
+    lines = [
+        "## 🔬 Skills Review — 6-paradigm consolidation",
+        "",
+        f"**{len(consolidated)} findings across {n_skills} skill(s)** · "
+        f"🔴 critical={cnt['critical']} · 🟠 high={cnt['high']} · "
+        f"🟡 medium={cnt['medium']} · 🔵 low={cnt['low']}",
+        f"**{n_verify} need verification** (critical or single-lens). Full report in the run artifact.",
+    ]
+    if not consolidated:
+        lines.append("\n_No findings._")
+        return "\n".join(lines)
+
+    def table(title, rows):
+        if not rows:
+            return
+        lines.extend(["", f"### {title}", "| Sev | Agree | Skill | File | Finding |",
+                      "|---|---:|---|---|---|"])
+        for f in rows[:MAX_ROWS_PER_TABLE]:
+            lines.append(_row(f))
+        if len(rows) > MAX_ROWS_PER_TABLE:
+            lines.append(f"| | | | | …and {len(rows) - MAX_ROWS_PER_TABLE} more (see artifact) |")
+
+    act_now = [f for f in consolidated if f["severity"] in ("critical", "high")]
+    corroborated = [f for f in consolidated
+                    if f["severity"] in ("medium", "low") and f["agreement"] >= 2]
+    table("🔴 Critical / high (act now)", act_now)
+    table("🟠 Corroborated (agreement ≥ 2)", corroborated)
+
+    # Verify list in the comment = the dangerous-but-unconfirmed (critical/high
+    # that are single-lens or critical). Low single-lens findings are pure long
+    # tail — they stay in the artifact, not the scannable comment.
+    verify = [f for f in consolidated
+              if f["needs_verification"] and f["severity"] in ("critical", "high")]
+    if verify:
+        lines.extend(["", "### ⚠️ Verify before acting (critical or single-lens)"])
+        for f in verify[:MAX_ROWS_PER_TABLE]:
+            lines.append(f"- {SEV_EMOJI[f['severity']]} **{f['skill']}** {_loc(f)} — "
+                         f"{f['title']} _(agreement {f['agreement']})_")
+        if len(verify) > MAX_ROWS_PER_TABLE:
+            lines.append(f"- …and {len(verify) - MAX_ROWS_PER_TABLE} more (see artifact)")
+
+    foot = "_Skills Review (advisory)_"
+    if run_url:
+        foot += f" · [run]({run_url})"
+    lines.extend(["", "---", foot])
+    return "\n".join(lines)
+
+
+def build_markdown(consolidated: list[dict]) -> str:
+    """Full human triage doc, grouped by category bucket (like the manual triage doc)."""
+    cnt = _counts(consolidated)
+    lines = [
+        "# Skills Review — consolidated report",
+        "",
+        f"{len(consolidated)} findings · 🔴 {cnt['critical']} · 🟠 {cnt['high']} · "
+        f"🟡 {cnt['medium']} · 🔵 {cnt['low']} · "
+        f"{sum(1 for f in consolidated if f['needs_verification'])} need verification",
+    ]
+    by_cat: dict[str, list[dict]] = {}
+    for f in consolidated:
+        by_cat.setdefault(f["category"], []).append(f)
+    for cat in CATEGORY_ORDER + [c for c in by_cat if c not in CATEGORY_ORDER]:
+        rows = by_cat.get(cat)
+        if not rows:
+            continue
+        lines.extend(["", f"## {CATEGORY_LABEL.get(cat, cat)} ({len(rows)})"])
+        for f in rows:
+            verify = " ⚠️ VERIFY" if f["needs_verification"] else ""
+            lines.append(
+                f"\n### {SEV_EMOJI[f['severity']]} {f['severity'].upper()} · "
+                f"agreement {f['agreement']} ({', '.join(f['paradigms'])}){verify}")
+            lines.append(f"- **{f['skill']}** {_loc(f)} — {f['title']}")
+            if f["rationale"]:
+                lines.append(f"- Rationale: {f['rationale']}")
+            if f["suggested_fix"]:
+                lines.append(f"- Fix: {f['suggested_fix']}")
+            if len(f["members"]) > 1:
+                lines.append(f"- Raised by {len(f['members'])} members:")
+                for m in f["members"]:
+                    r = f" — {m['rationale']}" if m["rationale"] else ""
+                    lines.append(f"  - `{m['paradigm']}` ({m['severity']}){r}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    artifacts = pathlib.Path(os.environ.get("REVIEW_ARTIFACTS_DIR", "."))
+    consolidated = rf.consolidate(load_legs(artifacts))
+
+    json_path = os.environ.get("CONSOLIDATED_JSON", "skills-review-consolidated.json")
+    md_path = os.environ.get("CONSOLIDATED_MD", "skills-review-consolidated.md")
+    body_path = os.environ.get("COMMENT_BODY", "review-comment.md")
+    pathlib.Path(json_path).write_text(json.dumps(consolidated, indent=2) + "\n")
+    pathlib.Path(md_path).write_text(build_markdown(consolidated))
+    pathlib.Path(body_path).write_text(build_comment(consolidated, os.environ.get("RUN_URL")))
+
+    cnt = _counts(consolidated)
+    print(f"skills-review: {len(consolidated)} findings "
+          f"(critical={cnt['critical']} high={cnt['high']} "
+          f"medium={cnt['medium']} low={cnt['low']}) -> {json_path}, {md_path}, {body_path}")
+    return 0  # advisory: never fail the gate
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills-review/findings-schema.json
+++ b/.github/skills-review/findings-schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "skills-review canonical findings",
+  "description": "Schema shared by every review paradigm leg and the consolidated report. Adopted from compound-engineering ce-code-review's findings-schema so ce-code-review/ce-doc-review JSON passes through unchanged; the [P1]/[P2]-marker paradigms (gstack-review, codex) and the prompt-driven ones (review, best-practices) normalize into it via review_findings.canonical_finding().",
+  "definitions": {
+    "finding": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["skill", "paradigm", "file", "title", "severity"],
+      "properties": {
+        "skill": {"type": "string", "description": "skill dir name, e.g. vss-manage-alerts"},
+        "paradigm": {"type": "string", "enum": ["review", "gstack-review", "codex", "ce-code-review", "ce-doc-review", "best-practices"]},
+        "file": {"type": "string", "description": "repo-relative path, e.g. skills/vss-manage-alerts/SKILL.md"},
+        "line": {"type": "integer", "minimum": 0, "description": "1-based line; 0 when not line-anchored"},
+        "title": {"type": "string", "description": "<= ~12 words"},
+        "severity": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
+        "category": {"type": "string", "enum": ["deploy-breaking", "api-contract", "security", "packaging-style", "tone"]},
+        "rationale": {"type": "string"},
+        "suggested_fix": {"type": "string"},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1, "description": "the single paradigm's self-rated confidence"}
+      }
+    },
+    "leg_artifact": {
+      "type": "object",
+      "required": ["skill", "paradigm", "findings"],
+      "properties": {
+        "skill": {"type": "string"},
+        "paradigm": {"type": "string"},
+        "status": {"type": "string", "enum": ["ok", "skipped", "degraded", "failed"]},
+        "findings": {"type": "array", "items": {"$ref": "#/definitions/finding"}}
+      }
+    },
+    "consolidated_finding": {
+      "type": "object",
+      "required": ["key", "skill", "file", "title", "severity", "agreement", "paradigms", "needs_verification", "members"],
+      "properties": {
+        "key": {"type": "string"},
+        "skill": {"type": "string"},
+        "file": {"type": "string"},
+        "line": {"type": "integer"},
+        "title": {"type": "string"},
+        "severity": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
+        "category": {"type": "string"},
+        "agreement": {"type": "integer", "minimum": 1, "description": "count of DISTINCT paradigms that raised it"},
+        "paradigms": {"type": "array", "items": {"type": "string"}},
+        "confidence_tier": {"type": "string", "enum": ["high", "medium", "low"]},
+        "needs_verification": {"type": "boolean", "description": "true when severity==critical OR agreement==1"},
+        "rationale": {"type": "string"},
+        "suggested_fix": {"type": "string"},
+        "members": {"type": "array", "items": {"$ref": "#/definitions/finding"}}
+      }
+    }
+  }
+}

--- a/.github/skills-review/plan_review_matrix.py
+++ b/.github/skills-review/plan_review_matrix.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compute the skills-review dispatch matrix.
+
+Pure Python, no LLM. Fans out one leg per (changed-skill x paradigm) so the
+six review paradigms run independently and in parallel via the Actions matrix.
+Prints `matrix` and `has_targets` to $GITHUB_OUTPUT.
+
+This is the skill-dir-granularity sibling of .github/skill-eval/plan_matrix.py;
+it deliberately reuses that module's change-detection contract (the
+`FETCH_HEAD...HEAD` cumulative-diff, the CHANGED_FILES test override, the
+slug/duplicate guards) but drops the eval-specific spec/platform/adapter
+expansion — a static review fans by skill dir, not by (spec, platform).
+
+Rules:
+  - any changed file under skills/<skill>/  -> review <skill>
+  - matrix leg = (skill, paradigm) for each PARADIGM
+  - a harness-only diff (no skills/** change) yields an empty matrix and the
+    review job is skipped (validate the harness via workflow_dispatch).
+
+Env:
+    PR_BASE               base branch, diffed as FETCH_HEAD...HEAD (pull_request)
+    MANUAL_SKILLS_FILTER  workflow_dispatch: `*` (all), a comma list, or a JSON
+                          array of skill-dir names — reviewed instead of diffing
+    CHANGED_FILES         optional newline-separated override (tests / local)
+    GITHUB_OUTPUT         optional; key=value lines are appended here
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# .github/skills-review/plan_review_matrix.py -> parents[2] = repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+# Any tracked file under a skill dir puts the whole skill in review scope.
+SKILL_FILE_RE = re.compile(r"^skills/([^/]+)/")
+# A skill-dir name accepted from the workflow_dispatch input (path-escape guard).
+SAFE_SKILL_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]*$")
+# A leg's slug names its artifact (skills-review-<slug>) and its scratch path;
+# enforce the token so a future name with a space/slash/colon fails the plan
+# loudly instead of corrupting an artifact name or escaping a path.
+SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# The six review paradigms (each its own parallel matrix leg). Order is the
+# triage-report order; it does not affect parallelism.
+PARADIGMS = [
+    "review",            # VSS /review correctness rubric (diff-based)
+    "gstack-review",     # gstack review rubric (SQL/trust-boundary/structure)
+    "codex",             # codex adversarial second opinion
+    "ce-code-review",    # compound-engineering code review (native JSON)
+    "ce-doc-review",     # compound-engineering doc review (SKILL.md as a doc)
+    "best-practices",    # Anthropic skill-authoring rubric (whole-skill read)
+]
+
+
+def list_changed_files() -> list[str]:
+    """Changed files in the cumulative PR diff (base...head).
+
+    Mirrors plan_matrix.list_changed_files() for the diff + CHANGED_FILES
+    paths. Uses a local `git diff FETCH_HEAD...HEAD` (three-dot = merge-base
+    ..head) rather than the GitHub compare API (which caps `.files` at 300).
+    The manual workflow_dispatch path is handled in resolve_skills() instead.
+    """
+    override = os.environ.get("CHANGED_FILES")
+    if override is not None:
+        return [ln.strip() for ln in override.splitlines() if ln.strip()]
+
+    base = os.environ["PR_BASE"]
+    subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "fetch", "--no-tags", "--quiet",
+         "origin", base],
+        check=True,
+    )
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "diff", "--name-only", "FETCH_HEAD...HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    return [ln.strip() for ln in out.splitlines() if ln.strip()]
+
+
+def changed_skills(changed: list[str]) -> list[str]:
+    """Sorted, deduped skill-dir names from a changed-file list (live dirs only)."""
+    out: set[str] = set()
+    for f in changed:
+        m = SKILL_FILE_RE.match(f)
+        # Only review live skill dirs — a deleted skill still shows in the diff.
+        if m and (SKILLS_DIR / m.group(1)).is_dir():
+            out.add(m.group(1))
+    return sorted(out)
+
+
+def parse_manual(manual: str) -> list[str]:
+    """Resolve a workflow_dispatch `skills` input to validated skill names.
+
+    Accepts three forms: `*` (all skill dirs), a JSON array `["a","b"]`, or a
+    comma list `a,b` (or a single name). Every name is validated against the
+    path-escape guard and confirmed to exist — a typo fails the plan loudly
+    rather than emitting an empty matrix the review job would silently skip.
+    """
+    manual = manual.strip()
+    if manual == "*":
+        return sorted(p.name for p in SKILLS_DIR.iterdir() if p.is_dir())
+    if manual.startswith("["):
+        try:
+            names = json.loads(manual)
+        except ValueError as exc:
+            raise ValueError(f"skills input is not valid JSON: {manual!r}") from exc
+        if not isinstance(names, list):
+            raise ValueError(f"skills JSON must be an array, got {type(names).__name__}")
+    else:
+        names = [s.strip() for s in manual.split(",") if s.strip()]
+
+    for n in names:
+        if not isinstance(n, str) or not SAFE_SKILL_RE.fullmatch(n):
+            raise ValueError(
+                f"unsafe skill name {n!r}: expected a skill-dir name "
+                f"([A-Za-z0-9_-], not starting with '-')"
+            )
+        if not (SKILLS_DIR / n).is_dir():
+            raise ValueError(
+                f"skills/{n}/ does not exist on this ref — check the skill name"
+            )
+    return sorted(set(names))
+
+
+def resolve_skills() -> list[str]:
+    """The set of skills to review, from whichever trigger fired."""
+    manual = os.environ.get("MANUAL_SKILLS_FILTER", "").strip()
+    if manual:
+        return parse_manual(manual)
+    return changed_skills(list_changed_files())
+
+
+def build_matrix(skills: list[str]) -> list[dict]:
+    """Cartesian (skill x paradigm) -> one leg each."""
+    include: list[dict] = []
+    for skill in sorted(set(skills)):
+        for paradigm in PARADIGMS:
+            include.append({
+                "skill": skill,
+                "paradigm": paradigm,
+                "slug": f"{skill}__{paradigm}",
+                "name": f"{skill} · {paradigm}",
+            })
+    return include
+
+
+def emit(include: list[dict]) -> None:
+    # Fail fast on an unsafe slug before it names an artifact or scratch path.
+    for leg in include:
+        if not SAFE_SLUG_RE.match(leg["slug"]):
+            raise ValueError(
+                f"unsafe leg slug {leg['slug']!r}: skill / paradigm must match "
+                f"[A-Za-z0-9_-] (the slug names the workflow artifact and the "
+                f"scratch path)."
+            )
+    # Fail fast on a duplicate slug (would clobber a sibling leg's artifact).
+    seen: set[str] = set()
+    for leg in include:
+        if leg["slug"] in seen:
+            raise ValueError(f"duplicate leg slug {leg['slug']!r}")
+        seen.add(leg["slug"])
+
+    matrix = json.dumps({"include": include}, separators=(",", ":"))
+    has_targets = "true" if include else "false"
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as fh:
+            fh.write(f"matrix={matrix}\n")
+            fh.write(f"has_targets={has_targets}\n")
+
+    print(f"has_targets={has_targets}")
+    print(f"legs={len(include)}")
+    for leg in include:
+        print(f"  - {leg['name']}")
+    print(f"matrix={matrix}")
+
+
+def main() -> int:
+    skills = resolve_skills()
+    print(f"skills to review ({len(skills)}): {', '.join(skills) or '(none)'}",
+          file=sys.stderr)
+    emit(build_matrix(skills))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills-review/post_review_comment.py
+++ b/.github/skills-review/post_review_comment.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Post or update the sticky Skills-Review PR comment.
+
+Thin fork of .github/skills-nv-base/post_comment.py: the comment body is
+composed by consolidate.py (read from $COMMENT_BODY); this module only
+prepends the hidden marker and upserts it (PATCH the existing marked comment,
+else POST). Manual-mode (no PR) falls back to $GITHUB_STEP_SUMMARY.
+
+Advisory: every failure is surfaced as a ::warning and the script exits 0 —
+posting the review must never fail the PR.
+
+Env:
+  GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER   (PR mode)
+  COMMENT_BODY        path to the body markdown (default: review-comment.md)
+  GITHUB_STEP_SUMMARY (manual-mode fallback target)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+MARKER = "<!-- skills-review-bot:v1 -->"
+
+
+def _gh_request(method: str, url: str, body: Optional[dict] = None) -> dict:
+    token = os.environ["GITHUB_TOKEN"]
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return {} if resp.status == 204 else json.loads(resp.read())
+
+
+def find_sticky_comment(repo: str, pr: str) -> Optional[int]:
+    url = f"https://api.github.com/repos/{repo}/issues/{pr}/comments?per_page=100"
+    while url:
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        })
+        with urllib.request.urlopen(req) as resp:
+            comments = json.loads(resp.read())
+            link = resp.headers.get("Link") or ""
+        for c in comments:
+            if MARKER in (c.get("body") or ""):
+                return c["id"]
+        url = None
+        for piece in link.split(","):
+            if 'rel="next"' in piece:
+                s, e = piece.find("<") + 1, piece.find(">", piece.find("<") + 1)
+                if s > 0 and e > s:
+                    url = piece[s:e]
+                break
+    return None
+
+
+def upsert_comment(repo: str, pr: str, body: str) -> None:
+    existing = find_sticky_comment(repo, pr)
+    if existing is not None:
+        _gh_request("PATCH",
+                    f"https://api.github.com/repos/{repo}/issues/comments/{existing}",
+                    {"body": body})
+        print(f"::notice::Updated sticky comment id={existing}", flush=True)
+    else:
+        _gh_request("POST",
+                    f"https://api.github.com/repos/{repo}/issues/{pr}/comments",
+                    {"body": body})
+        print("::notice::Posted new sticky comment", flush=True)
+
+
+def marked_body() -> str:
+    """The comment body from $COMMENT_BODY, with the sticky marker prepended."""
+    path = os.environ.get("COMMENT_BODY", "review-comment.md")
+    try:
+        body = Path(path).read_text()
+    except OSError as exc:
+        print(f"::warning::skills-review: comment body {path} unreadable: {exc}",
+              flush=True)
+        body = "## 🔬 Skills Review\n\n_(report body unavailable)_"
+    return f"{MARKER}\n{body}"
+
+
+def _write_step_summary(body: str) -> bool:
+    path = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+    if not path:
+        return False
+    try:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(body)
+            if not body.endswith("\n"):
+                fh.write("\n")
+            fh.write("\n")
+        return True
+    except OSError as exc:
+        print(f"::warning::Could not write GITHUB_STEP_SUMMARY ({path}): {exc}",
+              flush=True)
+        return False
+
+
+def main() -> int:
+    pr = os.environ.get("PR_NUMBER", "").strip()
+    repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    token = os.environ.get("GITHUB_TOKEN", "")
+    body = marked_body()
+
+    if not pr:
+        if _write_step_summary(body):
+            print("Manual mode: review appended to $GITHUB_STEP_SUMMARY", flush=True)
+        else:
+            print("::warning::PR_NUMBER unset and no step summary; printing body",
+                  flush=True)
+            print(body, flush=True)
+        return 0
+
+    if not repo or not token:
+        print("::warning::GITHUB_REPOSITORY or GITHUB_TOKEN missing; cannot post",
+              flush=True)
+        return 0
+
+    try:
+        upsert_comment(repo, pr, body)
+    except urllib.error.HTTPError as exc:
+        print(f"::warning::Could not post/update comment ({exc.code} {exc.reason}): "
+              f"{exc.read().decode(errors='replace')[:200]}", flush=True)
+    except Exception as exc:  # advisory: never fail the gate
+        print(f"::warning::Comment poster failed: {exc!r}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills-review/prompts/best-practices.md
+++ b/.github/skills-review/prompts/best-practices.md
@@ -1,0 +1,14 @@
+# Paradigm: best-practices (Anthropic skill-authoring)
+You review an agent **skill** against Anthropic skill-authoring best practices — FORMATTING & CONTENT QUALITY, not factual bugs. Read SKILL.md (frontmatter + body) and the whole skill dir. Flag (category: packaging-style or tone):
+1. description quality: must be a crisp third-person capability statement with WHAT + WHEN; flag keyword-stuffing / many near-duplicate trigger phrases, vague or first/second-person descriptions
+2. missing NEGATIVE triggers (when NOT to use it / what to use instead)
+3. progressive disclosure: every references/*.md MUST be linked from SKILL.md with a just-in-time cue ("Read references/x.md when…"); list each reference file that is never linked (dead weight); flag SKILL.md bloat
+4. human-oriented files inside the skill (README.md / CHANGELOG.md / INSTALLATION_GUIDE.md) — anti-patterns; skills are for agents
+5. empty/ghost dirs: SKILL.md references references/ or scripts/ (or run_script) but the dir is missing or only .gitkeep
+6. voice: must be imperative third-person; flag role-play ("You are a … assistant") and conversational ("Show the user…", "Ask the user…")
+7. large output templates inlined in SKILL.md body that belong in assets/
+8. missing/centralized Error Handling section
+## Output contract (required)
+Read only the skill's files under the given skill dir, plus the live repo for fact-checking. Do NOT modify anything. Return ONLY one JSON object, no prose around it:
+`{"findings":[{"file":"skills/<skill>/<path>","line":<int>,"title":"<=12 words","severity":"critical|high|medium|low","category":"deploy-breaking|api-contract|security|packaging-style|tone","rationale":"what's wrong + evidence from both the skill and the repo","suggested_fix":"...","confidence":0.0-1.0}]}`
+Cite a real file+line. Don't invent issues; lower confidence when unsure. Empty findings → `{"findings":[]}`.

--- a/.github/skills-review/prompts/ce-code-review.md
+++ b/.github/skills-review/prompts/ce-code-review.md
@@ -1,0 +1,2 @@
+# Paradigm: ce-code-review (handled by the installed skill)
+This paradigm is NOT prompt-driven — review_agent.py's `ce_skill` engine invokes the installed compound-engineering `ce-code-review` skill headless (`/ce-code-review mode:agent base:<ref>`), which emits the canonical findings JSON directly. This file documents the lens (structured multi-persona correctness/quality code review over the PR diff) for readers; the engine does not read it.

--- a/.github/skills-review/prompts/ce-doc-review.md
+++ b/.github/skills-review/prompts/ce-doc-review.md
@@ -1,0 +1,2 @@
+# Paradigm: ce-doc-review (handled by the installed skill)
+This paradigm is NOT prompt-driven — review_agent.py's `ce_skill` engine invokes the installed compound-engineering `ce-doc-review` skill headless (`/ce-doc-review mode:headless <skill>/SKILL.md`), reviewing the SKILL.md as a document and emitting the canonical findings JSON. This file documents the lens for readers; the engine does not read it.

--- a/.github/skills-review/prompts/codex.md
+++ b/.github/skills-review/prompts/codex.md
@@ -1,0 +1,10 @@
+# Paradigm: codex (adversarial second opinion)
+You are an adversarial reviewer of an agent **skill** — the 200-IQ second opinion. Be skeptical and hunt for what the other lenses miss. Prioritize:
+- credential/readiness gates that prove a PROXY, not the requirement (auth token mints != the key's ORG can ACCESS the model repo; a port is open != the model is served; container count/.State != real health)
+- fabricated/hallucinated facts in the skill: endpoints, env vars, container names, or repo paths that DO NOT EXIST in the product (verify against the repo)
+- security and destructive-command risks
+- single-lens-but-real defects others would overlook
+## Output contract (required)
+Read only the skill's files under the given skill dir, plus the live repo for fact-checking. Do NOT modify anything. Return ONLY one JSON object, no prose around it:
+`{"findings":[{"file":"skills/<skill>/<path>","line":<int>,"title":"<=12 words","severity":"critical|high|medium|low","category":"deploy-breaking|api-contract|security|packaging-style|tone","rationale":"what's wrong + evidence from both the skill and the repo","suggested_fix":"...","confidence":0.0-1.0}]}`
+Cite a real file+line. Don't invent issues; lower confidence when unsure. Empty findings → `{"findings":[]}`.

--- a/.github/skills-review/prompts/gstack-review.md
+++ b/.github/skills-review/prompts/gstack-review.md
@@ -1,0 +1,10 @@
+# Paradigm: gstack-review
+You are the gstack review lens applied to an agent **skill**. Focus on robustness and safety of the instructions an agent will execute:
+- dangerous or non-portable shell (mapfile/process-substitution/bash-arrays, `sed -i` without backup, missing `curl --max-time`, subshell `exit` that doesn't abort, `set -e` assumptions)
+- trust-boundary / side-effect issues: destructive commands (global `docker prune`, broad `rm`), secret leaks (echoing keys)
+- conditional side effects and structural issues (steps that silently no-op, gates that pass vacuously)
+- proxy checks: a "verify X" that proves something weaker than X
+## Output contract (required)
+Read only the skill's files under the given skill dir, plus the live repo for fact-checking. Do NOT modify anything. Return ONLY one JSON object, no prose around it:
+`{"findings":[{"file":"skills/<skill>/<path>","line":<int>,"title":"<=12 words","severity":"critical|high|medium|low","category":"deploy-breaking|api-contract|security|packaging-style|tone","rationale":"what's wrong + evidence from both the skill and the repo","suggested_fix":"...","confidence":0.0-1.0}]}`
+Cite a real file+line. Don't invent issues; lower confidence when unsure. Empty findings → `{"findings":[]}`.

--- a/.github/skills-review/prompts/review.md
+++ b/.github/skills-review/prompts/review.md
@@ -1,0 +1,11 @@
+# Paradigm: review (VSS correctness)
+You are the VSS `/review` correctness lens applied to an agent **skill** (SKILL.md + references are instructions an agent reads and EXECUTES). Find defects that would make an agent following the skill FAIL or do the wrong thing, fact-checked against the live repo (`git grep`/`git show` against the deploy/services trees):
+- stale/wrong container image refs, orgs (nvstaging leftovers), tags
+- dead/renamed container_names, wrong ports, endpoints, env var names + defaults
+- ghost paths/dirs the skill references that don't exist
+- broken cross-links / missing anchors between SKILL.md and references/
+- eval ground-truth that contradicts the skill or the source .env
+## Output contract (required)
+Read only the skill's files under the given skill dir, plus the live repo for fact-checking. Do NOT modify anything. Return ONLY one JSON object, no prose around it:
+`{"findings":[{"file":"skills/<skill>/<path>","line":<int>,"title":"<=12 words","severity":"critical|high|medium|low","category":"deploy-breaking|api-contract|security|packaging-style|tone","rationale":"what's wrong + evidence from both the skill and the repo","suggested_fix":"...","confidence":0.0-1.0}]}`
+Cite a real file+line. Don't invent issues; lower confidence when unsure. Empty findings → `{"findings":[]}`.

--- a/.github/skills-review/review_agent.py
+++ b/.github/skills-review/review_agent.py
@@ -195,6 +195,7 @@ def _engine_ce_skill(paradigm: str, skill: str, skill_dir: pathlib.Path,
         ["claude", "-p", f"/{paradigm} {args}"],
         cwd=str(REPO_ROOT), capture_output=True, text=True,
         env={**os.environ, "CLAUDE_CODE_DISABLE_THINKING": "1"},
+        timeout=1200,  # bound the leg so a stalled CLI can't hold the runner slot
     )
     if proc.returncode != 0 and not proc.stdout.strip():
         raise SkippedLeg(f"{paradigm} returned {proc.returncode}: "
@@ -222,6 +223,7 @@ def _engine_codex(paradigm: str, skill: str, skill_dir: pathlib.Path,
          "--skip-git-repo-check", "-c", 'model_reasoning_effort="high"'],
         capture_output=True, text=True, env={**os.environ, "SPAWNED_SESSION": "1"},
         stdin=subprocess.DEVNULL,
+        timeout=1200,  # bound the leg so a stalled codex can't hold the runner slot
     )
     return extract_findings(proc.stdout)
 
@@ -241,6 +243,10 @@ def run_leg(skill: str, paradigm: str, *, base_ref: str = "origin/develop") -> d
     except SkippedLeg as exc:
         status = "skipped"
         print(f"::warning::skills-review {skill}·{paradigm}: skipped — {exc}", flush=True)
+    except subprocess.TimeoutExpired:
+        status = "skipped"
+        print(f"::warning::skills-review {skill}·{paradigm}: skipped — engine timed out",
+              flush=True)
     except Exception as exc:  # advisory: a broken leg never fails the job
         status = "failed"
         print(f"::warning::skills-review {skill}·{paradigm}: failed — {exc!r}", flush=True)

--- a/.github/skills-review/review_agent.py
+++ b/.github/skills-review/review_agent.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run ONE (skill, paradigm) review leg and write a canonical-schema artifact.
+
+Mirrors .github/skill-eval/skills_eval_agent.py's substrate: a single
+synchronous Claude Agent SDK session per leg (parallelism comes from the
+Actions matrix, not in-agent subagents). Each paradigm reads only the repo
+checkout skills/<skill>/ and emits review-<slug>.json in the canonical schema
+(findings-schema.json) via review_findings.
+
+Paradigm engines (KTD4):
+  review / gstack-review / best-practices  -> Claude Agent SDK + a vendored rubric
+  ce-code-review / ce-doc-review           -> the installed CE skill (headless JSON)
+  codex                                    -> codex exec (degrades if codex absent)
+
+Invariant: a leg ALWAYS writes a schema-valid artifact (status ok|degraded|
+skipped|failed) and exits 0 — advisory CI never fails on a review leg.
+
+Env:
+  EVAL_SKILL, EVAL_PARADIGM   the one leg to run
+  REVIEW_OUT_DIR              where review-<slug>.json is written (default: cwd)
+  PR_BASE                     merge base ref (for diff-based paradigms)
+  ANTHROPIC_* / GH_TOKEN      sourced from the coordinator .env by the workflow
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import review_findings as rf  # noqa: E402
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+PROMPTS_DIR = HERE / "prompts"
+
+# Diff-based paradigms review the PR change; whole-read paradigms read the
+# entire skill dir (skill-authoring quality lives in the full file, not a diff).
+DIFF_BASED = {"review", "gstack-review", "codex", "ce-code-review"}
+WHOLE_READ = {"ce-doc-review", "best-practices"}
+# Which engine drives each paradigm.
+ENGINE = {
+    "review": "claude", "gstack-review": "claude", "best-practices": "claude",
+    "ce-code-review": "ce_skill", "ce-doc-review": "ce_skill", "codex": "codex",
+}
+
+
+class SkippedLeg(Exception):
+    """Raised when a paradigm cannot run in this environment (degrade, don't fail)."""
+
+
+def prompt_for(paradigm: str) -> str:
+    return (PROMPTS_DIR / f"{paradigm}.md").read_text()
+
+
+def _json_blocks(text: str) -> list[str]:
+    """All balanced top-level {...} / [...] blocks (string-aware brace matching)."""
+    blocks, depth, start, instr, esc = [], 0, None, False, False
+    for i, ch in enumerate(text):
+        if instr:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                instr = False
+            continue
+        if ch == '"':
+            instr = True
+        elif ch in "{[":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch in "}]" and depth > 0:
+            depth -= 1
+            if depth == 0 and start is not None:
+                blocks.append(text[start:i + 1])
+                start = None
+    return blocks
+
+
+def extract_findings(text: str) -> list[dict]:
+    """Pull the findings list out of an agent's final message.
+
+    Accepts either a `{"findings": [...]}` object or a bare `[...]` array,
+    scanning balanced JSON blocks from the end so a trailing/revised block
+    wins over an earlier one or surrounding prose.
+    """
+    for block in reversed(_json_blocks(text)):
+        try:
+            obj = json.loads(block)
+        except ValueError:
+            continue
+        if isinstance(obj, dict) and isinstance(obj.get("findings"), list):
+            return obj["findings"]
+        if isinstance(obj, list):
+            return obj
+    return []
+
+
+def _git_diff(skill: str, base_ref: str) -> str:
+    """The PR diff for one skill, computed in Python (NOT via the agent's shell).
+
+    Precomputing here is what lets diff-based paradigms see the change while the
+    agent's tools stay read-only (Read/Grep/Glob) — no Bash surface for a crafted
+    SKILL.md to prompt-inject. Capped so the prompt stays bounded.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "diff", f"{base_ref}...HEAD",
+             "--", f"skills/{skill}/"],
+            capture_output=True, text=True, timeout=60,
+        ).stdout
+    except Exception:
+        return ""
+    return out[:20000]
+
+
+# ── engines (overridable for tests) ─────────────────────────────────────
+
+def _engine_claude(paradigm: str, skill: str, skill_dir: pathlib.Path,
+                   base_ref: str) -> list[dict]:
+    """Run a vendored-rubric paradigm via the Claude Agent SDK (one serial session)."""
+    try:
+        from claude_agent_sdk import (ClaudeSDKClient, ClaudeAgentOptions,  # type: ignore
+                                      AssistantMessage, TextBlock)
+    except ImportError:
+        # >=0.0.5 matches the sibling skills_eval_agent.py; the runner is stateful.
+        subprocess.run([sys.executable, "-m", "pip", "install", "-q",
+                        "claude-agent-sdk>=0.0.5"], check=True)
+        from claude_agent_sdk import (ClaudeSDKClient, ClaudeAgentOptions,  # type: ignore
+                                      AssistantMessage, TextBlock)
+
+    os.environ.setdefault("CLAUDE_CODE_DISABLE_THINKING", "1")  # NVIDIA proxy rejects otherwise
+    system = prompt_for(paradigm)
+    parts = [f"Skill: {skill}", f"Skill dir: {skill_dir}"]
+    if paradigm in DIFF_BASED:
+        diff = _git_diff(skill, base_ref)
+        parts.append(
+            f"Review the change below (diff vs {base_ref}); also Read the full "
+            f"files for context.\n\n```diff\n{diff}\n```" if diff
+            else f"Diff vs {base_ref} is empty — review the current files (Read/Grep/Glob).")
+    else:
+        parts.append("Review the whole skill directory (Read/Grep/Glob its files).")
+    parts.append('Return ONLY a JSON object {"findings": [...]} per the schema.')
+    user = "\n".join(parts)
+    options = ClaudeAgentOptions(
+        system_prompt=system,
+        # READ-ONLY tools only — no Bash/Edit/Write. The diff is precomputed and
+        # passed in (above), so a crafted SKILL.md can't prompt-inject shell
+        # access to the sourced .env credentials.
+        allowed_tools=["Read", "Grep", "Glob"],
+        disallowed_tools=["Bash", "Edit", "Write", "TaskCreate", "TaskUpdate",
+                          "TaskGet", "TaskList", "TaskOutput", "TaskStop",
+                          "BashOutput", "KillShell"],
+        permission_mode="bypassPermissions",
+        cwd=str(REPO_ROOT),
+    )
+    text_parts: list[str] = []
+    import anyio  # claude-agent-sdk dependency
+
+    async def _run():
+        # Same pattern as skills_eval_agent.py: query() then drain
+        # receive_response() (it replays the buffered response for the query).
+        async with ClaudeSDKClient(options=options) as client:
+            await client.query(user)
+            async for msg in client.receive_response():
+                if isinstance(msg, AssistantMessage):
+                    for block in msg.content:
+                        if isinstance(block, TextBlock) and block.text:
+                            text_parts.append(block.text)
+
+    anyio.run(_run)
+    return extract_findings("\n".join(text_parts))
+
+
+def _engine_ce_skill(paradigm: str, skill: str, skill_dir: pathlib.Path,
+                     base_ref: str) -> list[dict]:
+    """Run an installed compound-engineering review skill headless and parse its JSON."""
+    from shutil import which
+    if which("claude") is None:
+        raise SkippedLeg("claude CLI / CE plugin not installed on this runner")
+    if paradigm == "ce-code-review":
+        args = f"mode:agent base:{base_ref}"
+    else:  # ce-doc-review reviews the SKILL.md as a document
+        skillmd = skill_dir / "SKILL.md"
+        if not skillmd.is_file():
+            raise SkippedLeg(f"{skill}/SKILL.md not found for ce-doc-review")
+        args = f"mode:headless {skillmd}"
+    proc = subprocess.run(
+        ["claude", "-p", f"/{paradigm} {args}"],
+        cwd=str(REPO_ROOT), capture_output=True, text=True,
+        env={**os.environ, "CLAUDE_CODE_DISABLE_THINKING": "1"},
+    )
+    if proc.returncode != 0 and not proc.stdout.strip():
+        raise SkippedLeg(f"{paradigm} returned {proc.returncode}: "
+                         f"{proc.stderr.strip()[:200]}")
+    return extract_findings(proc.stdout)
+
+
+def _engine_codex(paradigm: str, skill: str, skill_dir: pathlib.Path,
+                  base_ref: str) -> list[dict]:
+    """Run the codex adversary review (degrades to skipped if codex is absent)."""
+    from shutil import which
+    if which("codex") is None:
+        raise SkippedLeg("codex CLI not installed on this runner")
+    # The prompt MUST name the skill + dir (codex runs read-only with no stdin,
+    # so it can't ask). Pass the precomputed diff too for the diff-based lens.
+    diff = _git_diff(skill, base_ref)
+    ctx = [f"\n\nSkill to review: {skill}", f"Skill dir (relative to cwd): skills/{skill}/"]
+    if diff:
+        ctx.append(f"Change under review (diff vs {base_ref}):\n```diff\n{diff}\n```")
+    else:
+        ctx.append("Review the current files under the skill dir.")
+    full_prompt = prompt_for("codex") + "\n".join(ctx)
+    proc = subprocess.run(
+        ["codex", "exec", full_prompt, "-C", str(REPO_ROOT), "-s", "read-only",
+         "--skip-git-repo-check", "-c", 'model_reasoning_effort="high"'],
+        capture_output=True, text=True, env={**os.environ, "SPAWNED_SESSION": "1"},
+        stdin=subprocess.DEVNULL,
+    )
+    return extract_findings(proc.stdout)
+
+
+ENGINE_FN = {"claude": _engine_claude, "ce_skill": _engine_ce_skill, "codex": _engine_codex}
+
+
+def run_leg(skill: str, paradigm: str, *, base_ref: str = "origin/develop") -> dict:
+    """Run one leg; always return a schema-valid artifact dict."""
+    skill_dir = REPO_ROOT / "skills" / skill
+    status, findings = "ok", []
+    try:
+        if not skill_dir.is_dir():
+            raise SkippedLeg(f"skills/{skill}/ not found on this ref")
+        raw = ENGINE_FN[ENGINE[paradigm]](paradigm, skill, skill_dir, base_ref)
+        findings = rf.normalize(paradigm, raw, skill=skill)
+    except SkippedLeg as exc:
+        status = "skipped"
+        print(f"::warning::skills-review {skill}·{paradigm}: skipped — {exc}", flush=True)
+    except Exception as exc:  # advisory: a broken leg never fails the job
+        status = "failed"
+        print(f"::warning::skills-review {skill}·{paradigm}: failed — {exc!r}", flush=True)
+    return {"skill": skill, "paradigm": paradigm, "status": status, "findings": findings}
+
+
+def main() -> int:
+    skill = os.environ["EVAL_SKILL"]
+    paradigm = os.environ["EVAL_PARADIGM"]
+    base_ref = os.environ.get("PR_BASE", "origin/develop")
+    out_dir = pathlib.Path(os.environ.get("REVIEW_OUT_DIR", "."))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    artifact = run_leg(skill, paradigm, base_ref=base_ref)
+    out = out_dir / f"review-{skill}__{paradigm}.json"
+    out.write_text(json.dumps(artifact, indent=2) + "\n")
+    print(f"skills-review {skill}·{paradigm}: status={artifact['status']} "
+          f"findings={len(artifact['findings'])} -> {out}")
+    return 0  # advisory
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills-review/review_findings.py
+++ b/.github/skills-review/review_findings.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Normalize + consolidate skills-review findings across paradigms.
+
+Stdlib only (mirrors the skills-nv-base post_comment.py constraint). Two jobs:
+
+  canonical_finding(raw, skill, paradigm)
+      Coerce one paradigm's raw finding into the canonical schema
+      (findings-schema.json). Accepts severity as a word
+      (critical/high/medium/low) or a P-code (P0..P3) or a [P1]/[P2] marker.
+
+  consolidate(findings)
+      Dedupe across paradigms by (skill, file, ~fuzzy title), then for each
+      cluster compute:
+        agreement  = count of DISTINCT paradigms (NOT raw member count)
+        severity   = MAX across members (worst-case wins)
+        needs_verification = (severity == critical) OR (agreement == 1)
+      These encode the manual-triage rules: cross-paradigm agreement = high
+      confidence; always verify criticals and single-lens outliers.
+"""
+from __future__ import annotations
+
+import difflib
+import re
+from collections import Counter
+
+SEVERITIES = ("critical", "high", "medium", "low")
+SEV_ORDER = {s: i for i, s in enumerate(SEVERITIES)}  # 0 = most severe
+# One P-code map serves both ce (P0..P3) and gstack/codex ([P1]/[P2]) markers:
+# P0->critical, P1->high, P2->medium, P3->low.
+PCODE_TO_SEV = {"P0": "critical", "P1": "high", "P2": "medium", "P3": "low", "P4": "low"}
+CATEGORIES = ("deploy-breaking", "api-contract", "security", "packaging-style", "tone")
+# Soft default category per paradigm (consolidation majority-vote overrides it).
+PARADIGM_DEFAULT_CATEGORY = {
+    "review": "deploy-breaking",
+    "gstack-review": "deploy-breaking",
+    "codex": "deploy-breaking",
+    "ce-code-review": "deploy-breaking",
+    "ce-doc-review": "packaging-style",
+    "best-practices": "packaging-style",
+}
+FUZZY_THRESHOLD = 0.82      # SequenceMatcher ratio on the bag-of-words key
+OVERLAP_THRESHOLD = 0.6     # |A∩B| / min(|A|,|B|) on title token sets
+
+
+def norm_severity(value) -> str:
+    """Accept a word, a P-code, or a [P1]/[P2] marker -> canonical severity."""
+    s = str(value or "").strip().strip("[]").upper()
+    if s.lower() in SEV_ORDER:
+        return s.lower()
+    if s in PCODE_TO_SEV:
+        return PCODE_TO_SEV[s]
+    return "medium"  # unknown -> middle, never crash
+
+
+def _int_line(value) -> int:
+    try:
+        n = int(value)
+        return n if n >= 0 else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def canonical_finding(raw: dict, *, skill: str, paradigm: str) -> dict | None:
+    """Coerce one raw finding into the canonical schema, or None if unusable."""
+    if not isinstance(raw, dict):
+        return None
+    title = str(raw.get("title") or "").strip()
+    file = str(raw.get("file") or "").strip()
+    if not title or not file:
+        return None  # a finding with no title/file can't be deduped or shown
+    category = raw.get("category")
+    if category not in CATEGORIES:
+        category = PARADIGM_DEFAULT_CATEGORY.get(paradigm, "deploy-breaking")
+    conf = raw.get("confidence")
+    try:
+        conf = max(0.0, min(1.0, float(conf)))
+    except (TypeError, ValueError):
+        conf = 0.5
+    return {
+        "skill": skill,
+        "paradigm": paradigm,
+        "file": file,
+        "line": _int_line(raw.get("line")),
+        "title": title,
+        "severity": norm_severity(raw.get("severity")),
+        "category": category,
+        "rationale": str(raw.get("rationale") or "").strip(),
+        "suggested_fix": str(raw.get("suggested_fix") or "").strip(),
+        "confidence": conf,
+    }
+
+
+def normalize(paradigm: str, raw_findings, *, skill: str) -> list[dict]:
+    """Coerce a paradigm's raw finding list into canonical findings (drops unusable)."""
+    out = []
+    for raw in raw_findings or []:
+        f = canonical_finding(raw, skill=skill, paradigm=paradigm)
+        if f is not None:
+            out.append(f)
+    return out
+
+
+def norm_title(title: str) -> str:
+    """Order-independent bag-of-words key for fuzzy title matching."""
+    t = re.sub(r"[`'\"]", "", title.lower())
+    t = re.sub(r"[^a-z0-9 ]", " ", t)
+    return " ".join(sorted(set(t.split())))
+
+
+def _similar(a: str, b: str) -> bool:
+    na, nb = norm_title(a), norm_title(b)
+    if na == nb:
+        return True
+    # Token-overlap (containment) catches paraphrases that share the defect's
+    # nouns ("container vss-foo-alerts ...") but reorder/reword around them —
+    # where SequenceMatcher on the sorted string alone falls short. Distinct
+    # defects on the same file share ~no tokens, so this won't over-merge them.
+    ta, tb = set(na.split()), set(nb.split())
+    if ta and tb and len(ta & tb) / min(len(ta), len(tb)) >= OVERLAP_THRESHOLD:
+        return True
+    return difflib.SequenceMatcher(None, na, nb).ratio() >= FUZZY_THRESHOLD
+
+
+def _cluster(group: list[dict]) -> list[list[dict]]:
+    """Greedy union within one (skill, file) group by fuzzy title."""
+    clusters: list[list[dict]] = []
+    for f in group:
+        for c in clusters:
+            if any(_similar(f["title"], m["title"]) for m in c):
+                c.append(f)
+                break
+        else:
+            clusters.append([f])
+    return clusters
+
+
+def _confidence_tier(agreement: int) -> str:
+    if agreement >= 3:
+        return "high"
+    if agreement == 2:
+        return "medium"
+    return "low"
+
+
+def consolidate(findings: list[dict]) -> list[dict]:
+    """Merge canonical findings into ranked consolidated findings."""
+    groups: dict[tuple, list[dict]] = {}
+    for f in findings:
+        groups.setdefault((f["skill"], f["file"]), []).append(f)
+
+    out: list[dict] = []
+    for (skill, file), group in groups.items():
+        for cluster in _cluster(group):
+            paradigms = sorted({m["paradigm"] for m in cluster})
+            agreement = len(paradigms)
+            severity = min((m["severity"] for m in cluster), key=lambda s: SEV_ORDER[s])
+            lines = [m["line"] for m in cluster if m["line"] > 0]
+            line = min(lines) if lines else 0
+            # category: majority vote; tie broken by the most-severe member's category
+            cat_counts = Counter(m["category"] for m in cluster)
+            top = max(cat_counts.values())
+            tied = [c for c, n in cat_counts.items() if n == top]
+            if len(tied) == 1:
+                category = tied[0]
+            else:
+                category = min(cluster, key=lambda m: SEV_ORDER[m["severity"]])["category"]
+            # representative title/rationale: the longest-titled member (most descriptive)
+            rep = max(cluster, key=lambda m: len(m["title"]))
+            rationale = max((m["rationale"] for m in cluster), key=len, default="")
+            fix = next((m["suggested_fix"] for m in cluster if m["suggested_fix"]), "")
+            out.append({
+                "key": f"{skill}|{file}|{norm_title(rep['title'])}",
+                "skill": skill,
+                "file": file,
+                "line": line,
+                "title": rep["title"],
+                "severity": severity,
+                "category": category,
+                "agreement": agreement,
+                "paradigms": paradigms,
+                "confidence_tier": _confidence_tier(agreement),
+                "needs_verification": (severity == "critical") or (agreement == 1),
+                "rationale": rationale,
+                "suggested_fix": fix,
+                "members": cluster,
+            })
+
+    out.sort(key=lambda c: (SEV_ORDER[c["severity"]], -c["agreement"], c["skill"], c["file"]))
+    return out

--- a/.github/skills-review/tests/test_consolidate.py
+++ b/.github/skills-review/tests/test_consolidate.py
@@ -101,6 +101,7 @@ class Reports(unittest.TestCase):
         self.assertFalse(eh["needs_verification"])         # medium + agreement 2
 
     def test_comment_compact(self):
+        import re
         body = con.build_comment(self._consolidated(), run_url="http://run")
         self.assertIn("6-paradigm consolidation", body)
         self.assertIn("Critical / high", body)
@@ -108,6 +109,14 @@ class Reports(unittest.TestCase):
         self.assertIn("http://run", body)
         # the low singleton stays OUT of the compact comment (corroborated>=2 only)
         self.assertNotIn("redis tag stale", body)
+        # headline "N need verification" must equal what the Verify list shows
+        # (2 criticals here; the low single-lens redis is needs_verification too
+        # but is not displayed, so it must not be counted).
+        m = re.search(r"\*\*(\d+) need verification\*\*", body)
+        self.assertIsNotNone(m)
+        shown = body.split("Verify before acting")[1].count("\n- ")
+        self.assertEqual(int(m.group(1)), shown)
+        self.assertEqual(shown, 2)
 
     def test_markdown_buckets_and_verify(self):
         md = con.build_markdown(self._consolidated())

--- a/.github/skills-review/tests/test_consolidate.py
+++ b/.github/skills-review/tests/test_consolidate.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for consolidate — leg loading + report/comment composition.
+
+Run:
+    python3 -m pytest .github/skills-review/tests/test_consolidate.py -v
+Or directly:
+    python3 .github/skills-review/tests/test_consolidate.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+_DIR = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location("consolidate", _DIR / "consolidate.py")
+con = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(con)
+rf = con.rf
+
+
+def leg(skill, paradigm, findings):
+    return {"skill": skill, "paradigm": paradigm, "status": "ok", "findings": findings}
+
+
+class LoadLegs(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, slug, obj):
+        (self.dir / f"review-{slug}.json").write_text(json.dumps(obj))
+
+    def test_loads_and_normalizes(self):
+        self._write("a__review", leg("a", "review", [
+            {"file": "skills/a/SKILL.md", "line": 5, "title": "ghost path deployments", "severity": "critical"}]))
+        self._write("a__codex", leg("a", "codex", [
+            {"file": "skills/a/SKILL.md", "line": 5, "title": "deployments path is a ghost dir", "severity": "[P1]"}]))
+        out = con.load_legs(self.dir)
+        self.assertEqual(len(out), 2)
+        # order follows filename sort, not insertion — assert the set
+        self.assertEqual({f["severity"] for f in out}, {"critical", "high"})  # [P1] -> high
+        self.assertEqual({f["paradigm"] for f in out}, {"review", "codex"})
+
+    def test_skips_malformed(self):
+        (self.dir / "review-bad.json").write_text("{not json")
+        self._write("ok__review", leg("a", "review", [
+            {"file": "f", "title": "t", "severity": "low"}]))
+        self._write("nometa.json", {"findings": []})  # not review-*.json -> ignored anyway
+        out = con.load_legs(self.dir)
+        self.assertEqual(len(out), 1)
+
+    def test_leg_missing_skill_skipped(self):
+        (self.dir / "review-x.json").write_text(json.dumps({"paradigm": "review", "findings": []}))
+        self.assertEqual(con.load_legs(self.dir), [])
+
+
+class Reports(unittest.TestCase):
+    def _consolidated(self):
+        findings = []
+        # critical, 2 paradigms agree (-> high confidence, still verify because critical)
+        findings += rf.normalize("review", [
+            {"file": "skills/a/SKILL.md", "line": 142, "title": "container vss-foo-alerts does not exist",
+             "severity": "critical", "category": "deploy-breaking"}], skill="a")
+        findings += rf.normalize("ce-code-review", [
+            {"file": "skills/a/SKILL.md", "line": 142, "title": "vss-foo-alerts container missing",
+             "severity": "P0", "category": "deploy-breaking"}], skill="a")
+        # lone-lens critical (-> verify)
+        findings += rf.normalize("codex", [
+            {"file": "skills/b/SKILL.md", "line": 3, "title": "invented /v1/chat HITL flow",
+             "severity": "critical", "category": "api-contract"}], skill="b")
+        # corroborated medium (agreement 2, no verify)
+        findings += rf.normalize("best-practices", [
+            {"file": "skills/a/SKILL.md", "line": 1, "title": "missing error handling section",
+             "severity": "medium", "category": "packaging-style"}], skill="a")
+        findings += rf.normalize("ce-doc-review", [
+            {"file": "skills/a/SKILL.md", "line": 1, "title": "no error handling section present",
+             "severity": "medium", "category": "tone"}], skill="a")
+        # low singleton (long tail)
+        findings += rf.normalize("review", [
+            {"file": "skills/a/x.md", "line": 9, "title": "redis tag stale", "severity": "low"}], skill="a")
+        return rf.consolidate(findings)
+
+    def test_consolidation_shape(self):
+        c = self._consolidated()
+        # 4 consolidated: container(crit,agree2), hitl(crit,agree1), error-handling(med,agree2), redis(low,agree1)
+        self.assertEqual(len(c), 4)
+        self.assertEqual(c[0]["severity"], "critical")     # ranked first
+        container = next(x for x in c if "container" in x["title"])
+        self.assertEqual(container["agreement"], 2)
+        self.assertTrue(container["needs_verification"])   # critical
+        eh = next(x for x in c if "error handling" in x["title"])
+        self.assertEqual(eh["agreement"], 2)
+        self.assertFalse(eh["needs_verification"])         # medium + agreement 2
+
+    def test_comment_compact(self):
+        body = con.build_comment(self._consolidated(), run_url="http://run")
+        self.assertIn("6-paradigm consolidation", body)
+        self.assertIn("Critical / high", body)
+        self.assertIn("Verify before acting", body)
+        self.assertIn("http://run", body)
+        # the low singleton stays OUT of the compact comment (corroborated>=2 only)
+        self.assertNotIn("redis tag stale", body)
+
+    def test_markdown_buckets_and_verify(self):
+        md = con.build_markdown(self._consolidated())
+        self.assertIn("Deploy-breaking", md)
+        self.assertIn("⚠️ VERIFY", md)                     # criticals flagged
+        self.assertIn("redis tag stale", md)               # full report keeps the tail
+        self.assertIn("Raised by 2 members", md)           # merged members listed
+
+    def test_empty(self):
+        self.assertIn("No findings", con.build_comment([]))
+        self.assertEqual(json.loads(json.dumps([])), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/skills-review/tests/test_plan_review_matrix.py
+++ b/.github/skills-review/tests/test_plan_review_matrix.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for plan_review_matrix — changed-skill x paradigm dispatch.
+
+SKILLS_DIR is pointed at a temp fake skill tree so the assertions don't drift
+as the real skills/ tree changes.
+
+Run:
+    python3 -m pytest .github/skills-review/tests/test_plan_review_matrix.py -v
+Or directly:
+    python3 .github/skills-review/tests/test_plan_review_matrix.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "plan_review_matrix", Path(__file__).resolve().parents[1] / "plan_review_matrix.py"
+)
+prm = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(prm)
+
+N_PARADIGMS = len(prm.PARADIGMS)
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        skills = Path(self._tmp.name) / "skills"
+        for name in ("vss-ask-video", "vss-manage-alerts", "vss-deploy-profile"):
+            (skills / name).mkdir(parents=True)
+        (skills / "README.md").write_text("not a skill dir\n")  # top-level file
+        self._orig = prm.SKILLS_DIR
+        prm.SKILLS_DIR = skills
+        # isolate env across tests
+        for k in ("CHANGED_FILES", "MANUAL_SKILLS_FILTER", "PR_BASE", "GITHUB_OUTPUT"):
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        prm.SKILLS_DIR = self._orig
+        self._tmp.cleanup()
+        for k in ("CHANGED_FILES", "MANUAL_SKILLS_FILTER", "PR_BASE", "GITHUB_OUTPUT"):
+            os.environ.pop(k, None)
+
+
+class ChangedSkills(Base):
+    def test_single_skill_file(self):
+        self.assertEqual(prm.changed_skills(["skills/vss-ask-video/SKILL.md"]),
+                         ["vss-ask-video"])
+
+    def test_multi_skill_dedupe(self):
+        files = [
+            "skills/vss-ask-video/SKILL.md",
+            "skills/vss-ask-video/references/x.md",   # same skill twice
+            "skills/vss-manage-alerts/evals/a.json",
+        ]
+        self.assertEqual(prm.changed_skills(files),
+                         ["vss-ask-video", "vss-manage-alerts"])
+
+    def test_deleted_dir_excluded(self):
+        # a file under a skill dir that no longer exists is skipped (live dirs only)
+        self.assertEqual(prm.changed_skills(["skills/vss-gone/SKILL.md"]), [])
+
+    def test_top_level_skills_file_ignored(self):
+        # skills/README.md has no trailing-slash dir segment -> not a skill
+        self.assertEqual(prm.changed_skills(["skills/README.md"]), [])
+
+    def test_harness_only_diff_empty(self):
+        self.assertEqual(
+            prm.changed_skills([".github/skills-review/plan_review_matrix.py"]), [])
+
+
+class BuildMatrix(Base):
+    def test_cartesian(self):
+        inc = prm.build_matrix(["vss-ask-video", "vss-manage-alerts"])
+        self.assertEqual(len(inc), 2 * N_PARADIGMS)
+        slugs = {leg["slug"] for leg in inc}
+        self.assertIn("vss-ask-video__review", slugs)
+        self.assertIn("vss-manage-alerts__best-practices", slugs)
+        # every leg carries skill + paradigm + name
+        for leg in inc:
+            self.assertEqual(set(leg), {"skill", "paradigm", "slug", "name"})
+
+    def test_empty(self):
+        self.assertEqual(prm.build_matrix([]), [])
+
+
+class ParseManual(Base):
+    def test_star_all_dirs_only(self):
+        # '*' enumerates dirs; the README.md file is excluded
+        self.assertEqual(prm.parse_manual("*"),
+                         ["vss-ask-video", "vss-deploy-profile", "vss-manage-alerts"])
+
+    def test_csv(self):
+        self.assertEqual(prm.parse_manual("vss-ask-video, vss-manage-alerts"),
+                         ["vss-ask-video", "vss-manage-alerts"])
+
+    def test_single(self):
+        self.assertEqual(prm.parse_manual("vss-ask-video"), ["vss-ask-video"])
+
+    def test_json_array(self):
+        self.assertEqual(prm.parse_manual('["vss-ask-video","vss-deploy-profile"]'),
+                         ["vss-ask-video", "vss-deploy-profile"])
+
+    def test_path_escape_rejected(self):
+        with self.assertRaises(ValueError):
+            prm.parse_manual("../etc")
+
+    def test_missing_dir_rejected(self):
+        with self.assertRaises(ValueError):
+            prm.parse_manual("vss-nonexistent")
+
+    def test_bad_json_rejected(self):
+        with self.assertRaises(ValueError):
+            prm.parse_manual("[not valid json")
+
+
+class Emit(Base):
+    def _run_emit(self, include):
+        out = Path(self._tmp.name) / "gh_output"
+        os.environ["GITHUB_OUTPUT"] = str(out)
+        prm.emit(include)
+        return dict(
+            line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+        )
+
+    def test_has_targets_and_matrix(self):
+        kv = self._run_emit(prm.build_matrix(["vss-ask-video"]))
+        self.assertEqual(kv["has_targets"], "true")
+        matrix = json.loads(kv["matrix"])
+        self.assertEqual(len(matrix["include"]), N_PARADIGMS)
+
+    def test_empty_has_targets_false(self):
+        kv = self._run_emit([])
+        self.assertEqual(kv["has_targets"], "false")
+        self.assertEqual(json.loads(kv["matrix"]), {"include": []})
+
+    def test_duplicate_slug_raises(self):
+        dup = [{"skill": "a", "paradigm": "review", "slug": "x", "name": "n"},
+               {"skill": "b", "paradigm": "review", "slug": "x", "name": "n"}]
+        with self.assertRaises(ValueError):
+            prm.emit(dup)
+
+    def test_unsafe_slug_raises(self):
+        bad = [{"skill": "a", "paradigm": "p", "slug": "a/b", "name": "n"}]
+        with self.assertRaises(ValueError):
+            prm.emit(bad)
+
+
+class ResolveSkills(Base):
+    def test_changed_files_env(self):
+        os.environ["CHANGED_FILES"] = "skills/vss-ask-video/SKILL.md\nskills/README.md"
+        self.assertEqual(prm.resolve_skills(), ["vss-ask-video"])
+
+    def test_manual_overrides_diff(self):
+        os.environ["MANUAL_SKILLS_FILTER"] = "vss-manage-alerts"
+        os.environ["CHANGED_FILES"] = "skills/vss-ask-video/SKILL.md"
+        self.assertEqual(prm.resolve_skills(), ["vss-manage-alerts"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/skills-review/tests/test_post_review_comment.py
+++ b/.github/skills-review/tests/test_post_review_comment.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for post_review_comment — marker prepend, upsert dispatch, fallbacks.
+
+The GitHub HTTP layer is stubbed; these assert the advisory behavior.
+
+Run:
+    python3 .github/skills-review/tests/test_post_review_comment.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_DIR = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "post_review_comment", _DIR / "post_review_comment.py")
+prc = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(prc)
+
+
+class MarkedBody(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        for k in ("COMMENT_BODY", "PR_NUMBER", "GITHUB_REPOSITORY",
+                  "GITHUB_TOKEN", "GITHUB_STEP_SUMMARY"):
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        for k in ("COMMENT_BODY", "PR_NUMBER", "GITHUB_REPOSITORY",
+                  "GITHUB_TOKEN", "GITHUB_STEP_SUMMARY"):
+            os.environ.pop(k, None)
+
+    def test_marker_prepended(self):
+        p = Path(self._tmp.name) / "body.md"
+        p.write_text("## report body")
+        os.environ["COMMENT_BODY"] = str(p)
+        body = prc.marked_body()
+        self.assertTrue(body.startswith(prc.MARKER))
+        self.assertIn("## report body", body)
+
+    def test_missing_body_graceful(self):
+        os.environ["COMMENT_BODY"] = str(Path(self._tmp.name) / "nope.md")
+        body = prc.marked_body()
+        self.assertIn(prc.MARKER, body)  # still has marker, no crash
+
+    def test_manual_mode_writes_step_summary(self):
+        body_p = Path(self._tmp.name) / "body.md"
+        body_p.write_text("findings here")
+        summ = Path(self._tmp.name) / "summary.md"
+        os.environ.update(COMMENT_BODY=str(body_p), GITHUB_STEP_SUMMARY=str(summ))
+        # no PR_NUMBER -> manual mode
+        rc = prc.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("findings here", summ.read_text())
+        self.assertIn(prc.MARKER, summ.read_text())
+
+    def test_pr_mode_upserts(self):
+        body_p = Path(self._tmp.name) / "body.md"
+        body_p.write_text("findings")
+        os.environ.update(COMMENT_BODY=str(body_p), PR_NUMBER="42",
+                          GITHUB_REPOSITORY="o/r", GITHUB_TOKEN="t")
+        calls = {}
+        orig = prc.upsert_comment
+        prc.upsert_comment = lambda repo, pr, body: calls.update(repo=repo, pr=pr, body=body)
+        try:
+            rc = prc.main()
+        finally:
+            prc.upsert_comment = orig
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls["pr"], "42")
+        self.assertTrue(calls["body"].startswith(prc.MARKER))
+
+    def test_pr_mode_missing_token_no_crash(self):
+        body_p = Path(self._tmp.name) / "body.md"
+        body_p.write_text("findings")
+        os.environ.update(COMMENT_BODY=str(body_p), PR_NUMBER="42")  # no repo/token
+        self.assertEqual(prc.main(), 0)  # advisory: never raises
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/skills-review/tests/test_review_agent.py
+++ b/.github/skills-review/tests/test_review_agent.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for review_agent — a leg ALWAYS writes a schema-valid artifact.
+
+The LLM engines are stubbed (no SDK / no network), so these assert the
+harness contract, not the model output.
+
+Run:
+    python3 .github/skills-review/tests/test_review_agent.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_DIR = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location("review_agent", _DIR / "review_agent.py")
+ra = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(ra)
+
+# created under a temp REPO_ROOT in setUp — the contract test must not depend on
+# which skills exist on the current branch (main's skills/ tree differs from develop's).
+FAKE_SKILL = "vss-test-skill"
+
+
+class ExtractFindings(unittest.TestCase):
+    def test_findings_object(self):
+        t = 'prose\n{"findings": [{"file": "f", "title": "t", "severity": "high"}]}'
+        self.assertEqual(len(ra.extract_findings(t)), 1)
+
+    def test_bare_array(self):
+        t = '[{"file": "f", "title": "t", "severity": "low"}]'
+        self.assertEqual(len(ra.extract_findings(t)), 1)
+
+    def test_trailing_block_wins(self):
+        t = '{"findings": [1,2,3]}\n... revised ...\n{"findings": [{"x": 1}]}'
+        self.assertEqual(ra.extract_findings(t), [{"x": 1}])
+
+    def test_prose_only(self):
+        self.assertEqual(ra.extract_findings("no json here"), [])
+
+
+class RunLegContract(unittest.TestCase):
+    def setUp(self):
+        self._orig = dict(ra.ENGINE_FN)
+        # point REPO_ROOT at a temp tree with a fake skill so the contract test
+        # doesn't depend on which skills exist on the current branch.
+        self._orig_root = ra.REPO_ROOT
+        self._tmp = tempfile.TemporaryDirectory()
+        d = Path(self._tmp.name) / "skills" / FAKE_SKILL
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("# fake skill\n")
+        ra.REPO_ROOT = Path(self._tmp.name)
+
+    def tearDown(self):
+        ra.ENGINE_FN.clear()
+        ra.ENGINE_FN.update(self._orig)
+        ra.REPO_ROOT = self._orig_root
+        self._tmp.cleanup()
+
+    def _patch(self, fn):
+        for k in ra.ENGINE_FN:
+            ra.ENGINE_FN[k] = fn
+
+    def test_ok(self):
+        self._patch(lambda *a, **k: [
+            {"file": "skills/x/SKILL.md", "line": 3, "title": "bug", "severity": "P0"}])
+        art = ra.run_leg(FAKE_SKILL, "review")
+        self.assertEqual(art["status"], "ok")
+        self.assertEqual(len(art["findings"]), 1)
+        self.assertEqual(art["findings"][0]["severity"], "critical")  # normalized
+
+    def test_skipped(self):
+        def boom(*a, **k):
+            raise ra.SkippedLeg("codex not installed")
+        self._patch(boom)
+        art = ra.run_leg(FAKE_SKILL, "codex")
+        self.assertEqual(art["status"], "skipped")
+        self.assertEqual(art["findings"], [])
+
+    def test_failed_on_exception(self):
+        def boom(*a, **k):
+            raise RuntimeError("sdk exploded")
+        self._patch(boom)
+        art = ra.run_leg(FAKE_SKILL, "best-practices")
+        self.assertEqual(art["status"], "failed")
+        self.assertEqual(art["findings"], [])
+
+    def test_missing_skill_dir_skipped(self):
+        self._patch(lambda *a, **k: [])
+        art = ra.run_leg("vss-does-not-exist", "review")
+        self.assertEqual(art["status"], "skipped")
+
+    def test_main_writes_valid_artifact(self):
+        self._patch(lambda *a, **k: [
+            {"file": "skills/x/SKILL.md", "title": "t", "severity": "medium"}])
+        with tempfile.TemporaryDirectory() as d:
+            os.environ.update(EVAL_SKILL=FAKE_SKILL, EVAL_PARADIGM="review",
+                              REVIEW_OUT_DIR=d, PR_BASE="origin/develop")
+            try:
+                rc = ra.main()
+            finally:
+                for k in ("EVAL_SKILL", "EVAL_PARADIGM", "REVIEW_OUT_DIR", "PR_BASE"):
+                    os.environ.pop(k, None)
+            self.assertEqual(rc, 0)
+            art = json.loads((Path(d) / f"review-{FAKE_SKILL}__review.json").read_text())
+            self.assertEqual(set(art) >= {"skill", "paradigm", "status", "findings"}, True)
+            self.assertEqual(art["skill"], FAKE_SKILL)
+            self.assertEqual(art["findings"][0]["paradigm"], "review")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/skills-review/tests/test_review_findings.py
+++ b/.github/skills-review/tests/test_review_findings.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for review_findings — normalization + consolidation rules.
+
+Run:
+    python3 -m pytest .github/skills-review/tests/test_review_findings.py -v
+Or directly:
+    python3 .github/skills-review/tests/test_review_findings.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "review_findings", Path(__file__).resolve().parents[1] / "review_findings.py"
+)
+rf = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(rf)
+
+
+def F(skill, paradigm, file, title, severity, **kw):
+    raw = {"file": file, "title": title, "severity": severity, **kw}
+    return rf.canonical_finding(raw, skill=skill, paradigm=paradigm)
+
+
+class NormSeverity(unittest.TestCase):
+    def test_words(self):
+        for s in ("critical", "high", "medium", "low"):
+            self.assertEqual(rf.norm_severity(s), s)
+
+    def test_pcodes(self):
+        self.assertEqual(rf.norm_severity("P0"), "critical")
+        self.assertEqual(rf.norm_severity("P1"), "high")
+        self.assertEqual(rf.norm_severity("P2"), "medium")
+        self.assertEqual(rf.norm_severity("P3"), "low")
+
+    def test_marker_brackets(self):
+        self.assertEqual(rf.norm_severity("[P1]"), "high")
+        self.assertEqual(rf.norm_severity("[P2]"), "medium")
+
+    def test_unknown_defaults_medium(self):
+        self.assertEqual(rf.norm_severity("weird"), "medium")
+        self.assertEqual(rf.norm_severity(None), "medium")
+
+
+class Canonical(unittest.TestCase):
+    def test_passthrough_ce_json(self):
+        raw = {"file": "skills/x/SKILL.md", "line": 10, "title": "Bug",
+               "severity": "P0", "category": "security", "confidence": 0.9}
+        f = rf.canonical_finding(raw, skill="x", paradigm="ce-code-review")
+        self.assertEqual(f["severity"], "critical")
+        self.assertEqual(f["category"], "security")
+        self.assertEqual(f["line"], 10)
+        self.assertEqual(f["confidence"], 0.9)
+
+    def test_missing_title_or_file_dropped(self):
+        self.assertIsNone(rf.canonical_finding(
+            {"file": "x", "severity": "high"}, skill="x", paradigm="review"))
+        self.assertIsNone(rf.canonical_finding(
+            {"title": "t", "severity": "high"}, skill="x", paradigm="review"))
+
+    def test_default_category_by_paradigm(self):
+        f = rf.canonical_finding({"file": "f", "title": "t", "severity": "low"},
+                                 skill="x", paradigm="best-practices")
+        self.assertEqual(f["category"], "packaging-style")
+
+    def test_bad_line_and_confidence_coerced(self):
+        f = rf.canonical_finding(
+            {"file": "f", "title": "t", "severity": "low", "line": "nope", "confidence": "x"},
+            skill="x", paradigm="review")
+        self.assertEqual(f["line"], 0)
+        self.assertEqual(f["confidence"], 0.5)
+
+
+class Consolidate(unittest.TestCase):
+    def test_cross_paradigm_merge(self):
+        # 4 paradigms raise the same defect with slightly different wording.
+        findings = [
+            F("a", "review", "skills/a/SKILL.md", "Container name vss-foo-alerts does not exist", "critical"),
+            F("a", "codex", "skills/a/SKILL.md", "container vss-foo-alerts not found in compose", "high"),
+            F("a", "ce-code-review", "skills/a/SKILL.md", "vss-foo-alerts container does not exist", "P0"),
+            F("a", "gstack-review", "skills/a/SKILL.md", "nonexistent container name vss-foo-alerts", "P1"),
+        ]
+        out = rf.consolidate(findings)
+        self.assertEqual(len(out), 1)
+        c = out[0]
+        self.assertEqual(c["agreement"], 4)              # distinct paradigms
+        self.assertEqual(c["severity"], "critical")      # MAX wins
+        self.assertEqual(c["confidence_tier"], "high")
+        self.assertTrue(c["needs_verification"])         # critical
+        self.assertEqual(len(c["members"]), 4)
+
+    def test_agreement_counts_distinct_paradigms(self):
+        # same paradigm twice is NOT corroboration
+        findings = [
+            F("a", "review", "skills/a/x.md", "stale tag 3.2.0-rc11 should be 3.2.0", "medium"),
+            F("a", "review", "skills/a/x.md", "tag 3.2.0-rc11 is stale, use 3.2.0", "medium"),
+        ]
+        out = rf.consolidate(findings)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["agreement"], 1)
+        self.assertTrue(out[0]["needs_verification"])    # agreement == 1
+
+    def test_distinct_defects_not_merged(self):
+        findings = [
+            F("a", "review", "skills/a/SKILL.md", "wrong port 9000 should be 8000", "high"),
+            F("a", "codex", "skills/a/SKILL.md", "ghost path deployments does not exist", "high"),
+        ]
+        out = rf.consolidate(findings)
+        self.assertEqual(len(out), 2)
+
+    def test_needs_verification_matrix(self):
+        # lone critical -> verify; 3-paradigm medium -> no verify
+        lone_crit = [F("a", "review", "skills/a/f", "lone crit", "critical")]
+        self.assertTrue(rf.consolidate(lone_crit)[0]["needs_verification"])
+        med3 = [
+            F("a", "review", "skills/a/g", "agreed medium issue here", "medium"),
+            F("a", "codex", "skills/a/g", "agreed medium issue here too", "medium"),
+            F("a", "ce-code-review", "skills/a/g", "the agreed medium issue", "medium"),
+        ]
+        c = rf.consolidate(med3)[0]
+        self.assertEqual(c["agreement"], 3)
+        self.assertFalse(c["needs_verification"])
+
+    def test_ranking(self):
+        findings = [
+            F("a", "review", "skills/a/lo", "low single", "low"),
+            F("a", "review", "skills/a/hi", "high agreed issue", "high"),
+            F("a", "codex", "skills/a/hi", "high agreed issue indeed", "high"),
+            F("a", "review", "skills/a/cr", "critical thing", "critical"),
+        ]
+        out = rf.consolidate(findings)
+        # critical first, then high (agreement 2), then low
+        self.assertEqual([c["severity"] for c in out], ["critical", "high", "low"])
+
+    def test_empty(self):
+        self.assertEqual(rf.consolidate([]), [])
+
+    def test_fuzzy_threshold_boundary(self):
+        # unrelated titles on same (skill,file) stay separate
+        findings = [
+            F("a", "review", "skills/a/SKILL.md", "redis tag is stale", "low"),
+            F("a", "codex", "skills/a/SKILL.md", "missing error handling section", "low"),
+        ]
+        self.assertEqual(len(rf.consolidate(findings)), 2)
+
+
+class NormalizeList(unittest.TestCase):
+    def test_drops_unusable(self):
+        raws = [
+            {"file": "f", "title": "ok", "severity": "high"},
+            {"file": "f", "severity": "high"},          # no title -> dropped
+            "not a dict",                                 # -> dropped
+        ]
+        out = rf.normalize("review", raws, skill="a")
+        self.assertEqual(len(out), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/skills-review.yml
+++ b/.github/workflows/skills-review.yml
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-paradigm skill review (ADVISORY). On a PR touching skills/**, or on
+# manual dispatch, fan out 6 review paradigms per changed skill (one matrix leg
+# each), consolidate by cross-paradigm agreement + severity, and post a sticky
+# PR comment + upload a full artifact. Never fails the merge; not a required
+# status check. See .github/skills-review/README.md for the runner prerequisites
+# (Anthropic coordinator .env + CE plugin on the vss-brev-runner host).
+#
+# No top-level `paths:` filter — GitHub evaluates `paths:` per-push, not over the
+# cumulative PR diff (the skills-eval PR #188 regression), so the changed-skill
+# gate lives inside the `plan` job (plan_review_matrix.py, FETCH_HEAD...HEAD).
+name: Skills Review
+
+on:
+  push:
+    branches: ["pull-request/[0-9]+"]   # copy-pr-bot mirror branches
+  workflow_dispatch:
+    inputs:
+      skills:
+        description: "Skills to review: * (all), a comma list, or a JSON array of skill dirs"
+        type: string          # NOT choice — choice caps at 10; the skills tree has >10
+        default: "*"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: >-
+    skills-review-${{ github.event_name == 'workflow_dispatch'
+      && format('manual-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  plan:
+    runs-on: [self-hosted, vss-brev-runner]
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      has_targets: ${{ steps.plan.outputs.has_targets }}
+      pr: ${{ steps.pr.outputs.number }}
+      base: ${{ steps.pr.outputs.base }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - id: pr
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PR="${REF##pull-request/}"
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+          echo "base=$(gh pr view "$PR" --json baseRefName --jq .baseRefName)" >> "$GITHUB_OUTPUT"
+      - id: plan
+        env:
+          PR_BASE: ${{ steps.pr.outputs.base }}
+          MANUAL_SKILLS_FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.skills || '' }}
+        run: python3 .github/skills-review/plan_review_matrix.py
+
+  review:
+    needs: plan
+    if: needs.plan.outputs.has_targets == 'true'
+    runs-on: [self-hosted, vss-brev-runner]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      max-parallel: 12        # LLM API legs (no GPU/box lock) — tune to the proxy rate limit
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run review leg (${{ matrix.skill }} · ${{ matrix.paradigm }})
+        env:
+          EVAL_SKILL: ${{ matrix.skill }}
+          EVAL_PARADIGM: ${{ matrix.paradigm }}
+          PR_BASE_BRANCH: ${{ needs.plan.outputs.base || 'develop' }}
+          REVIEW_OUT_DIR: ${{ runner.temp }}/review
+          GH_TOKEN: ${{ github.token }}
+          # per-leg gh config scratch so a host OAuth can't reauthor bot output
+          GH_CONFIG_DIR: ${{ runner.temp }}/ghcfg-${{ matrix.slug }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "$PR_BASE_BRANCH" || true
+          export PR_BASE="origin/${PR_BASE_BRANCH}"
+          # Anthropic coordinator creds (ANTHROPIC_*, etc.). See README.md —
+          # this file must be provisioned on the vss-brev-runner host.
+          if [ -f /home/ubuntu/eval-coordinator/.env ]; then
+            set -a; source /home/ubuntu/eval-coordinator/.env; set +a
+          fi
+          export CLAUDE_CODE_DISABLE_THINKING=1   # NVIDIA Anthropic proxy rejects context_management
+          python3 .github/skills-review/review_agent.py
+      - name: Upload leg findings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skills-review-leg-${{ matrix.slug }}
+          # ONLY the JSON findings — never agent trajectory dirs (PR #516 secret-leak lesson)
+          path: ${{ runner.temp }}/review/review-*.json
+          if-no-files-found: ignore
+          retention-days: 7
+
+  report:
+    needs: [plan, review]
+    if: always() && needs.plan.outputs.has_targets == 'true'
+    runs-on: [self-hosted, vss-brev-runner]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Download leg findings
+        uses: actions/download-artifact@v4
+        with:
+          pattern: skills-review-leg-*
+          path: ${{ runner.temp }}/legs
+          merge-multiple: true
+      - name: Consolidate
+        env:
+          REVIEW_ARTIFACTS_DIR: ${{ runner.temp }}/legs
+          CONSOLIDATED_JSON: ${{ runner.temp }}/skills-review-consolidated.json
+          CONSOLIDATED_MD: ${{ runner.temp }}/skills-review-consolidated.md
+          COMMENT_BODY: ${{ runner.temp }}/review-comment.md
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: python3 .github/skills-review/consolidate.py
+      - name: Post sticky comment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.plan.outputs.pr }}
+          COMMENT_BODY: ${{ runner.temp }}/review-comment.md
+        run: python3 .github/skills-review/post_review_comment.py
+      - name: Upload consolidated report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skills-review-consolidated
+          path: |
+            ${{ runner.temp }}/skills-review-consolidated.json
+            ${{ runner.temp }}/skills-review-consolidated.md
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
## Description

Adds the **advisory multi-paradigm skill-review CI** to `main`. The feature was merged to `develop` in #971; it must **also be on `main`** because **`main` is the repo default branch and GitHub only exposes `workflow_dispatch` for workflows on the default branch** — so manual trigger (`gh workflow run skills-review.yml -f skills=<…>`) doesn't work until the workflow lives here. This matches `skills-eval.yml` / `skills-nv-base.yml`, which are already on `main`.

> Dispatch with `--ref develop` to review the develop `vss-*` skills (`main`'s `skills/` tree is the older layout).

## What it does

On a PR touching `skills/**` (matrix over **changed** skills) or on `workflow_dispatch`, fans out **6 review paradigms per skill in parallel** (`review`, `gstack-review`, `codex`, `ce-code-review`, `ce-doc-review`, Anthropic `best-practices`), then a `report` job **consolidates** by **cross-paradigm agreement + severity**, posts a **sticky PR comment**, and uploads a full **artifact**.

- **Advisory** — never fails the merge; not a required status check.
- Runs on `[self-hosted, vss-brev-runner]` (the `vss-skill-validator` host, **not** v2).
- Review legs are **read-only** (`Read`/`Grep`/`Glob`; the diff is precomputed in Python — no agent `Bash`, so a crafted `SKILL.md` can't shell out to the sourced `.env`).
- Plan: `Projects/skills/docs/plans/2026-06-07-001-feat-multi-paradigm-skill-review-ci-plan.md` (vault).

## Notes
- Same code as #971 (develop), with the `review_agent` contract test made **checkout-independent** (temp `REPO_ROOT` + fake skill) so it passes on `main`, whose `skills/` tree differs from develop's.
- **57 unit tests** green; workflow YAML validates; modules `py_compile`.
- Runner prereq (see `README.md`): the `.env`+`ANTHROPIC_*` keys are present on the pool; install `claude` (+ CE plugin, `codex`) to enable the legs — until then the report is empty/skipped and the job stays green.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (57 unit tests)
- [x] The documentation is up to date with these changes. (`README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
