### PR TITLE
fix(skills-review): verify-count overcount + engine timeouts (follow-up to #971)

### DIFF
--- a/.github/skills-review/.gitignore
+++ b/.github/skills-review/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.github/skills-review/consolidate.py
+++ b/.github/skills-review/consolidate.py
@@ -85,7 +85,11 @@ def _row(f: dict) -> str:
 def build_comment(consolidated: list[dict], run_url: str | None = None) -> str:
     """Compact sticky-comment body — corroborated rows + verify list; tail stays in artifact."""
     cnt = _counts(consolidated)
-    n_verify = sum(1 for f in consolidated if f["needs_verification"])
+    # Count only what the Verify table below actually shows (critical/high). Low
+    # single-lens findings are needs_verification too, but they stay in the
+    # artifact, so counting them here would overstate the displayed list.
+    n_verify = sum(1 for f in consolidated
+                   if f["needs_verification"] and f["severity"] in ("critical", "high"))
     n_skills = len({f["skill"] for f in consolidated})
     lines = [
         "## 🔬 Skills Review — 6-paradigm consolidation",

--- a/.github/skills-review/review_agent.py
+++ b/.github/skills-review/review_agent.py
@@ -195,6 +195,7 @@ def _engine_ce_skill(paradigm: str, skill: str, skill_dir: pathlib.Path,
         ["claude", "-p", f"/{paradigm} {args}"],
         cwd=str(REPO_ROOT), capture_output=True, text=True,
         env={**os.environ, "CLAUDE_CODE_DISABLE_THINKING": "1"},
+        timeout=1200,  # bound the leg so a stalled CLI can't hold the runner slot
     )
     if proc.returncode != 0 and not proc.stdout.strip():
         raise SkippedLeg(f"{paradigm} returned {proc.returncode}: "
@@ -222,6 +223,7 @@ def _engine_codex(paradigm: str, skill: str, skill_dir: pathlib.Path,
          "--skip-git-repo-check", "-c", 'model_reasoning_effort="high"'],
         capture_output=True, text=True, env={**os.environ, "SPAWNED_SESSION": "1"},
         stdin=subprocess.DEVNULL,
+        timeout=1200,  # bound the leg so a stalled codex can't hold the runner slot
     )
     return extract_findings(proc.stdout)
 
@@ -241,6 +243,10 @@ def run_leg(skill: str, paradigm: str, *, base_ref: str = "origin/develop") -> d
     except SkippedLeg as exc:
         status = "skipped"
         print(f"::warning::skills-review {skill}·{paradigm}: skipped — {exc}", flush=True)
+    except subprocess.TimeoutExpired:
+        status = "skipped"
+        print(f"::warning::skills-review {skill}·{paradigm}: skipped — engine timed out",
+              flush=True)
     except Exception as exc:  # advisory: a broken leg never fails the job
         status = "failed"
         print(f"::warning::skills-review {skill}·{paradigm}: failed — {exc!r}", flush=True)

--- a/.github/skills-review/tests/test_consolidate.py
+++ b/.github/skills-review/tests/test_consolidate.py
@@ -101,6 +101,7 @@ class Reports(unittest.TestCase):
         self.assertFalse(eh["needs_verification"])         # medium + agreement 2
 
     def test_comment_compact(self):
+        import re
         body = con.build_comment(self._consolidated(), run_url="http://run")
         self.assertIn("6-paradigm consolidation", body)
         self.assertIn("Critical / high", body)
@@ -108,6 +109,14 @@ class Reports(unittest.TestCase):
         self.assertIn("http://run", body)
         # the low singleton stays OUT of the compact comment (corroborated>=2 only)
         self.assertNotIn("redis tag stale", body)
+        # headline "N need verification" must equal what the Verify list shows
+        # (2 criticals here; the low single-lens redis is needs_verification too
+        # but is not displayed, so it must not be counted).
+        m = re.search(r"\*\*(\d+) need verification\*\*", body)
+        self.assertIsNotNone(m)
+        shown = body.split("Verify before acting")[1].count("\n- ")
+        self.assertEqual(int(m.group(1)), shown)
+        self.assertEqual(shown, 2)
 
     def test_markdown_buckets_and_verify(self):
         md = con.build_markdown(self._consolidated())

--- a/.github/skills-review/tests/test_review_agent.py
+++ b/.github/skills-review/tests/test_review_agent.py
@@ -23,8 +23,9 @@ _SPEC = importlib.util.spec_from_file_location("review_agent", _DIR / "review_ag
 ra = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(ra)
 
-# a real skill dir exists in the checkout; use it for the happy path
-REAL_SKILL = "vss-ask-video"
+# created under a temp REPO_ROOT in setUp — the contract test must not depend on
+# which skills exist on the current branch (main's skills/ tree differs from develop's).
+FAKE_SKILL = "vss-test-skill"
 
 
 class ExtractFindings(unittest.TestCase):
@@ -47,10 +48,20 @@ class ExtractFindings(unittest.TestCase):
 class RunLegContract(unittest.TestCase):
     def setUp(self):
         self._orig = dict(ra.ENGINE_FN)
+        # point REPO_ROOT at a temp tree with a fake skill so the contract test
+        # doesn't depend on which skills exist on the current branch.
+        self._orig_root = ra.REPO_ROOT
+        self._tmp = tempfile.TemporaryDirectory()
+        d = Path(self._tmp.name) / "skills" / FAKE_SKILL
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("# fake skill\n")
+        ra.REPO_ROOT = Path(self._tmp.name)
 
     def tearDown(self):
         ra.ENGINE_FN.clear()
         ra.ENGINE_FN.update(self._orig)
+        ra.REPO_ROOT = self._orig_root
+        self._tmp.cleanup()
 
     def _patch(self, fn):
         for k in ra.ENGINE_FN:
@@ -59,7 +70,7 @@ class RunLegContract(unittest.TestCase):
     def test_ok(self):
         self._patch(lambda *a, **k: [
             {"file": "skills/x/SKILL.md", "line": 3, "title": "bug", "severity": "P0"}])
-        art = ra.run_leg(REAL_SKILL, "review")
+        art = ra.run_leg(FAKE_SKILL, "review")
         self.assertEqual(art["status"], "ok")
         self.assertEqual(len(art["findings"]), 1)
         self.assertEqual(art["findings"][0]["severity"], "critical")  # normalized
@@ -68,7 +79,7 @@ class RunLegContract(unittest.TestCase):
         def boom(*a, **k):
             raise ra.SkippedLeg("codex not installed")
         self._patch(boom)
-        art = ra.run_leg(REAL_SKILL, "codex")
+        art = ra.run_leg(FAKE_SKILL, "codex")
         self.assertEqual(art["status"], "skipped")
         self.assertEqual(art["findings"], [])
 
@@ -76,7 +87,7 @@ class RunLegContract(unittest.TestCase):
         def boom(*a, **k):
             raise RuntimeError("sdk exploded")
         self._patch(boom)
-        art = ra.run_leg(REAL_SKILL, "best-practices")
+        art = ra.run_leg(FAKE_SKILL, "best-practices")
         self.assertEqual(art["status"], "failed")
         self.assertEqual(art["findings"], [])
 
@@ -89,7 +100,7 @@ class RunLegContract(unittest.TestCase):
         self._patch(lambda *a, **k: [
             {"file": "skills/x/SKILL.md", "title": "t", "severity": "medium"}])
         with tempfile.TemporaryDirectory() as d:
-            os.environ.update(EVAL_SKILL=REAL_SKILL, EVAL_PARADIGM="review",
+            os.environ.update(EVAL_SKILL=FAKE_SKILL, EVAL_PARADIGM="review",
                               REVIEW_OUT_DIR=d, PR_BASE="origin/develop")
             try:
                 rc = ra.main()
@@ -97,9 +108,9 @@ class RunLegContract(unittest.TestCase):
                 for k in ("EVAL_SKILL", "EVAL_PARADIGM", "REVIEW_OUT_DIR", "PR_BASE"):
                     os.environ.pop(k, None)
             self.assertEqual(rc, 0)
-            art = json.loads((Path(d) / f"review-{REAL_SKILL}__review.json").read_text())
+            art = json.loads((Path(d) / f"review-{FAKE_SKILL}__review.json").read_text())
             self.assertEqual(set(art) >= {"skill", "paradigm", "status", "findings"}, True)
-            self.assertEqual(art["skill"], REAL_SKILL)
+            self.assertEqual(art["skill"], FAKE_SKILL)
             self.assertEqual(art["findings"][0]["paradigm"], "review")
 
 


### PR DESCRIPTION
## Description

Follow-up to #971 — applies the review fixes (from Greptile on the main-targeted #975) back to `develop` so the two branches stay consistent.

- **consolidate.py** — the `N need verification` headline counted *all* `needs_verification` findings, but the "Verify before acting" table renders only critical/high → the number overcounted whenever low/medium single-lens findings were present. Scoped the count to the displayed critical/high set (long tail stays in the artifact). Added a regression test asserting headline == rendered rows.
- **review_agent.py** — `_engine_codex` and `_engine_ce_skill` had no `subprocess` timeout; a stalled `codex`/`claude` could hold the leg for the full 30-min job. Added `timeout=1200` to both + a `subprocess.TimeoutExpired` handler in `run_leg` that degrades the leg to `status=skipped`.
- **test_review_agent.py** — made the contract test checkout-independent (temp `REPO_ROOT` + fake skill) so it doesn't depend on which skills exist on the ref.
- **.gitignore** — `__pycache__/`, `*.pyc`.

All advisory; no behavior change to the gate. 57 unit tests green.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
