### PR TITLE
Feat/graph rag

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -179,14 +179,10 @@ functions:
   #   top_k: 5
   #   llm_name: ${LLM_MODEL_TYPE:-nim}_llm
   #   backend_config:
-  #     # Optional. Defaults to arango_graph; custom providers can use provider_config.
-  #     provider: arango_graph
-  #     # Provider-specific connection settings. These can also come from
-  #     # ARANGO_* env vars.
-  #     provider_config:
-  #       arango_url: ${ARANGO_URL:-http://arango-db:8529}
-  #       arango_database: ${ARANGO_DB:-example_graphs}
-  #       arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #     # Connection settings can also come from ARANGO_* env vars.
+  #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
+  #     arango_database: ${ARANGO_DB:-example_graphs}
+  #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
   #     schema_description: |
   #       node_a vertices connect to node_b vertices through related_to edges.
   #       Replace these names with your existing graph schema.

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -177,10 +177,10 @@ functions:
   #   _type: knowledge_retrieval
   #   backend: arango_graph
   #   top_k: 5
+  #   llm_name: ${LLM_MODEL_TYPE:-nim}_llm
   #   backend_config:
   #     # Optional. Defaults to arango; custom providers can use provider_config.
   #     provider: arango
-  #     llm_name: ${LLM_MODEL_TYPE:-nim}_llm
   #     # Provider-specific connection settings. These can also come from
   #     # ARANGO_* env vars.
   #     provider_config:

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -179,8 +179,8 @@ functions:
   #   top_k: 5
   #   llm_name: ${LLM_MODEL_TYPE:-nim}_llm
   #   backend_config:
-  #     # Optional. Defaults to arango; custom providers can use provider_config.
-  #     provider: arango
+  #     # Optional. Defaults to arango_graph; custom providers can use provider_config.
+  #     provider: arango_graph
   #     # Provider-specific connection settings. These can also come from
   #     # ARANGO_* env vars.
   #     provider_config:

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -169,45 +169,32 @@ functions:
       timeout: 300
   # <<< frag
 
-  # >>> graph_rag: reference-only ArangoDB graph retrieval example
-  # VSS does not create, seed, or manage this graph. The database,
-  # collections, edges, and graph name must already exist in ArangoDB.
-  # To use this example, uncomment the block, replace the placeholder schema
-  # names, configure the ARANGO_* environment variables, and add the tool name
-  # to workflow.tool_names.
+  # >>> arango_graph: reference-only ArangoDB retrieval example
+  # VSS does not create, seed, or manage this graph. Point this tool at an
+  # existing ArangoDB graph and add it to workflow.tool_names.
   #
   # example_graph_retrieval:
   #   _type: knowledge_retrieval
-  #   backend: graph_rag
+  #   backend: arango_graph
   #   top_k: 5
   #   backend_config:
-  #     provider: langchain_arango
-  #
-  #     # LLM used by LangChain to generate read-only AQL and summarize results.
-  #     llm_model: ${LLM_NAME}
-  #     llm_base_url: ${LLM_BASE_URL}/v1
-  #     llm_api_key: ${NVIDIA_API_KEY:-}
-  #     temperature: 0.0
-  #     llm_reasoning: false
-  #
-  #     # Existing ArangoDB graph connection.
-  #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
-  #     arango_database: ${ARANGO_DB:-example_graphs}
-  #     arango_username: ${ARANGO_USER:-root}
-  #     arango_password: ${ARANGO_PASSWORD:-}
-  #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
-  #
-  #     # LangChain graph QA chains require this before running generated AQL.
-  #     # Use read-only ArangoDB credentials in production.
-  #     allow_dangerous_requests: true
-  #     return_intermediate_steps: true
-  #     max_aql_generation_attempts: 4
-  #
+  #     # Optional. Defaults to arango; custom providers can use provider_config.
+  #     provider: arango
+  #     llm_name: ${LLM_MODEL_TYPE:-nim}_llm
+  #     # Provider-specific connection settings. These can also come from
+  #     # ARANGO_* env vars.
+  #     provider_config:
+  #       arango_url: ${ARANGO_URL:-http://arango-db:8529}
+  #       arango_database: ${ARANGO_DB:-example_graphs}
+  #       arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
   #     schema_description: |
-  #       Example reference graph. node_a vertices connect to node_b vertices
-  #       through related_to edges. Replace these collection and edge names with
-  #       the schema from an existing ArangoDB graph.
-  #
+  #       node_a vertices connect to node_b vertices through related_to edges.
+  #       Replace these names with your existing graph schema.
+  #     allowed_vertex_collections:
+  #     - node_a
+  #     - node_b
+  #     allowed_edge_collections:
+  #     - related_to
   #     graph_semantics:
   #     - name: example_relationship
   #       user_terms: ["node", "related", "relationship", "connection"]
@@ -215,14 +202,7 @@ functions:
   #       edge_collection: related_to
   #       target_collection: node_b
   #       meaning: node_a records are connected to related node_b records.
-  #
-  #     allowed_vertex_collections:
-  #     - node_a
-  #     - node_b
-  #
-  #     allowed_edge_collections:
-  #     - related_to
-  # <<< graph_rag reference
+  # <<< arango_graph reference
 
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -169,6 +169,61 @@ functions:
       timeout: 300
   # <<< frag
 
+  # >>> graph_rag: reference-only ArangoDB graph retrieval example
+  # VSS does not create, seed, or manage this graph. The database,
+  # collections, edges, and graph name must already exist in ArangoDB.
+  # To use this example, uncomment the block, replace the placeholder schema
+  # names, configure the ARANGO_* environment variables, and add the tool name
+  # to workflow.tool_names.
+  #
+  # example_graph_retrieval:
+  #   _type: knowledge_retrieval
+  #   backend: graph_rag
+  #   top_k: 5
+  #   backend_config:
+  #     provider: langchain_arango
+  #
+  #     # LLM used by LangChain to generate read-only AQL and summarize results.
+  #     llm_model: ${LLM_NAME}
+  #     llm_base_url: ${LLM_BASE_URL}/v1
+  #     llm_api_key: ${NVIDIA_API_KEY:-}
+  #     temperature: 0.0
+  #     llm_reasoning: false
+  #
+  #     # Existing ArangoDB graph connection.
+  #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
+  #     arango_database: ${ARANGO_DB:-example_graphs}
+  #     arango_username: ${ARANGO_USER:-root}
+  #     arango_password: ${ARANGO_PASSWORD:-}
+  #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #
+  #     # LangChain graph QA chains require this before running generated AQL.
+  #     # Use read-only ArangoDB credentials in production.
+  #     allow_dangerous_requests: true
+  #     return_intermediate_steps: true
+  #     max_aql_generation_attempts: 4
+  #
+  #     schema_description: |
+  #       Example reference graph. node_a vertices connect to node_b vertices
+  #       through related_to edges. Replace these collection and edge names with
+  #       the schema from an existing ArangoDB graph.
+  #
+  #     graph_semantics:
+  #     - name: example_relationship
+  #       user_terms: ["node", "related", "relationship", "connection"]
+  #       source_collection: node_a
+  #       edge_collection: related_to
+  #       target_collection: node_b
+  #       meaning: node_a records are connected to related node_b records.
+  #
+  #     allowed_vertex_collections:
+  #     - node_a
+  #     - node_b
+  #
+  #     allowed_edge_collections:
+  #     - related_to
+  # <<< graph_rag reference
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -183,6 +183,9 @@ functions:
   #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
   #     arango_database: ${ARANGO_DB:-example_graphs}
   #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #     # Required LangChain opt-in for generated AQL. Use read-only
+  #     # ArangoDB credentials to enforce retrieval-only access.
+  #     allow_dangerous_requests: true
   #     schema_description: |
   #       node_a vertices connect to node_b vertices through related_to edges.
   #       Replace these names with your existing graph schema.

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -239,8 +239,8 @@ functions:
   #   top_k: 5
   #   llm_name: ${LLM_MODEL_TYPE:-nim}_llm
   #   backend_config:
-  #     # Optional. Defaults to arango; custom providers can use provider_config.
-  #     provider: arango
+  #     # Optional. Defaults to arango_graph; custom providers can use provider_config.
+  #     provider: arango_graph
   #     # Provider-specific connection settings. These can also come from
   #     # ARANGO_* env vars.
   #     provider_config:

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -229,45 +229,32 @@ functions:
       timeout: 300
   # <<< frag
 
-  # >>> graph_rag: reference-only ArangoDB graph retrieval example
-  # VSS does not create, seed, or manage this graph. The database,
-  # collections, edges, and graph name must already exist in ArangoDB.
-  # To use this example, uncomment the block, replace the placeholder schema
-  # names, configure the ARANGO_* environment variables, and add the tool name
-  # to workflow.tool_names.
+  # >>> arango_graph: reference-only ArangoDB retrieval example
+  # VSS does not create, seed, or manage this graph. Point this tool at an
+  # existing ArangoDB graph and add it to workflow.tool_names.
   #
   # example_graph_retrieval:
   #   _type: knowledge_retrieval
-  #   backend: graph_rag
+  #   backend: arango_graph
   #   top_k: 5
   #   backend_config:
-  #     provider: langchain_arango
-  #
-  #     # LLM used by LangChain to generate read-only AQL and summarize results.
-  #     llm_model: ${LLM_NAME}
-  #     llm_base_url: ${LLM_BASE_URL}/v1
-  #     llm_api_key: ${NVIDIA_API_KEY:-}
-  #     temperature: 0.0
-  #     llm_reasoning: false
-  #
-  #     # Existing ArangoDB graph connection.
-  #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
-  #     arango_database: ${ARANGO_DB:-example_graphs}
-  #     arango_username: ${ARANGO_USER:-root}
-  #     arango_password: ${ARANGO_PASSWORD:-}
-  #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
-  #
-  #     # LangChain graph QA chains require this before running generated AQL.
-  #     # Use read-only ArangoDB credentials in production.
-  #     allow_dangerous_requests: true
-  #     return_intermediate_steps: true
-  #     max_aql_generation_attempts: 4
-  #
+  #     # Optional. Defaults to arango; custom providers can use provider_config.
+  #     provider: arango
+  #     llm_name: ${LLM_MODEL_TYPE:-nim}_llm
+  #     # Provider-specific connection settings. These can also come from
+  #     # ARANGO_* env vars.
+  #     provider_config:
+  #       arango_url: ${ARANGO_URL:-http://arango-db:8529}
+  #       arango_database: ${ARANGO_DB:-example_graphs}
+  #       arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
   #     schema_description: |
-  #       Example reference graph. node_a vertices connect to node_b vertices
-  #       through related_to edges. Replace these collection and edge names with
-  #       the schema from an existing ArangoDB graph.
-  #
+  #       node_a vertices connect to node_b vertices through related_to edges.
+  #       Replace these names with your existing graph schema.
+  #     allowed_vertex_collections:
+  #     - node_a
+  #     - node_b
+  #     allowed_edge_collections:
+  #     - related_to
   #     graph_semantics:
   #     - name: example_relationship
   #       user_terms: ["node", "related", "relationship", "connection"]
@@ -275,14 +262,7 @@ functions:
   #       edge_collection: related_to
   #       target_collection: node_b
   #       meaning: node_a records are connected to related node_b records.
-  #
-  #     allowed_vertex_collections:
-  #     - node_a
-  #     - node_b
-  #
-  #     allowed_edge_collections:
-  #     - related_to
-  # <<< graph_rag reference
+  # <<< arango_graph reference
 
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -239,14 +239,10 @@ functions:
   #   top_k: 5
   #   llm_name: ${LLM_MODEL_TYPE:-nim}_llm
   #   backend_config:
-  #     # Optional. Defaults to arango_graph; custom providers can use provider_config.
-  #     provider: arango_graph
-  #     # Provider-specific connection settings. These can also come from
-  #     # ARANGO_* env vars.
-  #     provider_config:
-  #       arango_url: ${ARANGO_URL:-http://arango-db:8529}
-  #       arango_database: ${ARANGO_DB:-example_graphs}
-  #       arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #     # Connection settings can also come from ARANGO_* env vars.
+  #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
+  #     arango_database: ${ARANGO_DB:-example_graphs}
+  #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
   #     schema_description: |
   #       node_a vertices connect to node_b vertices through related_to edges.
   #       Replace these names with your existing graph schema.

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -229,6 +229,61 @@ functions:
       timeout: 300
   # <<< frag
 
+  # >>> graph_rag: reference-only ArangoDB graph retrieval example
+  # VSS does not create, seed, or manage this graph. The database,
+  # collections, edges, and graph name must already exist in ArangoDB.
+  # To use this example, uncomment the block, replace the placeholder schema
+  # names, configure the ARANGO_* environment variables, and add the tool name
+  # to workflow.tool_names.
+  #
+  # example_graph_retrieval:
+  #   _type: knowledge_retrieval
+  #   backend: graph_rag
+  #   top_k: 5
+  #   backend_config:
+  #     provider: langchain_arango
+  #
+  #     # LLM used by LangChain to generate read-only AQL and summarize results.
+  #     llm_model: ${LLM_NAME}
+  #     llm_base_url: ${LLM_BASE_URL}/v1
+  #     llm_api_key: ${NVIDIA_API_KEY:-}
+  #     temperature: 0.0
+  #     llm_reasoning: false
+  #
+  #     # Existing ArangoDB graph connection.
+  #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
+  #     arango_database: ${ARANGO_DB:-example_graphs}
+  #     arango_username: ${ARANGO_USER:-root}
+  #     arango_password: ${ARANGO_PASSWORD:-}
+  #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #
+  #     # LangChain graph QA chains require this before running generated AQL.
+  #     # Use read-only ArangoDB credentials in production.
+  #     allow_dangerous_requests: true
+  #     return_intermediate_steps: true
+  #     max_aql_generation_attempts: 4
+  #
+  #     schema_description: |
+  #       Example reference graph. node_a vertices connect to node_b vertices
+  #       through related_to edges. Replace these collection and edge names with
+  #       the schema from an existing ArangoDB graph.
+  #
+  #     graph_semantics:
+  #     - name: example_relationship
+  #       user_terms: ["node", "related", "relationship", "connection"]
+  #       source_collection: node_a
+  #       edge_collection: related_to
+  #       target_collection: node_b
+  #       meaning: node_a records are connected to related node_b records.
+  #
+  #     allowed_vertex_collections:
+  #     - node_a
+  #     - node_b
+  #
+  #     allowed_edge_collections:
+  #     - related_to
+  # <<< graph_rag reference
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -237,10 +237,10 @@ functions:
   #   _type: knowledge_retrieval
   #   backend: arango_graph
   #   top_k: 5
+  #   llm_name: ${LLM_MODEL_TYPE:-nim}_llm
   #   backend_config:
   #     # Optional. Defaults to arango; custom providers can use provider_config.
   #     provider: arango
-  #     llm_name: ${LLM_MODEL_TYPE:-nim}_llm
   #     # Provider-specific connection settings. These can also come from
   #     # ARANGO_* env vars.
   #     provider_config:

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -243,6 +243,9 @@ functions:
   #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
   #     arango_database: ${ARANGO_DB:-example_graphs}
   #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #     # Required LangChain opt-in for generated AQL. Use read-only
+  #     # ArangoDB credentials to enforce retrieval-only access.
+  #     allow_dangerous_requests: true
   #     schema_description: |
   #       node_a vertices connect to node_b vertices through related_to edges.
   #       Replace these names with your existing graph schema.

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
@@ -169,6 +169,37 @@ functions:
       timeout: 300
   # <<< frag
 
