### PR TITLE
Fix: Add container gate loop at end of deploy

### DIFF
--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -333,7 +333,7 @@ be running and no required container may be `unhealthy`, `restarting`, or
 
 ```bash
 expected=$(docker compose --env-file "$ENV_GEN" -f "$REPO/deploy/docker/resolved.yml" config --services | wc -l)
-actual=$(docker compose -f "$REPO/deploy/docker/resolved.yml" ps -q | wc -l)
+actual=$(docker compose -f "$REPO/deploy/docker/resolved.yml" ps -a -q | wc -l)
 if [ "$expected" -le 0 ] || [ "$actual" -le 0 ] || [ "$actual" -lt "$expected" ]; then
   echo "FAIL: expected $expected services, got $actual" >&2
   exit 1
@@ -361,9 +361,9 @@ necessary with two concise sentences explaining what the issue was and what fix
 was applied dynamically.
 
 If targeted fix attempts do not work after multiple iterations to get the
-container check gate passing, gather useful evidence. These issues must be surfaces 
+container check gate passing, gather useful evidence. These issues must be surfaced
 in the final deploy summary. Do not declare the deploy complete by silently ignoring
-failed containers. Call them out explicitly with two concise sentences explaining what 
+failed containers. Call them out explicitly with two concise sentences explaining what
 the issue is and what was attempted.
 
 ## Tear Down

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -322,6 +322,50 @@ docker compose --env-file $ENV_GEN -f resolved.yml up -d
 
 Cold deploys can take 10–20 min, and each profile reference lists the required endpoints. **Never declare deploy done after `up -d`; only after every documented endpoint succeeds.**
 
+### Step 5c — Validation loop for deployment
+
+Before reporting success, run a whole-project container-state gate. This must
+inspect **all** containers from the resolved Compose project, including exited
+containers; `docker ps` alone is not enough because it hides crashed services.
+One-shot init containers may be `exited 0`, but every long-running service must
+be running and no required container may be `unhealthy`, `restarting`, or
+`exited` with a non-zero code.
+
+```bash
+expected=$(docker compose --env-file "$ENV_GEN" -f "$REPO/deploy/docker/resolved.yml" config --services | wc -l)
+actual=$(docker compose -f "$REPO/deploy/docker/resolved.yml" ps -q | wc -l)
+if [ "$expected" -le 0 ] || [ "$actual" -le 0 ] || [ "$actual" -lt "$expected" ]; then
+  echo "FAIL: expected $expected services, got $actual" >&2
+  exit 1
+fi
+
+bad=$(
+  docker compose -f "$REPO/deploy/docker/resolved.yml" ps -a --format json \
+    | jq -r 'select((.State == "running" or (.State == "exited" and .ExitCode == 0)) | not)
+             | "\(.Name)\t\(.State)\texit=\(.ExitCode // "?")\t\(.Status)"'
+)
+if [ -n "$bad" ]; then
+  echo "FAIL: failing containers:" >&2
+  echo "$bad" >&2
+  exit 1
+fi
+```
+
+If this container gate fails, report the failing container names, inspect their
+logs, and attempt a targeted fix for each failing container. Do not declare the
+deploy complete until this container check gate and the profile's endpoint
+checks pass.
+
+If the deploy completes in the end, call out what additional fixes were
+necessary with two concise sentences explaining what the issue was and what fix
+was applied dynamically.
+
+If targeted fix attempts do not work after multiple iterations to get the
+container check gate passing, gather useful evidence. These issues must be surfaces 
+in the final deploy summary. Do not declare the deploy complete by silently ignoring
+failed containers. Call them out explicitly with two concise sentences explaining what 
+the issue is and what was attempted.
+
 ## Tear Down
 
 To tear down a deployment — full host reclaim or cache-preserving redeploy / profile
@@ -338,8 +382,8 @@ Each profile reference has a **Debugging** section listing the exact commands an
 ### Quick checks (all profiles)
 
 ```bash
-# 1. All expected containers Up
-docker ps --format 'table {{.Names}}\t{{.Status}}'
+# 1. Run the Step 5c container-state gate.
+docker compose --env-file "$ENV_GEN" -f "$REPO/deploy/docker/resolved.yml" ps -a
 
 # 2. Agent API + UI responding
 curl -sf http://localhost:8000/health >/dev/null && echo "agent OK"

