### PR TITLE
skills-eval CI: mirror #1131 to develop (nightly ref, 28d retention, alerts)

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -45,6 +45,7 @@ additional_vetters:
   - purvag3091
   - rahul3349
   - romalakar
+  - sarathm-nvidia
   - shubham050300
   - soumilinandi
   - ssmmoo1

--- a/.github/nv-slack-bot.yaml
+++ b/.github/nv-slack-bot.yaml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# nv-slack-bot configuration — turns GitHub webhook events into Slack messages.
+# Docs: https://github.com/nv-gha-runners/github-apps/tree/main/packages/nv-slack-bot
+#
+# Scope: the "Skills Eval Daily" nightly sweep only. Posts to the configured
+# alerts channel; failures/timeouts tag the interested-parties group.
+#
+# NOTE: this app reads its config from the repository's DEFAULT BRANCH (main),
+# regardless of which branch the workflow checks out/evaluates. So this file
+# must live on main to be active.
+#
+# `match` / `message.vars` are JSONata over the webhook payload (root = $).
+# Do NOT put spaces inside {{var}} braces.
+
+$schema: https://public.gha-runners.nvidia.com/nv-slack-bot/schemas/config-v1.json
+enabled: true
+
+notifications:
+  # ── run-level: one event per nightly run ─────────────────────────────────
+  - name: "Skills Eval Daily — started"
+    event: workflow_run
+    slack:
+      nvidia:
+        channels:
+          - id: C0BDC2SBZK9
+    match: workflow_run.name = "Skills Eval Daily" and action = "requested"
+    message:
+      body: ":rocket: <{{url}}|Skills Eval Daily> started — run {{run}} ({{trigger}})"
+      vars:
+        url: workflow_run.html_url
+        run: workflow_run.run_number
+        trigger: workflow_run.event
+
+  - name: "Skills Eval Daily — succeeded"
+    event: workflow_run
+    slack:
+      nvidia:
+        channels:
+          - id: C0BDC2SBZK9
+    match: workflow_run.name = "Skills Eval Daily" and workflow_run.conclusion = "success"
+    message:
+      body: ":white_check_mark: <{{url}}|Skills Eval Daily> passed — run {{run}}"
+      vars:
+        url: workflow_run.html_url
+        run: workflow_run.run_number
+
+  - name: "Skills Eval Daily — failed"
+    event: workflow_run
+    slack:
+      nvidia:
+        channels:
+          - id: C0BDC2SBZK9
+    match: workflow_run.name = "Skills Eval Daily" and workflow_run.conclusion = "failure"
+    message:
+      body: ":red_circle: <{{url}}|Skills Eval Daily FAILED> — run {{run}} <!subteam^S0BE3B5GAS0>"
+      vars:
+        url: workflow_run.html_url
+        run: workflow_run.run_number
+
+  - name: "Skills Eval Daily — timed out"
+    event: workflow_run
+    slack:
+      nvidia:
+        channels:
+          - id: C0BDC2SBZK9
+    match: workflow_run.name = "Skills Eval Daily" and workflow_run.conclusion = "timed_out"
+    message:
+      body: ":hourglass_flowing_sand: <{{url}}|Skills Eval Daily TIMED OUT> — run {{run}} <!subteam^S0BE3B5GAS0>"
+      vars:
+        url: workflow_run.html_url
+        run: workflow_run.run_number
+
+  - name: "Skills Eval Daily — cancelled"
+    event: workflow_run
+    slack:
+      nvidia:
+        channels:
+          - id: C0BDC2SBZK9
+    match: workflow_run.name = "Skills Eval Daily" and workflow_run.conclusion = "cancelled"
+    message:
+      body: ":warning: <{{url}}|Skills Eval Daily was cancelled> — run {{run}}"
+      vars:
+        url: workflow_run.html_url
+        run: workflow_run.run_number
+
+  # ── job-level: the developer crux — only failed / timed-out legs ─────────
+  # A leg that exceeds its timeout-minutes is reported by GitHub with
+  # conclusion="cancelled" (not "timed_out"); for the nightly, superseding is
+  # rare, so a cancelled leg here is effectively a timed-out leg. Each failed /
+  # timed-out leg tags the group so owners see exactly which legs broke
+  # (this is in addition to the single run-level failure/timeout tag above).
+  - name: "Skills Eval Daily — leg failed"
+    event: workflow_job
+    slack:
+      nvidia:
+        channels:
+          - id: C0BDC2SBZK9
+    match: workflow_job.workflow_name = "Skills Eval Daily" and workflow_job.conclusion = "failure"
+    message:
+      body: ":x: leg failed — <{{url}}|{{leg}}> <!subteam^S0BE3B5GAS0>"
+      vars:
+        url: workflow_job.html_url
+        leg: workflow_job.name
+
+  - name: "Skills Eval Daily — leg timed out / cancelled"
+    event: workflow_job
+    slack:
+      nvidia:
+        channels:
+          - id: C0BDC2SBZK9
+    match: workflow_job.workflow_name = "Skills Eval Daily" and workflow_job.conclusion = "cancelled"
+    message:
+      body: ":hourglass: leg timed out / cancelled — <{{url}}|{{leg}}> <!subteam^S0BE3B5GAS0>"
+      vars:
+        url: workflow_job.html_url
+        leg: workflow_job.name

