### PR TITLE
vios: fix - delete uploaded file by streamId

### DIFF
--- a/services/vios/src/modules/storage_management/storage_management.cpp
+++ b/services/vios/src/modules/storage_management/storage_management.cpp
@@ -2394,7 +2394,29 @@ VmsErrorCode StorageManagement::deleteFilesByNames(const Json::Value& req_info, 
     CivetServer::getParam(query_string, "id", id);
     if (id.empty() == false)
     {
+        // The upload response (POST /api/v1/storage/file) advertises both the
+        // file's unique object id ("id") and the "streamId" of the stream
+        // created to serve it; both look like valid delete handles to clients.
+        // Resolve against the object id first, then fall back to the streamId
+        // (which maps to that single uploaded file) before reporting failure —
+        // without the fallback, deleting by the returned streamId failed with
+        // InvalidParameterError and orphaned the uploaded file (bug 6164097).
+        //
+        // Deliberately NOT falling back to sensor id: a sensor-id lookup over
+        // [0, max] matches every recording for that sensor, so accepting it as
+        // a delete handle would mass-delete unrelated files (review: data-loss).
         vector<VideoRecordDBColumns> fileRecords = GET_DB_INSTANCE()->getVideoRecordFilePathsIdBased(id);
+        if (fileRecords.empty())
+        {
+            fileRecords = GET_DB_INSTANCE()->getVideoRecordFilePaths(
+                id, 0, std::numeric_limits<int64_t>::max());
+            if (!fileRecords.empty())
+            {
+                LOG(info) << "Resolved delete handle " << id
+                          << " by stream id to " << fileRecords.size()
+                          << " file(s)" << endl;
+            }
+        }
         if (fileRecords.empty())
         {
             LOG(error) << "File not found for Unique ID " << id << endl;

--- a/services/vios/test/bdd_tests/features/unit_tests/storage_management/storage_management_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/storage_management/storage_management_api.feature
@@ -39,3 +39,22 @@ Feature: VST Storage Management Service API Unit Tests
     Given the VST storage management API is accessible
     When I request the protected file list
     Then the storage response status is 200
+
+  # Regression for NVBug 6164097: DELETE must accept any identifier the upload
+  # returns for a file (id or streamId), not just id.
+  Scenario: A file uploaded via POST can be deleted using the returned streamId
+    Given the VST storage management API is accessible
+    And the static test video is available
+    When I upload a media file via POST to the storage service
+    Then the upload response contains both an id and a streamId
+    When I delete the uploaded file using the returned streamId
+    Then the storage delete response status is 200
+    And the uploaded file is no longer present on the storage service
+
+  Scenario: A file uploaded via POST can still be deleted using the returned id
+    Given the VST storage management API is accessible
+    And the static test video is available
+    When I upload a media file via POST to the storage service
+    And I delete the uploaded file using the returned id
+    Then the storage delete response status is 200
+    And the uploaded file is no longer present on the storage service

--- a/services/vios/test/bdd_tests/tests/unit_tests/storage_management/test_storage_management_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/storage_management/test_storage_management_api.py
@@ -19,13 +19,20 @@ Unit tests for the VST Storage Management Service API.
 Tests: storage size, info, version, help, configuration, file list, protected files.
 """
 import logging
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
 
 import pytest
+import requests
 from pytest_bdd import scenarios, given, when, then
 
 from ..unit_test_utils import (
     UnitTestContext,
     api_get,
+    api_delete,
     validate_json_response,
     validate_list_response,
     validate_string_response,
@@ -168,3 +175,239 @@ def check_storage_configuration_fields(context: UnitTestContext) -> None:
     assert isinstance(data, dict), "Configuration must be a JSON object"
     assert len(data) > 0, "Configuration is empty"
     logger.info("Configuration has %d fields", len(data))
+
+
+# ===========================================================================
+# Regression coverage for NVBug 6164097.
+#
+# POST /api/v1/storage/file returns several identifiers for the uploaded media
+# (``id``, ``sensorId`` and ``streamId``). Both ``id`` and ``streamId`` are
+# returned as unique handles for the same upload, yet
+# DELETE /api/v1/storage/file/{handle} historically accepted only the ``id``
+# value: deleting with the returned ``streamId`` failed with
+# ``InvalidParameterError`` ("File not found for Unique ID ..."), leaving the
+# uploaded file orphaned on disk. The scenarios below assert that BOTH
+# identifiers handed back by the upload are accepted by the delete API and that
+# the file is actually removed.
+# ===========================================================================
+
+
+STATIC_VIDEO = (
+    Path(__file__).resolve().parent.parent.parent.parent / "data" / "test_video.mp4"
+)
+
+# Worker-scoped naming prefix so concurrent xdist workers do not clobber each
+# other's in-flight uploads during the pre/post sweep.
+TEST_PREFIX = (
+    f"vios-uldelid-{os.environ.get('PYTEST_XDIST_WORKER', 'main')}-"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _post_upload(
+    base_url: str,
+    filename: str,
+    verify_ssl: bool,
+    timeout: int,
+) -> requests.Response:
+    """Upload the static video via multipart POST /storage/file.
+
+    Mirrors the bug's reproduction curl:
+        curl -F "file=@sample.mp4" -F "fileName=sample.mp4" \
+             -F "fileSize=<bytes>" .../storage/file
+    """
+    url = f"{base_url}/vst/api/v1/storage/file"
+    payload = STATIC_VIDEO.read_bytes()
+    files = {"file": (filename, payload, "video/mp4")}
+    data = {"fileName": filename, "fileSize": str(len(payload))}
+    return requests.post(
+        url, files=files, data=data, timeout=timeout, verify=verify_ssl,
+    )
+
+
+def _file_in_storage_list(
+    base_url: str, needle: str, verify_ssl: bool, timeout: int,
+) -> bool:
+    """Report whether *needle* (filename or id) is referenced by the file list."""
+    try:
+        resp = api_get(
+            base_url, "/vst/api/v1/storage/file/list",
+            verify_ssl=verify_ssl, timeout=timeout,
+        )
+        if resp.status_code == 200:
+            return needle in resp.text
+    except Exception as exc:
+        logger.warning("storage/file/list probe failed: %s", exc)
+    return False
+
+
+def _wait_file_gone(
+    base_url: str,
+    needle: str,
+    verify_ssl: bool,
+    timeout: int,
+    poll_attempts: int = 120,
+    poll_delay: float = 0.5,
+) -> bool:
+    """Poll /storage/file/list until *needle* disappears or attempts exhausted."""
+    for _ in range(poll_attempts):
+        if not _file_in_storage_list(base_url, needle, verify_ssl, timeout):
+            return True
+        time.sleep(poll_delay)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup_uploaded_file(request, api_config: dict, unit_test_params: dict):
+    """Best-effort teardown: delete the uploaded file by its (always-valid) id.
+
+    The "delete by streamId" scenario leaves the file behind on the unfixed
+    code, so we always attempt an id-based delete afterwards to avoid leaking
+    uploads across runs.
+    """
+    base_url = api_config["base_url"]
+    verify_ssl = api_config.get("verify_ssl", False)
+    timeout = unit_test_params.get("timeout", 30)
+
+    yield
+
+    ctx = request.node.funcargs.get("context")
+    file_id = getattr(ctx, "upload_id", None) if ctx is not None else None
+    if not file_id:
+        return
+    try:
+        api_delete(
+            base_url, f"/vst/api/v1/storage/file/{file_id}",
+            verify_ssl=verify_ssl, timeout=timeout,
+        )
+    except Exception as exc:
+        logger.warning("teardown delete by id %s failed: %s", file_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Given (NVBug 6164097)
+# ---------------------------------------------------------------------------
+
+
+@given("the static test video is available")
+def static_video_available() -> None:
+    assert STATIC_VIDEO.exists(), f"Static test video missing: {STATIC_VIDEO}"
+
+
+# ---------------------------------------------------------------------------
+# When (NVBug 6164097)
+# ---------------------------------------------------------------------------
+
+
+@when("I upload a media file via POST to the storage service")
+def upload_via_post(
+    context: UnitTestContext, api_config: dict, unit_test_params: dict,
+) -> None:
+    base_url = api_config["base_url"]
+    verify_ssl = api_config.get("verify_ssl", False)
+    timeout = unit_test_params.get("timeout", 60)
+
+    filename = f"{TEST_PREFIX}{uuid.uuid4().hex[:8]}.mp4"
+    resp = _post_upload(base_url, filename, verify_ssl, timeout)
+    assert resp.status_code in (200, 201), (
+        f"POST upload should succeed, got {resp.status_code}: {resp.text[:300]}"
+    )
+    body = resp.json()
+    assert isinstance(body, dict), f"Upload response should be a JSON object: {body!r}"
+
+    context.upload_filename = filename  # type: ignore[attr-defined]
+    context.upload_id = body.get("id")  # type: ignore[attr-defined]
+    context.upload_stream_id = body.get("streamId")  # type: ignore[attr-defined]
+    context.response_json = body
+
+
+@when("I delete the uploaded file using the returned streamId")
+def delete_by_stream_id(
+    context: UnitTestContext, api_config: dict, unit_test_params: dict,
+) -> None:
+    base_url = api_config["base_url"]
+    verify_ssl = api_config.get("verify_ssl", False)
+    timeout = unit_test_params.get("timeout", 30)
+
+    stream_id = getattr(context, "upload_stream_id", None)
+    assert stream_id, (
+        "Upload response did not include a streamId to delete with; "
+        f"response was: {context.response_json!r}"
+    )
+    context.response = api_delete(
+        base_url, f"/vst/api/v1/storage/file/{stream_id}",
+        verify_ssl=verify_ssl, timeout=timeout,
+    )
+    context.status_code = context.response.status_code
+
+
+@when("I delete the uploaded file using the returned id")
+def delete_by_id(
+    context: UnitTestContext, api_config: dict, unit_test_params: dict,
+) -> None:
+    base_url = api_config["base_url"]
+    verify_ssl = api_config.get("verify_ssl", False)
+    timeout = unit_test_params.get("timeout", 30)
+
+    file_id = getattr(context, "upload_id", None)
+    assert file_id, (
+        "Upload response did not include an id to delete with; "
+        f"response was: {context.response_json!r}"
+    )
+    context.response = api_delete(
+        base_url, f"/vst/api/v1/storage/file/{file_id}",
+        verify_ssl=verify_ssl, timeout=timeout,
+    )
+    context.status_code = context.response.status_code
+
+
+# ---------------------------------------------------------------------------
+# Then (NVBug 6164097)
+# ---------------------------------------------------------------------------
+
+
+@then("the upload response contains both an id and a streamId")
+def upload_has_both_identifiers(context: UnitTestContext) -> None:
+    body = context.response_json
+    assert isinstance(body, dict), f"Upload response should be a JSON object: {body!r}"
+    file_id = body.get("id")
+    stream_id = body.get("streamId")
+    assert file_id, f"Upload response must include a non-empty 'id': {body!r}"
+    assert stream_id, f"Upload response must include a non-empty 'streamId': {body!r}"
+
+
+@then("the storage delete response status is 200")
+def delete_status_200(context: UnitTestContext) -> None:
+    resp = context.response
+    assert resp is not None, "No delete response was captured"
+    body = resp.text[:300]
+    assert resp.status_code == 200, (
+        f"Deleting the uploaded file with a handle returned by the upload "
+        f"response must succeed (200); got {resp.status_code}: {body}. "
+        f"Both 'id' and 'streamId' are advertised by the upload as identifiers "
+        f"for the same file, so the delete API must accept either."
+    )
+
+
+@then("the uploaded file is no longer present on the storage service")
+def uploaded_file_gone(
+    context: UnitTestContext, api_config: dict, unit_test_params: dict,
+) -> None:
+    base_url = api_config["base_url"]
+    verify_ssl = api_config.get("verify_ssl", False)
+    timeout = unit_test_params.get("timeout", 30)
+    filename: Optional[str] = getattr(context, "upload_filename", None)
+    assert filename, "No uploaded filename recorded"
+    assert _wait_file_gone(base_url, filename, verify_ssl, timeout), (
+        f"File {filename} is still listed after a successful delete; the "
+        f"returned identifier must actually remove the uploaded media from disk."
+    )


### PR DESCRIPTION
## Description
- Resolve the delete handle by object id then stream id so an uploaded file can be deleted by its returned streamId; no sensor-wide delete.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
