### PR TITLE
feat(ci): QA drop release-note automation — tag-triggered notes pipeline + tracking-ref check

### DIFF
--- a/.github/scripts/check_tracking_ref.py
+++ b/.github/scripts/check_tracking_ref.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Warn-first tracking-reference check for PRs (tracking-ref-check.yml).
+
+Scans the PR's title, description, comments, commit messages, and branch
+name for a JIRA (VIA-<n>) or NVBugs reference — the same patterns the QA
+drop release-notes pipeline uses. PRs without one get a
+``needs-tracking-ref`` label and a bot comment asking the author to add
+a reference to the description. Always exits 0 (non-blocking): with ~2%
+of PRs carrying a reference today, a required check would halt the repo.
+Flip the workflow to a required check once compliance is healthy.
+
+Exemptions: bot authors (filtered in the workflow) and PRs carrying the
+``no-tracking-ref`` label (deliberate opt-out, e.g. pure chores).
+
+SECURITY: runs under pull_request_target — reads PR metadata via the
+REST API only and must never execute PR code.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from release_notes import github_api  # noqa: E402
+from release_notes.patterns import scan_surfaces  # noqa: E402
+
+LABEL = "needs-tracking-ref"
+OPT_OUT_LABEL = "no-tracking-ref"
+COMMENT_MARKER = "<!-- vss-tracking-ref-check -->"
+COMMENT_BODY = f"""{COMMENT_MARKER}
+No JIRA (`VIA-<number>`) or NVBugs reference found on this PR.
+
+QA drop release notes attribute every change to its tracker — without a
+reference this PR lands in the "Unreferenced PRs" section and QA has no
+issue to verify it against. Please add the JIRA issue or NVBug id to the
+PR **description** (e.g. `Fixes NVBug 6217188` or `VIA-2035`).
+
+If this change genuinely has no tracker (pure chore), apply the
+`{OPT_OUT_LABEL}` label instead. This check is informational and does not
+block merging.
+"""
+RESOLVED_BODY = f"{COMMENT_MARKER}\n✅ Tracking reference found — thanks!"
+
+
+def main() -> int:
+    repo = os.environ["GITHUB_REPOSITORY"]
+    number = int(os.environ["PR_NUMBER"])
+
+    pr = github_api.get(f"/repos/{repo}/pulls/{number}")
+    labels = {label.get("name", "") for label in pr.get("labels") or []}
+    if OPT_OUT_LABEL in labels:
+        print(f"PR #{number} opted out via '{OPT_OUT_LABEL}' label")
+        return 0
+
+    surfaces: list[tuple[str, str]] = [
+        ("title", pr.get("title") or ""),
+        ("body", pr.get("body") or ""),
+        ("branch", (pr.get("head") or {}).get("ref") or ""),
+    ]
+    for comment in github_api.get_paginated(f"/repos/{repo}/issues/{number}/comments"):
+        surfaces.append(("comment", comment.get("body") or ""))
+    for commit in github_api.get_paginated(f"/repos/{repo}/pulls/{number}/commits"):
+        message = (commit.get("commit") or {}).get("message") or ""
+        subject, _, rest = message.partition("\n")
+        surfaces.append(("commit_subject", subject))
+        if rest.strip():
+            surfaces.append(("commit_message", rest))
+
+    references = scan_surfaces(surfaces)
+    bot_comment = _find_bot_comment(repo, number)
+
+    if references:
+        found = ", ".join(sorted({f"{r.kind}:{r.key}" for r in references}))
+        print(f"PR #{number} has tracking reference(s): {found}")
+        if LABEL in labels:
+            github_api.request(
+                "DELETE", f"/repos/{repo}/issues/{number}/labels/{LABEL}"
+            )
+        if bot_comment and RESOLVED_BODY not in (bot_comment.get("body") or ""):
+            github_api.request(
+                "PATCH",
+                f"/repos/{repo}/issues/comments/{bot_comment['id']}",
+                {"body": RESOLVED_BODY},
+            )
+        return 0
+
+    print(f"PR #{number} has no tracking reference — labeling (non-blocking)")
+    if LABEL not in labels:
+        github_api.request("POST", f"/repos/{repo}/issues/{number}/labels", {"labels": [LABEL]})
+    if bot_comment is None:
+        github_api.request(
+            "POST", f"/repos/{repo}/issues/{number}/comments", {"body": COMMENT_BODY}
+        )
+    elif RESOLVED_BODY in (bot_comment.get("body") or ""):
+        # Reference was removed again (e.g. description edited) — re-warn.
+        github_api.request(
+            "PATCH",
+            f"/repos/{repo}/issues/comments/{bot_comment['id']}",
+            {"body": COMMENT_BODY},
+        )
+    return 0
+
+
+def _find_bot_comment(repo: str, number: int) -> dict | None:
+    for comment in github_api.get_paginated(f"/repos/{repo}/issues/{number}/comments"):
+        if COMMENT_MARKER in (comment.get("body") or ""):
+            return comment
+    return None
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_tracking_ref.py
+++ b/.github/scripts/check_tracking_ref.py
@@ -31,13 +31,16 @@ from release_notes.patterns import scan_surfaces  # noqa: E402
 LABEL = "needs-tracking-ref"
 OPT_OUT_LABEL = "no-tracking-ref"
 COMMENT_MARKER = "<!-- vss-tracking-ref-check -->"
+# NOTE: examples deliberately use <id> placeholders that do NOT match the
+# reference regexes — this comment becomes a scanned surface on the next
+# run, and a real-format example would satisfy the check by itself.
 COMMENT_BODY = f"""{COMMENT_MARKER}
-No JIRA (`VIA-<number>`) or NVBugs reference found on this PR.
+No JIRA (`VIA-<id>`) or NVBugs reference found on this PR.
 
 QA drop release notes attribute every change to its tracker — without a
 reference this PR lands in the "Unreferenced PRs" section and QA has no
 issue to verify it against. Please add the JIRA issue or NVBug id to the
-PR **description** (e.g. `Fixes NVBug 6217188` or `VIA-2035`).
+PR **description** (e.g. `Fixes NVBug <id>` or `VIA-<id>`).
 
 If this change genuinely has no tracker (pure chore), apply the
 `{OPT_OUT_LABEL}` label instead. This check is informational and does not
@@ -61,7 +64,14 @@ def main() -> int:
         ("body", pr.get("body") or ""),
         ("branch", (pr.get("head") or {}).get("ref") or ""),
     ]
-    for comment in github_api.get_paginated(f"/repos/{repo}/issues/{number}/comments"):
+    # Fetched once — reused below to locate our own marker comment
+    # (Greptile P2: avoid paginating the same list twice).
+    comments = github_api.get_paginated(f"/repos/{repo}/issues/{number}/comments")
+    for comment in comments:
+        # Bot comments (this check's own reminder, review bots, …) are not
+        # author intent — scanning them would let the reminder satisfy itself.
+        if (comment.get("user") or {}).get("type") == "Bot":
+            continue
         surfaces.append(("comment", comment.get("body") or ""))
     for commit in github_api.get_paginated(f"/repos/{repo}/pulls/{number}/commits"):
         message = (commit.get("commit") or {}).get("message") or ""
@@ -71,7 +81,9 @@ def main() -> int:
             surfaces.append(("commit_message", rest))
 
     references = scan_surfaces(surfaces)
-    bot_comment = _find_bot_comment(repo, number)
+    bot_comment = next(
+        (c for c in comments if COMMENT_MARKER in (c.get("body") or "")), None
+    )
 
     if references:
         found = ", ".join(sorted({f"{r.kind}:{r.key}" for r in references}))
@@ -103,13 +115,6 @@ def main() -> int:
             {"body": COMMENT_BODY},
         )
     return 0
-
-
-def _find_bot_comment(repo: str, number: int) -> dict | None:
-    for comment in github_api.get_paginated(f"/repos/{repo}/issues/{number}/comments"):
-        if COMMENT_MARKER in (comment.get("body") or ""):
-            return comment
-    return None
 
 
 if __name__ == "__main__":

--- a/.github/scripts/release_notes/__init__.py
+++ b/.github/scripts/release_notes/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""QA drop release-note generation.
+
+Collects PRs merged between two trigger tags (dev-* / v*), extracts
+JIRA (VIA-<n>) and NVBugs references, classifies them with an agent,
+renders release notes, and cross-posts to JIRA / NVBugs.
+
+Runs downstream on GitLab (ci-vss-oss) where JIRA/NVBugs are reachable;
+see docs in the workflow files and `python -m release_notes --help`.
+"""

