### PR TITLE
Add Red Hat OpenShift deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Follow the steps from the [documentation](https://docs.nvidia.com/vss/latest/clo
 
 Please refer to [Prerequisites section here for installation details](https://docs.nvidia.com/vss/latest/prerequisites.html).
 
+### Deployment on Red Hat OpenShift AI (RHOAI)
+
+**Ideal for:** Deploying VSS on a Red Hat OpenShift cluster with Helm.
+
+For prerequisites, install commands for all developer profiles, verification, and troubleshooting, see [`deploy/helm/developer-profiles/openshift-deployment.md`](deploy/helm/developer-profiles/openshift-deployment.md).
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, branch naming convention, and PR guidelines.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ Follow the steps from the [documentation](https://docs.nvidia.com/vss/latest/clo
 
 Please refer to [Prerequisites section here for installation details](https://docs.nvidia.com/vss/latest/prerequisites.html).
 
+### Deployment on Red Hat OpenShift AI (RHOAI)
+
+**Ideal for:** Deploying VSS on a Red Hat OpenShift cluster with Helm.
+
+For prerequisites, install commands for all developer profiles, verification, and troubleshooting, see [`deploy/helm/developer-profiles/openshift-deployment.md`](deploy/helm/developer-profiles/openshift-deployment.md).
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, branch naming convention, and PR guidelines.

--- a/deploy/helm/developer-profiles/dev-profile-alerts/templates/openshift-routes.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/templates/openshift-routes.yaml
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.global.openshift.enabled }}
+{{- $vi := .Values.vssIngress }}
+{{- $host := default .Values.global.externalHost ($vi.host | default "") }}
+{{- $infra := index .Values "infra" | default dict }}
+{{- $phoenixVals := index $infra "phoenix" | default dict }}
+{{- $phoenixEnabled := default false (index $phoenixVals "enabled") }}
+{{- $kibanaVals := index $infra "kibana" | default dict }}
+{{- $kibanaEnabled := default false (index $kibanaVals "enabled") }}
+{{- $analytics := index .Values "analytics" | default dict }}
+{{- $videoAnalyticsVals := index $analytics "vss-video-analytics-api" | default dict }}
+{{- $analyticsEnabled := default false (index $videoAnalyticsVals "enabled") }}
+{{- $alertBridgeVals := index .Values "vss-alert-bridge" | default dict }}
+{{- $alertBridgeEnabled := default false (index $alertBridgeVals "enabled") }}
+{{- $vios := index .Values "vios" | default dict }}
+{{- $nvstreamerVals := index $vios "vss-vios-nvstreamer" | default dict }}
+{{- $streamerEnabled := default false (index $nvstreamerVals "enabled") }}
+# Route: / -> vss-agent-ui (port 3000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-ui
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "60s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-agent-ui") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssUiPort | default 3000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /api/chat -> vss-agent-ui (port 3000) -- must precede /api so longest-path wins
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-api-chat
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /api/chat
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-agent-ui") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssUiPort | default 3000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /api -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-api
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /api
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /chat -> vss-agent (port 8000) -- inference/chat endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-chat
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /chat
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /websocket -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-websocket
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /websocket
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /static -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-static
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /static
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /vst -> vss-vios-ingress (port 30888)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-vst
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /vst
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-vios-ingress") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vstIngressPort | default 30888 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- if $analyticsEnabled }}
+---
+# Route: /video-analytics-api -> vss-video-analytics-api (port 8081)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-video-analytics-api
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /video-analytics-api
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-video-analytics-api") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.videoAnalyticsApiPort | default 8081 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $alertBridgeEnabled }}
+---
+# Route: /alert-bridge -> vss-alert-bridge (port 9080)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-alert-bridge
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /alert-bridge
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-alert-bridge") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.alertBridgePort | default 9080 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $phoenixEnabled }}
+---
+# Route: /phoenix -> phoenix (port 6006)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-phoenix
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /phoenix
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "phoenix") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.phoenixPort | default 6006 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $kibanaEnabled }}
+---
+# Route: kibana -> kibana (port 5601) on separate host
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-kibana
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ printf "kibana-%s" $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "kibana") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.kibanaPort | default 5601 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $streamerEnabled }}
+---
+# Route: streamer -> vss-vios-nvstreamer (port 31000) on separate host
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-streamer
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ printf "streamer-%s" $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-vios-nvstreamer") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.streamerPort | default 31000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- end }}

--- a/deploy/helm/developer-profiles/dev-profile-alerts/templates/openshift-routes.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/templates/openshift-routes.yaml
@@ -26,6 +26,14 @@
 {{- $analyticsEnabled := default false (index $videoAnalyticsVals "enabled") }}
 {{- $alertBridgeVals := index .Values "vss-alert-bridge" | default dict }}
 {{- $alertBridgeEnabled := default false (index $alertBridgeVals "enabled") }}
+{{- $esVals := index $infra "elasticsearch" | default dict }}
+{{- $esEnabled := default false (index $esVals "enabled") }}
+{{- $agentRoot := index .Values "agent" | default dict }}
+{{- $vaMcpVals := index $agentRoot "vss-va-mcp" | default dict }}
+{{- $vaMcpEnabled := default false (index $vaMcpVals "enabled") }}
+{{- $rtvi := index .Values "rtvi" | default dict }}
+{{- $cvVals := index $rtvi "vss-rtvi-cv" | default dict }}
+{{- $cvEnabled := default false (index $cvVals "enabled") }}
 {{- $vios := index .Values "vios" | default dict }}
 {{- $nvstreamerVals := index $vios "vss-vios-nvstreamer" | default dict }}
 {{- $streamerEnabled := default false (index $nvstreamerVals "enabled") }}
@@ -262,6 +270,93 @@ spec:
     weight: 100
   port:
     targetPort: {{ $vi.alertBridgePort | default 9080 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $vaMcpEnabled }}
+---
+# Route: /va-mcp -> vss-va-mcp (port 9901) — Video Analytics MCP endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-va-mcp
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /va-mcp
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-va-mcp") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vaMcpPort | default 9901 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $esEnabled }}
+---
+# Route: /elasticsearch -> elasticsearch (port 9200)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-elasticsearch
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /elasticsearch
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "elasticsearch") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.elasticsearchPort | default 9200 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $cvEnabled }}
+---
+# Route: /rtvi-cv -> vss-rtvi-cv (port 9010) — real-time computer vision endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-rtvi-cv
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /rtvi-cv
+  to:
+    kind: Service
+    name: {{ include "vss.alerts.serviceShort" (dict "root" . "short" "vss-rtvi-cv") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.rtviCvPort | default 9010 }}
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values-openshift.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values-openshift.yaml
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OpenShift / RHOAI values overlay for alerts profile.
+#
+# Before installing, export the required variables:
+#
+#   export NGC_CLI_API_KEY='<your NGC API key>'
+#   export APPS_DOMAIN=$(oc get ingress.config.openshift.io/cluster \
+#   -o jsonpath='{.spec.domain}')
+#
+# Install:
+#   helm install vss-alerts . \
+#   -f values-verification.yaml \
+#   -f values-openshift.yaml \
+#   --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+#   --set global.externalHost=vss-alerts.${APPS_DOMAIN} \
+#   -n vss-alerts --create-namespace
+#
+# Optional: --set global.storageClass="<name>" to override the
+# cluster's default StorageClass.
+
+global:
+  openshift:
+    enabled: true
+  externalScheme: "https"
+
+# Disable Kubernetes Ingress (replaced by OpenShift Routes in openshift-routes.yaml)
+vssIngress:
+  enabled: false
+
+# GPU settings for OpenShift cluster (set nims.gpuType via --set if needed)
+nims:
+  nemotron:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+  cosmos:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# VIOS: security contexts + GPU tolerations for streamprocessing
+vios:
+  vss-vios-sensor:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - vss-vios-streamprocessing
+            topologyKey: kubernetes.io/hostname
+  vss-vios-streamprocessing:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# RTVI: null security contexts + GPU tolerations
+rtvi:
+  vss-rtvi-cv:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values-openshift.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values-openshift.yaml
@@ -43,7 +43,7 @@ vssIngress:
 
 # GPU settings for OpenShift cluster (set nims.gpuType via --set if needed)
 nims:
