### PR TITLE
refactor(search): route NAT search through search_core

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
@@ -71,6 +71,14 @@ functions:
     _type: search
     embed_search_tool: embed_search
     attribute_search_tool: attribute_search  # Optional: enable object-level search
+    es_endpoint: ${ELASTIC_SEARCH_ENDPOINT}
+    cosmos_embed_endpoint: ${COSMOS_EMBED_ENDPOINT}
+    cosmos_embed_model: ${RTVI_EMBED_MODEL:-cosmos-embed1-448p}
+    rtvi_cv_endpoint: ${RTVI_CV_ENDPOINT}
+    video_embed_index: ${ELASTIC_SEARCH_INDEX}
+    behavior_index: mdx-behavior-2025-01-01
+    frames_index: mdx-raw-2025-01-01
+    enable_frame_lookup: false
     agent_mode_llm: ${LLM_MODEL_TYPE:-nim}_llm
     use_attribute_search: true  # Internal config: enable fusion reranking with attribute search
     critic_agent: critic_agent  # Optional: enables VLM verification
@@ -85,6 +93,14 @@ functions:
     _type: search_agent
     embed_search_tool: embed_search
     attribute_search_tool: attribute_search
+    es_endpoint: ${ELASTIC_SEARCH_ENDPOINT}
+    cosmos_embed_endpoint: ${COSMOS_EMBED_ENDPOINT}
+    cosmos_embed_model: ${RTVI_EMBED_MODEL:-cosmos-embed1-448p}
+    rtvi_cv_endpoint: ${RTVI_CV_ENDPOINT}
+    video_embed_index: ${ELASTIC_SEARCH_INDEX}
+    behavior_index: mdx-behavior-2025-01-01
+    frames_index: mdx-raw-2025-01-01
+    enable_frame_lookup: false
     agent_mode_llm: ${LLM_MODEL_TYPE:-nim}_llm
     use_attribute_search: true
     vst_internal_url: ${VST_INTERNAL_URL}  # For stream_id to sensor_id conversion in fusion reranking

--- a/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
@@ -71,6 +71,14 @@ functions:
     _type: search
     embed_search_tool: embed_search
     attribute_search_tool: attribute_search
+    es_endpoint: ${ELASTIC_SEARCH_ENDPOINT}
+    cosmos_embed_endpoint: ${COSMOS_EMBED_ENDPOINT}
+    cosmos_embed_model: {{ .Values.rtviEmbedModel | default "cosmos-embed1-448p-anomaly-detection" }}
+    rtvi_cv_endpoint: ${RTVI_CV_BASE_URL}
+    video_embed_index: ${ELASTIC_SEARCH_INDEX}
+    behavior_index: mdx-behavior-2025-01-01
+    frames_index: mdx-raw-2025-01-01
+    enable_frame_lookup: false
     agent_mode_llm: ${LLM_MODEL_TYPE:-nim}_llm
     use_attribute_search: true
     critic_agent: critic_agent
@@ -85,6 +93,14 @@ functions:
     _type: search_agent
     embed_search_tool: embed_search
     attribute_search_tool: attribute_search
+    es_endpoint: ${ELASTIC_SEARCH_ENDPOINT}
+    cosmos_embed_endpoint: ${COSMOS_EMBED_ENDPOINT}
+    cosmos_embed_model: {{ .Values.rtviEmbedModel | default "cosmos-embed1-448p-anomaly-detection" }}
+    rtvi_cv_endpoint: ${RTVI_CV_BASE_URL}
+    video_embed_index: ${ELASTIC_SEARCH_INDEX}
+    behavior_index: mdx-behavior-2025-01-01
+    frames_index: mdx-raw-2025-01-01
+    enable_frame_lookup: false
     agent_mode_llm: ${LLM_MODEL_TYPE:-nim}_llm
     use_attribute_search: true
     vst_internal_url: ${VST_INTERNAL_URL}

--- a/services/agent/packages/vss_agents/src/vss_agents/agents/search_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/search_agent.py
@@ -50,14 +50,14 @@ from vss_agents.agents.data_models import AgentMessageChunk
 from vss_agents.agents.data_models import AgentMessageChunkType
 from vss_agents.agents.data_models import AgentOutput
 from vss_agents.agents.data_models import AgentRequestOptions
-from vss_agents.tools.attribute_search import DEFAULT_BEHAVIOR_INDEX
+from vss_agents.tools.search import SearchCoreRuntimeConfig
 from vss_agents.tools.search import SearchInput
 from vss_agents.tools.search import SearchOutput
 from vss_agents.tools.search import SearchResult
 from vss_agents.tools.search import execute_core_search
-from vss_agents.tools.vst.timeline import get_timeline
-from vss_agents.tools.vst.utils import get_name_to_stream_id_map
 from vss_agents.utils.time_convert import iso8601_to_datetime
+from vss_core.vst import get_name_to_stream_id_map
+from vss_core.vst import get_timeline
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +157,7 @@ def _candidate_top_k(search_agent_input: SearchAgentInput, default_top_k: int) -
     return max(default_top_k, max_results)
 
 
-class SearchAgentConfig(FunctionBaseConfig, name="search_agent"):
+class SearchAgentConfig(SearchCoreRuntimeConfig, FunctionBaseConfig, name="search_agent"):
     """Config for search agent."""
 
     # Tool references - we'll call these directly
@@ -247,11 +247,6 @@ class SearchAgentConfig(FunctionBaseConfig, name="search_agent"):
         description="Elasticsearch endpoint for behavior index (needed for object_id re-search).",
     )
 
-    behavior_index: str = Field(
-        default=DEFAULT_BEHAVIOR_INDEX,
-        description="Behavior index name for object embedding lookup.",
-    )
-
 
 # ===== Presentation converters (moved from embed_search.py) =====
 # These operate on SearchOutput (from search.py) instead of VisionLLM.
@@ -337,7 +332,7 @@ def _to_pts(ts: str | float) -> str:
         return str(ts)
 
 
-async def _add_offsets(results: list[SearchResult]) -> None:
+async def _add_offsets(results: list[SearchResult], vst_internal_url: str = "") -> None:
     """Populate start_offset/end_offset (seconds since each stream's timeline start).
 
     video_understanding runs in offset mode, so the agent must pass seconds-since-start, not
@@ -353,7 +348,7 @@ async def _add_offsets(results: list[SearchResult]) -> None:
             continue
         try:
             if r.sensor_id not in stream_start_cache:
-                stream_start_iso, _ = await get_timeline(r.sensor_id)
+                stream_start_iso, _ = await get_timeline(r.sensor_id, vst_internal_url)
                 stream_start_cache[r.sensor_id] = iso8601_to_datetime(stream_start_iso)
             stream_start = stream_start_cache[r.sensor_id]
             # Clamp at 0 to guard against minor clock skew (clip start slightly before timeline
@@ -435,10 +430,6 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
     and streams intermediate steps as AgentMessageChunk.
     """
 