--- a/.github/scripts/release_notes/__init__.py
+++ b/.github/scripts/release_notes/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """QA drop release-note generation.
 
-Collects PRs merged between two trigger tags (dev-* / v*), extracts
+Collects PRs merged between two weekly drop tags (dev-YY.MM.N[-h]), extracts
 JIRA (VIA-<n>) and NVBugs references, classifies them with an agent,
 renders release notes, and cross-posts to JIRA / NVBugs.
 

--- a/.github/scripts/release_notes/__main__.py
+++ b/.github/scripts/release_notes/__main__.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Release-notes pipeline entrypoint (runs downstream on ci-vss-oss).
+
+Usage (from a clone of the repo with tag history):
+
+    python -m release_notes \
+        --repo NVIDIA-AI-Blueprints/video-search-and-summarization \
+        --tag dev-26.07.3 --tracker-bug 6470596 \
+        --output release-notes-dev-26.07.3.md [--dry-run]
+
+Env: RELEASE_NOTES_GITHUB_TOKEN (or GITHUB_TOKEN), JIRA_TOKEN,
+ANTHROPIC_API_KEY (optional — fail-open), nvbugs-cli pre-authenticated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .classify import classify_pr, make_client
+from .collect import collect
+from .post import post_jira_comment, post_nvbug_comment
+from .render import NotesData, issue_comment, render
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="release_notes")
+    parser.add_argument("--repo", required=True, help="owner/name of the GitHub repo")
+    parser.add_argument("--tag", required=True, help="the trigger tag (dev-* or v*)")
+    parser.add_argument("--tracker-bug", required=True, help="QA Drop Tracker NVBug id")
+    parser.add_argument("--git-dir", default=".", help="path to a clone with tag history")
+    parser.add_argument("--output", default=None, help="write notes markdown here")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="render notes but post nothing anywhere"
+    )
+    args = parser.parse_args(argv)
+
+    window = collect(args.repo, args.git_dir, args.tag)
+    print(
+        f"window {window.previous_tag or '(none)'}..{args.tag}: "
+        f"{window.commit_count} commits, {len(window.pull_requests)} PRs"
+    )
+
+    client = make_client()
+    verdicts, unclassified = {}, set()
+    for pr in window.pull_requests:
+        if pr.is_bot:
+            continue
+        pr_verdicts, by_agent = classify_pr(pr, client)
+        verdicts[pr.number] = pr_verdicts
+        if pr_verdicts and not by_agent:
+            unclassified.add(pr.number)
+
+    data = NotesData(window=window, verdicts=verdicts, unclassified=unclassified)
+    notes = render(data)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(notes)
+        print(f"wrote {args.output}")
+    else:
+        print(notes)
+
+    failures = 0
+    for key, prs in sorted(data.issue_index("jira").items()):
+        failures += _attempt(post_jira_comment, key, issue_comment("jira", key, prs, args.tag), args)
+    for key, prs in sorted(data.issue_index("nvbug").items(), key=lambda kv: int(kv[0])):
+        failures += _attempt(
+            post_nvbug_comment, key, issue_comment("nvbug", key, prs, args.tag), args
+        )
+    # Full notes to the standing QA Drop Tracker — QA's single subscription point.
+    failures += _attempt(post_nvbug_comment, args.tracker_bug, notes, args)
+
+    if failures:
+        print(f"ERROR: {failures} post(s) failed")
+        return 1
+    return 0
+
+
+def _attempt(poster, key: str, body: str, args: argparse.Namespace) -> int:
+    try:
+        print(poster(key, body, args.tag, args.dry_run))
+        return 0
+    except Exception as err:  # keep going — one bad issue must not sink the drop notes
+        print(f"WARNING: posting to {key} failed: {err}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/release_notes/__main__.py
+++ b/.github/scripts/release_notes/__main__.py
@@ -27,7 +27,7 @@ from .render import NotesData, issue_comment, render
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="release_notes")
     parser.add_argument("--repo", required=True, help="owner/name of the GitHub repo")
-    parser.add_argument("--tag", required=True, help="the trigger tag (dev-* or v*)")
+    parser.add_argument("--tag", required=True, help="the weekly drop tag (dev-YY.MM.N[-h])")
     parser.add_argument("--tracker-bug", required=True, help="QA Drop Tracker NVBug id")
     parser.add_argument("--git-dir", default=".", help="path to a clone with tag history")
     parser.add_argument("--output", default=None, help="write notes markdown here")

--- a/.github/scripts/release_notes/classify.py
+++ b/.github/scripts/release_notes/classify.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Classify candidate references with Claude.
+
+The deterministic regex pass (patterns.py) is recall-biased: comments are
+scanned, so a reviewer writing "similar to bug 6123456" produces a
+candidate that must NOT be cross-posted. A per-PR agent call classifies
+every candidate as addressed / related / mentioned_only. The agent is
+constrained to the regex's candidate set — it annotates, never invents.
+
+Fail-open: if the API is unavailable for a PR, its candidates fall back
+to "related" (recall over precision — a stray note entry is cheaper than
+a silently dropped fix) and the notes flag the PR as unclassified.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from .collect import PullRequest
+
+MODEL = "claude-opus-4-8"
+
+CLASSIFICATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "classifications": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {"type": "string"},
+                    "classification": {
+                        "type": "string",
+                        "enum": ["addressed", "related", "mentioned_only"],
+                    },
+                    "reason": {"type": "string"},
+                },
+                "required": ["key", "classification", "reason"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["classifications"],
+    "additionalProperties": False,
+}
+
+PROMPT = """\
+You are classifying issue-tracker references found on a merged pull request so \
+that QA release notes only credit the PR with issues it actually worked on.
+
+Pull request #{number}: {title}
+Branch: {branch}
+Author: {author}
+
+Candidate references (kind, key, surface it was found on, and the line it \
+appeared in):
+{candidates}
+
+Classify EVERY candidate key exactly once:
+- "addressed": the PR fixes/implements/closes this issue (e.g. "fixes NVBug \
+6217188", the bug id in the branch name or title of a fix PR).
+- "related": materially connected to the PR's change but not its primary \
+target (e.g. a tracking parent, a partially-addressed issue).
+- "mentioned_only": incidental discussion — comparisons ("similar to bug X"), \
+unrelated context, pasted logs, references to other work.
+
+Titles/branch names referencing an id are almost always addressed. Reviewer \
+comments referencing a different id than the title/branch are usually \
+mentioned_only unless the discussion says the PR handles it.\
+"""
+
+
+@dataclass
+class Verdict:
+    kind: str  # "jira" | "nvbug"
+    key: str
+    classification: str  # "addressed" | "related" | "mentioned_only"
+    reason: str
+
+
+def _candidate_lines(pr: PullRequest) -> str:
+    return "\n".join(
+        f"- {ref.kind} {ref.key} (on {ref.surface}): {ref.context!r}" for ref in pr.references
+    )
+
+
+def classify_pr(pr: PullRequest, client: "object | None") -> tuple[list[Verdict], bool]:
+    """Return (verdicts, classified_by_agent) for one PR's candidates."""
+    unique: dict[str, str] = {}  # key -> kind
+    for ref in pr.references:
+        unique.setdefault(ref.key, ref.kind)
+    if not unique:
+        return [], True
+    if client is None:
+        return _fallback(unique, "agent unavailable"), False
+
+    import anthropic
+
+    prompt = PROMPT.format(
+        number=pr.number,
+        title=pr.title,
+        branch=pr.branch,
+        author=pr.author,
+        candidates=_candidate_lines(pr),
+    )
+    try:
+        response = client.messages.create(
+            model=MODEL,
+            max_tokens=16000,
+            thinking={"type": "adaptive"},
+            output_config={"format": {"type": "json_schema", "schema": CLASSIFICATION_SCHEMA}},
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except anthropic.APIError as err:
+        print(f"WARNING: classification failed for PR #{pr.number}: {err}")
+        return _fallback(unique, f"classification error: {type(err).__name__}"), False
+
+    if response.stop_reason == "refusal":
+        return _fallback(unique, "classification refused"), False
+    text = next((block.text for block in response.content if block.type == "text"), "")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return _fallback(unique, "unparseable classification output"), False
+
+    by_key = {item["key"]: item for item in parsed.get("classifications", [])}
+    verdicts = []
+    for key, kind in unique.items():
+        item = by_key.get(key)
+        if item is None:
+            verdicts.append(Verdict(kind, key, "related", "not classified by agent"))
+        else:
+            verdicts.append(Verdict(kind, key, item["classification"], item["reason"]))
+    return verdicts, True
+
+
+def _fallback(unique: dict[str, str], reason: str) -> list[Verdict]:
+    return [Verdict(kind, key, "related", reason) for key, kind in unique.items()]
+
+
+def make_client() -> "object | None":
+    """Anthropic client, or None when no key is configured (fail-open)."""
+    import os
+
+    if not os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        print("WARNING: ANTHROPIC_API_KEY not set — all candidates default to 'related'")
+        return None
+    import anthropic
+
+    return anthropic.Anthropic()

--- a/.github/scripts/release_notes/classify.py
+++ b/.github/scripts/release_notes/classify.py
@@ -16,35 +16,25 @@ a silently dropped fix) and the notes flag the PR as unclassified.
 from __future__ import annotations
 
 import json
