### PR TITLE
Fix - Route remote Cosmos VLM through video_url to avoid per-prompt image limit (422)

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -236,7 +236,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.1-26.07.1-f968707640f8
+VSS_AGENT_VERSION=3.2.1-26.07.1-e33af13d2f59
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -183,7 +183,7 @@ VLM_NIM_MODEL_NAME=
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.1-26.07.1-f968707640f8
+VSS_AGENT_VERSION=3.2.1-26.07.1-e33af13d2f59
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -190,7 +190,7 @@ EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 # Used by: vss-agent, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.1-26.07.1-f968707640f8
+VSS_AGENT_VERSION=3.2.1-26.07.1-e33af13d2f59
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -242,7 +242,7 @@ VLM_NIM_MODEL_NAME=
 # Used by: vss-agent, vss-va-mcp, vss-ui
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.1-26.07.1-f968707640f8
+VSS_AGENT_VERSION=3.2.1-26.07.1-e33af13d2f59
 VSS_AGENT_CONFIG_FILE=./deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -248,7 +248,7 @@ VLM_NIM_KVCACHE_PERCENT="0.7"
 # Used by: vss-agent, vss-va-mcp, vss-ui services
 
 # VSS Agent Core
-VSS_AGENT_VERSION=3.2.1-26.07.1-f968707640f8
+VSS_AGENT_VERSION=3.2.1-26.07.1-e33af13d2f59
 VSS_AGENT_CONFIG_FILE=./deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -309,7 +309,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-f968707640f8" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-e33af13d2f59" }}'
     waitForDependencies:
       enabled: true
   vss-va-mcp:

--- a/deploy/helm/developer-profiles/dev-profile-base/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/values.yaml
@@ -259,7 +259,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-f968707640f8" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-e33af13d2f59" }}'
 vss-agent-ui:
   enabled: true
   # Empty URL fields: deployment uses global.external* then in-cluster defaults.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -252,7 +252,7 @@ Use the table below for additional keys. Order follows **`values.yaml`**. **`ngc
 | **`agent.vss-agent.vstInternalUrl`** | **`""`** | In-cluster **VST** URL for the agent when the default wiring is insufficient. |
 | **`agent.vss-agent.vstInternalIp`** | **`""`** | In-cluster **VST** host/IP override when defaults are insufficient. |
 | **`agent.vss-agent.vssAgentExternalUrl`** | **`""`** | External **vss-agent** URL override for browser / callbacks when **`global.external*`** is not enough. |
-| **`agent.vss-agent.vssAgentVersion`** | **`3.2.1-26.07.1-f968707640f8`** | Optional version label / env; adjust per release. |
+| **`agent.vss-agent.vssAgentVersion`** | **`3.2.1-26.07.1-e33af13d2f59`** | Optional version label / env; adjust per release. |
 | **`agent.vss-agent.llmName`** | **`""`** | Optional **vss-agent-only** override of **`global.llmName`** (**`LLM_NAME`**). |
 | **`agent.vss-agent.vlmName`** | **`""`** | Optional **vss-agent-only** override of **`global.vlmName`** (**`VLM_NAME`**). |
 | **`agent.vss-agent.llmBaseUrl`** | **`""`** | Optional **vss-agent-only** override of **`global.llmBaseUrl`**. |

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -207,7 +207,7 @@ agent:
     vstInternalUrl: ""
     vstInternalIp: ""
     vssAgentExternalUrl: ""
-    vssAgentVersion: "3.2.1-26.07.1-f968707640f8"
+    vssAgentVersion: "3.2.1-26.07.1-e33af13d2f59"
     evalLlmJudgeName: ""
     evalLlmJudgeBaseUrl: ""
     reportsBaseUrl: ""
@@ -298,7 +298,7 @@ agent:
       - name: AGENT_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-f968707640f8" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-e33af13d2f59" }}'
       # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
       # Set enableAudio=true for Nemotron Nano Omni audio-aware VLM.
       - name: ENABLE_AUDIO

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -482,7 +482,7 @@ agent:
     videoAnalysisMcpUrl: ''
     template:
       name: ''