-    # Load function references (for execute_core_search)
-    embed_search_fn = await builder.get_function(config.embed_search_tool)
-    attribute_search_fn = None  # Function reference for fusion_search_rerank
-
     stream_name_resolver = _StreamNameResolver(config.vst_internal_url)
 
     agent_llm = None
@@ -450,7 +441,20 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
     if config.critic_agent:
         critic_agent = await builder.get_function(config.critic_agent)
 
-    logger.info("Search agent initialized with direct tool references")
+    from vss_agents.tools.search_adapter import NATSearchAdapter
+    from vss_agents.tools.search_adapter import build_search_runtime
+
+    library_runtime = build_search_runtime(config)
+    library_adapter = (
+        NATSearchAdapter(library_runtime, config, agent_llm, critic_agent) if library_runtime is not None else None
+    )
+    embed_search_fn = None if library_adapter is not None else await builder.get_function(config.embed_search_tool)
+    attribute_search_fn = None  # Function reference for legacy fusion_search_rerank
+
+    logger.info(
+        "Search agent initialized with %s retrieval",
+        "lib.search_core" if library_adapter is not None else "legacy NAT tool",
+    )
 
     async def _execute_search(search_agent_input: SearchAgentInput) -> SearchOutput:
         """Non-streaming search execution. Returns SearchOutput directly."""
@@ -483,25 +487,31 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
             use_critic=use_critic,
         )
 
-        # Use shared core search function (async generator, collect all progress and return final result)
-        search_output = SearchOutput(data=[])
-        async for update in execute_core_search(
-            search_input=search_input,
-            embed_search=embed_search_fn,
-            agent_llm=agent_llm,
-            config=config,
-            builder=builder,
-            attribute_search_fn=attribute_search_fn,
-            critic_agent=critic_agent,
-        ):
-            if isinstance(update, SearchOutput):
-                search_output = update
+        if library_adapter is not None:
+            search_output = await library_adapter.run(
+                search_input,
+                use_attribute_search=search_agent_input.use_attribute_search,
+            )
+        else:
+            assert embed_search_fn is not None
+            search_output = SearchOutput(data=[])
+            async for update in execute_core_search(
+                search_input=search_input,
+                embed_search=embed_search_fn,
+                agent_llm=agent_llm,
+                config=config,
+                builder=builder,
+                attribute_search_fn=attribute_search_fn,
+                critic_agent=critic_agent,
+            ):
+                if isinstance(update, SearchOutput):
+                    search_output = update
 
         final_results = _apply_final_result_limit(
             await stream_name_resolver.resolve(search_output.data),
             search_agent_input,
         )
-        await _add_offsets(final_results)
+        await _add_offsets(final_results, config.vst_internal_url)
         return SearchOutput(data=final_results, search_messages=search_output.search_messages)
 
     async def _execute_search_stream(
@@ -561,15 +571,20 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
             # Use shared core search function (async generator) - yield progress updates in real-time
             search_output = SearchOutput(data=[])
 
-            async for update in execute_core_search(
-                search_input=search_input,
-                embed_search=embed_search_fn,
-                agent_llm=agent_llm,
-                config=config,
-                builder=builder,
-                attribute_search_fn=attribute_search_fn,
-                critic_agent=critic_agent,
-            ):
+            updates = (
+                library_adapter.stream(search_input, use_attribute_search=use_attribute_search_flag)
+                if library_adapter is not None
+                else execute_core_search(
+                    search_input=search_input,
+                    embed_search=embed_search_fn,
+                    agent_llm=agent_llm,
+                    config=config,
+                    builder=builder,
+                    attribute_search_fn=attribute_search_fn,
+                    critic_agent=critic_agent,
+                )
+            )
+            async for update in updates:
                 if isinstance(update, AgentMessageChunk):
                     # Forward progress updates directly
                     yield update
@@ -580,7 +595,7 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
                 await stream_name_resolver.resolve(search_output.data),
                 search_agent_input,
             )
-            await _add_offsets(final_results)
+            await _add_offsets(final_results, config.vst_internal_url)
             result_count = len(final_results)
 
             # Build SearchOutput-compatible JSON
@@ -661,17 +676,21 @@ async def search_agent(config: SearchAgentConfig, builder: Builder) -> AsyncGene
         return SearchAgentInput.model_validate_json(request.messages[-1].content)
 
     # Register the agent