+import os
+import re
 from dataclasses import dataclass
 
 from .collect import PullRequest
 
-MODEL = "claude-opus-4-8"
+# Default is the first-party alias; the ci-vss-oss job overrides this to the
+# NVIDIA Inference Hub's routed id (e.g. "azure/anthropic/claude-opus-4-8").
+DEFAULT_MODEL = "claude-opus-4-8"
 
-CLASSIFICATION_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "classifications": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "key": {"type": "string"},
-                    "classification": {
-                        "type": "string",
-                        "enum": ["addressed", "related", "mentioned_only"],
-                    },
-                    "reason": {"type": "string"},
-                },
-                "required": ["key", "classification", "reason"],
-                "additionalProperties": False,
-            },
-        }
-    },
-    "required": ["classifications"],
-    "additionalProperties": False,
-}
+# JSON is enforced by prompt, not by output_config.format: the Inference Hub
+# workspace this runs under has structured outputs disabled
+# ("structured_outputs not supported in your workspace").
+JSON_SHAPE = (
+    '{"classifications": [{"key": "<exact key as listed>", '
+    '"classification": "addressed|related|mentioned_only", "reason": "<short>"}]}'
+)
+
+FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
 
 PROMPT = """\
 You are classifying issue-tracker references found on a merged pull request so \
@@ -68,7 +58,12 @@ unrelated context, pasted logs, references to other work.
 
 Titles/branch names referencing an id are almost always addressed. Reviewer \
 comments referencing a different id than the title/branch are usually \
-mentioned_only unless the discussion says the PR handles it.\
+mentioned_only unless the discussion says the PR handles it.
+
+Respond with ONLY a JSON object (no markdown fences, no prose) of the shape:
+{json_shape}
+The "key" field must echo the candidate key EXACTLY as listed above (e.g. \
+"6217188" or "VIA-2035" — without the kind prefix).\
 """
 
 
@@ -104,13 +99,13 @@ def classify_pr(pr: PullRequest, client: "object | None") -> tuple[list[Verdict]
         branch=pr.branch,
         author=pr.author,
         candidates=_candidate_lines(pr),
+        json_shape=JSON_SHAPE,
     )
     try:
         response = client.messages.create(
-            model=MODEL,
+            model=os.environ.get("RELEASE_NOTES_CLAUDE_MODEL", DEFAULT_MODEL),
             max_tokens=16000,
             thinking={"type": "adaptive"},
-            output_config={"format": {"type": "json_schema", "schema": CLASSIFICATION_SCHEMA}},
             messages=[{"role": "user", "content": prompt}],
         )
     except anthropic.APIError as err:
