### PR TITLE
fix(agent): preserve runner compatibility during package rename

### DIFF
--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -34,6 +34,7 @@ def main() -> int:
     parser.add_argument("--attempts", type=int, default=240)
     parser.add_argument("--interval-seconds", type=int, default=15)
     parser.add_argument("--release-set", type=Path)
+    parser.add_argument("--release-set-output", type=Path)
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN", "").strip()
@@ -65,6 +66,12 @@ def main() -> int:
     )
     if problems:
         raise RuntimeError("invalid release set: " + "; ".join(problems))
+
+    if args.release_set_output:
+        args.release_set_output.parent.mkdir(parents=True, exist_ok=True)
+        args.release_set_output.write_text(
+            json.dumps(release_set, indent=2, sort_keys=True) + "\n"
+        )
 
     variables = downstream_variables(release_set)
     with Path(github_env).open("a") as output:

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -43,6 +43,7 @@ class DownstreamVariablesTest(unittest.TestCase):
         }
         with tempfile.TemporaryDirectory() as tmp:
             release_path = Path(tmp) / "release-set.json"
+            release_output_path = Path(tmp) / "handoff/release-set.json"
             env_path = Path(tmp) / "github.env"
             release_path.write_text(json.dumps(release_set))
             argv = [
@@ -51,6 +52,8 @@ class DownstreamVariablesTest(unittest.TestCase):
                 sha,
                 "--release-set",
                 str(release_path),
+                "--release-set-output",
+                str(release_output_path),
             ]
             with mock.patch("sys.argv", argv), mock.patch.dict(
                 os.environ, {"GITHUB_ENV": str(env_path)}, clear=True
@@ -60,6 +63,7 @@ class DownstreamVariablesTest(unittest.TestCase):
                 self.assertEqual(module.main(), 0)
                 download.assert_not_called()
             self.assertIn("DOWNSTREAM_EXTRA_VARIABLES_JSON", env_path.read_text())
+            self.assertEqual(json.loads(release_output_path.read_text()), release_set)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -852,7 +852,43 @@ jobs:
         run: python3 .github/scripts/release_set.py closure
 
   # ---------------------------------------------------------------------------
-  # Job 12: Trigger downstream pipeline and poll it to completion
+  # Job 12: Wait for this commit's separate Build Dev Images workflow
+  # ---------------------------------------------------------------------------
+  # GitHub Actions cannot express `needs` across workflow files. Treat the
+  # successful release-set artifact as the completion signal, then pass that
+  # exact artifact to the downstream trigger job.
+  wait-for-build-dev-images:
+    name: Wait for Build Dev Images
+    needs: prepare-source
+    runs-on: ubuntu-latest
+    timeout-minutes: 140
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Wait for successful GHCR release set
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/scripts/prepare_downstream_release_set.py \
+            --attempts 520 \
+            --interval-seconds 15 \
+            --release-set-output downstream-release-set.json
+
+      - name: Upload downstream release-set handoff
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: downstream-release-set
+          path: downstream-release-set.json
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Job 13: Trigger downstream pipeline and poll it to completion
   # ---------------------------------------------------------------------------
   trigger-downstream-pipeline:
     name: Trigger Downstream Pipeline
@@ -872,6 +908,7 @@ jobs:
       - license-check-python
       - license-check-ui
       - folder-structure
+      - wait-for-build-dev-images
     runs-on: [self-hosted, downstream-pipeline]
     # Holds the runner until the downstream pipeline completes. Must be
     # at least as long as MAX_POLL_DURATION_SECONDS in the poll step
@@ -906,10 +943,18 @@ jobs:
           mv .source-artifact/tracked-files.txt .ci/tracked-files.txt
           rm -rf .source-artifact
 
+      - name: Download completed GHCR release set
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: downstream-release-set
+          path: .downstream-release-set
+
       - name: Prepare GHCR release-set handoff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 .github/scripts/prepare_downstream_release_set.py
+        run: >-
+          python3 .github/scripts/prepare_downstream_release_set.py
+          --release-set .downstream-release-set/downstream-release-set.json
 
       - name: Trigger pipeline
         id: trigger

--- a/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     # Configuration for streaming video ingest endpoint
     streaming_ingest:

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
@@ -18,7 +18,7 @@ general:
   front_end:
     _type: vss_fastapi
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}
       vst_external_url: ${VST_EXTERNAL_URL}

--- a/deploy/docker/industry-profiles/smartcities/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/smartcities/vss-agent/configs/config.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/configs/vss-agent/config.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     # Configuration for streaming video ingest endpoint
     streaming_ingest:

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
@@ -17,7 +17,7 @@ general:
   use_uvloop: true
   front_end:
     _type: vss_fastapi
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}  # Set to local_object_store or remote_object_store
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}

--- a/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
@@ -18,7 +18,7 @@ general:
   front_end:
     _type: vss_fastapi
     object_store: ${VSS_AGENT_OBJECT_STORE_TYPE}
