### PR TITLE
Fix/document overrides better

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
@@ -4,34 +4,35 @@
 # =============================================================================
 # DEV-PROFILE-ALERTS ENVIRONMENT OVERRIDES
 # =============================================================================
-# Active defaults here are values that dev-profile.sh rewrites, values
-# derived from those rewritten values, and host-published port overrides
-# used to resolve local port conflicts. Docker Compose reads the profile
-# .env first and generated.env/overrides.env second so these values win.
-# dev-profile.sh copies this file to generated.env, updates it, and passes
-# generated.env after .env during startup.
+# Mutable deployment-specific values: hardware, model placement, model
+# endpoints, host paths, public ingress, credentials, and host-published
+# port overrides. Docker Compose should read the profile .env first and
+# this file second so these values win.
 # =============================================================================
 
 # =============================================================================
 # DEPLOYMENT SELECTION
 # =============================================================================
-# Alerts only. --mode verification writes 2d_cv; --mode real-time writes 2d_vlm.
+# Alerts mode. Use 2d_cv for CV alert verification; use 2d_vlm for real-time VLM alerts.
 MODE=2d_cv
-# -H/--hardware-profile. Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
+# Hardware profile for NIM, RTVI, and perception optimization.
+# Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
 HARDWARE_PROFILE=H100
 
 # =============================================================================
 # MODEL PLACEMENT AND RUNTIME MODE
 # =============================================================================
-# --llm-device-id unless edge hardware forces device 0.
+# Local LLM GPU device. Edge hardware may require device 0.
 LLM_DEVICE_ID='1'
-# --vlm-device-id unless remote VLM or edge hardware forces device 0.
+# Local VLM GPU device. Remote VLM and edge hardware may use device 0.
 VLM_DEVICE_ID='1'
 # Alerts/LVS RT-VLM device. local_shared follows the shared VLM device; remote and THOR edge use 0.
 RT_VLM_DEVICE_ID='1'
-# Derived from --use-remote-llm, device IDs, reserved devices, and fixed shared devices.
+# LLM runtime mode: local_shared when LLM and VLM share one GPU, local for
+# a dedicated local LLM GPU, or remote for an external endpoint.
 LLM_MODE=local_shared
-# Derived from --use-remote-vlm, device IDs, reserved devices, and fixed shared devices.
+# VLM runtime mode: local_shared when VLM shares a GPU, local for a
+# dedicated local VLM GPU, or remote for an external endpoint.
 VLM_MODE=local_shared
 
 # =============================================================================
@@ -43,15 +44,15 @@ VLM_MODE=local_shared
 # - nvidia/nemotron-3-nano -> nemotron-3-nano
 # - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
 # - openai/gpt-oss-20b -> gpt-oss-20b
-# --llm, or remote /v1/models when --use-remote-llm is used without --llm.
+# Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
 LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
-# Derived from LLM_NAME; set to none for remote LLM.
+# Enables the local LLM compose profile; set to none for remote LLM.
 LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
-# --llm-env-file. Local LLM only.
+# Extra env file for local LLM container settings.
 LLM_ENV_FILE=''
-# LLM_ENDPOINT_URL when --use-remote-llm is passed.
+# LLM endpoint base URL. Local deployments use the Compose service; remote deployments use the external endpoint.
 LLM_BASE_URL=http://vss-llm-nim:8000
-# --llm-model-type for remote LLM, otherwise profile default.
+# Model API type for the selected LLM endpoint.
 LLM_MODEL_TYPE=nim
 
 # =============================================================================
@@ -59,15 +60,15 @@ LLM_MODEL_TYPE=nim
 # =============================================================================
 # Local deployments route VLM traffic through RT-VLM. Keep VLM_NAME aligned
 # with the model id advertised by the RT-VLM /v1/models endpoint.
-# --vlm, fixed RT-VLM model for alerts/LVS, THOR edge base, or remote /v1/models.
+# Select the RT-VLM advertised model id, THOR edge base model id, or remote /v1/models model id.
 VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_bf16-final
-# Derived from VLM_NAME; set to none for remote VLM, alerts/LVS RT-VLM, or disabled search critic.
+# Enables the local VLM compose profile; keep none for alerts/LVS RT-VLM or remote VLM.
 VLM_NAME_SLUG=none
-# --vlm-env-file. Local VLM only.
+# Extra env file for local VLM container settings.
 VLM_ENV_FILE=''
-# VLM_ENDPOINT_URL when --use-remote-vlm is passed; alerts/LVS local VLM uses rtvi-vlm.
+# VLM endpoint base URL. Alerts/LVS local VLM uses rtvi-vlm; remote deployments use the external endpoint.
 VLM_BASE_URL=http://rtvi-vlm:8000
-# --vlm-model-type for remote VLM, or rtvi for fixed RT-VLM profiles/hardware.
+# Model API type for the selected VLM endpoint; use rtvi for fixed RT-VLM profiles/hardware.
 VLM_MODEL_TYPE=rtvi
 # Alerts/LVS only. Local RT-VLM uses 8018; remote VLM compatibility uses 30082.
 VLM_PORT=8018
@@ -77,25 +78,25 @@ VLM_PORT=8018
 # =============================================================================
 # HOST PATHS AND INGRESS
 # =============================================================================
-# Script sets this to deploy/docker.
+# Absolute path to this repository's deploy/docker directory.
 VSS_APPS_DIR="/path/to/deploy/docker"
-# Script sets this to deploy/docker/data-dir unless overridden by script defaults.
+# Data directory for downloaded models, videos, and runtime logs.
 VSS_DATA_DIR="/path/to/vss-apps-data"
-# -i/--host-ip, or primary host IP from ip route.
+# Hostname or IP clients should use when services are reachable directly.
 HOST_IP='<HOST_IP>'
-# -e/--external-ip. When unset, public URLs use HOST_IP through VSS_PUBLIC_HOST.
+# Public hostname/IP for generated URLs. On local hosts this usually matches HOST_IP; on cloud VMs use the public address.
 EXTERNAL_IP="${HOST_IP}"
-# Brev secure links set this to ${PROXY_PORT:-7777}.
+# For Brev secure links, use ${PROXY_PORT:-7777}.
 HAPROXY_PORT=7777
-# Brev secure links switch this to https.
+# Direct local ingress uses http; TLS or secure-link ingress uses https.
 VSS_PUBLIC_HTTP_PROTOCOL=http
-# Brev secure links switch this to wss.
+# Direct local WebSocket ingress uses ws; TLS or secure-link ingress uses wss.
 VSS_PUBLIC_WS_PROTOCOL=ws
-# Brev secure links set this to ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
+# For Brev secure links, use ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
 VSS_PUBLIC_HOST=${EXTERNAL_IP}
 # Host-published HAProxy port. Change this if 7777 conflicts locally.
 HAPROXY_HOST_PORT=7777
-# Brev secure links set this to 443.
+# Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
 
 # =============================================================================
@@ -123,50 +124,50 @@ SDRC_CONTROLLER_HOST_PORT=5003
 SDRC_PROXY_HOST_PORT=10000
 SDRC_DIRECT_HOST_PORT=8011
 SDRC_ENVOY_ADMIN_HOST_PORT=9902