-  nemotron:
+  nemotron35:
     tolerations:
       # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
       # - key: "nvidia.com/gpu"
@@ -84,6 +84,12 @@ vios:
 # RTVI: null security contexts + GPU tolerations
 rtvi:
   vss-rtvi-cv:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+  vss-rtvi-vlm:
     tolerations:
       # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
       # - key: "nvidia.com/gpu"

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -36,6 +36,8 @@ ngc:
 # (verification: RTVI tracks VLM; real-time: RTVI uses remote VLM URL when set, else vss-rtvi-vlm). Override per-agent with agent.vss-agent.llmBaseUrl / vlmBaseUrl.
 # global.llmName / vlmName: shared defaults for vss-agent (override with agent.vss-agent.llmName, etc. when needed).
 global:
+  openshift:
+    enabled: false
   useReleaseNamePrefix: false
   postgresServiceHost: ""
   imagePullSecrets:

--- a/deploy/helm/developer-profiles/dev-profile-base/templates/openshift-routes.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/templates/openshift-routes.yaml
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.global.openshift.enabled }}
+{{- $vi := .Values.vssIngress }}
+{{- $host := default .Values.global.externalHost ($vi.host | default "") }}
+# Route: / -> vss-agent-ui (port 3000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-ui
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "60s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "vss-agent-ui" "chartName" "vss-agent-ui") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssUiPort | default 3000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /api/chat -> vss-agent-ui (port 3000) — must precede /api so longest-path wins
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-api-chat
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /api/chat
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "vss-agent-ui" "chartName" "vss-agent-ui") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssUiPort | default 3000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /api -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-api
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /api
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "vss-agent" "chartName" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /chat -> vss-agent (port 8000) — inference/chat endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-chat
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /chat
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "vss-agent" "chartName" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /websocket -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-websocket
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /websocket
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "vss-agent" "chartName" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /static -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-static
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /static
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "vss-agent" "chartName" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /vst -> vss-vios-ingress (port 30888)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-vst
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /vst
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "vss-vios-ingress" "chartName" "vss-vios-ingress") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vstIngressPort | default 30888 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}

