### PR TITLE
Update RTVI_VLM_IMAGE_TAG in warehouse operations overrides.env to sp…

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -183,9 +183,8 @@ SDR_CONTROLLER_CONFIG_PATH=${VSS_APPS_DIR}/industry-profiles/warehouse-operation
 # Use the regular multi-arch tag by default; switch to the commented sbsa tag for DGX-SPARK/SBSA images.
 PERCEPTION_TAG="3.3.0-26.07.1"
 # PERCEPTION_TAG="3.3.0-sbsa-26.07.1"
-# Use the regular multi-arch tag by default; switch to the commented sbsa tag for DGX-SPARK/SBSA images.
+# RTVI-VLM image tag for x86_64
 RTVI_VLM_IMAGE_TAG="3.2.1"
-#RTVI_VLM_IMAGE_TAG="3.2.1-sbsa"
 
 # =============================================================================
 # COMPOSE PROFILE SELECTION


### PR DESCRIPTION
…ecify x86_64 image tag

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
