### PR TITLE
fix(agent): treat VST sensor-delete 404 as idempotent success

### DIFF
--- a/services/agent/src/agent/tools/vst/utils.py
+++ b/services/agent/src/agent/tools/vst/utils.py
@@ -250,6 +250,14 @@ async def delete_vst_sensor(vst_url: str, sensor_id: str) -> tuple[bool, str]:
             if response.status in (200, 204):
                 logger.info("VST sensor deleted: %s", scrub_log(sensor_id))
                 return True, "OK"
+            if response.status == 404:
+                # Idempotent delete: VST storage deletion can cascade the
+                # sensor registration away before this paired call runs, so
+                # "not found" means the goal state (absent) is already met.
+                # Counting it as failure downgrades fully-clean deletions to
+                # status "partial" (observed live in the search Harbor eval).
+                logger.info("VST sensor already absent: %s", scrub_log(sensor_id))
+                return True, "already absent"
             text = await response.text()
             return False, f"VST returned {response.status}: {text}"
     except Exception as e:

--- a/services/agent/tests/unit_test/tools/vst/test_utils.py
+++ b/services/agent/tests/unit_test/tools/vst/test_utils.py
@@ -522,3 +522,28 @@ class TestValidateVideoUrl:
             await validate_video_url("http://example.com/video.mp4", timeout=60)
             # Verify ClientSession was called
             mock_cls.assert_called_once()
+
+
+class TestDeleteVSTSensorIdempotency:
+    """DELETE of an already-absent sensor must count as success.
+
+    VST storage deletion can cascade the sensor registration away before the
+    paired sensor delete runs; a 404 then means the goal state (absent) is
+    already met. Counting it as failure downgrades fully-clean deletions to
+    status "partial" (observed live in the search Harbor eval, run
+    29638556120 step-6).
+    """
+
+    @pytest.mark.asyncio
+    async def test_delete_vst_sensor_404_is_success(self):
+        mock_delete_response = create_mock_response(404, "{}")
+        mock_session = MagicMock()
+        mock_session.delete = MagicMock(return_value=mock_delete_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("agent.tools.vst.utils.aiohttp.ClientSession", return_value=mock_session):
+            success, message = await delete_vst_sensor("http://localhost:30888", "gone-already")
+
+        assert success is True
+        assert message == "already absent"


### PR DESCRIPTION
Caught live by the search Harbor eval (run 29638556120, step-6 — its first-ever execution): the agent DELETE endpoint returned `partial` for a **fully clean** deletion (VST listing empty, zero docs across all three ES indexes) because VST storage deletion cascades the sensor registration away and the paired sensor DELETE then 404s, which `delete_vst_sensor` counted as failure. Idempotent-delete semantics: 404 = goal state already met = success.

Review note: `delete_vst_storage`'s timeline-fetch path may deserve the same idempotency treatment, but its failure modes are broader — left unchanged pending a live observation.

Verification: vst utils tests 23 passed (incl. new 404 regression test); mypy/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
