### PR TITLE
vios: fix - /storage/file/protect rejects bad body

### DIFF
--- a/services/vios/src/modules/storage_management/storage_management.cpp
+++ b/services/vios/src/modules/storage_management/storage_management.cpp
@@ -2292,6 +2292,18 @@ VmsErrorCode StorageManagement::addOrRemoveFileInProtectList(const Json::Value& 
         return VmsErrorCode::MethodNotAllowedError;
     }
 
+    // Defense in depth: Json::Value::get()/find() throw Json::LogicError (uncaught
+    // -> SIGABRT, crashing the service) when invoked on a non-object such as an
+    // array body. The schema validator should already have rejected such bodies,
+    // but guard the handler too so a malformed body can never abort the process
+    // (bug 6217188).
+    if (!in.isObject())
+    {
+        LOG(error) << "Request body must be a JSON object with a 'filePath' field" << endl;
+        SET_VMS_ERROR2(VmsErrorCode::InvalidParameterError, response, "Request body must be a JSON object with a 'filePath' field");
+        return VmsErrorCode::InvalidParameterError;
+    }
+
     vector<string> fileList;
 
     Json::Value fileListJson = in.get("filePath", EMPTY_STRING);

--- a/services/vios/test/bdd_tests/features/unit_tests/storage_management/storage_management_api.feature
+++ b/services/vios/test/bdd_tests/features/unit_tests/storage_management/storage_management_api.feature
@@ -50,3 +50,11 @@ Feature: VST Storage Management Service API Unit Tests
     Given the VST storage management API is accessible
     When I request the protected file list
     Then the storage response status is 200
+
+  # Regression for NVBug 6217188: a JSON array body to /storage/file/protect
+  # must return 400, not crash streamprocessing-ms via uncaught Json::LogicError.
+  Scenario: POST /storage/file/protect with a JSON array body is rejected, not crashed
+    Given the VST storage management API is accessible
+    When I POST a JSON array body to the storage file protect endpoint
+    Then the storage protect request is rejected with status 400
+    And the streamprocessing storage service is still alive

--- a/services/vios/test/bdd_tests/tests/unit_tests/storage_management/test_storage_management_api.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/storage_management/test_storage_management_api.py
@@ -21,11 +21,13 @@ Tests: storage size, info, version, help, configuration, file list, protected fi
 import logging
 
 import pytest
+import requests
 from pytest_bdd import scenarios, given, when, then
 
 from ..unit_test_utils import (
     UnitTestContext,
     api_get,
+    api_post,
     validate_json_response,
     validate_list_response,
     validate_string_response,
@@ -226,3 +228,82 @@ def check_storage_configuration_fields(context: UnitTestContext) -> None:
     assert isinstance(data, dict), "Configuration must be a JSON object"
     assert len(data) > 0, "Configuration is empty"
     logger.info("Configuration has %d fields", len(data))
+
+
+# ---------------------------------------------------------------------------
+# Regression for NVBug 6217188: malformed (JSON array) body to
+# /storage/file/protect must be rejected with HTTP 400 and must not crash
+# streamprocessing-ms via an uncaught Json::LogicError (SIGABRT).
+# ---------------------------------------------------------------------------
+
+# Array-shaped body matching the bug report: a JSON array where the handler
+# expects an object. The exact field values are irrelevant -- it is the array
+# shape that triggers the Json::LogicError.
+MALFORMED_ARRAY_BODY = [
+    {
+        "sensorId": "regression-6217188",
+        "startTime": 1779692211032,
+        "endTime": 1779692250571,
+        "action": "add",
+    }
+]
+
+PROTECT_PATH = "/vst/api/v1/storage/file/protect"
+HEALTHCHECK_PATH = "/vst/api/v1/storage/info"
+
+
+@when("I POST a JSON array body to the storage file protect endpoint")
+def post_array_body_to_protect(
+    context: UnitTestContext, api_config: dict, unit_test_params: dict
+) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    try:
+        context.response = api_post(
+            api_config["base_url"],
+            PROTECT_PATH,
+            json_body=MALFORMED_ARRAY_BODY,
+            verify_ssl=api_config.get("verify_ssl", False),
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException as exc:
+        # On the unfixed build the upstream container aborts mid-request, so
+        # the connection may be reset rather than returning a proxied 5xx.
+        context.response = None
+        context.error = f"{type(exc).__name__}: {exc}"
+        logger.error("POST to %s failed at the transport layer: %s", PROTECT_PATH, context.error)
+
+
+@then("the storage protect request is rejected with status 400")
+def protect_rejected_400(context: UnitTestContext) -> None:
+    assert context.error is None, (
+        "Malformed array body should be rejected cleanly with HTTP 400, but the "
+        f"request did not complete (likely an upstream crash): {context.error}"
+    )
+    assert context.response is not None, "No response captured for the protect request"
+    assert context.response.status_code == 400, (
+        "Malformed array body must be rejected with HTTP 400, got "
+        f"{context.response.status_code}: {context.response.text[:500]}"
+    )
+
+
+@then("the streamprocessing storage service is still alive")
+def storage_service_still_alive(
+    context: UnitTestContext, api_config: dict, unit_test_params: dict
+) -> None:
+    timeout = unit_test_params.get("timeout", 30)
+    try:
+        health = api_get(
+            api_config["base_url"],
+            HEALTHCHECK_PATH,
+            verify_ssl=api_config.get("verify_ssl", False),
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException as exc:
+        pytest.fail(
+            "Storage service is unreachable after the malformed protect request "
+            f"(container likely crashed/restarting): {type(exc).__name__}: {exc}"
+        )
+    assert health.status_code == 200, (
+        "Storage service must remain available after a malformed protect request; "
+        f"GET {HEALTHCHECK_PATH} returned {health.status_code}: {health.text[:500]}"
+    )


### PR DESCRIPTION
## Description
- Reject a malformed (non-object) /storage/file/protect body with a 4xx instead of crashing the service.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
