### PR TITLE
fix(skill): narrow search capability owner

### DIFF
--- a/skills/vss-build-vision-agent/references/profiles/search.md
+++ b/skills/vss-build-vision-agent/references/profiles/search.md
@@ -20,7 +20,7 @@ kibana-init-container-search,vss-search-analytics-2d-fusion,vss-video-analytics-
 
 | Owner | Service profile keys |
 |---|---|
-| Search | `vss-search-analytics-2d-fusion`, `vss-video-analytics-api-fusion` |
+| Search | `vss-search-analytics-2d-fusion` |
 | RT-CV | `perception-2d-init`, `perception-2d-fusion` |
 | RT-Embed | `rtvi-embed` |
 | RT-VLM | `rtvi-vlm` |

--- a/skills/vss-build-vision-agent/references/profiles/search.md
+++ b/skills/vss-build-vision-agent/references/profiles/search.md
@@ -3,7 +3,7 @@
 ## Capabilities and routing cues
 
 - Video ingest, RT-CV detection/tracking, RT-Embed video/text embeddings,
-  Elasticsearch retrieval, and optional VLM critique.
+  Elasticsearch retrieval, and default-enabled VLM critique.
 - Choose for natural-language video search or combined ingestion + detection +
   embedding requests.
 
@@ -36,7 +36,7 @@ kibana-init-container-search,vss-search-analytics-2d-fusion,vss-video-analytics-
 | `RT_CV_DEVICE_ID`, `RTVI_CV_HOST_PORT`, `MODEL_TYPE`, `MODEL_NAME_2D` | Configure the perception pipeline. |
 | `VISION_ENCODER_MODEL`, `VISION_ENCODER_VERSION` | Select the vision encoder NGC artifact owned by `perception-2d-init`; the checked-in RT-CV config uses the fixed RT-DETR warehouse artifact. |
 | `RT_EMBED_DEVICE_ID`, `RTVI_EMBED_PORT`, `MODEL_PATH`, `HF_TOKEN` | Place and configure RT-Embed. |
-| `ENABLE_CRITIC`, `VLM_NAME`, `VLM_BASE_URL`, `VLM_MODEL_TYPE`, `RTVI_VLM_*` | Enable and configure optional result critique through RT-VLM. |
+| `ENABLE_CRITIC`, `VLM_NAME`, `VLM_BASE_URL`, `VLM_MODEL_TYPE`, `RTVI_VLM_*` | Configure default-enabled result critique through RT-VLM; set `ENABLE_CRITIC=false` only when critique is explicitly excluded. |
 | `COSMOS_EMBED_ENDPOINT`, `ELASTIC_SEARCH_ENDPOINT`, `ELASTIC_SEARCH_INDEX` | Wire the agent to embedding and retrieval services. |
 | `ELASTICSEARCH_ENABLE_EMBEDDINGS`, `ELASTICSEARCH_RTVI_CV_EMBEDDINGS_DIM`, `ELASTICSEARCH_VISION_LLM_EMBEDDINGS_DIM` | Configure indexed vectors. |
 | `LLM_DEVICE_ID`, `RT_VLM_DEVICE_ID`, `RESERVED_DEVICE_IDS`, `FIXED_SHARED_DEVICE_IDS` | Preserve the intended multi-GPU layout. |
