### PR TITLE
Expand vss-manage-alerts for Skill Extension 4.0 — verification, always-on, on-demand, Slack (VIA-2035)

### DIFF
--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -226,7 +226,7 @@ How a CV alert becomes a verdict: RT-CV (Grounding DINO) detections → Behavior
    ```bash
    curl -sf "http://${HOST_IP}:9200/mdx-vlm-alerts-*/_search?size=10" | jq '.hits.hits[]._source'
    ```
-   An **empty hit list is a valid answer** — report "no verification results yet" and stop; never substitute the rules list or `/incidents` for a verdict question.
+   An **empty hit list is a valid answer** — report "no verification results yet" and stop. Never substitute another source for a verdict question: not the rules list, not `/incidents`, and **not the `mdx-vlm-incidents-*` ES index** (that is Workflow C's incident store — its documents carry no verification verdicts; presenting them as "verdicts recorded" is a wrong answer even when `mdx-vlm-alerts-*` is empty).
 3. **Verifier-prompt config** — REST CRUD on `$AB/api/v1/verification/config[/{alert_type}]` (`GET` list / `GET` one / `POST` / `PUT` / `DELETE`), or the config-file + restart path — rules and payload shapes in `references/verification.md`.
 
 Load `references/verification.md` for the full verdict table, probe recipes, and prompt-customization rules. CV mode only for execution; explain-only asks are answerable in any mode.

--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -250,7 +250,11 @@ Load and follow `references/alert-subscriptions.md` as the authoritative playboo
 Use when the user **explicitly mentions Slack or the webhook relay** (start/stop webhook server, check status/health, send a test message, set Slack channel/token). The word `notify` alone is **not** enough.
 
 > **`alert-notify` (port 9090) ≠ `vss-alert-bridge` (`/api/v1/realtime`).**
-> Do NOT touch `vss-alert-bridge` for Slack ops.
+> Do NOT touch `vss-alert-bridge` for Slack ops — Slack is never configured through Alert Bridge realtime rule APIs.
+
+One relay, **two backends**: the `alert-notify` webhook server fans incidents out to **Slack** and/or the **OpenClaw Dashboard**, selected by `NOTIFY_BACKENDS` (default **`dashboard`** — a Slack setup MUST set `NOTIFY_BACKENDS=slack`, or `slack,dashboard` for both). The four skill-level ops all hit `:9090`: **status** (`GET /webhook/alert-notify/status`), **start** (creds gate below), **test** (POST a sample incident to `/webhook/alert-notify`), **stop**.
+
+**Credentials gate before any start:** Slack needs `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` (plus `VST_ENDPOINT`); the server **exits at startup** on a failed Slack auth or missing `VST_ENDPOINT` — never start it with placeholder values. Ask for real credentials and stop until provided.
 
 Routes here: "Set up Slack notifications", "Check if alert-notify is running", "Send a test alert to Slack". Does **not** route here: "Notify me when someone enters the zone" (→ Workflow D), "Alert and notify on my phone" (ambiguous — ask).
 

--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: vss-manage-alerts
-description: Use for VSS alert workflows — real-time monitoring, Alert-Bridge subscriptions, Slack notifications, incident queries, camera onboarding. Not for non-alert analytics.
+description: Use for VSS alert workflows — real-time monitoring, Alert-Bridge subscriptions, verification verdicts, on-demand verification, always-on operation, Slack notifications, incident queries, camera onboarding. Not for non-alert analytics.
 license: Apache-2.0
 metadata:
-  version: "3.2.0"
+  version: "3.3.0"
   author: "NVIDIA Video Search and Summarization Team <vss-team@nvidia.com>"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"
 ---
 ## Purpose
 
-Operate the VSS alert pipeline (mode detection, Alert-Bridge subscriptions, Slack notifications, queries, camera onboarding, verifier-prompt customization).
+Operate the VSS alert pipeline (mode detection, Alert-Bridge subscriptions, verification verdicts, on-demand verification, always-on operation, Slack notifications, queries, camera onboarding, verifier-prompt customization).
 
 ## Prerequisites
 
@@ -333,7 +333,7 @@ CV-verified alerts carry `verdict` + `verificationResponseCode` + `reasoning` in
 ## Gotchas
 
 - **`alert-notify` (port 9090) ≠ `vss-alert-bridge`.** Slack ops → Workflow E (`alert-notify`); never route Slack to `vss-alert-bridge`'s `/api/v1/realtime`.
-- **Workflow scope by mode:** A and B are CV-only (B's explain-only asks answerable anywhere); **C queries the real-time incident store** (`/api/v1/realtime/incidents`; CV behavior-alert verdicts live in `mdx-vlm-alerts-*` — **no REST query endpoint yet**, use Workflow B's interim ES probe); D and E are VLM real-time only (refuse on CV with the canonical text).
+- **Workflow scope by mode:** A, B, and F are CV-only (B/F explain-only asks answerable anywhere); **C queries the real-time incident store** (`/api/v1/realtime/incidents`; CV behavior-alert verdicts live in `mdx-vlm-alerts-*` — **no REST query endpoint yet**, use Workflow B's interim ES probe); D, E, and G are VLM real-time only (refuse on CV with the canonical text).
 - **On-demand verification is `POST /api/v1/verification/ondemand`** — not `/verification/verify`, not a realtime rule, not `/generate`. 202 = accepted (async), never a verdict.
 - **Always-on has no health endpoint** — status is the `alert_agent.always_on` config gate (default off) or a `503 ALWAYS_ON_DISABLED` from `POST /api/v1/realtime/always-on`; its rules are in-memory (not in the ES rules index), so absence from Workflow D's rules list is expected.
 - **Don't use `vss-rtvi-vlm` as a mode signal** — it runs in both modes. Use `vss-behavior-analytics` (CV-only) or the `MODE` env var.

--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -47,6 +47,7 @@ The alerts profile runs in one of two modes (chosen at `/vss-deploy-profile -p a
 - Set up or manage Slack incident notifications
 - List or query detected incidents / alerts (Workflow C)
 - Inspect CV verification results and verdicts (confirmed/rejected/not-confirmed/verification-failed), explain how verification works, customize VLM-verifier prompts (CV mode — Workflow B)
+- Check whether always-on alerting is active, query its incidents, troubleshoot missing always-on alerts (VLM real-time — Workflow G; operate only, no config authoring)
 - Add a new camera to the alerts pipeline (Workflow A)
 
 ---
@@ -71,7 +72,7 @@ If the probe fails, ask which mode to deploy and hand off to `/vss-deploy-profil
 | Mode | Deploy flag | Env (`.env`) | What runs | What is available |
 |---|---|---|---|---|
 | **CV (verification)** | `-m verification` | `MODE=2d_cv` | RT-CV (Grounding DINO) + Behavior Analytics + `alert-bridge` VLM verifier + **`rtvi-vlm`** | Static CV pipeline (**Workflow A**) + verification results & verdicts (**Workflow B**). Realtime rule CRUD (**D**) and Slack (**E**) are gated to real-time mode (skill refuses on CV). |
-| **VLM (real-time)** | `-m real-time` | `MODE=2d_vlm` | `alert-bridge` + `rtvi-vlm` | Dynamic VLM real-time alerts (**Workflow D**), Slack (**E**), and incident queries (**C**). No static CV pipeline. |
+| **VLM (real-time)** | `-m real-time` | `MODE=2d_vlm` | `alert-bridge` + `rtvi-vlm` | Dynamic VLM real-time alerts (**Workflow D**), Slack (**E**), incident queries (**C**), and always-on operation (**Workflow G** — feature-gated via `alert_agent.always_on`, default **off**). No static CV pipeline. |
 
 **Switching modes** uses the `vss-deploy-profile` teardown + deploy flow with the other `-m` flag (VLM → CV adds the CV pipeline; CV → VLM tears it down). `rtvi-vlm` runs in both modes.
 
@@ -109,6 +110,8 @@ grep -E '^MODE=' deploy/docker/developer-profiles/dev-profile-alerts/generated.e
 | Deployed mode | User asks about… | Action |
 |---|---|---|
 | **VLM real-time** | Slack webhook setup/status/test/stop | **Workflow E** — `references/alert-notify.md` |
+| **VLM real-time** | always-on status ("is always-on active?"), always-on incidents, "why aren't always-on alerts appearing?" | **Workflow G** — `references/always-on.md` (operate only; config authoring is out of scope) |
+| **CV verification** | always-on operation | Refuse — always-on rides the realtime rule engine; canonical refusal text below |
 | **VLM real-time** | rule CRUD, or start/stop a realtime alert on a sensor (with **or without** a detection condition — no condition → default prompt), or stop/delete a named alert (by `alert_type`/condition or rule ID) | **Workflow D** — `references/alert-subscriptions.md` (incl. two-step stop/confirm) |
 | **CV verification** | subscription/rule CRUD or Slack/notification setup | Refuse — see canonical refusal text below |
 | **CV or VLM** | incident lookup / *what happened* (recent alerts, time-range, casual "any alerts today?") | **Workflow C (Query)** — works on both; **always run the query, never answer from memory** |
@@ -123,10 +126,11 @@ grep -E '^MODE=' deploy/docker/developer-profiles/dev-profile-alerts/generated.e
 ### Intent precedence (first match wins)
 
 1. **Workflow E (Slack)** — Slack-specific keywords (`slack`, `webhook` + `slack`, `bot token`, `slack channel`). `notify` alone is **not** sufficient.
-2. **Workflow B (Verification results)** — verification/verdict keywords (`verdict`, `confirmed?`/`rejected?`, `verification results`, "how does verification work", verifier prompt/config) **without** a start/stop/rule intent. Reads the `mdx-vlm-alerts-*` store (interim ES probe) and the verifier config — never the rules list. Bare "any alerts today?" is **not** B — it stays Workflow C.
-3. **Workflow D (Alert rules)** — any realtime-alert request on a sensor: rule CRUD keywords (`rule`, `subscription`, rule ID), a sensor with a detection condition, a **bare start/stop with no condition** (→ default prompt), **or stopping/deleting a named alert by type/condition** ("stop the PPE alert", "delete the collision rule"). A named `alert_type`/condition = an existing **rule** → D's two-step stop protocol (`GET /api/v1/realtime` → yes/no confirm → delete).
-4. **Workflow C (Query)** — incident lookup / *what happened* (`show/list incidents`, `recent alerts`, time-range queries, **and casual "any alerts…?" / "any alerts so far today?" / "what's been triggered?" phrasings**). Bare `alerts` (without `rule`/`subscription`/`active rules`) means **incidents** → Workflow C, never Workflow D.
-5. **Workflow A (CV)** — CV deployment handling for anything not matched above.
+2. **Workflow G (Always-on)** — the literal `always-on` (status, incidents, troubleshooting phrasings). Operate-not-author: status checks and queries only; never author or edit always-on rule config. A request to *create* an ordinary realtime rule is **not** G — that's D.
+3. **Workflow B (Verification results)** — verification/verdict keywords (`verdict`, `confirmed?`/`rejected?`, `verification results`, "how does verification work", verifier prompt/config) **without** a start/stop/rule intent. Reads the `mdx-vlm-alerts-*` store (interim ES probe) and the verifier config — never the rules list. Bare "any alerts today?" is **not** B — it stays Workflow C.
+4. **Workflow D (Alert rules)** — any realtime-alert request on a sensor: rule CRUD keywords (`rule`, `subscription`, rule ID), a sensor with a detection condition, a **bare start/stop with no condition** (→ default prompt), **or stopping/deleting a named alert by type/condition** ("stop the PPE alert", "delete the collision rule"). A named `alert_type`/condition = an existing **rule** → D's two-step stop protocol (`GET /api/v1/realtime` → yes/no confirm → delete).
+5. **Workflow C (Query)** — incident lookup / *what happened* (`show/list incidents`, `recent alerts`, time-range queries, **and casual "any alerts…?" / "any alerts so far today?" / "what's been triggered?" phrasings**). Bare `alerts` (without `rule`/`subscription`/`active rules`) means **incidents** → Workflow C, never Workflow D.
+6. **Workflow A (CV)** — CV deployment handling for anything not matched above.
 
 > **`alerts` vs `alert rules` (C vs D) — pick exactly one, never both:**
 > *what happened / has been triggered* (incidents) → **Workflow C**
@@ -146,11 +150,11 @@ grep -E '^MODE=' deploy/docker/developer-profiles/dev-profile-alerts/generated.e
 
 If a prompt mixes workflows ("start monitoring and send to Slack"), ask one clarifying question to split execution order.
 
-### CV-mode refusal text for D and E intents
+### CV-mode refusal text for D, E, and G intents
 
-When the deployed mode is CV verification and the user asks for an alert-subscription or Slack/notification intent, refuse with this message verbatim:
+When the deployed mode is CV verification and the user asks for an alert-subscription, always-on, or Slack/notification intent, refuse with this message verbatim:
 
-> "Alert subscriptions and Slack notifications are only supported in VLM real-time mode. Your current deployment is `<CV verification | not deployed>`. To use these features, redeploy with `/vss-deploy-profile -p alerts -m real-time` (note: switching tears down current CV monitoring)."
+> "Alert subscriptions, always-on operation, and Slack notifications are only supported in VLM real-time mode. Your current deployment is `<CV verification | not deployed>`. To use these features, redeploy with `/vss-deploy-profile -p alerts -m real-time` (note: switching tears down current CV monitoring)."
 
 No auto-redeploy. The user decides whether to switch modes.
 
@@ -251,6 +255,18 @@ Load and follow `references/alert-notify.md`. Code lives in `scripts/alert-notif
 
 ---
 
+## Workflow G — Always-On Operation (VLM real-time mode only)
+
+Always-on alerting starts pre-configured rules automatically when SDR announces a camera (`camera_streaming` → one realtime rule per `always_on_rules` YAML entry; `camera_remove` tears them down) via `POST $AB/api/v1/realtime/always-on`. **Operate, don't author** — this workflow never creates or edits always-on rule config; it checks status, queries results, and troubleshoots.
+
+1. **Status** — the feature is opt-in via `alert_agent.always_on` in the Alert Bridge `config.yaml` (default **false**). There is **no** `/always-on/health` endpoint — do not invent one. Signals: the config gate itself, or a `503 {"reason":"ALWAYS_ON_DISABLED"}` from the endpoint. Zero-side-effect probe options in `references/always-on.md`.
+2. **Query incidents** — always-on rules are ordinary realtime rules once started; their incidents surface through **Workflow C** (`GET $AB/api/v1/realtime/incidents`). The rules live in an **in-memory sidecar** (not the ES-backed rules index), so they may not appear in Workflow D's rules list — that is expected, not a bug.
+3. **Troubleshoot "no always-on alerts"** — walk the ladder in `references/always-on.md`: feature gate → rules YAML resolves/validates at boot → SDR events actually reaching Alert Bridge → stream registered on `rtvi-vlm` → incidents query.
+
+Load `references/always-on.md` for the event contract, reason-code table, YAML resolution chain, and the troubleshooting ladder. VLM real-time mode only; refuse on CV with the canonical text. Config authoring (editing `always_on_rules`) is **out of scope** in this pass — say so when asked.
+
+---
+
 ## Workflow C — Query Incidents (real-time incident store)
 
 Query past incidents **directly** from Alert Bridge — no `/generate`:
@@ -264,7 +280,7 @@ curl -sf "$AB/api/v1/realtime/incidents?sensor_id=<UUID>&start_time=<ISO>&end_ti
 
 Response is an `IncidentListResponse`: `{ "status", "incidents": [...], "count", "total", "timestamp" }`. Summarize each incident's timestamp, sensor (reverse-resolve `sensor_id` → name), and category. **Run the query — never answer from memory.** An **empty `incidents` list is a valid answer**: report "none found / count 0" and STOP; do not fall back to listing rules.
 
-**Casual phrasings route here too** — "Any alerts so far today?", "What's been triggered?", "Anything detected lately?" are all incident queries. A bare "alerts" question is *always* an incident lookup (C), never a rule listing (D).
+**Casual phrasings route here too** — "Any alerts so far today?", "What's been triggered?", "Anything detected lately?" are all incident queries. A bare "alerts" question is *always* an incident lookup (C), never a rule listing (D). Incidents produced by **always-on** rules (Workflow G) appear here like any other realtime incident.
 
 > **Do NOT list subscription rules for an incident query.** The **bare** `GET /api/v1/realtime` (no `/incidents`) lists *rules* (Workflow D) and is wrong for "what happened".
 
@@ -292,6 +308,7 @@ CV-verified alerts carry `verdict` + `verificationResponseCode` + `reasoning` in
 
 - **`alert-notify` (port 9090) ≠ `vss-alert-bridge`.** Slack ops → Workflow E (`alert-notify`); never route Slack to `vss-alert-bridge`'s `/api/v1/realtime`.
 - **Workflow scope by mode:** A and B are CV-only (B's explain-only asks answerable anywhere); **C queries the real-time incident store** (`/api/v1/realtime/incidents`; CV behavior-alert verdicts live in `mdx-vlm-alerts-*` — **no REST query endpoint yet**, use Workflow B's interim ES probe); D and E are VLM real-time only (refuse on CV with the canonical text).
+- **Always-on has no health endpoint** — status is the `alert_agent.always_on` config gate (default off) or a `503 ALWAYS_ON_DISABLED` from `POST /api/v1/realtime/always-on`; its rules are in-memory (not in the ES rules index), so absence from Workflow D's rules list is expected.
 - **Don't use `vss-rtvi-vlm` as a mode signal** — it runs in both modes. Use `vss-behavior-analytics` (CV-only) or the `MODE` env var.
 - **A mode switch tears down the current deployment** — running VLM streams and un-persisted CV alert state are lost.
 - **Alert ops call Alert Bridge (`:9080`) directly** — the skill does not use the VSS Agent `/generate`, and never calls `rtvi-vlm` directly. The VLM trigger is a `"yes"`/`"true"` token match (case-insensitive); prompts must force a Yes/No answer.

--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -47,6 +47,7 @@ The alerts profile runs in one of two modes (chosen at `/vss-deploy-profile -p a
 - Set up or manage Slack incident notifications
 - List or query detected incidents / alerts (Workflow C)
 - Inspect CV verification results and verdicts (confirmed/rejected/not-confirmed/verification-failed), explain how verification works, customize VLM-verifier prompts (CV mode — Workflow B)
+- Run a one-shot on-demand verification of a specific video/image URL (CV mode — Workflow F)
 - Check whether always-on alerting is active, query its incidents, troubleshoot missing always-on alerts (VLM real-time — Workflow G; operate only, no config authoring)
 - Add a new camera to the alerts pipeline (Workflow A)
 
@@ -71,7 +72,7 @@ If the probe fails, ask which mode to deploy and hand off to `/vss-deploy-profil
 
 | Mode | Deploy flag | Env (`.env`) | What runs | What is available |
 |---|---|---|---|---|
-| **CV (verification)** | `-m verification` | `MODE=2d_cv` | RT-CV (Grounding DINO) + Behavior Analytics + `alert-bridge` VLM verifier + **`rtvi-vlm`** | Static CV pipeline (**Workflow A**) + verification results & verdicts (**Workflow B**). Realtime rule CRUD (**D**) and Slack (**E**) are gated to real-time mode (skill refuses on CV). |
+| **CV (verification)** | `-m verification` | `MODE=2d_cv` | RT-CV (Grounding DINO) + Behavior Analytics + `alert-bridge` VLM verifier + **`rtvi-vlm`** | Static CV pipeline (**Workflow A**) + verification results & verdicts (**Workflow B**) + on-demand verification (**Workflow F**). Realtime rule CRUD (**D**) and Slack (**E**) are gated to real-time mode (skill refuses on CV). |
 | **VLM (real-time)** | `-m real-time` | `MODE=2d_vlm` | `alert-bridge` + `rtvi-vlm` | Dynamic VLM real-time alerts (**Workflow D**), Slack (**E**), incident queries (**C**), and always-on operation (**Workflow G** — feature-gated via `alert_agent.always_on`, default **off**). No static CV pipeline. |
 
 **Switching modes** uses the `vss-deploy-profile` teardown + deploy flow with the other `-m` flag (VLM → CV adds the CV pipeline; CV → VLM tears it down). `rtvi-vlm` runs in both modes.
@@ -116,8 +117,9 @@ grep -E '^MODE=' deploy/docker/developer-profiles/dev-profile-alerts/generated.e
 | **CV verification** | subscription/rule CRUD or Slack/notification setup | Refuse — see canonical refusal text below |
 | **CV or VLM** | incident lookup / *what happened* (recent alerts, time-range, casual "any alerts today?") | **Workflow C (Query)** — works on both; **always run the query, never answer from memory** |
 | **CV** | verification results / verdicts ("was it confirmed?", "show verification results"), *how does verification work*, verifier-prompt customization | **Workflow B (Verification)** — `references/verification.md` |
+| **CV** | one-shot "verify **this** clip/image" with a media URL, or the literal "on-demand" | **Workflow F (On-demand)** — `references/on-demand-verification.md` |
 | **CV** | static CV alert onboarding | **Workflow A (CV)** — onboard RTSP via `vss-manage-video-io-storage`; pipeline auto-picks it up |
-| **VLM** | verification results / verdict inspection or verifier-prompt config (CV-only capabilities) | *Explain-only* asks → answer from **Workflow B** background, no calls needed. *Execution* asks → VLM-mode refusal text below (redeploy hint `-m verification`) |
+| **VLM** | verification results / verdict inspection, verifier-prompt config, or on-demand verification (CV-only capabilities) | *Explain-only* asks → answer from **Workflow B/F** background, no calls needed. *Execution* asks → VLM-mode refusal text below (redeploy hint `-m verification`) |
 | **VLM** | a CV / behavior-analytics / PPE-rule alert needing the static CV pipeline | **Redeployment required** — confirm first, then `vss-deploy-profile -m verification` |
 | **any** | video summarization, highlight reels, reports, non-alert analytics | **Out of scope** — hand off to `vss-generate-video-report` / `vss-query-analytics` (Cross-Skill Links); do **not** answer it via incidents or rules, even when incidents are empty |
 
@@ -126,11 +128,12 @@ grep -E '^MODE=' deploy/docker/developer-profiles/dev-profile-alerts/generated.e
 ### Intent precedence (first match wins)
 
 1. **Workflow E (Slack)** — Slack-specific keywords (`slack`, `webhook` + `slack`, `bot token`, `slack channel`). `notify` alone is **not** sufficient.
-2. **Workflow G (Always-on)** — the literal `always-on` (status, incidents, troubleshooting phrasings). Operate-not-author: status checks and queries only; never author or edit always-on rule config. A request to *create* an ordinary realtime rule is **not** G — that's D.
-3. **Workflow B (Verification results)** — verification/verdict keywords (`verdict`, `confirmed?`/`rejected?`, `verification results`, "how does verification work", verifier prompt/config) **without** a start/stop/rule intent. Reads the `mdx-vlm-alerts-*` store (interim ES probe) and the verifier config — never the rules list. Bare "any alerts today?" is **not** B — it stays Workflow C.
-4. **Workflow D (Alert rules)** — any realtime-alert request on a sensor: rule CRUD keywords (`rule`, `subscription`, rule ID), a sensor with a detection condition, a **bare start/stop with no condition** (→ default prompt), **or stopping/deleting a named alert by type/condition** ("stop the PPE alert", "delete the collision rule"). A named `alert_type`/condition = an existing **rule** → D's two-step stop protocol (`GET /api/v1/realtime` → yes/no confirm → delete).
-5. **Workflow C (Query)** — incident lookup / *what happened* (`show/list incidents`, `recent alerts`, time-range queries, **and casual "any alerts…?" / "any alerts so far today?" / "what's been triggered?" phrasings**). Bare `alerts` (without `rule`/`subscription`/`active rules`) means **incidents** → Workflow C, never Workflow D.
-6. **Workflow A (CV)** — CV deployment handling for anything not matched above.
+2. **Workflow F (On-demand)** — a one-shot "verify / check / analyze **this**" pointing at a **specific media artifact** (video/image URL, clip, file), or the literal `on-demand`. Guard: *continuous monitoring of a sensor/stream* is **never** F — that's D ("watch camera X for PPE" → D; "verify this clip URL for PPE" → F).
+3. **Workflow G (Always-on)** — the literal `always-on` (status, incidents, troubleshooting phrasings). Operate-not-author: status checks and queries only; never author or edit always-on rule config. A request to *create* an ordinary realtime rule is **not** G — that's D.
+4. **Workflow B (Verification results)** — verification/verdict keywords (`verdict`, `confirmed?`/`rejected?`, `verification results`, "how does verification work", verifier prompt/config) **without** a media artifact to verify and without a start/stop/rule intent. Reads the `mdx-vlm-alerts-*` store (interim ES probe) and the verifier config — never the rules list. Bare "any alerts today?" is **not** B — it stays Workflow C.
+5. **Workflow D (Alert rules)** — any realtime-alert request on a sensor: rule CRUD keywords (`rule`, `subscription`, rule ID), a sensor with a detection condition, a **bare start/stop with no condition** (→ default prompt), **or stopping/deleting a named alert by type/condition** ("stop the PPE alert", "delete the collision rule"). A named `alert_type`/condition = an existing **rule** → D's two-step stop protocol (`GET /api/v1/realtime` → yes/no confirm → delete).
+6. **Workflow C (Query)** — incident lookup / *what happened* (`show/list incidents`, `recent alerts`, time-range queries, **and casual "any alerts…?" / "any alerts so far today?" / "what's been triggered?" phrasings**). Bare `alerts` (without `rule`/`subscription`/`active rules`) means **incidents** → Workflow C, never Workflow D.
+7. **Workflow A (CV)** — CV deployment handling for anything not matched above.
 
 > **`alerts` vs `alert rules` (C vs D) — pick exactly one, never both:**
 > *what happened / has been triggered* (incidents) → **Workflow C**
@@ -158,11 +161,11 @@ When the deployed mode is CV verification and the user asks for an alert-subscri
 
 No auto-redeploy. The user decides whether to switch modes.
 
-### VLM-mode text for verification-execution intents (Workflow B)
+### VLM-mode text for verification-execution intents (Workflows B and F)
 
-Verification verdicts exist only on a CV (verification) deployment. On VLM real-time, *explain-only* asks ("how does verification work?") are always answerable from Workflow B background — no calls, no refusal. For *execution* asks (inspect verdicts, customize verifier prompts), reply with this message verbatim:
+Verification verdicts and on-demand verification exist only on a CV (verification) deployment. On VLM real-time, *explain-only* asks ("how does verification work?") are always answerable from Workflow B/F background — no calls, no refusal. For *execution* asks (inspect verdicts, customize verifier prompts, verify a clip on demand), reply with this message verbatim:
 
-> "Verification verdicts and verifier-prompt configuration require the verification (CV) deployment. Your current deployment is VLM real-time. To use them, redeploy with `/vss-deploy-profile -p alerts -m verification` (note: switching stops currently-running realtime monitoring)."
+> "Verification workflows (verdict inspection, verifier-prompt configuration, on-demand verification) require the verification (CV) deployment. Your current deployment is VLM real-time. To use them, redeploy with `/vss-deploy-profile -p alerts -m verification` (note: switching stops currently-running realtime monitoring)."
 
 No auto-redeploy here either.
 
@@ -255,6 +258,25 @@ Load and follow `references/alert-notify.md`. Code lives in `scripts/alert-notif
 
 ---
 
+## Workflow F — On-Demand Verification (CV mode)
+
+One-shot verification of a **specific media artifact** the user points at — never a continuous rule. Endpoint is **`POST $AB/api/v1/verification/ondemand`** (there is **no** `/verification/verify` route):
+
+1. **Resolve the category first** — `GET $AB/api/v1/verification/config` and pick the existing `alert_type` matching the user's ask (e.g. a ladder/PPE config for a ladder-safety question). Never invent a category: an unknown one is a deterministic `400 {"error":"unknown_category"}`.
+2. **Submit**:
+   ```bash
+   curl -sf -X POST "$AB/api/v1/verification/ondemand" -H 'Content-Type: application/json' -d '{
+     "category": "<alert_type from config>",
+     "info": { "media_urls": ["<video/image URL>"], "media_type": "video" }
+   }'
+   ```
+   Response is **HTTP 202** `{"status":"accepted","correlationId":"…","message":…,"timestamp":…}` — report the actual `correlationId` (server default `ondemand-<uuid>`; your own `id` field is used if you send one). 400 = `unknown_category` / `invalid_request` (`info.media_urls` list + `media_type` ∈ `video`|`image` are required).
+3. **Result lands async** in the same `mdx-vlm-alerts-*` store as CV verification — inspect via **Workflow B**'s interim ES probe keyed on the `correlationId` (allow ≥2 min; the VLM must fetch the URL itself, so an unreachable URL still lands a document via the error path with a non-200 `verificationResponseCode`).
+
+Load `references/on-demand-verification.md` for the full contract, media constraints, and result-validation checklist. CV mode for execution; explain-only asks answerable anywhere. A 202 means **accepted**, not verified — never report a verdict at submit time.
+
+---
+
 ## Workflow G — Always-On Operation (VLM real-time mode only)
 
 Always-on alerting starts pre-configured rules automatically when SDR announces a camera (`camera_streaming` → one realtime rule per `always_on_rules` YAML entry; `camera_remove` tears them down) via `POST $AB/api/v1/realtime/always-on`. **Operate, don't author** — this workflow never creates or edits always-on rule config; it checks status, queries results, and troubleshoots.
@@ -308,6 +330,7 @@ CV-verified alerts carry `verdict` + `verificationResponseCode` + `reasoning` in
 
 - **`alert-notify` (port 9090) ≠ `vss-alert-bridge`.** Slack ops → Workflow E (`alert-notify`); never route Slack to `vss-alert-bridge`'s `/api/v1/realtime`.
 - **Workflow scope by mode:** A and B are CV-only (B's explain-only asks answerable anywhere); **C queries the real-time incident store** (`/api/v1/realtime/incidents`; CV behavior-alert verdicts live in `mdx-vlm-alerts-*` — **no REST query endpoint yet**, use Workflow B's interim ES probe); D and E are VLM real-time only (refuse on CV with the canonical text).
+- **On-demand verification is `POST /api/v1/verification/ondemand`** — not `/verification/verify`, not a realtime rule, not `/generate`. 202 = accepted (async), never a verdict.
 - **Always-on has no health endpoint** — status is the `alert_agent.always_on` config gate (default off) or a `503 ALWAYS_ON_DISABLED` from `POST /api/v1/realtime/always-on`; its rules are in-memory (not in the ES rules index), so absence from Workflow D's rules list is expected.
 - **Don't use `vss-rtvi-vlm` as a mode signal** — it runs in both modes. Use `vss-behavior-analytics` (CV-only) or the `MODE` env var.
 - **A mode switch tears down the current deployment** — running VLM streams and un-persisted CV alert state are lost.

--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -45,8 +45,9 @@ The alerts profile runs in one of two modes (chosen at `/vss-deploy-profile -p a
 - Start/stop a real-time alert on a sensor ("Start real-time alert for boxes dropped on warehouse_sample")
 - Create/list/stop realtime subscription rules on Alert Bridge
 - Set up or manage Slack incident notifications
-- List or query detected incidents / alerts; check verdicts (confirmed/rejected/not-confirmed/verification-failed)
-- Add a new camera to the alerts pipeline; customize VLM-verifier prompts (CV mode)
+- List or query detected incidents / alerts (Workflow C)
+- Inspect CV verification results and verdicts (confirmed/rejected/not-confirmed/verification-failed), explain how verification works, customize VLM-verifier prompts (CV mode — Workflow B)
+- Add a new camera to the alerts pipeline (Workflow A)
 
 ---
 
@@ -69,7 +70,7 @@ If the probe fails, ask which mode to deploy and hand off to `/vss-deploy-profil
 
 | Mode | Deploy flag | Env (`.env`) | What runs | What is available |
 |---|---|---|---|---|
-| **CV (verification)** | `-m verification` | `MODE=2d_cv` | RT-CV (Grounding DINO) + Behavior Analytics + `alert-bridge` VLM verifier + **`rtvi-vlm`** | Static CV pipeline (**Workflow A**) + verification verdicts. Realtime rule CRUD (**D**) and Slack (**E**) are gated to real-time mode (skill refuses on CV). |
+| **CV (verification)** | `-m verification` | `MODE=2d_cv` | RT-CV (Grounding DINO) + Behavior Analytics + `alert-bridge` VLM verifier + **`rtvi-vlm`** | Static CV pipeline (**Workflow A**) + verification results & verdicts (**Workflow B**). Realtime rule CRUD (**D**) and Slack (**E**) are gated to real-time mode (skill refuses on CV). |
 | **VLM (real-time)** | `-m real-time` | `MODE=2d_vlm` | `alert-bridge` + `rtvi-vlm` | Dynamic VLM real-time alerts (**Workflow D**), Slack (**E**), and incident queries (**C**). No static CV pipeline. |
 
 **Switching modes** uses the `vss-deploy-profile` teardown + deploy flow with the other `-m` flag (VLM → CV adds the CV pipeline; CV → VLM tears it down). `rtvi-vlm` runs in both modes.
@@ -111,7 +112,9 @@ grep -E '^MODE=' deploy/docker/developer-profiles/dev-profile-alerts/generated.e
 | **VLM real-time** | rule CRUD, or start/stop a realtime alert on a sensor (with **or without** a detection condition — no condition → default prompt), or stop/delete a named alert (by `alert_type`/condition or rule ID) | **Workflow D** — `references/alert-subscriptions.md` (incl. two-step stop/confirm) |
 | **CV verification** | subscription/rule CRUD or Slack/notification setup | Refuse — see canonical refusal text below |
 | **CV or VLM** | incident lookup / *what happened* (recent alerts, time-range, casual "any alerts today?") | **Workflow C (Query)** — works on both; **always run the query, never answer from memory** |
-| **CV** | static CV alert onboarding / verdict-prompt customization | **Workflow A (CV)** — onboard RTSP via `vss-manage-video-io-storage`; pipeline auto-picks it up |
+| **CV** | verification results / verdicts ("was it confirmed?", "show verification results"), *how does verification work*, verifier-prompt customization | **Workflow B (Verification)** — `references/verification.md` |
+| **CV** | static CV alert onboarding | **Workflow A (CV)** — onboard RTSP via `vss-manage-video-io-storage`; pipeline auto-picks it up |
+| **VLM** | verification results / verdict inspection or verifier-prompt config (CV-only capabilities) | *Explain-only* asks → answer from **Workflow B** background, no calls needed. *Execution* asks → VLM-mode refusal text below (redeploy hint `-m verification`) |
 | **VLM** | a CV / behavior-analytics / PPE-rule alert needing the static CV pipeline | **Redeployment required** — confirm first, then `vss-deploy-profile -m verification` |
 | **any** | video summarization, highlight reels, reports, non-alert analytics | **Out of scope** — hand off to `vss-generate-video-report` / `vss-query-analytics` (Cross-Skill Links); do **not** answer it via incidents or rules, even when incidents are empty |
 
@@ -120,9 +123,10 @@ grep -E '^MODE=' deploy/docker/developer-profiles/dev-profile-alerts/generated.e
 ### Intent precedence (first match wins)
 
 1. **Workflow E (Slack)** — Slack-specific keywords (`slack`, `webhook` + `slack`, `bot token`, `slack channel`). `notify` alone is **not** sufficient.
-2. **Workflow D (Alert rules)** — any realtime-alert request on a sensor: rule CRUD keywords (`rule`, `subscription`, rule ID), a sensor with a detection condition, a **bare start/stop with no condition** (→ default prompt), **or stopping/deleting a named alert by type/condition** ("stop the PPE alert", "delete the collision rule"). A named `alert_type`/condition = an existing **rule** → D's two-step stop protocol (`GET /api/v1/realtime` → yes/no confirm → delete).
-3. **Workflow C (Query)** — incident lookup / *what happened* (`show/list incidents`, `recent alerts`, time-range queries, **and casual "any alerts…?" / "any alerts so far today?" / "what's been triggered?" phrasings**). Bare `alerts` (without `rule`/`subscription`/`active rules`) means **incidents** → Workflow C, never Workflow D.
-4. **Workflow A (CV)** — CV deployment handling for anything not matched above.
+2. **Workflow B (Verification results)** — verification/verdict keywords (`verdict`, `confirmed?`/`rejected?`, `verification results`, "how does verification work", verifier prompt/config) **without** a start/stop/rule intent. Reads the `mdx-vlm-alerts-*` store (interim ES probe) and the verifier config — never the rules list. Bare "any alerts today?" is **not** B — it stays Workflow C.
+3. **Workflow D (Alert rules)** — any realtime-alert request on a sensor: rule CRUD keywords (`rule`, `subscription`, rule ID), a sensor with a detection condition, a **bare start/stop with no condition** (→ default prompt), **or stopping/deleting a named alert by type/condition** ("stop the PPE alert", "delete the collision rule"). A named `alert_type`/condition = an existing **rule** → D's two-step stop protocol (`GET /api/v1/realtime` → yes/no confirm → delete).
+4. **Workflow C (Query)** — incident lookup / *what happened* (`show/list incidents`, `recent alerts`, time-range queries, **and casual "any alerts…?" / "any alerts so far today?" / "what's been triggered?" phrasings**). Bare `alerts` (without `rule`/`subscription`/`active rules`) means **incidents** → Workflow C, never Workflow D.
+5. **Workflow A (CV)** — CV deployment handling for anything not matched above.
 
 > **`alerts` vs `alert rules` (C vs D) — pick exactly one, never both:**
 > *what happened / has been triggered* (incidents) → **Workflow C**
@@ -132,6 +136,11 @@ grep -E '^MODE=' deploy/docker/developer-profiles/dev-profile-alerts/generated.e
 > incidents (C); `alert rules` / `subscriptions` / `active rules` =
 > inventory (D). Never answer from memory; run the one correct call —
 > full endpoint detail in Workflow C below.
+
+> **`verdicts` vs `alerts` (B vs C) — pick exactly one:** *was it
+> confirmed / show verdicts / verification results* → **Workflow B**
+> (interim ES probe on `mdx-vlm-alerts-*`). *What happened / any alerts
+> today* → **Workflow C** (`/incidents`), even on a CV deployment.
 
 **All start/stop requests → Workflow D.** A start with a condition uses it verbatim as the `prompt`; a bare start with no condition uses D's **default prompt** (don't ask the user for one). Any stop — bare or type-named ("stop the **PPE** alert") — resolves the rule via `GET /api/v1/realtime`, then D's two-step confirm; never `POST /generate`.
 
@@ -144,6 +153,14 @@ When the deployed mode is CV verification and the user asks for an alert-subscri
 > "Alert subscriptions and Slack notifications are only supported in VLM real-time mode. Your current deployment is `<CV verification | not deployed>`. To use these features, redeploy with `/vss-deploy-profile -p alerts -m real-time` (note: switching tears down current CV monitoring)."
 
 No auto-redeploy. The user decides whether to switch modes.
+
+### VLM-mode text for verification-execution intents (Workflow B)
+
+Verification verdicts exist only on a CV (verification) deployment. On VLM real-time, *explain-only* asks ("how does verification work?") are always answerable from Workflow B background — no calls, no refusal. For *execution* asks (inspect verdicts, customize verifier prompts), reply with this message verbatim:
+
+> "Verification verdicts and verifier-prompt configuration require the verification (CV) deployment. Your current deployment is VLM real-time. To use them, redeploy with `/vss-deploy-profile -p alerts -m verification` (note: switching stops currently-running realtime monitoring)."
+
+No auto-redeploy here either.
 
 ---
 
@@ -187,9 +204,25 @@ call to "create" one.
 1. Check if the sensor is in VIOS via `vss-manage-video-io-storage`'s `GET /sensor/list` (idempotent — don't blindly `POST /sensor/add`).
 2. If missing, onboard via that skill's `POST /sensor/add`. The CV pipeline auto-picks up the stream once registered and online.
 3. Confirm online: `curl -s "http://<VST_ENDPOINT>/vst/api/v1/sensor/<sensorId>/status" | jq .`
-4. Verified alerts land in Elasticsearch (`mdx-vlm-alerts-*`, Behavior Analytics → `alert-bridge` verification per `alert_type_config.json`). This store has **no REST query endpoint** — Workflow C's `/incidents` covers real-time incident-kind results only, not these CV behavior-alert verdicts.
+4. Verified alerts land in Elasticsearch (`mdx-vlm-alerts-*`, Behavior Analytics → `alert-bridge` verification per `alert_type_config.json`). This store has **no REST query endpoint** — Workflow C's `/incidents` covers real-time incident-kind results only; inspect these CV behavior-alert verdicts via **Workflow B**'s interim ES probe.
 
 A static-CV-pipeline alert on a VLM-only deployment is a mode mismatch — see the routing table above.
+
+---
+
+## Workflow B — Verification Results & Verdicts (CV mode)
+
+How a CV alert becomes a verdict: RT-CV (Grounding DINO) detections → Behavior Analytics emits a candidate alert → Alert Bridge invokes the VLM verifier (prompts per `alert_type`) → the verified document lands in Elasticsearch **`mdx-vlm-alerts-*`** with `verdict` + `verificationResponseCode` in its `info` block.
+
+1. **Explain / interpret** — verdict values are `confirmed` / `rejected` / `not-confirmed` / `verification-failed` / `""` (pluggable parser); full table in `references/verification.md`.
+2. **Inspect results — interim ES probe.** This store has **no REST query endpoint yet** (a dedicated Alert Bridge endpoint is planned); query Elasticsearch directly:
+   ```bash
+   curl -sf "http://${HOST_IP}:9200/mdx-vlm-alerts-*/_search?size=10" | jq '.hits.hits[]._source'
+   ```
+   An **empty hit list is a valid answer** — report "no verification results yet" and stop; never substitute the rules list or `/incidents` for a verdict question.
+3. **Verifier-prompt config** — REST CRUD on `$AB/api/v1/verification/config[/{alert_type}]` (`GET` list / `GET` one / `POST` / `PUT` / `DELETE`), or the config-file + restart path — rules and payload shapes in `references/verification.md`.
+
+Load `references/verification.md` for the full verdict table, probe recipes, and prompt-customization rules. CV mode only for execution; explain-only asks are answerable in any mode.
 
 ---
 
@@ -239,7 +272,7 @@ Response is an `IncidentListResponse`: `{ "status", "incidents": [...], "count",
 
 ### Verdict interpretation (CV mode)
 
-CV-verified incidents carry a `verdict` (`confirmed` / `rejected` / `not-confirmed` / `verification-failed`, or empty when a pluggable parser is used) plus `verificationResponseCode` and `reasoning` in their `info` block; VLM real-time incidents have no separate verdict (the trigger is itself a Yes/No answer). See `references/cv-verifier-prompts.md` for the verdict table and prompt-customization rules.
+CV-verified alerts carry `verdict` + `verificationResponseCode` + `reasoning` in their `info` block; VLM real-time incidents have no separate verdict (the trigger is itself a Yes/No answer). Verdict table, result inspection, and verifier-prompt rules → **Workflow B** / `references/verification.md`.
 
 ---
 
@@ -258,7 +291,7 @@ CV-verified incidents carry a `verdict` (`confirmed` / `rejected` / `not-confirm
 ## Gotchas
 
 - **`alert-notify` (port 9090) ≠ `vss-alert-bridge`.** Slack ops → Workflow E (`alert-notify`); never route Slack to `vss-alert-bridge`'s `/api/v1/realtime`.
-- **Workflow scope by mode:** A is CV-only; **C queries the real-time incident store** (`/api/v1/realtime/incidents`; CV behavior-alert verdicts live in `mdx-vlm-alerts-*` with no query endpoint); D and E are VLM real-time only (refuse on CV with the canonical text).
+- **Workflow scope by mode:** A and B are CV-only (B's explain-only asks answerable anywhere); **C queries the real-time incident store** (`/api/v1/realtime/incidents`; CV behavior-alert verdicts live in `mdx-vlm-alerts-*` — **no REST query endpoint yet**, use Workflow B's interim ES probe); D and E are VLM real-time only (refuse on CV with the canonical text).
 - **Don't use `vss-rtvi-vlm` as a mode signal** — it runs in both modes. Use `vss-behavior-analytics` (CV-only) or the `MODE` env var.
 - **A mode switch tears down the current deployment** — running VLM streams and un-persisted CV alert state are lost.
 - **Alert ops call Alert Bridge (`:9080`) directly** — the skill does not use the VSS Agent `/generate`, and never calls `rtvi-vlm` directly. The VLM trigger is a `"yes"`/`"true"` token match (case-insensitive); prompts must force a Yes/No answer.

--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -275,7 +275,7 @@ One-shot verification of a **specific media artifact** the user points at — ne
    }'
    ```
    Response is **HTTP 202** `{"status":"accepted","correlationId":"…","message":…,"timestamp":…}` — report the actual `correlationId` (server default `ondemand-<uuid>`; your own `id` field is used if you send one). 400 = `unknown_category` / `invalid_request` (`info.media_urls` list + `media_type` ∈ `video`|`image` are required).
-3. **Result lands async** in the same `mdx-vlm-alerts-*` store as CV verification — inspect via **Workflow B**'s interim ES probe keyed on the `correlationId` (allow ≥2 min; the VLM must fetch the URL itself, so an unreachable URL still lands a document via the error path with a non-200 `verificationResponseCode`).
+3. **Result lands async** in the same `mdx-vlm-alerts-*` store as CV verification — inspect via **Workflow B**'s interim ES probe keyed on the `correlationId` (allow ≥2 min; the VLM must fetch the URL itself, so an unreachable URL still lands a document via the error path with a non-200 `verificationResponseCode`). **When describing the result fields**, report: `verificationResponseCode` (200 = VLM success, 4xx/5xx = error path) and the raw VLM output (`reasoning` / `vlm_response`) — and **always note that `verdict` may be absent or empty** on the default deploy (`use_verdict: false` freestyle mode); never present `verdict` as a guaranteed field.
 
 Load `references/on-demand-verification.md` for the full contract, media constraints, and result-validation checklist. CV mode for execution; explain-only asks answerable anywhere. A 202 means **accepted**, not verified — never report a verdict at submit time.
 

--- a/skills/vss-manage-alerts/evals/always_on_operate.json
+++ b/skills/vss-manage-alerts/evals/always_on_operate.json
@@ -1,0 +1,45 @@
+{
+  "skills": [
+    "vss-manage-alerts",
+    "vss-deploy-profile"
+  ],
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
+    }
+  },
+  "deploy_mode": "real-time",
+  "description": "Always-on operation as a first-class workflow (Workflow G, operate-not-author): on a stock real-time deploy (feature gate alert_agent.always_on defaults to false), the agent must (a) determine always-on is NOT active via the config gate and/or a benign probe interpreting 503 ALWAYS_ON_DISABLED, explain the enable path WITHOUT editing anything, and (b) answer 'have any always-on alerts fired' grounded in the incidents endpoint plus a root-cause that names the disabled gate. Also guards against inventing a nonexistent /always-on/health endpoint and against authoring always-on config.",
+  "expects": [
+    {
+      "query": "Deploy the VSS alerts profile on {{platform}} in real-time (VLM) mode using remote LLM and remote VLM endpoints.",
+      "checks": [
+        "`sh -c 'i=1; while [ \"$i\" -le 12 ]; do curl -sf --max-time 10 http://localhost:8000/docs >/dev/null 2>&1 && exit 0; sleep 5; i=$((i+1)); done; exit 1'` returns exit 0 (VSS Agent REST API responsive; polls up to ~3 min to absorb deploy readiness timing).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0 (continuous VLM processor — required for VLM real-time mode).",
+        "`! docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (CV-only perception is NOT running — confirms VLM real-time, not verification)."
+      ]
+    },
+    {
+      "query": "Is always-on alerting active on this deployment? Don't change anything — just check and explain what you find.",
+      "checks": [
+        "`sh -c 'code=$(curl -s -o /dev/null -w \"%{http_code}\" --max-time 15 -X POST http://localhost:9080/api/v1/realtime/always-on -H \"Content-Type: application/json\" -d \"{\\\"source\\\":\\\"vst\\\",\\\"event\\\":{\\\"camera_id\\\":\\\"00000000-0000-0000-0000-0000000000aa\\\",\\\"change\\\":\\\"camera_remove\\\"}}\"); [ \"$code\" = \"503\" ]'` returns exit 0 (ground truth: the stock deploy ships with the alert_agent.always_on feature gate OFF, so the endpoint answers 503 ALWAYS_ON_DISABLED to a benign camera_remove no-op probe).",
+        "The agent correctly reports that always-on alerting is NOT active, grounded in evidence it actually gathered — either the `alert_agent.always_on` config gate (config file / container config read) or an endpoint response whose 503/ALWAYS_ON_DISABLED it interpreted. Claiming it is active, answering from memory with no probe/config evidence, or claiming the deployment does not support always-on at all, are failures.",
+        "The agent honors 'don't change anything': the trajectory contains NO config file edits, NO container restarts, NO redeploys, and NO rule-creating calls (no rule-creating `POST http://localhost:9080/api/v1/realtime`; a benign always-on probe such as a `camera_remove` for a nonexistent camera, and read-only GETs / docker inspection, are acceptable). It also does NOT call or cite a `/api/v1/realtime/always-on/health` endpoint — no such route exists.",
+        "The reply explains how always-on WOULD be enabled (the `alert_agent.always_on` config gate plus an always-on rules YAML — env var `ALWAYS_ON_RULES_CONFIG` or `realtime-config.yaml` — and an alert-bridge restart) as information for the user, while stopping short of performing any of it."
+      ]
+    },
+    {
+      "query": "Have any always-on alerts fired on this deployment? If not, what would explain that?",
+      "checks": [
+        "The agent grounds the 'have any fired' part in the realtime incident store: the trajectory issues a `GET http://localhost:9080/api/v1/realtime/incidents` (any scoping) and the reply reflects what it returned — an empty list reported as 'none' is the expected valid outcome. Fabricating incidents or answering from the rules list is a failure.",
+        "The root-cause explanation names the disabled `alert_agent.always_on` feature gate (established in the previous step or re-checked) as the primary reason, plus at least one other real link of the always-on chain (rules YAML present/valid, SDR camera events reaching Alert Bridge, stream registration on rtvi-vlm). Naming only generic reasons ('no events matched') without the gate is a failure.",
+        "Operate-not-author holds through the turn: no config authoring, no sensor onboarding, no rule creation, no restarts — the agent diagnoses and reports; read-only inspection is acceptable."
+      ]
+    }
+  ]
+}

