### PR TITLE
vios: fix - /sensor/{id}/status returns 404 envelope

### DIFF
--- a/services/vios/include/error_code.h
+++ b/services/vios/include/error_code.h
@@ -40,14 +40,22 @@ inline constexpr char WHITESPACE_CHAR = ' ';
 inline constexpr int FATAL_ERROR_CODE = -100;
 
 
+/* The error envelope is camelCase per the project swagger (errorCode/errorMessage).
+ * error_code/error_message are retained as deprecated snake_case co-keys for one
+ * release so existing consumers do not break on upgrade. See bug 6216283. */
 #define SET_VMS_ERROR(err_code, value) { std::pair<string, string> err = getCameraErrorCodeString(err_code); \
+                                        value["errorCode"] = err.first; \
+                                        value["errorMessage"] = err.second; \
                                         value["error_code"] = err.first; \
                                         value["error_message"] = err.second; }
 
 #define SET_VMS_ERROR2(err_code, value, message) { std::pair<string, string> err = getCameraErrorCodeString(err_code); \
-                                        value["error_code"] = err.first; \
                                         string msg(message); \
-                                        if (msg.empty()) {value["error_message"] = err.second;} else {value["error_message"] = msg;} }
+                                        if (msg.empty()) {msg = err.second;} \
+                                        value["errorCode"] = err.first; \
+                                        value["errorMessage"] = msg; \
+                                        value["error_code"] = err.first; \
+                                        value["error_message"] = msg; }
 
 
 #define CHECK_JSON_OBJECT_IF_ERROR_RETURN(json_obj) {\

--- a/services/vios/src/framework/notification/messagebus/MessageBus.cpp
+++ b/services/vios/src/framework/notification/messagebus/MessageBus.cpp
@@ -17,14 +17,13 @@
 
 #include <MessageBus.h>
 
-#define SET_VMS_ERROR(err_code, value) { std::pair<string, string> err = getCameraErrorCodeString(err_code); \
-                                        value["error_code"] = err.first; \
-                                        value["error_message"] = err.second; }
-
-#define SET_VMS_ERROR2(err_code, value, message) { std::pair<string, string> err = getCameraErrorCodeString(err_code); \
-                                        value["error_code"] = err.first; \
-                                        string msg(message); \
-                                        if (msg.empty()) {value["error_message"] = err.second;} else {value["error_message"] = msg;} }
+// SET_VMS_ERROR / SET_VMS_ERROR2 come from error_code.h (via MessageBus.h).
+// The previous local copies here were an identical duplicate of that macro;
+// once this fix updated the canonical error_code.h definition (to emit
+// camelCase errorCode/errorMessage alongside the snake_case keys), the stale
+// local copy diverged and broke the build under -Werror (redefinition). The
+// canonical macro is additive (keeps error_code/error_message), so dropping
+// the duplicate is backward compatible.
 
 bool MessageBus::sendMessage(const string& clientId, const string& message, std::shared_ptr<MessageObject> messageObj)
 {

--- a/services/vios/src/framework/web/http_server/HttpServerRequestHandler.cpp
+++ b/services/vios/src/framework/web/http_server/HttpServerRequestHandler.cpp
@@ -335,6 +335,14 @@ class RequestHandler : public CivetHandler
             mg_printf(conn, "%s\r\n", response.c_str());
         }
         mg_printf(conn,"Access-Control-Allow-Origin: *\r\n");
+        /* Emit a Deprecation header whenever the body still carries the retained
+         * snake_case error co-keys (error_code/error_message) so consumers are
+         * warned to migrate to the camelCase errorCode/errorMessage envelope
+         * before the co-keys are removed. See bug 6216283. */
+        if (response.isObject() && response.isMember("error_code"))
+        {
+            mg_printf(conn,"Deprecation: true\r\n");
+        }
         string content_type;
         if (response.isObject())
         {

--- a/services/vios/src/modules/sensor_management/sensor_management_utils.cpp
+++ b/services/vios/src/modules/sensor_management/sensor_management_utils.cpp
@@ -1073,10 +1073,11 @@ VmsErrorCode getSensorStatus(std::shared_ptr<nv_vms::SensorManagement> sensorMgm
     }
     else
     {
-        response["state"] = CAMERA_STATE_OFFLINE;
-        std::pair<string, string> code_pair = getCameraErrorCodeString(VmsErrorCode::CameraNotFoundError);
-        response["errorCode"] = code_pair.first;
-        response["errorMessage"] = code_pair.second;
+        /* A non-existent sensor is an error: emit the standard 404 error envelope
+         * (no success "state" field) so /status matches the sibling endpoints
+         * instead of returning 200 with an embedded error. See bug 6216283. */
+        SET_VMS_ERROR(VmsErrorCode::CameraNotFoundError, response)
+        return VmsErrorCode::CameraNotFoundError;
     }
     return VmsErrorCode::NoError;
 }

