### PR TITLE
refactor(vss-ask-video): call the VLM endpoint directly

### DIFF
--- a/.github/skill-eval/adapters/vss-ask-video/generate.py
+++ b/.github/skill-eval/adapters/vss-ask-video/generate.py
@@ -112,7 +112,7 @@ def generate_solve_script(platform: str) -> str:
         "# vss-ask-video calls the VLM /v1/chat/completions endpoint directly\n"
         "# (NOT POST /generate). The solution script asserts VST + a VLM\n"
         "# endpoint are reachable, then defers to the verifier.\n"
-        "set -uo pipefail\n"
+        "set -euo pipefail\n"
         "\n"
         'HOST_IP="${HOST_IP:-localhost}"\n'
         "\n"

--- a/.github/skill-eval/adapters/vss-ask-video/generate.py
+++ b/.github/skill-eval/adapters/vss-ask-video/generate.py
@@ -3,17 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 """Generate Harbor tasks for the vss-ask-video skill.
 
-The vss-ask-video skill answers visual questions about a named sensor
-by calling ``POST /generate`` on the VSS agent, instructing it to invoke the
-``video_understanding`` tool.  It requires a **full-remote deployed VSS base
-profile** (deploy mode = ``remote-all``; both LLM and VLM via remote
-launchpad endpoints, no local NIMs required). It does NOT deploy VSS itself;
-the coordinator chains a deploy task in front, plus a VIOS seed step to
-upload the sample warehouse video.
+The vss-ask-video skill answers visual questions about a recorded clip by
+calling an OpenAI-compatible **VLM ``chat/completions`` endpoint directly**:
+it resolves a clip URL via VST/VIOS, picks the live VLM endpoint/model
+(NIM Cosmos on :30082 or RT-VLM on :8018/:30082), uploads the clip in the
+format the target VLM requires (``video_url`` / ``file_base64``), and
+returns the answer. It does **NOT** call ``POST
+/generate`` on the VSS agent and does **not** require the NAT agent to be
+running — only a reachable VLM endpoint plus VST. It does NOT deploy VSS
+itself; the coordinator chains a deploy task in front (or points the skill
+at an already-running VLM endpoint), plus a VIOS seed step to upload the
+sample warehouse video.
 
-Because vss-ask-video is a thin wrapper around POST /generate — purely
-HTTP, GPU-independent at the harness level — the spec targets **ONE platform**
-by default (L40S — cheapest available host).  Override with ``--platform``.
+Because vss-ask-video drives the VLM endpoint over plain HTTP — the heavy
+lifting is on the (already-deployed) VLM, GPU-independent at the harness
+level — the spec targets **ONE platform** by default (L40S — cheapest
+available host).  Override with ``--platform``.
 
 ## Directory layout
 
@@ -95,24 +100,40 @@ def generate_test_script(step: int, spec_name: str) -> str:
 
 
 def generate_solve_script(platform: str) -> str:
-    """Gold solution — assumes VSS base profile is already deployed and a
+    """Gold solution — assumes VST and a VLM endpoint are reachable and a
     sample warehouse video is already uploaded via VIOS.  The verifier drives
-    the POST /generate assertion; the solution script asserts the agent is
-    live, then defers."""
+    the direct VLM chat/completions assertion; the solution script just
+    asserts the prerequisites (VST + a resolvable VLM endpoint) are live,
+    then defers. It deliberately does NOT require the VSS agent (:8000) —
+    vss-ask-video no longer calls POST /generate."""
     return (
         "#!/bin/bash\n"
         f"# Gold solution: vss-ask-video on {platform}\n"
-        "# The verifier calls POST /generate directly — the solution script\n"
-        "# just asserts VSS agent is reachable then defers to the verifier.\n"
-        "set -euo pipefail\n"
+        "# vss-ask-video calls the VLM /v1/chat/completions endpoint directly\n"
+        "# (NOT POST /generate). The solution script asserts VST + a VLM\n"
+        "# endpoint are reachable, then defers to the verifier.\n"
+        "set -uo pipefail\n"
         "\n"
-        "curl -sf --connect-timeout 5 "
-        "${VSS_AGENT_URL:-http://localhost:8000}/docs "
-        ">/dev/null || {\n"
-        "    echo 'VSS agent is not deployed — cannot solve vss-ask-video task'\n"
+        'HOST_IP="${HOST_IP:-localhost}"\n'
+        "\n"
+        "# VST must be up to resolve the clip URL.\n"
+        "curl -sf --connect-timeout 5 --max-time 10 \\\n"
+        '  "http://${HOST_IP}:30888/vst/api/v1/sensor/version" >/dev/null || {\n'
+        "    echo 'VST is not reachable on :30888 — cannot solve vss-ask-video task'\n"
         "    exit 1\n"
         "}\n"
-        "echo 'VSS agent is live — verifier will drive POST /generate.'\n"
+        "\n"
+        "# A VLM endpoint must resolve — try caller-provided VLM_ENDPOINT, then\n"
+        "# NIM Cosmos (:30082, base default), then RT-VLM (:8018, alerts/lvs).\n"
+        "vlm_ok=0\n"
+        'for base in "${VLM_ENDPOINT:-}" "http://${HOST_IP}:30082/v1" "http://${HOST_IP}:8018/v1"; do\n'
+        '    [ -n "$base" ] || continue\n'
+        '    if curl -sf --connect-timeout 5 --max-time 10 "${base}/models" >/dev/null; then\n'
+        '        echo "VLM endpoint reachable at ${base}"; vlm_ok=1; break\n'
+        "    fi\n"
+        "done\n"
+        '[ "$vlm_ok" = 1 ] || { echo \'No reachable VLM endpoint (:30082 / :8018 / VLM_ENDPOINT)\'; exit 1; }\n'
+        "echo 'Prerequisites live (VST + VLM) — verifier will drive the direct VLM call.'\n"
     )
 
 
@@ -172,7 +193,7 @@ def generate_task(
             "[task]",
             f'name = "nvidia-vss/vss-ask-video-{profile}-{platform_short}{step_suffix}"',
             f'description = "vss-ask-video query {idx}/{len(expects)} on {platform}"',
-            f'keywords = ["vss-ask-video", "generate", "{profile}", "{platform}"]',
+            f'keywords = ["vss-ask-video", "vlm", "chat-completions", "{profile}", "{platform}"]',
             "",
             "[environment]",
             'skills_dir = "/skills"',
@@ -192,8 +213,10 @@ def generate_task(
             f'gpu_type = "{pspec["gpu_type"]}"',
             f'brev_search = "{pspec["brev_search"]}"',
             f'min_vram_gb_per_gpu = {pspec["min_vram_per_gpu"]}',
-            "# Deploy mode is FULL-REMOTE (LLM + VLM both remote) — vss-ask-video",
-            "# exercises POST /generate only, so there is no benefit to local NIMs.",
+            "# vss-ask-video calls the VLM chat/completions endpoint directly (not",
+            "# POST /generate). The VLM that serves the clip must be able to fetch the",
+            "# VST clip URL: prefer a LOCAL VLM (NIM :30082 / RT-VLM :8018) so the",
+            "# internal clip URL is reachable; a remote VLM forces inline frame upload.",
             f"step_index = {idx}",
             f"step_count = {len(expects)}",
             f"check_count = {len(expect.get('checks') or [])}",

--- a/.github/skill-eval/adapters/vss-build-vision-agent/__init__.py
+++ b/.github/skill-eval/adapters/vss-build-vision-agent/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/.github/skill-eval/adapters/vss-build-vision-agent/__init__.py
+++ b/.github/skill-eval/adapters/vss-build-vision-agent/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0

--- a/skills/README.md
+++ b/skills/README.md
@@ -117,7 +117,7 @@ Match the user's intent to a skill. Start here before opening any individual `SK
 |---|---|
 | [vss-search-archive](vss-search-archive/SKILL.md) | Search video archives with natural language using multi-embedding fusion (Cosmos-Embed1) plus CV attribute matching; also ingests files/RTSP for search. |
 | [vss-summarize-video](vss-summarize-video/SKILL.md) | Summarize a recorded video via chunking, dense captioning, and aggregation using the Long Video Summarization (LVS) microservice (HITL-gated, VLM fallback). |
-| [vss-ask-video](vss-ask-video/SKILL.md) | Answer a fresh text question about a recorded clip via the VSS agent's `video_understanding` (VLM) tool. |
+| [vss-ask-video](vss-ask-video/SKILL.md) | Answer a fresh visual question about a recorded clip by calling a VLM endpoint directly (OpenAI-compatible `chat/completions`) — the same direct-VLM path `vss-generate-video-report` Mode A uses. |
 | [vss-generate-video-report](vss-generate-video-report/SKILL.md) | Produce a formatted markdown report by querying the VSS agent's `/generate` endpoint — per-clip VLM (Mode A) or incident-range (Mode B). |
 | [vss-generate-video-report-rag](vss-generate-video-report-rag/SKILL.md) | Generate video summary reports with Enterprise RAG context using the VSS frag/RAG pipeline and HITL parameter collection. |
 | [vss-query-analytics](vss-query-analytics/SKILL.md) | Query analytics metrics, incidents, alerts, and sensor data from Elasticsearch via the VA-MCP server (port 9901). |

--- a/skills/README.md
+++ b/skills/README.md
@@ -117,7 +117,7 @@ Match the user's intent to a skill. Start here before opening any individual `SK
 |---|---|
 | [vss-search-archive](vss-search-archive/SKILL.md) | Search video archives with natural language using multi-embedding fusion (Cosmos-Embed1) plus CV attribute matching; also ingests files/RTSP for search. |
 | [vss-summarize-video](vss-summarize-video/SKILL.md) | Summarize a recorded video via chunking, dense captioning, and aggregation using the Long Video Summarization (LVS) microservice (HITL-gated, VLM fallback). |
-| [vss-ask-video](vss-ask-video/SKILL.md) | Answer a fresh visual question about a recorded clip by calling a VLM endpoint directly (OpenAI-compatible `chat/completions`) — the same direct-VLM path `vss-generate-video-report` Mode A uses. |
+| [vss-ask-video](vss-ask-video/SKILL.md) | Answer a fresh text question about a recorded clip via the VSS agent's `video_understanding` (VLM) tool. |
 | [vss-generate-video-report](vss-generate-video-report/SKILL.md) | Produce a formatted markdown report by querying the VSS agent's `/generate` endpoint — per-clip VLM (Mode A) or incident-range (Mode B). |
 | [vss-generate-video-report-rag](vss-generate-video-report-rag/SKILL.md) | Generate video summary reports with Enterprise RAG context using the VSS frag/RAG pipeline and HITL parameter collection. |
 | [vss-query-analytics](vss-query-analytics/SKILL.md) | Query analytics metrics, incidents, alerts, and sensor data from Elasticsearch via the VA-MCP server (port 9901). |

--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -89,7 +89,8 @@ endpoint is up, point the skill at it and use it; no deploy step is needed. At r
 
 1. **A reachable OpenAI-compatible VLM `chat/completions` endpoint** *(the only hard
    requirement)* — NIM Cosmos, RT-VLM, or any other. If one is already running, set
-   `VLM_ENDPOINT` / `VLM_MODEL` directly (Step 2).
+   `VLM_ENDPOINT` / `VLM_MODEL` directly (Step 2). If none is running, Step 2 discovers one and,
+   failing that, can prompt to **deploy a local RT-VLM** via `/vss-deploy-dense-captioning`.
 2. **A video to ask about.** Either of:
    - **Provided directly by the user** — a local file (inlined as a base64 video block) or a URL
      (sent as a `video_url` block the VLM fetches). **No VST/VIOS needed.** This is the default
@@ -286,8 +287,44 @@ is loaded:
 curl -sf --max-time 5 "${VLM_ENDPOINT}/models" | jq -r '.data[].id'
 ```
 
-If the probe fails or the listed ids don't include `${VLM_MODEL}`, fall back to the other backend
-(or surface the error — never silently pick a model that isn't on the server).
+If the probe fails or the listed ids don't include `${VLM_MODEL}`, fall back to the other backend.
+If **no** endpoint resolves at all (nothing reachable), there is no default VLM selection in
+place — follow *No default VLM selection?* below instead of silently failing.
+
+### No default VLM selection? Discover first, then prompt (VIA-E-114-04)
+
+Discovery above always runs **first** — an explicit `VLM_ENDPOINT`, then the running `vss-agent`
+env, then the default ports (`:30082` NIM / `:8018` RT-VLM), each confirmed live with `/v1/models`.
+When that yields a reachable endpoint, use it and continue to Step 3 — **do not prompt**.
+
+Only when **no** endpoint resolves (no default selection is in place) prompt the user for how to
+supply a VLM (HITL-optional — see the non-interactive default below). Offer three choices:
+
+1. **Provide an endpoint** — take `VLM_ENDPOINT` (+ optional `VLM_MODEL`), then re-probe
+   `/v1/models` and continue.
+2. **Pick a discovered suggestion** — list any endpoints that responded (from the `vss-agent`
+   env, or the default `:30082` / `:8018` ports) and let the user choose one.
+3. **Deploy a local RT-VLM** — hand off to
+   [`/vss-deploy-dense-captioning`](../vss-deploy-dense-captioning/SKILL.md) (default model
+   **cosmos-reason2-8b**, profile `bp_developer_alerts_2d_vlm`; this tracks the RT-VLM deploy
+   default — cosmos-reason2 today, cosmos-reason3 once 3.2.1 ships), then resume against the
+   **live** service — never a hardcoded endpoint/model:
+
+   ```bash
+   VLM_ENDPOINT="http://${HOST_IP}:${RTVI_VLM_PORT:-8018}/v1"   # matches the RT-VLM deploy contract
+   curl -sf --max-time 5 "${VLM_ENDPOINT}/health/ready"          # first boot can take ~20 min
+   # Resolve the model id from the endpoint — the cosmos-reason2 name is a backend selector,
+   # NOT an API model id, so read the real id the server advertises:
+   VLM_MODEL="$(curl -sf --max-time 5 "${VLM_ENDPOINT}/models" | jq -r '.data[0].id // empty')"
+   VLM_BACKEND="rtvlm"
+   # If the deployed RT-VLM is token-gated, add the bearer on every request:
+   #   -H "Authorization: Bearer ${RTVI_VLM_API_KEY:-${NGC_CLI_API_KEY:-}}"
+   ```
+
+**Non-interactive / HITL-disabled (CI, headless agents):** do not block on a prompt. If a
+discovered endpoint already exists, use it; otherwise the default action is to **deploy a local
+RT-VLM** (option 3) and continue. Hard-fail only when a deploy is impossible (no GPU or no
+`NGC_CLI_API_KEY`), printing the three options above so the caller can set `VLM_ENDPOINT`.
 
 ---
 
@@ -472,6 +509,9 @@ Return only the VLM's answer text to the user.
 
 - **`/vss-manage-video-io-storage`** — *optional* (Step 1, Path B): sensor list, timelines, and
   the clip URL when sourcing the video from VST/VIOS. Not needed when the user supplies the video.
+- **`/vss-deploy-dense-captioning`** — *optional* (Step 2): stand up a standalone **RT-VLM**
+  endpoint on a local GPU when no VLM is reachable, then point this skill at it
+  (`http://${HOST_IP}:${RTVI_VLM_PORT:-8018}/v1`, model resolved from `/v1/models`).
 - **`/vss-generate-video-report`** — timestamped **reports** via Mode A (the same direct-VLM
   mechanism) or Mode B (video-analytics incidents); this skill returns an ad-hoc **answer**, not a report.
 - **`/vss-query-analytics`** — read already-computed incidents/metrics (no live VLM inference).

--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -208,10 +208,15 @@ distroless (no `sh`/`bash`/`printenv` on `PATH`), so `docker exec vss-agent sh -
 
 ```bash
 # Only when an agent is actually running; otherwise supply VLM_ENDPOINT/VLM_MODEL directly (above).
+# Assign into a fixed whitelist of vars WITHOUT eval, so a hostile or malformed env value
+# (e.g. VLM_NAME='x; rm -rf /') is always treated as data and never executed.
 if docker ps --format '{{.Names}}' | grep -qx vss-agent; then
-  eval "$(docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}' \
-    | grep -E '^(HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL|RTVI_VLM_MODEL_TO_USE)=' \
-    | sed 's/^/export /')"
+  while IFS='=' read -r _k _v; do
+    case "$_k" in
+      HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL|RTVI_VLM_MODEL_TO_USE)
+        printf -v "$_k" '%s' "$_v"; export "$_k" ;;
+    esac
+  done < <(docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}')
 fi
 ```
 
@@ -234,13 +239,31 @@ if [ -z "${VLM_ENDPOINT:-}" ]; then
     VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
     VLM_MODEL="${VLM_NAME}"
   else
-    VLM_BACKEND="rtvlm"
-    VLM_ENDPOINT="${RTVI_VLM_BASE_URL:+${RTVI_VLM_BASE_URL%/}/v1}"
-    [ -z "${VLM_ENDPOINT}" ] && [ -n "${VLM_BASE_URL:-}" ] && VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
-    [ -z "${VLM_ENDPOINT}" ] && VLM_ENDPOINT="http://${HOST_IP}:30082/v1"  # base default
-    VLM_MODEL="${VLM_NAME:-${RTVI_VLM_MODEL_TO_USE}}"
+    # Fallback discovery: set VLM_BACKEND to match the endpoint we actually resolve, so the
+    # nim_cosmos mm_processor_kwargs step below fires when we land on a NIM Cosmos endpoint.
+    if [ -n "${RTVI_VLM_BASE_URL:-}" ]; then
+      VLM_BACKEND="rtvlm"
+      VLM_ENDPOINT="${RTVI_VLM_BASE_URL%/}/v1"
+      VLM_MODEL="${VLM_NAME:-${RTVI_VLM_MODEL_TO_USE}}"
+    elif [ -n "${VLM_BASE_URL:-}" ]; then
+      VLM_BACKEND="nim_cosmos"
+      VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
+      VLM_MODEL="${VLM_NAME}"
+    else
+      VLM_BACKEND="nim_cosmos"
+      VLM_ENDPOINT="http://${HOST_IP}:30082/v1"  # base default (NIM Cosmos)
+      VLM_MODEL="${VLM_NAME}"
+    fi
   fi
 fi
+
+# Never proceed with an empty model id (e.g. nim_cosmos when VLM_NAME was unset, or a
+# caller who supplied VLM_ENDPOINT but not VLM_MODEL): adopt the first id the endpoint
+# actually serves, then hard-fail if it is still empty rather than sending model="".
+if [ -z "${VLM_MODEL:-}" ] && [ -n "${VLM_ENDPOINT:-}" ]; then
+  VLM_MODEL="$(curl -sf --max-time 5 "${VLM_ENDPOINT}/models" | jq -r '.data[0].id // empty')"
+fi
+[ -n "${VLM_MODEL:-}" ] || { echo "Could not resolve a VLM model id for ${VLM_ENDPOINT:-<unset>}; set VLM_MODEL explicitly"; exit 1; }
 ```
 
 Probe `/v1/models` before sending a chat request to confirm the endpoint is alive and the model
@@ -272,7 +295,9 @@ if the VLM supports them:
 
 So: URL → `video_url`; local file / base64 → `file_base64`. Use `file_base64` (not `video_url`)
 whenever the VLM can't fetch the URL — a **remote** VLM that can't reach a `localhost`/internal
-`VIDEO_URL`. Mind the RT-VLM inline-base64 cap (~7.5 MB, `nim_compat.py max_length=10000000`). Set
+`VIDEO_URL`. Mind the RT-VLM inline-base64 cap: `nim_compat.py max_length=10000000` limits the
+base64 **string** to 10M characters, which — since base64 adds ~33% — means a raw clip of only
+**~7.5 MB** (a 10 MB MP4 base64-encodes to ~13.3M chars and is rejected). Set
 `UPLOAD_FORMAT` to force either one.
 
 On a NIM Cosmos **video block** — *both* the `video_url` path and the `file_base64` data-URI

--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -4,7 +4,6 @@ description: Use this skill to ask a fresh visual question about a recorded vide
 license: Apache-2.0
 metadata:
   version: "3.2.0"
-  author: "NVIDIA Video Search and Summarization team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"
 ---
@@ -173,6 +172,16 @@ Then go straight to Step 2 — **skip the Sensor check**.
 
 ### Path B — resolve from VST/VIOS (optional)
 
+> **Hard rule — on Path B the clip URL MUST come from VST.** When the video source is a VST
+> sensor / `streamId` (not a user-supplied local `VIDEO_FILE` or external URL), you **must**
+> obtain the clip by executing the VST clip-URL request below
+> (`GET /vst/api/v1/storage/file/<streamId>/url?startTime=…&endTime=…`) and binding its
+> `videoUrl` to `VIDEO_URL`. Do **not** skip this call by inlining some other local copy of the
+> clip as a `data:` base64 URI — that bypasses VST entirely and is wrong for this path. Inlining
+> is allowed **only after** the VST `videoUrl` is fetched and solely because a *remote* VLM can't
+> reach it (Step 3 then downloads *that* `VIDEO_URL` and base64-encodes it). The VST `/url` GET is
+> non-negotiable on Path B, even when the answer is a temporal question ("at what timestamp…").
+
 When the clip lives on a named sensor, hand off to `/vss-manage-video-io-storage` to:
 
 1. Confirm the named `<sensor-id>` exists (handled by the *Sensor check* above — required on
@@ -191,7 +200,9 @@ When the clip lives on a named sensor, hand off to `/vss-manage-video-io-storage
    Bind the result to `VIDEO_URL` (a direct `mp4` URL) and capture `CLIP_SECONDS`
    (endTime − startTime; default `15` if you analyzed the whole short clip). **If the `/url` call
    returns empty, fix the request — re-fetch timelines and pass `startTime`/`endTime`; do not
-   silently fall back to the local file on this VST path.**
+   silently fall back to the local file or a base64 data URI on this VST path.** This GET is the
+   single source of the clip on Path B (see the hard rule above); Step 3 may later inline the bytes
+   for a remote VLM, but only by downloading *this* `videoUrl`.
 
 Whether the VLM consumes `VIDEO_URL` as-is or needs the bytes uploaded inline depends on the
 target VLM — **Step 3 picks the right upload format**. A **local / in-cluster** VLM can usually
@@ -210,6 +221,23 @@ reachable OpenAI-compatible `chat/completions` endpoint:
 # Caller-provided (preferred when the full agent stack is not deployed):
 #   VLM_ENDPOINT  e.g. http://${HOST_IP}:30082/v1   (must end in /v1)
 #   VLM_MODEL     e.g. nvidia/cosmos-reason1-7b
+```
+
+Or, when only a **deployed VSS** is reachable (you have its **public URL**, not the VLM's own
+port), route through the VSS **ingress proxy** instead of hitting the VLM/RT-VLM port directly.
+The proxy exposes the active VLM (RT-VLM or NIM) under one stable path, so this works cross-host,
+without Docker access, and regardless of which backend the profile deployed:
+
+```bash
+#   VSS_ENDPOINT  e.g. http://<vss-public-host>:<ingress-port>   (the deployed VSS public URL)
+if [ -z "${VLM_ENDPOINT:-}" ] && [ -n "${VSS_ENDPOINT:-}" ]; then
+  _proxy="${VSS_ENDPOINT%/}/vlm/v1"                 # ingress VLM route (haproxy /vlm backend)
+  if curl -sf --max-time 5 "${_proxy}/models" >/dev/null 2>&1; then
+    VLM_ENDPOINT="${_proxy}"
+    VLM_MODEL="${VLM_MODEL:-$(curl -sf --max-time 5 "${_proxy}/models" | jq -r '.data[0].id // empty')}"
+    # If the VLM is token-gated behind the proxy, add: -H "Authorization: Bearer <token>"
+  fi
+fi
 ```
 
 Otherwise auto-discover the live endpoint from the running `vss-agent` container. The deploy may
@@ -293,18 +321,22 @@ place — follow *No default VLM selection?* below instead of silently failing.
 
 ### No default VLM selection? Discover first, then prompt (VIA-E-114-04)
 
-Discovery above always runs **first** — an explicit `VLM_ENDPOINT`, then the running `vss-agent`
-env, then the default ports (`:30082` NIM / `:8018` RT-VLM), each confirmed live with `/v1/models`.
-When that yields a reachable endpoint, use it and continue to Step 3 — **do not prompt**.
+Discovery above always runs **first** — an explicit `VLM_ENDPOINT`, then a deployed VSS via its
+public URL (`VSS_ENDPOINT` → ingress proxy `/vlm/v1`), then the running `vss-agent` env, then the
+default ports (`:30082` NIM / `:8018` RT-VLM), each confirmed live with `/v1/models`. When that
+yields a reachable endpoint, use it and continue to Step 3 — **do not prompt**.
 
 Only when **no** endpoint resolves (no default selection is in place) prompt the user for how to
 supply a VLM (HITL-optional — see the non-interactive default below). Offer three choices:
 
-1. **Provide an endpoint** — take `VLM_ENDPOINT` (+ optional `VLM_MODEL`), then re-probe
+1. **Provide a VLM endpoint** — take `VLM_ENDPOINT` (+ optional `VLM_MODEL`), then re-probe
    `/v1/models` and continue.
-2. **Pick a discovered suggestion** — list any endpoints that responded (from the `vss-agent`
-   env, or the default `:30082` / `:8018` ports) and let the user choose one.
-3. **Deploy a local RT-VLM** — hand off to
+2. **Provide a deployed VSS public URL** — take `VSS_ENDPOINT`; resolve the VLM through the VSS
+   ingress proxy (`${VSS_ENDPOINT%/}/vlm/v1`), confirm with `/v1/models`, then continue. Use this
+   when the VLM/RT-VLM port isn't directly reachable but the VSS ingress is.
+3. **Pick a discovered suggestion** — list any endpoints that responded (the VSS proxy, the
+   `vss-agent` env, or the default `:30082` / `:8018` ports) and let the user choose one.
+4. **Deploy a local RT-VLM** — hand off to
    [`/vss-deploy-dense-captioning`](../vss-deploy-dense-captioning/SKILL.md) (default model
    **cosmos-reason2-8b**, profile `bp_developer_alerts_2d_vlm`; this tracks the RT-VLM deploy
    default — cosmos-reason2 today, cosmos-reason3 once 3.2.1 ships), then resume against the
@@ -323,8 +355,8 @@ supply a VLM (HITL-optional — see the non-interactive default below). Offer th
 
 **Non-interactive / HITL-disabled (CI, headless agents):** do not block on a prompt. If a
 discovered endpoint already exists, use it; otherwise the default action is to **deploy a local
-RT-VLM** (option 3) and continue. Hard-fail only when a deploy is impossible (no GPU or no
-`NGC_CLI_API_KEY`), printing the three options above so the caller can set `VLM_ENDPOINT`.
+RT-VLM** (option 4) and continue. Hard-fail only when a deploy is impossible (no GPU or no
+`NGC_CLI_API_KEY`), printing the options above so the caller can set `VLM_ENDPOINT` / `VSS_ENDPOINT`.
 
 ---
 
@@ -378,9 +410,12 @@ fi
 
 # Derive backend if Step 2 was skipped (caller supplied VLM_ENDPOINT/VLM_MODEL directly).
 [ -z "${VLM_BACKEND:-}" ] && {
+  # Prefix-agnostic (matches the *cosmos* family used by the MM_KWARGS block below), so a
+  # self-hosted NIM advertising a bare id (e.g. cosmos-reason2-8b, no nvidia/ prefix) still
+  # resolves to nim_cosmos and gets the required frame-sampling kwargs.
   case "${VLM_MODEL:-}" in
-    nvidia/cosmos*) VLM_BACKEND="nim_cosmos" ;;
-    *)              VLM_BACKEND="rtvlm" ;;
+    *cosmos*) VLM_BACKEND="nim_cosmos" ;;
+    *)        VLM_BACKEND="rtvlm" ;;
   esac
 }
 

--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -20,6 +20,14 @@ straight from the user (a local file inlined as base64, or a URL the VLM fetches
 **VST/VIOS is optional**: when it is available the skill can resolve a recorded clip URL
 from a named sensor, but it is never required.
 
+> **Hard rule — never call `/generate`.** Every question, including **temporal /
+> timing ones** ("at what timestamp did X happen", "how long", "when does Y start"),
+> is answered by a single **`POST {VLM_ENDPOINT}/v1/chat/completions`** call built in
+> Step 3. Do **not** `POST` to `http://<host>:8000/generate` (the VSS agent's summarize
+> pipeline) or `/v1/summarize` under any circumstances — a timestamp question does **not**
+> mean you should switch to the summarization pipeline; ask the VLM directly and read the
+> timing out of its answer.
+
 This is the same direct-VLM mechanism `vss-generate-video-report` uses in Mode A — the
 difference is that this skill sends the **user's own question** as the prompt and returns
 the **plain VLM answer**, not a filled report template.
@@ -213,7 +221,7 @@ distroless (no `sh`/`bash`/`printenv` on `PATH`), so `docker exec vss-agent sh -
 if docker ps --format '{{.Names}}' | grep -qx vss-agent; then
   while IFS='=' read -r _k _v; do
     case "$_k" in
-      HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL|RTVI_VLM_MODEL_TO_USE)
+      HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL)
         printf -v "$_k" '%s' "$_v"; export "$_k" ;;
     esac
   done < <(docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}')
@@ -227,32 +235,33 @@ if [ -z "${VLM_ENDPOINT:-}" ]; then
   if [ "${VLM_MODEL_TYPE:-}" = "rtvi" ]; then
     # RT-VLM (lvs / alerts). The API model id is VLM_NAME (e.g. nim_nvidia_cosmos-reason2-8b_hf-1208)
     # — it matches RT-VLM's /v1/models and is what the agent itself uses (config rtvi_vlm.model_name:
-    # ${VLM_NAME}). Do NOT use RTVI_VLM_MODEL_TO_USE: it is an RT-VLM *backend selector* (e.g.
-    # "cosmos-reason2"), not an API model id, and it is not even exposed on the vss-agent container.
+    # ${VLM_NAME}). We deliberately do NOT read RTVI_VLM_MODEL_TO_USE: it is an RT-VLM *backend
+    # selector* (e.g. "cosmos-reason2"), not an API model id, and it is not exposed on the
+    # vss-agent container. If VLM_NAME is empty the /v1/models guard below resolves the real id.
     VLM_BACKEND="rtvlm"
     VLM_ENDPOINT="${RTVI_VLM_BASE_URL:+${RTVI_VLM_BASE_URL%/}/v1}"
     [ -z "${VLM_ENDPOINT}" ] && [ -n "${VLM_BASE_URL:-}" ] && VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
     [ -z "${VLM_ENDPOINT}" ] && VLM_ENDPOINT="http://${HOST_IP}:8018/v1"   # lvs/alerts default
-    VLM_MODEL="${VLM_NAME:-${RTVI_VLM_MODEL_TO_USE}}"
+    VLM_MODEL="${VLM_NAME:-}"
   elif [ -n "${VLM_BASE_URL:-}" ] && [ "${VLM_MODE:-}" != "none" ]; then
     VLM_BACKEND="nim_cosmos"
     VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
-    VLM_MODEL="${VLM_NAME}"
+    VLM_MODEL="${VLM_NAME:-}"
   else
     # Fallback discovery: set VLM_BACKEND to match the endpoint we actually resolve, so the
     # nim_cosmos mm_processor_kwargs step below fires when we land on a NIM Cosmos endpoint.
     if [ -n "${RTVI_VLM_BASE_URL:-}" ]; then
       VLM_BACKEND="rtvlm"
       VLM_ENDPOINT="${RTVI_VLM_BASE_URL%/}/v1"
-      VLM_MODEL="${VLM_NAME:-${RTVI_VLM_MODEL_TO_USE}}"
+      VLM_MODEL="${VLM_NAME:-}"
     elif [ -n "${VLM_BASE_URL:-}" ]; then
       VLM_BACKEND="nim_cosmos"
       VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
-      VLM_MODEL="${VLM_NAME}"
+      VLM_MODEL="${VLM_NAME:-}"
     else
       VLM_BACKEND="nim_cosmos"
       VLM_ENDPOINT="http://${HOST_IP}:30082/v1"  # base default (NIM Cosmos)
-      VLM_MODEL="${VLM_NAME}"
+      VLM_MODEL="${VLM_NAME:-}"
     fi
   fi
 fi

--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -176,17 +176,21 @@ When the clip lives on a named sensor, hand off to `/vss-manage-video-io-storage
 
 1. Confirm the named `<sensor-id>` exists (handled by the *Sensor check* above — required on
    this path).
-2. Fetch `/storage/<streamId>/timelines` for the recorded range when the user did not name a
-   specific segment.
-3. Request a clip URL (default to the full recorded range when the user did not ask about a
-   specific time window):
+2. **Always fetch `/storage/<streamId>/timelines` first** to obtain a valid recorded range —
+   you need concrete `startTime`/`endTime` values for the next call. Do this even when the user
+   did not name a specific segment (use the full returned range in that case).
+3. Request a clip URL. **`startTime` and `endTime` are required** — the `/url` endpoint returns
+   an **empty body** when they are omitted, so always pass the range from step 2 (default to the
+   full recorded range when the user did not ask about a specific window):
 
    ```bash
    curl -s "http://${HOST_IP}:30888/vst/api/v1/storage/file/<streamId>/url?startTime=<startTime>&endTime=<endTime>&container=mp4&disableAudio=true" | jq -r .videoUrl
    ```
 
    Bind the result to `VIDEO_URL` (a direct `mp4` URL) and capture `CLIP_SECONDS`
-   (endTime − startTime; default `15` if you analyzed the whole short clip).
+   (endTime − startTime; default `15` if you analyzed the whole short clip). **If the `/url` call
+   returns empty, fix the request — re-fetch timelines and pass `startTime`/`endTime`; do not
+   silently fall back to the local file on this VST path.**
 
 Whether the VLM consumes `VIDEO_URL` as-is or needs the bytes uploaded inline depends on the
 target VLM — **Step 3 picks the right upload format**. A **local / in-cluster** VLM can usually

--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -27,18 +27,13 @@ from a named sensor, but it is never required.
 > mean you should switch to the summarization pipeline; ask the VLM directly and read the
 > timing out of its answer.
 
-This is the same direct-VLM mechanism `vss-generate-video-report` uses in Mode A — the
-difference is that this skill sends the **user's own question** as the prompt and returns
-the **plain VLM answer**, not a filled report template.
-
 ---
 
 ## Agent harness
 
-This skill is **harness-agnostic** — whatever runs it (Claude Code, Codex, Cursor, or the NAT
-VSS Agent) is the orchestrator. It calls the VLM `chat/completions` REST API directly and never
-uses the agent's `POST /generate`. A running `vss-agent` is optional: Step 2 can auto-discover the
-VLM from it, but you can always pass `VLM_ENDPOINT` / `VLM_MODEL` yourself instead.
+**Harness-agnostic** — whatever runs it (Claude Code, Codex, Cursor, or the NAT VSS Agent) calls
+the VLM REST API directly. A running `vss-agent` is optional: Step 2 auto-discovers the VLM from
+it, or you pass `VLM_ENDPOINT` / `VLM_MODEL` yourself.
 
 ---
 
@@ -82,20 +77,14 @@ Do **not** use this skill when the request is one of the following:
 
 ## Prerequisites
 
-This skill has prerequisites but **does not require any specific VSS profile**, and it **does
-not require VST/VIOS**. It runs at runtime against whatever is already serving — if a VLM/RT-VLM
-endpoint is up, point the skill at it and use it; no deploy step is needed. At runtime it needs:
+No specific VSS profile is required, and VST/VIOS is optional — the skill runs against whatever is
+already serving. At runtime it needs:
 
-1. **A reachable OpenAI-compatible VLM `chat/completions` endpoint** *(the only hard
-   requirement)* — NIM Cosmos, RT-VLM, or any other. If one is already running, set
-   `VLM_ENDPOINT` / `VLM_MODEL` directly (Step 2). If none is running, Step 2 discovers one and,
-   failing that, can prompt to **deploy a local RT-VLM** via `/vss-deploy-dense-captioning`.
-2. **A video to ask about.** Either of:
-   - **Provided directly by the user** — a local file (inlined as a base64 video block) or a URL
-     (sent as a `video_url` block the VLM fetches). **No VST/VIOS needed.** This is the default
-     path (Step 1, Path A).
-   - **Resolved from VST/VIOS** *(optional)* — when the clip lives on a named sensor, the skill
-     looks it up and requests a clip URL (Step 1, Path B).
+1. **A reachable OpenAI-compatible VLM `chat/completions` endpoint** *(the only hard requirement)*
+   — NIM Cosmos, RT-VLM, or any other. Set `VLM_ENDPOINT` / `VLM_MODEL` directly, or let Step 2
+   discover one (and, failing that, deploy a local RT-VLM via `/vss-deploy-dense-captioning`).
+2. **A video** — either provided directly (local file → base64, or URL → `video_url`; Step 1
+   Path A), or resolved from a VST/VIOS sensor *(optional)* (Step 1 Path B).
 
 Probe what's actually available — only the VLM endpoint is mandatory:
 
@@ -172,15 +161,11 @@ Then go straight to Step 2 — **skip the Sensor check**.
 
 ### Path B — resolve from VST/VIOS (optional)
 
-> **Hard rule — on Path B the clip URL MUST come from VST.** When the video source is a VST
-> sensor / `streamId` (not a user-supplied local `VIDEO_FILE` or external URL), you **must**
-> obtain the clip by executing the VST clip-URL request below
-> (`GET /vst/api/v1/storage/file/<streamId>/url?startTime=…&endTime=…`) and binding its
-> `videoUrl` to `VIDEO_URL`. Do **not** skip this call by inlining some other local copy of the
-> clip as a `data:` base64 URI — that bypasses VST entirely and is wrong for this path. Inlining
-> is allowed **only after** the VST `videoUrl` is fetched and solely because a *remote* VLM can't
-> reach it (Step 3 then downloads *that* `VIDEO_URL` and base64-encodes it). The VST `/url` GET is
-> non-negotiable on Path B, even when the answer is a temporal question ("at what timestamp…").
+> **Hard rule — on Path B the clip URL MUST come from VST.** When the source is a VST
+> sensor/`streamId`, obtain the clip via the `/url` GET below and bind its `videoUrl` to
+> `VIDEO_URL`. Do **not** skip this by inlining a local copy as base64 — that bypasses VST.
+> Inlining is allowed only for a genuinely remote VLM, and only by downloading *that* `videoUrl`.
+> Applies even to temporal questions ("at what timestamp…").
 
 When the clip lives on a named sensor, hand off to `/vss-manage-video-io-storage` to:
 
@@ -197,12 +182,10 @@ When the clip lives on a named sensor, hand off to `/vss-manage-video-io-storage
    curl -s "http://${HOST_IP}:30888/vst/api/v1/storage/file/<streamId>/url?startTime=<startTime>&endTime=<endTime>&container=mp4&disableAudio=true" | jq -r .videoUrl
    ```
 
-   Bind the result to `VIDEO_URL` (a direct `mp4` URL) and capture `CLIP_SECONDS`
-   (endTime − startTime; default `15` if you analyzed the whole short clip). **If the `/url` call
-   returns empty, fix the request — re-fetch timelines and pass `startTime`/`endTime`; do not
-   silently fall back to the local file or a base64 data URI on this VST path.** This GET is the
-   single source of the clip on Path B (see the hard rule above); Step 3 may later inline the bytes
-   for a remote VLM, but only by downloading *this* `videoUrl`.
+   Bind the result to `VIDEO_URL` (a direct `mp4` URL), set `VST_SOURCED=1` (marks this run as
+   Path B), and capture `CLIP_SECONDS` (endTime − startTime; default `15`). **If the `/url` call
+   returns empty, re-fetch timelines and pass `startTime`/`endTime`; do not fall back to a local
+   file or base64 on this path.**
 
 Whether the VLM consumes `VIDEO_URL` as-is or needs the bytes uploaded inline depends on the
 target VLM — **Step 3 picks the right upload format**. A **local / in-cluster** VLM can usually
@@ -382,6 +365,11 @@ base64 **string** to 10M characters, which — since base64 adds ~33% — means 
 **~7.5 MB** (a 10 MB MP4 base64-encodes to ~13.3M chars and is rejected). Set
 `UPLOAD_FORMAT` to force either one.
 
+> **VST-sourced (Path B) ⇒ `video_url`.** Use the VST `videoUrl` (in `VIDEO_URL`) as a `video_url`
+> block — an in-cluster VLM (incl. base NIM Cosmos) can fetch the `localhost:30888` URL. Never
+> inline a stray local copy as `file_base64`; do that only for a genuinely remote VLM, and only by
+> downloading *that* `videoUrl`. Applies to temporal questions too. (Enforced by the guard below.)
+
 On a NIM Cosmos **video block** — *both* the `video_url` path and the `file_base64` data-URI
 path — also send `mm_processor_kwargs` / `media_io_kwargs` to match the agent's frame-sampling and
 visual-token budget. This is **required**, not optional: without `media_io_kwargs.num_frames` the
@@ -418,6 +406,15 @@ fi
     *)        VLM_BACKEND="rtvlm" ;;
   esac
 }
+
+# Path B guard: a VST-sourced clip is ALWAYS the VST videoUrl, never a stray local copy.
+# If this run came from VST (VST_SOURCED=1) but VIDEO_URL is empty, the VST /url GET was skipped —
+# stop and fetch it (Step 1 Path B) instead of inlining a local file as base64.
+if [ "${VST_SOURCED:-0}" = "1" ] && [ -z "${VIDEO_URL:-}" ]; then
+  echo "VST-sourced clip but VIDEO_URL is empty — you skipped the VST /url GET (Path B). Fetch the clip URL first, do not inline a local copy."; exit 1
+fi
+# On Path B, ignore any stray local file: the VST videoUrl is the source of truth.
+[ "${VST_SOURCED:-0}" = "1" ] && VIDEO_FILE=""
 
 # Pick the format from the input you have (override by setting UPLOAD_FORMAT):
 #   a URL        -> video_url   (the VLM fetches it)

--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -1,62 +1,136 @@
 ---
 name: vss-ask-video
-description: Use this skill to ask the VSS agent's video_understanding tool a fresh visual question about a recorded clip. Not for prior tool output, search hits, or metadata-answerable questions.
+description: Use this skill to ask a fresh visual question about a recorded video clip by calling a VLM endpoint directly (OpenAI-compatible chat/completions). Not for prior tool output, search hits, or metadata-answerable questions.
 license: Apache-2.0
 metadata:
   version: "3.2.0"
+  author: "NVIDIA Video Search and Summarization team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"
 ---
 
-# Video QnA using VLM through VSS Agent
+# Video QnA using a VLM endpoint
 
-Use this skill when you need details about the video which requires VLM to look at the video frames — for example the agent has **no** usable prior answer and needs a **fresh look at the pixels** for a specific clip.
+Answer a fresh visual question about a video by calling an OpenAI-compatible
+**VLM `chat/completions` endpoint directly** — obtain the video, pick the live VLM
+endpoint/model, send the user's question with the video, and return the answer.
+**This skill does not call** `POST /generate` on the VSS agent. The **only hard
+requirement is a reachable, OpenAI-compatible VLM endpoint** — the video can come
+straight from the user (a local file inlined as base64, or a URL the VLM fetches). VSS
+**VST/VIOS is optional**: when it is available the skill can resolve a recorded clip URL
+from a named sensor, but it is never required.
+
+This is the same direct-VLM mechanism `vss-generate-video-report` uses in Mode A — the
+difference is that this skill sends the **user's own question** as the prompt and returns
+the **plain VLM answer**, not a filled report template.
+
+---
+
+## Agent harness
+
+This skill is **harness-agnostic** — whatever runs it (Claude Code, Codex, Cursor, or the NAT
+VSS Agent) is the orchestrator. It calls the VLM `chat/completions` REST API directly and never
+uses the agent's `POST /generate`. A running `vss-agent` is optional: Step 2 can auto-discover the
+VLM from it, but you can always pass `VLM_ENDPOINT` / `VLM_MODEL` yourself instead.
 
 ---
 
 ## When to Use
 
-- The user asks **what happens in the video**, what **objects / people / actions** appear, **colors**, **timing**, **safety**, or other **visual facts** that require watching the clip.
-- The user asks for **details** that **cannot be answered** from existing messages, summaries, Elasticsearch/MCP results, or filenames alone—you need **model inference on the video**.
+- The user asks **what happens in the video**, what **objects / people / actions** appear,
+  **colors**, **timing**, **safety**, or other **visual facts** that require watching the clip.
+- The user asks for **details** that **cannot be answered** from existing messages, summaries,
+  Elasticsearch/MCP results, or filenames alone—you need **model inference on the video**.
 - Follow-up questions about **content details** after a coarse summary or after report generation.
 
-Do **not** use this skill when a **database / MCP / prior tool output** already answers the question, unless the user explicitly wants **verification** against the video.
+---
+
+## Negative Triggers
+
+Do **not** use this skill when the request is one of the following:
+
+- A **database / MCP / prior tool output** already answers the question, unless the user
+  explicitly wants **verification** against the video → use `/vss-query-analytics`.
+- Archive/semantic similarity retrieval ("find forklifts", "search all videos for tailgating")
+  → use `/vss-search-archive`.
+- A request for a **formatted/structured report** ("generate a report", "analysis report")
+  → use `/vss-generate-video-report`.
+- Summarizing a long recording → use `/vss-summarize-video`.
+- Deploy/teardown/profile changes → use `/vss-deploy-profile`.
 
 ---
 
-## Deployment prerequisite
+## Instructions
 
-This skill requires a VSS profile that serves the `video_understanding` tool — typically **base** (recommended) or **lvs**. Before any request:
-
-1. Probe the VSS agent:
-   ```bash
-   curl -sf --max-time 5 "http://${HOST_IP}:8000/docs" >/dev/null
-   ```
-
-2. **If the probe fails**, ask the user:
-   > *"No VSS profile is running on `$HOST_IP`. Shall I deploy `base` (recommended for per-clip VLM QnA) using the `/vss-deploy-profile` skill? If you prefer `lvs`, say so."*
-
-   - If yes → hand off to `/vss-deploy-profile -p base` (or `-p lvs` if the user prefers). Return here once it succeeds.
-   - If no → stop.
-
-3. If the probe passes, proceed.
+1. **Verify prerequisites** — a reachable VLM endpoint (the only hard requirement) and a
+   video to ask about. No specific VSS profile is required, and VST/VIOS is optional
+   (see *Prerequisites*).
+2. **Run the numbered steps** — *Step 1* (obtain the video — directly from the user, or
+   optionally a clip URL from VST/VIOS) → *Step 2* (VLM endpoint/model) → *Step 3* (upload
+   the video in the format the target VLM requires and ask the user's question) →
+   *Step 4* (return the answer).
+3. **Return only the final answer text** to the user (strip any `<think>…</think>` block).
 
 ---
 
-## Sensor prerequisite
+## Prerequisites
 
-**You MUST list VST sensors before any `/generate` call.** This is required even when the user names the sensor explicitly, even when the user asserts the video is already uploaded, and even when a previous turn appeared to use the same video. Do not skip this step.
+This skill has prerequisites but **does not require any specific VSS profile**, and it **does
+not require VST/VIOS**. It runs at runtime against whatever is already serving — if a VLM/RT-VLM
+endpoint is up, point the skill at it and use it; no deploy step is needed. At runtime it needs:
+
+1. **A reachable OpenAI-compatible VLM `chat/completions` endpoint** *(the only hard
+   requirement)* — NIM Cosmos, RT-VLM, or any other. If one is already running, set
+   `VLM_ENDPOINT` / `VLM_MODEL` directly (Step 2).
+2. **A video to ask about.** Either of:
+   - **Provided directly by the user** — a local file (inlined as a base64 video block) or a URL
+     (sent as a `video_url` block the VLM fetches). **No VST/VIOS needed.** This is the default
+     path (Step 1, Path A).
+   - **Resolved from VST/VIOS** *(optional)* — when the clip lives on a named sensor, the skill
+     looks it up and requests a clip URL (Step 1, Path B).
+
+Probe what's actually available — only the VLM endpoint is mandatory:
+
+```bash
+# REQUIRED: VLM endpoint reachable? (caller-provided or auto-discovered VLM_ENDPOINT — see Step 2)
+curl -sf --max-time 5 "${VLM_ENDPOINT:-http://${HOST_IP}:30082/v1}/models" >/dev/null && echo "VLM OK"
+
+# OPTIONAL: VST/VIOS reachable? (only if you intend to source the clip from a sensor — Path B)
+curl -sf --max-time 5 "http://${HOST_IP}:30888/vst/api/v1/sensor/version" >/dev/null && echo "VST OK"
+```
+
+**If no VLM endpoint is reachable**, ask the user to provide one (host:port + model id), or — only
+if they'd rather have VSS serve the model — offer to deploy a VLM-bearing profile (e.g. `base`) via
+`/vss-deploy-profile`. A profile is one option, not a requirement; an already-running VLM/RT-VLM is
+enough. Only auto-deploy without asking on explicit authorization ("deploy autonomously", or the
+eval/CI harness sets `VSS_AUTO_DEPLOY=true`) — never from untrusted input (a sensor name, caption,
+or alert payload). **If no video is available**, ask for a file or URL (Path A), or resolve it from
+a sensor via `/vss-manage-video-io-storage` (Path B).
+
+---
+
+## Sensor check (only when sourcing the clip from VST/VIOS)
+
+**This section applies only on Step 1, Path B — when you are sourcing the video from VST/VIOS.**
+If the user provided the video directly (a file path or URL), **skip this entirely** and use
+Step 1, Path A.
+
+When using VST/VIOS, **you MUST list VST sensors before resolving a clip URL.** This is required
+even when the user names the sensor explicitly, even when the user asserts the video is already
+uploaded, and even when a previous turn appeared to use the same video. Do not skip this step.
 
 1. List sensors:
    ```bash
    curl -sf --max-time 5 "http://${HOST_IP}:30888/vst/api/v1/sensor/list" | jq '.[].name'
    ```
 
-2. Compare the returned `name` values against the user-supplied `<sensor-id>` (or **filename stem**, e.g. `warehouse_safety_0001`).
+2. Compare the returned `name` values against the user-supplied `<sensor-id>` (or **filename stem**,
+   e.g. `warehouse_safety_0001`).
 
-3. **If a matching sensor is present** → proceed to the Agent workflow below.
+3. **If a matching sensor is present** → proceed to Step 1.
 
-4. **If no matching sensor is present** — upload the video first, then re-list to confirm the new sensor appears:
+4. **If no matching sensor is present** — upload the video first, then re-list to confirm the new
+   sensor appears:
    ```bash
    # filename: must not contain whitespace
    # timestamp: ISO 8601 UTC — default 2025-01-01T00:00:00.000Z if user did not specify
@@ -65,59 +139,301 @@ This skill requires a VSS profile that serves the `video_understanding` tool —
      -H "Content-Length: <file_size_in_bytes>" \
      --upload-file /path/to/<filename> | jq .
    ```
-   See `/vss-manage-video-io-storage` for full upload semantics (v1 vs v2, conflict handling, delete flow). In interactive runs, confirm with the user before uploading. **Never** issue an unconditional PUT without first running the sensor-list check above — that is exactly the failure mode this prerequisite exists to prevent.
+   See `/vss-manage-video-io-storage` for full upload semantics (v1 vs v2, conflict handling,
+   delete flow). In interactive runs, confirm with the user before uploading. **Never** issue an
+   unconditional PUT without first running the sensor-list check above.
 
 ---
 
-## Agent workflow
+## Step 1 — Obtain the video
 
-The Sensor prerequisite above must have already confirmed (or made) the sensor exist on VST. Then:
+You need either a **local file** (`VIDEO_FILE`) or a **URL** (`VIDEO_URL`) for the clip. Pick
+the path that matches how the video was provided. Also capture the clip length in seconds as
+`CLIP_SECONDS` when known (used for frame sampling; default `15`).
 
-1. **Clip** — Identify **sensor id**, **filename**, or **URL** for one video segment. If ambiguous, ask the user.
-2. Call vss agent with the sensor id and ask for it to call video_understanding tool to answer the user's question.
-3. Return the vss agent's answer back to the user.
+### Path A — provided directly by the user (default; no VST/VIOS)
 
+If the user hands you a file path or a URL, use it directly — **VST/VIOS is not involved**:
 
-## Query VSS agent (`/generate`)
+- **Local file** → set `VIDEO_FILE=/path/to/clip.mp4`. Step 3 inlines it as a base64 video block
+  (`file_base64`) so the VLM ingests the video directly. Nothing is downloaded.
+- **URL the VLM can fetch** → set `VIDEO_URL=<url>`. Step 3 sends it as a `video_url` block; if the
+  VLM is remote and can't reach the URL, inline it instead (`file_base64`).
+
+Then go straight to Step 2 — **skip the Sensor check**.
+
+### Path B — resolve from VST/VIOS (optional)
+
+When the clip lives on a named sensor, hand off to `/vss-manage-video-io-storage` to:
+
+1. Confirm the named `<sensor-id>` exists (handled by the *Sensor check* above — required on
+   this path).
+2. Fetch `/storage/<streamId>/timelines` for the recorded range when the user did not name a
+   specific segment.
+3. Request a clip URL (default to the full recorded range when the user did not ask about a
+   specific time window):
+
+   ```bash
+   curl -s "http://${HOST_IP}:30888/vst/api/v1/storage/file/<streamId>/url?startTime=<startTime>&endTime=<endTime>&container=mp4&disableAudio=true" | jq -r .videoUrl
+   ```
+
+   Bind the result to `VIDEO_URL` (a direct `mp4` URL) and capture `CLIP_SECONDS`
+   (endTime − startTime; default `15` if you analyzed the whole short clip).
+
+Whether the VLM consumes `VIDEO_URL` as-is or needs the bytes uploaded inline depends on the
+target VLM — **Step 3 picks the right upload format**. A **local / in-cluster** VLM can usually
+fetch `VIDEO_URL` directly; a **remote** VLM generally cannot reach `localhost`, a private
+`HOST_IP`, or VST-internal URLs, so Step 3 downloads the clip and sends it inline (full-file
+base64). A user-supplied `VIDEO_FILE` (Path A) is always inlined — there is no URL to fetch.
+
+---
+
+## Step 2 — Resolve the VLM endpoint and model
+
+If the caller already provides a VLM endpoint, use it directly — this skill only requires a
+reachable OpenAI-compatible `chat/completions` endpoint:
 
 ```bash
-# Set from deployment (compose / .env / host where vss-agent listens)
-export VSS_AGENT_BASE_URL="http://localhost:8000"
-
-curl -s -X POST "${VSS_AGENT_BASE_URL}/generate" \
-  -H "Content-Type: application/json" \
-  -d '{"input_message": "Call video_understanding tool to answer the following question about <sensor-id>: <user query>"}' | jq .
+# Caller-provided (preferred when the full agent stack is not deployed):
+#   VLM_ENDPOINT  e.g. http://${HOST_IP}:30082/v1   (must end in /v1)
+#   VLM_MODEL     e.g. nvidia/cosmos-reason1-7b
 ```
 
-### Response contract and extraction
+Otherwise auto-discover the live endpoint from the running `vss-agent` container. The deploy may
+serve the VLM through either of two OpenAI-compatible stacks — read the live values, do not guess.
 
-`/generate` returns a JSON object with the assistant output in `value`, for example:
-
-```json
-{"value":"<agent-think><agent-think-step ...>...</agent-think-step></agent-think>\n\n<final answer>\n\n"}
-```
-
-There is no separate clean-answer field. The consumable answer is the text in `.value` after removing any `<agent-think>...</agent-think>` block.
-
-Required handling for this skill (and any downstream caller):
-
-1. Read `.value` from the JSON response.
-2. Strip `<agent-think>...</agent-think>` sections wherever they appear.
-3. Return only the remaining final-answer text to the user.
-
-Example extraction:
+Read the agent's env with `docker inspect`, **not** `docker exec`: the `vss-agent` image is
+distroless (no `sh`/`bash`/`printenv` on `PATH`), so `docker exec vss-agent sh -lc …` fails with
+`exec: "sh": executable file not found`. `docker inspect` reads the configured env without a shell:
 
 ```bash
-curl -s -X POST "${VSS_AGENT_BASE_URL}/generate" \
-  -H "Content-Type: application/json" \
-  -d '{"input_message":"Call video_understanding tool to answer the following question about <sensor-id>: <user query>"}' \
-| jq -r '.value' \
-| python3 -c 'import re,sys; t=sys.stdin.read(); t=re.sub(r"<agent-think>.*?</agent-think>\s*", "", t, flags=re.S); print(t.strip())'
+# Only when an agent is actually running; otherwise supply VLM_ENDPOINT/VLM_MODEL directly (above).
+if docker ps --format '{{.Names}}' | grep -qx vss-agent; then
+  eval "$(docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}' \
+    | grep -E '^(HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL|RTVI_VLM_MODEL_TO_USE)=' \
+    | sed 's/^/export /')"
+fi
 ```
+
+Selection rule (only when `VLM_ENDPOINT` is not already set):
+
+```bash
+if [ -z "${VLM_ENDPOINT:-}" ]; then
+  if [ "${VLM_MODEL_TYPE:-}" = "rtvi" ]; then
+    # RT-VLM (lvs / alerts). The API model id is VLM_NAME (e.g. nim_nvidia_cosmos-reason2-8b_hf-1208)
+    # — it matches RT-VLM's /v1/models and is what the agent itself uses (config rtvi_vlm.model_name:
+    # ${VLM_NAME}). Do NOT use RTVI_VLM_MODEL_TO_USE: it is an RT-VLM *backend selector* (e.g.
+    # "cosmos-reason2"), not an API model id, and it is not even exposed on the vss-agent container.
+    VLM_BACKEND="rtvlm"
+    VLM_ENDPOINT="${RTVI_VLM_BASE_URL:+${RTVI_VLM_BASE_URL%/}/v1}"
+    [ -z "${VLM_ENDPOINT}" ] && [ -n "${VLM_BASE_URL:-}" ] && VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
+    [ -z "${VLM_ENDPOINT}" ] && VLM_ENDPOINT="http://${HOST_IP}:8018/v1"   # lvs/alerts default
+    VLM_MODEL="${VLM_NAME:-${RTVI_VLM_MODEL_TO_USE}}"
+  elif [ -n "${VLM_BASE_URL:-}" ] && [ "${VLM_MODE:-}" != "none" ]; then
+    VLM_BACKEND="nim_cosmos"
+    VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
+    VLM_MODEL="${VLM_NAME}"
+  else
+    VLM_BACKEND="rtvlm"
+    VLM_ENDPOINT="${RTVI_VLM_BASE_URL:+${RTVI_VLM_BASE_URL%/}/v1}"
+    [ -z "${VLM_ENDPOINT}" ] && [ -n "${VLM_BASE_URL:-}" ] && VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
+    [ -z "${VLM_ENDPOINT}" ] && VLM_ENDPOINT="http://${HOST_IP}:30082/v1"  # base default
+    VLM_MODEL="${VLM_NAME:-${RTVI_VLM_MODEL_TO_USE}}"
+  fi
+fi
+```
+
+Probe `/v1/models` before sending a chat request to confirm the endpoint is alive and the model
+is loaded:
+
+```bash
+curl -sf --max-time 5 "${VLM_ENDPOINT}/models" | jq -r '.data[].id'
+```
+
+If the probe fails or the listed ids don't include `${VLM_MODEL}`, fall back to the other backend
+(or surface the error — never silently pick a model that isn't on the server).
+
+---
+
+## Step 3 — Upload the clip in the target VLM's format and ask the question
+
+Send the **user's question** (not a fixed prompt) to the OpenAI-compatible `chat/completions`
+endpoint — but **upload the clip in the format the target VLM/microservice requires**, the same
+way the agent's `video_understanding` tool does (`src/vss_agents/tools/video_understanding.py`,
+`_build_vlm_messages`). There is no one-size-fits-all payload:
+
+**The input you have decides the block** — there's no priority to agonize over; all three work
+if the VLM supports them:
+
+| `UPLOAD_FORMAT` | What it sends | Use when the input is… |
+|---|---|---|
+| `video_url` | a `video_url` block with the URL (the VLM fetches it) | a **URL** the VLM can reach (a VST clip URL, or a user-supplied URL) |
+| `file_base64` | the MP4 inlined as a `data:video/mp4;base64,…` URI | a **local file** (or already-base64 data) — the VLM ingests the video directly |
+
+So: URL → `video_url`; local file / base64 → `file_base64`. Use `file_base64` (not `video_url`)
+whenever the VLM can't fetch the URL — a **remote** VLM that can't reach a `localhost`/internal
+`VIDEO_URL`. Mind the RT-VLM inline-base64 cap (~7.5 MB, `nim_compat.py max_length=10000000`). Set
+`UPLOAD_FORMAT` to force either one.
+
+On a NIM Cosmos **video block** — *both* the `video_url` path and the `file_base64` data-URI
+path — also send `mm_processor_kwargs` / `media_io_kwargs` to match the agent's frame-sampling and
+visual-token budget. This is **required**, not optional: without `media_io_kwargs.num_frames` the
+NIM under-samples the inline MP4 and can return a confident but wrong description (verified against
+`cosmos-reason2-8b`). Read the live `video_understanding` settings if the `vss-agent` container is
+up, else use the documented defaults.
+
+```bash
+USER_QUESTION='<the user's question, verbatim>'
+
+# Reasoning is OFF by default (matches the base-profile video_understanding config: reasoning=false).
+# Append the Cosmos Reason reasoning suffix ONLY when the user explicitly asks for reasoning
+# (and only for cosmos-reason models). With reasoning off, the response has no <think> block.
+PROMPT="${USER_QUESTION}"
+if [ "${REASONING:-false}" = "true" ]; then
+PROMPT="${PROMPT}
+
+Answer the question using the following format:
+
+<think>
+Your reasoning.
+</think>
+
+Write your final answer immediately after the </think> tag."
+fi
+
+# Derive backend if Step 2 was skipped (caller supplied VLM_ENDPOINT/VLM_MODEL directly).
+[ -z "${VLM_BACKEND:-}" ] && {
+  case "${VLM_MODEL:-}" in
+    nvidia/cosmos*) VLM_BACKEND="nim_cosmos" ;;
+    *)              VLM_BACKEND="rtvlm" ;;
+  esac
+}
+
+# Pick the format from the input you have (override by setting UPLOAD_FORMAT):
+#   a URL        -> video_url   (the VLM fetches it)
+#   a local file -> file_base64 (inline the MP4 as a data: URI; the VLM ingests the video)
+if [ -z "${UPLOAD_FORMAT:-}" ]; then
+  if [ -n "${VIDEO_URL:-}" ]; then
+    UPLOAD_FORMAT="video_url"
+  elif [ -n "${VIDEO_FILE:-}" ]; then
+    UPLOAD_FORMAT="file_base64"
+  else
+    echo "No video input: set VIDEO_URL (a URL) or VIDEO_FILE (a local path)"; exit 1
+  fi
+fi
+
+# Frame-sampling + visual-token budget — these are the base-profile video_understanding
+# defaults; override via env if your deployment customized them.
+MAX_FPS="${MAX_FPS:-2}"; MAX_FRAMES="${MAX_FRAMES:-30}"
+MIN_PIXELS="${MIN_PIXELS:-3136}"; MAX_PIXELS="${MAX_PIXELS:-8388608}"
+
+# num_frames = min(int(clip_seconds) * max_fps, max_frames), min 1 — matches video_understanding.py.
+CLIP_SECONDS=$(awk -v s="${CLIP_SECONDS:-15}" 'BEGIN{printf "%d", s}')
+NUM_FRAMES=$(( CLIP_SECONDS * MAX_FPS ))
+[ "$NUM_FRAMES" -gt "$MAX_FRAMES" ] && NUM_FRAMES=$MAX_FRAMES
+[ "$NUM_FRAMES" -lt 1 ] && NUM_FRAMES=1
+
+# When the clip must be inlined, work from a local file: use a user-supplied VIDEO_FILE
+# (Path A) as-is, otherwise download VIDEO_URL (Path B) once.
+LOCAL_CLIP="${VIDEO_FILE:-}"
+if [ -z "$LOCAL_CLIP" ] && [ "$UPLOAD_FORMAT" = "file_base64" ]; then
+  LOCAL_CLIP=/tmp/ask_video_clip.mp4
+  curl -sf --max-time 300 "${VIDEO_URL}" -o "$LOCAL_CLIP" || { echo "Failed to fetch clip for inline upload"; exit 1; }
+fi
+
+# Build the media content block(s) per UPLOAD_FORMAT. (base64 -w0 is GNU coreutils.)
+MM_KWARGS=""
+case "$UPLOAD_FORMAT" in
+  video_url)
+    [ -n "${VIDEO_URL:-}" ] || { echo "UPLOAD_FORMAT=video_url needs a fetchable VIDEO_URL — for a local VIDEO_FILE use file_base64"; exit 1; }
+    MEDIA_CONTENT="{\"type\": \"video_url\", \"video_url\": {\"url\": $(jq -n --arg u "${VIDEO_URL}" '$u')}}"
+    ;;
+  file_base64)
+    B64=$(base64 -w0 "$LOCAL_CLIP")
+    MEDIA_CONTENT="{\"type\": \"video_url\", \"video_url\": {\"url\": \"data:video/mp4;base64,${B64}\"}}"
+    ;;
+esac
+
+# Cosmos NIM frame-sampling + visual-token budget. REQUIRED on both video-block paths
+# (`video_url` AND `file_base64` data-URI): without `media_io_kwargs.num_frames` the NIM
+# under-samples the inline MP4 and can hallucinate (verified on cosmos-reason2-8b). Not needed
+# for RT-VLM (preprocesses server-side).
+if [ "${VLM_BACKEND}" = "nim_cosmos" ] && { [ "$UPLOAD_FORMAT" = "video_url" ] || [ "$UPLOAD_FORMAT" = "file_base64" ]; }; then
+  case "$VLM_MODEL" in
+    *cosmos-reason2*) MM_KWARGS=", \"mm_processor_kwargs\": {\"size\": {\"shortest_edge\": ${MIN_PIXELS}, \"longest_edge\": ${MAX_PIXELS}}}, \"media_io_kwargs\": {\"video\": {\"num_frames\": ${NUM_FRAMES}}}" ;;
+    *cosmos*)         MM_KWARGS=", \"mm_processor_kwargs\": {\"videos_kwargs\": {\"min_pixels\": ${MIN_PIXELS}, \"max_pixels\": ${MAX_PIXELS}}}, \"media_io_kwargs\": {\"video\": {\"num_frames\": ${NUM_FRAMES}}}" ;;
+  esac
+fi
+
+curl -s --connect-timeout 5 --max-time 120 -X POST "${VLM_ENDPOINT}/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d @- <<EOF | jq -r '.choices[0].message.content'
+{
+  "model": $(jq -n --arg m "${VLM_MODEL}" '$m'),
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": $(jq -n --arg t "${PROMPT}" '$t')},
+        ${MEDIA_CONTENT}
+      ]
+    }
+  ],
+  "max_tokens": 1024,
+  "temperature": 0.0${MM_KWARGS}
+}
+EOF
+```
+
+---
+
+## Step 4 — Return the answer
+
+Return only the VLM's answer text to the user.
+
+- If the response contains a `<think>…</think>` block (Cosmos Reason reasoning mode), keep only
+  the text after `</think>`.
+- Do not wrap the answer in a report template — this skill returns the plain answer (light
+  markdown is fine).
+
+---
+
+## Examples
+
+- "What's happening in this clip? `/home/me/forklift.mp4`" → **no VST/VIOS**: set
+  `VIDEO_FILE`, inline it as a base64 video block (Path A), call the VLM, return the answer.
+- "Is the worker wearing PPE? `https://example.com/clip.mp4`" → set `VIDEO_URL` (Path A); a
+  local VLM fetches it directly, a remote VLM gets it inlined.
+- "Is the worker in `warehouse_safety_0001` wearing PPE?" → sensor name → VST/VIOS (Path B):
+  resolve clip URL, call the VLM, return the answer.
+- "At what timestamp did the worker climb the ladder?" → same VST path; the answer includes a timestamp.
+- "What color is the truck at 00:12 in `dock_cam`?" → VST path; resolve the segment around 00:12, call the VLM.
+
+---
+
+## Error Handling
+
+- If a probe, `curl`, or VLM call fails, stop and report the failing endpoint, HTTP status or
+  command error, and the next useful recovery step. Do not fabricate an answer.
+- If **no video is available** (neither `VIDEO_FILE` nor `VIDEO_URL`, and no sensor to resolve),
+  stop and ask the user for a file or URL — do not call the VLM without a video.
+- If `UPLOAD_FORMAT=video_url` but only a local `VIDEO_FILE` was provided, switch to
+  `file_base64` — there is no URL for the VLM to fetch.
+- If `/v1/models` succeeds but `${VLM_MODEL}` is not listed, fall back to the other backend or
+  surface the mismatch — never send a chat request for a model the server has not loaded.
+- If the VLM endpoint is **remote** and `VIDEO_URL` is a `localhost` / private-`HOST_IP` /
+  VST-internal URL, do **not** send a `video_url` block — Step 3 inlines the media instead
+  (`UPLOAD_FORMAT=file_base64`). Only surface an error if the inline upload itself fails
+  (download error, `base64` missing, or payload rejected as too large).
+- If the VLM response is empty, malformed, or contains only a reasoning block, surface that
+  response problem and suggest checking model readiness/logs before retrying.
 
 ---
 
 ## Cross-Reference
 
-- **vss-manage-video-io-storage** — VST storage/replay URLs so **`VIDEO_URL`** is valid for the VLM.
-- **vss-generate-video-report** — timestamped **reports** via **Mode A (direct VLM)** or **Mode B (video-analytics incidents)**; this skill is **VSS-agent `/generate`** for ad-hoc **video Q&A**.
+- **`/vss-manage-video-io-storage`** — *optional* (Step 1, Path B): sensor list, timelines, and
+  the clip URL when sourcing the video from VST/VIOS. Not needed when the user supplies the video.
+- **`/vss-generate-video-report`** — timestamped **reports** via Mode A (the same direct-VLM
+  mechanism) or Mode B (video-analytics incidents); this skill returns an ad-hoc **answer**, not a report.
+- **`/vss-query-analytics`** — read already-computed incidents/metrics (no live VLM inference).

--- a/skills/vss-ask-video/evals/base_profile_video_understanding.json
+++ b/skills/vss-ask-video/evals/base_profile_video_understanding.json
@@ -12,7 +12,7 @@
   },
   "expects": [
     {
-      "query": "Deploy the VSS **base** profile on `{{platform}}` via `/vss-deploy-profile -p base`. Run autonomously.\n\n**Environment & prerequisites:** VSS **base** profile on the target host: VST reachable at http://localhost:30888/vst/api/v1, VLM endpoint reachable at either ${VLM_BASE_URL}/v1 (NIM Cosmos, picked when VLM_BASE_URL non-empty and VLM_MODE != none) or ${RTVI_VLM_BASE_URL}/v1 (RT-VLM Cosmos, picked otherwise; base default port 30082, alerts default 8018). Read VLM_BASE_URL / VLM_NAME / VLM_MODE / RTVI_VLM_BASE_URL / RTVI_VLM_MODEL_TO_USE off the vss-agent container env. The skill answers a visual question by calling the resolved VLM endpoint's /v1/chat/completions directly with a video_url block (it does NOT call POST /generate). The chosen VLM endpoint must be able to fetch the VST clip URL; prefer local NIM/RT-VLM unless the clip URL is externally reachable by the remote VLM. Set Brev secure-link vars if checks validate media URLs. (See `skills/vss-ask-video/SKILL.md`).",
+      "query": "Deploy the VSS **base** profile on `{{platform}}` via `/vss-deploy-profile -p base`. Run autonomously.\n\n**Environment & prerequisites:** VSS **base** profile on the target host: VST reachable at http://localhost:30888/vst/api/v1, VLM endpoint reachable at either ${VLM_BASE_URL}/v1 (NIM Cosmos, picked when VLM_BASE_URL non-empty and VLM_MODE != none) or ${RTVI_VLM_BASE_URL}/v1 (RT-VLM Cosmos, picked otherwise; base default port 30082, alerts default 8018). Read VLM_BASE_URL / VLM_NAME / VLM_MODE / RTVI_VLM_BASE_URL off the vss-agent container env. The skill answers a visual question by calling the resolved VLM endpoint's /v1/chat/completions directly with a video_url block (it does NOT call POST /generate). The chosen VLM endpoint must be able to fetch the VST clip URL; prefer local NIM/RT-VLM unless the clip URL is externally reachable by the remote VLM. Set Brev secure-link vars if checks validate media URLs. (See `skills/vss-ask-video/SKILL.md`).",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
@@ -34,7 +34,7 @@
       "checks": [
         "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:30888/vst/api/v1/sensor/version returns 200",
         "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body",
-        "Either VLM_BASE_URL + VLM_NAME (NIM Cosmos) or RTVI_VLM_BASE_URL + RTVI_VLM_MODEL_TO_USE (RT-VLM Cosmos) are resolvable from the vss-agent container environment (read via `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`; the image is distroless so `docker exec vss-agent env` will not work), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
+        "Either VLM_BASE_URL + VLM_NAME (NIM Cosmos) or RTVI_VLM_BASE_URL + VLM_NAME (RT-VLM Cosmos) are resolvable from the vss-agent container environment (read via `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`; the image is distroless so `docker exec vss-agent env` will not work), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
       ]
     },
     {

--- a/skills/vss-ask-video/evals/base_profile_video_understanding.json
+++ b/skills/vss-ask-video/evals/base_profile_video_understanding.json
@@ -12,7 +12,7 @@
   },
   "expects": [
     {
-      "query": "Deploy the VSS **base** profile on `{{platform}}` via `/vss-deploy-profile -p base`. Run autonomously.\n\n**Environment & prerequisites:** VSS **base** profile with the **`video_understanding` tool** exposed on the VSS agent. VSS agent HTTP API on **8000** (e.g. `http://localhost:8000/docs`), VST reachable at http://localhost:30888/vst/api/v1. Use **remote-all** (remote LLM + VLM) so no local NIMs are required.Set Brev secure-link env vars if checks validate `localhost` media URLs. The skill's canonical pattern is `POST /generate` with `input_message` that instructs the agent to use **`video_understanding`** to answer a **visual** question about a **named sensor** (see `skills/vss-ask-video/SKILL.md`).",
+      "query": "Deploy the VSS **base** profile on `{{platform}}` via `/vss-deploy-profile -p base`. Run autonomously.\n\n**Environment & prerequisites:** VSS **base** profile on the target host: VST reachable at http://localhost:30888/vst/api/v1, VLM endpoint reachable at either ${VLM_BASE_URL}/v1 (NIM Cosmos, picked when VLM_BASE_URL non-empty and VLM_MODE != none) or ${RTVI_VLM_BASE_URL}/v1 (RT-VLM Cosmos, picked otherwise; base default port 30082, alerts default 8018). Read VLM_BASE_URL / VLM_NAME / VLM_MODE / RTVI_VLM_BASE_URL / RTVI_VLM_MODEL_TO_USE off the vss-agent container env. The skill answers a visual question by calling the resolved VLM endpoint's /v1/chat/completions directly with a video_url block (it does NOT call POST /generate). The chosen VLM endpoint must be able to fetch the VST clip URL; prefer local NIM/RT-VLM unless the clip URL is externally reachable by the remote VLM. Set Brev secure-link vars if checks validate media URLs. (See `skills/vss-ask-video/SKILL.md`).",
       "checks": [
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
         "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
@@ -30,26 +30,29 @@
       ]
     },
     {
-      "query": "Verify the VSS stack is ready for the **vss-ask-video** skill. Confirm the agent serves OpenAPI at `/docs` and that VST lists at least one stream.",
+      "query": "Verify the VSS stack is ready for the **vss-ask-video** skill. Confirm VST is reachable and lists at least one stream, and that a VLM endpoint resolves.",
       "checks": [
-        "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:8000/docs returns 200",
-        "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body"
+        "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:30888/vst/api/v1/sensor/version returns 200",
+        "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body",
+        "Either VLM_BASE_URL + VLM_NAME (NIM Cosmos) or RTVI_VLM_BASE_URL + RTVI_VLM_MODEL_TO_USE (RT-VLM Cosmos) are resolvable from the vss-agent container environment (e.g. docker exec vss-agent env returns one set), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
       ]
     },
     {
       "query": "Is the worker in warehouse_safety_0001 wearing PPE?",
       "checks": [
-        "The run performed at least one successful `POST` to `http://localhost:8000/generate` (or equivalent agent base) with `Content-Type: application/json` and a body including `input_message` (HTTP 2xx).",
-        "The `input_message` text asks the user question and includes the sensor id warehouse_safety_0001",
-        "The final assistant reply is answers plain text or light markdown that the worker is wearing PPE according to the user question. There should be no errors included in the final response."
+        "The run performed at least one successful GET to a VST clip-URL endpoint of the form http://localhost:30888/vst/api/v1/storage/file/<streamId>/url with startTime and endTime query params and returned a JSON body containing videoUrl (the clip is sourced through /vss-manage-video-io-storage).",
+        "The run performed at least one successful POST to /v1/chat/completions on the resolved VLM endpoint (either ${VLM_BASE_URL}/v1 for NIM Cosmos or ${RTVI_VLM_BASE_URL}/v1 for RT-VLM Cosmos), with Content-Type application/json, a JSON body containing the resolved model id and a messages array whose first user content list contains both a text block with the user's question and a video_url block referencing the clip URL from the prior step; HTTP 2xx.",
+        "The run did NOT POST to http://localhost:8000/generate.",
+        "The final assistant reply answers in plain text or light markdown whether the worker is wearing PPE according to the user question, derived from the VLM response (any <think>...</think> block stripped). There should be no errors included in the final response."
       ]
     },
     {
       "query": "At what timestamp did the worker climb up the ladder?",
       "checks": [
-        "The run performed at least one successful `POST` to `http://localhost:8000/generate` (or equivalent agent base) with `Content-Type: application/json` and a body including `input_message` (HTTP 2xx).",
-        "The `input_message` text asks the user question and includes the sensor id warehouse_safety_0001",
-        "The final assistant reply answers the question in plain text or light markdown and includes a timestamp. There should be no errors included in the final response."
+        "The run performed at least one successful GET to a VST clip-URL endpoint of the form http://localhost:30888/vst/api/v1/storage/file/<streamId>/url with startTime and endTime query params and returned a JSON body containing videoUrl.",
+        "The run performed at least one successful POST to /v1/chat/completions on the resolved VLM endpoint with a video_url block referencing that clip URL and the user's question as a text block; HTTP 2xx.",
+        "The run did NOT POST to http://localhost:8000/generate.",
+        "The final assistant reply answers the question in plain text or light markdown and includes a timestamp, derived from the VLM response (any <think>...</think> block stripped). There should be no errors included in the final response."
       ]
     }
   ]

--- a/skills/vss-ask-video/evals/base_profile_video_understanding.json
+++ b/skills/vss-ask-video/evals/base_profile_video_understanding.json
@@ -34,7 +34,7 @@
       "checks": [
         "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:30888/vst/api/v1/sensor/version returns 200",
         "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body",
-        "Either VLM_BASE_URL + VLM_NAME (NIM Cosmos) or RTVI_VLM_BASE_URL + RTVI_VLM_MODEL_TO_USE (RT-VLM Cosmos) are resolvable from the vss-agent container environment (e.g. docker exec vss-agent env returns one set), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
+        "Either VLM_BASE_URL + VLM_NAME (NIM Cosmos) or RTVI_VLM_BASE_URL + RTVI_VLM_MODEL_TO_USE (RT-VLM Cosmos) are resolvable from the vss-agent container environment (read via `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`; the image is distroless so `docker exec vss-agent env` will not work), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
       ]
     },
     {

--- a/skills/vss-ask-video/evals/direct_vlm_video_understanding.json
+++ b/skills/vss-ask-video/evals/direct_vlm_video_understanding.json
@@ -1,0 +1,47 @@
+{
+  "skills": [
+    "vss-ask-video",
+    "vss-deploy-profile"
+  ],
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "gpu_count": 1
+      }
+    }
+  },
+  "expects": [
+    {
+      "query": "Deploy the VSS **base** profile on `{{platform}}` via `/vss-deploy-profile -p base` so a local NIM Cosmos VLM is serving. Run autonomously.\n\n**Purpose of this eval:** it exercises the **vss-ask-video direct-VLM path with NO VST/VIOS** — later steps answer a question about a *local* video file by POSTing it straight to the VLM's `/v1/chat/completions` (inline base64 or a self-served URL). The skill does NOT call `POST /generate` and does NOT resolve a VST clip URL. For this step, only bring the base profile up so a VLM endpoint resolves. Read `VLM_BASE_URL` / `VLM_NAME` / `VLM_MODE` (and `RTVI_VLM_BASE_URL` for RT-VLM) off the `vss-agent` container env — the image is distroless, so use `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`, not `docker exec`. (See `skills/vss-ask-video/SKILL.md`.)",
+      "checks": [
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
+        "A VLM endpoint resolves from the vss-agent container environment (read via `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`): either VLM_BASE_URL + VLM_NAME (NIM Cosmos, base default :30082) or RTVI_VLM_BASE_URL + VLM_NAME (RT-VLM), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
+      ]
+    },
+    {
+      "query": "Obtain the VSS sample data **as a local file on disk** (do NOT upload it to VST/VIOS). Configure NGC access, then run `ngc registry resource download-version nvidia/vss-developer/dev-profile-sample-data:3.2.0` and extract it (e.g. `tar -xf dev-profile-sample-data_v3.2.0/dev-profile-sample-data.tar.gz -C ./sample-data`) so that a local copy of `warehouse_safety_0001.mp4` exists on disk. This route uses the local file directly — it must NOT be registered as a VST sensor or uploaded via VIOS.",
+      "checks": [
+        "A local, non-empty file named warehouse_safety_0001.mp4 exists on disk after this step (e.g. `find . -name warehouse_safety_0001.mp4` returns a path to a file with size > 0), sourced from the NGC `nvidia/vss-developer/dev-profile-sample-data` resource.",
+        "The trajectory shows the video was obtained as a local file (NGC resource download + extract) and was NOT uploaded to VIOS/VST for this step (no PUT to the VST sensor/stream registration endpoints such as /vst/api/v1/... for warehouse_safety_0001)."
+      ]
+    },
+    {
+      "query": "Answer this question about the **local** video file `warehouse_safety_0001.mp4` (the on-disk copy from the previous step) by calling the VLM directly with the file inlined — do NOT use VST/VIOS and do NOT call the agent's summarize pipeline: **Is the worker wearing PPE?**",
+      "checks": [
+        "The run inlined the LOCAL mp4 as base64: it POSTed to the resolved VLM endpoint's /v1/chat/completions with Content-Type application/json and a messages array whose first user content list contains a text block with the question AND a video block whose url is a `data:video/mp4;base64,...` data URI (the file_base64 path, NOT a remote/VST URL). On NIM Cosmos the request body also includes mm_processor_kwargs / media_io_kwargs (with num_frames). HTTP 2xx.",
+        "The run did NOT perform any GET to a VST clip-URL endpoint (no request to a http://<host>:30888/vst/api/v1/storage/file/.../url style URL) — the video came from the local file, not VST.",
+        "The run did NOT POST to http://<host>:8000/generate.",
+        "The final assistant reply answers whether the worker is wearing PPE in plain text or light markdown, derived from the VLM response (any <think>...</think> block stripped), with no errors in the final response."
+      ]
+    },
+    {
+      "query": "Now answer a second question about the same local `warehouse_safety_0001.mp4` using the **`video_url`** input format (a URL the VLM fetches) instead of inline base64 — still WITHOUT VST/VIOS and WITHOUT `POST /generate`. Serve the local file over a simple HTTP URL the VLM can reach (e.g. `python3 -m http.server` bound to the host IP) and pass that URL in a `video_url` block: **At what timestamp does the worker climb the ladder?**",
+      "checks": [
+        "The run served the local mp4 over a reachable HTTP URL and POSTed to the resolved VLM endpoint's /v1/chat/completions with a `video_url` block whose url is that self-served http URL (NOT a VST /vst/api/v1/... clip URL and NOT a `data:` URI), plus the user's question as a text block. On NIM Cosmos the request body also includes mm_processor_kwargs / media_io_kwargs. HTTP 2xx.",
+        "The run did NOT perform any GET to a VST clip-URL endpoint (no http://<host>:30888/vst/api/v1/storage/file/.../url request).",
+        "The run did NOT POST to http://<host>:8000/generate.",
+        "The final assistant reply answers the question in plain text or light markdown and includes a timestamp, derived from the VLM response (any <think>...</think> block stripped), with no errors in the final response."
+      ]
+    }
+  ]
+}

--- a/skills/vss-ask-video/skill-card.md
+++ b/skills/vss-ask-video/skill-card.md
@@ -1,5 +1,5 @@
 ## Description: <br>
-Use this skill to ask the VSS agent's video_understanding tool a fresh visual question about a recorded clip. <br>
+Use this skill to ask a fresh visual question about a recorded video clip by calling a VLM endpoint directly (OpenAI-compatible chat/completions). <br>
 
 This skill is ready for commercial/non-commercial use. <br>
 
@@ -9,7 +9,7 @@ NVIDIA <br>
 ### License/Terms of Use: <br>
 Apache-2.0 <br>
 ## Use Case: <br>
-Developers and engineers building video analytics applications who need to ask ad-hoc visual questions about recorded video clips using a vision language model through the VSS agent. <br>
+Developers and engineers building video analytics applications who need to ask ad-hoc visual questions about recorded video clips by calling a vision language model endpoint directly. <br>
 
 ### Deployment Geography for Use: <br>
 Global <br>
@@ -27,7 +27,7 @@ Mitigation: Review and scan skill before deployment. <br>
 **Output Type(s):** [Analysis, API Calls] <br>
 **Output Format:** [Markdown with extracted VLM response text] <br>
 **Output Parameters:** [1D] <br>
-**Other Properties Related to Output:** [Agent-think blocks are stripped from the VSS agent response before returning the final answer] <br>
+**Other Properties Related to Output:** [VLM reasoning (`<think>...</think>`) blocks are stripped before returning the final answer] <br>
 
 ## Evaluation Agents Used: <br>
 - Claude Code (`claude-code`) <br>


### PR DESCRIPTION
## Description

Simplify **vss-ask-video** to require only an OpenAI-compatible VLM endpoint,
calling `chat/completions` directly instead of the VSS agent's `POST /generate`.

- **Direct VLM calls.** VST/VIOS optional; input-driven upload — local file →
  `file_base64`, URL → `video_url`.
- **Discover-first.** Endpoint/model from a running `vss-agent` (`docker inspect`),
  or `VLM_ENDPOINT`/`VLM_MODEL`, or default ports (`:30082` NIM / `:8018` RT-VLM),
  each confirmed via `/v1/models`. Backends: NIM Cosmos (base) and RT-VLM (lvs/alerts).
- **VLM-selection prompt (VIA-E-114-04).** If nothing resolves, prompt to provide
  an endpoint, pick a discovered one, or deploy a local RT-VLM via
  `/vss-deploy-dense-captioning`; headless default = deploy RT-VLM (resolved from
  the live deploy contract, never hardcoded).
- **VST clip-URL hardening.** Fetch `timelines` and pass `startTime`/`endTime`
  (VST returns no `videoUrl` without them); no silent local-file fallback.
- Updated the skill-eval adapter, base-profile eval, skill-card, and README index.

## Test plan

End-to-end  — **base / lvs / alerts** profiles, **with and
without agent**, × **url / file / base64**. Plus VIA-E-114-04 (all 3 prompt
choices + headless deploy default) and a fresh-machine run (no VLM → auto-deploy
RT-VLM → answers).