-# Script sets this to ${VSS_APPS_DIR}/services/vios/configs as an absolute host path.
+# Absolute host path to services/vios/configs under VSS_APPS_DIR.
 VST_CONFIG_PATH=${VSS_APPS_DIR}/services/vios/configs
-# Derived from the public ingress values above; keep after them for Compose interpolation.
+# Computed from the public ingress values above; keep after them for Compose interpolation.
 VST_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
-# Derived from VST_EXTERNAL_URL.
+# Keep aligned with VST_EXTERNAL_URL.
 VST_BASE_URL=${VST_EXTERNAL_URL}
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_REPORTS_BASE_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}/static/
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
 
 # =============================================================================
 # CREDENTIALS
 # =============================================================================
-# Script writes host NGC_CLI_API_KEY here for image/model pulls.
+# Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
 NGC_CLI_API_KEY=''
-# Script writes host NVIDIA_API_KEY when set.
+# Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
 NVIDIA_API_KEY=''
-# Script writes host OPENAI_API_KEY when set.
+# Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
 
 # =============================================================================
-# PROFILE-SPECIFIC SCRIPT TOGGLES
+# PROFILE-SPECIFIC SCENARIO OVERRIDES
 # =============================================================================
-# Alerts only. Edge hardware sets EDGE-.
+# Alerts edge hardware uses the EDGE- Dockerfile prefix.
 PERCEPTION_DOCKERFILE_PREFIX=''
-# Alerts only. IGX-THOR/AGX-THOR local VLM sets EDGE-LOCAL-VLM-.
+# Alerts IGX-THOR/AGX-THOR with local VLM uses the EDGE-LOCAL-VLM- verifier config prefix.
 VLM_AS_VERIFIER_CONFIG_FILE_PREFIX=''
-# Derived from VSS_APPS_DIR and VLM_AS_VERIFIER_CONFIG_FILE_PREFIX.
+# Alerts verifier config path under VSS_APPS_DIR; choose the prefix for edge/local-VLM scenarios.
 VLM_AS_VERIFIER_CONFIG_FILE=${VSS_APPS_DIR}/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/${VLM_AS_VERIFIER_CONFIG_FILE_PREFIX}config.yml
-# Derived from VSS_APPS_DIR.
+# Path under VSS_APPS_DIR.
 VLM_AS_VERIFIER_ALERT_TYPE_CONFIG_FILE=${VSS_APPS_DIR}/developer-profiles/dev-profile-alerts/vlm-as-verifier/configs/alert_type_config.json
-# Alerts only. Script switches the subtitle between CV and VLM based on MODE.
+# Alerts subtitle. Use "Vision (Alerts - CV)" with MODE=2d_cv and "Vision (Alerts - VLM)" with MODE=2d_vlm.
 NEXT_PUBLIC_APP_SUBTITLE="Vision (Alerts - CV)"
-# Alerts DGX-SPARK switches to the commented sbsa tag.
+# Use the commented sbsa tag for alerts on DGX-SPARK/SBSA images.
 PERCEPTION_TAG="3.3.0-26.07.1"
 #PERCEPTION_TAG="3.3.0-sbsa-26.07.1"
-# DGX-SPARK valid profiles switch to the commented sbsa tag.
+# Use the regular tag by default; switch to the commented sbsa tag for DGX-SPARK/SBSA images.
 RTVI_VLM_IMAGE_TAG="3.2.1"
 #RTVI_VLM_IMAGE_TAG="3.2.1-sbsa"
-# Remote VLM sets this to ${VLM_BASE_URL}/v1.
+# Use ${VLM_BASE_URL}/v1 for remote VLM endpoints.
 RTVI_VLM_ENDPOINT=http://rtvi-vlm:8000/v1
 # Alerts/LVS remote VLM uses openai-compat; local RT-VLM uses cosmos-reason3.
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
@@ -174,15 +175,15 @@ RTVI_VLM_MODEL_TO_USE=cosmos-reason3
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
 # Set to 18000 for RTXPRO4500BW local RT-VLM.
 RTVI_VLM_MAX_MODEL_LEN=''
-# Remote VLM sets none; RTXPRO4500BW local alerts/LVS uses Cosmos3 Nano BF16 path.
+# Remote VLM uses none; RTXPRO4500BW local alerts/LVS uses the Cosmos3 Nano BF16 path.
 RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final'
 # Alerts bridge deployment name follows the effective VLM_NAME.
 RTVI_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${VLM_NAME}
-# Derived from VSS_APPS_DIR and MODE for this profile.
+# Profile path under VSS_APPS_DIR selected by MODE.
 SDR_CONTROLLER_CONFIG_PATH=${VSS_APPS_DIR}/developer-profiles/dev-profile-alerts/sdrc/${MODE}
 
 # =============================================================================
 # COMPOSE PROFILE SELECTION
 # =============================================================================
-# Derived from profile, mode, hardware, and model slugs. Keep after referenced values.
+# Compose profiles for the selected profile, mode, hardware, and model slugs. Keep after referenced values.
 COMPOSE_PROFILES=${BP_PROFILE}_${MODE},${BP_PROFILE}_${MODE}_${HARDWARE_PROFILE},llm_${LLM_MODE}_${LLM_NAME_SLUG}

--- a/deploy/docker/developer-profiles/dev-profile-base/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/overrides.env
@@ -4,30 +4,31 @@
 # =============================================================================
 # DEV-PROFILE-BASE ENVIRONMENT OVERRIDES
 # =============================================================================
-# Active defaults here are values that dev-profile.sh rewrites, values
-# derived from those rewritten values, and host-published port overrides
-# used to resolve local port conflicts. Docker Compose reads the profile
-# .env first and generated.env/overrides.env second so these values win.
-# dev-profile.sh copies this file to generated.env, updates it, and passes
-# generated.env after .env during startup.
+# Mutable deployment-specific values: hardware, model placement, model
+# endpoints, host paths, public ingress, credentials, and host-published
+# port overrides. Docker Compose should read the profile .env first and
+# this file second so these values win.
 # =============================================================================
 
 # =============================================================================
 # DEPLOYMENT SELECTION
 # =============================================================================
-# -H/--hardware-profile. Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
+# Hardware profile for NIM and RTVI optimization.
+# Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
 HARDWARE_PROFILE=H100
 
 # =============================================================================
 # MODEL PLACEMENT AND RUNTIME MODE
 # =============================================================================
-# --llm-device-id unless edge hardware forces device 0.
+# Local LLM GPU device. Edge hardware may require device 0.
 LLM_DEVICE_ID='0'
-# --vlm-device-id unless remote VLM or edge hardware forces device 0.
+# Local VLM GPU device. Remote VLM and edge hardware may use device 0.
 VLM_DEVICE_ID='0'
-# Derived from --use-remote-llm, device IDs, reserved devices, and fixed shared devices.
+# LLM runtime mode: local_shared when LLM and VLM share one GPU, local for
+# a dedicated local LLM GPU, or remote for an external endpoint.
 LLM_MODE=local_shared
