### PR TITLE
Optimize replay overlay metadata fetch and fix bbox rendering

### DIFF
--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -92,6 +92,7 @@ services:
       - VST_INGRESS_ENDPOINT=${VST_INGRESS_ENDPOINT}
       - ENABLE_AGING_POLICY=true
       - VST_ENABLE_NOTIFICATION=${VST_ENABLE_NOTIFICATION:-${VST_USE_SDRC:-false}}
+      - DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION=1
     volumes:
       - ${VST_CONFIG_PATH}:/home/vst/vst_release/configs
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data

--- a/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.cpp
@@ -192,10 +192,57 @@ GstElement* TranscodeWriterConsumer::buildOverlayBinIfNeeded()
     params.m_startTime = mCfg.user_start_time_iso;
     params.m_endTime = mCfg.user_end_time_iso;
     params.m_sensorName = mCfg.sensor_name;
-    // Defaults; can be refined later if needed
-    params.m_frameRate = 30;
-    params.m_frameSize.m_width = 1920;
-    params.m_frameSize.m_height = 1080;
+    // Use the stream's real frame rate (from the file-list query, passed in via
+    // cfg) so the overlay bbox match tolerance (1000/fps ms, when
+    // bbox_tolerance_ms config is 0) matches the actual cadence. A hardcoded 30
+    // made the window too tight for lower-fps clips (e.g. 10fps -> 33ms instead
+    // of 100ms), dropping boxes on offset frames. Fall back to the default when
+    // the file fps is unknown (0).
+    params.m_frameRate = (mCfg.frame_rate > 0.0) ? mCfg.frame_rate
+                                                 : DEFAULT_VIDEO_FRAME_RATE;
+    LOG(info) << mLogPrefix << "TranscodeWriter: overlay frame rate = "
+              << params.m_frameRate << " fps (file fps=" << mCfg.frame_rate
+              << (mCfg.frame_rate > 0.0 ? "" : " -> default") << ")" << endl;
+    // Use the stream's real resolution for the overlay. The transcode pipeline
+    // preserves the source resolution (no scaler), so drawing at a hardcoded
+    // 1920x1080 on a smaller stream made the debug font oversized and pushed the
+    // debug timestamp text off the frame (positions are computed for 1080p). Fall
+    // back to 1920x1080 when the DB has no usable resolution.
+    int overlayWidth = 1920;
+    int overlayHeight = 1080;
+    if (!mCfg.stream_id.empty())
+    {
+        auto dbHelper = GET_DB_INSTANCE();
+        if (dbHelper)
+        {
+            SensorStreamsDBColumns row = dbHelper->readSensorStreams(mCfg.stream_id);
+            const std::string& resStr = row.resolution_value;  // e.g. "640x428"
+            const auto xpos = resStr.find('x');
+            if (xpos != std::string::npos)
+            {
+                try
+                {
+                    const int w = std::stoi(resStr.substr(0, xpos));
+                    const int h = std::stoi(resStr.substr(xpos + 1));
+                    if (w > 0 && h > 0)
+                    {
+                        overlayWidth = w;
+                        overlayHeight = h;
+                    }
+                }
+                catch (const std::exception& e)
+                {
+                    LOG(warning) << mLogPrefix << "TranscodeWriter: invalid resolution '"
+                                 << resStr << "': " << e.what() << ", using "
+                                 << overlayWidth << "x" << overlayHeight << endl;
+                }
+            }
+        }
+    }
+    params.m_frameSize.m_width = overlayWidth;
+    params.m_frameSize.m_height = overlayHeight;
+    LOG(info) << mLogPrefix << "TranscodeWriter: overlay resolution = "
+              << overlayWidth << "x" << overlayHeight << endl;
     if (mCfg.overlay_params)
     {
         params.m_bboxParams = *mCfg.overlay_params;
@@ -208,6 +255,13 @@ GstElement* TranscodeWriterConsumer::buildOverlayBinIfNeeded()
     std::shared_ptr<IMetadataStore> metadataStore = std::make_shared<ElasticMetadataStore>(metadataParams, false);
     // Store overlay instance as member to keep it alive for pipeline duration
     mOverlayInst = std::make_unique<NvLLOverlayInternal>(params, metadataStore, false, true);
+    if (mOverlayInst)
+    {
+        // Keep source == draw resolution so bbox coordinates (already in source
+        // space) map 1:1 (unchanged from the previous 1920==1920 behaviour),
+        // while font size and debug-text positions scale to the real frame.
+        mOverlayInst->updateSourceResolution(overlayWidth, overlayHeight);
+    }
     GstElement* overlay = mOverlayInst ? mOverlayInst->create() : nullptr;
     if (!overlay)
     {

--- a/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.h
@@ -47,6 +47,7 @@ struct TranscodeWriterConfig
     std::string user_start_time_iso;
     std::string user_end_time_iso;
     OverlayBBoxParams* overlay_params = nullptr; // optional
+    double frame_rate = 0.0;           // stream fps (from file list) for overlay tolerance; 0 = unknown
     bool is_software_encoder = false;  // true when not using NV v4l2 enc
 
     int64_t seek_start_ms = 0;         // for decoder/output filtering

--- a/services/vios/src/framework/media/metadata/ElasticMetadataStore.cpp
+++ b/services/vios/src/framework/media/metadata/ElasticMetadataStore.cpp
@@ -17,6 +17,38 @@
 
 #include "ElasticMetadataStore.h"
 #include "logger.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    // Prefetch tuning (constants, not config, to keep the change self-contained).
+    // Slice window kept small enough that even high-fps streams stay well under
+    // the Elasticsearch max_result_window (10k) for a single-shot slice query.
+    constexpr int64_t  PREFETCH_SLICE_MS      = 60 * 1000;      // 60s per slice
+    constexpr int      PREFETCH_SLICE_MAX_HITS = 10000;         // ES size cap per slice
+    // Cap total look-ahead so very long downloads don't load the whole clip into
+    // RAM. Beyond this, the incremental refill (checkAndRefillMetadata) handles
+    // the tail - the large head start keeps it ahead of consumption.
+    constexpr int64_t  PREFETCH_MAX_WINDOW_MS = 10 * 60 * 1000; // 10 min
+    constexpr uint16_t PREFETCH_DATASIZE_CAP  = 60000;          // fits atomic<uint16_t>
+    // Non-zero seed for m_dataSize when a tail beyond the look-ahead window may
+    // still need fetching. Must be >= 2 so the refill threshold (dataSize/2)
+    // actually fires when the queue is empty; the incremental fetch overwrites
+    // it with the real batch size on the first successful call.
+    constexpr uint16_t PREFETCH_TAIL_BOOTSTRAP = 300;
+
+    // Bounded blocking wait in getMetadata (download path only). getMetadata
+    // wakes on the m_dataReady signal as soon as a fetch delivers data; this is
+    // only the backstop timeout so a slow/unavailable Elasticsearch degrades to
+    // occasional flicker, never a hung download.
+    constexpr int      GET_WAIT_BUDGET_MS = 300;
+}
 
 ElasticMetadataStore::ElasticMetadataStore(MetadataParams& params, bool use_frameid)
     : m_bboxMetadata(m_metadataQueue, m_metadataQueueMutex)
@@ -33,6 +65,19 @@ ElasticMetadataStore::ElasticMetadataStore(MetadataParams& params, bool use_fram
 
 ElasticMetadataStore::~ElasticMetadataStore()
 {
+    // Both tasks capture `this`; join them before destruction to avoid
+    // use-after-free.
+    if (m_prefetchTask.valid())
+    {
+        try
+        {
+            m_prefetchTask.get();
+        }
+        catch(const std::exception& e)
+        {
+            LOG(error) << "Caught Exception for m_prefetchTask Async task: " <<  e.what() << endl;
+        }
+    }
     if (m_elasticTask.valid())
     {
         try
@@ -46,39 +91,108 @@ ElasticMetadataStore::~ElasticMetadataStore()
     }
 }
 
-Json::Value ElasticMetadataStore::getMetadata(const int64_t frameTS)
+// Pops queue entries older than frameTS and returns the first entry whose
+// timestamp is >= frameTS (the "ceiling" match), or nullValue if the queue
+// drained. Caller must NOT hold m_metadataQueueMutex.
+Json::Value ElasticMetadataStore::matchQueueFront(const int64_t frameTS)
 {
-    checkAndRefillMetadata(frameTS);
-
+    std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
     Json::Value metadata = Json::nullValue;
+    if (!m_metadataQueue.empty())
     {
-        std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
-        int64_t elasticTS = 0;
-        if (!m_metadataQueue.empty())
+        metadata = m_metadataQueue.front();
+        int64_t elasticTS = metadata["epocTime"].asUInt64() * 1000;
+        while(elasticTS < frameTS && !m_metadataQueue.empty())
         {
-            metadata = m_metadataQueue.front();
-            elasticTS = metadata["epocTime"].asUInt64() * 1000;
-            while(elasticTS < frameTS && !m_metadataQueue.empty())
+            m_metadataQueue.pop();
+            if (!m_metadataQueue.empty())
             {
-                m_metadataQueue.pop();
-                if (!m_metadataQueue.empty())
-                {
-                    metadata = m_metadataQueue.front();
-                    elasticTS = metadata["epocTime"].asUInt64() * 1000;
-                }
-                else
-                {
-                    metadata = Json::nullValue;
-                    break;
-                }
+                metadata = m_metadataQueue.front();
+                elasticTS = metadata["epocTime"].asUInt64() * 1000;
+            }
+            else
+            {
+                metadata = Json::nullValue;
+                break;
             }
         }
     }
     return metadata;
 }
 
+Json::Value ElasticMetadataStore::getMetadata(const int64_t frameTS)
+{
+    checkAndRefillMetadata(frameTS);
+    Json::Value metadata = matchQueueFront(frameTS);
+
+    // Default (recorded playback / webrtc replay / vod): non-blocking, exactly
+    // as before - realtime playback keeps the async prefetch ahead, so an empty
+    // queue is rare and simply skips the box for that frame.
+    if (metadata != Json::nullValue || !m_blockingGet)
+    {
+        return metadata;
+    }
+
+    // Download path only (m_blockingGet set by startPrefetch): the transcode
+    // produces frames far faster than real time, so a momentarily empty queue
+    // must NOT drop the overlay. Block until a fetch signals that new metadata
+    // is available, then retry. m_dataReady is signaled by the prefetch and the
+    // incremental refill when they push/complete, so we wake as soon as data
+    // lands - no polling. The deadline is only a backstop so a slow/unavailable
+    // Elasticsearch degrades to occasional flicker instead of a hung download.
+    const auto deadline = std::chrono::steady_clock::now()
+                        + std::chrono::milliseconds(GET_WAIT_BUDGET_MS);
+    while (true)
+    {
+        // The prefetch turns blocking off if Elasticsearch came back empty /
+        // unreachable; bail immediately so we never keep stalling per frame.
+        if (!m_blockingGet)
+        {
+            return Json::nullValue;
+        }
+
+        const bool moreExpected = m_prefetchInFlight
+                                || m_bboxMetadata.m_searching
+                                || (!m_fullyPrefetched && m_bboxMetadata.m_dataSize != 0);
+        if (!moreExpected)
+        {
+            return Json::nullValue;  // genuinely exhausted - nothing more will arrive
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline)
+        {
+            return Json::nullValue;
+        }
+
+        // Make sure a fetch is in flight for the tail case (nothing running but
+        // more data expected). checkAndRefillMetadata won't double-spawn, and
+        // its lock is independent of m_dataReady's, so there is no deadlock.
+        checkAndRefillMetadata(frameTS);
+
+        const auto remainMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  deadline - now).count();
+        // Wakes immediately if a signal already arrived (persistent flag) or as
+        // soon as one does; otherwise returns at the bounded timeout.
+        m_dataReady.wait(static_cast<unsigned int>(remainMs));
+
+        metadata = matchQueueFront(frameTS);
+        if (metadata != Json::nullValue)
+        {
+            return metadata;
+        }
+    }
+}
+
 void ElasticMetadataStore::checkAndRefillMetadata(const int64_t frameTS)
 {
+    // While the eager prefetch owns the queue, or once it has loaded the whole
+    // range, the incremental (search_after) refill must stay out of the way -
+    // it would race the prefetch on m_search_after / the queue and reorder data.
+    if (m_prefetchInFlight || m_fullyPrefetched)
+    {
+        return;
+    }
     uint32_t currentSize = 0;
     {
         std::lock_guard<std::mutex> guard(m_bboxMetadata.m_hitsLock);
@@ -107,6 +221,9 @@ void ElasticMetadataStore::checkAndRefillMetadata(const int64_t frameTS)
                 }
             }
             elasticSearch::getBboxPosition(m_bboxMetadata);
+            // Wake any getMetadata blocked in the bounded wait: new records were
+            // pushed (or the fetch finished with none, so it can re-evaluate).
+            m_dataReady.signal();
         });
     }
 }
