### PR TITLE
docs(readme): add value proposition and CTA links above table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 <h2>NVIDIA AI Blueprint: Video Search and Summarization (VSS)</h2>
 
+**Build GPU-accelerated video AI agents that search, analyze, summarize, and reason over live or recorded video using natural language.**
+
+NVIDIA AI Blueprint for Video Search and Summarization (VSS) combines vision-language models, RAG, and NVIDIA NIM microservices to deliver real-time video analytics, visual Q&A, alert verification, clip retrieval, and long-video summarization.
+
+- Search video streams or archives using natural language queries
+- Summarize hours of video
+- Ask visual questions and automatically generate reports
+- Detect and verify real-time alerts with VLMs
+
+**[🚀 Try the Demo](https://build.nvidia.com/nvidia/video-search-and-summarization)** · **[⚡ Quickstart](#quickstart-guide)** · **[📚 Documentation](https://docs.nvidia.com/vss/latest/index.html)** · **[🏗️ Architecture](#software-components)** · **[📦 Latest Release](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/releases/latest)**
+
 ### Table of Contents
 - [Overview](#overview)
 - [Use Case / Problem Description](#use-case--problem-description)


### PR DESCRIPTION
## Summary

Implements the README half of the **"Do immediately"** items from the *Improving VSS GitHub search* thread (Esther Lee, 2026-07-21):

- **Value proposition above the ToC** — a keyword-rich two-sentence explanation plus four capability bullets now open the README, so the first screen communicates what the blueprint does (video AI agents, natural-language search, summarization, visual Q&A, alert verification) before the table of contents.
- **Conversion-oriented CTA row** — direct links to [Try the Demo](https://build.nvidia.com/nvidia/video-search-and-summarization), Quickstart (in-repo), [Documentation](https://docs.nvidia.com/vss/latest/index.html), Architecture (in-repo), and [Latest Release](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/releases/latest).

Copy is marketing's recommended text with two mechanical fixes: "NVIDIA AI Blueprint" naming (matches the repo title and build.nvidia.com) and a grammar fix in the second sentence.

## Repo settings applied alongside this PR (audit trail)

The other two immediate items are repo **settings**, not files — applied via API on 2026-07-21:

**About description** (was: *"The NVIDIA VSS Blueprint is a suite of reference architectures for building GPU-accelerated vision agents and AI-powered video analytics applications."*):

> NVIDIA AI Blueprint for video search and summarization (VSS) is a GPU-accelerated reference architecture for building video analytics agents with real-time verified alerts, visual Q&A, and automated reporting. The VSS Blueprint uses vision language models (VLMs) such as NVIDIA Cosmos, LLMs such as NVIDIA Nemotron, RAG, and NVIDIA NIMs.

**Topics** (7 → 20, the GitHub max — adds broader-category terms; drops `agents`/`llm` per marketing's list):

`video-agent` `vision-agent` `video-search` `video-summarization` `video-analytics` `video-understanding` `skills` `video-rag` `long-video-understanding` `real-time-video-analytics` `natural-language-search` `vision-language-model` `vlm` `retrieval-augmented-generation` `rag` `multimodal-ai` `computer-vision` `generative-ai` `model-context-protocol` `nvidia-nim`

## Not in this PR (follow-ups from the thread)

- License recognition fix (root `LICENSE` preamble breaks GitHub's detector → NOASSERTION) — separate PR, may need legal review
- Demo GIF, architecture visual refresh, keyword-targeted README sections, branded social preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)