-    runner_class: agent.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
+    runner_class: vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker
     streaming_ingest:
       vst_internal_url: ${VST_INTERNAL_URL}
       vst_external_url: ${VST_EXTERNAL_URL}

--- a/services/agent/docker/Dockerfile
+++ b/services/agent/docker/Dockerfile
@@ -43,10 +43,11 @@ COPY --chown=root:root --chmod=0444 agent/LICENSE-3rd-party.txt /vss-agent
 COPY --chown=root:root --chmod=0444 agent/NVIDIA-Software-License-Agreement.pdf /vss-agent/NVIDIA-Software-License-Agreement.pdf
 COPY --chown=root:root --chmod=0444 agent/uv.lock /vss-agent
 COPY --chown=root:root --chmod=0555 agent/src/agent /vss-agent/src/agent
-# `lib/` and `cli/` are sibling top-level packages shipped in the same wheel
-# (see pyproject.toml `packages = ["src/agent", "src/cli", "src/lib"]`);
-# without these copies the hatchling build inside the image would fail and
-# lib.knowledge would be missing from the built image.
+# Keep the former runner-class import path available while deployments move
+# from the currently pinned pre-rename image to the repackaged image.
+COPY --chown=root:root --chmod=0555 agent/src/vss_agents /vss-agent/src/vss_agents
+# `lib/` and `cli/` are sibling top-level packages shipped in the same wheel;
+# without these copies the hatchling build inside the image would fail.
 COPY --chown=root:root --chmod=0555 agent/src/lib /vss-agent/src/lib
 COPY --chown=root:root --chmod=0555 agent/src/cli /vss-agent/src/cli
 COPY --chown=root:root --chmod=0444 agent/docker/cleanup_vulnerabilities.py /vss-agent/cleanup_vulnerabilities.py

--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -10,14 +10,16 @@ raw-options.root = "../.."
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
-# Two top-level packages ship in the same wheel:
-#   - agent: agent code, tools, NAT plugins (incl. register_knowledge_layers)
+# Top-level packages shipped in the same wheel:
+#   - agent:      agent code, tools, NAT plugins (incl. register_knowledge_layers)
+#   - vss_agents: compatibility namespace for deployment configs using the former name
+#   - cli:        NAT-independent command-line interface
 #   - lib:        NAT-independent libraries. lib.knowledge holds the BackendAdapter
 #                 ABC, schema, factory, and adapter implementations.
 # The base install carries only the light `lib` dependencies; agent and
 # lib.knowledge become importable once the `agent` extra's dependencies are
 # installed (see [project.optional-dependencies]).
-packages = ["src/agent", "src/cli", "src/lib"]
+packages = ["src/agent", "src/vss_agents", "src/cli", "src/lib"]
 
 
 [tool.uv]

--- a/services/agent/src/vss_agents/__init__.py
+++ b/services/agent/src/vss_agents/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility namespace for deployment configuration using the former package name."""

--- a/services/agent/src/vss_agents/api/__init__.py
+++ b/services/agent/src/vss_agents/api/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility API namespace for the former ``vss_agents`` package."""

--- a/services/agent/src/vss_agents/api/custom_fastapi_worker.py
+++ b/services/agent/src/vss_agents/api/custom_fastapi_worker.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backward-compatible import for the configured FastAPI worker."""
+
+from agent.api.custom_fastapi_worker import CustomFastApiFrontEndWorker
+
+__all__ = ["CustomFastApiFrontEndWorker"]

--- a/services/agent/tests/unit_test/api/test_runner_class_compat.py
+++ b/services/agent/tests/unit_test/api/test_runner_class_compat.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for runner-class compatibility during the package rename."""
+
+from pathlib import Path
+
+from agent.api.custom_fastapi_worker import CustomFastApiFrontEndWorker
+from vss_agents.api.custom_fastapi_worker import CustomFastApiFrontEndWorker as LegacyCustomFastApiFrontEndWorker
+
+LEGACY_RUNNER_CLASS = "vss_agents.api.custom_fastapi_worker.CustomFastApiFrontEndWorker"
+
+
+def test_legacy_runner_class_resolves_to_current_worker() -> None:
+    assert LegacyCustomFastApiFrontEndWorker is CustomFastApiFrontEndWorker
+
+
+def test_deployment_configs_use_image_compatible_runner_class() -> None:
+    repo_root = Path(__file__).resolve().parents[5]
+    configured_runner_classes: list[tuple[Path, str]] = []
+
+    for config_path in (repo_root / "deploy").rglob("*.yml"):
+        for line in config_path.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("runner_class:"):
+                configured_runner_classes.append((config_path, stripped.partition(":")[2].strip()))
+
+    assert configured_runner_classes
+    assert all(runner_class == LEGACY_RUNNER_CLASS for _, runner_class in configured_runner_classes)


### PR DESCRIPTION
Restore the legacy runner path for the currently pinned image while shipping a forwarding namespace so rebuilt images remain compatible.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
