### PR TITLE
Config changes for Warehouse Redis

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/sdrc/configs/config.yml.tmpl
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/sdrc/configs/config.yml.tmpl
@@ -27,7 +27,7 @@ docker-workload-streamprocessing:
   WDM_KFK_ENABLE: false
   WDM_MSG_TOPIC: vst_events
   WDM_DS_SWAP_ID_NAME: false
-  WDM_ADD_REMOVE_RETRY_ATTEMPTS: 50
+  WDM_ADD_REMOVE_RETRY_ATTEMPTS: 500
   WDM_DISABLE_WERKZEUG_LOGGING: true
   WDM_WL_OBJECT_NAME: vss-vios-streamprocessing
   VST_STREAMS_ENDPOINT: http://localhost:30000/api/v1/sensor/streams
@@ -40,7 +40,7 @@ docker-workload-streamprocessing:
   WDM_MS_LISTENER_PORT: 10000
   NOHEADERTARGETROUTE: true
   HEADERLESS_SERVICE_ENDPOINTS: "[\"${HOST_IP}:30001\"]"
-  WDM_WL_REDIS_MSG_FIELD: sensor.id
+  WDM_WL_REDIS_MSG_FIELD: value
   WDM_MSG_KEY: vst_events
   WDM_CLUSTER_CONFIG_FILE: /configs/docker_cluster_config-streamprocessing.json
 
@@ -54,6 +54,7 @@ docker-workload-rtvi-cv:
   WDM_XDS_USE_POD_DNS: false
   WDM_XDS_USE_IP_ADDRESS: true
   WDM_REDIS_MSG_KEY: vst.event
+  WDM_WL_REDIS_MSG_FIELD: value
   REDIS_MSG_KEY: vst.event
   WDM_CLUSTER_TYPE: docker
   WDM_CLUSTER_CONTAINER_NAMES: '["vss-rtvi-cv"]'

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
@@ -155,7 +155,7 @@ services:
       WDM_REDIS_HOST: localhost
       WDM_REDIS_PORT: 6379
       WDM_REDIS_STREAM_NAME: vst.event
-      WDM_REDIS_MSG_KEY: sensor.id
+      WDM_REDIS_MSG_KEY: value
       WDM_KFK_MSG_KEY: vst.event
       WDM_KFK_BOOTSTRAP_URL: localhost:9092
       WDM_KFK_TOPIC: mdx-notification

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/sdrc/configs/config.yml.tmpl
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/sdrc/configs/config.yml.tmpl
@@ -27,7 +27,7 @@ docker-workload-streamprocessing:
   WDM_KFK_ENABLE: false
   WDM_MSG_TOPIC: vst_events
   WDM_DS_SWAP_ID_NAME: false
-  WDM_ADD_REMOVE_RETRY_ATTEMPTS: 50
+  WDM_ADD_REMOVE_RETRY_ATTEMPTS: 500
   WDM_DISABLE_WERKZEUG_LOGGING: true
   WDM_WL_OBJECT_NAME: vss-vios-streamprocessing
   VST_STREAMS_ENDPOINT: http://localhost:30000/api/v1/sensor/streams
@@ -40,7 +40,7 @@ docker-workload-streamprocessing:
   WDM_MS_LISTENER_PORT: 10000
   NOHEADERTARGETROUTE: true
   HEADERLESS_SERVICE_ENDPOINTS: "[\"${HOST_IP}:30001\"]"
-  WDM_WL_REDIS_MSG_FIELD: sensor.id
+  WDM_WL_REDIS_MSG_FIELD: value
   WDM_MSG_KEY: vst_events
   WDM_CLUSTER_CONFIG_FILE: /configs/docker_cluster_config-streamprocessing.json
 
@@ -55,6 +55,7 @@ docker-workload-rtvi-cv:
   WDM_XDS_USE_IP_ADDRESS: true
   WDM_REDIS_MSG_KEY: vst.event
   REDIS_MSG_KEY: vst.event
+  WDM_WL_REDIS_MSG_FIELD: value
   WDM_CLUSTER_TYPE: docker
   WDM_CLUSTER_CONTAINER_NAMES: '["vss-rtvi-cv"]'
   WDM_CLUSTER_CONFIG_FILE: /configs/docker_cluster_config-rtvi-cv.json

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
@@ -174,7 +174,7 @@ services:
       WDM_REDIS_HOST: localhost
       WDM_REDIS_PORT: 6379
       WDM_REDIS_STREAM_NAME: vst.event
-      WDM_REDIS_MSG_KEY: sensor.id
+      WDM_REDIS_MSG_KEY: value
       WDM_KFK_MSG_KEY: vst.event
       WDM_KFK_BOOTSTRAP_URL: localhost:9092
       WDM_KFK_TOPIC: mdx-notification

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/sdrc/configs/config.yml.tmpl
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/sdrc/configs/config.yml.tmpl
@@ -27,7 +27,7 @@ docker-workload-streamprocessing:
   WDM_KFK_ENABLE: false
   WDM_MSG_TOPIC: vst_events
   WDM_DS_SWAP_ID_NAME: false
-  WDM_ADD_REMOVE_RETRY_ATTEMPTS: 50
+  WDM_ADD_REMOVE_RETRY_ATTEMPTS: 500
   WDM_DISABLE_WERKZEUG_LOGGING: true
   WDM_WL_OBJECT_NAME: vss-vios-streamprocessing
   VST_STREAMS_ENDPOINT: http://localhost:30000/api/v1/sensor/streams
