### PR TITLE
fix(helm): align LVS vss-summarization dependency version

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/Chart.lock
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 3.2.0
 - name: vss-summarization
   repository: file://../../services/video-summarization
-  version: 3.2.0
+  version: 3.2.1-rc1-d16a216
 - name: rtvi
   repository: file://../../services/rtvi
   version: 3.2.0
-digest: sha256:534967259172ce61fc12343beb2a0d6749ed065b4b2922fa858b0c72a95b2c60
-generated: "2026-06-04T16:43:49.632262+05:30"
+digest: sha256:523325589b88d89d7804f9cca67430bf8359a244ed39ce5b367712f2611e0596
+generated: "2026-07-07T00:29:08.865023301-07:00"

--- a/deploy/helm/developer-profiles/dev-profile-lvs/Chart.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/Chart.yaml
@@ -41,7 +41,7 @@ dependencies:
     repository: "file://../../services/nims"
     condition: nims.enabled
   - name: vss-summarization
-    version: 3.2.0
+    version: 3.2.1-rc1-d16a216
     repository: "file://../../services/video-summarization"
     condition: vss-summarization.enabled
   - name: rtvi


### PR DESCRIPTION
## Description
Bump the dependency to 3.2.1-rc1-d16a216 to match the child chart and regenerate Chart.lock.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
