### PR TITLE
Fix RTVI-CV Docker workload SDRC configs

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/sdrc/2d_cv/configs/config.yml.tmpl
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/sdrc/2d_cv/configs/config.yml.tmpl
@@ -48,15 +48,21 @@ docker-workload-rtvi-cv:
   wl_obj_name: perception-sdr
   port: 4004
   enable: true
-  WDM_INITIALIZE_FROM_VST: true
+  WDM_INITIALIZE_FROM_VST: false
   WDM_KFK_ENABLE: false
   WDM_PRELOAD_DELAY_FOR_DS_API: true
   WDM_WL_THRESHOLD: ${NUM_SENSORS}
   WDM_POD_WATCH_DOCKER_DELAY: 0.5
+  WDM_XDS_USE_POD_DNS: true
+  WDM_XDS_USE_IP_ADDRESS: false
   WDM_WL_OBJECT_NAME: vss-rtvi-cv
   WDM_CONSUMER_GRP_ID: sdr-deepstream-cg
   WDM_CLUSTER_CONTAINER_NAMES: '["vss-rtvi-cv"]'
   WDM_REDIS_MSG_KEY: vst.event
   WDM_CLUSTER_CONFIG_FILE: /configs/docker_cluster_config-rtvi-cv.json
+  WDM_WL_ADD_URL: /api/v1/stream/add
+  WDM_WL_DELETE_URL: /api/v1/stream/remove
+  WDM_WL_CHANGE_ID_ADD: camera_streaming
+  WDM_WL_CHANGE_ID_DEL: camera_remove
   NOHEADERTARGETROUTE: false
   WDM_ADD_REMOVE_RETRY_ATTEMPTS: 15000

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/sdrc/configs/config.yml.tmpl
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/sdrc/configs/config.yml.tmpl
@@ -56,6 +56,7 @@ docker-workload-rtvi-cv:
   WDM_REDIS_MSG_KEY: vst.event
   WDM_WL_REDIS_MSG_FIELD: value
   REDIS_MSG_KEY: vst.event
+  WDM_INITIALIZE_FROM_VST: false
   WDM_KFK_ENABLE: ${RTVI_CV_WDM_KFK_ENABLE}
   WDM_CLUSTER_TYPE: docker
   WDM_CLUSTER_CONTAINER_NAMES: '["vss-rtvi-cv"]'
@@ -68,6 +69,10 @@ docker-workload-rtvi-cv:
   NOHEADERTARGETROUTE: false
   HEADERLESS_SERVICE_ENDPOINTS: "[]"
   WDM_REAPPLY_ON_WL_RESTART: true
+  WDM_WL_ADD_URL: /api/v1/stream/add
+  WDM_WL_DELETE_URL: /api/v1/stream/remove
+  WDM_WL_CHANGE_ID_ADD: camera_streaming
+  WDM_WL_CHANGE_ID_DEL: camera_remove
   WDM_WL_THRESHOLD: 100
   WDM_ADD_REMOVE_RETRY_ATTEMPTS: 15000
 

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/sdrc/configs/config.yml.tmpl
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/sdrc/configs/config.yml.tmpl
@@ -66,9 +66,11 @@ docker-workload-rtvi-cv:
   NOHEADERTARGETROUTE: false
   HEADERLESS_SERVICE_ENDPOINTS: "[]"
   WDM_KFK_ENABLE: ${RTVI_CV_WDM_KFK_ENABLE}
-  WDM_INITIALIZE_FROM_VST: true
+  WDM_INITIALIZE_FROM_VST: false
   WDM_PRELOAD_DELAY_FOR_DS_API: true
-  WDM_WL_CHANGE_ID_ADD: camera_proxy
+  WDM_WL_ADD_URL: /api/v1/stream/add
+  WDM_WL_DELETE_URL: /api/v1/stream/remove
+  WDM_WL_CHANGE_ID_ADD: camera_streaming
   WDM_WL_CHANGE_ID_DEL: camera_remove
   WDM_WL_THRESHOLD: 100
   WDM_POD_WATCH_DOCKER_DELAY: 0.5


### PR DESCRIPTION
## Summary

Updates Docker SDRC config templates for the `docker-workload-rtvi-cv` workload across
warehouse and developer profiles to use the correct stream registration API and disable
VST-based initialization.

### Changes

- **`dev-profile-alerts` (2d_cv):**
  - Set `WDM_INITIALIZE_FROM_VST: false` to disable VST-driven stream init
  - Added `WDM_XDS_USE_POD_DNS: true` and `WDM_XDS_USE_IP_ADDRESS: false` for pod DNS resolution
  - Added stream add/remove URLs (`/api/v1/stream/add`, `/api/v1/stream/remove`)
  - Set change IDs to `camera_streaming` / `camera_remove`

- **`warehouse-2d-app`:**
  - Set `WDM_INITIALIZE_FROM_VST: false`
  - Added stream add/remove URLs and change IDs (`camera_streaming`, `camera_remove`)

- **`warehouse-3d-app`:**
  - Set `WDM_INITIALIZE_FROM_VST: false`
  - Replaced `camera_proxy` change ID with `camera_streaming`
  - Added explicit `WDM_WL_ADD_URL` and `WDM_WL_DELETE_URL`

