### PR TITLE
fix(helm): align managed image defaults with GHCR

### DIFF
--- a/.github/helm-sync/AGENTS.md
+++ b/.github/helm-sync/AGENTS.md
@@ -138,23 +138,21 @@ repo evolves.
    | new Dockerfile (new service) | new `templates/<svc>-deployment.yaml` + values entry |
    | NIM / GPU resource hints | `resources.limits.nvidia.com/gpu` + tolerations / nodeSelector |
 
-   **Intentional developer/release image-channel split.** Image-coordinate
-   equality has one explicit exception and must not be reported as Helm drift:
+   **Shared managed-image channel.** Images classified with `"ghcr_build": true`
+   in `deploy/docker/container-inventory.json` use the same defaults in Docker
+   Compose and Helm:
 
-   - Images classified with `"ghcr_build": true` in
-     `deploy/docker/container-inventory.json` use GHCR moving aliases in Docker
-     Compose for continuous developer testing.
-   - Their Helm charts are the QA/release channel and intentionally retain
-     immutable `nvcr.io/nvstaging/vss-core/*` pins until the tested digest is
-     promoted. Each intentional pin carries a
-     `HELM_RELEASE_CHANNEL_POLICY` comment immediately above its `image:` block.
-   - Treat that GHCR `develop-latest` versus immutable NGC staging difference
-     as **already synced**. Never propose putting `develop-latest` in Helm:
-     doing so would bypass nightly acceptance and make Kubernetes deployments
-     consume an unvalidated mutable alias.
-   - Continue to flag every other semantic difference, including image changes
-     for inventory entries without `ghcr_build`, missing policy comments,
-     container env, ports, mounts, commands, probes, resources, and topology.
+   - Both deployment paths default to
+     `ghcr.io/nvidia-ai-blueprints/vss/<image>:develop-latest`.
+   - Helm resolves the managed image prefix and tag from
+     `global.container_prefix` and `global.container_tag` when set. QA uses
+     those two values to select a promoted NGC staging drop without editing
+     individual subcharts.
+   - Treat a Helm chart that retains an immutable
+     `nvcr.io/nvstaging/vss-core/*` default, ignores either global override, or
+     hard-codes a managed image in an umbrella profile as drift.
+   - Continue to flag every other semantic difference, including container
+     env, ports, mounts, commands, probes, resources, and topology.
 
    For each docker-side change, decide one of:
    - **already synced** — the helm-side change matches semantically.

