### PR TITLE
fix(deploy): upgrade Phoenix container to 19.8.0

### DIFF
--- a/deploy/LICENSE-3rd-party.txt
+++ b/deploy/LICENSE-3rd-party.txt
@@ -33,8 +33,8 @@ running developer profiles via scripts/dev-profile.sh or docker compose).
    curl: https://curl.se/docs/copyright.html
 
 
-3. arizephoenix/phoenix:14.15.0
-   Image: arizephoenix/phoenix:14.15.0
+3. arizephoenix/phoenix:19.8.0
+   Image: arizephoenix/phoenix:19.8.0
    License: Elastic License 2.0 (ELv2)
    Registry: https://hub.docker.com/r/arizephoenix/phoenix
    Source: https://github.com/Arize-ai/phoenix

--- a/deploy/docker/services/infra/compose.yml
+++ b/deploy/docker/services/infra/compose.yml
@@ -91,7 +91,7 @@ services:
 
   phoenix:
     container_name: phoenix
-    image: 'arizephoenix/phoenix:14.15.0'
+    image: 'arizephoenix/phoenix:19.8.0'
     profiles: ["phoenix"]
     environment:
       PHOENIX_WORKING_DIR: '/.phoenix/'

--- a/deploy/docker/test-scripts/compose-images.golden
+++ b/deploy/docker/test-scripts/compose-images.golden
@@ -25,7 +25,7 @@ deploy/docker/services/analytics/video-analytics-api/compose.yml nvcr.io/nvidia/
 deploy/docker/services/auto-calibration/ms/compose.yml nvcr.io/nvidia/vss-core/vss-auto-calibration:3.2.1
 deploy/docker/services/auto-calibration/ui/compose.yml nvcr.io/nvidia/vss-core/vss-auto-calibration-ui:3.2.1
 deploy/docker/services/infra/compose.yml alpine:3.24.1
-deploy/docker/services/infra/compose.yml arizephoenix/phoenix:14.15.0
+deploy/docker/services/infra/compose.yml arizephoenix/phoenix:19.8.0
 deploy/docker/services/infra/compose.yml confluentinc/cp-kafka:8.3.0
 deploy/docker/services/infra/compose.yml coturn/coturn:4.14.0
 deploy/docker/services/infra/compose.yml docker.elastic.co/kibana/kibana:9.4.3

--- a/deploy/helm/services/infra/charts/phoenix/Chart.yaml
+++ b/deploy/helm/services/infra/charts/phoenix/Chart.yaml
@@ -18,4 +18,4 @@ name: phoenix
 description: Arize Phoenix observability and tracing UI
 type: application
 version: 3.2.0
-appVersion: "14.15.0"
+appVersion: "19.8.0"

--- a/deploy/helm/services/infra/values.yaml
+++ b/deploy/helm/services/infra/values.yaml
@@ -27,7 +27,7 @@ phoenix:
   replicas: 1
   image:
     repository: arizephoenix/phoenix
-    tag: "14.15.0"
+    tag: "19.8.0"
     pullPolicy: IfNotPresent
   phoenixHost: "0.0.0.0"
   env: []


### PR DESCRIPTION
## Summary
- upgrade `arizephoenix/phoenix` from 14.15.0 to 19.8.0 for Docker Compose and Helm
- synchronize the resolved-image golden file and third-party license attribution
- retain the existing Phoenix working directory, path-prefix, persistence, and OTLP configuration

## Test plan
- [x] Verify the 19.8.0 image manifest supports linux/amd64 and linux/arm64
- [x] Run compose image golden verification and unit tests
- [x] Lint and render the infra Helm chart
- [x] Start Phoenix 14.15.0, reuse its persisted data volume with 19.8.0, and verify startup plus `POST /v1/traces`