### PR TITLE
ci(skills-signatures): enforce signature check only for PRs targeting main

### DIFF
--- a/.github/workflows/skills-signatures.yml
+++ b/.github/workflows/skills-signatures.yml
@@ -7,6 +7,12 @@
 # skill gates: `/ok to test` causes copy-pr-bot to update pull-request/<N>,
 # and that push runs this check. Branch protection/rulesets can make
 # `Skills Signatures / signature-check` a required status check.
+#
+# Signature verification is only enforced for PRs targeting `main`
+# (release promotions). PRs targeting `develop` resolve their base, log a
+# skip notice, and pass without verifying — skills iterate on develop and
+# are re-signed by the signing service, so enforcing there only produced
+# noise. Manual workflow_dispatch runs always verify.
 
 name: Skills Signatures
 
@@ -74,8 +80,20 @@ jobs:
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
           echo "PR #$PR, base=$BASE"
 
+      - name: Skip for non-main base
+        if: github.event_name == 'push' && steps.pr.outputs.base != 'main'
+        env:
+          PR_BASE: ${{ steps.pr.outputs.base }}
+        run: |
+          {
+            echo "# Agent skill signature check"
+            echo
+            echo "Skipped: enforcement is scoped to PRs targeting \`main\`; this PR targets \`$PR_BASE\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Resolve target skills
         id: targets
+        if: github.event_name == 'workflow_dispatch' || steps.pr.outputs.base == 'main'
         env:
           EVENT_NAME: ${{ github.event_name }}
           MANUAL_SKILLS: ${{ github.event_name == 'workflow_dispatch' && (inputs.skills || '*') || '' }}
@@ -131,6 +149,7 @@ jobs:
 
       - name: Resolve blocking mode
         id: blocking
+        if: github.event_name == 'workflow_dispatch' || steps.pr.outputs.base == 'main'
         env:
           EVENT_NAME: ${{ github.event_name }}
           MANUAL_BLOCKING: ${{ inputs.blocking }}
@@ -150,7 +169,7 @@ jobs:
 
       - name: Verify skill signatures
         id: verify
-        if: steps.targets.outputs.count != '0'
+        if: (github.event_name == 'workflow_dispatch' || steps.pr.outputs.base == 'main') && steps.targets.outputs.count != '0'
         env:
           TARGETS_FILE: ${{ steps.targets.outputs.targets_file }}
           BLOCKING: ${{ steps.blocking.outputs.value }}
@@ -216,7 +235,7 @@ jobs:
           fi
 
       - name: No signature targets
-        if: steps.targets.outputs.count == '0'
+        if: (github.event_name == 'workflow_dispatch' || steps.pr.outputs.base == 'main') && steps.targets.outputs.count == '0'
         run: |
           {
             echo "# Agent skill signature check"
@@ -225,7 +244,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload signature report
-        if: always() && steps.targets.outputs.count != '0'
+        if: always() && (github.event_name == 'workflow_dispatch' || steps.pr.outputs.base == 'main') && steps.targets.outputs.count != '0'
         uses: actions/upload-artifact@v4
         with:
           name: skill-signature-results


### PR DESCRIPTION
## Summary

Scopes the agent-skill signature check (`Skills Signatures / signature-check`) to PRs targeting `main`:

- **PRs into `develop`**: the job resolves the PR base, writes a skip notice to the step summary, and exits green without verifying. Skills iterate on develop and get re-signed by the signing service, so enforcing signatures there produced noise without value.
- **PRs into `main`** (release promotions): full verification, blocking as before.
- **Manual `workflow_dispatch` sweeps**: always verify (unchanged).

The job still completes successfully on develop PRs (rather than being skipped at the job level), so nothing would hang if `signature-check` is ever added as a required status check by name. Verified the check is not currently required by any ruleset or branch protection on either branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)