-# Derived from --use-remote-vlm, device IDs, reserved devices, and fixed shared devices.
+# VLM runtime mode: local_shared when VLM shares a GPU, local for a
+# dedicated local VLM GPU, or remote for an external endpoint.
 VLM_MODE=local_shared
 
 # =============================================================================
@@ -39,15 +40,15 @@ VLM_MODE=local_shared
 # - nvidia/nemotron-3-nano -> nemotron-3-nano
 # - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
 # - openai/gpt-oss-20b -> gpt-oss-20b
-# --llm, or remote /v1/models when --use-remote-llm is used without --llm.
+# Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
 LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
-# Derived from LLM_NAME; set to none for remote LLM.
+# Enables the local LLM compose profile; set to none for remote LLM.
 LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
-# --llm-env-file. Local LLM only.
+# Extra env file for local LLM container settings.
 LLM_ENV_FILE=''
-# LLM_ENDPOINT_URL when --use-remote-llm is passed.
+# LLM endpoint base URL. Local deployments use the Compose service; remote deployments use the external endpoint.
 LLM_BASE_URL=http://vss-llm-nim:8000
-# --llm-model-type for remote LLM, otherwise profile default.
+# Model API type for the selected LLM endpoint.
 LLM_MODEL_TYPE=nim
 
 # =============================================================================
@@ -58,15 +59,15 @@ LLM_MODEL_TYPE=nim
 # - nvidia/cosmos-reason2-8b -> cosmos-reason2-8b
 # - nvidia/cosmos3-reasoner -> cosmos3-reasoner; set NIM_MODEL_SIZE=nano or super
 # - Qwen/Qwen3-VL-8B-Instruct -> qwen3-vl-8b-instruct
-# --vlm, fixed RT-VLM model for alerts/LVS, THOR edge base, or remote /v1/models.
+# Select the local VLM model name, fixed RT-VLM model id, or remote /v1/models model id.
 VLM_NAME=nvidia/cosmos3-nano-reasoner
-# Derived from VLM_NAME; set to none for remote VLM, alerts/LVS RT-VLM, or disabled search critic.
+# Enables the local VLM compose profile; set to none for remote VLM, alerts/LVS RT-VLM, or disabled search critic.
 VLM_NAME_SLUG=cosmos3-reasoner
-# --vlm-env-file. Local VLM only.
+# Extra env file for local VLM container settings.
 VLM_ENV_FILE=''
-# VLM_ENDPOINT_URL when --use-remote-vlm is passed; alerts/LVS local VLM uses rtvi-vlm.
+# VLM endpoint base URL. Local NIM uses vss-vlm-nim; alerts/LVS local VLM uses rtvi-vlm; remote deployments use the external endpoint.
 VLM_BASE_URL=http://vss-vlm-nim:8000
-# --vlm-model-type for remote VLM, or rtvi for fixed RT-VLM profiles/hardware.
+# Model API type for the selected VLM endpoint; use rtvi for fixed RT-VLM profiles/hardware.
 VLM_MODEL_TYPE=nim
 # Cosmos3 Reasoner only. Selects the model size baked into the NIM.
 NIM_MODEL_SIZE=nano
@@ -76,25 +77,25 @@ NIM_MODEL_SIZE=nano
 # =============================================================================
 # HOST PATHS AND INGRESS
 # =============================================================================
-# Script sets this to deploy/docker.
+# Absolute path to this repository's deploy/docker directory.
 VSS_APPS_DIR="/path/to/deploy/docker"
-# Script sets this to deploy/docker/data-dir unless overridden by script defaults.
+# Data directory for downloaded models, videos, and runtime logs.
 VSS_DATA_DIR="/path/to/vss-apps-data"
-# -i/--host-ip, or primary host IP from ip route.
+# Hostname or IP clients should use when services are reachable directly.
 HOST_IP='<HOST_IP>'
-# -e/--external-ip. When unset, public URLs use HOST_IP through VSS_PUBLIC_HOST.
+# Public hostname/IP for generated URLs. On local hosts this usually matches HOST_IP; on cloud VMs use the public address.
 EXTERNAL_IP="${HOST_IP}"
-# Brev secure links set this to ${PROXY_PORT:-7777}.
+# For Brev secure links, use ${PROXY_PORT:-7777}.
 HAPROXY_PORT=7777
-# Brev secure links switch this to https.
+# Direct local ingress uses http; TLS or secure-link ingress uses https.
 VSS_PUBLIC_HTTP_PROTOCOL=http
-# Brev secure links switch this to wss.
+# Direct local WebSocket ingress uses ws; TLS or secure-link ingress uses wss.
 VSS_PUBLIC_WS_PROTOCOL=ws
-# Brev secure links set this to ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
+# For Brev secure links, use ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
 VSS_PUBLIC_HOST=${EXTERNAL_IP}
 # Host-published HAProxy port. Change this if 7777 conflicts locally.
 HAPROXY_HOST_PORT=7777
-# Brev secure links set this to 443.
+# Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
 
 # =============================================================================
@@ -111,51 +112,51 @@ SENSOR_HTTP_HOST_PORT=30000
 STREAM_PROCESSOR_HTTP_HOST_PORT=30001
 RTSP_SERVER_HOST_PORT=30554
 RTSP_SERVER_HOST_PORT_END=30564
-# Script sets this to ${VSS_APPS_DIR}/services/vios/configs as an absolute host path.
+# Absolute host path to services/vios/configs under VSS_APPS_DIR.
 VST_CONFIG_PATH=${VSS_APPS_DIR}/services/vios/configs
-# Derived from the public ingress values above; keep after them for Compose interpolation.
+# Computed from the public ingress values above; keep after them for Compose interpolation.
 VST_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
-# Derived from VST_EXTERNAL_URL.
+# Keep aligned with VST_EXTERNAL_URL.
 VST_BASE_URL=${VST_EXTERNAL_URL}
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_REPORTS_BASE_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}/static/
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
 
 # =============================================================================
 # CREDENTIALS
 # =============================================================================
-# Script writes host NGC_CLI_API_KEY here for image/model pulls.
+# Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
 NGC_CLI_API_KEY=''
-# Script writes host NVIDIA_API_KEY when set.
+# Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
 NVIDIA_API_KEY=''
-# Script writes host OPENAI_API_KEY when set.
+# Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
 
 # =============================================================================
-# PROFILE-SPECIFIC SCRIPT TOGGLES
+# PROFILE-SPECIFIC SCENARIO OVERRIDES
 # =============================================================================
-# Derived from the effective LLM_NAME.
+# Keep aligned with the selected LLM model.
 EVAL_LLM_JUDGE_NAME=${LLM_NAME}
-# Derived from the effective LLM_BASE_URL.
+# Keep aligned with the selected LLM endpoint.
 EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
-# DGX-SPARK valid profiles switch to the commented sbsa tag.
+# Use the regular tag by default; switch to the commented sbsa tag for DGX-SPARK/SBSA images.
 RTVI_VLM_IMAGE_TAG="3.2.1"
 #RTVI_VLM_IMAGE_TAG="3.2.1-sbsa"
