### PR TITLE
fix(ci): run release notes on tag-capable runner

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -30,7 +30,10 @@ permissions:
 jobs:
   trigger-release-notes:
     name: Trigger Release Notes Pipeline
-    runs-on: [self-hosted, downstream-pipeline]
+    # The downstream-pipeline pool is restricted by its runner hook to
+    # copy-pr-bot's pull-request/* refs, so tag-triggered jobs are rejected
+    # during runner setup before any workflow step can execute.
+    runs-on: [self-hosted, vss-brev-runner]
     timeout-minutes: 15
     env:
       DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}


### PR DESCRIPTION
## Summary
- move the tag-triggered release-notes job from the `downstream-pipeline` runner pool to `vss-brev-runner`
- document why the PR-only pool cannot execute release-tag workflows
- fix failures in runs [30240262649](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/30240262649) and [30238700299](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/30238700299), where `block-pr-workflows.sh` exited 10 during runner setup before checkout

## Test plan
- [x] Parse `.github/workflows/release-notes.yml` with PyYAML
- [x] Run `git diff --check`
- [ ] Verify the next weekly `dev-YY.MM.N` tag reaches the `Trigger pipeline` step