### PR TITLE
Gate ES dense_vector templates on flag rather than profile [VIA-2427]

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/.env
@@ -49,6 +49,9 @@ RTVI_CV_PORT=9010
 # Elasticsearch ILM policy retention period
 ELASTICSEARCH_ILM_MIN_AGE=4h
 
+# Elasticsearch dense vector embedding fields (off for alerts profile)
+ELASTICSEARCH_ENABLE_EMBEDDINGS=false
+
 # =============================================================================
 # MESSAGE BROKER CONFIGURATION
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -52,6 +52,9 @@ FIXED_SHARED_DEVICE_IDS=''
 # Elasticsearch ILM policy retention period
 ELASTICSEARCH_ILM_MIN_AGE=4h
 
+# Elasticsearch dense vector embedding fields (off for base profile)
+ELASTICSEARCH_ENABLE_EMBEDDINGS=false
+
 # =============================================================================
 # MESSAGE BROKER CONFIGURATION
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-base/.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/.env
@@ -52,9 +52,6 @@ FIXED_SHARED_DEVICE_IDS=''
 # Elasticsearch ILM policy retention period
 ELASTICSEARCH_ILM_MIN_AGE=4h
 
-# Elasticsearch dense vector embedding fields (off for base profile)
-ELASTICSEARCH_ENABLE_EMBEDDINGS=false
-
 # =============================================================================
 # MESSAGE BROKER CONFIGURATION
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -65,6 +65,9 @@ MINIO_PASSWORD=''
 # Elasticsearch ILM policy retention period
 ELASTICSEARCH_ILM_MIN_AGE=4h
 
+# Elasticsearch dense vector embedding fields (off for LVS profile)
+ELASTICSEARCH_ENABLE_EMBEDDINGS=false
+
 # =============================================================================
 # MESSAGE BROKER CONFIGURATION
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -57,6 +57,7 @@ RT_EMBED_DEVICE_ID='1'
 ELASTICSEARCH_ILM_MIN_AGE=48h
 
 # Elasticsearch dense vector embedding dimensions
+ELASTICSEARCH_ENABLE_EMBEDDINGS=true
 ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM=1152   #1536 for radio-clip v1.0
 ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM=768
 # =============================================================================

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -77,6 +77,9 @@ VST_STATIC_TURNURL_LIST=
 # Elasticsearch ILM policy retention period
 ELASTICSEARCH_ILM_MIN_AGE=4h
 
+# Elasticsearch dense vector embedding fields (off for warehouse profiles)
+ELASTICSEARCH_ENABLE_EMBEDDINGS=false
+
 # =============================================================================
 # HARDWARE & PERCEPTION CONFIGURATION
 # =============================================================================

--- a/deploy/docker/services/infra/compose.yml
+++ b/deploy/docker/services/infra/compose.yml
@@ -154,7 +154,7 @@ services:
     profiles: ["bp_wh_2d","bp_wh_kafka_2d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_3d${MINIMAL_PROFILE:+_extended}","bp_wh_kafka_mv3dt${MINIMAL_PROFILE:+_extended}","bp_wh_redis_2d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_3d${MINIMAL_PROFILE:+_extended}","bp_wh_redis_mv3dt${MINIMAL_PROFILE:+_extended}","playback_kafka_2d","playback_kafka_3d","playback_redis_2d","playback_redis_3d","bp_developer_search_2d","bp_developer_lvs_2d","bp_developer_alerts_2d_cv", "bp_developer_alerts_2d_vlm"]
     container_name: vss-elasticsearch-init
     environment:
-      - BP_PROFILE=${BP_PROFILE}
+      - ELASTICSEARCH_ENABLE_EMBEDDINGS=${ELASTICSEARCH_ENABLE_EMBEDDINGS:-false}
       - ELASTICSEARCH_URL=${ELASTICSEARCH_URL:-http://elasticsearch:9200}
       - ELASTICSEARCH_CONNECTION_MAX_ATTEMPTS=${ELASTICSEARCH_CONNECTION_MAX_ATTEMPTS:-20}
       - ELASTICSEARCH_ILM_MIN_AGE=${ELASTICSEARCH_ILM_MIN_AGE:-4h}

--- a/deploy/docker/services/infra/elk/elasticsearch/init-scripts/elasticsearch-template-creation.sh
+++ b/deploy/docker/services/infra/elk/elasticsearch/init-scripts/elasticsearch-template-creation.sh
@@ -22,8 +22,9 @@ ELASTICSEARCH_CONNECTION_RETRY_ATTEMPTS="${ELASTICSEARCH_CONNECTION_RETRY_ATTEMP
 ELASTICSEARCH_CONNECTION_MAX_ATTEMPTS="${ELASTICSEARCH_CONNECTION_MAX_ATTEMPTS:-20}"
 ELASTICSEARCH_URL="${ELASTICSEARCH_URL:-http://elasticsearch:9200}"
 
-BP_PROFILE=${BP_PROFILE:-}
-echo "BP_PROFILE: ${BP_PROFILE}"
+# Master switch: create kNN-searchable dense_vector fields in mdx-behavior-* / mdx-raw-* templates
+ELASTICSEARCH_ENABLE_EMBEDDINGS=${ELASTICSEARCH_ENABLE_EMBEDDINGS:-false}
+echo "ELASTICSEARCH_ENABLE_EMBEDDINGS: ${ELASTICSEARCH_ENABLE_EMBEDDINGS}"
 
 # Embedding dimensions for Elasticsearch dense_vector
 ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM=${ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM:-1536}
@@ -129,7 +130,7 @@ setup_elasticsearch_templates(){
         }
       }'
 
