### PR TITLE
vios: fix for GET api /v1/sensor/configuration returns null

### DIFF
--- a/services/vios/src/framework/utilities/utils.cpp
+++ b/services/vios/src/framework/utilities/utils.cpp
@@ -2337,7 +2337,7 @@ bool blockSensor(const string ip, string action)
 
 Json::Value vectorToJson(const std::vector<string>& vec)
 {
-	Json::Value jsonArray = Json::nullValue;
+	Json::Value jsonArray = Json::arrayValue;
 	for(auto itr : vec)
 	{
 		jsonArray.append(itr);

--- a/services/vios/test/bdd_tests/features/unit_tests/sensor_management/sensor_management_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/sensor_management/sensor_management_api.feature
@@ -36,6 +36,15 @@ Feature: VST Sensor Management Service API Unit Tests
     Then the sensor response status is 200
     And the sensor response contains configuration fields
 
+  # Bug 6177255: GET /v1/sensor/configuration returned null (not []) for the
+  # required, non-nullable array fields ntpServers and deviceDiscoveryInterfaces
+  # when no values were configured, violating the GetConfiguration swagger contract.
+  Scenario: Configuration required array fields are arrays not null
+    Given the VST sensor management API is accessible
+    When I request the sensor management service configuration
+    Then the sensor response status is 200
+    And the configuration required array fields are JSON arrays
+
   Scenario: Get QOS stats for all sensors
     Given the VST sensor management API is accessible
     When I request the QOS stats

--- a/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_sensor_management_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_sensor_management_api.py
@@ -253,3 +253,23 @@ def check_sensor_configuration_fields(context: UnitTestContext) -> None:
     assert isinstance(data, dict), "Configuration must be a JSON object"
     assert len(data) > 0, "Configuration is empty"
     logger.info("Configuration has %d fields", len(data))
+
+
+@then("the configuration required array fields are JSON arrays")
+def check_configuration_required_arrays(context: UnitTestContext) -> None:
+    """Bug 6177255: required, non-nullable array fields in the GetConfiguration
+    swagger schema must be JSON arrays, never null, even when no values are set."""
+    data = validate_json_response(context.response)
+    assert isinstance(data, dict), "Configuration must be a JSON object"
+    for field in ("ntpServers", "deviceDiscoveryInterfaces"):
+        assert field in data, f"Configuration is missing required field '{field}'"
+        assert isinstance(data[field], list), (
+            f"Configuration field '{field}' must be a JSON array per the swagger "
+            f"contract, got {type(data[field]).__name__} ({data[field]!r}); "
+            f"empty configuration must serialize as [] not null"
+        )
+    logger.info(
+        "ntpServers=%r deviceDiscoveryInterfaces=%r",
+        data["ntpServers"],
+        data["deviceDiscoveryInterfaces"],
+    )


### PR DESCRIPTION
## Description
- [VST Standalone]: GET /v1/sensor/configuration returns null for required array fields

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
