### PR TITLE
Consolidate duplicate RT VLM realtime alert results

### DIFF
--- a/services/alert/config.yaml
+++ b/services/alert/config.yaml
@@ -292,10 +292,10 @@ rtvi_vlm:
   enable_realtime_persistence: true
 
   # Realtime alert consolidation — group repeated VLM positives from the same
-  # camera and alert type into a single event at read time. Raw chunk-level
-  # documents are left untouched in Elasticsearch.
+  # camera and alert type into a single event. Controlled per request via the
+  # `consolidate` query param on GET /api/v1/realtime/incidents (omitted/false =
+  # raw chunk-level documents; true = consolidated). The keys below only tune the grouping.
   consolidation:
-    enabled: true                      # default for the `consolidate` query param
     max_inter_alert_gap_seconds: 60    # a positive arriving after this gap starts a new event
     max_event_duration_seconds: 300    # cap on a single consolidated event (null = unbounded)
     representative: "latest"           # chunk that supplies the representative fields: latest | longest_reasoning

--- a/services/alert/config.yaml
+++ b/services/alert/config.yaml
@@ -291,6 +291,15 @@ rtvi_vlm:
   # one only disables the realtime-rules path.
   enable_realtime_persistence: true
 
+  # Realtime alert consolidation — group repeated VLM positives from the same
+  # camera and alert type into a single event at read time. Raw chunk-level
+  # documents are left untouched in Elasticsearch.
+  consolidation:
+    enabled: true                      # default for the `consolidate` query param
+    max_inter_alert_gap_seconds: 60    # a positive arriving after this gap starts a new event
+    max_event_duration_seconds: 300    # cap on a single consolidated event (null = unbounded)
+    representative: "latest"           # chunk that supplies the representative fields: latest | longest_reasoning
+
 # Webhook Notification — fire-and-forget POST on VLM-verified incidents
 # When enabled, every successfully verified incident is POSTed to the
 # configured URL (e.g. OpenClaw).  No retry / no queue / no dead-letter.

--- a/services/alert/openapi.json
+++ b/services/alert/openapi.json
@@ -2026,18 +2026,24 @@
                         },
                         "type": "array",
                         "title": "Incidents",
-                        "description": "List of incident documents from Elasticsearch",
+                        "description": "Incident documents in nvschema shape. By default these are raw chunk-level documents from Elasticsearch; when consolidate=true they are consolidated events (same schema, with info.isConsolidated set to \"true\").",
                         "default": []
                     },
                     "count": {
                         "type": "integer",
                         "title": "Count",
-                        "description": "Number of incidents returned"
+                        "description": "Number of items in `incidents` on this page — raw documents, or consolidated events when consolidate=true."
                     },
                     "total": {
                         "type": "integer",
                         "title": "Total",
-                        "description": "Total number of matching incidents in ES"
+                        "description": "Total matches for the query. Raw chunk count by default; the number of consolidated events in the requested window when consolidate=true."
+                    },
+                    "truncated": {
+                        "type": "boolean",
+                        "title": "Truncated",
+                        "description": "True only in the consolidated view when the window held more raw chunks than the internal scan cap; the oldest chunks were dropped and events may be incomplete. Narrow the time window.",
+                        "default": false
                     },
                     "timestamp": {
                         "type": "string",

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -103,7 +103,6 @@ class IncidentService:
             extra={
                 "es_enabled": es_client is not None,
                 "index_base": self._index_base,
-                "consolidation_enabled": bool(self._consolidation.get("enabled", False)),
             },
         )
 
@@ -185,12 +184,7 @@ class IncidentService:
                 doc["_index"] = hit.get("_index")
                 incidents.append(doc)
 
-            do_consolidate = (
-                bool(self._consolidation.get("enabled", False))
-                if consolidate is None
-                else bool(consolidate)
-            )
-            items = self._consolidate(incidents) if do_consolidate else incidents
+            items = self._consolidate(incidents) if consolidate else incidents
 
             logger.info(
                 "Incidents query completed",
@@ -198,7 +192,7 @@ class IncidentService:
                     **ctx,
                     "returned": len(items),
                     "raw_hits": len(incidents),
-                    "consolidated": do_consolidate,
+                    "consolidated": bool(consolidate),
                     "total": total_count,
                     "duration_s": round(duration, 3),
                 },

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -50,9 +50,6 @@ except ImportError:
 
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
-# Two adjacent chunks may skip at most this many indices and still count as the
-# same continuous event (tolerates an occasional dropped/non-positive chunk).
-_MAX_CHUNK_SKIP = 2
 
 
 def _parse_ts(value) -> Optional[datetime]:
@@ -277,9 +274,10 @@ class IncidentService:
     def _is_continuous(current: List[dict], doc: dict, gap_seconds, max_duration) -> bool:
         """Whether ``doc`` extends the open event ``current``.
 
-        Continuation requires the event to stay within the duration cap and
-        either belong to the same caption session with consecutive chunk
-        indices, or fall within the inter-alert gap of the previous chunk.
+        Continuation requires the event to stay within the outer duration cap
+        and the next positive to arrive within ``max_inter_alert_gap_seconds``
+        of the previous chunk. The time gap is authoritative — there is no
+        per-session bypass. Unparseable timestamps end the current event.
         """
         first = current[0]
         prev = current[-1]
@@ -290,25 +288,11 @@ class IncidentService:
             if start and doc_end and (doc_end - start).total_seconds() > max_duration:
                 return False
 
-        prev_info = _info_of(prev)
-        doc_info = _info_of(doc)
-        prev_idx = _to_int(prev_info.get("chunkIdx"))
-        doc_idx = _to_int(doc_info.get("chunkIdx"))
-        same_session = bool(
-            prev_info.get("requestId")
-            and prev_info.get("requestId") == doc_info.get("requestId")
-            and prev_idx is not None
-            and doc_idx is not None
-            and 0 < (doc_idx - prev_idx) <= _MAX_CHUNK_SKIP
-        )
-
-        within_gap = False
         prev_end = _parse_ts(prev.get("end")) or _parse_ts(prev.get("timestamp"))
         doc_start = _parse_ts(doc.get("timestamp"))
-        if prev_end and doc_start:
-            within_gap = (doc_start - prev_end).total_seconds() <= gap_seconds
-
-        return same_session or within_gap
+        if prev_end is None or doc_start is None:
+            return False
+        return (doc_start - prev_end).total_seconds() <= gap_seconds
 
     @staticmethod
     def _build_event(chunks: List[dict], representative: str) -> dict:

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -20,6 +20,7 @@ Service for querying incidents from Elasticsearch.
 
 import asyncio
 import copy
+import hashlib
 import logging
 import time
 from datetime import datetime, timezone
@@ -239,7 +240,7 @@ class IncidentService:
 
         Operates only on the documents already returned for this page; the
         underlying store is never modified and raw documents stay available
-        (``consolidate=false`` or the per-event ``info.rawIds``).
+        via a ``consolidate=false`` query.
         """
         cfg = self._consolidation
         gap_seconds = cfg.get("max_inter_alert_gap_seconds", 60)
@@ -314,10 +315,10 @@ class IncidentService:
         """Build one consolidated event from its chunks.
 
         The event is a clone of the representative chunk — a real document, so
-        the result keeps the same shape as a raw incident — with the span
-        widened to cover all chunks and consolidation metadata added under
-        ``info``. Original document ids are recorded so the raw chunks remain
-        reachable.
+        the result keeps the same shape as a raw incident — with its own stable
+        identity, the span widened to cover all chunks, and consolidation
+        metadata added under ``info``. The underlying raw chunks remain
+        retrievable via a ``consolidate=false`` query over the same window.
         """
         if representative == "longest_reasoning":
             rep = max(chunks, key=lambda c: len(_info_of(c).get("reasoning") or ""))
@@ -331,6 +332,17 @@ class IncidentService:
             chunks,
             key=lambda c: _parse_ts(c.get("end")) or _parse_ts(c.get("timestamp")) or _EPOCH,
         )
+
+        event_key = "|".join((
+            str(rep.get("sensorId", "")),
+            str(rep.get("category", "")),
+            str(_info_of(first_chunk).get("requestId", "")),
+            str(first_chunk.get("timestamp", "")),
+        ))
+        event_id = "evt-" + hashlib.sha1(event_key.encode("utf-8")).hexdigest()
+        event["Id"] = event_id
+        event["_id"] = event_id
+
         if first_chunk.get("timestamp"):
             event["timestamp"] = first_chunk["timestamp"]
         end_value = last_chunk.get("end") or last_chunk.get("timestamp")
@@ -338,15 +350,12 @@ class IncidentService:
             event["end"] = end_value
 
         idxs = [i for i in (_to_int(_info_of(c).get("chunkIdx")) for c in chunks) if i is not None]
-        raw_ids = [c.get("_id") or c.get("Id") for c in chunks if (c.get("_id") or c.get("Id"))]
 
         info = dict(event.get("info") or {})
         info["isConsolidated"] = "true"
         info["chunkCount"] = str(len(chunks))
         if idxs:
             info["chunkIdxRange"] = f"{min(idxs)}-{max(idxs)}"
-        if raw_ids:
-            info["rawIds"] = ",".join(str(r) for r in raw_ids)
         event["info"] = info
 
         merged_queries: list = []

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -266,9 +266,9 @@ class IncidentService:
             if current:
                 events.append(self._build_event(current, representative))
 
-        # Newest first, matching the raw query's sort order.
+        # Order: event start descending
         events.sort(
-            key=lambda e: _parse_ts(e.get("end")) or _parse_ts(e.get("timestamp")) or _EPOCH,
+            key=lambda e: _parse_ts(e.get("timestamp")) or _EPOCH,
             reverse=True,
         )
         return events

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -462,7 +462,9 @@ class IncidentService:
 
         if first_chunk.get("timestamp"):
             event["timestamp"] = first_chunk["timestamp"]
-        end_value = last_chunk.get("end") or last_chunk.get("timestamp")
+        # Use the chunk's end only if it parses; a present-but-unparseable end
+        # falls back to its timestamp so the event never carries a garbage end.
+        end_value = last_chunk.get("end") if _parse_ts(last_chunk.get("end")) else last_chunk.get("timestamp")
         if end_value:
             event["end"] = end_value
 

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -55,6 +55,10 @@ _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 # safety net for an unexpectedly dense window; Elasticsearch caps from_+size
 # at index.max_result_window (10000 by default).
 _SCAN_CAP = 10000
+# Cap on VLM queries merged onto one consolidated event. A dense window can
+# hold thousands of chunks each carrying full reasoning; the true total is kept
+# in info.mergedQueryCount.
+_MAX_MERGED_QUERIES = 200
 
 
 def _parse_ts(value) -> Optional[datetime]:
@@ -82,6 +86,45 @@ def _info_of(doc: dict) -> dict:
     return info if isinstance(info, dict) else {}
 
 
+_CONSOLIDATION_BOUND_MIN = 1
+_CONSOLIDATION_BOUND_MAX = 3600
+
+
+def _validate_consolidation(cfg: dict) -> None:
+    """Validate consolidation tuning, rejecting out-of-range values.
+
+    ``max_inter_alert_gap_seconds`` must be an integer in [1, 3600].
+    ``max_event_duration_seconds`` must be an integer in [1, 3600] or null
+    (unbounded). ``representative`` must be a known strategy. Raises
+    ``ValueError`` so a misconfiguration fails fast rather than misbehaving at
+    request time.
+    """
+    if not cfg:
+        return
+
+    def _bounded_int(name, value):
+        if isinstance(value, bool) or not isinstance(value, int) or not (
+            _CONSOLIDATION_BOUND_MIN <= value <= _CONSOLIDATION_BOUND_MAX
+        ):
+            raise ValueError(
+                f"rtvi_vlm.consolidation.{name} must be an integer in "
+                f"[{_CONSOLIDATION_BOUND_MIN}, {_CONSOLIDATION_BOUND_MAX}], got {value!r}"
+            )
+
+    _bounded_int("max_inter_alert_gap_seconds", cfg.get("max_inter_alert_gap_seconds", 60))
+
+    duration = cfg.get("max_event_duration_seconds", 300)
+    if duration is not None:
+        _bounded_int("max_event_duration_seconds", duration)
+
+    representative = cfg.get("representative", "latest")
+    if representative not in ("latest", "longest_reasoning"):
+        raise ValueError(
+            "rtvi_vlm.consolidation.representative must be 'latest' or "
+            f"'longest_reasoning', got {representative!r}"
+        )
+
+
 class IncidentService:
     """Service for querying incidents from Elasticsearch.
 
