### PR TITLE
fix(skills): remove here-string jq inputs in VLM report

### DIFF
--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -237,11 +237,11 @@ print(json.dumps({
 ')
 )
 [ -n "${CFG_JSON}" ] || { echo "Failed to read video_understanding config from vss-agent"; exit 1; }
-jq -e . >/dev/null <<< "${CFG_JSON}" || { echo "Invalid config JSON from vss-agent"; exit 1; }
-MAX_FPS="$(jq -r '.max_fps' <<< "${CFG_JSON}")"
-MAX_FRAMES="$(jq -r '.max_frames' <<< "${CFG_JSON}")"
-MIN_PIXELS="$(jq -r '.min_pixels' <<< "${CFG_JSON}")"
-MAX_PIXELS="$(jq -r '.max_pixels' <<< "${CFG_JSON}")"
+printf '%s' "${CFG_JSON}" | jq -e . >/dev/null || { echo "Invalid config JSON from vss-agent"; exit 1; }
+MAX_FPS="$(printf '%s' "${CFG_JSON}" | jq -r '.max_fps')"
+MAX_FRAMES="$(printf '%s' "${CFG_JSON}" | jq -r '.max_frames')"
+MIN_PIXELS="$(printf '%s' "${CFG_JSON}" | jq -r '.min_pixels')"
+MAX_PIXELS="$(printf '%s' "${CFG_JSON}" | jq -r '.max_pixels')"
 
 # num_frames = min(int(clip_seconds) * max_fps, max_frames), min 1 — matches video_understanding.py.
 # clip_seconds (Step 1 endTime-startTime) may be fractional; truncate to integer seconds — bash $((...))
@@ -266,13 +266,13 @@ curl -s --connect-timeout 5 --max-time 120 -X POST "${VLM_ENDPOINT}/chat/complet
   -H "Content-Type: application/json" \
   -d @- <<EOF | jq -r '.choices[0].message.content'
 {
-  "model": $(jq -Rs . <<< "${VLM_MODEL}"),
+  "model": $(printf '%s' "${VLM_MODEL}" | jq -Rs .),
   "messages": [
     {
       "role": "user",
       "content": [
-        {"type": "text", "text": $(jq -Rs . <<< "${PROMPT}")},
-        {"type": "video_url", "video_url": {"url": $(jq -Rs . <<< "${VIDEO_URL}")}}
+        {"type": "text", "text": $(printf '%s' "${PROMPT}" | jq -Rs .)},
+        {"type": "video_url", "video_url": {"url": $(printf '%s' "${VIDEO_URL}" | jq -Rs .)}}
       ]
     }
   ],


### PR DESCRIPTION
## Description

Fixes NVBug 6408520.

Mode A in `vss-generate-video-report` used bash here-strings (`<<<`) when passing values into `jq`. Here-strings append a trailing newline and are not POSIX-shell portable, which can cause strict VLM endpoints to receive payload values with `\n` and reject requests.

This PR replaces here-string based `jq` input with `printf '%s' "${VAR}" | jq ...` for both:
- `CFG_JSON` parsing values (`max_fps`, `max_frames`, `min_pixels`, `max_pixels`)
- VLM payload fields (`VLM_MODEL`, `PROMPT`, `VIDEO_URL`)

This preserves JSON parsing/escaping without adding trailing whitespace or depending on bash-only here-strings.

Validation:
- Confirmed the here-string path adds one trailing byte while `printf '%s'` preserves the exact value.
- Confirmed no `<<<` remains in `skills/vss-generate-video-report/SKILL.md`.
- Ran `pre-commit run --files skills/vss-generate-video-report/SKILL.md`.
- Commit is DCO signed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.