### PR TITLE
feat(agent): add opt-in TwelveLabs Marengo embedding backend

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -205,6 +205,33 @@ or are only needed for specific features.
 | `EVAL_LLM_JUDGE_BASE_URL` | no | same as `LLM_BASE_URL` | Endpoint for evaluation judge |
 | `NGC_CLI_API_KEY` | cond. | — | Required when `LLM_MODE` / `VLM_MODE` is `local` or `local_shared` (Docker Compose) |
 | `NVIDIA_API_KEY` | cond. | — | Required for build.nvidia.com remote endpoints |
+| `TWELVELABS_API_KEY` | cond. | — | Required only when using the opt-in TwelveLabs embedding backend (see below) |
+| `TWELVELABS_EMBED_MODEL` | no | `marengo3.0` | TwelveLabs Marengo model name for the opt-in embedding backend |
+
+## Embedding backends
+
+The default semantic-search embedding backend is NVIDIA Cosmos
+(`CosmosEmbedClient`). As an **opt-in, non-breaking** alternative,
+`vss_agents.embed.TwelveLabsEmbedClient` provides text, image and video
+embeddings from [TwelveLabs](https://twelvelabs.io) Marengo — a multimodal
+model that maps all three modalities into one shared 512-dimensional space, so
+a text query and the media it is compared against live in the same vector space.
+
+It implements the same `EmbedClient` interface as the built-in backends, so it
+is a drop-in replacement anywhere an `EmbedClient` is constructed. Install the
+optional dependency and set your API key:
+
+```bash
+uv sync --extra twelvelabs
+export TWELVELABS_API_KEY=...   # free tier at https://twelvelabs.io
+```
+
+```python
+from vss_agents.embed import TwelveLabsEmbedClient
+
+client = TwelveLabsEmbedClient()          # reads TWELVELABS_API_KEY
+vec = await client.get_text_embedding("a person walking a dog")  # 512-dim
+```
 
 ## Testing
 

--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -130,6 +130,8 @@ langchain = [
     "langchain-chroma>=0.1",
     "langchain-nvidia-ai-endpoints>=0.3",
 ]
+# Opt-in TwelveLabs Marengo embedding backend (vss_agents.embed.TwelveLabsEmbedClient).
+twelvelabs = ["twelvelabs>=1.2.8"]
 
 [dependency-groups]
 dev = [

--- a/services/agent/src/vss_agents/embed/__init__.py
+++ b/services/agent/src/vss_agents/embed/__init__.py
@@ -15,5 +15,6 @@
 from .cosmos_embed import CosmosEmbedClient
 from .embed import EmbedClient
 from .rtvi_cv_embed import RTVICVEmbedClient
+from .twelvelabs_embed import TwelveLabsEmbedClient
 
-__all__ = ["CosmosEmbedClient", "EmbedClient", "RTVICVEmbedClient"]
+__all__ = ["CosmosEmbedClient", "EmbedClient", "RTVICVEmbedClient", "TwelveLabsEmbedClient"]

--- a/services/agent/src/vss_agents/embed/twelvelabs_embed.py
+++ b/services/agent/src/vss_agents/embed/twelvelabs_embed.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TwelveLabs Marengo embedding client.
+
+Opt-in alternative to the default ``CosmosEmbedClient``. Marengo is a
+multimodal embedding model that maps text, images and video into a shared
+512-dimensional space, so the same client can embed a search query and the
+indexed media it is compared against.
+
+Requires the optional ``twelvelabs`` dependency::
+
+    uv sync --extra twelvelabs
+
+and an API key (grab a free one at https://twelvelabs.io). The key is read from
+``TWELVELABS_API_KEY`` by default, or passed explicitly to the constructor.
+
+The official SDK is synchronous, so blocking calls are dispatched to a worker
+thread via :func:`asyncio.to_thread` to satisfy the async ``EmbedClient``
+contract without blocking the event loop.
+"""
+
+import asyncio
+import logging
+import os
+import time
+from typing import TYPE_CHECKING
+from typing import Any
+
+from typing_extensions import override  # noqa: UP035  # mypy targets 3.11
+
+if TYPE_CHECKING:
+    from twelvelabs.types.image_embedding_result import ImageEmbeddingResult
+    from twelvelabs.types.text_embedding_result import TextEmbeddingResult
+
+from vss_agents.embed.embed import EmbedClient
+from vss_agents.embed.embed import LRUEmbeddingCache
+
+logger = logging.getLogger(__name__)
+
+# Marengo embeddings are fixed at 512 dimensions across all modalities.
+TWELVELABS_EMBED_DIM = 512
+
+_DEFAULT_MODEL = os.getenv("TWELVELABS_EMBED_MODEL", "marengo3.0")
+_TEXT_EMBEDDING_CACHE_MAXSIZE = 1024
+# Polling cadence for the asynchronous video-embedding task.
+_VIDEO_POLL_INTERVAL_SEC = 5.0
+_VIDEO_POLL_TIMEOUT_SEC = 600.0
+
+
+class TwelveLabsEmbedClient(EmbedClient):
+    """Embedding client backed by the TwelveLabs Marengo model.
+
+    Text and image embeddings are synchronous round-trips. Video embeddings are
+    produced by an asynchronous TwelveLabs task; this client submits the task,
+    waits for completion and returns the whole-video (``"video"`` scope) vector.
+    """
+
+    def __init__(self, api_key: str | None = None, model_name: str = _DEFAULT_MODEL):
+        """Initialize the TwelveLabs embedding client.
+
+        Args:
+            api_key: TwelveLabs API key. Defaults to the ``TWELVELABS_API_KEY``
+                environment variable.
+            model_name: Marengo model name. Defaults to ``TWELVELABS_EMBED_MODEL``
+                or ``"marengo3.0"``.
+        """
+        key = api_key or os.getenv("TWELVELABS_API_KEY")
+        if not key:
+            raise ValueError(
+                "TwelveLabs API key not provided. Set TWELVELABS_API_KEY or pass api_key=. "
+                "Get a free key at https://twelvelabs.io."
+            )
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError as e:  # pragma: no cover - exercised only without the extra installed
+            raise ImportError(
+                "The 'twelvelabs' package is required for TwelveLabsEmbedClient. "
+                "Install it with: uv sync --extra twelvelabs"
+            ) from e
+
+        self.model_name = model_name
+        self._client = TwelveLabs(api_key=key)
+        # Bounded LRU cache for text embeddings (with per-key async locks)
+        self._text_cache = LRUEmbeddingCache(maxsize=_TEXT_EMBEDDING_CACHE_MAXSIZE)
+
+    @override
+    async def aclose(self) -> None:
+        """Clear cached embeddings and locks."""
+        self._text_cache.clear()
+
+    @override
+    async def get_text_embedding(self, text: str) -> list[float]:
+        """Generate a 512-dim embedding for text input.
+
+        Results are cached (bounded LRU) so concurrent callers with the same
+        query share a single network round-trip.
+        """
+        cached = self._text_cache.get(text)
+        if cached is not None:
+            logger.debug(f"Text embedding cache hit for: {text[:80]}")
+            return cached
+
+        # Per-key lock so only one caller fetches a given text
+        lock = self._text_cache.get_lock(text)
+
+        async with lock:
+            # Double-check after acquiring lock
+            cached = self._text_cache.get(text)
+            if cached is not None:
+                return cached
+
+            embedding = await asyncio.to_thread(self._fetch_text_embedding, text)
+            self._text_cache.put(text, embedding)
+            return embedding
+
+    def _fetch_text_embedding(self, text: str) -> list[float]:
+        """Fetch a text embedding from TwelveLabs (blocking; run in a thread)."""
+        res = self._client.embed.create(model_name=self.model_name, text=text)
+        return _extract_segment(res.text_embedding, "text")
+
+    @override
+    async def get_image_embedding(self, image_url: str) -> list[float]:
+        """Generate a 512-dim embedding for an image URL."""
+        return await asyncio.to_thread(self._fetch_image_embedding, image_url)
+
+    def _fetch_image_embedding(self, image_url: str) -> list[float]:
+        res = self._client.embed.create(model_name=self.model_name, image_url=image_url)
+        return _extract_segment(res.image_embedding, "image")
+
+    @override
+    async def get_video_embedding(self, video_url: str) -> list[float]:
+        """Generate a 512-dim whole-video embedding for a video URL.
+
+        Submits an asynchronous TwelveLabs embedding task, waits for it to
+        finish, then returns the ``"video"``-scope vector. May take tens of
+        seconds depending on clip length.
+        """
+        return await asyncio.to_thread(self._fetch_video_embedding, video_url)
+
+    def _fetch_video_embedding(self, video_url: str) -> list[float]:
+        task = self._client.embed.tasks.create(
+            model_name=self.model_name,
+            video_url=video_url,
+            video_embedding_scope=["video"],
+        )
+        task_id = task.id
+        if not task_id:
+            raise ValueError("TwelveLabs embedding task creation returned no task id")
+
+        deadline = time.monotonic() + _VIDEO_POLL_TIMEOUT_SEC
+        while True:
+            status = self._client.embed.tasks.status(task_id=task_id)
+            if status.status == "ready":
+                break
+            if status.status == "failed":
+                raise ValueError(f"TwelveLabs video embedding task {task_id} failed")
+            if time.monotonic() > deadline:
+                raise TimeoutError(f"TwelveLabs video embedding task {task_id} did not finish in time")
+            time.sleep(_VIDEO_POLL_INTERVAL_SEC)
+
+        res = self._client.embed.tasks.retrieve(task_id=task_id)
+        return _extract_segment(res.video_embedding, "video")
+
+
+def _extract_segment(embedding: "TextEmbeddingResult | ImageEmbeddingResult | Any", kind: str) -> list[float]:
+    """Pull the first segment's float vector out of an embedding response."""
+    segments = getattr(embedding, "segments", None) if embedding else None
+    if not segments:
+        raise ValueError(f"TwelveLabs returned no {kind} embedding segments")
+    floats = segments[0].float_
+    if floats is None:
+        raise ValueError(f"TwelveLabs {kind} embedding segment missing float values")
+    return list(floats)

--- a/services/agent/tests/unit_test/embed/test_twelvelabs_embed.py
+++ b/services/agent/tests/unit_test/embed/test_twelvelabs_embed.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for twelvelabs_embed module.
+
+The no-network tests patch the TwelveLabs SDK so they run without the optional
+``twelvelabs`` dependency installed. The ``TestLive*`` cases hit the real API
+and are skipped unless ``TWELVELABS_API_KEY`` is set.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from vss_agents.embed.twelvelabs_embed import TWELVELABS_EMBED_DIM
+from vss_agents.embed.twelvelabs_embed import TwelveLabsEmbedClient
+
+
+def _make_client_with_mock() -> tuple[TwelveLabsEmbedClient, MagicMock]:
+    """Build a client whose SDK ``TwelveLabs`` is a mock, no network, no install."""
+    fake_sdk = MagicMock()
+    fake_instance = MagicMock()
+    fake_sdk.return_value = fake_instance
+    fake_module = types.ModuleType("twelvelabs")
+    fake_module.TwelveLabs = fake_sdk  # type: ignore[attr-defined]
+    saved = sys.modules.get("twelvelabs")
+    sys.modules["twelvelabs"] = fake_module
+    try:
+        client = TwelveLabsEmbedClient(api_key="test-key")
+    finally:
+        if saved is not None:
+            sys.modules["twelvelabs"] = saved
+        else:
+            sys.modules.pop("twelvelabs", None)
+    return client, fake_instance
+
+
+def _segment(values: list[float]) -> MagicMock:
+    seg = MagicMock()
+    seg.float_ = values
+    return seg
+
+
+class TestInit:
+    def test_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="API key"):
+            TwelveLabsEmbedClient()
+
+    def test_default_model(self):
+        client, _ = _make_client_with_mock()
+        assert client.model_name == "marengo3.0"
+
+    def test_custom_model(self):
+        fake_module = types.ModuleType("twelvelabs")
+        fake_module.TwelveLabs = MagicMock()  # type: ignore[attr-defined]
+        sys.modules["twelvelabs"] = fake_module
+        try:
+            client = TwelveLabsEmbedClient(api_key="k", model_name="marengo-custom")
+            assert client.model_name == "marengo-custom"
+        finally:
+            sys.modules.pop("twelvelabs", None)
+
+    def test_embed_dim_constant(self):
+        assert TWELVELABS_EMBED_DIM == 512
+
+
+class TestGetTextEmbedding:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        client, sdk = _make_client_with_mock()
+        sdk.embed.create.return_value = MagicMock(text_embedding=MagicMock(segments=[_segment([0.1, 0.2, 0.3])]))
+
+        result = await client.get_text_embedding("hello world")
+
+        assert result == [0.1, 0.2, 0.3]
+        _, kwargs = sdk.embed.create.call_args
+        assert kwargs["text"] == "hello world"
+        assert kwargs["model_name"] == "marengo3.0"
+
+    @pytest.mark.asyncio
+    async def test_caches_repeat_queries(self):
+        client, sdk = _make_client_with_mock()
+        sdk.embed.create.return_value = MagicMock(text_embedding=MagicMock(segments=[_segment([1.0])]))
+
+        await client.get_text_embedding("same")
+        await client.get_text_embedding("same")
+
+        # Second call served from cache -> only one network round-trip.
+        assert sdk.embed.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_segments_raises(self):
+        client, sdk = _make_client_with_mock()
+        sdk.embed.create.return_value = MagicMock(text_embedding=MagicMock(segments=[]))
+
+        with pytest.raises(ValueError, match="no text embedding segments"):
+            await client.get_text_embedding("x")
+
+
+class TestGetImageEmbedding:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        client, sdk = _make_client_with_mock()
+        sdk.embed.create.return_value = MagicMock(image_embedding=MagicMock(segments=[_segment([0.4, 0.5])]))
+
+        result = await client.get_image_embedding("http://example.com/cat.jpg")
+
+        assert result == [0.4, 0.5]
+        _, kwargs = sdk.embed.create.call_args
+        assert kwargs["image_url"] == "http://example.com/cat.jpg"
+
+
+class TestGetVideoEmbedding:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        client, sdk = _make_client_with_mock()
+        sdk.embed.tasks.create.return_value = MagicMock(id="task-123")
+        sdk.embed.tasks.status.return_value = MagicMock(status="ready")
+        sdk.embed.tasks.retrieve.return_value = MagicMock(video_embedding=MagicMock(segments=[_segment([0.7, 0.8])]))
+
+        result = await client.get_video_embedding("http://example.com/clip.mp4")
+
+        assert result == [0.7, 0.8]
+        sdk.embed.tasks.status.assert_called_with(task_id="task-123")
+        sdk.embed.tasks.retrieve.assert_called_once_with(task_id="task-123")
+        _, kwargs = sdk.embed.tasks.create.call_args
+        assert kwargs["video_url"] == "http://example.com/clip.mp4"
+        assert kwargs["video_embedding_scope"] == ["video"]
+
+    @pytest.mark.asyncio
+    async def test_task_failure_raises(self):
+        client, sdk = _make_client_with_mock()
+        sdk.embed.tasks.create.return_value = MagicMock(id="task-x")
+        sdk.embed.tasks.status.return_value = MagicMock(status="failed")
+
+        with pytest.raises(ValueError, match="failed"):
+            await client.get_video_embedding("http://example.com/clip.mp4")
+
+    @pytest.mark.asyncio
+    async def test_no_segments_raises(self):
+        client, sdk = _make_client_with_mock()
+        sdk.embed.tasks.create.return_value = MagicMock(id="t")
+        sdk.embed.tasks.status.return_value = MagicMock(status="ready")
+        sdk.embed.tasks.retrieve.return_value = MagicMock(video_embedding=MagicMock(segments=[]))
+
+        with pytest.raises(ValueError, match="no video embedding segments"):
+            await client.get_video_embedding("http://example.com/clip.mp4")
+
+
+class TestAclose:
+    @pytest.mark.asyncio
+    async def test_clears_cache(self):
+        client, sdk = _make_client_with_mock()
+        sdk.embed.create.return_value = MagicMock(text_embedding=MagicMock(segments=[_segment([1.0])]))
+        await client.get_text_embedding("cached")
+        assert len(client._text_cache) == 1
+
+        await client.aclose()
+        assert len(client._text_cache) == 0
+
+
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set; skipping live TwelveLabs API test",
+)
+class TestLive:
+    """Live smoke tests against the real TwelveLabs API (requires the SDK + key)."""
+
+    @pytest.mark.asyncio
+    async def test_text_embedding_dim(self):
+        pytest.importorskip("twelvelabs")
+        client = TwelveLabsEmbedClient()
+        vec = await client.get_text_embedding("a person walking a dog")
+        assert len(vec) == TWELVELABS_EMBED_DIM
+        assert all(isinstance(x, float) for x in vec)
+        await client.aclose()


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Description

This PR adds **`TwelveLabsEmbedClient`**, an opt-in alternative to the default `CosmosEmbedClient` for VSS's semantic-search embeddings. It implements the existing `EmbedClient` interface (`get_text_embedding` / `get_image_embedding` / `get_video_embedding`) using [TwelveLabs](https://twelvelabs.io) **Marengo**.

**Why it helps this project:** Marengo is a multimodal embedding model that maps text, images, and video into one shared **512-dimensional** space, so a search query and the media it is compared against live in the same vector space — a natural fit for VSS's video search. Offering it as a backend gives users a managed, no-GPU-required option alongside the self-hosted Cosmos/RTVI backends.

**Design (mirrors the existing backends):**
- Same `EmbedClient` ABC and the repo's bounded `LRUEmbeddingCache` for text queries, matching `CosmosEmbedClient`.
- The official `twelvelabs` SDK is synchronous, so blocking calls run via `asyncio.to_thread` to honor the async contract without blocking the event loop.
- Video embeddings use Marengo's asynchronous task API (submit → poll `status` → `retrieve`, `video` scope).

**Opt-in / non-breaking:**
- No defaults change. The SDK is an **optional** dependency (`[twelvelabs]` extra) and is imported lazily, so the default image and existing backends are untouched.
- Configured via `TWELVELABS_API_KEY` (and optional `TWELVELABS_EMBED_MODEL`), documented in `services/agent/README.md`.

**How it was tested:**
- Added `tests/unit_test/embed/test_twelvelabs_embed.py`: 12 no-network unit tests (SDK mocked) covering text/image/video paths, caching, the async task poll loop, failure/empty-segment handling, and `aclose`, plus 1 live test gated on `TWELVELABS_API_KEY`.
- Ran `ruff check`, `ruff format --check`, and `mypy` (repo config, py3.11 target) on the changed files — all clean.
- Verified live against the real API: a Marengo text embedding returns a **512-dim** float vector (the gated live test passes with a key set).

**Note on the lockfile:** I added the `twelvelabs` optional dependency to `pyproject.toml` but could not regenerate `services/agent/uv.lock` from my environment (it requires the private NVIDIA package index). A maintainer with index access should run `uv lock` to refresh the lockfile; CI's `uv sync --group dev --frozen` does not install this optional extra, so it is unaffected.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (ran ruff + mypy on changed files directly; full pre-commit needs the private NVIDIA index).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.