### PR TITLE
fix: send x-stream-id header on RTVI-CV /stream/remove

### DIFF
--- a/services/agent/src/vss_agents/api/video_delete.py
+++ b/services/agent/src/vss_agents/api/video_delete.py
@@ -120,7 +120,10 @@ async def _remove_from_rtvi_cv(
     logger.info(f"Removing from RTVI-CV: POST {url}")
 
     try:
-        response = await client.post(url, json=payload)
+        # `x-stream-id` is the consistent-hash routing key for multi-replica
+        # RTVI-CV deployments — it must match the header sent on /stream/add
+        # so the remove lands on the pod that owns the stream.
+        response = await client.post(url, json=payload, headers={"x-stream-id": sensor_id})
         if response.status_code in (200, 201, 204):
             logger.info("RTVI-CV stream removed: %s", scrub_log(sensor_id))
             return True, "OK"

--- a/services/agent/tests/unit_test/api/test_video_delete.py
+++ b/services/agent/tests/unit_test/api/test_video_delete.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for video_delete module.
+
+Covers the RTVI-CV cleanup helper used by ``DELETE /api/v1/videos/{video_id}``.
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from vss_agents.api.video_delete import _remove_from_rtvi_cv
+
+
+class TestRemoveFromRtviCv:
+    """Test _remove_from_rtvi_cv function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_remove_sends_stream_routing_header(self):
+        """The remove request must carry ``x-stream-id`` so consistent-hash
+        routing lands it on the RTVI-CV pod that owns the stream (nvbug 6455296)."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        success, msg = await _remove_from_rtvi_cv(mock_client, "http://rtvi-cv:9000", "sensor-123", "camera-1")
+
+        assert success is True
+        assert msg == "OK"
+        mock_client.post.assert_called_once_with(
+            "http://rtvi-cv:9000/api/v1/stream/remove",
+            json={
+                "key": "sensor",
+                "value": {
+                    "camera_id": "sensor-123",
+                    "camera_name": "camera-1",
+                    "camera_url": "",
+                    "change": "camera_remove",
+                    "metadata": {"resolution": "1920x1080", "codec": "h264", "framerate": 30},
+                },
+                "headers": {"source": "vst"},
+            },
+            headers={"x-stream-id": "sensor-123"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_not_configured(self):
+        mock_client = MagicMock()
+
+        success, msg = await _remove_from_rtvi_cv(mock_client, "", "sensor-123", "camera-1")
+
+        assert success is True
+        assert "Skipped" in msg
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_reports_failure(self):
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "internal error"
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        success, msg = await _remove_from_rtvi_cv(mock_client, "http://rtvi-cv:9000", "sensor-123", "camera-1")
+
+        assert success is False
+        assert "500" in msg
+
+    @pytest.mark.asyncio
+    async def test_network_error_reports_failure(self):
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(side_effect=ConnectionError("boom"))
+
+        success, msg = await _remove_from_rtvi_cv(mock_client, "http://rtvi-cv:9000", "sensor-123", "camera-1")
+
+        assert success is False
+        assert "boom" in msg


### PR DESCRIPTION
## Summary

The video delete endpoint (`DELETE /api/v1/videos/{video_id}`) called RTVI-CV `POST /api/v1/stream/remove` without the `x-stream-id` routing header. On multi-replica RTVI-CV deployments behind HAProxy Ingress with consistent-hash routing, the ingress injects a random `uuid()` when the header is missing, so the remove request lands on a random pod instead of the pod that owns the stream — silently orphaning streams (and their GPU / DeepStream pipeline resources) on the original pod.

The `/stream/add` path already sends this header (`video_ingest.py`), as do all RTSP ingest/delete paths. This change makes the remove path consistent.

Fixes NVBUG 6455296.

## Changes
- `services/agent/src/vss_agents/api/video_delete.py`: send `headers={"x-stream-id": sensor_id}` on the RTVI-CV remove POST.
- `services/agent/tests/unit_test/api/test_video_delete.py` (new): unit tests for `_remove_from_rtvi_cv`, pinning the URL/payload/header contract.

## Testing
- `uv run pytest tests/unit_test/api` — 178 passed.
- Pre-commit hooks (ruff, mypy, SPDX, DCO, TruffleHog) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)