### PR TITLE
chore(analytics): update behavior analytics image and distroless tag

### DIFF
--- a/deploy/docker/services/analytics/behavior-analytics/compose.yml
+++ b/deploy/docker/services/analytics/behavior-analytics/compose.yml
@@ -24,7 +24,7 @@
 services:
 
   vss-behavior-analytics-base:
-    image: nvcr.io/nvstaging/vss-core/vss-behavior-analytics:3.2.1-26.06.4
+    image: nvcr.io/nvstaging/vss-core/vss-behavior-analytics:3.2.1-26.07.1
     network_mode: "host"
     restart: always
     volumes:

--- a/services/analytics/behavior-analytics/docker/Dockerfile
+++ b/services/analytics/behavior-analytics/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG PYTHON_VERSION=3.13
 # manylinux CPython tag for the OpenCV build; must track PYTHON_VERSION
 # (e.g. 3.13 -> cp313-cp313, 3.14 -> cp314-cp314).
 ARG PYBIN_TAG=cp313-cp313
-ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.0.6
+ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.0.8
 ARG DISTROLESS_IMG=nvcr.io/nvidia/distroless/python
 
 ###################################################


### PR DESCRIPTION
Bump the vss-behavior-analytics image to version 3.2.1-26.07.1 in the Docker Compose file and update the distroless base image tag to 3.13-v4.0.8 in the Dockerfile for consistency and compatibility.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
