### PR TITLE
vios: fix - camelCase recordingStatus on /record/status

### DIFF
--- a/services/vios/src/modules/stream_recorder/streamrecorder.cpp
+++ b/services/vios/src/modules/stream_recorder/streamrecorder.cpp
@@ -413,6 +413,11 @@ VmsErrorCode StreamRecorder::recordStatus(Json::Value &response)
             current_state = recording_status_unknown;
         }
         resp["id"] = stream_id;
+        // Use the camelCase "recordingStatus" key to match the per-stream
+        // GET /record/{streamId}/status endpoint and the project-wide camelCase
+        // swagger (NVBug 6216297). Retain the snake_case "recording_status" as a
+        // deprecated co-key for one release so existing consumers do not break.
+        resp["recordingStatus"] = current_state;
         resp["recording_status"] = current_state;
         response[stream_id] = resp;
     }

--- a/services/vios/test/bdd_tests/features/unit_tests/stream_recorder/stream_recorder_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/stream_recorder/stream_recorder_api.feature
@@ -29,3 +29,13 @@ Feature: VST Stream Recorder Service API Unit Tests
     Given the VST stream recorder API is accessible
     When I request the recording timelines for all record streams
     Then the recorder response status is 200
+
+  # Regression for NVBug 6216297: aggregate /record/status must expose state
+  # under the same camelCase key "recordingStatus" as the per-stream endpoint.
+  Scenario: Aggregate record status uses the same camelCase key as the per-stream endpoint
+    Given the VST stream recorder API is accessible
+    And at least one record stream is present
+    When I request the per-stream record status for that stream
+    And I request the aggregate record status for all streams
+    Then the per-stream record status uses the camelCase key "recordingStatus"
+    And every aggregate record status entry uses the camelCase key "recordingStatus"

