### PR TITLE
vios: fix - reject reversed delete time range

### DIFF
--- a/services/vios/src/modules/storage_management/storage_management.cpp
+++ b/services/vios/src/modules/storage_management/storage_management.cpp
@@ -2156,6 +2156,17 @@ VmsErrorCode StorageManagement::deleteFilesByTime(const Json::Value& req_info, J
         return VmsErrorCode::InvalidParameterError;
     }
 
+    /* Reject a reversed range: startTime must be earlier than or equal to endTime.
+       Wildcards ('*' -> startTime=-1 / endTime=int64 max) never trip this check. */
+    if(startTime > endTime)
+    {
+        LOG(error) << "deleteFilesByTime invalid time range: startTime " << start_time
+                   << " is later than endTime " << end_time << endl;
+        SET_VMS_ERROR2(VmsErrorCode::InvalidParameterError, response,
+                       "startTime must be earlier than or equal to endTime")
+        return VmsErrorCode::InvalidParameterError;
+    }
+
     if(deleteFilesByTime(stream_id, startTime, endTime, spaceSaved) != 0)
     {
         SET_VMS_ERROR(VmsErrorCode::VMSInternalError, response)

--- a/services/vios/test/bdd_tests/features/unit_tests/storage_management/storage_management_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/storage_management/storage_management_api.feature
@@ -58,3 +58,13 @@ Feature: VST Storage Management Service API Unit Tests
     When I POST a JSON array body to the storage file protect endpoint
     Then the storage protect request is rejected with status 400
     And the streamprocessing storage service is still alive
+  # Regression for NVBug 6141778: reject reversed delete-videos time range (startTime > endTime)
+  Scenario: Delete videos rejects a reversed time range
+    Given the VST storage management API is accessible
+    When I request to delete videos with a reversed time range
+    Then the delete videos response status is 400
+
+  Scenario: Delete videos accepts a valid forward time range
+    Given the VST storage management API is accessible
+    When I request to delete videos with a valid forward time range
+    Then the delete videos response status is 200

--- a/services/vios/test/bdd_tests/tests/unit_tests/storage_management/test_storage_management_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/storage_management/test_storage_management_api.py
@@ -27,6 +27,7 @@ from pytest_bdd import scenarios, given, when, then
 from ..unit_test_utils import (
     UnitTestContext,
     api_get,
+    api_delete,
     api_post,
     validate_json_response,
     validate_list_response,
@@ -306,4 +307,67 @@ def storage_service_still_alive(
     assert health.status_code == 200, (
         "Storage service must remain available after a malformed protect request; "
         f"GET {HEALTHCHECK_PATH} returned {health.status_code}: {health.text[:500]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression for NVBug 6141778: Delete Videos time range validation.
+#
+# DELETE /vst/api/v1/storage/file/{streamId} accepted a reversed time range
+# (startTime > endTime) and returned HTTP 200 with {"spaceSaved": 0}, making an
+# invalid destructive request look successful. It must reject a reversed range
+# with 400 while still accepting a well-formed forward range. Both probes use a
+# future year-2099 window so nothing can ever match and no data is deleted.
+# ---------------------------------------------------------------------------
+
+# Stream id from the bug report. Validation of the time range must happen before
+# any file/sensor lookup, so the result does not depend on this stream existing.
+STREAM_ID = "20250306train-station"
+
+# Future no-data window: nothing can match, so neither request deletes anything.
+EARLIER_TIME = "2099-01-01T00:00:00.000Z"
+LATER_TIME = "2099-01-01T00:01:00.000Z"
+
+
+@when("I request to delete videos with a reversed time range")
+def delete_reversed_range(context: UnitTestContext, api_config: dict, unit_test_params: dict) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    # startTime (LATER) is after endTime (EARLIER) -> invalid input.
+    context.response = api_delete(
+        api_config["base_url"],
+        f"/vst/api/v1/storage/file/{STREAM_ID}",
+        params={"startTime": LATER_TIME, "endTime": EARLIER_TIME},
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+
+
+@when("I request to delete videos with a valid forward time range")
+def delete_forward_range(context: UnitTestContext, api_config: dict, unit_test_params: dict) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    # startTime (EARLIER) is before endTime (LATER) -> valid; future window deletes nothing.
+    context.response = api_delete(
+        api_config["base_url"],
+        f"/vst/api/v1/storage/file/{STREAM_ID}",
+        params={"startTime": EARLIER_TIME, "endTime": LATER_TIME},
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+
+
+@then("the delete videos response status is 400")
+def check_delete_status_400(context: UnitTestContext) -> None:
+    # Bug 6141778: this currently returns 200 with {"spaceSaved": 0}.
+    assert context.response.status_code == 400, (
+        f"A reversed time range (startTime > endTime) must be rejected with "
+        f"400 Bad Request, got {context.response.status_code}: "
+        f"{context.response.text[:300]}"
+    )
+
+
+@then("the delete videos response status is 200")
+def check_delete_status_200(context: UnitTestContext) -> None:
+    assert context.response.status_code == 200, (
+        f"A valid forward time range must be accepted with 200, got "
+        f"{context.response.status_code}: {context.response.text[:300]}"
     )


### PR DESCRIPTION
## Description
- Reject a reversed (end before start) time range on delete-videos instead of reporting success.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
