### PR TITLE
refactor(skills-review): collapse review matrix into a single job

### DIFF
--- a/.github/skills-review/run_review_legs.py
+++ b/.github/skills-review/run_review_legs.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run every skills-review leg in-process with bounded concurrency.
+
+Replaces the old GitHub Actions review matrix. The per-(skill x paradigm) legs
+are pure LLM API calls (no GPU/box lock) that each write an independent
+review-<skill>__<paradigm>.json into REVIEW_OUT_DIR, so there is nothing to gain
+from GitHub-level leg isolation — running them here as N bounded subprocesses
+keeps the whole workflow to a SINGLE advisory check instead of
+2 + (changed_skills x 6). Concurrency here replaces the matrix `max-parallel`.
+
+Each leg runs review_agent.py with EVAL_SKILL / EVAL_PARADIGM set for that leg
+and every other variable inherited (PR_BASE, REVIEW_OUT_DIR, ANTHROPIC_*, GH_*).
+review_agent.py's git access is read-only (`git diff base...HEAD`), so parallel
+legs share one checkout safely. A leg that fails or times out logs a GitHub
+`::warning::` and is skipped; this driver always exits 0 (advisory — a review
+leg must never fail the merge, matching the old matrix's fail-fast: false).
+
+Env:
+    MATRIX_JSON              leg list from plan_review_matrix.py, shape
+                             {"include": [{"skill","paradigm","slug","name"}, ...]}
+    REVIEW_FANOUT            max concurrent legs (default 12)
+    REVIEW_LEG_TIMEOUT_SEC   per-leg wall-clock cap in seconds (default 1200)
+    (plus everything review_agent.py reads, inherited unchanged)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+AGENT = HERE / "review_agent.py"
+
+
+def _leg_name(leg: dict) -> str:
+    return leg.get("name") or f"{leg.get('skill')} · {leg.get('paradigm')}"
+
+
+def run_leg(leg: dict) -> tuple[dict, int, str]:
+    """Run one review_agent.py leg; return (leg, returncode, tail-of-stderr)."""
+    env = {
+        **os.environ,
+        "EVAL_SKILL": leg["skill"],
+        "EVAL_PARADIGM": leg["paradigm"],
+    }
+    timeout = int(os.environ.get("REVIEW_LEG_TIMEOUT_SEC", "1200"))
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(AGENT)],
+            env=env,
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+        )
+        return leg, proc.returncode, (proc.stderr or "")[-2000:]
+    except subprocess.TimeoutExpired:
+        return leg, 124, f"timed out after {timeout}s"
+
+
+def main() -> int:
+    raw = os.environ.get("MATRIX_JSON", "").strip()
+    if not raw:
+        print("MATRIX_JSON is empty — no legs to run", file=sys.stderr)
+        return 0
+    include = json.loads(raw).get("include", [])
+    if not include:
+        print("no legs to run", file=sys.stderr)
+        return 0
+
+    fanout = max(1, int(os.environ.get("REVIEW_FANOUT", "12")))
+    print(f"running {len(include)} legs, up to {fanout} concurrent", file=sys.stderr)
+
+    failures = 0
+    with ThreadPoolExecutor(max_workers=fanout) as pool:
+        futures = {pool.submit(run_leg, leg): leg for leg in include}
+        for fut in as_completed(futures):
+            leg, rc, err = fut.result()
+            name = _leg_name(leg)
+            if rc == 0:
+                print(f"[ok]   {name}", file=sys.stderr)
+            else:
+                failures += 1
+                # Advisory: surface the failure, never fail the job.
+                print(
+                    f"::warning title=skills-review::leg failed (rc={rc}): "
+                    f"{name} — {err.strip()[:300]}"
+                )
+                print(f"[fail] {name} (rc={rc})", file=sys.stderr)
+
+    print(
+        f"legs done: {len(include) - failures} ok, {failures} failed/timed out",
+        file=sys.stderr,
+    )
+    return 0  # advisory — a review leg error must not fail the merge
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills-review/run_review_legs.py
+++ b/.github/skills-review/run_review_legs.py
@@ -42,7 +42,14 @@ def _leg_name(leg: dict) -> str:
 
 
 def run_leg(leg: dict) -> tuple[dict, int, str]:
-    """Run one review_agent.py leg; return (leg, returncode, tail-of-stderr)."""
+    """Run one review_agent.py leg; return (leg, returncode, tail of combined output).
+
+    stdout and stderr are merged into one stream so a failing leg's diagnostics
+    are surfaced in full — an unhandled traceback that review_agent.py (or a C
+    extension it imports) writes to stdout would otherwise be dropped, leaving
+    the ``::warning::`` annotation empty. Legs transfer their results via JSON
+    files in REVIEW_OUT_DIR, not stdout, so nothing useful is lost by merging.
+    """
     env = {
         **os.environ,
         "EVAL_SKILL": leg["skill"],
@@ -54,12 +61,15 @@ def run_leg(leg: dict) -> tuple[dict, int, str]:
             [sys.executable, str(AGENT)],
             env=env,
             timeout=timeout,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
         )
-        return leg, proc.returncode, (proc.stderr or "")[-2000:]
-    except subprocess.TimeoutExpired:
-        return leg, 124, f"timed out after {timeout}s"
+        return leg, proc.returncode, (proc.stdout or "")[-2000:]
+    except subprocess.TimeoutExpired as e:
+        tail = (e.stdout or "").strip()[-2000:] if e.stdout else ""
+        msg = f"timed out after {timeout}s"
+        return leg, 124, f"{msg}\n{tail}" if tail else msg
 
 
 def main() -> int:
@@ -86,9 +96,11 @@ def main() -> int:
             else:
                 failures += 1
                 # Advisory: surface the failure, never fail the job.
+                # err is the tail of the leg's output; take the LAST 300 chars
+                # so the annotation shows the failure, not startup chatter.
                 print(
                     f"::warning title=skills-review::leg failed (rc={rc}): "
-                    f"{name} — {err.strip()[:300]}"
+                    f"{name} — {err.strip()[-300:]}"
                 )
                 print(f"[fail] {name} (rc={rc})", file=sys.stderr)
 

