### PR TITLE
Synchronize late-joining and reconnecting NVStreamer RTSP clients

### DIFF
--- a/services/vios/src/framework/media/media_pipelines/gstdemux.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstdemux.cpp
@@ -836,8 +836,8 @@ on_new_sample_from_sink_audio (GstElement * appsink, GstDeMux *gstDemux)
 void GstDeMux::setGstClock(GstClock* global_clock, GstClockTime base_time)
 {
     LOG(info) << "Setting gstclock for demux pipeline filename:" << m_filename << " m_baseGstTime:" << base_time << endl;
-    m_globalGstClock = global_clock;
-    m_baseGstTime = base_time;
+    m_globalGstClock.store(global_clock);
+    m_baseGstTime.store(base_time);
 }
 
 int GstDeMux::create_playbin ()
@@ -1879,10 +1879,11 @@ void GstDeMux::seek (int64_t seek_pos , uint64_t end_time, float rate /*1*/)
              * to the group's current position would free-run and drift.
              * No-op when this demux is not part of a synchronized group
              * (m_globalGstClock is null). */
-            if (m_globalGstClock)
+            GstClock* syncClock = m_globalGstClock.load();
+            if (syncClock)
             {
-                gst_pipeline_use_clock(GST_PIPELINE(m_pipeline), m_globalGstClock);
-                gst_element_set_base_time(m_pipeline, m_baseGstTime);
+                gst_pipeline_use_clock(GST_PIPELINE(m_pipeline), syncClock);
+                gst_element_set_base_time(m_pipeline, m_baseGstTime.load());
                 gst_element_set_start_time(m_pipeline, GST_CLOCK_TIME_NONE);
             }
 
@@ -1927,17 +1928,18 @@ void GstDeMux::seekToStart ()
         return;
     }
 
-    if (m_globalGstClock)
+    GstClock* syncClock = m_globalGstClock.load();
+    if (syncClock)
     {
-        gst_pipeline_use_clock(GST_PIPELINE(m_pipeline), m_globalGstClock);
-        gst_element_set_base_time(m_pipeline, m_baseGstTime);
+        gst_pipeline_use_clock(GST_PIPELINE(m_pipeline), syncClock);
+        gst_element_set_base_time(m_pipeline, m_baseGstTime.load());
         gst_element_set_start_time(m_pipeline, GST_CLOCK_TIME_NONE);
     }
 
     /* Seek on the appropriate capsfilter for the configured media type.
      * For an audio-only demux instance m_filterVideo is null, and vice versa. */
     GstElement* seekTarget = (m_mediaType == MediaTypeAudio) ? m_filterAudio : m_filterVideo;
-    LOG(info) << "Seeking to start for demux pipeline filename:" << m_filename << " m_baseGstTime:" << m_baseGstTime << endl;
+    LOG(info) << "Seeking to start for demux pipeline filename:" << m_filename << " m_baseGstTime:" << m_baseGstTime.load() << endl;
     if (seekTarget == nullptr)
     {
         LOG(error) << "seekToStart: seek target is null for mediaType:"
@@ -1985,10 +1987,11 @@ void GstDeMux::play_internal ()
         }
         LOG(info) << "File Name = " <<  m_filename << endl;
 
-        if (m_globalGstClock)
+        GstClock* syncClock = m_globalGstClock.load();
+        if (syncClock)
         {
-            gst_pipeline_use_clock(GST_PIPELINE(m_pipeline), m_globalGstClock);
-            gst_element_set_base_time(m_pipeline, m_baseGstTime);
+            gst_pipeline_use_clock(GST_PIPELINE(m_pipeline), syncClock);
+            gst_element_set_base_time(m_pipeline, m_baseGstTime.load());
             gst_element_set_start_time(m_pipeline, GST_CLOCK_TIME_NONE);
         }
         gst_element_set_state (m_pipeline, GST_STATE_PLAYING);

--- a/services/vios/src/framework/media/media_pipelines/gstdemux.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstdemux.cpp
@@ -1873,6 +1873,19 @@ void GstDeMux::seek (int64_t seek_pos , uint64_t end_time, float rate /*1*/)
             m_callbackData.m_index = 0;
             m_isEOS = false;
 
