### PR TITLE
feat(helm): expose ingest file-size limits via values.yaml

### DIFF
--- a/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
@@ -220,6 +220,8 @@ spec:
               value: "10"
             - name: ASSET_DOWNLOAD_TOTAL_TIMEOUT
               value: "300"
+            - name: ASSET_DOWNLOAD_MAX_FILE_SIZE_GB
+              value: {{ .Values.assetDownloadMaxFileSizeGb | default 8 | quote }}
             - name: ERROR_MESSAGE_TOPIC
               value: "vision-embed-errors"
           startupProbe:

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/values.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/values.yaml
@@ -83,6 +83,8 @@ installProprietaryCodes: false
 rtspReconnectionInterval: "5"
 rtspReconnectionMaxAttempts: "10"
 rtspReconnectionWindow: "60"
+# Max HTTP/data-URI asset download size in GB (ASSET_DOWNLOAD_MAX_FILE_SIZE_GB). Increase for large corpus videos.
+assetDownloadMaxFileSizeGb: 8
 startupProbe:
   initialDelaySeconds: 240
   periodSeconds: 30

--- a/deploy/helm/services/vios/charts/vios-ingress/configs/nginx-vst.conf.template
+++ b/deploy/helm/services/vios/charts/vios-ingress/configs/nginx-vst.conf.template
@@ -53,7 +53,7 @@ http {
                           '$status rt:$request_time ut:$upstream_response_time '
                           'up:$upstream_addr us:$upstream_status';
     
-    client_max_body_size 25G;
+    client_max_body_size {{ .Values.clientMaxBodySize | default "25G" }};
 
     # WebSocket proxy settings
     map $http_upgrade $connection_upgrade {

--- a/deploy/helm/services/vios/charts/vios-ingress/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-ingress/values.yaml
@@ -47,6 +47,8 @@ hostIpFollowsExternallyAccessibleIp: false
 # Empty: use global.externalHost, then 127.0.0.1 for EXTERNALLY_ACCESSIBLE_IP only.
 externallyAccessibleIp: ""
 vstIngressHttpPort: "30888"
+# Nginx upload limit for VST ingest (client_max_body_size). Increase for large video uploads (e.g. 20G).
+clientMaxBodySize: "25G"
 # Sensor API backend. Empty = use Release.Name-vss-vios-sensor:30000 (e.g. vss-alerts-vss-vios-sensor:30000).
 # Override if sensor API is elsewhere (e.g. nvstreamer in minimal setups).
 sensorUpstream: ""


### PR DESCRIPTION
## Summary
Expose two ingest path limits via Helm values so large video uploads (20GB/50GB)
work without post-deploy kubectl patches.
- `vios.vss-vios-ingress.clientMaxBodySize` → nginx `client_max_body_size`
- `rtvi.vss-rtvi-embed.assetDownloadMaxFileSizeGb` → `ASSET_DOWNLOAD_MAX_FILE_SIZE_GB`