### PR TITLE
vios: fix - read-only endpoints return 405

### DIFF
--- a/services/vios/src/framework/web/http_server/HttpServerRequestHandler.cpp
+++ b/services/vios/src/framework/web/http_server/HttpServerRequestHandler.cpp
@@ -17,6 +17,9 @@
 
 #include <string.h>
 #include <iostream>
+#include <algorithm>
+#include <map>
+#include <vector>
 
 #include "HttpServerRequestHandler.h"
 #include "UserAuthHandler.h"
@@ -52,8 +55,117 @@ constexpr const char* HTTP_METHOD_POST = "POST";
 constexpr const char* HTTP_METHOD_PUT = "PUT";
 constexpr const char* HTTP_METHOD_PATCH = "PATCH";
 
+/* ---------------------------------------------------------------------------
+**  Centralized HTTP method policy (bug 6267433)
+**
+**  Method validation used to live inside individual handlers, so GET-only
+**  handlers silently executed their GET logic for POST/PUT/DELETE and returned
+**  200 instead of 405. This table maps each routed path (normalized: the /vst
+**  prefix is stripped before lookup) to the verbs its handler actually
+**  implements. The dispatch layer consults it so every routed path rejects
+**  unsupported verbs uniformly with 405 + Allow, and answers OPTIONS preflight.
+**
+**  Routes absent from the table have no policy and are left unvalidated to
+**  preserve their existing behavior.
+** -------------------------------------------------------------------------*/
+static const std::map<std::string, std::vector<std::string>>& getMethodPolicyTable()
+{
+    static const std::map<std::string, std::vector<std::string>> table = {
+        // Sensor management - read-only (GET) endpoints
+        {"/api/v1/sensor/list",          {HTTP_METHOD_GET}},
+        {"/api/v1/sensor/streams",       {HTTP_METHOD_GET}},
+        {"/api/v1/sensor/status",        {HTTP_METHOD_GET}},
+        {"/api/v1/sensor/version",       {HTTP_METHOD_GET}},
+        {"/api/v1/sensor/help",          {HTTP_METHOD_GET}},
+        {"/api/v1/sensor/qos",           {HTTP_METHOD_GET}},
+        {"/api/v1/sensor/timelines",     {HTTP_METHOD_GET}},
+        // Sensor management - write endpoints
+        {"/api/v1/sensor/add",           {HTTP_METHOD_POST}},
+        {"/api/v1/sensor/configuration", {HTTP_METHOD_GET, HTTP_METHOD_POST}},
+        // Sensor scan is a verb-agnostic trigger; clients invoke it via POST.
+        {"/api/v1/sensor/scan",          {HTTP_METHOD_GET, HTTP_METHOD_POST}},
+        // Storage management - read-only (GET) endpoint (handler rejects non-GET internally)
+        {"/api/v1/storage/info",         {HTTP_METHOD_GET}},
+        // Recorder - read-only (GET) endpoints (+ configuration read/update)
+        {"/api/v1/record/status",        {HTTP_METHOD_GET}},
+        {"/api/v1/record/version",       {HTTP_METHOD_GET}},
+        {"/api/v1/record/help",          {HTTP_METHOD_GET}},
+        {"/api/v1/record/streams",       {HTTP_METHOD_GET}},
+        {"/api/v1/record/timelines",     {HTTP_METHOD_GET}},
+        {"/api/v1/record/configuration", {HTTP_METHOD_GET, HTTP_METHOD_POST}},
+        // Storage management - read-only (GET) endpoints (+ configuration read/update)
+        {"/api/v1/storage/version",      {HTTP_METHOD_GET}},
+        {"/api/v1/storage/help",         {HTTP_METHOD_GET}},
+        {"/api/v1/storage/size",         {HTTP_METHOD_GET}},
+        {"/api/v1/storage/capacity",     {HTTP_METHOD_GET}},
+        {"/api/v1/storage/aging",        {HTTP_METHOD_GET}},
+        {"/api/v1/storage/streams",      {HTTP_METHOD_GET}},
+        {"/api/v1/storage/timelines",    {HTTP_METHOD_GET}},
+        {"/api/v1/storage/configuration",{HTTP_METHOD_GET, HTTP_METHOD_POST}},
+        // Live stream - read-only (GET) endpoints (+ configuration read/update)
+        {"/api/v1/live/version",         {HTTP_METHOD_GET}},
+        {"/api/v1/live/help",            {HTTP_METHOD_GET}},
+        {"/api/v1/live/streams",         {HTTP_METHOD_GET}},
+        {"/api/v1/live/configuration",   {HTTP_METHOD_GET, HTTP_METHOD_POST}},
+        // Replay stream - read-only (GET) endpoints (+ configuration read/update)
+        {"/api/v1/replay/version",       {HTTP_METHOD_GET}},
+        {"/api/v1/replay/help",          {HTTP_METHOD_GET}},
+        {"/api/v1/replay/streams",       {HTTP_METHOD_GET}},
+        {"/api/v1/replay/configuration", {HTTP_METHOD_GET, HTTP_METHOD_POST}},
+        // RTSP proxy - read-only (GET) endpoints (+ configuration read/update)
+        {"/api/v1/proxy/info",           {HTTP_METHOD_GET}},
+        {"/api/v1/proxy/streams",        {HTTP_METHOD_GET}},
+        {"/api/v1/proxy/configuration",  {HTTP_METHOD_GET, HTTP_METHOD_POST}},
+        // Metadata (read-only)
+        {"/v1/metadata",                 {HTTP_METHOD_GET}},
+        // Health probes (Kubernetes httpGet)
+        {"/v1/live",                     {HTTP_METHOD_GET}},
+        {"/v1/ready",                    {HTTP_METHOD_GET}},
+        {"/v1/startup",                  {HTTP_METHOD_GET}},
+    };
+    return table;
+}
 
