### PR TITLE
Expose RTVI Embed asset download limits in Helm

### DIFF
--- a/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
@@ -217,11 +217,21 @@ spec:
             - name: RTVI_RTSP_RECONNECTION_WINDOW
               value: {{ .Values.rtspReconnectionWindow | quote }}
             - name: ASSET_DOWNLOAD_CONNECT_TIMEOUT
-              value: "10"
+              value: {{ .Values.assetDownloadConnectTimeout | default "10" | quote }}
             - name: ASSET_DOWNLOAD_TOTAL_TIMEOUT
-              value: "300"
+              value: {{ .Values.assetDownloadTotalTimeout | default "300" | quote }}
             - name: ASSET_DOWNLOAD_MAX_FILE_SIZE_GB
               value: {{ .Values.assetDownloadMaxFileSizeGb | default 8 | quote }}
+            - name: ASSET_DOWNLOAD_SSL_SKIP_VERIFY_DOMAINS
+              value: {{ .Values.assetDownloadSslSkipVerifyDomains | default "" | quote }}
+            - name: ASSET_DOWNLOAD_MAX_REDIRECTS
+              value: {{ .Values.assetDownloadMaxRedirects | default "0" | quote }}
+            - name: FILE_URL_ALLOWED_DIRS
+              value: {{ .Values.fileUrlAllowedDirs | default "" | quote }}
+            - name: MAX_ASSET_STORAGE_SIZE_GB
+              value: {{ .Values.maxAssetStorageSizeGb | default "" | quote }}
+            - name: ASSET_MAX_AGE_HOURS
+              value: {{ .Values.assetMaxAgeHours | default "0" | quote }}
             - name: ERROR_MESSAGE_TOPIC
               value: "vision-embed-errors"
           startupProbe:

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/values.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/values.yaml
@@ -83,8 +83,18 @@ installProprietaryCodes: false
 rtspReconnectionInterval: "5"
 rtspReconnectionMaxAttempts: "10"
 rtspReconnectionWindow: "60"
+assetDownloadConnectTimeout: "10"
+assetDownloadTotalTimeout: "300"
 # Max HTTP/data-URI asset download size in GB (ASSET_DOWNLOAD_MAX_FILE_SIZE_GB). Increase for large corpus videos.
 assetDownloadMaxFileSizeGb: 8
+# Comma-separated domains where RTVI Embed should skip TLS certificate verification
+# for asset downloads. This weakens TLS trust; use only for controlled, trusted
+# internal endpoints with self-signed or otherwise unverifiable certificates.
+assetDownloadSslSkipVerifyDomains: ""
+assetDownloadMaxRedirects: "0"
+fileUrlAllowedDirs: ""
+maxAssetStorageSizeGb: ""
+assetMaxAgeHours: "0"
 startupProbe:
   initialDelaySeconds: 240
   periodSeconds: 30


### PR DESCRIPTION
## Summary
- expose `ASSET_DOWNLOAD_MAX_FILE_SIZE_GB` in the `vss-rtvi-embed` Helm chart for large-video ingest deployments
- make related asset/download controls configurable via `values.yaml`: download timeouts, redirect/SSL options, file URL allowlist, max asset storage, and asset max age
- preserve existing runtime defaults unless deployments override values

## Context
NVBug: https://nvbugspro.nvidia.com/bug/6446823

Large-video ingest tests need deploy-time control of the Embed download size limit instead of patching live clusters after Helm deploy.

## Validation
- parsed `deploy/helm/services/rtvi/charts/rtvi-embed/values.yaml` with Python YAML
- ran `git diff --check` on the modified Helm files
- checked IDE lints for the modified files

Note: `helm template` was not run locally because `helm` is not installed on this machine.