@@ -52,7 +52,8 @@ curl -sf "http://${HOST_IP}:9200/_cluster/health"
 curl -sf "http://${HOST_IP}:3000/"
 ```
 
-When `ENABLE_CRITIC=true`, also probe RT-VLM's `/v1/models` endpoint.
+Because critique is enabled by default, also probe RT-VLM's `/v1/models`
+endpoint. Skip this check only when `ENABLE_CRITIC=false`.
 
 ## Sources
 

--- a/skills/vss-build-vision-agent/references/services/search.md
+++ b/skills/vss-build-vision-agent/references/services/search.md
@@ -12,8 +12,8 @@
   profile's VIOS/NvStreamer path.
 - Agent search requires `COSMOS_EMBED_ENDPOINT`, `ELASTIC_SEARCH_ENDPOINT`, and
   `ELASTIC_SEARCH_INDEX`.
-- RT-VLM is required only when critique is enabled; omit it when critique is
-  disabled.
+- Critique is enabled by default, so RT-VLM is required unless the user
+  explicitly disables critique.
 
 ## Configuration knobs
 
@@ -23,7 +23,7 @@
 | `STREAM_TYPE` | Select the checked-in Kafka or Redis analytics config. |
 | `COSMOS_EMBED_ENDPOINT` | Point the Agent at RT-Embed. |
 | `ELASTIC_SEARCH_ENDPOINT`, `ELASTIC_SEARCH_INDEX` | Point the Agent at indexed search data. |
-| `ENABLE_CRITIC` | Add or remove critique VLM requirements. |
+| `ENABLE_CRITIC` | Keep critique enabled by default; set to `false` only when the user explicitly disables critique. |
 
 ## Sources
 

--- a/skills/vss-build-vision-agent/references/services/search.md
+++ b/skills/vss-build-vision-agent/references/services/search.md
@@ -5,7 +5,6 @@
 | Capability | Canonical service profile keys |
 |---|---|
 | Search analytics and indexing flow | `vss-search-analytics-2d-fusion` |
-| Search HTTP API | `vss-video-analytics-api-fusion` |
 
 ## Required peers
 
@@ -13,19 +12,18 @@
   profile's VIOS/NvStreamer path.
 - Agent search requires `COSMOS_EMBED_ENDPOINT`, `ELASTIC_SEARCH_ENDPOINT`, and
   `ELASTIC_SEARCH_INDEX`.
-- VLM NIM is required only when critique is enabled.
+- RT-VLM is required only when critique is enabled; omit it when critique is
+  disabled.
 
 ## Configuration knobs
 
 | Environment variable | Use |
 |---|---|
 | `VSS_BEHAVIOR_ANALYTICS_IMAGE`, `VSS_BEHAVIOR_ANALYTICS_TAG` | Select the Search analytics image inherited from Behavior Analytics. |
-| `VSS_VIDEO_ANALYTICS_API_IMAGE`, `VSS_VIDEO_ANALYTICS_API_TAG`, `MDX_PORT` | Configure the Search API image and port. |
 | `STREAM_TYPE` | Select the checked-in Kafka or Redis analytics config. |
 | `COSMOS_EMBED_ENDPOINT` | Point the Agent at RT-Embed. |
 | `ELASTIC_SEARCH_ENDPOINT`, `ELASTIC_SEARCH_INDEX` | Point the Agent at indexed search data. |
 | `ENABLE_CRITIC` | Add or remove critique VLM requirements. |
-| `REACT_APP_API_ENDPOINT_BASE_URL`, `UI_PORT` | Configure the Search UI/API route where exposed. |
 
 ## Sources
 
@@ -33,5 +31,4 @@
 - `deploy/docker/developer-profiles/dev-profile-search/overrides.env`
 - `deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml`
 - `deploy/docker/services/analytics/behavior-analytics/compose.yml`
-- `deploy/docker/services/analytics/video-analytics-api/compose.yml`
 - `skills/vss-search-archive/references/deployment_resolution.md`


### PR DESCRIPTION
## Summary

- remove `vss-video-analytics-api-fusion` from the Search capability-owner contract
- keep the stock Search Foundation service set unchanged and authoritative
- identify RT-VLM as optional when critique is disabled
- remove Video Analytics API and stale legacy UI/API knobs from the Search owner reference

## Why

The archived Agent search path uses RT-Embed and Elasticsearch directly. It does not require the Video Analytics API service. Keeping that service in the owner contract caused lean Search-derived deltas to retain an unrelated API surface.

The stock Search profile still activates `vss-video-analytics-api-fusion`; exact stock deployments continue to preserve that checked-in set.

## Validation

- `quick_validate.py skills/vss-build-vision-agent`
- `git diff --check`
- DCO-signed commit

## Review focus

Confirm the distinction between the exact stock Foundation service set and the minimal Search capability-owner dependency set.