@@ -100,6 +143,7 @@ class IncidentService:
         self._es_client = es_client
         self._index_base = index_base
         self._consolidation = consolidation or {}
+        _validate_consolidation(self._consolidation)
 
         logger.info(
             "IncidentService initialized",
@@ -161,6 +205,17 @@ class IncidentService:
                     range_query["range"]["timestamp"]["lte"] = end_time
                 must_clauses.append(range_query)
 
+            if consolidate:
+                # Realtime-only discriminator (read-time filter — never mutates
+                # ES). mdx-vlm-incidents-* is shared: the realtime RT-VLM path
+                # sets info.chunkIdx per chunk (rtvi rt-vlm stream handler),
+                # whereas verifier-path incidents (detection modules, enriched by
+                # vlm_enhanced_sink) never set it. Requiring info.chunkIdx keeps
+                # the consolidated view to genuine RT-VLM chunks so verifier docs
+                # are never folded into an event. Raw view (consolidate=false) is
+                # unfiltered.
+                must_clauses.append({"exists": {"field": "info.chunkIdx"}})
+
             query = {"bool": {"must": must_clauses}} if must_clauses else {"match_all": {}}
             index_pattern = f"{self._index_base}-*"
 
@@ -178,22 +233,35 @@ class IncidentService:
                 return t.get("value", 0) if isinstance(t, dict) else t
 
             if consolidate:
+                # Scan newest-first: if the window exceeds the cap we keep the
+                # most recent chunks (the operationally relevant ones) and drop
+                # the oldest. The consolidator re-sorts each bucket ascending, so
+                # scan order does not affect grouping correctness.
                 response = await asyncio.to_thread(
                     self._es_client.client.search,
                     index=index_pattern,
                     query=query,
                     from_=0,
                     size=_SCAN_CAP,
-                    sort=[{"timestamp": {"order": "asc"}}],
+                    sort=[{"timestamp": {"order": "desc"}}],
+                    # Force an exact match count; without this Elasticsearch caps
+                    # hits.total at 10000 and the truncation check below (total >
+                    # scanned) could never fire when size == _SCAN_CAP.
+                    track_total_hits=True,
                 )
                 duration = time.monotonic() - t0
                 if INCIDENT_QUERY_DURATION is not None:
                     INCIDENT_QUERY_DURATION.observe(duration)
 
                 raw_docs = _hits_to_docs(response)
-                if _es_total(response) > len(raw_docs):
+                # track_total_hits above makes the total exact, so this alone is
+                # correct: N <= cap -> all fetched -> not truncated; N > cap ->
+                # only _SCAN_CAP fetched -> truncated.
+                truncated = _es_total(response) > len(raw_docs)
+                if truncated:
                     logger.warning(
-                        "Consolidation scan hit the cap; narrow the time window",
+                        "Consolidation scan hit the cap; oldest chunks dropped — "
+                        "narrow the time window",
                         extra={**ctx, "scanned": len(raw_docs), "cap": _SCAN_CAP},
                     )
 
@@ -208,6 +276,7 @@ class IncidentService:
                         "raw_scanned": len(raw_docs),
                         "events": len(events),
                         "consolidated": True,
+                        "truncated": truncated,
                         "duration_s": round(duration, 3),
                     },
                 )
@@ -216,6 +285,7 @@ class IncidentService:
                     "incidents": page,
                     "count": len(page),
                     "total": len(events),
+                    "truncated": truncated,
                     "timestamp": now,
                 }, 200
 
@@ -294,12 +364,27 @@ class IncidentService:
 
         groups: dict = {}
         for doc in docs:
+            # Drop malformed chunks — a chunk missing its grouping keys, or with
+            # a missing/unparseable ordering timestamp, cannot be placed in an
+            # event.
+            if not doc.get("sensorId") or not doc.get("category"):
+                continue
+            if _parse_ts(doc.get("timestamp")) is None:
+                continue
             key = (doc.get("sensorId"), doc.get("category"))
             groups.setdefault(key, []).append(doc)
 
         events: List[dict] = []
         for items in groups.values():
-            items_sorted = sorted(items, key=lambda d: _parse_ts(d.get("timestamp")) or _EPOCH)
+            # Sort by (timestamp, id) so equal-timestamp chunks order
+            # deterministically regardless of ES scan direction.
+            items_sorted = sorted(
+                items,
+                key=lambda d: (
+                    _parse_ts(d.get("timestamp")) or _EPOCH,
+                    str(d.get("Id") or d.get("_id") or ""),
+                ),
+            )
             current: List[dict] = []
             for doc in items_sorted:
                 if current and self._is_continuous(current, doc, gap_seconds, max_duration):
@@ -383,6 +468,10 @@ class IncidentService:
 
         idxs = [i for i in (_to_int(_info_of(c).get("chunkIdx")) for c in chunks) if i is not None]
 
+        # Raw chunk ids underlying the event, as a real list (traceability).
+        chunk_ids = [str(cid) for cid in (c.get("Id") or c.get("_id") for c in chunks) if cid]
+        event["chunk_ids"] = chunk_ids
+
         info = dict(event.get("info") or {})
         info["isConsolidated"] = "true"
         info["chunkCount"] = str(len(chunks))
@@ -390,12 +479,22 @@ class IncidentService:
             info["chunkIdxRange"] = f"{min(idxs)}-{max(idxs)}"
         event["info"] = info
 
+        # Merge chunk queries, but cap the stored payload — a dense window can
+        # hold thousands of chunks, each with full VLM reasoning. Count the true
+        # total for observability while bounding what we accumulate.
         merged_queries: list = []
+        total_queries = 0
         for chunk in chunks:
             llm = chunk.get("llm")
             if isinstance(llm, dict) and isinstance(llm.get("queries"), list):
-                merged_queries.extend(llm["queries"])
-        if merged_queries and isinstance(event.get("llm"), dict):
+                qs = llm["queries"]
+                total_queries += len(qs)
+                if len(merged_queries) < _MAX_MERGED_QUERIES:
+                    merged_queries.extend(qs[: _MAX_MERGED_QUERIES - len(merged_queries)])
+        if total_queries:
+            info["mergedQueryCount"] = str(total_queries)
+            if not isinstance(event.get("llm"), dict):
+                event["llm"] = {}
             event["llm"]["queries"] = merged_queries
 
         return event

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -19,10 +19,11 @@ Service for querying incidents from Elasticsearch.
 """
 
 import asyncio
+import copy
 import logging
 import time
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from ..config import ErrorCode, ResponseStatus
 
@@ -47,6 +48,37 @@ except ImportError:
     INCIDENT_QUERY_FAILURES = None
 
 
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+# Two adjacent chunks may skip at most this many indices and still count as the
+# same continuous event (tolerates an occasional dropped/non-positive chunk).
+_MAX_CHUNK_SKIP = 2
+
+
+def _parse_ts(value) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp string into an aware datetime, or None."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _to_int(value) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _info_of(doc: dict) -> dict:
+    info = doc.get("info")
+    return info if isinstance(info, dict) else {}
+
+
 class IncidentService:
     """Service for querying incidents from Elasticsearch.
 
@@ -60,13 +92,19 @@ class IncidentService:
         self,
         es_client: Optional["ElasticClient"] = None,
         index_base: str = "mdx-vlm-incidents",
+        consolidation: Optional[dict] = None,
     ):
         self._es_client = es_client
         self._index_base = index_base
+        self._consolidation = consolidation or {}
 
         logger.info(
             "IncidentService initialized",
-            extra={"es_enabled": es_client is not None, "index_base": self._index_base},
+            extra={
+                "es_enabled": es_client is not None,
+                "index_base": self._index_base,
+                "consolidation_enabled": bool(self._consolidation.get("enabled", False)),
+            },
         )
 
     async def list_incidents(
@@ -77,8 +115,15 @@ class IncidentService:
         end_time: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
+        consolidate: Optional[bool] = None,
     ) -> Tuple[dict, int]:
