### PR TITLE
Add AAC audio decode support for WebRTC-live

### DIFF
--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -193,6 +193,7 @@ for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
+      libswscale7 libpostproc57 \
       libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \
       libde265-dev libde265-0 libx265-199 libx264-164 libmpeg2encpp-2.1-0 libmpeg2-4 \
       libmpg123-0 libbs2b0 libreadline8 libcdio19 libdca0 libdvdnav4 libmjpegutils-2.1-0 \

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -188,6 +188,7 @@ for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
+      libswscale7 libpostproc57 \
       libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \
       libde265-dev libde265-0 libx265-199 libx264-164 libmpeg2encpp-2.1-0 libmpeg2-4 \
       libmpg123-0 libbs2b0 libreadline8 libcdio19 libdca0 libdvdnav4 libmjpegutils-2.1-0 \

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.cpp
@@ -458,6 +458,18 @@ int GstNvAudioDecoder::create (bool blocking)
     {
         LOG (error) << "Gstreamer element creation failed (isAac=" << isAac
                     << ", aacparse/decodebin available?) for uri = " << m_uri << endl;
+        /* None of these are parented to the bin yet (gst_bin_add_many runs
+        ** below), so destroy() -- which only unrefs m_pipeline -- would leak
+        ** every other created element. Unref the ones that got made here. */
+        for (GstElement** e : { &m_pipeline, &m_source, &m_decoder, &m_parser,
+                                &m_audioconvert, &m_capsfilter, &m_sink })
+        {
+            if (*e)
+            {
+                gst_object_unref (*e);
+                *e = nullptr;
+            }
+        }
         return -1;
     }
 

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.cpp
@@ -151,7 +151,11 @@ static GstBusSyncReply audio_bus_sync_handler (GstBus* /*bus*/, GstMessage* msg,
         if (err) g_error_free (err);
         g_free (dbg);
     }
-    return GST_BUS_PASS;
+    /* Drop (free) every message after logging. Nothing polls this bus -- there is
+    ** no gst_bus_add_watch/GMainLoop -- so returning GST_BUS_PASS would queue each
+    ** message on the async queue with no consumer, leaking memory for a long-lived
+    ** RTSP stream. GST_BUS_DROP frees the message immediately. */
+    return GST_BUS_DROP;
 }
 
 static void on_pad_added (GstElement *element, GstPad *pad, void *data)

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.cpp
@@ -127,6 +127,33 @@ on_new_sample_from_sink (GstElement * appsink, GstNvAudioDecoder* nvAudioDecoder
     return GST_FLOW_OK;
 }
 
