### PR TITLE
fix(env): update VLM_MODEL_TYPE and RTVI_VLM_IMAGE_TAG for warehouse …

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -105,7 +105,7 @@ VLM_NAME=nim_nvidia_cosmos-reason2-8b_hf-1208
 VLM_NAME_SLUG=none
 
 VLM_ENV_FILE=''
-VLM_MODEL_TYPE=nim
+VLM_MODEL_TYPE=rtvi
 
 RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-1208
 RTVI_VLM_MODEL_TO_USE=cosmos-reason2
@@ -303,9 +303,9 @@ VSS_AGENT_REPORTS_BASE_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VS
 # Used by: RTVI services (for bp_wh 2d mode)
 
 # RTVI VLM Container Image tags for x86 and THOR
-RTVI_VLM_IMAGE_TAG="3.2.0"
+RTVI_VLM_IMAGE_TAG="3.2.1-26.06.2"
 # Uncomment below RTVI VLM Container Image tag for DGX-SPARK
-#RTVI_VLM_IMAGE_TAG="3.2.0-sbsa"
+#RTVI_VLM_IMAGE_TAG="3.2.1-26.06.2-sbsa"
 
 VLM_BASE_URL=http://${HOST_IP}:8018
 RTVI_VLM_BASE_URL=http://${HOST_IP}:8018

--- a/deploy/docker/scripts/deploy_warehouse_launchable.ipynb
+++ b/deploy/docker/scripts/deploy_warehouse_launchable.ipynb
@@ -1436,7 +1436,7 @@
     "Once Kibana is accessible, open the **Discover** or **Dashboard** tab to view behavior analytics events\n",
     "(ROI crossings, proximity alerts, object tracking metadata) flowing from the warehouse deployment.\n",
     "\n",
-    "For more details see the [VSS Warehouse Blueprint documentation](https://docs.nvidia.com/vss/3.2.0/).\n"
+    "For more details see the [VSS Warehouse Blueprint documentation](https://docs.nvidia.com/vss/3.2.0/warehouse-docs/warehouse-toc.html).\n"
    ]
   },
   {

--- a/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
+++ b/deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml
@@ -18,7 +18,7 @@
 services:
   rtvi-vlm:
     # for release, change this to the versioned image from the registry
-    image: nvcr.io/nvidia/vss-core/vss-rt-vlm:${RTVI_VLM_IMAGE_TAG:-3.2.0}
+    image: nvcr.io/nvstaging/vss-core/vss-rt-vlm:${RTVI_VLM_IMAGE_TAG:-3.2.1-26.06.2}
     container_name: vss-rtvi-vlm
     user: "1001:1001"
     shm_size: '16gb'


### PR DESCRIPTION
…operations

- Changed VLM_MODEL_TYPE from 'nim' to 'rtvi'.
- Updated RTVI_VLM_IMAGE_TAG from '3.2.0' to '3.2.1-26.06.2'.
- Corrected documentation link in deploy_warehouse_launchable.ipynb for VSS Warehouse Blueprint.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