-# Remote VLM sets this to ${VLM_BASE_URL}/v1.
+# Use ${VLM_BASE_URL}/v1 for remote VLM endpoints.
 RTVI_VLM_ENDPOINT=http://vss-vlm-nim:8000/v1
 # Alerts/LVS remote VLM uses openai-compat; local RT-VLM uses cosmos-reason3.
 RTVI_VLM_MODEL_TO_USE=openai-compat
 # Set per hardware/mode for local RT-VLM; THOR edge can pass host env override.
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
-# Remote VLM sets none; RTXPRO4500BW local alerts/LVS uses Cosmos3 Nano BF16 path.
+# Remote VLM uses none; RTXPRO4500BW local alerts/LVS uses the Cosmos3 Nano BF16 path.
 RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final'
 
 # =============================================================================
 # COMPOSE PROFILE SELECTION
 # =============================================================================
-# Derived from profile, mode, hardware, and model slugs. Keep after referenced values.
+# Compose profiles for the selected profile, mode, hardware, and model slugs. Keep after referenced values.
 COMPOSE_PROFILES=${BP_PROFILE}_${MODE},${BP_PROFILE}_${MODE}_${HARDWARE_PROFILE},llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}

--- a/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
@@ -4,32 +4,33 @@
 # =============================================================================
 # DEV-PROFILE-LVS ENVIRONMENT OVERRIDES
 # =============================================================================
-# Active defaults here are values that dev-profile.sh rewrites, values
-# derived from those rewritten values, and host-published port overrides
-# used to resolve local port conflicts. Docker Compose reads the profile
-# .env first and generated.env/overrides.env second so these values win.
-# dev-profile.sh copies this file to generated.env, updates it, and passes
-# generated.env after .env during startup.
+# Mutable deployment-specific values: hardware, model placement, model
+# endpoints, host paths, public ingress, credentials, and host-published
+# port overrides. Docker Compose should read the profile .env first and
+# this file second so these values win.
 # =============================================================================
 
 # =============================================================================
 # DEPLOYMENT SELECTION
 # =============================================================================
-# -H/--hardware-profile. Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
+# Hardware profile for NIM, RTVI, and LVS optimization.
+# Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
 HARDWARE_PROFILE=H100
 
 # =============================================================================
 # MODEL PLACEMENT AND RUNTIME MODE
 # =============================================================================
-# --llm-device-id unless edge hardware forces device 0.
+# Local LLM GPU device. Edge hardware may require device 0.
 LLM_DEVICE_ID='0'
-# --vlm-device-id unless remote VLM or edge hardware forces device 0.
+# Local VLM GPU device. Remote VLM and edge hardware may use device 0.
 VLM_DEVICE_ID='0'
 # Alerts/LVS RT-VLM device. local_shared follows the shared VLM device; remote and THOR edge use 0.
 RT_VLM_DEVICE_ID='0'
-# Derived from --use-remote-llm, device IDs, reserved devices, and fixed shared devices.
+# LLM runtime mode: local_shared when LLM and VLM share one GPU, local for
+# a dedicated local LLM GPU, or remote for an external endpoint.
 LLM_MODE=local_shared
-# Derived from --use-remote-vlm, device IDs, reserved devices, and fixed shared devices.
+# VLM runtime mode: local_shared when VLM shares a GPU, local for a
+# dedicated local VLM GPU, or remote for an external endpoint.
 VLM_MODE=local_shared
 
 # =============================================================================
@@ -41,15 +42,15 @@ VLM_MODE=local_shared
 # - nvidia/nemotron-3-nano -> nemotron-3-nano
 # - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
 # - openai/gpt-oss-20b -> gpt-oss-20b
-# --llm, or remote /v1/models when --use-remote-llm is used without --llm.
+# Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
 LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
-# Derived from LLM_NAME; set to none for remote LLM.
+# Enables the local LLM compose profile; set to none for remote LLM.
 LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
-# --llm-env-file. Local LLM only.
+# Extra env file for local LLM container settings.
 LLM_ENV_FILE=''
-# LLM_ENDPOINT_URL when --use-remote-llm is passed.
+# LLM endpoint base URL. Local deployments use the Compose service; remote deployments use the external endpoint.
 LLM_BASE_URL=http://vss-llm-nim:8000
-# --llm-model-type for remote LLM, otherwise profile default.
+# Model API type for the selected LLM endpoint.
 LLM_MODEL_TYPE=nim
 
 # =============================================================================
@@ -57,15 +58,15 @@ LLM_MODEL_TYPE=nim
 # =============================================================================
 # Local deployments route VLM traffic through RT-VLM. Keep VLM_NAME aligned
 # with the model id advertised by the RT-VLM /v1/models endpoint.
-# --vlm, fixed RT-VLM model for alerts/LVS, THOR edge base, or remote /v1/models.
+# Select the RT-VLM advertised model id, THOR edge base model id, or remote /v1/models model id.
 VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_bf16-final
-# Derived from VLM_NAME; set to none for remote VLM, alerts/LVS RT-VLM, or disabled search critic.
+# Enables the local VLM compose profile; keep none for alerts/LVS RT-VLM or remote VLM.
 VLM_NAME_SLUG=none
-# --vlm-env-file. Local VLM only.
+# Extra env file for local VLM container settings.
 VLM_ENV_FILE=''
-# VLM_ENDPOINT_URL when --use-remote-vlm is passed; alerts/LVS local VLM uses rtvi-vlm.
+# VLM endpoint base URL. Alerts/LVS local VLM uses rtvi-vlm; remote deployments use the external endpoint.
 VLM_BASE_URL=http://rtvi-vlm:8000
-# --vlm-model-type for remote VLM, or rtvi for fixed RT-VLM profiles/hardware.
+# Model API type for the selected VLM endpoint; use rtvi for fixed RT-VLM profiles/hardware.
 VLM_MODEL_TYPE=rtvi
 # Alerts/LVS only. Local RT-VLM uses 8018; remote VLM compatibility uses 30082.
 VLM_PORT=8018
@@ -75,25 +76,25 @@ VLM_PORT=8018
 # =============================================================================
 # HOST PATHS AND INGRESS
 # =============================================================================
-# Script sets this to deploy/docker.
+# Absolute path to this repository's deploy/docker directory.
 VSS_APPS_DIR="/path/to/deploy/docker"
-# Script sets this to deploy/docker/data-dir unless overridden by script defaults.
+# Data directory for downloaded models, videos, and runtime logs.
 VSS_DATA_DIR="/path/to/vss-apps-data"
-# -i/--host-ip, or primary host IP from ip route.
+# Hostname or IP clients should use when services are reachable directly.
 HOST_IP='<HOST_IP>'
-# -e/--external-ip. When unset, public URLs use HOST_IP through VSS_PUBLIC_HOST.
+# Public hostname/IP for generated URLs. On local hosts this usually matches HOST_IP; on cloud VMs use the public address.
 EXTERNAL_IP="${HOST_IP}"
-# Brev secure links set this to ${PROXY_PORT:-7777}.
+# For Brev secure links, use ${PROXY_PORT:-7777}.
 HAPROXY_PORT=7777
