### PR TITLE
vios: fix - /sensor/add conflict includes existing id/name

### DIFF
--- a/services/vios/src/modules/sensor_management/sensor_management_utils.cpp
+++ b/services/vios/src/modules/sensor_management/sensor_management_utils.cpp
@@ -765,6 +765,8 @@ VmsErrorCode addSensor(std::shared_ptr<nv_vms::SensorManagement> sensorMgmt, con
     {
         string error_message = "Sensor exists already, sensorId: " + existingSensor->id + ", sensorName: " + existingSensor->name;
         LOG(error) << error_message << endl;
+        response["existingSensorId"] = existingSensor->id;
+        response["existingSensorName"] = existingSensor->name;
         SET_VMS_ERROR2(VmsErrorCode::InvalidParameterError, response, error_message.c_str())
         return VmsErrorCode::InvalidParameterError;
     }
@@ -776,6 +778,8 @@ VmsErrorCode addSensor(std::shared_ptr<nv_vms::SensorManagement> sensorMgmt, con
             string error_message = string("User given name is invalid or already exists");
             if (nameConflictSensor)
             {
+                response["existingSensorId"] = nameConflictSensor->id;
+                response["existingSensorName"] = nameConflictSensor->name;
                 error_message += ", sensorId: " + nameConflictSensor->id + ", sensorName: " + nameConflictSensor->name;
             }
             SET_VMS_ERROR2(VmsErrorCode::InvalidParameterError, response, error_message.c_str());

--- a/services/vios/test/bdd_tests/features/unit_tests/sensor_management/sensor_add_duplicate.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/sensor_management/sensor_add_duplicate.feature
@@ -1,6 +1,9 @@
 Feature: VST Sensor Add — duplicate-sensor rejection reports the conflicting check
   Rejections from POST /vst/api/v1/sensor/add caused by another sensor with the
-  same RTSP URL, IP, or name must surface the conflict in the error_message.
+  same RTSP URL, IP, or name must surface the conflict in the error_message AND
+  as structured JSON fields (existingSensorId / existingSensorName) so clients
+  can recover programmatically without re-fetching /sensor/list or regex-parsing
+  the free-form error_message.
   A URL/IP conflict (including the case where the name also collides) is
   reported as "Sensor exists already"; a pure name collision is reported as
   "User given name is invalid or already exists".
@@ -13,6 +16,8 @@ Feature: VST Sensor Add — duplicate-sensor rejection reports the conflicting c
     When I POST to sensor/add with the same RTSP URL but a different name
     Then the sensor add response status is 4xx
     And the response error_message contains "Sensor exists already"
+    And the response includes existingSensorId matching the first sensor
+    And the response includes existingSensorName matching the first sensor
     And I clean up the first added sensor
 
   Scenario: Re-adding the same RTSP URL with the same name reports the URL conflict
@@ -20,6 +25,8 @@ Feature: VST Sensor Add — duplicate-sensor rejection reports the conflicting c
     When I POST to sensor/add with the same RTSP URL and the same name
     Then the sensor add response status is 4xx
     And the response error_message contains "Sensor exists already"
+    And the response includes existingSensorId matching the first sensor
+    And the response includes existingSensorName matching the first sensor
     And I clean up the first added sensor
 
   Scenario: Adding with a different URL but a name already in use reports the name conflict
@@ -27,4 +34,6 @@ Feature: VST Sensor Add — duplicate-sensor rejection reports the conflicting c
     When I POST to sensor/add with a different RTSP URL but the same name
     Then the sensor add response status is 4xx
     And the response error_message contains "User given name is invalid or already exists"
+    And the response includes existingSensorId matching the first sensor
+    And the response includes existingSensorName matching the first sensor
     And I clean up the first added sensor

--- a/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_sensor_add_duplicate.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_sensor_add_duplicate.py
@@ -257,6 +257,48 @@ def assert_error_message_contains(context: UnitTestContext, expected: str) -> No
     )
 
 
+@then("the response includes existingSensorId matching the first sensor")
+def assert_existing_sensor_id(context: UnitTestContext) -> None:
+    assert isinstance(context.response_json, dict), (
+        f"Expected JSON object response, got: {context.response_json!r}"
+    )
+    assert "existingSensorId" in context.response_json, (
+        "Conflict response is missing the structured 'existingSensorId' JSON "
+        "field; the conflicting sensor identity must be exposed as a JSON key, "
+        "not only embedded in error_message.\n"
+        f"  response keys: {sorted(context.response_json.keys())}\n"
+        f"  full body: {context.response_json!r}"
+    )
+    actual = context.response_json["existingSensorId"]
+    assert actual == context.first_sensor_id, (
+        f"existingSensorId did not match the first sensor.\n"
+        f"  expected: {context.first_sensor_id!r}\n"
+        f"  actual:   {actual!r}\n"
+        f"  full body: {context.response_json!r}"
+    )
+
+
+@then("the response includes existingSensorName matching the first sensor")
+def assert_existing_sensor_name(context: UnitTestContext) -> None:
+    assert isinstance(context.response_json, dict), (
+        f"Expected JSON object response, got: {context.response_json!r}"
+    )
+    assert "existingSensorName" in context.response_json, (
+        "Conflict response is missing the structured 'existingSensorName' JSON "
+        "field; the conflicting sensor identity must be exposed as a JSON key, "
+        "not only embedded in error_message.\n"
+        f"  response keys: {sorted(context.response_json.keys())}\n"
+        f"  full body: {context.response_json!r}"
+    )
+    actual = context.response_json["existingSensorName"]
+    assert actual == context.added_sensor_name, (
+        f"existingSensorName did not match the first sensor.\n"
+        f"  expected: {context.added_sensor_name!r}\n"
+        f"  actual:   {actual!r}\n"
+        f"  full body: {context.response_json!r}"
+    )
+
+
 @then("I clean up the first added sensor")
 def cleanup_first_sensor(
     context: UnitTestContext, api_config: dict, unit_test_params: dict


### PR DESCRIPTION
## Description
- Include existingSensorId and existingSensorName in the /sensor/add duplicate-conflict response.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