-int log_message(const struct mg_connection *conn, const char *message) 
+// Returns the allowed methods for a normalized route, or nullptr when the route
+// has no method policy (validation is then skipped to preserve behavior).
+static const std::vector<std::string>* lookupAllowedMethods(const std::string& normalizedUri)
+{
+    const auto& table = getMethodPolicyTable();
+    auto it = table.find(normalizedUri);
+    return (it != table.end()) ? &it->second : nullptr;
+}
+
+static bool isMethodAllowed(const std::vector<std::string>& allowed, const std::string& method)
+{
+    return std::find(allowed.begin(), allowed.end(), method) != allowed.end();
+}
+
+// Builds the value for the Allow header: the route's supported methods plus
+// OPTIONS, which the dispatch layer always answers for CORS preflight.
+static std::string buildAllowHeader(const std::vector<std::string>* allowed)
+{
+    std::string header;
+    if (allowed != nullptr)
+    {
+        for (const auto& m : *allowed)
+        {
+            if (!header.empty())
+            {
+                header += ", ";
+            }
+            header += m;
+        }
+    }
+    if (!header.empty())
+    {
+        header += ", ";
+    }
+    header += HTTP_METHOD_OPTIONS;
+    return header;
+}
+
+
+int log_message(const struct mg_connection *conn, const char *message)
 {
     fprintf(stderr, "%s\n", message);
     LOG(verbose) << "HTTP SERVER: " << message << endl;
@@ -192,7 +304,57 @@ class RequestHandler : public CivetHandler
                 return ret;
             }
         }
