### PR TITLE
feat(spatialai-data-utils): scope AICity MTMC eval to GT frames + fix missing-warehouse HOTA weighting

### DIFF
--- a/libs/analytics/spatialai-data-utils/README.md
+++ b/libs/analytics/spatialai-data-utils/README.md
@@ -116,14 +116,14 @@ index:
 pip install 'torch>=2.10.0' --index-url https://download.pytorch.org/whl/cpu   # or CUDA build
 pip install 'pytorch3d @ git+https://github.com/facebookresearch/pytorch3d.git@33824be' \
     --no-build-isolation
-pip install spatialai-data-utils==2.0.1 \
+pip install spatialai-data-utils==2.0.2 \
     --extra-index-url=https://edge.urm.nvidia.com/artifactory/api/pypi/sw-metropolis-pypi/simple
 # add optional extras as needed, e.g. the evaluation stack:
-#   pip install 'spatialai-data-utils[eval]==2.0.1' --extra-index-url=...
+#   pip install 'spatialai-data-utils[eval]==2.0.2' --extra-index-url=...
 ```
 
 If you already have a CUDA `torch` in your environment (e.g. from
-sparse4d), skip step 1. Bump `==2.0.1` to the version you want to
+sparse4d), skip step 1. Bump `==2.0.2` to the version you want to
 install; available versions can be browsed at
 <https://edge.urm.nvidia.com/artifactory/sw-metropolis-pypi/spatialai-data-utils/>.
 

--- a/libs/analytics/spatialai-data-utils/release/setup.py
+++ b/libs/analytics/spatialai-data-utils/release/setup.py
@@ -23,7 +23,7 @@ in warehouse, retail, and hospital environments.
 
 Package Information:
 - Name: spatialai-data-utils
-- Version: 2.0.1 (with optional suffix from VERSION_SUFFIX env var)
+- Version: 2.0.2 (with optional suffix from VERSION_SUFFIX env var)
 - Python: >=3.11
 - License: Apache-2.0
 
@@ -65,7 +65,7 @@ import os
 
 from setuptools import setup
 
-_BASE_VERSION = "2.0.1"
+_BASE_VERSION = "2.0.2"
 
 suffix = os.getenv("VERSION_SUFFIX", "")
 version = _BASE_VERSION + suffix

--- a/libs/analytics/spatialai-data-utils/spatialai_data_utils/datasets/cloud_utils/download_utils.py
+++ b/libs/analytics/spatialai-data-utils/spatialai_data_utils/datasets/cloud_utils/download_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import concurrent.futures
+import hashlib
 import json
 import logging
 import multiprocessing
@@ -170,7 +171,15 @@ def download_single_file_from_storage_streaming(
     :rtype: str | None
     """
     try:
-        safe_filename = file_key.replace("/", "_").replace("\\", "_")
+        # Derive a collision-safe staging filename from the full object key.
+        # Flattening separators (e.g. "a/b" -> "a_b") can collide across
+        # distinct keys ("a/b" vs "a_b"), causing concurrent downloads to
+        # overwrite each other in the shared temp_dir. Hash the exact key
+        # instead; the filename is only an opaque staging name (the file is
+        # later read back and concatenated), so we keep the original extension
+        # purely for readability.
+        _, ext = os.path.splitext(file_key)
+        safe_filename = hashlib.sha256(file_key.encode("utf-8")).hexdigest() + ext
         temp_file_path = os.path.join(temp_dir, safe_filename)
 
         storage_client.download_file(

--- a/libs/analytics/spatialai-data-utils/spatialai_data_utils/eval/tracking/aicity_mtmc_eval.py
+++ b/libs/analytics/spatialai-data-utils/spatialai_data_utils/eval/tracking/aicity_mtmc_eval.py
@@ -92,6 +92,11 @@ Evaluation protocol:
 1. Truncate to the first ``num_frames_to_eval`` frames per scene
    (matches the validation server's default of 9000).
 2. Split GT / pred into ``<scene>/<class>/`` MOT-format text files.
+   Evaluation is scoped to the frames the GT annotates: prediction rows
+   on frames absent from the GT for that scene are dropped (not scored as
+   false positives), so a full submission evaluated against a truncated /
+   partial GT is judged only on the annotated frames.  This is a no-op
+   when the GT spans every frame in the window.
 3. For each (scene, class) pair that has *both* GT and pred rows, run
    TrackEval's HOTA metric on ``MTMCChallenge3DBBox`` (3D IoU matching,
    the official metric) or ``MTMCChallenge3DLocation`` (centre
@@ -199,6 +204,8 @@ def split_aicity_mtmc_per_scene_per_class(
     is_pred: bool,
     class_id_to_name: Optional[Dict[int, str]] = None,
     frame_start: int = 0,
+    record_frames_by_scene: Optional[Dict[str, set]] = None,
+    allowed_frames_by_scene: Optional[Dict[str, set]] = None,
 ) -> Dict[str, Dict[str, int]]:
     """Stream-split an AICity MTMC file into per-(scene, class) MOT files.
 
@@ -252,6 +259,16 @@ def split_aicity_mtmc_per_scene_per_class(
         table are warned-and-skipped for GT and rejected for
         predictions; the class names from this table are used verbatim
         as the per-class output directory names.
+    :param record_frames_by_scene: Optional mutable dict populated in
+        place (on the GT pass) with ``{scene_id: {frame_ids}}`` — the set
+        of frames the GT actually annotates per scene, accumulated over
+        every written row.
+    :param allowed_frames_by_scene: Optional ``{scene_id: {frame_ids}}``
+        (on the prediction pass).  When given, a prediction row whose
+        frame id is not in its scene's set is dropped instead of being
+        scored, so a full submission evaluated against a truncated /
+        partial GT is not penalised with false positives on frames the GT
+        never annotates.  A no-op when the GT already spans every frame.
     :return: ``{scene_name: {class_name: number_of_rows_written}}``
         — used both for the per-scene weight and as a sanity log.
     :raises ValueError: If ``frame_start`` is negative or not strictly
@@ -274,6 +291,7 @@ def split_aicity_mtmc_per_scene_per_class(
 
     writers: Dict[tuple, Any] = {}
     counts: Dict[str, Dict[str, int]] = {}
+    dropped_by_scene: Dict[str, int] = {}
 
     try:
         with open(input_path, "r") as fp:
@@ -353,6 +371,22 @@ def split_aicity_mtmc_per_scene_per_class(
                 if frame_id_0based < frame_start or frame_id_0based >= num_frames_to_eval:
                     continue
 
+                # Scope evaluation to the frames the GT annotates: the GT
+                # pass records its frames per scene; the prediction pass
+                # drops rows on frames the GT never covers (so they are not
+                # scored as false positives).  No-op when the GT spans every
+                # frame in the window.
+                if record_frames_by_scene is not None:
+                    record_frames_by_scene.setdefault(
+                        scene_id_str, set()).add(frame_id_0based)
+                if (
+                    allowed_frames_by_scene is not None
+                    and frame_id_0based
+                    not in allowed_frames_by_scene.get(scene_id_str, ())
+                ):
+                    dropped_by_scene[scene_id_str] = dropped_by_scene.get(scene_id_str, 0) + 1
+                    continue
+
                 scene_name = scenes_str_to_name[scene_id_str]
                 class_name = class_id_to_name[class_id]
 
@@ -368,6 +402,14 @@ def split_aicity_mtmc_per_scene_per_class(
     finally:
         for writer in writers.values():
             writer.close()
+
+    if dropped_by_scene:
+        logger.debug(
+            "Dropped %d prediction row(s) on frames absent from GT "
+            "(per scene: %s)",
+            sum(dropped_by_scene.values()),
+            {scenes_str_to_name.get(k, k): v for k, v in sorted(dropped_by_scene.items())},
+        )
 
     return counts
 
@@ -472,17 +514,20 @@ def _run_hota_for_scene_class(
 def _weighted_average(weights: Dict[str, int], values: Dict[str, float]) -> float:
     """Weight per-scene metric *values* by per-scene GT *weights*.
 
-    Matches the official AICity MTMC validation rule: scenes that
-    lack either a weight or a value are dropped (rather than treated as
-    zero), so a scene with no surviving GT after truncation does not
-    pull the final number down.
+    The denominator spans EVERY scene in the evaluation set (every scene
+    that has a GT weight), so a scene that has ground truth but is missing
+    from the submission — i.e. absent from *values* — contributes its full
+    GT weight with a value of 0 instead of being dropped from the average.
+    This keeps scores comparable across submissions on a fixed evaluation
+    set: omitting a hard scene can no longer raise the final number. A
+    scene truncated to 0 GT rows has weight 0, so it still contributes
+    nothing (no artificial penalty, no division by zero).
     """
-    common = set(weights) & set(values)
-    if not common:
+    denominator = sum(weights.values())
+    if not denominator:
         return 0.0
-    numerator = sum(weights[k] * values[k] for k in common)
-    denominator = sum(weights[k] for k in common)
-    return numerator / denominator if denominator else 0.0
+    numerator = sum(w * values.get(scene, 0.0) for scene, w in weights.items())
+    return numerator / denominator
 
 
 # ---------------------------------------------------------------------------
@@ -592,17 +637,24 @@ def run_aicity_mtmc_evaluation(
             "MOT files under %s ...",
             ground_truth_file, prediction_file, split_root,
         )
+        # Scope evaluation to the frames the GT annotates: record the GT's
+        # per-scene frame set, then drop prediction rows on frames the GT
+        # never covers so they are not scored as false positives (a no-op
+        # when the GT spans every frame; matters for truncated / partial GTs).
+        gt_frames_by_scene: Dict[str, set] = {}
         gt_counts = split_aicity_mtmc_per_scene_per_class(
             ground_truth_file, split_root, "gt.txt",
             scene_id_to_name, num_frames_to_eval, is_pred=False,
             class_id_to_name=class_id_to_name,
             frame_start=frame_start,
+            record_frames_by_scene=gt_frames_by_scene,
         )
         pred_counts = split_aicity_mtmc_per_scene_per_class(
             prediction_file, split_root, "pred.txt",
             scene_id_to_name, num_frames_to_eval, is_pred=True,
             class_id_to_name=class_id_to_name,
             frame_start=frame_start,
+            allowed_frames_by_scene=gt_frames_by_scene,
         )
 
         scene_object_counts: Dict[str, int] = {

--- a/libs/analytics/spatialai-data-utils/spatialai_data_utils/utils/optional_dependencies.py
+++ b/libs/analytics/spatialai-data-utils/spatialai_data_utils/utils/optional_dependencies.py
@@ -84,13 +84,20 @@ def import_cv2(context: str):
     importing — and all non-OpenCV code paths keep working — when it is not
     installed. Raises a clear :class:`ImportError` with install instructions
     at call time instead of failing at import time.
+
+    Only a genuinely absent ``cv2`` (``ModuleNotFoundError`` with
+    ``exc.name == "cv2"``) is turned into the install hint; any other failure
+    (e.g. a broken OpenCV build whose C-extension import fails) propagates
+    unchanged so it is not masked as "not installed".
     """
     try:
         import cv2
-    except ImportError as exc:
-        raise ImportError(
-            f"{context} requires OpenCV (`cv2`) to be installed. {_OPENCV_INSTALL_HINT}"
-        ) from exc
+    except ModuleNotFoundError as exc:
+        if exc.name == "cv2":
+            raise ImportError(
+                f"{context} requires OpenCV (`cv2`) to be installed. {_OPENCV_INSTALL_HINT}"
+            ) from exc
+        raise
     return cv2
 
 

--- a/libs/analytics/spatialai-data-utils/tests/eval/tracking/test_aicity_mtmc_eval.py
+++ b/libs/analytics/spatialai-data-utils/tests/eval/tracking/test_aicity_mtmc_eval.py
@@ -520,24 +520,36 @@ class TestSplitAicityMtmcWithExplicitClassTable:
 
 
 class TestWeightedAverage:
-    """``_weighted_average`` drops missing keys instead of zeroing them."""
+    """``_weighted_average`` scores scenes missing from *values* as 0 over
+    the full GT-weighted evaluation set (regression guard for the
+    missing-warehouse leaderboard bug)."""
 
     def test_intersects_keys_and_normalizes(self):
-        """Final = sum(w_i * v_i) / sum(w_i) over keys present in both."""
+        """Final = sum(w_i * v_i) / sum(w_i) when every scene has a value."""
         weights = {"a": 100, "b": 200, "c": 700}
         values = {"a": 0.5, "b": 0.25, "c": 0.1}
         # 100*0.5 + 200*0.25 + 700*0.1 = 170; / 1000 = 0.17
         assert _weighted_average(weights, values) == pytest.approx(0.17)
 
-    def test_missing_value_keys_excluded_not_zeroed(self):
-        """A scene missing from *values* must not pull the mean toward zero."""
+    def test_missing_value_keys_scored_as_zero(self):
+        """A scene present in the GT weights but missing from *values*
+        (e.g. a warehouse omitted from the submission) must count as 0
+        with its full weight, NOT be dropped from the mean — otherwise a
+        partial submission could out-score a complete one."""
         weights = {"a": 100, "b": 200}
-        values = {"a": 0.5}  # 'b' has weight but no value
-        # Only key 'a' participates: 100*0.5 / 100 = 0.5.
-        assert _weighted_average(weights, values) == pytest.approx(0.5)
+        values = {"a": 0.5}  # 'b' has GT weight but no predicted value
+        # Full denominator (100 + 200); 'b' contributes 0:
+        #   (100*0.5 + 200*0.0) / 300 = 0.1666...
+        assert _weighted_average(weights, values) == pytest.approx(50.0 / 300.0)
 
-    def test_empty_intersection_returns_zero(self):
-        assert _weighted_average({"a": 1}, {"b": 0.5}) == 0.0
+    def test_all_scenes_missing_returns_zero(self):
+        """No scored scene at all -> 0 (full denominator, zero numerator)."""
+        assert _weighted_average({"a": 1, "b": 2}, {}) == 0.0
+
+    def test_zero_total_weight_returns_zero(self):
+        """A degenerate all-zero-weight set (e.g. every scene truncated to
+        0 GT rows) returns 0 without dividing by zero."""
+        assert _weighted_average({"a": 0, "b": 0}, {"a": 0.9}) == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/libs/analytics/spatialai-data-utils/tests/eval/tracking/test_aicity_mtmc_eval_orchestrator.py
+++ b/libs/analytics/spatialai-data-utils/tests/eval/tracking/test_aicity_mtmc_eval_orchestrator.py
@@ -258,6 +258,113 @@ class TestRunAicityMtmcEvaluation:
         # Per-scene record for the only scene we drove.
         assert SCENE_NAME in results["per_scene"]
 
+    def test_out_of_gt_frame_predictions_are_ignored(self, tmp_path, _force_sequential_trackeval):
+        """Predictions on frames absent from the GT are dropped, not scored
+        as false positives.
+
+        Evaluation is scoped to the frames the GT annotates, so a
+        full-length submission judged against a truncated GT is not
+        penalised for its out-of-GT-range predictions.  The GT covers
+        frames 0-3 while the prediction covers 0-7 within a 100-frame
+        window; the extra frames 4-7 must be ignored, leaving a perfect
+        self-eval on frames 0-3 -> HOTA approaches 1.0.
+        """
+        gt_lines = [
+            _aicity_row(object_id=1, frame_id=i, x=float(i), y=0.0)
+            for i in range(4)
+        ]
+        pred_lines = [
+            _aicity_row(object_id=1, frame_id=i, x=float(i), y=0.0)
+            for i in range(8)
+        ]
+        gt = tmp_path / "gt.txt"
+        pred = tmp_path / "pred.txt"
+        _write_lines(gt, gt_lines)
+        _write_lines(pred, pred_lines)
+
+        results = run_aicity_mtmc_evaluation(
+            ground_truth_file=str(gt),
+            prediction_file=str(pred),
+            scene_id_to_name=SCENE_MAP,
+            output_dir=str(tmp_path / "out"),
+            num_cores=1,
+            num_frames_to_eval=100,  # window spans frames 4-7, but the GT lacks them
+            eval_type="bbox",
+            fps=10.0,
+            quiet=True,
+        )
+        # The 4 extra predictions (frames 4-7, no GT) are ignored, so the
+        # self-consistent frames 0-3 still yield a perfect score.
+        assert results["final"]["HOTA"] == pytest.approx(1.0, abs=0.01)
+        assert results["per_scene_object_counts"] == {SCENE_NAME: 4}
+
+    def test_partial_submission_does_not_outscore_full_submission(
+        self, tmp_path, _force_sequential_trackeval,
+    ):
+        """Regression: omitting whole warehouses must not raise the score.
+
+        Reproduces the participant report (Team Xiilab_Calix): a submission
+        covering only a subset of warehouses previously out-scored a
+        complete submission because missing warehouses were dropped from
+        the weighted mean. With the fix they are scored 0 at their full GT
+        weight, so a partial submission can no longer beat the full one and
+        can no longer reach a perfect score.
+
+        GT: three warehouses (all Person, one track each). FULL is perfect
+        on W023 but wrong on W024/W025; PARTIAL contains only W023.
+        """
+        scene_map = {
+            "23": "Warehouse_023", "24": "Warehouse_024", "25": "Warehouse_025",
+        }
+        n_frames = 6
+
+        def perfect(scene):
+            return [
+                _aicity_row(scene=scene, object_id=1, frame_id=f, x=float(f), y=0.0)
+                for f in range(n_frames)
+            ]
+
+        def wrong(scene):
+            # Same cardinality but 1000 m away -> never overlaps GT -> HOTA 0.
+            return [
+                _aicity_row(scene=scene, object_id=1, frame_id=f, x=1000.0 + f, y=0.0)
+                for f in range(n_frames)
+            ]
+
+        gt = perfect("23") + perfect("24") + perfect("25")
+        full = perfect("23") + wrong("24") + wrong("25")
+        partial = perfect("23")  # W024 + W025 omitted entirely
+
+        gt_p = tmp_path / "gt.txt"
+        full_p = tmp_path / "full.txt"
+        part_p = tmp_path / "partial.txt"
+        _write_lines(gt_p, gt)
+        _write_lines(full_p, full)
+        _write_lines(part_p, partial)
+
+        def _final_hota(pred_path, out_name):
+            res = run_aicity_mtmc_evaluation(
+                ground_truth_file=str(gt_p),
+                prediction_file=str(pred_path),
+                scene_id_to_name=scene_map,
+                output_dir=str(tmp_path / out_name),
+                num_cores=1,
+                num_frames_to_eval=n_frames,
+                eval_type="bbox",
+                fps=10.0,
+                quiet=True,
+            )
+            return res["final"]["HOTA"]
+
+        full_hota = _final_hota(full_p, "out_full")
+        partial_hota = _final_hota(part_p, "out_partial")
+
+        # The two omitted warehouses are scored 0 with full weight, so the
+        # partial submission cannot beat the full one...
+        assert partial_hota <= full_hota + 1e-9
+        # ...and cannot reach a perfect score just by dropping hard scenes.
+        assert partial_hota < 1.0 - 1e-6
+
     def test_run_with_default_output_dir_uses_tempdir(self, tmp_path, _force_sequential_trackeval):
         """Passing ``output_dir=None`` triggers the tempfile branch.
         The orchestrator should still return a valid results dict."""

--- a/libs/analytics/spatialai-data-utils/tools/camera_grouping/README.md
+++ b/libs/analytics/spatialai-data-utils/tools/camera_grouping/README.md
@@ -1044,7 +1044,7 @@ See `spatialai_data_utils/core/cameras/bev.py` for programmatic usage.
 - Tripwire/ROI `groups` fields (automatically filled to match cluster assignments)
 
 ### 2. Visualization Image
-**Filename**: `map_plotted_{output_suffix}.png`
+**Filename**: `calibration_clustered_map.png`
 
 **Shows:**
 - Overhead map

--- a/libs/analytics/spatialai-data-utils/tools/evaluation/README.md
+++ b/libs/analytics/spatialai-data-utils/tools/evaluation/README.md
@@ -162,6 +162,75 @@ because each warehouse has more frames with PalletTruck instances.
 | `--fps`                        | No       | `30.0`    | FPS written into TrackEval's per-sequence `seqinfo.ini` (cosmetic for single-sequence runs). |
 | `--quiet`                      | No       | (off)     | Suppress TrackEval's per-(scene, class) `INFO` records and per-class metric tables, keeping the final summary table readable. |
 
+### Evaluating on a frame slice (`--frame_start` + `--num_frames_to_eval`)
+
+The pair of flags `--frame_start` (default `0`) and
+`--num_frames_to_eval` (default `9000`) define an arbitrary half-open
+frame window `[frame_start, num_frames_to_eval)` per scene. The default
+matches the official validation server (`[0, 9000)`); set `--frame_start`
+to evaluate a non-prefix slice:
+
+```bash
+# First half of a 9000-frame scene
+python tools/evaluation/evaluate_aicity_mtmc.py \
+    --ground_truth_file data/aicity26/ground_truth/ground_truth.txt \
+    --input_file /path/to/2026_submission.txt \
+    --num_frames_to_eval 4500
+
+# Second half of a 9000-frame scene
+python tools/evaluation/evaluate_aicity_mtmc.py \
+    --ground_truth_file data/aicity26/ground_truth/ground_truth.txt \
+    --input_file /path/to/2026_submission.txt \
+    --frame_start 4500 --num_frames_to_eval 9000
+```
+
+`--frame_start` must be in `[0, num_frames_to_eval)`; the CLI raises a
+clean `ValueError` otherwise.
+
+### GT frame scoping (partial ground truth)
+
+Scoring is **scoped to the frames the ground truth annotates**. During the
+split step the GT pass records which `frame_id` values appear per scene;
+the prediction pass then **drops** rows on frames outside that set instead
+of scoring them as false positives. When the GT spans every frame in the
+active window this is a no-op; it matters when the GT file covers only a
+subset of frames (e.g. a per-scene first-half GT) while the submission
+still contains predictions for the full sequence.
+
+**Practical recipe:** provide a GT that covers the frames you want to
+score and run your **unchanged full submission** against it — no manual
+prediction filtering is required. For example, the standalone
+`aicity_mtmc_eval` release bundle ships
+`data/aicity26/ground_truth_half.txt` (per-scene first half: scenes
+23–25 → `[0, 4500)`, 26/27 → `[0, 900)`); evaluating a full submission
+against it yields the true first-half HOTA with second-half predictions
+ignored.
+
+```bash
+python tools/evaluation/evaluate_aicity_mtmc.py \
+    --ground_truth_file /path/to/ground_truth_half.txt \
+    --input_file         /path/to/full_submission.txt \
+    --output_dir         /tmp/aicity_mtmc_eval_first_half \
+    --quiet
+```
+
+**Do not confuse this with a partial submission.** A submission that
+only covers part of the frame range is still penalised: any GT frame in
+the active window with no matching prediction counts as a missed
+detection. Always submit predictions for the full frame range; do **not**
+shrink `--num_frames_to_eval` to match a short submission.
+
+`--frame_start` / `--num_frames_to_eval` clip to a **uniform**
+`[start, end)` window across all scenes (e.g. the official server's
+`[0, 9000)`). GT frame scoping is orthogonal — it further restricts
+scoring to whatever frames the GT file actually contains within that
+window.
+
+At the library level, `run_aicity_mtmc_evaluation` wires this
+automatically via `split_aicity_mtmc_per_scene_per_class`'s optional
+`record_frames_by_scene` (GT pass) and `allowed_frames_by_scene`
+(prediction pass) kwargs.
+
 ### Output
 
 Two pieces of output:
@@ -209,8 +278,8 @@ Import the same functions the CLI uses from
 | Symbol                                | Purpose |
 |---------------------------------------|---------|
 | `HOTA_FIELDS`                         | `["HOTA", "DetA", "AssA", "LocA"]` — the metric quartet reported by the leaderboard. |
-| `split_aicity_mtmc_per_scene_per_class(...)` | Stream-split an AICity MTMC text file into `<scene>/<class>/<basename>` MOT-format files; returns `{scene: {class: row_count}}`. Optional kwarg `class_id_to_name` selects the active class table (defaults to AICity'26). Useful on its own for per-class analyses / visualizers / custom evaluators. |
-| `run_aicity_mtmc_evaluation(...)` | End-to-end orchestrator: splits, runs HOTA per (scene, class), aggregates, returns a results dict. Optional kwarg `class_id_to_name` selects the active class table (defaults to AICity'26; pass `aicity25.spec.CLASS_ID_TO_NAME` for the 2025 edition). |
+| `split_aicity_mtmc_per_scene_per_class(...)` | Stream-split an AICity MTMC text file into `<scene>/<class>/<basename>` MOT-format files; returns `{scene: {class: row_count}}`. Optional kwargs: `class_id_to_name` (active class table; defaults to AICity'26), `record_frames_by_scene` (GT pass — accumulate annotated frames per scene), `allowed_frames_by_scene` (prediction pass — drop rows on frames absent from GT). Useful on its own for per-class analyses / visualizers / custom evaluators. |
+| `run_aicity_mtmc_evaluation(...)` | End-to-end orchestrator: splits (with automatic GT frame scoping), runs HOTA per (scene, class), aggregates, returns a results dict. Optional kwarg `class_id_to_name` selects the active class table (defaults to AICity'26; pass `aicity25.spec.CLASS_ID_TO_NAME` for the 2025 edition). |
 | `print_aicity_mtmc_summary(results)` | Log the per-(scene, class) + per-scene summary table to the module's logger. |
 | `save_aicity_mtmc_results(results, output_dir)` | Persist a results dict to `<output_dir>/aicity_mtmc_hota_summary.json` in the 0–100 scale used by the official leaderboard. Returns the JSON path. |
 
@@ -297,6 +366,12 @@ persistence, matching the convention used by the official leaderboard.
 - `num_frames_to_eval` truncates by **frame ID**, not by **row count**,
   so it is safe to leave at its `9000` default even when one scene has
   many fewer rows.
+- **GT frame scoping:** predictions on frames the GT does not annotate
+  are ignored, not scored as false positives. Use a partial GT file to
+  score a frame subset against a full submission (see
+  [GT frame scoping](#gt-frame-scoping-partial-ground-truth) above). A
+  *partial submission* against a full GT is still penalised for missed
+  detections — that is different.
 - The auto-derived scene name (`scene_<id>`) is purely for display; the
   HOTA numbers under `scene_<id>` are identical to those under the
   named-scene mapping for the same underlying data.

--- a/libs/analytics/spatialai-data-utils/tools/validation_and_evaluation/README.md
+++ b/libs/analytics/spatialai-data-utils/tools/validation_and_evaluation/README.md
@@ -113,7 +113,7 @@ docker run --rm -it --user "$(id -u):$(id -g)" \
   -v "$(pwd)/results:/workspace/results" \
   -w /workspace \
   spatialai_data_utils \
-  python tools/validation_and_evaluation/run_validation_and_evaluation.py \
+  tools/validation_and_evaluation/run_validation_and_evaluation.py \
     --calibration_url <calibration-URL>
 ```
 

