### PR TITLE
chore: add agent skill signing helper

### DIFF
--- a/.github/scripts/sign-agent-skill.sh
+++ b/.github/scripts/sign-agent-skill.sh
@@ -13,6 +13,7 @@
 set -euo pipefail
 
 NVIDIA_ROOT_CERT_URL="https://raw.githubusercontent.com/NVIDIA/skills/main/nv-agent-root-cert.pem"
+MODEL_SIGNING_UVX_SPEC="model-signing==1.1.1"
 
 usage() {
   cat <<'EOF'
@@ -32,7 +33,8 @@ Options:
   --private-key PATH           PEM private key for the signing certificate. Required for sign.
   --signing-certificate PATH   PEM signing certificate. Required for sign.
   --model-signing-bin PATH     model_signing executable. Defaults to MODEL_SIGNING_BIN,
-                               then model_signing on PATH, then uvx --from model-signing.
+                               then model_signing on PATH, then uvx with pinned
+                               model-signing==1.1.1.
   -h, --help                   Show this help.
 
 Examples:
@@ -66,7 +68,7 @@ run_model_signing() {
   elif command -v model_signing >/dev/null 2>&1; then
     model_signing "$@"
   elif command -v uvx >/dev/null 2>&1; then
-    uvx --from model-signing model_signing "$@"
+    uvx --from "$MODEL_SIGNING_UVX_SPEC" model_signing "$@"
   else
     die "model_signing is not installed and uvx is unavailable"
   fi

--- a/.github/scripts/sign-agent-skill.sh
+++ b/.github/scripts/sign-agent-skill.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sign or verify a detached OpenSSF Model Signing / OMS signature for an
+# agent skill directory.
+#
+# The NVIDIA nv-agent-root-cert.pem file is a verification trust anchor. It is
+# not a private key and cannot sign a skill. Signing requires the private key
+# for the signing certificate, plus the certificate chain that roots in the
+# NVIDIA agent capabilities CA.
+
+set -euo pipefail
+
+NVIDIA_ROOT_CERT_URL="https://raw.githubusercontent.com/NVIDIA/skills/main/nv-agent-root-cert.pem"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  .github/scripts/sign-agent-skill.sh verify SKILL_DIR [options]
+  .github/scripts/sign-agent-skill.sh sign SKILL_DIR --private-key KEY --signing-certificate CERT --certificate-chain CHAIN [options]
+
+Modes:
+  verify  Verify SKILL_DIR/skill.oms.sig with the NVIDIA agent root cert.
+  sign    Generate SKILL_DIR/skill.oms.sig using private signing material, then verify it.
+
+Options:
+  --signature PATH             Signature path. Defaults to SKILL_DIR/skill.oms.sig.
+  --certificate-chain PATH     Certificate chain file. Required for sign. For verify, defaults to
+                               downloading nv-agent-root-cert.pem from NVIDIA/skills.
+                               May be repeated for sign.
+  --private-key PATH           PEM private key for the signing certificate. Required for sign.
+  --signing-certificate PATH   PEM signing certificate. Required for sign.
+  --model-signing-bin PATH     model_signing executable. Defaults to MODEL_SIGNING_BIN,
+                               then model_signing on PATH, then uvx --from model-signing.
+  -h, --help                   Show this help.
+
+Examples:
+  .github/scripts/sign-agent-skill.sh verify skills/vss-setup-behavior-analytics
+
+  .github/scripts/sign-agent-skill.sh sign skills/my-skill \
+    --private-key /secure/agent-skills-signing.key \
+    --signing-certificate /secure/agent-skills-signing.crt \
+    --certificate-chain /secure/agent-skills-chain.pem
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_file() {
+  local label="$1"
+  local path="$2"
+
+  [[ -n "$path" ]] || die "missing $label"
+  [[ -f "$path" ]] || die "$label does not exist: $path"
+}
+
+run_model_signing() {
+  if [[ -n "${model_signing_bin:-}" ]]; then
+    "$model_signing_bin" "$@"
+  elif [[ -n "${MODEL_SIGNING_BIN:-}" ]]; then
+    "$MODEL_SIGNING_BIN" "$@"
+  elif command -v model_signing >/dev/null 2>&1; then
+    model_signing "$@"
+  elif command -v uvx >/dev/null 2>&1; then
+    uvx --from model-signing model_signing "$@"
+  else
+    die "model_signing is not installed and uvx is unavailable"
+  fi
+}
+
+download_root_cert() {
+  local cert_path="$1"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$NVIDIA_ROOT_CERT_URL" -o "$cert_path"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$cert_path" "$NVIDIA_ROOT_CERT_URL"
+  else
+    die "curl or wget is required to download nv-agent-root-cert.pem"
+  fi
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+
+mode="$1"
+shift
+
+case "$mode" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  sign|verify)
+    ;;
+  *)
+    usage >&2
+    die "unknown mode: $mode"
+    ;;
+esac
+
+[[ $# -ge 1 ]] || die "missing SKILL_DIR"
+skill_dir="$1"
+shift
+
+signature=""
+private_key=""
+signing_certificate=""
+model_signing_bin=""
+certificate_chains=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --signature)
+      [[ $# -ge 2 ]] || die "--signature requires a value"
+      signature="$2"
+      shift 2
+      ;;
+    --private-key)
+      [[ $# -ge 2 ]] || die "--private-key requires a value"
+      private_key="$2"
+      shift 2
+      ;;
+    --signing-certificate)
+      [[ $# -ge 2 ]] || die "--signing-certificate requires a value"
+      signing_certificate="$2"
+      shift 2
+      ;;
+    --certificate-chain)
+      [[ $# -ge 2 ]] || die "--certificate-chain requires a value"
+      certificate_chains+=("$2")
+      shift 2
+      ;;
+    --model-signing-bin)
+      [[ $# -ge 2 ]] || die "--model-signing-bin requires a value"
+      model_signing_bin="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -d "$skill_dir" ]] || die "SKILL_DIR does not exist: $skill_dir"
+signature="${signature:-$skill_dir/skill.oms.sig}"
+
+tmp_dir=""
+cleanup() {
+  if [[ -n "$tmp_dir" ]]; then
+    rm -rf "$tmp_dir"
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$mode" == "verify" && "${#certificate_chains[@]}" -eq 0 ]]; then
+  tmp_dir="$(mktemp -d)"
+  root_cert="$tmp_dir/nv-agent-root-cert.pem"
+  download_root_cert "$root_cert"
+  certificate_chains=("$root_cert")
+fi
+
+verify_signature() {
+  local verify_args=(
+    verify certificate "$skill_dir"
+    --signature "$signature"
+    --log_fingerprints
+  )
+
+  for chain in "${certificate_chains[@]}"; do
+    verify_args+=(--certificate_chain "$chain")
+  done
+
+  run_model_signing "${verify_args[@]}"
+}
+
+if [[ "$mode" == "verify" ]]; then
+  require_file "signature" "$signature"
+  for chain in "${certificate_chains[@]}"; do
+    require_file "certificate chain" "$chain"
+  done
+  verify_signature
+  exit 0
+fi
+
+require_file "private key" "$private_key"
+require_file "signing certificate" "$signing_certificate"
+
+if [[ "${#certificate_chains[@]}" -eq 0 ]]; then
+  die "sign mode requires --certificate-chain. nv-agent-root-cert.pem can verify the result, but it cannot sign."
+fi
+for chain in "${certificate_chains[@]}"; do
+  require_file "certificate chain" "$chain"
+done
+
+sign_args=(
+  sign certificate "$skill_dir"
+  --signature "$signature"
+  --private_key "$private_key"
+  --signing_certificate "$signing_certificate"
+)
+
+for chain in "${certificate_chains[@]}"; do
+  sign_args+=(--certificate_chain "$chain")
+done
+
+run_model_signing "${sign_args[@]}"
+verify_signature

--- a/.github/workflows/skills-signatures.yml
+++ b/.github/workflows/skills-signatures.yml
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verifies detached OpenSSF Model Signing / OMS signatures for agent skills.
+#
+# This workflow follows the same mirror-branch trigger shape as the other
+# skill gates: `/ok to test` causes copy-pr-bot to update pull-request/<N>,
+# and that push runs this check. Branch protection/rulesets can make
+# `Skills Signatures / signature-check` a required status check.
+
+name: Skills Signatures
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch:
+    inputs:
+      skills:
+        # `type: string` rather than `type: choice` because the skills/
+        # tree has more than 10 entries.
+        description: "Which skill signature to verify. `*` sweeps all. Otherwise type a bare skill-dir name."
+        required: false
+        default: "*"
+        type: string
+      blocking:
+        description: "Fail the workflow on invalid signatures. Manual runs can turn this off for advisory sweeps."
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: >-
+    skills-signatures-${{ github.event_name == 'workflow_dispatch'
+      && format('manual-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  signature-check:
+    name: signature-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout mirror head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
+        with:
+          version: "0.6.2"
+
+      - name: Resolve PR number + base
+        id: pr
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PR="${REF_NAME##pull-request/}"
+          BASE="$(gh pr view "$PR" --json baseRefName --jq .baseRefName)"
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "PR #$PR, base=$BASE"
+
+      - name: Resolve target skills
+        id: targets
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_SKILLS: ${{ github.event_name == 'workflow_dispatch' && (inputs.skills || '*') || '' }}
+          PR_BASE: ${{ steps.pr.outputs.base }}
+        run: |
+          set -euo pipefail
+
+          targets_file="${RUNNER_TEMP}/signature-targets.txt"
+          : > "$targets_file"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ -z "$MANUAL_SKILLS" ] || [ "$MANUAL_SKILLS" = "*" ]; then
+              find skills -mindepth 1 -maxdepth 1 -type d -print \
+                | sed 's#^skills/##' \
+                | sort > "$targets_file"
+            else
+              if ! [[ "$MANUAL_SKILLS" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_-]*$ ]]; then
+                echo "::error::skills='$MANUAL_SKILLS' is not a valid skill-dir name. Use a bare name like 'vss-deploy-profile' or '*'."
+                exit 1
+              fi
+              if [ ! -d "skills/$MANUAL_SKILLS" ]; then
+                echo "::error::skills/$MANUAL_SKILLS does not exist on this ref."
+                exit 1
+              fi
+              printf '%s\n' "$MANUAL_SKILLS" > "$targets_file"
+            fi
+          else
+            git fetch --no-tags --quiet origin "${PR_BASE}:refs/remotes/origin/${PR_BASE}"
+            git diff --name-only "origin/${PR_BASE}...HEAD" \
+              | awk -F/ '$1 == "skills" && $2 != "" {print $2}' \
+              | sort -u > "$targets_file"
+          fi
+
+          count="$(grep -cve '^[[:space:]]*$' "$targets_file" || true)"
+          {
+            echo "targets_file=$targets_file"
+            echo "count=$count"
+            if [ "$count" -gt 0 ]; then
+              echo "skills<<EOF"
+              cat "$targets_file"
+              echo "EOF"
+            else
+              echo "skills="
+            fi
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$count" -eq 0 ]; then
+            echo "No changed skill directories need signature verification."
+          else
+            echo "Signature targets:"
+            sed 's/^/- /' "$targets_file"
+          fi
+
+      - name: Resolve blocking mode
+        id: blocking
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_BLOCKING: ${{ inputs.blocking }}
+          # PR mirror runs are blocking by default. Set repository variable
+          # SKILLS_SIGNATURE_CHECK_BLOCKING=false to make the status advisory
+          # while keeping the same `/ok to test` trigger.
+          PR_BLOCKING: ${{ vars.SKILLS_SIGNATURE_CHECK_BLOCKING != 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            blocking="$MANUAL_BLOCKING"
+          else
+            blocking="$PR_BLOCKING"
+          fi
+          echo "value=$blocking" >> "$GITHUB_OUTPUT"
+          echo "Signature failures blocking: $blocking"
+
+      - name: Verify skill signatures
+        id: verify
+        if: steps.targets.outputs.count != '0'
+        env:
+          TARGETS_FILE: ${{ steps.targets.outputs.targets_file }}
+          BLOCKING: ${{ steps.blocking.outputs.value }}
+          REPORT_MD: ${{ runner.temp }}/signature-results.md
+          LOG_DIR: ${{ runner.temp }}/signature-logs
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$LOG_DIR"
+          fail_count=0
+          pass_count=0
+
+          {
+            echo "# Agent skill signature check"
+            echo
+            echo "Blocking mode: \`$BLOCKING\`"
+            echo
+            echo "| Skill | Result | Detail |"
+            echo "|---|---|---|"
+          } > "$REPORT_MD"
+
+          while IFS= read -r skill; do
+            [ -n "$skill" ] || continue
+            skill_dir="skills/$skill"
+            signature="$skill_dir/skill.oms.sig"
+            log_file="$LOG_DIR/${skill}.log"
+
+            if [ ! -f "$signature" ]; then
+              echo "::error file=$signature::Missing skill.oms.sig"
+              printf '| `%s` | FAIL | Missing `skill.oms.sig` |\n' "$skill" >> "$REPORT_MD"
+              fail_count=$((fail_count + 1))
+              continue
+            fi
+
+            if .github/scripts/sign-agent-skill.sh verify "$skill_dir" > "$log_file" 2>&1; then
+              printf '| `%s` | PASS | Signature verified |\n' "$skill" >> "$REPORT_MD"
+              pass_count=$((pass_count + 1))
+            else
+              detail="$(grep -E 'Verification failed|Hash mismatch|Missing|error:' "$log_file" | tail -n 1 || true)"
+              if [ -z "$detail" ]; then
+                detail="Verification failed; see artifact log"
+              fi
+              detail="${detail//$'\r'/ }"
+              detail="${detail//$'\n'/ }"
+              detail="${detail//|/\\|}"
+              echo "::error file=$signature::Signature verification failed for $skill"
+              printf '| `%s` | FAIL | %s |\n' "$skill" "$detail" >> "$REPORT_MD"
+              fail_count=$((fail_count + 1))
+            fi
+          done < "$TARGETS_FILE"
+
+          {
+            echo
+            echo "Summary: ${pass_count} passed, ${fail_count} failed."
+          } >> "$REPORT_MD"
+
+          cat "$REPORT_MD" >> "$GITHUB_STEP_SUMMARY"
+          echo "pass_count=$pass_count" >> "$GITHUB_OUTPUT"
+          echo "fail_count=$fail_count" >> "$GITHUB_OUTPUT"
+
+          if [ "$fail_count" -gt 0 ] && [ "$BLOCKING" = "true" ]; then
+            exit 1
+          fi
+
+      - name: No signature targets
+        if: steps.targets.outputs.count == '0'
+        run: |
+          {
+            echo "# Agent skill signature check"
+            echo
+            echo "No changed skill directories need signature verification."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload signature report
+        if: always() && steps.targets.outputs.count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-signature-results
+          path: |
+            ${{ runner.temp }}/signature-results.md
+            ${{ runner.temp }}/signature-logs/*.log
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
## Summary
- add `.github/scripts/sign-agent-skill.sh` for detached OMS skill signatures
- add `Skills Signatures / signature-check` CI to verify `skill.oms.sig` on `pull-request/<N>` mirror pushes, matching the `/ok to test` trigger path used by the other skill gates
- add manual `workflow_dispatch` support for one skill or `*` for all skills
- make PR mirror runs blocking by default, with repository variable `SKILLS_SIGNATURE_CHECK_BLOCKING=false` available to keep the status advisory while the existing signature backlog is being cleaned up

## Notes
- `nv-agent-root-cert.pem` is a public root CA certificate and cannot sign skills by itself. It is only used to verify an existing `skill.oms.sig`.
- PR #974 is useful as a bundle format example, but its `skill.oms.sig` is tied to the exact `vss-setup-behavior-analytics` tree and cannot be reused for other skills.
- Branch protection/rulesets still need to mark `Skills Signatures / signature-check` as a required status check if we want GitHub to enforce it as a merge blocker.
- The automatic PR path checks only changed `skills/<name>/` directories, so this infrastructure PR is not blocked by unrelated stale signatures already on `develop`.

## Validation
- `bash -n .github/scripts/sign-agent-skill.sh`
- `.github/scripts/sign-agent-skill.sh --help`
- `uvx yamllint ... .github/workflows/skills-signatures.yml`
- push-style target resolver against this branch vs `origin/develop` -> `count=0` changed skills
- `.github/scripts/sign-agent-skill.sh verify <temp export of origin/pr-974>/skills/vss-setup-behavior-analytics` -> succeeded
- `.github/scripts/sign-agent-skill.sh sign skills/vss-setup-behavior-analytics` -> fails fast with `missing private key` as expected
- local advisory all-skill sweep on current `develop`: 6 passed, 10 failed due existing signature/content drift

Signed-off-by: Zac Wang <zacw@nvidia.com>
