### PR TITLE
fix(mosquitto): allow connections from service containers

### DIFF
--- a/deploy/docker/services/infra/compose.yml
+++ b/deploy/docker/services/infra/compose.yml
@@ -78,7 +78,7 @@ services:
     ports:
       - ${MQTT_HOST_PORT:-1883}:${MQTT_PORT:-1883}
     restart: always
-    command: ["mosquitto", "-c", "/mosquitto/config/mosquitto.conf", "-p", "${MQTT_PORT:-1883}"]
+    command: ["mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]
     volumes:
       - $VSS_APPS_DIR/services/infra/mosquitto/configs/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
     healthcheck:

--- a/deploy/docker/services/infra/mosquitto/configs/mosquitto.conf
+++ b/deploy/docker/services/infra/mosquitto/configs/mosquitto.conf
@@ -1,2 +1,3 @@
+listener 1883 0.0.0.0
 allow_anonymous true
 set_tcp_nodelay true


### PR DESCRIPTION
Configure Mosquitto to listen on all container interfaces and remove the command-line port override so MV3DT perception can connect over Compose DNS.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
