### PR TITLE
vios: fix - list streams in camera-name order

### DIFF
--- a/services/vios/src/modules/sensor_management/sensor_management_apis.cpp
+++ b/services/vios/src/modules/sensor_management/sensor_management_apis.cpp
@@ -21,6 +21,8 @@
 #include "gstnvvideodecoder.h"
 #include "health_probes.h"
 
+#include <algorithm>
+
 constexpr const char* SENSOR_API = "/api/v1/sensor/*";
 constexpr const char* DEBUG_API = "/api/v1/sensor/debug/*";
 constexpr const char* DEBUG_API_SUBSTR = "/api/v1/sensor/debug/";
@@ -626,6 +628,27 @@ VmsErrorCode SensorManagementApis::getSensorInfoList(const Json::Value& req_info
     vector<shared_ptr<SensorInfo>> currentSensors = m_deviceManager->getSensorList(false);
     bool shouldRefresh = vst_common::ShouldRefreshSensorCache(m_deviceManager->getDeviceId(), currentSensors.size());
     vector<shared_ptr<SensorInfo>> sensors = shouldRefresh ? m_deviceManager->getSensorList(true) : currentSensors;
+
+    // Return sensors in a deterministic, camera-name order (NVBug 6155392).
+    // The cache is a std::map keyed by a random UUID and the DB read has no
+    // ORDER BY, so without this sort the list order is unrelated to the camera
+    // name. Downstream consumers (e.g. the MV3DT perception service) register
+    // streams in the order returned here and rely on a predictable
+    // stream-to-camera mapping. Sort by name, then by id to keep the order
+    // stable for sensors that happen to share a name.
+    std::sort(sensors.begin(), sensors.end(),
+              [](const shared_ptr<SensorInfo>& a, const shared_ptr<SensorInfo>& b)
+              {
+                  if (a == nullptr || b == nullptr)
+                  {
+                      return b == nullptr ? false : true;
+                  }
+                  if (a->name != b->name)
+                  {
+                      return a->name < b->name;
+                  }
+                  return a->id < b->id;
+              });
 
     // Add connected sensors to list
     for (uint32_t i = 0; i < sensors.size(); i++ )

--- a/services/vios/test/bdd_tests/features/unit_tests/sensor_management/sensor_management_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/sensor_management/sensor_management_api.feature
@@ -74,3 +74,11 @@ Feature: VST Sensor Management Service API Unit Tests
     And at least one sensor exists
     When I request timelines for the first sensor
     Then the sensor response status is 200
+
+  # Regression for NVBug 6155392: sensor/list must return sensors sorted by
+  # camera name (deterministic order), regardless of add order.
+  Scenario: Sensors are listed in ascending camera-name order regardless of add order
+    Given the VST sensor management API is accessible
+    And a set of camera sensors added in non-sequential name order
+    When I request the list of sensors
+    Then the camera sensors I added appear in ascending camera-name order

--- a/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_sensor_management_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_sensor_management_api.py
@@ -20,6 +20,7 @@ Tests: sensor list, status, streams, info, QOS, system stats, timelines,
 version, help, configuration.
 """
 import logging
+import uuid
 
 import pytest
 from pytest_bdd import scenarios, given, when, then
@@ -27,6 +28,8 @@ from pytest_bdd import scenarios, given, when, then
 from ..unit_test_utils import (
     UnitTestContext,
     api_get,
+    api_post,
+    api_delete,
     validate_json_response,
     validate_list_response,
     validate_string_response,
@@ -253,3 +256,173 @@ def check_sensor_configuration_fields(context: UnitTestContext) -> None:
     assert isinstance(data, dict), "Configuration must be a JSON object"
     assert len(data) > 0, "Configuration is empty"
     logger.info("Configuration has %d fields", len(data))
+
+
+# ---------------------------------------------------------------------------
+# NVBug 6155392: deterministic camera-name ordering of GET /sensor/list.
+#
+# GET /sensor/list must return sensors sorted by camera name regardless of add
+# order. Root cause: each sensor is keyed by a random UUID and readSensorDetails
+# runs "SELECT * ... WHERE device_id = $1" with no ORDER BY, so the list comes
+# back in UUID/heap order. This scenario adds "Camera_*" sensors in reverse
+# order and asserts the API returns them in ascending camera-name order. The
+# sensor URLs use TEST-NET-1 (192.0.2.x, RFC 5737), so sensors are accepted but
+# never stream; each added sensor is cleaned up before and after the scenario.
+# ---------------------------------------------------------------------------
+
+SENSOR_LIST_PATH = "/vst/api/v1/sensor/list"
+SENSOR_ADD_PATH = "/vst/api/v1/sensor/add"
+
+# A unique-per-run prefix isolates this scenario's sensors from any others on
+# the device. Because the prefix is identical for every sensor we add, the
+# ascending order of the full names is determined entirely by the "Camera_*"
+# suffix, mirroring the camera-name ordering described in the bug.
+RUN_TAG = uuid.uuid4().hex[:8]
+TEST_SENSOR_NAME_PREFIX = f"bdd-order-{RUN_TAG}-"
+
+# Camera-name suffixes drawn from the bug's 28-camera dataset. "Camera" (no
+# numeric suffix) is included because it appeared in the reported list and is
+# a natural ordering edge case ("Camera" sorts before "Camera_08").
+CAMERA_SUFFIXES = [
+    "Camera",
+    "Camera_08",
+    "Camera_10",
+    "Camera_11",
+    "Camera_15",
+    "Camera_18",
+    "Camera_19",
+    "Camera_20",
+]
+
+
+def _full_name(suffix: str) -> str:
+    return f"{TEST_SENSOR_NAME_PREFIX}{suffix}"
+
+
+def _sensor_url(suffix: str) -> str:
+    # Distinct per sensor: the server treats sensorUrl as a uniqueness key.
+    return f"rtsp://192.0.2.1:554/{RUN_TAG}/{suffix}"
+
+
+def _wipe_leftover_test_sensors(api_config: dict, unit_test_params: dict) -> None:
+    """Delete any sensor created by this ordering scenario (self-healing)."""
+    base_url = api_config["base_url"]
+    timeout = unit_test_params.get("timeout", 30)
+    verify_ssl = api_config.get("verify_ssl", False)
+    try:
+        resp = api_get(
+            base_url, SENSOR_LIST_PATH, verify_ssl=verify_ssl, timeout=timeout,
+        )
+    except Exception as exc:
+        logger.warning("name-order cleanup: sensor/list call failed: %s", exc)
+        return
+    if resp.status_code != 200:
+        logger.warning("name-order cleanup: sensor/list returned %d", resp.status_code)
+        return
+    try:
+        sensors = resp.json()
+    except ValueError:
+        return
+    if not isinstance(sensors, list):
+        return
+    for sensor in sensors:
+        if not isinstance(sensor, dict):
+            continue
+        name = sensor.get("name") or ""
+        if not name.startswith(TEST_SENSOR_NAME_PREFIX):
+            continue
+        sid = sensor.get("sensorId")
+        if not sid:
+            continue
+        try:
+            del_resp = api_delete(
+                base_url, f"/vst/api/v1/sensor/{sid}",
+                verify_ssl=verify_ssl, timeout=timeout,
+            )
+            logger.info(
+                "name-order cleanup: deleted stale sensor %s (name=%s, status=%d)",
+                sid, name, del_resp.status_code,
+            )
+        except Exception as exc:
+            logger.warning("name-order cleanup: failed to delete sensor %s: %s", sid, exc)
+
+
+@pytest.fixture
+def _name_order_sensor_cleanup(api_config, unit_test_params):
+    """Wipe this scenario's sensors both before and after the scenario."""
+    _wipe_leftover_test_sensors(api_config, unit_test_params)
+    yield
+    _wipe_leftover_test_sensors(api_config, unit_test_params)
+
+
+@given("a set of camera sensors added in non-sequential name order")
+def add_cameras_out_of_order(
+    context: UnitTestContext,
+    api_config: dict,
+    unit_test_params: dict,
+    _name_order_sensor_cleanup,
+) -> None:
+    base_url = api_config["base_url"]
+    verify_ssl = api_config.get("verify_ssl", False)
+    timeout = unit_test_params.get("timeout", 30)
+
+    # Add in reverse-sorted order so the persisted/insertion order is the
+    # opposite of the expected camera-name order. This guarantees the pre-fix
+    # list (heap/UUID order) is not accidentally already sorted by name.
+    add_order = list(reversed(CAMERA_SUFFIXES))
+    context.added_camera_names = [_full_name(s) for s in CAMERA_SUFFIXES]
+
+    for suffix in add_order:
+        name = _full_name(suffix)
+        body = {
+            "name": name,
+            "sensorUrl": _sensor_url(suffix),
+            "location": "bdd-test",
+            "tags": "bdd-name-order",
+        }
+        resp = api_post(
+            base_url, SENSOR_ADD_PATH,
+            json_body=body, verify_ssl=verify_ssl, timeout=timeout,
+        )
+        assert resp.status_code == 200, (
+            f"Failed to add sensor {name}: status={resp.status_code}, "
+            f"body={resp.text[:300]}"
+        )
+        logger.info("Added sensor %s (url=%s)", name, _sensor_url(suffix))
+
+
+@then("the camera sensors I added appear in ascending camera-name order")
+def assert_cameras_in_name_order(context: UnitTestContext) -> None:
+    assert context.response.status_code == 200, (
+        f"sensor/list failed: status={context.response.status_code}, "
+        f"body={context.response.text[:300]}"
+    )
+    sensor_list = context.response.json()
+    assert isinstance(sensor_list, list), (
+        f"Expected a JSON array, got {type(sensor_list).__name__}"
+    )
+
+    expected_names = set(context.added_camera_names)
+
+    # Names of our test sensors, in the order the API returned them.
+    observed = [
+        s.get("name")
+        for s in sensor_list
+        if isinstance(s, dict) and s.get("name") in expected_names
+    ]
+
+    # All added sensors must be present (the bug also reported only a subset
+    # registering; here we additionally guard that none are dropped).
+    assert set(observed) == expected_names, (
+        f"sensor/list did not return all added camera sensors.\n"
+        f"Missing: {sorted(expected_names - set(observed))}\n"
+        f"Observed: {observed}"
+    )
+
+    expected_order = sorted(expected_names)
+    assert observed == expected_order, (
+        "sensor/list returned camera sensors in a non-deterministic order "
+        "instead of ascending camera-name order (NVBug 6155392).\n"
+        f"Observed order: {observed}\n"
+        f"Expected order: {expected_order}"
+    )


### PR DESCRIPTION
## Description
- List sensor streams in ascending cameraName order regardless of add order.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