--- a/.github/workflows/skills-review.yml
+++ b/.github/workflows/skills-review.yml
@@ -2,15 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Multi-paradigm skill review (ADVISORY). On a PR touching skills/**, or on
-# manual dispatch, fan out 6 review paradigms per changed skill (one matrix leg
-# each), consolidate by cross-paradigm agreement + severity, and post a sticky
-# PR comment + upload a full artifact. Never fails the merge; not a required
-# status check. See .github/skills-review/README.md for the runner prerequisites
-# (Anthropic coordinator .env + CE plugin on the vss-brev-runner host).
+# manual dispatch, run 6 review paradigms per changed skill, consolidate by
+# cross-paradigm agreement + severity, and post a sticky PR comment + upload a
+# report artifact. Never fails the merge; not a required status check. See
+# .github/skills-review/README.md for the runner prerequisites (Anthropic
+# coordinator .env + CE plugin on the vss-brev-runner host).
+#
+# SINGLE JOB by design. The per-(skill x paradigm) legs are pure LLM API calls
+# (no GPU/box lock) and are already decoupled through a directory of
+# review-<slug>.json files, so they fan out IN-PROCESS (run_review_legs.py,
+# bounded concurrency) instead of via an Actions matrix. That keeps a PR to ONE
+# advisory check instead of 2 + (changed_skills x 6), and drops the per-leg
+# artifact upload/download round-trip. Tune REVIEW_FANOUT to the proxy rate limit.
 #
 # No top-level `paths:` filter — GitHub evaluates `paths:` per-push, not over the
 # cumulative PR diff (the skills-eval PR #188 regression), so the changed-skill
-# gate lives inside the `plan` job (plan_review_matrix.py, FETCH_HEAD...HEAD).
+# gate lives in the `plan` step (plan_review_matrix.py, FETCH_HEAD...HEAD).
 name: Skills Review
 
 on:
@@ -34,14 +41,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
-  plan:
+  review:
     runs-on: [self-hosted, vss-brev-runner]
-    timeout-minutes: 10
-    outputs:
-      matrix: ${{ steps.plan.outputs.matrix }}
-      has_targets: ${{ steps.plan.outputs.has_targets }}
-      pr: ${{ steps.pr.outputs.number }}
-      base: ${{ steps.pr.outputs.base }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,6 +51,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      # Resolve the PR from the copy-pr-bot mirror branch (push trigger only).
       - id: pr
         if: github.event_name == 'push'
         env:
@@ -59,36 +63,35 @@ jobs:
           PR="${REF##pull-request/}"
           echo "number=$PR" >> "$GITHUB_OUTPUT"
           echo "base=$(gh pr view "$PR" --json baseRefName --jq .baseRefName)" >> "$GITHUB_OUTPUT"
+
+      # Compute the (skill x paradigm) leg list; gate on changed skills.
       - id: plan
         env:
           PR_BASE: ${{ steps.pr.outputs.base }}
           MANUAL_SKILLS_FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.skills || '' }}
         run: python3 .github/skills-review/plan_review_matrix.py
 
-  review:
-    needs: plan
-    if: needs.plan.outputs.has_targets == 'true'
-    runs-on: [self-hosted, vss-brev-runner]
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      max-parallel: 12        # LLM API legs (no GPU/box lock) — tune to the proxy rate limit
-      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Run review leg (${{ matrix.skill }} · ${{ matrix.paradigm }})
+      # Pre-install the Agent SDK once so parallel legs never race on pip.
+      - name: Prepare agent runtime
+        if: steps.plan.outputs.has_targets == 'true'
+        run: python3 -m pip install -q "claude-agent-sdk>=0.0.5"
+
+      # Fan out every leg in-process (bounded, each time-boxed). run_review_legs.py
+      # sets EVAL_SKILL/EVAL_PARADIGM per leg and always exits 0 (advisory).
+      - name: Run review legs
+        if: steps.plan.outputs.has_targets == 'true'
         env:
-          EVAL_SKILL: ${{ matrix.skill }}
-          EVAL_PARADIGM: ${{ matrix.paradigm }}
-          PR_BASE_BRANCH: ${{ needs.plan.outputs.base || 'develop' }}
+          MATRIX_JSON: ${{ steps.plan.outputs.matrix }}
+          PR_BASE_BRANCH: ${{ steps.pr.outputs.base || 'develop' }}
           REVIEW_OUT_DIR: ${{ runner.temp }}/review
+          REVIEW_FANOUT: "12"            # concurrent legs — tune to the proxy rate limit
+          REVIEW_LEG_TIMEOUT_SEC: "1200" # per-leg wall-clock cap
           GH_TOKEN: ${{ github.token }}
-          # per-leg gh config scratch so a host OAuth can't reauthor bot output
-          GH_CONFIG_DIR: ${{ runner.temp }}/ghcfg-${{ matrix.slug }}
+          # one gh config scratch for the job so a host OAuth can't reauthor bot output
+          GH_CONFIG_DIR: ${{ runner.temp }}/ghcfg
         run: |
           set -euo pipefail
+          mkdir -p "$REVIEW_OUT_DIR"
           git fetch --no-tags --quiet origin "$PR_BASE_BRANCH" || true
           export PR_BASE="origin/${PR_BASE_BRANCH}"
           # Anthropic coordinator creds (ANTHROPIC_*, etc.). See README.md —
@@ -97,54 +100,34 @@ jobs:
             set -a; source /home/ubuntu/eval-coordinator/.env; set +a
           fi
           export CLAUDE_CODE_DISABLE_THINKING=1   # NVIDIA Anthropic proxy rejects context_management
-          python3 .github/skills-review/review_agent.py
-      - name: Upload leg findings
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: skills-review-leg-${{ matrix.slug }}
-          # ONLY the JSON findings — never agent trajectory dirs (PR #516 secret-leak lesson)
-          path: ${{ runner.temp }}/review/review-*.json
-          if-no-files-found: ignore
-          retention-days: 7
+          python3 .github/skills-review/run_review_legs.py
 
-  report:
-    needs: [plan, review]
-    if: always() && needs.plan.outputs.has_targets == 'true'
-    runs-on: [self-hosted, vss-brev-runner]
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Download leg findings
-        uses: actions/download-artifact@v4
-        with:
-          pattern: skills-review-leg-*
-          path: ${{ runner.temp }}/legs
-          merge-multiple: true
-      - name: Consolidate
+      # Consolidate the leg findings and post/refresh the sticky PR comment.
+      - name: Consolidate and post comment
+        if: ${{ always() && steps.plan.outputs.has_targets == 'true' }}
         env:
-          REVIEW_ARTIFACTS_DIR: ${{ runner.temp }}/legs
+          REVIEW_ARTIFACTS_DIR: ${{ runner.temp }}/review
           CONSOLIDATED_JSON: ${{ runner.temp }}/skills-review-consolidated.json
           CONSOLIDATED_MD: ${{ runner.temp }}/skills-review-consolidated.md
           COMMENT_BODY: ${{ runner.temp }}/review-comment.md
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: python3 .github/skills-review/consolidate.py
-      - name: Post sticky comment
-        env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ needs.plan.outputs.pr }}
-          COMMENT_BODY: ${{ runner.temp }}/review-comment.md
-        run: python3 .github/skills-review/post_review_comment.py
-      - name: Upload consolidated report
-        if: always()
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          python3 .github/skills-review/consolidate.py
+          python3 .github/skills-review/post_review_comment.py
+
+      # Findings-only artifact: per-leg review-*.json + consolidated report.
+      # NEVER agent trajectory dirs (PR #516 secret-leak lesson).
+      - name: Upload report
+        if: ${{ always() && steps.plan.outputs.has_targets == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: skills-review-consolidated
+          name: skills-review
           path: |
+            ${{ runner.temp }}/review/review-*.json
             ${{ runner.temp }}/skills-review-consolidated.json
             ${{ runner.temp }}/skills-review-consolidated.md
           if-no-files-found: ignore


### PR DESCRIPTION
## Problem

The skills-review workflow fans out **one Actions matrix leg per (changed skill × 6 paradigms)**, plus a `plan` and a `report` job. So every PR touching `skills/**` produces `2 + (changed_skills × 6)` check runs:

| Changed skills | Checks today |
|---|---|
| 1 | 8 |
| 3 | 20 |

That bloats the PR checks UI and the merge box for what is an **advisory** review (never fails the merge, not a required status check).

## Change

Collapse `plan` + `review` + `report` into a **single `review` job**. The per-leg work fans out **in-process** via a new `run_review_legs.py` (bounded concurrency + per-leg timeout), replacing the matrix `max-parallel`.

- **Result: one advisory check** instead of `2 + (skills × 6)`.
- The per-leg artifact upload/download round-trip is gone — legs write straight into `REVIEW_OUT_DIR` and `consolidate.py` reads it directly (`rglob("review-*.json")`).
- `review_agent.py`, `consolidate.py`, `post_review_comment.py` are **unchanged**.

## Why it is safe

- `review_agent.py` git access is **read-only** (`git diff base...HEAD`, precomputed in Python; agent tools are Read/Grep/Glob) → parallel legs share one checkout with no `git checkout` race.
- Each leg writes a **unique** `review-<skill>__<paradigm>.json`, so a shared output dir is collision-free.
- **Advisory semantics preserved**: a failed/timed-out leg logs `::warning::` and `run_review_legs.py` always exits 0 — a review leg never fails the merge (matches the old matrix `fail-fast: false`).

## Validation

- YAML parses; `run_review_legs.py` compiles clean.
- Smoke-tested the fan-out driver: legs run concurrently, a simulated leg failure emits `::warning::` without failing the run (exit 0), and every unique `review-*.json` is written.

## Tuning knobs

`REVIEW_FANOUT` (default 12, tune to the Anthropic proxy rate limit) and `REVIEW_LEG_TIMEOUT_SEC` (default 1200) are set in the workflow step env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)