### PR TITLE
ci: add simings-nv to copy-pr-bot vetters

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -47,6 +47,7 @@ additional_vetters:
   - romalakar
   - sarathm-nvidia
   - shubham050300
+  - simings-nv
   - soumilinandi
   - ssmmoo1
   - trongp-nvidia


### PR DESCRIPTION
## Description

Add my GitHub username to `additional_vetters` so I can trigger CI via `/ok to test <sha>` on pull requests — per the Developer Onboard checklist (step 6). DL membership in Access-VSS-Github-Devs approved 2026-07-08.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is DCO sign-off'd.
- [x] New or existing tests cover these changes (config-only change; no testable surface).
- [x] The documentation is up to date with these changes (n/a — bot config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)