### PR TITLE
ci(build-dev-images): re-tag unchanged content instead of rebuilding

### DIFF
--- a/.github/scripts/container_build_plan.py
+++ b/.github/scripts/container_build_plan.py
@@ -22,6 +22,10 @@ class CandidateCoordinates:
     image: str
     tag: str
     tree_sha: str
+    # Content-addressed alias: identical source content shares this tag across
+    # commits, so a later build of unchanged content can re-tag from it instead
+    # of rebuilding (see ghcr_image_guard.py `reuse`).
+    content_tag: str
 
 
 @dataclass(frozen=True)
@@ -61,6 +65,7 @@ def candidate_coordinates(
         image=f"ghcr.io/{normalized_owner}/vss/{image_name}",
         tag=tag,
         tree_sha=tree_sha,
+        content_tag=f"tree-{tree_sha}",
     )
 
 
@@ -158,6 +163,7 @@ def main() -> int:
                 "tag": coordinates.tag,
                 "tree_sha": coordinates.tree_sha,
                 "image": coordinates.image,
+                "content_tag": coordinates.content_tag,
             },
         )
         print(

--- a/.github/scripts/ghcr_image_guard.py
+++ b/.github/scripts/ghcr_image_guard.py
@@ -69,6 +69,27 @@ def preflight_decision(
     )
 
 
+def reuse_decision(
+    labels: ImageManifestLabels | None,
+    reason: str | None,
+    expected_tree_sha: str,
+) -> tuple[bool, str]:
+    """Return ``(reuse, message)`` for the content-addressed re-tag path.
+
+    ``reuse`` is True only when a content-addressed image already exists AND
+    carries the exact source-tree SHA we would otherwise build — in which case
+    the caller can re-tag from it instead of rebuilding identical content.
+
+    Fail-*open* to a rebuild: a missing content tag, a mislabelled one, or any
+    fetch error just means "no safe shortcut — build normally". Unlike
+    preflight, this can never fail the job; the worst case is the status quo.
+    """
+    if labels and labels.source_tree_sha == expected_tree_sha:
+        return True, "content-addressed image already published; re-tagging instead of rebuilding"
+    detail = labels.source_tree_sha if labels else f"<no label: {reason}>"
+    return False, f"no reusable image for this content ({detail}); building"
+
+
 def verify_decision(
     labels: ImageManifestLabels | None,
     reason: str | None,
@@ -121,6 +142,14 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     return 1 if action == "fail" else 0
 
 
+def cmd_reuse(args: argparse.Namespace) -> int:
+    labels, reason, _ = read_image_manifest_labels(args.ref)
+    reuse, message = reuse_decision(labels, reason, args.expect_tree_sha)
+    print(f"{args.ref}: {message}")
+    _emit_output("reuse", "true" if reuse else "false")
+    return 0
+
+
 def cmd_verify(args: argparse.Namespace) -> int:
     labels, reason, _ = read_image_manifest_labels(args.ref)
     ok, message = verify_decision(
@@ -142,6 +171,12 @@ def main() -> int:
     preflight.add_argument("--ref", required=True, help="registry/name:tag")
     preflight.add_argument("--expect-tree-sha", required=True)
 
+    reuse = sub.add_parser(
+        "reuse", help="check whether a content-addressed image can be re-tagged"
+    )
+    reuse.add_argument("--ref", required=True, help="registry/name:content-tag")
+    reuse.add_argument("--expect-tree-sha", required=True)
+
     verify = sub.add_parser("verify", help="verify pushed labels match the source")
     verify.add_argument("--ref", required=True)
     verify.add_argument("--expect-tree-sha", required=True)
@@ -149,7 +184,9 @@ def main() -> int:
     verify.add_argument("--expect-image-name", required=True)
 
     args = parser.parse_args()
-    return {"preflight": cmd_preflight, "verify": cmd_verify}[args.command](args)
+    return {"preflight": cmd_preflight, "reuse": cmd_reuse, "verify": cmd_verify}[
+        args.command
+    ](args)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_container_build_plan.py
+++ b/.github/scripts/test_container_build_plan.py
@@ -35,6 +35,7 @@ class CandidateCoordinatesTest(unittest.TestCase):
             "ghcr.io/nvidia-ai-blueprints/vss/vss-agent",
         )
         self.assertEqual(result.tag, "pr-1190-" + "a" * 12)
+        self.assertEqual(result.content_tag, "tree-" + TREE)
 
     def test_develop_coordinates(self):
         result = candidate_coordinates(

--- a/.github/scripts/test_ghcr_image_guard.py
+++ b/.github/scripts/test_ghcr_image_guard.py
@@ -24,7 +24,7 @@ from check_container_tag_source import (  # noqa: E402
     ImageManifestLabels,
     _fetch_bearer_token,
 )
-from ghcr_image_guard import preflight_decision, verify_decision  # noqa: E402
+from ghcr_image_guard import preflight_decision, reuse_decision, verify_decision  # noqa: E402
 
 TREE = "a" * 40
 OTHER_TREE = "b" * 40
@@ -59,6 +59,27 @@ class PreflightTest(unittest.TestCase):
     def test_same_content_rerun_skips(self):
         action, _ = preflight_decision(labels(), None, TREE)
         self.assertEqual(action, "skip")
+
+
+class ReuseTest(unittest.TestCase):
+    def test_same_content_reuses(self):
+        reuse, _ = reuse_decision(labels(), None, TREE)
+        self.assertTrue(reuse)
+
+    def test_missing_content_builds(self):
+        reuse, _ = reuse_decision(
+            None, "index fetch failed: GET https://x returned 404: Not Found", TREE
+        )
+        self.assertFalse(reuse)
+
+    def test_different_content_builds(self):
+        reuse, _ = reuse_decision(labels(tree=OTHER_TREE), None, TREE)
+        self.assertFalse(reuse)
+
+    def test_error_fails_open_to_build(self):
+        # Unlike preflight, an error never fails the job — it just builds.
+        reuse, _ = reuse_decision(None, "network error fetching https://x", TREE)
+        self.assertFalse(reuse)
 
     def test_different_content_fails(self):
         action, message = preflight_decision(labels(tree=OTHER_TREE), None, TREE)

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -130,16 +130,39 @@ jobs:
             --ref "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}" \
             --expect-tree-sha "${{ steps.meta.outputs.tree_sha }}"
 
-      - name: Set up QEMU (arm64 emulation)
+      # Content-addressed reuse: if this exact source tree was already built and
+      # published under the content tag (tree-<tree_sha>), re-tag that multiarch
+      # manifest onto the per-commit tag instead of rebuilding identical content
+      # (which otherwise recompiles under slow arm64 QEMU emulation). Fail-open:
+      # a missing/mislabelled content tag or any error just builds normally.
+      - name: Check for reusable image (identical content)
+        id: reuse
         if: steps.preflight.outputs.skip != 'true'
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/scripts/ghcr_image_guard.py reuse \
+            --ref "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.content_tag }}" \
+            --expect-tree-sha "${{ steps.meta.outputs.tree_sha }}"
+
+      - name: Re-tag existing content onto the immutable candidate tag
+        if: steps.preflight.outputs.skip != 'true' && steps.reuse.outputs.reuse == 'true'
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}" \
+            "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.content_tag }}"
+
+      - name: Set up QEMU (arm64 emulation)
+        if: steps.preflight.outputs.skip != 'true' && steps.reuse.outputs.reuse != 'true'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
 
       - name: Set up Buildx
