### PR TITLE
refactor(lvs): switch LVS profile services to bridge networking

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -66,7 +66,7 @@ VLM_MODE=local_shared
 LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
 LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
 LLM_ENV_FILE=''
-LLM_BASE_URL=''
+LLM_BASE_URL=http://nvidia-nemotron-nano-9b-v2:8000
 LLM_MODEL_TYPE=nim
 
 # VLM is served by the RT-VLM container in the LVS profile. For local and
@@ -208,7 +208,7 @@ RTVI_VLM_PORT=8018
 RTVI_VLM_BASE_URL=http://${HOST_IP}:8018
 RTVI_VLM_ENDPOINT=''
 
-RTVI_VLM_URL=http://${HOST_IP}:${RTVI_VLM_PORT}
+RTVI_VLM_URL=http://rtvi-vlm:8000
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
 RTVI_VLM_MODEL_TO_USE=cosmos-reason2
 RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos-reason2-8b:hf-1208'
@@ -230,7 +230,7 @@ RTVI_VLM_KAFKA_ENABLED=true
 # Raw VLM event topic produced by rtvi-vlm and consumed by the shared
 # infra Logstash LVS pipeline.
 RTVI_VLM_KAFKA_TOPIC=mdx-vlm-captions
-RTVI_VLM_KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+RTVI_VLM_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
 RTVI_VLM_KAFKA_INCIDENT_TOPIC=mdx-vlm-incidents
 
 # =============================================================================
@@ -304,7 +304,7 @@ LVS_TAG="3.2.0"
 
 # Kafka integration: route LVS structured summaries through Kafka
 KAFKA_ENABLED=true
-KAFKA_BOOTSTRAP_SERVERS=${HOST_IP}:9092
+KAFKA_BOOTSTRAP_SERVERS=kafka:9092
 KAFKA_STRUCTURED_SUMMARY_TOPIC=mdx-structured-events-summary
 LVS_ENABLE_LLM_MERGING=true
 

--- a/deploy/docker/developer-profiles/dev-profile-lvs/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/compose.yml
@@ -18,9 +18,8 @@ services:
     build:
       context: $VSS_APPS_DIR/developer-profiles/dev-profile-lvs
       dockerfile: $VSS_APPS_DIR/developer-profiles/dev-profile-lvs/Dockerfiles/kibana-dashboard.Dockerfile
-    network_mode: "host"
+    networks: [app-network]
     profiles: ["bp_developer_lvs_2d"]
-    container_name: vss-kibana-init
     command: bash /opt/mdx/init-scripts/kibana-import-dashboard.sh
     restart: on-failure
 
@@ -33,12 +32,13 @@ services:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
-    network_mode: "host"
+    networks: [app-network]
+    ports:
+      - "${NVSTREAMER_HTTP_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}"
     deploy:
       restart_policy:
         condition: on-failure
         max_attempts: 2
-    container_name: vss-vios-nvstreamer-lvs
     volumes:
       - $VSS_APPS_DIR/developer-profiles/dev-profile-lvs/nvstreamer/configs/vst-config.json:/home/vst/vst_release/configs/vst_config.json
       - $VSS_APPS_DIR/developer-profiles/dev-profile-lvs/nvstreamer/configs/vst-storage.json:/home/vst/vst_release/configs/vst_storage.json
@@ -48,3 +48,7 @@ services:
     depends_on:
       broker-health-check:
         condition: service_completed_successfully
+
+networks:
+  app-network:
+    driver: bridge

--- a/deploy/docker/services/infra/compose.yml
+++ b/deploy/docker/services/infra/compose.yml
@@ -20,11 +20,12 @@ include:
 services:
   mosquitto:
     image: eclipse-mosquitto:2
-    network_mode: "host"
+    networks: [app-network]
     profiles: ["bp_wh_kafka_mv3dt", "bp_wh_redis_mv3dt"]
-    container_name: mosquitto
     restart: always
     command: ["mosquitto", "-c", "/mosquitto/config/mosquitto.conf", "-p", "${MQTT_PORT:-1883}"]
