### PR TITLE
fix(skill-eval): stop brev-cli ssh-agent leak from OOM-killing runner services

### DIFF
--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -158,6 +158,22 @@ jobs:
           BASH_MAX_TIMEOUT_MS: "10800000"
         run: |
           mkdir -p "$GH_CONFIG_DIR"
+          # ssh-agent leak guard: brev-cli spawns orphaned `ssh-agent -s`
+          # processes (reparented to PID 1, never killed) on every
+          # `brev exec` when SSH_AUTH_SOCK is unset — at eval cadence that
+          # accumulated 23k agents on the coordinator host and OOM-killed
+          # every runner service (2026-07-08). With SSH_AUTH_SOCK pointing
+          # at a live agent brev reuses it and spawns none, so give the
+          # whole leg one agent and kill it when the step ends.
+          eval "$(ssh-agent -s)" > /dev/null
+          trap 'ssh-agent -k > /dev/null 2>&1 || true' EXIT
+          # Reap strays a SIGKILLed leg (or pre-fix history) left behind.
+          # Orphaned agents older than the longest leg wallclock on any
+          # host sharing this pool (skills-eval.yml timeout-minutes: 360;
+          # 25200s = 7h) cannot belong to any live leg.
+          ps -eo pid=,ppid=,etimes=,args= \
+            | awk '$2==1 && $4=="ssh-agent" && $5=="-s" && $3>25200 {print $1}' \
+            | xargs -r kill 2>/dev/null || true
           set -a
           source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
           set +a

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -158,13 +158,18 @@ jobs:
           BASH_MAX_TIMEOUT_MS: "10800000"
         run: |
           mkdir -p "$GH_CONFIG_DIR"
+          set -a
+          source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
+          set +a
           # ssh-agent leak guard: brev-cli spawns orphaned `ssh-agent -s`
           # processes (reparented to PID 1, never killed) on every
           # `brev exec` when SSH_AUTH_SOCK is unset — at eval cadence that
           # accumulated 23k agents on the coordinator host and OOM-killed
           # every runner service (2026-07-08). With SSH_AUTH_SOCK pointing
           # at a live agent brev reuses it and spawns none, so give the
-          # whole leg one agent and kill it when the step ends.
+          # whole leg one agent and kill it when the step ends. Runs after
+          # the .env source so nothing can overwrite SSH_AUTH_SOCK /
+          # SSH_AGENT_PID behind the trap's back.
           eval "$(ssh-agent -s)" > /dev/null
           trap 'ssh-agent -k > /dev/null 2>&1 || true' EXIT
           # Reap strays a SIGKILLed leg (or pre-fix history) left behind.
@@ -174,9 +179,6 @@ jobs:
           ps -eo pid=,ppid=,etimes=,args= \
             | awk '$2==1 && $4=="ssh-agent" && $5=="-s" && $3>25200 {print $1}' \
             | xargs -r kill 2>/dev/null || true
-          set -a
-          source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
-          set +a
           # Pin the box-side repo sync to the SHA the runner actually checked
           # out — NOT github.sha. On a scheduled run github.sha is the default
           # branch (main) tip, but the checkout above is develop; using it here

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -190,6 +190,21 @@ jobs:
           BASH_MAX_TIMEOUT_MS: "21600000"
         run: |
           mkdir -p "$GH_CONFIG_DIR"
