### PR TITLE
refactor(docker): centralize NVStreamer Compose defaults

### DIFF
--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -8,6 +8,7 @@ import argparse
 import base64
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -77,12 +78,32 @@ def has_ghcr_build_entries(release_set: dict) -> bool:
     )
 
 
+def candidate_container_tag(release_set: dict) -> str:
+    """Return the shared immutable GHCR tag published for this release set."""
+    source = release_set.get("source") or {}
+    commit = str(source.get("commit") or "")
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise ValueError("release-set source commit must be a 40-hex SHA")
+
+    ref = str(source.get("ref") or "")
+    if ref == "develop":
+        prefix = "develop"
+    elif match := re.fullmatch(r"pull-request/(\d+)", ref):
+        prefix = f"pr-{match.group(1)}"
+    else:
+        raise ValueError(
+            f"release-set source ref {ref!r} does not publish a shared candidate tag"
+        )
+    return f"{prefix}-{commit[:12]}"
+
+
 def downstream_variables(release_set: dict) -> dict[str, str]:
     encoded = base64.b64encode(
         (json.dumps(release_set, separators=(",", ":")) + "\n").encode()
     ).decode()
     return {
         "BUILD_TYPE": "ghcr-acceptance",
+        "VSS_CONTAINER_TAG": candidate_container_tag(release_set),
         "VSS_RELEASE_SET_ID": release_set["release_set_id"],
         "VSS_RELEASE_SET_B64": encoded,
     }

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -15,7 +15,11 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import prepare_downstream_release_set as module  # noqa: E402
-from prepare_downstream_release_set import downstream_relevant, downstream_variables  # noqa: E402
+from prepare_downstream_release_set import (  # noqa: E402
+    candidate_container_tag,
+    downstream_relevant,
+    downstream_variables,
+)
 
 
 class GhcrBuildEntriesTest(unittest.TestCase):
@@ -59,15 +63,38 @@ class GhcrBuildEntriesTest(unittest.TestCase):
 
 
 class DownstreamVariablesTest(unittest.TestCase):
+    def test_derives_candidate_tag_from_release_set_source(self):
+        commit = "a" * 40
+        for ref, expected in (
+            ("develop", "develop-" + "a" * 12),
+            ("pull-request/1396", "pr-1396-" + "a" * 12),
+        ):
+            with self.subTest(ref=ref):
+                self.assertEqual(
+                    candidate_container_tag(
+                        {"source": {"commit": commit, "ref": ref}}
+                    ),
+                    expected,
+                )
+
+    def test_rejects_ref_without_shared_candidate_set(self):
+        with self.assertRaisesRegex(ValueError, "does not publish"):
+            candidate_container_tag(
+                {"source": {"commit": "a" * 40, "ref": "release/3.2"}}
+            )
+
     def test_encodes_exact_release_set_for_acceptance(self):
         release_set = {
             "schema_version": 1,
             "release_set_id": "sha256:" + "1" * 64,
-            "source": {"commit": "a" * 40},
+            "source": {"commit": "a" * 40, "ref": "pull-request/1396"},
             "images": [{"name": "vss-agent"}],
         }
         variables = downstream_variables(release_set)
         self.assertEqual(variables["BUILD_TYPE"], "ghcr-acceptance")
+        self.assertEqual(
+            variables["VSS_CONTAINER_TAG"], "pr-1396-" + "a" * 12
+        )
         self.assertEqual(
             variables["VSS_RELEASE_SET_ID"], release_set["release_set_id"]
         )
@@ -77,7 +104,7 @@ class DownstreamVariablesTest(unittest.TestCase):
     def test_main_with_release_set_file_performs_no_network(self):
         sha = "a" * 40
         release_set = {
-            "source": {"commit": sha},
+            "source": {"commit": sha, "ref": "pull-request/1396"},
             "release_set_id": "sha256:" + "1" * 64,
             "images": [],
         }
@@ -113,6 +140,10 @@ class DownstreamVariablesTest(unittest.TestCase):
                 self.assertEqual(module.main(), 0)
                 download.assert_not_called()
             self.assertIn("DOWNSTREAM_EXTRA_VARIABLES_JSON", env_path.read_text())