+/* Surface audio-pipeline errors/warnings that would otherwise be swallowed (the
+** audio decode pipeline had no bus watch, so a failing AAC decoder produced
+** silence with no visible cause). Sync handler: runs on the posting thread,
+** needs no GMainLoop. */
+static GstBusSyncReply audio_bus_sync_handler (GstBus* /*bus*/, GstMessage* msg, gpointer /*user_data*/)
+{
+    if (GST_MESSAGE_TYPE (msg) == GST_MESSAGE_ERROR)
+    {
+        GError* err = nullptr; gchar* dbg = nullptr;
+        gst_message_parse_error (msg, &err, &dbg);
+        LOG(error) << "Audio Decoder: pipeline ERROR from " << GST_OBJECT_NAME (msg->src)
+                   << ": " << (err ? err->message : "?") << " | " << (dbg ? dbg : "") << endl;
+        if (err) g_error_free (err);
+        g_free (dbg);
+    }
+    else if (GST_MESSAGE_TYPE (msg) == GST_MESSAGE_WARNING)
+    {
+        GError* err = nullptr; gchar* dbg = nullptr;
+        gst_message_parse_warning (msg, &err, &dbg);
+        LOG(warning) << "Audio Decoder: pipeline WARNING from " << GST_OBJECT_NAME (msg->src)
+                     << ": " << (err ? err->message : "?") << " | " << (dbg ? dbg : "") << endl;
+        if (err) g_error_free (err);
+        g_free (dbg);
+    }
+    return GST_BUS_PASS;
+}
+
 static void on_pad_added (GstElement *element, GstPad *pad, void *data)
 {
     GstElement *element2 = (GstElement *)data;
@@ -134,27 +161,36 @@ static void on_pad_added (GstElement *element, GstPad *pad, void *data)
     GstCaps *caps = nullptr;
     gchar *capsString = nullptr;
 
+    /* decodebin exposes the decoder src pad before caps are negotiated for some
+    ** decoders (e.g. avdec_aac negotiates lazily), so current caps can be NULL
+    ** here. Fall back to the pad's queryable caps so we can still identify an
+    ** audio pad. */
     caps = gst_pad_get_current_caps (pad);
-    capsString = gst_caps_to_string (caps);
-    sink_pad = gst_element_get_static_pad (element2, "sink");
-    LOG (info) << "Caps = " << capsString << endl;
-
-    /* Try to link pads only if format is audio */
-    if (g_strrstr(capsString, "audio"))
+    if (caps == nullptr)
     {
-        /* Check if sink_pad exists */
+        caps = gst_pad_query_caps (pad, nullptr);
+    }
+    capsString = caps ? gst_caps_to_string (caps) : nullptr;
+    sink_pad = gst_element_get_static_pad (element2, "sink");
+    LOG (info) << "Caps = " << (capsString ? capsString : "NULL") << endl;
+
+    /* This decodebin is fed audio-only caps (audio/x-mulaw or audio/mpeg), so
+    ** its only src pad is the decoded audio. Link when caps confirm audio, and
+    ** also when caps are still unresolved - refusing to link a not-yet-negotiated
+    ** pad would leave the audio path dangling and drop audio entirely. */
+    bool isAudio = (capsString != nullptr) && (g_strrstr (capsString, "audio") != nullptr);
+    if (isAudio || capsString == nullptr)
+    {
         if (!sink_pad)
         {
             LOG(error) << "Failed to get sink pad of element." << endl;
             GST_ELEMENT_ERROR(element2, STREAM, FAILED, ("Failed to get sink pad of element."), (nullptr));
-            if (caps != nullptr)
-            {
-                gst_caps_unref (caps);
-            }
-            goto _exit;
         }
-        /* Check if pads can be linked */
-        if (gst_pad_link (pad, sink_pad) != GST_PAD_LINK_OK)
+        else if (gst_pad_is_linked (sink_pad))
+        {
+            LOG(verbose) << "Audio decoder sink pad already linked" << endl;
+        }
+        else if (gst_pad_link (pad, sink_pad) != GST_PAD_LINK_OK)
         {
             LOG(error) << "Failed to link elements in pad-added callback. = " << sink_pad << endl;
             GST_ELEMENT_ERROR(element2, STREAM, FAILED, ("Failed to link elements in pad-added callback"), (nullptr));
@@ -170,8 +206,10 @@ static void on_pad_added (GstElement *element, GstPad *pad, void *data)
     {
         gst_caps_unref (caps);
     }
-_exit:
-    g_free(capsString);
+    if (capsString != nullptr)
+    {
+        g_free(capsString);
+    }
 }
 
 static bool link_decoder(GstElement* decoder, GstElement* element)
@@ -276,6 +314,13 @@ void GstNvAudioDecoder::updateAudioDataIfRequired()
         {
             m_audioData.m_freq               = it->second.frequency;
             m_audioData.m_channel            = it->second.channel;
+            /* The RTSP source codec (e.g. PCMU, MPEG4-GENERIC/AAC) is only known
+            ** from the negotiated SDP, so capture it here. It selects the appsrc
+            ** caps (and hence the decoder decodebin auto-plugs) in create(). */
+            if (!it->second.codec.empty())
+            {
+                m_audioData.m_audioCodec = it->second.codec;
+            }
             m_audioData.m_isAudioDataUpdated = true;
         }
     }
@@ -312,6 +357,67 @@ void GstNvAudioDecoder::onFrame(FrameParams& params)
     gst_app_src_push_buffer((GstAppSrc*)m_source, gstbuffer);
     return;
 }
