### PR TITLE
fix(skills): avoid here-string newline in VLM report

### DIFF
--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -237,11 +237,11 @@ print(json.dumps({
 ')
 )
 [ -n "${CFG_JSON}" ] || { echo "Failed to read video_understanding config from vss-agent"; exit 1; }
-jq -e . >/dev/null <<< "${CFG_JSON}" || { echo "Invalid config JSON from vss-agent"; exit 1; }
-MAX_FPS="$(jq -r '.max_fps' <<< "${CFG_JSON}")"
-MAX_FRAMES="$(jq -r '.max_frames' <<< "${CFG_JSON}")"
-MIN_PIXELS="$(jq -r '.min_pixels' <<< "${CFG_JSON}")"
-MAX_PIXELS="$(jq -r '.max_pixels' <<< "${CFG_JSON}")"
+printf '%s' "${CFG_JSON}" | jq -e . >/dev/null || { echo "Invalid config JSON from vss-agent"; exit 1; }
+MAX_FPS="$(printf '%s' "${CFG_JSON}" | jq -r '.max_fps')"
+MAX_FRAMES="$(printf '%s' "${CFG_JSON}" | jq -r '.max_frames')"
+MIN_PIXELS="$(printf '%s' "${CFG_JSON}" | jq -r '.min_pixels')"
+MAX_PIXELS="$(printf '%s' "${CFG_JSON}" | jq -r '.max_pixels')"
 
 # num_frames = min(int(clip_seconds) * max_fps, max_frames), min 1 — matches video_understanding.py.
 # clip_seconds (Step 1 endTime-startTime) may be fractional; truncate to integer seconds — bash $((...))
@@ -266,13 +266,13 @@ curl -s --connect-timeout 5 --max-time 120 -X POST "${VLM_ENDPOINT}/chat/complet
   -H "Content-Type: application/json" \
   -d @- <<EOF | jq -r '.choices[0].message.content'
 {
-  "model": $(jq -Rs . <<< "${VLM_MODEL}"),
+  "model": $(printf '%s' "${VLM_MODEL}" | jq -Rs .),
   "messages": [
     {
       "role": "user",
       "content": [
-        {"type": "text", "text": $(jq -Rs . <<< "${PROMPT}")},
-        {"type": "video_url", "video_url": {"url": $(jq -Rs . <<< "${VIDEO_URL}")}}
+        {"type": "text", "text": $(printf '%s' "${PROMPT}" | jq -Rs .)},
+        {"type": "video_url", "video_url": {"url": $(printf '%s' "${VIDEO_URL}" | jq -Rs .)}}
       ]
     }
   ],


### PR DESCRIPTION
## Description

Backports PR #1196 to dev/3.2.1.

Replaces bash here-string jq reads in the VSS generate video report skill with printf-based input so config parsing and VLM payload values do not gain trailing newline bytes and do not rely on non-POSIX here-strings.

NVBug 6408520

Cherry-picked from commit 18240a179a0f4d19d497cbf2f4fee42e8737d487.

## Validation

- Ran git diff --check origin/dev/3.2.1...HEAD.
- Ran targeted content regression check confirming no here-strings remain and CFG_JSON, VLM_MODEL, PROMPT, and VIDEO_URL jq inputs use printf-based input.
- Ran pre-commit run --config .pre-commit-config.yaml --files skills/vss-generate-video-report/SKILL.md.
- Commit is DCO signed and includes the cherry-pick source reference.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.