--- a/.github/nv-slack-bot.yaml
+++ b/.github/nv-slack-bot.yaml
@@ -39,7 +39,7 @@ notifications:
       nvidia:
         channels:
           - id: C0BDC2SBZK9
-    match: workflow_run.name = "Skills Eval Daily" and workflow_run.conclusion = "success"
+    match: workflow_run.name = "Skills Eval Daily" and action = "completed" and workflow_run.conclusion = "success"
     message:
       body: ":white_check_mark: <{{url}}|Skills Eval Daily> passed — run {{run}}"
       vars:
@@ -52,7 +52,7 @@ notifications:
       nvidia:
         channels:
           - id: C0BDC2SBZK9
-    match: workflow_run.name = "Skills Eval Daily" and workflow_run.conclusion = "failure"
+    match: workflow_run.name = "Skills Eval Daily" and action = "completed" and workflow_run.conclusion = "failure"
     message:
       body: ":red_circle: <{{url}}|Skills Eval Daily FAILED> — run {{run}} <!subteam^S0BE3B5GAS0>"
       vars:
@@ -65,7 +65,7 @@ notifications:
       nvidia:
         channels:
           - id: C0BDC2SBZK9
-    match: workflow_run.name = "Skills Eval Daily" and workflow_run.conclusion = "timed_out"
+    match: workflow_run.name = "Skills Eval Daily" and action = "completed" and workflow_run.conclusion = "timed_out"
     message:
       body: ":hourglass_flowing_sand: <{{url}}|Skills Eval Daily TIMED OUT> — run {{run}} <!subteam^S0BE3B5GAS0>"
       vars:
@@ -78,7 +78,7 @@ notifications:
       nvidia:
         channels:
           - id: C0BDC2SBZK9
-    match: workflow_run.name = "Skills Eval Daily" and workflow_run.conclusion = "cancelled"
+    match: workflow_run.name = "Skills Eval Daily" and action = "completed" and workflow_run.conclusion = "cancelled"
     message:
       body: ":warning: <{{url}}|Skills Eval Daily was cancelled> — run {{run}}"
       vars:
@@ -97,7 +97,7 @@ notifications:
       nvidia:
         channels:
           - id: C0BDC2SBZK9
-    match: workflow_job.workflow_name = "Skills Eval Daily" and workflow_job.conclusion = "failure"
+    match: workflow_job.workflow_name = "Skills Eval Daily" and action = "completed" and workflow_job.conclusion = "failure"
     message:
       body: ":x: leg failed — <{{url}}|{{leg}}> <!subteam^S0BE3B5GAS0>"
       vars:
@@ -110,7 +110,7 @@ notifications:
       nvidia:
         channels:
           - id: C0BDC2SBZK9