+/* Returns true if the RTSP audio codec name denotes MPEG-4 AAC. live555
+** reports AAC subsessions as "MPEG4-GENERIC"; other stacks may say "AAC". */
+static bool isAacCodec(const std::string& codec)
+{
+    std::string c(codec);
+    std::transform(c.begin(), c.end(), c.begin(), [](unsigned char ch){ return std::tolower(ch); });
+    return c.find("aac") != std::string::npos || c.find("mpeg4") != std::string::npos;
+}
+
+/* Build the MPEG-4 AudioSpecificConfig (codec_data) for AAC-LC from the
+** stream's sample rate and channel count. The RTSP MPEG4-GENERIC depayloader
+** delivers raw AAC access units (no ADTS header), so avdec_aac needs this
+** config to decode. Layout follows ISO/IEC 14496-3 and matches the recording
+** path in gstmux.cpp (CreateUnifiedStorage). Returns a new ref the caller
+** must unref, or nullptr on failure. */
+static GstBuffer* buildAacCodecData(int sampleRate, int channels)
+{
+    static const std::map<int, int, std::less<>> kAacFreqIdx = {
+        {96000, 0}, {88200, 1}, {64000, 2}, {48000, 3}, {44100, 4},
+        {32000, 5}, {24000, 6}, {22050, 7}, {16000, 8}, {12000, 9},
+        {11025, 10}, {8000, 11}, {7350, 12}
+    };
+    auto fit = kAacFreqIdx.find(sampleRate);
+    int  freqIdx = (fit != kAacFreqIdx.end()) ? fit->second : 8 /* 16000 */;
+    const int aot = 2; // AAC LC
+
+    unsigned int chanCfg;
+    if (channels >= 1 && channels <= 6)
+    {
+        chanCfg = static_cast<unsigned int>(channels);
+    }
+    else if (channels == 8)
+    {
+        chanCfg = 7; // 7.1 surround (ISO/IEC 14496-3, Table 1.18)
+    }
+    else
+    {
+        LOG(warning) << "Unsupported AAC channel count " << channels
+                     << "; using channel_configuration=2 (stereo) for codec_data" << endl;
+        chanCfg = 2;
+    }
+
+    unsigned int asc = (static_cast<unsigned int>(aot)     << 11)
+                     | (static_cast<unsigned int>(freqIdx) << 7)
+                     | (chanCfg                            << 3);
+    guint8 bytes[2];
+    bytes[0] = static_cast<guint8>((asc >> 8) & 0xFF);
+    bytes[1] = static_cast<guint8>( asc       & 0xFF);
+
+    GstBuffer* buf = gst_buffer_new_allocate(nullptr, sizeof(bytes), nullptr);
+    if (buf == nullptr)
+    {
+        return nullptr;
+    }
+    gst_buffer_fill(buf, 0, bytes, sizeof(bytes));
+    LOG(info) << "AAC codec_data = " << std::hex << asc << std::dec
+              << " (sample_rate=" << sampleRate << ", channels=" << channels
+              << ", channel_configuration=" << chanCfg << ", aot=LC)" << endl;
+    return buf;
+}
+
 int GstNvAudioDecoder::create (bool blocking)
 {
     LOG(info) << "Creating GstNvAudioDecoder pipeline for uri = " << m_uri << endl;
@@ -323,36 +429,103 @@ int GstNvAudioDecoder::create (bool blocking)
         StreamMonitor::getInstance()->registerDataCallback(m_uri, getself());
     }
 
+    const bool isAac = isAacCodec (m_audioData.m_audioCodec);
+
     std::lock_guard<std::mutex> guard(m_pipelineLock);
     m_pipeline     = gst_pipeline_new ("audio_decoder_pipeline");
     m_source       = gst_element_factory_make ("appsrc", nullptr);
-    m_decoder      = gst_element_factory_make ("decodebin", nullptr);
+    m_audioconvert = gst_element_factory_make ("audioconvert", nullptr);
+    m_capsfilter   = gst_element_factory_make ("capsfilter", nullptr);
     m_sink         = gst_element_factory_make ("appsink", nullptr);
 
