### PR TITLE
fix(search): add raw_index alias for SearchRuntime.frames_index

### DIFF
--- a/services/agent/src/lib/search_core/runtime.py
+++ b/services/agent/src/lib/search_core/runtime.py
@@ -264,6 +264,17 @@ class SearchRuntime:
     top_percent_filter: float | None = None
     request_timeout_seconds: int = 30
 
+    @property
+    def raw_index(self) -> str | None:
+        """Alias for :attr:`frames_index`.
+
+        The host-CLI RUNTIME_JSON contract (skills/vss-search-archive) exposes
+        this value under the key ``raw_index`` (the index family is
+        ``mdx-raw-*``), so callers routinely reach for ``runtime.raw_index``.
+        Keep both names valid rather than making one an AttributeError trap.
+        """
+        return self.frames_index
+
     def __post_init__(self) -> None:
         """Reject invalid behavior knobs before they reach backend code."""
         if self.default_max_results < 1:

--- a/services/agent/tests/unit_test/lib/search_core/test_runtime.py
+++ b/services/agent/tests/unit_test/lib/search_core/test_runtime.py
@@ -465,3 +465,20 @@ functions:
         )
         with pytest.raises(ConfigurationError, match="rrf_k"):
             RuntimeSnapshot.from_config_file(config, env={})
+
+
+def test_raw_index_aliases_frames_index() -> None:
+    """The RUNTIME_JSON contract key is ``raw_index``; the field is ``frames_index``.
+
+    Both attribute names must resolve so an improvised resolver reaching for
+    ``runtime.raw_index`` (as eval agents do) is not an AttributeError trap.
+    """
+    rt = SearchRuntime.from_kwargs(
+        es_endpoint="http://es:9200",
+        cosmos_embed_endpoint="http://embed:8000",
+        vst_external_url="https://vst.example",
+        video_embed_index="mdx-embed-filtered-2025-01-01",
+        frames_index="mdx-raw-2025-01-01",
+    )
+    assert rt.raw_index == "mdx-raw-2025-01-01"
+    assert rt.raw_index == rt.frames_index


### PR DESCRIPTION
One-liner ergonomics fix caught by the search Harbor eval: the RUNTIME_JSON contract key is `raw_index` but the runtime attribute is `frames_index`, making `runtime.raw_index` an AttributeError trap for improvised resolvers (observed in run 29631903918). Adds a read-only alias property + regression test. Lane: 611 passed, mypy/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)