+    ports:
+      - "${MQTT_PORT:-1883}:1883"
     volumes:
       - $VSS_APPS_DIR/services/infra/mosquitto/configs/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
     healthcheck:
@@ -36,16 +37,16 @@ services:
 
 
   phoenix:
-    container_name: phoenix
     image: 'arizephoenix/phoenix:14.15.0'
     profiles: ["bp_wh_2d","bp_developer_base_2d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
+    networks: [app-network]
     environment:
       PHOENIX_WORKING_DIR: '/.phoenix/'
       PHOENIX_HOST_ROOT_PATH: '/phoenix'
     volumes:
     - phoenix-data:/.phoenix
     ports:
-    - 6006:6006
+    - "${PHOENIX_PORT:-6006}:6006"
 
   elasticsearch:
     build:
@@ -53,7 +54,7 @@ services:
       dockerfile: Dockerfiles/elasticsearch.Dockerfile
       network: "host"
     image: elasticsearch
-    network_mode: "host"
+    networks: [app-network]
     environment:
       ES_JAVA_OPTS: "-Xmx1024m -Xms256m"
       discovery.type: single-node
@@ -62,7 +63,9 @@ services:
       - $VSS_APPS_DIR/services/infra/elk/elasticsearch/configs/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
       - mdx-elastic-data:/tmp/elastic/data:rw
       - mdx-elastic-logs:/tmp/elastic/logs:rw
-    container_name: elasticsearch
+    ports:
+      - "${ES_HTTP_PORT:-9200}:9200"
+      - "${ES_TRANSPORT_PORT:-9300}:9300"
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS 'http://localhost:9200/_cluster/health?local=false&wait_for_status=yellow&wait_for_events=normal&timeout=5s' | grep -q '\"timed_out\"[[:space:]]*:[[:space:]]*false'"]
@@ -77,8 +80,7 @@ services:
       dockerfile: Dockerfiles/elastic-init.Dockerfile
       network: "host"
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_mv3dt${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_mv3dt${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
-    network_mode: "host"
-    container_name: vss-elasticsearch-init
+    networks: [app-network]
     environment:
       - BP_PROFILE=${BP_PROFILE}
       - ELASTICSEARCH_CONNECTION_MAX_ATTEMPTS=${ELASTICSEARCH_CONNECTION_MAX_ATTEMPTS:-20}
@@ -97,7 +99,7 @@ services:
 
   kafka:
     image: confluentinc/cp-kafka:8.2.0
-    network_mode: "host"
+    networks: [app-network]
     volumes:
       - mdx-kafka:/tmp/kafka-data
       - $VSS_APPS_DIR/services/infra/kafka/scripts/kafka-entrypoint.sh:/usr/local/bin/kafka-entrypoint.sh:ro
@@ -108,7 +110,7 @@ services:
       KAFKA_NODE_ID: 1
       KAFKA_CONTROLLER_QUORUM_VOTERS: '1@localhost:9093'
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://localhost:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://$HOST_IP:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
@@ -122,7 +124,8 @@ services:
       KAFKA_MAX_PARTITION_FETCH_BYTES: 10485760
       KAFKA_REPLICA_FETCH_MAX_BYTES: 10485760
       KAFKA_LOG_DIRS: '/tmp/kafka-data'
-    container_name: kafka
+    ports:
+      - "${KAFKA_PORT:-9092}:9092"
     entrypoint: ["/bin/sh","/usr/local/bin/kafka-entrypoint.sh"]
     healthcheck:
       test: ["CMD", "sh", "-c", "kafka-topics --bootstrap-server localhost:9092 --list || exit 1"]
@@ -133,8 +136,7 @@ services:
 
   kafka-topic-init-container:
     image: confluentinc/cp-kafka:8.2.0
-    container_name: vss-kafka-topics
-    network_mode: "host"
+    networks: [app-network]
     profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","bp_wh_kafka_mv3dt","playback_kafka_2d","playback_kafka_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     volumes:
       - $VSS_APPS_DIR/services/infra/kafka/init-scripts/create-kafka-topics.sh:/usr/bin/create-kafka-topics.sh
@@ -143,7 +145,7 @@ services:
       DEFAULT_RETENTION_MS: "14400000"
       DEFAULT_SEGMENT_MS: "3600000"
       DEFAULT_REPLICATION_FACTOR: "1"
-      BOOTSTRAP_HOST: localhost
+      BOOTSTRAP_HOST: kafka
       KAFKA_PORT: 9092
       KAFKA_TOPICS: '[{"name": "mdx-raw"},
         {"name": "mdx-bev"},
@@ -176,8 +178,9 @@ services:
     profiles: ["bp_wh_2d","bp_wh_redis_2d","bp_wh_redis_3d","bp_wh_redis_mv3dt","bp_wh_kafka_2d","bp_wh_kafka_3d","bp_wh_kafka_mv3dt","bp_wh_auto_calib_2d","bp_wh_auto_calib_3d","bp_wh_auto_calib_mv3dt","bp_developer_base_2d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     restart: always
     command: redis-server /config/redis.conf
-    network_mode: host
-    container_name: redis
+    networks: [app-network]
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - $VSS_APPS_DIR/services/infra/redis/configs/redis.conf:/config/redis.conf
       - $VSS_DATA_DIR/data_log/redis/data:/data
@@ -185,11 +188,12 @@ services:
 
   kibana:
     image: docker.elastic.co/kibana/kibana:9.3.3
-    network_mode: "host"
+    networks: [app-network]
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_mv3dt${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_mv3dt${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     volumes:
       - $VSS_APPS_DIR/services/infra/elk/kibana/configs/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
-    container_name: kibana
+    ports:
+      - "${KIBANA_PORT:-5601}:5601"
     restart: always
     depends_on:
       elasticsearch:
@@ -203,7 +207,7 @@ services:
 
   logstash:
     image: docker.elastic.co/logstash/logstash:9.3.3
-    network_mode: "host"
+    networks: [app-network]
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_mv3dt${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_mv3dt${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     volumes:
       - mdx-logstash-libs:/opt/logstash-data-libs
@@ -218,7 +222,6 @@ services:
     environment:
       LS_JAVA_OPTS: "-Xmx1024m -Xms256m"
       STREAM_TYPE: ${STREAM_TYPE}
-    container_name: logstash
     restart: always
     depends_on:
       broker-health-check:
@@ -246,11 +249,11 @@ services:
       dockerfile: Dockerfiles/${STREAM_TYPE}-health-check.Dockerfile
       network: host
     profiles: ["bp_wh_2d","bp_wh_redis_3d","bp_wh_redis_mv3dt","bp_wh_redis_2d","bp_wh_kafka_2d","bp_wh_kafka_3d","bp_wh_kafka_mv3dt","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
-    network_mode: "host"
+    networks: [app-network]
     environment:
       MAX_RETRIES: 60
       RETRY_INTERVAL: 2
-      BOOTSTRAP_HOST: localhost
+      BOOTSTRAP_HOST: kafka
       KAFKA_PORT: 9092
       REDIS_PORT: 6379
       KAFKA_TOPICS: '[{"name": "mdx-raw"},
@@ -274,8 +277,11 @@ services:
         {"name": "mdx-structured-events-summary"},
         {"name": "mdx-embed"},
         {"name": "mdx-embed-filtered"}]'
-    container_name: vss-broker-health-check
     restart: "no"
+
+networks:
+  app-network:
+    driver: bridge
 
 volumes:
   phoenix-data:

--- a/deploy/docker/services/infra/haproxy/compose.yml
+++ b/deploy/docker/services/infra/haproxy/compose.yml
@@ -40,7 +40,6 @@ services:
       - "bp_wh_auto_calib_2d"
       - "bp_wh_auto_calib_3d"
       - "bp_wh_auto_calib_mv3dt"
-    container_name: vss-haproxy-ingress
     network_mode: host
     restart: always
     ulimits:

--- a/deploy/docker/services/infra/sdrc/docker-compose.yaml
+++ b/deploy/docker/services/infra/sdrc/docker-compose.yaml
@@ -25,7 +25,6 @@ services:
     image: alpine:3.23.4
     user: "0:0"
     entrypoint: ["/bin/sh", "-c"]
-    container_name: sdrc-init-dirs
     command:
       - |
         set -e
@@ -71,7 +70,6 @@ services:
       - ./render-config.sh:/render-config.sh:ro
       - ${SDR_CONTROLLER_CONFIG_PATH:-"./configs"}/configs:/tmpl
     restart: "no"
-    container_name: sdrc-render-config
 
   wdm-env-from-config:
     profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_kafka_3d","bp_wh_redis_3d", "bp_wh_kafka_mv3dt", "bp_wh_redis_mv3dt","bp_wh_auto_calib_2d","bp_wh_auto_calib_3d", "bp_wh_auto_calib_mv3dt","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm","bp_developer_search_2d","bp_developer_lvs_2d"]
@@ -95,7 +93,6 @@ services:
       render-config:
         condition: service_completed_successfully
     restart: "no"
-    container_name: sdrc-wdm-env-from-config
 
   wait-for-redis:
     profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_kafka_3d","bp_wh_redis_3d", "bp_wh_kafka_mv3dt", "bp_wh_redis_mv3dt","bp_wh_auto_calib_2d","bp_wh_auto_calib_3d", "bp_wh_auto_calib_mv3dt","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm","bp_developer_search_2d","bp_developer_lvs_2d"]
@@ -112,7 +109,6 @@ services:
       - ./wait-for-redis.sh:/wait-for-redis.sh:ro
       - ./.wdm-env:/wdm-env:ro
     entrypoint: ["/bin/sh", "/wait-for-redis.sh"]
-    container_name: sdrc-wait-for-redis
 
   wait-for-docker-workloads:
     profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_redis_2d","bp_wh_kafka_3d","bp_wh_redis_3d","bp_wh_kafka_mv3dt", "bp_wh_redis_mv3dt","bp_wh_auto_calib_2d","bp_wh_auto_calib_3d", "bp_wh_auto_calib_mv3dt","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm","bp_developer_search_2d","bp_developer_lvs_2d"]
@@ -131,14 +127,12 @@ services:
       - ./wait-for-docker-workloads.sh:/wait-for-docker-workloads.sh:ro
       - ./.wdm-env:/wdm-env:ro
       - /var/run/docker.sock:/var/run/docker.sock
-    container_name: sdrc-wait-for-workloads
 
   # sdr-mw-l: host network, Kubernetes API + CA, Docker socket, docker_cluster_config.json (mixed docker/k8s).
   # Does not use wdm-env-from-config (env is explicit below, like a hand-written docker run).
   sdr-controller:
     profiles: ["bp_wh_2d","bp_wh_kafka_2d","bp_wh_redis_2d", "bp_wh_kafka_3d","bp_wh_redis_3d", "bp_wh_kafka_mv3dt", "bp_wh_redis_mv3dt","bp_wh_auto_calib_2d","bp_wh_auto_calib_3d", "bp_wh_auto_calib_mv3dt","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm","bp_developer_search_2d","bp_developer_lvs_2d"]
     image: ${SDR_MW_L_IMAGE:-nvcr.io/nvidia/vss-core/sdr-mw-l:3.2.0}
-    container_name: sdr-controller
     network_mode: host
     restart: unless-stopped
     environment:

--- a/deploy/docker/services/nim/cosmos-reason1-7b/compose.yml
+++ b/deploy/docker/services/nim/cosmos-reason1-7b/compose.yml
@@ -16,7 +16,6 @@
 services:
   cosmos-reason1-7b:
     image: nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
-    container_name: cosmos-reason1-7b
     profiles:
     - vlm_local_cosmos-reason1-7b
     runtime: nvidia
@@ -58,7 +57,6 @@ services:
 
   cosmos-reason1-7b-shared-gpu:
     image: nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
-    container_name: cosmos-reason1-7b
     profiles:
     - vlm_local_shared_cosmos-reason1-7b
     runtime: nvidia

--- a/deploy/docker/services/nim/cosmos-reason2-8b/compose.yml
+++ b/deploy/docker/services/nim/cosmos-reason2-8b/compose.yml
@@ -16,7 +16,6 @@
 services:
   cosmos-reason2-8b:
     image: nvcr.io/nim/nvidia/cosmos-reason2-8b:1.6.0
-    container_name: nvidia-cosmos-reason2-8b
     profiles:
     - vlm_local_cosmos-reason2-8b
     runtime: nvidia
@@ -56,7 +55,6 @@ services:
 
   cosmos-reason2-8b-shared-gpu:
     image: nvcr.io/nim/nvidia/cosmos-reason2-8b:1.6.0
-    container_name: nvidia-cosmos-reason2-8b
     profiles:
     - vlm_local_shared_cosmos-reason2-8b
     runtime: nvidia

--- a/deploy/docker/services/nim/cosmos3-reasoner/compose.yml
+++ b/deploy/docker/services/nim/cosmos3-reasoner/compose.yml
@@ -22,7 +22,6 @@
 services:
   cosmos3-reasoner:
     image: nvcr.io/nim/nvidia/cosmos3-reasoner:1.7
-    container_name: nvidia-cosmos3-reasoner
     profiles:
     - vlm_local_cosmos3-reasoner
     runtime: nvidia
@@ -63,7 +62,6 @@ services:
 
   cosmos3-reasoner-shared-gpu:
     image: nvcr.io/nim/nvidia/cosmos3-reasoner:1.7
-    container_name: nvidia-cosmos3-reasoner
     profiles:
     - vlm_local_shared_cosmos3-reasoner
     runtime: nvidia

--- a/deploy/docker/services/nim/gpt-oss-20b/compose.yml
+++ b/deploy/docker/services/nim/gpt-oss-20b/compose.yml
@@ -26,7 +26,6 @@ services:
     restart: "no"
   gpt-oss-20b:
     image: nvcr.io/nim/openai/gpt-oss-20b:1
-    container_name: gpt-oss-20b
     profiles:
     - llm_local_gpt-oss-20b
     runtime: nvidia
@@ -62,7 +61,6 @@ services:
         required: true
   gpt-oss-20b-shared-gpu:
     image: nvcr.io/nim/openai/gpt-oss-20b:1
-    container_name: gpt-oss-20b
     profiles:
     - llm_local_shared_gpt-oss-20b
     runtime: nvidia

--- a/deploy/docker/services/nim/llama-3.3-nemotron-super-49b-v1.5/compose.yml
+++ b/deploy/docker/services/nim/llama-3.3-nemotron-super-49b-v1.5/compose.yml
@@ -16,7 +16,6 @@
 services:
   llama-3.3-nemotron-super-49b-v1.5:
     image: nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:1
-    container_name: llama-3.3-nemotron-super-49b-v1.5
     profiles:
     - llm_local_llama-3.3-nemotron-super-49b-v1.5
     runtime: nvidia
@@ -48,7 +47,6 @@ services:
       retries: 2
   llama-3.3-nemotron-super-49b-v1.5-shared-gpu:
     image: nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:1
-    container_name: llama-3.3-nemotron-super-49b-v1.5
     profiles:
     - llm_local_shared_llama-3.3-nemotron-super-49b-v1.5
     runtime: nvidia

--- a/deploy/docker/services/nim/nemotron-3-nano/compose.yml
+++ b/deploy/docker/services/nim/nemotron-3-nano/compose.yml
@@ -16,7 +16,6 @@
 services:
   nemotron-3-nano-init:
     image: alpine:3.23.4
-    container_name: llm-nim-init
     profiles:
     - llm_local_nemotron-3-nano
     - llm_local_shared_nemotron-3-nano
@@ -27,7 +26,6 @@ services:
     restart: "no"
   nemotron-3-nano:
     image: nvcr.io/nim/nvidia/nemotron-3-nano:1
-    container_name: nemotron-3-nano
     profiles:
     - llm_local_nemotron-3-nano
     runtime: nvidia
@@ -63,7 +61,6 @@ services:
         required: true
   nemotron-3-nano-shared-gpu:
     image: nvcr.io/nim/nvidia/nemotron-3-nano:1
-    container_name: nemotron-3-nano
     profiles:
     - llm_local_shared_nemotron-3-nano
     runtime: nvidia

--- a/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2-fp8/compose.yml
+++ b/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2-fp8/compose.yml
@@ -17,7 +17,6 @@ services:
   nvidia-nemotron-nano-9b-v2-fp8-toolcall-init:
     # Fetch toolcall parser from Hugging Face (public repo, no HF_TOKEN required).
     image: alpine/curl:8.17.0
-    container_name: nvidia-nemotron-nano-9b-v2-fp8-toolcall-init
     profiles:
     - llm_local_nvidia-nemotron-nano-9b-v2-fp8
     - llm_local_shared_nvidia-nemotron-nano-9b-v2-fp8
@@ -53,7 +52,6 @@ services:
       - /opt/toolcall_parser/nemotron_toolcall_parser_no_streaming.py
       - --tool-call-parser
       - nemotron_json
-    container_name: nvidia-nemotron-nano-9b-v2-fp8
     profiles:
     - llm_local_nvidia-nemotron-nano-9b-v2-fp8
     runtime: nvidia
@@ -112,7 +110,6 @@ services:
       - /opt/toolcall_parser/nemotron_toolcall_parser_no_streaming.py
       - --tool-call-parser
       - nemotron_json
-    container_name: nvidia-nemotron-nano-9b-v2-fp8
     profiles:
     - llm_local_shared_nvidia-nemotron-nano-9b-v2-fp8
     runtime: nvidia

--- a/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/compose.yml
+++ b/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/compose.yml
@@ -16,9 +16,9 @@
 services:
   nvidia-nemotron-nano-9b-v2:
     image: nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2:1
-    container_name: nvidia-nemotron-nano-9b-v2
     profiles:
     - llm_local_nvidia-nemotron-nano-9b-v2
+    networks: [app-network]
     runtime: nvidia
     shm_size: 16GB
     ports:
@@ -49,9 +49,9 @@ services:
       retries: 2
   nvidia-nemotron-nano-9b-v2-shared-gpu:
     image: nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2:1
-    container_name: nvidia-nemotron-nano-9b-v2
     profiles:
     - llm_local_shared_nvidia-nemotron-nano-9b-v2
+    networks: [app-network]
     runtime: nvidia
     shm_size: 16GB
     ports:
@@ -99,5 +99,9 @@ services:
       rtvi-embed:
         condition: service_healthy
         required: false
+networks:
+  app-network:
+    driver: bridge
+
 volumes:
   nvidia_nemotron_nano_9b_v2_cache:

--- a/deploy/docker/services/nim/qwen3-vl-8b-instruct/compose.yml
+++ b/deploy/docker/services/nim/qwen3-vl-8b-instruct/compose.yml
@@ -19,7 +19,6 @@ services:
     command: python3 -m vllm.entrypoints.openai.api_server --model
       Qwen/Qwen3-VL-8B-Instruct --trust-remote-code --tensor-parallel-size
       1 --gpu-memory-utilization 0.85 --port 8000
-    container_name: qwen3-vl-8b-instruct
     profiles:
     - vlm_local_qwen3-vl-8b-instruct
     runtime: nvidia
@@ -55,7 +54,6 @@ services:
     command: python3 -m vllm.entrypoints.openai.api_server --model
       Qwen/Qwen3-VL-8B-Instruct --trust-remote-code --tensor-parallel-size
       1 --gpu-memory-utilization 0.4 --port 8000 --max-model-len 32768
-    container_name: qwen3-vl-8b-instruct
     profiles:
     - vlm_local_shared_qwen3-vl-8b-instruct
     runtime: nvidia

--- a/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
+++ b/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
@@ -19,7 +19,6 @@ services:
   rtvi-vlm:
     # for release, change this to the versioned image from the registry
     image: nvcr.io/nvidia/vss-core/vss-rt-vlm:${RTVI_VLM_IMAGE_TAG:-3.2.0}
-    container_name: vss-rtvi-vlm
     user: "1001:1001"
     shm_size: '16gb'
     runtime: nvidia
@@ -98,7 +97,7 @@ services:
       # Bounded queue size for the async Kafka sender.
       KAFKA_ASYNC_SEND_QUEUE_MAXSIZE: "${RTVI_VLM_KAFKA_ASYNC_SEND_QUEUE_MAXSIZE:-1024}"
 
-      KAFKA_BOOTSTRAP_SERVERS: ${HOST_IP}:9092
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}
       NGC_API_KEY: "${RTVI_VLM_API_KEY:-${NGC_CLI_API_KEY:-}}"
       RTVI_EXTRA_ARGS: "${RTVI_EXTRA_ARGS:-}"
       HF_TOKEN: "${HF_TOKEN:-}"
@@ -165,6 +164,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 1200s
+    networks: [app-network]
     restart: unless-stopped
     depends_on:
       broker-health-check:
@@ -194,6 +194,10 @@ services:
       qwen3-vl-8b-instruct-shared-gpu:
         condition: service_healthy
         required: false
+
+networks:
+  app-network:
+    driver: bridge
 
 volumes:
   rtvi-hf-cache:

--- a/deploy/docker/services/video-summarization/.env
+++ b/deploy/docker/services/video-summarization/.env
@@ -42,7 +42,7 @@ LVS_ENABLE_MCP=false
 
 # Database Configuration - Elasticsearch
 # Update these to point to your external Elasticsearch service
-ES_HOST=${HOST_IP}
+ES_HOST=elasticsearch
 ES_PORT=9200
 ES_TRANSPORT_PORT=9300
 

--- a/deploy/docker/services/video-summarization/compose.yml
+++ b/deploy/docker/services/video-summarization/compose.yml
@@ -16,11 +16,12 @@
 services:
   lvs-server:
     image: ${CONTAINER_IMAGE:-nvcr.io/nvidia/vss-core/vss-video-summarization:3.2.0}
-    container_name: vss-lvs
 
     profiles: ["bp_developer_lvs_2d"]
 
-    network_mode: host
+    networks: [app-network]
+    ports:
+      - "${LVS_BACKEND_PORT:-38111}:38111"
 
     # Volume mounts
     volumes:
@@ -173,6 +174,6 @@ services:
         condition: service_healthy
         required: false
 
-    # Network mode: bridge (default) to enable port mapping
-    # To use host network instead (ignores port mapping), uncomment:
-    # network_mode: host
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
Remove hardcoded container_name fields and move the LVS-profile services (infra, NIM, rtvi-vlm, lvs-server, nvstreamer, kibana-init) from host networking to a shared app-network bridge with parametrized host port mappings. Inter-service references now use Docker service names (kafka:9092, elasticsearch:9200, nvidia-nemotron-nano-9b-v2:8000, rtvi-vlm:8000) instead of localhost/${HOST_IP}.

Goal: allow multiple LVS instances per host without container-name or port collisions on shared dev machines.

Scope note: conversion is partial. Config files (kibana.yml, logstash pipelines, ES init scripts), the 7 non-LVS NIM services, and host-networked consumers (vss-agent, vios stack, haproxy) still reference localhost/${HOST_IP} and need updating before multi-instance is fully functional. These shared definitions are also used by the warehouse/search/alerts profiles.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