@@ -121,18 +116,25 @@ def classify_pr(pr: PullRequest, client: "object | None") -> tuple[list[Verdict]
         return _fallback(unique, "classification refused"), False
     text = next((block.text for block in response.content if block.type == "text"), "")
     try:
-        parsed = json.loads(text)
+        parsed = json.loads(FENCE_RE.sub("", text).strip())
     except json.JSONDecodeError:
         return _fallback(unique, "unparseable classification output"), False
 
-    by_key = {item["key"]: item for item in parsed.get("classifications", [])}
+    items = [item for item in parsed.get("classifications", []) if isinstance(item, dict)]
     verdicts = []
     for key, kind in unique.items():
-        item = by_key.get(key)
-        if item is None:
+        # Exact key echo is instructed; tolerate a "nvbug 6217188"-style echo.
+        item = next(
+            (i for i in items if i.get("key") == key or key in str(i.get("key", ""))), None
+        )
+        if item is None or item.get("classification") not in (
+            "addressed",
+            "related",
+            "mentioned_only",
+        ):
             verdicts.append(Verdict(kind, key, "related", "not classified by agent"))
         else:
-            verdicts.append(Verdict(kind, key, item["classification"], item["reason"]))
+            verdicts.append(Verdict(kind, key, item["classification"], item.get("reason", "")))
     return verdicts, True
 
 
@@ -141,12 +143,18 @@ def _fallback(unique: dict[str, str], reason: str) -> list[Verdict]:
 
 
 def make_client() -> "object | None":
-    """Anthropic client, or None when no key is configured (fail-open)."""
-    import os
+    """Anthropic client, or None when no key is configured (fail-open).
 
+    The SDK reads ANTHROPIC_BASE_URL from the environment, which is how
+    the ci-vss-oss job points this at the NVIDIA Inference Hub gateway
+    (https://inference-api.nvidia.com) instead of the first-party API.
+    """
     if not os.environ.get("ANTHROPIC_API_KEY", "").strip():
         print("WARNING: ANTHROPIC_API_KEY not set — all candidates default to 'related'")
         return None
     import anthropic
 
+    base = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
+    model = os.environ.get("RELEASE_NOTES_CLAUDE_MODEL", DEFAULT_MODEL)
+    print(f"classifier: {model} via {base}")
     return anthropic.Anthropic()

--- a/.github/scripts/release_notes/classify.py
+++ b/.github/scripts/release_notes/classify.py
@@ -123,10 +123,13 @@ def classify_pr(pr: PullRequest, client: "object | None") -> tuple[list[Verdict]
     items = [item for item in parsed.get("classifications", []) if isinstance(item, dict)]
     verdicts = []
     for key, kind in unique.items():
-        # Exact key echo is instructed; tolerate a "nvbug 6217188"-style echo.
-        item = next(
-            (i for i in items if i.get("key") == key or key in str(i.get("key", ""))), None
-        )
+        # Exact key echo is instructed; tolerate a "nvbug 6217188"-style echo
+        # via a boundary-aware match (a bare substring test would let a
+        # shorter key claim a longer key's verdict, e.g. 621718 vs 6217188).
+        item = next((i for i in items if i.get("key") == key), None)
+        if item is None:
+            boundary = re.compile(rf"(?<![\w.-]){re.escape(key)}(?![\w.-])", re.IGNORECASE)
+            item = next((i for i in items if boundary.search(str(i.get("key", "")))), None)
         if item is None or item.get("classification") not in (
             "addressed",
             "related",

--- a/.github/scripts/release_notes/collect.py
+++ b/.github/scripts/release_notes/collect.py
@@ -194,6 +194,11 @@ def fetch_pull_request(repo: str, number: int) -> PullRequest | None:
         ("branch", (pr.get("head") or {}).get("ref") or ""),
     ]
     for comment in github_api.get_paginated(f"/repos/{repo}/issues/{number}/comments"):
+        # Bot comments are not author intent — in particular the
+        # tracking-ref reminder bot's own comment must not count as a
+        # reference source (nor should review-bot chatter).
+        if (comment.get("user") or {}).get("type") == "Bot":
+            continue
         surfaces.append(("comment", comment.get("body") or ""))
     for commit in github_api.get_paginated(f"/repos/{repo}/pulls/{number}/commits"):
         message = (commit.get("commit") or {}).get("message") or ""

--- a/.github/scripts/release_notes/collect.py
+++ b/.github/scripts/release_notes/collect.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import re
 import subprocess
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 
 from . import github_api
 from .patterns import Reference, scan_surfaces
@@ -97,19 +98,30 @@ def window_commits(git_dir: str, tag: str, previous_tag: str | None) -> list[tup
     if previous_tag and _is_ancestor(git_dir, previous_tag, tag):
         raw = _git(git_dir, "log", "--format=%H%x00%s", f"{previous_tag}..{tag}")
         return [tuple(line.split("\x00", 1)) for line in raw.splitlines() if "\x00" in line]
-    lower = tag_commit_date(git_dir, previous_tag) if previous_tag else ""
+    lower = tag_commit_date(git_dir, previous_tag) if previous_tag else None
     raw = _git(git_dir, "log", "--format=%H%x00%cI%x00%s", tag)
     out: list[tuple[str, str]] = []
     for line in raw.splitlines():
         parts = line.split("\x00", 2)
-        if len(parts) == 3 and parts[1] > lower:
+        if len(parts) == 3 and (lower is None or _parse_iso(parts[1]) > lower):
             out.append((parts[0], parts[2]))
     return out
 
 
-def tag_commit_date(git_dir: str, rev: str) -> str:
-    """ISO-8601 committer date of the commit a tag points at."""
-    return _git(git_dir, "log", "-1", "--format=%cI", rev)
+def tag_commit_date(git_dir: str, rev: str) -> datetime:
+    """Committer date of the commit a tag points at (timezone-aware)."""
+    return _parse_iso(_git(git_dir, "log", "-1", "--format=%cI", rev))
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Parse ISO-8601 with either a Z or a numeric offset.
+
+    Git %cI dates carry the committer's local offset while GitHub API
+    timestamps are UTC Z — comparing the raw strings lexicographically is
+    chronologically wrong across offsets, so all boundary comparisons go
+    through timezone-aware datetimes.
+    """
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
 
 
 def pr_numbers_for_window(
@@ -138,7 +150,11 @@ def pr_numbers_for_window(
     window_shas = {sha for sha, _ in commits}
     window_subjects = {subject for _, subject in commits}
     upper = tag_commit_date(git_dir, tag)
-    lower = tag_commit_date(git_dir, previous_tag) if previous_tag else ""
+    lower = (
+        tag_commit_date(git_dir, previous_tag)
+        if previous_tag
+        else datetime.min.replace(tzinfo=timezone.utc)
+    )
 
     numbers: set[int] = set()
     for _, subject in commits:
@@ -157,8 +173,9 @@ def pr_numbers_for_window(
             merged_at = pr.get("merged_at") or ""
             if not merged_at:
                 continue
+            merged_dt = _parse_iso(merged_at)
             base = (pr.get("base") or {}).get("ref") or ""
-            in_window = lower < merged_at <= upper and _is_integration_base(base)
+            in_window = lower < merged_dt <= upper and _is_integration_base(base)
             if in_window or pr.get("merge_commit_sha") in window_shas:
                 number = int(pr["number"])
                 numbers.add(number)
@@ -169,7 +186,9 @@ def pr_numbers_for_window(
                 ):
                     print(f"note: PR #{number} matched by merge time only ({merged_at})")
         # Stop once a whole page is older than the window's lower bound.
-        if parsed and all((pr.get("updated_at") or "") < lower for pr in parsed):
+        if parsed and all(
+            _parse_iso(pr["updated_at"]) < lower for pr in parsed if pr.get("updated_at")
+        ):
             break
         page_url = github_api._next_link(headers.get("Link", ""))
     return numbers

--- a/.github/scripts/release_notes/collect.py
+++ b/.github/scripts/release_notes/collect.py
@@ -3,7 +3,7 @@
 """Collect the Drop Window and the PRs merged inside it.
 
 The Drop Window is tag-to-tag: everything reachable from the new trigger
-tag but not from the *nearest previous* trigger tag (dev-* or v*) in its
+tag but not from the *nearest previous* weekly drop tag in its
 ancestry. Never a fixed time lookback — multiple drops can land in one
 week (hotfix re-tags get small incremental windows) and a lookback would
 double-count or leave gaps.
@@ -21,7 +21,10 @@ from dataclasses import dataclass, field
 from . import github_api
 from .patterns import Reference, scan_surfaces
 
-TRIGGER_TAG_MATCHES = ("dev-*", "v*")
+# Weekly QA drop tags only: dev-YY.MM.N with an optional hotfix suffix
+# (dev-26.07.3, dev-26.06.3-1). Other dev-* tags and v* GA tags neither
+# trigger notes nor act as window boundaries.
+TRIGGER_TAG_RE = re.compile(r"^dev-\d{2}\.\d{2}\.\d+(-\d+)?$")
 PR_NUMBER_RE = re.compile(r"\((?:PR )?#(\d+)\)")
 BOT_AUTHOR_RE = re.compile(r"(\[bot\]$|^svc-|^copy-pr-bot)", re.IGNORECASE)
 MAX_CLOSED_PR_PAGES = 15  # 1500 most recently updated closed PRs
@@ -55,29 +58,22 @@ def _git(git_dir: str, *args: str) -> str:
 
 
 def previous_trigger_tag(git_dir: str, tag: str) -> str | None:
-    """The *chronologically* previous trigger tag, if any.
+    """The *chronologically* previous weekly drop tag, if any.
 
-    Chronological (not ancestry) selection is deliberate: v* release
-    tags live on release branches, so the ancestry-nearest tag can skip
-    over the actual previous QA drop and make consecutive drop windows
-    overlap or gap. Consecutive trigger tags by creation time partition
-    the timeline exactly once.
+    Chronological (not ancestry) selection is deliberate: the ancestry-
+    nearest tag can skip over the actual previous QA drop and make
+    consecutive drop windows overlap or gap. Consecutive drop tags by
+    creation time partition the timeline exactly once.
     """
-    import fnmatch
-
     raw = _git(
         git_dir, "for-each-ref", "refs/tags", "--sort=creatordate",
         "--format=%(refname:short)%00%(creatordate:iso-strict)",
     )
     tags = [tuple(line.split("\x00", 1)) for line in raw.splitlines() if "\x00" in line]
-    trigger_tags = [
-        (name, date)
-        for name, date in tags
-        if any(fnmatch.fnmatchcase(name, pattern) for pattern in TRIGGER_TAG_MATCHES)
-    ]
+    trigger_tags = [(name, date) for name, date in tags if TRIGGER_TAG_RE.match(name)]
     own_date = next((date for name, date in trigger_tags if name == tag), None)
     if own_date is None:
-        raise SystemExit(f"tag {tag!r} is not a trigger tag (dev-*/v*)")
+        raise SystemExit(f"tag {tag!r} is not a weekly drop tag (dev-YY.MM.N[-h])")
     older = [name for name, date in trigger_tags if name != tag and date < own_date]
     return older[-1] if older else None
 
@@ -94,9 +90,9 @@ def window_commits(git_dir: str, tag: str, previous_tag: str | None) -> list[tup
     """(sha, subject) pairs in the window, newest first.
 
     Pure ancestry range when the previous tag is an ancestor (the normal
-    dev-*→dev-* case); otherwise (e.g. a v* tag cut from a release
-    branch) fall back to slicing the tag's own lineage by the boundary
-    tags' commit dates.
+    case); otherwise (e.g. a boundary tag cut from a release branch)
+    fall back to slicing the tag's own lineage by the boundary tags'
+    commit dates.
     """
     if previous_tag and _is_ancestor(git_dir, previous_tag, tag):
         raw = _git(git_dir, "log", "--format=%H%x00%s", f"{previous_tag}..{tag}")

--- a/.github/scripts/release_notes/collect.py
+++ b/.github/scripts/release_notes/collect.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Collect the Drop Window and the PRs merged inside it.
+
+The Drop Window is tag-to-tag: everything reachable from the new trigger
+tag but not from the *nearest previous* trigger tag (dev-* or v*) in its
+ancestry. Never a fixed time lookback — multiple drops can land in one
+week (hotfix re-tags get small incremental windows) and a lookback would
+double-count or leave gaps.
+
+Requires a git clone with tag history (``git clone --filter=tree:0`` is
+enough); PR metadata comes from the GitHub REST API.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+
+from . import github_api
+from .patterns import Reference, scan_surfaces
+
+TRIGGER_TAG_MATCHES = ("dev-*", "v*")
+PR_NUMBER_RE = re.compile(r"\((?:PR )?#(\d+)\)")
+BOT_AUTHOR_RE = re.compile(r"(\[bot\]$|^svc-|^copy-pr-bot)", re.IGNORECASE)
+MAX_CLOSED_PR_PAGES = 15  # 1500 most recently updated closed PRs
+
+
+@dataclass
+class PullRequest:
+    number: int
+    title: str
+    author: str
+    branch: str
+    url: str
+    merged_at: str
+    is_bot: bool
+    labels: list[str] = field(default_factory=list)
+    references: list[Reference] = field(default_factory=list)
+
+
+@dataclass
+class DropWindow:
+    tag: str
+    previous_tag: str | None
+    commit_count: int
+    pull_requests: list[PullRequest]
+
+
+def _git(git_dir: str, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", git_dir, *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def previous_trigger_tag(git_dir: str, tag: str) -> str | None:
+    """The *chronologically* previous trigger tag, if any.
+
+    Chronological (not ancestry) selection is deliberate: v* release
+    tags live on release branches, so the ancestry-nearest tag can skip
+    over the actual previous QA drop and make consecutive drop windows
+    overlap or gap. Consecutive trigger tags by creation time partition
+    the timeline exactly once.
+    """
+    import fnmatch
+
+    raw = _git(
+        git_dir, "for-each-ref", "refs/tags", "--sort=creatordate",
+        "--format=%(refname:short)%00%(creatordate:iso-strict)",
+    )
+    tags = [tuple(line.split("\x00", 1)) for line in raw.splitlines() if "\x00" in line]
+    trigger_tags = [
+        (name, date)
+        for name, date in tags
+        if any(fnmatch.fnmatchcase(name, pattern) for pattern in TRIGGER_TAG_MATCHES)
+    ]
+    own_date = next((date for name, date in trigger_tags if name == tag), None)
+    if own_date is None:
+        raise SystemExit(f"tag {tag!r} is not a trigger tag (dev-*/v*)")
+    older = [name for name, date in trigger_tags if name != tag and date < own_date]
+    return older[-1] if older else None
+
+
+def _is_ancestor(git_dir: str, ancestor: str, descendant: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", git_dir, "merge-base", "--is-ancestor", ancestor, descendant],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def window_commits(git_dir: str, tag: str, previous_tag: str | None) -> list[tuple[str, str]]:
+    """(sha, subject) pairs in the window, newest first.
+
+    Pure ancestry range when the previous tag is an ancestor (the normal
+    dev-*→dev-* case); otherwise (e.g. a v* tag cut from a release
+    branch) fall back to slicing the tag's own lineage by the boundary
+    tags' commit dates.
+    """
+    if previous_tag and _is_ancestor(git_dir, previous_tag, tag):
+        raw = _git(git_dir, "log", "--format=%H%x00%s", f"{previous_tag}..{tag}")
+        return [tuple(line.split("\x00", 1)) for line in raw.splitlines() if "\x00" in line]
+    lower = tag_commit_date(git_dir, previous_tag) if previous_tag else ""
+    raw = _git(git_dir, "log", "--format=%H%x00%cI%x00%s", tag)
+    out: list[tuple[str, str]] = []
+    for line in raw.splitlines():
+        parts = line.split("\x00", 2)
+        if len(parts) == 3 and parts[1] > lower:
+            out.append((parts[0], parts[2]))
+    return out
+
+
+def tag_commit_date(git_dir: str, rev: str) -> str:
+    """ISO-8601 committer date of the commit a tag points at."""
+    return _git(git_dir, "log", "-1", "--format=%cI", rev)
+
+
+def pr_numbers_for_window(
+    repo: str,
+    git_dir: str,
+    tag: str,
+    previous_tag: str | None,
+    commits: list[tuple[str, str]],
+) -> set[int]:
+    """Find the PRs whose merge landed inside the Drop Window.
+
+    SHA-based mapping does not work in this repo: a post-merge signing
+    bot rewrites just-merged commits (to attach NVSkills validation
+    signatures) and force-pushes the base branch, so a merged PR's
+    ``merge_commit_sha`` frequently dangles while its commits reach the
+    tag lineage under new SHAs with preserved subjects.
+
+    The window is therefore evaluated at PR granularity: a PR belongs to
+    the drop when it merged into an integration base branch strictly
+    after the previous trigger tag's commit and at-or-before this tag's
+    commit (still tag-to-tag — the boundaries are the tag commits, never
+    a fixed lookback). ``merge_commit_sha`` membership and subject
+    markers like ``(#N)`` / ``(PR #N)`` are kept as supplements, and PRs
+    with no subject overlap in the window are logged for visibility.
+    """
+    window_shas = {sha for sha, _ in commits}
+    window_subjects = {subject for _, subject in commits}
+    upper = tag_commit_date(git_dir, tag)
+    lower = tag_commit_date(git_dir, previous_tag) if previous_tag else ""
+
+    numbers: set[int] = set()
+    for _, subject in commits:
+        for found in PR_NUMBER_RE.findall(subject):
+            numbers.add(int(found))
+
+    page_url: str | None = (
+        f"{github_api.API_ROOT}/repos/{repo}/pulls"
+        "?state=closed&sort=updated&direction=desc&per_page=100"
+    )
+    pages = 0
+    while page_url and pages < MAX_CLOSED_PR_PAGES:
+        parsed, headers = github_api.request("GET", page_url)
+        pages += 1
+        for pr in parsed or []:
+            merged_at = pr.get("merged_at") or ""
+            if not merged_at:
+                continue
+            base = (pr.get("base") or {}).get("ref") or ""
+            in_window = lower < merged_at <= upper and _is_integration_base(base)
+            if in_window or pr.get("merge_commit_sha") in window_shas:
+                number = int(pr["number"])
+                numbers.add(number)
+                head_subject = pr.get("title") or ""
+                if (
+                    pr.get("merge_commit_sha") not in window_shas
+                    and head_subject not in window_subjects
+                ):
+                    print(f"note: PR #{number} matched by merge time only ({merged_at})")
+        # Stop once a whole page is older than the window's lower bound.
+        if parsed and all((pr.get("updated_at") or "") < lower for pr in parsed):
+            break
+        page_url = github_api._next_link(headers.get("Link", ""))
+    return numbers
+
+
+def _is_integration_base(base: str) -> bool:
+    return base in ("develop", "main") or base.startswith(("dev/", "release/"))
+
+
+def fetch_pull_request(repo: str, number: int) -> PullRequest | None:
+    """Fetch one PR and scan all decided surfaces for candidate references.
+
+    Surfaces (per the pipeline spec): title, description, review
+    conversation comments, commit messages, and branch name.
+    """
+    pr = github_api.get(f"/repos/{repo}/pulls/{number}")
+    if not pr or not pr.get("merged_at"):
+        return None
+    surfaces: list[tuple[str, str]] = [
+        ("title", pr.get("title") or ""),
+        ("body", pr.get("body") or ""),
+        ("branch", (pr.get("head") or {}).get("ref") or ""),
+    ]
+    for comment in github_api.get_paginated(f"/repos/{repo}/issues/{number}/comments"):
+        surfaces.append(("comment", comment.get("body") or ""))
+    for commit in github_api.get_paginated(f"/repos/{repo}/pulls/{number}/commits"):
+        message = (commit.get("commit") or {}).get("message") or ""
+        subject, _, rest = message.partition("\n")
+        surfaces.append(("commit_subject", subject))
+        if rest.strip():
+            surfaces.append(("commit_message", rest))
+    author = (pr.get("user") or {}).get("login") or "unknown"
+    return PullRequest(
+        number=number,
+        title=pr.get("title") or "",
+        author=author,
+        branch=(pr.get("head") or {}).get("ref") or "",
+        url=pr.get("html_url") or "",
+        merged_at=pr.get("merged_at") or "",
+        is_bot=bool(BOT_AUTHOR_RE.search(author)),
+        labels=[label.get("name", "") for label in pr.get("labels") or []],
+        references=scan_surfaces(surfaces),
+    )
+
+
+def collect(repo: str, git_dir: str, tag: str) -> DropWindow:
+    previous_tag = previous_trigger_tag(git_dir, tag)
+    commits = window_commits(git_dir, tag, previous_tag)
+    numbers = pr_numbers_for_window(repo, git_dir, tag, previous_tag, commits)
+    pull_requests = [
+        pr for number in sorted(numbers) if (pr := fetch_pull_request(repo, number)) is not None
+    ]
+    return DropWindow(
+        tag=tag,
+        previous_tag=previous_tag,
+        commit_count=len(commits),
+        pull_requests=pull_requests,
+    )

--- a/.github/scripts/release_notes/github_api.py
+++ b/.github/scripts/release_notes/github_api.py
@@ -32,6 +32,8 @@ def request(
         "Authorization": f"Bearer {token()}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
+        # GitHub rejects requests without an identifiable User-Agent.
+        "User-Agent": "vss-release-notes",
     }
     if data is not None:
         headers["Content-Type"] = "application/json"
@@ -43,10 +45,23 @@ def request(
                 parsed = json.loads(payload) if payload.strip() else None
                 return parsed, dict(resp.headers)
         except HTTPError as err:
-            if err.code in RETRYABLE_STATUS and attempt < retries:
-                time.sleep(2**attempt)
+            detail = ""
+            try:
+                detail = err.read().decode(errors="replace")[:300]
+            except Exception:
+                pass
+            # Primary/secondary rate limits surface as 403 with a retry-after
+            # or a rate-limit message — treat those as retryable too.
+            rate_limited = err.code == 403 and (
+                "rate limit" in detail.lower() or err.headers.get("Retry-After")
+            )
+            if (err.code in RETRYABLE_STATUS or rate_limited) and attempt < retries:
+                wait = int(err.headers.get("Retry-After") or 2**attempt)
+                print(f"retrying {method} {url} after HTTP {err.code} ({wait}s): {detail[:120]}")
+                time.sleep(min(wait, 120))
                 last_error = err
                 continue
+            print(f"ERROR: {method} {url} -> HTTP {err.code}: {detail}")
             raise
         except URLError as err:
             if attempt < retries:

--- a/.github/scripts/release_notes/github_api.py
+++ b/.github/scripts/release_notes/github_api.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal stdlib GitHub REST client (token auth, pagination, retries)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+API_ROOT = "https://api.github.com"
+RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+def token() -> str:
+    value = os.environ.get("RELEASE_NOTES_GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    if not value.strip():
+        raise SystemExit("RELEASE_NOTES_GITHUB_TOKEN or GITHUB_TOKEN must be set")
+    return value.strip()
+
+
+def request(
+    method: str, path: str, body: dict[str, Any] | None = None, retries: int = 3
+) -> tuple[Any, dict[str, str]]:
+    """Issue one API request; return (parsed JSON, response headers)."""
+    url = path if path.startswith("http") else f"{API_ROOT}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {
+        "Authorization": f"Bearer {token()}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    last_error: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            with urlopen(Request(url, data=data, headers=headers, method=method)) as resp:
+                payload = resp.read()
+                parsed = json.loads(payload) if payload.strip() else None
+                return parsed, dict(resp.headers)
+        except HTTPError as err:
+            if err.code in RETRYABLE_STATUS and attempt < retries:
+                time.sleep(2**attempt)
+                last_error = err
+                continue
+            raise
+        except URLError as err:
+            if attempt < retries:
+                time.sleep(2**attempt)
+                last_error = err
+                continue
+            raise
+    raise RuntimeError(f"unreachable: {last_error}")
+
+
+def get(path: str) -> Any:
+    parsed, _ = request("GET", path)
+    return parsed
+
+
+def get_paginated(path: str, per_page: int = 100, max_pages: int = 20) -> list[Any]:
+    """GET all pages of a list endpoint (follows the Link: rel=next header)."""
+    sep = "&" if "?" in path else "?"
+    url: str | None = f"{API_ROOT}{path}{sep}per_page={per_page}"
+    items: list[Any] = []
+    for _ in range(max_pages):
+        if url is None:
+            break
+        parsed, headers = request("GET", url)
+        items.extend(parsed or [])
+        url = _next_link(headers.get("Link", ""))
+    return items
+
+
+def _next_link(link_header: str) -> str | None:
+    for part in link_header.split(","):
+        if 'rel="next"' in part:
+            return part.split(";")[0].strip().strip("<>")
+    return None

--- a/.github/scripts/release_notes/patterns.py
+++ b/.github/scripts/release_notes/patterns.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reference-extraction patterns for JIRA issues and NVBugs.
+
+Patterns follow observed usage in this repo's history rather than an
+idealized convention: ``VIA-2035``, ``NVBug 6453445``, ``NVBugs 6200918``,
+``bug 6311754``, ``nvbug/6292153``, and bare ids in branch names like
+``fix/6217188-storage-...``.
+
+Bare numbers (no nvbug/bug prefix) are only trusted on *curated*
+surfaces — PR title, branch name, and commit subjects — where they are
+near-certainly bug ids. Prose surfaces (PR body, comments, full commit
+messages) frequently contain pasted logs, so they require a prefix.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Surfaces where a bare 6-8 digit number counts as an NVBugs reference.
+CURATED_SURFACES = frozenset({"title", "branch", "commit_subject"})
+
+JIRA_RE = re.compile(r"\b(VIA-\d+)\b", re.IGNORECASE)
+NVBUG_PREFIXED_RE = re.compile(r"\b(?:nv)?bugs?\b[\s/:#-]*(\d{6,8})\b", re.IGNORECASE)
+NVBUG_BARE_RE = re.compile(r"\b(\d{6,8})\b")
+# Bare 8-digit numbers starting with 20 are dates (e.g. 20260602), not bugs.
+DATE_LIKE_RE = re.compile(r"^20\d{6}$")
+
+
+@dataclass(frozen=True)
+class Reference:
+    """A candidate tracking reference found on a PR surface."""
+
+    kind: str  # "jira" | "nvbug"
+    key: str  # "VIA-2035" or "6217188"
+    surface: str  # "title" | "body" | "branch" | "comment" | "commit_subject" | "commit_message"
+    context: str  # the line the match was found on (for the classifier)
+
+
+def _context_line(text: str, start: int) -> str:
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", start)
+    if line_end == -1:
+        line_end = len(text)
+    return text[line_start:line_end].strip()[:300]
+
+
+def extract(surface: str, text: str) -> list[Reference]:
+    """Extract candidate references from one surface's text."""
+    if not text:
+        return []
+    refs: list[Reference] = []
+    for match in JIRA_RE.finditer(text):
+        refs.append(
+            Reference("jira", match.group(1).upper(), surface, _context_line(text, match.start()))
+        )
+    seen_nvbug_spans: set[int] = set()
+    for match in NVBUG_PREFIXED_RE.finditer(text):
+        seen_nvbug_spans.add(match.start(1))
+        refs.append(Reference("nvbug", match.group(1), surface, _context_line(text, match.start())))
+    if surface in CURATED_SURFACES:
+        for match in NVBUG_BARE_RE.finditer(text):
+            number = match.group(1)
+            if match.start(1) in seen_nvbug_spans or DATE_LIKE_RE.match(number):
+                continue
+            refs.append(Reference("nvbug", number, surface, _context_line(text, match.start())))
+    return refs
+
+
+def scan_surfaces(surfaces: list[tuple[str, str]]) -> list[Reference]:
+    """Extract from (surface, text) pairs, deduplicated by (kind, key, surface)."""
+    out: list[Reference] = []
+    seen: set[tuple[str, str, str]] = set()
+    for surface, text in surfaces:
+        for ref in extract(surface, text):
+            dedupe_key = (ref.kind, ref.key, ref.surface)
+            if dedupe_key not in seen:
+                seen.add(dedupe_key)
+                out.append(ref)
+    return out

--- a/.github/scripts/release_notes/post.py
+++ b/.github/scripts/release_notes/post.py
@@ -6,18 +6,21 @@ Every posted comment starts with a per-(issue, tag) marker so pipeline
 retries and hotfix re-runs never double-post: existing comments are
 listed first and the post is skipped when the marker is already there.
 
-JIRA (jirasw.nvidia.com) is reached via REST with bearer auth;
-NVBugs via ``nvbugs-cli`` (installed and authenticated by the CI job).
+Both trackers are reached via REST with bearer tokens: JIRA at
+jirasw.nvidia.com, NVBugs at prod.api.nvidia.com/int/nvbugs (the same
+NVAuth JWT used by nvbugs-cli; direct REST avoids installing internal
+tooling into the CI image).
 """
 
 from __future__ import annotations
 
 import json
 import os
-import subprocess
+import ssl
 from urllib.request import Request, urlopen
 
 JIRA_BASE = os.environ.get("JIRA_BASE_URL", "https://jirasw.nvidia.com")
+NVBUGS_BASE = os.environ.get("NVBUGS_BASE_URL", "https://prod.api.nvidia.com/int/nvbugs")
 
 
 def marker(tag: str) -> str:
@@ -67,16 +70,30 @@ def post_jira_comment(issue: str, body: str, tag: str, dry_run: bool) -> str:
 # --- NVBugs -----------------------------------------------------------------
 
 
-def _nvbugs_cli(*args: str) -> str:
-    result = subprocess.run(["nvbugs-cli", *args], capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(f"nvbugs-cli {args[0]} failed: {result.stderr.strip()[:300]}")
-    return result.stdout
+def _nvbugs_request(method: str, path: str, body: dict | None = None) -> dict | None:
+    token = os.environ.get("NVBUGS_TOKEN", "").strip()
+    if not token:
+        raise SystemExit("NVBUGS_TOKEN must be set")
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    # Internal service behind an internal CA (same verify=False the canonical
+    # Hinton connector uses).
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    request = Request(f"{NVBUGS_BASE}{path}", data=data, headers=headers, method=method)
+    with urlopen(request, context=context, timeout=60) as resp:
+        payload = resp.read()
+        return json.loads(payload) if payload.strip() else None
 
 
 def nvbug_already_posted(bug_id: str, tag: str) -> bool:
-    raw = _nvbugs_cli("comment", "list", bug_id, "--json")
-    return marker(tag) in raw
+    bug = _nvbugs_request("GET", f"/api/Bug/GetBug/{bug_id}")
+    return marker(tag) in json.dumps(bug or {})
 
 
 def post_nvbug_comment(bug_id: str, body: str, tag: str, dry_run: bool) -> str:
@@ -84,5 +101,9 @@ def post_nvbug_comment(bug_id: str, body: str, tag: str, dry_run: bool) -> str:
         return f"DRY-RUN nvbug {bug_id}"
     if nvbug_already_posted(bug_id, tag):
         return f"skip nvbug {bug_id} (already posted for {tag})"
-    _nvbugs_cli("comment", "add", bug_id, "--text", f"{marker(tag)}\n{body}", "--json")
+    _nvbugs_request(
+        "POST",
+        f"/api/Bug/Comments/{bug_id}",
+        {"Text": f"{marker(tag)}\n{body}", "Notification": True},
+    )
     return f"posted nvbug {bug_id}"

--- a/.github/scripts/release_notes/post.py
+++ b/.github/scripts/release_notes/post.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-post release notes to JIRA and NVBugs (idempotently).
+
+Every posted comment starts with a per-(issue, tag) marker so pipeline
+retries and hotfix re-runs never double-post: existing comments are
+listed first and the post is skipped when the marker is already there.
+
+JIRA (jirasw.nvidia.com) is reached via REST with bearer auth;
+NVBugs via ``nvbugs-cli`` (installed and authenticated by the CI job).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from urllib.request import Request, urlopen
+
+JIRA_BASE = os.environ.get("JIRA_BASE_URL", "https://jirasw.nvidia.com")
+
+
+def marker(tag: str) -> str:
+    return f"[vss-release-notes:{tag}]"
+
+
+# --- JIRA -------------------------------------------------------------------
+
+
+def _jira_request(method: str, path: str, body: dict | None = None) -> dict | list | None:
+    token = os.environ.get("JIRA_TOKEN", "").strip()
+    if not token:
+        raise SystemExit("JIRA_TOKEN must be set")
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    request = Request(f"{JIRA_BASE}{path}", data=data, headers=headers, method=method)
+    with urlopen(request) as resp:
+        payload = resp.read()
+        return json.loads(payload) if payload.strip() else None
+
+
+def jira_already_posted(issue: str, tag: str) -> bool:
+    start = 0
+    while True:
+        page = _jira_request(
+            "GET", f"/rest/api/2/issue/{issue}/comment?startAt={start}&maxResults=100"
+        )
+        comments = (page or {}).get("comments", [])
+        if any(marker(tag) in (comment.get("body") or "") for comment in comments):
+            return True
+        start += len(comments)
+        if start >= (page or {}).get("total", 0) or not comments:
+            return False
+
+
+def post_jira_comment(issue: str, body: str, tag: str, dry_run: bool) -> str:
+    if dry_run:
+        return f"DRY-RUN jira {issue}"
+    if jira_already_posted(issue, tag):
+        return f"skip jira {issue} (already posted for {tag})"
+    _jira_request(
+        "POST", f"/rest/api/2/issue/{issue}/comment", {"body": f"{marker(tag)}\n{body}"}
+    )
+    return f"posted jira {issue}"
+
+
+# --- NVBugs -----------------------------------------------------------------
+
+
+def _nvbugs_cli(*args: str) -> str:
+    result = subprocess.run(["nvbugs-cli", *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"nvbugs-cli {args[0]} failed: {result.stderr.strip()[:300]}")
+    return result.stdout
+
+
+def nvbug_already_posted(bug_id: str, tag: str) -> bool:
+    raw = _nvbugs_cli("comment", "list", bug_id, "--json")
+    return marker(tag) in raw
+
+
+def post_nvbug_comment(bug_id: str, body: str, tag: str, dry_run: bool) -> str:
+    if dry_run:
+        return f"DRY-RUN nvbug {bug_id}"
+    if nvbug_already_posted(bug_id, tag):
+        return f"skip nvbug {bug_id} (already posted for {tag})"
+    _nvbugs_cli("comment", "add", bug_id, "--text", f"{marker(tag)}\n{body}", "--json")
+    return f"posted nvbug {bug_id}"

--- a/.github/scripts/release_notes/render.py
+++ b/.github/scripts/release_notes/render.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Render the release-notes markdown document.
+
+Structure (per the pipeline spec): header (tag, window, counts) → JIRA
+list → NVBugs list → Unreferenced PRs (the compliance scoreboard that
+decides when the warn-first PR check flips to required) → bot PRs as a
+one-line count.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .classify import Verdict
+from .collect import DropWindow, PullRequest
+
+REPORTED = ("addressed", "related")
+
+
+@dataclass
+class NotesData:
+    window: DropWindow
+    verdicts: dict[int, list[Verdict]]  # PR number -> verdicts
+    unclassified: set[int] = field(default_factory=set)  # PRs where the agent fell back
+
+    def issue_index(self, kind: str) -> dict[str, list[tuple[PullRequest, Verdict]]]:
+        """issue key -> [(pr, verdict), ...] for addressed/related refs."""
+        index: dict[str, list[tuple[PullRequest, Verdict]]] = {}
+        for pr in self.window.pull_requests:
+            for verdict in self.verdicts.get(pr.number, []):
+                if verdict.kind == kind and verdict.classification in REPORTED:
+                    index.setdefault(verdict.key, []).append((pr, verdict))
+        return index
+
+    def unreferenced(self) -> list[PullRequest]:
+        return [
+            pr
+            for pr in self.window.pull_requests
+            if not pr.is_bot
+            and not any(
+                v.classification in REPORTED for v in self.verdicts.get(pr.number, [])
+            )
+        ]
+
+    def bot_prs(self) -> list[PullRequest]:
+        return [pr for pr in self.window.pull_requests if pr.is_bot]
+
+
+def _pr_line(pr: PullRequest, verdict: Verdict | None = None) -> str:
+    suffix = f" — {verdict.classification}" if verdict else ""
+    return f"- PR #{pr.number} [{pr.title}]({pr.url}) by @{pr.author}, merged {pr.merged_at[:10]}{suffix}"
+
+
+def render(data: NotesData) -> str:
+    window = data.window
+    human_prs = [pr for pr in window.pull_requests if not pr.is_bot]
+    jira_index = data.issue_index("jira")
+    nvbug_index = data.issue_index("nvbug")
+    unreferenced = data.unreferenced()
+    bots = data.bot_prs()
+
+    lines = [
+        f"# QA Drop Release Notes — {window.tag}",
+        "",
+        f"- **Window**: `{window.previous_tag or '(first drop)'}` → `{window.tag}` "
+        f"({window.commit_count} commits)",
+        f"- **PRs**: {len(human_prs)} ({len(bots)} bot PRs excluded below)",
+        f"- **JIRA issues**: {len(jira_index)} — **NVBugs**: {len(nvbug_index)} — "
+        f"**Unreferenced PRs**: {len(unreferenced)}",
+        "",
+        "## JIRA",
+        "",
+    ]
+    if jira_index:
+        for key in sorted(jira_index):
+            lines.append(f"### {key}")
+            lines.extend(_pr_line(pr, verdict) for pr, verdict in jira_index[key])
+            lines.append("")
+    else:
+        lines.extend(["_No JIRA references in this window._", ""])
+
+    lines.extend(["## NVBugs", ""])
+    if nvbug_index:
+        for key in sorted(nvbug_index, key=int):
+            lines.append(f"### NVBug {key}")
+            lines.extend(_pr_line(pr, verdict) for pr, verdict in nvbug_index[key])
+            lines.append("")
+    else:
+        lines.extend(["_No NVBugs references in this window._", ""])
+
+    lines.extend(
+        [
+            "## Unreferenced PRs",
+            "",
+            "_Merged without a JIRA/NVBugs reference — QA has no tracker for these._",
+            "",
+        ]
+    )
+    if unreferenced:
+        lines.extend(_pr_line(pr) for pr in unreferenced)
+    else:
+        lines.append("_None — every PR carried a reference._")
+    lines.append("")
+
+    if bots:
+        lines.append(f"_{len(bots)} bot PRs (helm-sync, mirrors, …) omitted._")
+    if data.unclassified:
+        numbers = ", ".join(f"#{n}" for n in sorted(data.unclassified))
+        lines.append(
+            f"_⚠ References on {numbers} were not agent-classified (defaulted to 'related')._"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def issue_comment(kind: str, key: str, prs: list[tuple[PullRequest, Verdict]], tag: str) -> str:
+    """Short cross-post comment for one issue, one drop."""
+    heading = f"The following PR(s) referencing this issue are included in QA drop {tag}:"
+    body = [heading, ""]
+    for pr, verdict in prs:
+        body.append(
+            f"- PR #{pr.number}: {pr.title} ({pr.url}) — merged {pr.merged_at[:10]}, "
+            f"{verdict.classification}"
+        )
+    return "\n".join(body)

--- a/.github/scripts/release_notes/trigger.py
+++ b/.github/scripts/release_notes/trigger.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Trigger the downstream release-notes pipeline for a tag push.
+
+Runs GitHub-side in release-notes.yml. Fires the same GitLab
+trigger-token API as trigger-downstream-pipeline.sh, but for tag refs
+and without polling: it passes RELEASE_NOTES=true and TAG_NAME so the
+downstream pipeline runs only the notes job, then exits.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"{name} must be set")
+    return value
+
+
+def add_mask(value: str) -> None:
+    if value:
+        print(f"::add-mask::{value}")
+
+
+def gitlab_json(url: str, token: str, data: bytes | None = None) -> dict:
+    request = Request(url, data=data, headers={"PRIVATE-TOKEN": token})
+    with urlopen(request) as resp:
+        return json.loads(resp.read())
+
+
+def main() -> int:
+    raw_url = require_env("DOWNSTREAM_CI_URL").rstrip("/")
+    token = require_env("DOWNSTREAM_CI_TOKEN")
+    project_path = require_env("DOWNSTREAM_PROJECT_PATH")
+    ref = os.environ.get("DOWNSTREAM_REF", "main")
+    tag = require_env("GITHUB_REF_NAME")
+    commit_sha = require_env("GITHUB_SHA")
+
+    base_url = raw_url if raw_url.endswith("/api/v4") else f"{raw_url}/api/v4"
+    for value in (raw_url, base_url, token, project_path):
+        add_mask(value)
+    for segment in project_path.split("/"):
+        add_mask(segment)
+
+    project_id = int(gitlab_json(f"{base_url}/projects/{quote(project_path, safe='')}", token)["id"])
+    variables = {
+        "RELEASE_NOTES": "true",
+        "TAG_NAME": tag,
+        "VSS_SUBMODULE_HASH": commit_sha,
+    }
+    payload_pairs: list[tuple[str, str]] = [("ref", ref)]
+    for key, value in variables.items():
+        payload_pairs.extend([("variables[][key]", key), ("variables[][value]", value)])
+    pipeline = gitlab_json(
+        f"{base_url}/projects/{project_id}/pipeline",
+        token,
+        data=urlencode(payload_pairs).encode(),
+    )
+
+    pipeline_url = str(pipeline.get("web_url") or "")
+    add_mask(pipeline_url)
+    print(f"Triggered release-notes pipeline for {tag} (pipeline id {pipeline.get('id')})")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(f"Release-notes pipeline triggered for `{tag}`.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,12 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Triggers the downstream release-notes pipeline when a QA drop tag
-# (dev-*) or GA release tag (v*) is pushed. The downstream job collects
-# every PR merged between the nearest previous trigger tag and this tag,
-# extracts JIRA (VIA-<n>) and NVBugs references, classifies them, and
-# posts release notes to the QA Drop Tracker bug — it runs on the GitLab
-# side because JIRA and NVBugs are internal systems.
+# Triggers the downstream release-notes pipeline when a weekly QA drop
+# tag is pushed. Only tags in the weekly drop format trigger —
+# dev-YY.MM.N with an optional hotfix suffix (dev-26.07.3,
+# dev-26.06.3-1). Other dev-* tags and v* GA release tags do NOT
+# generate notes. The downstream job collects every PR merged between
+# the previous weekly drop tag and this tag, extracts JIRA (VIA-<n>)
+# and NVBugs references, classifies them, and posts release notes to
+# the QA Drop Tracker bug — it runs on the GitLab side because JIRA and
+# NVBugs are internal systems.
 #
 # This workflow only fires the trigger and exits; unlike ci.yml's
 # Trigger Downstream Pipeline job it does not poll the downstream
@@ -17,8 +20,9 @@ name: Release Notes
 on:
   push:
     tags:
-      - "dev-*"
-      - "v*"
+      # Weekly drop format only (the downstream pipeline re-validates with
+      # a strict regex; glob filters here are necessarily looser).
+      - "dev-[0-9][0-9].[0-9][0-9].[0-9]*"
 
 permissions:
   contents: read

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Triggers the downstream release-notes pipeline when a QA drop tag
+# (dev-*) or GA release tag (v*) is pushed. The downstream job collects
+# every PR merged between the nearest previous trigger tag and this tag,
+# extracts JIRA (VIA-<n>) and NVBugs references, classifies them, and
+# posts release notes to the QA Drop Tracker bug — it runs on the GitLab
+# side because JIRA and NVBugs are internal systems.
+#
+# This workflow only fires the trigger and exits; unlike ci.yml's
+# Trigger Downstream Pipeline job it does not poll the downstream
+# pipeline to completion (notes generation does not gate anything here).
+
+name: Release Notes
+
+on:
+  push:
+    tags:
+      - "dev-*"
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-release-notes:
+    name: Trigger Release Notes Pipeline
+    runs-on: [self-hosted, downstream-pipeline]
+    timeout-minutes: 15
+    env:
+      DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
+      DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
+      DOWNSTREAM_PROJECT_PATH: ${{ secrets.DOWNSTREAM_PROJECT_PATH }}
+      DOWNSTREAM_REF: main
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Trigger pipeline
+        run: python3 .github/scripts/release_notes/trigger.py

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -32,7 +32,10 @@ jobs:
       DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
       DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
       DOWNSTREAM_PROJECT_PATH: ${{ secrets.DOWNSTREAM_PROJECT_PATH }}
-      DOWNSTREAM_REF: main
+      # Standing trigger ref in the downstream project whose pipeline contains
+      # only the notes job — a notes trigger against the default ref would
+      # start the full eval pipeline (its jobs are opt-out gated).
+      DOWNSTREAM_REF: release-notes-trigger
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 

--- a/.github/workflows/tracking-ref-check.yml
+++ b/.github/workflows/tracking-ref-check.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Warn-first tracking-reference check: nudges PR authors to reference a
+# JIRA issue (VIA-<n>) or NVBug so QA drop release notes can attribute
+# the change. Non-blocking by design (the job always succeeds) — PRs
+# without a reference get a `needs-tracking-ref` label and a bot comment.
+# Flip to a required check once compliance is healthy.
+#
+# Uses pull_request_target so the bot can label/comment on fork PRs.
+# SECURITY: only the BASE ref is checked out and no PR code is executed —
+# the script reads PR metadata via the REST API only. Keep it that way.
+
+name: Tracking Ref Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check for JIRA/NVBugs reference
+    # Bot PRs (helm-sync, copy-pr-bot, dependabot, …) are exempt.
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Base ref only — never the PR head (pull_request_target runs with
+      # write permissions; executing PR code here would be a vulnerability).
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Scan PR for tracking references
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python3 .github/scripts/check_tracking_ref.py


### PR DESCRIPTION
## Summary

QA cannot tell what a build drop contains without chasing JIRAs/NVBugs by hand. This PR automates release-note generation for QA drops:

- **`release-notes.yml`** — on `dev-*` / `v*` tag push, triggers the downstream GitLab pipeline (`RELEASE_NOTES=true`, `TAG_NAME`) where JIRA/NVBugs are reachable. Fire-and-forget; does not poll.
- **`release_notes/` package** — collects PRs merged in the tag-to-tag Drop Window (chronologically-previous trigger tag; PR membership by merge time between the tag commits, since merge SHAs do not survive the post-merge signing-bot rewrite), regex-scans PR title/description/comments/commits/branch for `VIA-<n>` and NVBugs references, classifies each candidate (addressed / related / mentioned-only; fail-open to related), renders notes (JIRA → NVBugs → Unreferenced PRs → bot count), and cross-posts idempotently (`[vss-release-notes:<tag>]` marker) to each issue plus the QA Drop Tracker bug.
- **`tracking-ref-check.yml`** — warn-first, non-blocking PR check: PRs without a tracking reference get a `needs-tracking-ref` label and a bot comment; `no-tracking-ref` label opts out; bot PRs exempt. Runs on `pull_request_target` reading PR metadata via API only — never checks out or executes PR code.

## Verification

- Pattern suite passes against real-world reference styles from the last 1000 PRs (`NVBug 6453445`, `nvbug/6292153`, `bug 6311754`, bare ids in branch names; dates/SHA fragments correctly rejected).
- Live window tests: `dev-26.07.3` → 10 PRs, `dev-26.06.3-1` → 5 PRs.
- End-to-end dry run on `dev-26.06.3-1` rendered correct notes (NVBug 6324793 attributed to #1068; 4 unreferenced PRs listed).

## Rollout (GitLab side, separate MR)

The downstream `release-notes` job + masked CI variables (`RELEASE_NOTES_GITHUB_TOKEN`, `JIRA_TOKEN`, `NVBUGS_TOKEN`, `ANTHROPIC_API_KEY`/`ANTHROPIC_BASE_URL`, `QA_DROP_TRACKER_BUG`) land in ci-vss-oss, starting with `RELEASE_NOTES_DRY_RUN=true`. Repo needs `needs-tracking-ref` / `no-tracking-ref` labels created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)