### PR TITLE
fix(skills): Update LVS skill shared-mode RT-VLM and LLM readiness guidance

### DIFF
--- a/skills/vss-deploy-profile/references/lvs-profile.md
+++ b/skills/vss-deploy-profile/references/lvs-profile.md
@@ -34,6 +34,14 @@ Container names below are the actual `container_name:` keys from `deploy/docker/
 
 Post-deploy readiness probe: `curl -sf http://${HOST_IP}:38111/v1/ready` should return exit 0 once `vss-lvs` is serving. The VSS Agent at `http://${HOST_IP}:8000/health` is the cross-profile readiness signal; this one confirms the LVS-specific microservice.
 
+For LVS with `LLM_MODE=local` or `LLM_MODE=local_shared`, also require:
+
+```bash
+curl -sf http://${HOST_IP}:${LLM_PORT:-30081}/v1/health/ready
+```
+
+This prevents a deploy from passing when the local LLM NIM is down.
+
 ## Default models
 
 | Role | `*_NAME` (env) | `*_NAME_SLUG` | Served by |
@@ -150,6 +158,8 @@ The RT-VLM container reads sizing knobs from `dev-profile-lvs/.env` with the `RT
 | `RT_VLM_DEVICE_ID` | (compose `device_ids`) | `${VLM_DEVICE_ID:-0}` | Which GPU RT-VLM pins to. In shared mode set this equal to `LLM_DEVICE_ID`. |
 
 The sizing flow is identical to base: pick the fraction with the formula in [`base.md`](base.md#sizing-math), write it into `dev-profile-lvs/generated.env` (one place — there is no per-hardware `hw-*.env` for RT-VLM), re-resolve the compose, deploy, watch the rtvi-vlm logs for `Maximum concurrency for X tokens per GPU: Y x` to confirm the KV-cache budget.
+
+**Skill deploy requirement:** when LVS runs RT-VLM on the same GPU as a local LLM (`LLM_MODE=local_shared` and `VLM_MODE=local_shared`), do not leave `RTVI_VLLM_GPU_MEMORY_UTILIZATION` empty. For H100 and RTXPRO6000BW shared deployments, write `RTVI_VLLM_GPU_MEMORY_UTILIZATION=0.40` into `generated.env` before resolving Compose.
 
 ## LVS-specific write location for the worked example
 


### PR DESCRIPTION
## Description
Cherry-picked from https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/1034 to re-target at dev/3.2.1

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
