### PR TITLE
Compartmentalize chunk-combination into a pluggable strategy

### DIFF
--- a/services/alert/src/realtime/services/incident_service.py
+++ b/services/alert/src/realtime/services/incident_service.py
@@ -137,6 +137,51 @@ def _validate_consolidation(cfg: dict) -> None:
         )
 
 
+class ChunkCombiner:
+    """Strategy deciding whether a candidate chunk extends the open event.
+
+    The consolidator's grouping, fold loop, and event construction hold **no**
+    combination policy — it lives entirely in a combiner, so how chunks are
+    checked and combined can be extended or replaced independently.
+    ``should_extend`` returns ``(extend, reason)``: ``reason`` is ``""`` when
+    the chunk extends the event, otherwise the split cause reported to the
+    ``dedup_split_reason_total`` metric. Future strategies can combine on signals
+    other than time — e.g. a visual-change combiner that compares consecutive
+    chunks' vision embeddings / VLM reasoning to detect that the alert condition
+    changed — and combiners may be composed.
+    """
+
+    def should_extend(self, event: List[dict], candidate: dict) -> Tuple[bool, str]:
+        raise NotImplementedError
+
+
+class TimeBoundCombiner(ChunkCombiner):
+    """v1 strategy: extend while the next positive arrives within the inter-alert
+    gap and the event stays within the outer duration cap (both end-based and
+    inclusive). The time gap is authoritative — there is no per-session bypass.
+    """
+
+    def __init__(self, gap_seconds, max_duration):
+        self._gap_seconds = gap_seconds
+        self._max_duration = max_duration
+
+    def should_extend(self, event: List[dict], candidate: dict) -> Tuple[bool, str]:
+        first = event[0]
+        prev = event[-1]
+        if self._max_duration is not None:
+            start = _parse_ts(first.get("timestamp"))
+            cand_end = _parse_ts(candidate.get("end")) or _parse_ts(candidate.get("timestamp"))
+            if start and cand_end and (cand_end - start).total_seconds() > self._max_duration:
+                return (False, "outer")  # outer duration cap breached
+        prev_end = _parse_ts(prev.get("end")) or _parse_ts(prev.get("timestamp"))
+        cand_start = _parse_ts(candidate.get("timestamp"))
+        if prev_end is None or cand_start is None:
+            return (False, "malformed")
+        if (cand_start - prev_end).total_seconds() <= self._gap_seconds:
+            return (True, "")
+        return (False, "gap")
+
+
 class IncidentService:
     """Service for querying incidents from Elasticsearch.
 
@@ -372,6 +417,16 @@ class IncidentService:
     # ------------------------------------------------------------------
     # Consolidation
     # ------------------------------------------------------------------
+    def _combiner(self) -> ChunkCombiner:
+        """The chunk-combination strategy — the single seam for *how* chunks are
+        checked and combined. v1 uses the configured time bounds; replace or
+        compose to combine on other signals (e.g. visual change)."""
+        cfg = self._consolidation
+        return TimeBoundCombiner(
+            cfg.get("max_inter_alert_gap_seconds", 60),
+            cfg.get("max_event_duration_seconds", 300),
+        )
+
     def _consolidate(self, docs: List[dict]) -> List[dict]:
         """Group consecutive same-camera, same-alert-type positives on the
         current page into single events.
