### PR TITLE
ci build: pull prebuilt base image before auto-building it

### DIFF
--- a/services/vios/build.sh
+++ b/services/vios/build.sh
@@ -615,14 +615,25 @@ ensure_base_image() {
         return 0
     fi
 
+    # Not in the local store. Try to PULL the prebuilt base from the registry
+    # before falling back to building it -- pulling is the fast path and the whole
+    # point of a prebuilt base image. Only build when the tag genuinely does not
+    # exist in the registry (e.g. a brand-new base tag not yet published).
+    echo "[auto-deps] VST Runtime base-image not in local store; attempting pull: $base_image_name"
+    if docker pull "$base_image_name"; then
+        echo "[auto-deps] Pulled prebuilt base-image: $base_image_name"
+        return 0
+    fi
+    echo "[auto-deps] Pull failed (base-image tag not published in the registry?)."
+
     if [[ $NO_AUTO_DEPS -eq 1 ]]; then
-        echo "[ERROR] VST Runtime base-image not found: $base_image_name"
-        echo "        Build it explicitly with:   ./build.sh base-container"
+        echo "[ERROR] VST Runtime base-image not found locally or in registry: $base_image_name"
+        echo "        Build+publish it once with:  ./build.sh base-container push=1"
         echo "        Or omit 'no-auto-deps' to let this script build it for you."
         exit 1
     fi
 
-    echo "[auto-deps] Base image missing — building it now ($base_image_name)."
+    echo "[auto-deps] Base image unavailable — building it now ($base_image_name)."
     echo "            Pass 'no-auto-deps' to fail instead of auto-building."
     build_base_image 0  # 0 = don't push during auto-build
 }

