### PR TITLE
Seed NVStreamer from baked BDD clips at test time

### DIFF
--- a/services/vios/.claude/agents/vios-dev-sanity.md
+++ b/services/vios/.claude/agents/vios-dev-sanity.md
@@ -525,8 +525,15 @@ PASS if: HTTP 200 and response contains expected data (non-empty array, expected
 Steps say "Upload file to NvStreamer" or reference the media-upload page:
 
 ```
-1. Find a test file:
-   bash: find . -name "*.mkv" -o -name "*.mp4" | grep -E "(test|bdd_tests|tools)/data" | head -3
+1. Find a test file on the host. Sample clips are no longer committed under
+   tools/data -- they are baked into the BDD test image (/app/test_videos),
+   which is not on the host filesystem. Search, in order:
+   a. bash: find . -type f \( -name "*.mkv" -o -name "*.mp4" \) 2>/dev/null | grep -E "bdd_tests/(data|test_videos)" | head -3
+   b. bash: find . -type f \( -name "*.mkv" -o -name "*.mp4" -o -name "*.ts" \) 2>/dev/null | head -5
+   c. bash: find /tmp/nvstreamer_auto_deploy -type f \( -name "*.mkv" -o -name "*.mp4" -o -name "*.ts" \) 2>/dev/null | head -3
+   Use the first match. If no valid video file is found on disk, mark this test BLOCKED with reason
+   "no test video on disk (clips are baked into the BDD image, not on host)"
+   and continue to the next test. Do NOT prompt the user -- see Interaction Policy.
 2. browser_navigate → NVSTREAMER_URL/#/media-upload (or /#/dashboard)
 3. browser_snapshot → find file upload area
 4. browser_evaluate → find the file input element
@@ -1006,6 +1013,7 @@ Once execution starts (after the Step 0 permission gate), do not pause for user 
 | VIOS not reachable after auto-detect | Deploy via vios-deployment, then re-probe |
 | NvStreamer URL not provided | Derive from compose.env; fall back to `http://BASE_HOST:31000` |
 | NvStreamer URL unreachable | Mark NvStreamer-dependent tests BLOCKED; continue with remaining tests |
+| No test video file on disk (upload test) | Mark the file-upload test BLOCKED with "no test video on disk"; continue |
 | Sensor list empty for a test | Mark that test BLOCKED with reason; continue |
 | Test step ambiguous | Interpret the most literal reading; note interpretation in remarks |
 | Browser element not found | Retry once with fresh snapshot; if still missing, mark FAIL and continue |

--- a/services/vios/.claude/sqa/AGENT.md
+++ b/services/vios/.claude/sqa/AGENT.md
@@ -139,9 +139,28 @@ test/bdd_tests/
     junit.xml
     test_results.csv
     unit_tests/*.csv
+  test_videos/                        # sample clips, baked into the BDD image (gitignored, not in repo)
 
 webroot/index.html                    # UI entry point
 ```
+
+---
+
+## Sample Video Files
+
+There are no longer sample clips committed under `tools/data/`. The BDD sample
+clips (10s H.264/H.265, MP4/MKV) are **baked into the BDD test image** at
+`/app/test_videos` and are gitignored, not stored in the repo. The BDD suite
+seeds NVStreamer from them automatically (session prerequisite uploads them and
+runs a VST scan when NVStreamer has no streams).
+
+When a deployment or an ad-hoc test needs a video source and none is available:
+
+- **Ask the user to point to a directory that contains valid video files**
+  (MP4/MKV/TS carrying H.264 or H.265). Do not assume a path exists.
+- Upload those files to NVStreamer (`PUT /vst/api/v1/storage/file/<name>`), then
+  run a sensor scan from the VST UI (or `POST /vst/api/v1/sensor/scan`) so VIOS
+  imports the RTSP streams.
 
 ---
 

--- a/services/vios/.claude/sqa/guides/troubleshooting.md
+++ b/services/vios/.claude/sqa/guides/troubleshooting.md
@@ -164,8 +164,15 @@ Then restart sensor-ms so it reloads: `docker restart sensor-ms`.
 
 **Option B — stage a backing file so the stream resolves:**
 ```bash
-cp /tmp/nvstreamer_auto_deploy/nvstreamer-1/<existing_file>.mp4 \
-   /tmp/nvstreamer_auto_deploy/nvstreamer-1/<missing_file>.mp4
+# Copy any valid clip already served by this NVStreamer instance over the
+# missing filename. If the instance has no clips, upload one first (PUT
+# /vst/api/v1/storage/file/<name>) or ask the user for a directory of valid
+# video files. Sample clips are no longer shipped in the repo -- they are baked
+# into the BDD test image at /app/test_videos.
+# Preserve the missing file's original extension (.mp4/.mkv/.ts); the source
+# clip should use the same container so the stream plays.
+cp /tmp/nvstreamer_auto_deploy/nvstreamer-1/<existing_clip>.<ext> \
+   /tmp/nvstreamer_auto_deploy/nvstreamer-1/<missing_file>.<ext>
 ```
 NVStreamer picks up new files without a restart.
 

--- a/services/vios/.claude/sqa/skills/deployment/deploy.md
+++ b/services/vios/.claude/sqa/skills/deployment/deploy.md
@@ -190,6 +190,22 @@ Report to the user:
 
 ---
 
+## Sample Video Files
+
+Deployments now start **without** any pre-seeded videos -- the sample clips are
+no longer shipped under `tools/data/` (they are baked into the BDD test image
+and used only by the BDD suite). NVStreamer comes up with no streams.
+
+If a deployment needs a video source:
+
+- **Ask the user to point to a directory that contains valid video files**
+  (MP4/MKV/TS carrying H.264 or H.265). Do not assume `tools/data/` exists.
+- Upload those files to NVStreamer (`PUT /vst/api/v1/storage/file/<name>`), then
+  run a sensor scan from the VST UI (or `POST /vst/api/v1/sensor/scan`) so VIOS
+  imports the RTSP streams.
+
+---
+
 ## Image Tag Flags Reference
 
 | Flag | Controls |

--- a/services/vios/.claude/sqa/skills/testing/run-bdd-tests.md
+++ b/services/vios/.claude/sqa/skills/testing/run-bdd-tests.md
@@ -141,6 +141,24 @@ Reports are always written to `test/bdd_tests/reports/`. Proceed to `skills/test
 
 ---
 
+## Sample Video Files
+
+The BDD sample clips (10s H.264/H.265, MP4/MKV) are **baked into the BDD test
+image** at `/app/test_videos` -- they are no longer committed under
+`tools/data/`. Tests do not reference them directly: a session prerequisite
+(`scripts/stream_prerequisite.py`) uploads them to NVStreamer and triggers a VST
+sensor scan when NVStreamer has no streams.
+
+If you need to seed a video source manually (e.g. a non-default deployment where
+NVStreamer has no streams and the prerequisite did not run):
+
+- **Ask the user to point to a directory that contains valid video files**
+  (MP4/MKV/TS with H.264 or H.265). Do not assume `tools/data/` exists.
+- Upload them to NVStreamer (`PUT /vst/api/v1/storage/file/<name>`), then run a
+  sensor scan from the VST UI (or `POST /vst/api/v1/sensor/scan`).
+
+---
+
 ## Environment Setup (first-time only)
 
 ```bash

--- a/services/vios/.cursor/skills/bdd-container-update/SKILL.md
+++ b/services/vios/.cursor/skills/bdd-container-update/SKILL.md
@@ -25,6 +25,14 @@ needs to be rebuilt when the things it bakes in change.
 - `test/bdd_tests/docker-entrypoint.sh`
 - `test/bdd_tests/pyproject.toml` (any change -- deps or pytest config)
 - `test/bdd_tests/poetry.lock`
+- `test/bdd_tests/test_videos/*` (sample clips baked to `/app/test_videos`)
+
+> **Note on `test_videos/`:** the clip binaries are **gitignored** -- they are
+> NOT in the repo, only baked into the published image. The pushed image is the
+> source of truth. Before rebuilding you must repopulate
+> `test/bdd_tests/test_videos/` from the current published image (or a backup);
+> see `test/bdd_tests/test_videos/README.md`. A rebuild from a clean checkout
+> without these files would bake an empty `/app/test_videos`.
 
 **Rebuild NOT required** -- bind-mounted at runtime by
 `cicd_files/docker-compose-test/start_test.sh`:

--- a/services/vios/cicd_files/docker-compose-test/start_test.sh
+++ b/services/vios/cicd_files/docker-compose-test/start_test.sh
@@ -413,7 +413,7 @@ update_docker_compose() {
     cat > "$test_compose_file" << 'EOL'
 services:
   test:
-    image: ${BDD_TEST_IMAGE:-bdd_tests:v1.9.5_x86}
+    image: ${BDD_TEST_IMAGE:-bdd_tests:v1.10.0_x86}
     network_mode: host
     container_name: bdd_test
     group_add:
@@ -575,17 +575,18 @@ update_nvstreamer_compose_env() {
     temp_compose_file=$(mktemp) || error "Failed to create temporary file for nvstreamer compose.env"
 
     local nvstreamer_video_base="$VST_BASE_PATH/vst_volume/nvstreamer_data"
-    local nvstreamer_video_src="$TOP/tools/data"
-    if [[ ! -d "$nvstreamer_video_src" ]]; then
-        error "Video source directory not found: $nvstreamer_video_src"
-    fi
+    # NVStreamer now starts WITHOUT any pre-seeded videos. The sample clips are
+    # baked into the BDD test image (/app/test_videos) and the BDD session
+    # prerequisite uploads them to NVStreamer + triggers a VST sensor scan when
+    # NVStreamer has no streams (see test/bdd_tests/scripts/stream_prerequisite.py).
+    # Here we only create the per-instance video directories that NVStreamer
+    # bind-mounts as its streamer-videos volume so uploads have a landing spot.
     for i in 1 2 3 4 5; do
         local instance_dir="${nvstreamer_video_base}/nvstreamer-${i}"
         mkdir -p "${instance_dir}/vst_data"
-        if ! cp -n "$nvstreamer_video_src"/* "${instance_dir}/" 2>/dev/null; then
-            info "WARNING: Failed to copy video files to ${instance_dir}/ -- nvstreamer-${i} may lack test videos"
-        fi
     done
+    info "NVStreamer video directories prepared (no videos pre-seeded)."
+    info "To get streams outside the BDD suite: upload videos to NVStreamer and run a sensor scan from the VST UI."
 
     if ! sed -e "s|^NVSTREAMER_VIDEO_[1-5]=.*|#&|" \
             -e "\$a\\
@@ -698,7 +699,13 @@ run_docker_compose() {
     info "Starting nvstreamer containers..."
     cd "$NVSTREAMER_BASE_PATH" || error "Failed to change directory to NVSTREAMER_BASE_PATH"
     docker compose --env-file ./compose.env down
-    docker compose --env-file ./compose.env up -d || error "Failed to start nvstreamer containers"
+    # Start only the first NVSTREAMER_COUNT instance(s) -- the test run seeds and
+    # uses just these (default 1). Avoids spinning up unused streamer containers.
+    local ns_services=()
+    for ((i = 1; i <= NVSTREAMER_COUNT; i++)); do
+        ns_services+=("nvstreamer-$i")
+    done
+    docker compose --env-file ./compose.env up -d "${ns_services[@]}" || error "Failed to start nvstreamer containers"
 
     # Wait for nvstreamer containers to initialize
     info "Waiting for nvstreamer containers to initialize..."
@@ -718,7 +725,15 @@ run_docker_compose() {
     cd "$VST_BASE_PATH" || error "Failed to change directory to VST_BASE_PATH"
 
     docker compose -f docker-compose.yaml -f docker-compose.test.yaml --env-file ./compose.env down
-    
+
+    # Always re-pull the ingress image before starting. Its tag may have been
+    # re-pushed in place (same version, fixed content); a stale cached image
+    # would otherwise be reused and can leave vst-ingress unhealthy. The tag
+    # itself is whatever NGINX_IMAGE resolves to in compose.env.
+    info "Re-pulling ingress image (vst-ingress) to pick up any in-place tag update..."
+    docker compose -f docker-compose.yaml -f docker-compose.test.yaml --env-file ./compose.env pull vst-ingress \
+        || info "WARNING: failed to re-pull vst-ingress image -- proceeding with cached image"
+
     local exit_code=0
     docker compose -f docker-compose.yaml -f docker-compose.test.yaml --env-file ./compose.env up --remove-orphans --exit-code-from test --attach test || exit_code=$?
 
@@ -815,31 +830,26 @@ collect_logs() {
         done
     } > "$artifact_log_dir/healthcheck_details.txt" 2>&1
 
-    if grep -q "unhealthy" "$artifact_log_dir/healthcheck_details.txt" 2>/dev/null; then
-        info "Unhealthy containers detected -- see $artifact_log_dir/healthcheck_details.txt for details"
+    # Flag only containers that are STILL RUNNING but unhealthy. A container that
+    # is merely stopping or exited at teardown (the normal end of a green run) can
+    # briefly report "unhealthy", so grepping the report text gives false positives.
+    local unhealthy_running="" cstate chealth
+    for container in $containers; do
+        cstate=$(docker inspect --format='{{.State.Status}}' "$container" 2>/dev/null) || continue
+        chealth=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$container" 2>/dev/null)
+        if [[ "$cstate" == "running" && "$chealth" == "unhealthy" ]]; then
+            unhealthy_running+=" $container"
+        fi
+    done
+    if [[ -n "$unhealthy_running" ]]; then
+        info "Unhealthy containers detected:${unhealthy_running} -- see $artifact_log_dir/healthcheck_details.txt for details"
     fi
 
     info "Container logs saved to $artifact_log_dir"
-
-    # Also archive to /tmp for backward compatibility with Jenkins post-build steps
-    local log_base_dir="/tmp/vst_test_logs"
-    local timestamp
-    timestamp=$(date +'%Y%m%d_%H%M%S')
-    local jenkins_log_dir="/tmp/last_run_logs"
-
-    [[ -d "$jenkins_log_dir" ]] && rm -rf "$jenkins_log_dir"
-    mkdir -p "$log_base_dir" "$jenkins_log_dir" || {
-        echo "Failed to create Jenkins log directory: $jenkins_log_dir"
-        return 1
-    }
-
-    local tar_file="${log_base_dir}/docker_logs_${timestamp}.tar.gz"
-    if tar -czf "$tar_file" -C "$(dirname "$artifact_log_dir")" "$(basename "$artifact_log_dir")"; then
-        echo "Logs archived to: $tar_file"
-        mv "$tar_file" "${jenkins_log_dir}/docker_logs.tar.gz"
-    else
-        echo "Failed to archive logs"
-    fi
+    # No /tmp archival. DevOps archives the workspace path
+    # (deployment/scaling/docker-compose/bdd_test_reports/, mirrored below) and
+    # does not consume /tmp/last_run_logs. The old fixed /tmp paths also broke
+    # with permission errors when the runner started as a different (sudo) user.
 }
 
 # Idempotent collection of docker logs + BDD reports.  Invoked both
@@ -1060,8 +1070,14 @@ main() {
     info "Bind-mounting BDD test sources from: $BDD_TESTS_DIR"
 
     # Defaults formerly provided by config.env; callers can still override them.
-    NVSTREAMER_COUNT="${NVSTREAMER_COUNT:-5}"
+    # Only one NVStreamer instance is started/seeded for the test run (the BDD
+    # prerequisite uploads the baked clips to it). Override NVSTREAMER_COUNT to
+    # bring up and wire more instances (up to MAX_NVSTREAMER_INSTANCES).
+    NVSTREAMER_COUNT="${NVSTREAMER_COUNT:-1}"
     NVSTREAMER_PORT_BASE="${NVSTREAMER_PORT_BASE:-31000}"
+    # The nvstreamer docker-compose provisions exactly this many services
+    # (nvstreamer-1 .. nvstreamer-5); requesting more would fail at startup.
+    MAX_NVSTREAMER_INSTANCES=5
 
     # Validate required variables
     : "${NVSTREAMER_COUNT:?NVSTREAMER_COUNT is not set in config}"
@@ -1070,6 +1086,9 @@ main() {
     # Validate values
     validate_integer "$NVSTREAMER_COUNT" "NVSTREAMER_COUNT"
     validate_integer "$NVSTREAMER_PORT_BASE" "NVSTREAMER_PORT_BASE"
+    if (( NVSTREAMER_COUNT < 1 || NVSTREAMER_COUNT > MAX_NVSTREAMER_INSTANCES )); then
+        error "NVSTREAMER_COUNT must be between 1 and ${MAX_NVSTREAMER_INSTANCES}: $NVSTREAMER_COUNT"
+    fi
     validate_path "$RTSP_STREAMS_JSON" "RTSP_STREAMS_JSON"
     validate_path "$VST_CONFIG_JSON" "VST_CONFIG_JSON"
 

--- a/services/vios/test/bdd_tests/.dockerignore
+++ b/services/vios/test/bdd_tests/.dockerignore
@@ -30,6 +30,11 @@ test-results/
 clip_*.mp4
 test_upload_*.mp4
 
+# Keep the baked sample clips: the *.mp4 rule above is root-level only, but be
+# explicit so the BDD image always contains test_videos/ regardless of future
+# changes to the rules above.
+!test_videos/
+
 # IDE
 .vscode/
 .idea/

--- a/services/vios/test/bdd_tests/Dockerfile
+++ b/services/vios/test/bdd_tests/Dockerfile
@@ -73,7 +73,11 @@ COPY pyproject.toml poetry.lock* ./
 # Install Python dependencies (without dev dependencies)
 RUN poetry install --no-root --only main
 
-# Copy the entire project
+# Copy the entire project. This also bakes test_videos/ (the sample clips) into
+# the image -- .dockerignore explicitly un-ignores test_videos/. Unlike tests/,
+# features/, scripts/, data/, conftest.py, it is NOT bind-mounted at runtime, so
+# the baked /app/test_videos copies are always available. The BDD session
+# prerequisite (conftest.py) uploads them to NVStreamer when it has no streams.
 COPY . .
 
 # Clean any cached Python bytecode with absolute paths

--- a/services/vios/test/bdd_tests/config.json
+++ b/services/vios/test/bdd_tests/config.json
@@ -3,6 +3,14 @@
     "base_url": "http://localhost:30888",
     "verify_ssl": false
   },
+  "nvstreamer": {
+    "host": "localhost",
+    "port_base": 31000,
+    "instances": 1,
+    "upload_timestamp": "2025-01-01T00:00:00.000Z",
+    "live_ready_timeout_sec": 150,
+    "replay_ready_timeout_sec": 300
+  },
   "reporting": {
     "junit_xml": "reports/junit.xml",
     "html_report": "reports/report.html",

--- a/services/vios/test/bdd_tests/conftest.py
+++ b/services/vios/test/bdd_tests/conftest.py
@@ -18,6 +18,7 @@ import logging
 import os
 import pytest
 from pathlib import Path
+from typing import Any, Iterator
 
 from scripts.container_monitor import get_monitor, cleanup_monitor
 from scripts.nvenc_capacity import (
@@ -210,8 +211,38 @@ def api_config(config, request):
     cli_base_url = request.config.getoption("--base-url")
     if cli_base_url:
         api_conf['base_url'] = cli_base_url
-    
+
     return api_conf
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_streams(api_config: dict[str, Any], config: dict[str, Any]) -> Iterator[None]:
+    """Prerequisite for the whole suite: make sure NVStreamer has streams.
+
+    If NVStreamer reports no sensors, upload the sample clips baked into this
+    container (``/app/test_videos``) and trigger a VST sensor scan so VIOS
+    imports the resulting RTSP streams. Best-effort: any failure (NVStreamer
+    not deployed, no baked clips, scan error) is logged and the suite proceeds
+    -- tests that don't need live streams are unaffected.
+    """
+    try:
+        from scripts.stream_prerequisite import ensure_streams as _ensure_streams
+
+        summary = _ensure_streams(
+            api_config['base_url'],
+            api_config.get('verify_ssl', False),
+            config,
+        )
+        if summary.get('seeded'):
+            logger.info(
+                "Stream prerequisite: uploaded %d clip(s), VST scan=%s, "
+                "live_ready=%s, replay_ready=%s",
+                summary.get('uploaded', 0), summary.get('scanned'),
+                summary.get('live_ready'), summary.get('replay_ready'),
+            )
+    except Exception as exc:  # never block the session on the prerequisite
+        logger.warning("Stream prerequisite skipped: %s", exc)
+    yield
 
 
 @pytest.fixture(scope="session")

--- a/services/vios/test/bdd_tests/scripts/run_unit_tests.sh
+++ b/services/vios/test/bdd_tests/scripts/run_unit_tests.sh
@@ -20,14 +20,17 @@
 # streamprocessing-ms), producing one CSV and one JUnit XML per group under
 # reports/unit_tests/:
 #
-#   vst-sensor.xml          <- sensor_management
+#   vst-sensor.xml           <- sensor_management            (sensor-ms container)
 #   vst-streamprocessing.xml <- live_stream, replay_stream, rtsp_proxy,
 #                               storage_management, stream_recorder
-#   vst-mcp.xml             <- mcp_gateway (kept for dashboard continuity;
-#                              tests are gated by the mcp_gateway pytest
-#                              marker and skipped by default in this flow
-#                              because vst-mcp is not part of the
-#                              stream-processing compose stack)
+#                               (all run inside the streamprocessing-ms monolith)
+#   vst-ingress.xml          <- ingress (basic nginx-gateway health and routing
+#                               tests: /health, and that sensor + streamprocessing
+#                               APIs are proxied through the gateway)
+#
+# These three match the containers the stream-processing compose deploys
+# (sensor-ms, streamprocessing-ms, vst-ingress). mcp_gateway is intentionally not
+# grouped here -- vst-mcp is not part of this stack.
 #
 # Usage:
 #   ./scripts/run_unit_tests.sh [--base-url http://host:30888]
@@ -65,13 +68,15 @@ GROUP_RESULTS=()
 
 # Container groups: <junit-name>|<csv-name>|<space-separated test subdirs>
 # Update this list if the deployed container topology changes.
-GROUPS=(
+# NB: do NOT name this array GROUPS -- that is a reserved bash array (the
+# caller's group IDs) and assignments to it are ignored/error in bash 5.x.
+CONTAINER_GROUPS=(
     "vst-sensor|sensor_management|sensor_management"
-    "vst-mcp|mcp_gateway|mcp_gateway"
     "vst-streamprocessing|streamprocessing|live_stream replay_stream rtsp_proxy storage_management stream_recorder"
+    "vst-ingress|ingress|ingress"
 )
 
-for GROUP in "${GROUPS[@]}"; do
+for GROUP in "${CONTAINER_GROUPS[@]}"; do
     JUNIT_NAME="${GROUP%%|*}"
     REST="${GROUP#*|}"
     CSV_NAME="${REST%%|*}"

--- a/services/vios/test/bdd_tests/scripts/stream_prerequisite.py
+++ b/services/vios/test/bdd_tests/scripts/stream_prerequisite.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BDD session prerequisite: make sure NVStreamer has at least one stream.
+
+The sample clips are baked into the BDD test image under ``/app/test_videos``
+(see the project Dockerfile). When NVStreamer reports no file-backed sensors,
+this module uploads those clips to NVStreamer (PUT v2) and then triggers a VST
+sensor scan so VIOS imports the resulting RTSP streams.
+
+It is best-effort: a missing baked directory, an unreachable NVStreamer, or a
+failed scan only logs a warning -- it never raises into the session. Suites
+that don't need live streams (e.g. file-upload, unit tests) still run.
+"""
+import logging
+import os
+import time
+from pathlib import Path
+from typing import List
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ISO 8601 UTC timestamp stamped on uploaded clips when none is configured.
+DEFAULT_UPLOAD_TIMESTAMP = "2025-01-01T00:00:00.000Z"
+# Supported test-clip containers (codec is validated server-side on upload).
+VIDEO_SUFFIXES = (".mp4", ".mkv", ".ts")
+# VST endpoints the first BDD tests (live/replay WebRTC) read -- the prerequisite
+# waits for these to be populated so freshly-seeded streams have warmed up.
+LIVE_STREAMS_PATH = "/vst/api/v1/live/streams"
+REPLAY_STREAMS_PATH = "/vst/api/v1/replay/streams"
+# Default readiness timeouts (seconds). Recordings (replay) take longer to appear
+# than live streams. Overridable via the `nvstreamer` config block.
+DEFAULT_LIVE_READY_TIMEOUT_SEC = 150
+DEFAULT_REPLAY_READY_TIMEOUT_SEC = 300
+# Candidate locations for the baked clips, in priority order.
+_DEFAULT_BAKED_DIRS = ("/app/test_videos",)
+
+
+def baked_videos_dir() -> Path:
+    """Resolve the directory holding the baked sample clips.
+
+    Priority: ``TEST_VIDEOS_DIR`` env var, then ``/app/test_videos`` (the path
+    baked into the container), then the repo copy under ``test/bdd_tests``.
+    """
+    env_dir = os.environ.get("TEST_VIDEOS_DIR")
+    candidates = []
+    if env_dir:
+        candidates.append(Path(env_dir))
+    candidates.extend(Path(d) for d in _DEFAULT_BAKED_DIRS)
+    # Repo-relative fallback for local (non-container) runs.
+    candidates.append(Path(__file__).resolve().parent.parent / "test_videos")
+    for path in candidates:
+        if path.is_dir() and any(
+            p.suffix.lower() in VIDEO_SUFFIXES for p in path.iterdir()
+        ):
+            return path
+    # Return the first preference so callers can log a useful "not found" path.
+    return candidates[0]
+
+
+def _list_videos(directory: Path) -> List[Path]:
+    if not directory.is_dir():
+        return []
+    return sorted(
+        p for p in directory.iterdir() if p.suffix.lower() in VIDEO_SUFFIXES
+    )
+
+
+def nvstreamer_endpoints(config: dict) -> List[str]:
+    """Resolve the NVStreamer REST endpoint(s) to seed.
+
+    Priority: ``NVSTREAMER_ENDPOINTS`` env var (comma-separated full URLs),
+    then the ``nvstreamer`` block in config.json (host + port_base + instances),
+    then a single default of ``http://localhost:31000`` (the BDD container is
+    host-networked, so NVStreamer's host ports are reachable as localhost).
+    """
+    env_eps = os.environ.get("NVSTREAMER_ENDPOINTS")
+    if env_eps:
+        return [e.strip().rstrip("/") for e in env_eps.split(",") if e.strip()]
+
+    ns = config.get("nvstreamer", {}) if isinstance(config, dict) else {}
+    host = ns.get("host", "localhost")
+    port_base = int(ns.get("port_base", 31000))
+    instances = int(ns.get("instances", 1))
+    return [f"http://{host}:{port_base + i}" for i in range(max(instances, 1))]
+
+
+def nvstreamer_stream_count(endpoint: str, timeout: int = 10) -> int:
+    """Return the number of sensors NVStreamer is currently serving.
+
+    Raises on transport error so the caller can treat the endpoint as
+    unreachable and skip it.
+    """
+    resp = requests.get(
+        f"{endpoint}/vst/api/v1/sensor/list", timeout=timeout
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    # NVStreamer returns either a bare list or {"sensors":[...]} depending on
+    # version -- handle both.
+    if isinstance(data, dict):
+        data = data.get("sensors", data.get("data", []))
+    return len(data) if isinstance(data, list) else 0
+
+
+def upload_video(endpoint: str, video: Path, timestamp: str, timeout: int = 120) -> bool:
+    """Upload one clip to NVStreamer via PUT v2. Returns True on success."""
+    payload = video.read_bytes()
+    # Filenames must not contain whitespace (NVStreamer rejects with 400).
+    name = video.name.replace(" ", "_")
+    url = f"{endpoint}/vst/api/v1/storage/file/{name}?timestamp={timestamp}"
+    resp = requests.put(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/octet-stream"},
+        timeout=timeout,
+    )
+    if resp.status_code == 200:
+        logger.info("Uploaded %s to %s", name, endpoint)
+        return True
+    # 409 = already present; treat as success (the stream exists).
+    if resp.status_code == 409:
+        logger.info("%s already present on %s (409)", name, endpoint)
+        return True
+    logger.warning(
+        "Upload of %s to %s failed: HTTP %s %s",
+        name, endpoint, resp.status_code, resp.text[:200],
+    )
+    return False
+
+
+def vst_scan(base_url: str, verify_ssl: bool = False, timeout: int = 60) -> bool:
+    """Trigger a VST sensor scan so VIOS imports NVStreamer RTSP streams."""
+    url = f"{base_url}/vst/api/v1/sensor/scan"
+    resp = requests.post(url, timeout=timeout, verify=verify_ssl)
+    if resp.status_code == 200:
+        logger.info("VST sensor scan triggered (%s)", url)
+        return True
+    logger.warning("VST sensor scan failed: HTTP %s %s", resp.status_code, resp.text[:200])
+    return False
+
+
+def _endpoint_list_count(base_url: str, path: str, verify_ssl: bool = False, timeout: int = 15) -> int:
+    """Count the list items returned by a VST list endpoint (sensor/live/replay)."""
+    resp = requests.get(f"{base_url}{path}", timeout=timeout, verify=verify_ssl)
+    resp.raise_for_status()
+    data = resp.json()
+    if isinstance(data, dict):
+        data = data.get("streams", data.get("sensors", data.get("data", [])))
+    return len(data) if isinstance(data, list) else 0
+
+
+def _wait_for_count(base_url: str, path: str, verify_ssl: bool,
+                    timeout_s: int, interval_s: int, label: str) -> bool:
+    """Poll a VST list endpoint until it returns >0 items or the timeout elapses."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            n = _endpoint_list_count(base_url, path, verify_ssl)
+            if n > 0:
+                logger.info("%s ready: %d", label, n)
+                return True
+        except Exception as exc:
+            # Transient while the endpoint warms up; keep polling but surface it.
+            logger.debug("%s readiness check failed: %s", label, exc)
+        time.sleep(interval_s)
+    logger.warning("%s not ready after %ds", label, timeout_s)
+    return False
+
+
+def ensure_streams(base_url: str, verify_ssl: bool, config: dict) -> dict:
+    """Ensure NVStreamer has streams, seeding the baked clips if it is empty.
+
+    Returns a summary dict: ``{"seeded": bool, "uploaded": int, "scanned": bool}``.
+    Best-effort -- logs and returns instead of raising on any failure.
+    """
+    summary = {"seeded": False, "uploaded": 0, "scanned": False}
+    timestamp = config.get("nvstreamer", {}).get(
+        "upload_timestamp", DEFAULT_UPLOAD_TIMESTAMP
+    )
+
+    endpoints = nvstreamer_endpoints(config)
+    videos = _list_videos(baked_videos_dir())
+
+    seeded_any = False
+    reachable_any = False
+    for endpoint in endpoints:
+        try:
+            count = nvstreamer_stream_count(endpoint)
+        except Exception as exc:  # unreachable / not deployed
+            logger.info("NVStreamer %s not reachable (%s) -- skipping", endpoint, exc)
+            continue
+        reachable_any = True
+        if count > 0:
+            logger.info("NVStreamer %s already has %d stream(s)", endpoint, count)
+            continue
+        if not videos:
+            logger.warning(
+                "NVStreamer %s has no streams but no baked clips were found in %s",
+                endpoint, baked_videos_dir(),
+            )
+            continue
+        logger.info("NVStreamer %s has no streams -- uploading %d baked clip(s)", endpoint, len(videos))
+        for video in videos:
+            try:
+                if upload_video(endpoint, video, timestamp):
+                    summary["uploaded"] += 1
+                    seeded_any = True
+            except Exception as exc:
+                logger.warning("Upload of %s to %s raised: %s", video.name, endpoint, exc)
+
+    if not reachable_any:
+        logger.warning("No NVStreamer endpoint reachable %s -- stream prerequisite skipped", endpoints)
+        return summary
+
+    if seeded_any:
+        summary["seeded"] = True
+        # Give NVStreamer's discovery cycle a moment to register the files,
+        # then ask VST to scan and import the RTSP streams.
+        time.sleep(5)
+        try:
+            summary["scanned"] = vst_scan(base_url, verify_ssl)
+        except Exception as exc:
+            logger.warning("VST scan raised: %s", exc)
+
+        ns = config.get("nvstreamer", {}) if isinstance(config, dict) else {}
+        live_timeout = int(ns.get("live_ready_timeout_sec", DEFAULT_LIVE_READY_TIMEOUT_SEC))
+        replay_timeout = int(ns.get("replay_ready_timeout_sec", DEFAULT_REPLAY_READY_TIMEOUT_SEC))
+
+        # Wait for the streams to actually warm up before tests run. Seeding at
+        # test-time (vs at deploy-time) means the first stream-dependent tests
+        # (live/replay WebRTC) would otherwise race the pipeline coming up:
+        #   1. sensors imported into VST,
+        #   2. live streams reachable (/live/streams populated),
+        #   3. recordings replayable (/replay/streams populated).
+        _wait_for_count(base_url, "/vst/api/v1/sensor/list", verify_ssl, 60, 5, "VST sensors")
+        summary["live_ready"] = _wait_for_count(
+            base_url, LIVE_STREAMS_PATH, verify_ssl, live_timeout, 5, "VST live streams"
+        )
+        summary["replay_ready"] = _wait_for_count(
+            base_url, REPLAY_STREAMS_PATH, verify_ssl, replay_timeout, 10, "VST replay streams"
+        )
+
+    return summary

--- a/services/vios/test/bdd_tests/test_videos/.gitignore
+++ b/services/vios/test/bdd_tests/test_videos/.gitignore
@@ -1,0 +1,9 @@
+# Sample test clips are baked into the BDD test image at build time and are
+# intentionally NOT committed to the repository. Keep this directory tracked
+# (via README.md and this file) so the Dockerfile `COPY test_videos/` step has
+# a target, but never commit the binaries themselves. See README.md.
+*.mp4
+*.mkv
+*.ts
+*.mov
+*.avi

--- a/services/vios/test/bdd_tests/test_videos/README.md
+++ b/services/vios/test/bdd_tests/test_videos/README.md
@@ -1,0 +1,40 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# test_videos
+
+Sample clips used to seed NVStreamer for the BDD suite:
+
+| File | Codec / container |
+|---|---|
+| `sample_10sec_h264.mp4` | H.264 / MP4 |
+| `sample_10sec_h264.mkv` | H.264 / MKV |
+| `sample_10sec_h265.mp4` | H.265 / MP4 |
+| `sample_10sec_h265.mkv` | H.265 / MKV |
+
+## These binaries are NOT in the repository
+
+They are **baked into the BDD test image** at build time
+(`Dockerfile` -> `COPY test_videos/ ./test_videos/` -> `/app/test_videos`) and
+pushed to `gitlab-master.nvidia.com:5005/l4tmm/vms_shim/bdd_tests`. The pushed
+image is the source of truth. `.gitignore` excludes the binaries so they never
+land in git history.
+
+At test time the session prerequisite in `conftest.py`
+(`scripts/stream_prerequisite.py`) uploads these clips to NVStreamer and runs a
+VST sensor scan when NVStreamer has no streams.
+
+## How to obtain the clips for a rebuild
+
+The files must be present in this directory before building/pushing the image.
+Obtain them from any of:
+
+- The current published image:
+  `docker run --rm <bdd-image> tar -C /app/test_videos -cf - . | tar -C test/bdd_tests/test_videos -xf -`
+- A local backup (e.g. created during the migration): `~/vms_shim_test_videos_backup/`
+- Regenerate equivalent 10-second H.264/H.265 clips with ffmpeg.
+
+After placing the files here, follow `.cursor/skills/bdd-container-update/SKILL.md`
+to rebuild, push, and bump the image tag.

--- a/services/vios/test/bdd_tests/tests/unit_tests/ingress/__init__.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/ingress/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/services/vios/test/bdd_tests/tests/unit_tests/ingress/test_ingress_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/ingress/test_ingress_api.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Basic unit tests for the VST ingress (nginx gateway).
+
+The ingress has no business logic of its own -- it terminates HTTP on port
+30888 and proxies requests to the backend microservices. These tests verify the
+gateway is up and routing correctly:
+
+  * its own /health endpoint returns 200,
+  * sensor APIs are proxied to sensor-ms,
+  * stream APIs are proxied to the streamprocessing-ms monolith,
+  * an unknown route is answered by the gateway (a 4xx, not a dead connection).
+"""
+import logging
+
+from ..unit_test_utils import api_get, validate_list_response
+
+logger = logging.getLogger(__name__)
+
+
+def _timeout(unit_test_params: dict) -> int:
+    return unit_test_params.get("timeout", 30)
+
+
+def test_ingress_health_endpoint_returns_200(api_config: dict, unit_test_params: dict) -> None:
+    """The gateway's own /health endpoint responds 200 when the stack is up."""
+    response = api_get(
+        api_config["base_url"],
+        "/health",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    assert response.status_code == 200, (
+        f"ingress /health returned {response.status_code} (gateway not healthy)"
+    )
+
+
+def test_ingress_proxies_sensor_service(api_config: dict, unit_test_params: dict) -> None:
+    """Sensor APIs route through the gateway to sensor-ms and return a list."""
+    response = api_get(
+        api_config["base_url"],
+        "/vst/api/v1/sensor/list",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    # validate_list_response asserts HTTP 200 + JSON array (may be empty).
+    validate_list_response(response)
+
+
+def test_ingress_proxies_streamprocessing_service(api_config: dict, unit_test_params: dict) -> None:
+    """Live-stream APIs route through the gateway to streamprocessing-ms."""
+    response = api_get(
+        api_config["base_url"],
+        "/vst/api/v1/live/streams",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    validate_list_response(response)
+
+
+def test_ingress_returns_client_error_for_unknown_route(api_config: dict, unit_test_params: dict) -> None:
+    """An unknown path is answered by the gateway with a 4xx, proving it is up
+    and routing (as opposed to a connection refused / 5xx upstream failure)."""
+    response = api_get(
+        api_config["base_url"],
+        "/vst/api/v1/__nonexistent_ingress_probe__",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    assert 400 <= response.status_code < 500, (
+        f"expected a 4xx for an unknown route, got {response.status_code}"
+    )


### PR DESCRIPTION
* Add a session prerequisite that uploads the baked sample clips to NVStreamer and triggers a VST sensor scan when it has no streams.
* Bake test_videos into the BDD image and stop pre-seeding videos into NVStreamer at deploy time.
* Start and validate only NVSTREAMER_COUNT instances, re-pull the ingress image, and flag only still-running unhealthy containers at teardown.
* Add ingress gateway unit tests and regroup unit-test reports into sensor, streamprocessing, and ingress.
* Update SQA skills and agent docs to reflect that clips are baked into the image rather than shipped under tools/data.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