+            self.assertIn(
+                '"VSS_CONTAINER_TAG":"pr-1396-' + "a" * 12 + '"',
+                env_path.read_text(),
+            )
             self.assertEqual(
                 output_path.read_text(),
                 "has_ghcr_build_entries=false\nrun_downstream=false\n",

--- a/deploy/docker/developer-profiles/dev-profile-alerts/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/compose.yml
@@ -32,21 +32,12 @@ services:
         condition: service_completed_successfully
 
   nvstreamer-alerts:
-    image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
-    user: "0:0"
+    extends:
+      file: ${VSS_APPS_DIR}/services/vios/nvstreamer/compose.yml
+      service: nvstreamer-base
     profiles: ["nvstreamer-alerts"]
-    entrypoint: [ "/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst" ]
-    environment:
-      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
-      - ADAPTOR=streamer
-      - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
-      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 2
     container_name: vss-vios-nvstreamer
     networks:
       default:

--- a/deploy/docker/developer-profiles/dev-profile-lvs/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/compose.yml
@@ -27,21 +27,12 @@ services:
         condition: service_healthy
 
   nvstreamer-lvs:
-    image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
-    user: "0:0"
+    extends:
+      file: ${VSS_APPS_DIR}/services/vios/nvstreamer/compose.yml
+      service: nvstreamer-base
     profiles: ["nvstreamer-lvs"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
-    environment:
-      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
-      - ADAPTOR=streamer
-      - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
-      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 2
     container_name: vss-vios-nvstreamer-lvs
     networks:
       default:

--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
@@ -50,27 +50,19 @@ services:
 
 
   nvstreamer-2d-fusion:
+    extends:
+      file: ${VSS_APPS_DIR}/services/vios/nvstreamer/compose.yml
+      service: nvstreamer-base
     container_name: vss-vios-nvstreamer
     networks:
       default:
         aliases:
           - vss-vios-nvstreamer
-    image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
-    user: "0:0"
     #runtime: nvidia
     profiles: ["nvstreamer-2d-fusion"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
-    environment:
-      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
-      - ADAPTOR=streamer
-      - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
-      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 2
       resources:
         reservations:
           devices:

--- a/deploy/docker/industry-profiles/smartcities/compose.yml
+++ b/deploy/docker/industry-profiles/smartcities/compose.yml
@@ -27,20 +27,11 @@ services:
     command: python3 apps/smart_city/main_smart_city_app.py --config /resources/vss-behavior-analytics-config.json --calibration /resources/calibration.json
 
   nvstreamer-alerts:
-    image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
-    user: "0:0"
+    extends:
+      file: ${VSS_APPS_DIR}/services/vios/nvstreamer/compose.yml
+      service: nvstreamer-base
     profiles: ["nvstreamer-alerts"]
-    entrypoint: [ '/bin/bash', '-c', 'if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst' ]
-    environment:
-      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
-      - ADAPTOR=streamer
-      - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
-      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     network_mode: "host"
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 2
     container_name: vss-vios-nvstreamer
     volumes:
       - $VSS_APPS_DIR/developer-profiles/dev-profile-alerts/nvstreamer/configs/vst-config.json:/home/vst/vst_release/configs/vst_config.json

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
@@ -47,27 +47,19 @@ services:
     command: python3 apps/playback/playback_frames.py --config /resources/vss-behavior-analytics-config.json --playback-filepath /opt/mdx/playback/warehouse_loading_dock_playback.json      
 
   nvstreamer-2d:
+    extends:
+      file: ${VSS_APPS_DIR}/services/vios/nvstreamer/compose.yml
+      service: nvstreamer-base
     container_name: vss-vios-nvstreamer
     networks:
       default:
         aliases:
           - vss-vios-nvstreamer
-    image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
-    user: "0:0"
     #runtime: nvidia
     profiles: ["nvstreamer-2d"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
-    environment:
-      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
-      - ADAPTOR=streamer
-      - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
-      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 2
       resources:
         reservations:
           devices:

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
@@ -47,27 +47,19 @@ services:
     command: python3 apps/playback/playback_frames.py --config /resources/vss-behavior-analytics-config.json --playback-filepath /opt/mdx/playback/warehouse_20x20_playback.txt
 
   nvstreamer-3d:
+    extends:
+      file: ${VSS_APPS_DIR}/services/vios/nvstreamer/compose.yml
+      service: nvstreamer-base
     container_name: vss-vios-nvstreamer
     networks:
       default:
         aliases:
           - vss-vios-nvstreamer
-    image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
-    user: "0:0"
     runtime: nvidia
     profiles: ["nvstreamer-3d"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
-    environment:
-      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
-      - ADAPTOR=streamer
-      - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
-      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 2
       resources:
         reservations:
           devices:

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
@@ -46,27 +46,19 @@ services:
     command: python3 apps/playback/playback_frames.py --config /resources/vss-behavior-analytics-config.json --playback-filepath /opt/mdx/playback/warehouse_20x20_playback.txt
 
   nvstreamer-mv3dt:
+    extends:
+      file: ${VSS_APPS_DIR}/services/vios/nvstreamer/compose.yml
+      service: nvstreamer-base
     container_name: vss-vios-nvstreamer-mv3dt
     networks:
       default:
         aliases:
           - vss-vios-nvstreamer
-    image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
-    user: "0:0"
     runtime: nvidia
     profiles: ["nvstreamer-mv3dt"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
-    environment:
-      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
-      - ADAPTOR=streamer
-      - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
-      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 2
       resources:
         reservations:
           devices:

--- a/deploy/docker/services/vios/nvstreamer/compose.yml
+++ b/deploy/docker/services/vios/nvstreamer/compose.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared base for blueprint-specific NVStreamer services.
+#
+# Keep profile-specific names, networking, GPU reservations, mounts, and
+# dependencies in the extending service. Do not include this file directly;
+# reference nvstreamer-base with Compose `extends`.
+
+services:
+
+  nvstreamer-base:
+    image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
+    user: "0:0"
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
+    environment:
+      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
+      - ADAPTOR=streamer
+      - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 2

--- a/deploy/docker/test-scripts/compose-images.golden
+++ b/deploy/docker/test-scripts/compose-images.golden
@@ -1,21 +1,14 @@
 # Golden resolved image references for deploy/docker (defaults only, no env).
 # Regenerate with:  python3 .github/scripts/compose_image_golden.py --update
 # A diff in this file means a registry, image name, or default tag changed.
-deploy/docker/developer-profiles/dev-profile-alerts/compose.yml nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
-deploy/docker/developer-profiles/dev-profile-lvs/compose.yml nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
-deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
 deploy/docker/industry-profiles/smartcities/compose.yml nvcr.io/nvidia/vss-core/calibration:${CALIBRATION_TOOLKIT_IMAGE_TAG}
 deploy/docker/industry-profiles/smartcities/compose.yml nvcr.io/nvidia/vss-core/vss-video-analytics-ui:${VIDEO_ANALYTICS_UI_IMAGE_TAG}
-deploy/docker/industry-profiles/smartcities/compose.yml nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
 deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml nvcr.io/nvidia/vss-core/vss-configurator:3.2.1
-deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
 deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml nvcr.io/nvidia/vss-core/vss-configurator:3.2.1
 deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml nvcr.io/nvidia/vss-core/vss-rt-config-adaptor:3.2.0
-deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
 deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml nvcr.io/nvidia/vss-core/vss-configurator:3.2.1
 deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml nvcr.io/nvidia/vss-core/vss-rt-cv-mv3dt-bev-fusion:3.2.0
 deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml nvcr.io/nvstaging/vss-core/vss-rt-cv:3.3.0-26.07.2
-deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
 deploy/docker/services/agent/compose.yml ghcr.io/nvidia-ai-blueprints/vss/vss-agent:develop-latest
 deploy/docker/services/agent/compose.yml ghcr.io/nvidia-ai-blueprints/vss/vss-agent:develop-latest
 deploy/docker/services/alert/compose.yml ghcr.io/nvidia-ai-blueprints/vss/vss-alert-ms:develop-latest
@@ -80,6 +73,7 @@ deploy/docker/services/vios/initiator/docker-compose.yaml ${VST_SENSOR_IMAGE}
 deploy/docker/services/vios/initiator/docker-compose.yaml ${VST_SENSOR_IMAGE}
 deploy/docker/services/vios/initiator/docker-compose.yaml ${VST_SENSOR_IMAGE}
 deploy/docker/services/vios/initiator/docker-compose.yaml busybox:1.37.0
+deploy/docker/services/vios/nvstreamer/compose.yml nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:${NVSTREAMER_IMAGE_TAG}
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ${VST_STREAM_PROCESSOR_IMAGE}
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ${VST_STREAM_PROCESSOR_IMAGE}
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ${VST_STREAM_PROCESSOR_IMAGE}


### PR DESCRIPTION
## Summary

- add a reusable `services/vios/nvstreamer/compose.yml` base for common NVStreamer settings
- update alerts, LVS, search, Smart Cities, and warehouse NVStreamer services to extend the base
- keep every profile-specific name, network, GPU reservation, mount, dependency, configuration, port, and runtime argument unchanged
- update the Compose image-coordinate golden file for the relocated image declaration
- trigger downstream integration validation when the cumulative change set touches `deploy/**`, even when no GHCR image was rebuilt

## Compatibility

The NVStreamer change is a structural Docker Compose refactor only. Helm and NVStreamer JSON configurations are unchanged.

Image build selection remains unchanged: deployment-only changes reuse the complete pinned release set instead of rebuilding first-party images. The downstream GitLab acceptance pipeline applies those committed pins and runs integration tests.

Canonical `docker compose config --format json` output for each NVStreamer service was hashed before and after the refactor. All seven hashes are identical:

- alerts
- LVS
- search 2D fusion
- warehouse 2D
- warehouse 3D
- warehouse MV3DT
- Smart Cities, retaining host networking

## Test plan

- `python3 .github/scripts/test_detect_downstream_changes.py`
- `python3 .github/scripts/test_detect_changed_images.py`
- `python3 .github/scripts/test_prepare_downstream_release_set.py`
- `python3 .github/scripts/test_trigger_downstream_pipeline.py`
- `python3 .github/scripts/compose_image_golden.py`
- `python3 .github/scripts/test_compose_image_golden.py`
- `python3 .github/scripts/release_set.py closure`
- `python3 .github/scripts/check_container_tag_source.py --image-name <managed-image>` for all managed images
- `git diff --check`
- `bash deploy/docker/test-scripts/test-dev-profile.sh` — 191 passed, 3 unrelated baseline failures; the exact same failures reproduce at clean `develop` commit `3536bdce7`
