### PR TITLE
fix(search): omit screenshot URLs for streams absent from VST timelines

### DIFF
--- a/services/agent/src/lib/search_core/primitives/_attribute_helpers.py
+++ b/services/agent/src/lib/search_core/primitives/_attribute_helpers.py
@@ -644,8 +644,9 @@ async def enrich_attribute_results(
             stream_id = await get_stream_id(r.metadata.sensor_id, resolution_base_url)
             if stream_id:
                 if ts:
-                    ts = _map_to_timeline(ts, stream_id, timelines)
-                    r.screenshot_url = build_screenshot_url(screenshot_base_url, stream_id, ts)
+                    mapped_ts = _map_to_timeline(ts, stream_id, timelines)
+                    if mapped_ts is not None:
+                        r.screenshot_url = build_screenshot_url(screenshot_base_url, stream_id, mapped_ts)
                 r.metadata.sensor_id = stream_id
         except Exception as e:
             logger.warning(f"Failed to enrich result for sensor {r.metadata.sensor_id}: {e}")
@@ -668,12 +669,20 @@ async def _get_timelines_best_effort(vst_base_url: str) -> dict[str, tuple[str, 
         return {}
 
 
-def _map_to_timeline(ts: str, stream_id: str, timelines: dict[str, tuple[str, str]]) -> str:
-    """Map one ES timestamp onto the stream's VST timeline (identity if unknown)."""
+def _map_to_timeline(ts: str, stream_id: str, timelines: dict[str, tuple[str, str]]) -> str | None:
+    """Map one ES timestamp onto the stream's VST timeline.
+
+    Returns None when VST reported its replayable streams (non-empty map) and
+    this stream is not among them — a stale ES document from a prior
+    registration; a picture URL for it is a guaranteed VST error. Identity
+    when the timelines could not be fetched at all (best-effort).
+    """
     timeline = timelines.get(stream_id)
-    if not timeline:
-        return ts
-    return map_timestamp_to_timeline(ts, timeline[0], timeline[1])
+    if timeline:
+        return map_timestamp_to_timeline(ts, timeline[0], timeline[1])
+    if timelines:
+        return None
+    return ts
 
 
 async def _extend_clip_to_one_second(
@@ -1099,7 +1108,8 @@ async def _attach_screenshots(
                 result.metadata.sensor_id = stream_id
                 if not result.screenshot_url:
                     screenshot_ts = _map_to_timeline(result.metadata.frame_timestamp, stream_id, timelines)
-                    result.screenshot_url = build_screenshot_url(vst_external_url, stream_id, screenshot_ts)
+                    if screenshot_ts is not None:
+                        result.screenshot_url = build_screenshot_url(vst_external_url, stream_id, screenshot_ts)
         except Exception as e:
             logger.warning(
                 f"Failed to generate screenshot for attribute '{scrub_log(attr_query)}' "

--- a/services/agent/src/lib/search_core/primitives/embed_search.py
+++ b/services/agent/src/lib/search_core/primitives/embed_search.py
@@ -215,11 +215,20 @@ class EmbedSearch:
             timeline = (timelines or {}).get(parsed.sensor_id)
             if timeline:
                 screenshot_ts = map_timestamp_to_timeline(screenshot_ts, timeline[0], timeline[1])
-            screenshot_url = self._vst.build_screenshot_url(
-                sensor_id=parsed.sensor_id,
-                timestamp=screenshot_ts,
-                internal=False,
-            )
+            if timelines and not timeline:
+                # VST reported its replayable streams and this hit's stream is
+                # not among them (stale ES document from a prior registration).
+                # A picture URL for an unknown stream is a guaranteed VST
+                # error; return the hit without a screenshot instead.
+                logger.warning(
+                    f"Stream {scrub_log(parsed.sensor_id)} not in VST timelines; returning hit without screenshot"
+                )
+            else:
+                screenshot_url = self._vst.build_screenshot_url(
+                    sensor_id=parsed.sensor_id,
+                    timestamp=screenshot_ts,
+                    internal=False,
+                )
 
         return EmbedSearchResultItem(
             video_name=parsed.video_name,

--- a/services/agent/tests/unit_test/lib/search_core/test_screenshot_timeline.py
+++ b/services/agent/tests/unit_test/lib/search_core/test_screenshot_timeline.py
@@ -49,3 +49,17 @@ def test_wall_clock_before_timeline_start_is_rebased_not_clamped_blindly() -> No
     # midnight-anchored offsets always rebase, never silently pin to start.
     mapped = map_timestamp_to_timeline("2025-01-01T00:00:30Z", TL_START, TL_END)
     assert mapped == "2026-07-18T04:15:51.640Z"
+
+
+def test_unknown_stream_in_populated_timelines_means_no_url() -> None:
+    """Stale ES docs reference streams VST no longer knows; their picture URLs
+    are guaranteed VMSInternalError 500s (observed: eval run 29637290995,
+    hit-2 referenced a prior deploy registration). With a populated timelines
+    map, an unknown stream must yield no screenshot rather than a dead URL."""
+    from lib.search_core.primitives._attribute_helpers import _map_to_timeline
+
+    timelines = {"known-stream": (TL_START, TL_END)}
+    assert _map_to_timeline("2025-01-01T00:01:00Z", "stale-stream", timelines) is None
+    assert _map_to_timeline("2025-01-01T00:01:00Z", "known-stream", timelines) == "2026-07-18T04:16:21.640Z"
+    # Empty map = timelines unavailable; best-effort identity applies.
+    assert _map_to_timeline("2025-01-01T00:01:00Z", "stale-stream", {}) == "2025-01-01T00:01:00Z"


### PR DESCRIPTION
Stale-document defense caught live by the search Harbor eval (run 29637290995): reused boxes accumulate ES docs whose stream ids reference prior VST registrations — their picture URLs are guaranteed 500s. With a populated timelines map, unknown-stream hits now return without a screenshot (existing best-effort contract) instead of a dead URL; an empty map (fetch failure) keeps identity behavior. Lane: 612 passed, mypy/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)