-        
+
+        // Centralized HTTP method validation (bug 6267433). Enforced here in the
+        // dispatch layer so every routed path uniformly rejects verbs its handler
+        // does not implement with 405 + Allow, and answers OPTIONS preflight,
+        // instead of letting GET-only handlers run their GET logic for any verb.
+        {
+            const std::string METHOD_URL_PREFIX = "/vst";
+            std::string routeUri = uri;
+            if (routeUri.find(METHOD_URL_PREFIX) == 0)
+            {
+                routeUri = routeUri.substr(METHOD_URL_PREFIX.length());
+            }
+            const std::vector<std::string>* allowedMethods = lookupAllowedMethods(routeUri);
+
+            if (method == HTTP_METHOD_OPTIONS)
+            {
+                // Only answer preflight for routes with a known method policy, so
+                // the Allow header reflects the real supported verbs. Untabled
+                // routes have no policy to advertise; preserve their prior 404
+                // behavior rather than claiming only OPTIONS is supported.
+                if (allowedMethods == nullptr)
+                {
+                    return false;
+                }
+                // Answer CORS preflight here rather than returning 404.
+#ifdef USE_OTEL
+                if (span)
+                {
+                    span->SetAttribute(trace_semantic::kHttpStatusCode, 204);
+                    span->SetStatus(trace_api::StatusCode::kOk);
+                    span->End();
+                }
+#endif
+                return sendOptionsResponse(conn, allowedMethods);
+            }
+
+            if (allowedMethods != nullptr && !isMethodAllowed(*allowedMethods, method))
+            {
+                LOG(error) << "Method " << method << " not allowed for uri:" << uri << std::endl;
+#ifdef USE_OTEL
+                if (span)
+                {
+                    span->SetAttribute(trace_semantic::kHttpStatusCode, 405);
+                    span->SetStatus(trace_api::StatusCode::kError, "Method Not Allowed");
+                    span->End();
+                }
+#endif
+                return sendMethodNotAllowed(conn, allowedMethods, method);
+            }
+        }
+
         // read input
         Json::Value  in;
         result = this->getInputMessage(req_info, conn, in);
@@ -384,6 +546,54 @@ class RequestHandler : public CivetHandler
     bool handleDelete(CivetServer *server, struct mg_connection *conn)
     {
         return handle(server, conn);
+    }
+    // Route OPTIONS through the shared dispatch so method validation answers
+    // CORS preflight (bug 6267433) instead of falling through to a 404.
+    bool handleOptions(CivetServer *server, struct mg_connection *conn)
+    {
+        return handle(server, conn);
+    }
+
+    // Emits a uniform 405 Method Not Allowed: an Allow header listing the
+    // supported verbs plus the consistent error_code/error_message body.
+    bool sendMethodNotAllowed(struct mg_connection *conn,
+                              const std::vector<std::string>* allowedMethods,
+                              const std::string& method)
+    {
+        const std::string allowHeader = buildAllowHeader(allowedMethods);
+        Json::Value response;
+        const std::string message = "Method " + method + " is not allowed; supported methods: " + allowHeader;
+        SET_VMS_ERROR2(VmsErrorCode::MethodNotAllowedError, response, message.c_str());
+
+        std::pair<int, string> http_err_code = translateVmsErrorCodeToCameraHttpErrorCode(VmsErrorCode::MethodNotAllowedError);
+        const std::string body(Json::writeString(m_writerBuilder, response));
+
+        mg_printf(conn, "HTTP/1.1 %d %s\r\n", http_err_code.first, http_err_code.second.c_str());
+        mg_printf(conn, "Access-Control-Allow-Origin: *\r\n");
+        mg_printf(conn, "Allow: %s\r\n", allowHeader.c_str());
+        mg_printf(conn, "Access-Control-Allow-Methods: %s\r\n", allowHeader.c_str());
+        mg_printf(conn, "Content-Type: application/json\r\n");
+        mg_printf(conn, "Content-Length: %zd\r\n", body.size());
+        mg_printf(conn, "Connection: close\r\n");
+        mg_printf(conn, "\r\n");
+        mg_write(conn, body.c_str(), body.size());
+        return true;
+    }
+
+    // Answers a CORS preflight (OPTIONS) with 204 + Allow listing supported verbs.
+    bool sendOptionsResponse(struct mg_connection *conn,
+                             const std::vector<std::string>* allowedMethods)
+    {
+        const std::string allowHeader = buildAllowHeader(allowedMethods);
+        mg_printf(conn, "HTTP/1.1 204 No Content\r\n");
+        mg_printf(conn, "Access-Control-Allow-Origin: *\r\n");
+        mg_printf(conn, "Allow: %s\r\n", allowHeader.c_str());
+        mg_printf(conn, "Access-Control-Allow-Methods: %s\r\n", allowHeader.c_str());
+        mg_printf(conn, "Access-Control-Allow-Headers: Content-Type, Authorization\r\n");
+        mg_printf(conn, "Content-Length: 0\r\n");
+        mg_printf(conn, "Connection: close\r\n");
+        mg_printf(conn, "\r\n");
+        return true;
     }
 
   private:

