### PR TITLE
fix: search rtsp streams with proper message shape

### DIFF
--- a/skills/vss-search-archive/SKILL.md
+++ b/skills/vss-search-archive/SKILL.md
@@ -241,6 +241,8 @@ curl -s -X POST http://${HOST_IP}:8000/generate \
 
 ### More Examples
 
+Use the `messages` request shape when passing structured request options such as `search_source_type`; the `input_message` shortcut does not accept extra fields.
+
 ```bash
 # Search by object
 curl -s -X POST http://${HOST_IP}:8000/generate \
@@ -260,7 +262,7 @@ curl -s -X POST http://${HOST_IP}:8000/generate \
 # Consider only RTSP sources with `search_source_type` filter i.e. live camera streams
 curl -s -X POST http://${HOST_IP}:8000/generate \
   -H "Content-Type: application/json" \
-  -d '{"input_message": "find all instances of forklifts", "search_source_type": "rtsp"}' | jq .
+  -d '{"messages": [{"role": "user", "content": "find all instances of forklifts"}], "search_source_type": "rtsp"}' | jq .
 ```
 
 ### Advanced control knobs

--- a/skills/vss-search-archive/references/discovery_modes.md
+++ b/skills/vss-search-archive/references/discovery_modes.md
@@ -21,6 +21,7 @@ Typical follow-ups:
 When the camera location and time window are known. Reduces search space and returns faster, more relevant results.
 
 Specify camera names as the video sources in the user input. Set explicit time range, keep critic enabled.
+For RTSP camera streams, use the RTSP `messages` + `search_source_type` request shape from the main SKILL.md instead of the `input_message` shortcut.
 
 ```bash
 curl -s -X POST http://${HOST_IP}:8000/generate \

--- a/skills/vss-search-archive/references/troubleshooting.md
+++ b/skills/vss-search-archive/references/troubleshooting.md
@@ -67,11 +67,21 @@ curl -s -X POST http://${HOST_IP}:${PORT}/v1/chat/completions \
 # List all indices with doc counts
 curl -s "http://${HOST_IP}:9200/_cat/indices?h=index,docs.count,store.size&v"
 
-# Count embeddings
+# Count uploaded video_file embeddings
 curl -s "http://${HOST_IP}:9200/mdx-embed-filtered-2025-01-01/_count"
 
-# Sample one embedding doc (without the vector)
+# Count RTSP embeddings for a source name; RTSP streams use date-based indices
+curl -s "http://${HOST_IP}:9200/mdx-embed-filtered-*,-mdx-embed-filtered-2025-01-01/_count" \
+  -H "Content-Type: application/json" \
+  -d '{"query": {"query_string": {"query": "*<sensor-name>*"}}}'
+
+# Sample one uploaded video_file embedding doc (without the vector)
 curl -s "http://${HOST_IP}:9200/mdx-embed-filtered-2025-01-01/_search?size=1&pretty" \
   -H "Content-Type: application/json" \
   -d '{"_source": {"excludes": ["embedding"]}, "query": {"match_all": {}}}'
+
+# Sample one RTSP embedding doc for a source name (without the vector)
+curl -s "http://${HOST_IP}:9200/mdx-embed-filtered-*,-mdx-embed-filtered-2025-01-01/_search?size=1&pretty" \
+  -H "Content-Type: application/json" \
+  -d '{"_source": {"excludes": ["embedding"]}, "query": {"query_string": {"query": "*<sensor-name>*"}}}'
 ```


### PR DESCRIPTION
## Description
The issue was that the vss-search-archive skill documented an invalid RTSP /generate request shape: 
- either it uses `input_message` with `search_source_type`, but this API only accepts extra options with the `messages` envelope.
- or it uses `input_message` only, with “rtsp” in text → accepted, but defaults to video_file internally and searches the wrong index.

We updated the skill and RTSP troubleshooting references accordingly to differentiate video file vs RTSP operations as well. We document the proper message shape for RTSP.

Tested on new Brev machine with search profile deployment. Reproduced and tested fix.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<img width="1312" height="803" alt="Screenshot 2026-06-09 at 1 31 00 PM" src="https://github.com/user-attachments/assets/071abdbd-aa95-4dd8-95bc-d08eae9bbdbb" />
