### PR TITLE
fix RTVI_VLM_IMAGE_TAG env var in profiles

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -263,14 +263,14 @@ MDX_PORT=8081
 # Used by: RTVI services (for 2d_vlm mode)
 
 # RTVI VLM Container Image tag
-# For multi-arch: 3.2.0
+# For multi-arch: 3.2.1-26.06.2
 # For DGX-SPARK (SBSA): use the commented -sbsa tag when present
 
 # RTVI VLM Container Image tags for x86 and THOR
-RTVI_VLM_IMAGE_TAG="3.2.0"
+RTVI_VLM_IMAGE_TAG="3.2.1-26.06.2"
 
 # Uncomment below RTVI VLM Container Image tag for DGX-SPARK
-#RTVI_VLM_IMAGE_TAG="3.2.0-sbsa"
+#RTVI_VLM_IMAGE_TAG="3.2.1-26.06.2-sbsa"
 
 RTVI_VLM_BASE_URL=http://${HOST_IP}:8018
 RTVI_VLM_ENDPOINT=http://${HOST_IP}:8018/v1

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -196,14 +196,14 @@ ENABLE_AUDIO=false
 # Used by: RTVI services (for 2d_vlm mode)
 
 # RTVI VLM Container Image tag
-# For multi-arch: 3.2.0
-# For DGX-SPARK (SBSA): 3.2.0-sbsa
+# For multi-arch: 3.2.1-26.06.2
+# For DGX-SPARK (SBSA): 3.2.1-26.06.2-sbsa
 
 # RTVI VLM Container Image tags for x86 and THOR
-RTVI_VLM_IMAGE_TAG="3.2.0"
+RTVI_VLM_IMAGE_TAG="3.2.1-26.06.2"
 
 # Uncomment below RTVI VLM Container Image tag for DGX-SPARK
-#RTVI_VLM_IMAGE_TAG="3.2.0-sbsa"
+#RTVI_VLM_IMAGE_TAG="3.2.1-26.06.2-sbsa"
 
 RTVI_VLM_BASE_URL=http://${HOST_IP}:8018
 RTVI_VLM_ENDPOINT=http://${HOST_IP}:30082/v1

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -206,10 +206,10 @@ LVS_BACKEND_URL=http://${HOST_IP}:38111
 # Used by: RTVI services, LVS backend
 
 # RTVI VLM Container Image tags for x86 and THOR
-RTVI_VLM_IMAGE_TAG="3.2.0"
+RTVI_VLM_IMAGE_TAG="3.2.1-26.06.2"
 
 # Uncomment below RTVI VLM Container Image tag for DGX-SPARK
-#RTVI_VLM_IMAGE_TAG="3.2.0-sbsa"
+#RTVI_VLM_IMAGE_TAG="3.2.1-26.06.2-sbsa"
 
 RTVI_VLM_PORT=8018
 RTVI_VLM_BASE_URL=http://${HOST_IP}:8018

--- a/deploy/docker/scripts/vss_orchestrator_mcp_config.yml
+++ b/deploy/docker/scripts/vss_orchestrator_mcp_config.yml
@@ -103,7 +103,7 @@ function_groups:
           OTHER:
           DGX-SPARK:
             PERCEPTION_TAG: "3.2.0-sbsa"
-            RTVI_VLM_IMAGE_TAG: "3.2.0-sbsa"
+            RTVI_VLM_IMAGE_TAG: "3.2.1-26.06.2-sbsa"
             base:
               VLM_NIM_KVCACHE_PERCENT: "0.2"
             alerts.verification:

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -937,7 +937,7 @@ COMPOSE_PROFILES=bp_wh_2d,llm_local_nvidia-nemotron-nano-9b-v2
 
 > **`COMPOSE_PROFILES` must be exported** before running any `docker compose` command with the warehouse `.env`. The variable is defined as a template inside `.env` and is not expanded by `--env-file` in all Docker Compose versions. Set it as a literal value directly in `.env` (e.g. `COMPOSE_PROFILES=bp_wh_2d,llm_remote_nvidia-nemotron-nano-9b-v2`) and also `export COMPOSE_PROFILES=bp_wh_2d,...` in the shell before running `docker compose up`.
 
-> **DGX-SPARK (SBSA):** swap to the `-sbsa`-tagged image variants. Comment the default `PERCEPTION_TAG="3.2.0"` and uncomment `PERCEPTION_TAG="3.2.0-sbsa"`. Apply the same pattern to `RTVI_VLM_IMAGE_TAG`.
+> **DGX-SPARK (SBSA):** swap to the `-sbsa`-tagged image variants. Comment the default `PERCEPTION_TAG="3.2.1-26.06.2"` and uncomment `PERCEPTION_TAG="3.2.1-26.06.2-sbsa"`. Apply the same pattern to `RTVI_VLM_IMAGE_TAG`.
 
 ---
 

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -937,7 +937,7 @@ COMPOSE_PROFILES=bp_wh_2d,llm_local_nvidia-nemotron-nano-9b-v2
 
 > **`COMPOSE_PROFILES` must be exported** before running any `docker compose` command with the warehouse `.env`. The variable is defined as a template inside `.env` and is not expanded by `--env-file` in all Docker Compose versions. Set it as a literal value directly in `.env` (e.g. `COMPOSE_PROFILES=bp_wh_2d,llm_remote_nvidia-nemotron-nano-9b-v2`) and also `export COMPOSE_PROFILES=bp_wh_2d,...` in the shell before running `docker compose up`.
 
-> **DGX-SPARK (SBSA):** swap to the `-sbsa`-tagged image variants. Comment the default `PERCEPTION_TAG="3.2.1-26.06.2"` and uncomment `PERCEPTION_TAG="3.2.1-26.06.2-sbsa"`. Apply the same pattern to `RTVI_VLM_IMAGE_TAG`.
+> **DGX-SPARK (SBSA):** swap to the `-sbsa`-tagged image variants. Comment the default `PERCEPTION_TAG="3.2.0"` and uncomment `PERCEPTION_TAG="3.2.0-sbsa"`. Apply the same pattern to `RTVI_VLM_IMAGE_TAG`.
 
 ---
 


### PR DESCRIPTION

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