+            /* Keep a late joiner / reconnecting stream locked to the group's
+             * shared clock across the seek. seek() otherwise leaves the
+             * pipeline on whatever clock it had, so a source that is seeked
+             * to the group's current position would free-run and drift.
+             * No-op when this demux is not part of a synchronized group
+             * (m_globalGstClock is null). */
+            if (m_globalGstClock)
+            {
+                gst_pipeline_use_clock(GST_PIPELINE(m_pipeline), m_globalGstClock);
+                gst_element_set_base_time(m_pipeline, m_baseGstTime);
+                gst_element_set_start_time(m_pipeline, GST_CLOCK_TIME_NONE);
+            }
+
             if (rate > 0)
             {
                 if (!gst_element_seek_simple (m_pipeline, GST_FORMAT_TIME,

--- a/services/vios/src/framework/media/media_pipelines/gstdemux.h
+++ b/services/vios/src/framework/media/media_pipelines/gstdemux.h
@@ -22,6 +22,7 @@
 #include <gst/gstmessage.h>
 #include "config.h"
 #include <iomanip>
+#include <atomic>
 #include "stream_monitor.h"
 #include "event_loop.h"
 #include "stream_buffer.h"
@@ -217,8 +218,11 @@ namespace nv_vms
             string                  m_prevFileName;
             uint64_t                m_actualStartTime = 0;
             uint64_t                m_fileEndTime = 0;
-            GstClock*               m_globalGstClock = nullptr;
-            GstClockTime            m_baseGstTime = GST_CLOCK_TIME_NONE;
+            /* Written by setGstClock() from the RtspSyncPlayback management
+             * thread and read from the GStreamer pipeline thread in seek()/
+             * seekToStart()/play_internal(); atomic to avoid a data race. */
+            std::atomic<GstClock*>      m_globalGstClock{nullptr};
+            std::atomic<GstClockTime>   m_baseGstTime{GST_CLOCK_TIME_NONE};
             bool                    m_loop = false;
         public:
             std::shared_ptr<IMediaDataConsumer>     m_mediaConsumer = nullptr;

--- a/services/vios/src/modules/rtsp_server/DynamicRTSPServer.cpp
+++ b/services/vios/src/modules/rtsp_server/DynamicRTSPServer.cpp
@@ -253,18 +253,11 @@ void DynamicRTSPServer
         return;
     }
 
-    if (GET_CONFIG().nv_streamer_sync_file_count > 0)
-    {
-        if (RtspSyncPlayback::getInstance()->getMediaSourceListSize() >= (size_t)GET_CONFIG().nv_streamer_sync_file_count)
-        {
-            LOG(info) << "RTSP lookup: Exceeded sync file count, ignoring the request" << std::endl;
-            if (completionFunc != nullptr)
-            {
-                (*completionFunc)(completionClientData, sms);
-            }
-            return;
-        }
-    }
+    /* nv_streamer_sync_file_count is the initial quorum for a clean
+     * frame-0 start, NOT a hard cap. Late joiners (e.g. a 5th RTSP client)
+     * and reconnecting streams are allowed through here and are aligned to
+     * the group's current loop position in NvFileServerMediaSubsession::
+     * startStream() -> joinRunningSyncGroup(). */
 
     // First, check whether the specified "streamName" exists as a local file:
     string token = string(NV_STREAMER);

--- a/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
+++ b/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
@@ -257,6 +257,34 @@ void H264ByteStreamSource::doGetNextFrame()
     do
     {
         fFrameSize = 0;
+        /* Quorum parking: with nv_streamer_sync_file_count>0 a synchronized
+         * source must not emit ANY frame until the group has actually started
+         * (the quorum of sync_file_count clients has requested PLAY and
+         * startPlayingAllSources() has released them together). Frames primed
+         * into the stream buffer while building the SDP would otherwise leak a
+         * lone stale frame to a client that connects before the quorum is met.
+         * Drop those primed frames and keep waiting so the client stays paused
+         * at PLAY with no output. The DESCRIBE probe source (sourceState
+         * "describe") is exempt so SPS/PPS can still be read for the SDP. */
+        if (GET_CONFIG().nv_streamer_sync_file_count > 0 &&
+            m_sourceState != "describe" &&
+            !RtspSyncPlayback::getInstance()->isSyncPlaybackStarted())
+        {
+            /* Drop frames primed during DESCRIBE exactly once. The demux is
+             * paused while parked, so the buffer stays empty afterwards; guard
+             * on queue size so we don't re-clear (and re-log) on every poll. */
+            if (m_mediaSource && m_mediaSource->m_streamBuf.getQueueSize() > 0)
+            {
+                m_mediaSource->m_streamBuf.clear();
+            }
+            if (!m_trunctedBytes.empty())
+            {
+                m_trunctedBytes.clear();
+            }
+            nextTask() = envir().taskScheduler().scheduleDelayedTask(DEFAULT_VIDEO_FRAME_PLAY_TIME_USEC,
+                (TaskFunc*)H264ByteStreamSource::retryGetFrame, this);
+            return;
+        }
         if (m_mediaSource)
         {
             if (m_trunctedBytes.size() > 0)

--- a/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
+++ b/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
@@ -627,7 +627,7 @@ void H264ByteStreamSource::closeSource()
 void H264ByteStreamSource::restartForLoop()
 {
     LOG(info) << "H264ByteStreamSource restartForLoop, m_sessionId:" << m_sessionId << endl;
-    if (GET_CONFIG().nv_streamer_sync_playback == true)
+    if (GET_CONFIG().nv_streamer_sync_playback == true && GET_CONFIG().nv_streamer_sync_file_count <= 0)
     {
         m_seekOffset = 0;
         m_start = 0;

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
@@ -325,12 +325,13 @@ void NvFileServerMediaSubsession
                 if (GET_CONFIG().nv_streamer_sync_file_count > 0)
                 {
                     RtspSyncPlayback *syncPlaybackInstance = RtspSyncPlayback::getInstance();
-                    if (GET_CONFIG().nv_streamer_sync_file_count > 0)
+                    syncPlaybackInstance->insertMediaSource(m_mediaSource);
+                    if (!syncPlaybackInstance->isSyncPlaybackStarted())
                     {
-                        RtspSyncPlayback::getInstance()->insertMediaSource(m_mediaSource);
-                    }
-                    if (syncPlaybackInstance && !syncPlaybackInstance->isSyncPlaybackStarted())
-                    {
+                        /* Initial synchronized start: park this source until the
+                         * quorum (nv_streamer_sync_file_count streams) have
+                         * requested PLAY, then release them all together at
+                         * frame 0 on a shared clock. */
                         if (syncPlaybackInstance->getMediaSourceListSize() >= (size_t)GET_CONFIG().nv_streamer_sync_file_count)
                         {
                             syncPlaybackInstance->startPlayingAllSources();
@@ -338,7 +339,11 @@ void NvFileServerMediaSubsession
                     }
                     else
                     {
-                        m_mediaSource->play();
+                        /* Group already running: this is a late joiner (e.g. a
+                         * 5th RTSP client) or a reconnecting stream. Align it to
+                         * the group's current loop position instead of
+                         * restarting from frame 0. */
+                        joinRunningSyncGroup();
                     }
                 }
                 else
@@ -715,6 +720,37 @@ void NvFileServerMediaSubsession::seekStreamByGlobalFrameId(H264ByteStreamSource
     }
 }
 
+void NvFileServerMediaSubsession::joinRunningSyncGroup()
+{
+    RtspSyncPlayback* sync = RtspSyncPlayback::getInstance();
+
+    /* Bind this source's demux to the group's shared clock/base time so its
+     * pacing stays locked to the running group (must happen before the seek,
+     * which reapplies the clock while flushing to the target position). */
+    sync->bindSourceToGroupClock(m_mediaSource);
+
+    /* Seek to the group's current loop position, snapped forward to the next
+     * IDR boundary. The demux seek uses GST_SEEK_FLAG_KEY_UNIT, so it always
+     * lands on a keyframe and decoding starts cleanly. */
+    int64_t targetFrame = sync->getGlobalFrameId() + sync->framesToWait();
+    m_syncSourceToGlobalFrameId = targetFrame;
+    LOG(info) << "Joining running sync group, streamName:" << m_streamName
+              << ", targetFrame:" << targetFrame
+              << ", m_sessionId:" << m_sessionId << endl;
+
+    if (m_mediaType == MediaTypeVideo && m_videoStreamSource)
+    {
+        seekStreamByGlobalFrameId(m_videoStreamSource);
+    }
+    else
+    {
+        /* Audio-only subsession, or the video source is not built yet: play
+         * bound to the shared clock. Audio realignment then rides on the
+         * AV-loop-sync coordinator at the next loop boundary. */
+        m_mediaSource->play();
+    }
+}
+
 FramedSource* NvFileServerMediaSubsession
 ::createNewStreamSource(unsigned /*clientSessionId*/, unsigned& estBitrate)
 {
@@ -770,6 +806,22 @@ FramedSource* NvFileServerMediaSubsession
             (GET_CONFIG().nv_streamer_sync_file_count > 0 && RtspSyncPlayback::getInstance()->isSyncPlaybackStarted())) &&
             m_syncSourceToGlobalFrameId > 0)
         {
+            /* Late joiner / reconnecting stream into a running group. Register
+             * with the group and bind to its shared clock/base time BEFORE the
+             * seek below. The seek reapplies the clock (gstdemux::seek), so this
+             * keeps the joiner frame-locked to the group rather than free-running
+             * from the seek point, and insertMediaSource() makes it participate
+             * in the group's loop-restart barrier. Guarded on sync_file_count so
+             * the legacy nv_streamer_sync_playback path is untouched. This is the
+             * effective join point: seekStreamByGlobalFrameId() sets PlayState,
+             * so startStream()'s join branch is intentionally skipped. */
+            if (GET_CONFIG().nv_streamer_sync_file_count > 0)
+            {
+                RtspSyncPlayback::getInstance()->insertMediaSource(m_mediaSource);
+                RtspSyncPlayback::getInstance()->bindSourceToGroupClock(m_mediaSource);
+                LOG(info) << "Late-join into running sync group, streamName:" << m_streamName
+                          << ", m_sessionId:" << m_sessionId << endl;
+            }
             int timeInDescribeAndPlay = abs(m_syncSourceToGlobalFrameId - RtspSyncPlayback::getInstance()->getGlobalFrameId());
             LOG(info) << "Time (frames) between describe and play:" << timeInDescribeAndPlay << endl;
             if (timeInDescribeAndPlay > 5)

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
@@ -443,7 +443,7 @@ void NvFileServerMediaSubsession::checkForAuxSDPLine1()
 {
     nextTask() = nullptr;
 
-    if ((GET_CONFIG().nv_streamer_sync_playback == true ||
+    if ((((GET_CONFIG().nv_streamer_sync_playback == true) && (GET_CONFIG().nv_streamer_sync_file_count <= 0)) ||
         (GET_CONFIG().nv_streamer_sync_file_count > 0 && RtspSyncPlayback::getInstance()->isSyncPlaybackStarted())) &&
         (m_syncSourceToGlobalFrameId == -1))
     {
@@ -632,8 +632,10 @@ void NvFileServerMediaSubsession::seekStreamSource(FramedSource* inputSource,
         return;
     }
 
-    /* Ignore this seek in case of sync_playback, It will be handled while createNewStreamSource */
-    if (GET_CONFIG().nv_streamer_sync_playback == true || m_vodEnableOverlay)
+    /* Ignore this seek in case of sync_playback, It will be handled while createNewStreamSource.
+     * The new sync_file_count quorum engine takes precedence: when it is active the legacy
+     * sync_playback branch is suppressed so both engines never drive the same source. */
+    if ((GET_CONFIG().nv_streamer_sync_playback == true && GET_CONFIG().nv_streamer_sync_file_count <= 0) || m_vodEnableOverlay)
     {
         delete[] absStart; absStart = nullptr;
         delete[] absEnd; absEnd = nullptr;
@@ -805,7 +807,7 @@ FramedSource* NvFileServerMediaSubsession
         // Create a framer for the Video Elementary Stream:
         estBitrate = 500; // kbps, estimate`
         m_videoStreamSource = H264ByteStreamSource::createNew(envir(), m_streamName, m_mediaSource, m_url_params, sourceState, m_sessionId);
-        if ((GET_CONFIG().nv_streamer_sync_playback == true ||
+        if ((((GET_CONFIG().nv_streamer_sync_playback == true) && (GET_CONFIG().nv_streamer_sync_file_count <= 0)) ||
             (GET_CONFIG().nv_streamer_sync_file_count > 0 && RtspSyncPlayback::getInstance()->isSyncPlaybackStarted())) &&
             m_syncSourceToGlobalFrameId > 0)
         {

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
@@ -447,15 +447,15 @@ void NvFileServerMediaSubsession::checkForAuxSDPLine1()
         (GET_CONFIG().nv_streamer_sync_file_count > 0 && RtspSyncPlayback::getInstance()->isSyncPlaybackStarted())) &&
         (m_syncSourceToGlobalFrameId == -1))
     {
-        int frames_to_wait = RtspSyncPlayback::getInstance()->framesToWait();
+        int64_t currentFrame = RtspSyncPlayback::getInstance()->getGlobalFrameId();
+        int frames_to_wait = RtspSyncPlayback::getInstance()->framesToWait(currentFrame);
         if (frames_to_wait == 0)
         {
             m_syncSourceToGlobalFrameId = 0;
         }
         else
         {
-            m_syncSourceToGlobalFrameId = RtspSyncPlayback::getInstance()->getGlobalFrameId();
-            m_syncSourceToGlobalFrameId += frames_to_wait;
+            m_syncSourceToGlobalFrameId = currentFrame + frames_to_wait;
         }
 
         int timeTosync_us = RtspSyncPlayback::getInstance()->timeToSync() * 1000;
@@ -731,8 +731,11 @@ void NvFileServerMediaSubsession::joinRunningSyncGroup()
 
     /* Seek to the group's current loop position, snapped forward to the next
      * IDR boundary. The demux seek uses GST_SEEK_FLAG_KEY_UNIT, so it always
-     * lands on a keyframe and decoding starts cleanly. */
-    int64_t targetFrame = sync->getGlobalFrameId() + sync->framesToWait();
+     * lands on a keyframe and decoding starts cleanly. Sample the frame id once
+     * and reuse it for framesToWait() so both are computed from a single,
+     * consistent clock read (no IDR-boundary skew from a second read). */
+    int64_t currentFrame = sync->getGlobalFrameId();
+    int64_t targetFrame = currentFrame + sync->framesToWait(currentFrame);
     m_syncSourceToGlobalFrameId = targetFrame;
     LOG(info) << "Joining running sync group, streamName:" << m_streamName
               << ", targetFrame:" << targetFrame
@@ -829,15 +832,15 @@ FramedSource* NvFileServerMediaSubsession
                 /* There is much time difference between describe & play, this can happen in case of proxyserver,where
                 *  proxyserver just sends describe & seats idle till new client request.
                 *  In this case get new seek point from global clock */
-                int frames_to_wait = RtspSyncPlayback::getInstance()->framesToWait();
+                int64_t currentFrame = RtspSyncPlayback::getInstance()->getGlobalFrameId();
+                int frames_to_wait = RtspSyncPlayback::getInstance()->framesToWait(currentFrame);
                 if (frames_to_wait == 0)
                 {
                     m_syncSourceToGlobalFrameId = 0;
                 }
                 else
                 {
-                    m_syncSourceToGlobalFrameId = RtspSyncPlayback::getInstance()->getGlobalFrameId();
-                    m_syncSourceToGlobalFrameId += frames_to_wait;
+                    m_syncSourceToGlobalFrameId = currentFrame + frames_to_wait;
                 }
                 int timeTosync_us = RtspSyncPlayback::getInstance()->timeToSync() * 1000;
                 m_stream_state = PlayState;

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.h
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.h
@@ -44,6 +44,7 @@ public:
   void afterPlayingDummy1();
   void frameSourceEventChange(eFrameSourceEvent sourceEvent);
   void seekStreamByGlobalFrameId(H264ByteStreamSource* source);
+  void joinRunningSyncGroup();
   H264ByteStreamSource* getVideoStreamSource() { return m_videoStreamSource; }
 
   /* Inject the AV-loop-sync coordinator. Called from

--- a/services/vios/src/modules/rtsp_server/NvMediaSource.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaSource.cpp
@@ -63,7 +63,10 @@ NvMediaSource
             m_demux->setUrlParams(url_params);
             m_demux->setSessionId(m_sessionId);
         }
-        if (GET_CONFIG().nv_streamer_sync_playback == true)
+        /* Legacy sync_playback engine only. The sync_file_count quorum engine
+         * takes precedence and manages sources itself, so skip the legacy
+         * demuxer registration when it is active. */
+        if (GET_CONFIG().nv_streamer_sync_playback == true && GET_CONFIG().nv_streamer_sync_file_count <= 0)
         {
             RtspSyncPlayback::getInstance()->insertDemuxer(m_demux);
         }
@@ -270,7 +273,7 @@ void NvMediaSource::onFrame(FrameParams& params)
                     if (m_sourceState.find("play") != string::npos)
                     {
                         int randomTimeInMilliSeconds = 0;
-                        if (GET_CONFIG().nv_streamer_sync_playback == true)
+                        if (GET_CONFIG().nv_streamer_sync_playback == true && GET_CONFIG().nv_streamer_sync_file_count <= 0)
                         {
                             randomTimeInMilliSeconds = RtspSyncPlayback::getInstance()->getSimulationWaitTime();
                         }
@@ -807,7 +810,8 @@ void NvMediaSource::destroy()
     if (m_sourceType == SourceTypeFile && m_demux)
     {
         m_demux->deregisterDataCallback(getself(), m_filename);
-        if (GET_CONFIG().nv_streamer_sync_playback == true)
+        /* Mirror the insert gate: only the legacy engine registered this demux. */
+        if (GET_CONFIG().nv_streamer_sync_playback == true && GET_CONFIG().nv_streamer_sync_file_count <= 0)
         {
             RtspSyncPlayback::getInstance()->removeDemuxer(m_demux);
         }

--- a/services/vios/src/modules/rtsp_server/NvMediaSource.hh
+++ b/services/vios/src/modules/rtsp_server/NvMediaSource.hh
@@ -101,6 +101,7 @@ class NvMediaSource : public IMediaDataConsumer
         int64_t getStartTime();
         int64_t getActualStartTime();
         double getFrameRate();
+        int getFrameCount() { return m_demux ? m_demux->getFrameCount() : 0; }
         string getVideoCodec();
         string getAudioCodec();
         int getSampleRate();

--- a/services/vios/src/modules/rtsp_server/RtspSyncPlayback.h
+++ b/services/vios/src/modules/rtsp_server/RtspSyncPlayback.h
@@ -44,10 +44,11 @@ public:
     {
         try {
             stop();
-            if (m_globalGstClock)
+            GstClock* clock = m_globalGstClock.load();
+            if (clock)
             {
-                gst_object_unref(m_globalGstClock);
-                m_globalGstClock = nullptr;
+                gst_object_unref(clock);
+                m_globalGstClock.store(nullptr);
             }
         } catch (const std::exception& e) {
             try { LOG(error) << "Exception in ~RtspSyncPlayback: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
@@ -227,7 +228,18 @@ public:
 
     int framesToWait()
     {
-        int64_t current_frameId = getGlobalFrameId();
+        return framesToWait(getGlobalFrameId());
+    }
+
+    /*
+     * Overload that takes an already-sampled frame position, so callers that
+     * also need the frame id (e.g. joinRunningSyncGroup: target = frameId +
+     * framesToWait(frameId)) compute both from a single, consistent read of the
+     * clock-derived position instead of two reads separated by scheduling
+     * jitter (which could straddle an IDR boundary and skew the residual).
+     */
+    int framesToWait(int64_t current_frameId)
+    {
         int16_t idr_interval = m_idrInterval == 0 ? DEFAULT_IDR_INTERVAL : m_idrInterval;
 
         if ((getMaxFrameCount() - current_frameId) <= m_idrInterval)
@@ -276,7 +288,11 @@ public:
      */
     int64_t getCurrentGroupOffsetMs()
     {
-        if (!m_isSyncPlaybackStarted || m_globalGstClock == nullptr)
+        /* Snapshot the atomic clock pointer once so the null-check and the value
+         * passed to gst_clock_get_time() are consistent even if another thread
+         * re-obtains the clock at a loop boundary. */
+        GstClock* clock = m_globalGstClock.load();
+        if (!m_isSyncPlaybackStarted || clock == nullptr)
         {
             return 0;
         }
@@ -285,7 +301,7 @@ public:
         {
             return 0;
         }
-        GstClockTime now = gst_clock_get_time(m_globalGstClock);
+        GstClockTime now = gst_clock_get_time(clock);
         if (now <= base)
         {
             return 0;
@@ -308,7 +324,7 @@ public:
      */
     int64_t getGlobalFrameId()
     {
-        if (m_isSyncPlaybackStarted && m_globalGstClock != nullptr)
+        if (m_isSyncPlaybackStarted && m_globalGstClock.load() != nullptr)
         {
             return (int64_t)(getCurrentGroupOffsetMs() * groupFrameRate() / 1000.0);
         }
@@ -329,9 +345,10 @@ public:
             return;
         }
         std::lock_guard<std::mutex> guard(m_mediaSourceListLock);
-        if (m_globalGstClock)
+        GstClock* clock = m_globalGstClock.load();
+        if (clock)
         {
-            source->setClock(m_globalGstClock, m_baseGstTime.load());
+            source->setClock(clock, m_baseGstTime.load());
         }
     }
 
@@ -401,8 +418,11 @@ public:
         if (m_mediaSourceList.empty())
         {
             /* Last participant left: tear the group down so a fresh set of
-             * clients re-forms the quorum and starts cleanly at frame 0. */
+             * clients re-forms the quorum and starts cleanly at frame 0. Reset
+             * the group frame rate too so a new group never inherits the old
+             * group's rate before startPlayingAllSources re-captures it. */
             m_isSyncPlaybackStarted = false;
+            m_groupFrameRate.store(DEFAULT_FRAMERATE);
             std::lock_guard<std::mutex> rguard(m_replayListLock);
             m_replayList.clear();
             LOG(info) << "Sync group drained, resetting for a fresh start" << endl;
@@ -432,18 +452,23 @@ public:
     {
         std::lock_guard<std::mutex> guard(m_mediaSourceListLock);
         // Start playing from all the sources
-        if (m_globalGstClock)
+        GstClock* clock = m_globalGstClock.load();
+        if (clock)
         {
-            gst_object_unref(m_globalGstClock);
+            gst_object_unref(clock);
         }
-        m_globalGstClock = gst_system_clock_obtain();
-        GstClockTime baseTime = gst_clock_get_time(m_globalGstClock);
+        clock = gst_system_clock_obtain();
+        m_globalGstClock.store(clock);
+        GstClockTime baseTime = gst_clock_get_time(clock);
         m_baseGstTime.store(baseTime);
 
         /* Capture the group's frame rate and least frame count so the
          * shared-clock elapsed time can be converted to a frame position
-         * (getGlobalFrameId / loopDurationMs) for late joiners. */
+         * (getGlobalFrameId / loopDurationMs) for late joiners. Use the FIRST
+         * source's non-zero rate as the group baseline (synchronized sources
+         * share a rate); this is deterministic regardless of iteration order. */
         int least_framecount = INT_MAX;
+        bool rateCaptured = false;
         for (auto source : m_mediaSourceList)
         {
             if (!source)
@@ -451,9 +476,10 @@ public:
                 continue;
             }
             double fr = source->getFrameRate();
-            if (fr > 0)
+            if (fr > 0 && !rateCaptured)
             {
                 m_groupFrameRate.store(fr);
+                rateCaptured = true;
             }
             int fc = source->getFrameCount();
             if (fc > 0 && fc < least_framecount)
@@ -471,7 +497,7 @@ public:
                   << ", maxFrameCount:" << getMaxFrameCount() << endl;
         for (auto source : m_mediaSourceList)
         {
-            source->setClock(m_globalGstClock, baseTime);
+            source->setClock(clock, baseTime);
         }
         for (auto source : m_mediaSourceList)
         {
@@ -519,12 +545,14 @@ private:
      */
     void triggerGroupReplayLocked()
     {
-        if (m_globalGstClock)
+        GstClock* clock = m_globalGstClock.load();
+        if (clock)
         {
-            gst_object_unref(m_globalGstClock);
+            gst_object_unref(clock);
         }
-        m_globalGstClock = gst_system_clock_obtain();
-        GstClockTime baseTime = gst_clock_get_time(m_globalGstClock);
+        clock = gst_system_clock_obtain();
+        m_globalGstClock.store(clock);
+        GstClockTime baseTime = gst_clock_get_time(clock);
         m_baseGstTime.store(baseTime);
         LOG(info) << "Replaying all sources baseGstTime:" << baseTime
                   << ", count:" << m_mediaSourceList.size() << endl;
@@ -532,7 +560,7 @@ private:
         {
             if (source)
             {
-                source->setClock(m_globalGstClock, baseTime);
+                source->setClock(clock, baseTime);
             }
         }
         for (auto source : m_mediaSourceList)
@@ -557,7 +585,7 @@ private:
     vector<shared_ptr<GstDeMux>> m_demuxList;
     std::mutex              m_demuxerListLock;
     std::atomic<int>        m_simulationWaitTime {0};
-    GstClock*              m_globalGstClock = nullptr;
+    std::atomic<GstClock*> m_globalGstClock{nullptr};
     std::atomic<GstClockTime> m_baseGstTime{GST_CLOCK_TIME_NONE};
     std::atomic<double>    m_groupFrameRate{DEFAULT_FRAMERATE};
     std::mutex              m_mediaSourceListLock;

--- a/services/vios/src/modules/rtsp_server/RtspSyncPlayback.h
+++ b/services/vios/src/modules/rtsp_server/RtspSyncPlayback.h
@@ -240,10 +240,99 @@ public:
         return frames_to_wait;
     }
 
+    /*
+     * Group frame rate captured when the synchronized group starts. Used
+     * to convert the shared-clock elapsed time into a frame position.
+     */
+    double groupFrameRate()
+    {
+        double fr = m_groupFrameRate.load();
+        return (fr > 0) ? fr : DEFAULT_FRAMERATE;
+    }
+
+    /*
+     * Duration of one synchronized loop in milliseconds, derived from the
+     * group's least frame count and frame rate. Returns 0 when unknown, in
+     * which case callers skip the modulo (baseGstTime resets every loop, so
+     * the raw elapsed time is already in-loop).
+     */
+    int64_t loopDurationMs()
+    {
+        int maxFrames = getMaxFrameCount();
+        if (maxFrames <= 0)
+        {
+            return 0;
+        }
+        return (int64_t)(maxFrames * (1000.0 / groupFrameRate()));
+    }
+
+    /*
+     * Current position of the running synchronized group within its loop,
+     * in milliseconds. Computed from the shared GstClock so any late joiner
+     * or reconnecting stream can align to where the group actually is right
+     * now. baseGstTime is reset at every loop boundary (addToReplayList), so
+     * (now - base) is the in-loop offset; the modulo is a safety net for the
+     * brief window around a loop restart.
+     */
+    int64_t getCurrentGroupOffsetMs()
+    {
+        if (!m_isSyncPlaybackStarted || m_globalGstClock == nullptr)
+        {
+            return 0;
+        }
+        GstClockTime base = m_baseGstTime.load();
+        if (base == GST_CLOCK_TIME_NONE)
+        {
+            return 0;
+        }
+        GstClockTime now = gst_clock_get_time(m_globalGstClock);
+        if (now <= base)
+        {
+            return 0;
+        }
+        int64_t elapsed_ms = (int64_t)((now - base) / GST_MSECOND);
+        int64_t loop_ms = loopDurationMs();
+        if (loop_ms > 0)
+        {
+            elapsed_ms %= loop_ms;
+        }
+        return elapsed_ms;
+    }
+
+    /*
+     * Global frame id of the running synchronized group. When the group is
+     * live this is DERIVED from the shared clock (single source of truth),
+     * so late joiners/reconnects seek to the group's real position. When no
+     * synchronized group is running it falls back to the legacy member used
+     * by the older nv_streamer_sync_playback path.
+     */
     int64_t getGlobalFrameId()
     {
+        if (m_isSyncPlaybackStarted && m_globalGstClock != nullptr)
+        {
+            return (int64_t)(getCurrentGroupOffsetMs() * groupFrameRate() / 1000.0);
+        }
         std::lock_guard<std::mutex> guard(m_frameIdLock);
         return m_globalFrameId;
+    }
+
+    /*
+     * Bind a single source's demux to the running group's shared clock and
+     * base time. Called for a late joiner / reconnecting stream just before
+     * it is seeked to the group's current position, so its pacing stays
+     * locked to the rest of the group.
+     */
+    void bindSourceToGroupClock(std::shared_ptr<NvMediaSource>& source)
+    {
+        if (!source)
+        {
+            return;
+        }
+        std::lock_guard<std::mutex> guard(m_mediaSourceListLock);
+        if (m_globalGstClock)
+        {
+            source->setClock(m_globalGstClock, m_baseGstTime.load());
+        }
     }
 
     void replay()
@@ -302,10 +391,34 @@ public:
 
     void removeMediaSource(std::shared_ptr<NvMediaSource>& media_source)
     {
-        if (media_source)
+        if (!media_source)
         {
-            std::lock_guard<std::mutex> guard(m_mediaSourceListLock);
-            m_mediaSourceList.erase(std::remove(m_mediaSourceList.begin(), m_mediaSourceList.end(), media_source), m_mediaSourceList.end());
+            return;
+        }
+        std::lock_guard<std::mutex> mguard(m_mediaSourceListLock);
+        m_mediaSourceList.erase(std::remove(m_mediaSourceList.begin(), m_mediaSourceList.end(), media_source), m_mediaSourceList.end());
+
+        if (m_mediaSourceList.empty())
+        {
+            /* Last participant left: tear the group down so a fresh set of
+             * clients re-forms the quorum and starts cleanly at frame 0. */
+            m_isSyncPlaybackStarted = false;
+            std::lock_guard<std::mutex> rguard(m_replayListLock);
+            m_replayList.clear();
+            LOG(info) << "Sync group drained, resetting for a fresh start" << endl;
+            return;
+        }
+
+        /* A source that surviving participants were parked on at the loop
+         * barrier just left. Re-evaluate so the survivors don't stall. */
+        size_t arrived = 0;
+        {
+            std::lock_guard<std::mutex> rguard(m_replayListLock);
+            arrived = m_replayList.size();
+        }
+        if (arrived > 0 && arrived >= m_mediaSourceList.size())
+        {
+            triggerGroupReplayLocked();
         }
     }
 
@@ -319,12 +432,46 @@ public:
     {
         std::lock_guard<std::mutex> guard(m_mediaSourceListLock);
         // Start playing from all the sources
+        if (m_globalGstClock)
+        {
+            gst_object_unref(m_globalGstClock);
+        }
         m_globalGstClock = gst_system_clock_obtain();
-        m_baseGstTime = gst_clock_get_time(m_globalGstClock);
-        LOG(info) << "Starting to play all sources m_baseGstTime:" << m_baseGstTime << endl;
+        GstClockTime baseTime = gst_clock_get_time(m_globalGstClock);
+        m_baseGstTime.store(baseTime);
+
+        /* Capture the group's frame rate and least frame count so the
+         * shared-clock elapsed time can be converted to a frame position
+         * (getGlobalFrameId / loopDurationMs) for late joiners. */
+        int least_framecount = INT_MAX;
         for (auto source : m_mediaSourceList)
         {
-            source->setClock(m_globalGstClock, m_baseGstTime);
+            if (!source)
+            {
+                continue;
+            }
+            double fr = source->getFrameRate();
+            if (fr > 0)
+            {
+                m_groupFrameRate.store(fr);
+            }
+            int fc = source->getFrameCount();
+            if (fc > 0 && fc < least_framecount)
+            {
+                least_framecount = fc;
+            }
+        }
+        if (least_framecount != INT_MAX)
+        {
+            updateMaxFrameCount(least_framecount);
+        }
+
+        LOG(info) << "Starting to play all sources m_baseGstTime:" << baseTime
+                  << ", groupFrameRate:" << m_groupFrameRate.load()
+                  << ", maxFrameCount:" << getMaxFrameCount() << endl;
+        for (auto source : m_mediaSourceList)
+        {
+            source->setClock(m_globalGstClock, baseTime);
         }
         for (auto source : m_mediaSourceList)
         {
@@ -336,22 +483,20 @@ public:
 
     void addToReplayList(const std::string& filename)
     {
-        std::lock_guard<std::mutex> guard(m_replayListLock);
-        m_replayList.push_back(filename);
-        if (m_replayList.size() == m_mediaSourceList.size())
+        std::lock_guard<std::mutex> mguard(m_mediaSourceListLock);
+        size_t arrived = 0;
         {
-            m_globalGstClock = gst_system_clock_obtain();
-            m_baseGstTime = gst_clock_get_time(m_globalGstClock);
-            LOG(info) << "Replaying all sources baseGstTime:" << m_baseGstTime << endl;
-            for (auto source : m_mediaSourceList)
-            {
-                source->setClock(m_globalGstClock, m_baseGstTime);
-            }
-            for (auto source : m_mediaSourceList)
-            {
-                source->seekToStart();
-            }
-            m_replayList.clear();
+            std::lock_guard<std::mutex> rguard(m_replayListLock);
+            m_replayList.push_back(filename);
+            arrived = m_replayList.size();
+        }
+        /* Restart the loop once every currently-registered source has
+         * reached EOS. Using >= (rather than ==) keeps the barrier robust
+         * to membership that shrank after some sources already signalled,
+         * so the group can never deadlock at a loop boundary. */
+        if (!m_mediaSourceList.empty() && arrived >= m_mediaSourceList.size())
+        {
+            triggerGroupReplayLocked();
         }
     }
 
@@ -366,6 +511,41 @@ public:
     }
 
 private:
+    /*
+     * Restart the whole synchronized group at the loop boundary on a fresh
+     * shared clock/base time. Caller MUST hold m_mediaSourceListLock. The
+     * source->setClock()/seekToStart() calls post to per-source event loops
+     * and never block, so it is safe to invoke them under the lock.
+     */
+    void triggerGroupReplayLocked()
+    {
+        if (m_globalGstClock)
+        {
+            gst_object_unref(m_globalGstClock);
+        }
+        m_globalGstClock = gst_system_clock_obtain();
+        GstClockTime baseTime = gst_clock_get_time(m_globalGstClock);
+        m_baseGstTime.store(baseTime);
+        LOG(info) << "Replaying all sources baseGstTime:" << baseTime
+                  << ", count:" << m_mediaSourceList.size() << endl;
+        for (auto source : m_mediaSourceList)
+        {
+            if (source)
+            {
+                source->setClock(m_globalGstClock, baseTime);
+            }
+        }
+        for (auto source : m_mediaSourceList)
+        {
+            if (source)
+            {
+                source->seekToStart();
+            }
+        }
+        std::lock_guard<std::mutex> rguard(m_replayListLock);
+        m_replayList.clear();
+    }
+
     std::atomic<int64_t>    m_globalFrameId{-1};
     shared_ptr<GstDeMux>    m_demux;
     std::mutex              m_fileLock;
@@ -378,7 +558,8 @@ private:
     std::mutex              m_demuxerListLock;
     std::atomic<int>        m_simulationWaitTime {0};
     GstClock*              m_globalGstClock = nullptr;
-    GstClockTime           m_baseGstTime;
+    std::atomic<GstClockTime> m_baseGstTime{GST_CLOCK_TIME_NONE};
+    std::atomic<double>    m_groupFrameRate{DEFAULT_FRAMERATE};
     std::mutex              m_mediaSourceListLock;
     std::vector<std::shared_ptr<NvMediaSource>> m_mediaSourceList;
     std::mutex              m_replayListLock;

--- a/services/vios/src/modules/rtsp_server/rtspserver.cpp
+++ b/services/vios/src/modules/rtsp_server/rtspserver.cpp
@@ -190,7 +190,7 @@ RtspServer::~RtspServer()
     m_env.stop();
     m_thread->join();
 
-    if (GET_CONFIG().nv_streamer_sync_playback == true)
+    if (GET_CONFIG().nv_streamer_sync_playback == true && GET_CONFIG().nv_streamer_sync_file_count <= 0)
     {
         RtspSyncPlayback::getInstance()->stop();
     }


### PR DESCRIPTION
## Summary
Synchronize late-joining and reconnecting NVStreamer RTSP clients so a viewer that connects after the group has started, or reconnects after dropping, joins at the group's current frame instead of restarting from frame zero.

## Changes
* Derive the global frame position from the shared GStreamer clock so late joiners and reconnects seek to the group's current frame instead of frame zero.
* Bind a joining or reconnecting source to the group clock and register it in the loop barrier so it stays frame locked and re-seeks with the group each loop.
* Apply the shared clock inside the demux seek so a seeked source stays paced by the group rather than free running.
* Treat nv_streamer_sync_file_count as an initial start quorum rather than a hard cap so additional viewers are admitted.
* Harden the loop restart barrier against dynamic membership and reset the group cleanly when the last source leaves.

## Testing
Verified on a live deployment with four synchronized streams: the group starts together and holds zero cross-stream drift across loop boundaries; a fifth viewer and a reconnecting stream each seek to the group's current frame on an IDR, stay frame locked, and re-seek with the group at every loop.

## Risk
Low. Behavior is gated by nv_streamer_sync_file_count; when it is zero the paths are unchanged.