-    vssAgentVersion: 3.2.1-26.07.1-f968707640f8
+    vssAgentVersion: 3.2.1-26.07.1-e33af13d2f59
     # Copied from rtvi.* defaults (vss-agent subchart env tpl only sees agent.vss-agent; keep in sync with rtvi.vss-rtvi-embed.port / vss-rtvi-cv.httpPort).
     rtviEmbedPort: '8000'
     rtviCvPort: '9000'
@@ -590,7 +590,7 @@ agent:
       - name: RTVI_EMBED_MODEL
         value: '{{ .Values.rtviEmbedModelName | default "cosmos-embed1-448p-anomaly-detection" }}'
       - name: VSS_AGENT_VERSION
-        value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-f968707640f8" }}'
+        value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-e33af13d2f59" }}'
 
 vss-agent-ui:
   enabled: true

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -23,7 +23,7 @@ serviceAccount:
   create: false
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.1-26.07.1-f968707640f8"
+  tag: "3.2.1-26.07.1-e33af13d2f59"
   pullPolicy: IfNotPresent
 replicas: 1
 service:
@@ -90,7 +90,7 @@ reportsBaseUrl: ""
 vssAgentExternalUrl: ""
 externalIp: ""
 vstInternalIp: ""
-vssAgentVersion: "3.2.1-26.07.1-f968707640f8"
+vssAgentVersion: "3.2.1-26.07.1-e33af13d2f59"
 lvsBackendService: ""
 
 # [Optional] HTTP-client timeouts (seconds) for the post-upload pipeline in
@@ -218,7 +218,7 @@ env:
 - name: AGENT_BASE_URL
   value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ coalesce .Values.vssAgentExternalUrl .Values.vstExternalUrl $globalBase $vssAgentHttp }}'
 - name: VSS_AGENT_VERSION
-  value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-f968707640f8" }}'
+  value: '{{ .Values.vssAgentVersion | default "3.2.1-26.07.1-e33af13d2f59" }}'
 # Audio configuration (compose parity: deploy/docker/services/agent/compose.yml).
 # Set ENABLE_AUDIO=true for Nemotron Nano Omni audio-aware VLM.
 - name: ENABLE_AUDIO

--- a/deploy/helm/services/agent/charts/va-mcp/values.yaml
+++ b/deploy/helm/services/agent/charts/va-mcp/values.yaml
@@ -18,7 +18,7 @@ global: {}
 
 image:
   repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.2.1-26.07.1-f968707640f8"
+  tag: "3.2.1-26.07.1-e33af13d2f59"
   pullPolicy: IfNotPresent
 # Image must have mcp[cli] (typer) installed for `mcp serve` (same as Docker Compose).
 replicas: 1

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -703,20 +703,41 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             max_fps=config.max_fps,
         )
 
