### PR TITLE
fix(skills-eval): forward RTSP sample URL

### DIFF
--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -53,6 +53,18 @@ BREV_COPY_TIMEOUT = int(os.environ.get("BREV_COPY_TIMEOUT", "300"))
 BREV_DOWNLOAD_RETRIES = int(os.environ.get("BREV_DOWNLOAD_RETRIES", "3"))
 BREV_DOWNLOAD_BACKOFF_SEC = float(os.environ.get("BREV_DOWNLOAD_BACKOFF_SEC", "5"))
 
+# Public NVIDIA sample used by the RT-VLM test suite. Operators can override it
+# for isolated environments, but the eval remains runnable without extra CI
+# configuration.
+DEFAULT_RTSP_SAMPLE_URL = (
+    "rtsp://nv-wowza-pdc.nvidia.com:1935/vod/sample_1080p_h264.mp4"
+)
+
+
+def _resolve_rtsp_sample_url() -> str:
+    """Return the operator-provided RTSP sample URL or the public default."""
+    return os.environ.get("RTSP_SAMPLE_URL") or DEFAULT_RTSP_SAMPLE_URL
+
 
 class BrevEnvironmentType(str, Enum):
     BREV = "brev"
@@ -287,12 +299,14 @@ class BrevEnvironment(BaseEnvironment):
             # don't rely on extended thinking, so the cost is negligible.
             # Revisit if/when the proxy accepts the field.
             ("CLAUDE_CODE_DISABLE_THINKING", "1"),
+            # Dense-captioning evals require one URL that both the Brev host
+            # and its bridge-networked RT-VLM container can reach.
+            ("RTSP_SAMPLE_URL", _resolve_rtsp_sample_url()),
         ]
         for key in (
             "NGC_CLI_API_KEY", "NVIDIA_API_KEY", "HF_TOKEN",
             "LLM_REMOTE_URL", "LLM_REMOTE_MODEL",
             "VLM_REMOTE_URL", "VLM_REMOTE_MODEL",
-            "RTSP_SAMPLE_URL",
             # Pin the eval's deploy step to the PR's actual head SHA on
             # the actual source repo — the pre-deploy script reads these
             # and resets $REPO to that SHA. Without them, the adapter's

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -292,6 +292,7 @@ class BrevEnvironment(BaseEnvironment):
             "NGC_CLI_API_KEY", "NVIDIA_API_KEY", "HF_TOKEN",
             "LLM_REMOTE_URL", "LLM_REMOTE_MODEL",
             "VLM_REMOTE_URL", "VLM_REMOTE_MODEL",
+            "RTSP_SAMPLE_URL",
             # Pin the eval's deploy step to the PR's actual head SHA on
             # the actual source repo — the pre-deploy script reads these
             # and resets $REPO to that SHA. Without them, the adapter's

--- a/.github/skill-eval/envs/tests/test_registered_node.py
+++ b/.github/skill-eval/envs/tests/test_registered_node.py
@@ -14,11 +14,13 @@ Or directly:
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 # Stub the harbor.environments.base import so brev_env is importable.
 _base = types.ModuleType("harbor.environments.base")
@@ -42,6 +44,20 @@ ENVS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ENVS_DIR))
 
 import brev_env  # noqa: E402
+
+
+class RtspSampleUrlResolution(unittest.TestCase):
+    def test_uses_public_default_when_unset(self):
+        with mock.patch.dict(os.environ, {"RTSP_SAMPLE_URL": ""}):
+            self.assertEqual(
+                brev_env._resolve_rtsp_sample_url(),
+                brev_env.DEFAULT_RTSP_SAMPLE_URL,
+            )
+
+    def test_preserves_operator_override(self):
+        custom_url = "rtsp://stream.example.test:8554/eval"
+        with mock.patch.dict(os.environ, {"RTSP_SAMPLE_URL": custom_url}):
+            self.assertEqual(brev_env._resolve_rtsp_sample_url(), custom_url)
 
 
 class RegisteredNodeDetection(unittest.TestCase):


### PR DESCRIPTION
Make the coordinator-provided stream URL available on Brev instances so RTSP evals can exercise probing and stream lifecycle checks.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
