### PR TITLE
fix(search): configure RT-VLM NGC secret

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -30,6 +30,10 @@ global:
   vios:
     useSdrc: true
 
+  ngcApiSecret:
+    name: ngc-api-key-secret
+    key: NGC_API_KEY
+
   # rtviInternalIngress lives under `global` so the agent sub-chart's env-var
   # templates (rendered via `tpl` in the agent context) can read it — only
   # `global.*` propagates across sub-charts. When enabled, this drives:


### PR DESCRIPTION
## Description
Configured search helm to reference **ngc-api-key-secret** to fix RT-VLM template rendering caused by the missing global.ngcApiSecret

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
