### PR TITLE
fix(skill): updating vss-deploy-detection-tracking-2d with VDR-suggested fix

### DIFF
--- a/skills/vss-deploy-detection-tracking-2d/SKILL.md
+++ b/skills/vss-deploy-detection-tracking-2d/SKILL.md
@@ -62,7 +62,7 @@ Unified skill for the **Real Time Video Intelligence CV (RTVI-CV)** microservice
 
 **Selection rule:** match the user's phrasing against the table above and immediately load the corresponding reference file. Do not mix the flows — DEPLOY assumes no running container yet; API USAGE assumes the container is already running on `http://<host>:9000`.
 
-If intent is genuinely ambiguous (e.g., the user says just "I want to use rtvi-cv"), ask one `AskQuestion`: deploy a new instance, or call an already-running one?
+If intent is genuinely ambiguous (e.g., the user says just "I want to use rtvi-cv"), ask one `AskUserQuestion`: deploy a new instance, or call an already-running one?
 
 ---
 
@@ -113,7 +113,7 @@ For the full inventory of helpers (cache, GPU checks, setup) browse
 1. **Read this file first.** It only routes — it does not contain workflows.
 2. **Match the user's intent** against the routing table above.
 3. **Load exactly one reference doc** (DEPLOY or API USAGE). Don't preload both — each reference is large and contains its own full contract.
-4. **Follow the loaded reference exactly.** The reference docs are the byte-for-byte preserved contracts from the predecessor skills `vss-deploy-detection-tracking-2d` (deploy/teardown/debug) and `rtvicv-api` (REST API) — every step ordering invariant, bash-batching rule, box-rendering rule, and `AskQuestion` contract is retained.
+4. **Follow the loaded reference exactly.** The reference docs are the byte-for-byte preserved contracts from the predecessor skills `vss-deploy-detection-tracking-2d` (deploy/teardown/debug) and `rtvicv-api` (REST API) — every step ordering invariant, bash-batching rule, box-rendering rule, and `AskUserQuestion` contract is retained.
 5. **For DEPLOY**, the reference doc enforces its own startup contract: one-line acknowledgement → planning-tool call (`TodoWrite` array of 5 todos, OR 5 successive `TaskCreate` calls on newer Claude Code) → Step 1 question. Do not narrate, do not pre-flight, and never print "loading TodoWrite/TaskCreate" or any deferred-tool resolution prose — the planning tool is loaded silently.
 
 ---
