### PR TITLE
Update VIOS UI skills for dev

### DIFF
--- a/services/vios/.claude/commands/ui-dev-server.md
+++ b/services/vios/.claude/commands/ui-dev-server.md
@@ -1,12 +1,14 @@
 ---
 description: Configure backend IP in config.tsx, install deps, and start the UI dev server
 argument-hint: <ip:port> [/path]
-allowed-tools: AskUserQuestion, Read, Edit, Bash(npm run install:link), Bash(npm run dev)
+allowed-tools: AskUserQuestion, Read, Edit, Bash
 ---
 
 ## Task
 
 Start the VST UI dev server pointed at a backend host.
+
+The UI project lives at `ui/vios-ui/` (package `vst-ui-ts`) relative to the `services/vios` tree. All `npm` commands below must run from that directory — `cd` into it first. Do not assume the session working directory is the UI project root.
 
 **Arguments provided:** $ARGUMENTS
 
@@ -20,7 +22,7 @@ Start the VST UI dev server pointed at a backend host.
 - Default path is `/vst` if none provided.
 - Construct the full URL: `http://<ip>:<port><path>`
 
-### 2. Edit `src/config.tsx`
+### 2. Edit `ui/vios-ui/src/config.tsx`
 
 Read the file first, then apply **one** of the two cases below:
 
@@ -93,10 +95,22 @@ const url = "<CONSTRUCTED_URL>"
 
 ### 3. Install dependencies
 
-Run `npm run install:link` from the project root.
+Run from `ui/vios-ui`:
+
+```bash
+cd ui/vios-ui && npm run install:link
+```
+
+This builds the sibling `ui/streaming-lib` package and links it as `vst-streaming-lib`.
 
 ### 4. Start the dev server
 
-Run `npm run dev` from the project root.
+Run from `ui/vios-ui`:
+
+```bash
+cd ui/vios-ui && npm run dev
+```
+
+The Vite dev server defaults to `http://localhost:5173`.
 
 Execute steps 2 → 3 → 4 in order.

--- a/services/vios/.claude/commands/ui-dev-server.md
+++ b/services/vios/.claude/commands/ui-dev-server.md
@@ -1,7 +1,7 @@
 ---
 description: Configure backend IP in config.tsx, install deps, and start the UI dev server
 argument-hint: <ip:port> [/path]
-allowed-tools: AskUserQuestion, Read, Edit, Bash
+allowed-tools: AskUserQuestion, Read, Edit, Bash(cd ui/vios-ui && npm run install:link), Bash(cd ui/vios-ui && npm run dev)
 ---
 
 ## Task

--- a/services/vios/.claude/commands/update-vst-ui.md
+++ b/services/vios/.claude/commands/update-vst-ui.md
@@ -16,23 +16,13 @@ The UI source lives at `<VIOS_DIR>/ui/vios-ui/` (package `vst-ui-ts`). The WebRT
 
 ## Step 1 — Locate the vios tree
 
-The VST UI deploys into the `vios` component, which lives at `services/vios/` inside the `video-search-and-summarization` monorepo. Resolve `VIOS_DIR` (the path to that `services/vios` directory) using this priority order:
+The VST UI source and its deployment targets all live inside the `vios` component (`services/vios/`) of the `video-search-and-summarization` monorepo. This skill runs from a session opened in that monorepo, so the tree is already checked out — no cloning is needed. Resolve `VIOS_DIR` (the path to the `services/vios` directory):
 
-1. **Argument provided** — if `$ARGUMENTS` is non-empty, use that path directly (it should point at the `services/vios` directory). Skip all further checks and go straight to verifying the directory exists.
-2. **Current directory** — if the current directory is itself a vios tree (contains `webroot` and `deployment/scaling/ingress`), use `.`; otherwise if `./services/vios` exists (you are at the monorepo root), use it.
-3. **Default location** — check `~/work/video-search-and-summarization/services/vios`.
+1. **Argument provided** — if `$ARGUMENTS` is non-empty, use that path directly (it should point at the `services/vios` directory).
+2. **Current directory is the vios tree** — if it contains `webroot` and `deployment/scaling/ingress`, use `.`.
+3. **Monorepo root** — if `./services/vios` exists, use it.
 
-If none of (1)–(3) resolves, use `AskUserQuestion` to ask:
-
-> "I couldn't find the vios tree (services/vios). Would you like to provide a path to an existing checkout, or should I clone the video-search-and-summarization monorepo from GitHub? (reply with a path, or type 'clone')"
-
-- If the user supplies a path, use that as `VIOS_DIR`.
-- If the user says `clone` (or any variant meaning "go ahead and clone"), clone the monorepo and point `VIOS_DIR` at its `services/vios` directory:
-
-```bash
-git clone git@github.com:NVIDIA-AI-Blueprints/video-search-and-summarization.git ~/work/video-search-and-summarization
-# VIOS_DIR=~/work/video-search-and-summarization/services/vios
-```
+Verify the resolved directory contains `ui/vios-ui` and `deployment/scaling/ingress`. If none of the above resolves (you are not inside a checkout), ask the user for the path to their `services/vios` directory rather than cloning.
 
 Store the resolved path as `VIOS_DIR` for subsequent steps.
 