-        # Retry logic for VLM call — only retry transient errors (connection/timeout/5xx).
-        # Client errors like 400 (e.g. unsupported video format) are not retryable.
-        async for retry in create_retry_strategy(retries=3, exceptions=_VLM_RETRYABLE_ERRORS):
-            with retry:
-                try:
-                    response = await vlm_chain.ainvoke(
-                        {"messages": messages},
-                        config={"callbacks": []},
-                    )
-                    logger.debug(f"Response: {response}")
-                    break
-                except Exception as e:
-                    logger.error(f"Error understanding video {video_understanding_input.sensor_id}: {e}")
-                    raise e
+        # Suppress NAT's LangchainProfilerHandler for the VLM call.
+        #
+        # NAT registers LangchainProfilerHandler via LangChain's
+        # register_configure_hook(callback_handler_var, inheritable=True).
+        # This hook deep-copies the full input messages (including base64
+        # video/image payloads) on on_chat_model_start and streams them to
+        # the browser as intermediate-step SSE events.  With remote VLM,
+        # this leaks 10-60 MB per call into the chat API response, causing
+        # 200 MB+ responses and UI timeouts.
+        #
+        # Temporarily unsetting the ContextVar disables the hook for this
+        # call only.  The tool's text output is already surfaced in the
+        # ToolMessage; top-agent-level telemetry is unaffected.
+        try:
+            from nat.plugins.profiler.decorators.framework_wrapper import callback_handler_var
+
+            _saved_token = callback_handler_var.set(None)
+        except ImportError:
+            _saved_token = None
+
+        try:
+            # Retry logic for VLM call — only retry transient errors (connection/timeout/5xx).
+            # Client errors like 400 (e.g. unsupported video format) are not retryable.
+            async for retry in create_retry_strategy(retries=3, exceptions=_VLM_RETRYABLE_ERRORS):
+                with retry:
+                    try:
+                        response = await vlm_chain.ainvoke({"messages": messages})
+                        logger.debug(f"Response: {response}")
+                        break
+                    except Exception as e:
+                        logger.error(f"Error understanding video {video_understanding_input.sensor_id}: {e}")
+                        raise e
+        finally:
+            if _saved_token is not None:
+                callback_handler_var.reset(_saved_token)
 
         content = str(response.content) if response.content is not None else ""
         # Filter thinking traces

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -111,12 +111,13 @@ def _should_use_video_base64(
     enable_audio: bool = False,
     model_name: str = "",
 ) -> bool:
-    """Return whether the video payload should be downloaded locally and sent as base64 frames.
+    """Return whether the video payload should be downloaded locally and sent as base64 JPEG frames.
 
-    Audio-capable VLMs (e.g. Nemotron Omni) need the full MP4 via ``video_url``; JPEG frame
-    sampling drops the audio track. When ``enable_audio`` is True and the model supports
-    embedded audio, use ``video_url`` (or the data-URI path for remote Omni — see
-    ``_should_use_video_file_base64``).
+    Returns ``False`` when the full-MP4 ``video_url`` path should be used instead
+    (see ``_should_use_video_file_base64``).  That covers:
+
+    * Remote Omni + ``enable_audio`` — preserves the audio track.
+    * Remote Cosmos models — avoids the per-prompt image count limit.
 
     Edge case: ``enable_audio=True`` with a non-Omni remote VLM. The model can't process
     the audio track anyway, and the internal VST URL is unreachable from a remote NIM, so