--- a/deploy/helm/developer-profiles/dev-profile-base/templates/openshift-routes.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/templates/openshift-routes.yaml
@@ -195,4 +195,56 @@ spec:
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /phoenix -> phoenix (port 6006)
+# Phoenix is configured with PHOENIX_HOST_ROOT_PATH=/phoenix so no path rewrite needed.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-phoenix
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /phoenix
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "phoenix" "chartName" "phoenix") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.phoenixPort | default 6006 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /rtvi-vlm -> vss-rtvi-vlm (port 8000) — VLM inference endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-rtvi-vlm
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /rtvi-vlm
+  to:
+    kind: Service
+    name: {{ include "vss.subchartFullname" (dict "Values" .Values "Release" .Release "depKey" "vss-rtvi-vlm" "chartName" "vss-rtvi-vlm") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.rtviVlmPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
 {{- end }}

--- a/deploy/helm/developer-profiles/dev-profile-base/values-openshift.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/values-openshift.yaml
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OpenShift / RHOAI values overlay.
+#
+# Before installing, export the required variables:
+#
+#   export NGC_CLI_API_KEY='<your NGC API key>'
+#   export APPS_DOMAIN=$(oc get ingress.config.openshift.io/cluster \
+#   -o jsonpath='{.spec.domain}')
+#
+# Install:
+#   helm install vss . \
+#   -f values-base.yaml \
+#   -f values-openshift.yaml \
+#   --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+#   --set global.externalHost=vss.${APPS_DOMAIN} \
+#   -n vss --create-namespace
+#
+# Optional: --set global.storageClass="<name>" to override the
+# cluster's default StorageClass.
+
+global:
+  openshift:
+    enabled: true
+  externalScheme: "https"
+  # When switching to cosmos3, uncomment:
+  # vlmName: "nvidia/cosmos3-nano-reasoner"
+  # vlmBaseUrl: "http://nvidia-cosmos3-reasoner:8000"
+
+# Disable Kubernetes Ingress (replaced by OpenShift Routes in openshift-routes.yaml)
+vssIngress:
+  enabled: false
+
+# GPU settings for OpenShift cluster (set nims.gpuType via --set if needed)
+nims:
+  nemotron:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+  cosmos:          # cosmos-reason2-8b
+    enabled: true  # on by default
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+  cosmos3:          # cosmos3-reasoner
+    enabled: false  # off by default — flip with cosmos above to switch VLM
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# VIOS: security contexts + GPU tolerations for streamprocessing
+vios:
+  vss-vios-sensor:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - vss-vios-streamprocessing
+            topologyKey: kubernetes.io/hostname
+  vss-vios-streamprocessing:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# RTVI: null security contexts (templates already nullable-friendly)
+rtvi:
+  # RTVI Embed
+  rtvi-embed:
+    podSecurityContext: null
+    securityContext: null
+  # RTVI VLM: null security context + GPU tolerations
+  rtvi-vlm:
+    securityContext: null
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule

--- a/deploy/helm/developer-profiles/dev-profile-base/values-openshift.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/values-openshift.yaml
@@ -46,7 +46,7 @@ vssIngress:
 
 # GPU settings for OpenShift cluster (set nims.gpuType via --set if needed)
 nims:
-  nemotron:
+  nemotron35:
     tolerations:
       # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
       # - key: "nvidia.com/gpu"
@@ -95,11 +95,11 @@ vios:
 # RTVI: null security contexts (templates already nullable-friendly)
 rtvi:
   # RTVI Embed
-  rtvi-embed:
+  vss-rtvi-embed:
     podSecurityContext: null
     securityContext: null
   # RTVI VLM: null security context + GPU tolerations
-  rtvi-vlm:
+  vss-rtvi-vlm:
     securityContext: null
     tolerations:
       # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).

--- a/deploy/helm/developer-profiles/dev-profile-base/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-base/values.yaml
@@ -35,6 +35,9 @@ ngc:
 # Set global.imagePullSecrets when using a private registry (e.g. nvcr.io). Set global.storageClass for PVCs.
 # When using NGC (or copy from values-ngc-secrets.example.yaml):
 global:
+  # OpenShift / RHOAI toggle: set to true (or use values-openshift.yaml overlay) for OpenShift deployments.
+  openshift:
+    enabled: false
   # When true, all subcharts default to <release>-<chart> naming again.
   # Per-subchart <subchart>.useReleaseNamePrefix overrides this value.
   useReleaseNamePrefix: false

--- a/deploy/helm/developer-profiles/dev-profile-lvs/templates/openshift-routes.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/templates/openshift-routes.yaml
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.global.openshift.enabled }}
+{{- $vi := .Values.vssIngress }}
+{{- $host := default .Values.global.externalHost ($vi.host | default "") }}
+{{- $fk := index (.Values.infra | default dict) "kibana" | default dict }}
+{{- $kibanaEnabled := and $fk (default true $fk.enabled) }}
+{{- $fp := index (.Values.infra | default dict) "phoenix" | default dict }}
+{{- $phoenixEnabled := and $fp (default true $fp.enabled) }}
+{{- $vios := index .Values "vios" | default dict }}
+{{- $nvstreamerVals := index $vios "vss-vios-nvstreamer" | default dict }}
+{{- $streamerEnabled := default false (index $nvstreamerVals "enabled") }}
+# Route: / -> vss-agent-ui (port 3000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-ui
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "60s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-agent-ui") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssUiPort | default 3000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /api/chat -> vss-agent-ui (port 3000) -- must precede /api so longest-path wins
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-api-chat
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /api/chat
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-agent-ui") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssUiPort | default 3000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /api -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-api
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /api
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /chat -> vss-agent (port 8000) -- inference/chat endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-chat
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /chat
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /websocket -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-websocket
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /websocket
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /static -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-static
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /static
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /vst -> vss-vios-ingress (port 30888)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-vst
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /vst
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-vios-ingress") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.vstIngressPort | default 30888 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- if $phoenixEnabled }}
+---
+# Route: /phoenix -> phoenix (port 6006)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-phoenix
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /phoenix
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "phoenix") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.phoenixPort | default 6006 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $kibanaEnabled }}
+---
+# Route: kibana -> kibana (port 5601) on separate host
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-kibana
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ printf "kibana-%s" $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "kibana") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.kibanaPort | default 5601 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $streamerEnabled }}
+---
+# Route: streamer -> vss-vios-nvstreamer (port 31000) on separate host
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-streamer
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if $host }}
+  host: {{ printf "streamer-%s" $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-vios-nvstreamer") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.streamerPort | default 31000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- end }}

--- a/deploy/helm/developer-profiles/dev-profile-lvs/templates/openshift-routes.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/templates/openshift-routes.yaml
@@ -23,6 +23,13 @@
 {{- $vios := index .Values "vios" | default dict }}
 {{- $nvstreamerVals := index $vios "vss-vios-nvstreamer" | default dict }}
 {{- $streamerEnabled := default false (index $nvstreamerVals "enabled") }}
+{{- $summVals := index .Values "vss-summarization" | default dict }}
+{{- $summEnabled := default false (index $summVals "enabled") }}
+{{- $esVals := index (.Values.infra | default dict) "elasticsearch" | default dict }}
+{{- $esEnabled := default false (index $esVals "enabled") }}
+{{- $rtvi := index .Values "rtvi" | default dict }}
+{{- $vlmVals := index $rtvi "vss-rtvi-vlm" | default dict }}
+{{- $vlmEnabled := default false (index $vlmVals "enabled") }}
 # Route: / -> vss-agent-ui (port 3000)
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -202,6 +209,93 @@ spec:
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
+{{- if $summEnabled }}
+---
+# Route: /lvs -> vss-summarization (port 38111) — LVS summarization API
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-lvs
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /lvs
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-summarization") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.lvsBackendPort | default 38111 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $vlmEnabled }}
+---
+# Route: /rtvi-vlm -> vss-rtvi-vlm (port 8000) — VLM inference endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-rtvi-vlm
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /rtvi-vlm
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "vss-rtvi-vlm") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.rtviVlmPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $esEnabled }}
+---
+# Route: /elasticsearch -> elasticsearch (port 9200)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-elasticsearch
+  labels:
+    app.kubernetes.io/name: vss
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /elasticsearch
+  to:
+    kind: Service
+    name: {{ include "vss.lvs.serviceShort" (dict "root" . "short" "elasticsearch") }}
+    weight: 100
+  port:
+    targetPort: {{ $vi.elasticsearchPort | default 9200 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
 {{- if $phoenixEnabled }}
 ---
 # Route: /phoenix -> phoenix (port 6006)

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values-openshift.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values-openshift.yaml
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OpenShift / RHOAI values overlay for LVS profile.
+#
+# Before installing, export the required variables:
+#
+#   export NGC_CLI_API_KEY='<your NGC API key>'
+#   export APPS_DOMAIN=$(oc get ingress.config.openshift.io/cluster \
+#   -o jsonpath='{.spec.domain}')
+#
+# Install:
+#   helm install vss-lvs . \
+#   -f values-lvs.yaml \
+#   -f values-openshift.yaml \
+#   --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+#   --set global.externalHost=vss-lvs.${APPS_DOMAIN} \
+#   -n vss-lvs --create-namespace
+#
+# Optional: --set global.storageClass="<name>" to override the
+# cluster's default StorageClass.
+
+global:
+  openshift:
+    enabled: true
+  externalScheme: "https"
+
+# Disable Kubernetes Ingress (replaced by OpenShift Routes in openshift-routes.yaml)
+vssIngress:
+  enabled: false
+
+# GPU settings for OpenShift cluster (set nims.gpuType via --set if needed)
+nims:
+  nemotron:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+  cosmos:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# VIOS: security contexts + GPU tolerations for streamprocessing
+vios:
+  vss-vios-sensor:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - vss-vios-streamprocessing
+            topologyKey: kubernetes.io/hostname
+  vss-vios-streamprocessing:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# RTVI: null security contexts + GPU tolerations
+rtvi:
+  vss-rtvi-vlm:
+    securityContext: null
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# LVS summarization requests 1 GPU — same toleration stub as other GPU workloads
+vss-summarization:
+  tolerations:
+    # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+    # - key: "nvidia.com/gpu"
+    #   operator: Exists
+    #   effect: NoSchedule

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values-openshift.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values-openshift.yaml
@@ -43,7 +43,7 @@ vssIngress:
 
 # GPU settings for OpenShift cluster (set nims.gpuType via --set if needed)
 nims:
-  nemotron:
+  nemotron35:
     tolerations:
       # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
       # - key: "nvidia.com/gpu"

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -26,6 +26,8 @@ ngc:
   apiKey: ""
 
 global:
+  openshift:
+    enabled: false
   # When false (default), Service/Workload names use chart short names (redis, vss-vios-streamprocessing, vss-summarization, …). Set true for <release>-<chart> naming.
   useReleaseNamePrefix: false
   imagePullSecrets:

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -28,6 +28,8 @@ ngc:
   apiKey: ""
 
 global:
+  openshift:
+    enabled: false
   # When false (default), Service/Workload names use chart short names (redis, vss-vios-streamprocessing, vss-summarization, …). Set true for <release>-<chart> naming.
   useReleaseNamePrefix: false
   imagePullSecrets:

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/openshift-routes.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/openshift-routes.yaml
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.global.openshift.enabled }}
+{{- $host := .Values.global.externalHost | default "" }}
+{{- $ing := .Values.ingress }}
+{{- $vios := index .Values "vios" | default dict }}
+{{- $analytics := index .Values "analytics" | default dict }}
+{{- $videoAnalyticsVals := index $analytics "vss-video-analytics-api" | default dict }}
+{{- $videoAnalyticsEnabled := default false (index $videoAnalyticsVals "enabled") }}
+{{- $fp := index (.Values.infra | default dict) "phoenix" | default dict }}
+{{- $phoenixEnabled := and $fp (default true $fp.enabled) }}
+{{- $fk := index (.Values.infra | default dict) "kibana" | default dict }}
+{{- $kibanaEnabled := and $fk (default false $fk.enabled) }}
+{{- $nvstreamerVals := index $vios "vss-vios-nvstreamer" | default dict }}
+{{- $streamerEnabled := default false (index $nvstreamerVals "enabled") }}
+{{- $agentUiEnabled := (index .Values "vss-agent-ui").enabled }}
+{{- $agent := index .Values "agent" | default dict }}
+{{- $vssAgent := index $agent "vss-agent" | default (index .Values "vss-agent") | default dict }}
+{{- $agentEnabled := and (index $agent "enabled" | default true) $vssAgent.enabled }}
+{{- $vioIng := index $vios "vss-vios-ingress" | default dict }}
+{{- $vioIngEnabled := default false $vioIng.enabled }}
+{{- if $agentUiEnabled }}
+# Route: / -> vss-agent-ui (port 3000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-ui
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "60s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-agent-ui") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.vssUiPort | default 3000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /api/chat -> vss-agent-ui (port 3000) -- must precede /api so longest-path wins
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-api-chat
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /api/chat
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-agent-ui") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.vssUiPort | default 3000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $agentEnabled }}
+---
+# Route: /api -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-api
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /api
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /chat -> vss-agent (port 8000) -- inference/chat endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-chat
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /chat
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /websocket -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-websocket
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /websocket
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+# Route: /static -> vss-agent (port 8000)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-static
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /static
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-agent") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.vssAgentPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $vioIngEnabled }}
+---
+# Route: /vst -> vss-vios-ingress (port 30888)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-vst
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /vst
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-vios-ingress") }}
+    weight: 100
+  port:
+    {{- $vioIngSvc := index $vioIng "service" | default dict }}
+    targetPort: {{ coalesce $vioIng.port $vioIngSvc.port 30888 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $videoAnalyticsEnabled }}
+---
+# Route: /video-analytics-api -> vss-video-analytics-api (port 8081)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-video-analytics-api
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /video-analytics-api
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-video-analytics-api") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.videoAnalyticsApiPort | default 8081 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $phoenixEnabled }}
+---
+# Route: /phoenix -> phoenix (port 6006)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-phoenix
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /phoenix
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "phoenix") }}
+    weight: 100
+  port:
+    targetPort: {{ $fp.port | default 6006 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $kibanaEnabled }}
+---
+# Route: kibana -> kibana (port 5601) on separate host
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-kibana
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+spec:
+  {{- if $host }}
+  host: {{ printf "kibana-%s" $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "kibana") }}
+    weight: 100
+  port:
+    targetPort: {{ (index (.Values.infra | default dict) "kibana" | default dict).service.port | default 5601 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $streamerEnabled }}
+---
+# Route: streamer -> vss-vios-nvstreamer (port 31000) on separate host
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-streamer
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+spec:
+  {{- if $host }}
+  host: {{ printf "streamer-%s" $host | quote }}
+  {{- end }}
+  path: /
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-vios-nvstreamer") }}
+    weight: 100
+  port:
+    targetPort: {{ (index $vios "vss-vios-nvstreamer").service.port | default 31000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- end }}

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/openshift-routes.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/openshift-routes.yaml
@@ -32,6 +32,17 @@
 {{- $agentEnabled := and (index $agent "enabled" | default true) $vssAgent.enabled }}
 {{- $vioIng := index $vios "vss-vios-ingress" | default dict }}
 {{- $vioIngEnabled := default false $vioIng.enabled }}