@@ -144,7 +134,7 @@ git -C $VIOS_DIR commit -m "<COMMIT_MESSAGE>"
 ## Step 7 — Report results
 
 Report to the user:
-- Whether the vios tree was found locally or the monorepo was cloned, and the resolved `VIOS_DIR` path
+- The resolved `VIOS_DIR` path
 - The VST UI build commit/version used
 - Confirmation that old assets were removed from both targets
 - Confirmation that new dist files were copied to both targets

--- a/services/vios/.claude/commands/update-vst-ui.md
+++ b/services/vios/.claude/commands/update-vst-ui.md
@@ -1,23 +1,25 @@
 ---
 description: Build the VST UI and deploy the static files into the vios tree (services/vios of the video-search-and-summarization repo), both ingress/vst-ui and webroot, then commit.
 argument-hint: [/path/to/services/vios]
-allowed-tools: AskUserQuestion, Read, Bash, Bash(git clone *), Bash(git -C * status), Bash(git -C * add *), Bash(git -C * commit *), Bash(git -C * log *), Bash(npm run install:link), Bash(npm run build), Bash(rm -rf *), Bash(cp -r *)
+allowed-tools: AskUserQuestion, Read, Bash
 ---
 
 ## Task
 
-Build the VST UI and deploy the compiled static assets into the vios component (`services/vios`) of the video-search-and-summarization repository, replacing the old files in both deployment locations, then commit the repo.
+Build the VST UI and deploy the compiled static assets into the `vios` component (`services/vios`) of the video-search-and-summarization repository, replacing the old files in both deployment locations, then commit the repo.
+
+The UI source lives at `<VIOS_DIR>/ui/vios-ui/` (package `vst-ui-ts`). The WebRTC streaming library is the sibling `<VIOS_DIR>/ui/streaming-lib/` directory, built and linked by `npm run install:link`.
 
 **Arguments provided:** $ARGUMENTS
 
 ---
 
-## Step 1 — Locate or clone the vios tree
+## Step 1 — Locate the vios tree
 
 The VST UI deploys into the `vios` component, which lives at `services/vios/` inside the `video-search-and-summarization` monorepo. Resolve `VIOS_DIR` (the path to that `services/vios` directory) using this priority order:
 
 1. **Argument provided** — if `$ARGUMENTS` is non-empty, use that path directly (it should point at the `services/vios` directory). Skip all further checks and go straight to verifying the directory exists.
-2. **Current directory** — if `./services/vios` exists (you are at the monorepo root), use it; if the current directory is itself a vios tree (contains `webroot` and `deployment/scaling/ingress`), use `.`.
+2. **Current directory** — if the current directory is itself a vios tree (contains `webroot` and `deployment/scaling/ingress`), use `.`; otherwise if `./services/vios` exists (you are at the monorepo root), use it.
 3. **Default location** — check `~/work/video-search-and-summarization/services/vios`.
 
 If none of (1)–(3) resolves, use `AskUserQuestion` to ask:
@@ -28,7 +30,7 @@ If none of (1)–(3) resolves, use `AskUserQuestion` to ask:
 - If the user says `clone` (or any variant meaning "go ahead and clone"), clone the monorepo and point `VIOS_DIR` at its `services/vios` directory:
 
 ```bash
-git clone https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization.git ~/work/video-search-and-summarization
+git clone git@github.com:NVIDIA-AI-Blueprints/video-search-and-summarization.git ~/work/video-search-and-summarization
 # VIOS_DIR=~/work/video-search-and-summarization/services/vios
 ```
 
@@ -37,6 +39,8 @@ Store the resolved path as `VIOS_DIR` for subsequent steps.
 The two deployment targets inside `VIOS_DIR` are:
 - `TARGET_INGRESS = $VIOS_DIR/deployment/scaling/ingress/vst-ui`
 - `TARGET_WEBROOT = $VIOS_DIR/webroot`
+
+The UI source directory is `UI_DIR = $VIOS_DIR/ui/vios-ui`.
 
 ---
 
@@ -53,30 +57,30 @@ rm -rf $TARGET_WEBROOT/assets $TARGET_WEBROOT/favicon $TARGET_WEBROOT/index.html
 
 ## Step 3 — Install dependencies in the VST UI repo
 