--- a/services/vios/test/bdd_tests/features/unit_tests/sensor_management/http_method_validation.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/sensor_management/http_method_validation.feature
@@ -1,0 +1,51 @@
+Feature: VST API HTTP method validation (405 Method Not Allowed)
+  The shared HTTP request handler must enforce method validation uniformly.
+  Read-only (GET) endpoints must reject POST/PUT/DELETE with 405 instead of
+  silently executing the GET handler and returning 200, every rejection must
+  carry an Allow header and a consistent error schema, and OPTIONS preflight
+  must be handled rather than returning 404.
+
+  Regression test for bug 6267433.
+
+  Scenario Outline: Read-only endpoints reject unsupported methods with 405
+    Given the VST sensor management API is accessible
+    When I send a "<method>" request to "<path>"
+    Then the API response status is 405
+    And the response carries an Allow header
+    And the response body uses the consistent error schema
+
+    Examples:
+      | method | path                            |
+      | POST   | /vst/api/v1/sensor/streams      |
+      | POST   | /vst/api/v1/sensor/list         |
+      | POST   | /vst/api/v1/sensor/status       |
+      | PUT    | /vst/api/v1/sensor/list         |
+      | DELETE | /vst/api/v1/sensor/list         |
+      | POST   | /vst/api/v1/record/version      |
+      | POST   | /vst/api/v1/record/help         |
+      | DELETE | /vst/api/v1/record/version      |
+      | POST   | /vst/api/v1/storage/version     |
+      | POST   | /vst/api/v1/storage/help        |
+      | POST   | /vst/api/v1/live/version        |
+      | POST   | /vst/api/v1/replay/version      |
+
+  Scenario Outline: OPTIONS preflight is handled, not 404
+    Given the VST sensor management API is accessible
+    When I send a "OPTIONS" request to "<path>"
+    Then the API response status is one of 200, 204, 405
+    And the response carries an Allow header
+
+    Examples:
+      | path                    |
+      | /vst/api/v1/sensor/add  |
+      | /vst/api/v1/sensor/list |
+
+  Scenario: GET on a read-only endpoint still succeeds after the fix
+    Given the VST sensor management API is accessible
+    When I send a "GET" request to "/vst/api/v1/sensor/list"
+    Then the API response status is 200
+
+  Scenario: Control - POST on a write-only endpoint already returns 405
+    Given the VST sensor management API is accessible
+    When I send a "POST" request to "/vst/api/v1/sensor/configuration"
+    Then the API response status is 405

