### PR TITLE
Enforce uniform 405 for unsupported HTTP methods on VST APIs

### DIFF
--- a/services/vios/src/framework/apis/common/modules_apis.cpp
+++ b/services/vios/src/framework/apis/common/modules_apis.cpp
@@ -388,6 +388,7 @@ namespace vst_recorder
             Json::Value in;
             Json::Value out;
             struct mg_connection *conn = nullptr;
+            req_info["method"] = "post";
             in["id"] = id;
             in["url"] = url;
             if (recorder != nullptr && recorder->m_func.find(api_key) != recorder->m_func.end() &&
@@ -801,6 +802,7 @@ namespace vst_replaystream
             Json::Value in;
             Json::Value out;
             struct mg_connection *conn = nullptr;
+            req_info["method"] = "post";
             in["id"] = id;
             in["url"] = url;
             auto func_map = replay_mngt->getHttpApi();

--- a/services/vios/src/framework/apis/common/vst_common.cpp
+++ b/services/vios/src/framework/apis/common/vst_common.cpp
@@ -1954,8 +1954,8 @@ namespace vst_common
         if (!(iequals(request_method, "get")))
         {
             LOG(error) << "Request Method is not supported" << endl;
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, out, "Request Method is not supported");
-            return VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, out, "Request Method is not supported");
+            return VmsErrorCode::MethodNotAllowedError;
         }
 
         int streamCount = 0;