+  # >>> arango_graph: reference-only ArangoDB retrieval example
+  # VSS does not create, seed, or manage this graph. Point this tool at an
+  # existing ArangoDB graph and add it to workflow.tool_names.
+  #
+  # example_graph_retrieval:
+  #   _type: knowledge_retrieval
+  #   backend: arango_graph
+  #   top_k: 5
+  #   llm_name: ${LLM_MODEL_TYPE:-nim}_llm
+  #   backend_config:
+  #     # Connection settings can also come from ARANGO_* env vars.
+  #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
+  #     arango_database: ${ARANGO_DB:-example_graphs}
+  #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #     schema_description: |
+  #       node_a vertices connect to node_b vertices through related_to edges.
+  #       Replace these names with your existing graph schema.
+  #     allowed_vertex_collections:
+  #     - node_a
+  #     - node_b
+  #     allowed_edge_collections:
+  #     - related_to
+  #     graph_semantics:
+  #     - name: example_relationship
+  #       user_terms: ["node", "related", "relationship", "connection"]
+  #       source_collection: node_a
+  #       edge_collection: related_to
+  #       target_collection: node_b
+  #       meaning: node_a records are connected to related node_b records.
+  # <<< arango_graph reference
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
@@ -183,6 +183,9 @@ functions:
   #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
   #     arango_database: ${ARANGO_DB:-example_graphs}
   #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #     # Required LangChain opt-in for generated AQL. Use read-only
+  #     # ArangoDB credentials to enforce retrieval-only access.
+  #     allow_dangerous_requests: true
   #     schema_description: |
   #       node_a vertices connect to node_b vertices through related_to edges.
   #       Replace these names with your existing graph schema.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
@@ -229,6 +229,37 @@ functions:
       timeout: 300
   # <<< frag
 
+  # >>> arango_graph: reference-only ArangoDB retrieval example
+  # VSS does not create, seed, or manage this graph. Point this tool at an
+  # existing ArangoDB graph and add it to workflow.tool_names.
+  #
+  # example_graph_retrieval:
+  #   _type: knowledge_retrieval
+  #   backend: arango_graph
+  #   top_k: 5
+  #   llm_name: ${LLM_MODEL_TYPE:-nim}_llm
+  #   backend_config:
+  #     # Connection settings can also come from ARANGO_* env vars.
+  #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
+  #     arango_database: ${ARANGO_DB:-example_graphs}
+  #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #     schema_description: |
+  #       node_a vertices connect to node_b vertices through related_to edges.
+  #       Replace these names with your existing graph schema.
+  #     allowed_vertex_collections:
+  #     - node_a
+  #     - node_b
+  #     allowed_edge_collections:
+  #     - related_to
+  #     graph_semantics:
+  #     - name: example_relationship
+  #       user_terms: ["node", "related", "relationship", "connection"]
+  #       source_collection: node_a
+  #       edge_collection: related_to
+  #       target_collection: node_b
+  #       meaning: node_a records are connected to related node_b records.
+  # <<< arango_graph reference
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
@@ -243,6 +243,9 @@ functions:
   #     arango_url: ${ARANGO_URL:-http://arango-db:8529}
   #     arango_database: ${ARANGO_DB:-example_graphs}
   #     arango_graph_name: ${ARANGO_GRAPH_NAME:-example_graph}
+  #     # Required LangChain opt-in for generated AQL. Use read-only
+  #     # ArangoDB credentials to enforce retrieval-only access.
+  #     allow_dangerous_requests: true
   #     schema_description: |
   #       node_a vertices connect to node_b vertices through related_to edges.
   #       Replace these names with your existing graph schema.

--- a/services/agent/packages/vss_agents/src/vss_agents/register_knowledge_layers.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/register_knowledge_layers.py
@@ -32,12 +32,13 @@ from pydantic import ConfigDict
 from pydantic import Field
 
 from vss_agents.tools.lvs_media_state import configured_media
+from vss_core.knowledge import BackendAdapter
 from vss_core.knowledge import RetrievalResult
 from vss_core.knowledge import get_retriever
 
 logger = logging.getLogger(__name__)
 
-BackendType = Literal["frag_api", "es_caption", "frag_lib", "llama_index", "langchain"]
+BackendType = Literal["frag_api", "es_caption", "frag_lib", "llama_index", "langchain", "arango_graph"]
 
 SUMMARIZE_SYSTEM_PROMPT = (
     "You are an analyst summarising retrieved knowledge-base excerpts. "
@@ -69,6 +70,8 @@ class KnowledgeRetrievalConfig(FunctionBaseConfig, name="knowledge_retrieval"):
             "(requires the `nvidia-vss[agent,llama_index]` extras); "
             "'langchain' = in-process LangChain over a Chroma-backed vector store "
             "(requires the `nvidia-vss[agent,langchain]` extras); "
+            "'arango_graph' = in-process LangChain graph QA over ArangoDB "
+            "(requires the `nvidia-vss[arango_graph]` extra); "
             "'es_caption' = BM25 over RT-VLM caption store in Elasticsearch."
         ),
     )
@@ -83,6 +86,14 @@ class KnowledgeRetrievalConfig(FunctionBaseConfig, name="knowledge_retrieval"):
         description=(
             "Backend-specific config dict, validated against the chosen backend's "
             "pydantic model at boot. Shape depends on `backend`."
+        ),
+    )
+    llm_name: LLMRef | None = Field(
+        default=None,
+        description=(
+            "Optional LLM reference used by backends that generate structured "
+            "queries, such as `arango_graph`. This must point to an entry under "
+            "`llms:` so the workflow builder can resolve the dependency."
         ),
     )
 
@@ -126,14 +137,34 @@ class KnowledgeRetrievalInput(BaseModel):
 
 
 def _setup_backend(config: KnowledgeRetrievalConfig, _builder: Builder) -> tuple[str, dict[str, Any]]:
