### PR TITLE
fix(agent): pin RTVI x-stream-id routing to the VST stream UUID everywhere

### DIFF
--- a/services/agent/src/vss_agents/api/rtsp_ingest.py
+++ b/services/agent/src/vss_agents/api/rtsp_ingest.py
@@ -44,6 +44,7 @@ from vss_agents.tools.vst.utils import get_rtsp_url as vst_get_rtsp_url
 from vss_agents.tools.vst.utils import get_stream_info_by_name as vst_get_stream_info_by_name
 from vss_agents.utils.retry import create_retry_strategy
 from vss_agents.utils.sanitize import scrub_log
+from vss_agents.utils.stream_routing import stream_routing_headers
 from vss_agents.utils.time_measure import TimeMeasure
 
 logger = logging.getLogger(__name__)
@@ -251,12 +252,10 @@ async def add_to_rtvi_cv(
     logger.info(f"Adding stream to RTVI-CV: POST {url}")
     logger.debug(f"Payload: {payload}")
 
-    # `x-stream-id` is the routing key used by SDR's in-front-of-RTVI proxy
-    # (HAProxy Ingress / Envoy + SDR coordinator). Consistent-hashing on this
-    # header pins a stream to a single worker so subsequent add/delete/config
-    # calls all land on the same pod. See Projects/SDR/wiki.md.
+    # Routing convention: sensor_id here is the VST stream UUID — see
+    # vss_agents.utils.stream_routing for the contract.
     try:
-        response = await client.post(url, json=payload, headers={"x-stream-id": sensor_id})
+        response = await client.post(url, json=payload, headers=stream_routing_headers(sensor_id))
         if response.status_code not in (200, 201):
             error = f"RTVI-CV returned {response.status_code}: {response.text}"
             logger.error(error)
@@ -297,8 +296,7 @@ async def add_to_rtvi_embed(
     logger.info(f"Adding stream to RTVI-embed: POST {url}")
     logger.debug(f"Payload: {payload}")
 
-    # SDR routing key — same rationale as RTVI-CV add above.
-    headers = {"x-stream-id": sensor_id}
+    headers = stream_routing_headers(sensor_id)
     try:
         async for retry in create_retry_strategy(delay=2, retries=6, exceptions=(httpx.TransportError, RuntimeError)):
             with retry:
@@ -314,6 +312,15 @@ async def add_to_rtvi_embed(
 
                 streams = result.get("streams", [])
                 rtvi_stream_id = (streams[0].get("id") if streams else None) or sensor_id
+                if rtvi_stream_id != sensor_id:
+                    # The delete path resolves the stream by VST id only, so a
+                    # divergent service-minted id leaves an orphan on teardown.
+                    logger.warning(
+                        "RTVI-embed registered id %s != requested VST id %s; "
+                        "delete-by-VST-id may not find this stream.",
+                        rtvi_stream_id,
+                        sensor_id,
+                    )
 
                 logger.info(f"RTVI-embed stream registered: {rtvi_stream_id}")
                 return True, "Success", rtvi_stream_id
@@ -361,8 +368,7 @@ async def add_to_rtvi_vlm(
     )
     logger.debug("Payload: %s", scrub_log(payload))
 
-    # SDR routing key — RTVI-VLM is also fronted by the same SDR proxy.
-    headers = {"x-stream-id": sensor_id}
+    headers = stream_routing_headers(sensor_id)
     try:
         async for retry in create_retry_strategy(delay=2, retries=6, exceptions=(httpx.TransportError, RuntimeError)):
             with retry:
@@ -404,10 +410,17 @@ async def add_to_rtvi_vlm(
 
 
 async def start_embedding_generation(
-    client: httpx.AsyncClient, config: ServiceConfig, stream_id: str
+    client: httpx.AsyncClient, config: ServiceConfig, stream_id: str, routing_stream_id: str | None = None
 ) -> tuple[bool, str]:
     """
     Start embedding generation (fire-and-verify: confirm HTTP 200, then close).
+
+    ``stream_id`` is the RTVI-embed resource id (whatever ``/v1/streams/add``
+    registered); ``routing_stream_id`` is the VST stream UUID used for proxy
+    routing. They usually coincide, but when RTVI-embed echoes back its own
+    id the routing key must stay the VST UUID the add was hashed on —
+    otherwise this call lands on a pod that doesn't own the stream.
+
     Returns: (success, message)
     """
     if not config.rtvi_embed_url:
@@ -430,12 +443,10 @@ async def start_embedding_generation(
             "POST",
             url,
             json=payload,
-            headers={
-                "Content-Type": "application/json",
-                "Accept": "text/event-stream",
-                # SDR routing key — pin to the worker that owns this stream.
-                "x-stream-id": stream_id,
-            },
+            headers=stream_routing_headers(
+                routing_stream_id or stream_id,
+                extra={"Content-Type": "application/json", "Accept": "text/event-stream"},
+            ),
         ) as response:
             if response.status_code != 200:
                 error_body = await response.aread()
@@ -479,10 +490,8 @@ async def cleanup_rtvi_cv(
 
     logger.info(f"Removing from RTVI-CV: POST {url}")
 
-    # SDR routing key — same stream-id used on the add path, ensures the
-    # remove lands on the worker that holds this stream's state.
     try:
-        response = await client.post(url, json=payload, headers={"x-stream-id": sensor_id})
+        response = await client.post(url, json=payload, headers=stream_routing_headers(sensor_id))
         if response.status_code in (200, 201, 204):
             logger.info(f"RTVI-CV stream removed: {sensor_id}")
             return True, "OK"
@@ -492,17 +501,21 @@ async def cleanup_rtvi_cv(
 
 
 async def cleanup_rtvi_embed_stream(
-    client: httpx.AsyncClient, config: ServiceConfig, stream_id: str | None
+    client: httpx.AsyncClient, config: ServiceConfig, stream_id: str | None, routing_stream_id: str | None = None
 ) -> tuple[bool, str]:
-    """Remove stream from RTVI-embed."""
+    """Remove stream from RTVI-embed.
+
+    ``stream_id`` addresses the RTVI-embed resource; ``routing_stream_id``
+    (the VST stream UUID) selects the pod. Pass both when they differ.
+    """
     if not config.rtvi_embed_url:
         return True, "Skipped (not configured)"
 
     url = f"{config.rtvi_embed_url}/v1/streams/delete/{stream_id}"
     logger.info(f"Removing from RTVI-embed: DELETE {url}")
 
-    # SDR routing key — pin to the worker that owns this stream's state.
-    headers = {"x-stream-id": stream_id} if stream_id else {}
+    routing_key = routing_stream_id or stream_id
+    headers = stream_routing_headers(routing_key) if routing_key else {}
     try:
         response = await client.delete(url, headers=headers)
         if response.status_code in (200, 204):
@@ -514,17 +527,21 @@ async def cleanup_rtvi_embed_stream(
 
 
 async def cleanup_rtvi_embed_generation(
-    client: httpx.AsyncClient, config: ServiceConfig, stream_id: str | None
+    client: httpx.AsyncClient, config: ServiceConfig, stream_id: str | None, routing_stream_id: str | None = None
 ) -> tuple[bool, str]:
-    """Stop embedding generation in RTVI-embed."""
+    """Stop embedding generation in RTVI-embed.
+
+    Same id split as ``cleanup_rtvi_embed_stream``: resource id in the URL,
+    VST stream UUID in the routing header.
+    """
     if not config.rtvi_embed_url:
         return True, "Skipped (not configured)"
 
     url = f"{config.rtvi_embed_url}/v1/generate_video_embeddings/{stream_id}"
     logger.info(f"Stopping embedding generation: DELETE {url}")
 
-    # SDR routing key.
-    headers = {"x-stream-id": stream_id} if stream_id else {}
+    routing_key = routing_stream_id or stream_id
+    headers = stream_routing_headers(routing_key) if routing_key else {}
     try:
         response = await client.delete(url, headers=headers)
         if response.status_code in (200, 204):
@@ -536,17 +553,21 @@ async def cleanup_rtvi_embed_generation(
 
 
 async def cleanup_rtvi_vlm_stream(
-    client: httpx.AsyncClient, config: ServiceConfig, stream_id: str | None
+    client: httpx.AsyncClient, config: ServiceConfig, stream_id: str | None, routing_stream_id: str | None = None
 ) -> tuple[bool, str]:
-    """Remove stream from RTVI-VLM."""
+    """Remove stream from RTVI-VLM.
+
+    Same id split as ``cleanup_rtvi_embed_stream``: resource id in the URL,
+    VST stream UUID in the routing header.
+    """
     if not config.rtvi_vlm_url:
         return True, "Skipped (not configured)"
 
     url = f"{config.rtvi_vlm_url}/v1/streams/delete/{stream_id}"
     logger.info(f"Removing from RTVI-VLM: DELETE {url}")
 
-    # SDR routing key
-    headers = {"x-stream-id": stream_id} if stream_id else {}
+    routing_key = routing_stream_id or stream_id
+    headers = stream_routing_headers(routing_key) if routing_key else {}
     try:
         response = await client.delete(url, headers=headers)
         if response.status_code in (200, 204):
@@ -670,15 +691,19 @@ def create_rtsp_ingest_router(config: ServiceConfig) -> APIRouter:
                 )
             rtvi_embed_added = config.rtvi_embed_url != ""
 
-            # Step 4: Start embedding generation
+            # Step 4: Start embedding generation. The routing key stays the
+            # VST sensor/stream UUID even if RTVI-embed echoed back its own
+            # resource id — the proxy pinned this stream by the UUID at add.
             if rtvi_embed_stream_id is None:
                 rtvi_embed_stream_id = sensor_id
             with TimeMeasure("rtsp_stream: start embedding generation"):
-                success, msg = await start_embedding_generation(client, config, rtvi_embed_stream_id)
+                success, msg = await start_embedding_generation(
+                    client, config, rtvi_embed_stream_id, routing_stream_id=sensor_id
+                )
             if not success:
                 # Rollback: cleanup RTVI-embed, RTVI-CV, and VST (sensor + storage)
                 if rtvi_embed_added:
-                    await cleanup_rtvi_embed_stream(client, config, rtvi_embed_stream_id)
+                    await cleanup_rtvi_embed_stream(client, config, rtvi_embed_stream_id, routing_stream_id=sensor_id)
                 if rtvi_cv_added:
                     await cleanup_rtvi_cv(client, config, sensor_id, request.name, rtsp_url)
                 await cleanup_vst_sensor(config, sensor_id)

--- a/services/agent/src/vss_agents/api/video_delete.py
+++ b/services/agent/src/vss_agents/api/video_delete.py
@@ -39,6 +39,7 @@ from vss_agents.tools.vst.utils import delete_vst_sensor
 from vss_agents.tools.vst.utils import delete_vst_storage
 from vss_agents.tools.vst.utils import get_sensor_id_from_stream_id
 from vss_agents.utils.sanitize import scrub_log
+from vss_agents.utils.stream_routing import stream_routing_headers
 from vss_agents.utils.time_measure import TimeMeasure
 
 logger = logging.getLogger(__name__)
@@ -86,7 +87,7 @@ class EsCleanupConfig(BaseModel):
 
 
 async def _remove_from_rtvi_cv(
-    client: httpx.AsyncClient, rtvi_cv_url: str, sensor_id: str, sensor_name: str
+    client: httpx.AsyncClient, rtvi_cv_url: str, stream_id: str, sensor_name: str
 ) -> tuple[bool, str]:
     """
     Remove a video stream from RTVI-CV.
@@ -94,7 +95,8 @@ async def _remove_from_rtvi_cv(
     Args:
         client: HTTP client
         rtvi_cv_url: Base RTVI-CV URL (e.g., http://localhost:9000)
-        sensor_id: The sensor UUID
+        stream_id: The VST stream UUID (the ``video_id`` of the upload) — the
+            same value the add path registered as ``camera_id`` and routed by
         sensor_name: The sensor/video name
 
     Returns:
@@ -108,7 +110,7 @@ async def _remove_from_rtvi_cv(
     payload = {
         "key": "sensor",
         "value": {
-            "camera_id": sensor_id,
+            "camera_id": stream_id,
             "camera_name": sensor_name,
             "camera_url": "",
             "change": "camera_remove",
@@ -120,12 +122,9 @@ async def _remove_from_rtvi_cv(
     logger.info(f"Removing from RTVI-CV: POST {url}")
 
     try:
-        # `x-stream-id` is the consistent-hash routing key for multi-replica
-        # RTVI-CV deployments — it must match the header sent on /stream/add
-        # so the remove lands on the pod that owns the stream.
-        response = await client.post(url, json=payload, headers={"x-stream-id": sensor_id})
+        response = await client.post(url, json=payload, headers=stream_routing_headers(stream_id))
         if response.status_code in (200, 201, 204):
-            logger.info("RTVI-CV stream removed: %s", scrub_log(sensor_id))
+            logger.info("RTVI-CV stream removed: %s", scrub_log(stream_id))
             return True, "OK"
         return False, f"RTVI-CV returned {response.status_code}: {response.text}"
     except Exception as e:

--- a/services/agent/src/vss_agents/api/video_ingest.py
+++ b/services/agent/src/vss_agents/api/video_ingest.py
@@ -57,6 +57,7 @@ from pydantic import Field
 
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import VSTError
+from vss_agents.utils.stream_routing import stream_routing_headers
 from vss_agents.utils.time_measure import TimeMeasure
 from vss_agents.utils.url_translation import rewrite_url_host
 
@@ -342,12 +343,8 @@ async def _register_with_rtvi_cv(
     HTTP errors (non-2xx) raise ``HTTPException(502)`` so the caller surfaces a
     hard failure.
     """
-    # `x-stream-id` is the routing key for SDR-fronted RTVI deployments: the
-    # in-front-of-RTVI proxy (HAProxy Ingress or Envoy via SDR coordinator)
-    # consistent-hashes this header to pin a stream to one worker pod.
-    # Without it the proxy falls back to round-robin and subsequent
-    # /add → /delete → /config calls for the same sensor can land on different
-    # workers. See Projects/SDR/wiki.md for the routing contract.
+    # Routing convention: sensor_id is the uploaded asset's VST UUID — see
+    # vss_agents.utils.stream_routing for the contract.
     rtvi_cv_url = rtvi_cv_base_url.rstrip("/")
     rtvi_cv_add_url = f"{rtvi_cv_url}/api/v1/stream/add"
     rtvi_cv_payload = {
@@ -371,7 +368,7 @@ async def _register_with_rtvi_cv(
                 response = await client.post(
                     rtvi_cv_add_url,
                     json=rtvi_cv_payload,
-                    headers={"x-stream-id": sensor_id},
+                    headers=stream_routing_headers(sensor_id),
                 )
             if response.status_code not in (200, 201):
                 error_msg = f"RTVI-CV returned {response.status_code}: {response.text}"
@@ -424,12 +421,10 @@ async def _run_rtvi_embedding(
             response = await client.post(
                 embedding_url,
                 json=embed_request,
-                headers={
-                    "accept": "application/json",
-                    "Content-Type": "application/json",
-                    # SDR routing key — same rationale as RTVI-CV.
-                    "x-stream-id": sensor_id,
-                },
+                headers=stream_routing_headers(
+                    sensor_id,
+                    extra={"accept": "application/json", "Content-Type": "application/json"},
+                ),
             )
 
         if response.status_code != 200:

--- a/services/agent/src/vss_agents/utils/stream_routing.py
+++ b/services/agent/src/vss_agents/utils/stream_routing.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Consistent-hash stream-routing header for RTVI-bound requests.
+
+Multi-replica RTVI deployments front the workers with a proxy that
+consistent-hashes the ``x-stream-id`` request header — HAProxy
+``balance hdr(x-stream-id)`` + ``hash-type consistent``, nginx ingress
+``upstream-hash-by`` (the helm reference), or Envoy ring hash (used by the
+optional SDR coordinator, among others). The hash pins a stream's whole
+lifecycle — add, generate, config, remove — to a single worker pod, but only
+if every request for the stream carries the **same** header value. The
+contract is proxy-agnostic; SDR is just one deployment of it.
+
+The convention: ``x-stream-id`` carries the **VST stream UUID** — the
+``sensorId`` VST returns from ``/sensor/add`` (identical to the stream key in
+``/sensor/streams`` for live sensors) or the uploaded video's ``video_id``
+for file assets. Service-minted resource ids (e.g. the id RTVI-embed echoes
+back from ``/v1/streams/add``) are NOT routing keys: they address the
+resource *inside* a pod, not the pod. Hashing them lands follow-up calls on a
+pod that does not own the stream.
+
+Every RTVI call site must build its headers through this helper so the
+convention has one implementation and one place to change.
+"""
+
+from __future__ import annotations
+
+STREAM_ROUTING_HEADER = "x-stream-id"
+
+
+def stream_routing_headers(stream_id: str, extra: dict[str, str] | None = None) -> dict[str, str]:
+    """Return request headers that pin this call to the stream's worker pod.
+
+    ``stream_id`` must be the VST stream UUID (see module docstring) — the
+    same value on the add and every subsequent call for that stream.
+    """
+    headers = {STREAM_ROUTING_HEADER: stream_id}
+    if extra:
+        headers.update(extra)
+    return headers

--- a/services/agent/tests/unit_test/api/test_rtsp_ingest.py
+++ b/services/agent/tests/unit_test/api/test_rtsp_ingest.py
@@ -1078,3 +1078,93 @@ class TestRegisterRtspStreamApiRoutes:
 
         with pytest.raises(ValueError, match="vst_internal_url"):
             register_rtsp_ingest_routes(mock_app, mock_config)
+
+
+class TestRoutingKeyConvention:
+    """``x-stream-id`` must carry the VST stream UUID on every RTVI call.
+
+    The proxy in front of multi-replica RTVI consistent-hashes this header, so
+    a service-minted resource id (e.g. the id RTVI-embed echoes back from
+    ``/v1/streams/add``) must never become the routing key: the add was hashed
+    on the VST UUID, and hashing a different value sends the follow-up call to
+    a pod that does not own the stream. See vss_agents.utils.stream_routing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_generation_routes_by_vst_uuid_when_embed_echoes_own_id(self):
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_stream_cm = MagicMock()
+        mock_stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=mock_stream_cm)
+
+        success, _msg = await start_embedding_generation(
+            mock_client, config, "embed-minted-42", routing_stream_id="vst-uuid-123"
+        )
+
+        assert success is True
+        kwargs = mock_client.stream.call_args.kwargs
+        assert kwargs["headers"]["x-stream-id"] == "vst-uuid-123"
+        # The embed resource id stays in the payload — routing and resource
+        # identity are separate concerns.
+        assert kwargs["json"]["id"] == "embed-minted-42"
+
+    @pytest.mark.asyncio
+    async def test_embed_stream_cleanup_routes_by_vst_uuid_when_ids_diverge(self):
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = MagicMock()
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        success, _msg = await cleanup_rtvi_embed_stream(
+            mock_client, config, "embed-minted-42", routing_stream_id="vst-uuid-123"
+        )
+
+        assert success is True
+        args, kwargs = mock_client.delete.call_args
+        assert args[0].endswith("/v1/streams/delete/embed-minted-42")
+        assert kwargs["headers"]["x-stream-id"] == "vst-uuid-123"
+
+    @pytest.mark.asyncio
+    async def test_embed_generation_cleanup_routes_by_vst_uuid_when_ids_diverge(self):
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client = MagicMock()
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        success, _msg = await cleanup_rtvi_embed_generation(
+            mock_client, config, "embed-minted-42", routing_stream_id="vst-uuid-123"
+        )
+
+        assert success is True
+        args, kwargs = mock_client.delete.call_args
+        assert args[0].endswith("/v1/generate_video_embeddings/embed-minted-42")
+        assert kwargs["headers"]["x-stream-id"] == "vst-uuid-123"
+
+    @pytest.mark.asyncio
+    @patch("vss_agents.api.rtsp_ingest.create_retry_strategy")
+    async def test_embed_add_warns_when_service_echoes_divergent_id(self, mock_retry, caplog):
+        """A divergent echoed id breaks delete-by-VST-id; it must be loud."""
+        config = ServiceConfig(vst_internal_url="http://vst:30888", rtvi_embed_base_url="http://rtvi-embed:8017")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json = MagicMock(return_value={"streams": [{"id": "embed-minted-42"}]})
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_retry.return_value = _single_attempt_retry()
+
+        with caplog.at_level("WARNING"):
+            success, _msg, rtvi_stream_id = await add_to_rtvi_embed(
+                mock_client, config, "vst-uuid-123", "camera-1", "rtsp://vst:554/vst-uuid-123"
+            )
+
+        assert success is True
+        assert rtvi_stream_id == "embed-minted-42"
+        assert any("delete-by-VST-id" in record.message for record in caplog.records)


### PR DESCRIPTION
## Problem

Reported live (Giap, multi-replica RTVI behind an HAProxy stick-table LB): **adding streams 01, 02 lands on pod0, while removing 02, 01 lands on pod1** — the remove reaches a pod that doesn't own the stream, so teardown silently no-ops and stream state leaks.

Root cause on the agent side: the `x-stream-id` consistent-hash routing header was assembled ad hoc at **nine call sites**, and one of them genuinely diverges. `POST /v1/streams/add` to RTVI-embed is routed by the **VST stream UUID**, but the follow-up `generate_video_embeddings` (and the ingest-rollback delete) were routed by the **resource id RTVI-embed echoes back** from the add (`streams[0].id`). When the service echoes anything other than the requested id, the follow-up call hashes to a different pod than the one the proxy pinned at add time. The remaining eight call sites happened to agree today — but nothing enforced it, and the naming made drift easy (`get_sensor_id_from_stream_id()` returns the camera *name*; one wrong reuse of that as a routing key reintroduces this bug).

## Why the VST stream UUID is the right (and only) key

Verified against the VST/VIOS source in this repo:

- VST mints **exactly one UUID per sensor** — `services/vios/src/modules/sensor_management/sensor_management_utils.cpp:643` (`sensor->id = generate_uuid()`).
- VST's own API treats `sensorId` and `streamId` as **the same identifier**: the `{streamId}` path parameter is used directly as the sensor key (`getSensorInfo(streamId)`, `deleteSensor(streamId)`, `getRecordingTimelines(streamId)` in `sensor_management_apis.cpp`).
- It exists **before any RTVI call** (VST registration always precedes RTVI registration), it's immutable, and it's already what the delete paths hold (`video_id`). Camera *names* are mutable and reusable — never a routing key.

## Change

- New single source of truth: `vss_agents/utils/stream_routing.py` → `stream_routing_headers(stream_id)`. Every RTVI-bound request in `rtsp_ingest`, `rtsp_delete`, `video_ingest`, and `video_delete` now builds its headers through it. The module docstring is the written routing contract.
- `start_embedding_generation` and the embed/VLM cleanups now take the **routing key and the service resource id as separate parameters** — the resource id addresses the stream *inside* the pod (URL/payload), the VST UUID selects the pod (header). The ingest flow passes both explicitly.
- `add_to_rtvi_embed` now **warns loudly** when the service echoes a resource id different from the requested VST UUID (parity with the existing RTVI-VLM warning) — a divergent id also breaks delete-by-VST-id, so it should never be silent.
- `video_delete._remove_from_rtvi_cv`: parameter renamed `sensor_id` → `stream_id` (it receives the upload's `video_id` UUID) so the name states the contract.

No wire-format changes for well-behaved services: when RTVI-embed honors the requested id (the normal case), every header value is byte-identical to before. The behavioral fix is confined to the echoed-divergent-id case.

## The SDR question (reviewers: please weigh in)

This PR guarantees **agent-issued** calls all hash the same key. It does **not** by itself guarantee colocation when a *different producer* issues some of the lifecycle calls — which is exactly what SDR/SDRC deployments do, and SDRC just became the default in the smartcities/warehouse VIOS profiles (PR #1234 restore + `VST_USE_SDRC` toggles, merged 2026-07-20).

What needs verification with the SDR/VIOS owners:

1. **What does SDRC stamp as `x-stream-id`** (or whatever routing key its Envoy/coordinator uses) when it distributes a sensor to RTVI workers? If it keys by the VST sensor UUID, this PR's convention matches by construction — VST has only the one UUID, so any producer that uses "the VST id" agrees with us. If SDRC keys by **camera name** (or doesn't stamp a header at all, falling back to round-robin), then agent-issued removes will not colocate with SDRC-issued adds in SDRC-fronted deployments, and either SDRC or this convention needs a follow-up alignment.
2. **Who owns the add in each topology?** In agent-driven deployments (compose `search` profile, the reporter's setup), the agent issues every lifecycle call and this PR is sufficient. In VIOS/SDRC deployments, the webhook/coordinator may issue the RTVI add while the agent issues the delete — the cross-producer case in (1).
3. **Proxy configuration guidance.** The reference design is *stateless consistent hashing* (helm `rtvi-internal-ingress.yaml` `hashHeader: x-stream-id`; HAProxy equivalent: `balance hdr(x-stream-id)` + `hash-type consistent`). Stick tables are discouraged for this: the first request per key is load-balanced arbitrarily, entries expire out from under long-lived streams, and a proxy reload wipes the table unless peers are configured — three failure modes with no benefit given a deterministic key. Suggest we document this in the multi-replica deployment docs (follow-up).
4. **Missing-header behavior.** With `balance hdr(...)`, headerless requests all hash to one bucket — so a pre-fix client (or an SDRC that doesn't stamp the header) deterministically lands *one* pod, which is precisely the reported "all removes land pod1" signature. Worth keeping in mind when triaging: capture `x-stream-id` at the proxy (`capture request header x-stream-id len 64`) and compare add vs remove for one stream; empty ⇒ old client, differing ⇒ key mismatch, matching ⇒ proxy config.

## Verification

- 165 API unit tests pass, including 4 new regression tests pinning the invariant: the routing key stays the VST UUID even when the service-minted resource id diverges (generation-start, both embed cleanups, and a loud-warning test on the embed add).
- ruff check/format, mypy, TruffleHog, SPDX, DCO hooks all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