-    if [[ "${BP_PROFILE:-}" == "bp_developer_search" ]]; then
+    if [[ "${ELASTICSEARCH_ENABLE_EMBEDDINGS}" == "true" ]]; then
       create_index_template "mdx_behavior_template" '{
           "index_patterns": ["mdx-behavior-*"],
           "priority": 502,
@@ -169,7 +170,7 @@ setup_elasticsearch_templates(){
             }
           }
         }'
-      echo "Successfully created index template: mdx_behavior_template for bp_developer_search"
+      echo "Successfully created index template: mdx_behavior_template with dense_vector embeddings"
     else
       create_index_template "mdx_behavior_template" '{
         "index_patterns": ["mdx-behavior-*"],
@@ -446,7 +447,7 @@ setup_elasticsearch_templates(){
       }'
 
 #   if rawDataSchema is in json format then comment the following template
-    if [[ "${BP_PROFILE:-}" == "bp_developer_search" ]]; then
+    if [[ "${ELASTICSEARCH_ENABLE_EMBEDDINGS}" == "true" ]]; then
       create_index_template "mdx_raw_template" '{
           "index_patterns": ["mdx-raw-*"],
           "priority": 512,
@@ -479,7 +480,7 @@ setup_elasticsearch_templates(){
             }
           }
         }'
-        echo "Successfully created index template: mdx_raw_template for bp_developer_search"
+        echo "Successfully created index template: mdx_raw_template with dense_vector embeddings"
     else
       create_index_template "mdx_raw_template" '{
         "index_patterns": ["mdx-raw-*"],

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -108,9 +108,9 @@ infra:
       enabled: true
       env:
         ELASTICSEARCH_ILM_MIN_AGE: 4h
+        ELASTICSEARCH_ENABLE_EMBEDDINGS: "false"
         ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM: '1536'
         ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM: '768'
-        BP_PROFILE: bp_developer_alerts
   kibana:
     enabled: true
     init:

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -82,9 +82,9 @@ infra:
       enabled: true
       env:
         ELASTICSEARCH_ILM_MIN_AGE: 4h
+        ELASTICSEARCH_ENABLE_EMBEDDINGS: "false"
         ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM: '1536'
         ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM: '768'
-        BP_PROFILE: bp_developer_lvs
   kibana:
     enabled: true
     init:

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -191,9 +191,9 @@ infra:
       backoffLimit: 5
       env:
         ELASTICSEARCH_ILM_MIN_AGE: 48h
+        ELASTICSEARCH_ENABLE_EMBEDDINGS: "true"
         ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM: '1152'
         ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM: '768'
-        BP_PROFILE: bp_developer_search
   kibana:
     enabled: true
     init:

--- a/deploy/helm/services/infra/charts/elasticsearch/configs/elasticsearch-template-creation.sh
+++ b/deploy/helm/services/infra/charts/elasticsearch/configs/elasticsearch-template-creation.sh
@@ -21,8 +21,9 @@ ES_CONNECTION_RETRY_ATTEMPTS=0
 ES_CONNECTION_MAX_ATTEMPTS=10
 ES_URL="${ELASTICSEARCH_URL:-http://localhost:9200}"
 
-BP_PROFILE=${BP_PROFILE:-}
-echo "BP_PROFILE: ${BP_PROFILE}"
+# Master switch: create kNN-searchable dense_vector fields in mdx-behavior-* / mdx-raw-* templates
+ELASTICSEARCH_ENABLE_EMBEDDINGS=${ELASTICSEARCH_ENABLE_EMBEDDINGS:-false}
+echo "ELASTICSEARCH_ENABLE_EMBEDDINGS: ${ELASTICSEARCH_ENABLE_EMBEDDINGS}"
 
 # Embedding dimensions for Elasticsearch dense_vector
 ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM=${ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM:-1536}
@@ -128,7 +129,7 @@ setup_elasticsearch_templates(){
         }
       }'
 
-    if [[ "${BP_PROFILE:-}" == "bp_developer_search" ]]; then
+    if [[ "${ELASTICSEARCH_ENABLE_EMBEDDINGS}" == "true" ]]; then
       create_index_template "mdx_behavior_template" '{
           "index_patterns": ["mdx-behavior-*"],
           "priority": 502,
@@ -168,7 +169,7 @@ setup_elasticsearch_templates(){
             }
           }
         }'