@@ -158,4 +275,197 @@ void ElasticMetadataStore::fetchMetadataAgain(const std::string& newStartTime)
     m_bboxMetadata.m_searchParams.m_start_time = newStartTime;
     m_bboxMetadata.m_searchParams.m_search_after = 0;
     fetchMetadata();
+}
+
+void ElasticMetadataStore::startPrefetch()
+{
+    // If Elasticsearch is not configured there is no metadata to fetch (e.g. a
+    // local standalone setup that only exercises the debug timestamp overlay).
+    // Do NOT enable the blocking wait - getMetadata must stay non-blocking so
+    // every frame is emitted immediately, never stalling the download.
+    if (GET_CONFIG().video_metadata_server.empty())
+    {
+        LOG(info) << "startPrefetch: video metadata server not configured; "
+                     "overlay metadata disabled, getMetadata stays non-blocking" << endl;
+        return;  // m_blockingGet stays false
+    }
+
+    // Enable the bounded blocking wait in getMetadata for this (download) store.
+    m_blockingGet = true;
+
+    // Frame-id (streamer) mode is not used by the download path; keep the
+    // existing behavior for it.
+    if (m_useId)
+    {
+        fetchMetadata();
+        return;
+    }
+    if (m_prefetchInFlight)
+    {
+        return;
+    }
+
+    // Publish "work in flight" synchronously so a getMetadata() call that races
+    // ahead of the async task waits for the prefetch instead of returning null.
+    m_prefetchInFlight = true;
+    m_bboxMetadata.m_searching = true;
+    m_prefetchTask = async::spawn([this] { prefetchRange(); });
+}
+
+void ElasticMetadataStore::prefetchRange()
+{
+    try
+    {
+        const std::string sensor   = m_bboxMetadata.m_searchParams.m_sensor_id;
+        const std::string startIso = m_bboxMetadata.m_searchParams.m_start_time;
+        const std::string endIso   = m_bboxMetadata.m_searchParams.m_end_time;
+
+        const int64_t startMs = static_cast<int64_t>(getEpocTimeInMS(startIso));
+        const int64_t endMs   = static_cast<int64_t>(getEpocTimeInMS(endIso));
+
+        if (startMs <= 0 || endMs <= 0 || endMs <= startMs)
+        {
+            // Range is not usable for slicing (e.g. empty end time). Fall back to
+            // the proven sequential fetch; incremental refill handles the rest.
+            LOG(warning) << "prefetchRange: unusable range [" << startIso << " .. "
+                         << endIso << "], using sequential fetch" << endl;
+            elasticSearch::getBboxPosition(m_bboxMetadata);
+        }
+        else
+        {
+            const int64_t windowEndMs = std::min(endMs, startMs + PREFETCH_MAX_WINDOW_MS);
+            const bool coversWholeRange = (windowEndMs >= endMs);
+
+            // Time slices. Intermediate slices are half-open ([s, e-1ms]) so
+            // adjacent slices never return the same record twice; the final
+            // slice keeps the inclusive upper bound (== the original lte
+            // end_time semantics) so a record landing exactly on windowEndMs is
+            // not dropped.
+            std::vector<std::pair<std::string, std::string>> slices;
+            for (int64_t s = startMs; s < windowEndMs; s += PREFETCH_SLICE_MS)
+            {
+                const int64_t e = std::min(windowEndMs, s + PREFETCH_SLICE_MS);
+                const bool isLast = (e >= windowEndMs);
+                const int64_t endBoundMs = isLast ? e : (e - 1);
+                slices.emplace_back(convertEpocToISO8601_2(s * 1000),
+                                    convertEpocToISO8601_2(endBoundMs * 1000));
+            }
+
+            // Fetch all slices in parallel, then wait for them (same idiom as
+            // streamrecorder's parallel duration retrieval).
+            std::vector<async::task<std::pair<bool, std::vector<Json::Value>>>> tasks;
+            tasks.reserve(slices.size());
+            for (const auto& sl : slices)
+            {
+                const std::string sStart = sl.first;
+                const std::string sEnd   = sl.second;
+                tasks.push_back(async::spawn([sensor, sStart, sEnd]
+                {
+                    return elasticSearch::fetchRangeHits(sensor, sStart, sEnd,
+                                                         PREFETCH_SLICE_MAX_HITS);
+                }));
+            }
+
+            std::vector<Json::Value> all;
+            bool anyReachable = false;
+            for (auto& t : tasks)
+            {
+                std::pair<bool, std::vector<Json::Value>> part = t.get();
+                anyReachable = anyReachable || part.first;
+                all.insert(all.end(),
+                           std::make_move_iterator(part.second.begin()),
+                           std::make_move_iterator(part.second.end()));
+            }
+
+            // Parallel slices arrive out of order; the consumer needs ascending
+            // timestamps.
+            std::sort(all.begin(), all.end(),
+                      [](const Json::Value& a, const Json::Value& b)
+                      {
+                          return a["epocTime"].asUInt64() < b["epocTime"].asUInt64();
+                      });
+
+            {
+                std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
+                for (auto& h : all)
+                {
+                    m_metadataQueue.push(h);
+                }
+            }
+
+            if (!all.empty())
+            {
+                // NOTE: for 3D sensors epocTime derives from info[sensorId]
+                // rather than the @timestamp sort value; the incremental tail
+                // handoff below seeds search_after from epocTime, so a 3D-sensor
+                // clip longer than the look-ahead window may skip/re-fetch a few
+                // records at the seam. Acceptable for that niche path.
+                const Json::UInt64 lastTs = all.back()["epocTime"].asUInt64();
+                if (lastTs > m_bboxMetadata.m_searchParams.m_search_after)
+                {
+                    m_bboxMetadata.m_searchParams.m_search_after = lastTs;
+                }
+            }
+            m_fullyPrefetched = coversWholeRange;
+            if (all.empty())
+            {
+                if (!anyReachable)
+                {
+                    // Elasticsearch could not be reached. Turn off the per-frame
+                    // blocking wait so frames (e.g. the debug timestamp overlay)
+                    // are emitted immediately instead of each stalling for the
+                    // wait budget. Seed the tail so incremental refill can still
+                    // recover non-blockingly if ES comes back.
+                    m_blockingGet = false;
+                    m_bboxMetadata.m_dataSize = coversWholeRange ? 0 : PREFETCH_TAIL_BOOTSTRAP;
+                }
+                else if (coversWholeRange)
+                {
+                    // ES answered: the entire clip genuinely has no metadata.
+                    // Nothing will ever arrive, so stop blocking.
+                    m_blockingGet = false;
+                    m_bboxMetadata.m_dataSize = 0;
+                }
+                else
+                {
+                    // ES answered but this head window was empty (e.g. the camera
+                    // was idle early on); later parts of the clip may still have
+                    // metadata. Keep blocking and let the incremental refill fetch
+                    // the tail so those frames are not dropped.
+                    m_bboxMetadata.m_dataSize = PREFETCH_TAIL_BOOTSTRAP;
+                }
+            }
+            else
+            {
+                // m_dataSize drives both the incremental refill threshold and
+                // getMetadata's "more expected" check. When the whole range is
+                // loaded, m_fullyPrefetched short-circuits the refill regardless.
+                m_bboxMetadata.m_dataSize = static_cast<uint16_t>(
+                    std::min<size_t>(all.size(), PREFETCH_DATASIZE_CAP));
+            }
+
+            LOG(info) << "prefetchRange: loaded " << all.size() << " records over "
+                      << slices.size() << " slice(s), fullRange=" << coversWholeRange
+                      << ", camera=" << sensor << endl;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        LOG(error) << "prefetchRange: exception: " << e.what()
+                   << "; disabling blocking wait, incremental refill may recover" << endl;
+        // A fetch failed. Stop the per-frame blocking wait so the download is
+        // never stalled waiting on a broken Elasticsearch. Leave the incremental
+        // refill armed (non-blocking) in case it recovers later.
+        m_blockingGet = false;
+        if (m_bboxMetadata.m_dataSize == 0)
+        {
+            m_bboxMetadata.m_dataSize = PREFETCH_TAIL_BOOTSTRAP;
+        }
+    }
+
+    m_bboxMetadata.m_searching = false;
+    m_prefetchInFlight = false;
+    // Wake getMetadata: records are loaded (or the range is genuinely empty and
+    // the flags above now reflect that), so it can match or terminate.
+    m_dataReady.signal();
 }

--- a/services/vios/src/framework/media/metadata/ElasticMetadataStore.h
+++ b/services/vios/src/framework/media/metadata/ElasticMetadataStore.h
@@ -17,9 +17,12 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "ReplayMetadataStore.h"
 #include "libasync++/async++.h"
 #include "elasticSearch.h"
+#include "syncobject.h"
 
 class ElasticMetadataStore : public ReplayMetadataStore
 {
@@ -33,9 +36,34 @@ public:
     virtual void fetchMetadata() override;
     virtual bool isSearching() override;
     virtual void fetchMetadataAgain(const std::string& newStartTime) override;
+    virtual void startPrefetch() override;
 
 private:
+    // Runs on m_prefetchTask: time-slices [start,end], fetches slices in
+    // parallel, merges/sorts, and loads the queue in one shot.
+    void prefetchRange();
+
+    // Pops entries older than frameTS and returns the ceiling match (first
+    // entry with timestamp >= frameTS), or nullValue if the queue drained.
+    Json::Value matchQueueFront(const int64_t frameTS);
+
     async::task<void>           m_elasticTask;
+    async::task<void>           m_prefetchTask;
     BBoxMetaData                m_bboxMetadata;
     bool                        m_useId {false};
+
+    // Set only on the download path (via startPrefetch). Gates the bounded
+    // blocking wait in getMetadata so recorded-playback/webrtc/live behavior is
+    // byte-for-byte unchanged. Written on the build thread, read on the gst
+    // streaming thread, hence atomic.
+    std::atomic<bool>           m_blockingGet {false};
+    // True while the eager prefetch async task is running.
+    std::atomic<bool>           m_prefetchInFlight {false};
+    // True once the prefetch has loaded the entire requested range (no tail
+    // remains, so incremental refill is unnecessary).
+    std::atomic<bool>           m_fullyPrefetched {false};
+    // Signaled whenever a fetch pushes new records or completes, so a blocked
+    // getMetadata wakes immediately instead of polling. The bounded wait budget
+    // is only a safety backstop against a slow/unavailable Elasticsearch.
+    SyncObject                  m_dataReady = {};
 };

--- a/services/vios/src/framework/media/metadata/ReplayMetadataStore.h
+++ b/services/vios/src/framework/media/metadata/ReplayMetadataStore.h
@@ -33,4 +33,10 @@ public:
     virtual void fetchMetadata() =0;
     virtual void fetchMetadataAgain(const std::string& newStartTime) =0;
     virtual bool isSearching() =0;
+
+    // Optional eager prefetch used by the download path to fully populate the
+    // metadata queue before/while the pipeline starts, so faster-than-real-time
+    // transcoding never outruns the async fetch (bbox flicker). Default no-op
+    // preserves existing behavior for stores that do not implement it.
+    virtual void startPrefetch() {}
 };