-# Brev secure links switch this to https.
+# Direct local ingress uses http; TLS or secure-link ingress uses https.
 VSS_PUBLIC_HTTP_PROTOCOL=http
-# Brev secure links switch this to wss.
+# Direct local WebSocket ingress uses ws; TLS or secure-link ingress uses wss.
 VSS_PUBLIC_WS_PROTOCOL=ws
-# Brev secure links set this to ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
+# For Brev secure links, use ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
 VSS_PUBLIC_HOST=${EXTERNAL_IP}
 # Host-published HAProxy port. Change this if 7777 conflicts locally.
 HAPROXY_HOST_PORT=7777
-# Brev secure links set this to 443.
+# Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
 
 # =============================================================================
@@ -120,40 +121,40 @@ SDRC_CONTROLLER_HOST_PORT=5003
 SDRC_PROXY_HOST_PORT=10000
 SDRC_DIRECT_HOST_PORT=8011
 SDRC_ENVOY_ADMIN_HOST_PORT=9902
-# Script sets this to ${VSS_APPS_DIR}/services/vios/configs as an absolute host path.
+# Absolute host path to services/vios/configs under VSS_APPS_DIR.
 VST_CONFIG_PATH=${VSS_APPS_DIR}/services/vios/configs
-# Derived from the public ingress values above; keep after them for Compose interpolation.
+# Computed from the public ingress values above; keep after them for Compose interpolation.
 VST_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
-# Derived from VST_EXTERNAL_URL.
+# Keep aligned with VST_EXTERNAL_URL.
 VST_BASE_URL=${VST_EXTERNAL_URL}
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_REPORTS_BASE_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}/static/
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
 
 # =============================================================================
 # CREDENTIALS
 # =============================================================================
-# Script writes host NGC_CLI_API_KEY here for image/model pulls.
+# Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
 NGC_CLI_API_KEY=''
-# Script writes host NVIDIA_API_KEY when set.
+# Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
 NVIDIA_API_KEY=''
-# Script writes host OPENAI_API_KEY when set.
+# Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
 
 # =============================================================================
-# PROFILE-SPECIFIC SCRIPT TOGGLES
+# PROFILE-SPECIFIC SCENARIO OVERRIDES
 # =============================================================================
-# Derived from the effective LLM_NAME.
+# Keep aligned with the selected LLM model.
 EVAL_LLM_JUDGE_NAME=${LLM_NAME}
-# Derived from the effective LLM_BASE_URL.
+# Keep aligned with the selected LLM endpoint.
 EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
-# Derived from VSS_APPS_DIR and MODE for this profile.
+# Profile path under VSS_APPS_DIR selected by MODE.
 SDR_CONTROLLER_CONFIG_PATH=${VSS_APPS_DIR}/developer-profiles/dev-profile-lvs/sdrc/${MODE}
-# Remote VLM sets this to ${VLM_BASE_URL}/v1.
+# Use ${VLM_BASE_URL}/v1 for remote VLM endpoints.
 RTVI_VLM_IMAGE_TAG="3.2.1"
 #RTVI_VLM_IMAGE_TAG="3.2.1-sbsa"
 RTVI_VLM_ENDPOINT=''
@@ -163,7 +164,7 @@ RTVI_VLM_MODEL_TO_USE=cosmos-reason3
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
 # Set to 18000 for RTXPRO4500BW local RT-VLM.
 RTVI_VLM_MAX_MODEL_LEN=''
-# Remote VLM sets none; RTXPRO4500BW local alerts/LVS uses Cosmos3 Nano BF16 path.
+# Remote VLM uses none; RTXPRO4500BW local alerts/LVS uses the Cosmos3 Nano BF16 path.
 RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final'
 # Optional Nemotron Nano Omni RT-VLM override. Uncomment these together,
 # provide a Hugging Face token, and set ENABLE_AUDIO=true for audio clips.
@@ -178,11 +179,11 @@ RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final'
 
 # =============================================================================
 
-# LVS DGX-SPARK switches to the commented sbsa tag.
+# Use the commented sbsa tag for LVS on DGX-SPARK/SBSA images.
 LVS_TAG="3.2.1"
 # LVS_TAG="3.2.1-sbsa"
 
 # COMPOSE PROFILE SELECTION
 # =============================================================================
-# Derived from profile, mode, hardware, and model slugs. Keep after referenced values.
+# Compose profiles for the selected profile, mode, hardware, and model slugs. Keep after referenced values.
 COMPOSE_PROFILES=${BP_PROFILE}_${MODE},llm_${LLM_MODE}_${LLM_NAME_SLUG}

--- a/deploy/docker/developer-profiles/dev-profile-search/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/overrides.env
@@ -4,30 +4,31 @@
 # =============================================================================
 # DEV-PROFILE-SEARCH ENVIRONMENT OVERRIDES
 # =============================================================================
-# Active defaults here are values that dev-profile.sh rewrites, values
-# derived from those rewritten values, and host-published port overrides
-# used to resolve local port conflicts. Docker Compose reads the profile
-# .env first and generated.env/overrides.env second so these values win.
-# dev-profile.sh copies this file to generated.env, updates it, and passes
-# generated.env after .env during startup.
+# Mutable deployment-specific values: hardware, model placement, model
+# endpoints, host paths, public ingress, credentials, and host-published
+# port overrides. Docker Compose should read the profile .env first and
+# this file second so these values win.
 # =============================================================================
 
 # =============================================================================
 # DEPLOYMENT SELECTION
 # =============================================================================
-# -H/--hardware-profile. Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
+# Hardware profile for NIM, RTVI, and search optimization.
+# Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
 HARDWARE_PROFILE=H100
 
 # =============================================================================
 # MODEL PLACEMENT AND RUNTIME MODE
 # =============================================================================
-# --llm-device-id unless edge hardware forces device 0.
+# Local LLM GPU device. Edge hardware may require device 0.
 LLM_DEVICE_ID='1'
-# --vlm-device-id unless remote VLM or edge hardware forces device 0.
+# Local VLM GPU device. Remote VLM and edge hardware may use device 0.
 VLM_DEVICE_ID='2'
-# Derived from --use-remote-llm, device IDs, reserved devices, and fixed shared devices.
+# LLM runtime mode: local_shared when LLM and VLM share one GPU, local for
+# a dedicated local LLM GPU, or remote for an external endpoint.
 LLM_MODE=local_shared
-# Derived from --use-remote-vlm, device IDs, reserved devices, and fixed shared devices.
+# VLM runtime mode: local_shared when VLM shares a GPU, local for a
+# dedicated local VLM GPU, or remote for an external endpoint.
 VLM_MODE=local_shared
 
 # =============================================================================
@@ -39,15 +40,15 @@ VLM_MODE=local_shared
 # - nvidia/nemotron-3-nano -> nemotron-3-nano
 # - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
 # - openai/gpt-oss-20b -> gpt-oss-20b
-# --llm, or remote /v1/models when --use-remote-llm is used without --llm.
+# Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
 LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
-# Derived from LLM_NAME; set to none for remote LLM.
+# Enables the local LLM compose profile; set to none for remote LLM.
 LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
-# --llm-env-file. Local LLM only.
+# Extra env file for local LLM container settings.
 LLM_ENV_FILE=''