-    yield FunctionInfo.create(
-        single_fn=_execute_search,
-        stream_fn=_execute_search_stream,
-        input_schema=SearchAgentInput,
-        single_output_schema=SearchOutput,
-        stream_output_schema=AgentMessageChunk,
-        converters=[
-            _str_input_converter,
-            _chat_request_input_converter,
-            _to_chat_response,
-            _to_chat_response_chunk,
-            _helper_markdown_bullet_list,
-        ],
-    )
+    try:
+        yield FunctionInfo.create(
+            single_fn=_execute_search,
+            stream_fn=_execute_search_stream,
+            input_schema=SearchAgentInput,
+            single_output_schema=SearchOutput,
+            stream_output_schema=AgentMessageChunk,
+            converters=[
+                _str_input_converter,
+                _chat_request_input_converter,
+                _to_chat_response,
+                _to_chat_response_chunk,
+                _helper_markdown_bullet_list,
+            ],
+        )
+    finally:
+        if library_adapter is not None:
+            await library_adapter.aclose()

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/search.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/search.py
@@ -1449,7 +1449,27 @@ async def execute_core_search_wrapper(
     return SearchOutput(data=[])
 
 
-class SearchConfig(FunctionBaseConfig, name="search"):
+class SearchCoreRuntimeConfig(BaseModel):
+    """Shared opt-in configuration for the ``lib.search_core`` runtime."""
+
+    es_endpoint: str | None = Field(default=None, description="Elasticsearch endpoint for library-backed search.")
+    cosmos_embed_endpoint: str | None = Field(default=None, description="Cosmos embed service endpoint.")
+    cosmos_embed_model: str = Field(default="cosmos-embed1-448p", description="Cosmos embed model name.")
+    rtvi_cv_endpoint: str | None = Field(default=None, description="RTVI-CV attribute service endpoint.")
+    video_embed_index: str = Field(default="mdx-embed-filtered-2025-01-01")
+    video_embed_index_wildcard: str = Field(default="mdx-embed-filtered-*")
+    behavior_index: str = Field(
+        default=DEFAULT_BEHAVIOR_INDEX,
+        description="Behavior index name for object embedding lookup.",
+    )
+    behavior_index_wildcard: str = Field(default="mdx-behavior-*")
+    frames_index: str | None = Field(default=None)
+    frames_index_wildcard: str = Field(default="mdx-raw-*")
+    enable_frame_lookup: bool = Field(default=True)
+    request_timeout_seconds: int = Field(default=30, ge=1)
+
+
+class SearchConfig(SearchCoreRuntimeConfig, FunctionBaseConfig, name="search"):
     """Configuration for the Search tool."""
 
     embed_search_tool: FunctionRef = Field(
@@ -1549,11 +1569,6 @@ class SearchConfig(FunctionBaseConfig, name="search"):
     behavior_es_endpoint: str | None = Field(
         default=None,
         description="Elasticsearch endpoint for behavior index (needed for object_id re-search).",
-    )
-
-    behavior_index: str = Field(
-        default=DEFAULT_BEHAVIOR_INDEX,
-        description="Behavior index name for object embedding lookup.",
     )
 
 
@@ -1669,8 +1684,6 @@ class SearchOutput(BaseModel):
 
 @register_function(config_type=SearchConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def search(config: SearchConfig, _builder: Builder) -> AsyncGenerator[FunctionInfo]:
-    embed_search = await _builder.get_function(config.embed_search_tool)
-
     agent_llm = None
     if config.agent_mode_prompt:
         agent_llm = await _builder.get_llm(config.agent_mode_llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
@@ -1679,6 +1692,15 @@ async def search(config: SearchConfig, _builder: Builder) -> AsyncGenerator[Func
     critic_agent = None
     if config.critic_agent:
         critic_agent = await _builder.get_function(config.critic_agent)
+
+    from vss_agents.tools.search_adapter import NATSearchAdapter
+    from vss_agents.tools.search_adapter import build_search_runtime
+
+    library_runtime = build_search_runtime(config)
+    library_adapter = (
+        NATSearchAdapter(library_runtime, config, agent_llm, critic_agent) if library_runtime is not None else None
+    )
+    embed_search = None if library_adapter is not None else await _builder.get_function(config.embed_search_tool)
 
     async def _search(search_input: SearchInput) -> SearchOutput:
         """
@@ -1689,7 +1711,10 @@ async def search(config: SearchConfig, _builder: Builder) -> AsyncGenerator[Func
         Returns:
             SearchOutput: Search results matching the query.
         """
-        # Use shared core search function (wrapper that collects results)
+        if library_adapter is not None:
+            return await library_adapter.run(search_input)
+
+        assert embed_search is not None
         return await execute_core_search_wrapper(
             search_input=search_input,
             embed_search=embed_search,
@@ -1736,6 +1761,11 @@ async def search(config: SearchConfig, _builder: Builder) -> AsyncGenerator[Func
             ],
         )
     finally:
+        if library_adapter is not None:
+            try:
+                await library_adapter.aclose()
+            except Exception as e:
+                logger.warning(f"Error closing library search adapter: {e}")
         try:
             await VSSESClient.close_all()
         except Exception as e:

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/search_adapter.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/search_adapter.py
@@ -102,6 +102,30 @@ def _result_key(result: SearchResult) -> tuple[str, str, str]:
     return result.sensor_id, result.start_time, result.end_time
 
 
+def _results_overlap(left: SearchResult, right: SearchResult) -> bool:
+    """Return whether two results cover the same sensor and overlapping time."""
+    if left.sensor_id != right.sensor_id:
+        return False
+    try:
+        left_start = iso8601_to_datetime(left.start_time)
+        left_end = iso8601_to_datetime(left.end_time)
+        right_start = iso8601_to_datetime(right.start_time)
+        right_end = iso8601_to_datetime(right.end_time)
+    except (TypeError, ValueError):
+        return False
+    return left_start < right_end and right_start < left_end
+
+
+def _deduplicate_overlapping_results(results: list[SearchResult]) -> list[SearchResult]:
+    """Keep the highest-ranked result for each overlapping segment."""
+    deduplicated: list[SearchResult] = []
+    for result in results:
+        if any(_results_overlap(result, existing) for existing in deduplicated):
+            continue
+        deduplicated.append(result)
+    return deduplicated
+
+
 def _to_nat_result(result: Any) -> SearchResult:
     return SearchResult(
         video_name=result.video_name,
@@ -192,8 +216,10 @@ class NATSearchAdapter:
             )
             query = decomposed.query or query
             if decomposed.video_sources:
+                video_sources = list(decomposed.video_sources)
+            if video_sources:
                 video_sources = _resolve_video_sources_for_search(
-                    decomposed.video_sources,
+                    video_sources,
                     name_to_uuid,
                     search_input.source_type,
                 )
@@ -281,8 +307,7 @@ class NATSearchAdapter:
         search_messages: list[str] = []
         critic_agent = self._critic_agent
         critic_enabled = bool(
-            getattr(self._config, "enable_critic", False)
-            and search_input.agent_mode
+            search_input.agent_mode
             and search_input.use_critic
             and critic_agent is not None
             and prepared.search_mode != "object"
@@ -395,7 +420,9 @@ class NATSearchAdapter:
         if not visible_candidates:
             visible_candidates = list(accumulated.values())
 
-        results = sorted(visible_candidates, key=lambda result: result.similarity, reverse=True)
+        results = _deduplicate_overlapping_results(
+            sorted(visible_candidates, key=lambda result: result.similarity, reverse=True)
+        )
         for result in results:
             result.critic_result = verdicts.get(_result_key(result))
         results = results[:original_top_k]

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/search_adapter.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/search_adapter.py
@@ -1,0 +1,417 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NAT orchestration adapter for the framework-independent search library."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Literal
+
+from fastapi import HTTPException
+
+from vss_agents.agents.critic_agent import CriticAgentResult
+from vss_agents.agents.critic_agent import VideoInfo
+from vss_agents.agents.data_models import AgentMessageChunk
+from vss_agents.agents.data_models import AgentMessageChunkType
+from vss_agents.tools.search import CriticResult
+from vss_agents.tools.search import SearchInput
+from vss_agents.tools.search import SearchOutput
+from vss_agents.tools.search import SearchResult
+from vss_agents.tools.search import _resolve_video_sources_for_search
+from vss_agents.tools.search import decompose_query
+from vss_agents.utils.time_convert import iso8601_to_datetime
+from vss_core.search_core import ErrorEvent
+from vss_core.search_core import FinalResultEvent
+from vss_core.search_core import PartialResultEvent
+from vss_core.search_core import SearchRuntime
+from vss_core.search_core import StatusEvent
+from vss_core.search_core import VSSSearch
+from vss_core.search_core.models.search import SearchInput as CoreSearchInput
+from vss_core.vst import get_streams_info
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+_MAX_TOP_K = 1000
+logger = logging.getLogger(__name__)
+
+_ERROR_STATUS_CODES = {
+    "ValidationError": 400,
+    "InvalidInputError": 400,
+    "IndexNotFoundError": 404,
+    "BackendUnreachableError": 502,
+    "VSTError": 502,
+    "ConfigurationError": 500,
+}
+
+
+def build_search_runtime(config: Any) -> SearchRuntime | None:
+    """Build the library runtime when the NAT config opts into the new path."""
+    es_endpoint = getattr(config, "es_endpoint", None)
+    cosmos_embed_endpoint = getattr(config, "cosmos_embed_endpoint", None)
+    rtvi_cv_endpoint = getattr(config, "rtvi_cv_endpoint", None)
+    vst_internal_url = getattr(config, "vst_internal_url", None)
+    if not all((es_endpoint, cosmos_embed_endpoint, rtvi_cv_endpoint, vst_internal_url)):
+        return None
+
+    vst_external_url = getattr(config, "vst_external_url", None) or vst_internal_url
+    return SearchRuntime.from_kwargs(
+        es_endpoint=es_endpoint,
+        behavior_es_endpoint=getattr(config, "behavior_es_endpoint", None) or es_endpoint,
+        cosmos_embed_endpoint=cosmos_embed_endpoint,
+        cosmos_embed_model=getattr(config, "cosmos_embed_model", "cosmos-embed1-448p"),
+        rtvi_cv_endpoint=rtvi_cv_endpoint,
+        vst_internal_url=vst_internal_url,
+        vst_external_url=vst_external_url,
+        behavior_index=getattr(config, "behavior_index", "mdx-behavior-2025-01-01"),
+        behavior_index_wildcard=getattr(config, "behavior_index_wildcard", "mdx-behavior-*"),
+        video_embed_index=getattr(config, "video_embed_index", "mdx-embed-filtered-2025-01-01"),
+        video_embed_index_wildcard=getattr(config, "video_embed_index_wildcard", "mdx-embed-filtered-*"),
+        frames_index=getattr(config, "frames_index", None),
+        frames_index_wildcard=getattr(config, "frames_index_wildcard", "mdx-raw-*"),
+        enable_frame_lookup=getattr(config, "enable_frame_lookup", True),
+        default_max_results=getattr(config, "default_max_results", 10),
+        embed_confidence_threshold=getattr(config, "embed_confidence_threshold", 0.1),
+        fusion_method=getattr(config, "fusion_method", "rrf"),
+        w_attribute=getattr(config, "w_attribute", 0.55),
+        w_embed=getattr(config, "w_embed", 0.35),
+        rrf_k=getattr(config, "rrf_k", 60),
+        rrf_w=getattr(config, "rrf_w", 0.5),
+        top_percent_filter=getattr(config, "top_percent_filter", None),
+        request_timeout_seconds=getattr(config, "request_timeout_seconds", 30),
+    )
+
+
+def _result_key(result: SearchResult) -> tuple[str, str, str]:
+    return result.sensor_id, result.start_time, result.end_time
+
+
+def _to_nat_result(result: Any) -> SearchResult:
+    return SearchResult(
+        video_name=result.video_name,
+        description=result.description,
+        start_time=result.start_time,
+        end_time=result.end_time,
+        sensor_id=result.sensor_id,
+        screenshot_url=result.screenshot_url,
+        similarity=result.similarity,
+        object_ids=result.object_ids,
+    )
+
+
+def _status_chunk(event: StatusEvent) -> AgentMessageChunk:
+    chunk_type = AgentMessageChunkType.TOOL_CALL if event.stage == "tool_call" else AgentMessageChunkType.THOUGHT
+    return AgentMessageChunk(type=chunk_type, content=event.message)
+
+
+def _raise_search_error(event: ErrorEvent) -> None:
+    status_code = _ERROR_STATUS_CODES.get(event.error_code, 500)
+    detail = event.message if status_code < 500 else f"Search error: {event.message}"
+    raise HTTPException(status_code=status_code, detail=detail)
+
+
+class NATSearchAdapter:
+    """Bridge NAT decomposition/critic behavior to ``lib.search_core`` retrieval."""
+
+    def __init__(self, runtime: SearchRuntime, config: Any, agent_llm: Any | None, critic_agent: Any | None) -> None:
+        self._runtime = runtime
+        self._config = config
+        self._agent_llm = agent_llm
+        self._critic_agent = critic_agent
+        self._search = VSSSearch.from_runtime(runtime)
+
+    async def aclose(self) -> None:
+        await self._search.aclose()
+
+    async def _prepare_input(
+        self,
+        search_input: SearchInput,
+        use_attribute_search: bool,
+    ) -> AsyncGenerator[AgentMessageChunk | CoreSearchInput]:
+        query = search_input.query
+        video_sources = list(search_input.video_sources or [])
+        timestamp_start = search_input.timestamp_start
+        timestamp_end = search_input.timestamp_end
+        top_k = search_input.top_k or self._runtime.default_max_results
+        attributes: list[str] = []
+        has_action: bool | None = None
+        object_ids: list[int] | None = None
+
+        if search_input.agent_mode and self._agent_llm is not None:
+            yield AgentMessageChunk(
+                type=AgentMessageChunkType.TOOL_CALL,
+                content=f"Decomposing query: '{search_input.query}'",
+            )
+            video_file_names: list[str] = []
+            video_stream_names: list[str] = []
+            name_to_uuid: dict[str, str] = {}
+            try:
+                vst_internal_url = self._runtime.vst_internal_url
+                if not vst_internal_url:
+                    raise ValueError("VST internal URL is required for stream discovery")
+                streams_info = await get_streams_info(vst_internal_url)
+                for stream_id, stream_info in streams_info.items():
+                    name = stream_info.get("name", "")
+                    url = stream_info.get("url", "")
+                    if not name:
+                        continue
+                    is_rtsp = url.startswith("rtsp://")
+                    if search_input.source_type == "rtsp" and is_rtsp:
+                        video_stream_names.append(name)
+                        name_to_uuid[name] = stream_id
+                    elif search_input.source_type == "video_file" and not is_rtsp:
+                        video_file_names.append(name)
+                        name_to_uuid[name] = stream_id
+            except Exception as exc:
+                # Stream discovery only enriches the decomposition prompt. Search
+                # remains usable when VST discovery is temporarily unavailable.
+                logger.warning("Could not discover VST streams for query decomposition: %s", exc)
+                name_to_uuid = {}
+
+            decomposed = await decompose_query(
+                user_query=search_input.query,
+                llm=self._agent_llm,
+                video_file_names=video_file_names or None,
+                video_stream_names=video_stream_names or None,
+            )
+            query = decomposed.query or query
+            if decomposed.video_sources:
+                video_sources = _resolve_video_sources_for_search(
+                    decomposed.video_sources,
+                    name_to_uuid,
+                    search_input.source_type,
+                )
+            if decomposed.timestamp_start:
+                try:
+                    timestamp_start = iso8601_to_datetime(decomposed.timestamp_start)
+                except Exception as exc:
+                    logger.warning("Ignoring invalid decomposed start timestamp: %s", exc)
+            if decomposed.timestamp_end:
+                try:
+                    timestamp_end = iso8601_to_datetime(decomposed.timestamp_end)
+                except Exception as exc:
+                    logger.warning("Ignoring invalid decomposed end timestamp: %s", exc)
+            if decomposed.top_k is not None:
+                top_k = decomposed.top_k
+            attributes = [
+                attribute.strip()
+                for attribute in decomposed.attributes
+                if attribute.strip() and any(separator in attribute.strip() for separator in (" ", "-", "."))
+            ]
+            has_action = decomposed.has_action
+            object_ids = decomposed.object_ids
+            summary: dict[str, Any] = {"refined_query": query, "attributes": attributes}
+            if video_sources:
+                summary["video_sources"] = video_sources
+            if object_ids:
+                summary["object_ids"] = object_ids
+            yield AgentMessageChunk(
+                type=AgentMessageChunkType.THOUGHT,
+                content=f"Query decomposed: {json.dumps(summary)}",
+            )
+
+        if object_ids:
+            search_mode: Literal["embed", "attribute", "fusion", "object"] = "object"
+            attributes = []
+        elif attributes and (has_action is False or has_action is None):
+            search_mode = "attribute"
+        elif attributes and use_attribute_search:
+            search_mode = "fusion"
+        else:
+            search_mode = "embed"
+            attributes = []
+
+        yield CoreSearchInput(
+            query=query,
+            original_query=search_input.query,
+            source_type=search_input.source_type,
+            video_sources=video_sources or None,
+            description=search_input.description,
+            timestamp_start=timestamp_start,
+            timestamp_end=timestamp_end,
+            top_k=max(1, min(top_k, _MAX_TOP_K)),
+            search_mode=search_mode,
+            attributes=attributes,
+            object_ids=object_ids,
+            min_cosine_similarity=search_input.min_cosine_similarity,
+        )
+
+    async def stream(
+        self,
+        search_input: SearchInput,
+        *,
+        use_attribute_search: bool | None = None,
+    ) -> AsyncGenerator[AgentMessageChunk | SearchOutput]:
+        prepared: CoreSearchInput | None = None
+        effective_attribute_search = (
+            getattr(self._config, "use_attribute_search", False)
+            if use_attribute_search is None
+            else use_attribute_search
+        )
+        async for update in self._prepare_input(search_input, effective_attribute_search):
+            if isinstance(update, AgentMessageChunk):
+                yield update
+            else:
+                prepared = update
+        if prepared is None:
+            raise RuntimeError("query preparation did not produce a search input")
+
+        original_top_k = prepared.top_k or self._runtime.default_max_results
+        candidate_top_k = original_top_k
+        accumulated: dict[tuple[str, str, str], SearchResult] = {}
+        confirmed: set[tuple[str, str, str]] = set()
+        rejected: set[tuple[str, str, str]] = set()
+        verdicts: dict[tuple[str, str, str], CriticResult] = {}
+        search_messages: list[str] = []
+        critic_agent = self._critic_agent
+        critic_enabled = bool(
+            getattr(self._config, "enable_critic", False)
+            and search_input.agent_mode
+            and search_input.use_critic
+            and critic_agent is not None
+            and prepared.search_mode != "object"
+        )
+
+        for _iteration in range(getattr(self._config, "search_max_iterations", 1)):
+            iteration_input = prepared.model_copy(update={"top_k": min(candidate_top_k, _MAX_TOP_K)})
+            final_output = None
+            async for event in self._search.search_stream(**iteration_input.model_dump()):
+                if isinstance(event, StatusEvent):
+                    yield _status_chunk(event)
+                elif isinstance(event, PartialResultEvent):
+                    yield AgentMessageChunk(
+                        type=AgentMessageChunkType.THOUGHT,
+                        content=f"Search produced {len(event.results)} partial results",
+                    )
+                elif isinstance(event, ErrorEvent):
+                    _raise_search_error(event)
+                elif isinstance(event, FinalResultEvent):
+                    final_output = event.output
+
+            if final_output is None:
+                raise RuntimeError("lib.search_core returned no final search result")
+            search_messages.extend(
+                message for message in final_output.search_messages if message not in search_messages
+            )
+            current_results = [_to_nat_result(result) for result in final_output.data]
+            unseen_keys: set[tuple[str, str, str]] = set()
+            for result in current_results:
+                key = _result_key(result)
+                previous = accumulated.get(key)
+                if previous is None:
+                    unseen_keys.add(key)
+                if previous is None or result.similarity > previous.similarity:
+                    accumulated[key] = result
+
+            if not critic_enabled or not current_results:
+                break
+
+            critic_candidates = [
+                result for result in current_results if _result_key(result) not in confirmed | rejected
+            ]
+            if not critic_candidates or not unseen_keys:
+                break
+
+            yield AgentMessageChunk(
+                type=AgentMessageChunkType.THOUGHT,
+                content=f"Verifying {len(critic_candidates)} results with critic agent",
+            )
+            try:
+                assert critic_agent is not None
+                critic_output = await critic_agent.ainvoke(
+                    {
+                        "query": search_input.query,
+                        "videos": [
+                            VideoInfo(
+                                sensor_id=result.sensor_id,
+                                start_timestamp=result.start_time,
+                                end_timestamp=result.end_time,
+                            )
+                            for result in critic_candidates
+                        ],
+                    }
+                )
+            except Exception as exc:
+                logger.error("Critic verification failed: %s", exc, exc_info=True)
+                message = "VLM verification unavailable (VLM may be down). Returning results without verification."
+                search_messages.append(message)
+                yield AgentMessageChunk(type=AgentMessageChunkType.THOUGHT, content=message)
+                break
+
+            video_results = critic_output.video_results
+            rejected_this_iteration = 0
+            for critic_result in video_results:
+                key = (
+                    critic_result.video_info.sensor_id,
+                    critic_result.video_info.start_timestamp,
+                    critic_result.video_info.end_timestamp,
+                )
+                verdicts[key] = CriticResult(
+                    result=critic_result.result.value,
+                    criteria_met=critic_result.criteria_met or {},
+                )
+                if critic_result.result == CriticAgentResult.CONFIRMED:
+                    confirmed.add(key)
+                elif critic_result.result == CriticAgentResult.REJECTED:
+                    rejected.add(key)
+                    rejected_this_iteration += 1
+
+            if video_results and all(result.result == CriticAgentResult.UNVERIFIED for result in video_results):
+                message = "VLM verification unavailable. Returning search results without critic verification."
+                search_messages.append(message)
+                yield AgentMessageChunk(type=AgentMessageChunkType.THOUGHT, content=message)
+                break
+
+            verified_count = sum(result.result == CriticAgentResult.CONFIRMED for result in video_results)
+            unverified_count = sum(result.result == CriticAgentResult.UNVERIFIED for result in video_results)
+            yield AgentMessageChunk(
+                type=AgentMessageChunkType.THOUGHT,
+                content=(
+                    f"Critic verification complete: {verified_count}/{len(video_results)} results verified, "
+                    f"{unverified_count}/{len(video_results)} results unverified"
+                ),
+            )
+            if rejected_this_iteration == 0:
+                break
+            candidate_top_k += rejected_this_iteration
+
+        visible_candidates = [result for key, result in accumulated.items() if key not in rejected]
+        if not visible_candidates:
+            visible_candidates = list(accumulated.values())
+
+        results = sorted(visible_candidates, key=lambda result: result.similarity, reverse=True)
+        for result in results:
+            result.critic_result = verdicts.get(_result_key(result))
+        results = results[:original_top_k]
+        yield AgentMessageChunk(
+            type=AgentMessageChunkType.THOUGHT,
+            content=f"Found {len(results)} result{'s' if len(results) != 1 else ''}",
+        )
+        yield SearchOutput(data=results, search_messages=search_messages)
+
+    async def run(
+        self,
+        search_input: SearchInput,
+        *,
+        use_attribute_search: bool | None = None,
+    ) -> SearchOutput:
+        async for update in self.stream(search_input, use_attribute_search=use_attribute_search):
+            if isinstance(update, SearchOutput):
+                return update
+        raise RuntimeError("library search adapter returned no final output")

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_search.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_search.py
@@ -16,6 +16,7 @@
 
 from datetime import UTC
 from datetime import datetime
+import inspect
 import json
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -32,8 +33,10 @@ from vss_agents.tools.search import SearchConfig
 from vss_agents.tools.search import SearchInput
 from vss_agents.tools.search import SearchOutput
 from vss_agents.tools.search import SearchResult
+from vss_agents.tools.search import VSSESClient
 from vss_agents.tools.search import _resolve_video_sources_for_search
 from vss_agents.tools.search import decompose_query
+from vss_agents.tools.search import search
 
 
 class TestResolveVideoSourcesForSearch:
@@ -145,6 +148,32 @@ class TestSearchConfig:
         assert config.fusion_method == "rrf"
         assert config.rrf_k == 100
         assert config.rrf_w == 0.7
+
+
+@pytest.mark.asyncio
+async def test_search_cleanup_closes_es_clients_when_adapter_close_fails(monkeypatch):
+    from vss_agents.tools import search_adapter as search_adapter_module
+
+    adapter = MagicMock()
+    adapter.aclose = AsyncMock(side_effect=RuntimeError("adapter close failed"))
+    monkeypatch.setattr(search_adapter_module, "build_search_runtime", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(search_adapter_module, "NATSearchAdapter", MagicMock(return_value=adapter))
+    close_all = AsyncMock()
+    monkeypatch.setattr(VSSESClient, "close_all", close_all)
+
+    config = SearchConfig(
+        embed_search_tool="embed_search",
+        agent_mode_llm="gpt-4o",
+        agent_mode_prompt="",
+        vst_internal_url="http://localhost:30888",
+    )
+    search_generator = inspect.unwrap(search)(config, MagicMock())
+
+    await anext(search_generator)
+    await search_generator.aclose()
+
+    adapter.aclose.assert_awaited_once()
+    close_all.assert_awaited_once()
 
 
 class TestSearchInput:

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_search_adapter.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_search_adapter.py
@@ -1,0 +1,335 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import HTTPException
+import pytest
+
+from vss_agents.agents.critic_agent import CriticAgentResult
+from vss_agents.agents.critic_agent import VideoInfo
+from vss_agents.agents.critic_agent import VideoResult
+from vss_agents.agents.search_agent import SearchAgentConfig
+from vss_agents.tools.search import DecomposedQuery
+from vss_agents.tools.search import SearchConfig
+from vss_agents.tools.search import SearchInput
+from vss_agents.tools.search_adapter import NATSearchAdapter
+from vss_agents.tools.search_adapter import build_search_runtime
+from vss_core.search_core import ErrorEvent
+from vss_core.search_core import FinalResultEvent
+from vss_core.search_core import SearchRuntime
+from vss_core.search_core.models.search import SearchOutput as CoreSearchOutput
+from vss_core.search_core.models.search import SearchResult as CoreSearchResult
+
+
+def _runtime() -> SearchRuntime:
+    return SearchRuntime.from_kwargs(
+        es_endpoint="http://es",
+        cosmos_embed_endpoint="http://embed",
+        rtvi_cv_endpoint="http://cv",
+        vst_internal_url="http://vst",
+        vst_external_url="http://vst-public",
+    )
+
+
+def _config(**overrides):
+    values = {
+        "enable_critic": True,
+        "search_max_iterations": 3,
+        "use_attribute_search": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _result(index: int) -> CoreSearchResult:
+    return CoreSearchResult(
+        video_name=f"video-{index}",
+        description=f"result {index}",
+        start_time=f"2025-01-01T00:00:0{index}Z",
+        end_time=f"2025-01-01T00:00:1{index}Z",
+        sensor_id=f"sensor-{index}",
+        screenshot_url=f"http://example/{index}.jpg",
+        similarity=1.0 - index / 10,
+    )
+
+
+class _FakeSearch:
+    def __init__(self, outputs: list[list[CoreSearchResult]]) -> None:
+        self._outputs = outputs
+        self.calls: list[dict] = []
+
+    async def search_stream(self, **kwargs):
+        self.calls.append(kwargs)
+        output = self._outputs[min(len(self.calls) - 1, len(self._outputs) - 1)]
+        yield FinalResultEvent(output=CoreSearchOutput(data=output))
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _FakeErrorSearch:
+    def __init__(self, event: ErrorEvent) -> None:
+        self._event = event
+
+    async def search_stream(self, **kwargs):
+        yield self._event
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _critic_result(result: CoreSearchResult, verdict: CriticAgentResult) -> VideoResult:
+    return VideoResult(
+        video_info=VideoInfo(
+            sensor_id=result.sensor_id,
+            start_timestamp=result.start_time,
+            end_timestamp=result.end_time,
+        ),
+        result=verdict,
+        criteria_met={"subject": verdict == CriticAgentResult.CONFIRMED},
+    )
+
+
+def test_build_search_runtime_requires_explicit_library_endpoints() -> None:
+    assert build_search_runtime(SimpleNamespace(vst_internal_url="http://vst")) is None
+
+    runtime = build_search_runtime(
+        SimpleNamespace(
+            es_endpoint="http://es",
+            cosmos_embed_endpoint="http://embed",
+            rtvi_cv_endpoint="http://cv",
+            vst_internal_url="http://vst",
+            vst_external_url=None,
+        )
+    )
+
+    assert runtime is not None
+    assert runtime.vst_external_url == "http://vst"
+
+
+def test_custom_behavior_index_reaches_runtime_from_nat_configs() -> None:
+    runtime_options = {
+        "embed_search_tool": "embed_search",
+        "vst_internal_url": "http://vst",
+        "es_endpoint": "http://es",
+        "cosmos_embed_endpoint": "http://embed",
+        "rtvi_cv_endpoint": "http://cv",
+        "behavior_index": "custom-behavior-index",
+    }
+    configs = [
+        SearchConfig(agent_mode_llm="llm", **runtime_options),
+        SearchAgentConfig(**runtime_options),
+    ]
+
+    for config in configs:
+        runtime = build_search_runtime(config)
+
+        assert config.model_dump()["behavior_index"] == "custom-behavior-index"
+        assert runtime is not None
+        assert runtime.behavior_index == "custom-behavior-index"
+
+
+@pytest.mark.asyncio
+async def test_no_rejections_use_one_library_call() -> None:
+    result = _result(1)
+    critic = AsyncMock()
+    critic.ainvoke.return_value = SimpleNamespace(video_results=[_critic_result(result, CriticAgentResult.CONFIRMED)])
+    adapter = NATSearchAdapter(_runtime(), _config(), agent_llm=None, critic_agent=critic)
+    fake_search = _FakeSearch([[result]])
+    adapter._search = fake_search
+
+    output = await adapter.run(SearchInput(query="person walking", source_type="video_file", agent_mode=True))
+
+    assert len(fake_search.calls) == 1
+    assert output.data[0].critic_result is not None
+    assert output.data[0].critic_result.result == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_rejection_expands_top_k_and_retrieves_replacement() -> None:
+    rejected_result = _result(1)
+    replacement = _result(2)
+    critic = AsyncMock()
+    critic.ainvoke.side_effect = [
+        SimpleNamespace(video_results=[_critic_result(rejected_result, CriticAgentResult.REJECTED)]),
+        SimpleNamespace(video_results=[_critic_result(replacement, CriticAgentResult.CONFIRMED)]),
+    ]
+    adapter = NATSearchAdapter(_runtime(), _config(), agent_llm=None, critic_agent=critic)
+    fake_search = _FakeSearch([[rejected_result], [rejected_result, replacement]])
+    adapter._search = fake_search
+
+    output = await adapter.run(SearchInput(query="person walking", source_type="video_file", top_k=1, agent_mode=True))
+
+    assert [call["top_k"] for call in fake_search.calls] == [1, 2]
+    assert critic.ainvoke.await_count == 2
+    assert len(output.data) == 1
+    assert output.data[0].video_name == replacement.video_name
+    assert output.data[0].critic_result is not None
+    assert output.data[0].critic_result.result == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_rejected_results_returned_when_no_replacement_exists() -> None:
+    rejected_result = _result(1)
+    critic = AsyncMock()
+    critic.ainvoke.return_value = SimpleNamespace(
+        video_results=[_critic_result(rejected_result, CriticAgentResult.REJECTED)]
+    )
+    adapter = NATSearchAdapter(_runtime(), _config(), agent_llm=None, critic_agent=critic)
+    fake_search = _FakeSearch([[rejected_result], [rejected_result]])
+    adapter._search = fake_search
+
+    output = await adapter.run(SearchInput(query="person walking", source_type="video_file", top_k=1, agent_mode=True))
+
+    assert len(output.data) == 1
+    assert output.data[0].video_name == rejected_result.video_name
+    assert output.data[0].critic_result is not None
+    assert output.data[0].critic_result.result == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_repeated_results_stop_when_retrieval_makes_no_progress() -> None:
+    result = _result(1)
+    critic = AsyncMock()
+    critic.ainvoke.return_value = SimpleNamespace(video_results=[_critic_result(result, CriticAgentResult.REJECTED)])
+    adapter = NATSearchAdapter(_runtime(), _config(search_max_iterations=5), agent_llm=None, critic_agent=critic)
+    fake_search = _FakeSearch([[result]])
+    adapter._search = fake_search
+
+    await adapter.run(SearchInput(query="person walking", source_type="video_file", agent_mode=True))
+
+    assert len(fake_search.calls) == 2
+    assert critic.ainvoke.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retrieval_stops_at_search_max_iterations() -> None:
+    results = [_result(index) for index in range(1, 4)]
+    critic = AsyncMock()
+    critic.ainvoke.side_effect = [
+        SimpleNamespace(video_results=[_critic_result(result, CriticAgentResult.REJECTED)]) for result in results
+    ]
+    adapter = NATSearchAdapter(_runtime(), _config(search_max_iterations=3), agent_llm=None, critic_agent=critic)
+    fake_search = _FakeSearch([[results[0]], results[:2], results])
+    adapter._search = fake_search
+
+    output = await adapter.run(SearchInput(query="person walking", source_type="video_file", top_k=1, agent_mode=True))
+
+    assert [call["top_k"] for call in fake_search.calls] == [1, 2, 3]
+    assert critic.ainvoke.await_count == 3
+    assert len(output.data) == 1
+
+
+@pytest.mark.asyncio
+async def test_all_unverified_stops_and_preserves_annotation() -> None:
+    result = _result(1)
+    critic = AsyncMock()
+    critic.ainvoke.return_value = SimpleNamespace(video_results=[_critic_result(result, CriticAgentResult.UNVERIFIED)])
+    adapter = NATSearchAdapter(_runtime(), _config(), agent_llm=None, critic_agent=critic)
+    fake_search = _FakeSearch([[result]])
+    adapter._search = fake_search
+
+    output = await adapter.run(SearchInput(query="person walking", source_type="video_file", agent_mode=True))
+
+    assert len(fake_search.calls) == 1
+    assert output.data[0].critic_result is not None
+    assert output.data[0].critic_result.result == "unverified"
+    assert output.search_messages == [
+        "VLM verification unavailable. Returning search results without critic verification."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_critic_failure_is_non_fatal() -> None:
+    result = _result(1)
+    critic = AsyncMock()
+    critic.ainvoke.side_effect = RuntimeError("vlm unavailable")
+    adapter = NATSearchAdapter(_runtime(), _config(), agent_llm=None, critic_agent=critic)
+    fake_search = _FakeSearch([[result]])
+    adapter._search = fake_search
+
+    output = await adapter.run(SearchInput(query="person walking", source_type="video_file", agent_mode=True))
+
+    assert len(output.data) == 1
+    assert output.search_messages == [
+        "VLM verification unavailable (VLM may be down). Returning results without verification."
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_code", "expected_status"),
+    [
+        ("InvalidInputError", 400),
+        ("ValidationError", 400),
+        ("IndexNotFoundError", 404),
+        ("BackendUnreachableError", 502),
+        ("VSTError", 502),
+        ("ConfigurationError", 500),
+        ("UnexpectedError", 500),
+    ],
+)
+async def test_library_error_events_map_to_http_exceptions(error_code: str, expected_status: int) -> None:
+    adapter = NATSearchAdapter(_runtime(), _config(enable_critic=False), agent_llm=None, critic_agent=None)
+    adapter._search = _FakeErrorSearch(ErrorEvent(error_code=error_code, message="library failure"))
+
+    with pytest.raises(HTTPException) as exc:
+        await adapter.run(SearchInput(query="person walking", source_type="video_file", agent_mode=False))
+
+    assert exc.value.status_code == expected_status
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("decomposed", "use_attribute_search", "expected_mode"),
+    [
+        (DecomposedQuery(query="object 5", object_ids=[5]), True, "object"),
+        (DecomposedQuery(query="red shirt", attributes=["red shirt"], has_action=False), True, "attribute"),
+        (DecomposedQuery(query="red shirt running", attributes=["red shirt"], has_action=True), True, "fusion"),
+        (DecomposedQuery(query="red shirt running", attributes=["red shirt"], has_action=True), False, "embed"),
+        (DecomposedQuery(query="traffic"), True, "embed"),
+    ],
+)
+async def test_decomposition_routes_to_explicit_library_search_mode(
+    monkeypatch,
+    decomposed: DecomposedQuery,
+    use_attribute_search: bool,
+    expected_mode: str,
+) -> None:
+    async def _decompose(*args, **kwargs):
+        return decomposed
+
+    async def _streams(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr("vss_agents.tools.search_adapter.decompose_query", _decompose)
+    monkeypatch.setattr("vss_agents.tools.search_adapter.get_streams_info", _streams)
+    adapter = NATSearchAdapter(
+        _runtime(),
+        _config(enable_critic=False),
+        agent_llm=object(),
+        critic_agent=None,
+    )
+    fake_search = _FakeSearch([[]])
+    adapter._search = fake_search
+
+    await adapter.run(
+        SearchInput(query="original query", source_type="video_file", agent_mode=True),
+        use_attribute_search=use_attribute_search,
+    )
+
+    assert fake_search.calls[0]["search_mode"] == expected_mode

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_search_adapter.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_search_adapter.py
@@ -47,7 +47,6 @@ def _runtime() -> SearchRuntime:
 
 def _config(**overrides):
     values = {
-        "enable_critic": True,
         "search_max_iterations": 3,
         "use_attribute_search": True,
     }
@@ -217,6 +216,50 @@ async def test_repeated_results_stop_when_retrieval_makes_no_progress() -> None:
 
 
 @pytest.mark.asyncio
+async def test_overlapping_results_across_iterations_keep_best_ranked_segment() -> None:
+    narrow = _result(1).model_copy(
+        update={
+            "video_name": "narrow",
+            "sensor_id": "sensor-1",
+            "start_time": "2025-01-01T00:00:00Z",
+            "end_time": "2025-01-01T00:00:05Z",
+            "similarity": 0.9,
+        }
+    )
+    rejected = _result(2)
+    wide = narrow.model_copy(
+        update={
+            "video_name": "wide",
+            "end_time": "2025-01-01T00:00:10Z",
+            "similarity": 0.95,
+        }
+    )
+    replacement = _result(3).model_copy(update={"similarity": 0.7})
+    critic = AsyncMock()
+    critic.ainvoke.side_effect = [
+        SimpleNamespace(
+            video_results=[
+                _critic_result(narrow, CriticAgentResult.CONFIRMED),
+                _critic_result(rejected, CriticAgentResult.REJECTED),
+            ]
+        ),
+        SimpleNamespace(
+            video_results=[
+                _critic_result(wide, CriticAgentResult.CONFIRMED),
+                _critic_result(replacement, CriticAgentResult.CONFIRMED),
+            ]
+        ),
+    ]
+    adapter = NATSearchAdapter(_runtime(), _config(), agent_llm=None, critic_agent=critic)
+    fake_search = _FakeSearch([[narrow, rejected], [wide, rejected, replacement]])
+    adapter._search = fake_search
+
+    output = await adapter.run(SearchInput(query="person walking", source_type="video_file", top_k=2, agent_mode=True))
+
+    assert [result.video_name for result in output.data] == ["wide", replacement.video_name]
+
+
+@pytest.mark.asyncio
 async def test_retrieval_stops_at_search_max_iterations() -> None:
     results = [_result(index) for index in range(1, 4)]
     critic = AsyncMock()
@@ -333,3 +376,34 @@ async def test_decomposition_routes_to_explicit_library_search_mode(
     )
 
     assert fake_search.calls[0]["search_mode"] == expected_mode
+
+
+@pytest.mark.asyncio
+async def test_explicit_video_source_is_resolved_when_decomposition_has_no_sources(monkeypatch) -> None:
+    async def _decompose(*args, **kwargs):
+        return DecomposedQuery(query="person walking")
+
+    async def _streams(*args, **kwargs):
+        return {
+            "stream-id": {
+                "name": "clip.mp4",
+                "url": "file:///videos/clip.mp4",
+            }
+        }
+
+    monkeypatch.setattr("vss_agents.tools.search_adapter.decompose_query", _decompose)
+    monkeypatch.setattr("vss_agents.tools.search_adapter.get_streams_info", _streams)
+    adapter = NATSearchAdapter(_runtime(), _config(), agent_llm=object(), critic_agent=None)
+    fake_search = _FakeSearch([[]])
+    adapter._search = fake_search
+
+    await adapter.run(
+        SearchInput(
+            query="person walking",
+            source_type="video_file",
+            video_sources=["clip.mp4"],
+            agent_mode=True,
+        )
+    )
+
+    assert fake_search.calls[0]["video_sources"] == ["stream-id"]


### PR DESCRIPTION
## Description
* use lib.search_core and lib.* in search_agent
* closes VIA-2131

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