@@ -380,12 +435,14 @@ class IncidentService:
         underlying store is never modified and raw documents stay available
         via a ``consolidate=false`` query.
         """
-        cfg = self._consolidation
-        gap_seconds = cfg.get("max_inter_alert_gap_seconds", 60)
-        max_duration = cfg.get("max_event_duration_seconds", 300)
-        representative = cfg.get("representative", "latest")
+        representative = self._consolidation.get("representative", "latest")
+        combiner = self._combiner()
 
         t_fold = time.monotonic()
+        # Aggregate-only counter (no per-sensor/category labels): everything fed
+        # into the consolidator, including chunks dropped below as malformed.
+        if DEDUP_CHUNKS_IN is not None and docs:
+            DEDUP_CHUNKS_IN.inc(len(docs))
         groups: dict = {}
         for doc in docs:
             # Drop malformed chunks — a chunk missing its grouping keys, or with
@@ -412,23 +469,18 @@ class IncidentService:
             group_events: List[dict] = []
             current: List[dict] = []
             for doc in items_sorted:
-                if current and self._is_continuous(current, doc, gap_seconds, max_duration):
+                extend, reason = combiner.should_extend(current, doc) if current else (True, "")
+                if current and extend:
                     current.append(doc)
                 else:
                     if current:
                         group_events.append(self._build_event(current, representative))
-                        if DEDUP_SPLIT_REASON is not None:
-                            DEDUP_SPLIT_REASON.labels(
-                                reason=self._split_reason(current, doc, gap_seconds, max_duration)
-                            ).inc()
+                        if DEDUP_SPLIT_REASON is not None and reason:
+                            DEDUP_SPLIT_REASON.labels(reason=reason).inc()
                     current = [doc]
             if current:
                 group_events.append(self._build_event(current, representative))
             events.extend(group_events)
-            # Aggregate-only counters (no per-sensor/category labels) to avoid
-            # unbounded Prometheus cardinality from ES-sourced label values.
-            if DEDUP_CHUNKS_IN is not None:
-                DEDUP_CHUNKS_IN.inc(len(items))
             if DEDUP_EVENTS_OUT is not None:
                 DEDUP_EVENTS_OUT.inc(len(group_events))
 
@@ -442,48 +494,11 @@ class IncidentService:
         return events
 
     @staticmethod
-    def _is_continuous(current: List[dict], doc: dict, gap_seconds, max_duration) -> bool:
-        """Whether ``doc`` extends the open event ``current``.
-
-        Continuation requires the event to stay within the outer duration cap
-        and the next positive to arrive within ``max_inter_alert_gap_seconds``
-        of the previous chunk. The time gap is authoritative — there is no
-        per-session bypass. Unparseable timestamps end the current event.
-        """
-        first = current[0]
-        prev = current[-1]
-
-        if max_duration is not None:
-            start = _parse_ts(first.get("timestamp"))
-            doc_end = _parse_ts(doc.get("end")) or _parse_ts(doc.get("timestamp"))
-            if start and doc_end and (doc_end - start).total_seconds() > max_duration:
-                return False  # outer duration cap breached
-
-        prev_end = _parse_ts(prev.get("end")) or _parse_ts(prev.get("timestamp"))
-        doc_start = _parse_ts(doc.get("timestamp"))
-        if prev_end is None or doc_start is None:
-            return False
-        return (doc_start - prev_end).total_seconds() <= gap_seconds
-
-    @staticmethod
     def _split_reason(current: List[dict], doc: dict, gap_seconds, max_duration) -> str:
-        """Classify why ``doc`` did not extend ``current`` — for the
-        ``dedup_split_reason_total`` metric. Mirrors ``_is_continuous`` (outer
-        cap checked first, then the gap): returns ``outer``, ``gap``, or
-        ``malformed``.
-        """
-        first = current[0]
-        prev = current[-1]
-        if max_duration is not None:
-            start = _parse_ts(first.get("timestamp"))
-            doc_end = _parse_ts(doc.get("end")) or _parse_ts(doc.get("timestamp"))
-            if start and doc_end and (doc_end - start).total_seconds() > max_duration:
-                return "outer"
-        prev_end = _parse_ts(prev.get("end")) or _parse_ts(prev.get("timestamp"))
-        doc_start = _parse_ts(doc.get("timestamp"))
-        if prev_end is None or doc_start is None:
-            return "malformed"
-        return "gap"
+        """The split cause (``outer`` / ``gap`` / ``malformed``) when ``doc`` does
+        not extend ``current``; empty string when it extends. Thin wrapper over
+        ``TimeBoundCombiner`` kept for direct unit testing of the classification."""
+        return TimeBoundCombiner(gap_seconds, max_duration).should_extend(current, doc)[1]
 
     @staticmethod
     def _build_event(chunks: List[dict], representative: str) -> dict:

--- a/services/alert/test/unit/api/test_incident_service.py
+++ b/services/alert/test/unit/api/test_incident_service.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from realtime.config import ErrorCode, ResponseStatus
-from realtime.services.incident_service import IncidentService
+from realtime.services.incident_service import IncidentService, TimeBoundCombiner
 
 
 # ---------------------------------------------------------------------------
@@ -520,6 +520,62 @@ class TestConsolidationSplitReason:
         current = [_chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")]
         doc = _chunk(idx=2, start="2025-01-01T00:05:30.000Z", end="2025-01-01T00:06:00.000Z")
         assert IncidentService._split_reason(current, doc, 60, 300) == "outer"
+
+
+class TestTimeBoundCombiner:
+    """The pluggable combination strategy — should_extend -> (extend, reason)."""
+
+    def test_extends_within_bounds(self):
+        event = [_chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")]
+        cand = _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z")
+        assert TimeBoundCombiner(60, 300).should_extend(event, cand) == (True, "")
+
+    def test_gap_break(self):
+        event = [_chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")]
+        cand = _chunk(idx=2, start="2025-01-01T00:02:00.000Z", end="2025-01-01T00:02:30.000Z")
+        assert TimeBoundCombiner(60, 300).should_extend(event, cand) == (False, "gap")
+
+    def test_outer_break(self):
+        event = [_chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")]
+        cand = _chunk(idx=2, start="2025-01-01T00:05:30.000Z", end="2025-01-01T00:06:00.000Z")
+        assert TimeBoundCombiner(60, 300).should_extend(event, cand) == (False, "outer")
+
+    def test_malformed_candidate(self):
+        event = [_chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z")]
+        cand = _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z")
+        cand.pop("timestamp")
+        assert TimeBoundCombiner(60, 300).should_extend(event, cand) == (False, "malformed")
+
+    def test_consolidate_uses_the_combiner(self):
+        # the fold uses IncidentService._combiner(); default is TimeBoundCombiner
+        svc = IncidentService(consolidation=dict(_CONSOL_DEFAULT))
+        assert isinstance(svc._combiner(), TimeBoundCombiner)
+
+    def test_fold_emits_dedup_metrics(self, monkeypatch):
+        # the fold path must emit the aggregate counters + split reason
+        from realtime.services import incident_service as mod
+
+        chunks_in, events_out, duration = MagicMock(), MagicMock(), MagicMock()
+        split = MagicMock()
+        monkeypatch.setattr(mod, "DEDUP_CHUNKS_IN", chunks_in)
+        monkeypatch.setattr(mod, "DEDUP_EVENTS_OUT", events_out)
+        monkeypatch.setattr(mod, "DEDUP_SPLIT_REASON", split)
+        monkeypatch.setattr(mod, "DEDUP_DURATION", duration)
+
+        docs = [
+            _chunk(idx=1, start="2025-01-01T00:00:00.000Z", end="2025-01-01T00:00:30.000Z"),
+            _chunk(idx=2, start="2025-01-01T00:00:25.000Z", end="2025-01-01T00:00:55.000Z"),  # merges
+            _chunk(idx=9, start="2025-01-01T00:02:30.000Z", end="2025-01-01T00:03:00.000Z"),  # gap split (within outer cap)
+        ]
+        bad = _chunk(idx=3, start="not-a-timestamp")  # dropped, but still counted as fed-in
+        events = _consolidator()._consolidate(docs + [bad])
+
+        assert len(events) == 2
+        chunks_in.inc.assert_called_once_with(4)          # all fed docs incl. malformed
+        events_out.inc.assert_called_once_with(2)
+        split.labels.assert_called_once_with(reason="gap")
+        split.labels.return_value.inc.assert_called_once()
+        duration.observe.assert_called_once()
 
 
 class TestConsolidationConfigValidation:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