-        """Query incidents from Elasticsearch."""
+        """Query incidents from Elasticsearch.
+
+        When consolidation is active, consecutive positives from the same
+        camera and alert type on the returned page are grouped into single
+        events. ``consolidate`` overrides the configured default per request;
+        ``total`` always reflects the raw Elasticsearch match count.
+        """
         now = datetime.now(timezone.utc).isoformat()
         ctx = {
             "sensor_id": sensor_id,
@@ -140,11 +185,20 @@ class IncidentService:
                 doc["_index"] = hit.get("_index")
                 incidents.append(doc)
 
+            do_consolidate = (
+                bool(self._consolidation.get("enabled", False))
+                if consolidate is None
+                else bool(consolidate)
+            )
+            items = self._consolidate(incidents) if do_consolidate else incidents
+
             logger.info(
                 "Incidents query completed",
                 extra={
                     **ctx,
-                    "returned": len(incidents),
+                    "returned": len(items),
+                    "raw_hits": len(incidents),
+                    "consolidated": do_consolidate,
                     "total": total_count,
                     "duration_s": round(duration, 3),
                 },
@@ -152,8 +206,8 @@ class IncidentService:
 
             return {
                 "status": ResponseStatus.SUCCESS,
-                "incidents": incidents,
-                "count": len(incidents),
+                "incidents": items,
+                "count": len(items),
                 "total": total_count,
                 "timestamp": now,
             }, 200
@@ -181,3 +235,132 @@ class IncidentService:
                 "message": f"Elasticsearch query failed: {str(exc)}",
                 "timestamp": now,
             }, 500
+
+    # ------------------------------------------------------------------
+    # Consolidation
+    # ------------------------------------------------------------------
+    def _consolidate(self, docs: List[dict]) -> List[dict]:
+        """Group consecutive same-camera, same-alert-type positives on the
+        current page into single events.
+
+        Operates only on the documents already returned for this page; the
+        underlying store is never modified and raw documents stay available
+        (``consolidate=false`` or the per-event ``info.rawIds``).
+        """
+        cfg = self._consolidation
+        gap_seconds = cfg.get("max_inter_alert_gap_seconds", 60)
+        max_duration = cfg.get("max_event_duration_seconds", 300)
+        representative = cfg.get("representative", "latest")
+
+        groups: dict = {}
+        for doc in docs:
+            key = (doc.get("sensorId"), doc.get("category"))
+            groups.setdefault(key, []).append(doc)
+
+        events: List[dict] = []
+        for items in groups.values():
+            items_sorted = sorted(items, key=lambda d: _parse_ts(d.get("timestamp")) or _EPOCH)
+            current: List[dict] = []
+            for doc in items_sorted:
+                if current and self._is_continuous(current, doc, gap_seconds, max_duration):
+                    current.append(doc)
+                else:
+                    if current:
+                        events.append(self._build_event(current, representative))
+                    current = [doc]
+            if current:
+                events.append(self._build_event(current, representative))
+
+        # Newest first, matching the raw query's sort order.
+        events.sort(
+            key=lambda e: _parse_ts(e.get("end")) or _parse_ts(e.get("timestamp")) or _EPOCH,
+            reverse=True,
+        )
+        return events
+
+    @staticmethod
+    def _is_continuous(current: List[dict], doc: dict, gap_seconds, max_duration) -> bool:
+        """Whether ``doc`` extends the open event ``current``.
+
+        Continuation requires the event to stay within the duration cap and
+        either belong to the same caption session with consecutive chunk
+        indices, or fall within the inter-alert gap of the previous chunk.
+        """
+        first = current[0]
+        prev = current[-1]
+
+        if max_duration is not None:
+            start = _parse_ts(first.get("timestamp"))
+            doc_end = _parse_ts(doc.get("end")) or _parse_ts(doc.get("timestamp"))
+            if start and doc_end and (doc_end - start).total_seconds() > max_duration:
+                return False
+
+        prev_info = _info_of(prev)
+        doc_info = _info_of(doc)
+        prev_idx = _to_int(prev_info.get("chunkIdx"))
+        doc_idx = _to_int(doc_info.get("chunkIdx"))
+        same_session = bool(
+            prev_info.get("requestId")
+            and prev_info.get("requestId") == doc_info.get("requestId")
+            and prev_idx is not None
+            and doc_idx is not None
+            and 0 < (doc_idx - prev_idx) <= _MAX_CHUNK_SKIP
+        )
+
+        within_gap = False
+        prev_end = _parse_ts(prev.get("end")) or _parse_ts(prev.get("timestamp"))
+        doc_start = _parse_ts(doc.get("timestamp"))
+        if prev_end and doc_start:
+            within_gap = (doc_start - prev_end).total_seconds() <= gap_seconds
+
+        return same_session or within_gap
+
+    @staticmethod
+    def _build_event(chunks: List[dict], representative: str) -> dict:
+        """Build one consolidated event from its chunks.
+
+        The event is a clone of the representative chunk — a real document, so
+        the result keeps the same shape as a raw incident — with the span
+        widened to cover all chunks and consolidation metadata added under
+        ``info``. Original document ids are recorded so the raw chunks remain
+        reachable.
+        """
+        if representative == "longest_reasoning":
+            rep = max(chunks, key=lambda c: len(_info_of(c).get("reasoning") or ""))
+        else:
+            rep = max(chunks, key=lambda c: _parse_ts(c.get("timestamp")) or _EPOCH)
+
+        event = copy.deepcopy(rep)
+
+        first_chunk = min(chunks, key=lambda c: _parse_ts(c.get("timestamp")) or _EPOCH)
+        last_chunk = max(
+            chunks,
+            key=lambda c: _parse_ts(c.get("end")) or _parse_ts(c.get("timestamp")) or _EPOCH,
+        )
+        if first_chunk.get("timestamp"):
+            event["timestamp"] = first_chunk["timestamp"]
+        end_value = last_chunk.get("end") or last_chunk.get("timestamp")
+        if end_value:
+            event["end"] = end_value
+
+        idxs = [i for i in (_to_int(_info_of(c).get("chunkIdx")) for c in chunks) if i is not None]
+        raw_ids = [c.get("_id") or c.get("Id") for c in chunks if (c.get("_id") or c.get("Id"))]
+
+        info = dict(event.get("info") or {})
+        info["isConsolidated"] = "true"
+        info["chunkCount"] = str(len(chunks))
+        if idxs:
+            info["chunkIdxRange"] = f"{min(idxs)}-{max(idxs)}"
+        if raw_ids:
+            info["rawIds"] = ",".join(str(r) for r in raw_ids)
+        event["info"] = info
+
+        merged_queries: list = []
+        for chunk in chunks:
+            llm = chunk.get("llm")
+            if isinstance(llm, dict) and isinstance(llm.get("queries"), list):
+                merged_queries.extend(llm["queries"])
+        if merged_queries and isinstance(event.get("llm"), dict):
+            event["llm"]["queries"] = merged_queries
+
+        return event

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -50,6 +50,11 @@ except ImportError:
 
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+# Upper bound on raw chunks scanned for a consolidated query. Consolidation
+# requires a bounded time window (enforced at the route), so this is only a
+# safety net for an unexpectedly dense window; Elasticsearch caps from_+size
+# at index.max_result_window (10000 by default).
+_SCAN_CAP = 10000
 
 
 def _parse_ts(value) -> Optional[datetime]:
@@ -116,10 +121,11 @@ class IncidentService:
     ) -> Tuple[dict, int]:
         """Query incidents from Elasticsearch.
 
-        When consolidation is active, consecutive positives from the same
-        camera and alert type on the returned page are grouped into single
-        events. ``consolidate`` overrides the configured default per request;
-        ``total`` always reflects the raw Elasticsearch match count.
+        With ``consolidate`` true the whole matched window is grouped into
+        events and ``offset``/``limit`` paginate the events, so an event is
+        never split across pages; ``total`` is the number of events. With
+        ``consolidate`` false the raw chunk documents are returned with
+        Elasticsearch-side pagination and ``total`` is the raw match count.
         """
         now = datetime.now(timezone.utc).isoformat()
         ctx = {
@@ -158,6 +164,61 @@ class IncidentService:
             query = {"bool": {"must": must_clauses}} if must_clauses else {"match_all": {}}
             index_pattern = f"{self._index_base}-*"
 
+            def _hits_to_docs(resp):
+                out = []
+                for hit in resp.get("hits", {}).get("hits", []):
+                    doc = hit.get("_source", {})
+                    doc["_id"] = hit.get("_id")
+                    doc["_index"] = hit.get("_index")
+                    out.append(doc)
+                return out
+
+            def _es_total(resp):
+                t = resp.get("hits", {}).get("total", {})
+                return t.get("value", 0) if isinstance(t, dict) else t
+
+            if consolidate:
+                response = await asyncio.to_thread(
+                    self._es_client.client.search,
+                    index=index_pattern,
+                    query=query,
+                    from_=0,
+                    size=_SCAN_CAP,
+                    sort=[{"timestamp": {"order": "asc"}}],
+                )
+                duration = time.monotonic() - t0
+                if INCIDENT_QUERY_DURATION is not None:
+                    INCIDENT_QUERY_DURATION.observe(duration)
+
+                raw_docs = _hits_to_docs(response)
+                if _es_total(response) > len(raw_docs):
+                    logger.warning(
+                        "Consolidation scan hit the cap; narrow the time window",
+                        extra={**ctx, "scanned": len(raw_docs), "cap": _SCAN_CAP},
+                    )
+
+                events = self._consolidate(raw_docs)
+                page = events[offset:offset + limit]
+
+                logger.info(
+                    "Incidents query completed",
+                    extra={
+                        **ctx,
+                        "returned": len(page),
+                        "raw_scanned": len(raw_docs),
+                        "events": len(events),
+                        "consolidated": True,
+                        "duration_s": round(duration, 3),
+                    },
+                )
+                return {
+                    "status": ResponseStatus.SUCCESS,
+                    "incidents": page,
+                    "count": len(page),
+                    "total": len(events),
+                    "timestamp": now,
+                }, 200
+
             response = await asyncio.to_thread(
                 self._es_client.client.search,
                 index=index_pattern,
@@ -166,40 +227,27 @@ class IncidentService:
                 size=limit,
                 sort=[{"timestamp": {"order": "desc"}}],
             )
-
             duration = time.monotonic() - t0
             if INCIDENT_QUERY_DURATION is not None:
                 INCIDENT_QUERY_DURATION.observe(duration)
 
-            hits = response.get("hits", {})
-            total = hits.get("total", {})
-            total_count = total.get("value", 0) if isinstance(total, dict) else total
-
-            incidents = []
-            for hit in hits.get("hits", []):
-                doc = hit.get("_source", {})
-                doc["_id"] = hit.get("_id")
-                doc["_index"] = hit.get("_index")
-                incidents.append(doc)
-
-            items = self._consolidate(incidents) if consolidate else incidents
+            incidents = _hits_to_docs(response)
+            total_count = _es_total(response)
 
             logger.info(
                 "Incidents query completed",
                 extra={
                     **ctx,
-                    "returned": len(items),
-                    "raw_hits": len(incidents),
-                    "consolidated": bool(consolidate),
+                    "returned": len(incidents),
+                    "consolidated": False,
                     "total": total_count,
                     "duration_s": round(duration, 3),
                 },
             )
-
             return {
                 "status": ResponseStatus.SUCCESS,
-                "incidents": items,
-                "count": len(items),
+                "incidents": incidents,
+                "count": len(incidents),
                 "total": total_count,
                 "timestamp": now,
             }, 200

--- a/services/alert/src/web/api/realtime_routes.py
+++ b/services/alert/src/web/api/realtime_routes.py
@@ -603,6 +603,19 @@ async def list_incidents(
         offset,
         consolidate,
     )
+    if consolidate and (start_time is None or end_time is None):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "status": "error",
+                "error": "validation_failed",
+                "message": (
+                    "consolidate=true requires both start_time and end_time "
+                    "(a bounded time window)"
+                ),
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+            },
+        )
     response_data, status_code = await service.list_incidents(
         sensor_id=sensor_id,
         category=category,

--- a/services/alert/src/web/api/realtime_routes.py
+++ b/services/alert/src/web/api/realtime_routes.py
@@ -589,8 +589,8 @@ async def list_incidents(
         default=None,
         description=(
             "Group consecutive positives from the same camera and alert type "
-            "into a single event. Omit to use the configured default; set to "
-            "false to return raw chunk-level documents."
+            "into a single event. Omitted or false returns raw chunk-level "
+            "documents; set to true for the consolidated view."
         ),
     ),
     service: IncidentService = Depends(get_incident_service),

--- a/services/alert/src/web/api/realtime_routes.py
+++ b/services/alert/src/web/api/realtime_routes.py
@@ -285,9 +285,12 @@ def get_incident_service() -> IncidentService:
     if incident_cfg.get("type") == "elastic":
         index_base = incident_cfg.get("elastic", {}).get("index", index_base)
 
+    consolidation = config.get("rtvi_vlm", {}).get("consolidation", {})
+
     return IncidentService(
         es_client=get_elastic_client(),
         index_base=index_base,
+        consolidation=consolidation,
     )
 
 
@@ -582,14 +585,23 @@ async def list_incidents(
         ge=0,
         description="Number of incidents to skip (for pagination)",
     ),
+    consolidate: Optional[bool] = Query(
+        default=None,
+        description=(
+            "Group consecutive positives from the same camera and alert type "
+            "into a single event. Omit to use the configured default; set to "
+            "false to return raw chunk-level documents."
+        ),
+    ),
     service: IncidentService = Depends(get_incident_service),
 ):
     logger.info(
-        "GET /api/v1/realtime/incidents — sensor_id=%s category=%s limit=%d offset=%d",
+        "GET /api/v1/realtime/incidents — sensor_id=%s category=%s limit=%d offset=%d consolidate=%s",
         sensor_id,
         category,
         limit,
         offset,
+        consolidate,
     )
     response_data, status_code = await service.list_incidents(
         sensor_id=sensor_id,
@@ -598,6 +610,7 @@ async def list_incidents(
         end_time=end_time.isoformat() if end_time else None,
         limit=limit,
         offset=offset,
+        consolidate=consolidate,
     )
     return JSONResponse(status_code=status_code, content=response_data)
 

--- a/services/alert/src/web/api/realtime_routes.py
+++ b/services/alert/src/web/api/realtime_routes.py
@@ -34,7 +34,7 @@ tests) without going through HTTP.
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import lru_cache
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional
@@ -637,7 +637,7 @@ async def list_incidents(
                     "consolidate=true requires both start_time and end_time "
                     "(a bounded time window)"
                 ),
