### PR TITLE
Add Prometheus consolidation observability metrics

### DIFF
--- a/services/alert/src/metrics/prometheus_metrics.py
+++ b/services/alert/src/metrics/prometheus_metrics.py
@@ -447,6 +447,34 @@ INCIDENT_QUERY_FAILURES = Counter(
     'Failed Elasticsearch incident queries',
 )
 
+# --- Realtime RT-VLM alert consolidation (read-time dedup) -------------------
+# Emitted by IncidentService._consolidate when consolidate=true. Let operators
+# tune max_inter_alert_gap_seconds / max_event_duration_seconds empirically.
+DEDUP_CHUNKS_IN = Counter(
+    'alert_bridge_dedup_chunks_in_total',
+    'Raw RT-VLM chunk incidents fed into the consolidator',
+    ['sensorId', 'category'],
+)
+
+DEDUP_EVENTS_OUT = Counter(
+    'alert_bridge_dedup_events_out_total',
+    'Consolidated events emitted by the consolidator',
+    ['sensorId', 'category'],
+)
+
+# reason values: gap (continuity break) | outer (duration cap) | malformed
+DEDUP_SPLIT_REASON = Counter(
+    'alert_bridge_dedup_split_reason_total',
+    'Why an event ended and a new one began, by reason',
+    ['reason'],
+)
+
+DEDUP_DURATION = Histogram(
+    'alert_bridge_dedup_duration_seconds',
+    'Time spent folding chunks into events (excludes the Elasticsearch query)',
+    buckets=[0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0],
+)
+
 # Verification failures broken down by failure stage/reason.
 # Incremented for every event that does NOT produce a successful VLM verdict,
 # including events that never reach the VLM (VST failures, URL validation) and