--- a/skills/vss-deploy-profile/evals/alerts_cv.json
+++ b/skills/vss-deploy-profile/evals/alerts_cv.json
@@ -14,6 +14,7 @@
       "query": "Deploy the VSS **alerts** profile on {{platform}} for CV-driven alert generation with VLM-as-verifier. Run end-to-end and autonomously.",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
+        "`test -z \"$(docker compose -f $REPO/deploy/docker/resolved.yml ps -a --format json | jq -r 'select((.State == \"running\" or (.State == \"exited\" and .ExitCode == 0)) | not) | .Name')\"` returns exit 0 (no resolved Compose containers are unhealthy, restarting, or exited non-zero)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
         "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared message bus)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (RT-CV perception \u2014 the 'CV' in this mode)",

--- a/skills/vss-deploy-profile/evals/alerts_vlm.json
+++ b/skills/vss-deploy-profile/evals/alerts_vlm.json
@@ -14,6 +14,7 @@
       "query": "Deploy the VSS **alerts** profile on {{platform}} for continuous VLM-driven alert generation. Run end-to-end and autonomously.",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
+        "`test -z \"$(docker compose -f $REPO/deploy/docker/resolved.yml ps -a --format json | jq -r 'select((.State == \"running\" or (.State == \"exited\" and .ExitCode == 0)) | not) | .Name')\"` returns exit 0 (no resolved Compose containers are unhealthy, restarting, or exited non-zero)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0 (Agent backend)",
         "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0 (shared message bus)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0 (continuous VLM processor \u2014 the 'VLM' in this mode)",

--- a/skills/vss-deploy-profile/evals/base.json
+++ b/skills/vss-deploy-profile/evals/base.json
@@ -15,6 +15,7 @@
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
+        "`test -z \"$(docker compose -f $REPO/deploy/docker/resolved.yml ps -a --format json | jq -r 'select((.State == \"running\" or (.State == \"exited\" and .ExitCode == 0)) | not) | .Name')\"` returns exit 0 (no resolved Compose containers are unhealthy, restarting, or exited non-zero)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0",

--- a/skills/vss-deploy-profile/evals/lvs.json
+++ b/skills/vss-deploy-profile/evals/lvs.json
@@ -15,6 +15,7 @@
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
+        "`test -z \"$(docker compose -f $REPO/deploy/docker/resolved.yml ps -a --format json | jq -r 'select((.State == \"running\" or (.State == \"exited\" and .ExitCode == 0)) | not) | .Name')\"` returns exit 0 (no resolved Compose containers are unhealthy, restarting, or exited non-zero)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0",

--- a/skills/vss-deploy-profile/evals/search.json
+++ b/skills/vss-deploy-profile/evals/search.json
@@ -15,6 +15,7 @@
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
+        "`test -z \"$(docker compose -f $REPO/deploy/docker/resolved.yml ps -a --format json | jq -r 'select((.State == \"running\" or (.State == \"exited\" and .ExitCode == 0)) | not) | .Name')\"` returns exit 0 (no resolved Compose containers are unhealthy, restarting, or exited non-zero)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0",

--- a/skills/vss-deploy-profile/evals/warehouse.json
+++ b/skills/vss-deploy-profile/evals/warehouse.json
@@ -15,6 +15,7 @@
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/health` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
+        "`test -z \"$(docker compose -f $REPO/deploy/docker/resolved.yml ps -a --format json | jq -r 'select((.State == \"running\" or (.State == \"exited\" and .ExitCode == 0)) | not) | .Name')\"` returns exit 0 (no resolved Compose containers are unhealthy, restarting, or exited non-zero)",
         "`curl -sf --max-time 15 http://localhost:8081/livez` returns exit 0 (Video Analytics API health endpoint responsive)",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
         "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",


### PR DESCRIPTION
## Description
The deploy skill could report success while a required container had already exited, because it only looked at running containers/endpoints.
e.g. in the Search profile this allowed vss-rtvi-cv to fail with exit code 255 while the rest of the stack appeared healthy.

Changes:
- Add a container gate loop at the end of a deploy. It inspects all resolved containers, including exited ones, and fails on unhealthy/restarting/non-zero exits, and attempts to solve them autonomously.
- The deploy should not report success by ignoring certain containers failing, it should at least call them out.
- Also updates the deploy evals accordingly to detect this.

This is a general approach to handling edge cases seen at runtime. It will be in addition to a separate PR that adds a targeted static fix for the vss-rtvi-cv failing with exit code 255.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
