### PR TITLE
feat(video_understanding): dense chunked captioning for long-video summarization (opt-in)

### DIFF
--- a/services/agent/src/vss_agents/tools/_chunked_caption.py
+++ b/services/agent/src/vss_agents/tools/_chunked_caption.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dense chunked captioning for long videos.
+
+The base ``video_understanding`` tool samples a fixed frame budget
+(``num_frames = min(video_length * max_fps, max_frames)``) across the WHOLE clip.
+On a long video that saturates at ``max_frames`` and the effective frame rate drops
+far below 1 fps (e.g. a 210s clip at ``max_frames=30`` is ~1 frame / 7s), which
+starves the VLM and makes it confabulate events that never happen.
+
+This module holds the pure, dependency-free orchestration for the fix: tile the
+video into short fixed-length windows and caption each one densely (a ~30s window
+at the same frame budget is ~1 fps), then aggregate. Each window's caption is
+produced by a caller-supplied coroutine so this module never imports the VLM/VST
+stack (keeps it unit-testable and free of import cycles). The caller passes a
+``caption_window`` callable; this module never calls the ``video_understanding``
+tool itself, so the tool cannot recurse into itself.
+"""
+
+import asyncio
+from collections.abc import Awaitable
+from collections.abc import Callable
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Appended to the user's prompt for each window so the VLM grounds its answer in the
+# segment it can actually see and does not speculate about the rest of the video.
+DENSE_WINDOW_INSTRUCTION = (
+    "\n\nThis video is one short segment of a longer video. Describe in detail only what is "
+    "visibly happening in this segment, grounded in what you can actually see. Do not describe or "
+    "infer anything outside this segment, and do not invent events you cannot see."
+)
+
+
+def divide_into_windows(duration_seconds: float, window_seconds: int) -> list[tuple[float, float]]:
+    """Tile ``[0, duration_seconds]`` into consecutive windows of ``window_seconds``.
+
+    The final window may be shorter than ``window_seconds``. Always returns at least
+    one window (a video shorter than one window yields a single ``[0, duration]`` window).
+    """
+    if window_seconds <= 0:
+        raise ValueError(f"window_seconds must be > 0, got {window_seconds!r}")
+    if duration_seconds <= 0:
+        return [(0.0, float(duration_seconds))]
+    windows: list[tuple[float, float]] = []
+    start = 0.0
+    while start < duration_seconds:
+        end = min(start + window_seconds, duration_seconds)
+        windows.append((start, end))
+        start = end
+    return windows
+
+
+async def caption_in_windows(
+    *,
+    windows: list[tuple[float, float]],
+    caption_window: Callable[[float, float], Awaitable[str]],
+    max_concurrency: int = 3,
+    join_with: str = "\n\n",
+) -> str:
+    """Caption a long video over the given windows, then aggregate.
+
+    Args:
+        windows: the ``[(start, end), ...]`` windows to caption (from ``divide_into_windows``).
+            Passing them in rather than recomputing keeps the tiling decision single-sourced
+            in the caller.
+        caption_window: coroutine ``(window_start, window_end) -> caption`` supplied by the
+            caller. It owns the actual VLM/VST call for one sub-clip. Windows are absolute
+            offsets so the caller can fetch the matching sub-clip URL.
+        max_concurrency: upper bound on concurrent ``caption_window`` calls. The video model
+            is a shared, memory-bounded resource; an unbounded fan-out on a long video can
+            thrash it. Defaults to a conservative 3.
+        join_with: separator between window captions in the aggregated result.
+
+    Returns:
+        The window captions joined into one string, each prefixed with its ``[start-end s]`` time
+        range (relative to the start of the captioned span; the caller only enables this for spans
+        that start at 0, so the range doubles as the absolute video time) so the result stays
+        chronologically legible without depending on the VLM emitting its own timestamps.
+
+    Partial-failure policy: one window failing (after its own retries) must not discard the windows
+    that succeeded, since the whole point is coverage. A failed or empty window is kept in place with
+    a visible placeholder; the call raises only if EVERY window fails, so a total outage still fails
+    atomically like the single-pass path and a mostly-failed result never masquerades as success.
+    """
+    semaphore = asyncio.Semaphore(max(1, max_concurrency))
+    failures = 0
+
+    async def _run(window_start: float, window_end: float) -> str:
+        nonlocal failures
+        header = f"[{round(window_start)}-{round(window_end)}s]"
+        try:
+            async with semaphore:
+                caption = await caption_window(window_start, window_end)
+        except Exception as exc:  # one window must not sink the batch
+            failures += 1
+            logger.warning("dense caption window %s failed: %s: %s", header, type(exc).__name__, exc)
+            return f"{header} [caption unavailable]"
+        caption = (caption or "").strip()
+        return f"{header} {caption}" if caption else f"{header} [no caption returned]"
+
+    parts = await asyncio.gather(*(_run(start, end) for start, end in windows))
+    if failures == len(parts):
+        raise RuntimeError(f"dense chunked captioning: all {failures} window(s) failed")
+    return join_with.join(parts)

--- a/services/agent/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/src/vss_agents/tools/video_understanding.py
@@ -45,6 +45,9 @@ try:
 except ImportError:
     _profiler_callback_var = None
 
+from vss_agents.tools._chunked_caption import DENSE_WINDOW_INSTRUCTION
+from vss_agents.tools._chunked_caption import caption_in_windows
+from vss_agents.tools._chunked_caption import divide_into_windows
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import get_stream_id
 from vss_agents.utils.frame_select import frame_select
@@ -197,6 +200,17 @@ def _should_use_video_file_base64(
     )
 
 
+def _frame_budget(span_seconds: float, max_fps: int, max_frames: int) -> int:
+    """Frames to sample over a clip of ``span_seconds``: about ``max_fps`` per second, capped at
+    ``max_frames``, at least 1.
+
+    Single-sourced so the single-pass path (applied to the whole clip) and each dense window (applied
+    to the window) can never drift onto different frame math. This is exactly the density lever: the
+    same budget over a shorter span = more frames per second.
+    """
+    return max(min(int(span_seconds) * max_fps, max_frames), 1)
+
+
 class VideoUnderstandingConfig(FunctionBaseConfig, name="video_understanding"):
     """Configuration for the Video Understanding tool."""
 
@@ -235,6 +249,30 @@ class VideoUnderstandingConfig(FunctionBaseConfig, name="video_understanding"):
     max_pixels: int = Field(
         345600,
         description="The maximum number of pixels for 2 frames from the video, 28x28=784 will be converted to one video token",
+    )
+    dense_chunk_seconds: int = Field(
+        0,
+        description=(
+            "Dense chunked captioning for long videos. If > 0, videos longer than "
+            "dense_long_video_threshold_seconds are captioned in consecutive windows of this many "
+            "seconds and aggregated, so each window keeps a ~1 fps frame budget instead of starving "
+            "the VLM across the whole clip. 0 (default) keeps the original single-pass behavior."
+        ),
+    )
+    dense_long_video_threshold_seconds: float = Field(
+        60.0,
+        description=(
+            "Only apply dense chunked captioning to videos longer than this many seconds; shorter "
+            "clips already fit a dense frame budget in one pass and stay single-pass. Only consulted "
+            "when dense_chunk_seconds > 0."
+        ),
+    )
+    dense_max_concurrency: int = Field(
+        3,
+        description=(
+            "Maximum concurrent per-window VLM calls when dense chunked captioning is active, to bound "
+            "load on the shared VLM/GPU. Only consulted when dense_chunk_seconds > 0."
+        ),
     )
     reasoning: bool = Field(
         False,
@@ -481,6 +519,8 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
         f"enable_audio: {config.enable_audio}, use_base64: {use_video_base64}, "
         f"use_video_file_base64: {use_video_file_base64}"
     )
+    if config.enable_audio and _is_omni_audio_model(model_name):
+        logger.info("VLM audio-in-video enabled (mm_processor_kwargs.use_audio_in_video=true)")
 
     if not config.use_vst:
         s3_client = boto3.client(
@@ -583,112 +623,16 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             start_dt = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
             end_dt = datetime.fromisoformat(end_iso.replace("Z", "+00:00"))
         video_length_seconds = (end_dt - start_dt).total_seconds()
-        num_frames = min(int(video_length_seconds) * config.max_fps, config.max_frames)
-        # Ensure at least 1 frame
-        num_frames = max(num_frames, 1)
-        logger.info(
-            f"Video length: {video_length_seconds:.1f}s, num_frames: {num_frames} (max_fps={config.max_fps}, max_frames={config.max_frames})"
-        )
 
-        # Bind VLM with dynamic num_frames
-        if is_cosmos_model:
-            media_io_kwargs = {"video": {"num_frames": num_frames}}
-            if is_cosmos_reason2:
-                mm_processor_kwargs = {"size": {"shortest_edge": config.min_pixels, "longest_edge": config.max_pixels}}
-            else:
-                mm_processor_kwargs = {
-                    "videos_kwargs": {"min_pixels": config.min_pixels, "max_pixels": config.max_pixels}
-                }
-            vlm = base_vlm.bind(
-                mm_processor_kwargs=mm_processor_kwargs,
-                media_io_kwargs=media_io_kwargs,
-            )
-        elif config.enable_audio and _is_omni_audio_model(model_name):
-            # Nemotron Omni: MP4 audio is ignored unless use_audio_in_video is set.
-            # See NVIDIA NIM Omni API docs (mm_processor_kwargs).
-            vlm = base_vlm.bind(mm_processor_kwargs={"use_audio_in_video": True})
-            logger.info("VLM audio-in-video enabled (mm_processor_kwargs.use_audio_in_video=true)")
-        else:
-            vlm = base_vlm
-
-        # Select reasoning mode: default to config.reasoning if not specified in the input
+        # Reasoning mode and prompt template are per-request; the single-pass path and each dense
+        # window below reuse them through _run_vlm so the two never drift.
         use_reasoning = (
             video_understanding_input.vlm_reasoning
             if video_understanding_input.vlm_reasoning is not None
             else config.reasoning
         )
-
         prompt_template = reasoning_prompt_template if use_reasoning else non_reasoning_prompt_template
-
-        vlm_chain = prompt_template | vlm
         logger.info(f"VLM reasoning mode: {use_reasoning}")
-
-        # Step 1: Get the video URL (different paths for S3 vs VST)
-        if not config.use_vst:
-            # get the video URL from S3
-            if not s3_client:
-                raise ValueError("S3 client is not configured correctly")
-            video_url = s3_client.generate_presigned_url(
-                "get_object",
-                Params={
-                    "Bucket": config.bucket_name,
-                    "Key": video_understanding_input.sensor_id + ".mp4",
-                },
-                ExpiresIn=3600,
-            )
-            logger.info(f"Video URL from S3: {video_url}")
-        else:
-            if config.time_format == "iso":
-                # "iso" mode: pass ISO 8601 timestamps directly to the video URL tool.
-                logger.info(
-                    f"Using {config.video_url_tool} to get video URL for file {video_understanding_input.sensor_id} from {video_understanding_input.start_timestamp} to {video_understanding_input.end_timestamp}"
-                )
-
-                video_understanding_input.end_timestamp = extend_timestamp(
-                    str(video_understanding_input.start_timestamp), str(video_understanding_input.end_timestamp)
-                )
-
-                vst_video_url_args: dict[str, Any] = {
-                    "sensor_id": video_understanding_input.sensor_id,
-                    "start_time": video_understanding_input.start_timestamp,
-                    "end_time": video_understanding_input.end_timestamp,
-                }
-
-                if hasattr(video_understanding_input, "object_ids") and video_understanding_input.object_ids:
-                    vst_video_url_args["object_ids"] = video_understanding_input.object_ids
-                    logger.info(f"Passing object IDs to VST video URL: {video_understanding_input.object_ids}")
-
-                logger.debug(f"VST video URL arguments: {vst_video_url_args}")
-
-                vst_video_url_result = await vst_video_url.ainvoke(input=vst_video_url_args)
-
-                video_url = vst_video_url_result.video_url
-            else:
-                # "offset" mode: pass second-based offsets to the video URL tool.
-                vst_video_url_result = await vst_video_url.ainvoke(
-                    input={
-                        "sensor_id": video_understanding_input.sensor_id,
-                        "start_time": video_understanding_input.start_timestamp,
-                        "end_time": video_understanding_input.end_timestamp,
-                    }
-                )
-                video_url = vst_video_url_result.video_url
-                logger.debug(f"Video URL from VST: {video_url}")
-
-            if not config.vst_internal_url:
-                logger.warning("VST internal URL is not configured; using the original VST video URL.")
-            video_url = rewrite_to_internal_vst_url(video_url, config.vst_internal_url)
-
-        if use_video_file_base64:
-            logger.info(
-                f"[Video Understanding] Downloading MP4 for inline base64 payload (audio preserved): {video_url}"
-            )
-        elif use_video_base64:
-            logger.info(f"[Video Understanding] VIDEO URL FOR LOCAL MEDIA DOWNLOAD: {video_url}")
-        elif config.use_vst:
-            logger.info(f"[Video Understanding] INTERNAL VIDEO URL FOR VLM ANALYSIS: {video_url}")
-        else:
-            logger.info(f"[Video Understanding] VIDEO URL FOR VLM ANALYSIS: {video_url}")
 
         user_prompt = video_understanding_input.user_prompt
         if is_cosmos_reason2 and use_reasoning:
@@ -698,54 +642,221 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
                 "Write your final answer immediately after the </think> tag."
             )
 
-        messages = await _build_vlm_messages(
-            video_url,
-            user_prompt,
-            use_base64=use_video_base64,
-            use_video_file_base64=use_video_file_base64,
-            video_length_seconds=video_length_seconds,
-            num_frames=num_frames,
-            max_fps=config.max_fps,
-        )
+        async def _run_vlm(clip_url: str, prompt_text: str, span_seconds: float, frames: int) -> str:
+            """Bind the VLM for one clip (with this clip's frame budget), run it, return the caption.
 
-        # Suppress NAT's profiler for the VLM call — it deep-copies the full
-        # input messages (including base64 video) into the SSE response stream.
-        # ContextVar suppresses the configure hook; empty callbacks overrides
-        # handlers already inherited from ancestor chains.
-        _saved_token = _profiler_callback_var.set(None) if _profiler_callback_var is not None else None
-
-        try:
-            # Retry logic for VLM call — only retry transient errors (connection/timeout/5xx).
-            # Client errors like 400 (e.g. unsupported video format) are not retryable.
-            async for retry in create_retry_strategy(retries=3, exceptions=_VLM_RETRYABLE_ERRORS):
-                with retry:
-                    try:
-                        response = await vlm_chain.ainvoke(
-                            {"messages": messages},
-                            config={"callbacks": []},
-                        )
-                        logger.debug(f"Response: {response}")
-                        break
-                    except Exception as e:
-                        logger.error(f"Error understanding video {video_understanding_input.sensor_id}: {e}")
-                        raise e
-        finally:
-            if _saved_token is not None:
-                _profiler_callback_var.reset(_saved_token)
-
-        content = str(response.content) if response.content is not None else ""
-        # Filter thinking traces
-        if config.filter_thinking:
-            thinking, answer = _parse_thinking_from_content(content)
-            if thinking:
-                logger.info(
-                    f"Filtered out thinking trace ({len(thinking)} chars), returning answer ({len(answer)} chars)"
+            Shared by the single-pass path and each dense window so the two never diverge. ``frames``
+            is bound per call, so a short dense window is sampled densely while a whole-clip single
+            pass keeps today's behavior.
+            """
+            # Bind VLM with this clip's num_frames
+            if is_cosmos_model:
+                media_io_kwargs = {"video": {"num_frames": frames}}
+                if is_cosmos_reason2:
+                    mm_processor_kwargs = {
+                        "size": {"shortest_edge": config.min_pixels, "longest_edge": config.max_pixels}
+                    }
+                else:
+                    mm_processor_kwargs = {
+                        "videos_kwargs": {"min_pixels": config.min_pixels, "max_pixels": config.max_pixels}
+                    }
+                vlm = base_vlm.bind(
+                    mm_processor_kwargs=mm_processor_kwargs,
+                    media_io_kwargs=media_io_kwargs,
                 )
-                return answer
+            elif config.enable_audio and _is_omni_audio_model(model_name):
+                # Nemotron Omni: MP4 audio is ignored unless use_audio_in_video is set.
+                # See NVIDIA NIM Omni API docs (mm_processor_kwargs). The one-time "audio
+                # enabled" log is emitted once at setup, not here, to avoid a per-window line.
+                vlm = base_vlm.bind(mm_processor_kwargs={"use_audio_in_video": True})
             else:
-                logger.info("No thinking traces found in response")
+                vlm = base_vlm
 
-        return content
+            vlm_chain = prompt_template | vlm
+
+            messages = await _build_vlm_messages(
+                clip_url,
+                prompt_text,
+                use_base64=use_video_base64,
+                use_video_file_base64=use_video_file_base64,
+                video_length_seconds=span_seconds,
+                num_frames=frames,
+                max_fps=config.max_fps,
+            )
+
+            # Suppress NAT's profiler for the VLM call: it deep-copies the full input messages
+            # (including base64 video) into the SSE response stream. The ContextVar suppresses the
+            # configure hook; the empty callbacks list overrides handlers inherited from ancestor chains.
+            _saved_token = _profiler_callback_var.set(None) if _profiler_callback_var is not None else None
+            try:
+                # Retry only transient errors (connection/timeout/5xx); 4xx like 400 are not retryable.
+                async for retry in create_retry_strategy(retries=3, exceptions=_VLM_RETRYABLE_ERRORS):
+                    with retry:
+                        try:
+                            response = await vlm_chain.ainvoke(
+                                {"messages": messages},
+                                config={"callbacks": []},
+                            )
+                            logger.debug(f"Response: {response}")
+                            break
+                        except Exception as e:
+                            logger.error(f"Error understanding video {video_understanding_input.sensor_id}: {e}")
+                            raise e
+            finally:
+                if _saved_token is not None:
+                    _profiler_callback_var.reset(_saved_token)
+
+            content = str(response.content) if response.content is not None else ""
+            if config.filter_thinking:
+                thinking, answer = _parse_thinking_from_content(content)
+                if thinking:
+                    logger.info(
+                        f"Filtered out thinking trace ({len(thinking)} chars), returning answer ({len(answer)} chars)"
+                    )
+                    return answer
+                logger.info("No thinking traces found in response")
+            return content
+
+        # The request dispatches to one of two branches, defined next; everything they share (timeline,
+        # reasoning/prompt, _run_vlm, _frame_budget) is already set up above.
+
+        async def _caption_single_pass() -> str:
+            """Original behavior: one frame budget across the WHOLE clip, one VLM call.
+
+            The default path, taken whenever dense is off or the clip is short / offset-mode /
+            non-zero-start (see the dispatch gate below).
+            """
+            num_frames = _frame_budget(video_length_seconds, config.max_fps, config.max_frames)
+            logger.info(
+                f"Video length: {video_length_seconds:.1f}s, num_frames: {num_frames} (max_fps={config.max_fps}, max_frames={config.max_frames})"
+            )
+
+            # Step 1: Get the video URL (different paths for S3 vs VST)
+            if not config.use_vst:
+                # get the video URL from S3
+                if not s3_client:
+                    raise ValueError("S3 client is not configured correctly")
+                video_url = s3_client.generate_presigned_url(
+                    "get_object",
+                    Params={
+                        "Bucket": config.bucket_name,
+                        "Key": video_understanding_input.sensor_id + ".mp4",
+                    },
+                    ExpiresIn=3600,
+                )
+                logger.info(f"Video URL from S3: {video_url}")
+            else:
+                if config.time_format == "iso":
+                    # "iso" mode: pass ISO 8601 timestamps directly to the video URL tool.
+                    logger.info(
+                        f"Using {config.video_url_tool} to get video URL for file {video_understanding_input.sensor_id} from {video_understanding_input.start_timestamp} to {video_understanding_input.end_timestamp}"
+                    )
+
+                    video_understanding_input.end_timestamp = extend_timestamp(
+                        str(video_understanding_input.start_timestamp), str(video_understanding_input.end_timestamp)
+                    )
+
+                    vst_video_url_args: dict[str, Any] = {
+                        "sensor_id": video_understanding_input.sensor_id,
+                        "start_time": video_understanding_input.start_timestamp,
+                        "end_time": video_understanding_input.end_timestamp,
+                    }
+
+                    if hasattr(video_understanding_input, "object_ids") and video_understanding_input.object_ids:
+                        vst_video_url_args["object_ids"] = video_understanding_input.object_ids
+                        logger.info(f"Passing object IDs to VST video URL: {video_understanding_input.object_ids}")
+
+                    logger.debug(f"VST video URL arguments: {vst_video_url_args}")
+
+                    vst_video_url_result = await vst_video_url.ainvoke(input=vst_video_url_args)
+
+                    video_url = vst_video_url_result.video_url
+                else:
+                    # "offset" mode: pass second-based offsets to the video URL tool.
+                    vst_video_url_result = await vst_video_url.ainvoke(
+                        input={
+                            "sensor_id": video_understanding_input.sensor_id,
+                            "start_time": video_understanding_input.start_timestamp,
+                            "end_time": video_understanding_input.end_timestamp,
+                        }
+                    )
+                    video_url = vst_video_url_result.video_url
+                    logger.debug(f"Video URL from VST: {video_url}")
+
+                if not config.vst_internal_url:
+                    logger.warning("VST internal URL is not configured; using the original VST video URL.")
+                video_url = rewrite_to_internal_vst_url(video_url, config.vst_internal_url)
+
+            if use_video_file_base64:
+                logger.info(
+                    f"[Video Understanding] Downloading MP4 for inline base64 payload (audio preserved): {video_url}"
+                )
+            elif use_video_base64:
+                logger.info(f"[Video Understanding] VIDEO URL FOR LOCAL MEDIA DOWNLOAD: {video_url}")
+            elif config.use_vst:
+                logger.info(f"[Video Understanding] INTERNAL VIDEO URL FOR VLM ANALYSIS: {video_url}")
+            else:
+                logger.info(f"[Video Understanding] VIDEO URL FOR VLM ANALYSIS: {video_url}")
+
+            return await _run_vlm(video_url, user_prompt, video_length_seconds, num_frames)
+
+        async def _caption_densely() -> str:
+            """Dense chunked captioning: tile the whole clip into short windows, caption each densely
+            via a per-window sub-clip URL (each ~window keeps ~1 fps), then aggregate. Fixes the
+            sparse-sampling starvation the single pass hits on long videos.
+            """
+            dense_prompt = user_prompt + DENSE_WINDOW_INSTRUCTION
+            if not config.vst_internal_url:
+                logger.warning("VST internal URL is not configured; dense windows will use the original VST video URL.")
+
+            async def _caption_window(window_start: float, window_end: float) -> str:
+                span_seconds = window_end - window_start
+                frames = _frame_budget(span_seconds, config.max_fps, config.max_frames)
+                vst_result = await vst_video_url.ainvoke(
+                    input={
+                        "sensor_id": video_understanding_input.sensor_id,
+                        "start_time": window_start,
+                        "end_time": window_end,
+                    }
+                )
+                clip_url = rewrite_to_internal_vst_url(vst_result.video_url, config.vst_internal_url)
+                logger.info(
+                    f"[Dense window {window_start:.0f}-{window_end:.0f}s] num_frames={frames} "
+                    f"(~{config.max_fps}fps over {span_seconds:.0f}s), clip_url={clip_url}"
+                )
+                return await _run_vlm(clip_url, dense_prompt, span_seconds, frames)
+
+            windows = divide_into_windows(video_length_seconds, config.dense_chunk_seconds)
+            logger.info(
+                f"Dense chunked captioning: {video_length_seconds:.1f}s > "
+                f"{config.dense_long_video_threshold_seconds:.1f}s threshold -> {len(windows)} windows "
+                f"of {config.dense_chunk_seconds}s (max_concurrency={config.dense_max_concurrency})"
+            )
+            return await caption_in_windows(
+                windows=windows,
+                caption_window=_caption_window,
+                max_concurrency=config.dense_max_concurrency,
+            )
+
+        # Dispatch: use dense chunked captioning only for a long, whole-video (0-based) request on a
+        # VST offset-mode clip when the feature is enabled (dense_chunk_seconds > 0). Every other case
+        # -- the default -- takes the original single pass. Gating on a 0-based span keeps each window's
+        # [start-end s] header equal to absolute video time and avoids fetching past the stream end.
+        dense_enabled = (
+            config.dense_chunk_seconds > 0
+            and config.use_vst
+            and config.time_format != "iso"
+            and vst_video_url is not None
+            and video_length_seconds > config.dense_long_video_threshold_seconds
+            and (
+                video_understanding_input.start_timestamp is None
+                or float(video_understanding_input.start_timestamp) == 0.0
+            )
+        )
+        if dense_enabled:
+            return await _caption_densely()
+        else:
+            return await _caption_single_pass()
 
     # Register the tool with the appropriate input schema based on time_format:
     #   - "offset": accepts float offsets (seconds since start of stream).

--- a/services/agent/tests/unit_test/tools/test_chunked_caption.py
+++ b/services/agent/tests/unit_test/tools/test_chunked_caption.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the pure dense chunked captioning helpers (_chunked_caption).
+
+Covers the window-tiling math and the aggregation orchestrator in isolation
+(no VLM/VST dependencies), using a stub caption coroutine.
+"""
+
+import asyncio
+from itertools import pairwise
+
+import pytest
+
+from vss_agents.tools._chunked_caption import caption_in_windows
+from vss_agents.tools._chunked_caption import divide_into_windows
+
+
+class TestDivideIntoWindows:
+    def test_exact_multiple(self):
+        assert divide_into_windows(60, 30) == [(0.0, 30.0), (30.0, 60.0)]
+
+    def test_long_video_tiles_into_seven_windows(self):
+        # The 210s clip that confabulates: 7 windows of 30s at ~1 fps each.
+        assert divide_into_windows(210, 30) == [
+            (0.0, 30.0),
+            (30.0, 60.0),
+            (60.0, 90.0),
+            (90.0, 120.0),
+            (120.0, 150.0),
+            (150.0, 180.0),
+            (180.0, 210.0),
+        ]
+
+    def test_partial_last_window(self):
+        assert divide_into_windows(45, 30) == [(0.0, 30.0), (30.0, 45.0)]
+
+    def test_window_longer_than_video_yields_single_window(self):
+        assert divide_into_windows(20, 30) == [(0.0, 20.0)]
+
+    def test_zero_duration_yields_single_window(self):
+        assert divide_into_windows(0, 30) == [(0.0, 0.0)]
+
+    def test_invalid_window_seconds_raises(self):
+        with pytest.raises(ValueError):
+            divide_into_windows(100, 0)
+        with pytest.raises(ValueError):
+            divide_into_windows(100, -1)
+
+    def test_tiling_is_gapless_and_covers_full_duration(self):
+        windows = divide_into_windows(217, 30)
+        assert windows[0][0] == 0.0
+        assert windows[-1][1] == 217
+        for (_, prev_end), (next_start, _) in pairwise(windows):
+            assert prev_end == next_start  # no gaps, no overlaps
+
+
+class TestCaptionInWindows:
+    @pytest.mark.asyncio
+    async def test_one_call_per_window_with_absolute_headers(self):
+        calls = []
+
+        async def cap(window_start, window_end):
+            calls.append((window_start, window_end))
+            return f"caption for {int(window_start)}"
+
+        result = await caption_in_windows(
+            windows=divide_into_windows(90, 30),
+            caption_window=cap,
+            max_concurrency=4,
+        )
+        assert calls == [(0.0, 30.0), (30.0, 60.0), (60.0, 90.0)]
+        assert result == ("[0-30s] caption for 0\n\n[30-60s] caption for 30\n\n[60-90s] caption for 60")
+
+    @pytest.mark.asyncio
+    async def test_short_video_single_window(self):
+        calls = []
+
+        async def cap(window_start, window_end):
+            calls.append((window_start, window_end))
+            return "only"
+
+        result = await caption_in_windows(
+            windows=divide_into_windows(12, 30),
+            caption_window=cap,
+            max_concurrency=3,
+        )
+        assert calls == [(0.0, 12.0)]
+        assert result == "[0-12s] only"
+
+    @pytest.mark.asyncio
+    async def test_concurrency_is_bounded_by_max_concurrency(self):
+        active = 0
+        peak = 0
+
+        async def cap(window_start, window_end):
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return "x"
+
+        # 300s / 30s = 10 windows, but never more than 2 in flight at once.
+        await caption_in_windows(
+            windows=divide_into_windows(300, 30),
+            caption_window=cap,
+            max_concurrency=2,
+        )
+        assert peak <= 2
+
+    @pytest.mark.asyncio
+    async def test_output_order_follows_window_order_not_completion(self):
+        async def cap(window_start, window_end):
+            # Earlier windows finish last if order were driven by completion time.
+            await asyncio.sleep((100 - window_start) * 0.001)
+            return f"w{int(window_start)}"
+
+        result = await caption_in_windows(
+            windows=divide_into_windows(90, 30),
+            caption_window=cap,
+            max_concurrency=4,
+        )
+        assert result == "[0-30s] w0\n\n[30-60s] w30\n\n[60-90s] w60"
+
+    @pytest.mark.asyncio
+    async def test_caption_whitespace_is_stripped(self):
+        async def cap(window_start, window_end):
+            return "  padded caption  \n"
+
+        result = await caption_in_windows(
+            windows=divide_into_windows(30, 30),
+            caption_window=cap,
+            max_concurrency=1,
+        )
+        assert result == "[0-30s] padded caption"
+
+    @pytest.mark.asyncio
+    async def test_one_failed_window_keeps_the_others(self):
+        async def cap(window_start, window_end):
+            if window_start == 30.0:
+                raise RuntimeError("VLM boom")
+            return f"ok{int(window_start)}"
+
+        # [30-60s] fails after its retries -> placeholder; the successful windows are kept in place.
+        result = await caption_in_windows(
+            windows=divide_into_windows(90, 30),
+            caption_window=cap,
+            max_concurrency=4,
+        )
+        assert result == "[0-30s] ok0\n\n[30-60s] [caption unavailable]\n\n[60-90s] ok60"
+
+    @pytest.mark.asyncio
+    async def test_all_windows_failed_raises(self):
+        async def cap(window_start, window_end):
+            raise RuntimeError("VLM down")
+
+        # Total outage still fails atomically, like the single-pass path.
+        with pytest.raises(RuntimeError):
+            await caption_in_windows(
+                windows=divide_into_windows(90, 30),
+                caption_window=cap,
+                max_concurrency=2,
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_window_caption_gets_placeholder(self):
+        async def cap(window_start, window_end):
+            return "   " if window_start == 0.0 else "real content"
+
+        result = await caption_in_windows(
+            windows=divide_into_windows(60, 30),
+            caption_window=cap,
+            max_concurrency=2,
+        )
+        assert result == "[0-30s] [no caption returned]\n\n[30-60s] real content"

--- a/services/agent/tests/unit_test/tools/test_video_understanding.py
+++ b/services/agent/tests/unit_test/tools/test_video_understanding.py
@@ -19,6 +19,7 @@ import pytest
 from vss_agents.tools.video_understanding import VideoUnderstandingConfig
 from vss_agents.tools.video_understanding import _build_vlm_messages
 from vss_agents.tools.video_understanding import _effective_system_prompt
+from vss_agents.tools.video_understanding import _frame_budget
 from vss_agents.tools.video_understanding import _is_cosmos_model
 from vss_agents.tools.video_understanding import _is_omni_audio_model
 from vss_agents.tools.video_understanding import _parse_thinking_from_content
@@ -423,3 +424,27 @@ class TestVideoUnderstandingConfig:
 
     def test_remote_vlm_base64_toggle_is_not_exposed(self):
         assert "use_base64_for_remote_vlm" not in VideoUnderstandingConfig.model_fields
+
+
+class TestFrameBudget:
+    """The frame-budget formula is single-sourced and shared by the single-pass path (whole clip)
+    and each dense window; these lock it so the two paths can never drift onto different math."""
+
+    def test_short_clip_scales_with_fps(self):
+        # 30s window at 2 fps = 60 desired, but capped at max_frames.
+        assert _frame_budget(30, max_fps=2, max_frames=30) == 30
+        assert _frame_budget(10, max_fps=2, max_frames=30) == 20
+
+    def test_long_clip_saturates_at_cap(self):
+        # 210s whole clip at 2 fps = 420 desired -> clamped to max_frames (the sparse-sampling cause).
+        assert _frame_budget(210, max_fps=2, max_frames=30) == 30
+
+    def test_at_least_one_frame(self):
+        assert _frame_budget(0, max_fps=2, max_frames=30) == 1
+        assert _frame_budget(0.4, max_fps=2, max_frames=30) == 1
+
+    def test_density_lever_shorter_span_more_fps(self):
+        # Same budget over a shorter span = higher effective fps: the whole point of windowing.
+        whole = _frame_budget(210, max_fps=2, max_frames=30)  # 30 frames / 210s = 0.14 fps
+        window = _frame_budget(30, max_fps=2, max_frames=30)  # 30 frames / 30s  = 1.0 fps
+        assert window / 30 > whole / 210


### PR DESCRIPTION
## Summary

On long videos, the base `video_understanding` tool samples a fixed frame budget across the whole clip, which drops the effective frame rate far below 1 fps and causes the VLM to miss real events (and, run to run, to invent events that never happen). This PR adds an opt-in "dense chunked captioning" path: for long whole-video requests it captions the clip in short consecutive windows at ~1 fps each and aggregates them. It is default-off and leaves the single-pass path byte-for-byte unchanged.

## The gap

While evaluating long-video summarization, the base tool produced summaries that were confidently wrong on longer clips: real events were dropped, and on a 210s warehouse clip the model sometimes reported a worker "trips and falls" when no such event occurs. Short clips were reliable; long clips were not. That pattern points at frame density, not the model.

## Root cause

`video_understanding` computes one frame budget for the entire requested span:

```
num_frames = min(video_length_seconds * max_fps, max_frames)   # capped at max_frames
```

With `max_frames = 30`, any clip longer than ~15s saturates at 30 frames. A 210s clip is therefore sampled at ~1 frame every 7 seconds. At that density the VLM cannot see events that occur between samples, so it both misses real events and hallucinates to fill the gaps. The same clip captioned in 30s windows (~1 fps) reads accurately.

## The fix

When enabled, tile the whole clip into consecutive fixed-length windows, caption each one densely by fetching a per-window sub-clip URL (so the VLM samples its frame budget over a short span, ~1 fps), then aggregate the window captions into one chronological summary with a `[start-end s]` header per window. The density comes from the shorter clip URL, not from raising any frame or pixel cap, so token and pixel budgets are unchanged. Default-off via `dense_chunk_seconds = 0`.

## How it works

- `_video_understanding` is now a small dispatcher: shared per-request setup, then `if dense_enabled: _caption_densely() else: _caption_single_pass()`. Each branch is a named function.
- No path divergence: both branches call one shared `_run_vlm` (VLM bind, retry, thinking-strip) and one shared `_frame_budget()` helper, so neither the VLM logic nor the frame math is duplicated. Both are covered by tests.
- The pure window math and aggregation live in a new dependency-free module `_chunked_caption.py` (`divide_into_windows`, `caption_in_windows`). It imports no VLM/VST code (unit-testable, no import cycle) and takes a caption callable, so `video_understanding` cannot recurse into itself.
- Partial-failure tolerant: windows fan out under a bounded semaphore (`dense_max_concurrency`). A failed or empty window is kept in place with a visible placeholder; the call raises only if every window fails, so the fan-out is never less reliable than the single-pass path.

## Results (deterministic A/B)

The base `video_understanding` tool was queried by a deterministic oracle (a fixed "summarize the whole video" ask, no policy sampling) on a 210s clip, scored by a grounded verifier: recall over 4 real events plus a no-hallucination check, `reward = 0.7 * recall + 0.3 * (0 if any trap tripped else 1)`. Before = single-pass, After = dense 30s windows, 3 reps each.

| metric | before (single-pass) | after (dense 7x30s) |
|---|---|---|
| reward (mean) | 0.767 | **1.000** |
| per-rep reward | 0.65, 0.825, 0.825 | **1.0, 1.0, 1.0** |
| person-fall hallucination | 0 / 3 | 0 / 3 |

The dense arm is a consistent 1.0 across all reps (all four real events described, no hallucination). The single pass wobbles (0.65 to 0.825) because it inconsistently misses the on-screen forklift, which appears around 60 to 90s of the clip. Caveat: n = 3 on one clip; the single pass did not confabulate a person-fall in these runs (that failure is run to run variable), so this run demonstrates the recall/coverage gain rather than hallucination removal.

## Testing

- New `test_chunked_caption.py` (15 tests): window tiling, aggregation, the partial-failure policy, and a concurrency-bound assertion.
- New `TestFrameBudget` (4 tests) locking the shared frame-budget formula. The existing `video_understanding` tests still pass, confirming the single-pass path is unchanged.

## Observability

The dense path logs at parity with single-pass: a start summary (clip length, threshold, window count, concurrency) and one line per window (its range, frame budget and fps, and the sub-clip URL), plus a warning per failed window.

## Backward compatibility

Default-off (`dense_chunk_seconds = 0`), so no behavior changes unless an operator opts in. The change is confined to `video_understanding.py` plus one new leaf module and its tests. No new dependency (stdlib only), no new service, no schema change (`video_understanding` still returns `str`), and no change to routing.

## Alternatives considered

- Reusing the summarization (LVS) path: requires an external backend service not present in the base deployment and a different structured return type. Not viable as a base-native fix.
- Simply raising `max_frames`: reinflates the per-call token and pixel budget on one giant request. Windowing keeps each call at the same small budget while raising fps.

## Limitations / follow-ups

- Only whole-video (0-based) requests take the dense path; dense captioning of an arbitrary offset sub-range is a follow-up.
- Aggregation is a chronological concatenation; a reduce/summarize pass over the windows could produce a single narrative answer.
- `dense_max_concurrency` default of 3 is conservative and worth tuning per VLM deployment.

## Configuration

New fields on `VideoUnderstandingConfig`, all only consulted when dense is enabled:

```yaml
functions:
  video_understanding:
    dense_chunk_seconds: 30                 # 0 = off (default). >0 = window length in seconds.
    dense_long_video_threshold_seconds: 60  # only chunk clips longer than this.
    dense_max_concurrency: 3                 # max concurrent per-window VLM calls.
```