-    return config.backend, config.backend_config or {}
+    return config.backend, dict(config.backend_config or {})
+
+
+async def _setup_retriever(
+    config: KnowledgeRetrievalConfig,
+    backend: str,
+    backend_config: dict[str, Any],
+    builder: Builder,
+) -> BackendAdapter:
+    if backend != "arango_graph":
+        return await get_retriever(backend, backend_config)
+
+    if not config.llm_name:
+        raise ValueError("arango_graph requires top-level `llm_name`, e.g. llm_name: nim_llm.")
+
+    from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+    from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+    llm = await builder.get_llm(config.llm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+    logger.info("knowledge_retrieval arango_graph LLM resolved: %s", config.llm_name)
+    return ArangoGraphAdapter(ArangoGraphConfig(**backend_config), llm=llm)
 
 
 @register_function(config_type=KnowledgeRetrievalConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def knowledge_retrieval(config: KnowledgeRetrievalConfig, builder: Builder) -> AsyncGenerator[FunctionInfo]:
     """Retrieve excerpts with citations from indexed knowledge sources."""
     backend, backend_config = _setup_backend(config, builder)
-    retriever = await get_retriever(backend, backend_config)
+    retriever = await _setup_retriever(config, backend, backend_config, builder)
 
     summary_llm: Any | None = None
     if config.generate_summary and config.summary_model:

--- a/services/agent/packages/vss_agents/tests/unit_test/test_register_knowledge_layers.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/test_register_knowledge_layers.py
@@ -28,6 +28,7 @@ from vss_agents.register_knowledge_layers import KnowledgeRetrievalConfig
 from vss_agents.register_knowledge_layers import KnowledgeRetrievalInput
 from vss_agents.register_knowledge_layers import _format_results
 from vss_agents.register_knowledge_layers import _setup_backend
+from vss_agents.register_knowledge_layers import _setup_retriever
 from vss_agents.register_knowledge_layers import knowledge_retrieval
 from vss_agents.tools.lvs_media_state import LVSConfiguredMedia
 from vss_core.knowledge.schema import Chunk
@@ -82,6 +83,68 @@ class TestSetupBackend:
             "timeout": 120,
             "verify_ssl": False,
         }
+
+    @pytest.mark.asyncio
+    async def test_non_arango_backend_uses_common_factory(self):
+        backend_config = {"rag_url": "http://rag:8081/v1"}
+        expected_retriever = MagicMock(name="retriever")
+
+        with patch(
+            "vss_agents.register_knowledge_layers.get_retriever",
+            new=AsyncMock(return_value=expected_retriever),
+        ) as get_retriever_mock:
+            retriever = await _setup_retriever(
+                KnowledgeRetrievalConfig(backend="frag_api"),
+                "frag_api",
+                backend_config,
+                AsyncMock(),
+            )
+
+        assert retriever is expected_retriever
+        get_retriever_mock.assert_awaited_once_with("frag_api", backend_config)
+
+    @pytest.mark.asyncio
+    async def test_arango_graph_resolves_configured_llm(self, monkeypatch):
+        import vss_core.knowledge.adapters.arango_graph as arango_graph
+
+        builder = AsyncMock()
+        resolved_llm = MagicMock(name="resolved_llm")
+        builder.get_llm.return_value = resolved_llm
+        backend_config = {"arango_database": "example_graphs"}
+
+        class FakeArangoGraphConfig:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        class FakeArangoGraphAdapter:
+            def __init__(self, config, llm):
+                self.config = config
+                self.llm = llm
+
+        monkeypatch.setattr(arango_graph, "ArangoGraphConfig", FakeArangoGraphConfig)
+        monkeypatch.setattr(arango_graph, "ArangoGraphAdapter", FakeArangoGraphAdapter)
+
+        retriever = await _setup_retriever(
+            KnowledgeRetrievalConfig(backend="arango_graph", llm_name="nim_llm"),
+            "arango_graph",
+            backend_config,
+            builder,
+        )
+
+        assert isinstance(retriever, FakeArangoGraphAdapter)
+        assert retriever.config.kwargs == {"arango_database": "example_graphs"}
+        assert retriever.llm is resolved_llm
+        builder.get_llm.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_arango_graph_requires_llm_name(self):
+        with pytest.raises(ValueError, match="llm_name"):
+            await _setup_retriever(
+                KnowledgeRetrievalConfig(backend="arango_graph"),
+                "arango_graph",
+                {},
+                AsyncMock(),
+            )
 
 
 class TestFormatResults:

--- a/services/agent/packages/vss_agents/tests/unit_test/test_register_knowledge_layers.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/test_register_knowledge_layers.py
@@ -51,7 +51,17 @@ class TestKnowledgeRetrievalConfig:
         assert cfg.backend == "frag_api"
         assert cfg.top_k == 5
         assert cfg.backend_config == {}
+        assert cfg.llm_name is None
         assert cfg.generate_summary is False
+
+    def test_arango_graph_accepts_top_level_llm_ref(self):
+        cfg = KnowledgeRetrievalConfig(
+            backend="arango_graph",
+            llm_name="nim_llm",
+            backend_config={"arango_database": "example_graphs"},
+        )
+        assert cfg.llm_name == "nim_llm"
+        assert "llm_name" not in cfg.backend_config
 
     def test_unknown_top_level_field_rejected(self):
         # `extra="forbid"` — backend-specific knobs (incl. collection_name)
@@ -85,20 +95,16 @@ class TestSetupBackend:
         }
 
     @pytest.mark.asyncio
-    async def test_non_arango_backend_uses_common_factory(self):
+    async def test_non_graph_backend_uses_common_factory(self):
         backend_config = {"rag_url": "http://rag:8081/v1"}
+        cfg = KnowledgeRetrievalConfig(backend="frag_api", backend_config=backend_config)
         expected_retriever = MagicMock(name="retriever")
 
         with patch(
             "vss_agents.register_knowledge_layers.get_retriever",
             new=AsyncMock(return_value=expected_retriever),
         ) as get_retriever_mock:
-            retriever = await _setup_retriever(
-                KnowledgeRetrievalConfig(backend="frag_api"),
-                "frag_api",
-                backend_config,
-                AsyncMock(),
-            )
+            retriever = await _setup_retriever(cfg, "frag_api", backend_config, AsyncMock())
 
         assert retriever is expected_retriever
         get_retriever_mock.assert_awaited_once_with("frag_api", backend_config)
@@ -111,6 +117,11 @@ class TestSetupBackend:
         resolved_llm = MagicMock(name="resolved_llm")
         builder.get_llm.return_value = resolved_llm
         backend_config = {"arango_database": "example_graphs"}
+        cfg = KnowledgeRetrievalConfig(
+            backend="arango_graph",
+            llm_name="nim_llm",
+            backend_config=backend_config,
+        )
 
         class FakeArangoGraphConfig:
             def __init__(self, **kwargs):
@@ -124,27 +135,19 @@ class TestSetupBackend:
         monkeypatch.setattr(arango_graph, "ArangoGraphConfig", FakeArangoGraphConfig)
         monkeypatch.setattr(arango_graph, "ArangoGraphAdapter", FakeArangoGraphAdapter)
 
-        retriever = await _setup_retriever(
-            KnowledgeRetrievalConfig(backend="arango_graph", llm_name="nim_llm"),
-            "arango_graph",
-            backend_config,
-            builder,
-        )
+        retriever = await _setup_retriever(cfg, "arango_graph", backend_config, builder)
 
         assert isinstance(retriever, FakeArangoGraphAdapter)
-        assert retriever.config.kwargs == {"arango_database": "example_graphs"}
+        assert retriever.config.kwargs == backend_config
         assert retriever.llm is resolved_llm
+        assert backend_config == {"arango_database": "example_graphs"}
         builder.get_llm.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_arango_graph_requires_llm_name(self):
+        cfg = KnowledgeRetrievalConfig(backend="arango_graph", backend_config={})
         with pytest.raises(ValueError, match="llm_name"):
-            await _setup_retriever(
-                KnowledgeRetrievalConfig(backend="arango_graph"),
-                "arango_graph",
-                {},
-                AsyncMock(),
-            )
+            await _setup_retriever(cfg, "arango_graph", {}, AsyncMock())
 
 
 class TestFormatResults:

--- a/services/agent/packages/vss_core/src/vss_core/knowledge/adapters/arango_graph.py
+++ b/services/agent/packages/vss_core/src/vss_core/knowledge/adapters/arango_graph.py
@@ -65,7 +65,8 @@ class ArangoGraphConfig(BaseModel):
         description="ArangoDB database name.",
     )
     arango_username: str = Field(
-        default_factory=lambda: os.environ.get("ARANGO_USER", os.environ.get("ARANGO_DB_USERNAME", "root")),
+        default_factory=lambda: os.environ.get("ARANGO_USER", os.environ.get("ARANGO_DB_USERNAME", "vss_graph_reader")),
+        description="ArangoDB username. Use a read-only graph user in production.",
     )
     arango_password: str | None = Field(
         default_factory=lambda: os.environ.get("ARANGO_PASSWORD", os.environ.get("ARANGO_DB_PASSWORD")),
@@ -77,10 +78,10 @@ class ArangoGraphConfig(BaseModel):
 
     # Query safety and output shape.
     allow_dangerous_requests: bool = Field(
-        default=True,
+        default=False,
         description=(
-            "Required by LangChain graph QA before generated AQL can run. "
-            "Use a read-only DB user and restricted schema/collections in production."
+            "Required LangChain opt-in before generated AQL can run. "
+            "This is not a security boundary; enforce read-only access with ArangoDB credentials."
         ),
     )
     return_intermediate_steps: bool = Field(
@@ -329,5 +330,5 @@ def _failure(query: str, backend: str, message: str) -> RetrievalResult:
 def _missing_dependency_message() -> str:
     return (
         "arango_graph requires `python-arango`, `langchain-community`, and `langchain-classic`. Install via:\n"
-        "  pip install 'vss-agents[arango_graph]'"
+        "  pip install 'nvidia-vss[arango_graph]'"
     )

--- a/services/agent/packages/vss_core/src/vss_core/knowledge/adapters/arango_graph.py
+++ b/services/agent/packages/vss_core/src/vss_core/knowledge/adapters/arango_graph.py
@@ -1,0 +1,333 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""LangChain-backed ArangoDB graph retrieval adapter.
+
+This backend is retrieval-only from the agent's point of view. It assumes an
+ArangoDB graph already exists, runs a LangChain graph QA chain over that graph,
+and normalises the graph answer/evidence into the common ``RetrievalResult``
+shape used by the VSS knowledge tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+from typing import ClassVar
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+from vss_core.knowledge.base import BackendAdapter
+from vss_core.knowledge.factory import register_adapter
+from vss_core.knowledge.schema import Chunk
+from vss_core.knowledge.schema import ContentType
+from vss_core.knowledge.schema import RetrievalResult
+
+logger = logging.getLogger(__name__)
+
+
+class GraphSemantic(BaseModel):
+    name: str = Field(description="Short semantic relationship name, e.g. example_relationship.")
+    user_terms: list[str] = Field(
+        default_factory=list,
+        description="User-facing terms that should map to this graph relationship.",
+    )
+    source_collection: str = Field(description="Source vertex collection.")
+    edge_collection: str = Field(description="Edge collection.")
+    target_collection: str = Field(description="Target vertex collection.")
+    meaning: str = Field(default="", description="Human-readable relationship meaning.")
+
+
+class ArangoGraphConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    arango_url: str = Field(
+        default_factory=lambda: os.environ.get("ARANGO_URL", "http://arango-db:8529"),
+        description="ArangoDB HTTP endpoint.",
+    )
+    arango_database: str = Field(
+        default_factory=lambda: os.environ.get("ARANGO_DB", "example_graphs"),
+        description="ArangoDB database name.",
+    )
+    arango_username: str = Field(
+        default_factory=lambda: os.environ.get("ARANGO_USER", os.environ.get("ARANGO_DB_USERNAME", "root")),
+    )
+    arango_password: str | None = Field(
+        default_factory=lambda: os.environ.get("ARANGO_PASSWORD", os.environ.get("ARANGO_DB_PASSWORD")),
+    )
+    arango_graph_name: str = Field(
+        default_factory=lambda: os.environ.get("ARANGO_GRAPH_NAME", "example_graph"),
+        description="ArangoDB named graph.",
+    )
+
+    # Query safety and output shape.
+    allow_dangerous_requests: bool = Field(
+        default=True,
+        description=(
+            "Required by LangChain graph QA before generated AQL can run. "
+            "Use a read-only DB user and restricted schema/collections in production."
+        ),
+    )
+    return_intermediate_steps: bool = Field(
+        default=True,
+        description="Include generated AQL/evidence metadata when supported by LangChain.",
+    )
+    max_aql_generation_attempts: int = Field(
+        default=3,
+        ge=1,
+        description="Maximum AQL generation/fix attempts.",
+    )
+
+    default_collection_name: str = Field(
+        default="",
+        description="Optional logical graph scope used when callers omit collection.",
+    )
+    schema_description: str = Field(
+        default="",
+        description="Human-readable graph schema contract appended to graph retrieval queries.",
+    )
+    allowed_vertex_collections: list[str] = Field(
+        default_factory=list,
+        description="Optional allowlist of vertex collections the chain should use.",
+    )
+    allowed_edge_collections: list[str] = Field(
+        default_factory=list,
+        description="Optional allowlist of edge collections the chain should use.",
+    )
+    graph_semantics: list[GraphSemantic] = Field(
+        default_factory=list,
+        description=(
+            "Compact semantic mapping from user terms to graph relationships. "
+            "The adapter uses this to guide generated graph queries without hardcoded domain AQL."
+        ),
+    )
+    arango_aql_examples: str = Field(
+        default="",
+        description=(
+            "Optional few-shot AQL examples passed to the Arango query-generation prompt. "
+            "Prefer graph_semantics for compact domain guidance; use this only for hard query-generation cases."
+        ),
+    )
+
+
+@register_adapter("arango_graph", config_type=ArangoGraphConfig)
+class ArangoGraphAdapter(BackendAdapter):
+    tool_description_hint: ClassVar[str] = (
+        "Use this backend for relationship-aware questions over an existing ArangoDB graph, "
+        "such as finding linked records, shared attributes, source artifacts, external "
+        "references, and connection paths. Optional filters may include domain scope "
+        "hints such as `record_id`, `entity_id`, `allowed_vertex_collections`, or "
+        "`allowed_edge_collections`."
+    )
+
+    def __init__(self, config: ArangoGraphConfig, llm: Any | None = None) -> None:
+        super().__init__(config)
+        if llm is None:
+            raise ValueError("arango_graph requires a resolved LangChain LLM from the VSS `llms` config.")
+        self._chain = self._build_chain(llm)
+        self.collection_name = config.default_collection_name
+        logger.info("arango_graph initialised: graph=%s database=%s", config.arango_graph_name, config.arango_database)
+
+    async def retrieve(
+        self,
+        query: str,
+        collection_name: str,
+        top_k: int = 5,
+        filters: dict[str, Any] | None = None,
+    ) -> RetrievalResult:
+        scoped_query = _apply_scope_hints(
+            query=query,
+            collection_name=collection_name or self.collection_name,
+            top_k=top_k,
+            filters=filters if isinstance(filters, dict) else None,
+        )
+        try:
+            result = await asyncio.to_thread(_invoke_chain, self._chain, scoped_query)
+        except Exception as e:
+            logger.exception("arango_graph retrieve failed")
+            return _failure(query, self.backend_name, f"Arango graph retrieval failed: {str(e)[:100]}")
+
+        answer, metadata = _normalise_chain_result(result)
+        if not answer:
+            answer = "Arango graph retrieval completed, but the provider returned no answer text."
+
+        chunk = Chunk(
+            chunk_id=_chunk_id(metadata),
+            content=answer,
+            score=1.0,
+            metadata={
+                "file_name": "arango_graph",
+                "display_citation": "[arango_graph]",
+                "content_type": ContentType.TEXT,
+                "graph_provider": "arango_graph",
+                "collection_name": collection_name or self.collection_name,
+                "source_metadata": metadata,
+            },
+        )
+        return RetrievalResult(
+            chunks=[chunk],
+            query=query,
+            backend=self.backend_name,
+            success=True,
+            total_tokens=len(answer.split()),
+            summary=answer,
+        )
+
+    async def health_check(self) -> bool:
+        return self._chain is not None
+
+    def _build_chain(self, llm: Any) -> Any:
+        try:
+            from langchain_classic.chains import ArangoGraphQAChain
+        except ImportError as e:
+            raise ImportError(_missing_dependency_message()) from e
+
+        return ArangoGraphQAChain.from_llm(
+            llm=llm,
+            graph=self._build_graph(),
+            aql_examples=self._query_guidance(),
+            allow_dangerous_requests=self.config.allow_dangerous_requests,
+            return_aql_query=self.config.return_intermediate_steps,
+            return_aql_result=self.config.return_intermediate_steps,
+            max_aql_generation_attempts=self.config.max_aql_generation_attempts,
+        )
+
+    def _build_graph(self) -> Any:
+        try:
+            from langchain_community.graphs import ArangoGraph
+        except ImportError as e:
+            raise ImportError(_missing_dependency_message()) from e
+
+        db = self._connect_db()
+        try:
+            return ArangoGraph(db, graph_name=self.config.arango_graph_name)
+        except TypeError as e:
+            if "graph_name" not in str(e):
+                raise
+            # langchain-community versions differ here: some accept a named
+            # graph, while current releases infer graph metadata from the DB.
+            return ArangoGraph(db)
+
+    def _connect_db(self) -> Any:
+        try:
+            from arango import ArangoClient
+        except ImportError as e:
+            raise ImportError(_missing_dependency_message()) from e
+
+        client = ArangoClient(hosts=self.config.arango_url)
+        return client.db(
+            self.config.arango_database,
+            username=self.config.arango_username,
+            password=self.config.arango_password,
+        )
+
+    def _query_guidance(self) -> str:
+        sections = []
+        if self.config.schema_description.strip():
+            sections.append("Graph schema description:\n" + self.config.schema_description.strip())
+        if self.config.allowed_vertex_collections:
+            sections.append(f"Allowed vertex collections: {self.config.allowed_vertex_collections!r}")
+        if self.config.allowed_edge_collections:
+            sections.append(f"Allowed edge collections: {self.config.allowed_edge_collections!r}")
+        semantic_guidance = self._format_graph_semantics()
+        if semantic_guidance:
+            sections.append(
+                "Graph semantic mappings. Use these mappings to translate user language into graph traversals:\n"
+                f"{semantic_guidance}"
+            )
+        if self.config.arango_aql_examples.strip():
+            sections.append("AQL examples:\n" + self.config.arango_aql_examples.strip())
+        return "\n\n".join(sections)
+
+    def _format_graph_semantics(self) -> str:
+        lines = []
+        for semantic in self.config.graph_semantics:
+            terms = ", ".join(semantic.user_terms) if semantic.user_terms else "n/a"
+            line = (
+                f"- {semantic.name}: user terms [{terms}] map "
+                f"{semantic.source_collection} --{semantic.edge_collection}-> {semantic.target_collection}"
+            )
+            if semantic.meaning:
+                line += f"; meaning: {semantic.meaning}"
+            lines.append(line)
+        return "\n".join(lines)
+
+
+def _apply_scope_hints(
+    *,
+    query: str,
+    collection_name: str,
+    top_k: int,
+    filters: dict[str, Any] | None,
+) -> str:
+    hints: list[str] = [f"Return at most {top_k} concise evidence item(s)."]
+    if collection_name:
+        hints.append(f"Use graph scope or collection named {collection_name!r} when applicable.")
+    if filters:
+        for key in (
+            "case_id",
+            "entity_id",
+            "defect_type",
+            "component_id",
+            "allowed_vertex_collections",
+            "allowed_edge_collections",
+        ):
+            if key in filters:
+                hints.append(f"{key}: {filters[key]!r}")
+    return f"{query}\n\nGraph retrieval constraints:\n- " + "\n- ".join(hints)
+
+
+def _invoke_chain(chain: Any, query: str) -> Any:
+    if hasattr(chain, "invoke"):
+        return chain.invoke({"query": query})
+    if callable(chain):
+        return chain({"query": query})
+    raise TypeError("LangChain graph chain does not expose invoke() or __call__()")
+
+
+def _normalise_chain_result(result: Any) -> tuple[str, dict[str, Any]]:
+    if isinstance(result, dict):
+        answer = result.get("result") or result.get("answer") or result.get("output") or result.get("text") or ""
+        metadata = {k: v for k, v in result.items() if k not in {"result", "answer", "output", "text"}}
+        return str(answer).strip(), metadata
+    return str(result).strip(), {}
+
+
+def _chunk_id(metadata: dict[str, Any]) -> str:
+    query = metadata.get("query") or metadata.get("generated_query") or metadata.get("aql") or metadata.get("aql_query")
+    if query:
+        return f"arango_graph_{abs(hash(str(query))) % 10_000_000}"
+    return "arango_graph_result"
+
+
+def _failure(query: str, backend: str, message: str) -> RetrievalResult:
+    logger.error("%s: %s", backend, message)
+    return RetrievalResult(
+        chunks=[],
+        query=query,
+        backend=backend,
+        success=False,
+        error_message=message,
+    )
+
+
+def _missing_dependency_message() -> str:
+    return (
+        "arango_graph requires `python-arango`, `langchain-community`, and `langchain-classic`. Install via:\n"
+        "  pip install 'vss-agents[arango_graph]'"
+    )

--- a/services/agent/packages/vss_core/src/vss_core/knowledge/factory.py
+++ b/services/agent/packages/vss_core/src/vss_core/knowledge/factory.py
@@ -39,6 +39,7 @@ _LAZY_BACKENDS: dict[str, str] = {
     "frag_lib": "vss_core.knowledge.adapters.frag_lib",
     "llama_index": "vss_core.knowledge.adapters.llama_index",
     "langchain": "vss_core.knowledge.adapters.langchain",
+    "arango_graph": "vss_core.knowledge.adapters.arango_graph",
 }
 
 

--- a/services/agent/packages/vss_core/tests/unit_test/knowledge_retrieval/test_arango_graph_adapter.py
+++ b/services/agent/packages/vss_core/tests/unit_test/knowledge_retrieval/test_arango_graph_adapter.py
@@ -240,7 +240,7 @@ class TestArangoGraphArango:
         assert fake_arango.graph_cls.call_args_list[1].args == (fake_arango.db,)
         fake_arango.chain_cls.from_llm.assert_called_once()
         chain_kwargs = fake_arango.chain_cls.from_llm.call_args.kwargs
-        assert chain_kwargs["allow_dangerous_requests"] is True
+        assert chain_kwargs["allow_dangerous_requests"] is False
         assert "node_a vertices connect to node_b vertices." in chain_kwargs["aql_examples"]
         assert "Allowed vertex collections: ['node_a', 'node_b']" in chain_kwargs["aql_examples"]
         assert "Allowed edge collections: ['related_to']" in chain_kwargs["aql_examples"]

--- a/services/agent/packages/vss_core/tests/unit_test/knowledge_retrieval/test_arango_graph_adapter.py
+++ b/services/agent/packages/vss_core/tests/unit_test/knowledge_retrieval/test_arango_graph_adapter.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for vss_core.knowledge.adapters.arango_graph.
+
+The graph packages are optional. These tests inject fake LangChain graph
+modules so the adapter contract is covered without requiring live graph DBs.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def fake_arango(monkeypatch):
+    arango_mod = ModuleType("arango")
+    client_instance = MagicMock(name="arango_client")
+    db = MagicMock(name="arango_db")
+    client_instance.db.return_value = db
+    client_cls = MagicMock(name="ArangoClient", return_value=client_instance)
+    arango_mod.ArangoClient = client_cls
+    monkeypatch.setitem(sys.modules, "arango", arango_mod)
+
+    community_mod = ModuleType("langchain_community")
+    graphs_mod = ModuleType("langchain_community.graphs")
+    graph_cls = MagicMock(name="ArangoGraph")
+    graph_cls.side_effect = [TypeError("unexpected keyword argument 'graph_name'"), MagicMock(name="arango_graph")]
+    graphs_mod.ArangoGraph = graph_cls
+    monkeypatch.setitem(sys.modules, "langchain_community", community_mod)
+    monkeypatch.setitem(sys.modules, "langchain_community.graphs", graphs_mod)
+
+    classic_mod = ModuleType("langchain_classic")
+    chains_mod = ModuleType("langchain_classic.chains")
+    chain = MagicMock(name="arango_chain")
+    chain.invoke.return_value = {
+        "result": "node_b_1 is related to node_a_1.",
+        "aql_query": "FOR n IN node_b RETURN n",
+    }
+    chain_cls = MagicMock(name="ArangoGraphQAChain")
+    chain_cls.from_llm.return_value = chain
+    chains_mod.ArangoGraphQAChain = chain_cls
+    monkeypatch.setitem(sys.modules, "langchain_classic", classic_mod)
+    monkeypatch.setitem(sys.modules, "langchain_classic.chains", chains_mod)
+    return SimpleNamespace(
+        llm=MagicMock(name="resolved_llm"),
+        client_cls=client_cls,
+        client_instance=client_instance,
+        db=db,
+        graph_cls=graph_cls,
+        chain_cls=chain_cls,
+        chain=chain,
+    )
+
+
+@pytest.fixture
+def functional_arango(monkeypatch):
+    arango_mod = ModuleType("arango")
+    client_instance = MagicMock(name="arango_client")
+    db = MagicMock(name="arango_db")
+    client_instance.db.return_value = db
+    client_cls = MagicMock(name="ArangoClient", return_value=client_instance)
+    arango_mod.ArangoClient = client_cls
+    monkeypatch.setitem(sys.modules, "arango", arango_mod)
+
+    state = SimpleNamespace(graph=None, chain=None)
+
+    class FakeArangoGraph:
+        schema = "node_a -> related_to -> node_b"
+
+        def __init__(self, db, graph_name=None):
+            self.db = db
+            self.graph_name = graph_name
+            self.queries = []
+            state.graph = self
+
+        def query(self, aql_query):
+            self.queries.append(aql_query)
+            assert "FOR a IN node_a" in aql_query
+            assert 'FILTER a._key == "node_a_1"' in aql_query
+            return [
+                {
+                    "source": "node_a_1",
+                    "related": "node_b_1",
+                    "evidence": "node_a_1 connects to node_b_1 through related_to.",
+                }
+            ]
+
+    community_mod = ModuleType("langchain_community")
+    graphs_mod = ModuleType("langchain_community.graphs")
+    graphs_mod.ArangoGraph = FakeArangoGraph
+    monkeypatch.setitem(sys.modules, "langchain_community", community_mod)
+    monkeypatch.setitem(sys.modules, "langchain_community.graphs", graphs_mod)
+
+    class FakeGraphQAChain:
+        output_key = "result"
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.llm = kwargs["llm"]
+            self.graph = kwargs["graph"]
+            self.aql_examples = kwargs["aql_examples"]
+            state.chain = self
+
+        @classmethod
+        def from_llm(cls, **kwargs):
+            return cls(**kwargs)
+
+        def invoke(self, payload):
+            query = payload["query"]
+            aql_query = self.llm.invoke(
+                {
+                    "task": "generate_aql",
+                    "schema": self.graph.schema,
+                    "aql_examples": self.aql_examples,
+                    "query": query,
+                }
+            )
+            aql_result = self.graph.query(aql_query)
+            answer = self.llm.invoke(
+                {
+                    "task": "answer",
+                    "query": query,
+                    "aql_query": aql_query,
+                    "aql_result": aql_result,
+                }
+            )
+            result = {self.output_key: answer}
+            if self.kwargs["return_aql_query"]:
+                result["aql_query"] = aql_query
+            if self.kwargs["return_aql_result"]:
+                result["aql_result"] = aql_result
+            return result
+
+    classic_mod = ModuleType("langchain_classic")
+    chains_mod = ModuleType("langchain_classic.chains")
+    chains_mod.ArangoGraphQAChain = FakeGraphQAChain
+    monkeypatch.setitem(sys.modules, "langchain_classic", classic_mod)
+    monkeypatch.setitem(sys.modules, "langchain_classic.chains", chains_mod)
+
+    class FakeLLM:
+        def __init__(self):
+            self.calls = []
+
+        def invoke(self, payload):
+            self.calls.append(payload)
+            if payload["task"] == "generate_aql":
+                assert "Example graph" in payload["aql_examples"]
+                assert "example_relationship" in payload["aql_examples"]
+                assert "node_a --related_to-> node_b" in payload["aql_examples"]
+                return (
+                    "FOR a IN node_a\n"
+                    '  FILTER a._key == "node_a_1"\n'
+                    "  FOR edge IN related_to\n"
+                    "    FILTER edge._from == a._id\n"
+                    "    RETURN edge"
+                )
+            return "node_b_1 is related to node_a_1 through related_to."
+
+    return SimpleNamespace(
+        llm=FakeLLM(),
+        client_cls=client_cls,
+        client_instance=client_instance,
+        db=db,
+        state=state,
+    )
+
+
+class TestArangoGraphImport:
+    def test_missing_resolved_llm_raises_clear_error(self):
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        with pytest.raises(ValueError, match=r"resolved LangChain LLM"):
+            ArangoGraphAdapter(ArangoGraphConfig())
+
+    def test_missing_arango_package_raises_clear_error(self, monkeypatch):
+        for mod in ("arango", "langchain_community.graphs", "langchain_classic.chains"):
+            monkeypatch.setitem(sys.modules, mod, None)
+
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        with pytest.raises(ImportError, match=r"python-arango"):
+            ArangoGraphAdapter(ArangoGraphConfig(), llm=MagicMock(name="resolved_llm"))
+
+
+class TestArangoGraphArango:
+    def test_constructs_arango_chain(self, fake_arango):
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        ArangoGraphAdapter(
+            ArangoGraphConfig(
+                arango_url="http://arango:8529",
+                arango_database="example_graphs",
+                arango_username="root",
+                arango_password="pw",
+                arango_graph_name="example_graph",
+                schema_description="node_a vertices connect to node_b vertices.",
+                allowed_vertex_collections=["node_a", "node_b"],
+                allowed_edge_collections=["related_to"],
+                graph_semantics=[
+                    {
+                        "name": "example_relationship",
+                        "user_terms": ["related", "relationship", "connection"],
+                        "source_collection": "node_a",
+                        "edge_collection": "related_to",
+                        "target_collection": "node_b",
+                        "meaning": "node_a records are connected to related node_b records.",
+                    }
+                ],
+            ),
+            llm=fake_arango.llm,
+        )
+
+        fake_arango.client_cls.assert_called_once_with(hosts="http://arango:8529")
+        fake_arango.client_instance.db.assert_called_once_with(
+            "example_graphs",
+            username="root",
+            password="pw",
+        )
+        assert fake_arango.graph_cls.call_args_list[0].kwargs == {"graph_name": "example_graph"}
+        assert fake_arango.graph_cls.call_args_list[1].args == (fake_arango.db,)
+        fake_arango.chain_cls.from_llm.assert_called_once()
+        chain_kwargs = fake_arango.chain_cls.from_llm.call_args.kwargs
+        assert chain_kwargs["allow_dangerous_requests"] is True
+        assert "node_a vertices connect to node_b vertices." in chain_kwargs["aql_examples"]
+        assert "Allowed vertex collections: ['node_a', 'node_b']" in chain_kwargs["aql_examples"]
+        assert "Allowed edge collections: ['related_to']" in chain_kwargs["aql_examples"]
+        assert "example_relationship" in chain_kwargs["aql_examples"]
+        assert "node_a --related_to-> node_b" in chain_kwargs["aql_examples"]
+        assert "node_a records are connected to related node_b records" in chain_kwargs["aql_examples"]
+
+    @pytest.mark.asyncio
+    async def test_arango_retrieve_preserves_metadata(self, fake_arango):
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        adapter = ArangoGraphAdapter(ArangoGraphConfig(), llm=fake_arango.llm)
+
+        result = await adapter.retrieve(query="Which nodes are related?", collection_name="example_graph")
+
+        assert result.success is True
+        chunk = result.chunks[0]
+        assert "node_b_1" in chunk.content
+        assert chunk.metadata["graph_provider"] == "arango_graph"
+        assert chunk.metadata["collection_name"] == "example_graph"
+        assert chunk.metadata["source_metadata"]["aql_query"] == "FOR n IN node_b RETURN n"
+
+    def test_arango_config_can_override_env_defaults(self, fake_arango):
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        ArangoGraphAdapter(
+            ArangoGraphConfig(
+                arango_url="http://custom-arango:8529",
+                arango_database="custom_db",
+                arango_username="custom_user",
+                arango_password="custom_pw",
+                arango_graph_name="custom_graph",
+            ),
+            llm=fake_arango.llm,
+        )
+
+        fake_arango.client_cls.assert_called_once_with(hosts="http://custom-arango:8529")
+        fake_arango.client_instance.db.assert_called_once_with(
+            "custom_db",
+            username="custom_user",
+            password="custom_pw",
+        )
+        assert fake_arango.graph_cls.call_args_list[0].kwargs == {"graph_name": "custom_graph"}
+
+    def test_arango_chain_passes_query_guidance(self, fake_arango):
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        ArangoGraphAdapter(
+            ArangoGraphConfig(
+                arango_aql_examples="FOR a IN node_a LIMIT 5 RETURN a",
+                max_aql_generation_attempts=4,
+                return_intermediate_steps=True,
+            ),
+            llm=fake_arango.llm,
+        )
+
+        chain_kwargs = fake_arango.chain_cls.from_llm.call_args.kwargs
+        assert "AQL examples:" in chain_kwargs["aql_examples"]
+        assert "FOR a IN node_a LIMIT 5 RETURN a" in chain_kwargs["aql_examples"]
+        assert chain_kwargs["return_aql_query"] is True
+        assert chain_kwargs["return_aql_result"] is True
+        assert chain_kwargs["max_aql_generation_attempts"] == 4
+
+    def test_arango_chain_allows_no_semantics_or_examples(self, fake_arango):
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        ArangoGraphAdapter(ArangoGraphConfig(), llm=fake_arango.llm)
+
+        chain_kwargs = fake_arango.chain_cls.from_llm.call_args.kwargs
+        assert chain_kwargs["aql_examples"] == ""
+
+    def test_arango_config_rejects_unknown_fields(self, fake_arango):
+        from pydantic import ValidationError
+
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            ArangoGraphAdapter(
+                ArangoGraphConfig(arango_database="example_graphs", unexpected=True),
+                llm=fake_arango.llm,
+            )
+
+    @pytest.mark.asyncio
+    async def test_arango_retrieve_runs_aql_generation_execution_and_answer_flow(self, functional_arango):
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphAdapter
+        from vss_core.knowledge.adapters.arango_graph import ArangoGraphConfig
+
+        adapter = ArangoGraphAdapter(
+            ArangoGraphConfig(
+                arango_url="http://arango:8529",
+                arango_database="example_graphs",
+                arango_graph_name="example_graph",
+                schema_description="Example graph. node_a vertices connect to node_b vertices.",
+                graph_semantics=[
+                    {
+                        "name": "example_relationship",
+                        "user_terms": ["related", "relationship", "connection"],
+                        "source_collection": "node_a",
+                        "edge_collection": "related_to",
+                        "target_collection": "node_b",
+                        "meaning": "node_a records are connected to related node_b records.",
+                    }
+                ],
+            ),
+            llm=functional_arango.llm,
+        )
+
+        result = await adapter.retrieve(
+            query="Which node_b records are related to node_a_1?",
+            collection_name="example_graph",
+            top_k=3,
+            filters={"entity_id": "node_a_1"},
+        )
+
+        assert result.success is True
+        assert result.summary == "node_b_1 is related to node_a_1 through related_to."
+        chunk = result.chunks[0]
+        assert chunk.content == result.summary
+        assert chunk.metadata["graph_provider"] == "arango_graph"
+        assert chunk.metadata["collection_name"] == "example_graph"
+        assert chunk.metadata["source_metadata"]["aql_query"].startswith("FOR a IN node_a")
+        assert chunk.metadata["source_metadata"]["aql_result"] == [
+            {
+                "source": "node_a_1",
+                "related": "node_b_1",
+                "evidence": "node_a_1 connects to node_b_1 through related_to.",
+            }
+        ]
+        assert functional_arango.state.graph.graph_name == "example_graph"
+        assert functional_arango.state.graph.queries == [chunk.metadata["source_metadata"]["aql_query"]]
+        assert functional_arango.llm.calls[0]["task"] == "generate_aql"
+        assert "entity_id: 'node_a_1'" in functional_arango.llm.calls[0]["query"]
+        assert "Return at most 3" in functional_arango.llm.calls[0]["query"]
+        assert functional_arango.llm.calls[1]["task"] == "answer"
+        assert functional_arango.llm.calls[1]["aql_result"][0]["related"] == "node_b_1"
+
+
+class TestArangoGraphHelpers:
+    def test_string_result_supported(self):
+        from vss_core.knowledge.adapters.arango_graph import _normalise_chain_result
+
+        answer, metadata = _normalise_chain_result("plain answer")
+        assert answer == "plain answer"
+        assert metadata == {}
+
+    def test_invoke_chain_uses_langchain_invoke(self):
+        from vss_core.knowledge.adapters.arango_graph import _invoke_chain
+
+        chain = MagicMock(name="chain")
+        chain.invoke.return_value = {"result": "node_b_1 is related."}
+
+        result = _invoke_chain(chain, "Find related nodes.")
+
+        assert result["result"] == "node_b_1 is related."
+        chain.invoke.assert_called_once_with({"query": "Find related nodes."})

--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -137,6 +137,11 @@ cli = ["nvidia-vss-cli"]
 # installs `--extra agent`. Keeping cli here means `uv sync --extra agent`
 # resolves every package the suite imports. Do NOT drop nvidia-vss-cli.
 agent = ["nvidia-vss-agents", "nvidia-vss-cli"]
+arango_graph = [
+    "langchain-classic>=1.0",
+    "langchain-community>=0.3.27",
+    "python-arango>=8.2",
+]
 all = ["nvidia-vss-agents", "nvidia-vss-cli"]
 
 [dependency-groups]

--- a/services/agent/uv.lock
+++ b/services/agent/uv.lock
@@ -3960,6 +3960,11 @@ all = [
     { name = "nvidia-vss-agents" },
     { name = "nvidia-vss-cli" },
 ]
+arango-graph = [
+    { name = "langchain-classic" },
+    { name = "langchain-community" },
+    { name = "python-arango" },
+]
 cli = [
     { name = "nvidia-vss-cli" },
 ]
@@ -3998,14 +4003,17 @@ eval = [
 
 [package.metadata]
 requires-dist = [
+    { name = "langchain-classic", marker = "extra == 'arango-graph'", specifier = ">=1.0" },
+    { name = "langchain-community", marker = "extra == 'arango-graph'", specifier = ">=0.3.27" },
     { name = "nvidia-vss-agents", marker = "extra == 'agent'", editable = "packages/vss_agents" },
     { name = "nvidia-vss-agents", marker = "extra == 'all'", editable = "packages/vss_agents" },
     { name = "nvidia-vss-cli", marker = "extra == 'agent'", editable = "packages/vss_cli" },
     { name = "nvidia-vss-cli", marker = "extra == 'all'", editable = "packages/vss_cli" },
     { name = "nvidia-vss-cli", marker = "extra == 'cli'", editable = "packages/vss_cli" },
     { name = "nvidia-vss-core", editable = "packages/vss_core" },
+    { name = "python-arango", marker = "extra == 'arango-graph'", specifier = ">=8.2" },
 ]
-provides-extras = ["agent", "all", "cli"]
+provides-extras = ["agent", "all", "arango-graph", "cli"]
 
 [package.metadata.requires-dev]
 cli-dev = [
@@ -5468,6 +5476,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "python-arango"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyjwt" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/c6/482b66f5acede5556ebc3723fc15b386b1d3bb119bc37e275e46b9735fad/python_arango-8.3.3.tar.gz", hash = "sha256:399df2edb2f52d50ec41c9115ac20b46550a4808edf76450d77cdf36efeb0cf2", size = 155272, upload-time = "2026-06-01T11:18:39.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/b0/99c4e9ddaa192dab822718fbc5ef558d240fee7bf576142b19a6ba207937/python_arango-8.3.3-py3-none-any.whl", hash = "sha256:c09bc68a9a331a772d6e4fdcbf16a5ef64c3038f90833e834492da6041463408", size = 116346, upload-time = "2026-06-01T11:18:38.684Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR adds an optional ArangoDB-backed GraphRAG retrieval layer for the VSS Agent knowledge retrieval framework.

The change introduces a `graph_rag` backend that lets VSS Agent query an externally managed ArangoDB graph as a retrieval tool. This is intended for user managed structured knowledge graphs where VSS should retrieve relationship-aware context, but should not own graph ingestion, schema design, or database lifecycle.

Key changes:
- Added GraphRAG adapter support for ArangoDB via LangChain graph QA.
- Added top-level `llm_name` support to `knowledge_retrieval` so graph backends can use a configured VSS Agent LLM for structured query generation. Quality of AQL generated depends on LLM used.
- Kept backend-specific graph connection settings isolated under `backend_config`.
- Added reference-only commented GraphRAG config examples to developer RAG configs.
- Added unit tests covering GraphRAG adapter behavior and retrieval config wiring.

This keeps GraphRAG optional: existing knowledge retrieval backends are unchanged, and graph dependencies are only required when the `graph_rag` backend is enabled.

### Verifiction

- Results include correct answer using graph traversal - 
<img width="2111" height="711" alt="image" src="https://github.com/user-attachments/assets/26e3fa19-5d3b-4f9d-b17c-250e295dcf86" />

- 
<img width="2111" height="529" alt="image" src="https://github.com/user-attachments/assets/bedfd82b-ab85-4025-82a8-a46084acc5a4" />



## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