@@ -189,7 +189,7 @@ pressure, and they break the user's UX):
   into the DS main config's `[source-list]` block before app start.
   Switch to `dynamic` only when the user explicitly asks ("add streams
   later via REST", "use dynamic stream mode") OR when they pick `dynamic`
-  in the Step 2 AskQuestion. Picking `dynamic` for a generic "deploy
+  in the Step 2 AskUserQuestion. Picking `dynamic` for a generic "deploy
   rtvi-cv with N streams" query breaks the deploy rubric and the
   user's `/metrics` expectations. See
   [`references/pipeline-config.md`](references/pipeline-config.md)

--- a/skills/vss-deploy-detection-tracking-2d/assets/deploy-defaults.yml
+++ b/skills/vss-deploy-detection-tracking-2d/assets/deploy-defaults.yml
@@ -6,7 +6,7 @@
 #   • Local video file/directory  → replaces resolved `usecases.<X>.videos`
 #
 # This YAML never auto-deploys — it only pre-fills the *Recommended* choice
-# in `AskQuestion` blocks and supplies fall-back values when the user
+# in `AskUserQuestion` blocks and supplies fall-back values when the user
 # accepts the defaults.
 #
 # Path resolution

--- a/skills/vss-deploy-detection-tracking-2d/references/apply-config.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/apply-config.md
@@ -36,7 +36,7 @@ docker exec "$CONTAINER" /tmp/scripts/apply_config.sh \
 
 **Output markers to parse:**
 - `RESOLVE_OK: <label>=<path>` — 4.a found the asset
-- `RESOLVE_AMBIGUOUS: <label> count=<N>` — ambiguity → the skill must drive an `AskQuestion`, then re-run with `--onnx` / `--videos` flag
+- `RESOLVE_AMBIGUOUS: <label> count=<N>` — ambiguity → the skill must drive an `AskUserQuestion`, then re-run with `--onnx` / `--videos` flag
 - `ENGINE_PRELAUNCH: HIT_EXACT|HIT_COMPAT|MISS` — 4.f result
 - `CONFIG_APPLY_OK usecase=<uc> batch=<N> sink=<sink>` — all sub-steps done
 
@@ -369,7 +369,7 @@ NGC directory names change per version — discover them at runtime. The one-lin
 
 ```bash
 # resolve_or_ask <label> <find-expression...>  -> prints the chosen path on stdout;
-# drives an AskQuestion (via the agent) on ambiguity.
+# drives an AskUserQuestion (via the agent) on ambiguity.
 resolve_or_ask() {
     local label="$1"; shift
     mapfile -t CANDS < <(find "$@" 2>/dev/null | sort)
@@ -377,7 +377,7 @@ resolve_or_ask() {
         0)  echo "ERROR: no match for $label under '$*'" >&2; return 2 ;;
         1)  echo "Using $label: $(basename "${CANDS[0]}") (${CANDS[0]})" >&2
             printf '%s\n' "${CANDS[0]}" ;;
-        *)  # Agent should replace this branch with an AskQuestion covering CANDS[@]
+        *)  # Agent should replace this branch with an AskUserQuestion covering CANDS[@]
             echo "AMBIGUOUS: $label — $(printf '%d candidates' "${#CANDS[@]}")" >&2
             printf '  [%d] %s\n' "${!CANDS[@]}" "${CANDS[@]}" >&2
             return 3 ;;
@@ -443,11 +443,11 @@ SMC_VIDEOS=$(resolve_or_ask 'smartcity videos dir' \
     <(find_video_dirs "$RESOURCES"))
 ```
 
-> **If the same use case needs to disambiguate multiple ONNXs** (e.g. both RT-DETR and GDINO models live under `$RESOURCES` because both NGC models were pulled), the user's pick in the `AskQuestion` drives which ONNX the skill uses. Print the chosen basename + path on one line, the decision landmark on the next — the terminal output is the contract that a user can audit after the fact.
+> **If the same use case needs to disambiguate multiple ONNXs** (e.g. both RT-DETR and GDINO models live under `$RESOURCES` because both NGC models were pulled), the user's pick in the `AskUserQuestion` drives which ONNX the skill uses. Print the chosen basename + path on one line, the decision landmark on the next — the terminal output is the contract that a user can audit after the fact.
 
 ### Ambiguity handling (non-negotiable)
 
-If any `resolve_or_ask` call returns `3` (multiple candidates), the agent MUST pause and drive an `AskQuestion`:
+If any `resolve_or_ask` call returns `3` (multiple candidates), the agent MUST pause and drive an `AskUserQuestion`:
 
 ```json
 {
@@ -722,7 +722,7 @@ Set `FORCE_ENGINE_REBUILD=1` in the environment (or pass `--force` to either set
 
 ```bash
 # The ONNX paths were already resolved in Step 4.a (resolve_or_ask, with
-# AskQuestion fallback on multi-candidate). Just reuse the variables —
+# AskUserQuestion fallback on multi-candidate). Just reuse the variables —
 # do NOT re-scan with `find ... | head -n1` (that silently picks one
 # when the user has multiple NGC resource versions unpacked).
 

--- a/skills/vss-deploy-detection-tracking-2d/references/container-reuse.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/container-reuse.md
@@ -29,7 +29,7 @@ done
 
 A container that's been "Up" for many hours can silently lose its CUDA / NVML handle after a host driver service restart, NVIDIA Container Toolkit re-init, or cgroup remount. `docker ps` still shows the container as healthy and mounts look fine, but `nvidia-smi` fails inside it with `Failed to initialize NVML: Unknown Error`. If the agent picks **Reuse** in this state, the perception app crashes at `Cuda failure: status=100` / `NvBufSurfaceGetDeviceInfoImpl: Error: Failed to get GPU info` ~30 s into Step 5 — long after the decision window has closed.
 
-**Run the probe before the AskQuestion fires** (only when an existing matching container is found):
+**Run the probe before the AskUserQuestion fires** (only when an existing matching container is found):
 
 ```bash
 bash $SKILL_DIR/scripts/check_container_gpu.sh --container <NAME>
@@ -37,13 +37,13 @@ bash $SKILL_DIR/scripts/check_container_gpu.sh --container <NAME>
 
 | Probe exit | Meaning | Agent action |
 |------------|---------|--------------|
-| `0` (`GPU_OK`)    | GPU visible inside the container — CUDA / NVML healthy. | Proceed to the normal AskQuestion (`Reuse / Restart / Parallel`). The probe's stdout line is a one-liner you can fold into the Step 3 box description. |
-| `2` (`GPU_STALE`) | NVML init failed inside the container. Stale GPU handle. | **Hide the "Reuse" option** from the AskQuestion. Present only `Restart fresh / New parallel container`, with the description noting "existing container has lost GPU access (stale NVML); reuse is not viable". |
+| `0` (`GPU_OK`)    | GPU visible inside the container — CUDA / NVML healthy. | Proceed to the normal AskUserQuestion (`Reuse / Restart / Parallel`). The probe's stdout line is a one-liner you can fold into the Step 3 box description. |
+| `2` (`GPU_STALE`) | NVML init failed inside the container. Stale GPU handle. | **Hide the "Reuse" option** from the AskUserQuestion. Present only `Restart fresh / New parallel container`, with the description noting "existing container has lost GPU access (stale NVML); reuse is not viable". |
 | `1`               | Wrong args / container not running — should not happen at this point. | Treat as a hard error; surface the script's stderr and stop. |
 
 The probe runs in ~0.5 s on a healthy container and is read-only (`nvidia-smi -L` only — no CUDA work submitted), so adding it to the reuse path costs almost nothing on the happy path and saves a wasted ~30 s app launch on the unhappy one.
 
-## AskQuestion — all required mounts present
+## AskUserQuestion — all required mounts present
 
 ```json
 {
@@ -61,7 +61,7 @@ The probe runs in ~0.5 s on a healthy container and is read-only (`nvidia-smi -L
 }
 ```
 
-## AskQuestion — missing mounts (reuse not viable)
+## AskUserQuestion — missing mounts (reuse not viable)
 
 ```json
 {

--- a/skills/vss-deploy-detection-tracking-2d/references/deploy-vss-detection-tracking-2d.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/deploy-vss-detection-tracking-2d.md
@@ -51,7 +51,7 @@ use this ngc resource <WAREHOUSE_APP_DATA_NGC>
 use this model <WAREHOUSE_RTDETR_ONNX> with these videos <WAREHOUSE_VIDEOSET_NAME>
 ```
 
-Anything you omit, the skill asks for via `AskQuestion` or auto-detects from
+Anything you omit, the skill asks for via `AskUserQuestion` or auto-detects from
 the host (platform, existing containers, cached resources). At minimum you
 can say `deploy rtvi-cv warehouse 2d` and answer prompts one by one.
 
@@ -71,7 +71,7 @@ can say `deploy rtvi-cv warehouse 2d` and answer prompts one by one.
 
 ### What you can specify inline
 
-Anything *not* pinned by the user query is asked via the Step 2 `AskQuestion`
+Anything *not* pinned by the user query is asked via the Step 2 `AskUserQuestion`
 (no silent defaults — see the "What gets asked" section below).
 
 | Param            | Phrases that pin a value (skip the question)                                                            |
@@ -96,7 +96,7 @@ Anything *not* pinned by the user query is asked via the Step 2 `AskQuestion`
 | **TEARDOWN** | `stop`, `tear down`, `shutdown`, `kill`, `cleanup`, `remove container` | `teardown-flow.md`.                                            |
 
 If the user's intent is clearly deploy or teardown, do not ask — proceed
-directly to the matching flow. Only ask via `AskQuestion` when ambiguous.
+directly to the matching flow. Only ask via `AskUserQuestion` when ambiguous.
 
 ---
 
@@ -170,15 +170,15 @@ on the chosen model.
 digraph step_order {
     rankdir=LR;
     "platform + YAML defaults" [shape=box];
-    "Step 1 AskQuestion\n(image, NGC resource, model, videos)" [shape=box];
-    "Step 2 AskQuestion\n(batch, stream_mode, input, sink)" [shape=box];
+    "Step 1 AskUserQuestion\n(image, NGC resource, model, videos)" [shape=box];
+    "Step 2 AskUserQuestion\n(batch, stream_mode, input, sink)" [shape=box];
     "Step 3 launch / reuse" [shape=box];
     "Step 4 apply-config\n(includes engine-cache lookup)" [shape=box, color=red];
     "Step 5 start-app" [shape=box];
 
-    "platform + YAML defaults" -> "Step 1 AskQuestion\n(image, NGC resource, model, videos)";
-    "Step 1 AskQuestion\n(image, NGC resource, model, videos)" -> "Step 2 AskQuestion\n(batch, stream_mode, input, sink)";
-    "Step 2 AskQuestion\n(batch, stream_mode, input, sink)" -> "Step 3 launch / reuse";
+    "platform + YAML defaults" -> "Step 1 AskUserQuestion\n(image, NGC resource, model, videos)";
+    "Step 1 AskUserQuestion\n(image, NGC resource, model, videos)" -> "Step 2 AskUserQuestion\n(batch, stream_mode, input, sink)";
+    "Step 2 AskUserQuestion\n(batch, stream_mode, input, sink)" -> "Step 3 launch / reuse";
     "Step 3 launch / reuse" -> "Step 4 apply-config\n(includes engine-cache lookup)";
     "Step 4 apply-config\n(includes engine-cache lookup)" -> "Step 5 start-app";
 }
@@ -186,7 +186,7 @@ digraph step_order {
 
 **Hard rules:**
 
-1. **Step 1 `AskQuestion` fires BEFORE Step 2 `AskQuestion`.** Never merge
+1. **Step 1 `AskUserQuestion` fires BEFORE Step 2 `AskUserQuestion`.** Never merge
    them. Even when Step 1 has YAML defaults for every parameter, the user
    still picks each one in Step 1's question (defaults appear as the
    "Recommended" option). Don't skip ahead to Step 2 just because Step 1
@@ -202,10 +202,10 @@ digraph step_order {
    compatible.
 4. **No bash discovery beyond Step 1.b.** Steps 1.b (platform detect via
    `uname -m` + `nvidia-smi`) and 1.c (load YAML defaults via
-   `load_defaults.sh`) are the only allowed pre-AskQuestion bash.
+   `load_defaults.sh`) are the only allowed pre-AskUserQuestion bash.
    Everything else — `docker image inspect`, `docker ps`, listing engine
    cache, listing resources for *cosmetic* summaries — must wait until
-   the user has answered Step 1's `AskQuestion`. `docker ps` for the
+   the user has answered Step 1's `AskUserQuestion`. `docker ps` for the
    container-reuse decision belongs in Step 3, not Step 1.
 
 If the agent finds itself thinking "let me just check X to make the next
@@ -213,7 +213,7 @@ question prettier", that's the smell — stop, ask first, look later.
 If the agent finds itself thinking "the YAML defaults are good enough,
 let me skip Step 1's question", that's the same smell. Ask anyway.
 
-5. **Step 6 `AskQuestion` is the final step of every successful deploy.**
+5. **Step 6 `AskUserQuestion` is the final step of every successful deploy.**
    Right after the "Perception Application — Results" box, fire the
    Step 6 menu from `next-steps.md` § "11.c". Do NOT replace it with
    a free-form "Next steps:" bullet list. The menu is the user's
@@ -228,7 +228,7 @@ own, then runs to completion with progress prints but no further prompts.
 
 ### One-shot intake
 
-Before any work begins, the skill builds a single consolidated `AskQuestion`
+Before any work begins, the skill builds a single consolidated `AskUserQuestion`
 block covering:
 
 - Docker image ref (if not in the query).
@@ -244,12 +244,12 @@ re-prompt the user.
 
 ### What gets asked vs. applied silently
 
-**The skill drives TWO `AskQuestion` rounds in fixed order: Step 1 BEFORE
+**The skill drives TWO `AskUserQuestion` rounds in fixed order: Step 1 BEFORE
 Step 2. YAML defaults from `deploy-defaults.yml` appear inside
 each question as the "(Recommended)" option — they are NEVER applied
 silently.**
 
-**Step 1 (deploy targets) MUST drive an `AskQuestion` with exactly three
+**Step 1 (deploy targets) MUST drive an `AskUserQuestion` with exactly three
 parameters when the user query did not pin them — even if YAML defaults
 exist for the use case:**
 
@@ -324,10 +324,10 @@ Which model ONNX should I use?
      Provide a host path to a different ONNX file
 ```
 
-**Step 3 (container) MUST drive an `AskQuestion` whenever an existing
+**Step 3 (container) MUST drive an `AskUserQuestion` whenever an existing
 container is detected on the same image — never silently auto-decide:**
 
-| Detection result                              | AskQuestion fires?                                                                               |
+| Detection result                              | AskUserQuestion fires?                                                                               |
 |-----------------------------------------------|---------------------------------------------------------------------------------------------------|
 | No existing container on this image           | No — proceed straight to `docker run` (only one path).                                            |
 | Existing container, all required mounts match | **YES** — present `Reuse / Restart / New parallel container` (full JSON in `container-reuse.md`). |
@@ -337,13 +337,13 @@ The user always picks. The skill never auto-picks "reuse" just because
 mounts match — that information is presented in the question's
 description text and lets the user decide.
 
-**Step 2 (pipeline configuration) MUST drive an `AskQuestion` for these
+**Step 2 (pipeline configuration) MUST drive an `AskUserQuestion` for these
 four parameters when the user query did not pin them, AFTER Step 1 has
 finished:**
 
 | Step 2 parameter | Pin via query phrase                                                                | If unpinned                                                              |
 |------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| `batch_size`     | `with N streams`, `batch N`, `N cameras`                                            | **ASK** — see `pipeline-config.md` (4-question `AskQuestion` block).     |
+| `batch_size`     | `with N streams`, `batch N`, `N cameras`                                            | **ASK** — see `pipeline-config.md` (4-question `AskUserQuestion` block).     |
 | `stream_mode`    | `dynamic` / `via rest` / `add via api` / `live add` → dynamic                       | **ASK** — `static` appears as the "(Recommended)" option (default).      |
 | `input_type`     | `from rtsp <url>` → rtsp                                                            | **ASK** — `filesrc` appears as the "(Recommended)" option.               |
 | `output_sink`    | `display`/`on screen` → eglsink; `save to file` → filedump; `benchmark` → fakesink  | **ASK** — `fakesink` appears as the "(Recommended)" option.              |
@@ -351,13 +351,13 @@ finished:**
 **Strict ordering rules:**
 
 1. **Step 1 questions fire before Step 2 questions.** Never merge them into
-   a single `AskQuestion` block, and never ask Step 2 first because Step 1
+   a single `AskUserQuestion` block, and never ask Step 2 first because Step 1
    "has YAML defaults available."
 2. Only mark a step `completed` AFTER the user's values are confirmed
-   (either pinned by the query or returned from `AskQuestion`). **Never**
+   (either pinned by the query or returned from `AskUserQuestion`). **Never**
    mark a step done from a partially-specified query.
 3. The presence of a YAML default does NOT permit skipping the
-   `AskQuestion`. The default is the "Recommended" option *inside* the
+   `AskUserQuestion`. The default is the "Recommended" option *inside* the
    question — the user still chooses.
 
 **Truly silent defaults (applied without asking, but announced before use):**
@@ -379,7 +379,7 @@ finished:**
 4. Credentials missing on first run — API key must come from the user.
 
 Everything else runs without asking. See `ux-conventions.md`
-for the full visibility / `AskQuestion` contract.
+for the full visibility / `AskUserQuestion` contract.
 
 ### User-facing announcements — never include substep notation
 
@@ -558,7 +558,7 @@ delay`, no `RTSP URLs`). A `dynamic + filesrc + eglsink` deploy renders
 5 rows. A `dynamic + rtsp + eglsink` deploy renders 6.
 
 **Step 3 box content rule.** Render the container-decision receipt
-AFTER the user has answered the AskQuestion — never before. The box's
+AFTER the user has answered the AskUserQuestion — never before. The box's
 `Decision` row reflects the user's choice (`REUSE` / `RESTART` /
 `NEW PARALLEL`), not an auto-decision. If no existing container was
 found, the box still renders and the `Decision` row reads `LAUNCH new
@@ -648,7 +648,7 @@ NOT add a second "deployment summary" box; the Results box already
 carries every value (use case, container, image, batch/sink, FPS,
 GPU, log path, REST endpoints).
 
-**Step 6 — post-deploy AskQuestion is REQUIRED.**
+**Step 6 — post-deploy AskUserQuestion is REQUIRED.**
 See § "Step ordering invariants — DO NOT skip ahead" rule 5 above for the
 ordering rule; the full bucket table and forbidden-patterns list live in
 `next-steps.md` § "11.c".
@@ -848,7 +848,7 @@ There is no separate deployment-summary box.
    stay outside the box.
 4. **No box from a partially-specified step.** If any field would have to
    be `<unknown>` or `<not yet asked>`, the step is not done — finish the
-   `AskQuestion`s first.
+   `AskUserQuestion`s first.
 5. **Long values overflow to a continuation row inside the box** (see
    `start-app.md` for examples in the Results-box rows). Never spill
    outside the box.

--- a/skills/vss-deploy-detection-tracking-2d/references/next-steps.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/next-steps.md
@@ -17,7 +17,7 @@ ACTIVE=$(echo "$STREAM_INFO" | python3 -c \
 
 ## 11.b — Print the "what now?" menu block
 
-**Print this BEFORE the AskQuestion** so the user sees all options at a glance.
+**Print this BEFORE the AskUserQuestion** so the user sees all options at a glance.
 Build the block from live state: hide lines that don't apply.
 
 ```

--- a/skills/vss-deploy-detection-tracking-2d/references/pipeline-config.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/pipeline-config.md
@@ -1,6 +1,6 @@
 # Step 2 — Pipeline Configuration (batch size, streams, sink)
 
-Collect the 4 pipeline parameters in a single `AskQuestion` interaction, then a conditional follow-up for the stream-add delay (dynamic mode only).
+Collect the 4 pipeline parameters in a single `AskUserQuestion` interaction, then a conditional follow-up for the stream-add delay (dynamic mode only).
 
 ## Defaults — the skill is **static-mode by default**
 
@@ -21,10 +21,10 @@ Why static is the default:
 
 Dynamic mode is appropriate only when the user explicitly says so, or when
 they want to add cameras to a running deployment after the fact via REST
-`/api/v1/stream/add`. The Step 2 `AskQuestion` keeps `dynamic` available as
+`/api/v1/stream/add`. The Step 2 `AskUserQuestion` keeps `dynamic` available as
 a non-default option for those cases.
 
-## Primary `AskQuestion` (4 parameters at once)
+## Primary `AskUserQuestion` (4 parameters at once)
 
 ```json
 {
@@ -75,7 +75,7 @@ a non-default option for those cases.
 
 This only applies to `usecase == warehouse-3d` AND `input_type == filesrc`. For every other case, skip this section entirely.
 
-After the primary `AskQuestion` resolves, the agent counts `.mp4` files in the resolved videos directory (or the user-supplied custom dir). If the chosen `batch_size` exceeds that count, fire a follow-up `AskQuestion` with **exactly two options, cycle = Recommended**:
+After the primary `AskUserQuestion` resolves, the agent counts `.mp4` files in the resolved videos directory (or the user-supplied custom dir). If the chosen `batch_size` exceeds that count, fire a follow-up `AskUserQuestion` with **exactly two options, cycle = Recommended**:
 
 ```json
 {
@@ -95,7 +95,7 @@ After the primary `AskQuestion` resolves, the agent counts `.mp4` files in the r
 - **`cycle`** (default): proceed with the user's requested batch size. `discover_streams.sh` cycles the available `.mp4` files into `batch` unique stream ids (cycled ids get a `_<i>` suffix so REST `/stream/add` doesn't reject duplicates). No warning prose — treat cycling as expected.
 - **`reduce`**: overwrite `batch_size` with `<N>` (the available-cam count) and continue. The Step 2 exit box reflects the reduced batch.
 
-The follow-up is silent (no `AskQuestion`) when batch ≤ available cam count, and is skipped entirely for non-warehouse-3d use cases or when `input_type == rtsp` (RTSP URLs are user-supplied — no cycling concept).
+The follow-up is silent (no `AskUserQuestion`) when batch ≤ available cam count, and is skipped entirely for non-warehouse-3d use cases or when `input_type == rtsp` (RTSP URLs are user-supplied — no cycling concept).
 
 ## Delay between stream adds — dynamic mode only
 
@@ -114,7 +114,7 @@ the minimal-interaction contract. 20s spacing is stable on all platforms
 that happens with back-to-back `/stream/add` calls.
 
 **Apply silently, but announce before use** (per SKILL.md § Announce-before-
-applying). Do NOT drive an `AskQuestion` — the user can interrupt if they
+applying). Do NOT drive an `AskUserQuestion` — the user can interrupt if they
 want a different value.
 
 ```bash
@@ -141,7 +141,7 @@ when the user picked `dynamic`).
 
 **Legacy prompt (kept for reference — do NOT use by default):** if a future
 deploy mode explicitly asks for an interactive delay choice, here's the
-`AskQuestion` JSON:
+`AskUserQuestion` JSON:
 
 ```json
 {

--- a/skills/vss-deploy-detection-tracking-2d/references/resource-plan.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/resource-plan.md
@@ -73,9 +73,9 @@ or switch to a local path.
 
 ---
 
-## Step 4 — Source selection (3-question AskQuestion driven by YAML defaults)
+## Step 4 — Source selection (3-question AskUserQuestion driven by YAML defaults)
 
-The skill drives **one** `AskQuestion` block with exactly three questions:
+The skill drives **one** `AskUserQuestion` block with exactly three questions:
 **docker image**, **model**, **videos**. Each option carries the resolved
 NGC ref + in-resource path inline (read from
 [`deploy-defaults.yml`](../assets/deploy-defaults.yml)) so the user never has to
@@ -135,7 +135,7 @@ the videos). Either way, each option carries its own NGC ref so the user
 sees the source of truth per asset.
 
 If the user picks `custom` (or `rtsp` for videos), the agent collects the
