### PR TITLE
fix(skill-eval): purge host bind-mount data dirs on box reset

### DIFF
--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -530,7 +530,7 @@ echo "host data purge OK:${purged:- nothing to purge}"
             "Purging host bind-mount data dirs (data_log, nvstreamer state) on %s",
             self._instance_name,
         )
-        result = await _run_brev_exec(self._instance_name, cmd, timeout=120)
+        result = await _run_brev_exec(self._instance_name, cmd, timeout=300)
         if result.return_code != 0:
             tail = (result.stderr or result.stdout or "")[-500:]
             raise RuntimeError(

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -361,6 +361,11 @@ class BrevEnvironment(BaseEnvironment):
             )
         else:
             await self._reset_docker_runtime()
+            # Host bind-mount purge runs AFTER the docker reset so every
+            # container that writes into these dirs is already gone —
+            # purging first would race the writers and the dirs would be
+            # dirty again by the time the trial starts.
+            await self._purge_host_data_dirs()
 
         # Sync ~/video-search-and-summarization on the box to the PR's
         # actual head SHA before any deploy/agent step reads it.
@@ -463,6 +468,77 @@ echo "docker runtime reset OK; images preserved ($(docker images -q | wc -l | tr
             )
         logger.info(
             "Docker reset on %s: %s",
+            self._instance_name,
+            (result.stdout or "").strip().splitlines()[-1] if result.stdout else "<no output>",
+        )
+
+    async def _purge_host_data_dirs(self) -> None:
+        """Purge per-trial VSS state that lives in host bind-mounts.
+
+        `_reset_docker_runtime` removes containers/volumes/networks, but
+        several services persist state in **host directories bind-mounted
+        into the containers** — invisible to `docker volume rm`:
+
+        - `<root>/nvstreamer/videos{,-upload}/` — uploaded media. NvStreamer
+          auto-suffixes a new upload whose filename already exists, so a
+          leftover `warehouse_safety_0001.mp4` turns the next trial's upload
+          into `warehouse_safety_0001_5` and fails identifier-semantics
+          checks (observed: PR #1241 `nvstreamer_ops` step-1, six leftover
+          copies on the box).
+        - `<root>/nvstreamer/vst_data/` and `<root>/data_log/` — the
+          NvStreamer/VST sensor registry and runtime DB, so sensors from
+          prior trials survive the docker reset.
+        - `<root>/videos/nvstreamer/` — alternate layout used by some
+          profiles for the same uploaded-media state.
+
+        The GitLab `ci-vss-oss` eval jobs have always done the equivalent
+        ("Cleaning VSS_DATA_DIR data_log (kafka, elastic, redis, vst,
+        nvstreamer, ...)"); this brings the skill-eval harness to parity.
+
+        Roots are **globbed, not read from `$VSS_DATA_DIR`**: the env var is
+        chosen per-deploy inside the trial, and pool boxes accumulate more
+        than one root over time (observed: `/opt/vss-data` AND
+        `~/vss-data` on the same box). `$REPO/deploy/docker/data-dir` needs
+        no handling here — `_sync_repo_to_pr_head`'s `git clean` covers it.
+
+        Contents are deleted but the directories themselves are kept, so
+        operator-provisioned ownership/permissions on the mount points
+        survive. `sudo` is required — containers write these files as root.
+        Same first-trial-only gate as the docker reset: step-2+ of a
+        multi-step spec depends on the state step-1 uploaded.
+        """
+        cmd = r"""set -uo pipefail
+purged=""
+for root in /opt/vss-data "$HOME"/vss-data; do
+  [ -d "$root" ] || continue
+  for sub in data_log nvstreamer/videos nvstreamer/videos-upload nvstreamer/vst_data videos/nvstreamer; do
+    d="$root/$sub"
+    [ -d "$d" ] || continue
+    sudo find "$d" -mindepth 1 -delete 2>/dev/null || { echo "failed to purge $d" >&2; exit 1; }
+    purged="$purged $d"
+  done
+done
+# Fail loud if anything survived — a half-purged dir is the same silent
+# cross-trial contamination the docker-reset guard protects against.
+for d in $purged; do
+  n=$(sudo find "$d" -mindepth 1 2>/dev/null | wc -l | tr -d ' ')
+  [ "$n" = "0" ] || { echo "host data purge incomplete: $n entries remain in $d" >&2; exit 1; }
+done
+echo "host data purge OK:${purged:- nothing to purge}"
+"""
+        logger.info(
+            "Purging host bind-mount data dirs (data_log, nvstreamer state) on %s",
+            self._instance_name,
+        )
+        result = await _run_brev_exec(self._instance_name, cmd, timeout=120)
+        if result.return_code != 0:
+            tail = (result.stderr or result.stdout or "")[-500:]
+            raise RuntimeError(
+                f"host data purge failed on {self._instance_name}: "
+                f"exit {result.return_code}; tail:\n{tail}"
+            )
+        logger.info(
+            "Host data purge on %s: %s",
             self._instance_name,
             (result.stdout or "").strip().splitlines()[-1] if result.stdout else "<no output>",
         )

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -514,7 +514,7 @@ for root in /opt/vss-data "$HOME"/vss-data; do
   for sub in data_log nvstreamer/videos nvstreamer/videos-upload nvstreamer/vst_data videos/nvstreamer; do
     d="$root/$sub"
     [ -d "$d" ] || continue