-                "timestamp": datetime.utcnow().isoformat() + "Z",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             },
         )
     response_data, status_code = await service.list_incidents(

--- a/services/alert/src/web/api/realtime_routes.py
+++ b/services/alert/src/web/api/realtime_routes.py
@@ -547,11 +547,27 @@ async def delete_realtime_alert(
     response_model=IncidentListResponse,
     summary="List incidents from Elasticsearch",
     description=(
-        "Query incidents from Elasticsearch with optional filtering by sensor_id, "
-        "category, and time range. Supports pagination via limit and offset."
+        "Query incidents from Elasticsearch, optionally filtered by sensor_id, "
+        "category, and time range, with pagination via limit and offset.\n\n"
+        "**Raw view (default):** with `consolidate` omitted or false, returns raw "
+        "chunk-level documents (nvschema). `count` is the number of documents on "
+        "the page; `total` is the raw Elasticsearch match count.\n\n"
+        "**Consolidated view:** with `consolidate=true`, consecutive positives "
+        "from the same camera and alert type are grouped into single events "
+        "(same nvschema, with `info.isConsolidated=\"true\"`, `info.chunkCount` "
+        "and `info.chunkIdxRange`). This view requires a bounded time window: "
+        "both `start_time` and `end_time` must be supplied (otherwise 400). "
+        "Grouping runs over the whole window before pagination, so an event is "
+        "never split across pages; `count` is the number of events on the page "
+        "and `total` is the number of events in the window. The raw documents "
+        "remain available via the default view and are never modified."
     ),
     responses={
         200: {"description": "Incidents list", "model": IncidentListResponse},
+        400: {
+            "description": "consolidate=true without both start_time and end_time",
+            "model": RealtimeAlertErrorResponse,
+        },
         422: {"description": "Invalid timestamp format", "model": RealtimeAlertErrorResponse},
         500: {"description": "Elasticsearch query failed", "model": RealtimeAlertErrorResponse},
         503: {"description": "Elasticsearch unavailable", "model": RealtimeAlertErrorResponse},
@@ -568,11 +584,17 @@ async def list_incidents(
     ),
     start_time: Optional[datetime] = Query(
         default=None,
-        description="Filter incidents after this ISO-8601 timestamp (e.g. 2024-01-15T10:30:00Z)",
+        description=(
+            "Filter incidents after this ISO-8601 timestamp (e.g. 2024-01-15T10:30:00Z). "
+            "Required when consolidate=true."
+        ),
     ),
     end_time: Optional[datetime] = Query(
         default=None,
-        description="Filter incidents before this ISO-8601 timestamp (e.g. 2024-01-15T18:00:00Z)",
+        description=(
+            "Filter incidents before this ISO-8601 timestamp (e.g. 2024-01-15T18:00:00Z). "
+            "Required when consolidate=true."
+        ),
     ),
     limit: int = Query(
         default=100,
@@ -590,7 +612,9 @@ async def list_incidents(
         description=(
             "Group consecutive positives from the same camera and alert type "
             "into a single event. Omitted or false returns raw chunk-level "
-            "documents; set to true for the consolidated view."
+            "documents; true returns the consolidated view and requires both "
+            "start_time and end_time. When true, count and total count events "
+            "rather than raw documents."
         ),
     ),
     service: IncidentService = Depends(get_incident_service),

--- a/services/alert/src/web/schemas/realtime_schemas.py
+++ b/services/alert/src/web/schemas/realtime_schemas.py
@@ -602,10 +602,25 @@ class IncidentListResponse(BaseModel):
     status: str = Field(default=ResponseStatus.SUCCESS)
     incidents: List[dict] = Field(
         default=[],
-        description="List of incident documents from Elasticsearch",
+        description=(
+            "Incident documents in nvschema shape. By default these are raw "
+            "chunk-level documents from Elasticsearch; when consolidate=true "
+            "they are consolidated events (same schema, with info.isConsolidated "
+            "set to \"true\")."
+        ),
     )
-    count: int = Field(description="Number of incidents returned")
-    total: int = Field(description="Total number of matching incidents in ES")
+    count: int = Field(
+        description=(
+            "Number of items in `incidents` on this page — raw documents, or "
+            "consolidated events when consolidate=true."
+        )
+    )
+    total: int = Field(
+        description=(
+            "Total matches for the query. Raw chunk count by default; the number "
+            "of consolidated events in the requested window when consolidate=true."
+        )
+    )
     timestamp: str = Field(description="ISO-8601 response timestamp")
 
 

--- a/services/alert/src/web/schemas/realtime_schemas.py
+++ b/services/alert/src/web/schemas/realtime_schemas.py
@@ -621,6 +621,14 @@ class IncidentListResponse(BaseModel):
             "of consolidated events in the requested window when consolidate=true."
         )
     )
+    truncated: bool = Field(
+        default=False,
+        description=(
+            "True only in the consolidated view when the window held more raw "
+            "chunks than the internal scan cap; the oldest chunks were dropped "
+            "and events may be incomplete. Narrow the time window."
+        ),
+    )
     timestamp: str = Field(description="ISO-8601 response timestamp")
 
 

--- a/services/alert/test/functional/p1/README.md
+++ b/services/alert/test/functional/p1/README.md
@@ -51,6 +51,7 @@ These run against simulators with known inputs — not a live deployment.
 | `test_http_ondemand_verification` | POST to `/api/v1/verification/ondemand`: (1) valid request → 200; (2) unknown alert_type → 400; (3) NIM down → 503 | On-demand verification API contract, error handling, and VLM fault tolerance |
 | `test_kafka_sink_vlm` | Send incident with `info.video_path`; verify VLM result published to Kafka sink | Base64 encode + VLM + Kafka sink pipeline |
 | `test_realtime_replay` | 8 sub-tests for `POST /api/v1/realtime/replay`: happy-path, partial RTVI failure, concurrent 409, POST/DELETE blocked 503, GET available during replay, persistence-disabled 501, AB restart state survival | Replay API contract, concurrency guards, persistence fallback, durability |
+| `test_realtime_alerts` (Test 8c) | Index 3 consecutive positives (same camera + alert type); `GET /api/v1/realtime/incidents?consolidate=true` returns one event, `consolidate=false` returns 3 raw, `total` stays the raw count | Read-time consolidation groups duplicates into one event while raw chunk records remain available |
 
 ## Structure
 

--- a/services/alert/test/functional/p1/README.md
+++ b/services/alert/test/functional/p1/README.md
@@ -51,7 +51,8 @@ These run against simulators with known inputs — not a live deployment.
 | `test_http_ondemand_verification` | POST to `/api/v1/verification/ondemand`: (1) valid request → 200; (2) unknown alert_type → 400; (3) NIM down → 503 | On-demand verification API contract, error handling, and VLM fault tolerance |
 | `test_kafka_sink_vlm` | Send incident with `info.video_path`; verify VLM result published to Kafka sink | Base64 encode + VLM + Kafka sink pipeline |
 | `test_realtime_replay` | 8 sub-tests for `POST /api/v1/realtime/replay`: happy-path, partial RTVI failure, concurrent 409, POST/DELETE blocked 503, GET available during replay, persistence-disabled 501, AB restart state survival | Replay API contract, concurrency guards, persistence fallback, durability |
-| `test_realtime_alerts` (Test 8c) | Index 3 consecutive positives (same camera + alert type); `GET /api/v1/realtime/incidents?consolidate=true` returns one event, `consolidate=false` returns 3 raw, `total` stays the raw count | Read-time consolidation groups duplicates into one event while raw chunk records remain available |
+| `test_realtime_alerts` (Test 8c) | Index 3 consecutive positives (same camera + alert type); `GET /api/v1/realtime/incidents?consolidate=true` (with a time window) returns one event and `total=1` (event count), `consolidate=false` returns 3 raw, and `consolidate=true` without a window is rejected `400` | Read-time consolidation groups duplicates into one event over a required window while raw chunk records remain available |
+| `test_realtime_alerts` (Test 8d) | Index sensor A/alert (2 chunks), A/intrusion (1), B/alert (1); per-sensor `consolidate=true` returns A=2 events, B=1 event | Consolidation groups are isolated by `(sensorId, category)` |
 
 ## Structure
 

--- a/services/alert/test/functional/p1/README.md
+++ b/services/alert/test/functional/p1/README.md
@@ -53,6 +53,7 @@ These run against simulators with known inputs — not a live deployment.
 | `test_realtime_replay` | 8 sub-tests for `POST /api/v1/realtime/replay`: happy-path, partial RTVI failure, concurrent 409, POST/DELETE blocked 503, GET available during replay, persistence-disabled 501, AB restart state survival | Replay API contract, concurrency guards, persistence fallback, durability |
 | `test_realtime_alerts` (Test 8c) | Index 3 consecutive positives (same camera + alert type); `GET /api/v1/realtime/incidents?consolidate=true` (with a time window) returns one event and `total=1` (event count), `consolidate=false` returns 3 raw, and `consolidate=true` without a window is rejected `400` | Read-time consolidation groups duplicates into one event over a required window while raw chunk records remain available |
 | `test_realtime_alerts` (Test 8d) | Index sensor A/alert (2 chunks), A/intrusion (1), B/alert (1); per-sensor `consolidate=true` returns A=2 events, B=1 event | Consolidation groups are isolated by `(sensorId, category)` |
+| `test_realtime_alerts` (Test 8e) | Index one realtime chunk (has `info.chunkIdx`) + one verifier-path doc (`analyticsModule`, no `chunkIdx`) for the same sensor; `consolidate=true` returns 1 event from the realtime chunk only, raw returns both | REG-009: verifier-path incidents are filtered out of the consolidated view (realtime discriminator) |
 
 ## Structure
 

--- a/services/alert/test/functional/p1/test_realtime_alerts/run.sh
+++ b/services/alert/test/functional/p1/test_realtime_alerts/run.sh
@@ -583,6 +583,40 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 8c: consolidate groups consecutive positives; raw still available
+# ---------------------------------------------------------------------------
+print_status "wait" "Test 8c: consolidate groups consecutive positives..."
+CONSOL_IDX="mdx-vlm-incidents-2099-01-01"
+CONSOL_SENSOR="p1-consolidation"
+curl -s -X DELETE "${ES_HOST}/${CONSOL_IDX}" >/dev/null 2>&1 || true
+for i in 1 2 3; do
+    ss=$(( (i - 1) * 20 )); ee=$(( ss + 15 ))
+    start=$(printf "2099-01-01T00:00:%02d.000Z" "$ss")
+    end=$(printf "2099-01-01T00:00:%02d.000Z" "$ee")
+    curl -s -X PUT "${ES_HOST}/${CONSOL_IDX}/_doc/${CONSOL_SENSOR}-${i}" \
+        -H "Content-Type: application/json" \
+        -d "{\"sensorId\":\"${CONSOL_SENSOR}\",\"category\":\"alert\",\"timestamp\":\"${start}\",\"end\":\"${end}\",\"info\":{\"requestId\":\"p1\",\"chunkIdx\":\"${i}\",\"verdict\":\"confirmed\"}}" \
+        >/dev/null 2>&1
+done
+curl -s -X POST "${ES_HOST}/${CONSOL_IDX}/_refresh" >/dev/null 2>&1
+
+RAW_CNT=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=${CONSOL_SENSOR}&consolidate=false" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('count',-1))" 2>/dev/null || echo "-1")
+CONS=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=${CONSOL_SENSOR}&consolidate=true")
+CONS_CNT=$(echo "$CONS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('count',-1))" 2>/dev/null || echo "-1")
+CONS_TOTAL=$(echo "$CONS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('total',-1))" 2>/dev/null || echo "-1")
+CONS_FLAG=$(echo "$CONS" | python3 -c "import sys,json; d=json.load(sys.stdin); inc=d.get('incidents',[]); print(inc[0].get('info',{}).get('isConsolidated','') if inc else '')" 2>/dev/null || echo "")
+
+if [ "$RAW_CNT" = "3" ] && [ "$CONS_CNT" = "1" ] && [ "$CONS_TOTAL" = "3" ] && [ "$CONS_FLAG" = "true" ]; then
+    print_status "ok" "PASS: 3 raw chunks -> 1 consolidated event (total stays raw=3)"
+    ((PASSED++))
+else
+    print_status "fail" "FAIL: consolidate (raw=$RAW_CNT cons=$CONS_CNT total=$CONS_TOTAL flag=$CONS_FLAG)"
+    ((FAILED++))
+fi
+curl -s -X DELETE "${ES_HOST}/${CONSOL_IDX}" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
 # Test 9: Caption-start failure — RTVI rejects generate_captions_alerts
 #         Expects: stream rolled back on RTVI, rule absent in AB
 # ---------------------------------------------------------------------------

--- a/services/alert/test/functional/p1/test_realtime_alerts/run.sh
+++ b/services/alert/test/functional/p1/test_realtime_alerts/run.sh
@@ -620,6 +620,42 @@ fi
 curl -s -X DELETE "${ES_HOST}/${CONSOL_IDX}" >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
+# Test 8d: consolidation groups are isolated by (sensor, category)
+# ---------------------------------------------------------------------------
+print_status "wait" "Test 8d: consolidation grouping isolation by sensor and category..."
+ISO_IDX="mdx-vlm-incidents-2099-02-02"
+ISO_WINDOW="start_time=2099-02-02T00:00:00Z&end_time=2099-02-02T01:00:00Z"
+curl -s -X DELETE "${ES_HOST}/${ISO_IDX}" >/dev/null 2>&1 || true
+# sensor A / alert: two consecutive chunks (merge -> 1 event)
+# sensor A / intrusion: one chunk (separate category -> own event)
+# sensor B / alert: one chunk (separate sensor -> own event)
+iso_put() {  # <docId> <sensor> <category> <startISO> <endISO> <chunkIdx>
+    curl -s -X PUT "${ES_HOST}/${ISO_IDX}/_doc/$1" -H "Content-Type: application/json" \
+        -d "{\"sensorId\":\"$2\",\"category\":\"$3\",\"timestamp\":\"$4\",\"end\":\"$5\",\"info\":{\"requestId\":\"r\",\"chunkIdx\":\"$6\",\"verdict\":\"confirmed\"}}" \
+        >/dev/null 2>&1
+}
+iso_put isoA1 p1-iso-a alert     "2099-02-02T00:00:00.000Z" "2099-02-02T00:00:30.000Z" 1
+iso_put isoA2 p1-iso-a alert     "2099-02-02T00:00:25.000Z" "2099-02-02T00:00:55.000Z" 2
+iso_put isoA3 p1-iso-a intrusion "2099-02-02T00:00:00.000Z" "2099-02-02T00:00:30.000Z" 1
+iso_put isoB1 p1-iso-b alert     "2099-02-02T00:00:00.000Z" "2099-02-02T00:00:30.000Z" 1
+curl -s -X POST "${ES_HOST}/${ISO_IDX}/_refresh" >/dev/null 2>&1
+
+ISO_A=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=p1-iso-a&consolidate=true&${ISO_WINDOW}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('total',-1))" 2>/dev/null || echo "-1")
+ISO_B=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=p1-iso-b&consolidate=true&${ISO_WINDOW}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('total',-1))" 2>/dev/null || echo "-1")
+
+# sensor A -> 2 events (alert merged + intrusion); sensor B -> 1 event
+if [ "$ISO_A" = "2" ] && [ "$ISO_B" = "1" ]; then
+    print_status "ok" "PASS: groups isolated by (sensor, category) (A=2 events, B=1 event)"
+    ((PASSED++))
+else
+    print_status "fail" "FAIL: grouping isolation (A=$ISO_A expected 2, B=$ISO_B expected 1)"
+    ((FAILED++))
+fi
+curl -s -X DELETE "${ES_HOST}/${ISO_IDX}" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
 # Test 9: Caption-start failure — RTVI rejects generate_captions_alerts
 #         Expects: stream rolled back on RTVI, rule absent in AB
 # ---------------------------------------------------------------------------