--- a/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_http_method_validation.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_http_method_validation.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression test for bug 6267433.
+
+VST read-only API endpoints accept POST/PUT/DELETE and return 200 instead of
+405. The shared HttpServerRequestHandler dispatch layer only checks that the
+verb is a syntactically valid HTTP method, never that the verb is *allowed*
+for the matched route, so GET-only handlers execute their GET logic for any
+verb. This test drives the running service over HTTP and asserts the method
+validation contract from the bug's "Expected O/P":
+
+  * Unsupported methods on a routed path return 405 (not 200/400/404/501).
+  * Each method-rejection response carries an ``Allow`` header.
+  * Method-rejection bodies use the consistent ``error_code``/``error_message``
+    schema (same as the existing ``MethodNotAllowedError``).
+  * OPTIONS preflight is handled (200/204/405 + Allow), not 404.
+  * GET on a read-only endpoint still succeeds (the fix must not over-reject).
+
+On the unmodified base code the first scenario outline fails because
+``POST/PUT/DELETE`` on the read-only sensor endpoints return 200, and the
+OPTIONS scenario fails because OPTIONS returns 404. After the fix all
+scenarios pass.
+"""
+import logging
+
+import requests
+from pytest_bdd import scenarios, given, when, then, parsers
+
+from ..unit_test_utils import UnitTestContext
+
+logger = logging.getLogger(__name__)
+
+scenarios("../../../features/unit_tests/sensor_management/http_method_validation.feature")
+
+
+def _api_request(
+    base_url: str,
+    method: str,
+    path: str,
+    verify_ssl: bool = False,
+    timeout: int = 30,
+) -> requests.Response:
+    """Issue an arbitrary-verb request against the API (GET/POST/PUT/DELETE/OPTIONS)."""
+    url = f"{base_url}{path}"
+    logger.info("%s %s", method, url)
+    response = requests.request(
+        method,
+        url,
+        timeout=timeout,
+        verify=verify_ssl,
+    )
+    logger.info("Response: %d (%d bytes)", response.status_code, len(response.content))
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Given
+# ---------------------------------------------------------------------------
+
+@given("the VST sensor management API is accessible")
+def sensor_api_accessible(api_config: dict) -> None:
+    assert api_config["base_url"], "Base URL must be configured"
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+@when(parsers.parse('I send a "{method}" request to "{path}"'))
+def send_request(
+    context: UnitTestContext,
+    api_config: dict,
+    unit_test_params: dict,
+    method: str,
+    path: str,
+) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    context.response = _api_request(
+        api_config["base_url"],
+        method,
+        path,
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+@then(parsers.parse("the API response status is {expected:d}"))
+def check_status(context: UnitTestContext, expected: int) -> None:
+    assert context.response is not None, "No response captured"
+    assert context.response.status_code == expected, (
+        f"Expected {expected}, got {context.response.status_code}: "
+        f"{context.response.text[:500]}"
+    )
+
+
+@then(parsers.parse("the API response status is one of {codes}"))
+def check_status_one_of(context: UnitTestContext, codes: str) -> None:
+    allowed = {int(c.strip()) for c in codes.split(",")}
+    assert context.response is not None, "No response captured"
+    assert context.response.status_code in allowed, (
+        f"Expected one of {sorted(allowed)}, got {context.response.status_code}: "
+        f"{context.response.text[:500]}"
+    )
+
+
+@then("the response carries an Allow header")
+def check_allow_header(context: UnitTestContext) -> None:
+    assert context.response is not None, "No response captured"
+    allow = context.response.headers.get("Allow")
+    assert allow, (
+        "Method-rejection / preflight response must include an 'Allow' header "
+        f"listing supported methods; headers were: {dict(context.response.headers)}"
+    )
+    logger.info("Allow header: %s", allow)
+
+
+@then("the response body uses the consistent error schema")
+def check_error_schema(context: UnitTestContext) -> None:
+    assert context.response is not None, "No response captured"
+    try:
+        body = context.response.json()
+    except ValueError as exc:  # pragma: no cover - body must be JSON
+        raise AssertionError(
+            f"Method-rejection body must be JSON, got: {context.response.text[:500]}"
+        ) from exc
+    assert isinstance(body, dict), (
+        f"Method-rejection body must be a JSON object, got {type(body).__name__}: "
+        f"{context.response.text[:500]}"
+    )
+    assert "error_code" in body and "error_message" in body, (
+        "Method-rejection body must use the consistent error schema "
+        f"(error_code/error_message); got: {body}"
+    )
+    logger.info("Error schema: %s", body)


### PR DESCRIPTION
## Description
- Reject unsupported HTTP methods on read-only endpoints with 405 instead of 200.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