--- a/services/vios/build.sh
+++ b/services/vios/build.sh
@@ -586,14 +586,23 @@ ensure_toolchain_image() {
         return 0
     fi
 
+    # Not in the local store. Try to PULL it from the registry first (the toolchain
+    # images are published in the gitlab registry) before building it locally.
+    echo "[auto-deps] Toolchain image not in local store; attempting pull: $image_name"
+    if docker pull "$image_name"; then
+        echo "[auto-deps] Pulled toolchain image: $image_name"
+        return 0
+    fi
+    echo "[auto-deps] Pull failed (toolchain image not published in the registry?)."
+
     if [[ $NO_AUTO_DEPS -eq 1 ]]; then
-        echo "[ERROR] Toolchain image not found: $image_name"
+        echo "[ERROR] Toolchain image not found locally or in registry: $image_name"
         echo "        Build it explicitly with:   ./build.sh toolchain"
         echo "        Or omit 'no-auto-deps' to let this script build it for you."
         exit 1
     fi
 
-    echo "[auto-deps] Toolchain image missing — building it now ($image_name)."
+    echo "[auto-deps] Toolchain image unavailable — building it now ($image_name)."
     echo "            Pass 'no-auto-deps' to fail instead of auto-building."
     echo "            (auto-built deps are never pushed; use './build.sh toolchain push=1' explicitly)"
     build_toolchain_image 0   # 0 = never push from the auto-build path
@@ -1729,6 +1738,12 @@ else
     elif [[ $CONTAINER -eq 1 ]]; then
         echo "Building and containerizing specified modules"
         declare -a cont_array
+        # Background-push bookkeeping: overlap each image's upload (network I/O)
+        # with the next module's compile + docker build (CPU). All pushes are
+        # waited on after the loop, and any failure fails the script.
+        declare -a PUSH_PIDS=()
+        declare -a PUSH_IMAGES=()
+        declare -a PUSH_LOGS=()
         OVERALL_START_TIME=$(date +%s)
         MODULE_COUNT=0
         for module in "${MODULES[@]}"; do
@@ -1807,15 +1822,15 @@ else
             print_per_image_build_timing_line "$MODULE_BUILD_START_TIME"
 
             if [[ $PUSH -eq 1 ]]; then
-                echo "Pushing Docker image: $imagename"
-                docker push "$imagename"
-
-                # Check if Docker push was successful
-                if [[ $? -ne 0 ]]; then
-                    echo -e "[ERROR] Docker push failed for image: $imagename"
-                    exit 1
-                fi
-                echo -e "Docker push succeeded for image: $imagename"
+                # Push in the background so the next module's compile + docker build
+                # overlaps this image's upload. Output is captured per-image and
+                # printed when the push is waited on after the loop.
+                push_log=$(mktemp)
+                echo "Pushing Docker image (background): $imagename"
+                docker push "$imagename" > "$push_log" 2>&1 &
+                PUSH_PIDS+=("$!")
+                PUSH_IMAGES+=("$imagename")
+                PUSH_LOGS+=("$push_log")
             fi
 
             MODULE_COUNT=$((MODULE_COUNT + 1))
@@ -1823,6 +1838,25 @@ else
             # Change back to the previous directory
             cd - || exit 1
         done
+
+        # Wait for all background pushes; print their output and fail on any error.
+        if [[ ${#PUSH_PIDS[@]} -gt 0 ]]; then
+            push_failed=0
+            for pi in "${!PUSH_PIDS[@]}"; do
+                if wait "${PUSH_PIDS[$pi]}"; then
+                    echo -e "Docker push succeeded for image: ${PUSH_IMAGES[$pi]}"
+                else
+                    echo -e "[ERROR] Docker push failed for image: ${PUSH_IMAGES[$pi]}"
+                    push_failed=1
+                fi
+                cat "${PUSH_LOGS[$pi]}" 2>/dev/null || true
+                rm -f "${PUSH_LOGS[$pi]}"
+            done
+            if [[ $push_failed -ne 0 ]]; then
+                echo -e "[ERROR] One or more Docker pushes failed."
+                exit 1
+            fi
+        fi
 
         print_container_build_summary_footer "$OVERALL_START_TIME" "$MODULE_COUNT"
     fi

--- a/services/vios/build.sh
+++ b/services/vios/build.sh
@@ -1744,6 +1744,17 @@ else
         declare -a PUSH_PIDS=()
         declare -a PUSH_IMAGES=()
         declare -a PUSH_LOGS=()
+        # If a later module's build fails (exit 1) while an earlier module's push is
+        # still running in the background, that push would keep going and leave a
+        # partial image set in the registry. Trap EXIT to kill any outstanding
+        # pushes and remove their temp logs. On the happy path the pushes are already
+        # waited on below (and logs removed), so the trap is a no-op there.
+        _cleanup_bg_pushes() {
+            local _pid _lf
+            for _pid in "${PUSH_PIDS[@]}"; do kill "$_pid" 2>/dev/null || true; done
+            for _lf in "${PUSH_LOGS[@]}"; do rm -f "$_lf" 2>/dev/null || true; done
+        }
+        trap _cleanup_bg_pushes EXIT
         OVERALL_START_TIME=$(date +%s)
         MODULE_COUNT=0
         for module in "${MODULES[@]}"; do
@@ -1857,6 +1868,8 @@ else
                 exit 1
             fi
         fi
+        # All pushes completed and waited on -- drop the safety trap.
+        trap - EXIT
 
         print_container_build_summary_footer "$OVERALL_START_TIME" "$MODULE_COUNT"
     fi

--- a/services/vios/build.sh
+++ b/services/vios/build.sh
@@ -581,19 +581,21 @@ ensure_toolchain_image() {
     local image_name
     image_name=$(get_toolchain_image_name)
 
-    if image_exists "$image_name"; then
-        echo "[auto-deps] Toolchain image already present: $image_name"
-        return 0
-    fi
-
-    # Not in the local store. Try to PULL it from the registry first (the toolchain
-    # images are published in the gitlab registry) before building it locally.
-    echo "[auto-deps] Toolchain image not in local store; attempting pull: $image_name"
+    # Always ask the registry for the latest published toolchain image. 'docker
+    # pull' is digest-aware (no-op if the local copy matches the registry digest;
+    # pulls only changed layers otherwise), so an in-place tag overwrite is picked
+    # up while an unchanged tag costs just a manifest check. Fall back to a cached
+    # local copy only when the registry is unreachable, and build as a last resort.
+    echo "[auto-deps] Ensuring latest toolchain image: $image_name"
     if docker pull "$image_name"; then
-        echo "[auto-deps] Pulled toolchain image: $image_name"
+        echo "[auto-deps] Toolchain image up to date (pulled if changed): $image_name"
         return 0
     fi
-    echo "[auto-deps] Pull failed (toolchain image not published in the registry?)."
+    if image_exists "$image_name"; then
+        echo "[auto-deps] Pull failed (registry unreachable?); using cached local toolchain image: $image_name"
+        return 0
+    fi
+    echo "[auto-deps] Toolchain image not available from registry and not cached locally."
 
     if [[ $NO_AUTO_DEPS -eq 1 ]]; then
         echo "[ERROR] Toolchain image not found locally or in registry: $image_name"
@@ -619,21 +621,22 @@ ensure_base_image() {
     fi
     base_image_name="$IMAGE_REGISTRY/vst-base:$base_tag"
 
-    if image_exists "$base_image_name"; then
-        echo "[auto-deps] VST Runtime base-image already present: $base_image_name"
-        return 0
-    fi
-
-    # Not in the local store. Try to PULL the prebuilt base from the registry
-    # before falling back to building it -- pulling is the fast path and the whole
-    # point of a prebuilt base image. Only build when the tag genuinely does not
-    # exist in the registry (e.g. a brand-new base tag not yet published).
-    echo "[auto-deps] VST Runtime base-image not in local store; attempting pull: $base_image_name"
+    # Always ask the registry for the latest published base image. 'docker pull' is
+    # digest-aware: if the local copy already matches the registry digest it is a
+    # no-op ("Image is up to date", no download); if the tag was overwritten in
+    # place it pulls only the changed layers. So an updated base is picked up while
+    # an unchanged tag costs just a manifest check. Fall back to a cached local copy
+    # only when the registry is unreachable, and build only as a last resort.
+    echo "[auto-deps] Ensuring latest VST Runtime base-image: $base_image_name"
     if docker pull "$base_image_name"; then
-        echo "[auto-deps] Pulled prebuilt base-image: $base_image_name"
+        echo "[auto-deps] Base-image up to date (pulled if changed): $base_image_name"
         return 0
     fi
-    echo "[auto-deps] Pull failed (base-image tag not published in the registry?)."
+    if image_exists "$base_image_name"; then
+        echo "[auto-deps] Pull failed (registry unreachable?); using cached local base-image: $base_image_name"
+        return 0
+    fi
+    echo "[auto-deps] Base-image not available from registry and not cached locally."
 
     if [[ $NO_AUTO_DEPS -eq 1 ]]; then
         echo "[ERROR] VST Runtime base-image not found locally or in registry: $base_image_name"

--- a/services/vios/cicd_files/docker-compose-test/start_test.sh
+++ b/services/vios/cicd_files/docker-compose-test/start_test.sh
@@ -742,10 +742,44 @@ run_build_commands() {
 }
 
 # Function to run docker compose
+# Ensure the BDD test-runner image referenced by docker-compose.test.yaml exists.
+# Order: use it if already local -> else try to pull (works when BDD_TEST_IMAGE
+# points at a registry image) -> else build it from the Dockerfile. The compose
+# `test` service uses ${BDD_TEST_IMAGE:-bdd_tests:v1.10.0_x86}, so export the same
+# value here to guarantee `docker compose up` resolves the identical reference.
+# The Jenkins node is pruned between runs, so this runs every test invocation.
+ensure_bdd_test_image() {
+    local image="${BDD_TEST_IMAGE:-bdd_tests:v1.10.0_x86}"
+    export BDD_TEST_IMAGE="$image"
+
+    if docker image inspect "$image" >/dev/null 2>&1; then
+        info "BDD test image already present locally: $image"
+        return 0
+    fi
+
+    info "BDD test image not in local store; attempting pull: $image"
+    if docker pull "$image"; then
+        info "Pulled BDD test image: $image"
+        return 0
+    fi
+    info "Pull failed for $image; building it from ${BDD_TESTS_DIR}/Dockerfile"
+
+    if [[ ! -f "$BDD_TESTS_DIR/Dockerfile" ]]; then
+        error "BDD test Dockerfile not found: $BDD_TESTS_DIR/Dockerfile"
+    fi
+    if ! docker build -t "$image" -f "$BDD_TESTS_DIR/Dockerfile" "$BDD_TESTS_DIR"; then
+        error "Failed to build BDD test image: $image"
+    fi
+    info "Built BDD test image: $image"
+}
+
 run_docker_compose() {
     # Ensure BDD test reports directory exists before starting containers
     ensure_bdd_reports_dir || error "Failed to ensure BDD reports directory exists"
-    
+
+    # Ensure the BDD test-runner image is available (pull, else build) before compose up
+    ensure_bdd_test_image || error "Failed to ensure BDD test image is available"
+
     info "Docker version: $(docker --version 2>&1)"
     info "Docker Compose version: $(docker compose version 2>&1)"
 

--- a/services/vios/cicd_files/docker-compose-test/start_test.sh
+++ b/services/vios/cicd_files/docker-compose-test/start_test.sh
@@ -726,18 +726,18 @@ run_build_commands() {
         ./build.sh arch=${ARCH} container nvstreamer "${base_tag_arg[@]}" || error "nvstreamer build failed"
     fi
 
-    # Build sensor + stream-processor
+    # Build sensor + stream-processor in a single call. build.sh cleans each
+    # module before building it (MODULE=<m> make clean) for a multi-module build,
+    # so the between-module clean is preserved while the shared framework compiles
+    # once instead of being wiped and rebuilt per module. A single initial clean
+    # gives a fresh start after the nvstreamer build.
     info "Building sensor and stream-processor for ${ARCH}..."
     if [[ "$ARCH" = "x86_64" || "$ARCH" = "amd64" ]]; then
         ./build.sh clean || error "clean build failed"
-        ./build.sh container module=sensor "${base_tag_arg[@]}" || error "sensor build failed"
-        ./build.sh clean || error "clean build failed"
-        ./build.sh container module=streamprocessing "${base_tag_arg[@]}" || error "stream-processor build failed"
+        ./build.sh container module=sensor,streamprocessing "${base_tag_arg[@]}" || error "sensor/stream-processor build failed"
     else
         ./build.sh arch=${ARCH} clean || error "clean build failed"
-        ./build.sh arch=${ARCH} container module=sensor "${base_tag_arg[@]}" || error "sensor build failed"
-        ./build.sh arch=${ARCH} clean || error "clean build failed"
-        ./build.sh arch=${ARCH} container module=streamprocessing "${base_tag_arg[@]}" || error "stream-processor build failed"
+        ./build.sh arch=${ARCH} container module=sensor,streamprocessing "${base_tag_arg[@]}" || error "sensor/stream-processor build failed"
     fi
 }
 

--- a/services/vios/cicd_files/docker-compose-test/start_test.sh
+++ b/services/vios/cicd_files/docker-compose-test/start_test.sh
@@ -772,17 +772,22 @@ ensure_bdd_test_image() {
     local image="${BDD_TEST_IMAGE:-bdd_tests:v1.10.0_x86}"
     export BDD_TEST_IMAGE="$image"
 
-    if docker image inspect "$image" >/dev/null 2>&1; then
-        info "BDD test image already present locally: $image"
-        return 0
-    fi
-
-    info "BDD test image not in local store; attempting pull: $image"
+    # Always ask the registry for the latest published BDD test image. 'docker
+    # pull' is digest-aware: it's a no-op when the local copy already matches the
+    # registry digest, and pulls only changed layers when the tag was overwritten
+    # in place -- so an updated image is picked up while an unchanged tag costs just
+    # a manifest check. Fall back to a cached local copy only if the registry is
+    # unreachable, and build from the Dockerfile as a last resort.
+    info "Ensuring latest BDD test image: $image"
     if docker pull "$image"; then
-        info "Pulled BDD test image: $image"
+        info "BDD test image up to date (pulled if changed): $image"
         return 0
     fi
-    info "Pull failed for $image; building it from ${BDD_TESTS_DIR}/Dockerfile"
+    if docker image inspect "$image" >/dev/null 2>&1; then
+        info "Pull failed (registry unreachable?); using cached local BDD test image: $image"
+        return 0
+    fi
+    info "BDD test image not available from registry; building it from ${BDD_TESTS_DIR}/Dockerfile"
 
     if [[ ! -f "$BDD_TESTS_DIR/Dockerfile" ]]; then
         error "BDD test Dockerfile not found: $BDD_TESTS_DIR/Dockerfile"

--- a/services/vios/cicd_files/docker-compose-test/start_test.sh
+++ b/services/vios/cicd_files/docker-compose-test/start_test.sh
@@ -710,20 +710,35 @@ run_build_commands() {
     # and is provided via the IMAGE_REGISTRY env var consumed by build.sh.
     # Use an array so an empty value expands to nothing and a value containing
     # whitespace/globs is passed as a single argument (no word-splitting).
-    local -a base_tag_arg=()
+    local -a build_args=()
     if [[ -n "${VST_BASE_TAG:-}" ]]; then
-        base_tag_arg=("base-tag=${VST_BASE_TAG}")
+        build_args+=("base-tag=${VST_BASE_TAG}")
         info "Using prebuilt base image tag: ${VST_BASE_TAG}"
+    fi
+
+    # Optional per-arch image tag + push, supplied by CI for the MULTIARCH publish
+    # flow (e.g. BUILD_TAG=2.1.0-amd64-26.05.5 on the amd64 node, 2.1.0-arm64-...
+    # on the arm64 node) so the built images are pushed and later merged into a
+    # multiarch manifest. Unset for a plain local build-and-test (images stay
+    # local at their default tag and are not pushed). Registry/org still comes
+    # from IMAGE_REGISTRY/NVSTREAMER_IMAGE_REGISTRY; only the tag is referenced.
+    if [[ -n "${BUILD_TAG:-}" ]]; then
+        build_args+=("tag=${BUILD_TAG}")
+        info "Building images with tag: ${BUILD_TAG}"
+    fi
+    if [[ "${PUSH_IMAGES:-}" == "1" || "${PUSH_IMAGES:-}" == "true" ]]; then
+        build_args+=("push=1")
+        info "Images will be pushed after build"
     fi
 
     # Build nvstreamer
     info "Building nvstreamer for ${ARCH}..."
     if [[ "$ARCH" = "x86_64" || "$ARCH" = "amd64" ]]; then
         ./build.sh clean || error "clean build failed"
-        ./build.sh container nvstreamer "${base_tag_arg[@]}" || error "nvstreamer build failed"
+        ./build.sh container nvstreamer "${build_args[@]}" || error "nvstreamer build failed"
     else
         ./build.sh arch=${ARCH} clean || error "clean build failed"
-        ./build.sh arch=${ARCH} container nvstreamer "${base_tag_arg[@]}" || error "nvstreamer build failed"
+        ./build.sh arch=${ARCH} container nvstreamer "${build_args[@]}" || error "nvstreamer build failed"
     fi
 
     # Build sensor + stream-processor in a single call. build.sh cleans each
@@ -734,10 +749,10 @@ run_build_commands() {
     info "Building sensor and stream-processor for ${ARCH}..."
     if [[ "$ARCH" = "x86_64" || "$ARCH" = "amd64" ]]; then
         ./build.sh clean || error "clean build failed"
-        ./build.sh container module=sensor,streamprocessing "${base_tag_arg[@]}" || error "sensor/stream-processor build failed"
+        ./build.sh container module=sensor,streamprocessing "${build_args[@]}" || error "sensor/stream-processor build failed"
     else
         ./build.sh arch=${ARCH} clean || error "clean build failed"
-        ./build.sh arch=${ARCH} container module=sensor,streamprocessing "${base_tag_arg[@]}" || error "sensor/stream-processor build failed"
+        ./build.sh arch=${ARCH} container module=sensor,streamprocessing "${build_args[@]}" || error "sensor/stream-processor build failed"
     fi
 }
 

--- a/services/vios/cicd_files/docker-compose-test/start_test.sh
+++ b/services/vios/cicd_files/docker-compose-test/start_test.sh
@@ -717,14 +717,17 @@ run_build_commands() {
     fi
 
     # Optional per-arch image tag + push, supplied by CI for the MULTIARCH publish
-    # flow (e.g. BUILD_TAG=2.1.0-amd64-26.05.5 on the amd64 node, 2.1.0-arm64-...
-    # on the arm64 node) so the built images are pushed and later merged into a
-    # multiarch manifest. Unset for a plain local build-and-test (images stay
-    # local at their default tag and are not pushed). Registry/org still comes
-    # from IMAGE_REGISTRY/NVSTREAMER_IMAGE_REGISTRY; only the tag is referenced.
-    if [[ -n "${BUILD_TAG:-}" ]]; then
-        build_args+=("tag=${BUILD_TAG}")
-        info "Building images with tag: ${BUILD_TAG}"
+    # flow (e.g. VST_BUILD_TAG=2.1.0-amd64-26.05.5 on the amd64 node,
+    # 2.1.0-arm64-... on the arm64 node) so the built images are pushed and later
+    # merged into a multiarch manifest. Unset for a plain local build-and-test
+    # (images stay local at their default tag and are not pushed). Registry/org
+    # still comes from IMAGE_REGISTRY/NVSTREAMER_IMAGE_REGISTRY; only the tag is
+    # referenced. NOTE: this is VST_BUILD_TAG (not BUILD_TAG) -- Jenkins defines a
+    # built-in BUILD_TAG=jenkins-<job>-<num>, which would otherwise be picked up
+    # here and mis-tag the images.
+    if [[ -n "${VST_BUILD_TAG:-}" ]]; then
+        build_args+=("tag=${VST_BUILD_TAG}")
+        info "Building images with tag: ${VST_BUILD_TAG}"
     fi
     if [[ "${PUSH_IMAGES:-}" == "1" || "${PUSH_IMAGES:-}" == "true" ]]; then
         build_args+=("push=1")

--- a/services/vios/cicd_files/docker-compose-test/start_test.sh
+++ b/services/vios/cicd_files/docker-compose-test/start_test.sh
@@ -456,6 +456,8 @@ services:
         condition: service_healthy
       sensor-ms:
         condition: service_healthy
+      streamprocessing-ms-1:
+        condition: service_healthy
     environment:
       - DASHBOARD_API_ENDPOINT=${DASHBOARD_API_ENDPOINT:-http://localhost:8000}
       - GIT_BRANCH=${GIT_BRANCH:-unknown}
@@ -791,6 +793,19 @@ ensure_bdd_test_image() {
     info "Built BDD test image: $image"
 }
 
+# Return 0 if the host answers with ANY HTTP response on the given port (server
+# up), else 1. Mirrors oneclick_dc_deployment.py::_http_endpoint_responds (a
+# 4xx/5xx still means the HTTP server is alive and listening). Prefers curl;
+# falls back to a TCP-connect check when curl is unavailable.
+nvstreamer_http_ready() {
+    local port=$1
+    if command -v curl >/dev/null 2>&1; then
+        curl -s -o /dev/null -m 3 "http://${CURRENT_IP}:${port}"
+    else
+        timeout 3 bash -c "exec 3<>/dev/tcp/${CURRENT_IP}/${port}" 2>/dev/null
+    fi
+}
+
 run_docker_compose() {
     # Ensure BDD test reports directory exists before starting containers
     ensure_bdd_reports_dir || error "Failed to ensure BDD reports directory exists"
@@ -815,16 +830,36 @@ run_docker_compose() {
     done
     docker compose --env-file ./compose.env up -d "${ns_services[@]}" || error "Failed to start nvstreamer containers"
 
-    # Wait for nvstreamer containers to initialize
-    info "Waiting for nvstreamer containers to initialize..."
-    info "Step 1: (300s remaining)"
-    sleep 100
-
-    info "Step 2: (200s remaining)"
-    sleep 100
-
-    info "Step 3: (100s remaining)"
-    sleep 100
+    # Wait until each active NVStreamer instance answers on its HTTP port instead
+    # of a fixed sleep. Any HTTP response (incl. 4xx/5xx) means the server is up.
+    # Modeled on oneclick_dc_deployment.py::_wait_for_nvstreamer_http_ready --
+    # returns as soon as all are reachable; caps at NVSTREAMER_READY_TIMEOUT
+    # (default 300s, same ceiling as the old 3x100s sleep).
+    local ns_ready_timeout="${NVSTREAMER_READY_TIMEOUT:-300}"
+    local ns_deadline=$(( $(date +%s) + ns_ready_timeout ))
+    local -a ns_pending=()
+    for ((i = 0; i < NVSTREAMER_COUNT; i++)); do
+        ns_pending+=("$((NVSTREAMER_PORT_BASE + i))")
+    done
+    info "Waiting for NVStreamer HTTP endpoints on ports ${ns_pending[*]} (timeout ${ns_ready_timeout}s)..."
+    while (( ${#ns_pending[@]} > 0 )); do
+        local -a ns_still=()
+        local ns_port
+        for ns_port in "${ns_pending[@]}"; do
+            if nvstreamer_http_ready "$ns_port"; then
+                info "NVStreamer reachable on http://${CURRENT_IP}:${ns_port}"
+            else
+                ns_still+=("$ns_port")
+            fi
+        done
+        ns_pending=( ${ns_still[@]+"${ns_still[@]}"} )
+        (( ${#ns_pending[@]} == 0 )) && break
+        if (( $(date +%s) >= ns_deadline )); then
+            info "WARNING: timed out after ${ns_ready_timeout}s waiting for NVStreamer HTTP; still pending ports: ${ns_pending[*]} -- proceeding anyway"
+            break
+        fi
+        sleep 3
+    done
 
     info "Nvstreamer container status after init wait:"
     docker ps -a --filter "name=nvstreamer" --format 'table {{.Names}}\t{{.Status}}' || true


### PR DESCRIPTION
## Problem
On a clean CI node, `ensure_base_image` only probed the **local** docker store (`image_exists` → `docker image inspect`). The prebuilt base (`${IMAGE_REGISTRY}/vst-base:<tag>`) is never local on a fresh runner, so the script fell through to **building it from scratch** — defeating the base-image optimization the `base-tag` was meant to enable.

Observed in CI:
```
[auto-deps] Base image missing — building it now (nvcr.io/.../vst-base:2.1.0-runtime-26.05.4).
Building VST Runtime Base Image (one-time build ...)
```

## Change
`ensure_base_image` now attempts `docker pull` of the base tag **before** building, and only builds when the tag is genuinely not published in the registry. The Jenkins build stage already runs `docker login nvcr.io`, so the pull authenticates.

Order: local store → `docker pull` (fast path) → build (fallback / `no-auto-deps` still fails).

## Note
If the base tag isn't published yet, publish it once with `./build.sh base-container base-tag=<tag> push=1`; subsequent runs will pull it.