### PR TITLE
feat: add simings-nv to copy-pr-bot vetters

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -48,6 +48,7 @@ additional_vetters:
   - romalakar
   - sarathm-nvidia
   - shubham050300
+  - simings-nv
   - soumilinandi
   - ssmmoo1
   - trongp-nvidia


### PR DESCRIPTION
## Summary

Add `simings-nv` to `additional_vetters` in `.github/copy-pr-bot.yaml` so they can approve external PRs for CI.

## Test plan

- [ ] copy-pr-bot recognizes simings-nv as a vetter