--- a/services/vios/src/framework/media/overlays/ll_overlay.cpp
+++ b/services/vios/src/framework/media/overlays/ll_overlay.cpp
@@ -140,6 +140,31 @@ NvLLOverlay::NvLLOverlay (const std::string& consumer_name, const std::string& u
     m_overlay->setColorCode(m_overlayParams.m_colorCode);
     m_overlay->setEnableGodsEyeView(m_overlayParams.m_enableGodsEyeView);
 
+    if (m_imageCapture)
+    {
+        // Image capture emits a single frame, which can be drawn before the
+        // async setOriginalFrameSize() propagates the decoder resolution through
+        // the Transform -> Overlay chain. Seed the source resolution up-front so
+        // bbox coordinates (which are in the source resolution) scale 1:1.
+        // Otherwise m_sourceWidth stays 0 and interpolateCoordinate() defaults it
+        // to 1080p, shrinking boxes to ~1/3 and clustering them at the top-left.
+        int srcW = m_width;
+        int srcH = m_height;
+        const auto itW = m_opts.find("source_width");
+        const auto itH = m_opts.find("source_height");
+        if (itW != m_opts.end())
+        {
+            srcW = stringToInt(itW->second, m_width);
+        }
+        if (itH != m_opts.end())
+        {
+            srcH = stringToInt(itH->second, m_height);
+        }
+        m_overlay->updateSourceResolution(srcW, srcH);
+        LOG(info) << "Image capture: seeded overlay source resolution = "
+                  << srcW << "x" << srcH << endl;
+    }
+
     LOG(info) << "Creating m_overlay " << m_overlay << endl;
 
     m_surfacePool = std::make_shared<NvSurfacePool>();
@@ -442,6 +467,17 @@ void NvLLOverlay::setOriginalFrameSize(int w, int h)
     else
     {
         m_overlay->updateSourceResolution(w, h);
+    }
+    if (m_imageCapture)
+    {
+        // Image capture is a single frame, and the resolution propagated here
+        // during pipeline setup can be the decoder's pre-detection default
+        // (e.g. 1920x1080) - the real decoded resolution is detected later and
+        // is not re-propagated before the one frame is drawn. That scales the
+        // ES bbox coordinates (already in source resolution) by
+        // draw/1920 ~= 1/3, shrinking boxes to the top-left. Re-apply the known
+        // source resolution so bbox coordinates map 1:1.
+        m_overlay->updateSourceResolution(m_width, m_height);
     }
     if (isJetsonPlatform())
     {

--- a/services/vios/src/framework/media/overlays/overlay_internal.cpp
+++ b/services/vios/src/framework/media/overlays/overlay_internal.cpp
@@ -99,11 +99,20 @@ Point interpolateCoordinate(int x, int y, int oldWidth, int oldHeight, int newWi
 
 static int interpolateFontSize(int oldWidth, int newWidth)
 {
-    if(oldWidth <= 0 || newWidth <=0)
+    // DEFAULT_FONT_SIZE is tuned for 1080p. Scale it to the actual drawing
+    // width so the text is proportional at every resolution (smaller on
+    // low-res streams, larger on 4K). Previously this scaled by
+    // newWidth/oldWidth (source->output ratio), which returned the full 1080p
+    // size whenever source width == output width - e.g. a 640-wide stream kept
+    // font size 12 and looked oversized. Prefer the drawing (output) width;
+    // fall back to the source width if the output width is unknown.
+    int drawWidth = (newWidth > 0) ? newWidth : oldWidth;
+    if (drawWidth <= 0)
     {
         return DEFAULT_FONT_SIZE;
     }
-    return (DEFAULT_FONT_SIZE * newWidth) / oldWidth;
+    int font_size = (DEFAULT_FONT_SIZE * drawWidth) / WIDTH_1080p;
+    return (font_size > 0) ? font_size : 1;
 }
 
 // Function to convert box3d to corners3d
@@ -4228,13 +4237,34 @@ void NvLLOverlayInternal::enableOverlay(OverlayParams& params, bool use_frameid,
     m_sensorName = params.m_sensorName;
     m_bboxParams.m_searchParams = inData;
     m_bboxParams.m_isLive = params.m_isLive;
+    // Sanity-clamp the fps used to derive the bbox match tolerance. Stream
+    // settings can carry implausible values (e.g. a legacy sensor with
+    // STREAM_FRAMERATE=1000), which would otherwise yield a ~1ms window and drop
+    // most boxes. A real sensor here is <= 120 fps; fall back to the default
+    // outside that range. This only affects the fps->tolerance math, not the
+    // stored m_frameRate used elsewhere.
+    double toleranceFps = params.m_frameRate;
+    if (!(toleranceFps > 0.1 && toleranceFps <= 120.0))
+    {
+        LOG(warning) << "Overlay: implausible frameRate " << params.m_frameRate
+                     << " fps for sensor " << params.m_sensorName
+                     << "; using " << DEFAULT_VIDEO_FRAME_RATE
+                     << " fps for bbox tolerance" << endl;
+        toleranceFps = DEFAULT_VIDEO_FRAME_RATE;
+    }
     m_bboxParams.m_timestampTolerance = GET_CONFIG().bbox_tolerance_ms * 1000;
     if (m_bboxParams.m_timestampTolerance == 0)
     {
-        m_bboxParams.m_timestampTolerance = uint((1.0 / params.m_frameRate) * 1000) * 1000;
+        m_bboxParams.m_timestampTolerance = uint((1.0 / toleranceFps) * 1000) * 1000;
     }
     m_bboxParams.m_frameSize = params.m_frameSize;
     m_bboxParams.m_frameRate = params.m_frameRate;
+    LOG(info) << "Overlay bbox match: sensor=" << params.m_sensorName
+              << " frameRate=" << params.m_frameRate << " fps (tolerance fps="
+              << toleranceFps << ")"
+              << ", bbox_tolerance_ms(config)=" << GET_CONFIG().bbox_tolerance_ms
+              << ", effective tolerance=" << (m_bboxParams.m_timestampTolerance / 1000)
+              << " ms" << endl;
     m_bboxParams.m_overlay = params.m_bboxParams;
     m_enableBbox = params.m_bboxParams.m_enableBbox;
     m_enablePose = params.m_bboxParams.m_enablePose;
@@ -4269,7 +4299,21 @@ void NvLLOverlayInternal::enableOverlay(OverlayParams& params, bool use_frameid,
         {
             if (m_enableBbox || m_enablePose || m_enableHalos)
             {
-                m_replayMetadataStore->fetchMetadata();
+                if (m_isWaitForESQuery)
+                {
+                    // Download (transcode) path: frames are produced far faster
+                    // than real time. Eagerly prefetch the whole range async so
+                    // the metadata queue never starves (bbox flicker). This
+                    // overlaps the ES fetch with pipeline construction instead of
+                    // blocking on a single 300-row batch.
+                    m_replayMetadataStore->startPrefetch();
+                }
+                else
+                {
+                    // Recorded playback / webrtc replay / vod: unchanged - real
+                    // time playback keeps the async refill ahead on its own.
+                    m_replayMetadataStore->fetchMetadata();
+                }
             }
         }
     }

--- a/services/vios/src/framework/protocols/elastic_search/elasticSearch.cpp
+++ b/services/vios/src/framework/protocols/elastic_search/elasticSearch.cpp
@@ -216,3 +216,75 @@ void elasticSearch::getBboxPosition(BBoxMetaData& outData)
     outData.m_dataSize = hits.size();
     outData.m_searching = false;
 }
+
+std::pair<bool, std::vector<Json::Value>> elasticSearch::fetchRangeHits(
+                                                       const std::string& sensorId,
+                                                       const std::string& startIso,
+                                                       const std::string& endIso,
+                                                       int size)
+{
+    std::vector<Json::Value> results;
+    nv_vms::DeviceConfig config = GET_CONFIG();
+    std::string elasticsearch_url = config.video_metadata_server;
+    if (elasticsearch_url.empty())
+    {
+        LOG(warning) << "fetchRangeHits: Elasticsearch URL is empty" << endl;
+        return {false, results};
+    }
+
+    SearchParams inData(startIso, endIso, sensorId);
+    inData.m_search_after = 0;
+    std::string url = elasticsearch_url + "/_search?size=" + std::to_string(size);
+    std::string string_query = getQueryString(inData);
+
+    LOG(info) << "fetchRangeHits: querying camera: " << sensorId
+                << " Start: " << startIso << " End: " << endIso
+                << " size: " << size << endl;
+    Json::Value json_get = queryESMetadata(url, string_query);
+    // A reachable ES answers with a "hits" object even when there are zero
+    // matches; a failed/unreachable request yields an empty/invalid document.
+    const bool reachable = json_get.isObject() && json_get.isMember("hits");
+    Json::Value& hits = json_get["hits"]["hits"];
+    const bool is3dSensor = !config.overlay_3d_sensor_name.empty();
+    results.reserve(hits.size());
+    for (uint32_t i = 0; i < hits.size(); i++)
+    {
+        Json::Value& source = hits[i]["_source"];
+        Json::Value current_hit;
+        current_hit["objects"] = source["objects"];
+        current_hit["id"] = source["id"];
+
+        if (is3dSensor && source.isMember("info") && source["info"].isObject() &&
+            source["info"].isMember(sensorId) &&
+            source["info"][sensorId].isString())
+        {
+            std::time_t epochMs = isoToEpoch(source["info"][sensorId].asString());
+            if (epochMs != 0)
+            {
+                current_hit["epocTime"] = static_cast<Json::UInt64>(epochMs);
+            }
+            else
+            {
+                current_hit["epocTime"] = hits[i]["sort"][0].asUInt64();
+            }
+        }
+        else
+        {
+            current_hit["epocTime"] = hits[i]["sort"][0].asUInt64();
+        }
+        results.push_back(current_hit);
+    }
+
+    LOG(info) << "fetchRangeHits: camera: " << sensorId
+                << " received: " << hits.size() << " reachable: " << reachable << endl;
+    if (static_cast<int>(hits.size()) >= size)
+    {
+        // Slice hit the (unpaginated) size cap; records beyond it are not
+        // fetched. Should not happen with per-frame metadata docs, but log it
+        // so a per-object schema or unusually high fps is visible.
+        LOG(warning) << "fetchRangeHits: slice for camera " << sensorId
+                     << " [" << startIso << " .. " << endIso << "] hit the size cap "
+                     << size << "; some metadata may be truncated" << endl;
+    }
+    return {reachable, results};
+}

--- a/services/vios/src/framework/protocols/elastic_search/elasticSearch.h
+++ b/services/vios/src/framework/protocols/elastic_search/elasticSearch.h
@@ -22,6 +22,8 @@
 #include <mutex>
 #include <queue>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 #include "logger.h"
 #include "network_utils.h"
@@ -171,4 +173,24 @@ public:
 
     static void getBboxPositionStreamer(BBoxMetaData& outData);
     static void getBboxPosition(BBoxMetaData& outData);
+
+    /*
+     * Single-shot range query used by the download prefetch path. Returns up to
+     * `size` metadata hits for the window [startIso, endIso], sorted ascending,
+     * WITHOUT touching any shared queue. Safe to call concurrently (each call is
+     * independent), which lets the prefetch fan out across time-sliced windows
+     * in parallel. Does not paginate: choose `size`/window so the slice stays
+     * under the Elasticsearch max_result_window.
+     *
+     * Returns {reachable, hits}. `reachable` is true when Elasticsearch answered
+     * the query (even with zero hits) and false when the server could not be
+     * reached / returned no valid response - the prefetch uses this to tell
+     * "empty because idle" (keep waiting for later data) apart from "empty
+     * because ES is down" (stop blocking per frame).
+     */
+    static std::pair<bool, std::vector<Json::Value>> fetchRangeHits(
+                                                   const std::string& sensorId,
+                                                   const std::string& startIso,
+                                                   const std::string& endIso,
+                                                   int size);
 };

--- a/services/vios/src/modules/storage_management/storage_management_apis.cpp
+++ b/services/vios/src/modules/storage_management/storage_management_apis.cpp
@@ -1537,6 +1537,11 @@ VmsErrorCode StorageManagement::HandleFileDownload(const string& queryString, co
             return ret;
         }
 
+        // Split point: everything up to here is file generation (makeVideoFile);
+        // handleMediaFileDownload below is the HTTP send to the client, which is
+        // bounded by client/network speed, not server compute.
+        auto generation_end_tp = std::chrono::steady_clock::now();
+
         // Handle URL generation request
         if (isURLRequested)
         {
@@ -1591,11 +1596,15 @@ VmsErrorCode StorageManagement::HandleFileDownload(const string& queryString, co
             }
 
             ret = storageMngt->handleMediaFileDownload(fileName, conn);
-            /* Log download block time */
+            /* Log download block time, split into server-side generation vs the
+             * client-bound HTTP send (send is bounded by client/network speed). */
             {
                 auto download_block_end_tp = std::chrono::steady_clock::now();
-                auto download_block_ms = std::chrono::duration_cast<std::chrono::milliseconds>(download_block_end_tp - download_block_start_tp).count();
-                LOG(warning) << "#### Download perf for streamId: " << streamId << " took: " << download_block_ms << " ms ####" << endl;
+                auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(download_block_end_tp - download_block_start_tp).count();
+                auto generation_ms = std::chrono::duration_cast<std::chrono::milliseconds>(generation_end_tp - download_block_start_tp).count();
+                auto send_ms = std::chrono::duration_cast<std::chrono::milliseconds>(download_block_end_tp - generation_end_tp).count();
+                LOG(warning) << "#### Download perf for streamId: " << streamId << " took: " << total_ms
+                             << " ms (generation: " << generation_ms << " ms, send: " << send_ms << " ms) ####" << endl;
             }
 
             bool isFileDeleted = deleteFile (fileName);

--- a/services/vios/src/modules/storage_management/video_download.cpp
+++ b/services/vios/src/modules/storage_management/video_download.cpp
@@ -527,6 +527,10 @@ nv_vms::VmsErrorCode downloadVideoFile(
         wcfg.user_start_time_iso = user_start_time;
         wcfg.user_end_time_iso = user_end_time;
         wcfg.overlay_params = ol_params;
+        // Real fps from the file-list query (already fetched) so the overlay
+        // bbox match tolerance adapts to the clip's actual cadence instead of a
+        // hardcoded 30. 0 when unknown -> writer falls back to the default.
+        wcfg.frame_rate = static_cast<double>(fileNameArray[0].m_fileFPS);
         wcfg.is_software_encoder = is_sw_encoder;
         wcfg.seek_start_ms = params.seek_start_pos;
         wcfg.end_time_ms = params.seek_end_pos;


### PR DESCRIPTION
## Description
- Prefetch overlay metadata via parallel time-sliced Elasticsearch queries so faster-than-real-time downloads no longer starve and drop bounding boxes.
- Wake the metadata wait on a signal with a bounded timeout, and skip blocking when Elasticsearch is unreachable or not configured.
- Derive the bounding-box match tolerance from the real stream frame rate with a sanity clamp, replacing a hardcoded 30 fps assumption.
- Use the stream real resolution for the download overlay so the debug font and timestamp are sized and positioned correctly at every resolution.
- Fix image-capture bounding box scaling by re-applying the known source resolution, and split the download performance metric into generation and send.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
