### PR TITLE
fix(search): map screenshot timestamps onto the VST replay timeline

### DIFF
--- a/services/agent/src/lib/search_core/primitives/_attribute_helpers.py
+++ b/services/agent/src/lib/search_core/primitives/_attribute_helpers.py
@@ -44,9 +44,12 @@ from lib._foundation.time import datetime_to_iso8601
 from lib._foundation.time import iso8601_instants_match
 from lib._foundation.time import iso8601_to_datetime
 from lib._foundation.time import safe_iso8601_to_datetime
+from lib.vst import VSTError
 from lib.vst import build_screenshot_url
 from lib.vst import get_stream_id
 from lib.vst import get_timeline
+from lib.vst import get_timelines_map
+from lib.vst import map_timestamp_to_timeline
 
 from .._internal.coerce import _coerce_str
 from .._internal.es_filters import build_video_sources_filter
@@ -630,6 +633,9 @@ async def enrich_attribute_results(
     if not resolution_base_url or not screenshot_base_url:
         return
 
+    needs_screenshots = any(r.metadata and r.metadata.sensor_id and not r.screenshot_url for r in results)
+    timelines = await _get_timelines_best_effort(resolution_base_url) if needs_screenshots else {}
+
     async def _enrich(r: AttributeSearchResult) -> None:
         if not (r.metadata and r.metadata.sensor_id and not r.screenshot_url):
             return
@@ -638,12 +644,36 @@ async def enrich_attribute_results(
             stream_id = await get_stream_id(r.metadata.sensor_id, resolution_base_url)
             if stream_id:
                 if ts:
+                    ts = _map_to_timeline(ts, stream_id, timelines)
                     r.screenshot_url = build_screenshot_url(screenshot_base_url, stream_id, ts)
                 r.metadata.sensor_id = stream_id
         except Exception as e:
             logger.warning(f"Failed to enrich result for sensor {r.metadata.sensor_id}: {e}")
 
     await asyncio.gather(*(_enrich(r) for r in results))
+
+
+async def _get_timelines_best_effort(vst_base_url: str) -> dict[str, tuple[str, str]]:
+    """Fetch all VST replay timelines for screenshot-timestamp mapping.
+
+    File-ingested sources are indexed on a synthetic epoch while VST records
+    at ingest wall-clock; screenshot URLs built from raw ES timestamps point
+    outside the recording and VST returns 500 (see map_timestamp_to_timeline).
+    Best-effort: enrichment proceeds unmapped when the fetch fails.
+    """
+    try:
+        return await get_timelines_map(vst_base_url, timeout_seconds=5, retries=1)
+    except VSTError as e:
+        logger.warning(f"Could not fetch VST timelines; screenshot timestamps left unmapped: {e}")
+        return {}
+
+
+def _map_to_timeline(ts: str, stream_id: str, timelines: dict[str, tuple[str, str]]) -> str:
+    """Map one ES timestamp onto the stream's VST timeline (identity if unknown)."""
+    timeline = timelines.get(stream_id)
+    if not timeline:
+        return ts
+    return map_timestamp_to_timeline(ts, timeline[0], timeline[1])
 
 
 async def _extend_clip_to_one_second(
@@ -1044,6 +1074,13 @@ async def _attach_screenshots(
     screenshot), matching the parity of :func:`enrich_attribute_results` and the
     fuse path. Every input result is present in the returned list.
     """
+    vst_internal_for_resolution = vst_internal_url if vst_internal_url else vst_external_url
+    needs_screenshots = any(
+        r.metadata and r.metadata.sensor_id and r.metadata.frame_timestamp and not r.screenshot_url
+        for r in attr_results
+    )
+    timelines = await _get_timelines_best_effort(vst_internal_for_resolution) if needs_screenshots else {}
+
     for result in attr_results:
         if not (result.metadata and result.metadata.sensor_id):
             continue
@@ -1057,14 +1094,12 @@ async def _attach_screenshots(
             )
             continue
         try:
-            vst_internal_for_resolution = vst_internal_url if vst_internal_url else vst_external_url
             stream_id = await get_stream_id(result.metadata.sensor_id, vst_internal_for_resolution)
             if stream_id:
                 result.metadata.sensor_id = stream_id
                 if not result.screenshot_url:
-                    result.screenshot_url = build_screenshot_url(
-                        vst_external_url, stream_id, result.metadata.frame_timestamp
-                    )
+                    screenshot_ts = _map_to_timeline(result.metadata.frame_timestamp, stream_id, timelines)
+                    result.screenshot_url = build_screenshot_url(vst_external_url, stream_id, screenshot_ts)
         except Exception as e:
             logger.warning(
                 f"Failed to generate screenshot for attribute '{scrub_log(attr_query)}' "

--- a/services/agent/src/lib/search_core/primitives/embed_search.py
+++ b/services/agent/src/lib/search_core/primitives/embed_search.py
@@ -39,6 +39,8 @@ from typing import Any
 from pydantic import ValidationError
 
 from lib._foundation.sanitize import scrub_log
+from lib.vst import VSTError
+from lib.vst import map_timestamp_to_timeline
 
 from .._internal.time_measure import TimeMeasure
 from ..errors import BackendUnreachableError
@@ -120,7 +122,8 @@ class EmbedSearch:
                     "elasticsearch",
                     "search response did not contain a list at hits.hits",
                 )
-            results = self._process_hits(hits, inp)
+            timelines = await self._fetch_timelines_best_effort(hits)
+            results = self._process_hits(hits, inp, timelines)
 
         if inp.top_k is not None:
             results = results[: inp.top_k]
@@ -144,7 +147,35 @@ class EmbedSearch:
         """
         return await self._es.search(index=search_index, body=search_query)
 
-    def _process_hits(self, hits: list[dict], inp: EmbedSearchInput) -> list[EmbedSearchResultItem]:
+    async def _fetch_timelines_best_effort(self, hits: list[dict]) -> dict[str, tuple[str, str]]:
+        """Fetch VST replay timelines for screenshot-timestamp mapping.
+
+        File-ingested sources are indexed on a synthetic epoch while VST
+        records at ingest wall-clock; screenshot URLs built from raw ES
+        timestamps point outside the recording and VST returns 500. One
+        timelines call covers every stream. Best-effort: on any failure the
+        search proceeds with unmapped timestamps rather than losing hits.
+        ``getattr`` keeps older VSTSnapshot implementations (without
+        ``get_timelines_map``) working unmapped.
+        """
+        if not hits:
+            return {}
+        fetch = getattr(self._vst, "get_timelines_map", None)
+        if fetch is None:
+            return {}
+        try:
+            timelines: dict[str, tuple[str, str]] = await fetch()
+        except VSTError as e:
+            logger.warning(f"Could not fetch VST timelines; screenshot timestamps left unmapped: {e}")
+            return {}
+        return timelines
+
+    def _process_hits(
+        self,
+        hits: list[dict],
+        inp: EmbedSearchInput,
+        timelines: dict[str, tuple[str, str]] | None = None,
+    ) -> list[EmbedSearchResultItem]:
         """Map raw ES hits to result items, skipping filtered or unprocessable hits.
 
         Mapping is best-effort per document: a single corrupt/unexpected stored
@@ -155,7 +186,7 @@ class EmbedSearch:
         results: list[EmbedSearchResultItem] = []
         for hit in hits:
             try:
-                item = self._hit_to_item(hit, inp)
+                item = self._hit_to_item(hit, inp, timelines)
             except (AttributeError, KeyError, TypeError, ValueError, ValidationError):
                 logger.warning(f"Skipping unprocessable search hit {scrub_log(_safe_hit_id(hit))}", exc_info=True)
                 continue
@@ -163,7 +194,12 @@ class EmbedSearch:
                 results.append(item)
         return results
 
-    def _hit_to_item(self, hit: dict[str, Any], inp: EmbedSearchInput) -> EmbedSearchResultItem | None:
+    def _hit_to_item(
+        self,
+        hit: dict[str, Any],
+        inp: EmbedSearchInput,
+        timelines: dict[str, tuple[str, str]] | None = None,
+    ) -> EmbedSearchResultItem | None:
         """Convert a single ES hit into a result item, or None if it is filtered."""
         parsed = helpers.parse_hit(
             hit,
@@ -175,9 +211,13 @@ class EmbedSearch:
 
         screenshot_url = ""
         if parsed.sensor_id:
+            screenshot_ts = parsed.start_time
+            timeline = (timelines or {}).get(parsed.sensor_id)
+            if timeline:
+                screenshot_ts = map_timestamp_to_timeline(screenshot_ts, timeline[0], timeline[1])
             screenshot_url = self._vst.build_screenshot_url(
                 sensor_id=parsed.sensor_id,
-                timestamp=parsed.start_time,
+                timestamp=screenshot_ts,
                 internal=False,
             )
 

--- a/services/agent/src/lib/vst/__init__.py
+++ b/services/agent/src/lib/vst/__init__.py
@@ -10,7 +10,9 @@ from .client import get_sensor_id_from_stream_id
 from .client import get_stream_id
 from .client import get_streams_info
 from .client import get_timeline
+from .client import get_timelines_map
 from .client import get_video_clip_url
+from .client import map_timestamp_to_timeline
 from .protocols import VSTSnapshot
 
 __all__ = [
@@ -23,5 +25,7 @@ __all__ = [
     "get_stream_id",
     "get_streams_info",
     "get_timeline",
+    "get_timelines_map",
     "get_video_clip_url",
+    "map_timestamp_to_timeline",
 ]

--- a/services/agent/src/lib/vst/client.py
+++ b/services/agent/src/lib/vst/client.py
@@ -92,6 +92,85 @@ def build_screenshot_url(vst_external_url: str, stream_id: str, timestamp: str) 
     return f"{vst_external_url}/vst/api/v1/replay/stream/{stream_seg}/picture?startTime={ts_value}"
 
 
+def map_timestamp_to_timeline(timestamp: str, timeline_start: str, timeline_end: str) -> str:
+    """Map an ES hit timestamp onto a stream's VST replay timeline.
+
+    File-ingested sources are indexed on a synthetic, midnight-anchored epoch
+    (e.g. ``2025-01-01T00:01:00Z`` = 60s into the file) while VST anchors the
+    replay timeline at ingest wall-clock. A raw ES timestamp therefore points
+    outside the recording and VST rejects the picture request
+    (``VMSInternalError: no valid stream found for given timestamps``). Live
+    RTSP sources index real wall-clock, which lands inside the timeline and
+    must pass through unchanged.
+
+    Rules:
+      - timestamp within [start, end]: returned unchanged (live sources)
+      - otherwise: the time-of-day offset from the timestamp's own midnight is
+        re-based onto ``timeline_start``, clamped to ``timeline_end``.
+
+    Any parse failure returns the original timestamp (best-effort — a raw URL
+    that may 404 beats dropping the hit).
+    """
+    try:
+        ts = iso8601_to_datetime(timestamp)
+        start = iso8601_to_datetime(timeline_start)
+        end = iso8601_to_datetime(timeline_end)
+    except (TypeError, ValueError):
+        return timestamp
+    if start <= ts <= end:
+        return timestamp
+    offset = ts - ts.replace(hour=0, minute=0, second=0, microsecond=0)
+    mapped = start + offset
+    if mapped > end:
+        mapped = end
+    elif mapped < start:
+        mapped = start
+    return mapped.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+async def get_timelines_map(
+    vst_internal_url: str,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    retries: int = 3,
+) -> dict[str, tuple[str, str]]:
+    """Return {stream_id: (start_iso, end_iso)} for every stream VST knows.
+
+    One call to ``/vst/api/v1/storage/timelines`` covers all streams (unlike
+    :func:`get_timeline`, which filters to one). Streams with several recorded
+    segments are collapsed to their envelope (first start, last end). Raises
+    VSTError on transport/API failure; callers doing best-effort screenshot
+    enrichment should catch it and continue unmapped.
+    """
+    base = vst_internal_url.rstrip("/")
+    if base.endswith("/vst"):
+        base = base[:-4]
+    timelines_url = f"{base}/vst/api/v1/storage/timelines"
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async for retry in create_retry_strategy(retries=retries, exceptions=_VST_RETRYABLE_ERRORS):
+                with retry:
+                    async with session.get(timelines_url) as response:
+                        if response.status != 200:
+                            raise VSTError(f"VST timelines API returned status {response.status}")
+                        payload = json.loads(await response.text())
+                        out: dict[str, tuple[str, str]] = {}
+                        if isinstance(payload, dict):
+                            for stream_id, segments in payload.items():
+                                if not (isinstance(segments, list) and segments):
+                                    continue
+                                starts = [
+                                    str(s["startTime"]) for s in segments if isinstance(s, dict) and s.get("startTime")
+                                ]
+                                ends = [str(s["endTime"]) for s in segments if isinstance(s, dict) and s.get("endTime")]
+                                if starts and ends:
+                                    out[str(stream_id)] = (min(starts), max(ends))
+                        return out
+    except _VST_BOUNDARY_ERRORS as e:
+        raise VSTError("Failed to get timelines map after retrying transport errors", e) from e
+    return {}  # unreachable; satisfies mypy
+
+
 async def get_video_clip_url(
     *,
     stream_id: str,
@@ -428,6 +507,15 @@ class VSTClient:
         """
         base = self._internal_url if internal else self._external_url
         return build_screenshot_url(base, sensor_id, timestamp)
+
+    async def get_timelines_map(self) -> dict[str, tuple[str, str]]:
+        """Return {stream_id: (start_iso, end_iso)} for all streams.
+
+        One call, single attempt: this feeds best-effort screenshot-timestamp
+        mapping, which must not add retry backoff to every search when VST is
+        slow or down.
+        """
+        return await get_timelines_map(self._internal_url, timeout_seconds=self._timeout_seconds, retries=1)
 
     async def get_video_clip_url(
         self,

--- a/services/agent/tests/unit_test/lib/search_core/test_screenshot_timeline.py
+++ b/services/agent/tests/unit_test/lib/search_core/test_screenshot_timeline.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Screenshot-timestamp → VST replay-timeline mapping.
+
+File-ingested sources are indexed on a synthetic, midnight-anchored epoch
+(e.g. 2025-01-01T00:01:00Z = 60s into the file) while VST anchors the replay
+timeline at ingest wall-clock. Screenshot URLs built from raw ES timestamps
+point outside the recording and VST answers
+``VMSInternalError: no valid stream found for given timestamps`` (HTTP 500).
+"""
+
+from __future__ import annotations
+
+from lib.vst import map_timestamp_to_timeline
+
+TL_START = "2026-07-18T04:15:21.640Z"
+TL_END = "2026-07-18T04:18:51.640Z"
+
+
+def test_synthetic_epoch_timestamp_is_rebased_onto_timeline() -> None:
+    # 60s into the file, indexed at the canonical file epoch.
+    mapped = map_timestamp_to_timeline("2025-01-01T00:01:00Z", TL_START, TL_END)
+    assert mapped == "2026-07-18T04:16:21.640Z"
+
+
+def test_wall_clock_timestamp_inside_timeline_passes_through() -> None:
+    live = "2026-07-18T04:17:00.000Z"
+    assert map_timestamp_to_timeline(live, TL_START, TL_END) == live
+
+
+def test_offset_beyond_timeline_is_clamped_to_end() -> None:
+    # 2h into a 3.5-minute recording: clamp instead of letting VST 500.
+    mapped = map_timestamp_to_timeline("2025-01-01T02:00:00Z", TL_START, TL_END)
+    assert mapped == "2026-07-18T04:18:51.640Z"
+
+
+def test_timeline_boundaries_pass_through() -> None:
+    assert map_timestamp_to_timeline(TL_START, TL_START, TL_END) == TL_START
+    assert map_timestamp_to_timeline(TL_END, TL_START, TL_END) == TL_END
+
+
+def test_unparseable_inputs_return_original_timestamp() -> None:
+    assert map_timestamp_to_timeline("not-a-time", TL_START, TL_END) == "not-a-time"
+    assert map_timestamp_to_timeline("2025-01-01T00:01:00Z", "junk", TL_END) == "2025-01-01T00:01:00Z"
+
+
+def test_wall_clock_before_timeline_start_is_rebased_not_clamped_blindly() -> None:
+    # A timestamp 30s-of-day lands at timeline start + 30s once rebased —
+    # midnight-anchored offsets always rebase, never silently pin to start.
+    mapped = map_timestamp_to_timeline("2025-01-01T00:00:30Z", TL_START, TL_END)
+    assert mapped == "2026-07-18T04:15:51.640Z"


### PR DESCRIPTION
## What

Search hits for **file-ingested** sources are indexed on a synthetic, midnight-anchored epoch (`2025-01-01T00:01:00Z` = 60 s into the file), while VST anchors its replay timeline at **ingest wall-clock**. Screenshot URLs built from raw ES timestamps point outside the recording, so VST rejects every one:

```
GET /vst/api/v1/replay/stream/<id>/picture?startTime=2025-01-01T00:01:00Z
→ 500 {"error_code":"VMSInternalError","error_message":"no valid stream found for given timestamps"}
```

Observed live on the `vss-search-archive` Harbor eval (run 29573058835, PR #1170): step-3 media validation failed 5/6 on **every** attempt once the public origin was reachable. The old NAT `vst.snapshot` tool did this translation (`get_timeline` + offset) for its `offset` mode; the NAT-free direct-URL contract skipped it.

## How

- `lib.vst.map_timestamp_to_timeline` — pure mapper: in-timeline wall-clock (live RTSP) passes through; out-of-timeline timestamps get their midnight-anchored offset re-based onto the timeline start, clamped to the end; unparseable input passes through.
- `lib.vst.get_timelines_map` (+ `VSTClient` method) — one `/storage/timelines` call for all streams, collapsed to envelopes.
- Wired at all three build sites (embed `_hit_to_item`, `enrich_attribute_results`, `_attach_screenshots`), best-effort everywhere — timeline-fetch failure degrades to unmapped URLs, never drops hits. `getattr` guard keeps existing `VSTSnapshot` fakes working.

## Review notes

- The midnight-anchor assumption for the synthetic epoch matches the `mdx-*-2025-01-01` fixture convention; if ingestion records an explicit per-video ES epoch somewhere, deriving the offset from that would be stricter — pointer welcome.
- Draft until the eval re-runs green on top of this; diagnosis thread on PR #1170.

## Verification

NAT-free lane: 610 passed (incl. new mapping tests); mypy (51 files) and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)