--- a/skills/vss-manage-alerts/evals/cv_mode_gate.json
+++ b/skills/vss-manage-alerts/evals/cv_mode_gate.json
@@ -24,7 +24,7 @@
         "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (CV perception / Grounding DINO — required and present in verification (CV) mode).",
         "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics` returns exit 0 (Behavior Analytics is the CV-only mode signal — its presence confirms the deployment is verification (CV), not VLM real-time).",
         "`sh -c 'i=1; while [ \"$i\" -le 18 ]; do curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/list 2>/dev/null | grep -qi sample-warehouse-ladder && exit 0; sleep 5; i=$((i+1)); done; exit 1'` returns exit 0 (sample-warehouse-ladder onboarded into VIOS; in CV mode this VIOS registration is the whole Workflow A onboarding — the CV pipeline auto-attaches; polls up to ~1.5 min to absorb fetch/upload/registration delay).",
-        "`curl -sf --max-time 10 http://localhost:9080/api/v1/verification/config` returns HTTP 200 with a JSON list of alert-type verifier configs, including a ladder/PPE-related `alert_type` (the CV VLM-verifier prompt config that Workflow A / cv-verifier-prompts.md customizes) — confirms the CV verifier-config path is populated and queryable in verification mode."
+        "`curl -sf --max-time 10 http://localhost:9080/api/v1/verification/config` returns HTTP 200 with a JSON list of alert-type verifier configs, including a ladder/PPE-related `alert_type` (the CV VLM-verifier prompt config that Workflow B / references/verification.md customizes) — confirms the CV verifier-config path is populated and queryable in verification mode."
       ]
     },
     {

--- a/skills/vss-manage-alerts/evals/ondemand_verification.json
+++ b/skills/vss-manage-alerts/evals/ondemand_verification.json
@@ -1,0 +1,45 @@
+{
+  "skills": [
+    "vss-manage-alerts",
+    "vss-deploy-profile"
+  ],
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
+    }
+  },
+  "deploy_mode": "verification",
+  "description": "On-demand verification as a first-class workflow (Workflow F): on a verification (CV) deploy (no sensor onboarding needed - the verifier config ships populated), the agent must (a) submit a one-shot verification of a supplied clip URL via POST /api/v1/verification/ondemand with a category resolved from GET /verification/config (never /verify, never /generate, never a realtime rule - the no-conflict AC), reporting the real 202 correlationId, and (b) check whether the async result document landed in mdx-vlm-alerts-* via the interim ES probe and explain the verification fields. Verdict CONTENT is never asserted (stock deploy runs use_verdict:false freestyle; an unreachable-from-VLM URL degrades to the error path which still publishes a document - both outcomes are tolerated).",
+  "expects": [
+    {
+      "query": "Deploy the VSS alerts profile on {{platform}} in verification (CV) mode (i.e. `/vss-deploy-profile -p alerts -m verification`) using remote LLM and remote VLM endpoints. No sensor onboarding is needed for this scenario. Do NOT finish until the VSS Agent REST API (`curl -sf http://localhost:8000/docs`) responds successfully and the Alert Bridge verifier config is queryable (`curl -sf http://localhost:9080/api/v1/verification/config`) — wait and retry for a few minutes if a service is still starting.",
+      "checks": [
+        "`sh -c 'i=1; while [ \"$i\" -le 12 ]; do curl -sf --max-time 10 http://localhost:8000/docs >/dev/null 2>&1 && exit 0; sleep 5; i=$((i+1)); done; exit 1'` returns exit 0 (VSS Agent REST API responsive; polls up to ~3 min to absorb deploy readiness timing).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (CV perception / Grounding DINO — required and present in verification (CV) mode).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics` returns exit 0 (Behavior Analytics is the CV-only mode signal — its presence confirms the deployment is verification (CV), not VLM real-time).",
+        "`sh -c 'i=1; while [ \"$i\" -le 12 ]; do curl -sf --max-time 10 http://localhost:9080/api/v1/verification/config 2>/dev/null | grep -q alert_type && exit 0; sleep 5; i=$((i+1)); done; exit 1'` returns exit 0 (Alert Bridge verifier config populated and queryable — the category source Workflow F resolves against)."
+      ]
+    },
+    {
+      "query": "Run an on-demand verification of this clip for a ladder-safety violation and report the request id you get back: https://media.githubusercontent.com/media/NVIDIA-AI-Blueprints/video-search-and-summarization/main/services/alert/warmup/test.mp4",
+      "checks": [
+        "The agent submits the one-shot verification through the on-demand endpoint: the trajectory issues a `POST http://localhost:9080/api/v1/verification/ondemand` whose body carries a `category` plus `info.media_urls` containing the supplied URL and `info.media_type` set to `video`. Submitting via a nonexistent `/api/v1/verification/verify`, via the VSS Agent `POST /generate`, or by mutating `/api/v1/realtime*` (creating/deleting realtime rules for a one-shot clip ask) are failures — read-only GETs anywhere are acceptable.",
+        "The `category` used in the successful POST was resolved from the deployed verifier config: it equals (case-insensitively) an `alert_type` present in a `GET http://localhost:9080/api/v1/verification/config` response the agent actually fetched in this step (a ladder/PPE-related config ships with the profile). Inventing a category not present in the config (e.g. a made-up 'ladder_safety') and reporting its 400 as success is a failure; recovering from an initial 400 unknown_category by then resolving the real config IS acceptable if the final submit succeeded.",
+        "The final reply reports the request id from the actual 202 response: it quotes the `correlationId` value the API returned (server default shape `ondemand-<uuid>`, or the agent's own supplied `id`), and does NOT claim the clip was verified/confirmed/rejected — 202 means accepted for background processing, and no verdict exists at submit time.",
+        "`sh -c 'body=$(curl -s --max-time 15 -X POST http://localhost:9080/api/v1/verification/ondemand -H \"Content-Type: application/json\" -d \"{\\\"category\\\":\\\"__eval_unknown__\\\",\\\"info\\\":{\\\"media_urls\\\":[\\\"http://example.com/x.mp4\\\"],\\\"media_type\\\":\\\"video\\\"}}\"); echo \"$body\" | grep -q unknown_category'` returns exit 0 (deterministic contract probe: an unknown category is rejected with error=unknown_category, without polluting the result store)."
+      ]
+    },
+    {
+      "query": "Has the verification result for that on-demand request landed yet? Where does it live, and which fields should I look at to judge the outcome?",
+      "checks": [
+        "The agent checks the correct store the correct way: the trajectory queries Elasticsearch `mdx-vlm-alerts-*` (e.g. `http://localhost:9200/mdx-vlm-alerts-*/_search`, any query-body variant — ideally keyed on the correlationId or the media URL from the previous step) rather than `GET /api/v1/realtime/incidents`, the rules list, or a nonexistent Alert Bridge results endpoint. It may poll/wait — the result is produced by a background VLM round-trip.",
+        "`sh -c 'i=1; while [ \"$i\" -le 18 ]; do curl -sf --max-time 15 \"http://localhost:9200/mdx-vlm-alerts-*/_search?q=ondemand&size=10\" 2>/dev/null | grep -q \"\\\"total\\\"\" && exit 0; sleep 10; i=$((i+1)); done; exit 1'` returns exit 0 (deterministic: the interim ES probe answers with a well-formed search response — polls ~3 min; the assertion is store reachability + well-formedness, NOT that a hit exists, because the background VLM round-trip may exceed the window or run the error path).",
+        "The reply names the verification fields to inspect — a verification response code (`verificationResponseCode`, camelCase or snake_case) with 200 = VLM success and 4xx/5xx = error path, and the VLM output (`reasoning`/`vlm_response`), noting that `verdict` may be absent/empty on this deploy (freestyle `use_verdict:false`) — and is grounded in what the search actually returned: if a document landed it reports the real field values; if not, it says the result has not landed yet and suggests re-polling. Fabricating a document, a verdict, or claiming 'verified successfully' with no document, are failures."
+      ]
+    }
+  ]
+}

