### PR TITLE
fix(deploy): use promoted VSS agent image

### DIFF
--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -17,7 +17,7 @@
 
 services:
   vss-va-mcp:
-    image: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent:${VSS_AGENT_VERSION}
+    image: nvcr.io/nvstaging/vss-core/vss-agent:${VSS_AGENT_VERSION}
     container_name: vss-va-mcp
     profiles:
     - bp_wh_2d
@@ -61,9 +61,8 @@ services:
     restart: unless-stopped
 
   vss-agent:
-    # Version pinned via VSS_AGENT_VERSION (see the profile .env files). For the
-    # public release, switch the registry from nv-metropolis-dev to nvidia.
-    image: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent:${VSS_AGENT_VERSION}
+    # Version pinned via VSS_AGENT_VERSION (see the profile .env files).
+    image: nvcr.io/nvstaging/vss-core/vss-agent:${VSS_AGENT_VERSION}
     container_name: vss-agent
     profiles:
     - bp_wh_2d

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -22,7 +22,7 @@ global: {}
 serviceAccount:
   create: false
 image:
-  repository: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent
+  repository: nvcr.io/nvstaging/vss-core/vss-agent
   tag: "3.3.0-0dd034eaa4bb"
   pullPolicy: IfNotPresent
 replicas: 1

--- a/deploy/helm/services/agent/charts/va-mcp/values.yaml
+++ b/deploy/helm/services/agent/charts/va-mcp/values.yaml
@@ -17,7 +17,7 @@ enabled: false
 global: {}
 
 image:
-  repository: nvcr.io/nv-metropolis-dev/met-moe-agents/vss-agent
+  repository: nvcr.io/nvstaging/vss-core/vss-agent
   tag: "3.3.0-0dd034eaa4bb"
   pullPolicy: IfNotPresent
 # Image must have mcp[cli] (typer) installed for `mcp serve` (same as Docker Compose).


### PR DESCRIPTION
Point Docker Compose and Helm defaults at the NVstaging image promoted from the requested 3.3.0 build.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