--- a/services/vios/test/bdd_tests/tests/unit_tests/stream_recorder/test_stream_recorder_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/stream_recorder/test_stream_recorder_api.py
@@ -19,13 +19,16 @@ Unit tests for the VST Stream Recorder Service API.
 Tests: record streams list, version, help, configuration, recording timelines.
 """
 import logging
+import uuid
 
 import pytest
-from pytest_bdd import scenarios, given, when, then
+from pytest_bdd import scenarios, given, when, then, parsers
 
 from ..unit_test_utils import (
     UnitTestContext,
     api_get,
+    api_post,
+    api_delete,
     validate_json_response,
     validate_list_response,
     validate_string_response,
@@ -141,3 +144,195 @@ def check_recorder_configuration_fields(context: UnitTestContext) -> None:
     assert isinstance(data, dict), "Configuration must be a JSON object"
     assert len(data) > 0, "Configuration is empty"
     logger.info("Configuration has %d fields", len(data))
+
+
+# ===========================================================================
+# Regression for NVBug 6216297: record status field-name consistency.
+#
+# The per-stream endpoint GET /record/{streamId}/status returns the recording
+# state under the camelCase key "recordingStatus", while the aggregate endpoint
+# GET /record/status returns it under snake_case "recording_status". The
+# project-wide swagger declares camelCase, so both endpoints must expose the
+# state under "recordingStatus".
+# ===========================================================================
+
+# An RTSP URL is required because the recorder only accepts rtsp:// streams.
+# TEST-NET-1 (RFC 5737) is reserved for documentation and never answers, but
+# with verifyRtsp omitted (defaults to false) the sensor is still persisted,
+# which is all this test needs: a present stream so the aggregate map is
+# non-empty.
+_TEMP_SENSOR_RTSP_URL = "rtsp://192.0.2.1:554/nvbug-6216297"
+_TEMP_SENSOR_NAME_PREFIX = "bdd-6216297-"
+
+
+class _StatusKeyContext:
+    def __init__(self):
+        self.stream_id = None
+        self.added_sensor_id = None
+        self.per_stream_json = None
+        self.aggregate_json = None
+
+
+@pytest.fixture
+def context_6216297():
+    return _StatusKeyContext()
+
+
+def _list_sensor_ids(api_config, unit_test_params):
+    timeout = unit_test_params.get("timeout", 30)
+    resp = api_get(
+        api_config["base_url"],
+        "/vst/api/v1/sensor/list",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+    if resp.status_code != 200:
+        return []
+    try:
+        sensors = resp.json()
+    except ValueError:
+        return []
+    if not isinstance(sensors, list):
+        return []
+    return [
+        s["sensorId"]
+        for s in sensors
+        if isinstance(s, dict) and s.get("sensorId")
+    ]
+
+
+@given("at least one record stream is present")
+def ensure_stream_present(
+    context_6216297: _StatusKeyContext, api_config: dict, unit_test_params: dict
+) -> None:
+    existing = _list_sensor_ids(api_config, unit_test_params)
+    if existing:
+        context_6216297.stream_id = existing[0]
+        logger.info("Using existing stream %s for status check", context_6216297.stream_id)
+        return
+
+    # No sensors present: add a temporary one so the aggregate map is non-empty.
+    timeout = unit_test_params.get("timeout", 30)
+    name = f"{_TEMP_SENSOR_NAME_PREFIX}{uuid.uuid4().hex[:12]}"
+    resp = api_post(
+        api_config["base_url"],
+        "/vst/api/v1/sensor/add",
+        json_body={
+            "name": name,
+            "sensorUrl": _TEMP_SENSOR_RTSP_URL,
+            "location": "bdd-test",
+            "tags": "bdd-6216297",
+        },
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+    assert resp.status_code == 200, (
+        f"Could not provision a test sensor (status {resp.status_code}): "
+        f"{resp.text[:300]}"
+    )
+    try:
+        sensor_id = resp.json().get("sensorId")
+    except ValueError:
+        sensor_id = None
+    assert sensor_id, f"sensor/add did not return a sensorId: {resp.text[:300]}"
+    context_6216297.stream_id = sensor_id
+    context_6216297.added_sensor_id = sensor_id
+    logger.info("Provisioned temporary stream %s for status check", sensor_id)
+
+
+@when("I request the per-stream record status for that stream")
+def request_per_stream_status(
+    context_6216297: _StatusKeyContext, api_config: dict, unit_test_params: dict
+) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    resp = api_get(
+        api_config["base_url"],
+        f"/vst/api/v1/record/{context_6216297.stream_id}/status",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+    assert resp.status_code == 200, (
+        f"Per-stream /record/{context_6216297.stream_id}/status failed: "
+        f"{resp.status_code} {resp.text[:300]}"
+    )
+    context_6216297.per_stream_json = resp.json()
+
+
+@when("I request the aggregate record status for all streams")
+def request_aggregate_status(
+    context_6216297: _StatusKeyContext, api_config: dict, unit_test_params: dict
+) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    resp = api_get(
+        api_config["base_url"],
+        "/vst/api/v1/record/status",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=timeout,
+    )
+    assert resp.status_code == 200, (
+        f"Aggregate /record/status failed: {resp.status_code} {resp.text[:300]}"
+    )
+    context_6216297.aggregate_json = resp.json()
+
+
+@then(parsers.parse('the per-stream record status uses the camelCase key "{key}"'))
+def check_per_stream_key(context_6216297: _StatusKeyContext, key: str) -> None:
+    body = context_6216297.per_stream_json
+    assert isinstance(body, dict), (
+        f"Per-stream status body must be a JSON object, got {type(body).__name__}: "
+        f"{str(body)[:300]}"
+    )
+    assert key in body, (
+        f"Per-stream /record/{{streamId}}/status must report state under "
+        f"'{key}'; body was: {body}"
+    )
+
+
+@then(parsers.parse('every aggregate record status entry uses the camelCase key "{key}"'))
+def check_aggregate_key(context_6216297: _StatusKeyContext, key: str) -> None:
+    body = context_6216297.aggregate_json
+    assert isinstance(body, dict), (
+        f"Aggregate /record/status body must be a JSON object keyed by sensor id, "
+        f"got {type(body).__name__}: {str(body)[:300]}"
+    )
+    assert body, (
+        "Aggregate /record/status returned no entries; cannot verify the status "
+        "key. Expected at least the stream provisioned by this test "
+        f"({context_6216297.stream_id})."
+    )
+
+    offenders = {}
+    for sid, entry in body.items():
+        if not isinstance(entry, dict):
+            offenders[sid] = entry
+            continue
+        if key not in entry:
+            offenders[sid] = sorted(entry.keys())
+
+    assert not offenders, (
+        f"Aggregate /record/status entries must report state under the camelCase "
+        f"key '{key}' to match the per-stream endpoint (NVBug 6216297). "
+        f"Entries missing '{key}': {offenders}. Full body: {body}"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_added_sensor(context_6216297, api_config, unit_test_params):
+    yield
+    sensor_id = getattr(context_6216297, "added_sensor_id", None)
+    if not sensor_id:
+        return
+    timeout = unit_test_params.get("timeout", 30)
+    try:
+        resp = api_delete(
+            api_config["base_url"],
+            f"/vst/api/v1/sensor/{sensor_id}",
+            verify_ssl=api_config.get("verify_ssl", False),
+            timeout=timeout,
+        )
+        logger.info(
+            "Cleaned up temporary sensor %s (status %d)",
+            sensor_id, resp.status_code,
+        )
+    except Exception as exc:  # noqa: BLE001 - cleanup must never fail the test
+        logger.warning("Failed to clean up temporary sensor %s: %s", sensor_id, exc)


### PR DESCRIPTION
## Description
- Use the camelCase recordingStatus key on the aggregate /record/status response, matching the per-stream endpoint.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
