### PR TITLE
refactor(nim/cosmos-reason-3): drop GPU-mem knobs the container never reads

### DIFF
--- a/deploy/docker/services/nim/cosmos3-reasoner/compose.yml
+++ b/deploy/docker/services/nim/cosmos3-reasoner/compose.yml
@@ -37,7 +37,6 @@ services:
       NGC_API_KEY: "${NGC_CLI_API_KEY}"
       NIM_MODEL_NAME: "${VLM_NIM_MODEL_NAME:-${VLM_CUSTOM_WEIGHTS:-}}"
       NIM_MODEL_SIZE: "${NIM_MODEL_SIZE:-nano}"
-      VLM_NIM_KVCACHE_PERCENT: "${VLM_NIM_KVCACHE_PERCENT}"
     env_file:
       - ${VSS_APPS_DIR}/services/nim/cosmos3-reasoner/hw-${HARDWARE_PROFILE}.env
       - ${VLM_ENV_FILE:-${VSS_APPS_DIR}/services/nim/fallback-override.env}

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-DGX-SPARK-shared.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-DGX-SPARK-shared.env
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NIM_KVCACHE_PERCENT=0.4
 NIM_GPU_MEMORY_UTILIZATION=0.4
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization 0.4"
 NIM_MAX_MODEL_LEN=16384
 NIM_MAX_NUM_SEQS=4
 MAX_JOBS=4

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-DGX-SPARK.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-DGX-SPARK.env
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NIM_KVCACHE_PERCENT="${VLM_NIM_KVCACHE_PERCENT}"
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization ${VLM_NIM_KVCACHE_PERCENT}"
+# The user-facing VLM_NIM_KVCACHE_PERCENT knob maps to the NIM's gpu-memory-utilization fraction.
+NIM_GPU_MEMORY_UTILIZATION="${VLM_NIM_KVCACHE_PERCENT:-0.7}"
 NIM_MAX_MODEL_LEN=32768
 NIM_MAX_NUM_SEQS=4
 NIM_DISABLE_CUDA_GRAPH=1

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-H100-shared.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-H100-shared.env
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NIM_KVCACHE_PERCENT=0.4
 NIM_GPU_MEMORY_UTILIZATION=0.4
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization 0.4"
 NIM_MAX_MODEL_LEN=32768
 NIM_MAX_NUM_SEQS=4
 MAX_JOBS=4

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-H100.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-H100.env
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NIM_KVCACHE_PERCENT="${VLM_NIM_KVCACHE_PERCENT}"
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization ${VLM_NIM_KVCACHE_PERCENT}"
+# The user-facing VLM_NIM_KVCACHE_PERCENT knob maps to the NIM's gpu-memory-utilization fraction.
+NIM_GPU_MEMORY_UTILIZATION="${VLM_NIM_KVCACHE_PERCENT:-0.7}"
 NIM_DISABLE_MM_PREPROCESSOR_CACHE=1
 NIM_DELETE_LAST_FRAMES=1
 

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-L40S.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-L40S.env
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NIM_KVCACHE_PERCENT=0.8
 NIM_GPU_MEMORY_UTILIZATION=0.8
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization 0.8"
 NIM_MAX_MODEL_LEN=32768
 NIM_MAX_NUM_SEQS=4
 MAX_JOBS=4

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-OTHER-shared.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-OTHER-shared.env
@@ -18,9 +18,7 @@
 # (identical across H100 / L40S / RTXPRO6000BW / OTHER). Re-derive via `list-model-profiles`
 # if the cosmos3-reasoner image tag changes.
 NIM_MODEL_PROFILE=e55fdb44f41441032f546360d0dcf61caa8b39fa2852d31124c03953d01e1cb3
-NIM_KVCACHE_PERCENT=0.4
 NIM_GPU_MEMORY_UTILIZATION=0.4
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization 0.4"
 NIM_MAX_MODEL_LEN=32768
 NIM_MAX_NUM_SEQS=4
 MAX_JOBS=4

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-OTHER.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-OTHER.env
@@ -18,7 +18,7 @@
 # (identical across H100 / L40S / RTXPRO6000BW / OTHER). Re-derive via `list-model-profiles`
 # if the cosmos3-reasoner image tag changes.
 NIM_MODEL_PROFILE=e55fdb44f41441032f546360d0dcf61caa8b39fa2852d31124c03953d01e1cb3