-    /* Check if any of element failed to create */
-    if (!m_pipeline || !m_source || !m_decoder || !m_sink)
+    /* For AAC insert aacparse ahead of decodebin. The RTSP MPEG4-GENERIC
+    ** depayloader delivers raw AAC access units with no ADTS header and no
+    ** timestamps; decodebin autoplug over a live appsrc does not reliably frame
+    ** those (it exposes a src pad but never emits a decoded buffer). aacparse,
+    ** given the codec_data, frames the AUs deterministically so decodebin's
+    ** auto-plugged AAC decoder produces output. decodebin (rather than a
+    ** hard-coded avdec_aac) keeps us decoder-agnostic. For other codecs (PCMU)
+    ** decodebin alone plugs mulawdec directly. */
+    m_decoder = gst_element_factory_make ("decodebin", nullptr);
+    if (isAac)
     {
-        LOG (error) << "Gstreamer element creation failed" << endl;
+        m_parser = gst_element_factory_make ("aacparse", nullptr);
+    }
+
+    /* Check if any of element failed to create */
+    if (!m_pipeline || !m_source || !m_decoder || !m_audioconvert || !m_capsfilter || !m_sink ||
+        (isAac && !m_parser))
+    {
+        LOG (error) << "Gstreamer element creation failed (isAac=" << isAac
+                    << ", aacparse/decodebin available?) for uri = " << m_uri << endl;
         return -1;
     }
 
-    gst_bin_add_many (GST_BIN (m_pipeline), m_source, m_decoder, m_sink, nullptr);
-    std::string caps_string = "audio/x-mulaw, format=(string)S8, rate=(int)" + to_string(m_audioData.m_freq) + 
-                              ", channels=(int)" + to_string(m_audioData.m_channel);
-    capsSrc = gst_caps_from_string (caps_string.c_str());
+    gst_bin_add_many (GST_BIN (m_pipeline), m_source, m_decoder, m_audioconvert, m_capsfilter, m_sink, nullptr);
+    if (isAac)
+    {
+        gst_bin_add (GST_BIN (m_pipeline), m_parser);
+    }
 
-    LOG(info) << "Audio Decoder appsrc caps = " << caps_string << endl;
+    /* Surface otherwise-swallowed audio decode errors on the pipeline bus. */
+    {
+        GstBus* bus = gst_element_get_bus (m_pipeline);
+        if (bus)
+        {
+            gst_bus_set_sync_handler (bus, audio_bus_sync_handler, this, nullptr);
+            gst_object_unref (bus);
+        }
+    }
 
-    /* Setting properties of elements */
+    /* Select the appsrc caps from the negotiated RTSP audio codec. The
+    ** downstream audioconvert + capsfilter normalise the decoder output to
+    ** interleaved S16LE, which is what the WebRTC audio sink expects
+    ** (on_new_sample_from_sink treats samples as 16-bit). */
+    if (isAac)
+    {
+        capsSrc = gst_caps_new_simple ("audio/mpeg",
+                                       "mpegversion",   G_TYPE_INT,    4,
+                                       "stream-format", G_TYPE_STRING, "raw",
+                                       "rate",          G_TYPE_INT,    m_audioData.m_freq,
+                                       "channels",      G_TYPE_INT,    m_audioData.m_channel,
+                                       nullptr);
+        GstBuffer* codecData = buildAacCodecData (m_audioData.m_freq, m_audioData.m_channel);
+        if (codecData != nullptr)
+        {
+            gst_caps_set_simple (capsSrc, "codec_data", GST_TYPE_BUFFER, codecData, nullptr);
+            gst_buffer_unref (codecData);
+        }
+        LOG(info) << "Audio Decoder appsrc caps = audio/mpeg (AAC) mpegversion=4 stream-format=raw rate="
+                  << m_audioData.m_freq << " channels=" << m_audioData.m_channel
+                  << " codec=" << m_audioData.m_audioCodec << endl;
+    }
+    else
+    {
+        std::string caps_string = "audio/x-mulaw, format=(string)S8, rate=(int)" + to_string(m_audioData.m_freq) +
+                                  ", channels=(int)" + to_string(m_audioData.m_channel);
+        capsSrc = gst_caps_from_string (caps_string.c_str());
+        LOG(info) << "Audio Decoder appsrc caps = " << caps_string
+                  << " codec=" << m_audioData.m_audioCodec << endl;
+    }
+
+    /* Force the decoded output format the WebRTC sink consumes. */
+    GstCaps* sinkCaps = gst_caps_from_string ("audio/x-raw, format=(string)S16LE, layout=(string)interleaved");
+
+    /* Setting properties of elements. do-timestamp stamps the untimed RTSP AUs
+    ** with arrival running-time so aacparse/avdec_aac can frame and decode. */
     g_object_set (G_OBJECT (m_source), "caps", capsSrc, nullptr);
     g_object_set (G_OBJECT (m_source), "is-live", true, nullptr);