--- a/services/alert/src/metrics/prometheus_metrics.py
+++ b/services/alert/src/metrics/prometheus_metrics.py
@@ -450,16 +450,20 @@ INCIDENT_QUERY_FAILURES = Counter(
 # --- Realtime RT-VLM alert consolidation (read-time dedup) -------------------
 # Emitted by IncidentService._consolidate when consolidate=true. Let operators
 # tune max_inter_alert_gap_seconds / max_event_duration_seconds empirically.
+# Aggregate-only (no sensorId/category labels): the consolidator labels straight
+# from Elasticsearch documents, so per-sensor labels would mint unbounded,
+# permanent Prometheus series on high-cardinality or malformed sensor IDs. The
+# aggregate chunks-in / events-out ratio is the dedup-effectiveness signal; a
+# per-sensor breakdown, if ever needed, must go through the gated + sanitized
+# per-sensor path (metrics.recorder: per_sensor_labels_enabled / _sanitize_sensor_id).
 DEDUP_CHUNKS_IN = Counter(
     'alert_bridge_dedup_chunks_in_total',
     'Raw RT-VLM chunk incidents fed into the consolidator',
-    ['sensorId', 'category'],
 )
 
 DEDUP_EVENTS_OUT = Counter(
     'alert_bridge_dedup_events_out_total',
     'Consolidated events emitted by the consolidator',
-    ['sensorId', 'category'],
 )
 
 # reason values: gap (continuity break) | outer (duration cap) | malformed

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -399,7 +399,7 @@ class IncidentService:
             groups.setdefault(key, []).append(doc)
 
         events: List[dict] = []
-        for (sid, cat), items in groups.items():
+        for items in groups.values():
             # Sort by (timestamp, id) so equal-timestamp chunks order
             # deterministically regardless of ES scan direction.
             items_sorted = sorted(
@@ -425,10 +425,12 @@ class IncidentService:
             if current:
                 group_events.append(self._build_event(current, representative))
             events.extend(group_events)
+            # Aggregate-only counters (no per-sensor/category labels) to avoid
+            # unbounded Prometheus cardinality from ES-sourced label values.
             if DEDUP_CHUNKS_IN is not None:
-                DEDUP_CHUNKS_IN.labels(sensorId=str(sid), category=str(cat)).inc(len(items))
+                DEDUP_CHUNKS_IN.inc(len(items))
             if DEDUP_EVENTS_OUT is not None:
-                DEDUP_EVENTS_OUT.labels(sensorId=str(sid), category=str(cat)).inc(len(group_events))
+                DEDUP_EVENTS_OUT.inc(len(group_events))
 
         # Order: event start descending
         events.sort(

--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -39,14 +39,26 @@ try:
         from metrics.prometheus_metrics import (
             INCIDENT_QUERY_DURATION,
             INCIDENT_QUERY_FAILURES,
+            DEDUP_CHUNKS_IN,
+            DEDUP_EVENTS_OUT,
+            DEDUP_SPLIT_REASON,
+            DEDUP_DURATION,
         )
     else:
         INCIDENT_QUERY_DURATION = None
         INCIDENT_QUERY_FAILURES = None
+        DEDUP_CHUNKS_IN = None
+        DEDUP_EVENTS_OUT = None
+        DEDUP_SPLIT_REASON = None
+        DEDUP_DURATION = None
 except ImportError:
     PROMETHEUS_ENABLED = False
     INCIDENT_QUERY_DURATION = None
     INCIDENT_QUERY_FAILURES = None
+    DEDUP_CHUNKS_IN = None
+    DEDUP_EVENTS_OUT = None
+    DEDUP_SPLIT_REASON = None
+    DEDUP_DURATION = None
 
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
@@ -150,6 +162,17 @@ class IncidentService:
             extra={
                 "es_enabled": es_client is not None,
                 "index_base": self._index_base,
+                # Active consolidation bounds, logged so operators can correlate
+                # the dedup_* metrics with the configuration in effect.
+                "consolidation_max_inter_alert_gap_seconds": self._consolidation.get(
+                    "max_inter_alert_gap_seconds", 60
+                ),
+                "consolidation_max_event_duration_seconds": self._consolidation.get(
+                    "max_event_duration_seconds", 300
+                ),
+                "consolidation_representative": self._consolidation.get(
+                    "representative", "latest"
+                ),
             },
         )
 
@@ -362,6 +385,7 @@ class IncidentService:
         max_duration = cfg.get("max_event_duration_seconds", 300)
         representative = cfg.get("representative", "latest")
 
+        t_fold = time.monotonic()
         groups: dict = {}
         for doc in docs:
             # Drop malformed chunks — a chunk missing its grouping keys, or with
@@ -375,7 +399,7 @@ class IncidentService:
             groups.setdefault(key, []).append(doc)
 
         events: List[dict] = []
-        for items in groups.values():
+        for (sid, cat), items in groups.items():
             # Sort by (timestamp, id) so equal-timestamp chunks order
             # deterministically regardless of ES scan direction.
             items_sorted = sorted(
@@ -385,22 +409,34 @@ class IncidentService:
                     str(d.get("Id") or d.get("_id") or ""),
                 ),
             )
+            group_events: List[dict] = []
             current: List[dict] = []
             for doc in items_sorted:
                 if current and self._is_continuous(current, doc, gap_seconds, max_duration):
                     current.append(doc)
                 else:
                     if current:
-                        events.append(self._build_event(current, representative))
+                        group_events.append(self._build_event(current, representative))
+                        if DEDUP_SPLIT_REASON is not None:
+                            DEDUP_SPLIT_REASON.labels(
+                                reason=self._split_reason(current, doc, gap_seconds, max_duration)
+                            ).inc()
                     current = [doc]
             if current:
-                events.append(self._build_event(current, representative))
+                group_events.append(self._build_event(current, representative))
+            events.extend(group_events)
+            if DEDUP_CHUNKS_IN is not None:
+                DEDUP_CHUNKS_IN.labels(sensorId=str(sid), category=str(cat)).inc(len(items))
+            if DEDUP_EVENTS_OUT is not None:
+                DEDUP_EVENTS_OUT.labels(sensorId=str(sid), category=str(cat)).inc(len(group_events))
 
         # Order: event start descending
         events.sort(
             key=lambda e: _parse_ts(e.get("timestamp")) or _EPOCH,
             reverse=True,
         )
+        if DEDUP_DURATION is not None:
+            DEDUP_DURATION.observe(time.monotonic() - t_fold)
         return events
 
     @staticmethod
@@ -419,13 +455,33 @@ class IncidentService:
             start = _parse_ts(first.get("timestamp"))
             doc_end = _parse_ts(doc.get("end")) or _parse_ts(doc.get("timestamp"))
             if start and doc_end and (doc_end - start).total_seconds() > max_duration:
-                return False
+                return False  # outer duration cap breached
 
         prev_end = _parse_ts(prev.get("end")) or _parse_ts(prev.get("timestamp"))
         doc_start = _parse_ts(doc.get("timestamp"))
         if prev_end is None or doc_start is None:
             return False
         return (doc_start - prev_end).total_seconds() <= gap_seconds
+
+    @staticmethod
+    def _split_reason(current: List[dict], doc: dict, gap_seconds, max_duration) -> str:
+        """Classify why ``doc`` did not extend ``current`` — for the
+        ``dedup_split_reason_total`` metric. Mirrors ``_is_continuous`` (outer
+        cap checked first, then the gap): returns ``outer``, ``gap``, or
+        ``malformed``.
+        """
+        first = current[0]
+        prev = current[-1]
+        if max_duration is not None:
+            start = _parse_ts(first.get("timestamp"))
+            doc_end = _parse_ts(doc.get("end")) or _parse_ts(doc.get("timestamp"))
+            if start and doc_end and (doc_end - start).total_seconds() > max_duration:
+                return "outer"
+        prev_end = _parse_ts(prev.get("end")) or _parse_ts(prev.get("timestamp"))
+        doc_start = _parse_ts(doc.get("timestamp"))
+        if prev_end is None or doc_start is None:
+            return "malformed"
+        return "gap"
 
     @staticmethod
     def _build_event(chunks: List[dict], representative: str) -> dict:

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -508,6 +508,20 @@ class TestConsolidationGrouping:
         assert events[0]["info"]["chunkCount"] == "2"
 
 
+class TestConsolidationSplitReason:
+    """_split_reason classifies why an event ended (for the dedup metric)."""
+
+    def test_reason_gap(self):
+        current = [_chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")]
+        doc = _chunk(idx=2, start="2025-01-01T00:02:00.000Z", end="2025-01-01T00:02:30.000Z")
+        assert IncidentService._split_reason(current, doc, 60, 300) == "gap"
+
+    def test_reason_outer(self):
+        current = [_chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")]
+        doc = _chunk(idx=2, start="2025-01-01T00:05:30.000Z", end="2025-01-01T00:06:00.000Z")
+        assert IncidentService._split_reason(current, doc, 60, 300) == "outer"
+
+
 class TestConsolidationConfigValidation:
     """IncidentService construction validates consolidation tuning (fail-fast)."""
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