--- a/services/alert/test/functional/p1/test_realtime_alerts/run.sh
+++ b/services/alert/test/functional/p1/test_realtime_alerts/run.sh
@@ -600,18 +600,21 @@ for i in 1 2 3; do
 done
 curl -s -X POST "${ES_HOST}/${CONSOL_IDX}/_refresh" >/dev/null 2>&1
 
+CONSOL_WINDOW="start_time=2099-01-01T00:00:00Z&end_time=2099-01-01T01:00:00Z"
 RAW_CNT=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=${CONSOL_SENSOR}&consolidate=false" \
     | python3 -c "import sys,json; print(json.load(sys.stdin).get('count',-1))" 2>/dev/null || echo "-1")
-CONS=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=${CONSOL_SENSOR}&consolidate=true")
+CONS=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=${CONSOL_SENSOR}&consolidate=true&${CONSOL_WINDOW}")
 CONS_CNT=$(echo "$CONS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('count',-1))" 2>/dev/null || echo "-1")
 CONS_TOTAL=$(echo "$CONS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('total',-1))" 2>/dev/null || echo "-1")
 CONS_FLAG=$(echo "$CONS" | python3 -c "import sys,json; d=json.load(sys.stdin); inc=d.get('incidents',[]); print(inc[0].get('info',{}).get('isConsolidated','') if inc else '')" 2>/dev/null || echo "")
+# consolidate without a time window is rejected (a bounded window is required)
+NO_WINDOW_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$AB_HOST/api/v1/realtime/incidents?sensor_id=${CONSOL_SENSOR}&consolidate=true" 2>/dev/null || echo "0")
 
-if [ "$RAW_CNT" = "3" ] && [ "$CONS_CNT" = "1" ] && [ "$CONS_TOTAL" = "3" ] && [ "$CONS_FLAG" = "true" ]; then
-    print_status "ok" "PASS: 3 raw chunks -> 1 consolidated event (total stays raw=3)"
+if [ "$RAW_CNT" = "3" ] && [ "$CONS_CNT" = "1" ] && [ "$CONS_TOTAL" = "1" ] && [ "$CONS_FLAG" = "true" ] && [ "$NO_WINDOW_CODE" = "400" ]; then
+    print_status "ok" "PASS: 3 raw chunks -> 1 event (total=events=1); consolidate requires a window (400)"
     ((PASSED++))
 else
-    print_status "fail" "FAIL: consolidate (raw=$RAW_CNT cons=$CONS_CNT total=$CONS_TOTAL flag=$CONS_FLAG)"
+    print_status "fail" "FAIL: consolidate (raw=$RAW_CNT cons=$CONS_CNT total=$CONS_TOTAL flag=$CONS_FLAG no_window=$NO_WINDOW_CODE)"
     ((FAILED++))
 fi
 curl -s -X DELETE "${ES_HOST}/${CONSOL_IDX}" >/dev/null 2>&1 || true

--- a/services/alert/test/functional/p1/test_realtime_alerts/run.sh
+++ b/services/alert/test/functional/p1/test_realtime_alerts/run.sh
@@ -656,6 +656,38 @@ fi
 curl -s -X DELETE "${ES_HOST}/${ISO_IDX}" >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
+# Test 8e: REG-009 — verifier-path docs are excluded from the consolidated view
+# ---------------------------------------------------------------------------
+print_status "wait" "Test 8e: verifier-path docs excluded from consolidated view (REG-009)..."
+MIX_IDX="mdx-vlm-incidents-2099-03-03"
+MIX_SENSOR="p1-mixed"
+MIX_WINDOW="start_time=2099-03-03T00:00:00Z&end_time=2099-03-03T01:00:00Z"
+curl -s -X DELETE "${ES_HOST}/${MIX_IDX}" >/dev/null 2>&1 || true
+# realtime RT-VLM chunk (carries info.chunkIdx) — MUST appear
+curl -s -X PUT "${ES_HOST}/${MIX_IDX}/_doc/rt1" -H "Content-Type: application/json" \
+    -d "{\"sensorId\":\"${MIX_SENSOR}\",\"category\":\"alert\",\"timestamp\":\"2099-03-03T00:00:00.000Z\",\"end\":\"2099-03-03T00:00:30.000Z\",\"info\":{\"requestId\":\"r\",\"chunkIdx\":\"1\",\"verdict\":\"confirmed\"}}" >/dev/null 2>&1
+# verifier-path doc (detection module, NO info.chunkIdx) — MUST be excluded
+curl -s -X PUT "${ES_HOST}/${MIX_IDX}/_doc/vf1" -H "Content-Type: application/json" \
+    -d "{\"sensorId\":\"${MIX_SENSOR}\",\"category\":\"alert\",\"timestamp\":\"2099-03-03T00:00:10.000Z\",\"end\":\"2099-03-03T00:00:40.000Z\",\"analyticsModule\":{\"id\":\"Collision Detection Module\"},\"info\":{\"verdict\":\"confirmed\"}}" >/dev/null 2>&1
+curl -s -X POST "${ES_HOST}/${MIX_IDX}/_refresh" >/dev/null 2>&1
+
+MIX_CONS=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=${MIX_SENSOR}&consolidate=true&${MIX_WINDOW}")
+MIX_EVENTS=$(echo "$MIX_CONS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('total',-1))" 2>/dev/null || echo "-1")
+MIX_CC=$(echo "$MIX_CONS" | python3 -c "import sys,json; d=json.load(sys.stdin); inc=d.get('incidents',[]); print(inc[0].get('info',{}).get('chunkCount','') if inc else '')" 2>/dev/null || echo "")
+MIX_RAW=$(do_request "GET" "/api/v1/realtime/incidents?sensor_id=${MIX_SENSOR}&consolidate=false" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('count',-1))" 2>/dev/null || echo "-1")
+
+# consolidated: 1 event from the realtime chunk only (chunkCount=1); raw: both docs
+if [ "$MIX_EVENTS" = "1" ] && [ "$MIX_CC" = "1" ] && [ "$MIX_RAW" = "2" ]; then
+    print_status "ok" "PASS: verifier doc excluded from consolidated (events=1, chunkCount=1), raw shows both (2)"
+    ((PASSED++))
+else
+    print_status "fail" "FAIL: mixed-source (events=$MIX_EVENTS chunkCount=$MIX_CC raw=$MIX_RAW)"
+    ((FAILED++))
+fi
+curl -s -X DELETE "${ES_HOST}/${MIX_IDX}" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
 # Test 9: Caption-start failure — RTVI rejects generate_captions_alerts
 #         Expects: stream rolled back on RTVI, rule absent in AB
 # ---------------------------------------------------------------------------

