### PR TITLE
fix 'warehouse-2d-app.yml: include must be a list'

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
@@ -112,6 +112,11 @@ services:
       # Search-profile wrapper script (patches configs, then calls ds-start.sh)
       - $VSS_APPS_DIR/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/ds-search-start.sh:/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/ds-search-start.sh:ro
 
+      # Override the relative ./ds-start.sh from the extends base with an absolute path.
+      # Docker Compose v2 resolves relative sources in extended services relative to the
+      # consuming file's directory rather than the base file's directory, so we fix it here.
+      - $VSS_APPS_DIR/services/rtvi/rtvi-cv/ds-start.sh:/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/ds-start.sh:ro
+
       # Models directory — RT-DETR + vision encoder models (downloaded by init container)
       - $VSS_DATA_DIR/models/:/opt/storage/
     command:

--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/download-vision-encoder.sh
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/scripts/download-vision-encoder.sh
@@ -59,8 +59,13 @@ if ! command -v ngc &>/dev/null; then
   export DEBIAN_FRONTEND=noninteractive
   apt-get update -qq && apt-get install -y -qq wget unzip > /dev/null
   cd /tmp
-  wget -q https://ngc.nvidia.com/downloads/ngccli_linux.zip -O ngccli_linux.zip
-  unzip -q ngccli_linux.zip && chmod +x ngc-cli/ngc
+  _ngc_arch="$(uname -m)"
+  case "${_ngc_arch}" in
+    aarch64|arm64) _ngc_zip="ngccli_arm64.zip" ;;
+    *)             _ngc_zip="ngccli_linux.zip"  ;;
+  esac
+  wget -q "https://ngc.nvidia.com/downloads/${_ngc_zip}" -O ngccli.zip
+  rm -rf ngc-cli && unzip -qo ngccli.zip && chmod +x ngc-cli/ngc
   export PATH="/tmp/ngc-cli:$PATH"
   cd -
   ngc --version

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include:
-
 services:
 
   vss-behavior-analytics-2d:

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include:
 
 services:
 

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include:
 
 services:
   vss-behavior-analytics-mv3dt:

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -405,7 +405,7 @@ function usage() {
   echo "                                     - IGX-THOR"
   echo "                                     - AGX-THOR"
   echo "                                     - OTHER"
-  echo "                                   • DGX-SPARK, IGX-THOR, and AGX-THOR only valid when profile is base or alerts"
+  echo "                                   • DGX-SPARK, IGX-THOR, and AGX-THOR only valid when profile is base, alerts, or search"
   echo "                                   • DGX-SPARK, IGX-THOR, AGX-THOR: --llm-device-id, --vlm-device-id not accepted"
   echo "  -i, --host-ip                    Host IP."
   echo "                                   • Default: primary IP from ip route"
@@ -718,10 +718,10 @@ function process_args() {
         fi
       fi
 
-      # DGX-SPARK, IGX-THOR, AGX-THOR (edge_hardware_profiles): only valid for base and alerts; device ID options not accepted
+      # DGX-SPARK, IGX-THOR, AGX-THOR (edge_hardware_profiles): only valid for base, alerts, and search; device ID options not accepted
       if contains_element "${hardware_profile}" "${edge_hardware_profiles[@]}"; then
-        if [[ "${profile}" != "base" ]] && [[ "${profile}" != "alerts" ]]; then
-          echo "[ERROR] Hardware profile '${hardware_profile}' is only valid for profile base or alerts, not '${profile}'"
+        if [[ "${profile}" != "base" ]] && [[ "${profile}" != "alerts" ]] && [[ "${profile}" != "search" ]]; then
+          echo "[ERROR] Hardware profile '${hardware_profile}' is only valid for profile base, alerts, or search, not '${profile}'"
           ((_all_good++))
         fi
         if contains_element "llm-device-id" "${options_provided[@]}"; then
@@ -1337,6 +1337,12 @@ function state_up() {
   # Alerts profile: conditionally set vlm-as-verifier config prefix for IGX-THOR, AGX-THOR only; DGX-SPARK uses default config.yml
   if [[ "${profile}" == "alerts" ]] && ([[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]) && [[ "${vlm_mode}" != "remote" ]]; then
     set_env_var "VLM_AS_VERIFIER_CONFIG_FILE_PREFIX" "EDGE-LOCAL-VLM-"
+  fi
+
+  # Search profile on IGX-THOR or AGX-THOR: single GPU (device 0) shared by rtvi-cv and rtvi-embed
+  if ([[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]) && [[ "${profile}" == "search" ]]; then
+    set_env_var "RT_CV_DEVICE_ID" "0"
+    set_env_var "RT_EMBED_DEVICE_ID" "0"
   fi
 
   # Alerts or base profile on IGX-THOR or AGX-THOR: set VLM name/slug, base URL, and RTVI-related env (fixed configuration)

--- a/deploy/docker/services/infra/kafka/init-scripts/create-kafka-topics.sh
+++ b/deploy/docker/services/infra/kafka/init-scripts/create-kafka-topics.sh
@@ -15,25 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# installing required binaries
-ARCH=$(uname -m)
-JQ_URL=""
-
-if [ "$ARCH" = "x86_64" ]; then
-    JQ_URL="https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64"
-elif [ "$ARCH" = "aarch64" ]; then
-    JQ_URL="https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64"
-else
-    echo "Unsupported architecture: $ARCH"
-    exit 1
-fi
-
-mkdir -p ~/jqbin
-curl -L -o ~/jqbin/jq "$JQ_URL"
-chmod +x ~/jqbin/jq
-
-export PATH="/home/appuser/jqbin:${PATH}"
-
 # bootstrap kafka hosts
 KAFKA_HOST=${BOOTSTRAP_HOST:-localhost}
 KAFKA_PORT=${KAFKA_PORT:-9092}
@@ -55,12 +36,23 @@ echo "DEFAULT_SEGMENT_MS: $DEFAULT_SEGMENT_MS"
 echo "KAFKA_HOST: $KAFKA_HOST"
 echo "KAFKA_PORT: $KAFKA_PORT"
 
-kafkaTopics=$(echo "$KAFKA_TOPICS" | jq --arg default_partitions "${DEFAULT_PARTITIONS}" \
-  --arg default_retention_ms "${DEFAULT_RETENTION_MS}" \
-  --arg default_replication_factor "${DEFAULT_REPLICATION_FACTOR}" \
-  --arg default_segment_ms "${DEFAULT_SEGMENT_MS}" \
-  --arg kafka_host "${KAFKA_HOST}:${KAFKA_PORT}" \
-  -r '.[] | "kafka-topics --create --bootstrap-server \($kafka_host) --topic \(.name) --partitions \(.partitions // $default_partitions) --replication-factor \(.replication_factor // $default_replication_factor) --if-not-exists --config retention.ms=\(.retention_ms // $default_retention_ms) --config segment.ms=\(.segment_ms // $default_segment_ms)"')
+kafkaTopics=$(python3 - <<PYEOF
+import json, os, sys
+topics = json.loads(os.environ['KAFKA_TOPICS'])
+host   = '${KAFKA_HOST}:${KAFKA_PORT}'
+dp     = '${DEFAULT_PARTITIONS}'
+dr     = '${DEFAULT_RETENTION_MS}'
+drf    = '${DEFAULT_REPLICATION_FACTOR}'
+ds     = '${DEFAULT_SEGMENT_MS}'
+for t in topics:
+    name = t['name']
+    parts = t.get('partitions', dp)
+    rf    = t.get('replication_factor', drf)
+    ret   = t.get('retention_ms', dr)
+    seg   = t.get('segment_ms', ds)
+    print(f"kafka-topics --create --bootstrap-server {host} --topic {name} --partitions {parts} --replication-factor {rf} --if-not-exists --config retention.ms={ret} --config segment.ms={seg}")
+PYEOF
+)
 
 echo "bootstrap-server: $KAFKA_HOST:$KAFKA_PORT"
 

--- a/deploy/docker/services/infra/sdrc/docker-compose.yaml
+++ b/deploy/docker/services/infra/sdrc/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
       COMPOSE_PROFILES: ${COMPOSE_PROFILES:-}
     volumes:
       - ./render-config.sh:/render-config.sh:ro
-      - ${SDR_CONTROLLER_CONFIG_PATH:-"./configs"}/configs:/tmpl
+      - ${SDR_CONTROLLER_CONFIG_PATH:-./configs}/configs:/tmpl
     restart: "no"
     container_name: sdrc-render-config
 
@@ -86,7 +86,7 @@ services:
       NUM_STREAMS: ${NUM_STREAMS:-1}
       NUM_SENSORS: ${NUM_SENSORS:-1}
     volumes:
-      - ${SDR_CONTROLLER_CONFIG_PATH:-"./configs"}/configs/config.yml:/config.yml:ro
+      - ${SDR_CONTROLLER_CONFIG_PATH:-./configs}/configs/config.yml:/config.yml:ro
       - ./wdm-env-from-config.sh:/run.sh:ro
       - ./.wdm-env:/env
     depends_on:
@@ -157,7 +157,7 @@ services:
       - ./log:/logs
       - /var/run/docker.sock:/var/run/docker.sock
       # Host dir with docker-config.yml (see WDM_WORKLOADS_CONFIG). Same tree as wdm-env-from-config config.yml.
-      - "${SDR_CONTROLLER_CONFIG_PATH:-'./configs'}/configs:/configs/:ro"
+      - ${SDR_CONTROLLER_CONFIG_PATH:-./configs}/configs:/configs/:ro
     depends_on:
       broker-health-check:
         condition: service_completed_successfully


### PR DESCRIPTION
when running this in jetson thor:
```
export LLM_ENDPOINT_URL=https://<llm-endpoint>
deploy/docker/scripts/dev-profile.sh up -p base -H AGX-THOR --use-remote-llm --llm 'nvidia/llama-3.3-nemotron-super-49b-v1.5'
```

it gave this:
`validating video-search-and-summarization/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml: include must be a list`


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