+{{- $rtvi := index .Values "rtvi" | default dict }}
+{{- $vlmVals := index $rtvi "vss-rtvi-vlm" | default dict }}
+{{- $vlmEnabled := default false (index $vlmVals "enabled") }}
+{{- $cvVals := index $rtvi "vss-rtvi-cv" | default dict }}
+{{- $cvEnabled := default false (index $cvVals "enabled") }}
+{{- $embedVals := index $rtvi "vss-rtvi-embed" | default dict }}
+{{- $embedEnabled := default false (index $embedVals "enabled") }}
+{{- $esVals := index (.Values.infra | default dict) "elasticsearch" | default dict }}
+{{- $esEnabled := default false (index $esVals "enabled") }}
+{{- $behaviorVals := index $analytics "vss-behavior-analytics" | default dict }}
+{{- $behaviorEnabled := default false (index $behaviorVals "enabled") }}
 {{- if $agentUiEnabled }}
 # Route: / -> vss-agent-ui (port 3000)
 apiVersion: route.openshift.io/v1
@@ -227,6 +238,141 @@ spec:
     weight: 100
   port:
     targetPort: {{ $ing.videoAnalyticsApiPort | default 8081 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $vlmEnabled }}
+---
+# Route: /rtvi-vlm -> vss-rtvi-vlm (port 8000) — VLM inference endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-rtvi-vlm
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /rtvi-vlm
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-rtvi-vlm") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.rtviVlmPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $cvEnabled }}
+---
+# Route: /rtvi-cv -> vss-rtvi-cv (port 9000) — real-time computer vision endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-rtvi-cv
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /rtvi-cv
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-rtvi-cv") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.rtviCvPort | default 9000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $embedEnabled }}
+---
+# Route: /rtvi-embed -> vss-rtvi-embed (port 8000) — Cosmos Embed endpoint
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-rtvi-embed
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /rtvi-embed
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-rtvi-embed") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.rtviEmbedPort | default 8000 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $esEnabled }}
+---
+# Route: /elasticsearch -> elasticsearch (port 9200)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-elasticsearch
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+    haproxy.router.openshift.io/rewrite-target: /
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /elasticsearch
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "elasticsearch") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.elasticsearchPort | default 9200 }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+{{- if $behaviorEnabled }}
+---
+# Route: /behavior-analytics -> vss-behavior-analytics (port 8080)
+# No path rewrite: the canonical route table forwards this path intact.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-vss-behavior-analytics
+  labels:
+    {{- include "dev-profile-search.labels" . | nindent 4 }}
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+spec:
+  {{- if $host }}
+  host: {{ $host | quote }}
+  {{- end }}
+  path: /behavior-analytics
+  to:
+    kind: Service
+    name: {{ include "dev-profile-search.serviceShort" (dict "root" . "short" "vss-behavior-analytics") }}
+    weight: 100
+  port:
+    targetPort: {{ $ing.behaviorAnalyticsPort | default 8080 }}
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect

--- a/deploy/helm/developer-profiles/dev-profile-search/values-openshift.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values-openshift.yaml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OpenShift / RHOAI values overlay for search profile.
+#
+# Before installing, export the required variables:
+#
+#   export NGC_CLI_API_KEY='<your NGC API key>'
+#   export APPS_DOMAIN=$(oc get ingress.config.openshift.io/cluster \
+#   -o jsonpath='{.spec.domain}')
+#
+# Install:
+#   helm install vss-search . \
+#   -f values-openshift.yaml \
+#   --set-string global.ngcApiKey="$NGC_CLI_API_KEY" \
+#   --set global.externalHost=vss-search.${APPS_DOMAIN} \
+#   -n vss-search --create-namespace
+#
+# Optional: --set global.storageClass="<name>" to override the
+# cluster's default StorageClass.
+
+global:
+  openshift:
+    enabled: true
+  externalScheme: "https"
+
+# Disable Kubernetes Ingress (replaced by OpenShift Routes in openshift-routes.yaml)
+ingress:
+  enabled: false
+
+# GPU settings for OpenShift cluster (set nims.gpuType via --set if needed)
+nims:
+  nemotron:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+  cosmos:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# VIOS: security contexts + GPU tolerations for streamprocessing
+vios:
+  vss-vios-sensor:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - vss-vios-streamprocessing
+            topologyKey: kubernetes.io/hostname
+  vss-vios-streamprocessing:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+
+# RTVI: null security contexts + GPU tolerations
+rtvi:
+  vss-rtvi-cv:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+  vss-rtvi-embed:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule

--- a/deploy/helm/developer-profiles/dev-profile-search/values-openshift.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values-openshift.yaml
@@ -37,12 +37,15 @@ global:
   externalScheme: "https"
 
 # Disable Kubernetes Ingress (replaced by OpenShift Routes in openshift-routes.yaml)
+# This profile's Ingress template reads `ingress:` (the legacy key) with priority
+# over `vssIngress:` — see templates/vss-ingress.yaml line "if hasKey $legacy".
+# Setting `ingress.enabled: false` here is intentional and correct for this chart.
 ingress:
   enabled: false
 
 # GPU settings for OpenShift cluster (set nims.gpuType via --set if needed)
 nims:
-  nemotron:
+  nemotron35:
     tolerations:
       # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
       # - key: "nvidia.com/gpu"
@@ -89,6 +92,12 @@ rtvi:
       #   operator: Exists
       #   effect: NoSchedule
   vss-rtvi-embed:
+    tolerations:
+      # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+      # - key: "nvidia.com/gpu"
+      #   operator: Exists
+      #   effect: NoSchedule
+  vss-rtvi-vlm:
     tolerations:
       # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
       # - key: "nvidia.com/gpu"

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 global:
+  openshift:
+    enabled: false
   # Bare node IP, or full main hostname (e.g. vss-search.<ip>.nip.io) for install --set global.externalHost=…
   externalHost: ''
   # Search: critic behavior in vss-agent configs (vss-agent / search config.yml). Cosmos NIM is toggled with nims.cosmos.enabled — keep the same boolean (defaults below match true).

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 global:
+  openshift:
+    enabled: false
   # Bare node IP, or full main hostname (e.g. vss-search.<ip>.nip.io) for install --set global.externalHost=…
   externalHost: ''
   ngcApiKey: ''