-# LLM_ENDPOINT_URL when --use-remote-llm is passed.
+# LLM endpoint base URL. Local deployments use the Compose service; remote deployments use the external endpoint.
 LLM_BASE_URL=http://vss-llm-nim:8000
-# --llm-model-type for remote LLM, otherwise profile default.
+# Model API type for the selected LLM endpoint.
 LLM_MODEL_TYPE=nim
 
 # =============================================================================
@@ -57,15 +58,15 @@ LLM_MODEL_TYPE=nim
 # - nvidia/cosmos-reason1-7b -> cosmos-reason1-7b
 # - nvidia/cosmos-reason2-8b -> cosmos-reason2-8b
 # - Qwen/Qwen3-VL-8B-Instruct -> qwen3-vl-8b-instruct
-# --vlm, fixed RT-VLM model for alerts/LVS, THOR edge base, or remote /v1/models.
+# Select the local VLM model name, fixed RT-VLM model id, or remote /v1/models model id.
 VLM_NAME=nvidia/cosmos3-nano-reasoner
-# Derived from VLM_NAME; set to none for remote VLM, alerts/LVS RT-VLM, or disabled search critic.
+# Enables the local VLM compose profile; set to none for remote VLM, alerts/LVS RT-VLM, or disabled search critic.
 VLM_NAME_SLUG=cosmos3-reasoner
-# --vlm-env-file. Local VLM only.
+# Extra env file for local VLM container settings.
 VLM_ENV_FILE=''
-# VLM_ENDPOINT_URL when --use-remote-vlm is passed; alerts/LVS local VLM uses rtvi-vlm.
+# VLM endpoint base URL. Local NIM uses vss-vlm-nim; alerts/LVS local VLM uses rtvi-vlm; remote deployments use the external endpoint.
 VLM_BASE_URL=http://vss-vlm-nim:8000
-# --vlm-model-type for remote VLM, or rtvi for fixed RT-VLM profiles/hardware.
+# Model API type for the selected VLM endpoint; use rtvi for fixed RT-VLM profiles/hardware.
 VLM_MODEL_TYPE=nim
 NIM_MODEL_SIZE=nano
 # Optional local VLM custom weights path. Ignored when VLM_MODE=remote.
@@ -74,25 +75,25 @@ NIM_MODEL_SIZE=nano
 # =============================================================================
 # HOST PATHS AND INGRESS
 # =============================================================================
-# Script sets this to deploy/docker.
+# Absolute path to this repository's deploy/docker directory.
 VSS_APPS_DIR="/path/to/deploy/docker"
-# Script sets this to deploy/docker/data-dir unless overridden by script defaults.
+# Data directory for downloaded models, videos, and runtime logs.
 VSS_DATA_DIR="/path/to/vss-apps-data"
-# -i/--host-ip, or primary host IP from ip route.
+# Hostname or IP clients should use when services are reachable directly.
 HOST_IP='<HOST_IP>'
-# -e/--external-ip. When unset, public URLs use HOST_IP through VSS_PUBLIC_HOST.
+# Public hostname/IP for generated URLs. On local hosts this usually matches HOST_IP; on cloud VMs use the public address.
 EXTERNAL_IP="${HOST_IP}"
-# Brev secure links set this to ${PROXY_PORT:-7777}.
+# For Brev secure links, use ${PROXY_PORT:-7777}.
 HAPROXY_PORT=7777
-# Brev secure links switch this to https.
+# Direct local ingress uses http; TLS or secure-link ingress uses https.
 VSS_PUBLIC_HTTP_PROTOCOL=http
-# Brev secure links switch this to wss.
+# Direct local WebSocket ingress uses ws; TLS or secure-link ingress uses wss.
 VSS_PUBLIC_WS_PROTOCOL=ws
-# Brev secure links set this to ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
+# For Brev secure links, use ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
 VSS_PUBLIC_HOST=${EXTERNAL_IP}
 # Host-published HAProxy port. Change this if 7777 conflicts locally.
 HAPROXY_HOST_PORT=7777
-# Brev secure links set this to 443.
+# Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
 
 # =============================================================================
@@ -117,52 +118,52 @@ SDRC_CONTROLLER_HOST_PORT=5003
 SDRC_PROXY_HOST_PORT=10000
 SDRC_DIRECT_HOST_PORT=8011
 SDRC_ENVOY_ADMIN_HOST_PORT=9902
-# Script sets this to ${VSS_APPS_DIR}/services/vios/configs as an absolute host path.
+# Absolute host path to services/vios/configs under VSS_APPS_DIR.
 VST_CONFIG_PATH=${VSS_APPS_DIR}/services/vios/configs
-# Derived from the public ingress values above; keep after them for Compose interpolation.
+# Computed from the public ingress values above; keep after them for Compose interpolation.
 VST_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
-# Derived from VST_EXTERNAL_URL.
+# Keep aligned with VST_EXTERNAL_URL.
 VST_BASE_URL=${VST_EXTERNAL_URL}
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_REPORTS_BASE_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}/static/
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
 
 # =============================================================================
 # CREDENTIALS
 # =============================================================================
-# Script writes host NGC_CLI_API_KEY here for image/model pulls.
+# Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
 NGC_CLI_API_KEY=''
-# Script writes host NVIDIA_API_KEY when set.
+# Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
 NVIDIA_API_KEY=''
-# Script writes host OPENAI_API_KEY when set.
+# Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
 
 # =============================================================================
-# PROFILE-SPECIFIC SCRIPT TOGGLES
+# PROFILE-SPECIFIC SCENARIO OVERRIDES
 # =============================================================================
-# Search UI compatibility value derived from HOST_IP.
+# Search UI compatibility value; keep aligned with HOST_IP.
 MEDIA_SERVICE_ENDPOINT="${HOST_IP}"
-# Search UI compatibility value derived from HOST_IP.
+# Search UI compatibility value; keep aligned with HOST_IP.
 REACT_APP_API_ENDPOINT_BASE_URL="${HOST_IP}:8081"
-# Derived from the effective LLM_NAME.
+# Keep aligned with the selected LLM model.
 EVAL_LLM_JUDGE_NAME=${LLM_NAME}
-# Derived from the effective LLM_BASE_URL.
+# Keep aligned with the selected LLM endpoint.
 EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
-# Derived from VSS_APPS_DIR and MODE for this profile.
+# Profile path under VSS_APPS_DIR selected by MODE.
 SDR_CONTROLLER_CONFIG_PATH=${VSS_APPS_DIR}/developer-profiles/dev-profile-search/sdrc/${MODE}
 # Search only. false disables critic and skips the local critic VLM.
 ENABLE_CRITIC=true
 
 # =============================================================================
-# Search DGX-SPARK switches to the commented sbsa tag.
+# Use the commented sbsa tag for search on DGX-SPARK/SBSA images.
 PERCEPTION_TAG="3.3.0-26.07.1"
 # PERCEPTION_TAG="3.3.0-sbsa-26.07.1"
 
 # COMPOSE PROFILE SELECTION
 # =============================================================================
