### PR TITLE
feat(ci): skip downstream pipeline on docs/CI-only PRs

### DIFF
--- a/.github/scripts/trigger-downstream-pipeline.sh
+++ b/.github/scripts/trigger-downstream-pipeline.sh
@@ -288,16 +288,46 @@ def push_event_changed_files() -> set[str]:
     return filenames
 
 
-def launchable_notebook_changed() -> bool:
-    """Return true when this run's VSS changes touch the launchable notebook."""
+# Changes that cannot affect the built blueprint (services/ + deploy/), so the
+# downstream blueprint pipeline would only re-eval identical inputs. Fail OPEN:
+# run the eval on anything not clearly in this set, so a real change is never
+# skipped.
+_IRRELEVANT_PREFIXES = (".github/", "docs/")
+_IRRELEVANT_SUFFIXES = (".md", ".rst", ".txt")
+_IRRELEVANT_EXACT = frozenset({".pre-commit-config.yaml", "LICENSE", "NOTICE", ".gitignore"})
+
+
+def run_changed_files() -> set[str]:
+    """Changed filenames for this run (PR synthetic branch or push); empty if unknown."""
     ref_name = os.environ.get("GITHUB_REF_NAME", "").strip()
     pr_match = re.fullmatch(r"pull-request/(\d+)", ref_name)
     if pr_match:
-        pr_number = int(pr_match.group(1))
         repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
         token = os.environ.get("GITHUB_TOKEN", "").strip()
-        return LAUNCHABLE_NOTEBOOK_PATH in fetch_pr_changed_files(repo, pr_number, token)
-    return LAUNCHABLE_NOTEBOOK_PATH in push_event_changed_files()
+        if repo and token:
+            return fetch_pr_changed_files(repo, int(pr_match.group(1)), token)
+        return set()
+    return push_event_changed_files()
+
+
+def downstream_relevant(changed: set[str]) -> bool:
+    """True unless EVERY changed file clearly cannot affect the built blueprint."""
+    if not changed:  # undeterminable -> run (fail open)
+        return True
+
+    def irrelevant(path: str) -> bool:
+        return (
+            path.startswith(_IRRELEVANT_PREFIXES)
+            or path.endswith(_IRRELEVANT_SUFFIXES)
+            or path in _IRRELEVANT_EXACT
+        )
+
+    return any(not irrelevant(path) for path in changed)
+
+
+def launchable_notebook_changed(changed: set[str]) -> bool:
+    """Return true when this run's VSS changes touch the launchable notebook."""
+    return LAUNCHABLE_NOTEBOOK_PATH in changed
 
 
 def resolve_branches() -> tuple[str, str]:
@@ -365,8 +395,24 @@ def main() -> int:
             add_mask(segment)
 
         target_branch, compare_branch = resolve_branches()
+
+        # Skip the (hours-long, self-hosted-GPU) downstream eval on PRs whose
+        # changes cannot affect the built blueprint (docs/CI-only). The job
+        # exits 0, so its check goes green without holding a runner or being
+        # reddened by an unrelated downstream failure.
+        changed = run_changed_files()
+        is_pr_run = bool(re.fullmatch(r"pull-request/\d+", os.environ.get("GITHUB_REF_NAME", "").strip()))
+        if is_pr_run and changed and not downstream_relevant(changed):
+            print(
+                "::notice::Skipping downstream pipeline: this change only touches "
+                "docs/CI files (no services/ or deploy/ code), so the blueprint "
+                "eval cannot be affected."
+            )
+            write_summary("Downstream pipeline skipped: docs/CI-only change (no services/ or deploy/ files).")
+            return 0
+
         extra_variables: dict[str, str] = {}
-        if launchable_notebook_changed():
+        if launchable_notebook_changed(changed):
             extra_variables[LAUNCHABLE_NOTEBOOK_TRIGGER_VARIABLE] = "true"
 
         project_id = fetch_project_id(base_url, token, project_path)


### PR DESCRIPTION
## What
Skip the downstream blueprint pipeline on PRs whose changes cannot affect the built blueprint (docs- or CI-only changes).

## Why
The downstream pipeline runs on a self-hosted GPU runner and holds it for up to 245 minutes, and it triggers on every PR regardless of whether the PR can affect the blueprint.

## Evidence (recent CI history)
- **Self-hosted pool contention:** the `downstream-pipeline` runner failed at `Set up runner` **12 times** in the recent window, before the job could even start. Not triggering PRs that cannot affect the blueprint relieves that contention.
- **Docs/CI-only PRs needlessly trigger the full 245-min eval.** Concrete examples: this very stack of CI-only PRs, which touch only `.github/` and `.pre-commit-config.yaml` and cannot change the blueprint, each trigger the eval: #1352, #1353, #1354 (this PR).

## Change
In `trigger-downstream-pipeline.sh`, before triggering, check the PR's changed files (reusing the existing changed-file helpers) and skip when every changed file is clearly irrelevant (`.github/`, `docs/`, `*.md`, `.pre-commit-config.yaml`, license files). The job exits 0, so its check goes green without holding a runner.

Fail open: any change not clearly irrelevant, or any inability to determine the changed set, still runs the eval, so a real change is never skipped. Applies to PR runs (`pull-request/<N>`) only, never `main`/`develop` pushes. Also single-sources the changed-file computation shared with the launchable-notebook check.

## Live example (this PR stack)
#1353, a `.pre-commit-config.yaml`-only PR, has every one of its ~20 checks green except one: the downstream `Trigger Downstream Pipeline`, which is red solely because the downstream `helm static warehouse charts` gate fails. That gate fails **main-wide, on every PR, regardless of content**: it renders warehouse Helm charts from `deploy/helm/industry-profiles/warehouse-operations/` in the resolved VSS checkout, but that path does not exist on `develop` (the warehouse profile ships as docker-compose assets, not Helm charts — there are zero warehouse `Chart.yaml`). The gate has a "chart root missing -> skip" path, but it escalates to a hard failure whenever an explicit VSS ref is set, which every PR's downstream trigger does. So a `.pre-commit-config.yaml` change cannot possibly affect it, yet it blocks the PR. This PR would skip the downstream entirely for such a CI-only change, so a main-wide downstream failure would no longer block a trivial CI/docs PR. (The gate itself also needs a separate fix in ci-vss-oss; see notes.)

## Note
Draft for discussion. This is the surgical, safe half of "decouple the bridge" (it removes docs/CI-only PRs from the eval and relieves the self-hosted runner pool). It intentionally does NOT change the blocking semantics for code PRs; making the downstream advisory for code PRs is a separate, policy-level decision.
