### PR TITLE
Feat/vios tests schema

### DIFF
--- a/services/vios/.claude/commands/vios-architecture.md
+++ b/services/vios/.claude/commands/vios-architecture.md
@@ -243,10 +243,48 @@ Two Redis-backed channels are always in use in this topology.
 
 - **Producer:** sensor-MS (and the storage service, for file-based sensors).
 - **Consumer:** SDR.
-- **Actions:** `camera_add`, `camera_proxy`, `camera_remove`, `camera_status_change` (and a few more lifecycle states).
-- **Payload:** a JSON envelope describing one camera-status change. It carries a timestamp, the source service name, the alert type, and a nested object with the stream's id, name, proxy URL, the action, optional tags, and codec / resolution / framerate metadata. SDR keys placement on the stream id.
+- **Alert types:** `camera_status_change` (the lifecycle stream) and `service_status_change`.
+- **Actions** (the `event.change` field of a `camera_status_change`): `camera_add`, `camera_proxy`, `camera_streaming`, `camera_remove`.
 
-This is the only message bus SDR listens to.
+SDR keys pod placement on `event.camera_id`. This is the only message bus SDR listens to.
+
+Envelope:
+
+```json
+{
+  "created_at": "<ISO8601>",
+  "source": "vst",
+  "alert_type": "camera_status_change",
+  "event": {
+    "camera_id":      "<sensor or stream id>",
+    "camera_name":    "<stream name>",
+    "camera_type":    "rtsp | file",
+    "camera_url":     "<live proxy URL; http URL when camera_type is file>",
+    "camera_vod_url": "<replay URL>",
+    "change":         "camera_add | camera_proxy | camera_streaming | camera_remove",
+    "tags":           "<optional>",
+    "metadata": {
+      "sensor_type":     "<sensor_* type string>",
+      "codec":           "H264",
+      "resolution":      "1920x1080",
+      "framerate":       30,
+      "file_start_time": "<ISO8601>"
+    }
+  }
+}
+```
+
+Field rules:
+
+- `camera_type` is the sensor type with the `sensor_` prefix stripped.
+- `camera_url` is empty on `camera_add`. On every other action it carries the live URL — an RTSP proxy URL for `rtsp` sensors, an HTTP URL for `file` sensors.
+- `camera_vod_url` accompanies `camera_streaming` from the RTSP-server path.
+- `metadata` is omitted entirely when it would be empty; individual subfields are omitted when unset.
+- **`camera_streaming` is the strict one.** `camera_type` and `camera_url` are required on it, and when `camera_type` is `file`, `metadata.file_start_time` is required too. The other actions carry these fields opportunistically.
+
+`camera_streaming` is emitted by three separate payload builders — `rtspserver.cpp` (RTSP proxy registration, the one that adds `camera_vod_url`), `vst_common::notifyEvent` (storage / file-sensor and sensor-management paths, the only one that emits `file_start_time`), and `SensorMonitoring::notifyEvent` (decoder-playing path, which also adds `ipc_url`). Check the builder that owns your path before assuming a field is present.
+
+Consumer note: the live-stream and recorder APIs reject a `camera_streaming` whose `camera_url` is not `rtsp://` or `rtsps://`, so file sensors are skipped by those services by design.
 
 **2. Routing table.** Two Redis hashes — streamid→pod-name and pod-name→host:port — written by SDR and read by Envoy on every request.
 

--- a/services/vios/.cursor/skills/configure-webhook-bdd-test/SKILL.md
+++ b/services/vios/.cursor/skills/configure-webhook-bdd-test/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: configure-webhook-bdd-test
+description: Add or update the local Docker Compose webhook receivers required by the VIOS webhook notification BDD test. Use when preparing deployment/stream-processing/docker-compose/configs/notification_config.json for test_webhook_notifications.py, or when that test times out waiting for camera_add, camera_streaming, or camera_remove.
+---
+
+# Configure Webhook BDD Test
+
+1. Edit only `deployment/stream-processing/docker-compose/configs/notification_config.json`. Preserve unrelated settings and receivers.
+2. Under each matching `camera_status_change`, ensure these BDD requests exist exactly once:
+
+| Event | Method | URL | `camera_type` |
+|---|---|---|---|
+| `camera_add` | `POST` | `http://127.0.0.1:18088/bdd/webhooks/camera/add` | `["file"]` |
+| `camera_add` | `POST` | `http://127.0.0.1:18088/bdd/webhooks/camera/add/unfiltered` | Omit the field |
+| `camera_add` | `POST` | `http://127.0.0.1:18088/bdd/webhooks/camera/add/rtsp-only` | `["rtsp"]` |
+| `camera_streaming` | `PUT` | `http://127.0.0.1:18088/bdd/webhooks/camera/streaming` | `["file"]` |
+| `camera_streaming` | `PUT` | `http://127.0.0.1:18088/bdd/webhooks/camera/streaming/rtsp-only` | `["rtsp"]` |
+| `camera_remove` | `DELETE` | `http://127.0.0.1:18088/bdd/webhooks/camera/remove` | `["file"]` |
+
+The `streaming/rtsp-only` receiver serves the RTSP `camera_streaming` scenario, which is skipped unless `tests.notification_tests.test_parameters.rtsp_sensor` is set in `test/bdd_tests/config.json`.
+
+3. Give every BDD request these remaining fields:
+
+```json
+{
+  "headers": {"Content-Type": "application/json", "streamId": "{{event.camera_id}}"},
+  "query_params": {"change": "{{event.change}}"},
+  "timeout_ms": 5000,
+  "retry": {"max_attempts": 3, "backoff_ms": [1000, 5000, 15000], "retry_on_status": [408, 429, 500, 502, 503, 504]}
+}
+```
+
+4. Set or omit `camera_type` exactly as shown in the table. If an event group is absent, create an enabled group with its `camera_status_change` and `request` array. Update an existing BDD request in place instead of adding a duplicate.
+5. Validate the edited file with `python3 -m json.tool deployment/stream-processing/docker-compose/configs/notification_config.json`. Tell the user to restart VST if it was already running because VST loads this config at startup.
+6. Do not run pytest unless requested. Finish by giving both commands, to be run from `test/bdd_tests`:
+
+```bash
+poetry run pytest tests/notification/test_webhook_notifications.py
+poetry run pytest tests/notification/test_webhook_notifications.py -v --tb=short --log-cli-level=INFO
+```