-Run from the `vst-ui-ts` project root (the directory containing `package.json` — the working directory for this Claude session):
+Run from the UI source directory (`$UI_DIR`, the directory containing `package.json`):
 
 ```bash
-npm run install:link
+cd $UI_DIR && npm run install:link
 ```
 
-Wait for it to complete before continuing.
+This builds the sibling `ui/streaming-lib` package and links it as `vst-streaming-lib`. Wait for it to complete before continuing.
 
 ---
 
 ## Step 4 — Build the VST UI static files
 
 ```bash
-npm run build
+cd $UI_DIR && npm run build
 ```
 
-This runs `tsc && vite build` and outputs the static files to the `dist/` directory.
+This runs `tsc && vite build` and outputs the static files to `$UI_DIR/dist`.
 
 **Note:** `npm run dev` starts a live dev server and does **not** produce a `dist/` folder. Always use `npm run build` to generate deployable static assets.
 
 Wait for the build to complete. Verify `dist/` exists and is non-empty:
 
 ```bash
-ls dist/
+ls $UI_DIR/dist/
 ```
 
 If the build fails, stop and report the error to the user.
@@ -88,8 +92,8 @@ If the build fails, stop and report the error to the user.
 Copy every file and folder inside `dist/` to both target directories:
 
 ```bash
-cp -r dist/. $TARGET_INGRESS/
-cp -r dist/. $TARGET_WEBROOT/
+cp -r $UI_DIR/dist/. $TARGET_INGRESS/
+cp -r $UI_DIR/dist/. $TARGET_WEBROOT/
 ```
 
 Verify the copy:
@@ -103,10 +107,10 @@ ls $TARGET_WEBROOT/assets/ 2>/dev/null | head -5
 
 ## Step 6 — Commit the repo
 
-Get the current VST UI version or latest git commit short SHA from the VST UI repo to use in the commit message:
+Get the current VST UI version or latest git commit short SHA to use in the commit message:
 
 ```bash
-git log -1 --format="%h %s"
+git -C $VIOS_DIR log -1 --format="%h %s"
 ```
 
 Then stage and commit the changed files. Paths are relative to `VIOS_DIR` (i.e. `services/vios`):

--- a/services/vios/.claude/commands/update-vst-ui.md
+++ b/services/vios/.claude/commands/update-vst-ui.md
@@ -1,7 +1,7 @@
 ---
 description: Build the VST UI and deploy the static files into the vios tree (services/vios of the video-search-and-summarization repo), both ingress/vst-ui and webroot, then commit.
 argument-hint: [/path/to/services/vios]
-allowed-tools: AskUserQuestion, Read, Bash
+allowed-tools: AskUserQuestion, Read, Bash(cd * && npm run install:link), Bash(cd * && npm run build), Bash(ls *), Bash(rm -rf *), Bash(cp -r *), Bash(git -C * log *), Bash(git -C * add *), Bash(git -C * status), Bash(git -C * commit *)
 ---
 
 ## Task

--- a/services/vios/.claude/commands/vst-ui-dev.md
+++ b/services/vios/.claude/commands/vst-ui-dev.md
@@ -7,7 +7,9 @@ allowed-tools: AskUserQuestion, Read, Edit, Write, Bash, Bash(npm run format), B
 
 ## Overview
 
-The VST web client (`vst-ui-ts/`) is a React + TypeScript + Vite + MUI application. It connects to three possible backend types — **VST**, **MMS**, and **NVStreamer** — detected at runtime. WebRTC streaming comes from an external library (`vst-streaming-lib`) installed via the `vst-web-streamer` repo when running `npm run install:link`.
+The VST web client lives at `ui/vios-ui/` (package `vst-ui-ts`) relative to the `services/vios` tree. It is a React + TypeScript + Vite + MUI application that connects to three possible backend types — **VST**, **MMS**, and **NVStreamer** — detected at runtime. WebRTC streaming comes from `vst-streaming-lib`, the sibling `ui/streaming-lib/` directory, built and linked when running `npm run install:link`.
+
+All file paths in the Codebase Map below are relative to `ui/vios-ui/`, and all `npm`/`git` commands run from that directory — `cd ui/vios-ui` first. Do not assume the session working directory is the UI project root.
 
 Use this skill for any UI feature work. Follow the workflow top to bottom; skip steps only when clearly not applicable.
 
@@ -99,7 +101,7 @@ src/
 - **State:** Zustand store in `services/StateManagement.tsx`. Prefer reading state via store selectors; avoid prop-drilling through more than two levels.
 - **Styling:** MUI v5 with `sx` prop or `styled`. Theme lives in `theme/themeContextProvider.tsx`. Dark/light toggle is context-driven. Use theme tokens, not hard-coded colours.
 - **Scripts available:**