@@ -137,6 +138,10 @@ def _should_use_video_base64(
         if use_base64:
             logger.warning("use_base64=True is ignored because enable_audio=True requires the full MP4 via video_url.")
         return False
+
+    if _is_remote_vlm(vlm_mode) and _is_cosmos_model(model_name):
+        return False
+
     return use_base64 or _is_remote_vlm(vlm_mode)
 
 
@@ -148,6 +153,11 @@ def _is_remote_vlm(vlm_mode: str | None) -> bool:
 def _is_omni_audio_model(model_name: str) -> bool:
     """Return whether the VLM is Nemotron Omni (supports embedded audio in MP4)."""
     return "omni" in (model_name or "").lower()
+
+
+def _is_cosmos_model(model_name: str) -> bool:
+    """Return whether the VLM is a Cosmos model (supports native ``video_url``)."""
+    return "cosmos" in (model_name or "").lower()
 
 
 _OMNI_AUDIO_SYSTEM_SUFFIX = """
@@ -166,12 +176,20 @@ def _should_use_video_file_base64(
 ) -> bool:
     """Return whether to inline the full MP4 as base64 for the VLM.
 
-    Remote VLMs cannot rely on VST ``video_url`` reachability the way a co-located
-    local VLM can. Inlining the file preserves the audio track while avoiding
-    JPEG frame sampling. Only Omni audio-capable models support the
-    ``data:video/mp4;base64,…`` URI format expected by this path.
+    Two cases require this:
+
+    1. **Remote Omni + enable_audio** — preserves the audio track that JPEG
+       frame sampling would drop.
+    2. **Remote Cosmos models** — avoids the per-prompt image count limit
+       that rejects >5 individual ``image_url`` entries.  The NIM handles
+       frame sampling server-side via ``media_io_kwargs``.
+
+    Non-cosmos remote VLMs (Qwen, GPT-4o, etc.) stay on the ``image_url``
+    frame-sampling path for OpenAI API compatibility.
     """
-    return enable_audio and _is_remote_vlm(vlm_mode) and _is_omni_audio_model(model_name)
+    return _is_remote_vlm(vlm_mode) and (
+        _is_cosmos_model(model_name) or (enable_audio and _is_omni_audio_model(model_name))
+    )
 
 
 class VideoUnderstandingConfig(FunctionBaseConfig, name="video_understanding"):

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -708,7 +708,10 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
         async for retry in create_retry_strategy(retries=3, exceptions=_VLM_RETRYABLE_ERRORS):
             with retry:
                 try:
-                    response = await vlm_chain.ainvoke({"messages": messages})
+                    response = await vlm_chain.ainvoke(
+                        {"messages": messages},
+                        config={"callbacks": []},
+                    )
                     logger.debug(f"Response: {response}")
                     break
                 except Exception as e:

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -40,6 +40,11 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
 
+try:
+    from nat.plugins.profiler.decorators.framework_wrapper import callback_handler_var as _profiler_callback_var
+except ImportError:
+    _profiler_callback_var = None
+
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import get_stream_id
 from vss_agents.utils.frame_select import frame_select
@@ -703,25 +708,11 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             max_fps=config.max_fps,
         )
 
-        # Suppress NAT's LangchainProfilerHandler for the VLM call.
-        #
-        # NAT registers LangchainProfilerHandler via LangChain's
-        # register_configure_hook(callback_handler_var, inheritable=True).
-        # This hook deep-copies the full input messages (including base64
-        # video/image payloads) on on_chat_model_start and streams them to
-        # the browser as intermediate-step SSE events.  With remote VLM,
-        # this leaks 10-60 MB per call into the chat API response, causing
-        # 200 MB+ responses and UI timeouts.
-        #
-        # Temporarily unsetting the ContextVar disables the hook for this
-        # call only.  The tool's text output is already surfaced in the
-        # ToolMessage; top-agent-level telemetry is unaffected.
-        try:
-            from nat.plugins.profiler.decorators.framework_wrapper import callback_handler_var
-
-            _saved_token = callback_handler_var.set(None)
-        except ImportError:
-            _saved_token = None
+        # Suppress NAT's profiler for the VLM call — it deep-copies the full
+        # input messages (including base64 video) into the SSE response stream.
+        # ContextVar suppresses the configure hook; empty callbacks overrides
+        # handlers already inherited from ancestor chains.
+        _saved_token = _profiler_callback_var.set(None) if _profiler_callback_var is not None else None
 
         try:
             # Retry logic for VLM call — only retry transient errors (connection/timeout/5xx).
@@ -729,7 +720,10 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             async for retry in create_retry_strategy(retries=3, exceptions=_VLM_RETRYABLE_ERRORS):
                 with retry:
                     try:
-                        response = await vlm_chain.ainvoke({"messages": messages})
+                        response = await vlm_chain.ainvoke(
+                            {"messages": messages},
+                            config={"callbacks": []},
+                        )
                         logger.debug(f"Response: {response}")
                         break
                     except Exception as e:
@@ -737,7 +731,7 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
                         raise e
         finally:
             if _saved_token is not None:
-                callback_handler_var.reset(_saved_token)
+                _profiler_callback_var.reset(_saved_token)
 
         content = str(response.content) if response.content is not None else ""
         # Filter thinking traces

--- a/services/agent/tests/unit_test/tools/test_video_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_video_understanding.py
@@ -19,6 +19,7 @@ import pytest
 from vss_agents.tools.video_understanding import VideoUnderstandingConfig
 from vss_agents.tools.video_understanding import _build_vlm_messages
 from vss_agents.tools.video_understanding import _effective_system_prompt
+from vss_agents.tools.video_understanding import _is_cosmos_model
 from vss_agents.tools.video_understanding import _is_omni_audio_model
 from vss_agents.tools.video_understanding import _parse_thinking_from_content
 from vss_agents.tools.video_understanding import _should_use_video_base64
@@ -112,6 +113,34 @@ class TestIsOmniAudioModel:
         assert not _is_omni_audio_model("nvidia/cosmos-reason2-8b")
 
 
+class TestIsCosmosModel:
+    """Test _is_cosmos_model detection."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "nvidia/cosmos3-nano-reasoner",
+            "nvidia/cosmos3-super-reasoner",
+            "nvidia/cosmos-reason2-8b",
+            "nvidia/cosmos-reason1-7b",
+        ],
+    )
+    def test_detects_cosmos_models(self, model_name: str):
+        assert _is_cosmos_model(model_name)
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "Qwen/Qwen3-VL-8B-Instruct",
+            "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+            "gpt-4o",
+            "",
+        ],
+    )
+    def test_rejects_non_cosmos_models(self, model_name: str):
+        assert not _is_cosmos_model(model_name)
+
+
 class TestShouldUseVideoBase64:
     """Test video base64 selection for remote VLMs."""
 
