### PR TITLE
chore(ci): add yamllint pre-commit hook mirroring the CI step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,16 @@ repos:
     pass_filenames: false
     require_serial: true
 
+  # Mirrors CI job "Lint (Python)" yamllint step: lint tracked .github / services YAML.
+  # Run ephemerally via uvx so yamllint (GPL-3.0-or-later) never lands in the
+  # project venv or lockfile, matching the CI step's licensing rationale.
+  - id: yamllint
+    name: yamllint (.github / services YAML)
+    entry: 'uvx yamllint -d "{extends: default, rules: {line-length: {max: 200}, document-start: disable, indentation: {spaces: 2, indent-sequences: consistent}}}"'
+    language: system
+    files: ^(\.github/.*\.ya?ml|\.pre-commit-config\.yaml|services/.*\.ya?ml)$
+    stages: [pre-commit]
+
   # DCO sign-off check — mirrors CI job "DCO Sign-off".
   # Runs at `commit-msg` stage so we read the *new* commit's message
   # (passed in as $1) instead of `git log -1` on the parent — which


### PR DESCRIPTION
## What
Add yamllint as a pre-commit hook, mirroring the CI "Lint (Python)" yamllint step, so a YAML error is caught locally in ~1s instead of failing a CI run.

## Why
The "Lint (Python)" CI job runs two linters: **ruff** (Python) and **yamllint** (YAML). ruff is already a pre-commit hook, but yamllint is not, so a stray YAML change (e.g. an extra blank line producing an `empty-lines` error) is not caught until it burns a CI run and forces a re-push.

This is not hypothetical. In recent history it has failed CI on **4 PRs (6 runs, including re-runs)**, every one on the same trivial `too many blank lines` error:

- PR #1254 (failed 3x): [run 1](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/29761458387/job/88417254931), [run 2](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/29622349214/job/88019940118), [run 3](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/29780787899/job/88481894327)
- PR #1319: [run](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/29616593416/job/88429462099)
- PR #1320: [run](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/29616441981/job/88003030585)
- PR #1348: [run](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/29864691739/job/88750687313)

Each is a full CI round-trip (and often a maintainer re-trigger) spent on a blank line. Shifting the check left removes the round-trip. Python lint (ruff) already never gates because it is in pre-commit; this closes the same gap for YAML.

## Change
A `repo: local` hook running `uvx yamllint` with the same config and file scope as the CI step. Run ephemerally via `uvx` so yamllint (GPL-3.0-or-later) never lands in the project venv or lockfile, matching the CI step's rationale. It lints only changed in-scope files; warnings are non-blocking (yamllint exits 0 on warnings), so it fails only on real YAML errors, exactly like CI.