--- a/skills/vss-manage-alerts/evals/slack_notify_ops.json
+++ b/skills/vss-manage-alerts/evals/slack_notify_ops.json
@@ -1,0 +1,53 @@
+{
+  "skills": [
+    "vss-manage-alerts",
+    "vss-deploy-profile"
+  ],
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
+    }
+  },
+  "deploy_mode": "real-time",
+  "description": "Slack as the primary non-OpenClaw notification path (Workflow E): on a real-time deploy with NO alert-notify server running and NO Slack credentials available, the agent must (a) route a Slack setup ask to the alert-notify relay on :9090 (never Alert Bridge realtime APIs), hit the credentials gate - ask for SLACK_BOT_TOKEN + SLACK_CHANNEL_ID and mention selecting the Slack backend (NOTIFY_BACKENDS, default targets the OpenClaw Dashboard) - and STOP without starting the server (it hard-exits on placeholder creds), (b) handle a test-notification ask grounded in the not-running probe, and (c) explain the Slack-vs-OpenClaw two-backends-one-relay model. No fake-credentials start step exists BY DESIGN: the server sys.exit(1)s on failed Slack auth_test.",
+  "expects": [
+    {
+      "query": "Deploy the VSS alerts profile on {{platform}} in real-time (VLM) mode using remote LLM and remote VLM endpoints.",
+      "checks": [
+        "`sh -c 'i=1; while [ \"$i\" -le 12 ]; do curl -sf --max-time 10 http://localhost:8000/docs >/dev/null 2>&1 && exit 0; sleep 5; i=$((i+1)); done; exit 1'` returns exit 0 (VSS Agent REST API responsive; polls up to ~3 min to absorb deploy readiness timing).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0 (continuous VLM processor — required for VLM real-time mode).",
+        "`! docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (CV-only perception is NOT running — confirms VLM real-time, not verification)."
+      ]
+    },
+    {
+      "query": "Set up Slack notifications for alert incidents on this deployment.",
+      "checks": [
+        "The agent routes the ask to the alert-notify webhook relay (Workflow E, port 9090 / scripts/alert-notify), NOT to Alert Bridge: the trajectory contains no POST/PUT/DELETE against `http://localhost:9080/api/v1/realtime*` for this Slack ask (read-only GETs are acceptable) and it does not present a realtime rule as a notification setup.",
+        "The agent hits the credentials gate correctly: it asks the user for a real `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` (and may mention `VST_ENDPOINT`), and it does NOT start the webhook server in this turn — no server process is launched with placeholder/dummy credentials (the server exits at startup on a failed Slack auth, so a placeholder start is a known failure mode).",
+        "The agent mentions backend selection: Slack delivery requires selecting the Slack backend (`NOTIFY_BACKENDS=slack`, or `slack,dashboard`) because the relay's default backend is the OpenClaw Dashboard — a setup description that omits backend selection and would silently deliver to the Dashboard is a failure.",
+        "`sh -c '! curl -sf --max-time 5 http://localhost:9090/webhook/alert-notify/health >/dev/null 2>&1'` returns exit 0 (ground truth: no webhook server was started in this trial — the credentials gate held)."
+      ]
+    },
+    {
+      "query": "OK — for now just send a test alert notification to Slack so I can see what it looks like.",
+      "checks": [
+        "The agent attempts the test through the alert-notify path (a probe of `:9090` health/status or an explicit statement that the relay is not running), and grounds its reply in that evidence: the webhook server is not running / not yet configured, so no test message can be delivered until credentials are provided and the server is started. Offering to start it once credentials exist is good.",
+        "The agent does NOT fabricate success: no claim that a test notification was 'sent' or 'delivered', and no fallback that misuses Alert Bridge (`:9080/api/v1/realtime*`) or `POST /generate` to simulate a Slack notification.",
+        "`sh -c '! curl -sf --max-time 5 http://localhost:9090/webhook/alert-notify/health >/dev/null 2>&1'` returns exit 0 (still no server started — the agent did not launch it with placeholder credentials to force a test through)."
+      ]
+    },
+    {
+      "query": "Do Slack alerts and the OpenClaw Dashboard notifications go through the same service? How do I choose where alerts end up?",
+      "checks": [
+        "The reply explains the two-backends-one-relay model: a single alert-notify webhook server (port 9090) receives incidents from Alert Bridge on `POST /webhook/alert-notify` and fans them out to the enabled backends — Slack and/or the OpenClaw Dashboard.",
+        "The reply states that the destination is chosen via the `NOTIFY_BACKENDS` environment variable (default `dashboard`; `slack` / `slack,dashboard` for Slack delivery) with per-backend credential sets (Slack bot token + channel ID vs OpenClaw gateway URL + auth token), and explicitly notes that Slack notifications are NOT configured through Alert Bridge realtime rule APIs (`:9080`).",
+        "The answer is consistent with the deployment evidence gathered earlier in this trial (relay not currently running) and fabricates nothing — describing how it WOULD work is expected; claiming it is currently delivering is a failure."
+      ]
+    }
+  ]
+}