-NIM_KVCACHE_PERCENT="${VLM_NIM_KVCACHE_PERCENT}"
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization ${VLM_NIM_KVCACHE_PERCENT}"
+# The user-facing VLM_NIM_KVCACHE_PERCENT knob maps to the NIM's gpu-memory-utilization fraction.
+NIM_GPU_MEMORY_UTILIZATION="${VLM_NIM_KVCACHE_PERCENT:-0.7}"
 NIM_DISABLE_MM_PREPROCESSOR_CACHE=1
 NIM_DELETE_LAST_FRAMES=1

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-RTXPRO6000BW-shared.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-RTXPRO6000BW-shared.env
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NIM_KVCACHE_PERCENT=0.4
 NIM_GPU_MEMORY_UTILIZATION=0.4
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization 0.4"
 NIM_MAX_MODEL_LEN=32768
 NIM_MAX_NUM_SEQS=4
 MAX_JOBS=4

--- a/deploy/docker/services/nim/cosmos3-reasoner/hw-RTXPRO6000BW.env
+++ b/deploy/docker/services/nim/cosmos3-reasoner/hw-RTXPRO6000BW.env
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NIM_KVCACHE_PERCENT="${VLM_NIM_KVCACHE_PERCENT}"
-NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization ${VLM_NIM_KVCACHE_PERCENT}"
+# The user-facing VLM_NIM_KVCACHE_PERCENT knob maps to the NIM's gpu-memory-utilization fraction.
+NIM_GPU_MEMORY_UTILIZATION="${VLM_NIM_KVCACHE_PERCENT:-0.7}"
 NIM_DISABLE_MM_PREPROCESSOR_CACHE=1
 NIM_DELETE_LAST_FRAMES=1
 

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -797,6 +797,6 @@ nims:
         effect: NoSchedule
     env:
       CUDA_VISIBLE_DEVICES: '1'
-      NIM_KVCACHE_PERCENT: '0.75'
+      NIM_GPU_MEMORY_UTILIZATION: '0.75'
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: '1'
       NIM_DELETE_LAST_FRAMES: '1'

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -795,8 +795,8 @@ nims:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
+    # The cosmos3-reasoner subchart does not consume this env map — runtime env
+    # comes from the gpuProfiles.<gpuType>.cosmos3 ConfigMap. Override via
+    # nims.gpuProfiles.<gpuType>.cosmos3 instead.
     env:
       CUDA_VISIBLE_DEVICES: '1'
-      NIM_GPU_MEMORY_UTILIZATION: '0.75'
-      NIM_DISABLE_MM_PREPROCESSOR_CACHE: '1'
-      NIM_DELETE_LAST_FRAMES: '1'

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -734,6 +734,13 @@ vss-agent-ui:
 nims:
   enabled: true
   gpuType: H100
+  # Cap cosmos3 at 0.75 of the VLM GPU (device 1, co-hosted with other GPU
+  # services in this profile) — overrides the umbrella H100 profile's 0.9.
+  # Merged per-key into the rendered <cosmos3-fullname>-nim-env ConfigMap.
+  gpuProfiles:
+    H100:
+      cosmos3:
+        NIM_GPU_MEMORY_UTILIZATION: '0.75'
   global:
     # Must differ from chart root docker pull Secret name (`global.imagePullSecrets` → ngc-docker-reg-secret from templates/secrets.yaml).
     # Reusing ngc-docker-reg-secret here duplicates the same Secret in the nims subchart and breaks installs/upgrades (Helm SSA / original object errors).
@@ -796,7 +803,7 @@ nims:
         operator: Exists
         effect: NoSchedule
     # The cosmos3-reasoner subchart does not consume this env map — runtime env
-    # comes from the gpuProfiles.<gpuType>.cosmos3 ConfigMap. Override via
-    # nims.gpuProfiles.<gpuType>.cosmos3 instead.
+    # comes from the gpuProfiles.<gpuType>.cosmos3 ConfigMap (see the
+    # nims.gpuProfiles.H100.cosmos3 override above).
     env:
       CUDA_VISIBLE_DEVICES: '1'

--- a/deploy/helm/services/nims/charts/cosmos3-reasoner/templates/nim-service.yaml
+++ b/deploy/helm/services/nims/charts/cosmos3-reasoner/templates/nim-service.yaml
@@ -48,7 +48,7 @@ spec:
     - name: NIM_MODEL_PROFILE
       value: {{ .Values.nimModelProfile | quote }}
     {{- end }}
