### PR TITLE
docs: clarify LVS Brev secure links

### DIFF
--- a/deploy/docker/scripts/deploy_vss_launchable.ipynb
+++ b/deploy/docker/scripts/deploy_vss_launchable.ipynb
@@ -1505,10 +1505,10 @@
         "| 6006 | Phoenix (LLM tracing/observability) | all | Not needed (behind proxy at `/phoenix`) |\n",
         "| 9200 | Elasticsearch | search, alerts, lvs | Not needed |\n",
         "| 8081 | Video Analytics API | alerts | Not needed |\n",
-        "| 31000 | nvstreamer (WebRTC live view) | search, alerts | Required for live camera view |\n",
+        "| 31000 | nvstreamer (WebRTC live view) | search, alerts, lvs | Required for live camera view |\n",
         "| 8554 | RTSP (if using test stream) | alerts | Not needed |\n",
         "\n",
-        "**Brev summary:** For the **base** and **lvs** profiles, create 1 secure link (port 7777). For **search** and **alerts**, create secure links for ports 7777 and 31000. Kibana and Phoenix are accessible via proxy paths — no separate secure links needed.\n",
+        "**Brev summary:** For the **base** profile, create 1 secure link (port 7777). For **search**, **alerts**, and **lvs** profiles, create secure links for ports 7777 and 31000. Kibana and Phoenix are accessible via proxy paths — no separate secure links needed.\n",
         "\n",
         "If direct access is not possible, use SSH port forwarding or your CSP's port sharing/tunneling feature."
       ]
@@ -1569,7 +1569,7 @@
         "    if PROFILE in (\"search\", \"alerts\", \"lvs\"):\n",
         "        print(f\"  Kibana (via proxy):  {proxy_url}/kibana\")\n",
         "        print(f\"  Kibana (direct):     http://{EXTERNAL_IP or HOST_IP}:5601/kibana\")\n",
-        "        if PROFILE in (\"search\", \"alerts\"):\n",
+        "        if PROFILE in (\"search\", \"alerts\", \"lvs\"):\n",
         "            print(f\"  nvstreamer (live view): http://{EXTERNAL_IP or HOST_IP}:31000\")\n",
         "        print(f\"  Phoenix (via proxy): {proxy_url}/phoenix\")\n",
         "        print(f\"  Phoenix (direct):    http://{EXTERNAL_IP or HOST_IP}:6006\")"


### PR DESCRIPTION
## Description

Fixes NVBug 6420310.

Updates the Brev launchable Access the UI guidance for the dev/3.2.1 LVS profile. The notebook already prints a port 31000 nvstreamer secure link for lvs in Brev; this aligns the access table and Brev summary so users know to create secure links for both 7777 and 31000.

Also aligns the non-Brev direct-access output so lvs users see the port 31000 nvstreamer URL consistently with search and alerts.

## Validation

- Parsed deploy/docker/scripts/deploy_vss_launchable.ipynb as JSON.
- Ran git diff --check.
- Ran targeted notebook regression check confirming the 31000 table row, Brev summary, Brev nvstreamer print, and non-Brev nvstreamer print all include lvs.
- Ran pre-commit run --config .pre-commit-config.yaml --files deploy/docker/scripts/deploy_vss_launchable.ipynb.
- Commit hook reran DCO sign-off check; commit is DCO signed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.