### PR TITLE
fix(ci): grant statuses:read so NVSkills CI stops failing at startup

### DIFF
--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -14,9 +14,14 @@ jobs:
       (github.event_name == 'push' &&
         github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
         startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    # Must cover every permission the called workflow declares, otherwise the
+    # run dies with startup_failure before any job executes. NVIDIA/skills
+    # added `statuses: read` in bc8b450a (it reads the commit status list to
+    # find the NVSkills CI verdict), so the caller has to grant it too.
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## The `/nvskills-ci` slash command is dead

This is not a cosmetic-red-check PR. `Team Request NVSkills CI` is what dispatches NVSkills CI when someone comments `/nvskills-ci` on a PR — and since ~15:10 UTC on 2026-07-27 that dispatch has done **nothing**, silently.

**Every `issue_comment`-triggered run since the break: 72 runs, 100% `startup_failure`, zero successes** (most recent 2026-07-28T00:32Z).

The command is in active use — recent invocations on #1254, #1397, #1301, #1227, #1351. Each of those users commented `/nvskills-ci` and got silence: no dispatch, no error, no comment. `startup_failure` produces no jobs, no logs and no annotations, so there is nothing for them to look at. `gh run view --log` returns `log not found`.

## Root cause

`NVIDIA/skills` added `statuses: read` to the called workflow's permissions in [`bc8b450a`](https://github.com/NVIDIA/skills/commit/bc8b450a) (2026-07-20).

| | |
|---|---|
| This caller grants | `contents: read`, `pull-requests: read` |
| `NVIDIA/skills/.github/workflows/team-request.yml@main` declares | `contents: read`, `pull-requests: read`, **`statuses: read`** |

A reusable workflow cannot request a permission its caller withheld, so the run is rejected at startup. Permission validation happens *before* job-level `if:` evaluation, which is why even pushes the gate would have skipped come back red.

## Note: we are granting this for a job that cannot run here

Worth stating plainly, since it looks odd. The called workflow has two jobs:

| Job | Gate | Uses `statuses: read`? |
|---|---|---|
| `require-nvskills-ci` | `if: github.event_name == 'pull_request'` | **yes** — it is the only consumer (reads `/commits/{sha}/statuses`) |
| `request` | `issue_comment` with `/nvskills-ci`, or signature push | no |

This caller has no `pull_request` trigger, so `require-nvskills-ci` never executes for this repo. The permission is therefore required **purely to pass startup validation** for a job that is inert here.

Granting it is still the correct minimal fix: GitHub validates the called workflow's entire declared permission set at startup, regardless of which jobs will actually run. The alternative — adopting the upstream `pull_request` trigger so that job becomes live — is a real behaviour change and belongs in its own PR (see below).

## Confirmed by controlled A/B

Two branches pushed 16 seconds apart, identical with respect to this workflow except for the permission block:

| Time (UTC) | Branch | Result |
|---|---|---|
| 19:21:37 | `fix/nvskills-ci-statuses-permission` (**this PR**) | **`skipped`** ✅ |
| 19:21:53 | `fix/ghcr-anonymous-token-auth` (unchanged caller) | `startup_failure` ❌ |

`skipped` is the correct outcome for those pushes: the workflow resolves, loads the called workflow, and the `if:` gate correctly declines. That is the difference between "the gate evaluated and said no" and "the run died before the gate was read".

## Not specific to this repo

Other consumers of the same reusable workflow are startup-failing identically — worth flagging upstream:

| Repo | Latest `Request NVSkills CI` |
|---|---|
| `NVIDIA/Megatron-LM` | `startup_failure` |
| `NVIDIA-AI-Blueprints/aiq` | `startup_failure` |
| `NVIDIA/physicsnemo` | `startup_failure` |

The canonical caller template at [`NVIDIA/nvskills-ci:templates/team-request-workflow.yml`](https://github.com/NVIDIA/nvskills-ci/blob/main/templates/team-request-workflow.yml) already lists all three permissions; consumer repos drifted after `bc8b450a`.

## Deliberately out of scope

That template has also grown `pull_request` (path-filtered) and `status` triggers with matching `if:` clauses. This PR does **not** adopt them. Doing so would activate `require-nvskills-ci` and change which events gate a PR — a separate decision, worth taking on its own merits now that we know that job is currently inert here.

## Verification

`team-request.yml` parses as valid YAML; the A/B above is the functional proof.