--- a/skills/vss-manage-alerts/evals/verification_flow.json
+++ b/skills/vss-manage-alerts/evals/verification_flow.json
@@ -1,0 +1,47 @@
+{
+  "skills": [
+    "vss-manage-alerts",
+    "vss-deploy-profile",
+    "vss-manage-video-io-storage"
+  ],
+  "resources": {
+    "platforms": {
+      "L40S": {
+        "modes": [
+          "remote-all"
+        ]
+      }
+    }
+  },
+  "deploy_mode": "verification",
+  "description": "Alert verification as a first-class workflow (Workflow B): on a verification (CV) deploy with the ladder sample onboarded, the agent must (a) explain the RT-CV -> Behavior Analytics -> Alert Bridge -> VLM verification chain and all verdict values correctly without mutating anything, and (b) answer a 'what verdicts were recorded' ask from the mdx-vlm-alerts-* store via the interim Elasticsearch probe (the store has NO REST query endpoint), reporting grounded results or a grounded 'none yet'. Does NOT assert verdict contents (CV detection latency and pluggable/freestyle parser deploys make them non-deterministic).",
+  "expects": [
+    {
+      "query": "Deploy the VSS alerts profile on {{platform}} in verification (CV) mode (i.e. `/vss-deploy-profile -p alerts -m verification`) using remote LLM and remote VLM endpoints. Then onboard the ladder sample so the CV pipeline has PPE content to detect: obtain the `sample-warehouse-ladder.mp4` NGC sample video (one of the bundled sample videos — if it is not already in NVStreamer's streamer_videos, fetch it via the vss-manage-video-io-storage sample-data bootstrap), upload it through NVStreamer (port 31000) as a sensor named `sample-warehouse-ladder`, then register in VIOS (port 30888) the RTSP URL exactly as NVStreamer's streams API returns it (query NVStreamer for the served URL — do NOT hand-construct a host:port URL, and include BOTH keys in the `/sensor/add` payload — `sensorUrl` (the returned URL) and `name` (`sample-warehouse-ladder`); without the `name` key VST silently names the sensor `SENSOR`). In CV mode, registering the sensor in VIOS is the entire onboarding step — the CV pipeline auto-picks up the stream; do not look for a separate 'create alert' API. Do NOT finish until the VSS Agent REST API (`curl -sf http://localhost:8000/docs`) and VIOS (`curl -sf http://localhost:30888/vst/api/v1/sensor/list`) respond successfully and `sample-warehouse-ladder` is listed — wait and retry for a few minutes if a service is still starting.",
+      "checks": [
+        "`sh -c 'i=1; while [ \"$i\" -le 12 ]; do curl -sf --max-time 10 http://localhost:8000/docs >/dev/null 2>&1 && exit 0; sleep 5; i=$((i+1)); done; exit 1'` returns exit 0 (VSS Agent REST API responsive; polls up to ~3 min to absorb deploy readiness timing).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-cv` returns exit 0 (CV perception / Grounding DINO — required and present in verification (CV) mode).",
+        "`docker ps --format '{{.Names}}' | grep -qx vss-behavior-analytics` returns exit 0 (Behavior Analytics is the CV-only mode signal — its presence confirms the deployment is verification (CV), not VLM real-time).",
+        "`sh -c 'i=1; while [ \"$i\" -le 18 ]; do curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/list 2>/dev/null | grep -qi sample-warehouse-ladder && exit 0; sleep 5; i=$((i+1)); done; exit 1'` returns exit 0 (sample-warehouse-ladder onboarded into VIOS; in CV mode this VIOS registration is the whole Workflow A onboarding — the CV pipeline auto-attaches; polls up to ~1.5 min to absorb fetch/upload/registration delay).",
+        "`curl -sf --max-time 10 http://localhost:9080/api/v1/verification/config` returns HTTP 200 with a JSON list of alert-type verifier configs, including a ladder/PPE-related `alert_type` (the CV VLM-verifier prompt config that Workflow A / cv-verifier-prompts.md customizes) — confirms the CV verifier-config path is populated and queryable in verification mode."
+      ]
+    },
+    {
+      "query": "How does alert verification work in this deployment — what happens between a camera stream and a verified alert, and what do the different verdict values mean?",
+      "checks": [
+        "The agent's explanation covers the CV verification chain in order: RT-CV / Grounding DINO perception (vss-rtvi-cv) produces detections, Behavior Analytics (vss-behavior-analytics) turns them into candidate alerts, Alert Bridge invokes the VLM verifier with per-alert_type prompts, and the verified result lands in Elasticsearch (the `mdx-vlm-alerts-*` alert store). Component naming may vary slightly but the four stages and their order must be correct — an answer that describes the VLM real-time rule path (realtime subscriptions / rtvi-vlm triggers) as the verification chain is a failure.",
+        "The reply explains the verdict values with correct meanings: `confirmed` (VLM says the alert is real), `rejected` (false positive), `verification-failed` (VLM/API error — verification could not complete), and at least one of `not-confirmed` (VLM answer could not be parsed into confirmed/rejected) or the empty-verdict pluggable-parser case. Wrong meanings (e.g. calling `rejected` an error state, or `verification-failed` a false positive) are a failure.",
+        "This is an explain-only ask: the trajectory performs NO mutations — no POST/PUT/DELETE against `http://localhost:9080/api/v1/realtime*` or `/api/v1/verification/config*`, no `POST /generate`, and no redeploy/teardown attempt. Read-only peeks (GET on config, docker ps, ES searches) are acceptable."
+      ]
+    },
+    {
+      "query": "What verification verdicts have been recorded so far for sample-warehouse-ladder?",
+      "checks": [
+        "The agent sources its ANSWER from the CV verification store: the trajectory queries Elasticsearch `mdx-vlm-alerts-*` (e.g. `http://localhost:9200/mdx-vlm-alerts-*/_search`, any query-body variant) and the final reply reflects what that search returned. Answering the verdict question from the realtime rules list (`GET /api/v1/realtime`), from `/incidents` alone, or from memory/fabrication is a failure; an incidental read-only peek at those endpoints is tolerable.",
+        "`curl -sf --max-time 15 'http://localhost:9200/mdx-vlm-alerts-*/_search?size=5'` returns HTTP 200 with a well-formed Elasticsearch search response (deterministic data-plane probe; zero hits and populated hits are both valid states).",
+        "The final reply is grounded in the search result it actually received: if documents exist it reports their verdict values (and may cite `verificationResponseCode`/`reasoning` from the `info` block — camelCase or snake_case accepted); if the search returned zero hits it clearly states that no verification results have been recorded yet (optionally explaining CV detection latency) and STOPS — it does not fabricate verdicts, does not present subscription rules or incident-store results as verdicts, and does not claim the store is unreachable when the probe succeeded."
+      ]
+    }
+  ]
+}

