### PR TITLE
vios(ingress): pin nginx with apt satisfy to survive noble security bumps

### DIFF
--- a/services/vios/deployment/scaling/ingress/Dockerfile
+++ b/services/vios/deployment/scaling/ingress/Dockerfile
@@ -15,11 +15,14 @@
 
 FROM ubuntu:24.04
 
-# Install nginx and dependencies
+# Install nginx and dependencies.
+# Enforce a minimum version (>= 1.24.0-2ubuntu7.8) rather than an exact pin so the
+# CVE-2026-42945 fix is guaranteed while still resolving to whatever patched build
+# is currently in noble-security.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-         nginx=1.24.0-2ubuntu7.8 \
-         nginx-common=1.24.0-2ubuntu7.8 \
+    && apt-get satisfy -y --no-install-recommends \
+         "nginx (>= 1.24.0-2ubuntu7.8)" \
+         "nginx-common (>= 1.24.0-2ubuntu7.8)" \
          ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r nginx \


### PR DESCRIPTION
## Description
The ingress Dockerfile pinned nginx and nginx-common to the exact version 1.24.0-2ubuntu7.8 (added to pull in the CVE-2026-42945 fix). Ubuntu keeps only the latest build of a package in noble-updates/noble-security, so once that version was superseded (now 1.24.0-2ubuntu7.13) it was dropped from the mirror and the container build failed:

  E: Version '1.24.0-2ubuntu7.8' for 'nginx' was not found

Replace the exact equals-pin with 'apt-get satisfy' using a minimum-version floor (>= 1.24.0-2ubuntu7.8). This guarantees the CVE-2026-42945 fix while resolving to whatever patched build is currently in noble-security, so the build no longer breaks when Ubuntu ships a newer nginx. Keeps the approved ubuntu:24.04 base; no new base-image OSRB required.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
