### PR TITLE
fix(config): default agent_version when VSS_AGENT_VERSION is unset (warehouse/smartcities)

### DIFF
--- a/deploy/docker/industry-profiles/smartcities/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/smartcities/vss-agent/configs/config.yml
@@ -107,7 +107,7 @@ functions:
     base_url: ${VSS_AGENT_REPORTS_BASE_URL}
     template_path: ${VSS_AGENT_TEMPLATE_PATH}
     template_name: ${VSS_AGENT_TEMPLATE_NAME}
-    agent_version: ${VSS_AGENT_VERSION}
+    agent_version: ${VSS_AGENT_VERSION:-dev}
     llm_name: ${LLM_MODEL_TYPE:-nim}_llm
     video_understanding_tool: video_understanding
     picture_url_tool: vst_picture_url

--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
@@ -101,7 +101,7 @@ functions:
     base_url: ${VSS_AGENT_REPORTS_BASE_URL}
     template_path: ${VSS_AGENT_TEMPLATE_PATH}
     template_name: ${VSS_AGENT_TEMPLATE_NAME}
-    agent_version: ${VSS_AGENT_VERSION}
+    agent_version: ${VSS_AGENT_VERSION:-dev}
     llm_name: llm
     video_understanding_tool: video_understanding
     picture_url_tool: vst_picture_url


### PR DESCRIPTION
## Problem
`warehouse-operations` and `smartcities` set `agent_version: ${VSS_AGENT_VERSION}` with **no default**. When `VSS_AGENT_VERSION` isn't exported (the CI blueprint-eval deploy env doesn't set it), NAT interpolates `None`, failing the `str` validation for `functions.template_report_gen.agent_version` → **`vss-agent` container unhealthy** → the deploy/eval fails.

Surfaced by the gating `eval-warehouse-bp-wh-2d` job failing across branches:
```
pydantic_core.ValidationError: functions.template_report_gen.template_report_gen.agent_version
  Input should be a valid string [input_value=None]
```

## Fix
`${VSS_AGENT_VERSION}` → `${VSS_AGENT_VERSION:-dev}` in both configs. NAT config already uses `:-` defaults (`${LLM_MODEL_TYPE:-nim}`, `${ENABLE_AUDIO:-false}`), and the field's own default is `v1.0.0`, so a fallback is the intended behavior. Real deploys that set `VSS_AGENT_VERSION` are unaffected.

## Scope / not-a-regression
The line is identical across branches (not introduced by any recent PR); the warehouse eval fails the same way on other develop-based MRs. This fixes it repo-wide.

> Note: the downstream eval suite currently has *other* independent broad breakages too (e.g. `test-search` fails on `libcudart.so.12` — a CUDA-runtime/image infra issue). This PR only addresses the `agent_version` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)