### PR TITLE
fix(skill-eval): build Harbor trace URLs in run_leg.py

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -678,50 +678,63 @@ to pick up a trial, its directory must live under
 `/tmp/skill-eval/results/_viewer/<leg-slug>__<run_id>__<date>/` as a
 **real dir (not a symlink)**, flattened — no nested `<date>/` level.
 The `<leg-slug>` keeps concurrent legs from colliding on one viewer
-entry. **Copy** (don't move) from this leg's scoped results root:
+entry.
 
-```bash
-VIEWER_JOB="/tmp/skill-eval/results/_viewer/${LEG}__${GITHUB_RUN_ID}__<date>"
-mkdir -p "$VIEWER_JOB"
-cp -a "$RES/<date>/." "$VIEWER_JOB/"
-```
+**`run_leg.py` does this publish for you** (`publish_trace`), after
+every trial including timed-out ones. It copies (never moves) the
+date dir's *contents* into a pre-made job dir — the workflow's
+"Collect results" step runs *after* this agent and tars `$RES` for
+the artifact, so a `mv` would upload an artifact with no
+`result.json`. Copying keeps `$RES` intact for the collector (which
+excludes `agent/` from the public tarball) while the `_viewer` copy
+keeps `agent/` for the live Harbor Trace tab. You do not run `cp`
+yourself.
 
-`cp -a`, **not `mv`** — the workflow's "Collect results" step runs
-*after* this agent and scans + tars `$RES` for the artifact. A `mv`
-would leave `$RES` empty and the uploaded artifact would have no
-`result.json` or traces. Copying keeps `$RES` intact for the collector
-(which excludes `agent/` from the public tarball) while the `_viewer`
-copy keeps `agent/` for the live Harbor Trace tab.
+### Trace URLs — read them, never build them
 
-**Use the `mkdir -p` + `cp -a "$RES/<date>/."` (trailing `/.`) form
-above, not `cp -a "$RES/<date>" "$VIEWER_JOB"`** — the latter is not
-idempotent: on the *second* trial of a multi-step spec, `$VIEWER_JOB`
-already exists, so `cp -a <date> <existing-dir>` nests the trial as
-`$VIEWER_JOB/<date>/...` and Harbor only sees the first (top-level)
-trial. Copying the directory *contents* into a pre-made `$VIEWER_JOB`
-keeps every trial at the job's top level.
-
-Do this between trials so each new trial's traces are reachable
-via the SPA URL:
+`run_leg.py` writes one row per finished trial to
+`<results-root>/trace-urls.tsv`:
 
 ```
-https://harbor-${BREV_ENV_ID}.brevlab.com/jobs/<leg-slug>__<run_id>__<date>/tasks/<source>/<agent>/<provider>/<model>/<task>
+<include-task-name>\t<trial-dir>\t<url>
 ```
 
-**CRITICAL — `BREV_ENV_ID` in this URL is the coordinator host's
-env id** (the CI runner, set by Brev in `/etc/environment` — on the
-current coordinator it's `13xh5gpe7`). It is **NOT** a per-trial
-instance id you see in `brev ls --json` (the `id` field of
-`vss-eval-*` or `harbor-*` entries). The coordinator runs
-`harbor view`; per-trial boxes do not. Mixing these up produces a
-trace URL that resolves to the wrong brevlab subdomain and 404s.
-When generating the URL, read the value from the runner env
-(`echo "$BREV_ENV_ID"`) and paste it verbatim — never substitute
-from `brev ls` output.
+and echoes `[run-leg] trace: <step> -> <url>` to the job log. **Read
+the URL from there and paste it verbatim into the comment. Never
+assemble a Harbor URL by hand.** A step with no row errored before
+producing `result.json` — report it without a trace link rather than
+inventing one.
 
-Values for `<source>` / `<agent>` / `<model>` / `<task>` come from
-`GET http://localhost:8080/api/jobs/<leg-slug>__<run_id>__<date>/tasks`;
-slashes in `<model>` and `<task>` must be URL-encoded (`%2F`).
+The URL shape is:
+
+```
+https://harbor-<COORDINATOR_ENV_ID>.brevlab.com/jobs/<leg-slug>__<run_id>__<date>/tasks/<source>/<agent>/<provider>/<model>/<task>
+```
+
+Two things make hand-assembly unreliable, which is why it moved into
+the wrapper:
+
+- **`<task>` is Harbor's fully-qualified `task_name`**
+  (`nvidia-vss/<dataset>-step-N`), *not* the `--include-task-name`
+  filter (`step-N`) used to select the task. A bare `step-N` matches
+  no task, and because the viewer is a client-side SPA — every route
+  returns the same HTTP 200 shell — the page renders **blank** rather
+  than 404ing. That is indistinguishable from missing trace data.
+  (Observed on PR #1254, run 30284131217: all seven step links were
+  built with the filter and every one opened empty.)
+- **`BREV_ENV_ID` is the coordinator host's env id** (the CI runner,
+  set by Brev in `/etc/environment`). It is **NOT** a per-trial
+  instance id from `brev ls --json` (the `id` field of `vss-eval-*`
+  or `harbor-*` entries). The coordinator runs `harbor view`;
+  per-trial boxes do not. `run_leg.py` reads the runner env and falls
+  back to `/etc/environment` — never substitute from `brev ls`.
+
+Every segment `run_leg.py` emits comes from the trial's own
+`result.json` (`source`, `agent_info.name`,
+`agent_info.model_info.provider|name`, `task_name`), so the link
+cannot drift from what the viewer indexes, and it is produced even
+when `harbor-view.service` is down. To inspect the index by hand:
+`GET http://localhost:8080/api/jobs/<leg-slug>__<run_id>__<date>/tasks`.
 
 ### Per-trial trajectory isolation
 

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -210,17 +210,20 @@ python3 .github/skill-eval/run_leg.py \
     └── claude-code.txt   ← agent trace
 ```
 
-To view in the browser, **copy** (not move — the workflow's collector
-still tars the leg's results root after the agent) into the viewer dir,
-flattened with the leg slug:
+`run_leg.py` publishes each finished trial into the viewer dir itself
+(copying, not moving — the workflow's collector still tars the leg's
+results root afterwards) and appends the browsable URL to
+`<results-root>/trace-urls.tsv`:
 
-```bash
-VIEWER_JOB="/tmp/skill-eval/results/_viewer/<leg-slug>__<run_id>__<date>"
-mkdir -p "$VIEWER_JOB"
-cp -a "<leg-slug>/<run_id>/<date>/." "$VIEWER_JOB/"   # contents into a pre-made dir — idempotent
+```
+step-7	step-7__E6dBECL	https://harbor-<ENV_ID>.brevlab.com/jobs/<job>/tasks/<source>/<agent>/<provider>/<model>/<task>
 ```
 
-Then open `https://harbor-<BREV_ENV_ID>.brevlab.com/jobs/<leg-slug>__<run_id>__<date>`.
+Open the URL from that file rather than composing one: the trailing
+`<task>` is Harbor's fully-qualified `task_name`
+(`nvidia-vss/<dataset>-step-N`), not the `step-N` filter, and the
+viewer is an SPA that renders a wrong path as a **blank page**, never
+a 404.
 
 `harbor view` runs persistently on the CI runner host. If it's down:
 

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -28,12 +28,15 @@ import contextlib
 import dataclasses
 import errno
 import fcntl
+import json
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
 import time
+import urllib.parse
 from pathlib import Path
 
 
@@ -46,6 +49,10 @@ RTX4090_PREFIX = "vss-eval-geforce-rtx4090-"
 # its spec metadata declares gpu_type that matches GEFORCE RTX 4090.
 RTX4090_ALL_TESTS: frozenset[str] = frozenset()
 RTX4090_TESTS: dict[str, frozenset[str]] = {}
+# Shared root served by the coordinator's persistent `harbor-view.service`
+# (AGENTS.md § Harbor viewer). Fixed path — the viewer is started once for
+# the host, not per leg, so every leg publishes its trials in here.
+VIEWER_ROOT = Path("/tmp/skill-eval/results/_viewer")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -592,6 +599,106 @@ def latest_reward(
     return latest.read_text().strip()
 
 
+def _coordinator_env_id() -> str | None:
+    """Brev env id of the COORDINATOR host — the box running `harbor view`.
+
+    Never derive this from `brev ls`: that yields a per-trial instance id,
+    and the resulting URL points at a subdomain with no viewer behind it.
+    """
+    env_id = os.environ.get("BREV_ENV_ID", "").strip()
+    if env_id:
+        return env_id
+    try:
+        for line in Path("/etc/environment").read_text().splitlines():
+            key, _, value = line.partition("=")
+            if key.strip() == "BREV_ENV_ID":
+                return value.strip().strip('"').strip("'") or None
+    except OSError:
+        pass
+    return None
+
+
+def trace_url(result_json: Path, job_name: str) -> str | None:
+    """Harbor viewer deep-link for one finished trial.
+
+    Every segment is read from the trial's own result.json, so the link
+    cannot drift from what the viewer indexes. `task_name` in particular is
+    Harbor's fully-qualified name (`nvidia-vss/<dataset>-step-N`), NOT the
+    `--include-task-name` filter (`step-N`) that selects the task here — the
+    viewer resolves its task route by the former. A bare `step-N` matches
+    nothing and renders a BLANK PAGE rather than a 404, because the viewer
+    is a client-side SPA where every route returns the same HTTP 200 shell.
+    That failure mode is indistinguishable from missing trace data, which is
+    why the URL is built here instead of being assembled by hand.
+    """
+    env_id = _coordinator_env_id()
+    if not env_id:
+        return None
+    try:
+        data = json.loads(result_json.read_text())
+    except (OSError, ValueError):
+        return None
+    agent_info = data.get("agent_info") or {}
+    model_info = agent_info.get("model_info") or {}
+    parts = [
+        data.get("source"),
+        agent_info.get("name"),
+        model_info.get("provider"),
+        model_info.get("name"),
+        data.get("task_name"),
+    ]
+    if not all(parts):
+        return None
+    # safe="" so the slashes inside <model> and <task> encode as %2F — the
+    # viewer expects them as single path segments, not extra path levels.
+    encoded = "/".join(urllib.parse.quote(str(part), safe="") for part in parts)
+    return f"https://harbor-{env_id}.brevlab.com/jobs/{job_name}/tasks/{encoded}"
+
+
+def publish_trace(
+    results_root: Path,
+    invocation: HarborInvocation,
+    started_at: float,
+    leg_slug: str,
+    run_id: str,
+) -> str | None:
+    """Copy a finished trial into the viewer root and record its trace URL.
+
+    Returns None when the trial produced no result.json (errored or timed
+    out before the verifier ran) — such a step has no trace to link.
+    """
+    matches = [
+        path.parent
+        for path in results_root.glob(
+            f"*/{invocation.include_task_name}__*/result.json"
+        )
+        if path.stat().st_mtime >= started_at
+    ]
+    if not matches:
+        return None
+    trial_dir = max(matches, key=lambda path: path.stat().st_mtime)
+    date_dir = trial_dir.parent
+    job_name = f"{leg_slug}__{run_id}__{date_dir.name}"
+    viewer_job = VIEWER_ROOT / job_name
+    viewer_job.mkdir(parents=True, exist_ok=True)
+    # Copy (never move) the date dir's *contents*: the workflow's "Collect
+    # results" step runs after this and tars results_root for the artifact,
+    # and copying the dir itself would nest a later trial under
+    # <job>/<date>/ where the viewer cannot see it.
+    shutil.copytree(date_dir, viewer_job, dirs_exist_ok=True)
+    url = trace_url(trial_dir / "result.json", job_name)
+    if url:
+        with (results_root / "trace-urls.tsv").open("a") as handle:
+            handle.write(
+                f"{invocation.include_task_name}\t{trial_dir.name}\t{url}\n"
+            )
+        print(
+            f"[run-leg] trace: {invocation.include_task_name} -> {url}",
+            flush=True,
+        )
+    return url
+
+
 def _reward_value(reward: str | None) -> float:
     if reward is None:
         return 0.0
@@ -666,6 +773,10 @@ def run_invocations(
         return 1
 
     results_root.mkdir(parents=True, exist_ok=True)
+    # skills-eval.yml passes --results-root as <...>/results/<slug>/<run_id>;
+    # the env vars are the authoritative source when the agent exports them.
+    leg_slug = os.environ.get("EVAL_SLUG") or results_root.parent.name
+    run_id = os.environ.get("GITHUB_RUN_ID") or results_root.name
     skipped_after: dict[str, int] = {}
     overall_rc = 0
 
@@ -680,6 +791,14 @@ def run_invocations(
         cmd = build_harbor_command(invocation, results_root, model, base_url, agent)
         started_at = time.time() - 1.0
         rc = run_command(cmd, env, harbor_timeout_sec)
+        # Publish before the rc checks below: a timed-out (rc=124) trial
+        # returns early, and its partial trace is exactly what needs reading.
+        try:
+            publish_trace(results_root, invocation, started_at, leg_slug, run_id)
+        except Exception as exc:  # noqa: BLE001
+            # A trace link is reporting convenience; the verdict comes from
+            # reward.txt. Never let a viewer-publish error fail the leg.
+            print(f"[run-leg] trace publish failed: {exc!r}", flush=True)
         if rc != 0 and overall_rc == 0:
             overall_rc = rc
 

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -9,6 +9,8 @@ Run:
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
 import sys
 import tempfile
 import time
@@ -170,6 +172,139 @@ class SkipMarkers(unittest.TestCase):
                 step3.read_text().strip(),
                 "skipped (prior-step fail, step=2 reward=0.2)",
             )
+
+
+class TraceUrls(unittest.TestCase):
+    """Regression cover for the blank-Harbor-page bug.
+
+    PR #1254 / run 30284131217 shipped seven trace links whose final
+    segment was the `--include-task-name` filter (`step-7`) instead of
+    Harbor's `task_name`. The viewer is a client-side SPA, so every one
+    of them opened as an empty page instead of erroring.
+    """
+
+    # Shape mirrors a real trial's result.json.
+    RESULT = {
+        "task_name": "nvidia-vss/vss-generate-video-report-base-l40s-step-7",
+        "trial_name": "step-7__E6dBECL",
+        "source": "l40s",
+        "agent_info": {
+            "name": "claude-code",
+            "model_info": {
+                "name": "anthropic/bedrock-claude-opus-4-6",
+                "provider": "aws",
+            },
+        },
+    }
+    JOB = (
+        "vss-generate-video-report__base_profile_report__L40S"
+        "__30284131217__2026-07-27__17-16-47"
+    )
+
+    def setUp(self):
+        self._orig_env = os.environ.get("BREV_ENV_ID")
+        os.environ["BREV_ENV_ID"] = "13xh5gpe7"
+
+    def tearDown(self):
+        if self._orig_env is None:
+            os.environ.pop("BREV_ENV_ID", None)
+        else:
+            os.environ["BREV_ENV_ID"] = self._orig_env
+
+    def _write_result(self, directory: Path, payload=None) -> Path:
+        directory.mkdir(parents=True, exist_ok=True)
+        result = directory / "result.json"
+        result.write_text(json.dumps(payload if payload is not None else self.RESULT))
+        return result
+
+    def test_trace_url_matches_the_viewer_route(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = self._write_result(Path(td) / "step-7__E6dBECL")
+            url = run_leg.trace_url(result, self.JOB)
+
+        self.assertEqual(
+            url,
+            "https://harbor-13xh5gpe7.brevlab.com/jobs/"
+            + self.JOB
+            + "/tasks/l40s/claude-code/aws"
+            + "/anthropic%2Fbedrock-claude-opus-4-6"
+            + "/nvidia-vss%2Fvss-generate-video-report-base-l40s-step-7",
+        )
+
+    def test_trace_url_never_ends_in_the_include_task_filter(self):
+        """The exact regression: a bare `step-7` tail renders a blank page."""
+        with tempfile.TemporaryDirectory() as td:
+            result = self._write_result(Path(td) / "step-7__E6dBECL")
+            url = run_leg.trace_url(result, self.JOB)
+
+        self.assertFalse(url.endswith("/step-7"))
+        self.assertTrue(url.endswith("-step-7"))
+        # Slashes inside <model>/<task> must be segments, not path levels.
+        self.assertEqual(url.count("%2F"), 2)
+
+    def test_trace_url_none_on_incomplete_result(self):
+        with tempfile.TemporaryDirectory() as td:
+            partial = dict(self.RESULT)
+            partial.pop("task_name")
+            result = self._write_result(Path(td) / "step-7__X", partial)
+
+            self.assertIsNone(run_leg.trace_url(result, self.JOB))
+            self.assertIsNone(run_leg.trace_url(Path(td) / "missing.json", self.JOB))
+
+    def test_publish_trace_flattens_into_viewer_and_records_url(self):
+        invocation = run_leg.HarborInvocation(
+            harbor_root=Path("/tmp/datasets/base/l40s"),
+            include_task_name="step-7",
+            chain_key="base_l40s",
+            step_index=7,
+            step_count=8,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            results_root = root / "results" / "leg" / "30284131217"
+            trial = results_root / "2026-07-27__17-16-47" / "step-7__E6dBECL"
+            self._write_result(trial)
+            viewer_root = root / "_viewer"
+            orig_viewer = run_leg.VIEWER_ROOT
+            run_leg.VIEWER_ROOT = viewer_root
+            try:
+                url = run_leg.publish_trace(
+                    results_root, invocation, 0.0, "leg", "30284131217"
+                )
+            finally:
+                run_leg.VIEWER_ROOT = orig_viewer
+
+            job_dir = viewer_root / "leg__30284131217__2026-07-27__17-16-47"
+            # Flattened: the trial sits at the job's top level, with no
+            # intervening <date>/ level for the viewer to miss.
+            self.assertTrue((job_dir / "step-7__E6dBECL" / "result.json").is_file())
+            self.assertFalse((job_dir / "2026-07-27__17-16-47").exists())
+            # Copy, not move — the workflow collector still tars results_root.
+            self.assertTrue((trial / "result.json").is_file())
+
+            row = (results_root / "trace-urls.tsv").read_text().strip().split("\t")
+
+        self.assertEqual(row[0], "step-7")
+        self.assertEqual(row[1], "step-7__E6dBECL")
+        self.assertEqual(row[2], url)
+        self.assertIn("/jobs/leg__30284131217__2026-07-27__17-16-47/tasks/", url)
+
+    def test_publish_trace_returns_none_when_trial_produced_no_result(self):
+        invocation = run_leg.HarborInvocation(
+            harbor_root=Path("/tmp/datasets/base/l40s"),
+            include_task_name="step-1",
+            chain_key="base_l40s",
+            step_index=1,
+            step_count=8,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            results_root = Path(td) / "results"
+            results_root.mkdir(parents=True)
+
+            self.assertIsNone(
+                run_leg.publish_trace(results_root, invocation, 0.0, "leg", "1")
+            )
+            self.assertFalse((results_root / "trace-urls.tsv").exists())
 
 
 class PoolCandidates(unittest.TestCase):


### PR DESCRIPTION
## Problem

Trace links in skills-eval PR comments are assembled by hand by the eval agent from the template in `AGENTS.md`. On [PR #1254 / run 30284131217](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/30284131217), all seven step links ended in the `--include-task-name` **filter**:

```
…/aws/anthropic%2Fbedrock-claude-opus-4-6/step-7          ← what shipped
…/aws/anthropic%2Fbedrock-claude-opus-4-6/nvidia-vss%2Fvss-generate-video-report-base-l40s-step-7   ← what the viewer indexes
```

The viewer resolves its task route by Harbor's fully-qualified `task_name`, so nothing matched. And because the viewer is a client-side SPA (`"ssr": false, "isSpaMode": true`) where *every* route returns the same HTTP 200 shell, each link opened as a **blank page** rather than 404ing — indistinguishable from missing trace data.

This matters more than a cosmetic link bug: the results tarball deliberately excludes `agent/` trajectories (secret-leak fix, #516 leaked `NGC_CLI_API_KEY` that way). The trace link is therefore the *only* route to an agent's reasoning from CI, and when it's wrong there's no fallback.

Not a regression in code — every earlier comment on that PR got it right (90 links across 07-20 → 07-24; only the newest 7 are broken). It's a hand-assembly step that the agent will occasionally get wrong, so this moves it into the wrapper.

## Worked example — run 30284131217, step-7

The viewer's route table binds the last path segment to `:taskName`:

```
routes/task   path=jobs/:jobName/tasks/:source/:agent/:modelProvider/:modelName/:taskName
```

and the route module puts it straight on the wire as a `task_name` filter:

```js
queryFn: () => A(s, N, $, {taskName: n, source: u, agentName: m, modelName: x})
…
r?.taskName && n.set("task_name", r.taskName)
```

Replaying that exact `GET /api/jobs/<job>/trials` request with each candidate tail:

| `task_name=` | result |
|---|---|
| *(no filter — is the data even there?)* | `total=1  ['step-7__E6dBECL']` |
| `step-7` — what the comment linked | `total=0  []` |
| `nvidia-vss/vss-generate-video-report-base-l40s-step-7` | `total=1  ['step-7__E6dBECL']` |

Zero rows is the blank page. Note the first line: the trial was present the whole time — still returning `total=1` hours after the run — so this is not the 12 h scratch GC either. That sweep carries `! -path '*/_viewer/*'` and only reaps `results/<slug>/<run_id>/`, the artifact-side copy, never the `_viewer/<job>/` path the trace links point at.

Diagnostic tell for next time: **if browsing the viewer and filtering finds the trial but the link opens blank, the link is wrong — not the data.** Missing data fails both paths.

The working URL, which differs from the shipped one in exactly one segment:

```
https://harbor-13xh5gpe7.brevlab.com/jobs/vss-generate-video-report__base_profile_report__L40S__30284131217__2026-07-27__17-16-47/tasks/l40s/claude-code/aws/anthropic%2Fbedrock-claude-opus-4-6/nvidia-vss%2Fvss-generate-video-report-base-l40s-step-7
```

`trace_url()` in this PR reproduces that string byte-for-byte from the trial's own `result.json` — that equality is asserted in `test_trace_url_matches_the_viewer_route`.

## Change

`run_leg.py` now owns both halves of the viewer publish:

- **`publish_trace()`** — copies each finished trial into the shared `_viewer` root (contents, flattened, copy-not-move) after every harbor invocation, including timed-out ones. This is work the agent previously did by hand with a `cp -a "$RES/<date>/."` form that had to be spelled exactly right (trailing `/.`) to stay idempotent across a multi-step spec.
- **`trace_url()`** — derives every segment from the trial's own `result.json` (`source`, `agent_info.name`, `agent_info.model_info.provider|name`, `task_name`). The link cannot drift from what the viewer indexes, and it's produced even when `harbor-view.service` is down.

Why this layer: `HarborInvocation.include_task_name` is the *filter* (`step-7`) — the wrapper never had the fully-qualified name in process, and the agent had to make a separate `GET /api/jobs/<job>/tasks` call to learn it while `step-7` was already in front of it in the harbor command, the trial dir name, and the reward path. Reading the named `task_name` field out of `result.json` removes the choice: six fields in that file contain a `step-7`-shaped string, and only one is the right one.

URLs are appended to `<results-root>/trace-urls.tsv` and echoed as `[run-leg] trace: <step> -> <url>`. `AGENTS.md` and `README.md` now instruct the agent to paste them verbatim and never construct one; a step with no row errored before producing `result.json` and should be reported without a link.

Publish failures are caught and logged, never fatal — the verdict comes from `reward.txt`, not the viewer.

## Verification

- `trace_url()` run against the real `result.json` from run 30284131217 reproduces the hand-verified working URL byte-for-byte.
- 5 new tests in `tests/test_run_leg.py` cover the exact regression (tail must not be the bare filter), `%2F` segment encoding, incomplete/missing `result.json`, and that publish flattens into the viewer job dir without disturbing the collector's copy. All pass.
- `ruff check` clean on both changed Python files.

Note: `python3 .github/skill-eval/tests/test_run_leg.py` reports 3 failures in `PoolCandidates` (RTX 4090 allowlist). Those are **pre-existing on `develop`** — the same 3 fail on a pristine checkout (22 tests / 3 failures there, 27 / 3 here) and are untouched by this change.

## Known limits

- **Not yet exercised by a live leg.** This PR's own diff plans zero eval legs (`plan_matrix.py` selects on `skills/**` and `adapters/<skill>/**`), so `/ok to test` runs everything except an eval. A `workflow_dispatch` of Skills Eval against this branch with a single-leg skill would exercise it end to end.
- **`test_run_leg.py` is not in `ci.yml`'s pytest list** — that job runs a hand-listed subset of `.github/skill-eval/tests/`, so these tests only run locally. Adding it requires first fixing the 3 pre-existing `PoolCandidates` failures above; worth a follow-up.
- **The agent still has to paste the URL.** This change guarantees a correct URL is computed, logged, and one line away — it does not mechanically prevent an agent from hand-writing one anyway. A stronger follow-up would validate that every `harbor-*` link in a posted comment appears in `trace-urls.tsv`, turning a wrong link into a CI failure instead of a silent blank page.

## Scope

`.github/skill-eval/` only — no skill, adapter, or eval-spec surface is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