+          # ssh-agent leak guard: brev-cli spawns orphaned `ssh-agent -s`
+          # processes (reparented to PID 1, never killed) on every
+          # `brev exec` when SSH_AUTH_SOCK is unset — at eval cadence that
+          # accumulated 23k agents on the coordinator host and OOM-killed
+          # every runner service (2026-07-08). With SSH_AUTH_SOCK pointing
+          # at a live agent brev reuses it and spawns none, so give the
+          # whole leg one agent and kill it when the step ends.
+          eval "$(ssh-agent -s)" > /dev/null
+          trap 'ssh-agent -k > /dev/null 2>&1 || true' EXIT
+          # Reap strays a SIGKILLed leg (or pre-fix history) left behind.
+          # Orphaned agents older than the job's timeout-minutes (360m;
+          # 25200s = 7h) cannot belong to any live leg on this host.
+          ps -eo pid=,ppid=,etimes=,args= \
+            | awk '$2==1 && $4=="ssh-agent" && $5=="-s" && $3>25200 {print $1}' \
+            | xargs -r kill 2>/dev/null || true
           set -a
           source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
           set +a

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -190,13 +190,18 @@ jobs:
           BASH_MAX_TIMEOUT_MS: "21600000"
         run: |
           mkdir -p "$GH_CONFIG_DIR"
+          set -a
+          source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
+          set +a
           # ssh-agent leak guard: brev-cli spawns orphaned `ssh-agent -s`
           # processes (reparented to PID 1, never killed) on every
           # `brev exec` when SSH_AUTH_SOCK is unset — at eval cadence that
           # accumulated 23k agents on the coordinator host and OOM-killed
           # every runner service (2026-07-08). With SSH_AUTH_SOCK pointing
           # at a live agent brev reuses it and spawns none, so give the
-          # whole leg one agent and kill it when the step ends.
+          # whole leg one agent and kill it when the step ends. Runs after
+          # the .env source so nothing can overwrite SSH_AUTH_SOCK /
+          # SSH_AGENT_PID behind the trap's back.
           eval "$(ssh-agent -s)" > /dev/null
           trap 'ssh-agent -k > /dev/null 2>&1 || true' EXIT
           # Reap strays a SIGKILLed leg (or pre-fix history) left behind.
@@ -205,9 +210,6 @@ jobs:
           ps -eo pid=,ppid=,etimes=,args= \
             | awk '$2==1 && $4=="ssh-agent" && $5=="-s" && $3>25200 {print $1}' \
             | xargs -r kill 2>/dev/null || true
-          set -a
-          source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
-          set +a
           export PR_NUMBER="${{ needs.plan.outputs.pr_number }}"
           export PR_BASE="${{ needs.plan.outputs.pr_base }}"
           export PR_HEAD_SHA="${{ github.sha }}"


### PR DESCRIPTION
## Problem

`brev-cli` spawns orphaned `ssh-agent -s` processes (reparented to PID 1, never killed) on **every `brev exec` invocation** when `SSH_AUTH_SOCK` is unset — measured at 3 agents per call.

At eval cadence this accumulated:
- **23,456** leaked agents on `vss-skill-validator-v2` (29/31 GiB RSS consumed)
- **10,467** on the v1 coordinator (13/15 GiB)

The kernel OOM-killer then took down every runner service on both hosts (`systemd: Failed with result oom-kill`):
- v1 died fully on 2026-06-30 — starving the `vss-brev-runner` pool (Helm Sync / Skills Review queued repo-wide for a week)
- v2 died in waves on 2026-07-08 (18:07–23:32 UTC), killing in-flight eval legs with spurious failures (e.g. `search` / `alerts_vlm` on PR #1235)

## Fix

Verified behavior: with `SSH_AUTH_SOCK` pointing at a live agent, `brev exec` reuses it and spawns nothing (3 leaks/call bare → 0 with agent).

In both eval leg steps (`skills-eval.yml`, `skills-eval-daily.yml`):
1. Start **one ssh-agent per leg** and export it — every descendant (`skills_eval_agent.py` → `run_leg.py` → Harbor → `brev_env.py`, and any `brev exec` the eval agent runs in Bash) inherits the step env, so no brev call spawns its own.
2. Kill it via `EXIT` trap when the step ends.
3. Reap orphaned `ssh-agent -s` older than 7 h (> `timeout-minutes: 360`) — self-heals after SIGKILLed legs and drains pre-fix accumulation without touching agents owned by live legs.

Both boxes were manually cleaned and all 23 runner services restarted on 2026-07-09; this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)