### PR TITLE
Update RTVI VLM chart and skill to 3.2.1

### DIFF
--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/Chart.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v2
 name: vss-rtvi-vlm
-version: 3.2.0
+version: 3.2.1
 appVersion: "1.0"
 description: RTVI VLM microservice for alerts real-time mode (2d_vlm)
 maintainers: []

--- a/skills/vss-deploy-dense-captioning/SKILL.md
+++ b/skills/vss-deploy-dense-captioning/SKILL.md
@@ -3,7 +3,7 @@ name: vss-deploy-dense-captioning
 description: Use this skill when deploying standalone RT-VLM dense captioning or calling its REST API (uploads, captions, streams, chat-completions, Kafka). Not for VSS profile deploy or video-search ingestion.
 license: Apache-2.0
 metadata:
-  version: "3.2.0"
+  version: "3.2.1"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational deployment"
 ---

--- a/skills/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
+++ b/skills/vss-deploy-dense-captioning/references/deploy-rt-vlm-service.md
@@ -11,7 +11,7 @@
 Derive `<compose-default>` from the checked-out
 `deploy/docker/services/rtvi/rtvi-vlm/rtvi-vlm-docker-compose.yml` instead of
 hardcoding it in commands. The current `develop` compose default is
-`3.2.0`; Spark, GB10, and SBSA-class platforms append `-sbsa`. All other
+`3.2.1`; Spark, GB10, and SBSA-class platforms append `-sbsa`. All other
 platforms use the normal multiarch tag.
 
 Real-Time VLM is VSS's streaming vision-language inference service: RTSP decode →

--- a/skills/vss-deploy-dense-captioning/skill-card.md
+++ b/skills/vss-deploy-dense-captioning/skill-card.md
@@ -70,7 +70,7 @@ Underlying evaluation signals used in this run: <br>
 | Efficiency | 4 | 66% (+8%) | 46% (+10%) |
 
 ## Skill Version(s): <br>
-3.2.0 (source: frontmatter) <br>
+3.2.1 (source: frontmatter) <br>
 
 ## Ethical Considerations: <br>
 NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
