### PR TITLE
fix(ci): retry transient failures when triggering the downstream pipeline

### DIFF
--- a/.github/scripts/trigger-downstream-pipeline.sh
+++ b/.github/scripts/trigger-downstream-pipeline.sh
@@ -6,6 +6,7 @@ import re
 import socket
 import ssl
 import sys
+import time
 from typing import Any
 from urllib.error import ContentTooShortError
 from urllib.error import HTTPError
@@ -96,34 +97,62 @@ def request_json(
             headers["Content-Type"] = "application/x-www-form-urlencoded"
 
     request = Request(url, data=data, headers=headers)
-    try:
-        with urlopen(request) as response:
-            payload = response.read().decode("utf-8")
-    except HTTPError as exc:
-        # Extract just the "message" / "error" field from the JSON body
-        # (GitLab convention). We do NOT include the raw body because it
-        # sometimes echoes the full request URL, which is a secret. The
-        # message field itself is safe - typically "Reference not found",
-        # "Missing CI config file", "insufficient_scope", etc.
-        reason = ""
+    # Retry transient failures (connection errors, HTTP 429/5xx) with exponential
+    # backoff. A single network blip or GitLab hiccup would otherwise fail the
+    # whole job outright; on the downstream side that burns a held runner slot
+    # and forces a full re-trigger, so a couple of cheap retries pay for
+    # themselves. Non-transient errors (4xx) still fail fast.
+    retryable_status = frozenset({429, 500, 502, 503, 504})
+    max_attempts = 4
+    for attempt in range(1, max_attempts + 1):
         try:
-            body = exc.read().decode("utf-8", errors="replace")
-            body_json = json.loads(body) if body else {}
-            if isinstance(body_json, dict):
-                msg = body_json.get("message") or body_json.get("error")
-                if isinstance(msg, str):
-                    reason = msg
-                elif isinstance(msg, dict):
-                    # GitLab sometimes returns a dict of field: [errors]
-                    reason = ", ".join(f"{k}: {v}" for k, v in msg.items())
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            pass
-        suffix = f": {reason}" if reason else ""
-        emit_error(f"{action} failed with status {exc.code}{suffix}")
-        raise SystemExit(1) from exc
-    except (URLError, ContentTooShortError) as exc:
-        emit_error(f"{action} failed due to a connection error: {connection_error_detail(exc)}")
-        raise SystemExit(1) from exc
+            with urlopen(request) as response:
+                payload = response.read().decode("utf-8")
+            break
+        except HTTPError as exc:
+            if exc.code in retryable_status and attempt < max_attempts:
+                delay = 2 * 2 ** (attempt - 1)
+                print(
+                    f"::warning::{action} attempt {attempt}/{max_attempts} failed "
+                    f"with status {exc.code}; retrying in {delay}s",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                continue
+            # Extract just the "message" / "error" field from the JSON body
+            # (GitLab convention). We do NOT include the raw body because it
+            # sometimes echoes the full request URL, which is a secret. The
+            # message field itself is safe - typically "Reference not found",
+            # "Missing CI config file", "insufficient_scope", etc.
+            reason = ""
+            try:
+                body = exc.read().decode("utf-8", errors="replace")
+                body_json = json.loads(body) if body else {}
+                if isinstance(body_json, dict):
+                    msg = body_json.get("message") or body_json.get("error")
+                    if isinstance(msg, str):
+                        reason = msg
+                    elif isinstance(msg, dict):
+                        # GitLab sometimes returns a dict of field: [errors]
+                        reason = ", ".join(f"{k}: {v}" for k, v in msg.items())
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                pass
+            suffix = f": {reason}" if reason else ""
+            emit_error(f"{action} failed with status {exc.code}{suffix}")
+            raise SystemExit(1) from exc
+        except (URLError, ContentTooShortError) as exc:
+            if attempt < max_attempts:
+                delay = 2 * 2 ** (attempt - 1)
+                print(
+                    f"::warning::{action} attempt {attempt}/{max_attempts} failed due "
+                    f"to a connection error ({connection_error_detail(exc)}); "
+                    f"retrying in {delay}s",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                continue
+            emit_error(f"{action} failed due to a connection error: {connection_error_detail(exc)}")
+            raise SystemExit(1) from exc
 
     try:
         parsed = json.loads(payload)


### PR DESCRIPTION
## What
Retry transient failures in `trigger-downstream-pipeline.sh`. `request_json()` (the shared helper for every downstream GitLab call, including the pipeline trigger) did a single `urlopen` with no retry, so any transient connection error or HTTP 429/5xx failed the whole bridge job.

## Why
The bridge job holds a self-hosted runner for up to 245 minutes. A single transient blip on the trigger or a GitLab API lookup would fail that job outright and force a full re-trigger (another held slot plus a re-vet).

## Honest scope
This is **preventive hardening, not a fix for an observed failure.** In recent CI history the `Trigger Downstream Pipeline` job is the top red source, but its failures are:
- ~65 x `Poll pipeline` (the downstream pipeline genuinely failed; retry cannot and should not mask that)
- ~12 x `Set up runner` (self-hosted runner provisioning, which happens before this script runs)
- ~1 x other

None were transient trigger/connection failures, so there is no example run of the exact failure this fixes. It closes a real fragility (a 245-min runner held on a zero-retry call) that simply has not bitten in the recent window.

## Change
Bounded retry loop (4 attempts, exponential backoff 2/4/8s) on connection errors and HTTP 429/500/502/503/504; fails fast on non-transient 4xx. Emits a `::warning::` per retry. The existing secret-safe error extraction on final failure is unchanged.
