### PR TITLE
Bump RTVI-CV-3D skill to 3.2.1

### DIFF
--- a/skills/vss-deploy-detection-tracking-3d/SKILL.md
+++ b/skills/vss-deploy-detection-tracking-3d/SKILL.md
@@ -9,7 +9,7 @@ description: >
   `vss-deploy-detection-tracking-2d` for single-camera 2D detection.
 license: Apache-2.0
 metadata:
-  version: "3.2.0"
+  version: "3.2.1"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint rtvi-cv-3d mv3dt detection tracking 3d warehouse"
 ---

--- a/skills/vss-deploy-detection-tracking-3d/skill-card.md
+++ b/skills/vss-deploy-detection-tracking-3d/skill-card.md
@@ -73,7 +73,7 @@ Underlying evaluation signals used in this run: <br>
 | Efficiency | 3 | 82% (+52%) | 60% (+22%) |
 
 ## Skill Version(s): <br>
-3.2.0 (source: frontmatter) <br>
+3.2.1 (source: frontmatter) <br>
 
 ## Ethical Considerations: <br>
 NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>


### PR DESCRIPTION
## Description
Bump the RTVI-CV-3D skill version from 3.2.0 to 3.2.1.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
