### PR TITLE
ci(skills-eval): update skill eval to use internal brev runners

### DIFF
--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -15,6 +15,15 @@ from release_set import load_inventory, validate_release_set
 from update_pr_ghcr_candidates import GitHubApi, download_release_set
 
 
+def has_ghcr_build_entries(release_set: dict) -> bool:
+    """Whether downstream has newly built GHCR images to accept/promote."""
+    return any(
+        image.get("strategy") == "build"
+        and str(image.get("image", "")).startswith("ghcr.io/")
+        for image in release_set.get("images", [])
+    )
+
+
 def downstream_variables(release_set: dict) -> dict[str, str]:
     encoded = base64.b64encode(
         (json.dumps(release_set, separators=(",", ":")) + "\n").encode()
@@ -39,6 +48,7 @@ def main() -> int:
 
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     github_env = os.environ.get("GITHUB_ENV", "").strip()
+    github_output = os.environ.get("GITHUB_OUTPUT", "").strip()
     if not args.sha or not github_env:
         raise SystemExit(
             "SHA and GITHUB_ENV are required"
@@ -78,9 +88,16 @@ def main() -> int:
         output.write("DOWNSTREAM_EXTRA_VARIABLES_JSON<<EOF\n")
         output.write(json.dumps(variables, separators=(",", ":")) + "\n")
         output.write("EOF\n")
+    has_builds = has_ghcr_build_entries(release_set)
+    if github_output:
+        with Path(github_output).open("a") as output:
+            output.write(
+                f"has_ghcr_build_entries={'true' if has_builds else 'false'}\n"
+            )
     print(
         f"Prepared release set {release_set['release_set_id']} "
-        f"for downstream acceptance ({len(release_set['images'])} images)."
+        f"for downstream acceptance ({len(release_set['images'])} images, "
+        f"GHCR builds: {'yes' if has_builds else 'no'})."
     )
     return 0
 

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -18,6 +18,46 @@ import prepare_downstream_release_set as module  # noqa: E402
 from prepare_downstream_release_set import downstream_variables  # noqa: E402
 
 
+class GhcrBuildEntriesTest(unittest.TestCase):
+    def test_requires_new_ghcr_build(self):
+        self.assertTrue(
+            module.has_ghcr_build_entries(
+                {
+                    "images": [
+                        {
+                            "strategy": "build",
+                            "image": "ghcr.io/nvidia/vss-agent",
+                        }
+                    ]
+                }
+            )
+        )
+        self.assertFalse(
+            module.has_ghcr_build_entries(
+                {
+                    "images": [
+                        {
+                            "strategy": "reuse-pinned",
+                            "image": "ghcr.io/nvidia/vss-agent",
+                        }
+                    ]
+                }
+            )
+        )
+        self.assertFalse(
+            module.has_ghcr_build_entries(
+                {
+                    "images": [
+                        {
+                            "strategy": "build",
+                            "image": "nvcr.io/nvidia/vss-agent",
+                        }
+                    ]
+                }
+            )
+        )
+
+
 class DownstreamVariablesTest(unittest.TestCase):
     def test_encodes_exact_release_set_for_acceptance(self):
         release_set = {
@@ -45,6 +85,7 @@ class DownstreamVariablesTest(unittest.TestCase):
             release_path = Path(tmp) / "release-set.json"
             release_output_path = Path(tmp) / "handoff/release-set.json"
             env_path = Path(tmp) / "github.env"
+            output_path = Path(tmp) / "github.output"
             release_path.write_text(json.dumps(release_set))
             argv = [
                 "prepare_downstream_release_set.py",
@@ -56,13 +97,22 @@ class DownstreamVariablesTest(unittest.TestCase):
                 str(release_output_path),
             ]
             with mock.patch("sys.argv", argv), mock.patch.dict(
-                os.environ, {"GITHUB_ENV": str(env_path)}, clear=True
+                os.environ,
+                {
+                    "GITHUB_ENV": str(env_path),
+                    "GITHUB_OUTPUT": str(output_path),
+                },
+                clear=True,
             ), mock.patch.object(
                 module, "validate_release_set", return_value=[]
             ), mock.patch.object(module, "download_release_set") as download:
                 self.assertEqual(module.main(), 0)
                 download.assert_not_called()
             self.assertIn("DOWNSTREAM_EXTRA_VARIABLES_JSON", env_path.read_text())
+            self.assertEqual(
+                output_path.read_text(),
+                "has_ghcr_build_entries=false\n",
+            )
             self.assertEqual(json.loads(release_output_path.read_text()), release_set)
 
 

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -323,11 +323,13 @@ The canonical harbor command is in § Harbor invocation.
       "choosing" the same lock-free-looking one and serialising
       (check-then-act TOCTOU — the failure mode that motivated this).
 
-      Ordering inside the wrapper preserves pool partitioning: exact
-      name-hinted `gpu_count` matches (`*-1g*` → 1, `*-2g*` → 2) sort
-      before over-provisioned boxes; `envs/brev_env.py` still validates
-      the final pick (`gpu_count >=` required) and `start()` wipes the
-      box before the trial, so an over-provisioned fallback stays safe.
+      Ordering inside the wrapper uses connected registered nodes first so
+      dedicated capacity is consumed before managed cloud instances. Within
+      each tier, exact name-hinted `gpu_count` matches (`*-1g*` → 1,
+      `*-2g*` → 2) sort before over-provisioned boxes;
+      `envs/brev_env.py` still validates the final pick (`gpu_count >=`
+      required) and `start()` wipes the box before the trial, so an
+      over-provisioned fallback stays safe.
       `gpu_count = 0` specs (remote-all / GPU-independent) accept any
       RUNNING pool box.
 
@@ -488,15 +490,20 @@ The canonical harbor command is in § Harbor invocation.
 |---|---|---|
 | `l40s` | `vss-eval-l40s*` (e.g. `vss-eval-l40s`, `vss-eval-l40s-1g`, `vss-eval-l40s-2`) | 2× L40S 48 GB. No `shared` mode — LLM+VLM don't fit on one 48 GB GPU. |
 | `h100` | `vss-eval-h100*` | 2× H100 80 GB. Full matrix incl. `shared`. |
-| `rtx` / `rtxpro6000bw` | `vss-eval-rtx*` (e.g. `vss-eval-rtx-1g-2`, `vss-eval-rtx-2g-3`) | RTX PRO 6000 BW. Suffixes denote per-host GPU count (`-1g` = 1 GPU, `-2g` = 2 GPU). |
+| `rtx` / `rtxpro6000bw` | `vss-eval-rtx*` (e.g. `vss-eval-rtx-1g-2`, `vss-eval-rtx-2g-3`, registered `vss-eval-rtx-2g-VM1b`) | RTX PRO 6000 BW. Suffixes denote per-host GPU count (`-1g` = 1 GPU, `-2g` = 2 GPU). Connected registered nodes are eligible alongside managed instances. |
 | `spark` | BYOH registered node `SPARK` | Edge / unified memory; only `remote-llm` mode supported today. Already registered. |
 
-Pool naming is operator-managed; the actual fleet is whatever
-`brev ls` reports matching the prefix. Don't hardcode a specific
-instance name — `run_leg.py`'s pool selection (§ 5a) picks the
-candidate. **Lifecycle is the operator's job**; the box lock and the
-trials both live inside `run_leg.py` — see Hard rules about
-`brev create / start / stop / delete / reset`.
+Pool naming is operator-managed; the actual fleet is the union of managed
+instances from `brev ls --json` and connected registered nodes from
+`brev ls nodes --json` that are explicitly named in the coordinator's
+comma/space-separated `BREV_REGISTERED_POOL` allowlist. Registered-node
+JSON omits GPU metadata, so `run_leg.py` accepts only documented hardware prefixes
+(`vss-eval-rtx*`, `vss-eval-l40s*`, `vss-eval-h100*`) and fails closed for
+unknown GPU families. Don't hardcode a specific instance name —
+`run_leg.py`'s pool selection (§ 5a) picks the candidate. **Lifecycle is
+the operator's job**; the box lock and the trials both live inside
+`run_leg.py` — see Hard rules about `brev create / start / stop / delete /
+reset`.
 
 `vss-skill-validator-v2` is the CI runner host — **never** touch it,
 even though it shows up in `brev ls`.
@@ -537,10 +544,10 @@ Match rules enforced by `envs/brev_env.py::_check_instance_matches`
 - **gpu_count is `>=`, not exact.** `_check_instance_matches` accepts any
   box with **at least** the spec's `gpu_count` — a 1-GPU spec runs fine on
   a 2-GPU box (2nd GPU idles); only an *under*-provisioned box is rejected.
-  **Prefer** an exact match at selection time (`run_leg.py` orders
-  exact name-hinted counts first) so the pool stays partitioned, but an
-  over-provisioned box is a valid fallback when no exact match is
-  free/reachable. Because the `>=` check passes (rather
+  `run_leg.py` prefers registered capacity first, then exact name-hinted
+  counts within the registered/managed tier. An over-provisioned box is a
+  valid fallback when no exact match is free/reachable. Because the `>=`
+  check passes (rather
   than raising), `start()` runs `_reset_docker_runtime` on the fallback
   box, so it never inherits a prior trial's containers.
 

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -507,12 +507,15 @@ the operator's job**; the box lock and the trials both live inside
 reset`.
 
 `BREV_RTX4090_POOL` is a separate, capability-routed allowlist. Its nodes
-are selected only when task metadata names one of the skills in
-`run_leg.py::RTX4090_SKILLS`: ask-video, behavior analytics, video analytics
-API, detection/tracking 2D, video embedding, dense captioning, or video
-calibration. All other skills use the full-capability registered pool or
-managed instances. A registered `-1g-` node is also filtered from any task
-requiring two GPUs before lock acquisition.
+are selected only when the skill and spec stem match the resource-proven
+matrix in `run_leg.py::RTX4090_TESTS` / `RTX4090_ALL_TESTS`. This includes
+the proven ask-video, report, base/LVS/Alerts profile, summarize, alerts,
+query analytics, 2D detection, embedding, calibration, VIOS, setup, and
+standalone dense-captioning tests. Search, Warehouse, dense-captioning
+Alerts, and every 3D detection/calibration test remain on full-capability
+workers. Missing skill/spec metadata fails closed. A registered single-GPU
+node is also filtered from any task requiring two GPUs before lock
+acquisition.
 
 `vss-skill-validator-v2` is the CI runner host — **never** touch it,
 even though it shows up in `brev ls`.

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -490,16 +490,17 @@ The canonical harbor command is in § Harbor invocation.
 |---|---|---|
 | `l40s` | `vss-eval-l40s*` (e.g. `vss-eval-l40s`, `vss-eval-l40s-1g`, `vss-eval-l40s-2`) | 2× L40S 48 GB. No `shared` mode — LLM+VLM don't fit on one 48 GB GPU. |
 | `h100` | `vss-eval-h100*` | 2× H100 80 GB. Full matrix incl. `shared`. |
-| `rtx` / `rtxpro6000bw` | `vss-eval-rtx*` (e.g. `vss-eval-rtx-1g-2`, registered `vss-eval-rtx-2g-VM1b`, capability-routed `vss-eval-rtx-1g-2-runner`) | RTX PRO 6000 BW by default. Suffixes denote per-host GPU count (`-1g` = 1 GPU, `-2g` = 2 GPU). Allowlisted RTX 4090 nodes are eligible only for skills proven on 24 GB. |
+| `rtx` / `rtxpro6000bw` | RTX PRO: `vss-eval-rtx*` (e.g. registered `vss-eval-rtx-2g-VM1b`); GeForce: `vss-eval-geforce-rtx4090-vm*` | RTX PRO 6000 BW by default. RTX PRO suffixes denote per-host GPU count (`-1g` = 1 GPU, `-2g` = 2 GPU). Allowlisted single-GPU RTX 4090 nodes are eligible only for skills proven on 24 GB. |
 | `spark` | BYOH registered node `SPARK` | Edge / unified memory; only `remote-llm` mode supported today. Already registered. |
 
 Pool naming is operator-managed; the actual fleet is the union of managed
 instances from `brev ls --json` and connected registered nodes from
 `brev ls nodes --json` that are explicitly named in the coordinator's
 comma/space-separated `BREV_REGISTERED_POOL` allowlist. Registered-node
-JSON omits GPU metadata, so `run_leg.py` accepts only documented hardware prefixes
-(`vss-eval-rtx*`, `vss-eval-l40s*`, `vss-eval-h100*`) and fails closed for
-unknown GPU families. Don't hardcode a specific instance name —
+JSON omits GPU metadata, so `run_leg.py` accepts only documented hardware
+prefixes (`vss-eval-rtx*`, `vss-eval-geforce-rtx4090-vm*`,
+`vss-eval-l40s*`, `vss-eval-h100*`) and fails closed for unknown GPU
+families. Don't hardcode a specific instance name —
 `run_leg.py`'s pool selection (§ 5a) picks the candidate. **Lifecycle is
 the operator's job**; the box lock and the trials both live inside
 `run_leg.py` — see Hard rules about `brev create / start / stop / delete /

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -490,7 +490,7 @@ The canonical harbor command is in § Harbor invocation.
 |---|---|---|
 | `l40s` | `vss-eval-l40s*` (e.g. `vss-eval-l40s`, `vss-eval-l40s-1g`, `vss-eval-l40s-2`) | 2× L40S 48 GB. No `shared` mode — LLM+VLM don't fit on one 48 GB GPU. |
 | `h100` | `vss-eval-h100*` | 2× H100 80 GB. Full matrix incl. `shared`. |
-| `rtx` / `rtxpro6000bw` | `vss-eval-rtx*` (e.g. `vss-eval-rtx-1g-2`, `vss-eval-rtx-2g-3`, registered `vss-eval-rtx-2g-VM1b`) | RTX PRO 6000 BW. Suffixes denote per-host GPU count (`-1g` = 1 GPU, `-2g` = 2 GPU). Connected registered nodes are eligible alongside managed instances. |
+| `rtx` / `rtxpro6000bw` | `vss-eval-rtx*` (e.g. `vss-eval-rtx-1g-2`, registered `vss-eval-rtx-2g-VM1b`, capability-routed `vss-eval-rtx-1g-2-runner`) | RTX PRO 6000 BW by default. Suffixes denote per-host GPU count (`-1g` = 1 GPU, `-2g` = 2 GPU). Allowlisted RTX 4090 nodes are eligible only for skills proven on 24 GB. |
 | `spark` | BYOH registered node `SPARK` | Edge / unified memory; only `remote-llm` mode supported today. Already registered. |
 
 Pool naming is operator-managed; the actual fleet is the union of managed
@@ -504,6 +504,14 @@ unknown GPU families. Don't hardcode a specific instance name —
 the operator's job**; the box lock and the trials both live inside
 `run_leg.py` — see Hard rules about `brev create / start / stop / delete /
 reset`.
+
+`BREV_RTX4090_POOL` is a separate, capability-routed allowlist. Its nodes
+are selected only when task metadata names one of the skills in
+`run_leg.py::RTX4090_SKILLS`: ask-video, behavior analytics, video analytics
+API, detection/tracking 2D, video embedding, dense captioning, or video
+calibration. All other skills use the full-capability registered pool or
+managed instances. A registered `-1g-` node is also filtered from any task
+requiring two GPUs before lock acquisition.
 
 `vss-skill-validator-v2` is the CI runner host — **never** touch it,
 even though it shows up in `brev ls`.

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -31,7 +31,7 @@ The runner has no GPU. Eval trials run on a long-lived pool of `vss-eval-*` Brev
 |---|---|---|
 | `l40s` | `vss-eval-l40s`, `vss-eval-l40s-1g`, `vss-eval-l40s-2` | `massedcompute_L40S` / `massedcompute_L40Sx2` |
 | `h100` | `vss-eval-h100` (when needed) | launchpad `dmz.h100x2.pcie` preferred |
-| `rtx` | Managed `vss-eval-rtx-*` plus connected registered nodes such as `vss-eval-rtx-2g-VM1b`–`VM4b` | AWS `g7e.4xlarge` / `g7e.12xlarge` or registered RTX PRO Server 6000 |
+| `rtx` | Managed `vss-eval-rtx-*` plus registered RTX PRO workers such as `vss-eval-rtx-2g-VM1b`–`VM4b`; capability-routed RTX 4090 workers for approved skills | AWS `g7e.4xlarge` / `g7e.12xlarge`, registered RTX PRO Server 6000, or approved RTX 4090 |
 | `spark` | BYOH DGX Spark node registered via `brev register` | n/a |
 
 Per-CI-run hygiene is the trial's own responsibility: each spec's first agent turn invokes `/vss-deploy-profile` (or a standalone deploy runbook) to bring up whatever it needs, including `docker compose down` of any prior leftover containers on the box. The harness no longer pre-deploys profiles or maintains an `active-deploy.txt` marker — that machinery was removed in favour of putting deploy steps inside the trial trajectory where they're visible in the reward, judge, and `claude-code.txt`. Fleet-selection scoring + the wait-for-pool path on exhaustion live in [`AGENTS.md § Platform topology`](AGENTS.md).
@@ -49,6 +49,7 @@ Per-CI-run hygiene is the trial's own responsibility: each spec's first agent tu
 | `HF_TOKEN` | Required by the Edge 4B vLLM on SPARK / Thor `shared` mode |
 | `GITHUB_TOKEN` | Issued to `gh pr comment` when the agent posts results |
 | `BREV_REGISTERED_POOL` | Comma/space-separated registered-node names approved for automatic pool selection |
+| `BREV_RTX4090_POOL` | Registered RTX 4090 workers; routed only to the skills in `run_leg.py::RTX4090_SKILLS` |
 
 ## Layout
 

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -31,7 +31,7 @@ The runner has no GPU. Eval trials run on a long-lived pool of `vss-eval-*` Brev
 |---|---|---|
 | `l40s` | `vss-eval-l40s`, `vss-eval-l40s-1g`, `vss-eval-l40s-2` | `massedcompute_L40S` / `massedcompute_L40Sx2` |
 | `h100` | `vss-eval-h100` (when needed) | launchpad `dmz.h100x2.pcie` preferred |
-| `rtx` | Managed `vss-eval-rtx-*` plus registered RTX PRO workers such as `vss-eval-rtx-2g-VM1b`–`VM4b`; capability-routed RTX 4090 workers for approved skills | AWS `g7e.4xlarge` / `g7e.12xlarge`, registered RTX PRO Server 6000, or approved RTX 4090 |
+| `rtx` | Managed `vss-eval-rtx-*`, registered RTX PRO workers such as `vss-eval-rtx-2g-VM1b`–`VM4b`, and capability-routed `vss-eval-geforce-rtx4090-vm*` workers | AWS `g7e.4xlarge` / `g7e.12xlarge`, registered RTX PRO Server 6000, or approved RTX 4090 |
 | `spark` | BYOH DGX Spark node registered via `brev register` | n/a |
 
 Per-CI-run hygiene is the trial's own responsibility: each spec's first agent turn invokes `/vss-deploy-profile` (or a standalone deploy runbook) to bring up whatever it needs, including `docker compose down` of any prior leftover containers on the box. The harness no longer pre-deploys profiles or maintains an `active-deploy.txt` marker — that machinery was removed in favour of putting deploy steps inside the trial trajectory where they're visible in the reward, judge, and `claude-code.txt`. Fleet-selection scoring + the wait-for-pool path on exhaustion live in [`AGENTS.md § Platform topology`](AGENTS.md).

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -49,7 +49,7 @@ Per-CI-run hygiene is the trial's own responsibility: each spec's first agent tu
 | `HF_TOKEN` | Required by the Edge 4B vLLM on SPARK / Thor `shared` mode |
 | `GITHUB_TOKEN` | Issued to `gh pr comment` when the agent posts results |
 | `BREV_REGISTERED_POOL` | Comma/space-separated registered-node names approved for automatic pool selection |
-| `BREV_RTX4090_POOL` | Registered RTX 4090 workers; routed only to the skills in `run_leg.py::RTX4090_SKILLS` |
+| `BREV_RTX4090_POOL` | Registered RTX 4090 workers; routed only to the proven tests in `run_leg.py::RTX4090_TESTS` / `RTX4090_ALL_TESTS` |
 
 ## Layout
 

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -31,7 +31,7 @@ The runner has no GPU. Eval trials run on a long-lived pool of `vss-eval-*` Brev
 |---|---|---|
 | `l40s` | `vss-eval-l40s`, `vss-eval-l40s-1g`, `vss-eval-l40s-2` | `massedcompute_L40S` / `massedcompute_L40Sx2` |
 | `h100` | `vss-eval-h100` (when needed) | launchpad `dmz.h100x2.pcie` preferred |
-| `rtx` | `vss-eval-rtx-1g`, `vss-eval-rtx-1g-2`, `vss-eval-rtx-2g` | AWS `g7e.4xlarge` / `g7e.12xlarge` (RTX PRO Server 6000) |
+| `rtx` | Managed `vss-eval-rtx-*` plus connected registered nodes such as `vss-eval-rtx-2g-VM1b`–`VM4b` | AWS `g7e.4xlarge` / `g7e.12xlarge` or registered RTX PRO Server 6000 |
 | `spark` | BYOH DGX Spark node registered via `brev register` | n/a |
 
 Per-CI-run hygiene is the trial's own responsibility: each spec's first agent turn invokes `/vss-deploy-profile` (or a standalone deploy runbook) to bring up whatever it needs, including `docker compose down` of any prior leftover containers on the box. The harness no longer pre-deploys profiles or maintains an `active-deploy.txt` marker — that machinery was removed in favour of putting deploy steps inside the trial trajectory where they're visible in the reward, judge, and `claude-code.txt`. Fleet-selection scoring + the wait-for-pool path on exhaustion live in [`AGENTS.md § Platform topology`](AGENTS.md).
@@ -48,6 +48,7 @@ Per-CI-run hygiene is the trial's own responsibility: each spec's first agent tu
 | `VLM_REMOTE_URL` / `VLM_REMOTE_MODEL` | Remote-VLM endpoint used by `remote-*` deploy modes |
 | `HF_TOKEN` | Required by the Edge 4B vLLM on SPARK / Thor `shared` mode |
 | `GITHUB_TOKEN` | Issued to `gh pr comment` when the agent posts results |
+| `BREV_REGISTERED_POOL` | Comma/space-separated registered-node names approved for automatic pool selection |
 
 ## Layout
 

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -289,6 +289,97 @@ def _list_brev_instances() -> list[dict]:
     return []
 
 
+def _list_registered_nodes() -> list[dict]:
+    """Snapshot registered external nodes from ``brev ls nodes --json``.
+
+    The CLI intentionally keeps registered nodes out of ``brev ls --json``.
+    Treat a well-formed empty array (or ``null``) as authoritative, but retry
+    empty/malformed output because transient auth/RPC failures otherwise make
+    the external pool disappear for the whole lock wait.
+    """
+    for attempt in range(4):
+        try:
+            proc = subprocess.run(
+                ["brev", "ls", "nodes", "--json"],
+                capture_output=True, text=True, timeout=60,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            print(
+                f"[run-leg] brev ls nodes failed (attempt {attempt + 1}): {exc}",
+                flush=True,
+            )
+            time.sleep(5)
+            continue
+        raw = (proc.stdout or "").strip()
+        if raw.startswith("null"):
+            return []
+        if raw and raw.rfind("]") >= 0:
+            return _parse_brev_json(raw)
+        print(
+            f"[run-leg] brev ls nodes returned empty stdout "
+            f"(attempt {attempt + 1})",
+            flush=True,
+        )
+        time.sleep(5)
+    return []
+
+
+def _registered_gpu_hint(name: str) -> str:
+    """Infer hardware only for operator-controlled ``vss-eval-*`` names.
+
+    ``brev ls nodes --json`` currently reports name/status but no GPU model.
+    The pool's documented prefixes are therefore the only available hardware
+    contract. Unknown prefixes return empty so GPU-requiring legs fail closed.
+    """
+    normalized = name.lower()
+    if normalized.startswith("vss-eval-rtx"):
+        return "RTX PRO 6000"
+    if normalized.startswith("vss-eval-l40s"):
+        return "L40S"
+    if normalized.startswith("vss-eval-h100"):
+        return "H100"
+    return ""
+
+
+def _registered_pool_allowlist() -> set[str]:
+    """Names explicitly approved for automatic registered-node selection."""
+    raw = os.environ.get("BREV_REGISTERED_POOL", "")
+    return {
+        name.lower()
+        for name in re.split(r"[\s,]+", raw.strip())
+        if name
+    }
+
+
+def _list_pool_instances() -> list[dict]:
+    """Return managed instances plus connected registered pool nodes."""
+    instances = list(_list_brev_instances())
+    seen = {(inst.get("name") or "").lower() for inst in instances}
+    registered_allowlist = _registered_pool_allowlist()
+    if not registered_allowlist:
+        return instances
+    for node in _list_registered_nodes():
+        name = (node.get("name") or "").strip()
+        if (
+            not name
+            or name.lower() in seen
+            or name.lower() not in registered_allowlist
+        ):
+            continue
+        status = (node.get("status") or "").upper()
+        instances.append({
+            **node,
+            "name": name,
+            # Managed instances say RUNNING; registered nodes say Connected.
+            "status": "RUNNING" if status == "CONNECTED" else status,
+            "gpu": _registered_gpu_hint(name),
+            "instance_type": "registered-external-node",
+            "_registered": True,
+        })
+        seen.add(name.lower())
+    return instances
+
+
 def _loose_gpu_match(want: str, have: str) -> bool:
     """`RTX PRO 6000` ⊆ `RTX PRO SERVER 6000` — all tokens of `want` must
     appear in `have` (substring fallback for dashed variants). Mirrors
@@ -309,17 +400,17 @@ def pool_candidates(metadata: dict) -> list[str]:
     """Eligible `vss-eval-*` boxes for this leg, best-first.
 
     Hardware-hard, software-free (AGENTS.md § 5a): RUNNING + gpu_type
-    token match. Exact name-hinted gpu_count matches sort first so the
-    pool stays partitioned (don't tie up a 2-GPU box with 1-GPU work);
-    over-provisioned boxes remain as fallback — brev_env validates the
-    final pick with `gpu_count >=` and the box is reset either way.
+    token match. Dedicated registered nodes sort before managed cloud
+    instances; exact name-hinted gpu_count matches sort first within each
+    tier. Over-provisioned boxes remain valid — brev_env validates the final
+    pick with live nvidia-smi and the box is reset either way.
     gpu_count == 0 (remote-all / GPU-independent) accepts any RUNNING box.
     """
     required_type = (metadata.get("gpu_type") or "").upper()
     required_count = int(metadata.get("gpu_count", 1) or 0)
 
-    names: list[str] = []
-    for inst in _list_brev_instances():
+    candidates: list[tuple[str, bool]] = []
+    for inst in _list_pool_instances():
         name = inst.get("name") or ""
         if not name.startswith("vss-eval-"):
             continue
@@ -333,14 +424,18 @@ def pool_candidates(metadata: dict) -> list[str]:
             if not (_loose_gpu_match(required_type, gpu)
                     or _loose_gpu_match(required_type, itype)):
                 continue
-        names.append(name)
+        candidates.append((name, bool(inst.get("_registered"))))
 
-    def sort_key(name: str) -> tuple[int, str]:
+    def sort_key(candidate: tuple[str, bool]) -> tuple[int, int, str]:
+        name, registered = candidate
         hint = _name_gpu_count_hint(name)
         exact = 0 if (required_count > 0 and hint == required_count) else 1
-        return (exact, name)
+        # Use the dedicated registered pool before consuming managed cloud
+        # capacity. Within each pool tier, preserve exact-count partitioning.
+        # BrevEnvironment validates the chosen node with live nvidia-smi.
+        return (0 if registered else 1, exact, name.lower())
 
-    return sorted(names, key=sort_key)
+    return [name for name, _ in sorted(candidates, key=sort_key)]
 
 
 @contextlib.contextmanager

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -40,6 +40,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STEP_COUNT_RE = re.compile(r"^\s*step_count\s*=\s*(\d+)\s*$", re.MULTILINE)
 SAFE_PART_RE = re.compile(r"[^A-Za-z0-9_-]+")
+RTX4090_PREFIX = "vss-eval-geforce-rtx4090-"
 RTX4090_SKILLS = frozenset({
     "vss-ask-video",
     "vss-setup-behavior-analytics",
@@ -341,6 +342,8 @@ def _registered_gpu_hint(name: str) -> str:
     contract. Unknown prefixes return empty so GPU-requiring legs fail closed.
     """
     normalized = name.lower()
+    if normalized.startswith(RTX4090_PREFIX):
+        return "GEFORCE RTX 4090"
     if normalized.startswith("vss-eval-rtx"):
         return "RTX PRO 6000"
     if normalized.startswith("vss-eval-l40s"):
@@ -376,6 +379,9 @@ def _list_pool_instances(skill: str | None = None) -> list[dict]:
     instances = list(_list_brev_instances())
     seen = {(inst.get("name") or "").lower() for inst in instances}
     registered_allowlist = _registered_pool_allowlist(skill)
+    rtx4090_allowlist = _parse_pool_names(
+        os.environ.get("BREV_RTX4090_POOL", "")
+    )
     if not registered_allowlist:
         return instances
     for node in _list_registered_nodes():
@@ -395,6 +401,10 @@ def _list_pool_instances(skill: str | None = None) -> list[dict]:
             "gpu": _registered_gpu_hint(name),
             "instance_type": "registered-external-node",
             "_registered": True,
+            "_rtx4090_capability_routed": (
+                name.lower() in rtx4090_allowlist
+                and name.lower().startswith(RTX4090_PREFIX)
+            ),
         })
         seen.add(name.lower())
     return instances
@@ -412,6 +422,8 @@ def _loose_gpu_match(want: str, have: str) -> bool:
 def _name_gpu_count_hint(name: str) -> int | None:
     """Fleet-naming gpu_count hint: `*-1g*` → 1, `*-2g*` → 2 (AGENTS.md
     pool convention). None when the name encodes nothing."""
+    if name.lower().startswith(RTX4090_PREFIX):
+        return 1
     match = re.search(r"-(\d)g(?:-|$)", name)
     return int(match.group(1)) if match else None
 
@@ -444,10 +456,15 @@ def pool_candidates(metadata: dict) -> list[str]:
         if required_count > 0 and required_type:
             gpu = (inst.get("gpu") or "").upper()
             itype = (inst.get("instance_type") or "").upper()
+            capability_routed = (
+                bool(inst.get("_rtx4090_capability_routed"))
+                and skill in RTX4090_SKILLS
+            )
             # Accept via instance_type when `gpu` is a transient "-"/"" flake
             # (brev catalog refresh) — same soft-fail brev_env applies.
             if not (_loose_gpu_match(required_type, gpu)
-                    or _loose_gpu_match(required_type, itype)):
+                    or _loose_gpu_match(required_type, itype)
+                    or capability_routed):
                 continue
         candidates.append((name, bool(inst.get("_registered"))))
 

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -40,6 +40,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STEP_COUNT_RE = re.compile(r"^\s*step_count\s*=\s*(\d+)\s*$", re.MULTILINE)
 SAFE_PART_RE = re.compile(r"[^A-Za-z0-9_-]+")
+RTX4090_SKILLS = frozenset({
+    "vss-ask-video",
+    "vss-setup-behavior-analytics",
+    "vss-setup-video-analytics-api",
+    "vss-deploy-detection-tracking-2d",
+    "vss-deploy-video-embedding",
+    "vss-deploy-dense-captioning",
+    "vss-generate-video-calibration",
+})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -341,9 +350,7 @@ def _registered_gpu_hint(name: str) -> str:
     return ""
 
 
-def _registered_pool_allowlist() -> set[str]:
-    """Names explicitly approved for automatic registered-node selection."""
-    raw = os.environ.get("BREV_REGISTERED_POOL", "")
+def _parse_pool_names(raw: str) -> set[str]:
     return {
         name.lower()
         for name in re.split(r"[\s,]+", raw.strip())
@@ -351,11 +358,24 @@ def _registered_pool_allowlist() -> set[str]:
     }
 
 
-def _list_pool_instances() -> list[dict]:
+def _registered_pool_allowlist(skill: str | None = None) -> set[str]:
+    """Registered nodes approved for this skill.
+
+    ``BREV_REGISTERED_POOL`` contains full-capability workers. The separate
+    RTX 4090 pool is intentionally capability-routed because those 24 GB
+    cards cannot safely satisfy every RTX PRO 6000 task.
+    """
+    names = _parse_pool_names(os.environ.get("BREV_REGISTERED_POOL", ""))
+    if skill in RTX4090_SKILLS:
+        names.update(_parse_pool_names(os.environ.get("BREV_RTX4090_POOL", "")))
+    return names
+
+
+def _list_pool_instances(skill: str | None = None) -> list[dict]:
     """Return managed instances plus connected registered pool nodes."""
     instances = list(_list_brev_instances())
     seen = {(inst.get("name") or "").lower() for inst in instances}
-    registered_allowlist = _registered_pool_allowlist()
+    registered_allowlist = _registered_pool_allowlist(skill)
     if not registered_allowlist:
         return instances
     for node in _list_registered_nodes():
@@ -408,14 +428,19 @@ def pool_candidates(metadata: dict) -> list[str]:
     """
     required_type = (metadata.get("gpu_type") or "").upper()
     required_count = int(metadata.get("gpu_count", 1) or 0)
+    skill = metadata.get("skill") or os.environ.get("EVAL_SKILL") or None
 
     candidates: list[tuple[str, bool]] = []
-    for inst in _list_pool_instances():
+    for inst in _list_pool_instances(skill):
         name = inst.get("name") or ""
         if not name.startswith("vss-eval-"):
             continue
         if (inst.get("status") or "").upper() != "RUNNING":
             continue
+        if inst.get("_registered") and required_count > 0:
+            count_hint = _name_gpu_count_hint(name)
+            if count_hint is not None and count_hint < required_count:
+                continue
         if required_count > 0 and required_type:
             gpu = (inst.get("gpu") or "").upper()
             itype = (inst.get("instance_type") or "").upper()

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -41,15 +41,27 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 STEP_COUNT_RE = re.compile(r"^\s*step_count\s*=\s*(\d+)\s*$", re.MULTILINE)
 SAFE_PART_RE = re.compile(r"[^A-Za-z0-9_-]+")
 RTX4090_PREFIX = "vss-eval-geforce-rtx4090-"
-RTX4090_SKILLS = frozenset({
-    "vss-ask-video",
-    "vss-setup-behavior-analytics",
-    "vss-setup-video-analytics-api",
+RTX4090_ALL_TESTS = frozenset({
+    "vss-manage-alerts",
     "vss-deploy-detection-tracking-2d",
-    "vss-deploy-video-embedding",
-    "vss-deploy-dense-captioning",
-    "vss-generate-video-calibration",
+    "vss-manage-video-io-storage",
 })
+RTX4090_TESTS = {
+    "vss-ask-video": frozenset({"base_profile_video_understanding"}),
+    "vss-generate-video-report": frozenset({"base_profile_report"}),
+    "vss-deploy-profile": frozenset({
+        "base", "lvs", "alerts_vlm", "alerts_cv",
+    }),
+    "vss-summarize-video": frozenset({
+        "lvs_profile_summarize", "lvs_api_ops",
+    }),
+    "vss-query-analytics": frozenset({"query_analytics"}),
+    "vss-deploy-video-embedding": frozenset({"standalone_deploy"}),
+    "vss-generate-video-calibration": frozenset({"auto-calibration"}),
+    "vss-setup-behavior-analytics": frozenset({"standalone_deploy"}),
+    "vss-setup-video-analytics-api": frozenset({"standalone_deploy"}),
+    "vss-deploy-dense-captioning": frozenset({"standalone_api"}),
+}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -361,24 +373,40 @@ def _parse_pool_names(raw: str) -> set[str]:
     }
 
 
-def _registered_pool_allowlist(skill: str | None = None) -> set[str]:
-    """Registered nodes approved for this skill.
+def _rtx4090_supports(skill: str | None, spec_stem: str | None) -> bool:
+    """Whether resource data supports this exact test on a 24 GB RTX 4090."""
+    if not skill or not spec_stem:
+        return False
+    return (
+        skill in RTX4090_ALL_TESTS
+        or spec_stem in RTX4090_TESTS.get(skill, ())
+    )
+
+
+def _registered_pool_allowlist(
+    skill: str | None = None,
+    spec_stem: str | None = None,
+) -> set[str]:
+    """Registered nodes approved for this test.
 
     ``BREV_REGISTERED_POOL`` contains full-capability workers. The separate
     RTX 4090 pool is intentionally capability-routed because those 24 GB
     cards cannot safely satisfy every RTX PRO 6000 task.
     """
     names = _parse_pool_names(os.environ.get("BREV_REGISTERED_POOL", ""))
-    if skill in RTX4090_SKILLS:
+    if _rtx4090_supports(skill, spec_stem):
         names.update(_parse_pool_names(os.environ.get("BREV_RTX4090_POOL", "")))
     return names
 
 
-def _list_pool_instances(skill: str | None = None) -> list[dict]:
+def _list_pool_instances(
+    skill: str | None = None,
+    spec_stem: str | None = None,
+) -> list[dict]:
     """Return managed instances plus connected registered pool nodes."""
     instances = list(_list_brev_instances())
     seen = {(inst.get("name") or "").lower() for inst in instances}
-    registered_allowlist = _registered_pool_allowlist(skill)
+    registered_allowlist = _registered_pool_allowlist(skill, spec_stem)
     rtx4090_allowlist = _parse_pool_names(
         os.environ.get("BREV_RTX4090_POOL", "")
     )
@@ -428,7 +456,10 @@ def _name_gpu_count_hint(name: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
-def pool_candidates(metadata: dict) -> list[str]:
+def pool_candidates(
+    metadata: dict,
+    spec_stem: str | None = None,
+) -> list[str]:
     """Eligible `vss-eval-*` boxes for this leg, best-first.
 
     Hardware-hard, software-free (AGENTS.md § 5a): RUNNING + gpu_type
@@ -441,9 +472,15 @@ def pool_candidates(metadata: dict) -> list[str]:
     required_type = (metadata.get("gpu_type") or "").upper()
     required_count = int(metadata.get("gpu_count", 1) or 0)
     skill = metadata.get("skill") or os.environ.get("EVAL_SKILL") or None
+    spec_stem = (
+        spec_stem
+        or metadata.get("spec_stem")
+        or os.environ.get("EVAL_SPEC_STEM")
+        or None
+    )
 
     candidates: list[tuple[str, bool]] = []
-    for inst in _list_pool_instances(skill):
+    for inst in _list_pool_instances(skill, spec_stem):
         name = inst.get("name") or ""
         if not name.startswith("vss-eval-"):
             continue
@@ -458,7 +495,7 @@ def pool_candidates(metadata: dict) -> list[str]:
             itype = (inst.get("instance_type") or "").upper()
             capability_routed = (
                 bool(inst.get("_rtx4090_capability_routed"))
-                and skill in RTX4090_SKILLS
+                and _rtx4090_supports(skill, spec_stem)
             )
             # Accept via instance_type when `gpu` is a transient "-"/"" flake
             # (brev catalog refresh) — same soft-fail brev_env applies.
@@ -729,7 +766,9 @@ def main(argv: list[str] | None = None) -> int:
                   flush=True)
             candidates_fn = lambda: [pinned]  # noqa: E731
         else:
-            candidates_fn = lambda: pool_candidates(metadata)  # noqa: E731
+            candidates_fn = (  # noqa: E731
+                lambda: pool_candidates(metadata, args.spec_stem)
+            )
         with hold_pool_lock(
             candidates_fn, args.lock_dir, args.lock_timeout_sec
         ) as instance:

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -194,7 +194,9 @@ class PoolCandidates(unittest.TestCase):
 
     def setUp(self):
         self._orig = run_leg._list_pool_instances
-        run_leg._list_pool_instances = lambda _skill=None: self.FLEET
+        run_leg._list_pool_instances = (
+            lambda _skill=None, _spec_stem=None: self.FLEET
+        )
 
     def tearDown(self):
         run_leg._list_pool_instances = self._orig
@@ -302,9 +304,11 @@ class PoolCandidates(unittest.TestCase):
             ),
         }
         with mock.patch.dict(run_leg.os.environ, env, clear=True):
-            approved = run_leg._registered_pool_allowlist("vss-ask-video")
+            approved = run_leg._registered_pool_allowlist(
+                "vss-ask-video", "base_profile_video_understanding"
+            )
             unapproved = run_leg._registered_pool_allowlist(
-                "vss-deploy-profile"
+                "vss-deploy-profile", "search"
             )
 
         self.assertEqual(
@@ -317,6 +321,27 @@ class PoolCandidates(unittest.TestCase):
         )
         self.assertEqual(unapproved, {"vss-eval-rtx-2g-vm1b"})
 
+    def test_4090_test_capabilities_fail_closed(self):
+        self.assertTrue(run_leg._rtx4090_supports(
+            "vss-deploy-profile", "alerts_cv"
+        ))
+        self.assertTrue(run_leg._rtx4090_supports(
+            "vss-manage-alerts", "subscriptions_lifecycle"
+        ))
+        self.assertFalse(run_leg._rtx4090_supports(
+            "vss-deploy-profile", "search"
+        ))
+        self.assertFalse(run_leg._rtx4090_supports(
+            "vss-deploy-profile", "warehouse"
+        ))
+        self.assertFalse(run_leg._rtx4090_supports(
+            "vss-deploy-dense-captioning", "alerts_profile_api"
+        ))
+        self.assertFalse(run_leg._rtx4090_supports(
+            "vss-deploy-detection-tracking-3d", "deploy"
+        ))
+        self.assertFalse(run_leg._rtx4090_supports("vss-ask-video", None))
+
     def test_4090_capability_route_bypasses_rtx_pro_type_only_for_skill(self):
         fleet = [{
             "name": "vss-eval-geforce-rtx4090-vm1",
@@ -325,17 +350,19 @@ class PoolCandidates(unittest.TestCase):
             "_registered": True,
             "_rtx4090_capability_routed": True,
         }]
-        run_leg._list_pool_instances = lambda _skill=None: fleet
+        run_leg._list_pool_instances = (
+            lambda _skill=None, _spec_stem=None: fleet
+        )
         requirements = {"gpu_type": "RTX PRO 6000", "gpu_count": 1}
 
         approved = run_leg.pool_candidates({
             **requirements,
             "skill": "vss-ask-video",
-        })
+        }, "base_profile_video_understanding")
         unapproved = run_leg.pool_candidates({
             **requirements,
-            "skill": "vss-deploy-profile",
-        })
+            "skill": "vss-deploy-dense-captioning",
+        }, "alerts_profile_api")
 
         self.assertEqual(approved, ["vss-eval-geforce-rtx4090-vm1"])
         self.assertEqual(unapproved, [])
@@ -348,13 +375,15 @@ class PoolCandidates(unittest.TestCase):
             {"name": "vss-eval-rtx-2g-VM1b", "status": "RUNNING",
              "gpu": "RTX PRO 6000", "_registered": True},
         ]
-        run_leg._list_pool_instances = lambda _skill=None: fleet
+        run_leg._list_pool_instances = (
+            lambda _skill=None, _spec_stem=None: fleet
+        )
 
         names = run_leg.pool_candidates({
             "skill": "vss-ask-video",
             "gpu_type": "RTX PRO 6000",
             "gpu_count": 2,
-        })
+        }, "base_profile_video_understanding")
 
         self.assertEqual(names, ["vss-eval-rtx-2g-VM1b"])
 

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -194,7 +194,7 @@ class PoolCandidates(unittest.TestCase):
 
     def setUp(self):
         self._orig = run_leg._list_pool_instances
-        run_leg._list_pool_instances = lambda: self.FLEET
+        run_leg._list_pool_instances = lambda _skill=None: self.FLEET
 
     def tearDown(self):
         run_leg._list_pool_instances = self._orig
@@ -286,6 +286,47 @@ class PoolCandidates(unittest.TestCase):
             [instance["name"] for instance in instances],
             ["vss-eval-rtx-2g-VM1b"],
         )
+
+    def test_4090_pool_is_limited_to_approved_skills(self):
+        env = {
+            "BREV_REGISTERED_POOL": "vss-eval-rtx-2g-VM1b",
+            "BREV_RTX4090_POOL": (
+                "vss-eval-rtx-1g-2-runner,"
+                "vss-eval-rtx-1g-3-runner"
+            ),
+        }
+        with mock.patch.dict(run_leg.os.environ, env, clear=True):
+            approved = run_leg._registered_pool_allowlist("vss-ask-video")
+            unapproved = run_leg._registered_pool_allowlist(
+                "vss-deploy-profile"
+            )
+
+        self.assertEqual(
+            approved,
+            {
+                "vss-eval-rtx-2g-vm1b",
+                "vss-eval-rtx-1g-2-runner",
+                "vss-eval-rtx-1g-3-runner",
+            },
+        )
+        self.assertEqual(unapproved, {"vss-eval-rtx-2g-vm1b"})
+
+    def test_underprovisioned_registered_node_is_filtered(self):
+        fleet = [
+            {"name": "vss-eval-rtx-1g-2-runner", "status": "RUNNING",
+             "gpu": "RTX PRO 6000", "_registered": True},
+            {"name": "vss-eval-rtx-2g-VM1b", "status": "RUNNING",
+             "gpu": "RTX PRO 6000", "_registered": True},
+        ]
+        run_leg._list_pool_instances = lambda _skill=None: fleet
+
+        names = run_leg.pool_candidates({
+            "skill": "vss-ask-video",
+            "gpu_type": "RTX PRO 6000",
+            "gpu_count": 2,
+        })
+
+        self.assertEqual(names, ["vss-eval-rtx-2g-VM1b"])
 
 
 class HoldPoolLock(unittest.TestCase):

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -184,26 +185,36 @@ class PoolCandidates(unittest.TestCase):
         # gpu flake: catalog refresh returns "-" but instance_type carries it
         {"name": "vss-eval-l40s-2", "status": "RUNNING",
          "gpu": "-", "instance_type": "massedcompute_L40Sx2"},
+        {"name": "vss-eval-rtx-2g-VM1b", "status": "RUNNING",
+         "gpu": "RTX PRO 6000",
+         "instance_type": "registered-external-node", "_registered": True},
         {"name": "not-a-pool-box", "status": "RUNNING",
          "gpu": "RTX PRO Server 6000", "instance_type": "g7e.4xlarge"},
     ]
 
     def setUp(self):
-        self._orig = run_leg._list_brev_instances
-        run_leg._list_brev_instances = lambda: self.FLEET
+        self._orig = run_leg._list_pool_instances
+        run_leg._list_pool_instances = lambda: self.FLEET
 
     def tearDown(self):
-        run_leg._list_brev_instances = self._orig
+        run_leg._list_pool_instances = self._orig
 
     def test_filters_running_pool_and_gpu_type(self):
         names = run_leg.pool_candidates(
             {"gpu_type": "RTX PRO 6000", "gpu_count": 1})
-        self.assertEqual(names, ["vss-eval-rtx-1g-2", "vss-eval-rtx-2g-2"])
+        self.assertEqual(
+            names,
+            [
+                "vss-eval-rtx-2g-VM1b",
+                "vss-eval-rtx-1g-2",
+                "vss-eval-rtx-2g-2",
+            ],
+        )
 
     def test_exact_count_hint_sorts_first(self):
         names = run_leg.pool_candidates(
             {"gpu_type": "RTX PRO 6000", "gpu_count": 2})
-        self.assertEqual(names[0], "vss-eval-rtx-2g-2")
+        self.assertEqual(names[0], "vss-eval-rtx-2g-VM1b")
 
     def test_gpu_flake_accepted_via_instance_type(self):
         names = run_leg.pool_candidates({"gpu_type": "L40S", "gpu_count": 1})
@@ -211,9 +222,70 @@ class PoolCandidates(unittest.TestCase):
 
     def test_gpu_count_zero_accepts_any_running_pool_box(self):
         names = run_leg.pool_candidates({"gpu_count": 0})
-        self.assertEqual(len(names), 4)
+        self.assertEqual(len(names), 5)
         self.assertNotIn("not-a-pool-box", names)
         self.assertNotIn("vss-eval-rtx-1g-3", names)
+
+    def test_registered_gpu_hint_fails_closed_for_unknown_pool(self):
+        self.assertEqual(
+            run_leg._registered_gpu_hint("vss-eval-rtx-2g-VM1b"),
+            "RTX PRO 6000",
+        )
+        self.assertEqual(run_leg._registered_gpu_hint("vss-eval-mystery"), "")
+
+    def test_pool_snapshot_merges_and_normalizes_registered_nodes(self):
+        orig_managed = run_leg._list_brev_instances
+        orig_registered = run_leg._list_registered_nodes
+        try:
+            run_leg._list_brev_instances = lambda: [
+                {"name": "vss-eval-rtx-2g", "status": "RUNNING"}
+            ]
+            run_leg._list_registered_nodes = lambda: [
+                {"name": "vss-eval-rtx-2g-VM1b", "status": "Connected"},
+                # A duplicate must not be added twice.
+                {"name": "vss-eval-rtx-2g", "status": "Connected"},
+            ]
+
+            with mock.patch.dict(
+                run_leg.os.environ,
+                {"BREV_REGISTERED_POOL": "vss-eval-rtx-2g-VM1b"},
+            ):
+                instances = self._orig()
+        finally:
+            run_leg._list_brev_instances = orig_managed
+            run_leg._list_registered_nodes = orig_registered
+
+        self.assertEqual(len(instances), 2)
+        registered = instances[1]
+        self.assertEqual(registered["status"], "RUNNING")
+        self.assertEqual(registered["gpu"], "RTX PRO 6000")
+        self.assertTrue(registered["_registered"])
+
+    def test_registered_pool_requires_explicit_allowlist(self):
+        orig_managed = run_leg._list_brev_instances
+        orig_registered = run_leg._list_registered_nodes
+        try:
+            run_leg._list_brev_instances = lambda: []
+            run_leg._list_registered_nodes = lambda: [
+                {"name": "vss-eval-rtx-2g-VM1b", "status": "Connected"},
+                {"name": "vss-eval-rtx-2g-skybridge", "status": "Connected"},
+            ]
+            with mock.patch.dict(
+                run_leg.os.environ,
+                {
+                    "BREV_REGISTERED_POOL":
+                        "vss-eval-rtx-2g-VM1b, vss-eval-rtx-2g-VM2b"
+                },
+            ):
+                instances = self._orig()
+        finally:
+            run_leg._list_brev_instances = orig_managed
+            run_leg._list_registered_nodes = orig_registered
+
+        self.assertEqual(
+            [instance["name"] for instance in instances],
+            ["vss-eval-rtx-2g-VM1b"],
+        )
 
 
 class HoldPoolLock(unittest.TestCase):

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -231,6 +231,12 @@ class PoolCandidates(unittest.TestCase):
             run_leg._registered_gpu_hint("vss-eval-rtx-2g-VM1b"),
             "RTX PRO 6000",
         )
+        self.assertEqual(
+            run_leg._registered_gpu_hint(
+                "vss-eval-geforce-rtx4090-vm1"
+            ),
+            "GEFORCE RTX 4090",
+        )
         self.assertEqual(run_leg._registered_gpu_hint("vss-eval-mystery"), "")
 
     def test_pool_snapshot_merges_and_normalizes_registered_nodes(self):
@@ -291,8 +297,8 @@ class PoolCandidates(unittest.TestCase):
         env = {
             "BREV_REGISTERED_POOL": "vss-eval-rtx-2g-VM1b",
             "BREV_RTX4090_POOL": (
-                "vss-eval-rtx-1g-2-runner,"
-                "vss-eval-rtx-1g-3-runner"
+                "vss-eval-geforce-rtx4090-vm1,"
+                "vss-eval-geforce-rtx4090-vm2"
             ),
         }
         with mock.patch.dict(run_leg.os.environ, env, clear=True):
@@ -305,16 +311,40 @@ class PoolCandidates(unittest.TestCase):
             approved,
             {
                 "vss-eval-rtx-2g-vm1b",
-                "vss-eval-rtx-1g-2-runner",
-                "vss-eval-rtx-1g-3-runner",
+                "vss-eval-geforce-rtx4090-vm1",
+                "vss-eval-geforce-rtx4090-vm2",
             },
         )
         self.assertEqual(unapproved, {"vss-eval-rtx-2g-vm1b"})
 
+    def test_4090_capability_route_bypasses_rtx_pro_type_only_for_skill(self):
+        fleet = [{
+            "name": "vss-eval-geforce-rtx4090-vm1",
+            "status": "RUNNING",
+            "gpu": "GEFORCE RTX 4090",
+            "_registered": True,
+            "_rtx4090_capability_routed": True,
+        }]
+        run_leg._list_pool_instances = lambda _skill=None: fleet
+        requirements = {"gpu_type": "RTX PRO 6000", "gpu_count": 1}
+
+        approved = run_leg.pool_candidates({
+            **requirements,
+            "skill": "vss-ask-video",
+        })
+        unapproved = run_leg.pool_candidates({
+            **requirements,
+            "skill": "vss-deploy-profile",
+        })
+
+        self.assertEqual(approved, ["vss-eval-geforce-rtx4090-vm1"])
+        self.assertEqual(unapproved, [])
+
     def test_underprovisioned_registered_node_is_filtered(self):
         fleet = [
-            {"name": "vss-eval-rtx-1g-2-runner", "status": "RUNNING",
-             "gpu": "RTX PRO 6000", "_registered": True},
+            {"name": "vss-eval-geforce-rtx4090-vm1", "status": "RUNNING",
+             "gpu": "GEFORCE RTX 4090", "_registered": True,
+             "_rtx4090_capability_routed": True},
             {"name": "vss-eval-rtx-2g-VM1b", "status": "RUNNING",
              "gpu": "RTX PRO 6000", "_registered": True},
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -872,6 +872,8 @@ jobs:
     needs: prepare-source
     runs-on: ubuntu-latest
     timeout-minutes: 140
+    outputs:
+      has-ghcr-build-entries: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
     permissions:
       actions: read
       contents: read
@@ -881,6 +883,7 @@ jobs:
           persist-credentials: false
 
       - name: Wait for successful GHCR release set
+        id: release-set
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -919,6 +922,9 @@ jobs:
       - license-check-ui
       - folder-structure
       - wait-for-build-dev-images
+    if: >-
+      success() &&
+      needs.wait-for-build-dev-images.outputs.has-ghcr-build-entries == 'true'
     runs-on: [self-hosted, downstream-pipeline]
     # Holds the runner until the downstream pipeline completes. Must be
     # at least as long as MAX_POLL_DURATION_SECONDS in the poll step

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -103,9 +103,10 @@ jobs:
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false
-      # Cap concurrent legs near the vss-eval-* box count so legs don't
-      # all grab a runner slot only to block on flock. Excess legs queue.
-      max-parallel: 4
+      # Match the PR workflow: four static runner services plus one queued leg
+      # per active runner. run_leg.py still caps execution at one leg per GPU
+      # box through the per-instance flock.
+      max-parallel: 8
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     # Per-leg cap. One spec, but a multi-step spec runs step-1..N as
     # sequential harbor invocations, each up to the 1 h agent ceiling

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -103,9 +103,8 @@ jobs:
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false
-      # Match the PR workflow: four static runner services plus one queued leg
-      # per active runner. run_leg.py still caps execution at one leg per GPU
-      # box through the per-instance flock.
+      # Match the PR workflow's eight-leg limit. Unavailable runner slots
+      # queue in Actions; per-instance flock still serializes each GPU box.
       max-parallel: 8
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     # Per-leg cap. One spec, but a multi-step spec runs step-1..N as

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -138,9 +138,10 @@ jobs:
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false
-      # Cap concurrent legs near the vss-eval-* box count so legs don't
-      # all grab a runner slot only to wait inside run_leg.py. Excess legs queue.
-      max-parallel: 32
+      # The coordinator currently has four static vss-skill-eval runner
+      # services. Allow one queued leg per active runner without flooding the
+      # runner queue; run_leg.py still caps execution at one leg per GPU box.
+      max-parallel: 8
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     # Per-leg cap. One spec, but a multi-step spec runs step-1..N as
     # sequential harbor invocations, each up to the 1 h agent ceiling

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       # Cap concurrent legs near the vss-eval-* box count so legs don't
       # all grab a runner slot only to wait inside run_leg.py. Excess legs queue.
-      max-parallel: 4
+      max-parallel: 32
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     # Per-leg cap. One spec, but a multi-step spec runs step-1..N as
     # sequential harbor invocations, each up to the 1 h agent ceiling

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -138,9 +138,8 @@ jobs:
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false
-      # The coordinator currently has four static vss-skill-eval runner
-      # services. Allow one queued leg per active runner without flooding the
-      # runner queue; run_leg.py still caps execution at one leg per GPU box.
+      # Allow up to eight matrix legs. Unavailable runner slots queue in
+      # Actions; run_leg.py still caps execution at one leg per GPU box.
       max-parallel: 8
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     # Per-leg cap. One spec, but a multi-step spec runs step-1..N as

--- a/skills/vss-deploy-video-embedding/SKILL.md
+++ b/skills/vss-deploy-video-embedding/SKILL.md
@@ -13,6 +13,7 @@ metadata:
   tags: "nvidia blueprint operational deployment"
 ---
 
+
 # VSS Video Embedding (RT-Embed)
 
 Use this skill when you need to:

--- a/skills/vss-deploy-video-embedding/SKILL.md
+++ b/skills/vss-deploy-video-embedding/SKILL.md
@@ -13,7 +13,6 @@ metadata:
   tags: "nvidia blueprint operational deployment"
 ---
 
-
 # VSS Video Embedding (RT-Embed)
 
 Use this skill when you need to:


### PR DESCRIPTION
Allow more evaluation legs to queue for the available Brev workers and improve skill-eval throughput.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