--- a/services/vios/src/modules/sensor_management/sensor_management_apis.cpp
+++ b/services/vios/src/modules/sensor_management/sensor_management_apis.cpp
@@ -36,20 +36,39 @@ SensorManagementApis::SensorManagementApis(std::shared_ptr<SensorManagement> sen
         {
             return getSensorInfoList(req_info, out);
         }
-        return VmsErrorCode::NoError;
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func["/api/v1/sensor/streams"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
-        return vst_common::getSensorStreamListFromDB(m_deviceManager, out, true);
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (iequals(requestMethod, "get"))
+        {
+            return vst_common::getSensorStreamListFromDB(m_deviceManager, out, true);
+        }
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func["/api/v1/sensor/scan"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
-        m_sensorManagement->scanCameras(true);
-        return VmsErrorCode::NoError;
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (iequals(requestMethod, "post"))
+        {
+            m_sensorManagement->scanCameras(true);
+            return VmsErrorCode::NoError;
+        }
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func["/api/v1/sensor/add"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
-        return addSensor(m_sensorManagement, req_info, in, out);
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (iequals(requestMethod, "post"))
+        {
+            return addSensor(m_sensorManagement, req_info, in, out);
+        }
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func["/api/v1/sensor/status"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
@@ -58,7 +77,8 @@ SensorManagementApis::SensorManagementApis(std::shared_ptr<SensorManagement> sen
         {
             return getAllSensorStatus(m_deviceManager, out);
         }
-        return VmsErrorCode::NoError;
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func["/api/v1/sensor/configuration"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
@@ -66,15 +86,33 @@ SensorManagementApis::SensorManagementApis(std::shared_ptr<SensorManagement> sen
     };
     m_func["/api/v1/sensor/version"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
-        return getVersion(req_info, in, out);
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (iequals(requestMethod, "get"))
+        {
+            return getVersion(req_info, in, out);
+        }
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func["/api/v1/sensor/help"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
-        return getSensorHelp(req_info, in, out);
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (iequals(requestMethod, "get"))
+        {
+            return getSensorHelp(req_info, in, out);
+        }
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func["/api/v1/sensor/qos"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
-        return getSensorQosInfo(req_info, out);
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (iequals(requestMethod, "get"))
+        {
+            return getSensorQosInfo(req_info, out);
+        }
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func["/v1/live"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
@@ -95,7 +133,8 @@ SensorManagementApis::SensorManagementApis(std::shared_ptr<SensorManagement> sen
         {
             return getAllSensorTimelines(req_info, out);
         }
-        return VmsErrorCode::NoError;
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+        return VmsErrorCode::MethodNotAllowedError;
     };
     m_func[SENSOR_API] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
@@ -203,6 +242,11 @@ VmsErrorCode SensorManagementApis::handleSensorConfiguration(const Json::Value& 
                 }
             }
         }
+    }
+    else
+    {
+        SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+        return VmsErrorCode::MethodNotAllowedError;
     }
     return ret;
 }

--- a/services/vios/src/modules/storage_management/storage_management.cpp
+++ b/services/vios/src/modules/storage_management/storage_management.cpp
@@ -1253,8 +1253,8 @@ VmsErrorCode StorageManagement::checkStorageCapacity(const Json::Value & req_inf
     if (!(iequals(request_method, "post")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     vector<string> fileList;
@@ -1298,7 +1298,7 @@ VmsErrorCode StorageManagement::getStorageConfiguration(const Json::Value & req_
     }
     else
     {
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
         ret = VmsErrorCode::MethodNotAllowedError;
     }
     return ret;
@@ -2003,8 +2003,8 @@ VmsErrorCode StorageManagement::getUsedStorageSize(const Json::Value& req_info, 
     if (!(iequals(request_method, "get")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     int streamCount = 0;
@@ -2204,8 +2204,8 @@ VmsErrorCode StorageManagement::updateStorageSize(const Json::Value& req_info, c
     if (!(iequals(request_method, "post")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     vector<string> fileList;
@@ -2254,8 +2254,8 @@ VmsErrorCode StorageManagement::doAging(const Json::Value& req_info, const Json:
     if (!(iequals(request_method, "post")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     vector<string> fileList;
@@ -2287,8 +2287,8 @@ VmsErrorCode StorageManagement::addOrRemoveFileInProtectList(const Json::Value& 
     if (!(iequals(request_method, "post")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     vector<string> fileList;
@@ -2385,8 +2385,8 @@ VmsErrorCode StorageManagement::deleteFilesByNames(const Json::Value& req_info, 
     if (!(iequals(request_method, "delete")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     string id;
@@ -2733,8 +2733,8 @@ VmsErrorCode StorageManagement::getStorageInfo(const Json::Value& req_info, Json
     if (!(iequals(request_method, "get")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     DeviceConfig config = GET_CONFIG();
@@ -2774,8 +2774,8 @@ VmsErrorCode StorageManagement::getProtectedFiles(const Json::Value& req_info, J
     if (!(iequals(request_method, "get")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     {
@@ -3056,8 +3056,8 @@ VmsErrorCode StorageManagement::importFileFromCloud(const Json::Value& req_info,
     if (!(iequals(request_method, "post")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     // Check max sensors limit
@@ -3322,8 +3322,8 @@ VmsErrorCode StorageManagement::listCloudFiles(const Json::Value& req_info, cons
     if (!(iequals(request_method, "get")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     // Parse query parameters
@@ -3620,8 +3620,8 @@ VmsErrorCode StorageManagement::listLocalFiles(const Json::Value& req_info, cons
     if (!(iequals(request_method, "get")))
     {
         LOG(error) << "Request Method is not supported" << endl;
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        return VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        return VmsErrorCode::MethodNotAllowedError;
     }
 
     // Parse query parameters (both are optional)

--- a/services/vios/src/modules/storage_management/storage_management_apis.cpp
+++ b/services/vios/src/modules/storage_management/storage_management_apis.cpp
@@ -70,6 +70,12 @@ void StorageManagement::storageManagementApis()
     m_func["/api/v1/storage/configuration"] = [this](const Json::Value& req_info, const Json::Value &in,
                                 Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -83,6 +89,12 @@ void StorageManagement::storageManagementApis()
     m_func["/api/v1/storage/version"] = [this](const Json::Value& req_info, const Json::Value &in,
                                 Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -99,6 +111,12 @@ void StorageManagement::storageManagementApis()
     m_func["/api/v1/storage/help"] = [this](const Json::Value& req_info, const Json::Value &in,
                                 Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         Json::CharReaderBuilder builder;
         std::istringstream iss(gStorageManagementApiList);
 
@@ -131,6 +149,12 @@ void StorageManagement::storageManagementApis()
     m_func["/api/v1/storage/file/mediainfo"] = [this](const Json::Value& req_info, const Json::Value &in,
                                 Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -157,13 +181,19 @@ void StorageManagement::storageManagementApis()
         }
         else
         {
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-            return VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+            return VmsErrorCode::MethodNotAllowedError;
         }
     };
 
     m_func["/api/v1/storage/file/protect"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -175,6 +205,12 @@ void StorageManagement::storageManagementApis()
 
     m_func["/api/v1/storage/info"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -186,6 +222,12 @@ void StorageManagement::storageManagementApis()
 
     m_func["/api/v1/storage/file/protected"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -199,6 +241,12 @@ void StorageManagement::storageManagementApis()
 
     m_func["/api/v1/storage/aging"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -210,6 +258,12 @@ void StorageManagement::storageManagementApis()
 
     m_func["/api/v1/storage/size/update"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -221,6 +275,12 @@ void StorageManagement::storageManagementApis()
 
     m_func["/api/v1/storage/capacity"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -232,6 +292,12 @@ void StorageManagement::storageManagementApis()
 
     m_func["/api/v1/storage/file/list"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StorageManagement* storageMngt = GET_STORAGE_MNGT();
         if (storageMngt == nullptr)
         {
@@ -270,8 +336,8 @@ void StorageManagement::storageManagementApis()
         }
         else
         {
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, out, "Request Method is not supported");
-            return VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, out, "Request Method is not supported");
+            return VmsErrorCode::MethodNotAllowedError;
         }
     };
 
@@ -286,8 +352,8 @@ void StorageManagement::storageManagementApis()
         }
         else
         {
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-            return VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+            return VmsErrorCode::MethodNotAllowedError;
         }
     };
 
@@ -347,8 +413,8 @@ void StorageManagement::storageManagementApis()
         }
         else
         {
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-            return VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+            return VmsErrorCode::MethodNotAllowedError;
         }
     };
 
@@ -389,8 +455,8 @@ VmsErrorCode StorageManagement::handleStorageFileAPIrequest(const Json::Value& r
         }
         else
         {
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-            ret = VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+            ret = VmsErrorCode::MethodNotAllowedError;
         }
     }
     /* Upload API*/
@@ -706,8 +772,8 @@ VmsErrorCode StorageManagement::handleStorageFileAPIrequest(const Json::Value& r
             }
             else
             {
-                SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-                ret = VmsErrorCode::VMSNotSupportedError;
+                SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+                ret = VmsErrorCode::MethodNotAllowedError;
             }
         }
         else if((iequals(requestMethod, "delete")) && (requestApi.find(STORAGE_FILE_API_PREFIX) != string::npos))
@@ -761,14 +827,14 @@ VmsErrorCode StorageManagement::handleStorageFileAPIrequest(const Json::Value& r
             }
             else
             {
-                SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-                ret = VmsErrorCode::VMSNotSupportedError;
+                SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+                ret = VmsErrorCode::MethodNotAllowedError;
             }
         }
         else
         {
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-            ret = VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+            ret = VmsErrorCode::MethodNotAllowedError;
         }
     }
     else if (requestApi.find(STORAGE_API_PREFIX) != string::npos)
@@ -890,20 +956,20 @@ VmsErrorCode StorageManagement::handleStorageFileAPIrequest(const Json::Value& r
             }
             else
             {
-                SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-                ret = VmsErrorCode::VMSNotSupportedError;
+                SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+                ret = VmsErrorCode::MethodNotAllowedError;
             }
         }
         else
         {
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-            ret = VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+            ret = VmsErrorCode::MethodNotAllowedError;
         }
     }
     else
     {
-        SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, response, "Request Method is not supported");
-        ret = VmsErrorCode::VMSNotSupportedError;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, "Request Method is not supported");
+        ret = VmsErrorCode::MethodNotAllowedError;
     }
     return ret;
 }

--- a/services/vios/src/modules/stream_recorder/recorder_apis.cpp
+++ b/services/vios/src/modules/stream_recorder/recorder_apis.cpp
@@ -43,6 +43,12 @@ void StreamRecorder::recorderApis()
     m_func["/api/v1/record/streams"] = [this](const Json::Value& req_info, const Json::Value &in,
                                 Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StreamRecorder* recorder = GET_RECORDER();
         if (recorder == nullptr)
         {
@@ -54,6 +60,12 @@ void StreamRecorder::recorderApis()
 	m_func["/api/v1/record/stream/add"] = [this](const Json::Value& req_info, const Json::Value &in,
                                 Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         string url = in.get("url", EMPTY_STRING).asString();
         string id = in.get("id", EMPTY_STRING).asString();
         string codec = in.get("codec", EMPTY_STRING).asString();
@@ -104,6 +116,12 @@ void StreamRecorder::recorderApis()
     };
     m_func["/api/v1/record/status"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StreamRecorder* recorder = GET_RECORDER();
         if (recorder == nullptr)
         {
@@ -114,6 +132,12 @@ void StreamRecorder::recorderApis()
     };
     m_func["/api/v1/record/configuration"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StreamRecorder* recorder = GET_RECORDER();
         if (recorder == nullptr)
         {
@@ -125,6 +149,12 @@ void StreamRecorder::recorderApis()
     m_func["/api/v1/record/version"] = [this](const Json::Value& req_info, const Json::Value &in,
                                 Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         StreamRecorder* recorder = GET_RECORDER();
         if (recorder == nullptr)
         {
@@ -139,6 +169,12 @@ void StreamRecorder::recorderApis()
     m_func["/api/v1/record/help"] = [this](const Json::Value& req_info, const Json::Value &in,
                                 Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         Json::CharReaderBuilder builder;
         std::istringstream iss(gRecorderApiList);
 
@@ -166,8 +202,8 @@ void StreamRecorder::recorderApis()
         }
         else
         {
-            SET_VMS_ERROR2(VmsErrorCode::VMSNotSupportedError, out, "Request Method is not supported");
-            return VmsErrorCode::VMSNotSupportedError;
+            SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, out, "Request Method is not supported");
+            return VmsErrorCode::MethodNotAllowedError;
         }
     };
     m_func["/v1/live"] = [this](const Json::Value& req_info, const Json::Value &in,

--- a/services/vios/src/modules/webrtc_live/LivePeerConnection.cpp
+++ b/services/vios/src/modules/webrtc_live/LivePeerConnection.cpp
@@ -106,6 +106,12 @@ LivePeerConnection::LivePeerConnection(std::shared_ptr<PeerConnectionManager> pe
 
 	m_func["/api/v1/live/stream/add"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         string url = in.get("url", EMPTY_STRING).asString();
         string id = in.get("id", EMPTY_STRING).asString();
 
@@ -316,6 +322,12 @@ LivePeerConnection::LivePeerConnection(std::shared_ptr<PeerConnectionManager> pe
     };
     m_func["/api/v1/live/stream/swap"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         VmsErrorCode ret;
         const string protocol = in.get("protocol", EMPTY_STRING).asString();
         const string startTime = in.get("startTime", EMPTY_STRING).asString();
@@ -336,6 +348,12 @@ LivePeerConnection::LivePeerConnection(std::shared_ptr<PeerConnectionManager> pe
     };
     m_func["/api/v1/live/stream/stats"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         if (GET_CONFIG().enable_perf_logging == false)
         {
             LOG(error) << "Stream stats not enabled";
@@ -390,10 +408,22 @@ LivePeerConnection::LivePeerConnection(std::shared_ptr<PeerConnectionManager> pe
     };
     m_func["/api/v1/live/version"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         return getVersion(req_info, in, out);
     };
     m_func["/api/v1/live/help"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         return getLiveHelp(req_info, in, out);
     };
     m_func["/v1/live"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode

--- a/services/vios/src/modules/webrtc_replay/ReplayPeerConnection.cpp
+++ b/services/vios/src/modules/webrtc_replay/ReplayPeerConnection.cpp
@@ -120,6 +120,12 @@ ReplayPeerConnection::ReplayPeerConnection(std::shared_ptr<PeerConnectionManager
 
 	m_func["/api/v1/replay/stream/add"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         string url = in.get("url", EMPTY_STRING).asString();
         string id = in.get("id", EMPTY_STRING).asString();
 
@@ -381,6 +387,12 @@ ReplayPeerConnection::ReplayPeerConnection(std::shared_ptr<PeerConnectionManager
     };
     m_func["/api/v1/replay/stream/swap"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "post"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         VmsErrorCode ret;
         const string protocol = in.get("protocol", EMPTY_STRING).asString();
         const string startTime = in.get("startTime", EMPTY_STRING).asString();
@@ -401,6 +413,12 @@ ReplayPeerConnection::ReplayPeerConnection(std::shared_ptr<PeerConnectionManager
     };
     m_func["/api/v1/replay/stream/stats"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &response, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, response)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         if (GET_CONFIG().enable_perf_logging == false)
         {
             LOG(error) << "Stream stats not enabled";
@@ -436,10 +454,22 @@ ReplayPeerConnection::ReplayPeerConnection(std::shared_ptr<PeerConnectionManager
     };
     m_func["/api/v1/replay/version"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         return getVersion(req_info, in, out);
     };
     m_func["/api/v1/replay/help"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode
     {
+        const string requestMethod = req_info.get("method", UNKNOWN_STRING).asString();
+        if (!iequals(requestMethod, "get"))
+        {
+            SET_VMS_ERROR(VmsErrorCode::MethodNotAllowedError, out)
+            return VmsErrorCode::MethodNotAllowedError;
+        }
         return getReplayHelp(req_info, in, out);
     };
     m_func["/v1/live"] = [this](const Json::Value& req_info, const Json::Value &in, Json::Value &out, struct mg_connection *conn) -> VmsErrorCode

--- a/services/vios/test/bdd_tests/features/unit_tests/sensor_management/http_method_validation.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/sensor_management/http_method_validation.feature
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: VST HTTP method validation returns 405 uniformly (NVBug 6267433)
+  Wrong HTTP verbs on routed VST endpoints must be rejected uniformly with
+  405 MethodNotAllowedError and a consistent {error_code, error_message} body,
+  instead of the old inconsistent mix of 200 / 400 / 501. This spans the shared
+  HTTP request handler used by sensor, storage and recorder endpoints.
+
+  All wrong-verb requests below are non-mutating: a write verb on a read-only
+  endpoint (and a read verb on a write-only endpoint) must be rejected BEFORE
+  the handler runs, so the test never changes server state on a fixed build.
+
+  Background:
+    Given the VST API is accessible
+
+  Scenario Outline: Unsupported method on a routed endpoint returns 405 with MethodNotAllowedError
+    When I send a <method> request to "<path>"
+    Then the response status code is 405
+    And the response error_code is "MethodNotAllowedError"
+    And the response error_message is not empty
+
+    # Read-only (GET) endpoints must reject write verbs.
+    # Previously: 200 (+ data / null) on sensor paths, 501 on storage/info & storage/size.
+    Examples: GET-only endpoints reject POST/PUT/DELETE
+      | method | path                          |
+      | POST   | /vst/api/v1/sensor/list       |
+      | PUT    | /vst/api/v1/sensor/list       |
+      | DELETE | /vst/api/v1/sensor/list       |
+      | POST   | /vst/api/v1/sensor/streams    |
+      | POST   | /vst/api/v1/sensor/status     |
+      | POST   | /vst/api/v1/sensor/timelines  |
+      | POST   | /vst/api/v1/sensor/version    |
+      | POST   | /vst/api/v1/record/status     |
+      | POST   | /vst/api/v1/storage/info      |
+      | POST   | /vst/api/v1/storage/size      |
+
+    # Write-only (POST) endpoints must reject read/other verbs.
+    # Previously: GET/DELETE on sensor/add returned 400 InvalidParameterError.
+    Examples: POST-only endpoints reject GET/DELETE
+      | method | path                     |
+      | GET    | /vst/api/v1/sensor/add   |
+      | DELETE | /vst/api/v1/sensor/add   |
+      | GET    | /vst/api/v1/sensor/scan  |
+
+  Scenario Outline: The supported verb still succeeds (the guard does not block valid requests)
+    When I send a <method> request to "<path>"
+    Then the response status code is 200
+
+    Examples: Control — read endpoints still serve GET
+      | method | path                       |
+      | GET    | /vst/api/v1/sensor/list    |
+      | GET    | /vst/api/v1/sensor/status  |
+      | GET    | /vst/api/v1/sensor/version |

--- a/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_http_method_validation.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_http_method_validation.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for uniform HTTP method validation (NVBug 6267433).
+
+Wrong HTTP verbs on routed VST endpoints used to produce an inconsistent mix of
+outcomes: read-only sensor endpoints executed their GET logic and returned 200
+(POST /sensor/streams even returned the full payload), sensor/add returned 400,
+and storage/info & storage/size returned 501. The fix makes every handler reject
+an unsupported verb uniformly with 405 MethodNotAllowedError plus the standard
+{error_code, error_message} body.
+
+Every wrong-verb request exercised here is non-mutating: a write verb against a
+read-only endpoint, or a read verb against a write-only endpoint, must be
+rejected before the handler runs, so a passing (fixed) build is never mutated by
+this test. On an unfixed build the read-only sensor cases would return 200, the
+sensor/add cases 400, and storage/info & storage/size 501 — each failing the
+405 assertion, which is the regression signal.
+"""
+import logging
+
+import requests
+from pytest_bdd import given, scenarios, when, then, parsers
+
+from ..unit_test_utils import UnitTestContext
+
+logger = logging.getLogger(__name__)
+
+scenarios(
+    "../../../features/unit_tests/sensor_management/http_method_validation.feature"
+)
+
+
+# ---------------------------------------------------------------------------
+# Background
+# ---------------------------------------------------------------------------
+
+@given("the VST API is accessible")
+def vst_api_accessible(api_config: dict) -> None:
+    assert api_config["base_url"], "Base URL must be configured"
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+@when(parsers.parse('I send a {method} request to "{path}"'))
+def send_request_with_method(
+    context: UnitTestContext,
+    api_config: dict,
+    unit_test_params: dict,
+    method: str,
+    path: str,
+) -> None:
+    """Issue an arbitrary-verb request and capture the response on the context.
+
+    No request body is sent: the bug repro used bodyless wrong-verb requests,
+    and an empty body keeps body-bearing methods (POST/PUT) past the
+    dispatcher's schema validation so they reach the handler's method check.
+    """
+    base_url = api_config["base_url"]
+    verify_ssl = api_config.get("verify_ssl", False)
+    timeout = unit_test_params.get("timeout", 30)
+    url = f"{base_url}{path}"
+
+    logger.info("%s %s", method, url)
+    resp = requests.request(
+        method,
+        url,
+        timeout=timeout,
+        verify=verify_ssl,
+    )
+    context.response = resp
+    context.status_code = resp.status_code
+    try:
+        context.response_json = resp.json()
+    except ValueError:
+        context.response_json = None
+    logger.info(
+        "Response: status=%d body=%s",
+        resp.status_code,
+        str(context.response_json)[:300],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+@then(parsers.parse("the response status code is {expected_status:d}"))
+def assert_status_code(context: UnitTestContext, expected_status: int) -> None:
+    assert context.status_code == expected_status, (
+        f"Expected status {expected_status}, got {context.status_code}. "
+        f"Body: {str(context.response_json)[:500]}"
+    )
+
+
+@then(parsers.parse('the response error_code is "{expected_code}"'))
+def assert_error_code(context: UnitTestContext, expected_code: str) -> None:
+    assert isinstance(context.response_json, dict), (
+        f"Expected a JSON object body carrying error_code, got: "
+        f"{str(context.response_json)[:300]}"
+    )
+    actual = context.response_json.get("error_code")
+    assert actual == expected_code, (
+        f"Expected error_code '{expected_code}', got '{actual}'. "
+        f"Body: {str(context.response_json)[:500]}"
+    )
+
+
+@then("the response error_message is not empty")
+def assert_error_message_present(context: UnitTestContext) -> None:
+    assert isinstance(context.response_json, dict), (
+        f"Expected a JSON object body carrying error_message, got: "
+        f"{str(context.response_json)[:300]}"
+    )
+    message = context.response_json.get("error_message")
+    assert isinstance(message, str) and message.strip(), (
+        f"Expected a non-empty error_message, got: {message!r}. "
+        f"Body: {str(context.response_json)[:500]}"
+    )


### PR DESCRIPTION
Enforce uniform 405 for unsupported HTTP methods on VST APIs

## Description
* Reject unsupported verbs on sensor, storage, and recorder read endpoints with 405 MethodNotAllowedError instead of returning 200, 400, or 501.
* Guard write-only endpoints (sensor/add, sensor/scan, stream/add) against read verbs, and pass the method through the internal record and replay stream-add callers so they keep working.
* Normalize wrong-method paths that previously returned 501 VMSNotSupportedError to 405 across storage and recorder handlers.
* Add a pytest-bdd regression test asserting 405 and a consistent error_code on wrong-verb requests.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