--- a/services/alert/test/sim_scripts/elastic/elastic_sim.py
+++ b/services/alert/test/sim_scripts/elastic/elastic_sim.py
@@ -142,13 +142,45 @@ def _doc_matches_term(doc: Dict[str, Any], term: Dict[str, Any]) -> bool:
     return True
 
 
+def _range_ok(value: Any, op: str, bound: Any) -> bool:
+    """Compare a (string/ISO-8601 or numeric) field value against a range bound."""
+    if value is None:
+        return False
+    try:
+        if op == "gte":
+            return value >= bound
+        if op == "lte":
+            return value <= bound
+        if op == "gt":
+            return value > bound
+        if op == "lt":
+            return value < bound
+    except TypeError:
+        return False
+    return True
+
+
 def _apply_query(docs: list, query: Dict[str, Any]) -> list:
-    """Apply a minimal subset of ES query DSL (term, bool.must)."""
+    """Apply a minimal subset of ES query DSL (term, exists, range, bool.must)."""
     if not query:
         return docs
 
     if "term" in query:
         return [d for d in docs if _doc_matches_term(d, query["term"])]
+
+    if "exists" in query:
+        field = query["exists"].get("field", "")
+        return [d for d in docs if _resolve_field(d.get("_source", {}), field) is not None]
+
+    if "range" in query:
+        result = docs
+        for field, bounds in query["range"].items():
+            for op, bound in bounds.items():
+                result = [
+                    d for d in result
+                    if _range_ok(_resolve_field(d.get("_source", {}), field), op, bound)
+                ]
+        return result
 
     if "bool" in query:
         must = query["bool"].get("must", [])

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -430,7 +430,7 @@ class TestConsolidationService:
         assert all("isConsolidated" not in i.get("info", {}) for i in data["incidents"])
 
     @pytest.mark.asyncio