--- a/services/vios/.cursor/skills/configure-webhook-bdd-test/SKILL.md
+++ b/services/vios/.cursor/skills/configure-webhook-bdd-test/SKILL.md
@@ -5,21 +5,50 @@ description: Add or update the local Docker Compose webhook receivers required b
 
 # Configure Webhook BDD Test
 
+The suite covers two sensor types. File-sensor scenarios always run; the RTSP
+scenario is skipped unless `tests.notification_tests.test_parameters.rtsp_sensor`
+is set in `test/bdd_tests/config.json`. Configure **both** sets of receivers —
+a config with only the `["file"]` receivers silently starves every RTSP scenario,
+because a receiver filtered to `file` never sees an RTSP camera event.
+
 1. Edit only `deployment/stream-processing/docker-compose/configs/notification_config.json`. Preserve unrelated settings and receivers.
-2. Under each matching `camera_status_change`, ensure these BDD requests exist exactly once:
+2. Set `webhooks.enabled` to `true` and give each event group the `id` and `enabled` values below. The `id` is copied into the delivered body as `webhook_id`, and `test/bdd_tests/config.json` asserts these exact values under `webhook_ids`:
+
+| Event group | `id` | `enabled` |
+|---|---|---|
+| `camera_add` | `wh-001` | `true` |
+| `camera_streaming` | `wh-002` | `true` |
+| `camera_remove` | `wh-003` | `true` |
+
+3. Under each matching `camera_status_change`, ensure these BDD requests exist exactly once. The URL suffix matches the key under `webhook_paths` in `test/bdd_tests/config.json` — keep the two in sync when adding a receiver:
+
+**File-sensor receivers** (used by the file upload scenarios):
 
 | Event | Method | URL | `camera_type` |
 |---|---|---|---|
 | `camera_add` | `POST` | `http://127.0.0.1:18088/bdd/webhooks/camera/add` | `["file"]` |
-| `camera_add` | `POST` | `http://127.0.0.1:18088/bdd/webhooks/camera/add/unfiltered` | Omit the field |
-| `camera_add` | `POST` | `http://127.0.0.1:18088/bdd/webhooks/camera/add/rtsp-only` | `["rtsp"]` |
 | `camera_streaming` | `PUT` | `http://127.0.0.1:18088/bdd/webhooks/camera/streaming` | `["file"]` |
-| `camera_streaming` | `PUT` | `http://127.0.0.1:18088/bdd/webhooks/camera/streaming/rtsp-only` | `["rtsp"]` |
 | `camera_remove` | `DELETE` | `http://127.0.0.1:18088/bdd/webhooks/camera/remove` | `["file"]` |
 
-The `streaming/rtsp-only` receiver serves the RTSP `camera_streaming` scenario, which is skipped unless `tests.notification_tests.test_parameters.rtsp_sensor` is set in `test/bdd_tests/config.json`.
+**RTSP-sensor receivers** (used by the RTSP scenario, and as the negative filter case):
 
-3. Give every BDD request these remaining fields:
+| Event | Method | URL | `camera_type` |
+|---|---|---|---|
+| `camera_add` | `POST` | `http://127.0.0.1:18088/bdd/webhooks/camera/add/rtsp-only` | `["rtsp"]` |
+| `camera_streaming` | `PUT` | `http://127.0.0.1:18088/bdd/webhooks/camera/streaming/rtsp-only` | `["rtsp"]` |
+| `camera_remove` | `DELETE` | `http://127.0.0.1:18088/bdd/webhooks/camera/remove/rtsp-only` | `["rtsp"]` |
+
+**Unfiltered receiver** (proves an omitted `camera_type` accepts every type):
+
+| Event | Method | URL | `camera_type` |
+|---|---|---|---|
+| `camera_add` | `POST` | `http://127.0.0.1:18088/bdd/webhooks/camera/add/unfiltered` | Omit the field |
+
+`camera_add/rtsp-only` does double duty: the file scenarios assert it receives
+*nothing* for a file sensor, and an RTSP sensor delivers to it. Keep it filtered
+to `["rtsp"]` exactly — widening it to `["rtsp", "file"]` breaks the negative test.
+
+4. Give every BDD request these remaining fields:
 
 ```json
 {
@@ -30,9 +59,32 @@ The `streaming/rtsp-only` receiver serves the RTSP `camera_streaming` scenario, 
 }
 ```
 