-  - `npm run install:link` — installs deps and links vst-web-streamer
+  - `npm run install:link` — installs deps and builds/links the sibling `ui/streaming-lib` as `vst-streaming-lib`
   - `npm run dev` — starts the Vite dev server
   - `npm run build` — production build → `dist/`
   - `npm run lint` — ESLint check
@@ -138,11 +140,11 @@ Make focused, minimal changes. Follow these conventions:
 
 ### Step 4 — Lint and format
 
-Run both checks after implementation is complete:
+Run both checks after implementation is complete (from `ui/vios-ui`):
 
 ```bash
-npm run format
-npm run lint
+cd ui/vios-ui && npm run format
+cd ui/vios-ui && npm run lint
 ```
 
 Fix every lint error before proceeding. Do not skip or suppress rules without user approval.
@@ -164,8 +166,8 @@ When the user is satisfied, proceed.
 ### Step 7 — Final lint and format pass
 
 ```bash
-npm run format
-npm run lint
+cd ui/vios-ui && npm run format
+cd ui/vios-ui && npm run lint
 ```
 
 Ensure the working tree is clean before committing.
@@ -192,15 +194,10 @@ git add <file1> <file2> ...
 git status
 ```
 
-Write a concise commit message (imperative mood, ≤72 chars on the first line):
+Check and follow the repo's commit conventions (branch naming, commit message format, trailers, attribution rules) — see `/vios-git`. Write a concise commit message (imperative mood, ≤72 chars on the first line):
 
 ```bash
-git commit -m "$(cat <<'EOF'
-<Short summary of what and why>
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
-EOF
-)"
+git commit -m "<Short summary of what and why>"
 ```
 
 ### Step 9 — Report and prompt for PR
@@ -224,5 +221,5 @@ Then say:
 ## Related Skills
 
 - `/ui-dev-server` — Configure backend IP and start the Vite dev server
-- `/update-vst-ui` — Build and deploy static assets to the vms_shim repo (VIOS/VST deployment)
+- `/update-vst-ui` — Build and deploy static assets into the vios tree (ingress/vst-ui and webroot)
 - `/security-review` — Run before committing sensitive changes

--- a/services/vios/.claude/commands/vst-ui-dev.md
+++ b/services/vios/.claude/commands/vst-ui-dev.md
@@ -2,7 +2,7 @@
 name: vst-ui-dev
 description: This skill should be used when the user asks to "add a feature", "fix a bug", "create a component", "implement UI", "update the VST UI", "change the dashboard", "modify the video player", or any other development task on the VST web client (vst-ui-ts TypeScript/React codebase). Covers the full development loop: plan → implement → lint/format → dev server → user review → commit → branch → PR.
 argument-hint: <feature description>
-allowed-tools: AskUserQuestion, Read, Edit, Write, Bash, Bash(npm run format), Bash(npm run lint), Bash(npm run install:link), Bash(git *)
+allowed-tools: AskUserQuestion, Read, Edit, Write, Bash(cd ui/vios-ui && npm run format), Bash(cd ui/vios-ui && npm run lint), Bash(cd ui/vios-ui && npm run install:link), Bash(git *)
 ---
 
 ## Overview

--- a/services/vios/CLAUDE.md
+++ b/services/vios/CLAUDE.md
@@ -91,6 +91,9 @@ The shared skills and guides live in `.claude/sqa/`.
 | `/build-help` | Get the exact `build.sh` command for any build scenario |
 | `/bdd-test` | Write feature files and pytest-bdd steps for a new feature |
 | `/ui-test` | Run playwright-based UI tests against a running VIOS instance |
+| `/vst-ui-dev` | Full development loop for the VST web client (`ui/vios-ui`, package `vst-ui-ts`): plan, implement, lint/format, dev server, commit, PR |
+| `/ui-dev-server` | Configure the backend endpoint in `ui/vios-ui/src/config.tsx`, install deps, and start the Vite dev server |
+| `/update-vst-ui` | Build the VST UI (`ui/vios-ui`) and deploy the static assets into the vios tree (`deployment/scaling/ingress/vst-ui` and `webroot`), then commit |
 | `/setup-maas-mcp` | Install NVIDIA MaaS MCP servers (GitLab, Jira, Confluence, etc.) |
 | `/review-mr [<MR-URL-or-IID>]` | Fetch all MR review comments, verify each against the codebase, fix valid issues, and post a reply to every comment |
 


### PR DESCRIPTION
Update VIOS UI skills

## Description
* Move the ui-dev-server, update-vst-ui, and vst-ui-dev skills into services/vios/.claude/commands so a vios session loads them.
* Run all UI npm, lint, and format commands from ui/vios-ui to match the services/vios working directory.
* Deploy update-vst-ui into the in-repo vios tree targets and drop the external repo and AI-attribution references.
* List the three UI skills in the CLAUDE.md commands table.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