-# Derived from profile, mode, hardware, and model slugs. Keep after referenced values.
+# Compose profiles for the selected profile, mode, hardware, and model slugs. Keep after referenced values.
 COMPOSE_PROFILES=${BP_PROFILE}_${MODE},llm_${LLM_MODE}_${LLM_NAME_SLUG},vlm_${VLM_MODE}_${VLM_NAME_SLUG}

--- a/deploy/docker/industry-profiles/smartcities/overrides.env
+++ b/deploy/docker/industry-profiles/smartcities/overrides.env
@@ -4,10 +4,8 @@
 # =============================================================================
 # SMARTCITIES ENVIRONMENT OVERRIDES
 # =============================================================================
-# Active defaults here are values the smartcities launchable rewrites, values
-# derived from generated profile values, and runtime/path overrides. The
-# launchable merges this overlay after developer-profiles/dev-profile-alerts/
-# overrides.env, then dev-profile.sh copies the merged file to generated.env.
+# Smartcities-specific runtime inputs and evaluation settings. Apply this
+# overlay after the alerts profile overrides so the smartcities values win.
 # =============================================================================
 
 # =============================================================================
@@ -19,15 +17,15 @@ MODE=2d_cv
 # =============================================================================
 # EVALUATION CONFIGURATION
 # =============================================================================
-# Derived from the effective LLM selected in generated.env.
+# Keep aligned with the selected LLM model and endpoint.
 EVAL_LLM_JUDGE_NAME=${LLM_NAME}
 EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 
 # =============================================================================
 # SMARTCITIES RUNTIME INPUTS
 # =============================================================================
-# Launchable writes the user-provided Google Maps API key here.
+# Google Maps API key for smartcities map rendering.
 GOOGLE_MAPS_API_KEY=''
 
-# Launchable writes this as an absolute path under deploy/docker.
+# Video directory for nvstreamer sample input.
 NVSTREAMER_VIDEO_DIR='vss-nvstreamer-video-dir'

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -4,42 +4,45 @@
 # =============================================================================
 # WAREHOUSE ENVIRONMENT OVERRIDES
 # =============================================================================
-# Active defaults here are values that blueprint-deploy.sh rewrites, values
-# derived from those rewritten values, and host-published port overrides
-# used to resolve local port conflicts. Docker Compose reads the warehouse
-# .env first and generated.env/overrides.env second so these values win.
-# blueprint-deploy.sh copies this file to generated.env, updates it, and passes
-# generated.env after .env during startup.
+# Mutable deployment-specific values: mode, profile, model placement,
+# model endpoints, host paths, public ingress, credentials, and
+# host-published port overrides. Docker Compose should read the warehouse
+# .env first and this file second so these values win.
 # =============================================================================
 
 # =============================================================================
 # DEPLOYMENT SELECTION
 # =============================================================================
-# -m/--mode. Valid: 2d, 3d, mv3dt.
+# Deployment mode. Valid: 2d, 3d, mv3dt.
 MODE=2d
-# -p/--bp-profile. Valid by mode:
+# Blueprint profile. Valid by mode:
 # - 2d: bp_wh, bp_wh_kafka, bp_wh_redis, bp_wh_auto_calib
 # - 3d/mv3dt: bp_wh_kafka, bp_wh_redis, bp_wh_auto_calib
 BP_PROFILE=bp_wh
-# -E/--elasticsearch-mode. Valid: cpu, gpu.
+# Elasticsearch runtime. Use cpu by default; use gpu when enabling GPU-backed Elasticsearch.
 ELASTICSEARCH_MODE=cpu
-# -s/--sample-video-dataset, or derived from MODE and BP_PROFILE.
+# Sample dataset by warehouse scenario:
+# - MODE=2d, BP_PROFILE=bp_wh: nv-warehouse-4cams (NUM_STREAMS=4)
+# - MODE=2d, BP_PROFILE=bp_wh_kafka/bp_wh_redis/bp_wh_auto_calib: warehouse-loading-dock-3cams-synthetic (NUM_STREAMS=3)
+# - MODE=3d/mv3dt, BP_PROFILE=bp_wh_kafka/bp_wh_redis/bp_wh_auto_calib: warehouse-4cams-20mx20m-synthetic (NUM_STREAMS=4)
 SAMPLE_VIDEO_DATASET="nv-warehouse-4cams"
-# Derived from MODE, BP_PROFILE, and SAMPLE_VIDEO_DATASET defaults.
+# Match NUM_STREAMS to the selected sample dataset; defaults are shown above.
 NUM_STREAMS=4
-# -H/--hardware-profile. Valid: H100, L40, L40S, L4, A6000, RTXPRO6000BW, IGX-THOR, DGX-SPARK.
+# Hardware profile for NIM and perception optimization.
+# Valid: H100, L40, L40S, L4, A6000, RTXPRO6000BW, IGX-THOR, DGX-SPARK.
 HARDWARE_PROFILE=H100
-# Derived from BP_PROFILE.
+# Message broker. Use redis for bp_wh_redis; use kafka for bp_wh, bp_wh_kafka, and bp_wh_auto_calib.
 STREAM_TYPE=kafka
 
 # =============================================================================
 # LLM/VLM SELECTION
 # =============================================================================
-# --llm-device-id. Used by MODE=2d and BP_PROFILE=bp_wh when LLM_MODE is local.
+# Local LLM GPU device. Used by MODE=2d and BP_PROFILE=bp_wh when LLM_MODE is local.
 LLM_DEVICE_ID='2'
-# Derived from --use-remote-llm, BP_PROFILE, and MODE.
+# LLM runtime mode. Use local for MODE=2d + BP_PROFILE=bp_wh with local NIM,
+# remote for an external endpoint, and none for 3d/mv3dt or bp_wh_kafka/bp_wh_redis/bp_wh_auto_calib.
 LLM_MODE=local
-# Derived from --use-remote-vlm, BP_PROFILE, and MODE.
+# VLM runtime mode. Warehouse default RT-VLM uses none; use remote when routing VLM traffic to an external endpoint.
 VLM_MODE=none
 
 # Local LLM choices:
@@ -48,46 +51,46 @@ VLM_MODE=none
 # - nvidia/nemotron-3-nano -> nemotron-3-nano
 # - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
 # - openai/gpt-oss-20b -> gpt-oss-20b
-# --llm, or remote /v1/models when --use-remote-llm is used without --llm.
+# Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
 LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
-# Derived from LLM_NAME; set to none for remote LLM or profiles without local NIM.
+# Enables the local LLM compose profile; set to none for remote LLM or profiles without local NIM.
 LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
-# --llm-env-file. Local LLM only.
+# Extra env file for local LLM container settings.
 LLM_ENV_FILE=''
-# LLM_ENDPOINT_URL when --use-remote-llm is passed.
+# LLM endpoint base URL. Local deployments use the Compose service; remote deployments use the external endpoint.
 LLM_BASE_URL=http://vss-llm-nim:8000
-# --llm-model-type for remote LLM, otherwise profile default.
+# Model API type for the selected LLM endpoint.
 LLM_MODEL_TYPE=nim
 
 # Warehouse VLM traffic is served through RT-VLM by default.
 # Keep VLM_NAME aligned with the model id advertised by the RT-VLM /v1/models endpoint.