-    sudo find "$d" -mindepth 1 -delete 2>/dev/null || { echo "failed to purge $d" >&2; exit 1; }
+    sudo find "$d" -mindepth 1 -delete || { echo "failed to purge $d" >&2; exit 1; }
     purged="$purged $d"
   done
 done


### PR DESCRIPTION
## Problem

`_reset_docker_runtime` wipes all containers, volumes, and user-defined networks — but several services persist state in **host directories bind-mounted into the containers**, which `docker volume rm` can't see:

- `<root>/nvstreamer/videos{,-upload}/` — uploaded media. NvStreamer auto-suffixes an upload whose filename already exists, so a leftover `warehouse_safety_0001.mp4` turns the next trial's upload into `warehouse_safety_0001_5` and fails identifier-semantics checks. Observed on PR #1241's `nvstreamer_ops` step-1 (reward 0.5); **six** leftover copies verified on the L40S pool boxes (`/opt/vss-data/videos/nvstreamer/` on one, `~/vss-data/nvstreamer/videos{,-upload}/` on the other).
- `<root>/nvstreamer/vst_data/` + `<root>/data_log/` — the NvStreamer/VST sensor registry and runtime DB survive every reset (1.9 GB of `data_log/` accumulated on one box).

The GitLab `ci-vss-oss` eval jobs have always cleaned this ("Cleaning VSS_DATA_DIR data_log (kafka, elastic, redis, vst, nvstreamer, ...)"); the skill-eval harness reset never did.

## Fix

New `BrevEnvironment._purge_host_data_dirs()`, called under the **same first-trial-only gate** as the docker reset (step-2+ of a multi-step spec depends on step-1's uploads), and **after** it (writers must already be gone or the purge races them):

- Purges `data_log/`, `nvstreamer/videos/`, `nvstreamer/videos-upload/`, `nvstreamer/vst_data/`, `videos/nvstreamer/` under every discovered data root.
- Roots are **globbed** (`/opt/vss-data`, `~/vss-data`) rather than read from `$VSS_DATA_DIR` — the env var is chosen per-deploy inside the trial, and pool boxes demonstrably accumulate more than one root. `$REPO/deploy/docker/data-dir` is already covered by `_sync_repo_to_pr_head`'s `git clean`.
- Deletes **contents only** — mount-point directories, ownership, and configs (`nvstreamer/configs/`) are preserved.
- Fails loud if anything survives, mirroring the docker-reset guard.

Tested against a mock data tree: media/registry/data_log contents removed, dirs + `vst_config.json` intact, verification guard passes.

Part of the PR #1241 eval-failure triage (leftover-sensor failure class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
