### PR TITLE
vios: fix - /record/version returns the build version

### DIFF
--- a/services/vios/src/modules/storage_management/storage_management.cpp
+++ b/services/vios/src/modules/storage_management/storage_management.cpp
@@ -64,8 +64,6 @@ using namespace std;
 using namespace nv_vms;
 
 
-constexpr const char* STORAGE_MANAGEMENT_VERSION = "0.0.1";
-
 #define CONVERT_KBPS_TO_GBPERDAY(v) ((v/1024.0) * 60.0 * 60.0 * 24)/(8 * 1024.0);
 constexpr int DEFAULT_BITRATE = 5120;
 
@@ -1306,7 +1304,10 @@ VmsErrorCode StorageManagement::getStorageConfiguration(const Json::Value & req_
 
 VmsErrorCode StorageManagement::getVersion(string& version)
 {
-    version = STORAGE_MANAGEMENT_VERSION;
+    // Report the build/release version injected by the Makefile (-DVST_VERSION),
+    // matching the Sensor MS and other microservices, instead of a hardcoded
+    // placeholder. See bug 6303142.
+    version = VST_VERSION;
     return VmsErrorCode::NoError;
 }
 

--- a/services/vios/src/modules/stream_recorder/streamrecorder.cpp
+++ b/services/vios/src/modules/stream_recorder/streamrecorder.cpp
@@ -988,7 +988,10 @@ VmsErrorCode StreamRecorder::getConfiguration(Json::Value &out)
 
 VmsErrorCode StreamRecorder::getVersion(string &version)
 {
-    version = STREAM_RECORDER_VERSION;
+    // Report the build/release version injected by the Makefile (-DVST_VERSION),
+    // matching the Sensor MS and other microservices, instead of a hardcoded
+    // placeholder. See bug 6303142.
+    version = VST_VERSION;
     return VmsErrorCode::NoError;
 }
 

--- a/services/vios/src/modules/stream_recorder/streamrecorder.h
+++ b/services/vios/src/modules/stream_recorder/streamrecorder.h
@@ -31,8 +31,6 @@
 #include "Scheduler.h"
 #include "libasync++/async++.h"
 
-inline constexpr const char* STREAM_RECORDER_VERSION = "0.0.1";
-
 #define CHECK_RECORDER_INSTANCE(recorder)                             \
     do                                                                \
     {                                                                 \

--- a/services/vios/test/bdd_tests/features/unit_tests/storage_management/storage_management_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/storage_management/storage_management_api.feature
@@ -18,6 +18,17 @@ Feature: VST Storage Management Service API Unit Tests
     Then the storage response status is 200
     And the storage response is a valid version string
 
+  # Regression for bug 6303142 (extended to the Storage MS): the version
+  # endpoint returned a hardcoded placeholder ("0.0.1") instead of the deployed
+  # release/build version. The Sensor MS reports the correct build version in
+  # the same deployment, so it is used as the source of truth.
+  Scenario: Storage version matches the deployed build version
+    Given the VST storage management API is accessible
+    When I request the storage management service version
+    And I request the sensor service version
+    Then the storage reported version is not the placeholder "0.0.1"
+    And the storage reported version matches the sensor reported build version
+
   Scenario: Get storage management service help
     Given the VST storage management API is accessible
     When I request the storage management service help

--- a/services/vios/test/bdd_tests/features/unit_tests/stream_recorder/stream_recorder_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/stream_recorder/stream_recorder_api.feature
@@ -13,6 +13,18 @@ Feature: VST Stream Recorder Service API Unit Tests
     Then the recorder response status is 200
     And the recorder response is a valid version string
 
+  # Regression for bug 6303142: the Record MS version endpoint returned a
+  # hardcoded placeholder ("0.0.1") instead of the deployed release/build
+  # version. The Sensor MS reports the correct build version in the same
+  # deployment, so we use it as the source of truth (as the bug report did)
+  # rather than hardcoding a release string that changes every release.
+  Scenario: Stream recorder version matches the deployed build version
+    Given the VST stream recorder API is accessible
+    When I request the stream recorder service version
+    And I request the sensor service version
+    Then the recorder reported version is not the placeholder "0.0.1"
+    And the recorder reported version matches the sensor reported build version
+
   Scenario: Get stream recorder service help
     Given the VST stream recorder API is accessible
     When I request the stream recorder service help

--- a/services/vios/test/bdd_tests/tests/unit_tests/storage_management/test_storage_management_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/storage_management/test_storage_management_api.py
@@ -156,6 +156,64 @@ def check_storage_version_string(context: UnitTestContext) -> None:
     logger.info("Service version: %s", version)
 
 
+def _extract_version(response) -> str:
+    """Pull the version value out of a version-endpoint response.
+
+    Handles the object forms used across microservices (Storage MS:
+    ``{"storage_management_version": ...}``; Sensor MS: ``{"type": ...,
+    "version": ...}``) and the plain-string form.
+    """
+    assert response is not None, "Version endpoint was not queried"
+    assert response.status_code == 200, (
+        f"Expected status 200, got {response.status_code}: {response.text[:500]}"
+    )
+    data = response.json()
+    if isinstance(data, str):
+        return data.strip()
+    assert isinstance(data, dict), (
+        f"Unexpected version payload type {type(data).__name__}: {data!r}"
+    )
+    for key in ("storage_management_version", "version", "Version"):
+        if key in data and isinstance(data[key], str):
+            return data[key].strip()
+    raise AssertionError(f"No version field found in response: {data!r}")
+
+
+@when("I request the sensor service version")
+def request_sensor_version(context: UnitTestContext, api_config: dict, unit_test_params: dict) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    context.sensor_version_response = api_get(
+        api_config["base_url"],
+        "/vst/api/v1/sensor/version",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+
+
+@then('the storage reported version is not the placeholder "0.0.1"')
+def check_storage_version_not_placeholder(context: UnitTestContext) -> None:
+    storage_version = _extract_version(context.response)
+    logger.info("Storage MS reported version: %s", storage_version)
+    assert storage_version != "0.0.1", (
+        "Storage MS /storage/version returned the hardcoded placeholder '0.0.1' "
+        "instead of the deployed build version (bug 6303142)"
+    )
+
+
+@then("the storage reported version matches the sensor reported build version")
+def check_storage_version_matches_sensor(context: UnitTestContext) -> None:
+    storage_version = _extract_version(context.response)
+    sensor_version = _extract_version(context.sensor_version_response)
+    logger.info(
+        "Storage MS version: %s | Sensor MS (build) version: %s",
+        storage_version, sensor_version,
+    )
+    assert storage_version == sensor_version, (
+        f"Storage MS version mismatch: storage reports '{storage_version}' but "
+        f"the deployed build version is '{sensor_version}' (bug 6303142)"
+    )
+
+
 @then("the storage response is a list of supported API paths")
 def check_storage_help_list(context: UnitTestContext) -> None:
     data = validate_help_response(context.response)

--- a/services/vios/test/bdd_tests/tests/unit_tests/stream_recorder/test_stream_recorder_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/stream_recorder/test_stream_recorder_api.py
@@ -72,6 +72,17 @@ def request_recorder_version(context: UnitTestContext, api_config: dict, unit_te
     )
 
 
+@when("I request the sensor service version")
+def request_sensor_version(context: UnitTestContext, api_config: dict, unit_test_params: dict) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    context.sensor_version_response = api_get(
+        api_config["base_url"],
+        "/vst/api/v1/sensor/version",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+
+
 @when("I request the stream recorder service help")
 def request_recorder_help(context: UnitTestContext, api_config: dict, unit_test_params: dict) -> None:
     timeout = unit_test_params.get("timeout", 30)
@@ -127,6 +138,57 @@ def check_recorder_version_string(context: UnitTestContext) -> None:
     version = validate_string_response(context.response)
     assert len(version) > 0, "Version string is empty"
     logger.info("Service version: %s", version)
+
+
+def _extract_version(response) -> str:
+    """Pull the version value out of a version-endpoint response.
+
+    Handles both the plain-string form and the object forms used across
+    microservices (Record MS: ``{"recorder_version": ...}``; Sensor MS:
+    ``{"type": ..., "version": ...}``).
+    """
+    assert response is not None, "Version endpoint was not queried"
+    assert response.status_code == 200, (
+        f"Expected status 200, got {response.status_code}: {response.text[:500]}"
+    )
+    data = response.json()
+    if isinstance(data, str):
+        return data.strip()
+    assert isinstance(data, dict), (
+        f"Unexpected version payload type {type(data).__name__}: {data!r}"
+    )
+    for key in ("recorder_version", "version", "Version"):
+        if key in data and isinstance(data[key], str):
+            return data[key].strip()
+    raise AssertionError(f"No version field found in response: {data!r}")
+
+
+@then('the recorder reported version is not the placeholder "0.0.1"')
+def check_recorder_version_not_placeholder(context: UnitTestContext) -> None:
+    recorder_version = _extract_version(context.response)
+    logger.info("Record MS reported version: %s", recorder_version)
+    assert recorder_version != "0.0.1", (
+        "Record MS /record/version returned the hardcoded placeholder '0.0.1' "
+        "instead of the deployed build version (bug 6303142)"
+    )
+
+
+@then("the recorder reported version matches the sensor reported build version")
+def check_recorder_version_matches_build(context: UnitTestContext) -> None:
+    recorder_version = _extract_version(context.response)
+    sensor_version = _extract_version(context.sensor_version_response)
+    logger.info(
+        "Record MS version: %s | Sensor MS (build) version: %s",
+        recorder_version, sensor_version,
+    )
+    assert sensor_version and sensor_version != "0.0.1", (
+        f"Sensor MS version looks invalid ('{sensor_version}'); cannot use it "
+        "as the build-version source of truth"
+    )
+    assert recorder_version == sensor_version, (
+        f"Record MS version mismatch: recorder reports '{recorder_version}' but "
+        f"the deployed build version is '{sensor_version}' (bug 6303142)"
+    )
 
 
 @then("the recorder response is a list of supported API paths")


### PR DESCRIPTION
## Description
- Return the build-injected VST_VERSION from the Record MS /record/version endpoint instead of the hardcoded 0.0.1 placeholder (matching the Sensor MS).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