-    {{- range $key := (.Values.envConfigMapKeys | default (list "NIM_KVCACHE_PERCENT" "NIM_DISABLE_MM_PREPROCESSOR_CACHE")) }}
+    {{- range $key := (.Values.envConfigMapKeys | default (list "NIM_GPU_MEMORY_UTILIZATION" "NIM_DISABLE_MM_PREPROCESSOR_CACHE")) }}
     - name: {{ $key }}
       valueFrom:
         configMapKeyRef:

--- a/deploy/helm/services/nims/charts/cosmos3-reasoner/values.yaml
+++ b/deploy/helm/services/nims/charts/cosmos3-reasoner/values.yaml
@@ -64,18 +64,14 @@ nimModelProfile: "e55fdb44f41441032f546360d0dcf61caa8b39fa2852d31124c03953d01e1c
 
 # GPU-specific env vars. Populated by the umbrella chart via gpuProfiles lookup.
 env:
-  NIM_KVCACHE_PERCENT: "0.7"
   NIM_GPU_MEMORY_UTILIZATION: "0.7"
-  NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.7"
   NIM_MAX_MODEL_LEN: ""
   NIM_MAX_NUM_SEQS: ""
   MAX_JOBS: ""
 # Keys to import from <cosmos3-fullname>-nim-env ConfigMap into NIMService.spec.env.
 # Missing keys are skipped due to optional: true.
 envConfigMapKeys:
-  - NIM_KVCACHE_PERCENT
   - NIM_GPU_MEMORY_UTILIZATION
-  - NIM_PASSTHROUGH_ARGS
   - NIM_MAX_MODEL_LEN
   - NIM_MAX_NUM_SEQS
   - MAX_JOBS

--- a/deploy/helm/services/nims/values.yaml
+++ b/deploy/helm/services/nims/values.yaml
@@ -61,9 +61,7 @@ gpuProfiles:
       NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.7"
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
     cosmos3:
-      NIM_KVCACHE_PERCENT: "0.9"
       NIM_GPU_MEMORY_UTILIZATION: "0.9"
-      NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.7"
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
       NIM_DELETE_LAST_FRAMES: "1"
 
@@ -82,9 +80,7 @@ gpuProfiles:
       NIM_MAX_NUM_SEQS: "4"
       MAX_JOBS: "4"
     cosmos3:
-      NIM_KVCACHE_PERCENT: "0.8"
       NIM_GPU_MEMORY_UTILIZATION: "0.8"
-      NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.8"
       NIM_MAX_MODEL_LEN: "32768"
       NIM_MAX_NUM_SEQS: "4"
       MAX_JOBS: "4"
@@ -105,9 +101,7 @@ gpuProfiles:
       NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.7"
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
     cosmos3:
-      NIM_KVCACHE_PERCENT: "0.9"
       NIM_GPU_MEMORY_UTILIZATION: "0.9"
-      NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.7"
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
       NIM_DELETE_LAST_FRAMES: "1"
 
@@ -278,9 +272,7 @@ cosmos3:
   # Imported from <cosmos3-fullname>-nim-env ConfigMap into NIMService.spec.env.
   # Missing keys are ignored (optional: true).
   envConfigMapKeys:
-    - NIM_KVCACHE_PERCENT
     - NIM_GPU_MEMORY_UTILIZATION
-    - NIM_PASSTHROUGH_ARGS
     - NIM_MAX_MODEL_LEN
     - NIM_MAX_NUM_SEQS
     - MAX_JOBS

--- a/skills/vss-deploy-profile/references/base.md
+++ b/skills/vss-deploy-profile/references/base.md
@@ -108,7 +108,8 @@ The GPU-mem fraction knob is a fraction (0.0–1.0) of **total GPU VRAM** the NI
 
 > **Which env var is effective depends on the NIM's serving stack** (verified against container source, 2026-07):
 > - **LLM NIM** (`nim_llm_sdk`: nemotron / llama / gpt-oss) — `NIM_KVCACHE_PERCENT=<v>` *and* `NIM_GPU_MEM_FRACTION=<v>` (set both; version-dependent).
