### PR TITLE
docs: fix README links for NVBug 6453445

### DIFF
--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -18,7 +18,7 @@ The whole thing runs inside the 8-hour GitHub Actions job timeout. The `.github/
 The workflow runs on a self-hosted GitHub Actions runner installed on `vss-skill-validator` (a long-running Brev CPU instance in the NVIDIA org). That host needs:
 
 - **[uv](https://github.com/astral-sh/uv)** — harbor is invoked as `uvx harbor`.
-- **[Brev CLI](https://docs.brev.nvidia.com/)** — authenticated via `brev login --auth nvidia` (refresh token lasts ~30 days; a user-level `brev-keepalive.timer` keeps the access token warm).
+- **[Brev CLI](https://docs.nvidia.com/brev/latest/cli/cli-overview)** — authenticated via `brev login --auth nvidia` (refresh token lasts ~30 days; a user-level `brev-keepalive.timer` keeps the access token warm).
 - **`git`**, **`gh` (GitHub CLI)** — authenticated against the VSS repo.
 - **Python 3** — for the adapters.
 - **A `.env` at `/home/ubuntu/eval-coordinator/.env`** with the keys below — the workflow step `Load coordinator env` sources this file.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository implements the blueprint and powers the [NVIDIA build experience
 The NVIDIA AI Blueprint for Video Search and Summarization addresses the challenge of deploying visual agents capable of interacting with large volumes of video data, both stored and streamed. This can be used to create vision AI agents, that can be applied to a multitude of use cases such as monitoring smart spaces, warehouse automation, and SOP validation. This is important where quick and accurate video analysis can lead to better decision-making and enhanced operational efficiency.
 
 ## Agent Workflows
-We provide multiple reference [Agent Workflows](https://docs.nvidia.com/vss/latest/adding-workflows.html) which demonstrate how the individual components can be leveraged by an agent:
+We provide multiple reference [Agent Workflows](https://docs.nvidia.com/vss/latest/agent-workflows.html) which demonstrate how the individual components can be leveraged by an agent:
 
 | Workflow | Description |
 |----------|-------------|
@@ -44,7 +44,7 @@ We provide multiple reference [Agent Workflows](https://docs.nvidia.com/vss/late
 
 1. **NIM microservices**: Here are models used in this blueprint:
 
-    - [Cosmos-Reason2-8B](https://build.nvidia.com/nvidia/cosmos-reason2-8b)
+    - [Cosmos3 Nano Reasoner](https://build.nvidia.com/nvidia/cosmos3-nano-reasoner)
     - [NVIDIA Nemotron-Nano-9B-v2](https://build.nvidia.com/nvidia/nvidia-nemotron-nano-9b-v2)
 
 2. **Real-time video intelligence**: The Real-Time Video Intelligence layer extracts rich visual features, semantic embeddings, and contextual understanding from video data in real-time, publishing results to a message broker for downstream analytics and agentic workflows. It provides three core microservices for processing video streams.

--- a/services/rtvi/rt-vlm/README.md
+++ b/services/rtvi/rt-vlm/README.md
@@ -5,7 +5,7 @@ The video is segmented into chunks as per requested chunk duration and overlap i
 Frames are sampled and sent for VLM inference. Text output is generated at the end of inference.
 If Yes/No questions are asked, it also generates incidents based on set prompts.
 
-Default Docker Compose model: Cosmos Reason3 Nano BF16 with `MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final` (configurable; see [Model Configuration](#model-configuration)).
+Default Docker Compose model: Cosmos3 Nano Reasoner BF16 with `MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final` (configurable; see [Supported Models](#supported-models)).
 
 ## Prerequisites
 - **NGC API key** to download the base container and any NGC-hosted model.
@@ -220,16 +220,15 @@ Common service variables and chart values are listed in [Docker Compose and Helm
 
 RT-VLM supports local vLLM-compatible checkpoints, NGC model artifacts, and remote OpenAI-compatible endpoints. Use `MODEL_PATH=git:<Hugging Face URL>` for Hugging Face checkpoints, `MODEL_PATH=ngc:<org>/<team>/<model>:<version>` for NGC model artifacts, or `VLM_MODEL_TO_USE=openai-compat` with `VIA_VLM_ENDPOINT` for a remote endpoint.
 
-### Cosmos Reason2 Family (Default)
+### Cosmos Reason2 Family
 
 | Model or checkpoint | Example selector |
 |---------------------|------------------|
-| Cosmos Reason3 Nano BF16, `bf16-final` | `VLM_MODEL_TO_USE=cosmos-reason3`, `MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final` |
 | Cosmos Reason2 8B, `0303-fp8-dynamic-kv8` | `VLM_MODEL_TO_USE=cosmos-reason2`, `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:0303-fp8-dynamic-kv8` |
 | [Cosmos Reason2 8B, hf-0303](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/models/cosmos-reason2-8b?version=hf-0303) | `VLM_MODEL_TO_USE=cosmos-reason2`, `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:hf-0303` |
 | [Cosmos Reason2 8B, 0303-fp4-dynamic-kv8](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/models/cosmos-reason2-8b?version=0303-fp4-dynamic-kv8) | `VLM_MODEL_TO_USE=cosmos-reason2`, `MODEL_PATH=ngc:nim/nvidia/cosmos-reason2-8b:0303-fp4-dynamic-kv8`. Do not use this FP4/NVFP4 variant on GB200. |
 
-### Cosmos3 Family
+### Cosmos3 Family (Default)
 
 | Model or checkpoint | Example selector |
 |---------------------|------------------|
@@ -241,7 +240,7 @@ RT-VLM supports local vLLM-compatible checkpoints, NGC model artifacts, and remo
 | Model or checkpoint | Example selector |
 |---------------------|------------------|
 | [Nemotron-3-Nano-Omni-30B-A3B-Reasoning](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning) | `VLM_MODEL_TO_USE=vllm-compatible`, `VLM_TRUST_REMOTE_CODE=true`, `VLM_MODEL_SUPPORTS_AUDIO=true` for audio |
-| [Nemotron-Nano-V3-Omni-GA0420-FP8](https://huggingface.co/nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8) | `VLM_MODEL_TO_USE=vllm-compatible`, `VLM_TRUST_REMOTE_CODE=true`, `VLM_MODEL_SUPPORTS_AUDIO=true` for audio |
+| [Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8) | `VLM_MODEL_TO_USE=vllm-compatible`, `MODEL_PATH=git:https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8`, `VLM_TRUST_REMOTE_CODE=true`, `VLM_MODEL_SUPPORTS_AUDIO=true` for audio |
 
 ### Qwen Family
 


### PR DESCRIPTION
Fixes NVBug 6453445.

## Description

This PR fixes the agreed GitHub README documentation issues while leaving the stale Logstash BlueprintBuilderGenerated paths out of scope pending developer guidance.

Changes:
- Updates the root README Agent Workflows docs link to the current public page.
- Updates the root README Cosmos model entry to Cosmos3 Nano Reasoner.
- Replaces the stale Brev docs host in the skill-eval README with the current NVIDIA Brev CLI docs.
- Fixes the RT-VLM README supported-models anchor.
- Moves the RT-VLM default marker from Cosmos Reason2 to Cosmos3 and removes the misplaced Cosmos3 row from the Reason2 section.
- Replaces the old gated/unauthorized Nemotron Omni FP8 Hugging Face row with the current GitLab-docs model/link.

## Validation

- Ran `git diff --check -- README.md .github/skill-eval/README.md services/rtvi/rt-vlm/README.md`.
- Verified replacement public URLs return HTTP 200.
- Ran `uv run pre-commit run --files ../../README.md ../../.github/skill-eval/README.md ../rtvi/rt-vlm/README.md` from `services/agent`.
- Commit is DCO signed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.