-4. Set or omit `camera_type` exactly as shown in the table. If an event group is absent, create an enabled group with its `camera_status_change` and `request` array. Update an existing BDD request in place instead of adding a duplicate.
-5. Validate the edited file with `python3 -m json.tool deployment/stream-processing/docker-compose/configs/notification_config.json`. Tell the user to restart VST if it was already running because VST loads this config at startup.
-6. Do not run pytest unless requested. Finish by giving both commands, to be run from `test/bdd_tests`:
+The header name is `streamId` — the tests read it case-insensitively but do not
+accept `x-stream-id`. Omit `auth` on BDD requests; the in-process receiver does
+not verify signatures and an unresolved `{{secrets.*}}` placeholder only adds a
+failure path.
+
+5. Set or omit `camera_type` exactly as shown. If an event group is absent, create an enabled group with its `id`, `camera_status_change`, and `request` array. Update an existing BDD request in place instead of adding a duplicate.
+6. Validate the edited file:
+
+```bash
+python3 -m json.tool deployment/stream-processing/docker-compose/configs/notification_config.json
+```
+
+7. Confirm the deployed image actually supports webhooks. Images built before the
+   webhook feature ignore this config entirely, and the only symptom is every
+   scenario timing out with zero captured requests:
+
+```bash
+docker exec streamprocessing-ms-1 grep -ac "notification_config.json" /home/vst/vst_release/launch_vst
+```
+
+`0` means the running image predates the feature regardless of its tag — rebuild
+(`./build.sh container module=sensor,streamprocessing tag=<tag>`) and redeploy
+before running the tests. `1` or more means webhook support is present.
+
+8. Tell the user to restart VST if it was already running, because VST loads this config at startup.
+9. Do not run pytest unless requested. Finish by giving both commands, to be run from `test/bdd_tests`:
 
 ```bash
 poetry run pytest tests/notification/test_webhook_notifications.py

--- a/services/vios/.cursor/skills/configure-webhook-bdd-test/agents/openai.yaml
+++ b/services/vios/.cursor/skills/configure-webhook-bdd-test/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Configure Webhook BDD Test"
+  short_description: "Prepare deployment config for webhook BDD tests"
+  default_prompt: "Use $configure-webhook-bdd-test to add the BDD webhook receivers and show the focused pytest command."

--- a/services/vios/test/bdd_tests/config.json
+++ b/services/vios/test/bdd_tests/config.json
@@ -143,7 +143,8 @@
           "camera_add_rtsp_only": "/bdd/webhooks/camera/add/rtsp-only",
           "camera_streaming": "/bdd/webhooks/camera/streaming",
           "camera_streaming_rtsp": "/bdd/webhooks/camera/streaming/rtsp-only",
-          "camera_remove": "/bdd/webhooks/camera/remove"
+          "camera_remove": "/bdd/webhooks/camera/remove",
+          "camera_remove_rtsp": "/bdd/webhooks/camera/remove/rtsp-only"
         },
         "webhook_ids": {
           "camera_add": "wh-001",

--- a/services/vios/test/bdd_tests/config.json
+++ b/services/vios/test/bdd_tests/config.json
@@ -142,6 +142,7 @@
           "camera_add_unfiltered": "/bdd/webhooks/camera/add/unfiltered",
           "camera_add_rtsp_only": "/bdd/webhooks/camera/add/rtsp-only",
           "camera_streaming": "/bdd/webhooks/camera/streaming",
+          "camera_streaming_rtsp": "/bdd/webhooks/camera/streaming/rtsp-only",
           "camera_remove": "/bdd/webhooks/camera/remove"
         },
         "webhook_ids": {
@@ -153,7 +154,10 @@
         "filter_absence_timeout_sec": 2,
         "upload_timeout_sec": 60,
         "api_timeout_sec": 30,
-        "upload_timestamp": "2025-06-15T12:00:00.000Z"
+        "upload_timestamp": "2025-01-01T00:00:00.000Z",
+        "rtsp_sensor": "",
+        "rtsp_streaming_timeout_sec": 90,
+        "rtsp_stream_resolve_timeout_sec": 30
       }
     },
     "performance_tests": {

--- a/services/vios/test/bdd_tests/features/notification/webhook_notifications.feature
+++ b/services/vios/test/bdd_tests/features/notification/webhook_notifications.feature
@@ -13,6 +13,19 @@ Feature: Webhook notifications for file sensor lifecycle
     When I delete the uploaded webhook test sensor
     Then the camera_remove webhook is received and valid
 
+  Scenario: File sensor camera_streaming event carries the complete notification schema
+    When I upload a uniquely named file sensor for webhook testing
+    Then the camera_streaming notification has the expected structure
+    And the camera_streaming notification values are valid
+    And the camera_streaming notification metadata is valid for the camera type
+
+  # Skipped unless notification_tests.test_parameters.rtsp_sensor is set in config.json.
+  Scenario: RTSP sensor camera_streaming event carries the complete notification schema
+    When I add the configured RTSP sensor for webhook testing
+    Then the camera_streaming notification has the expected structure
+    And the camera_streaming notification values are valid
+    And the camera_streaming notification metadata is valid for the camera type
+
   Scenario: Unfiltered webhook receiver accepts a file camera event
     When I upload a uniquely named file sensor for webhook testing
     Then the unfiltered camera_add webhook is received and valid

--- a/services/vios/test/bdd_tests/features/notification/webhook_notifications.feature
+++ b/services/vios/test/bdd_tests/features/notification/webhook_notifications.feature
@@ -19,7 +19,15 @@ Feature: Webhook notifications for file sensor lifecycle
     And the camera_streaming notification values are valid
     And the camera_streaming notification metadata is valid for the camera type
 
-  # Skipped unless notification_tests.test_parameters.rtsp_sensor is set in config.json.
+  # The two RTSP scenarios are skipped unless notification_tests.test_parameters.rtsp_sensor
+  # is set in config.json.
+  Scenario: RTSP sensor lifecycle delivers to rtsp filtered webhook receivers
+    When I add the configured RTSP sensor for webhook testing
+    Then the rtsp camera_add webhook is received and valid
+    And the rtsp camera_streaming webhook is received and valid
+    When I delete the added RTSP webhook test sensor
+    Then the rtsp camera_remove webhook is received and valid
+
   Scenario: RTSP sensor camera_streaming event carries the complete notification schema
     When I add the configured RTSP sensor for webhook testing
     Then the camera_streaming notification has the expected structure

--- a/services/vios/test/bdd_tests/tests/notification/conftest.py
+++ b/services/vios/test/bdd_tests/tests/notification/conftest.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 
 import logging
 import uuid
-from dataclasses import dataclass
-from typing import Any, Dict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 import pytest
 import requests
 
-from .webhook_test_utils import WebhookReceiver
+from .webhook_test_utils import CapturedWebhookRequest, WebhookReceiver
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +26,17 @@ class WebhookTestContext:
 
     sensor_id: str
     filename: str
+    rtsp_sensor_name: str
     receiver_cursor: int = 0
     sensor_created: bool = False
     sensor_deleted: bool = False
+    streaming_event: Optional[CapturedWebhookRequest] = None
+    # Which receiver the camera_streaming assertions read, and which camera_id
+    # values are acceptable. RTSP sensors emit the event under a stream id that
+    # the add response does not return, so the ids are resolved after the add.
+    streaming_path_key: str = "camera_streaming"
+    streaming_timeout_sec: Optional[float] = None
+    expected_camera_ids: List[str] = field(default_factory=list)
 
 
 @pytest.fixture(scope="function")
@@ -38,6 +46,7 @@ def context() -> WebhookTestContext:
     return WebhookTestContext(
         sensor_id=f"{TEST_PREFIX}sensor-{tag}",
         filename=f"{TEST_PREFIX}{tag}.mp4",
+        rtsp_sensor_name=f"{TEST_PREFIX}rtsp-{tag}",
     )
 
 
@@ -45,6 +54,12 @@ def context() -> WebhookTestContext:
 def notification_test_params(config: Dict[str, Any]) -> Dict[str, Any]:
     """Return webhook notification parameters from the shared BDD config."""
     return config["tests"]["notification_tests"]["test_parameters"]
+
+
+@pytest.fixture(scope="session")
+def rtsp_sensor_url(notification_test_params: Dict[str, Any]) -> str:
+    """Return the configured RTSP URL; empty means the RTSP scenario is skipped."""
+    return str(notification_test_params.get("rtsp_sensor", "")).strip()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/services/vios/test/bdd_tests/tests/notification/conftest.py
+++ b/services/vios/test/bdd_tests/tests/notification/conftest.py
@@ -37,6 +37,8 @@ class WebhookTestContext:
     streaming_path_key: str = "camera_streaming"
     streaming_timeout_sec: Optional[float] = None
     expected_camera_ids: List[str] = field(default_factory=list)
+    expected_camera_names: List[str] = field(default_factory=list)
+    expected_camera_type: str = "file"
 
 
 @pytest.fixture(scope="function")

--- a/services/vios/test/bdd_tests/tests/notification/test_webhook_notifications.py
+++ b/services/vios/test/bdd_tests/tests/notification/test_webhook_notifications.py
@@ -5,8 +5,11 @@
 
 from __future__ import annotations
 
+import logging
+import time
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 import pytest
 import requests
@@ -16,18 +19,42 @@ from ..test_utils import assert_with_detailed_failure
 from .conftest import WebhookTestContext
 from .webhook_test_utils import CapturedWebhookRequest, WebhookReceiver
 
+logger = logging.getLogger(__name__)
+
 pytestmark = [pytest.mark.notification, pytest.mark.webhook]
 
 scenarios("../../features/notification/webhook_notifications.feature")
 
 STATIC_VIDEO = Path(__file__).resolve().parent.parent.parent / "data" / "test_video.mp4"
 
+# Schema of a camera_status_change notification, per .claude/commands/vios-architecture.md.
+REQUIRED_PAYLOAD_KEYS = ("alert_type", "created_at", "event", "source")
+REQUIRED_EVENT_KEYS = (
+    "camera_id",
+    "camera_name",
+    "camera_type",
+    "camera_url",
+    "change",
+    "metadata",
+)
+REQUIRED_EVENT_STRING_KEYS = tuple(key for key in REQUIRED_EVENT_KEYS if key != "metadata")
+# camera_url scheme is dictated by camera_type.
+CAMERA_URL_SCHEMES = {
+    "file": ("http://", "https://"),
+    "rtsp": ("rtsp://", "rtsps://"),
+}
+
+
+def _acceptable_camera_ids(context: WebhookTestContext) -> List[str]:
+    """Return the camera_id values this scenario's sensor may publish under."""
+    return context.expected_camera_ids or [context.sensor_id]
+
 
 def _event_matches(
     request: CapturedWebhookRequest,
     path: str,
     change: str,
-    sensor_id: str,
+    camera_ids: List[str],
 ) -> bool:
     if request.path != path or not isinstance(request.json_body, dict):
         return False
@@ -35,7 +62,7 @@ def _event_matches(
     return (
         isinstance(event, dict)
         and event.get("change") == change
-        and event.get("camera_id") == sensor_id
+        and event.get("camera_id") in camera_ids
     )
 
 
@@ -45,14 +72,16 @@ def _wait_for_event(
     notification_test_params: Dict[str, Any],
     change: str,
     path_key: str | None = None,
+    timeout: float | None = None,
 ) -> CapturedWebhookRequest:
     path_name = path_key or change
     path = notification_test_params["webhook_paths"][path_name]
-    timeout = notification_test_params["delivery_timeout_sec"]
+    timeout = timeout or notification_test_params["delivery_timeout_sec"]
+    camera_ids = _acceptable_camera_ids(context)
     try:
         return webhook_receiver.wait_for(
             predicate=lambda request: _event_matches(
-                request, path, change, context.sensor_id
+                request, path, change, camera_ids
             ),
             start_sequence=context.receiver_cursor,
             timeout=timeout,
@@ -66,7 +95,7 @@ def _wait_for_event(
             False,
             test_name=f"{path_name} webhook delivery",
             expected=(
-                f"Webhook path={path!r}, camera_id={context.sensor_id!r}, "
+                f"Webhook path={path!r}, camera_id in {camera_ids!r}, "
                 f"change={change!r} within {timeout}s"
             ),
             actual=str(exc),
@@ -159,7 +188,7 @@ def _assert_event_not_received(
     try:
         request = webhook_receiver.wait_for(
             predicate=lambda captured: _event_matches(
-                captured, path, change, context.sensor_id
+                captured, path, change, _acceptable_camera_ids(context)
             ),
             start_sequence=context.receiver_cursor,
             timeout=timeout,
@@ -291,6 +320,292 @@ def camera_streaming_webhook_is_valid(
     )
     _validate_event(
         request, context, notification_test_params, "camera_streaming", "PUT"
+    )
+
+
+def _resolve_camera_ids(
+    context: WebhookTestContext,
+    api_config: Dict[str, Any],
+    notification_test_params: Dict[str, Any],
+) -> List[str]:
+    """Return the sensor id plus every stream id VIOS created for the sensor.
+
+    An RTSP sensor publishes camera_streaming under its stream id, which the
+    add response does not return, so poll /sensor/<id>/streams until it is
+    populated. Falls back to the sensor id alone so the webhook wait still runs
+    and reports the real failure.
+    """
+    url = f"{api_config['base_url']}/vst/api/v1/sensor/{context.sensor_id}/streams"
+    deadline = time.monotonic() + notification_test_params["rtsp_stream_resolve_timeout_sec"]
+    camera_ids = [context.sensor_id]
+
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(
+                url,
+                timeout=notification_test_params["api_timeout_sec"],
+                verify=api_config.get("verify_ssl", False),
+            )
+        except requests.RequestException as exc:
+            logger.warning("sensor/streams poll failed for %s: %s", context.sensor_id, exc)
+            time.sleep(1)
+            continue
+
+        streams = response.json() if response.status_code == 200 else None
+        if isinstance(streams, list) and streams:
+            for stream in streams:
+                stream_id = stream.get("streamId") if isinstance(stream, dict) else None
+                if isinstance(stream_id, str) and stream_id and stream_id not in camera_ids:
+                    camera_ids.append(stream_id)
+            return camera_ids
+        time.sleep(1)
+
+    logger.warning(
+        "No streams reported for sensor %s within %ss; matching on the sensor id alone",
+        context.sensor_id,
+        notification_test_params["rtsp_stream_resolve_timeout_sec"],
+    )
+    return camera_ids
+
+
+def _captured_streaming_payload(
+    context: WebhookTestContext,
+) -> Tuple[CapturedWebhookRequest, Dict[str, Any], Dict[str, Any]]:
+    """Return the camera_streaming request captured by the structure step."""
+    request = context.streaming_event
+    assert request is not None, (
+        "The camera_streaming structure step must run before this step"
+    )
+    body = request.json_body if isinstance(request.json_body, dict) else {}
+    event = body.get("event")
+    return request, body, event if isinstance(event, dict) else {}
+
+
+def _is_iso8601(value: str) -> bool:
+    """Return True when the string parses as an ISO 8601 timestamp."""
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+@when("I add the configured RTSP sensor for webhook testing")
+def add_rtsp_sensor(
+    context: WebhookTestContext,
+    api_config: Dict[str, Any],
+    notification_test_params: Dict[str, Any],
+    rtsp_sensor_url: str,
+) -> None:
+    if not rtsp_sensor_url:
+        pytest.skip(
+            "tests.notification_tests.test_parameters.rtsp_sensor is empty in config.json; "
+            "set it to an RTSP URL to run the RTSP webhook test"
+        )
+
+    context.streaming_path_key = "camera_streaming_rtsp"
+    context.streaming_timeout_sec = notification_test_params["rtsp_streaming_timeout_sec"]
+
+    response = requests.post(
+        f"{api_config['base_url']}/vst/api/v1/sensor/add",
+        json={"sensorUrl": rtsp_sensor_url, "name": context.rtsp_sensor_name},
+        timeout=notification_test_params["api_timeout_sec"],
+        verify=api_config.get("verify_ssl", False),
+    )
+    assert response.status_code in (200, 201), (
+        f"RTSP sensor/add failed: HTTP {response.status_code}: {response.text[:500]}"
+    )
+
+    body = response.json()
+    sensor_id = body.get("sensorId") if isinstance(body, dict) else None
+    assert isinstance(sensor_id, str) and sensor_id, (
+        f"sensor/add did not return a sensorId: {body!r}"
+    )
+    context.sensor_id = sensor_id
+    context.sensor_created = True
+    context.expected_camera_ids = _resolve_camera_ids(
+        context, api_config, notification_test_params
+    )
+    logger.info(
+        "Added RTSP sensor %s (name=%s); camera ids %s",
+        sensor_id,
+        context.rtsp_sensor_name,
+        context.expected_camera_ids,
+    )
+
+
+@then("the camera_streaming notification has the expected structure")
+def camera_streaming_structure_is_valid(
+    context: WebhookTestContext,
+    webhook_receiver: WebhookReceiver,
+    notification_test_params: Dict[str, Any],
+) -> None:
+    request = _wait_for_event(
+        context,
+        webhook_receiver,
+        notification_test_params,
+        "camera_streaming",
+        path_key=context.streaming_path_key,
+        timeout=context.streaming_timeout_sec,
+    )
+    context.streaming_event = request
+
+    body = request.json_body
+    failures = []
+    if not isinstance(body, dict):
+        failures.append({"description": f"payload is not a JSON object: {request.body[:200]!r}"})
+        body = {}
+
+    failures.extend(
+        {"description": f"missing top-level key {key!r}"}
+        for key in REQUIRED_PAYLOAD_KEYS
+        if key not in body
+    )
+
+    event = body.get("event")
+    if not isinstance(event, dict):
+        failures.append({"description": f"event is not a JSON object: {event!r}"})
+    elif not event:
+        failures.append({"description": "event object is empty"})
+    else:
+        failures.extend(
+            {"description": f"missing event key {key!r}"}
+            for key in REQUIRED_EVENT_KEYS
+            if key not in event
+        )
+
+    assert_with_detailed_failure(
+        not failures,
+        test_name="camera_streaming notification structure",
+        expected=(
+            f"top-level keys {list(REQUIRED_PAYLOAD_KEYS)} and a non-empty event "
+            f"carrying {list(REQUIRED_EVENT_KEYS)}"
+        ),
+        actual=(
+            f"{request.summary()} top-level={sorted(body)} "
+            f"event={sorted(event) if isinstance(event, dict) else event!r}"
+        ),
+        failed_items=failures,
+    )
+
+
+@then("the camera_streaming notification values are valid")
+def camera_streaming_values_are_valid(context: WebhookTestContext) -> None:
+    request, body, event = _captured_streaming_payload(context)
+
+    failures = []
+    for key in ("alert_type", "created_at", "source"):
+        value = body.get(key)
+        if not isinstance(value, str):
+            failures.append({"description": f"{key} is not a string: {value!r}"})
+        elif not value.strip():
+            failures.append({"description": f"{key} is empty"})
+
+    for key in REQUIRED_EVENT_STRING_KEYS:
+        value = event.get(key)
+        if not isinstance(value, str):
+            failures.append({"description": f"event.{key} is not a string: {value!r}"})
+        elif not value.strip():
+            failures.append({"description": f"event.{key} is empty"})
+
+    metadata = event.get("metadata")
+    if not isinstance(metadata, dict):
+        failures.append({"description": f"event.metadata is not a JSON object: {metadata!r}"})
+
+    created_at = body.get("created_at")
+    if isinstance(created_at, str) and created_at.strip() and not _is_iso8601(created_at):
+        failures.append({"description": f"created_at is not ISO 8601: {created_at!r}"})
+
+    if body.get("alert_type") not in (None, "camera_status_change"):
+        failures.append({"description": f"alert_type={body.get('alert_type')!r}"})
+    if event.get("change") not in (None, "camera_streaming"):
+        failures.append({"description": f"event.change={event.get('change')!r}"})
+    if event.get("camera_id") not in [None, *_acceptable_camera_ids(context)]:
+        failures.append(
+            {
+                "description": (
+                    f"event.camera_id={event.get('camera_id')!r}, expected one of "
+                    f"{_acceptable_camera_ids(context)!r}"
+                )
+            }
+        )
+
+    camera_type = event.get("camera_type")
+    camera_url = event.get("camera_url")
+    schemes = CAMERA_URL_SCHEMES.get(camera_type) if isinstance(camera_type, str) else None
+    if schemes is None:
+        failures.append(
+            {
+                "description": (
+                    f"event.camera_type={camera_type!r} is not one of "
+                    f"{sorted(CAMERA_URL_SCHEMES)}"
+                )
+            }
+        )
+    elif isinstance(camera_url, str) and not camera_url.startswith(schemes):
+        failures.append(
+            {
+                "description": (
+                    f"event.camera_url={camera_url!r} does not use {list(schemes)} "
+                    f"required for camera_type={camera_type!r}"
+                )
+            }
+        )
+
+    assert_with_detailed_failure(
+        not failures,
+        test_name="camera_streaming notification values",
+        expected=(
+            "non-empty string fields, an ISO 8601 created_at, a metadata object, and a "
+            "camera_url whose scheme matches camera_type (rtsp:// for rtsp, http:// for file)"
+        ),
+        actual=f"{request.summary()} body={body!r}",
+        failed_items=failures,
+    )
+
+
+@then("the camera_streaming notification metadata is valid for the camera type")
+def camera_streaming_metadata_is_valid(
+    context: WebhookTestContext,
+    notification_test_params: Dict[str, Any],
+) -> None:
+    request, _, event = _captured_streaming_payload(context)
+    metadata = event.get("metadata")
+    camera_type = event.get("camera_type")
+    expected_start_time = notification_test_params["upload_timestamp"]
+
+    failures = []
+    if not isinstance(metadata, dict) or not metadata:
+        failures.append({"description": f"event.metadata is empty or not an object: {metadata!r}"})
+    elif camera_type == "file":
+        file_start_time = metadata.get("file_start_time")
+        if file_start_time is None:
+            failures.append(
+                {"description": f"metadata.file_start_time missing; metadata={metadata!r}"}
+            )
+        elif not isinstance(file_start_time, str):
+            failures.append(
+                {"description": f"metadata.file_start_time is not a string: {file_start_time!r}"}
+            )
+        elif file_start_time != expected_start_time:
+            failures.append(
+                {
+                    "description": (
+                        f"metadata.file_start_time={file_start_time!r}, "
+                        f"expected {expected_start_time!r}"
+                    )
+                }
+            )
+
+    assert_with_detailed_failure(
+        not failures,
+        test_name="camera_streaming notification metadata",
+        expected=(
+            f"non-empty metadata carrying file_start_time={expected_start_time!r} "
+            f"for a file sensor"
+        ),
+        actual=f"{request.summary()} camera_type={camera_type!r} metadata={metadata!r}",
+        failed_items=failures,
     )
 
 

--- a/services/vios/test/bdd_tests/tests/notification/test_webhook_notifications.py
+++ b/services/vios/test/bdd_tests/tests/notification/test_webhook_notifications.py
@@ -116,6 +116,8 @@ def _validate_event(
     expected_path = notification_test_params["webhook_paths"][path_name]
     body = request.json_body if isinstance(request.json_body, dict) else {}
     event = body.get("event") if isinstance(body.get("event"), dict) else {}
+    camera_ids = _acceptable_camera_ids(context)
+    camera_type = context.expected_camera_type
 
     failures = []
     checks = [
@@ -127,8 +129,8 @@ def _validate_event(
             f"Content-Type={request.header('Content-Type')!r}",
         ),
         (
-            request.header("streamId") == context.sensor_id,
-            f"streamId={request.header('streamId')!r}",
+            request.header("streamId") in camera_ids,
+            f"streamId={request.header('streamId')!r}, expected one of {camera_ids!r}",
         ),
         (body.get("alert_type") == "camera_status_change", f"body={body!r}"),
         (
@@ -139,25 +141,34 @@ def _validate_event(
         (bool(body.get("created_at")), f"created_at={body.get('created_at')!r}"),
         (event.get("change") == change, f"event.change={event.get('change')!r}"),
         (
-            event.get("camera_id") == context.sensor_id,
-            f"event.camera_id={event.get('camera_id')!r}",
+            event.get("camera_id") in camera_ids,
+            f"event.camera_id={event.get('camera_id')!r}, expected one of {camera_ids!r}",
         ),
         (
-            event.get("camera_name") == Path(context.filename).stem,
-            f"event.camera_name={event.get('camera_name')!r}",
+            event.get("camera_name") in context.expected_camera_names,
+            f"event.camera_name={event.get('camera_name')!r}, "
+            f"expected one of {context.expected_camera_names!r}",
         ),
         (
-            event.get("camera_type") == "file",
-            f"event.camera_type={event.get('camera_type')!r}",
+            event.get("camera_type") == camera_type,
+            f"event.camera_type={event.get('camera_type')!r}, expected {camera_type!r}",
         ),
     ]
+    # camera_url is empty on camera_add for every sensor type, and carries the
+    # live URL on the later actions with a scheme dictated by camera_type.
     if change == "camera_add":
         checks.append(
             (event.get("camera_url") == "", f"event.camera_url={event.get('camera_url')!r}")
         )
     if change == "camera_streaming":
+        camera_url = event.get("camera_url")
+        schemes = CAMERA_URL_SCHEMES[camera_type]
         checks.append(
-            (bool(event.get("camera_url")), f"event.camera_url={event.get('camera_url')!r}")
+            (
+                isinstance(camera_url, str) and camera_url.startswith(schemes),
+                f"event.camera_url={camera_url!r} does not use {list(schemes)} "
+                f"required for camera_type={camera_type!r}",
+            )
         )
 
     for passed, detail in checks:
@@ -168,7 +179,7 @@ def _validate_event(
         not failures,
         test_name=f"{change} webhook validation",
         expected=(
-            f"{expected_method} {expected_path} with the complete file-sensor "
+            f"{expected_method} {expected_path} with the complete {camera_type}-sensor "
             f"{change} payload"
         ),
         actual=request.summary(),
@@ -243,6 +254,8 @@ def upload_file_sensor(
         verify=api_config.get("verify_ssl", False),
     )
     context.sensor_created = response.status_code in (200, 201)
+    context.expected_camera_type = "file"
+    context.expected_camera_names = [Path(context.filename).stem]
 
     assert response.status_code in (200, 201), (
         f"File-sensor upload failed: HTTP {response.status_code}: {response.text[:500]}"
@@ -323,21 +336,95 @@ def camera_streaming_webhook_is_valid(
     )
 
 
-def _resolve_camera_ids(
+@then("the rtsp camera_add webhook is received and valid")
+def rtsp_camera_add_webhook_is_valid(
+    context: WebhookTestContext,
+    webhook_receiver: WebhookReceiver,
+    notification_test_params: Dict[str, Any],
+) -> None:
+    path_key = "camera_add_rtsp_only"
+    request = _wait_for_event(
+        context,
+        webhook_receiver,
+        notification_test_params,
+        "camera_add",
+        path_key=path_key,
+    )
+    _validate_event(
+        request,
+        context,
+        notification_test_params,
+        "camera_add",
+        "POST",
+        path_key=path_key,
+    )
+
+
+@then("the rtsp camera_streaming webhook is received and valid")
+def rtsp_camera_streaming_webhook_is_valid(
+    context: WebhookTestContext,
+    webhook_receiver: WebhookReceiver,
+    notification_test_params: Dict[str, Any],
+) -> None:
+    path_key = "camera_streaming_rtsp"
+    request = _wait_for_event(
+        context,
+        webhook_receiver,
+        notification_test_params,
+        "camera_streaming",
+        path_key=path_key,
+        timeout=notification_test_params["rtsp_streaming_timeout_sec"],
+    )
+    _validate_event(
+        request,
+        context,
+        notification_test_params,
+        "camera_streaming",
+        "PUT",
+        path_key=path_key,
+    )
+
+
+@then("the rtsp camera_remove webhook is received and valid")
+def rtsp_camera_remove_webhook_is_valid(
+    context: WebhookTestContext,
+    webhook_receiver: WebhookReceiver,
+    notification_test_params: Dict[str, Any],
+) -> None:
+    path_key = "camera_remove_rtsp"
+    request = _wait_for_event(
+        context,
+        webhook_receiver,
+        notification_test_params,
+        "camera_remove",
+        path_key=path_key,
+    )
+    _validate_event(
+        request,
+        context,
+        notification_test_params,
+        "camera_remove",
+        "DELETE",
+        path_key=path_key,
+    )
+
+
+def _resolve_sensor_identity(
     context: WebhookTestContext,
     api_config: Dict[str, Any],
     notification_test_params: Dict[str, Any],
-) -> List[str]:
-    """Return the sensor id plus every stream id VIOS created for the sensor.
+) -> Tuple[List[str], List[str]]:
+    """Return the camera ids and camera names the sensor may publish under.
 
-    An RTSP sensor publishes camera_streaming under its stream id, which the
-    add response does not return, so poll /sensor/<id>/streams until it is
-    populated. Falls back to the sensor id alone so the webhook wait still runs
-    and reports the real failure.
+    An RTSP sensor publishes its events under a stream id and stream name that
+    the add response does not return, so poll /sensor/<id>/streams until it is
+    populated. Falls back to the sensor identity alone so the webhook wait still
+    runs and reports the real failure.
     """
     url = f"{api_config['base_url']}/vst/api/v1/sensor/{context.sensor_id}/streams"
     deadline = time.monotonic() + notification_test_params["rtsp_stream_resolve_timeout_sec"]
     camera_ids = [context.sensor_id]
+    camera_names = [context.rtsp_sensor_name]
 
     while time.monotonic() < deadline:
         try:
@@ -354,18 +441,23 @@ def _resolve_camera_ids(
         streams = response.json() if response.status_code == 200 else None
         if isinstance(streams, list) and streams:
             for stream in streams:
-                stream_id = stream.get("streamId") if isinstance(stream, dict) else None
+                if not isinstance(stream, dict):
+                    continue
+                stream_id = stream.get("streamId")
                 if isinstance(stream_id, str) and stream_id and stream_id not in camera_ids:
                     camera_ids.append(stream_id)
-            return camera_ids
+                stream_name = stream.get("name")
+                if isinstance(stream_name, str) and stream_name and stream_name not in camera_names:
+                    camera_names.append(stream_name)
+            return camera_ids, camera_names
         time.sleep(1)
 
     logger.warning(
-        "No streams reported for sensor %s within %ss; matching on the sensor id alone",
+        "No streams reported for sensor %s within %ss; matching on the sensor identity alone",
         context.sensor_id,
         notification_test_params["rtsp_stream_resolve_timeout_sec"],
     )
-    return camera_ids
+    return camera_ids, camera_names
 
 
 def _captured_streaming_payload(
@@ -423,14 +515,16 @@ def add_rtsp_sensor(
     )
     context.sensor_id = sensor_id
     context.sensor_created = True
-    context.expected_camera_ids = _resolve_camera_ids(
+    context.expected_camera_type = "rtsp"
+    context.expected_camera_ids, context.expected_camera_names = _resolve_sensor_identity(
         context, api_config, notification_test_params
     )
     logger.info(
-        "Added RTSP sensor %s (name=%s); camera ids %s",
+        "Added RTSP sensor %s (name=%s); camera ids %s, camera names %s",
         sensor_id,
         context.rtsp_sensor_name,
         context.expected_camera_ids,
+        context.expected_camera_names,
     )
 
 
@@ -610,7 +704,8 @@ def camera_streaming_metadata_is_valid(
 
 
 @when("I delete the uploaded webhook test sensor")
-def delete_file_sensor(
+@when("I delete the added RTSP webhook test sensor")
+def delete_webhook_test_sensor(
     context: WebhookTestContext,
     api_config: Dict[str, Any],
     notification_test_params: Dict[str, Any],


### PR DESCRIPTION
## Description
Updated architecture skill with latest notification schema.
Added bdd_tests for event verification.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