-# --vlm, or remote /v1/models when --use-remote-vlm is used without --vlm.
+# Select the RT-VLM advertised model id, or the model id exposed by a remote /v1/models endpoint.
 VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_bf16-final
-# Derived from VLM_NAME; set to none for remote VLM or profiles without local VLM.
+# Enables the local VLM compose profile; keep none for warehouse RT-VLM or remote VLM.
 VLM_NAME_SLUG=none
-# --vlm-env-file. Local VLM only.
+# Extra env file for local VLM container settings.
 VLM_ENV_FILE=''
-# VLM_ENDPOINT_URL when --use-remote-vlm is passed; local warehouse VLM uses rtvi-vlm.
+# VLM endpoint base URL. Local warehouse VLM uses rtvi-vlm; remote deployments use the external endpoint.
 VLM_BASE_URL=http://rtvi-vlm:8000
-# --vlm-model-type for remote VLM, otherwise profile default.
+# Model API type for the selected VLM endpoint.
 VLM_MODEL_TYPE=rtvi
-# Remote VLM sets none; local RT-VLM uses the integrated Cosmos3 Nano BF16 checkpoint.
+# Use none for remote VLM; local RT-VLM uses the integrated Cosmos3 Nano BF16 checkpoint.
 RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final
 # Local RT-VLM uses cosmos-reason3; remote VLM compatibility can use openai-compat.
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
-# Remote VLM sets this to ${VLM_BASE_URL}/v1.
+# Use ${VLM_BASE_URL}/v1 for remote VLM endpoints.
 RTVI_VLM_ENDPOINT=http://rtvi-vlm:8000/v1
 
 # =============================================================================
 # HOST PATHS AND INGRESS
 # =============================================================================
-# Script sets this to deploy/docker.
+# Absolute path to this repository's deploy/docker directory.
 VSS_APPS_DIR="/path/to/deploy/docker"
-# -D/--data-dir.
+# Data directory for downloaded models, videos, and runtime logs.
 VSS_DATA_DIR="/path/to/vss-warehouse-app-data"
-# -i/--host-ip, or primary host IP from ip route.
+# Hostname or IP clients should use when services are reachable directly.
 HOST_IP='<HOST_IP>'
-# -e/--external-ip. When unset, public URLs use HOST_IP through VSS_PUBLIC_HOST.
+# Public hostname/IP for generated URLs. On local hosts this usually matches HOST_IP; on cloud VMs use the public address.
 EXTERNAL_IP="${HOST_IP}"
 HAPROXY_PORT=7777
 # Host-published HAProxy port. Change this if 7777 conflicts locally.
@@ -98,13 +101,13 @@ VSS_PUBLIC_HOST=${EXTERNAL_IP}
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
 TURN_PUBLIC_HOST=${VSS_PUBLIC_HOST}
 TURN_EXTERNAL_IP=${EXTERNAL_IP}
-# Derived from the public ingress values above; keep after them for Compose interpolation.
+# Computed from the public ingress values above; keep after them for Compose interpolation.
 VST_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
-# Derived from VST_EXTERNAL_URL.
+# Keep aligned with VST_EXTERNAL_URL.
 VST_BASE_URL=${VST_EXTERNAL_URL}
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
-# Derived from the public ingress values above.
+# Computed from the public ingress values above.
 VSS_AGENT_REPORTS_BASE_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}/static/
 
 # =============================================================================
@@ -148,13 +151,13 @@ VSS_AUTO_CALIBRATION_UI_HOST_PORT=5000
 # =============================================================================
 # CREDENTIALS
 # =============================================================================
-# Script writes host NGC_CLI_API_KEY here for image/model pulls.
+# Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
 NGC_CLI_API_KEY=''
-# Script writes host NVIDIA_API_KEY when set.
+# Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
 NVIDIA_API_KEY=''
-# Script writes host OPENAI_API_KEY when set.
+# Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
 
@@ -162,31 +165,30 @@ OPENAI_API_KEY=''
 # CONFIGURATOR AND PROFILE PATHS
 # =============================================================================
 # Compose-time env_file list for blueprint-configurator services defaults to
-# .env followed by overrides.env. blueprint-deploy.sh writes BP_CONFIGURATOR_ENV_FILE
-# to generated.env during startup.
-# Derived from VSS_APPS_DIR.
+# .env followed by this override layer so deployment-specific values are available.
+# Path under VSS_APPS_DIR.
 VLM_AS_VERIFIER_CONFIG_FILE=${VSS_APPS_DIR}/industry-profiles/warehouse-operations/vlm-as-verifier/configs/config.yml
-# Derived from VSS_APPS_DIR.
+# Path under VSS_APPS_DIR.
 VLM_AS_VERIFIER_CONFIG_FILE_REALTIME=${VSS_APPS_DIR}/industry-profiles/warehouse-operations/vlm-as-verifier/realtime-config.yml
-# Derived from VSS_APPS_DIR.
+# Path under VSS_APPS_DIR.
 VLM_AS_VERIFIER_ALERT_TYPE_CONFIG_FILE=${VSS_APPS_DIR}/industry-profiles/warehouse-operations/vlm-as-verifier/configs/alert_type_config.json
-# Derived from VSS_APPS_DIR.
+# Path under VSS_APPS_DIR.
 SENSOR_FILE_PATH=${VSS_APPS_DIR}/industry-profiles/warehouse-operations/camera_configs/camera_info.json
-# Derived from VSS_APPS_DIR and MODE.
+# Warehouse SDR controller path under VSS_APPS_DIR selected by MODE.
 SDR_CONTROLLER_CONFIG_PATH=${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-${MODE}-app/sdrc
 
 # =============================================================================
-# PROFILE-SPECIFIC SCRIPT TOGGLES
+# PROFILE-SPECIFIC SCENARIO OVERRIDES
 # =============================================================================
-# DGX-SPARK or --use-sbsa-images switches to the commented sbsa tag.
+# Use the regular multi-arch tag by default; switch to the commented sbsa tag for DGX-SPARK/SBSA images.
 PERCEPTION_TAG="3.3.0-26.07.1"
 # PERCEPTION_TAG="3.3.0-sbsa-26.07.1"
-# DGX-SPARK or --use-sbsa-images switches to the commented sbsa tag.
+# Use the regular multi-arch tag by default; switch to the commented sbsa tag for DGX-SPARK/SBSA images.
 RTVI_VLM_IMAGE_TAG="3.2.1"
 #RTVI_VLM_IMAGE_TAG="3.2.1-sbsa"
 
 # =============================================================================
 # COMPOSE PROFILE SELECTION
 # =============================================================================
-# Derived from profile, mode, and model slugs. Keep after referenced values.
+# Compose profiles for the selected profile, mode, and model slugs. Keep after referenced values.
 COMPOSE_PROFILES=${BP_PROFILE}_${MODE},llm_${LLM_MODE}_${LLM_NAME_SLUG}


### PR DESCRIPTION
## Description
Updates to inline comments in overrides.env to be based on scenario and not script args. Restoring examples of defaults per scenrario

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
