### PR TITLE
vios: decoder: Fix source resolution sent to consumers

### DIFF
--- a/services/vios/src/framework/media/overlays/overlay_internal.cpp
+++ b/services/vios/src/framework/media/overlays/overlay_internal.cpp
@@ -3776,8 +3776,9 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
             }
 
             /* Now set the offsets where the string should appear */
-            text_params->pos_x = std::min(10, m_width);
-            text_params->pos_y = std::min(900, m_height-100);
+            const Point dbg_pos = interpolateCoordinate(10, 900, WIDTH_1080p, HEIGHT_1080p, m_width, m_height);
+            text_params->pos_x = dbg_pos.x;
+            text_params->pos_y = dbg_pos.y;
             text_params->font_size = font_size;
             text_params->font_type = strdup(GET_CONFIG().overlay_text_font_type.c_str());
 
@@ -3813,8 +3814,9 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
                 }
 
                 /* Now set the offsets where the string should appear */
-                text_params_latency->pos_x = std::min(10, m_width);
-                text_params_latency->pos_y = std::min(900 + (3 * font_size), m_height - 100 + (3 * font_size));
+                const Point lat_pos = interpolateCoordinate(10, 900, WIDTH_1080p, HEIGHT_1080p, m_width, m_height);
+                text_params_latency->pos_x = lat_pos.x;
+                text_params_latency->pos_y = lat_pos.y + (3 * font_size);
                 text_params_latency->font_size = font_size;
                 text_params_latency->font_type = strdup(GET_CONFIG().overlay_text_font_type.c_str());
 
@@ -4045,9 +4047,10 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, Gs
                 text_params->text = cstr;
             }
 
-            /* Now set the offsets where the string should appe ar */
-            text_params->pos_x = std::min(10, m_width);
-            text_params->pos_y = std::min(900, m_height-100);
+            /* Now set the offsets where the string should appear */
+            const Point dbg_pos = interpolateCoordinate(10, 900, WIDTH_1080p, HEIGHT_1080p, m_width, m_height);
+            text_params->pos_x = dbg_pos.x;
+            text_params->pos_y = dbg_pos.y;
             text_params->font_size = interpolateFontSize(m_sourceWidth, m_width);
             text_params->font_type = strdup(GET_CONFIG().overlay_text_font_type.c_str());
 

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
@@ -1295,6 +1295,7 @@ failure:
 
 void GstNvVideoDecoder::setResolution(int width, int height)
 {
+    const bool changed = (m_decoderWidth != width) || (m_decoderHeight != height);
     m_decoderWidth = width;
     m_decoderHeight = height;
 
@@ -1309,6 +1310,30 @@ void GstNvVideoDecoder::setResolution(int width, int height)
             // Update frame size with actual decoder resolution (or resize dimensions if set)
             sink->m_frameSize.m_width = m_resizeWidth ? m_resizeWidth : width;
             sink->m_frameSize.m_height = m_resizeHeight ? m_resizeHeight : height;
+        }
+        return;
+    }
+
+    if (!changed || width <= 0 || height <= 0)
+    {
+        return;
+    }
+
+    /* The real decoded resolution is only known here, once the decodebin caps
+    ** are negotiated (asynchronously, after the pipeline is PLAYING). At
+    ** setConsumer() time the consumers were seeded with the decoder's default
+    ** resolution, so the consumer's coordinate reference (m_sourceWidth/
+    ** m_sourceHeight) is stale. Re-propagate the true resolution down the
+    ** consumer chain */
+    std::lock_guard<std::mutex> lock(m_videoSinkLock);
+    LOG(info) << "Decoder resolution negotiated: " << width << "x" << height
+              << "; propagating source frame size to " << m_videoSinkList.size()
+              << " consumer(s) for " << m_uri << endl;
+    for (auto& entry : m_videoSinkList)
+    {
+        if (entry.second && entry.second->m_consumer)
+        {
+            entry.second->m_consumer->setOriginalFrameSize(width, height);
         }
     }
 }


### PR DESCRIPTION
## Description
When decoder reoslution changes, propogate it
properly to all consumers. This fixes the alignment issue in overlay for non-1080p resolutions

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