@@ -40,7 +40,7 @@ docker-workload-streamprocessing:
   WDM_MS_LISTENER_PORT: 10000
   NOHEADERTARGETROUTE: true
   HEADERLESS_SERVICE_ENDPOINTS: "[\"${HOST_IP}:30001\"]"
-  WDM_WL_REDIS_MSG_FIELD: sensor.id
+  WDM_WL_REDIS_MSG_FIELD: value
   WDM_MSG_KEY: vst_events
   WDM_CLUSTER_CONFIG_FILE: /configs/docker_cluster_config-streamprocessing.json
 
@@ -54,6 +54,7 @@ docker-workload-rtvi-cv-mv3dt:
   WDM_XDS_USE_POD_DNS: false
   WDM_XDS_USE_IP_ADDRESS: true
   WDM_REDIS_MSG_KEY: vst.event
+  WDM_WL_REDIS_MSG_FIELD: value
   REDIS_MSG_KEY: vst.event
   WDM_CLUSTER_TYPE: docker
   WDM_CLUSTER_CONTAINER_NAMES: '["vss-rtvi-cv-mv3dt"]'

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
@@ -151,7 +151,7 @@ services:
       WDM_REDIS_HOST: localhost
       WDM_REDIS_PORT: 6379
       WDM_REDIS_STREAM_NAME: vst.event
-      WDM_REDIS_MSG_KEY: sensor.id
+      WDM_REDIS_MSG_KEY: value
       WDM_KFK_MSG_KEY: vst.event
       WDM_KFK_BOOTSTRAP_URL: localhost:9092
       WDM_KFK_TOPIC: mdx-notification

--- a/deploy/docker/services/vios/initiator/docker-compose.yaml
+++ b/deploy/docker/services/vios/initiator/docker-compose.yaml
@@ -91,6 +91,7 @@ services:
       - CENTRALIZE_DB_NAME=${CENTRALIZE_DB_NAME}
       - CENTRALIZE_DB_USERNAME=${CENTRALIZE_DB_USERNAME}
       - STREAM_PROCESSOR_MODULE_ENDPOINT=${STREAM_PROCESSOR_MODULE_ENDPOINT}
+      - DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION=1
     volumes:
       - ${VST_CONFIG_PATH:-${VSS_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-2d-app/vst/configs/vst_config.json:/home/vst/vst_release/configs/vst_config.json
@@ -134,6 +135,7 @@ services:
       - CENTRALIZE_DB_NAME=${CENTRALIZE_DB_NAME}
       - CENTRALIZE_DB_USERNAME=${CENTRALIZE_DB_USERNAME}
       - STREAM_PROCESSOR_MODULE_ENDPOINT=${STREAM_PROCESSOR_MODULE_ENDPOINT}
+      - DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION=1
     volumes:
       - ${VST_CONFIG_PATH:-${VSS_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-3d-app/vst/configs/vst_config.json:/home/vst/vst_release/configs/vst_config.json
@@ -174,6 +176,7 @@ services:
       - CENTRALIZE_DB_NAME=${CENTRALIZE_DB_NAME}
       - CENTRALIZE_DB_USERNAME=${CENTRALIZE_DB_USERNAME}
       - STREAM_PROCESSOR_MODULE_ENDPOINT=${STREAM_PROCESSOR_MODULE_ENDPOINT}
+      - DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION=1
     volumes:
       - ${VST_CONFIG_PATH:-${VSS_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-mv3dt-app/vst/configs/vst_config.json:/home/vst/vst_release/configs/vst_config.json

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
@@ -83,6 +83,7 @@ services:
       - VST_INGRESS_ENDPOINT=${VST_INGRESS_ENDPOINT}
       - ENABLE_AGING_POLICY=true
       - VST_VIDEO_STORAGE_SIZE_MB=${VST_VIDEO_STORAGE_SIZE_MB}
+      - DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION=1
     volumes:
       - ${VST_CONFIG_PATH:-${VSS_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-2d-app/vst/configs/vst_config.json:/home/vst/vst_release/configs/vst_config.json
@@ -132,6 +133,7 @@ services:
       - VST_INGRESS_ENDPOINT=${VST_INGRESS_ENDPOINT}
       - ENABLE_AGING_POLICY=true
       - VST_VIDEO_STORAGE_SIZE_MB=${VST_VIDEO_STORAGE_SIZE_MB}
+      - DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION=1
     volumes:
       - ${VST_CONFIG_PATH:-${VSS_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-3d-app/vst/configs/vst_config.json:/home/vst/vst_release/configs/vst_config.json
@@ -183,6 +185,7 @@ services:
       - VST_INGRESS_ENDPOINT=${VST_INGRESS_ENDPOINT}
       - ENABLE_AGING_POLICY=true
       - VST_VIDEO_STORAGE_SIZE_MB=${VST_VIDEO_STORAGE_SIZE_MB}
+      - DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION=1
     volumes:
       - ${VST_CONFIG_PATH:-${VSS_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-mv3dt-app/vst/configs/vst_config.json:/home/vst/vst_release/configs/vst_config.json


### PR DESCRIPTION
Redis schema change puts payload under key "value" instead of "sensor.id"

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
