### PR TITLE
fix(skills): bump vss-summarize-video metadata version to 3.2.1

### DIFF
--- a/skills/vss-summarize-video/SKILL.md
+++ b/skills/vss-summarize-video/SKILL.md
@@ -3,7 +3,7 @@ name: vss-summarize-video
 description: Use to summarize a recorded video via the LVS summarization microservice (HITL-gated) with a VLM fallback. Not for report generation or live RTSP captioning.
 license: Apache-2.0
 metadata:
-  version: "3.2.0"
+  version: "3.2.1"
   author: "NVIDIA Video Search and Summarization team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"

--- a/skills/vss-summarize-video/skill-card.md
+++ b/skills/vss-summarize-video/skill-card.md
@@ -73,7 +73,7 @@ Underlying evaluation signals used in this run: <br>
 | Efficiency | 1 | 90% (+19%) | 83% (+7%) |
 
 ## Skill Version(s): <br>
-3.2.0 (source: frontmatter) <br>
+3.2.1 (source: frontmatter) <br>
 
 ## Ethical Considerations: <br>
 NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>


### PR DESCRIPTION
## Description
bump vss-summarize-video metadata version to 3.2.1
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