--- a/libs/analytics/spatialai-data-utils/tools/validation_and_evaluation/run_validation_and_evaluation.py
+++ b/libs/analytics/spatialai-data-utils/tools/validation_and_evaluation/run_validation_and_evaluation.py
@@ -213,6 +213,7 @@ def load_env_variables(env_file_path=DEFAULT_ENV_FILE_PATH):
             "GCS_HMAC_ACCESS_KEY_ID",
             "GCS_HMAC_SECRET_ACCESS_KEY",
             "GCS_BUCKET",
+            "GCS_ENDPOINT_URL",
         ]
     else:
         raise EnvironmentError(


### PR DESCRIPTION
## Description

Brings the `spatialai-data-utils` sub-package in line with the canonical repo, rebased cleanly onto the latest `develop` — a **9-file diff** with no unrelated commits.

**Supersedes #1295**, which is based on a stale, since-force-pushed `develop` (297 commits / 1,117 files / `mergeable_state: dirty`) and only carried the frame-scoping change. This PR is the same feature plus the participant-reported fix, on a clean base.

Two evaluation fixes for the AICity MTMC (Multi-Camera 3D People Tracking) HOTA evaluator:

1. **Scope evaluation to GT-annotated frames** — predictions on frames the ground truth does not annotate are ignored instead of being counted as false positives, so a full submission evaluated against a partial/truncated GT is not unfairly penalised. (This is the change from #1295.)

2. **Fix missing-warehouse HOTA weighting** (reported by a Track-1 participant) — a warehouse present in the evaluation GT but missing from a submission is now scored `HOTA=0` at its full GT weight, instead of being dropped from the GT-count-weighted mean. Previously a partial submission covering only a subset of warehouses could out-score a complete one. A scene truncated to 0 GT rows still contributes nothing (weight 0).

Smaller self-contained fixes to the same sub-package:
- Narrow the optional `cv2` import guard to `ModuleNotFoundError` so a broken OpenCV build no longer masquerades as "not installed".
- Derive SHA-256 staging filenames in the cloud download path to avoid collisions.
- Require `GCS_ENDPOINT_URL` when `STORAGE_PROVIDER=gcs`; doc fixes (cluster-map output filename, docker entrypoint invocation).

### Verification
- New regression tests: a partial submission can no longer beat — or exceed a perfect score above — an equivalent full submission; plus unit coverage of the weighted-average aggregator.
- Non-regression: the bundled full sample submission still scores weighted **HOTA 20.15** (unchanged).
- Tracking test suite passes (50 tests).

> Follow-up: the `spatialai-data-utils` package version bump (the open TODO from #1295) is still pending a decision.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] I have installed and run pre-commit hooks locally.
- [x] Every commit on this PR is DCO sign-off'd.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.