+    g_object_set (G_OBJECT (m_source), "do-timestamp", true, nullptr);
     g_object_set (G_OBJECT (m_source), "format", 3, nullptr);
+    g_object_set (G_OBJECT (m_capsfilter), "caps", sinkCaps, nullptr);
     g_object_set (G_OBJECT (m_sink)  , "emit-signals", TRUE, "sync", FALSE, nullptr);
     gst_caps_unref (capsSrc);
+    gst_caps_unref (sinkCaps);
 
-    if (!gst_element_link_many (m_source, m_decoder, nullptr))
+    /* audioconvert -> capsfilter -> appsink is a static link in both paths. */
+    if (!gst_element_link_many (m_audioconvert, m_capsfilter, m_sink, nullptr))
     {
-        LOG (error) << "Audio Decoder: source and decoder elements could not be linked for uri = " << m_uri << endl;
+        LOG (error) << "Audio Decoder: audioconvert/capsfilter/sink could not be linked for uri = " << m_uri << endl;
         return -1;
     }
 
@@ -360,12 +533,22 @@ int GstNvAudioDecoder::create (bool blocking)
     g_signal_connect( m_pipeline, "deep-notify", G_CALLBACK( gst_object_default_deep_notify ), nullptr );
 #endif
 
-    if (!link_decoder(m_decoder, m_sink))
+    /* appsrc -> [aacparse ->] decodebin. aacparse (AAC only) frames the raw AUs
+    ** before decodebin. decodebin's src pad is dynamic and is linked to
+    ** audioconvert in the pad-added callback for both paths. */
+    bool sourceLinked = isAac ? gst_element_link_many (m_source, m_parser, m_decoder, nullptr)
+                              : gst_element_link_many (m_source, m_decoder, nullptr);
+    if (!sourceLinked)
     {
-        LOG (error) << "Audio Decoder: decoder and sink elements could not be linked for uri = " << m_uri << endl;
+        LOG (error) << "Audio Decoder: source/parser/decoder elements could not be linked for uri = " << m_uri << endl;
         return -1;
     }
-    
+    if (!link_decoder(m_decoder, m_audioconvert))
+    {
+        LOG (error) << "Audio Decoder: decoder and audioconvert elements could not be linked for uri = " << m_uri << endl;
+        return -1;
+    }
+
     if(!g_signal_connect (m_sink, "new-sample", G_CALLBACK (on_new_sample_from_sink), (void*)this))
     {
         LOG(error) << "Audio Decoder: Error in g_signal_connect of new-sample for uri = " << m_uri << endl;

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.h
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.h
@@ -114,7 +114,10 @@ class GstNvAudioDecoder : public IMediaDataConsumer, public GstNvDecoder
         std::string             m_uri;
         GstElement*             m_pipeline = nullptr;
         GstElement*             m_source = nullptr;
+        GstElement*             m_parser = nullptr;
         GstElement*             m_decoder = nullptr;
+        GstElement*             m_audioconvert = nullptr;
+        GstElement*             m_capsfilter = nullptr;
         GstElement*             m_sink = nullptr;
         std::mutex              m_pipelineLock;
         std::atomic<bool>       m_error{false};


### PR DESCRIPTION
## Summary
Add AAC audio decode support for WebRTC-live.

## Changes
* Make GstNvAudioDecoder codec-aware, building audio/mpeg raw caps with AAC codec_data for MPEG4-GENERIC sources instead of hardcoded G.711 mu-law.
* Insert aacparse with an audioconvert and S16LE capsfilter stage so decoded AAC is normalised to the format the WebRTC audio sink expects.
* Link the decoder pad in on_pad_added when caps are not yet negotiated, fixing avdec_aac lazy negotiation that dropped audio.
* Add a pipeline bus handler so audio decode errors are logged instead of silently swallowed.
* Reinstall libswscale7 and libpostproc57 in the deploy scripts so gst-libav provides avdec_aac for AAC decode.

## Testing
* Verified on the live deployment: WebRTC-live plays AAC (MPEG4-GENERIC) RTSP audio; confirmed decodebin auto-plugs avdec_aac and decodes to PCM.

## Risk
Low - scoped to the audio decode path; the G.711 mu-law path is unchanged; the deploy-script change only restores two gst-libav runtime dependencies that libgstlibav.so links.