@@ -133,9 +162,14 @@ class TestShouldUseVideoBase64:
             vlm_mode="local_shared",
         )
 
+    def test_remote_cosmos_skips_jpeg_for_video_url_path(self):
+        assert not _should_use_video_base64(
+            use_base64=False,
+            vlm_mode="remote",
+            model_name="nvidia/cosmos3-nano-reasoner",
+        )
+
     def test_enable_audio_omni_remote_skips_jpeg(self):
-        # Omni + remote uses the data-URI path (handled by _should_use_video_file_base64),
-        # so this fn returns False so the file-base64 path takes over.
         assert not _should_use_video_base64(
             use_base64=False,
             vlm_mode="remote",
@@ -153,14 +187,12 @@ class TestShouldUseVideoBase64:
         )
 
     def test_enable_audio_non_omni_remote_falls_back_to_jpeg(self, caplog):
-        # Non-Omni + remote can't honor audio AND can't reach the internal VST URL.
-        # Fall back to JPEG frame sampling (degraded but functional) and warn.
         with caplog.at_level("WARNING"):
             assert _should_use_video_base64(
                 use_base64=False,
                 vlm_mode="remote",
                 enable_audio=True,
-                model_name="nvidia/cosmos-reason2-8b",
+                model_name="Qwen/Qwen3-VL-8B-Instruct",
             )
         assert "non-Omni remote VLM" in caplog.text
         assert "Falling back to JPEG" in caplog.text
@@ -188,13 +220,41 @@ class TestShouldUseVideoBase64:
         assert not _should_use_video_file_base64(
             enable_audio=True,
             vlm_mode="remote",
-            model_name="nvidia/cosmos-reason2-8b",
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
         )
 
     def test_enable_audio_local_does_not_use_video_file_base64(self):
         assert not _should_use_video_file_base64(
             enable_audio=True,
             vlm_mode="local",
+        )
+
+    def test_remote_cosmos_uses_video_file_base64(self):
+        assert _should_use_video_file_base64(
+            enable_audio=False,
+            vlm_mode="remote",
+            model_name="nvidia/cosmos3-nano-reasoner",
+        )
+
+    def test_remote_cosmos_reason2_uses_video_file_base64(self):
+        assert _should_use_video_file_base64(
+            enable_audio=False,
+            vlm_mode="remote",
+            model_name="nvidia/cosmos-reason2-8b",
+        )
+
+    def test_remote_non_cosmos_skips_video_file_base64(self):
+        assert not _should_use_video_file_base64(
+            enable_audio=False,
+            vlm_mode="remote",
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
+        )
+
+    def test_local_cosmos_skips_video_file_base64(self):
+        assert not _should_use_video_file_base64(
+            enable_audio=False,
+            vlm_mode="local",
+            model_name="nvidia/cosmos3-nano-reasoner",
         )
 
     def test_enable_audio_defaults_false(self):