--- a/skills/vss-manage-alerts/references/alert-notify.md
+++ b/skills/vss-manage-alerts/references/alert-notify.md
@@ -16,9 +16,27 @@ This skill is invoked as a **sub-workflow** of the parent `alerts` skill (Workfl
 - "Stop the alert Slack webhook"
 - "What's the status of the Slack notification service?"
 
-**Not this skill** (handled by parent Workflow D or B instead):
+**Not this skill** (handled by parent Workflow D instead):
 - "Notify me when someone enters the zone" — alert creation, not Slack setup
 - "Alert and notify on incidents" — no Slack/webhook keyword, ambiguous destination
+
+---
+
+## Two backends, one relay
+
+The webhook server is a single relay on `:9090`; Alert Bridge POSTs incidents to `POST /webhook/alert-notify`, and the server fans each incident out to **all enabled backends**:
+
+| Backend | Selected by | Credentials |
+|---|---|---|
+| **Slack** | `NOTIFY_BACKENDS=slack` | `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` |
+| **OpenClaw Dashboard** | `NOTIFY_BACKENDS=dashboard` (the **default** when unset) | `OPENCLAW_GATEWAY_URL` + `OPENCLAW_GATEWAY_AUTH_TOKEN` |
+| Both | `NOTIFY_BACKENDS=slack,dashboard` | both sets |
+
+- **Slack is the primary non-OpenClaw path** — a Slack-only setup MUST set `NOTIFY_BACKENDS=slack`; leaving the default silently targets the Dashboard instead.
+- Where alerts go is chosen here, by env — **never** through Alert Bridge realtime rule APIs (`:9080/api/v1/realtime*` plays no role in notification routing).
+- The `/status` endpoint reports per-backend state — use it to tell the user which destinations are live.
+
+> ⚠️ **The server exits at startup on a bad backend.** A failed Slack `auth_test` (invalid/placeholder `SLACK_BOT_TOKEN`), missing Dashboard credentials, or an unset `VST_ENDPOINT` each terminate the process (`sys.exit(1)`) — there is no degraded half-started mode. Collect real credentials **before** starting; never launch with placeholders to "see if it works".
 
 ---
 

--- a/skills/vss-manage-alerts/references/always-on.md
+++ b/skills/vss-manage-alerts/references/always-on.md
@@ -1,0 +1,70 @@
+# Always-On Operation (Workflow G — VLM real-time mode only)
+
+Operational reference for **Workflow G**: checking whether always-on alerting is active, querying its incidents, and troubleshooting missing always-on alerts.
+
+> **Operate, don't author.** This workflow never creates, edits, or deletes always-on rule configuration. Authoring `always_on_rules` entries, rule lifecycle redesign, and enabling the feature on a user's behalf are **out of scope in this pass** — when asked, say so and describe the enable path instead of performing it.
+
+## How always-on works
+
+SDR (sensor discovery) posts camera lifecycle events to Alert Bridge; Alert Bridge fans each `camera_streaming` event out into **one realtime rule per entry** in the always-on rules YAML, targeting that camera's stream on `rtvi-vlm`:
+
+```
+SDR event ──POST /api/v1/realtime/always-on──▶ Alert Bridge
+  change=camera_streaming  → start every configured always_on_rule for that camera (idempotent per camera_id)
+  change=camera_remove     → tear down that camera's always-on rules
+```
+
+- Event body (top level): `{source?, alert_type?, created_at?, event: {camera_id, camera_name?, camera_url?, change, …}}` with `change ∈ {camera_streaming, camera_remove}`. `camera_name` and `camera_url` are required on `camera_streaming`, ignored on `camera_remove`.
+- Started rules are ordinary realtime rules — their incidents surface through Workflow C's `GET /api/v1/realtime/incidents` like any other.
+- The rules live in an **in-memory sidecar**, not the ES-backed rules index: they do not survive a restart by themselves (SDR re-announces cameras) and **may not appear in Workflow D's rules list** — that is expected, not a bug.
+
+## Status — is always-on active?
+
+There is **no `/always-on/health` endpoint** — never invent one. Two signals, in preference order:
+
+1. **Config gate (zero side effects).** The feature is opt-in via `alert_agent.always_on` in the Alert Bridge `config.yaml` (default **false**). On a compose deploy, check the mounted config or the container:
+   ```bash
+   docker exec vss-alert-bridge sh -c 'grep -A1 -E "^\s*always_on" /app/config.yaml' 2>/dev/null \
+     || grep -rn "always_on" deploy/docker/developer-profiles/dev-profile-alerts/ 2>/dev/null | grep -v sample
+   ```
+2. **Endpoint probe (benign POST).** A `camera_remove` for a nonexistent camera is a no-op when enabled and returns the gate response when disabled:
+   ```bash
+   curl -s -o /tmp/ao.json -w '%{http_code}\n' -X POST "http://${HOST_IP}:9080/api/v1/realtime/always-on" \
+     -H 'Content-Type: application/json' \
+     -d '{"source":"vst","event":{"camera_id":"00000000-0000-0000-0000-0000000000aa","change":"camera_remove"}}'
+   # 503 + {"reason":"ALWAYS_ON_DISABLED"} → feature off (the default)
+   # 200-range / REMOVE_* reason           → feature on (no-op for an unknown camera)
+   ```
+
+Report the state you actually observed. If the user wants it enabled, describe the path (set `alert_agent.always_on: true` + provide a rules YAML + restart `alert-bridge`) — do **not** perform it.
+
+## Response envelope & reason codes
+
+Every response: `{"reason": "<REASON>", "status": "HTTP/1.1 <code> <phrase>", "details": [...]?}` — `details` (one entry per rule, with per-rule `status`/`result`) appears only when the service fanned out across rules.
+
+| `reason` | Meaning |
+|---|---|
+| `ALWAYS_ON_DISABLED` | Feature gate `alert_agent.always_on` is off (HTTP 503) |
+| `INVALID_PAYLOAD` | Event body failed validation (HTTP 422, custom shape — not FastAPI's `detail`) |
+| `CONFIG_ERROR` | Rules YAML missing/malformed (also raised at startup validation) |
+| `STREAM_ADD_SUCCESS` | All configured rules started for the camera |
+| `STREAM_ADD_PARTIAL_SUCCESS` | Some rules started, some failed — see `details` |
+| `STREAM_ADD_FAILED` | No rule could be started — see `details` |
+| `STREAM_ADD_ALREADY_ACTIVE` | Rules already running for this `camera_id` (idempotent short-circuit) |
+| `STREAM_REMOVE_SUCCESS` / `STREAM_REMOVE_FAILED` | Teardown outcome for `camera_remove` |
+
+## Rules YAML (read-only knowledge)
+
+Resolution order (first match wins): `$ALWAYS_ON_RULES_CONFIG` → `./realtime-config.yaml` → `./realtime-config-sample.yaml` (sample ships at `services/alert/realtime-config-sample.yaml`). Shape: top-level `always_on_rules:` — a non-empty list with unique `rule_id`s; each entry carries `rule_id`, `alert_type`, optional `description`, and `always_on_params` where `prompt` / `system_prompt` / `model` are **required** and `live_stream_url` / `alert_type` / `sensor_name` are **derived** from the camera event (setting them is a config error). The YAML is validated at Alert Bridge startup when the gate is on.
+
+## Troubleshooting — "why aren't always-on alerts appearing?"
+
+Walk the chain top-down; stop at the first broken link and report it:
+
+1. **Feature gate** — `alert_agent.always_on` false (the default) explains everything; see Status above.
+2. **Rules YAML** — resolves via the chain above and validated at boot; a `CONFIG_ERROR` in `alert-bridge` startup logs means no rule can ever start: `docker logs vss-alert-bridge 2>&1 | grep -i "always"`.
+3. **SDR events reaching Alert Bridge** — the same logs show each incoming `POST /api/v1/realtime/always-on`; no log lines = SDR never announced the camera (VIOS/SDR side, hand off to `vss-manage-video-io-storage`).
+4. **Stream registered on rtvi-vlm** — the fan-out `details` entries carry per-rule upstream errors; a 502-class `error` means `rtvi-vlm` rejected the stream.
+5. **Incidents** — finally, query Workflow C (`GET /api/v1/realtime/incidents`, scope by camera/time). Empty with all links healthy = nothing matched the rule prompts yet; report that grounded, don't fabricate.
+
+Never "fix" a broken link by authoring config or onboarding sensors the user didn't ask for — report the diagnosis and the enable path.

--- a/skills/vss-manage-alerts/references/cv-verifier-prompts.md
+++ b/skills/vss-manage-alerts/references/cv-verifier-prompts.md
@@ -1,37 +1,3 @@
-# CV Verifier Prompts & Verdicts (CV mode only)
+# CV Verifier Prompts & Verdicts (moved)
 
-Operational reference for Workflow A / Workflow C on a **CV (verification)** deployment: how to read VLM verification verdicts on alerts and how to customize the VLM-verifier prompts. Not applicable to VLM real-time mode (there is no separate verdict field — see below).
-
-## Verdict interpretation
-
-Verified CV alerts carry an extended `info` block:
-
-| `verdict` | Meaning |
-|---|---|
-| `confirmed` | VLM determined the alert is real |
-| `rejected` | VLM determined it is a false positive |
-| `not-confirmed` | VLM response could not be parsed into a confirmed/rejected verdict (parse failure) |
-| `verification-failed` | Verification could not complete — API/VLM error |
-| `""` (empty) | A pluggable response parser was used instead of the verdict path |
-
-- Check `verificationResponseCode` (`200` = success) and `reasoning` for the VLM's explanation. These live in the incident `info` block and appear camelCase (`verificationResponseCode`, `verificationResponseStatus`).
-- VLM real-time mode incidents are always "confirmed" at source (the trigger itself is a Yes/No VLM answer), so there is **no** separate verdict field in VLM mode.
-
-## Customize CV verifier prompts
-
-CV-path verifier prompts live in:
-
-```
-deploy/docker/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/alert_type_config.json
-```
-
-Each entry maps a CV `alert_type` (the `category` field emitted by Behavior Analytics) to the VLM `system` / `user` / optional `enrichment` prompts.
-
-Key rules:
-
-- `alert_type` must match the `category` emitted by Behavior Analytics.
-- `output_category` is the display name in Elasticsearch / UI.
-- `enrichment` triggers a second VLM call for a richer description; requires `alert_agent.enrichment.enabled: true`.
-- Edits require an `alert-bridge` container restart to take effect.
-
-VLM real-time prompts are **not** configured in a file — they are per-request, shaped by `rtvi_prompt_gen` from the user's natural-language detection description.
+This reference has been absorbed into `references/verification.md` (Workflow B — verification pipeline, verdict table, result inspection, and verifier-prompt customization). Load that file instead; this pointer remains only for older links.

--- a/skills/vss-manage-alerts/references/on-demand-verification.md
+++ b/skills/vss-manage-alerts/references/on-demand-verification.md
@@ -1,0 +1,55 @@
+# On-Demand Verification (Workflow F — CV mode)
+
+Operational reference for **Workflow F**: one-shot VLM verification of a specific video/image URL through Alert Bridge. Execution requires a CV (verification) deployment; *explain-only* asks are answerable anywhere. Routing guard: continuous monitoring of a sensor/stream is **Workflow D**, never F.
+
+## Endpoint & request contract
+
+**`POST $AB/api/v1/verification/ondemand`** — there is **no** `/verification/verify` route; do not use `POST /generate` or any `/api/v1/realtime*` mutation for this.
+
+```bash
+AB="http://${HOST_IP}:9080"
+curl -sf -X POST "$AB/api/v1/verification/ondemand" -H 'Content-Type: application/json' -d '{
+  "category": "<alert_type>",
+  "info": {
+    "media_urls": ["https://…/clip.mp4"],
+    "media_type": "video"
+  }
+}'
+```
+
+- `category` (required, case-insensitive — normalized to lowercase): must match an existing verifier-config `alert_type`. **Resolve it first** via `GET $AB/api/v1/verification/config` and pick the config matching the user's ask; never invent one.
+- `info.media_urls` (required): non-empty list of URLs. `info.media_type` (required): `video` or `image`.
+- Everything else is optional (`extra=allow` — the endpoint accepts a full `nv.Incident` payload, same shape DirectMedia consumes from Kafka). Useful optional fields: `id` (becomes the `correlationId`), `sensorId`, `timestamp`/`end`. Defaults when omitted: `id=ondemand-<uuid4>`, `sensorId="ondemand"`, timestamps = now.
+
+## Responses
+
+| Code | Body | Meaning |
+|---|---|---|
+| **202** | `{"status":"accepted","correlationId":"…","message":…,"timestamp":…}` | Accepted for **background** processing — not a verdict. Report the returned `correlationId` verbatim. |
+| **400** | `{"status":"error","error":"unknown_category",…}` | `category` has no verifier config — list configs and pick a real one. |
+| **400** | `{"status":"error","error":"invalid_request",…}` | Payload shape problem (missing `media_urls`, bad `media_type`, …). |
+
+A 202 means **accepted, not verified** — never report a verdict, confirmation, or failure at submit time.
+
+## Media constraints
+
+- With the default `vlm_media_source_using_base64: false`, the URL is handed to the VLM endpoint, which **fetches it itself** — the URL must be reachable *from the VLM*, not just from the caller. A `localhost`/container-internal URL that the remote VLM cannot reach fails the fetch.
+- `media_download.*` config (`max_media_count`, `timeout_seconds`, `max_size_mb`, `allow_private_urls`) applies on the base64/download path.
+- An unreachable or invalid URL does **not** error the submit — the 202 stands and the **error path still publishes a result document** with a non-200 `verificationResponseCode` and `verdict: "verification-failed"`.
+
+## Result lifecycle & validation
+
+Background task → VLM call → result published via the same sink as the Kafka pipeline → document in **`mdx-vlm-alerts-*`** (Workflow B's store; no REST query endpoint yet — use the interim ES probe):
+
+```bash
+# poll for the result document (allow ≥2 minutes for the VLM round-trip)
+curl -sf "http://${HOST_IP}:9200/mdx-vlm-alerts-*/_search?q=\"<correlationId>\"" | jq '.hits.hits[]._source'
+```
+
+Validation checklist for a landed document (fields live in the `info` block):
+
+- `verificationResponseCode` — `200` = VLM call succeeded; 4xx/5xx = error path (fetch/VLM failure). Accept camelCase or snake_case.
+- `verdict` — populated (`confirmed`/`rejected`/…) only when the deploy runs verdict parsing (`use_verdict: true` or a pluggable parser). The default `use_verdict: false` is **freestyle**: the raw VLM text is stored (see `vlm_response`/`reasoning`) and `verdict` may be absent or empty — that is a valid success, not a failure.
+- `reasoning` / `vlm_response` — the VLM's output; quote it rather than paraphrasing a verdict into existence.
+
+No document after the poll window: report that the result has not landed yet (grounded), suggest re-polling; do not fabricate one. Verdict meanings: see `references/verification.md`.

--- a/skills/vss-manage-alerts/references/verification.md
+++ b/skills/vss-manage-alerts/references/verification.md
@@ -1,0 +1,116 @@
+# Verification Results & Verdicts (Workflow B — CV mode)
+
+Operational reference for **Workflow B** on a **CV (verification)** deployment: how a CV alert becomes a verdict, how to inspect verification results, and how to customize the VLM-verifier prompts. Execution requires CV mode; *explain-only* asks ("how does verification work?") are answerable in any mode from this background. VLM real-time mode has no separate verdict field (see the verdict table's last note).
+
+## The verification pipeline
+
+```
+camera (VIOS/VST)
+  → vss-rtvi-cv            RT-CV perception (Grounding DINO object detections)
+  → vss-behavior-analytics rule engine → candidate alert (PPE / ladder / proximity / restricted-area …)
+  → vss-alert-bridge       VLM verifier: fetches the clip from VIOS, prompts per alert_type
+  → vss-rtvi-vlm           vision-language inference (runs in both modes)
+  → Elasticsearch          verified document in mdx-vlm-alerts-* (alert-kind store)
+```
+
+- Candidate alerts reach Alert Bridge over Kafka (or `POST /api/v1/alerts` for `nv.Behavior` submissions); Alert Bridge looks up the verifier prompts by the alert's `category` (= `alert_type`), calls the VLM on the clip, and stamps the result into the document's `info` block before publishing.
+- This whole path exists only when the alerts profile is deployed with `-m verification` (`MODE=2d_cv`). Deploy/mode-switch belongs to `vss-deploy-profile` — never duplicate it here.
+- The **real-time** path (VLM mode, Workflow D rules) writes *incident-kind* results to `mdx-vlm-incidents-*`, queryable via Workflow C's `GET /api/v1/realtime/incidents`. The two stores do not mix.
+
+## Verdict interpretation
+
+Verified CV alerts carry an extended `info` block:
+
+| `verdict` | Meaning |
+|---|---|
+| `confirmed` | VLM determined the alert is real |
+| `rejected` | VLM determined it is a false positive |
+| `not-confirmed` | VLM response could not be parsed into a confirmed/rejected verdict (parse failure) |
+| `verification-failed` | Verification could not complete — API/VLM error |
+| `""` (empty) | A pluggable response parser was used instead of the verdict path |
+
+- Companion fields (camelCase, inside `info`): `verificationResponseCode` (HTTP-like; `200` = success), `verificationResponseStatus` (`OK` or an error description), `reasoning` (the VLM's explanation), and `vlm_response` (pluggable-parser output only).
+- VLM real-time mode incidents are always "confirmed" at source (the trigger itself is a Yes/No VLM answer), so there is **no** separate verdict field in VLM mode.
+
+## Inspecting verification results — interim ES probe
+
+> **Interim path.** The `mdx-vlm-alerts-*` store has **no REST query endpoint yet** — Workflow C's `/incidents` reads only the real-time incident store and will NOT surface these documents. A dedicated Alert Bridge query endpoint is planned; until it lands, query Elasticsearch (`:9200`, host-published) directly.
+
+```bash
+ES="http://${HOST_IP}:9200"
+
+# latest verification results
+curl -sf "$ES/mdx-vlm-alerts-*/_search?size=10&sort=@timestamp:desc" | jq '.hits.hits[]._source'
+
+# by alert category (alert_type / output_category as shown in ES)
+curl -sf "$ES/mdx-vlm-alerts-*/_search" -H 'Content-Type: application/json' -d '{
+  "size": 10, "sort": [{"@timestamp": "desc"}],
+  "query": {"match": {"category": "<alert_type>"}}
+}' | jq '.hits.hits[]._source'
+
+# by verdict
+curl -sf "$ES/mdx-vlm-alerts-*/_search" -H 'Content-Type: application/json' -d '{
+  "size": 10,
+  "query": {"match": {"info.verdict": "confirmed"}}
+}' | jq '.hits.hits[]._source'
+
+# by time range
+curl -sf "$ES/mdx-vlm-alerts-*/_search" -H 'Content-Type: application/json' -d '{
+  "size": 50,
+  "query": {"range": {"@timestamp": {"gte": "now-24h"}}}
+}' | jq '.hits.hits[]._source | {category, timestamp, verdict: .info.verdict}'
+
+# by on-demand correlationId (Workflow F results land in this same store)
+curl -sf "$ES/mdx-vlm-alerts-*/_search?q=<correlationId>" | jq '.hits.hits[]._source'
+```
+
+Reading the results:
+
+- Summarize each hit's `category`, timestamp, sensor, `info.verdict`, and `info.reasoning`. Accept camelCase or snake_case on the response-code field (`verificationResponseCode` / `verification_response_code`) — index mappings have varied.
+- **Zero hits is a valid answer.** CV detection has latency (stream must be online, detections must trip a Behavior Analytics rule, VLM round-trip). Report "no verification results yet", optionally note the latency reasons, and STOP — never pad the answer with the rules list, `/incidents`, or invented documents.
+- Never report a verdict you did not read from a returned document.
+
+## Customize CV verifier prompts
+
+Two equivalent surfaces; prefer the REST API on a live deployment (no restart needed).
+
+### REST API (live)
+
+```bash
+AB="http://${HOST_IP}:9080"
+
+curl -sf "$AB/api/v1/verification/config" | jq .                 # list all alert-type configs
+curl -sf "$AB/api/v1/verification/config/<alert_type>" | jq .    # read one
+curl -sf -X PUT "$AB/api/v1/verification/config/<alert_type>" \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "<user prompt>", "system_prompt": "<system prompt>"}'
+# POST "" creates a new alert_type (409 if it exists); DELETE removes one (404 if missing)
+```
+
+Config fields: `alert_type`, `prompt`, `system_prompt`, `enrichment_prompt`, `vlm_params`, `output_category` (+ server-stamped `created_at`/`updated_at`). `PUT` is a partial update — only the fields you send change.
+
+### Config file (deploy-time)
+
+CV-path verifier prompts also live in:
+
+```
+deploy/docker/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/alert_type_config.json
+```
+
+Each entry maps a CV `alert_type` (the `category` field emitted by Behavior Analytics) to the VLM `system` / `user` / optional `enrichment` prompts.
+
+Key rules:
+
+- `alert_type` must match the `category` emitted by Behavior Analytics.
+- `output_category` is the display name in Elasticsearch / UI.
+- `enrichment` triggers a second VLM call for a richer description; requires `alert_agent.enrichment.enabled: true`.
+- File edits require an `alert-bridge` container restart to take effect (REST edits do not).
+
+VLM real-time prompts are **not** configured in a file — they are per-request, shaped by `rtvi_prompt_gen` from the user's natural-language detection description.
+
+## Routing guards
+
+- *Was it confirmed / show verdicts / verification results* → **this workflow (B)**: ES probe on `mdx-vlm-alerts-*`, never the rules list.
+- *What happened / any alerts today* → **Workflow C** (`GET /api/v1/realtime/incidents`), even on a CV deployment.
+- *Verify this specific clip/image URL right now* → **Workflow F** (on-demand verification) — its result document lands in this same `mdx-vlm-alerts-*` store, inspected with the probes above.
+- Verdict-keyword asks on a **VLM** deployment: explain-only → answer from this reference; execution → the VLM-mode refusal text in SKILL.md (redeploy hint `-m verification`); no auto-redeploy.

--- a/skills/vss-manage-alerts/references/verification.md
+++ b/skills/vss-manage-alerts/references/verification.md
@@ -67,7 +67,7 @@ curl -sf "$ES/mdx-vlm-alerts-*/_search?q=<correlationId>" | jq '.hits.hits[]._so
 Reading the results:
 
 - Summarize each hit's `category`, timestamp, sensor, `info.verdict`, and `info.reasoning`. Accept camelCase or snake_case on the response-code field (`verificationResponseCode` / `verification_response_code`) — index mappings have varied.
-- **Zero hits is a valid answer.** CV detection has latency (stream must be online, detections must trip a Behavior Analytics rule, VLM round-trip). Report "no verification results yet", optionally note the latency reasons, and STOP — never pad the answer with the rules list, `/incidents`, or invented documents.
+- **Zero hits is a valid answer.** CV detection has latency (stream must be online, detections must trip a Behavior Analytics rule, VLM round-trip). Report "no verification results yet", optionally note the latency reasons, and STOP — never pad the answer with the rules list, `/incidents`, the `mdx-vlm-incidents-*` ES index (incident-kind docs carry no verdicts — a populated incidents index next to an empty alerts index is normal, not a substitute), or invented documents.
 - Never report a verdict you did not read from a returned document.
 
 ## Customize CV verifier prompts


### PR DESCRIPTION
## Description

**VIA-2035 — Expand VSS alerts skill support for Skill Extension 4.0** (stacked on #1126; base = `feat/update-alert-ms-eval-coverage`, retarget to `develop` after #1126 merges).

Expands `skills/vss-manage-alerts` (v3.2.0 → 3.3.0) from a realtime-subscription-centric skill into a full Alerts MS operating skill, per the five VIA-2035 sub-tickets:

1. **Alert verification first-class — new Workflow B** (`references/verification.md`): pipeline walk-through (RT-CV → Behavior Analytics → Alert Bridge VLM verifier → ES), full verdict table, verifier-config REST CRUD, and result inspection via an **interim ES probe** on `mdx-vlm-alerts-*` — that store still has no REST query endpoint (Alert Bridge ticket to be filed); the skill marks the probe as interim. `cv-verifier-prompts.md` is absorbed and left as a pointer tombstone.
2. **Always-on operation — new Workflow G** (`references/always-on.md`): operate-not-author. Status via the `alert_agent.always_on` config gate / `503 ALWAYS_ON_DISABLED` (there is **no** `/always-on/health` endpoint), full reason-code table, rules-YAML resolution chain, in-memory-sidecar caveat, 5-step troubleshooting ladder. Config authoring is explicitly out of scope.
3. **On-demand verification — new Workflow F** (`references/on-demand-verification.md`): `POST /api/v1/verification/ondemand` (not `/verify`), category pre-resolution against `GET /verification/config`, 202 = accepted-not-verified with `correlationId`, async result in `mdx-vlm-alerts-*`, freestyle `use_verdict:false` field-validation checklist.
4. **Slack non-OpenClaw notifications — Workflow E sharpened**: two-backends-one-relay (`NOTIFY_BACKENDS`, default `dashboard` — Slack setup must select the slack backend), the four `:9090` ops, startup hard-exit credentials gate; Slack is never configured through Alert Bridge realtime APIs.
5. **Eval coverage — 4 new specs** (`verification_flow`, `always_on_operate`, `ondemand_verification`, `slack_notify_ops`): CI matrix grows 7 → **11 legs** for alerts-skill diffs; no adapter changes needed (`plan_matrix`/`generate.py` pick them up as-is).

Routing: intent precedence is now **E → F → G → B → D → C → A** (additive, keyword-scoped); all existing A/C/D/E text is unchanged except the extended CV refusal.

### Validation (local CI-parity rig, 2×L40S, opus agent+judge)

- Single-leg: 4/4 new specs GREEN; regression legs `routing_vlm_c_vs_d`, `routing_e_gate_negative`, `cv_mode_gate` GREEN (no routing steals).
- Full 11-spec soak: 11/11 GREEN after two payload-specific guards found by the runs — (a) F-block: `verdict` is not a guaranteed field on freestyle deploys; (b) B-block: `mdx-vlm-incidents-*` is never a verdict source even when the alerts store is empty.
- Every embedded shell check was validated against live service behavior (ondemand `400 unknown_category`, always-on `503 ALWAYS_ON_DISABLED`, ES store probes, `:9090` health).
- `plan_matrix` dry-run = exactly 11 legs; harness pytest 29/29; all specs JSON-lint clean.

### Notes for reviewers

- `skill.oms.sig` is intentionally stale — maintainer re-sign requested (same as #1126). `skill-card.md` / `BENCHMARK.md` deliberately untouched.
- The on-demand eval's media URL uses the repo's own LFS-served warmup clip (`media.githubusercontent.com/.../services/alert/warmup/test.mp4`) — publicly fetchable, no external dependency.
- Known follow-ups (separate tickets, not in this PR): Alert Bridge REST query endpoint for `mdx-vlm-alerts-*`; `RTVI_VLM_BASE_URL` wiring for remote-VLM deploys.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
