### PR TITLE
fix(agent): default missing industry profile version

### DIFF
--- a/.github/scripts/test_agent_config_defaults.py
+++ b/.github/scripts/test_agent_config_defaults.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INDUSTRY_AGENT_CONFIGS = (
+    ROOT
+    / "deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml",
+    ROOT / "deploy/docker/industry-profiles/smartcities/vss-agent/configs/config.yml",
+)
+
+
+class AgentConfigDefaultsTest(unittest.TestCase):
+    def test_agent_version_has_unset_environment_fallback(self) -> None:
+        for path in INDUSTRY_AGENT_CONFIGS:
+            with self.subTest(path=path):
+                lines = [line.strip() for line in path.read_text().splitlines()]
+                self.assertIn("agent_version: ${VSS_AGENT_VERSION:-dev}", lines)
+                self.assertNotIn("agent_version: ${VSS_AGENT_VERSION}", lines)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,8 +867,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Unit-test the golden resolver and SSOT-aware name matching
+      - name: Unit-test static CI and deployment guards
         run: |
+          python3 .github/scripts/test_agent_config_defaults.py
           python3 .github/scripts/test_compose_image_golden.py
           python3 .github/scripts/test_helm_release_channel_policy.py
           python3 .github/scripts/test_diagnose_sonarqube_failure.py

--- a/deploy/docker/industry-profiles/smartcities/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/smartcities/vss-agent/configs/config.yml
@@ -107,7 +107,7 @@ functions:
     base_url: ${VSS_AGENT_REPORTS_BASE_URL}
     template_path: ${VSS_AGENT_TEMPLATE_PATH}
     template_name: ${VSS_AGENT_TEMPLATE_NAME}
-    agent_version: ${VSS_AGENT_VERSION}
+    agent_version: ${VSS_AGENT_VERSION:-dev}
     llm_name: ${LLM_MODEL_TYPE:-nim}_llm
     video_understanding_tool: video_understanding
     picture_url_tool: vst_picture_url

--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/config.yml
@@ -101,7 +101,7 @@ functions:
     base_url: ${VSS_AGENT_REPORTS_BASE_URL}
     template_path: ${VSS_AGENT_TEMPLATE_PATH}
     template_name: ${VSS_AGENT_TEMPLATE_NAME}
-    agent_version: ${VSS_AGENT_VERSION}
+    agent_version: ${VSS_AGENT_VERSION:-dev}
     llm_name: llm
     video_understanding_tool: video_understanding
     picture_url_tool: vst_picture_url


### PR DESCRIPTION
## Summary
- default missing agent-version metadata to `dev` in warehouse and smartcities NAT configs
- prevent unset `VSS_AGENT_VERSION` from becoming `None` and failing strict configuration validation
- add a CI guard covering both industry profiles

## Test plan
- [x] Run the new agent-config default regression test
- [x] Run existing Compose golden, Helm release-channel, and Sonar diagnostic tests
- [x] Validate Ruff formatting and whitespace

## Downstream companion
- https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/merge_requests/282 derives and exports the exact resolved candidate version.