### PR TITLE
Tear down the RTSP proxy on delete even for never-streamed streams

### DIFF
--- a/services/vios/src/modules/rtsp_server/rtspservermanager.cpp
+++ b/services/vios/src/modules/rtsp_server/rtspservermanager.cpp
@@ -746,11 +746,38 @@ VmsErrorCode RtspServerManager::handleStreamDelete(const std::string &streamId, 
     }
 
     VmsErrorCode eventResult = VmsErrorCode::NoError;
+    bool proxyTornDownByEvent = false;
     if (!streamUrl.empty() && parentSensorType != std::string(SENSOR_TYPE_FILE))
     {
         StreamEncParam details;
         eventResult = StreamEventManager::getInstance().sendEventBlocking(
             streamUrl, STREAM_STATUS_REMOVED, details);
+        /* The STREAM_STATUS_REMOVED path (RtspStreamStatusCallback -> removeStream)
+         * synchronously tears down the RTSP proxy for this stream. */
+        proxyTornDownByEvent = true;
+    }
+
+    /* Tear down the RTSP proxy here only if the STREAM_STATUS_REMOVED path above
+     * did NOT run. That path is skipped when the stream never reached STREAMING
+     * (the back-end DESCRIBE never succeeded, e.g. a cold or unreachable source):
+     * sdpReady/registerStreamAsync never ran, so the stream is absent from the
+     * device-manager stream list and streamUrl is empty. Without this, removeProxy
+     * is never invoked and the ProxyServerMediaSession (with its self-rescheduling
+     * ProxyRTSPClient) is orphaned and keeps contacting the source forever. The
+     * guard ensures removeProxy runs exactly once - no redundant call on the
+     * normal (streaming) delete path. */
+    if (!proxyTornDownByEvent && deviceManager->needRtspServer)
+    {
+        int lbResult = m_lb.removeStream(streamId);
+        if (lbResult != 0)
+        {
+            /* Surface (do not silently swallow) a proxy-teardown failure - e.g.
+             * deleteProxy timing out in the load balancer - so it is not masked
+             * as success. Mirrors removeStream()'s handling of the same call. */
+            LOG(error) << "Failed to remove RTSP proxy for never-streamed stream id: "
+                       << streamId << endl;
+            eventResult = VmsErrorCode::VMSInternalError;
+        }
     }
 
     // For SENSOR_TYPE_FILE, remove the uploaded file from disk before the


### PR DESCRIPTION
## Description
* handleStreamDelete only fired STREAM_STATUS_REMOVED - which drives the proxy teardown (removeStream -> removeProxy -> deleteServerMediaSession) - when the stream was present in the device-manager stream list with a live_proxy_url.
* That list entry is created by registerStreamAsync, which runs only after the back-end DESCRIBE succeeds (sdpReady). A sensor whose source never becomes SDP-ready (cold or unreachable back-end) is therefore never torn down, leaving an orphaned ProxyServerMediaSession whose ProxyRTSPClient keeps retrying DESCRIBE against the source indefinitely.
* Remove the proxy directly in handleStreamDelete when the STREAM_STATUS_REMOVED path was skipped, so teardown happens exactly once regardless of streaming state and without a redundant removeProxy on the normal delete path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