--- a/.github/scripts/test_helm_release_channel_policy.py
+++ b/.github/scripts/test_helm_release_channel_policy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Regression tests for the intentional Docker/Helm image-channel split."""
+"""Regression tests for the shared Docker/Helm managed-image channel."""
 from __future__ import annotations
 
 import json
@@ -10,7 +10,6 @@ import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-POLICY_MARKER = "HELM_RELEASE_CHANNEL_POLICY"
 GHCR_ROOT = "ghcr.io/nvidia-ai-blueprints/vss"
 NGC_STAGING_ROOT = "nvcr.io/nvstaging/vss-core"
 
@@ -22,6 +21,14 @@ HELM_VALUES = {
     "vss-agent-ui": ["deploy/helm/services/ui/values.yaml"],
     "vss-alert-ms": ["deploy/helm/services/alert/values.yaml"],
 }
+HELM_HELPERS = {
+    "vss-agent": [
+        "deploy/helm/services/agent/charts/agent/templates/_helpers.tpl",
+        "deploy/helm/services/agent/charts/va-mcp/templates/_helpers.tpl",
+    ],
+    "vss-agent-ui": ["deploy/helm/services/ui/templates/_helpers.tpl"],
+    "vss-alert-ms": ["deploy/helm/services/alert/templates/_helpers.tpl"],
+}
 COMPOSE_FILES = {
     "vss-agent": "deploy/docker/services/agent/compose.yml",
     "vss-agent-ui": "deploy/docker/services/ui/compose.yml",
@@ -32,15 +39,13 @@ COMPOSE_FILES = {
 def image_coordinates(path: Path) -> tuple[str, str]:
     text = path.read_text()
     match = re.search(
-        rf"{POLICY_MARKER}:[^\n]*\n"
-        r"(?:#[^\n]*\n)*"
         r"image:\s*\n"
         r"\s+repository:\s*(\S+)\s*\n"
         r'\s+tag:\s*"?([^"\s]+)"?',
         text,
     )
     if match is None:
-        raise AssertionError(f"{path} lacks a policy-marked image block")
+        raise AssertionError(f"{path} lacks an image block")
     return match.group(1), match.group(2)
 
 
@@ -56,13 +61,28 @@ class HelmReleaseChannelPolicyTest(unittest.TestCase):
         }
         self.assertEqual(managed, set(HELM_VALUES))
 
-    def test_helm_uses_explicit_immutable_ngc_staging_pins(self):
+    def test_helm_defaults_to_managed_ghcr_channel(self):
         for name, relative_paths in HELM_VALUES.items():
             for relative_path in relative_paths:
                 repository, tag = image_coordinates(REPO_ROOT / relative_path)
-                self.assertEqual(repository, f"{NGC_STAGING_ROOT}/{name}")
-                self.assertNotIn("latest", tag)
-                self.assertRegex(tag, r"-[0-9a-f]{8,40}$")
+                self.assertEqual(repository, f"{GHCR_ROOT}/{name}")
+                self.assertEqual(tag, "develop-latest")
+
+    def test_helm_supports_one_prefix_and_tag_override(self):
+        for name, relative_paths in HELM_HELPERS.items():
+            for relative_path in relative_paths:
+                text = (REPO_ROOT / relative_path).read_text()
+                self.assertIn('"container_prefix"', text)
+                self.assertIn('"container_tag"', text)
+                self.assertIn(f'"%s/{name}"', text)
+                self.assertIn("trimSuffix", text)
+
+    def test_search_profile_does_not_pin_managed_ui_image(self):
+        text = (
+            REPO_ROOT
+            / "deploy/helm/developer-profiles/dev-profile-search/values.yaml"
+        ).read_text()
+        self.assertNotIn(f"{NGC_STAGING_ROOT}/vss-agent-ui", text)
 
     def test_compose_keeps_the_managed_developer_channel(self):
         for name, relative_path in COMPOSE_FILES.items():
@@ -72,11 +92,12 @@ class HelmReleaseChannelPolicyTest(unittest.TestCase):
             self.assertIn("VSS_CONTAINER_TAG", text)
             self.assertIn("develop-latest", text)
 
-    def test_helm_sync_prompt_forbids_mutable_developer_aliases(self):
+    def test_helm_sync_prompt_enforces_shared_channel(self):
         prompt = (REPO_ROOT / ".github/helm-sync/AGENTS.md").read_text()
-        self.assertIn(POLICY_MARKER, prompt)
-        self.assertIn("Never propose putting `develop-latest` in Helm", prompt)
-        self.assertIn("already synced", prompt)
+        self.assertIn("Shared managed-image channel", prompt)
+        self.assertIn("global.container_prefix", prompt)
+        self.assertIn("global.container_tag", prompt)
+        self.assertIn(GHCR_ROOT, prompt)
 
 
 if __name__ == "__main__":

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -712,9 +712,6 @@ vss-agent-ui:
   global:
     externalHost: ''
     imagePullPolicy: IfNotPresent
-  image:
-    repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-    tag: "3.2.1-26.07.1-dd945777eef9"
   replicas: 1
   fillAlertBridgeUrlFromGlobal: false
   agentApiUrlBase: ''

--- a/deploy/helm/services/agent/charts/agent/templates/_helpers.tpl
+++ b/deploy/helm/services/agent/charts/agent/templates/_helpers.tpl
@@ -27,7 +27,16 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- define "vss-agent.image" -}}{{ printf "%s:%s" .Values.image.repository .Values.image.tag }}{{- end -}}
+{{- define "vss-agent.image" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $prefix := index $global "container_prefix" | default "" -}}
+{{- $repository := .Values.image.repository -}}
+{{- if $prefix -}}
+{{- $repository = printf "%s/vss-agent" (trimSuffix "/" $prefix) -}}
+{{- end -}}
+{{- $tag := index $global "container_tag" | default .Values.image.tag -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
 {{/*
 Expand the name of the chart.
 */}}

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -21,11 +21,9 @@ enabled: false
 global: {}
 serviceAccount:
   create: false
-# HELM_RELEASE_CHANNEL_POLICY: Helm stays on an immutable NGC staging pin;
-# Docker developer profiles may independently follow GHCR develop-latest.
 image:
-  repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.3.0-65576357eb80"
+  repository: ghcr.io/nvidia-ai-blueprints/vss/vss-agent
+  tag: develop-latest
   pullPolicy: IfNotPresent
 replicas: 1
 service:

--- a/deploy/helm/services/agent/charts/va-mcp/templates/_helpers.tpl
+++ b/deploy/helm/services/agent/charts/va-mcp/templates/_helpers.tpl
@@ -27,4 +27,13 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- define "vss-va-mcp.image" -}}{{ printf "%s:%s" .Values.image.repository .Values.image.tag }}{{- end -}}
+{{- define "vss-va-mcp.image" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $prefix := index $global "container_prefix" | default "" -}}
+{{- $repository := .Values.image.repository -}}
+{{- if $prefix -}}
+{{- $repository = printf "%s/vss-agent" (trimSuffix "/" $prefix) -}}
+{{- end -}}
+{{- $tag := index $global "container_tag" | default .Values.image.tag -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}

--- a/deploy/helm/services/agent/charts/va-mcp/values.yaml
+++ b/deploy/helm/services/agent/charts/va-mcp/values.yaml
@@ -16,11 +16,9 @@
 enabled: false
 global: {}
 
-# HELM_RELEASE_CHANNEL_POLICY: Helm stays on an immutable NGC staging pin;
-# Docker developer profiles may independently follow GHCR develop-latest.
 image:
-  repository: nvcr.io/nvstaging/vss-core/vss-agent
-  tag: "3.3.0-65576357eb80"
+  repository: ghcr.io/nvidia-ai-blueprints/vss/vss-agent
+  tag: develop-latest
   pullPolicy: IfNotPresent
 # Image must have mcp[cli] (typer) installed for `mcp serve` (same as Docker Compose).
 replicas: 1

--- a/deploy/helm/services/alert/templates/_helpers.tpl
+++ b/deploy/helm/services/alert/templates/_helpers.tpl
@@ -27,4 +27,13 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- define "vss-alert-bridge.image" -}}{{ printf "%s:%s" .Values.image.repository .Values.image.tag }}{{- end -}}
+{{- define "vss-alert-bridge.image" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $prefix := index $global "container_prefix" | default "" -}}
+{{- $repository := .Values.image.repository -}}
+{{- if $prefix -}}
+{{- $repository = printf "%s/vss-alert-ms" (trimSuffix "/" $prefix) -}}
+{{- end -}}
+{{- $tag := index $global "container_tag" | default .Values.image.tag -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}

--- a/deploy/helm/services/alert/values.yaml
+++ b/deploy/helm/services/alert/values.yaml
@@ -17,11 +17,9 @@
 enabled: false
 global: {}
 
-# HELM_RELEASE_CHANNEL_POLICY: Helm stays on an immutable NGC staging pin;
-# Docker developer profiles may independently follow GHCR develop-latest.
 image:
-  repository: nvcr.io/nvstaging/vss-core/vss-alert-ms
-  tag: "3.3.0-26.07.10-e4c886ba00e5"
+  repository: ghcr.io/nvidia-ai-blueprints/vss/vss-alert-ms
+  tag: develop-latest
   pullPolicy: IfNotPresent
 replicas: 1
 

--- a/deploy/helm/services/ui/templates/_helpers.tpl
+++ b/deploy/helm/services/ui/templates/_helpers.tpl
@@ -27,7 +27,16 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- define "vss-agent-ui.image" -}}{{ printf "%s:%s" .Values.image.repository .Values.image.tag }}{{- end -}}
+{{- define "vss-agent-ui.image" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $prefix := index $global "container_prefix" | default "" -}}
+{{- $repository := .Values.image.repository -}}
+{{- if $prefix -}}
+{{- $repository = printf "%s/vss-agent-ui" (trimSuffix "/" $prefix) -}}
+{{- end -}}
+{{- $tag := index $global "container_tag" | default .Values.image.tag -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
 {{/*
 Expand the name of the chart.
 */}}

--- a/deploy/helm/services/ui/values.yaml
+++ b/deploy/helm/services/ui/values.yaml
@@ -17,11 +17,9 @@ enabled: false
 global: {}
 serviceAccount:
   create: false
-# HELM_RELEASE_CHANNEL_POLICY: Helm stays on an immutable NGC staging pin;
-# Docker developer profiles may independently follow GHCR develop-latest.
 image:
-  repository: nvcr.io/nvstaging/vss-core/vss-agent-ui
-  tag: "3.2.1-26.07.1-dd945777eef9"
+  repository: ghcr.io/nvidia-ai-blueprints/vss/vss-agent-ui
+  tag: develop-latest
   pullPolicy: IfNotPresent
 replicas: 1
 service:


### PR DESCRIPTION
## Summary
- default managed Helm images to the same GHCR `develop-latest` channel as Docker Compose
- add shared `global.container_prefix` and `global.container_tag` overrides for QA staging drops
- update Helm sync policy and regression coverage for the shared channel

## Test plan
- [x] Run `.github/scripts/test_helm_release_channel_policy.py`
- [x] Lint the agent, VA-MCP, UI, and alert service charts
- [x] Render each managed image with shared NGC staging prefix/tag overrides