-    async def test_consolidate_true_groups_and_keeps_raw_total(self, mock_es_client):
+    async def test_consolidate_true_total_is_event_count(self, mock_es_client):
         chunks = [
             _chunk(sensor="cam-1", idx=1),
             _chunk(sensor="cam-1", idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
@@ -442,9 +442,30 @@ class TestConsolidationService:
         svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
         data, code = await svc.list_incidents(consolidate=True)
         assert code == 200
-        assert data["total"] == 3
-        assert data["count"] == 2
+        assert data["count"] == 2          # cam-1 (2 chunks) -> 1 event, cam-2 -> 1
+        assert data["total"] == 2          # total counts events, not raw chunks
         assert all(i["info"]["isConsolidated"] == "true" for i in data["incidents"])
+
+    @pytest.mark.asyncio
+    async def test_consolidate_paginates_on_events(self, mock_es_client):
+        # Three far-apart positives -> three separate events; pagination must
+        # apply to events (never split one across a page boundary).
+        chunks = [
+            _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=5, start="2025-01-01T00:05:00.000Z", end="2025-01-01T00:05:30.000Z"),
+            _chunk(idx=9, start="2025-01-01T00:10:00.000Z", end="2025-01-01T00:10:30.000Z"),
+        ]
+        mock_es_client.client.search.return_value = {
+            "hits": {"total": {"value": 3}, "hits": [_as_hit(c) for c in chunks]}
+        }
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
+        page1, _ = await svc.list_incidents(consolidate=True, limit=2, offset=0)
+        page2, _ = await svc.list_incidents(consolidate=True, limit=2, offset=2)
+        assert page1["count"] == 2 and page1["total"] == 3   # page 1: 2 of 3 events
+        assert page2["count"] == 1 and page2["total"] == 3   # page 2: remaining event
+        ids1 = {e["Id"] for e in page1["incidents"]}
+        ids2 = {e["Id"] for e in page2["incidents"]}
+        assert ids1.isdisjoint(ids2)                          # no event on both pages
 
     @pytest.mark.asyncio
     async def test_omit_param_returns_raw(self, mock_es_client):

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -474,6 +474,11 @@ class TestConsolidationGrouping:
         assert len(events) == 1
         assert events[0]["info"]["chunkCount"] == "1"
 
+    def test_unparseable_end_falls_back_to_timestamp(self):
+        c = _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="not-a-timestamp")
+        event = _consolidator()._consolidate([c])[0]
+        assert event["end"] == "2025-01-01T00:00:00.000Z"
+
     def test_event_carries_chunk_ids_list(self):
         docs = [
             _chunk(idx=1, doc_id="c1", start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -345,6 +345,19 @@ class TestConsolidationGrouping:
         assert events[0]["sensorId"] == "cam-2"
         assert events[-1]["sensorId"] == "cam-1"
 
+    def test_events_sorted_by_start_not_end(self):
+        docs = [
+            # cam-1: started earliest, ends latest (two chunks merged)
+            _chunk(sensor="cam-1", idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(sensor="cam-1", idx=2, start="2025-01-01T00:00:20.000Z", end="2025-01-01T00:05:00.000Z"),
+            # cam-2: started later but ends earlier
+            _chunk(sensor="cam-2", idx=1, start="2025-01-01T00:03:00.000Z", end="2025-01-01T00:03:30.000Z"),
+        ]
+        events = _consolidator()._consolidate(docs)
+        assert len(events) == 2
+        assert events[0]["sensorId"] == "cam-2"  # later start ranks first
+        assert events[1]["sensorId"] == "cam-1"
+
     def test_empty_input(self):
         assert _consolidator()._consolidate([]) == []
 

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -456,15 +456,41 @@ class TestConsolidationGrouping:
         assert len(events) == 1
         assert events[0]["info"]["chunkCount"] == "12"
 
-    def test_missing_timestamp_does_not_crash(self):
+    def test_malformed_chunks_are_dropped(self):
         good = _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")
-        bad = _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z")
-        bad.pop("timestamp")
-        bad.pop("end")
+        no_ts = _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z")
+        no_ts.pop("timestamp")
+        no_sensor = _chunk(sensor=None, idx=3, start="2025-01-01T00:00:40.000Z")
+        no_cat = _chunk(category=None, idx=4, start="2025-01-01T00:00:45.000Z")
+        events = _consolidator()._consolidate([good, no_ts, no_sensor, no_cat])
+        # malformed chunks (missing sensorId/category/timestamp) are dropped
+        assert len(events) == 1
+        assert events[0]["info"]["chunkCount"] == "1"
+
+    def test_unparseable_timestamp_dropped(self):
+        good = _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")
+        bad = _chunk(idx=2, start="not-a-timestamp", end="2025-01-01T00:00:55.000Z")
         events = _consolidator()._consolidate([good, bad])
-        # no exception; a chunk with no parseable time cannot chain -> separate
-        assert len(events) == 2
-        assert sum(int(e["info"]["chunkCount"]) for e in events) == 2
+        assert len(events) == 1
+        assert events[0]["info"]["chunkCount"] == "1"
+
+    def test_event_carries_chunk_ids_list(self):
+        docs = [
+            _chunk(idx=1, doc_id="c1", start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=2, doc_id="c2", start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
+        ]
+        event = _consolidator()._consolidate(docs)[0]
+        assert isinstance(event["chunk_ids"], list)
+        assert set(event["chunk_ids"]) == {"c1", "c2"}
+        assert len(event["chunk_ids"]) == int(event["info"]["chunkCount"])
+
+    def test_merged_llm_queries_are_capped(self):
+        # one chunk carrying more queries than the cap -> capped, true count kept
+        big = _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")
+        big["llm"] = {"queries": [{"id": f"q{i}"} for i in range(500)]}
+        event = _consolidator()._consolidate([big])[0]
+        assert len(event["llm"]["queries"]) == 200      # _MAX_MERGED_QUERIES
+        assert event["info"]["mergedQueryCount"] == "500"
 
     def test_missing_info_key_handled(self):
         c1 = _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")
@@ -477,8 +503,90 @@ class TestConsolidationGrouping:
         assert events[0]["info"]["chunkCount"] == "2"
 
 
+class TestConsolidationConfigValidation:
+    """IncidentService construction validates consolidation tuning (fail-fast)."""
+
+    @pytest.mark.parametrize("bad", [
+        {"max_inter_alert_gap_seconds": 0},
+        {"max_inter_alert_gap_seconds": 3601},
+        {"max_inter_alert_gap_seconds": -1},
+        {"max_inter_alert_gap_seconds": "60"},
+        {"max_inter_alert_gap_seconds": True},
+        {"max_event_duration_seconds": 0},
+        {"max_event_duration_seconds": 3601},
+        {"representative": "bogus"},
+    ])
+    def test_invalid_config_rejected(self, bad):
+        with pytest.raises(ValueError):
+            IncidentService(consolidation=dict(_CONSOL_DEFAULT, **bad))
+
+    def test_null_duration_allowed(self):
+        IncidentService(consolidation=dict(_CONSOL_DEFAULT, max_event_duration_seconds=None))
+
+    def test_empty_config_ok(self):
+        IncidentService(consolidation={})
+        IncidentService(consolidation=None)
+
+
 class TestConsolidationService:
     """IncidentService.list_incidents — consolidation behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_consolidate_filters_to_realtime_docs(self, mock_es_client):
+        # REQ-007: consolidated query must exclude verifier-path docs via the
+        # realtime discriminator (read-time filter; ES is never modified).
+        mock_es_client.client.search.return_value = {"hits": {"total": {"value": 0}, "hits": []}}
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
+        await svc.list_incidents(
+            sensor_id="cam1", category="intrusion",
+            start_time="2025-01-01T00:00:00Z", end_time="2025-01-01T01:00:00Z",
+            consolidate=True,
+        )
+        musts = mock_es_client.client.search.call_args.kwargs["query"]["bool"]["must"]
+        assert {"exists": {"field": "info.chunkIdx"}} in musts
+
+    @pytest.mark.asyncio
+    async def test_raw_view_does_not_filter_verifier_docs(self, mock_es_client):
+        mock_es_client.client.search.return_value = {"hits": {"total": {"value": 0}, "hits": []}}
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
+        await svc.list_incidents(sensor_id="cam1", consolidate=False)
+        query = mock_es_client.client.search.call_args.kwargs["query"]
+        musts = query.get("bool", {}).get("must", [])
+        assert {"exists": {"field": "info.chunkIdx"}} not in musts
+
+    @pytest.mark.asyncio
+    async def test_truncated_true_when_total_exceeds_scanned(self, mock_es_client):
+        # ES caps hits.total; a window denser than the scan must flag truncated.
+        chunks = [
+            _chunk(idx=1),
+            _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
+        ]
+        mock_es_client.client.search.return_value = {
+            "hits": {"total": {"value": 15000, "relation": "gte"},
+                     "hits": [_as_hit(c) for c in chunks]}
+        }
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
+        data, _ = await svc.list_incidents(
+            sensor_id="cam-1", category="alert",
+            start_time="2025-01-01T00:00:00Z", end_time="2025-01-01T01:00:00Z",
+            consolidate=True,
+        )
+        assert data["truncated"] is True
+        # track_total_hits must be requested so the count is exact
+        assert mock_es_client.client.search.call_args.kwargs.get("track_total_hits") is True
+
+    @pytest.mark.asyncio
+    async def test_truncated_false_when_complete(self, mock_es_client):
+        mock_es_client.client.search.return_value = {
+            "hits": {"total": {"value": 1}, "hits": [_as_hit(_chunk(idx=1))]}
+        }
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
+        data, _ = await svc.list_incidents(
+            sensor_id="cam-1", category="alert",
+            start_time="2025-01-01T00:00:00Z", end_time="2025-01-01T01:00:00Z",
+            consolidate=True,
+        )
+        assert data["truncated"] is False
 
     @pytest.mark.asyncio
     async def test_consolidate_false_passthrough(self, mock_es_client):

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -208,7 +208,6 @@ class TestIncidentServiceInit:
 # ---------------------------------------------------------------------------
 
 _CONSOL_DEFAULT = {
-    "enabled": True,
     "max_inter_alert_gap_seconds": 60,
     "max_event_duration_seconds": 300,
     "representative": "latest",
@@ -424,7 +423,8 @@ class TestConsolidationService:
         assert all(i["info"]["isConsolidated"] == "true" for i in data["incidents"])
 
     @pytest.mark.asyncio
-    async def test_default_follows_config_enabled_true(self, mock_es_client):
+    async def test_omit_param_returns_raw(self, mock_es_client):
+        # Consolidation is opt-in: omitting the param returns raw chunks.
         chunks = [
             _chunk(idx=1),
             _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
@@ -432,25 +432,13 @@ class TestConsolidationService:
         mock_es_client.client.search.return_value = {
             "hits": {"total": {"value": 2}, "hits": [_as_hit(c) for c in chunks]}
         }
-        svc = IncidentService(es_client=mock_es_client, consolidation={"enabled": True})
-        data, _ = await svc.list_incidents()
-        assert data["count"] == 1
-
-    @pytest.mark.asyncio
-    async def test_default_follows_config_enabled_false(self, mock_es_client):
-        chunks = [
-            _chunk(idx=1),
-            _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
-        ]
-        mock_es_client.client.search.return_value = {
-            "hits": {"total": {"value": 2}, "hits": [_as_hit(c) for c in chunks]}
-        }
-        svc = IncidentService(es_client=mock_es_client, consolidation={"enabled": False})
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
         data, _ = await svc.list_incidents()
         assert data["count"] == 2
+        assert all("isConsolidated" not in i.get("info", {}) for i in data["incidents"])
 
     @pytest.mark.asyncio
-    async def test_explicit_param_overrides_config(self, mock_es_client):
+    async def test_consolidate_true_groups_with_tuning_only_config(self, mock_es_client):
         chunks = [
             _chunk(idx=1),
             _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
@@ -458,6 +446,6 @@ class TestConsolidationService:
         mock_es_client.client.search.return_value = {
             "hits": {"total": {"value": 2}, "hits": [_as_hit(c) for c in chunks]}
         }
-        svc = IncidentService(es_client=mock_es_client, consolidation={"enabled": False})
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
         data, _ = await svc.list_incidents(consolidate=True)
         assert data["count"] == 1

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -274,15 +274,15 @@ class TestConsolidationGrouping:
         assert merged["end"] == "2025-01-01T00:00:55.000Z"
         assert len(merged["llm"]["queries"]) == 2
 
-    def test_session_consecutive_chunkidx_merges_beyond_gap(self):
-        # Time gap exceeds the bound, but same requestId + consecutive chunkIdx.
+    def test_large_gap_splits_even_same_session(self):
+        # Same requestId + consecutive chunkIdx, but the inter-alert gap exceeds
+        # the bound (65s > 60s): the gap is authoritative, so these split.
         docs = [
             _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
             _chunk(idx=2, start="2025-01-01T00:01:35.000Z", end="2025-01-01T00:02:05.000Z"),
         ]
         events = _consolidator()._consolidate(docs)
-        assert len(events) == 1
-        assert events[0]["info"]["chunkCount"] == "2"
+        assert len(events) == 2
 
     def test_new_event_after_bound(self):
         docs = [

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -409,6 +409,73 @@ class TestConsolidationGrouping:
         assert event["_id"] == event["Id"]
         assert event["Id"].startswith("evt-")
 
+    def test_gap_exactly_at_bound_merges(self):
+        # gap == max_inter_alert_gap_seconds (60s) is inclusive -> merge
+        docs = [
+            _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=2, start="2025-01-01T00:01:30.000Z", end="2025-01-01T00:02:00.000Z"),
+        ]
+        assert len(_consolidator()._consolidate(docs)) == 1
+
+    def test_gap_one_second_over_bound_splits(self):
+        docs = [
+            _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=2, start="2025-01-01T00:01:31.000Z", end="2025-01-01T00:02:01.000Z"),
+        ]
+        assert len(_consolidator()._consolidate(docs)) == 2
+
+    def test_duration_exactly_at_cap_merges(self):
+        # span == max_event_duration_seconds is inclusive -> merge
+        cfg = dict(_CONSOL_DEFAULT, max_event_duration_seconds=60)
+        docs = [
+            _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=2, start="2025-01-01T00:00:30.000Z", end="2025-01-01T00:01:00.000Z"),
+        ]
+        assert len(_consolidator(cfg)._consolidate(docs)) == 1
+
+    def test_duration_one_second_over_cap_splits(self):
+        cfg = dict(_CONSOL_DEFAULT, max_event_duration_seconds=60)
+        docs = [
+            _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=2, start="2025-01-01T00:00:30.000Z", end="2025-01-01T00:01:01.000Z"),
+        ]
+        assert len(_consolidator(cfg)._consolidate(docs)) == 2
+
+    def test_null_max_duration_is_unbounded(self):
+        # max_event_duration_seconds=None disables the outer cap entirely
+        cfg = dict(_CONSOL_DEFAULT, max_event_duration_seconds=None)
+        docs = [
+            _chunk(
+                idx=i,
+                start=f"2025-01-01T00:{i:02d}:00.000Z",
+                end=f"2025-01-01T00:{i:02d}:30.000Z",
+            )
+            for i in range(0, 12)  # ~11 min span, well past the old 300s cap
+        ]
+        events = _consolidator(cfg)._consolidate(docs)
+        assert len(events) == 1
+        assert events[0]["info"]["chunkCount"] == "12"
+
+    def test_missing_timestamp_does_not_crash(self):
+        good = _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")
+        bad = _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z")
+        bad.pop("timestamp")
+        bad.pop("end")
+        events = _consolidator()._consolidate([good, bad])
+        # no exception; a chunk with no parseable time cannot chain -> separate
+        assert len(events) == 2
+        assert sum(int(e["info"]["chunkCount"]) for e in events) == 2
+
+    def test_missing_info_key_handled(self):
+        c1 = _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")
+        c2 = _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z")
+        c1.pop("info")
+        c2.pop("info")
+        events = _consolidator()._consolidate([c1, c2])
+        assert len(events) == 1
+        assert events[0]["info"]["isConsolidated"] == "true"
+        assert events[0]["info"]["chunkCount"] == "2"
+
 
 class TestConsolidationService:
     """IncidentService.list_incidents — consolidation behaviour."""

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -201,3 +201,263 @@ class TestIncidentServiceInit:
     def test_custom_index_base(self):
         svc = IncidentService(index_base="my-incidents")
         assert svc._index_base == "my-incidents"
+
+
+# ---------------------------------------------------------------------------
+# Consolidation — read-time grouping of repeated positives
+# ---------------------------------------------------------------------------
+
+_CONSOL_DEFAULT = {
+    "enabled": True,
+    "max_inter_alert_gap_seconds": 60,
+    "max_event_duration_seconds": 300,
+    "representative": "latest",
+}
+
+
+def _chunk(
+    sensor="cam-1",
+    category="alert",
+    req="req-1",
+    idx=1,
+    start="2025-01-01T00:00:00.000Z",
+    end="2025-01-01T00:00:30.000Z",
+    reasoning="r",
+    doc_id=None,
+    extra=None,
+):
+    """Build a raw chunk-level incident document (post-read shape)."""
+    doc = {
+        "sensorId": sensor,
+        "category": category,
+        "timestamp": start,
+        "end": end,
+        "info": {
+            "requestId": req,
+            "chunkIdx": str(idx),
+            "verdict": "confirmed",
+            "reasoning": reasoning,
+        },
+        "llm": {"queries": [{"id": f"{req}:{idx}"}]},
+        "_id": doc_id or f"{sensor}-{req}-{idx}",
+        "_index": "mdx-vlm-incidents-2025-01-01",
+    }
+    if extra:
+        doc.update(extra)
+    return doc
+
+
+def _as_hit(chunk):
+    """Convert a chunk document into an Elasticsearch search hit."""
+    body = {k: v for k, v in chunk.items() if k not in ("_id", "_index")}
+    return {"_id": chunk["_id"], "_index": chunk["_index"], "_source": body}
+
+
+def _consolidator(cfg=None):
+    return IncidentService(consolidation=cfg or dict(_CONSOL_DEFAULT))
+
+
+class TestConsolidationGrouping:
+    """Pure grouping logic — IncidentService._consolidate."""
+
+    def test_consecutive_within_gap_merge(self):
+        docs = [
+            _chunk(idx=13, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=14, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
+            _chunk(idx=20, start="2025-01-01T00:05:00.000Z", end="2025-01-01T00:05:30.000Z"),
+        ]
+        events = _consolidator()._consolidate(docs)
+        assert len(events) == 2
+        merged = next(e for e in events if e["info"]["chunkCount"] == "2")
+        assert merged["info"]["isConsolidated"] == "true"
+        assert merged["info"]["chunkIdxRange"] == "13-14"
+        assert merged["timestamp"] == "2025-01-01T00:00:00.000Z"
+        assert merged["end"] == "2025-01-01T00:00:55.000Z"
+        assert len(merged["llm"]["queries"]) == 2
+        assert merged["info"]["rawIds"].count(",") == 1
+
+    def test_session_consecutive_chunkidx_merges_beyond_gap(self):
+        # Time gap exceeds the bound, but same requestId + consecutive chunkIdx.
+        docs = [
+            _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=2, start="2025-01-01T00:01:35.000Z", end="2025-01-01T00:02:05.000Z"),
+        ]
+        events = _consolidator()._consolidate(docs)
+        assert len(events) == 1
+        assert events[0]["info"]["chunkCount"] == "2"
+
+    def test_new_event_after_bound(self):
+        docs = [
+            _chunk(req="a", idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(req="b", idx=9, start="2025-01-01T00:02:00.000Z", end="2025-01-01T00:02:30.000Z"),
+        ]
+        events = _consolidator()._consolidate(docs)
+        assert len(events) == 2
+        assert all(e["info"]["chunkCount"] == "1" for e in events)
+
+    def test_duration_cap_splits(self):
+        cfg = dict(_CONSOL_DEFAULT, max_event_duration_seconds=60)
+        docs = [
+            _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=2, start="2025-01-01T00:00:30.000Z", end="2025-01-01T00:01:00.000Z"),
+            _chunk(idx=3, start="2025-01-01T00:01:00.000Z", end="2025-01-01T00:01:30.000Z"),
+            _chunk(idx=4, start="2025-01-01T00:01:30.000Z", end="2025-01-01T00:02:00.000Z"),
+        ]
+        events = _consolidator(cfg)._consolidate(docs)
+        assert len(events) == 2
+
+    def test_different_sensor_not_merged(self):
+        docs = [_chunk(sensor="cam-1", idx=1), _chunk(sensor="cam-2", idx=1)]
+        assert len(_consolidator()._consolidate(docs)) == 2
+
+    def test_different_category_not_merged(self):
+        docs = [_chunk(category="fire", idx=1), _chunk(category="smoke", idx=1)]
+        assert len(_consolidator()._consolidate(docs)) == 2
+
+    def test_end_missing_falls_back_to_timestamp(self):
+        d0 = _chunk(idx=1, start="2025-01-01T00:00:00.000Z")
+        d1 = _chunk(idx=2, start="2025-01-01T00:00:20.000Z")
+        d0.pop("end")
+        d1.pop("end")
+        events = _consolidator()._consolidate([d0, d1])
+        assert len(events) == 1
+        assert events[0]["end"] == "2025-01-01T00:00:20.000Z"
+
+    def test_representative_longest_reasoning(self):
+        cfg = dict(_CONSOL_DEFAULT, representative="longest_reasoning")
+        docs = [
+            _chunk(idx=1, reasoning="short"),
+            _chunk(
+                idx=2,
+                start="2025-01-01T00:00:25.000Z",
+                end="2025-01-01T00:00:55.000Z",
+                reasoning="a much longer reasoning text",
+            ),
+        ]
+        events = _consolidator(cfg)._consolidate(docs)
+        assert len(events) == 1
+        assert events[0]["info"]["reasoning"] == "a much longer reasoning text"
+
+    def test_events_sorted_newest_first(self):
+        docs = [
+            _chunk(sensor="cam-1", idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(sensor="cam-2", idx=1, start="2025-01-01T01:00:00.000Z", end="2025-01-01T01:00:30.000Z"),
+        ]
+        events = _consolidator()._consolidate(docs)
+        assert events[0]["sensorId"] == "cam-2"
+        assert events[-1]["sensorId"] == "cam-1"
+
+    def test_empty_input(self):
+        assert _consolidator()._consolidate([]) == []
+
+    def test_single_doc_one_event(self):
+        events = _consolidator()._consolidate([_chunk(idx=1)])
+        assert len(events) == 1
+        assert events[0]["info"]["chunkCount"] == "1"
+
+    def test_nvschema_fields_preserved(self):
+        extra = {
+            "type": "mdx-vlm-incidents",
+            "isAnomaly": True,
+            "analyticsModule": {"source": "rtvi-vlm"},
+            "place": {"name": "dock"},
+        }
+        docs = [
+            _chunk(idx=1, extra=extra),
+            _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z", extra=extra),
+        ]
+        e = _consolidator()._consolidate(docs)[0]
+        assert e["type"] == "mdx-vlm-incidents"
+        assert e["isAnomaly"] is True
+        assert e["analyticsModule"]["source"] == "rtvi-vlm"
+        assert e["place"]["name"] == "dock"
+
+    def test_rawids_bijection_no_loss(self):
+        docs = [
+            _chunk(idx=i, start=f"2025-01-01T00:0{i}:00.000Z", end=f"2025-01-01T00:0{i}:30.000Z")
+            for i in range(1, 4)
+        ]
+        events = _consolidator()._consolidate(docs)
+        all_ids = []
+        total_chunks = 0
+        for e in events:
+            all_ids += e["info"]["rawIds"].split(",")
+            total_chunks += int(e["info"]["chunkCount"])
+        assert total_chunks == len(docs)
+        assert set(all_ids) == {d["_id"] for d in docs}
+
+
+class TestConsolidationService:
+    """IncidentService.list_incidents — consolidation behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_consolidate_false_passthrough(self, mock_es_client):
+        chunks = [
+            _chunk(idx=1),
+            _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
+        ]
+        mock_es_client.client.search.return_value = {
+            "hits": {"total": {"value": 2}, "hits": [_as_hit(c) for c in chunks]}
+        }
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
+        data, code = await svc.list_incidents(consolidate=False)
+        assert code == 200
+        assert data["count"] == 2
+        assert data["total"] == 2
+        assert all("isConsolidated" not in i.get("info", {}) for i in data["incidents"])
+
+    @pytest.mark.asyncio
+    async def test_consolidate_true_groups_and_keeps_raw_total(self, mock_es_client):
+        chunks = [
+            _chunk(sensor="cam-1", idx=1),
+            _chunk(sensor="cam-1", idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
+            _chunk(sensor="cam-2", idx=1),
+        ]
+        mock_es_client.client.search.return_value = {
+            "hits": {"total": {"value": 3}, "hits": [_as_hit(c) for c in chunks]}
+        }
+        svc = IncidentService(es_client=mock_es_client, consolidation=dict(_CONSOL_DEFAULT))
+        data, code = await svc.list_incidents(consolidate=True)
+        assert code == 200
+        assert data["total"] == 3
+        assert data["count"] == 2
+        assert all(i["info"]["isConsolidated"] == "true" for i in data["incidents"])
+
+    @pytest.mark.asyncio
+    async def test_default_follows_config_enabled_true(self, mock_es_client):
+        chunks = [
+            _chunk(idx=1),
+            _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
+        ]
+        mock_es_client.client.search.return_value = {
+            "hits": {"total": {"value": 2}, "hits": [_as_hit(c) for c in chunks]}
+        }
+        svc = IncidentService(es_client=mock_es_client, consolidation={"enabled": True})
+        data, _ = await svc.list_incidents()
+        assert data["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_default_follows_config_enabled_false(self, mock_es_client):
+        chunks = [
+            _chunk(idx=1),
+            _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
+        ]
+        mock_es_client.client.search.return_value = {
+            "hits": {"total": {"value": 2}, "hits": [_as_hit(c) for c in chunks]}
+        }
+        svc = IncidentService(es_client=mock_es_client, consolidation={"enabled": False})
+        data, _ = await svc.list_incidents()
+        assert data["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_explicit_param_overrides_config(self, mock_es_client):
+        chunks = [
+            _chunk(idx=1),
+            _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),
+        ]
+        mock_es_client.client.search.return_value = {
+            "hits": {"total": {"value": 2}, "hits": [_as_hit(c) for c in chunks]}
+        }
+        svc = IncidentService(es_client=mock_es_client, consolidation={"enabled": False})
+        data, _ = await svc.list_incidents(consolidate=True)
+        assert data["count"] == 1

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -273,7 +273,6 @@ class TestConsolidationGrouping:
         assert merged["timestamp"] == "2025-01-01T00:00:00.000Z"
         assert merged["end"] == "2025-01-01T00:00:55.000Z"
         assert len(merged["llm"]["queries"]) == 2
-        assert merged["info"]["rawIds"].count(",") == 1
 
     def test_session_consecutive_chunkidx_merges_beyond_gap(self):
         # Time gap exceeds the bound, but same requestId + consecutive chunkIdx.
@@ -371,19 +370,31 @@ class TestConsolidationGrouping:
         assert e["analyticsModule"]["source"] == "rtvi-vlm"
         assert e["place"]["name"] == "dock"
 
-    def test_rawids_bijection_no_loss(self):
+    def test_chunk_count_sums_to_input_no_loss(self):
         docs = [
             _chunk(idx=i, start=f"2025-01-01T00:0{i}:00.000Z", end=f"2025-01-01T00:0{i}:30.000Z")
             for i in range(1, 4)
         ]
         events = _consolidator()._consolidate(docs)
-        all_ids = []
-        total_chunks = 0
-        for e in events:
-            all_ids += e["info"]["rawIds"].split(",")
-            total_chunks += int(e["info"]["chunkCount"])
+        total_chunks = sum(int(e["info"]["chunkCount"]) for e in events)
         assert total_chunks == len(docs)
-        assert set(all_ids) == {d["_id"] for d in docs}
+
+    def test_event_id_distinct_from_raw_chunk_ids(self):
+        docs = [
+            _chunk(idx=1, doc_id="fp1", extra={"Id": "fp1"}),
+            _chunk(
+                idx=2,
+                start="2025-01-01T00:00:25.000Z",
+                end="2025-01-01T00:00:55.000Z",
+                doc_id="fp2",
+                extra={"Id": "fp2"},
+            ),
+        ]
+        event = _consolidator()._consolidate(docs)[0]
+        raw_ids = {"fp1", "fp2"}
+        assert event["Id"] not in raw_ids
+        assert event["_id"] == event["Id"]
+        assert event["Id"].startswith("evt-")
 
 
 class TestConsolidationService:

--- a/services/alert/test/unit/api/test_realtime_routes.py
+++ b/services/alert/test/unit/api/test_realtime_routes.py
@@ -2630,3 +2630,22 @@ class TestAlwaysOnConcurrency:
         assert second_body["reason"] == "STREAM_ADD_SUCCESS"
         assert second_body["details"][0]["alert_rule_id"] == "alert-2"
         assert realtime_mock.start_alert.await_count == 2
+
+
+class TestGetIncidentsConsolidate:
+    """GET /api/v1/realtime/incidents — `consolidate` query param wiring."""
+
+    def test_consolidate_true_forwarded(self, client, mocks):
+        resp = client.get("/api/v1/realtime/incidents?consolidate=true")
+        assert resp.status_code == 200
+        assert mocks["incident"].list_incidents.await_args.kwargs["consolidate"] is True
+
+    def test_consolidate_false_forwarded(self, client, mocks):
+        resp = client.get("/api/v1/realtime/incidents?consolidate=false")
+        assert resp.status_code == 200
+        assert mocks["incident"].list_incidents.await_args.kwargs["consolidate"] is False
+
+    def test_consolidate_default_none(self, client, mocks):
+        resp = client.get("/api/v1/realtime/incidents")
+        assert resp.status_code == 200
+        assert mocks["incident"].list_incidents.await_args.kwargs["consolidate"] is None

--- a/services/alert/test/unit/api/test_realtime_routes.py
+++ b/services/alert/test/unit/api/test_realtime_routes.py
@@ -2636,9 +2636,23 @@ class TestGetIncidentsConsolidate:
     """GET /api/v1/realtime/incidents — `consolidate` query param wiring."""
 
     def test_consolidate_true_forwarded(self, client, mocks):
-        resp = client.get("/api/v1/realtime/incidents?consolidate=true")
+        resp = client.get(
+            "/api/v1/realtime/incidents?consolidate=true"
+            "&start_time=2025-01-01T00:00:00Z&end_time=2025-01-01T01:00:00Z"
+        )
         assert resp.status_code == 200
         assert mocks["incident"].list_incidents.await_args.kwargs["consolidate"] is True
+
+    def test_consolidate_without_window_returns_400(self, client):
+        resp = client.get("/api/v1/realtime/incidents?consolidate=true")
+        assert resp.status_code == 400
+        assert "start_time" in resp.json()["message"]
+
+    def test_consolidate_with_only_start_time_returns_400(self, client):
+        resp = client.get(
+            "/api/v1/realtime/incidents?consolidate=true&start_time=2025-01-01T00:00:00Z"
+        )
+        assert resp.status_code == 400
 
     def test_consolidate_false_forwarded(self, client, mocks):
         resp = client.get("/api/v1/realtime/incidents?consolidate=false")


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