-path / URL list in chat as a free-form follow-up — no extra `AskQuestion`.
+path / URL list in chat as a free-form follow-up — no extra `AskUserQuestion`.
 
 ### Refs / paths collection
 
@@ -175,7 +175,7 @@ If the user mentioned a **specific ONNX filename** or **specific videos
 directory name** in their initial request (e.g. `"use model
 rtdetr_warehouse_v1.0.1.fp16.onnx with videos nv-warehouse-4cams"`), save
 those as **hints** so Step 1.g can pre-select the matching candidate inside
-an `AskQuestion` picker — not to silently auto-pick it.
+an `AskUserQuestion` picker — not to silently auto-pick it.
 
 ```bash
 # Optional — empty if the user didn't mention a specific name.
@@ -198,7 +198,7 @@ Hints **never** replace the dynamic-discovery pass. Every deploy:
 2. **Decide** — apply the dispatch rules below. Most cases are
    auto-decided (1 candidate, hint uniquely matches, 0 candidates → hard
    error). Only truly ambiguous cases (>1 candidates, no hint) produce an
-   `AskQuestion` picker.
+   `AskUserQuestion` picker.
 3. **Tell the user** — print `✔ <role>: <filename>` with the concrete
    committed choice, plus any selection context (`1 of 1 found`,
    `matched query hint`, `selected from 3 candidates`). The user sees
@@ -371,8 +371,8 @@ E.g. `model:ngc:$DEFAULT_MODEL_NGC_REF` (resolved from YAML at runtime).
 |---|---|
 | Exactly 1 model artifact | Auto-use. Print `    ✔ model: <filename> (1 of 1 found)`. No prompt. |
 | >1 model artifacts, `MODEL_NAME_HINT` uniquely matches one | Auto-select the hint match. Print `    ✔ model: <filename> (matched query hint)`. No prompt. |
-| >1 model artifacts, hint matches none / no hint | `AskQuestion` picker with one option per candidate. Committed choice feeds Step 4.a. This is the only case that prompts. |
-| 0 model artifacts | `✖ <ref> does not contain any model files (*.onnx/*.engine/*.etlt).` → `AskQuestion`: (a) retry with another NGC ref, (b) switch to a local model path, (c) abort. Re-enter Refs / paths collection for this asset only — other roles stay resolved. |
+| >1 model artifacts, hint matches none / no hint | `AskUserQuestion` picker with one option per candidate. Committed choice feeds Step 4.a. This is the only case that prompts. |
+| 0 model artifacts | `✖ <ref> does not contain any model files (*.onnx/*.engine/*.etlt).` → `AskUserQuestion`: (a) retry with another NGC ref, (b) switch to a local model path, (c) abort. Re-enter Refs / paths collection for this asset only — other roles stay resolved. |
 | Extras present (e.g. videos in a model-role resource) | Silently ignored — not this entry's role. |
 
 #### Role = `videos`
@@ -383,7 +383,7 @@ E.g. `videos:ngc:$DEFAULT_VIDEOS_NGC_REF` (resolved from YAML at runtime).
 |---|---|
 | Exactly 1 video directory | Auto-use. Print `    ✔ videos: <dirname> (1 of 1 found, N .mp4 files)`. No prompt. |
 | >1 video directories, `VIDEOS_DIR_HINT` uniquely matches one basename | Auto-select the hint match. Print `    ✔ videos: <dirname> (matched query hint)`. No prompt. |
-| >1 video directories, hint matches none / no hint | `AskQuestion` picker with one option per candidate (dir name + file count). For `warehouse-3d`, post-check the chosen dir's `.mp4` stems against `sensors[].id` in `calibration.json` and warn on mismatch. This is the only case that prompts. |
+| >1 video directories, hint matches none / no hint | `AskUserQuestion` picker with one option per candidate (dir name + file count). For `warehouse-3d`, post-check the chosen dir's `.mp4` stems against `sensors[].id` in `calibration.json` and warn on mismatch. This is the only case that prompts. |
 | 0 video directories | `✖ <ref> does not contain any directories with .mp4/.mkv files.` → retry-ref / switch-to-local / abort. |
 | Extras present (e.g. an ONNX inside a videos-role resource) | Ignored — not this entry's role. |
 
@@ -451,7 +451,7 @@ of the NGC decision — add them per `platforms.md` as usual.
 ## Edge cases
 
 - **User changes their mind mid-flow.** If scan reveals a missing asset
-  (Step 1.g second/third row), treat the follow-up AskQuestion answer as a
+  (Step 1.g second/third row), treat the follow-up AskUserQuestion answer as a
   partial Step 4 re-run for that asset only. Don't re-ask for the assets
   that already resolved.
 - **User pastes a path that doesn't exist.** `stage_local()` returns

--- a/skills/vss-deploy-detection-tracking-2d/references/task-list.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/task-list.md
@@ -36,7 +36,7 @@ The skill only prints progress narration (`→` step start, `✔` step result, `
 1. **5 separate `TaskCreate` calls back-to-back** — full set of 5 tasks (templates under "Initial `TaskCreate` calls" below). NEVER collapse all 5 into one `TaskCreate`'s `description` field.
 2. **`TaskUpdate` to pre-complete inferred tasks** — one `TaskUpdate` call per task whose value is already pinned by the query.
 
-In either case: do NOT run any bash, file read, `AskQuestion`, or other tool between actions 1 and 2 above. No platform detection, no NGC config check, no docker inspect — those belong to later steps.
+In either case: do NOT run any bash, file read, `AskUserQuestion`, or other tool between actions 1 and 2 above. No platform detection, no NGC config check, no docker inspect — those belong to later steps.
 
 ## After startup — update-on-transition pattern
 
@@ -77,7 +77,7 @@ Every todo `content` field is a **short canonical label** (≤ 30 chars) set onc
 
 When the runtime exposes `TaskCreate` instead of `TodoWrite`, issue **5 separate
 `TaskCreate` calls in immediate succession**, one per task, BEFORE any other tool
-runs (no bash, no file reads, no `AskQuestion` between them). Same 5 subjects as
+runs (no bash, no file reads, no `AskUserQuestion` between them). Same 5 subjects as
 the `TodoWrite` template, plus a `description` field that names what the task
 covers — the description is what makes each task auditable as covering a distinct
 deploy concern (platform detection, NGC resource staging, container launch,

--- a/skills/vss-deploy-detection-tracking-2d/references/teardown-flow.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/teardown-flow.md
@@ -35,7 +35,7 @@ Otherwise, present the matched containers as a small table and proceed to T2.
 
 ## Step T2 — Select Which Container to Stop
 
-If multiple match, use `AskQuestion` with one option per container plus an "all" option:
+If multiple match, use `AskUserQuestion` with one option per container plus an "all" option:
 
 ```json
 {
@@ -52,7 +52,7 @@ If multiple match, use `AskQuestion` with one option per container plus an "all"
 }
 ```
 
-Single-container case: skip `AskQuestion` and confirm `Will stop: <name>.`
+Single-container case: skip `AskUserQuestion` and confirm `Will stop: <name>.`
 
 ## Step T3 — Choose Stop Method
 

--- a/skills/vss-deploy-detection-tracking-2d/references/usage-vss-detection-tracking-2d.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/usage-vss-detection-tracking-2d.md
@@ -124,7 +124,7 @@ If the intent is ambiguous, use `AskUserQuestion`:
 
 ## Step 3 — Collect Required Parameters
 
-**Use `AskQuestion` for structured choices.** Ask the user in chat for free-text values. Always collect all unknowns in a **single interaction**.
+**Use `AskUserQuestion` for structured choices.** Ask the user in chat for free-text values. Always collect all unknowns in a **single interaction**.
 
 ### For Stream Add
 
@@ -143,7 +143,7 @@ For any missing required values, ask in chat:
 >
 > Please provide the URL and ID.
 
-Then use `AskQuestion` for optional settings (with sensible defaults pre-selected):
+Then use `AskUserQuestion` for optional settings (with sensible defaults pre-selected):
 
 ```json
 {
@@ -196,7 +196,7 @@ curl -s "${BASE_URL}/api/v1/stream/get-stream-info" -H "Accept: application/json
 
 **Print:** `Fetching active streams from RTVI-CV...`
 
-If streams exist, present them as a choice using `AskQuestion`:
+If streams exist, present them as a choice using `AskUserQuestion`:
 
 ```json
 {
@@ -223,7 +223,7 @@ If no streams are active, tell the user:
 
 **Print:** `Preparing to generate text embeddings...`
 
-Ask for text input in chat, then use `AskQuestion` for the model:
+Ask for text input in chat, then use `AskUserQuestion` for the model:
 
 > What text do you want to generate embeddings for?
 
@@ -296,7 +296,7 @@ Show the exact curl command with all values filled in:
 >
 > Shall I run this?
 
-Use `AskQuestion` for confirmation:
+Use `AskUserQuestion` for confirmation:
 
 ```json
 {
@@ -422,7 +422,7 @@ If a probe fails, flag it: `| Readiness | NOT READY — service may still be loa
 
 ## Step 6 — Suggest Next Actions
 
-Use `AskQuestion` to offer logical follow-ups:
+Use `AskUserQuestion` to offer logical follow-ups:
 
 ```json
 {

--- a/skills/vss-deploy-detection-tracking-2d/references/workflow-reference.md
+++ b/skills/vss-deploy-detection-tracking-2d/references/workflow-reference.md
@@ -112,7 +112,7 @@ Keep the split clean — scripts do the brittle multi-file work; the agent does 
 
 | Task | Owner |
 |---|---|
-| Collect user inputs (use case, batch, sink, etc.) | Agent (`AskQuestion`) |
+| Collect user inputs (use case, batch, sink, etc.) | Agent (`AskUserQuestion`) |
 | Detect platform | Agent (one-liner: `uname -m`, `nvidia-smi`, `/etc/nv_tegra_release`) |
 | Write `~/.ngc/config` | Agent (simple `cat > file` + `chmod 600`) |
 | Download NGC resources | Agent (one-liner: `ngc registry resource download-version ...`) |

--- a/skills/vss-deploy-detection-tracking-2d/scripts/apply_config.sh
+++ b/skills/vss-deploy-detection-tracking-2d/scripts/apply_config.sh
@@ -34,7 +34,7 @@
 # Output markers (parseable by the skill):
 #   RESOLVE_OK: <label>=<path>      — 4.a discovery result
 #   RESOLVE_MISS: <label> (no match)  — 4.a found zero candidates; skill should run fetch_resources.sh
-#   RESOLVE_AMBIGUOUS: <label> count=<N>  — 4.a needs AskQuestion from skill (N >= 2 candidates)
+#   RESOLVE_AMBIGUOUS: <label> count=<N>  — 4.a needs AskUserQuestion from skill (N >= 2 candidates)
 #   BATCH_UPDATE_OK <usecase> <N>   — 4.c done
 #   SINK_UPDATE_OK <usecase> <sink> — 4.d done
 #   STREAM_SOURCES_OK <usecase> <mode> — 4.e done

--- a/skills/vss-deploy-detection-tracking-2d/scripts/discover_streams.sh
+++ b/skills/vss-deploy-detection-tracking-2d/scripts/discover_streams.sh
@@ -11,7 +11,7 @@
 # Scans $RESOURCES for any directory that contains .mp4/.mkv files (NO
 # hardcoded NGC subdirectory names like 'nv-warehouse-4cams' or 'smc-app').
 # Emits RESOLVE_OK / RESOLVE_AMBIGUOUS on stderr so the calling skill can
-# drive an AskQuestion when multiple video directories exist. Once a
+# drive an AskUserQuestion when multiple video directories exist. Once a
 # directory is chosen, lists .mp4 files in stable (sorted) order and cycles
 # them to produce exactly N (id, url) pairs (cycled entries get a `_<i>`
 # suffix to avoid REST-add duplicate-id errors).
@@ -86,7 +86,7 @@ case "$FORMAT" in env|json|lines) ;; *) die "Invalid --format: $FORMAT (env|json
 #   0  → die (exit 2) — no videos at all
 #   1  → use it (RESOLVE_OK)
 #   >1 → emit RESOLVE_AMBIGUOUS with a numbered list on stderr and exit 3.
-#        The caller (rtvicv-deploy skill) must drive an AskQuestion, then
+#        The caller (rtvicv-deploy skill) must drive an AskUserQuestion, then
 #        re-invoke with --videos-dir <chosen>.
 if [[ -z "$VIDEOS_DIR" ]]; then
     require_dir "$RESOURCES"
@@ -157,7 +157,7 @@ done
 # ── Warn if cycling occurred ────────────────────────────────────
 # Cycling is permitted for every use case (including warehouse-3d, where
 # the agent has already confirmed the user's intent via Step 2's
-# "Warehouse-3d batch > calibrated cameras" AskQuestion before reaching
+# "Warehouse-3d batch > calibrated cameras" AskUserQuestion before reaching
 # this script).
 if (( BATCH > orig_count )) && (( WARN_CYCLE == 1 )); then
     echo "WARN: BATCH=$BATCH > videos=$orig_count — cycled ids get '_<i>' suffix starting at stream $((orig_count+1))" >&2


### PR DESCRIPTION
## Summary

Addresses a VDR review comment on the `vss-deploy-detection-tracking-2d` skill.

**VDR comment:** the skill referenced a non-existent `AskQuestion` tool (the real one is `AskUserQuestion`), causing the agent to either invent a tool or skip disambiguation.

**Fix:** replaced all `AskQuestion` references with `AskUserQuestion` across the skill — SKILL.md, reference docs, scripts, and assets (73 occurrences in 14 files).

## Verification
- No remaining `AskQuestion` references
- No accidental double-replacements (`AskUserUserQuestion`)
- Files already using `AskUserQuestion` left untouched