### PR TITLE
fix(dev-profile-search): prepend /usr/lib64 to LD_LIBRARY_PATH so rtvi-cv finds the real libnvidia-ml on OpenShift

### DIFF
--- a/deploy/docker/services/rtvi/rtvi-cv/ds-start.sh
+++ b/deploy/docker/services/rtvi/rtvi-cv/ds-start.sh
@@ -7,6 +7,15 @@
 
 set -euo pipefail
 
+# RHEL hosts (Docker via nvidia-container-toolkit) and OpenShift/RHCOS (GPU Operator)
+# inject the real driver libraries (e.g. libnvidia-ml.so.1) into /usr/lib64, while
+# this Ubuntu-based DeepStream image looks under /usr/lib/x86_64-linux-gnu where it
+# only finds a 0-byte stub -> "libnvidia-ml.so.1: file too short" and the GStreamer
+# pipeline fails to create src_nvmultiurisrcbin. Prepend /usr/lib64 so the loader
+# resolves the real libs first; the image's path is preserved, so vanilla Ubuntu
+# Docker behavior is unchanged.
+export LD_LIBRARY_PATH=/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
 DS_MODEL_FAMILY="${DS_MODEL_FAMILY:?DS_MODEL_FAMILY must be set (cnn, rtdetr, sparse4d)}"
 STREAM_TYPE="${STREAM_TYPE:-kafka}"
 DS_MODE_FLAG="${DS_MODE_FLAG:-1}"

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/vss-rtvi-cv-configmap.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/vss-rtvi-cv-configmap.yaml
@@ -26,6 +26,14 @@ metadata:
 data:
   ds-start.sh: |
     #!/bin/bash
+    # OpenShift/RHCOS: the GPU Operator injects the real driver libraries (e.g.
+    # libnvidia-ml.so.1) into /usr/lib64 (RHEL layout), while this Ubuntu-based
+    # DeepStream image looks under /usr/lib/x86_64-linux-gnu where it only finds
+    # a 0-byte stub -> "libnvidia-ml.so.1: file too short" and the GStreamer
+    # pipeline fails to create src_nvmultiurisrcbin. Prepend /usr/lib64 so the
+    # loader resolves the real libs first; the image's path is preserved, so
+    # vanilla Kubernetes behavior is unchanged.
+    export LD_LIBRARY_PATH=/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     if [[ $MODEL_TYPE == "cnn" ]]; then
           echo "##### $MODEL_TYPE models will be used. #####"
           echo "##### Copying onnx-files to DS docker volume for preserving PVCs... #####"


### PR DESCRIPTION
## Summary
On OpenShift/RHCOS, `vss-rtvi-cv` (search profile) crashes with
`libnvidia-ml.so.1: file too short`, failing to create `src_nvmultiurisrcbin`.

## Cause
The GPU Operator injects the real driver libs into `/usr/lib64` (RHEL layout),
but the Ubuntu DeepStream image looks in `/usr/lib/x86_64-linux-gnu`, where it
finds only a 0-byte stub → loader picks the stub.

## Fix
Prepend `/usr/lib64` to `LD_LIBRARY_PATH` at the top of the search profile's
`ds-start.sh`:
\`export LD_LIBRARY_PATH=/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}\`

Prepend (not replace) → image paths preserved; no effect on vanilla k8s
(/usr/lib64 has no driver libs there). Container command unchanged.