### PR TITLE
chore(promote): pin vss-agent to promoted 3.2.0-26.05.5 candidate image

### DIFF
--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -17,7 +17,7 @@
 
 services:
   vss-va-mcp:
-    image: nvcr.io/nvidia/vss-core/vss-agent:${VSS_AGENT_VERSION}
+    image: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent:3.2.0-26.05.5-f6a2547b9b0e@sha256:6d19dd1178ca42abe1de64fcbbd3e3eedc9ee3494850edbcef068b2e472902f5
     container_name: vss-va-mcp
     profiles:
     - bp_wh_2d
@@ -62,7 +62,7 @@ services:
 
   vss-agent:
     # for release, change this to the versioned image from the registry
-    image: nvcr.io/nvidia/vss-core/vss-agent:${VSS_AGENT_VERSION}
+    image: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent:3.2.0-26.05.5-f6a2547b9b0e@sha256:6d19dd1178ca42abe1de64fcbbd3e3eedc9ee3494850edbcef068b2e472902f5
     container_name: vss-agent
     profiles:
     - bp_wh_2d


### PR DESCRIPTION
## Container promotion for PR #1141 (codec removal)

Replicates the GitLab container-promotion step for downstream pipeline [56394374](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/pipelines/56394374) (all eval green).

- Candidate `vss-agent:dev-f6a2547b9b0e` was promoted (retagged) to `vss-agent:3.2.0-26.05.5-f6a2547b9b0e` `@sha256:6d19dd11…`.
- This PR pins `deploy/docker/services/agent/compose.yml` (both agent services) to that digest so deployments run the exact validated, codec-fixed image.

### ⚠️ Reviewer notes
- Points at the **dev registry** `nvcr.io/nv-metropolis-dev/met-moe-agents` — the only place the validated image currently exists. External users cannot pull it.
- The public `nvcr.io/nvidia/vss-core/vss-agent:3.2.0-26.05.5` is **not published yet** (only `3.2.0` exists). Revert to `nvidia/vss-core` + `${VSS_AGENT_VERSION}` once the public release is published.
- Depends on **#1141** (the codec source changes) landing; this only bumps the image ref.
- Agent-only; UI/alert-ms not bumped.