-    match: workflow_job.workflow_name = "Skills Eval Daily" and workflow_job.conclusion = "cancelled"
+    match: workflow_job.workflow_name = "Skills Eval Daily" and action = "completed" and workflow_job.conclusion = "cancelled"
     message:
       body: ":hourglass: leg timed out / cancelled — <{{url}}|{{leg}}> <!subteam^S0BE3B5GAS0>"
       vars:

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -225,4 +225,4 @@ jobs:
           name: skills-eval-daily-results-${{ matrix.slug }}-${{ github.run_id }}
           path: /tmp/skills-eval-daily-results-${{ matrix.slug }}-${{ github.run_id }}.tar.gz
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: 28   # 4 weeks (was 7) — longer window for trend ingest + investigation

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -71,8 +71,11 @@ jobs:
       - name: Checkout mirror head
         uses: actions/checkout@v4
         with:
-          # ref: develop <-- after get merged into develop, I would need to uncomment this setting to specify
-          # develop branch as target branch for scheduled skill eval run
+          # The scheduled nightly fires from the DEFAULT branch (main) but must
+          # EVALUATE develop, where active skill/harness work lands. Schedule ->
+          # develop; workflow_dispatch -> the ref picked in the dropdown
+          # (github.ref) so on-demand runs can still target any branch.
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
           fetch-depth: 0   # plan diffs the cumulative head...base range
 
       - name: Compute matrix
@@ -110,6 +113,9 @@ jobs:
       - name: Checkout mirror head
         uses: actions/checkout@v4
         with:
+          # Match the plan job: nightly evaluates develop; dispatch uses the
+          # chosen ref. Both jobs must check out the same tree.
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
           fetch-depth: 0   # agent needs full history to fetch + commit to the contributor's branch (§ 3c)
 
       - name: Load coordinator env (Anthropic, NGC, Brev, remote endpoints)
@@ -146,7 +152,14 @@ jobs:
           set -a
           source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
           set +a
-          export PR_HEAD_SHA="${{ github.sha }}"
+          # Pin the box-side repo sync to the SHA the runner actually checked
+          # out — NOT github.sha. On a scheduled run github.sha is the default
+          # branch (main) tip, but the checkout above is develop; using it here
+          # would make BrevEnvironment._sync_repo_to_pr_head deploy main's code
+          # while the harness ran develop. git rev-parse HEAD = the checked-out
+          # commit (develop on the nightly, the dispatch ref otherwise), so both
+          # code sources stay on the same tree.
+          export PR_HEAD_SHA="$(git rev-parse HEAD)"
           export PR_REPO="${{ github.repository }}"
           export GITHUB_RUN_ID="${{ github.run_id }}"
           # Single-spec mode — plan already decided this leg's target, so

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -260,4 +260,4 @@ jobs:
           name: skills-eval-results-pr-${{ needs.plan.outputs.pr_number }}-${{ matrix.slug }}-${{ github.run_id }}
           path: /tmp/skills-eval-results-${{ matrix.slug }}-${{ github.run_id }}.tar.gz
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: 28   # 4 weeks (was 7) — longer window for trend ingest + investigation


### PR DESCRIPTION
Mirrors #1131 onto `develop` for parity (that PR landed on `main`). Same four
files / five commits, cherry-picked cleanly (develop hadn't touched any of them
since the merge-base).

- `skills-eval-daily.yml` — nightly evaluates develop (ref conditional + PR_HEAD_SHA pin)
- `skills-eval-daily.yml` + `skills-eval.yml` — artifact retention 7 → 28 days
- `.github/nv-slack-bot.yaml` — Slack alerts (run + per-leg), matchers guarded on `action = "completed"`
- `.github/copy-pr-bot.yaml` — add a vetter

Why on develop:
- `skills-eval.yml` retention is **functional** here (per-PR eval reads develop's copy).
- The rest is parity so the files don't drift from main; the scheduled nightly and
  the nv-slack-bot app still read their config from the default branch (`main`).
