### PR TITLE
fix(ci): stop sending the NGC key to ghcr.io in the container source check

### DIFF
--- a/.github/scripts/check_container_tag_source.py
+++ b/.github/scripts/check_container_tag_source.py
@@ -515,7 +515,14 @@ def _fetch_bearer_token(
     token_url = f"{realm}?service={urllib.parse.quote(params.get('service', ''))}&scope={urllib.parse.quote(scope)}"
 
     req = urllib.request.Request(token_url)
-    if ngc_key:
+    # The NGC key is only a credential for nvcr.io. Sending it to any other
+    # registry is worse than sending nothing: ghcr.io answers a Basic header it
+    # cannot resolve with 403, whereas an unauthenticated request to the same
+    # endpoint yields a perfectly good anonymous pull token for a public
+    # package. Gating on the registry also keeps the registry-specific branch
+    # below reachable — NGC_CLI_API_KEY is set on every run of this check, so an
+    # unguarded `if ngc_key` made those credentials dead code.
+    if ngc_key and registry.endswith("nvcr.io"):
         basic = base64.b64encode(f"$oauthtoken:{ngc_key}".encode()).decode()
         req.add_header("Authorization", f"Basic {basic}")
     elif registry_username and registry_password:

--- a/.github/workflows/check-agent-container-source.yml
+++ b/.github/workflows/check-agent-container-source.yml
@@ -67,4 +67,9 @@ jobs:
         if: steps.filter.outputs.skip != 'true' && !startsWith(github.ref_name, 'pull-request/')
         env:
           NGC_CLI_API_KEY: ${{ secrets.NGC_CLI_API_KEY }}
+          # Deployable tags now resolve to ghcr.io, which the NGC key cannot
+          # authenticate. Public packages read fine anonymously; these let the
+          # check keep working if a package is ever made private.
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         run: python3 .github/scripts/check_container_tag_source.py --image-name vss-agent

--- a/.github/workflows/check-ui-container-source.yml
+++ b/.github/workflows/check-ui-container-source.yml
@@ -68,4 +68,9 @@ jobs:
         if: steps.filter.outputs.skip != 'true' && !startsWith(github.ref_name, 'pull-request/')
         env:
           NGC_CLI_API_KEY: ${{ secrets.NGC_CLI_API_KEY }}
+          # Deployable tags now resolve to ghcr.io, which the NGC key cannot
+          # authenticate. Public packages read fine anonymously; these let the
+          # check keep working if a package is ever made private.
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         run: python3 .github/scripts/check_container_tag_source.py --image-name vss-agent-ui


### PR DESCRIPTION
## Problem

`Check Agent Container Source` and `Check UI Container Source` both fail on `develop`:

```
tag:      develop-latest
manifest: UNREACHABLE (token endpoint returned 403: Forbidden)
[FAIL] could not fetch the image manifest for
       ghcr.io/nvidia-ai-blueprints/vss/vss-agent:develop-latest.
       The image is missing from the registry, the credentials are wrong,
       or the network is broken — fix the upstream promotion rather than
       falling back to the tag's git-SHA suffix.
```

The image is fine. The credential is the bug.

Deployable tags now resolve to `ghcr.io`, but `_fetch_bearer_token()` guarded the NGC credential on `if ngc_key:` alone, with no registry check. The workflow sets `NGC_CLI_API_KEY` on every run, so ghcr.io always received a Basic header carrying `$oauthtoken:<NGC key>` — and rejected it.

Reproduced against the live registry:

```
ghcr + NGC key set  -> token endpoint returned 403: Forbidden
ghcr + no creds     -> OK (anonymous pull token)
```

The credential was strictly worse than sending nothing.

## Two defects, one root cause

1. **NGC creds leak to non-NGC registries.** `nvcr.io` needs `$oauthtoken` + NGC key; ghcr.io answers that Basic header with 403. The public package resolves anonymously without it.
2. **The GHCR credential branch was dead code.** `elif registry_username and registry_password:` sits directly below the NGC branch. Since `NGC_CLI_API_KEY` is set on every run, the `elif` was unreachable — the `GHCR_USERNAME`/`GHCR_TOKEN` support already in the script had never once executed. The workflows did not pass those secrets either.

The failure message also actively misdirects: it blames a missing image or broken promotion, so the natural next step is to go hunting through the promotion pipeline rather than the auth header.

## Fix

- Gate the NGC credential on `registry.endswith("nvcr.io")`, so ghcr.io falls through to anonymous (public) or to the registry-specific branch (private).
- Pass the existing `GHCR_USERNAME` / `GHCR_TOKEN` secrets through both workflows, making that branch reachable.

## Verification

Against the live registries, using the patched function:

| Case | Before | After |
|---|---|---|
| `ghcr.io` + NGC key set | `403 Forbidden` | **OK**, token len 76 |
| `ghcr.io`, no creds | OK | OK, token len 76 |
| `nvcr.io` + NGC key | Basic auth sent | Basic auth still sent (unchanged) |

The `nvcr.io` case still returns 403 under test only because the test key is fake — that confirms the NGC path is preserved rather than bypassed.

`.github/scripts/test_source_check_only_nonbuild.py`: **26 tests, OK**.

## Related, not fixed here

Both workflows skip this step on `pull-request/*` refs (`if: ... && !startsWith(github.ref_name, 'pull-request/')`), so the check only ever runs on `main`/`develop` — where it has been failing 100% of the time. It therefore cannot block a PR today. Worth a separate look at whether that skip is still wanted.