### PR TITLE
fix(sdrc): remove extra blank line failing yamllint in config.yml

### DIFF
--- a/services/sdrc/config.yml
+++ b/services/sdrc/config.yml
@@ -89,7 +89,6 @@ k8s-workerset2:
   WDM_MS_LISTENER_PORT: 9002
 
 
-
 workload-c:
   wl_obj_name: sdrc-example-c
   port: 4003


### PR DESCRIPTION
## What

`services/sdrc/config.yml` had 3 consecutive blank lines (lines 89-92), which yamllint's `empty-lines` rule flags as an error (`too many blank lines (3 > 2)`).

## Why it matters

The `Lint (Python)` CI job runs yamllint over all repo YAML files, so this one file fails the **required** `Lint (Python)` check on **every** open PR against `develop` (observed on #1320, where the agent code is clean but Lint fails solely on this file). Reducing the blank run to 2 clears it.

## Change

One blank line removed. yamllint passes (exit 0) with the CI config; the file's remaining items are pre-existing comment-spacing warnings, which do not fail the check.