--- a/deploy/helm/developer-profiles/openshift-deployment.md
+++ b/deploy/helm/developer-profiles/openshift-deployment.md
@@ -1,0 +1,430 @@
+# Deploy VSS on Red Hat OpenShift AI (RHOAI)
+
+Use the following documentation to deploy the [NVIDIA Video Search and Summarization Blueprint](../../../README.md) on a Red Hat OpenShift cluster with Helm.
+
+Four developer profiles are available. Each profile targets a different use case; choose the one that matches your workflow:
+
+| Profile | Directory | Description |
+|---------|-----------|-------------|
+| **base** | `dev-profile-base/` | Full stack — all services, both NIMs |
+| **alerts** | `dev-profile-alerts/` | Real-time alert/verification pipeline with RTVI-CV |
+| **lvs** | `dev-profile-lvs/` | Long-video summarization with RTVI-VLM |
+| **search** | `dev-profile-search/` | Video search with RTVI-CV + RTVI-Embed |
+
+## Prerequisites
+
+1. [Get an NGC API Key](https://org.ngc.nvidia.com/setup/api-keys).
+
+2. Verify that you meet the hardware requirements. GPU counts depend on the profile — see the GPU table in each profile's deploy section under [step 3](#3-deploy-the-application).
+
+3. Verify that you have **OpenShift 4.14 or later** with cluster-admin access, and the `oc` CLI configured.
+
+4. Verify that you have **Helm 3** installed. To install Helm 3, follow the official [Helm installation instructions](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3).
+
+5. Verify that you have the **NVIDIA GPU Operator** installed and functional. For details, see [GPU Operator documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html). Pin the driver version via the GPU Operator's driver settings: `580.105.08` (Ubuntu 24.04 nodes) or `580.65.06` (Ubuntu 22.04 nodes).
+
+6. Verify that you have the **NVIDIA NIM Operator** installed (`apps.nvidia.com/v1alpha1` API available). Required when `nims` subcharts are enabled (`NIMCache`/`NIMService`) — skip this if you're using remote LLM/VLM only (see each profile's remote install under [step 3](#3-deploy-the-application)). If not installed, install it:
+
+   ```bash
+   helm repo add nvidia https://helm.ngc.nvidia.com/nvidia \
+     --username='$oauthtoken' \
+     --password=$NGC_CLI_API_KEY
+   helm repo update
+   helm install nim-operator nvidia/k8s-nim-operator \
+     -n nim-operator --create-namespace
+   ```
+
+   For details, see the [NIM Operator installation guide](https://docs.nvidia.com/nim-operator/latest/install.html).
+
+7. Verify that a **default StorageClass** with dynamic provisioning is available (e.g., `gp3-csi` on AWS):
+
+   ```bash
+   oc get storageclass
+   ```
+
+8. Check GPU node taints. GPU nodes on OpenShift clusters typically have taints that prevent non-GPU workloads from scheduling on them. You need the taint key(s) to fill in the tolerations below:
+
+   ```bash
+   oc get nodes -l nvidia.com/gpu.present=true \
+     -o custom-columns=\
+   "NODE:.metadata.name,TAINTS:.spec.taints[*].key"
+   ```
+
+   The `values-openshift.yaml` overlay ships with the `tolerations` block for every GPU-scheduled workload (NIMs, `vios-sensor`, `vios-streamprocessing`, and the profile's GPU-using RTVI component(s)) commented out — uncomment and set the `key` to match your cluster's taint (e.g. `nvidia.com/gpu`, or a cloud-specific key like `g6-gpu` on AWS G6e node groups) before installing. If your GPU nodes are untainted, leave the tolerations commented out.
+
+## 1. Login to OpenShift cluster
+
+```bash
+oc login --token=$OPENSHIFT_TOKEN \
+  --server=$OPENSHIFT_CLUSTER_URL
+```
+
+## 2. Export your API key and cluster domain
+
+```bash
+export NGC_CLI_API_KEY='<your NGC API key>'
+export APPS_DOMAIN=$(oc get \
+  ingress.config.openshift.io/cluster \
+  -o jsonpath='{.spec.domain}')
+```
+
+## 3. Deploy the application
+
+Pick **one** of the profiles below.
+
+> `values-openshift.yaml` sets `global.openshift.enabled: true`, which turns on OpenShift Routes (replacing the Kubernetes Ingress), grants the `anyuid` SCC to the VIOS root services (`vss-vios-nvstreamer`, `-sensor`, `-streamprocessing`), adds a dedicated SCC for the NIM model-cache ServiceAccount (avoids a PVC SELinux relabel timeout on 200Gi+ model caches), nulls out security contexts that conflict with `restricted-v2`, and ships commented-out GPU tolerations for every GPU-scheduled workload (see [step 8](#prerequisites)).
+
+---
+
+### Base profile
+
+Same install flow as `dev-profile-base/README.md`, with the OpenShift overlay (`-f values-openshift.yaml`) and OpenShift host/exposure settings.
+
+   | Workload | GPU |
+   |----------|-----|
+   | `nvidia-cosmos-reason2-8b` (NIM) | 1 |
+   | `nvidia-nemotron-nano-9b-v2` (NIM) | 1 |
+   | `vss-vios-streamprocessing` | 1 |
+   | **Total** | **3** |
+
+```bash
+cd deploy/helm/developer-profiles
+helm dependency build ./dev-profile-base
+```
+
+**In-cluster NIMs** (default):
+
+```bash
+helm upgrade --install vss-base ./dev-profile-base \
+  -f ./dev-profile-base/values-base.yaml \
+  -f ./dev-profile-base/values-openshift.yaml \
+  -n vss-base --create-namespace \
+  --set llmNameSlug=nvidia-nemotron-nano-9b-v2 \
+  --set vlmNameSlug=nvidia-cosmos-reason2-8b \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss.${APPS_DOMAIN}
+```
+
+**Remote LLM/VLM** (no NIM subcharts); URLs must be reachable from `vss-agent` pods:
+
+```bash
+export LLM_BASE_URL='<REMOTE LLM ENDPOINT>'
+export VLM_BASE_URL='<REMOTE VLM ENDPOINT>'
+
+helm upgrade --install vss-base ./dev-profile-base \
+  -f ./dev-profile-base/values-base.yaml \
+  -f ./dev-profile-base/values-openshift.yaml \
+  -n vss-base --create-namespace \
+  --set nims.enabled=false \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss.${APPS_DOMAIN} \
+  --set-string global.llmBaseUrl="$LLM_BASE_URL" \
+  --set-string global.vlmBaseUrl="$VLM_BASE_URL" \
+  --set-string global.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set-string global.vlmName="nvidia/cosmos-reason2-8b"
+```
+
+**Switching the VLM model:** The default deployment uses Cosmos-Reason2-8B. To switch to Cosmos3, uncomment the two lines already stubbed under `global:` in `values-openshift.yaml`:
+
+```yaml
+global:
+  vlmName: "nvidia/cosmos3-nano-reasoner"
+  vlmBaseUrl: "http://nvidia-cosmos3-reasoner:8000"
+```
+
+Then flip the NIM toggle via `--set` and re-run the upgrade:
+
+```bash
+helm upgrade vss-base ./dev-profile-base \
+  -f ./dev-profile-base/values-base.yaml \
+  -f ./dev-profile-base/values-openshift.yaml \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost="vss.${APPS_DOMAIN}" \
+  --set nims.cosmos.enabled=false \
+  --set nims.cosmos3.enabled=true \
+  -n vss-base
+```
+
+---
+
+### Alerts profile
+
+Same install flow as `dev-profile-alerts/README.md` (verification mode), with the OpenShift overlay (`-f values-openshift.yaml`) and OpenShift host/exposure settings.
+
+**Alert verification** (`values-verification.yaml`):
+
+   | Workload | GPU |
+   |----------|-----|
+   | `vss-rtvi-cv` | 1 |
+   | `vss-rtvi-vlm` | 1 |
+   | `vss-vios-streamprocessing` | 1 |
+   | `nvidia-nemotron-nano-9b-v2` (NIM) | 1 |
+   | **Total** | **4** |
+
+**Alert real-time** (`values-realtime.yaml`):
+
+   | Workload | GPU |
+   |----------|-----|
+   | `vss-vios-streamprocessing` | 1 |
+   | `vss-rtvi-vlm` | 1 |
+   | `nvidia-nemotron-nano-9b-v2` (NIM) | 1 |
+   | **Total** | **3** |
+
+```bash
+cd deploy/helm/developer-profiles
+helm dependency build ./dev-profile-alerts
+```
+
+**Verification — in-cluster NIMs** (default):
+
+```bash
+helm upgrade --install vss-alerts ./dev-profile-alerts \
+  -f ./dev-profile-alerts/values-verification.yaml \
+  -f ./dev-profile-alerts/values-openshift.yaml \
+  -n vss-alerts --create-namespace \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss-alerts.${APPS_DOMAIN}
+```
+
+**Verification — remote LLM/VLM** (no in-cluster NIMs):
+
+```bash
+export LLM_BASE_URL='<REMOTE LLM ENDPOINT>'
+export VLM_BASE_URL='<REMOTE VLM ENDPOINT>'
+
+helm upgrade --install vss-alerts ./dev-profile-alerts \
+  -f ./dev-profile-alerts/values-verification.yaml \
+  -f ./dev-profile-alerts/values-openshift.yaml \
+  -n vss-alerts --create-namespace \
+  --set nims.enabled=false \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss-alerts.${APPS_DOMAIN} \
+  --set-string global.llmBaseUrl="$LLM_BASE_URL" \
+  --set-string global.vlmBaseUrl="$VLM_BASE_URL" \
+  --set-string global.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set-string global.vlmName="nvidia/cosmos-reason2-8b"
+```
+
+**Real-time — in-cluster NIMs:**
+
+```bash
+helm upgrade --install vss-alerts ./dev-profile-alerts \
+  -f ./dev-profile-alerts/values-realtime.yaml \
+  -f ./dev-profile-alerts/values-openshift.yaml \
+  -n vss-alerts --create-namespace \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss-alerts.${APPS_DOMAIN}
+```
+
+**Real-time — remote LLM/VLM** (no in-cluster NIMs):
+
+```bash
+export LLM_BASE_URL='<REMOTE LLM ENDPOINT>'
+export VLM_BASE_URL='<REMOTE VLM ENDPOINT>'
+
+helm upgrade --install vss-alerts ./dev-profile-alerts \
+  -f ./dev-profile-alerts/values-realtime.yaml \
+  -f ./dev-profile-alerts/values-openshift.yaml \
+  -n vss-alerts --create-namespace \
+  --set nims.enabled=false \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss-alerts.${APPS_DOMAIN} \
+  --set-string global.llmBaseUrl="$LLM_BASE_URL" \
+  --set-string global.vlmBaseUrl="$VLM_BASE_URL" \
+  --set-string global.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set-string global.vlmName="nvidia/cosmos-reason2-8b"
+```
+
+---
+
+### LVS profile
+
+Same install flow as `dev-profile-lvs/README.md`, with the OpenShift overlay (`-f values-openshift.yaml`) and OpenShift host/exposure settings.
+
+   | Workload | GPU |
+   |----------|-----|
+   | `vss-summarization` | 1 |
+   | `nvidia-nemotron-nano-9b-v2` (NIM) | 1 |
+   | `vss-vios-streamprocessing` | 1 |
+   | `vss-rtvi-vlm` (integrated Cosmos checkpoint) | 1 |
+   | **Total** | **4** |
+
+```bash
+cd deploy/helm/developer-profiles
+helm dependency build ./dev-profile-lvs
+```
+
+**In-cluster NIMs** (default):
+
+```bash
+helm upgrade --install vss-lvs ./dev-profile-lvs \
+  -f ./dev-profile-lvs/values-lvs.yaml \
+  -f ./dev-profile-lvs/values-openshift.yaml \
+  -n vss-lvs --create-namespace \
+  --set llmNameSlug=nvidia-nemotron-nano-9b-v2 \
+  --set vlmNameSlug=none \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss-lvs.${APPS_DOMAIN}
+```
+
+**Remote LLM/VLM** (no NIM subcharts); URLs must be reachable from `vss-agent` and `vss-summarization` pods (service root, no trailing `/v1`):
+
+```bash
+export LLM_BASE_URL='<REMOTE LLM SERVICE ROOT, no trailing /v1>'
+export VLM_BASE_URL='<REMOTE VLM SERVICE ROOT, no trailing /v1>'
+
+helm upgrade --install vss-lvs ./dev-profile-lvs \
+  -f ./dev-profile-lvs/values-lvs.yaml \
+  -f ./dev-profile-lvs/values-openshift.yaml \
+  -n vss-lvs --create-namespace \
+  --set nims.enabled=false \
+  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss-lvs.${APPS_DOMAIN} \
+  --set-string global.llmBaseUrl="$LLM_BASE_URL" \
+  --set-string global.vlmBaseUrl="$VLM_BASE_URL" \
+  --set-string global.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set-string global.vlmName="nim_nvidia_cosmos-reason2-8b_hf-1208" \
+  --set rtvi.vss-rtvi-vlm.useSharedNim=true
+```
+
+---
+
+### Search profile
+
+Same install flow as `dev-profile-search/README.md`, with the OpenShift overlay (`-f values-openshift.yaml`) and OpenShift host/exposure settings.
+
+   | Workload | GPU |
+   |----------|-----|
+   | `nvidia-cosmos-reason2-8b` (NIM) | 1 |
+   | `nvidia-nemotron-nano-9b-v2` (NIM) | 1 |
+   | `vss-vios-streamprocessing` | 1 |
+   | `vss-rtvi-cv` | 1 |
+   | `vss-rtvi-embed` | 1 |
+   | **Total** | **5** |
+
+```bash
+cd deploy/helm/developer-profiles
+helm dependency build ./dev-profile-search
+```
+
+**In-cluster NIMs** (default):
+
+```bash
+helm upgrade --install vss-search ./dev-profile-search \
+  -f ./dev-profile-search/values-openshift.yaml \
+  -n vss-search --create-namespace \
+  --set-string global.ngcApiKey="$NGC_CLI_API_KEY" \
+  --set global.externalHost=vss-search.${APPS_DOMAIN}
+```
+
+**Remote LLM/VLM** (custom remote NIM; no in-cluster NIMs). Uses `values-build-endpoint.yaml` and `agent.vss-agent.*` keys — see `dev-profile-search/README.md`:
+
+```bash
+export LLM_BASE_URL='<REMOTE LLM ENDPOINT>'
+export VLM_BASE_URL='<REMOTE VLM ENDPOINT>'
+
+helm upgrade --install vss-search ./dev-profile-search \
+  -f ./dev-profile-search/values-build-endpoint.yaml \
+  -f ./dev-profile-search/values-openshift.yaml \
+  -n vss-search --create-namespace \
+  --set global.externalHost=vss-search.${APPS_DOMAIN} \
+  --set-string global.ngcApiKey="$NGC_CLI_API_KEY" \
+  --set-string agent.vss-agent.apiKeys.nvidia="$NGC_CLI_API_KEY" \
+  --set nims.enabled=false \
+  --set agent.vss-agent.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set agent.vss-agent.vlmName="nvidia/cosmos-reason2-8b" \
+  --set agent.vss-agent.llmBaseUrl="$LLM_BASE_URL" \
+  --set agent.vss-agent.vlmBaseUrl="$VLM_BASE_URL" \
+  --wait=false
+```
+
+> Scaling `vss-rtvi-cv` / `vss-rtvi-embed` past 1 replica each requires consistent-hash routing on the stream ID so retries land on the same replica (`global.rtviInternalIngress`, disabled by default). That path is unrelated to the Routes above — it needs the HAProxy Kubernetes Ingress controller installed separately (see the profile's own README, "Install Ingress Controller"), which works the same on OpenShift as elsewhere. Leave it disabled at the default 1 replica.
+
+## 4. Creating NGC secrets manually (optional)
+
+Applies to **base**, **alerts**, and **lvs**. By default those charts create `ngc-api` and `ngc-secret` when `ngc.createSecrets=true` and `ngc.apiKey` is set. If `ngc.createSecrets=false`, create both secrets yourself in the release namespace before installing, then keep `global.ngcApiSecret` and `global.imagePullSecrets` aligned with the names and keys you chose.
+
+```bash
+export NAMESPACE='<NAMESPACE>'
+export NGC_CLI_API_KEY='<your NGC API key>'
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic ngc-api \
+  -n "$NAMESPACE" \
+  --from-literal=NGC_API_KEY="$NGC_CLI_API_KEY" \
+  --from-literal=NGC_CLI_API_KEY="$NGC_CLI_API_KEY"
+
+kubectl create secret docker-registry ngc-secret \
+  -n "$NAMESPACE" \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password="$NGC_CLI_API_KEY"
+```
+
+> **Search** uses `global.ngcApiKey` instead and creates its own secrets from that value — see `dev-profile-search/README.md`.
+
+## 5. Setting the GPU type (optional)
+
+Chart defaults for `nims.gpuType` (for example `RTXPRO6000BW` in `values-base.yaml`) may not match your cluster. On the in-cluster NIM path, add this flag to the `helm install` command for your chosen profile in [step 3](#3-deploy-the-application):
+
+```
+--set nims.gpuType=H100
+```
+
+Use `L40S` or another supported value if that matches your cluster's GPU. This selects NIM tuning presets; an unrecognized value fails the install.
+
+## 6. Setting the StorageClass (optional)
+
+If the cluster's default StorageClass isn't suitable, add this flag to the `helm install` command for your chosen profile in [step 3](#3-deploy-the-application):
+
+```
+--set global.storageClass="<Storage Class Name>"
+```
+
+Use a StorageClass that exists on the cluster (for example `gp3-csi` on AWS). List available classes with `oc get storageclass`.
+
+## 7. Verify the deployment
+
+Replace `vss` below with your release name and namespace (`vss-alerts`, `vss-lvs`, or `vss-search` if using a non-base profile).
+
+```bash
+# All pods should be Running
+oc get pods -n vss
+
+# Get the UI URL
+echo "https://vss.${APPS_DOMAIN}/"
+
+# API health check
+oc exec -n vss deploy/vss-agent -- \
+  curl -s localhost:8000/health
+
+# OpenShift Routes
+oc get routes -n vss
+
+# NIM model cache / serving status
+oc get nimcache -n vss
+oc get nimservice -n vss
+```
+
+> **Wait until everything is Ready before using the application in the browser.** With in-cluster NIM enabled (`nims.enabled: true`, the usual default), NIM model workloads need extra time (image pull, `NIMCache`/`NIMService`, model download and warm-up). Opening `vss-agent-ui` while NIM or other backends are still starting can produce transient errors (failed API calls, timeouts, empty screens).
+>
+> A pod's `READY` column (e.g. `1/1`) only reflects its own readiness probe — for the NIM Operator-managed pods, don't stop there. Check the `NIMService`'s own `.status.state` instead, since that's the field the Operator itself uses to report whether the model is actually loaded and serving:
+>
+> ```bash
+> oc get nimservice -n vss -w
+> ```
+>
+> Wait until every `NIMService` shows `Ready` (not just `Pending`/`NotReady`), and confirm the rest of the pods in `oc get pods -n vss` are `Running`. With remote LLM/VLM only (`nims.enabled: false`), there's no `NIMService` to watch — just confirm all pods are ready.
+
+## 8. Uninstall
+
+Replace `vss` with your release name and namespace.
+
+```bash
+helm uninstall vss -n vss
+oc delete scc -l app.kubernetes.io/instance=vss
+oc delete nimcache --all -n vss
+oc delete pvc --all -n vss
+oc delete project vss
+```

--- a/deploy/helm/services/nims/templates/openshift-nim-scc.yaml
+++ b/deploy/helm/services/nims/templates/openshift-nim-scc.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.global.openshift.enabled }}
+# Custom SCC for NIM services: seLinuxContext:RunAsAny prevents recursive
+# SELinux relabeling timeout on large model PVCs (200Gi+).
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $fullName := printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ $fullName }}-nim
+  labels:
+    app.kubernetes.io/name: nims
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+priority: 15
+allowPrivilegedContainer: false
+allowPrivilegeEscalation: true
+allowedCapabilities: []
+defaultAddCapabilities: []
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:nim-cache-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-nim-scc
+  labels:
+    app.kubernetes.io/name: nims
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:{{ $fullName }}-nim
+subjects:
+  - kind: ServiceAccount
+    name: nim-cache-sa
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/services/nims/templates/openshift-nim-scc.yaml
+++ b/deploy/helm/services/nims/templates/openshift-nim-scc.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 priority: 15
 allowPrivilegedContainer: false
-allowPrivilegeEscalation: true
+allowPrivilegeEscalation: false
 allowedCapabilities: []
 defaultAddCapabilities: []
 requiredDropCapabilities:
@@ -51,8 +51,6 @@ volumes:
   - persistentVolumeClaim
   - projected
   - secret
-users:
-  - system:serviceaccount:{{ .Release.Namespace }}:nim-cache-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/helm/services/nims/values.yaml
+++ b/deploy/helm/services/nims/values.yaml
@@ -25,6 +25,8 @@
 # Override-values files are kept as thin convenience wrappers for CI/scripts.
 
 global:
+  openshift:
+    enabled: false
   # NGC API key for model download and NIM authentication
   ngcApiKey: ""
   # Pre-existing pull secret name (auto-created by parent chart or by user)

--- a/deploy/helm/services/nims/values.yaml
+++ b/deploy/helm/services/nims/values.yaml
@@ -26,6 +26,8 @@
 # Override-values files are kept as thin convenience wrappers for CI/scripts.
 
 global:
+  openshift:
+    enabled: false
   # NGC API key for model download and NIM authentication
   ngcApiKey: ""
   # Pre-existing pull secret name (auto-created by parent chart or by user)

--- a/deploy/helm/services/vios/charts/vios-sensor/templates/deployment.yaml
+++ b/deploy/helm/services/vios/charts/vios-sensor/templates/deployment.yaml
@@ -136,6 +136,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/services/vios/charts/vios-sensor/templates/deployment.yaml
+++ b/deploy/helm/services/vios/charts/vios-sensor/templates/deployment.yaml
@@ -190,6 +190,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/services/vios/templates/openshift-scc-anyuid.yaml
+++ b/deploy/helm/services/vios/templates/openshift-scc-anyuid.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.global.openshift.enabled }}
+# Grants anyuid SCC to ServiceAccounts that need it under restricted-v2.
+# Same pattern as RAG/AIQ OpenShift overlays: one RoleBinding, explicit SA
+# subjects (not only default). Placed in this shared chart since all four
+# dev-profile-* umbrellas depend on vios.
+#
+# - default: most pods (incl. root-running VIOS nvstreamer/sensor/streamprocessing)
+# - sdrc: infra/sdrc creates its own SA; without anyuid the controller dies on
+#   Permission denied: '/logs' while Envoy keeps the pod Ready
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-vios-anyuid-scc
+  labels:
+    app.kubernetes.io/name: vios
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}
+  # sdrc chart default name (useReleaseNamePrefix: false). Prefixed form kept
+  # so installs with useReleaseNamePrefix: true still match.
+  - kind: ServiceAccount
+    name: sdrc
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ printf "%s-sdrc" .Release.Name | trunc 63 | trimSuffix "-" }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/services/vios/values.yaml
+++ b/deploy/helm/services/vios/values.yaml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+global:
+  openshift:
+    enabled: false
+
 # Master switch when this chart is a dependency of a developer profile.
 enabled: true
 


### PR DESCRIPTION
## Description

This PR adds Red Hat OpenShift deployment support for all four developer profiles (`base`, `alerts`, `lvs`, `search`), validated end-to-end on an OpenShift cluster. The entire deployment is declarative via Helm overlays with no external scripts required.

**What's included:**
- `global.openshift.enabled` flag (off by default, zero impact on non-OpenShift deployments)
- `values-openshift.yaml` overlay per profile - enables OpenShift Routes, GPU-toleration stubs (commented, cluster-specific), and other OpenShift-only overrides
- `templates/openshift-routes.yaml` per profile - conditional Routes (edge TLS) replacing Kubernetes Ingress, mirroring each profile's existing Ingress path structure
- SCC templates across the `nims` and `vios` charts - a custom SecurityContextConstraints (prevents SELinux relabeling on large NIM model volumes) and an `anyuid` SCC RoleBinding for `vios` ServiceAccounts
- `deploy/helm/developer-profiles/openshift-deployment.md` - runbook covering prerequisites, per-profile install commands (in-cluster and remote LLM/VLM), NGC secret handling, GPU type / StorageClass config, verification, and uninstallation

**How it works:** Users deploy with a single command per profile - Routes and SCC grants are all handled by the chart, e.g. for alerts:
```shell
export NGC_CLI_API_KEY='<your NGC API key>'
export APPS_DOMAIN=$(oc get ingress.config.openshift.io/cluster \
  -o jsonpath='{.spec.domain}')

helm install vss-alerts . \
  -f values-verification.yaml \
  -f values-openshift.yaml \
  --set-string ngc.apiKey="$NGC_CLI_API_KEY" \
  --set global.externalHost=vss-alerts.${APPS_DOMAIN} \
  -n vss-alerts --create-namespace
```

**Validated:** All four profiles installed and tested end-to-end on an OpenShift cluster - Routes reachable, SCCs applied, pods scheduling correctly with GPU tolerations.

**Known limitations:**
- `vss-rtvi-cv`'s SigLIP TensorRT engine build can fail - appears to be an existing export issue in the vss-rt-cv image, unrelated to this overlay.
- Our test clusters didn't have a validated driver build for the local Cosmos VLM (nvidia-cosmos-reason2-8b), so the model was validated using the remote NVIDIA Build Endpoint instead.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.