### PR TITLE
update behavior analytics Docker configuration and OpenCV build process

### DIFF
--- a/deploy/docker/services/analytics/behavior-analytics/compose.yml
+++ b/deploy/docker/services/analytics/behavior-analytics/compose.yml
@@ -24,7 +24,7 @@
 services:
 
   vss-behavior-analytics-base:
-    image: nvcr.io/nvidia/vss-core/vss-behavior-analytics:3.2.0
+    image: nvcr.io/nvstaging/vss-core/vss-behavior-analytics:3.2.1-26.06.4
     network_mode: "host"
     restart: always
     volumes:

--- a/services/analytics/behavior-analytics/docker/Dockerfile
+++ b/services/analytics/behavior-analytics/docker/Dockerfile
@@ -14,8 +14,51 @@
 # limitations under the License.
 
 ARG PYTHON_VERSION=3.13
+# manylinux CPython tag for the OpenCV build; must track PYTHON_VERSION
+# (e.g. 3.13 -> cp313-cp313, 3.14 -> cp314-cp314).
+ARG PYBIN_TAG=cp313-cp313
 ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.0.6
 ARG DISTROLESS_IMG=nvcr.io/nvidia/distroless/python
+
+###################################################
+# OpenCV (headless) rebuilt WITHOUT FFmpeg/GStreamer.
+#
+# The PyPI `opencv-python-headless` wheel bundles FFmpeg shared libraries
+# (libavcodec/avformat/avutil/swscale, LGPLv2.1) hard-linked into cv2. This
+# codebase only uses OpenCV for image + calibration ops (no video I/O), so we
+# recompile OpenCV with WITH_FFMPEG=OFF to avoid shipping those codecs.
+#
+# Built on manylinux (old glibc) and repaired with auditwheel so the wheel is
+# self-contained and installs cleanly into the distroless runtime stage. Image
+# codecs (jpeg/png/webp/tiff/jp2) come from OpenCV's bundled static 3rdparty.
+ARG MANYLINUX_IMG=quay.io/pypa/manylinux_2_28
+# opencv-python release tag; "92" == 4.13.0.92 (must match Pipfile.lock).
+ARG OPENCV_PYTHON_TAG=92
+
+FROM ${MANYLINUX_IMG}_x86_64 AS ocv-amd64
+FROM ${MANYLINUX_IMG}_aarch64 AS ocv-arm64
+FROM ocv-${TARGETARCH} AS opencv-builder
+ARG OPENCV_PYTHON_TAG
+ARG PYBIN_TAG
+ENV PYBIN=/opt/python/${PYBIN_TAG}/bin \
+    ENABLE_HEADLESS=1 \
+    ENABLE_CONTRIB=0 \
+    CMAKE_ARGS="-DWITH_FFMPEG=OFF -DWITH_GSTREAMER=OFF -DWITH_V4L=OFF -DWITH_1394=OFF -DWITH_GPHOTO2=OFF -DWITH_ANDROID_MEDIANDK=OFF -DVIDEOIO_ENABLE_PLUGINS=OFF -DWITH_AVIF=OFF -DBUILD_LIST=python3,calib3d,imgcodecs"
+RUN $PYBIN/pip install --no-cache-dir --upgrade pip auditwheel
+RUN git clone --depth 1 --branch ${OPENCV_PYTHON_TAG} --recursive --shallow-submodules \
+        https://github.com/opencv/opencv-python.git /src
+RUN cd /src && $PYBIN/pip wheel . --no-deps --no-cache-dir -w /raw
+RUN $PYBIN/auditwheel repair -w /opencv-wheels /raw/*.whl
+# Fail the build if any FFmpeg/GStreamer lib slipped into the repaired wheel.
+RUN $PYBIN/python - <<'PY'
+import glob, zipfile
+whl = glob.glob('/opencv-wheels/*.whl')[0]
+bad = [n for n in zipfile.ZipFile(whl).namelist()
+       if any(s in n.lower() for s in ('libav', 'swscale', 'swresample', 'libgst'))]
+print('repaired wheel:', whl)
+assert not bad, f'FFmpeg/GStreamer libs present in wheel: {bad}'
+print('OK: no FFmpeg/GStreamer libs in wheel')
+PY
 
 ###################################################
 # Container used to build and download libraries
@@ -60,11 +103,19 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 # Install pipenv and other tools
 RUN pip install --upgrade pip pipenv setuptools wheel
 
-# Install requirements and py analytics library itself
+# FFmpeg-free OpenCV wheel built in the opencv-builder stage above.
+COPY --from=opencv-builder /opencv-wheels/ /tmp/opencv-wheels/
+
+# Install requirements and py analytics library itself.
+# opencv-python-headless is filtered out of the locked requirements and installed
+# from our FFmpeg-free wheel instead of the PyPI wheel (which bundles LGPL FFmpeg).
 COPY . .
-RUN pipenv requirements --hash > requirements.txt && \
+RUN pipenv requirements --hash > requirements.full.txt && \
+    awk '/^opencv-python-headless/{skip=1;next} /^[^ \t]/{skip=0} !skip' requirements.full.txt > requirements.txt && \
     pip install --no-deps --no-cache-dir -r requirements.txt && \
+    pip install --no-deps --no-cache-dir /tmp/opencv-wheels/*.whl && \
     pip install --no-deps --no-cache-dir . && \
+    rm -rf /tmp/opencv-wheels requirements.full.txt && \
     pip uninstall -y wheel pipenv pip
 
 # Prepare clean runtime directory with only required files


### PR DESCRIPTION
- Updated the behavior analytics image version in the Docker Compose file to 3.2.1-26.06.4.
- Enhanced the Dockerfile to build a FFmpeg-free OpenCV wheel, ensuring no unwanted codecs are included.
- Adjusted the installation process to utilize the custom-built OpenCV wheel instead of the default PyPI version.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
