### PR TITLE
fix(agent): make video_understanding max_frames configurable via VLM_MAX_FRAMES

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
@@ -52,7 +52,7 @@ functions:
   video_understanding:
     _type: video_understanding
     vlm_name: ${VLM_MODEL_TYPE:-nim}_vlm # e.g. nim_vlm, openai_vlm
-    max_frames: 30
+    max_frames: ${VLM_MAX_FRAMES:-30}  # override via VLM_MAX_FRAMES; default 30 unchanged. Lower for VLMs that cap images per prompt.
     max_fps: 2  # for CR1, max fps is 2
     min_pixels: 3136
     max_pixels: 8388608

--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -114,6 +114,10 @@ services:
       RTVI_VLM_BASE_URL: ${RTVI_VLM_BASE_URL}
       ALERT_BRIDGE_URL: ${ALERT_BRIDGE_URL:-http://alert-bridge:${ALERT_BRIDGE_PORT:-9080}}
 
+      # Video understanding: frames packed into a single VLM prompt.
+      # Default 30 (unchanged); lower via VLM_MAX_FRAMES for VLMs that cap images per prompt.
+      VLM_MAX_FRAMES: ${VLM_MAX_FRAMES:-30}
+
       # Audio Configuration
       ENABLE_AUDIO: ${ENABLE_AUDIO:-false}
 


### PR DESCRIPTION
## What
Make the `video_understanding` tool's `max_frames` (frames packed into a single VLM prompt) overridable from the environment via `VLM_MAX_FRAMES`, defaulting to the current value. Two coordinated changes:
- Template `max_frames` in the base agent config (`${VLM_MAX_FRAMES:-30}`).
- Forward `VLM_MAX_FRAMES` into the agent container (`services/agent/compose.yml`) so the value reaches NAT's config interpolation, mirroring `ENABLE_AUDIO` / `VLM_MODE`. (Without this the config override would never take effect.)

## Why
`max_frames` is hard-coded in the agent config (base profile: `30`). Some VLM backends cap the number of images allowed in a single prompt, so a deployment served by such a model must lower the per-prompt frame count to stay within that cap. Today that requires editing the committed `config.yml`.

## Behavior / compatibility
- Default unchanged: with `VLM_MAX_FRAMES` unset it resolves to `30`, identical to today. Existing deployments are unaffected.
- Only deployments that explicitly set `VLM_MAX_FRAMES` (e.g. `VLM_MAX_FRAMES=4`) see a different value.
- `num_frames = min(video_length * max_fps, max_frames)`, so `max_frames` is a hard ceiling on frames per prompt regardless of clip length.

## Scope
Base developer profile (docker). The container plumbing in `services/agent/compose.yml` is shared, so other profiles can adopt the same knob by templating their own `max_frames`.