-        if: steps.preflight.outputs.skip != 'true'
+        if: steps.preflight.outputs.skip != 'true' && steps.reuse.outputs.reuse != 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
 
       - name: Build and push (multiarch, immutable tag only)
-        if: steps.preflight.outputs.skip != 'true'
+        if: steps.preflight.outputs.skip != 'true' && steps.reuse.outputs.reuse != 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
         with:
           context: ${{ matrix.context }}
@@ -148,8 +171,11 @@ jobs:
           push: true
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          # Publish the content-addressed alias too so a later build of the same
+          # source tree can re-tag from it instead of rebuilding.
           tags: |
             ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.content_tag }}
           labels: |
             com.nvidia.vss.image_name=${{ matrix.name }}
             com.nvidia.vss.source_path=${{ matrix.source_path }}


### PR DESCRIPTION
## Problem
Images in a **shared-tag set** (`vss-agent` + `vss-agent-ui` + `vss-alert-ms`) are all rebuilt whenever *any* member changes, so they share one immutable tag. When only `vss-agent` changes, `vss-agent-ui` still gets a **full multi-arch rebuild** — its `linux/arm64` layer recompiled under **QEMU emulation** — purely to mint a new per-commit tag pointing at **byte-identical** source. Observed on #1379: the UI image took **~15 min** (vs ~7.5 min for the agent that actually changed), and it wasn't a cache-hit re-tag.

Root cause: the immutable tag is per-commit (`pr-N-<commit12>`), so a new commit → new tag → the preflight's "identical content re-run" skip never fires, even when the `source_tree_sha` is unchanged.

## Fix — content-addressed re-tag
- **`container_build_plan.py`**: also emit `content_tag = "tree-<source_tree_sha>"` (a stable alias for identical content).
- **`build-dev-images.yml`**:
  - `build & push` also publishes `image:content_tag`.
  - A new **reuse** step checks whether `image:content_tag` already exists with the matching tree-sha; if so, `docker buildx imagetools create` **copies that multi-arch manifest onto the per-commit tag** and QEMU/Buildx/build are skipped (seconds vs minutes).
- **`ghcr_image_guard.py`**: new `reuse` subcommand. **Fail-open** — a missing/mislabelled content tag or any fetch error just builds normally; it can never fail the job (unlike the immutability `preflight`, which fails closed).

Immutability + provenance are preserved: the per-commit tag is still write-once, and the copied manifest carries the same `source_tree_sha`/`source_path`/`image_name` annotations, so the existing **Verify pushed labels** gate and the digest/fragment steps run unchanged.

## Tests
Added unit coverage for `content_tag` and `reuse_decision` (fail-open on 404/mismatch/error). `python3 -m unittest test_container_build_plan test_ghcr_image_guard` → **21 pass**. yamllint clean.

## ⚠️ Not validated against a live pipeline
Needs a real GHCR + buildx run to confirm:
1. `docker buildx imagetools create` **preserves the index-level `com.nvidia.vss.source_tree_sha` annotation** so the post-copy **Verify** gate passes. *(If it strips annotations, the copy step must re-apply them.)*
2. The **first** build of any tree-sha still runs (content tag not yet published); reuse only kicks in on **subsequent** identical-content builds — so the first PR after merge won't show savings.

CI owners (@hugoverjus — you've been in `fix-container-source-gate`) should confirm (1) and (2) before this leaves draft. Also worth a policy check: is rebuild-per-commit intentional for supply-chain attestation? A copied digest was still built in this same pipeline, so it's generally fine — but that's your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)