-> - **VLM NIM, current gen** (`nim_inference_sdk`: `cosmos3-reasoner`, `cosmos-reason2-*`) — `NIM_GPU_MEMORY_UTILIZATION=<v>` **only** (container default 0.90; an explicit value also overrides the NIM's built-in per-GPU auto-tuning). These containers ignore `NIM_KVCACHE_PERCENT`.
+> - **VLM NIM, current gen** (`nim_inference_sdk`: `cosmos3-reasoner`) — `NIM_GPU_MEMORY_UTILIZATION=<v>` **only** (container default 0.90; an explicit value also overrides the NIM's built-in per-GPU auto-tuning). The container ignores `NIM_KVCACHE_PERCENT`.
+> - **VLM NIM, `cosmos-reason2-*`** — the container is the same `nim_inference_sdk` stack and reads `NIM_GPU_MEMORY_UTILIZATION`, but the in-tree CR2 deploy files are intentionally left on the legacy keys. For Docker you can set `NIM_GPU_MEMORY_UTILIZATION` in the CR2 `hw-*.env` (`env_file` passes every key through); for Helm the `cosmos-reason2-8b` chart's `envConfigMapKeys` does **not** include it, so the value will not reach the container.
 > - **VLM NIM, legacy** (`nim_llm_sdk`: `cosmos-reason1-7b`) — `NIM_KVCACHE_PERCENT=<v>` (maps to vLLM `gpu_memory_utilization` internally).
 > - `NIM_PASSTHROUGH_ARGS` is consumed by **no** cosmos VLM container (CR1/CR2/CR3 all ignore it) — do not set it.
 >
@@ -190,7 +191,7 @@ Wait for the user to pick. **Don't silently substitute a different local model**
 
 1. **Compute** the start fraction from [Sizing math](#sizing-math). Round to 2 decimal places.
 2. **Write** it into the env file the resolved compose will load. The path is `deploy/docker/services/nim/<model-slug>/hw-<HARDWARE_PROFILE>(-shared).env` — pick or create whichever `HARDWARE_PROFILE` label fits (use the host's actual profile for documentation value, or `OTHER` if none matches and you're not contributing back).
-   - **LLM NIM**: `NIM_KVCACHE_PERCENT=<v>` **and** `NIM_GPU_MEM_FRACTION=<v>`. **VLM NIM**: `NIM_GPU_MEMORY_UTILIZATION=<v>` for current-gen cosmos (`cosmos3-reasoner`, `cosmos-reason2-*`), `NIM_KVCACHE_PERCENT=<v>` for legacy `cosmos-reason1-7b`. Also set `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` if you need to constrain context/concurrency.
+   - **LLM NIM**: `NIM_KVCACHE_PERCENT=<v>` **and** `NIM_GPU_MEM_FRACTION=<v>`. **VLM NIM**: `NIM_GPU_MEMORY_UTILIZATION=<v>` for `cosmos3-reasoner`, `NIM_KVCACHE_PERCENT=<v>` for legacy `cosmos-reason1-7b` (for `cosmos-reason2-*` see the stack table caveat above). Also set `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` if you need to constrain context/concurrency.
    - vLLM: edit the model's `compose.yml` to set `--gpu-memory-utilization <value>` (or pass through an env var if the compose supports it)
 3. **Re-resolve and deploy**: `docker compose --env-file <env> config > resolved.yml && docker compose --env-file <env> -f resolved.yml up -d`. `--env-file` is required on `up` too — without it `COMPOSE_PROFILES` is unset and `up` exits 0 with zero services (see `SKILL.md` Step 5). Before running `up -d`, verify `resolved.yml` includes the right LLM/VLM service for your `LLM_NAME_SLUG` / `VLM_NAME_SLUG` and that the sizing values you wrote are visible in its `environment:` block.
 4. **Watch container logs** for the KV-cache report on startup (NIM logs `KV cache size: X GB` once it boots; vLLM logs `Maximum concurrency for X tokens per GPU: Y x`):
@@ -234,7 +235,7 @@ If yes (NGC catalog has an `nvcr.io/nim/<org>/<model>:<tag>` image): create a ne
 1. Create `deploy/docker/services/nim/<your-slug>/compose.yml` modeled on `cosmos-reason2-8b/compose.yml`. Two services:
    - `<your-slug>` with `profiles: [llm_local_<slug>]` (or `vlm_local_<slug>`) and the dedicated-GPU device assignment.
    - `<your-slug>-shared-gpu` with `profiles: [llm_local_shared_<slug>]` (or `vlm_local_shared_<slug>`) and `device_ids: ["${SHARED_LLM_VLM_DEVICE_ID:-${LLM_DEVICE_ID:-0}}"]`.
-2. Add `hw-<HARDWARE_PROFILE>.env` and `hw-<HARDWARE_PROFILE>-shared.env` files. Compute the starting fraction from the formula in [Sizing math](#sizing-math). Set the stack's effective knob per the table above: **LLM** → `NIM_KVCACHE_PERCENT=<v>` and `NIM_GPU_MEM_FRACTION=<v>`; **VLM** → `NIM_GPU_MEMORY_UTILIZATION=<v>` (current-gen cosmos) or `NIM_KVCACHE_PERCENT=<v>` (legacy `cosmos-reason1-7b`). Add `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` per the model's documented limits.
+2. Add `hw-<HARDWARE_PROFILE>.env` and `hw-<HARDWARE_PROFILE>-shared.env` files. Compute the starting fraction from the formula in [Sizing math](#sizing-math). Set the stack's effective knob per the table above: **LLM** → `NIM_KVCACHE_PERCENT=<v>` and `NIM_GPU_MEM_FRACTION=<v>`; **VLM** → `NIM_GPU_MEMORY_UTILIZATION=<v>` (`cosmos3-reasoner`) or `NIM_KVCACHE_PERCENT=<v>` (legacy `cosmos-reason1-7b`). Add `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` per the model's documented limits.
 3. Add the new compose file to the `include:` list in `deploy/docker/services/nim/compose.yml`.
 4. Edit `dev-profile-base/generated.env` to set `LLM_NAME` / `LLM_NAME_SLUG` (or VLM equivalents).
 5. Run the [Tuning workflow](#tuning-workflow) above.

--- a/skills/vss-deploy-profile/references/base.md
+++ b/skills/vss-deploy-profile/references/base.md
@@ -97,20 +97,22 @@ fits_shared    = total_GB(LLM) + total_GB(VLM)
 
 # In single-GPU shared mode, KV / GPU-mem fraction per service:
 fraction       = (this_num_params / total_num_params) × 0.85
-# Set this in NIM_KVCACHE_PERCENT (NIMs) and --gpu-memory-utilization (vLLM/DLFW).
+# Set this in the NIM's effective GPU-mem knob (see table below) or --gpu-memory-utilization (vLLM/DLFW).
 ```
 
 `bits_per_param` = 16 for FP16/BF16, 8 for FP8/INT8, 4 for INT4/MXFP4.
 
 ### `NIM_KVCACHE_PERCENT` ↔ GB on common GPUs
 
-`NIM_KVCACHE_PERCENT` is a fraction (0.0–1.0) of **total GPU VRAM** the NIM container is allowed to consume (weights + KV cache + activations all included). For vLLM containers, the same fraction is `--gpu-memory-utilization`.
+The GPU-mem fraction knob is a fraction (0.0–1.0) of **total GPU VRAM** the NIM container is allowed to consume (weights + KV cache + activations all included). For vLLM containers, the same fraction is `--gpu-memory-utilization`.
 
-> **NIM 2.x renames the knob.** Set both forms in every `hw-*.env` so the deploy works on either major version:
-> - **LLM NIM** — `NIM_KVCACHE_PERCENT=<v>` *and* `NIM_GPU_MEM_FRACTION=<v>`.
-> - **VLM NIM** — `NIM_KVCACHE_PERCENT=<v>` *and* `NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization <v>"`.
+> **Which env var is effective depends on the NIM's serving stack** (verified against container source, 2026-07):
+> - **LLM NIM** (`nim_llm_sdk`: nemotron / llama / gpt-oss) — `NIM_KVCACHE_PERCENT=<v>` *and* `NIM_GPU_MEM_FRACTION=<v>` (set both; version-dependent).
+> - **VLM NIM, current gen** (`nim_inference_sdk`: `cosmos3-reasoner`, `cosmos-reason2-*`) — `NIM_GPU_MEMORY_UTILIZATION=<v>` **only** (container default 0.90; an explicit value also overrides the NIM's built-in per-GPU auto-tuning). These containers ignore `NIM_KVCACHE_PERCENT`.
+> - **VLM NIM, legacy** (`nim_llm_sdk`: `cosmos-reason1-7b`) — `NIM_KVCACHE_PERCENT=<v>` (maps to vLLM `gpu_memory_utilization` internally).
+> - `NIM_PASSTHROUGH_ARGS` is consumed by **no** cosmos VLM container (CR1/CR2/CR3 all ignore it) — do not set it.
 >
-> The rest of this doc uses `NIM_KVCACHE_PERCENT` for brevity; mirror the value into the matching 2.x form per the table above.
+> The rest of this doc uses `NIM_KVCACHE_PERCENT` for brevity; write the value into the stack's effective knob per the table above.
 
 | Fraction | H100 / A100-80 (80 GB) | H200 (141 GB) | RTX PRO 6000 (96 GB) | GB10 / Thor (128 GB) | L40S (48 GB) |
 |---|---|---|---|---|---|
@@ -127,8 +129,8 @@ Read this as: at `NIM_KVCACHE_PERCENT=0.7` on an H100, the NIM is allowed 56 GB 
 ```text
 H100 max safe shared budget = 0.85 × 80 GB = 68 GB
 
-LLM fraction = 0.40  →  NIM_KVCACHE_PERCENT=0.40  →  32 GB cap
-VLM fraction = 0.40  →  NIM_KVCACHE_PERCENT=0.40  →  32 GB cap
+LLM fraction = 0.40  →  NIM_KVCACHE_PERCENT=0.40           →  32 GB cap
+VLM fraction = 0.40  →  NIM_GPU_MEMORY_UTILIZATION=0.40    →  32 GB cap  (cosmos3-reasoner)
 
 shared check: 32 + 32 = 64 GB ≤ 68 GB ✓ fits
 reserved     = 1 - (0.40 + 0.40) = 0.20  (framework/CUDA buffer)
@@ -188,7 +190,7 @@ Wait for the user to pick. **Don't silently substitute a different local model**
 
 1. **Compute** the start fraction from [Sizing math](#sizing-math). Round to 2 decimal places.
 2. **Write** it into the env file the resolved compose will load. The path is `deploy/docker/services/nim/<model-slug>/hw-<HARDWARE_PROFILE>(-shared).env` — pick or create whichever `HARDWARE_PROFILE` label fits (use the host's actual profile for documentation value, or `OTHER` if none matches and you're not contributing back).
-   - **LLM NIM**: `NIM_KVCACHE_PERCENT=<v>` **and** `NIM_GPU_MEM_FRACTION=<v>`. **VLM NIM**: `NIM_KVCACHE_PERCENT=<v>` **and** `NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization <v>"`. Also set `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` if you need to constrain context/concurrency.
+   - **LLM NIM**: `NIM_KVCACHE_PERCENT=<v>` **and** `NIM_GPU_MEM_FRACTION=<v>`. **VLM NIM**: `NIM_GPU_MEMORY_UTILIZATION=<v>` for current-gen cosmos (`cosmos3-reasoner`, `cosmos-reason2-*`), `NIM_KVCACHE_PERCENT=<v>` for legacy `cosmos-reason1-7b`. Also set `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` if you need to constrain context/concurrency.
    - vLLM: edit the model's `compose.yml` to set `--gpu-memory-utilization <value>` (or pass through an env var if the compose supports it)
 3. **Re-resolve and deploy**: `docker compose --env-file <env> config > resolved.yml && docker compose --env-file <env> -f resolved.yml up -d`. `--env-file` is required on `up` too — without it `COMPOSE_PROFILES` is unset and `up` exits 0 with zero services (see `SKILL.md` Step 5). Before running `up -d`, verify `resolved.yml` includes the right LLM/VLM service for your `LLM_NAME_SLUG` / `VLM_NAME_SLUG` and that the sizing values you wrote are visible in its `environment:` block.
 4. **Watch container logs** for the KV-cache report on startup (NIM logs `KV cache size: X GB` once it boots; vLLM logs `Maximum concurrency for X tokens per GPU: Y x`):
@@ -232,7 +234,7 @@ If yes (NGC catalog has an `nvcr.io/nim/<org>/<model>:<tag>` image): create a ne
 1. Create `deploy/docker/services/nim/<your-slug>/compose.yml` modeled on `cosmos-reason2-8b/compose.yml`. Two services:
    - `<your-slug>` with `profiles: [llm_local_<slug>]` (or `vlm_local_<slug>`) and the dedicated-GPU device assignment.
    - `<your-slug>-shared-gpu` with `profiles: [llm_local_shared_<slug>]` (or `vlm_local_shared_<slug>`) and `device_ids: ["${SHARED_LLM_VLM_DEVICE_ID:-${LLM_DEVICE_ID:-0}}"]`.
-2. Add `hw-<HARDWARE_PROFILE>.env` and `hw-<HARDWARE_PROFILE>-shared.env` files. Compute the starting fraction from the formula in [Sizing math](#sizing-math). Set both forms per the v1.x↔v2.x table above: **LLM** → `NIM_KVCACHE_PERCENT=<v>` and `NIM_GPU_MEM_FRACTION=<v>`; **VLM** → `NIM_KVCACHE_PERCENT=<v>` and `NIM_PASSTHROUGH_ARGS="--gpu-memory-utilization <v>"`. Add `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` per the model's documented limits.
+2. Add `hw-<HARDWARE_PROFILE>.env` and `hw-<HARDWARE_PROFILE>-shared.env` files. Compute the starting fraction from the formula in [Sizing math](#sizing-math). Set the stack's effective knob per the table above: **LLM** → `NIM_KVCACHE_PERCENT=<v>` and `NIM_GPU_MEM_FRACTION=<v>`; **VLM** → `NIM_GPU_MEMORY_UTILIZATION=<v>` (current-gen cosmos) or `NIM_KVCACHE_PERCENT=<v>` (legacy `cosmos-reason1-7b`). Add `NIM_MAX_MODEL_LEN` and `NIM_MAX_NUM_SEQS` per the model's documented limits.
 3. Add the new compose file to the `include:` list in `deploy/docker/services/nim/compose.yml`.
 4. Edit `dev-profile-base/generated.env` to set `LLM_NAME` / `LLM_NAME_SLUG` (or VLM equivalents).
 5. Run the [Tuning workflow](#tuning-workflow) above.

--- a/skills/vss-deploy-profile/references/base.md
+++ b/skills/vss-deploy-profile/references/base.md
@@ -111,7 +111,7 @@ The GPU-mem fraction knob is a fraction (0.0–1.0) of **total GPU VRAM** the NI
 > - **VLM NIM, current gen** (`nim_inference_sdk`: `cosmos3-reasoner`) — `NIM_GPU_MEMORY_UTILIZATION=<v>` **only** (container default 0.90; an explicit value also overrides the NIM's built-in per-GPU auto-tuning). The container ignores `NIM_KVCACHE_PERCENT`.
 > - **VLM NIM, `cosmos-reason2-*`** — the container is the same `nim_inference_sdk` stack and reads `NIM_GPU_MEMORY_UTILIZATION`, but the in-tree CR2 deploy files are intentionally left on the legacy keys. For Docker you can set `NIM_GPU_MEMORY_UTILIZATION` in the CR2 `hw-*.env` (`env_file` passes every key through); for Helm the `cosmos-reason2-8b` chart's `envConfigMapKeys` does **not** include it, so the value will not reach the container.
 > - **VLM NIM, legacy** (`nim_llm_sdk`: `cosmos-reason1-7b`) — `NIM_KVCACHE_PERCENT=<v>` (maps to vLLM `gpu_memory_utilization` internally).
-> - `NIM_PASSTHROUGH_ARGS` is consumed by **no** cosmos VLM container (CR1/CR2/CR3 all ignore it) — do not set it.
+> - `NIM_PASSTHROUGH_ARGS` is consumed by **no** cosmos VLM container (CR1/CR2/CR3 all ignore it) — do not set it in new configs. The in-tree CR1/CR2 files still carry it; it is inert there and intentionally left untouched.
 >
 > The rest of this doc uses `NIM_KVCACHE_PERCENT` for brevity; write the value into the stack's effective knob per the table above.
 
@@ -306,7 +306,7 @@ Then add the file to `nim/compose.yml`'s `include:` list and edit `dev-profile-b
 
 For shared mode, compute it via the formula. As sanity-check defaults / in-tree precedents:
 
-| Co-residency | LLM `--gpu-memory-utilization` | VLM `NIM_KVCACHE_PERCENT` | Source |
+| Co-residency | LLM `--gpu-memory-utilization` | VLM GPU-mem fraction (effective knob per the [stack table](#nim_kvcache_percent--gb-on-common-gpus)) | Source |
 |---|---|---|---|
 | Nano 9B v2 + Cosmos3 Reasoner Nano BF16 (shared) | 0.40 | 0.40 | Cosmos3 `*-shared.env` |
 | DGX Spark Nano 9B NIM + Cosmos3 Reasoner Nano BF16 on DGX Spark | 0.40 | 0.40 | `edge.md` standalone NIM recipe |

--- a/skills/vss-deploy-profile/references/ngc.md
+++ b/skills/vss-deploy-profile/references/ngc.md
@@ -1,15 +1,10 @@
----
-name: ngc
-description: Install, configure, or verify NVIDIA NGC CLI and API key access. Use when NGC CLI is missing, the NGC API key needs to be set or tested, or NGC resource access fails.
----
-
 # NGC CLI — Install, Configure, Verify
 
 Manages NVIDIA NGC CLI setup and API key access. Required before deploying any VSS profile.
 
 ## When to Use
 
-Use this skill when:
+Use this reference when:
 
 - NGC CLI is not installed (`ngc: command not found`)
 - NGC API key is missing or needs to be verified

--- a/skills/vss-deploy-profile/references/prerequisites.md
+++ b/skills/vss-deploy-profile/references/prerequisites.md
@@ -1,12 +1,7 @@
----
-name: vss-prerequisites
-description: Check VSS system prerequisites — GPU driver, Docker, NVIDIA Container Toolkit, and NGC access. Use when troubleshooting a deploy failure, after a system change, or to verify the system is ready for VSS.
----
-
 # VSS Prerequisites Check
 <a id="preflight"></a>
 
-Verifies system readiness for any VSS developer profile. For NGC CLI setup specifically, use the `ngc` skill.
+Verifies system readiness for any VSS developer profile. For NGC CLI setup specifically, see [`ngc.md`](ngc.md).
 
 ## Preflight — quick reference
 
@@ -60,7 +55,7 @@ fi
 
 ## When to Use
 
-Use this skill when:
+Use this reference when:
 
 - A VSS deploy failed and you need to diagnose why
 - User asks to verify GPU, Docker, or system setup


### PR DESCRIPTION
## Summary

Follow-up to #773. I extracted and traced the env-var handling in the actual container source of `nvcr.io/nim/nvidia/cosmos3-reasoner:1.7` (and the newest staging `1.7.1.rc3`): the launch path (`/opt/nim/inference.py` + `nim_inference_sdk` vLLM backend) consumes **`NIM_GPU_MEMORY_UTILIZATION`** and **`NIM_DISABLE_MM_PREPROCESSOR_CACHE`**, but has **zero references** to `NIM_KVCACHE_PERCENT` (a cosmos-reason1-7b / `nim_llm_sdk`-era knob) or `NIM_PASSTHROUGH_ARGS` (consumed by no cosmos VLM container of any generation). This PR removes the dead knobs from every cosmos3-reasoner deployment path and fixes the deploy-skill guidance that prescribed them.

## Changes

- **Docker env files** (`hw-*.env`): drop `NIM_KVCACHE_PERCENT` and `NIM_PASSTHROUGH_ARGS`. Dedicated (non-shared) profiles now map the user-facing `VLM_NIM_KVCACHE_PERCENT` knob to `NIM_GPU_MEMORY_UTILIZATION` (default 0.7).
- **compose.yml**: drop the `VLM_NIM_KVCACHE_PERCENT` container env entry (unused inside the container).
- **Helm**: remove the dead keys from `gpuProfiles.*.cosmos3`, the subchart env defaults, and both `envConfigMapKeys` lists; update the template fallback list and the dev-profile-search override (`NIM_KVCACHE_PERCENT` -> `NIM_GPU_MEMORY_UTILIZATION`).
- **skills/vss-deploy-profile/references/base.md**: replace the incorrect "NIM 2.x renames the knob" note (there is no 2.x cosmos NIM; `NIM_PASSTHROUGH_ARGS` never worked) with a verified per-stack table: current-gen VLM NIMs (`cosmos3-reasoner`, `cosmos-reason2-*`) -> `NIM_GPU_MEMORY_UTILIZATION`; legacy `cosmos-reason1-7b` -> `NIM_KVCACHE_PERCENT`.

## Behavior change (intentional)

Dedicated (non-shared) cosmos3 profiles previously ran at the NIM's built-in **0.90** default because `VLM_NIM_KVCACHE_PERCENT` landed only in dead vars. They now honor the knob and default to **0.7** (matching the documented dedicated-VLM default). Shared profiles keep their effective values (0.4/0.8) — no change there.

Out of scope: `cosmos-reason2-8b` and `cosmos-reason1-7b` deploy files are **intentionally left unchanged** (legacy paths kept as-is); the deploy-skill doc documents the CR2 caveat instead.

## Validation

- `docker compose config` resolves correctly for all hardware profiles, dedicated + shared; the knob override propagates (`VLM_NIM_KVCACHE_PERCENT=0.55` -> `NIM_GPU_MEMORY_UTILIZATION: 0.55`).
- `helm lint` passes; `helm template --set cosmos3.enabled=true --set gpuType=H100` renders the ConfigMap and NIMService env with only live keys.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