### PR DESCRIPTION
## Description

### Summary

Remote VLM (e.g. `nvidia/cosmos3-nano-reasoner`) rejects prompts with >5 `image_url` entries (422 UnprocessableEntityError). Today, for any remote VLM, VSS samples video frames client-side and sends them as individual base64 `image_url` entries. With `max_fps=2` and `max_frames=60`, any clip longer than ~2.5s exceeds the 5-image limit, causing the critic agent to return `unverified` for all evaluated videos.

Bug - https://nvbugspro.nvidia.com/bug/6395823

**Root cause:** The `_should_use_video_file_base64` gate only returned `True` for remote Omni models with `enable_audio`, so remote Cosmos models always fell through to the JPEG frame-sampling path — which hits the per-prompt image limit.

### Fix

Widen the existing `_should_use_video_file_base64` condition to also return `True` for remote Cosmos models. This routes them through the already-existing `video_url` data URI path (`data:video/mp4;base64,...`), where the NIM handles frame sampling server-side via `media_io_kwargs`. Coordinate `_should_use_video_base64` to return `False` for remote Cosmos so the two flags never conflict.

**No new transport/encoding code.** The full-MP4 `video_url` path already existed for the Omni audio use case — the fix only changes which models are routed to it.

#### Changes

| Function | Change | Detail |
|---|---|---|
| `_is_cosmos_model()` | **New** | 3-line helper, matches `"cosmos"` in model name |
| `_should_use_video_file_base64()` | **Modified** | `remote AND (cosmos OR omni+audio)` — single expression |
| `_should_use_video_base64()` | **Modified** | Early return `False` for remote Cosmos to avoid conflicting flags |
| `_build_vlm_messages()` | Unchanged | Existing `video_file_base64` branch handles it |
| VLM binding (`base_vlm.bind`) | Unchanged | `media_io_kwargs` already computed for Cosmos |

#### Decision matrix

| Scenario | `use_video_base64` | `use_video_file_base64` | Content sent | Path |
|---|---|---|---|---|
| **Remote Cosmos** (the fix) | False | True | `data:video/mp4;base64,...` as `video_url` | NIM samples frames server-side |
| Remote non-Cosmos (Qwen, GPT-4o) | True | False | N × `image_url` JPEG frames | OpenAI-compatible, existing behavior |
| Remote Omni + audio | False | True | `data:video/mp4;base64,...` as `video_url` | Audio track preserved |
| Local (any model) | False | False | VST HTTP URL as `video_url` | NIM reaches VST directly |


### Note: NAT profiler suppression on VLM chain (`callback_handler_var` ContextVar)

NAT registers its `LangchainProfilerHandler` via LangChain's `register_configure_hook(callback_handler_var, inheritable=True)` — a global context hook that injects into every LangChain `ChatModel` call. The handler's `on_chat_model_start` deep-copies the full input messages (including base64 video/image payloads) and streams them to the browser as intermediate-step SSE events via `intermediate_steps_subscriber.py`. Each VLM call's base64 payload is sent to the client 3× (`LLM_START`, `LLM_NEW_TOKEN`, `LLM_END`).

### Impact

- **Affected profiles:** Base and Search (use NIM VLM via `video_understanding` tool)
- **Unaffected:** LVS, Alerts, Warehouse (use RT-VLM which has its own `video_url` handling)
- **Local deployments:** Unchanged — `_is_remote_vlm("local")` is `False`, all conditions fall through to the direct VST URL path


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