-      echo "Successfully created index template: mdx_behavior_template for bp_developer_search"
+      echo "Successfully created index template: mdx_behavior_template with dense_vector embeddings"
     else
       create_index_template "mdx_behavior_template" '{
         "index_patterns": ["mdx-behavior-*"],
@@ -445,7 +446,7 @@ setup_elasticsearch_templates(){
       }'
 
 #   if rawDataSchema is in json format then comment the following template
-    if [[ "${BP_PROFILE:-}" == "bp_developer_search" ]]; then
+    if [[ "${ELASTICSEARCH_ENABLE_EMBEDDINGS}" == "true" ]]; then
       create_index_template "mdx_raw_template" '{
           "index_patterns": ["mdx-raw-*"],
           "priority": 512,
@@ -478,7 +479,7 @@ setup_elasticsearch_templates(){
             }
           }
         }'
-        echo "Successfully created index template: mdx_raw_template for bp_developer_search"
+        echo "Successfully created index template: mdx_raw_template with dense_vector embeddings"
     else
       create_index_template "mdx_raw_template" '{
         "index_patterns": ["mdx-raw-*"],

--- a/deploy/helm/services/infra/charts/elasticsearch/templates/job-init.yaml
+++ b/deploy/helm/services/infra/charts/elasticsearch/templates/job-init.yaml
@@ -42,9 +42,9 @@ spec:
               apk add --no-cache bash curl
               export ES_URL="${ELASTICSEARCH_URL}"
               export ELASTICSEARCH_ILM_MIN_AGE="${ELASTICSEARCH_ILM_MIN_AGE}"
+              export ELASTICSEARCH_ENABLE_EMBEDDINGS="${ELASTICSEARCH_ENABLE_EMBEDDINGS}"
               export ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM="${ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM}"
               export ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM="${ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM}"
-              export BP_PROFILE="${BP_PROFILE}"
               bash /opt/mdx/init-scripts/elasticsearch-ilm-policy-creation.sh && \
               bash /opt/mdx/init-scripts/elasticsearch-template-creation.sh && \
               bash /opt/mdx/init-scripts/elasticsearch-ingest-pipeline-creation.sh
@@ -53,12 +53,12 @@ spec:
               value: {{ .Values.init.elasticsearchUrl | default (include "elasticsearch.httpServiceUrl" .) | quote }}
             - name: ELASTICSEARCH_ILM_MIN_AGE
               value: {{ .Values.init.env.ELASTICSEARCH_ILM_MIN_AGE | quote }}
+            - name: ELASTICSEARCH_ENABLE_EMBEDDINGS
+              value: {{ .Values.init.env.ELASTICSEARCH_ENABLE_EMBEDDINGS | quote }}
             - name: ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM
               value: {{ .Values.init.env.ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM | quote }}
             - name: ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM
               value: {{ .Values.init.env.ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM | quote }}
-            - name: BP_PROFILE
-              value: {{ .Values.init.env.BP_PROFILE | quote }}
           volumeMounts:
             - name: scripts
               mountPath: /opt/mdx/init-scripts

--- a/deploy/helm/services/infra/charts/elasticsearch/values.yaml
+++ b/deploy/helm/services/infra/charts/elasticsearch/values.yaml
@@ -52,9 +52,9 @@ init:
   elasticsearchUrl: ""
   env:
     ELASTICSEARCH_ILM_MIN_AGE: "4h"
+    ELASTICSEARCH_ENABLE_EMBEDDINGS: "false"
     ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM: "1536"
     ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM: "768"
-    BP_PROFILE: ""
 
 exporter:
   enabled: false


### PR DESCRIPTION
## Description

Elasticsearch index templates for `mdx-behavior-*` and `mdx-raw-*` only created kNN-searchable `dense_vector` fields when `BP_PROFILE` was exactly `bp_developer_search`. That tied ES schema to a static profile name, so generated or combined deployments (e.g. build-vision-agent with invented flags) silently got non-vector mappings and search broke at query time with no deploy-time error.

This change decouples embedding schema from profile identity and makes vector creation an explicit, capability-driven setting.

### Jira
[Gate ES dense_vector templates on flag rather than profile](https://jirasw.nvidia.com/browse/VIA-2427)

### Approach

Introduce `ELASTICSEARCH_ENABLE_EMBEDDINGS` as the master switch for CV dense-vector fields in the ES init scripts. Default is `false` at the infra/service level; only the search profile opts in with `true`. Alerts, LVS, and base keep vectors off, preserving today’s behavior for static profiles while allowing any deployment to enable embeddings without hardcoding `bp_developer_search`.

`BP_PROFILE` is no longer used for ES template gating. Embedding dimensions and `mdx-embed-filtered-*` handling are unchanged.

### Changes

- ES init logic now gates `mdx-behavior-*` / `mdx-raw-*` vector mappings on `ELASTICSEARCH_ENABLE_EMBEDDINGS=true` instead of profile name.
- Docker Compose and Helm elasticsearch init pass the new flag through, with `false` as the service default.
- Developer profile config sets `ELASTICSEARCH_ENABLE_EMBEDDINGS=true` for search and `false` for alerts, LVS, and base.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
