### PR TITLE
add GST_PLUGIN_PATH to fix primary_gie_conv from Alerts profile

### DIFF
--- a/deploy/docker/services/rtvi/rtvi-cv/ds-start.sh
+++ b/deploy/docker/services/rtvi/rtvi-cv/ds-start.sh
@@ -14,6 +14,12 @@ DS_MESSAGE_RATE="${DS_MESSAGE_RATE:-1}"
 DS_TRACKER_REID="${DS_TRACKER_REID:-false}"
 DS_SHOW_SENSOR_ID="${DS_SHOW_SENSOR_ID:-false}"
 
+# Prepend core DeepStream plugin dirs so GStreamer can find nvvideoconvert and
+# other elements required by metropolis_perception_app (e.g. alerts rtdetr-gdino).
+_ARCH="$(uname -m)"
+export GST_PLUGIN_PATH="/opt/nvidia/deepstream/deepstream/lib/gst-plugins:/usr/lib/${_ARCH}-linux-gnu/gstreamer-1.0/deepstream${GST_PLUGIN_PATH:+:${GST_PLUGIN_PATH}}"
+unset _ARCH
+
 # Shared: build extra flags from env vars
 build_extra_flags() {
     local flags=""


### PR DESCRIPTION
libgstnvvideoconvert.so fails to load during GStreamer plugin scan → blacklisted → primary_gie_conv fails

## Description
Fixes Alerts Verification (vss-rtvi-cv) failing to start with Failed to create 'primary_gie_conv'.  GStreamer was blacklisting libgstnvvideoconvert.so during plugin scan because core DeepStream plugin paths were not on GST_PLUGIN_PATH.  This change prepends the standard DeepStream plugin directories to GST_PLUGIN_PATH at the top of deploy/docker/services/rtvi/rtvi-cv/ds-start.sh

NVBUG ==> https://nvbugspro.nvidia.com/bug/6324793

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