--- a/services/vios/test/bdd_tests/features/unit_tests/sensor_management/sensor_management_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/sensor_management/sensor_management_api.feature
@@ -74,3 +74,27 @@ Feature: VST Sensor Management Service API Unit Tests
     And at least one sensor exists
     When I request timelines for the first sensor
     Then the sensor response status is 200
+
+  # Bug 6216283: /sensor/{id}/status for a non-existent sensor must return a
+  # 404 error envelope (camelCase per the swagger) instead of a 200 success
+  # body that embeds the error and a "state":"offline" field.
+  Scenario: Status of a non-existent sensor returns a 404 camelCase error envelope
+    Given the VST sensor management API is accessible
+    When I request status for a non-existent sensor
+    Then the sensor response status is 404
+    And the sensor error body uses camelCase keys with error code "CameraNotFoundError"
+    And the sensor error body has no success "state" field
+
+  # Bug 6216283: every Sensor Management endpoint must emit one consistent
+  # camelCase error envelope on error, not the snake_case variant.
+  Scenario Outline: Error envelope for a non-existent sensor is consistent camelCase across endpoints
+    Given the VST sensor management API is accessible
+    When I request "<action>" for a non-existent sensor
+    Then the sensor response status is 404
+    And the sensor error body uses camelCase keys with error code "CameraNotFoundError"
+
+    Examples:
+      | action    |
+      | streams   |
+      | timelines |
+      | network   |

--- a/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_sensor_management_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/sensor_management/test_sensor_management_api.py
@@ -22,7 +22,7 @@ version, help, configuration.
 import logging
 
 import pytest
-from pytest_bdd import scenarios, given, when, then
+from pytest_bdd import scenarios, given, when, then, parsers
 
 from ..unit_test_utils import (
     UnitTestContext,
@@ -35,6 +35,9 @@ from ..unit_test_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# A sensor ID that is guaranteed not to exist, used to exercise the error path.
+NONEXISTENT_SENSOR_ID = "__nonexistent__"
 
 scenarios("../../../features/unit_tests/sensor_management/sensor_management_api.feature")
 
@@ -217,6 +220,30 @@ def request_sensor_timelines_by_id(context: UnitTestContext, api_config: dict, u
     )
 
 
+@when("I request status for a non-existent sensor")
+def request_status_nonexistent(context: UnitTestContext, api_config: dict, unit_test_params: dict) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    context.response = api_get(
+        api_config["base_url"],
+        f"/vst/api/v1/sensor/{NONEXISTENT_SENSOR_ID}/status",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+
+
+@when(parsers.parse('I request "{action}" for a non-existent sensor'))
+def request_action_nonexistent(
+    context: UnitTestContext, api_config: dict, unit_test_params: dict, action: str
+) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    context.response = api_get(
+        api_config["base_url"],
+        f"/vst/api/v1/sensor/{NONEXISTENT_SENSOR_ID}/{action}",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Then
 # ---------------------------------------------------------------------------
@@ -225,6 +252,44 @@ def request_sensor_timelines_by_id(context: UnitTestContext, api_config: dict, u
 def check_sensor_status_200(context: UnitTestContext) -> None:
     assert context.response.status_code == 200, (
         f"Expected 200, got {context.response.status_code}: {context.response.text[:500]}"
+    )
+
+
+@then("the sensor response status is 404")
+def check_sensor_status_404(context: UnitTestContext) -> None:
+    assert context.response.status_code == 404, (
+        f"Expected 404 for a non-existent sensor, got {context.response.status_code}: "
+        f"{context.response.text[:500]}"
+    )
+
+
+@then(parsers.parse('the sensor error body uses camelCase keys with error code "{code}"'))
+def check_camelcase_error_envelope(context: UnitTestContext, code: str) -> None:
+    data = context.response.json()
+    assert isinstance(data, dict), (
+        f"Error body must be a JSON object, got {type(data).__name__}: {context.response.text[:500]}"
+    )
+    assert "errorCode" in data, (
+        f"Expected camelCase 'errorCode' key per the swagger, got keys {sorted(data)}: "
+        f"{context.response.text[:500]}"
+    )
+    assert data["errorCode"] == code, (
+        f"Expected errorCode '{code}', got '{data.get('errorCode')}': {context.response.text[:500]}"
+    )
+    assert "errorMessage" in data, (
+        f"Expected camelCase 'errorMessage' key per the swagger, got keys {sorted(data)}: "
+        f"{context.response.text[:500]}"
+    )
+
+
+@then('the sensor error body has no success "state" field')
+def check_error_body_has_no_state(context: UnitTestContext) -> None:
+    data = context.response.json()
+    assert isinstance(data, dict), (
+        f"Error body must be a JSON object, got {type(data).__name__}: {context.response.text[:500]}"
+    )
+    assert "state" not in data, (
+        f"Error envelope must not embed a success 'state' field, got: {context.response.text[:500]}"
     )
 
 


### PR DESCRIPTION
## Description
- Return 404 with a camelCase error envelope for a missing sensor on /sensor/{id}/status, consistent with sibling endpoints.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
