### PR TITLE
fix(ci): exclude PR base branch from DCO sign-off walker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,13 +419,27 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO sign-off
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Only check commits that are authored on this branch — i.e. NOT already
           # reachable from any long-lived upstream branch (main, develop, release/*,
-          # hotfix/*) or from the PR base (when running on a `pull_request` event).
-          # This avoids re-checking historical commits that were inherited via a sync
-          # or rebase from another branch and that pre-date the DCO requirement.
-          BASE="${GITHUB_BASE_REF:-develop}"
+          # hotfix/*) or from the PR base branch. This avoids re-checking historical
+          # commits that were inherited via a sync or rebase from another branch and
+          # that pre-date the DCO requirement.
+          #
+          # The base ref matters for STACKED PRs (base = another feature branch):
+          # without it, the walker re-checks the base branch's entire inherited
+          # history and fails on unsigned commits the PR author never touched
+          # (seen on PR #1200: 12 inherited failures, 0 from the PR's own commits).
+          # On `pull-request/<N>` mirror pushes GITHUB_BASE_REF is empty, so resolve
+          # the base from the PR API — same pattern as the license-diff fix (#622).
+          BASE="${GITHUB_BASE_REF:-}"
+          if [ -z "$BASE" ] && [[ "$GITHUB_REF_NAME" =~ ^pull-request/([0-9]+)$ ]]; then
+            BASE=$(gh api "repos/$GITHUB_REPOSITORY/pulls/${BASH_REMATCH[1]}" \
+              --jq .base.ref 2>/dev/null || true)
+          fi
+          BASE="${BASE:-develop}"
 
           # `actions/checkout` only fetches the checked-out ref. Make sure the refs we
           # use as exclusion bases exist locally. Failures are tolerated (e.g. a fresh
@@ -454,6 +468,11 @@ jobs:
               'refs/remotes/origin/release/*' \
               'refs/remotes/origin/hotfix/*' \
               'refs/remotes/origin/dev/*' 2>/dev/null)
+
+          # Exclude the PR base branch too (no-op when it is one of the refs
+          # above; load-bearing when the base is a feature branch).
+          git rev-parse --verify "origin/$BASE" >/dev/null 2>&1 && \
+            EXCLUDES+=("^origin/$BASE")
 
           # --no-merges: skip auto-generated merge commits (e.g. from "Update branch" /
           # `git merge develop` into a feature branch). They have no Signed-off-by and


### PR DESCRIPTION
## Problem

The DCO walker in `ci.yml` builds its exclusion set from `main` / `develop` / `release/*` / `hotfix/*` / `dev/*` — but never the **PR base branch**, despite its own comment claiming base exclusion. A **stacked PR** (base = another feature branch) therefore re-checks the base branch's entire inherited history and fails on unsigned commits the PR author never touched.

Observed on #1200 (base `feat/build-vision-agent-skill`): the walker checked **304 commits**, failed on **12** — all inherited from the base branch (GitHub-UI reverts and direct-push CI commits carried over from `main` under new SHAs), **0** from the PR's own 18 commits (all signed).

## Fix

Resolve the base ref and append `^origin/<base>` to the exclusion set:
- `GITHUB_BASE_REF` when set (`pull_request` events);
- on `pull-request/<N>` mirror pushes it is empty, so fall back to the PR API (`/pulls/<N>` → `.base.ref`) — the same blind spot fixed for license-diff in #622;
- default to `develop` as before. The exclusion is a no-op when the base is one of the long-lived refs already excluded.

The step gets `GH_TOKEN: ${{ github.token }}` for the (read-only) API call.

## Verification

Simulated the extracted script against real history:
- `GITHUB_REF_NAME=pull-request/1200`, empty `GITHUB_BASE_REF`, on #1200's head → resolves base `feat/build-vision-agent-skill`, checks exactly the **18 PR-authored commits**, passes (previously 304 checked / 12 failures).
- Control (`GITHUB_BASE_REF=develop`, this branch) → checks 1 commit, passes.
- `yaml.safe_load` + `bash -n` on the extracted script both clean.

Note: the workflow executes from PR-head content, so #1200 turns green once its branch contains this change (merge develop into its base branch, or cherry-pick this commit onto the PR head).

🤖 Generated with [Claude Code](https://claude.com/claude-code)