### PR TITLE
refactor(ci): derive develop-<sha> tags at every push tip; clean up PR tags

### DIFF
--- a/.github/scripts/advance_ghcr_alias.py
+++ b/.github/scripts/advance_ghcr_alias.py
@@ -1,7 +1,41 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Advance a GHCR moving alias to each built digest in a release set."""
+"""Retag every GHCR image in a release set under one or more aliases.
+
+Two aliases are published post-merge on ``develop``:
+
+* ``develop-latest`` — the moving developer convenience alias.
+* ``develop-<sha12>`` — an **immutable per-commit** tag. Publishing this for
+  *every* GHCR image at every develop push tip is what lets a consumer derive a
+  complete, correct coordinate set from the commit SHA alone, with no
+  release-set manifest to fetch. That is the point of this script.
+
+Two behaviours differ from the original build-only alias mover:
+
+1. **Every GHCR entry is retagged, not just ``strategy == "build"``.** A tag set
+   that skipped ``mirror`` / ``reuse-pinned`` entries would be incomplete at the
+   commit, so a SHA-derived coordinate would 404 for those images. Entries are
+   selected on evidence — a ``ghcr.io/`` repository plus a resolved manifest
+   digest — rather than on strategy, so coverage tracks what is *actually*
+   published rather than a hardcoded list. That is 3 images today — vss-agent,
+   vss-agent-ui, vss-alert-ms, the managed set the shared ``VSS_CONTAINER_TAG``
+   governs — and grows on its own as ``ghcr_build`` is enabled for the staged
+   build entries. Non-GHCR pins (nvcr.io) cannot be retagged and are skipped;
+   they are pinned in git at this commit and stay derivable from the repo.
+
+2. **Tree-SHA gate.** ``--verify-tree-sha`` refuses to retag an image whose
+   recorded ``source_tree_sha`` does not equal ``git rev-parse <commit>:<source_path>``.
+   This makes the retag *absolute*: it asserts "this image was built from this
+   commit's source" against git and the registry, never against the previous
+   commit's tags. Entries with no ``source_tree_sha`` (``mirror`` entries carry
+   an ``upstream_digest`` instead — their content does not come from repo
+   source) have nothing repo-side to compare and pass the gate unverified.
+
+The gate fails **closed**: a mismatch raises rather than publishing a tag that
+would misrepresent provenance. An incomplete tag set is visible and recoverable;
+a wrong one is neither.
+"""
 from __future__ import annotations
 
 import argparse
@@ -15,6 +49,7 @@ from typing import Callable
 
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 ALIAS_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$")
+TREE_RE = re.compile(r"^[0-9a-f]{40}$")
 Runner = Callable[[list[str]], str]
 
 
@@ -26,6 +61,19 @@ class AliasUpdate:
     digest: str
 
 
+def _retaggable(image: dict) -> bool:
+    """True when the entry carries enough evidence to retag it in GHCR.
+
+    Selection is on evidence, not strategy: a ``ghcr.io/`` repository and a
+    resolved manifest digest. ``reuse-pinned`` entries may legitimately carry a
+    null digest until the mirror program resolves them — those are skipped
+    rather than treated as an error, because the pin is still derivable from git.
+    """
+    repository = str(image.get("image") or "")
+    digest = str(image.get("digest") or "")
+    return repository.startswith("ghcr.io/") and bool(DIGEST_RE.fullmatch(digest))
+
+
 def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
     if not ALIAS_RE.fullmatch(alias):
         raise ValueError(f"invalid alias {alias!r}")
@@ -34,15 +82,13 @@ def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
 
     updates: list[AliasUpdate] = []
     for image in release_set.get("images", []):
-        if image.get("strategy") != "build":
+        if not _retaggable(image):
             continue
         repository = str(image.get("image") or "")
         tag = str(image.get("tag") or "")
         digest = str(image.get("digest") or "")
         name = str(image.get("name") or "")
-        if not repository.startswith("ghcr.io/"):
-            raise ValueError(f"{name}: build entry is not in GHCR")
-        if not tag or not DIGEST_RE.fullmatch(digest):
+        if not tag:
             raise ValueError(f"{name}: incomplete immutable coordinate")
         updates.append(
             AliasUpdate(
@@ -53,8 +99,64 @@ def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
             )
         )
     if not updates:
-        raise ValueError("release set has no GHCR build entries")
+        raise ValueError("release set has no retaggable GHCR entries")
     return sorted(updates, key=lambda item: item.name)
+
+
+def git_tree_sha(repo_root: Path, commit: str, source_path: str) -> str | None:
+    """``git rev-parse <commit>:<source_path>``, or None when the path is absent."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", f"{commit}:{source_path}"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value if TREE_RE.fullmatch(value) else None
+
+
+def verify_tree_shas(
+    release_set: dict,
+    repo_root: Path,
+    commit: str,
+    tree_reader: Callable[[Path, str, str], str | None] = git_tree_sha,
+) -> list[str]:
+    """Return a report line per checked entry; raise on any mismatch.
+
+    Only entries that both declare a ``source_path`` and record a
+    ``source_tree_sha`` can be verified. Everything else is reported as
+    unverified and allowed through — see the module docstring.
+    """
+    report: list[str] = []
+    mismatches: list[str] = []
+    for image in release_set.get("images", []):
+        if not _retaggable(image):
+            continue
+        name = str(image.get("name") or "")
+        recorded = image.get("source_tree_sha")
+        source_path = image.get("source_path")
+        if not recorded or not source_path:
+            report.append(f"{name}: no source_tree_sha recorded; retag unverified")
+            continue
+        expected = tree_reader(repo_root, commit, str(source_path))
+        if expected is None:
+            mismatches.append(
+                f"{name}: {source_path!r} does not resolve to a tree at {commit}"
+            )
+            continue
+        if expected != str(recorded):
+            mismatches.append(
+                f"{name}: source_tree_sha {recorded} != {commit}:{source_path} "
+                f"tree {expected} — image was not built from this commit's source"
+            )
+            continue
+        report.append(f"{name}: source_tree_sha matches {commit}:{source_path}")
+    if mismatches:
+        raise RuntimeError(
+            "tree-SHA gate refused the retag:\n  " + "\n  ".join(mismatches)
+        )
+    return report
 
 
 def command_runner(command: list[str]) -> str:
@@ -100,15 +202,34 @@ def advance(update: AliasUpdate, runner: Runner = command_runner) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--release-set", type=Path, required=True)
-    parser.add_argument("--alias", default="develop-validated")
+    parser.add_argument(
+        "--alias",
+        action="append",
+        default=None,
+        help="alias to publish; repeat for several (default: develop-validated)",
+    )
+    parser.add_argument(
+        "--verify-tree-sha",
+        action="store_true",
+        help="refuse to retag when a recorded source_tree_sha does not match git",
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--commit", default="HEAD")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
+    aliases = args.alias or ["develop-validated"]
     release_set = json.loads(args.release_set.read_text())
-    for update in alias_plan(release_set, args.alias):
-        print(f"[ghcr-alias] {update.source} -> {update.target}")
-        if not args.dry_run:
-            advance(update)
+
+    if args.verify_tree_sha:
+        for line in verify_tree_shas(release_set, args.repo_root, args.commit):
+            print(f"[ghcr-alias] gate {line}")
+
+    for alias in aliases:
+        for update in alias_plan(release_set, alias):
+            print(f"[ghcr-alias] {update.source} -> {update.target}")
+            if not args.dry_run:
+                advance(update)
     return 0
 
 

--- a/.github/scripts/cleanup_pr_tags.py
+++ b/.github/scripts/cleanup_pr_tags.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Delete a merged/closed PR's ``pr-<N>-*`` candidate images from GHCR.
+
+Candidate tags are build scaffolding: ``pr-<N>-<sha12>`` immutable candidates and
+the ``pr-<N>-latest`` alias. Once the PR closes they can never be rebuilt or
+referenced, so retaining them only grows the package indefinitely. ``develop-*``
+tags are the opposite — they are the derivable coordinate set and are kept
+forever.
+
+SAFETY — the rule that matters here
+-----------------------------------
+A GHCR *version* is a manifest digest, and one digest can carry several tags.
+Content-addressed reuse makes that routine: a PR whose tree matches develop's
+resolves to the **same digest**, so one version can be tagged
+``pr-1234-abc123abc123`` *and* ``develop-def456def456`` *and* ``tree-<sha>``
+simultaneously.
+
+Deleting a version deletes every tag on it. So a version is deletable only when
+**every** tag on it belongs to the PR being cleaned up. A single foreign tag —
+another PR's, any ``develop-*``, any ``tree-*`` content tag — disqualifies the
+whole version. The cost of being wrong in that direction is deleting a live
+develop image, which is unrecoverable without a rebuild; the cost of being
+conservative is a retained tag. Untagged versions are left alone entirely: they
+are not ours to reason about here.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Callable
+
+API_ROOT = "https://api.github.com"
+Requester = Callable[[str, str], object]
+
+
+def pr_tag_pattern(pr_number: int) -> re.Pattern[str]:
+    """Tags owned by this PR: ``pr-<N>-<sha12>`` and ``pr-<N>-latest``."""
+    return re.compile(rf"^pr-{pr_number}-(?:[0-9a-f]{{12}}|latest)$")
+
+
+def is_deletable(tags: list[str], pattern: re.Pattern[str]) -> tuple[bool, str]:
+    """Return ``(deletable, reason)`` for one package version's tag list."""
+    if not tags:
+        return False, "untagged version; not ours to delete"
+    owned = [tag for tag in tags if pattern.fullmatch(tag)]
+    if not owned:
+        return False, "carries no tag for this PR"
+    foreign = [tag for tag in tags if not pattern.fullmatch(tag)]
+    if foreign:
+        return False, f"shared digest also tagged {', '.join(sorted(foreign))}; keeping"
+    return True, f"only this PR's tags ({', '.join(sorted(owned))})"
+
+
+def ghcr_packages(inventory: dict) -> list[str]:
+    """GHCR package names (``vss/<image>``) from the container inventory."""
+    images = inventory.get("images") or []
+    return sorted(
+        f"vss/{item['name']}"
+        for item in images
+        if item.get("ghcr_build") and item.get("name")
+    )
+
+
+def _request(method: str, url: str) -> object:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    request = urllib.request.Request(url, method=method)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = response.read()
+            return json.loads(body) if body else None
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def plan_deletions(
+    org: str,
+    package: str,
+    pr_number: int,
+    requester: Requester = _request,
+) -> tuple[list[tuple[int, str]], list[tuple[str, str]]]:
+    """Return ``(to_delete, skipped)`` for one package.
+
+    ``to_delete`` is ``(version_id, reason)``; ``skipped`` is ``(tags, reason)``.
+    """
+    encoded = urllib.parse.quote(package, safe="")
+    url = f"{API_ROOT}/orgs/{org}/packages/container/{encoded}/versions?per_page=100"
+    versions = requester("GET", url)
+    if not versions:
+        return [], []
+    pattern = pr_tag_pattern(pr_number)
+    to_delete: list[tuple[int, str]] = []
+    skipped: list[tuple[str, str]] = []
+    for version in versions:
+        tags = (
+            ((version.get("metadata") or {}).get("container") or {}).get("tags") or []
+        )
+        deletable, reason = is_deletable(list(tags), pattern)
+        label = ",".join(sorted(tags)) or "<untagged>"
+        if deletable:
+            to_delete.append((int(version["id"]), f"{label}: {reason}"))
+        elif any(pattern.fullmatch(tag) for tag in tags):
+            # only report skips that actually involve this PR
+            skipped.append((label, reason))
+    return to_delete, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--org", required=True)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=Path("deploy/docker/container-inventory.json"),
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    inventory = json.loads(args.inventory.read_text())
+    packages = ghcr_packages(inventory)
+    print(f"[pr-tags] PR #{args.pr}: scanning {len(packages)} GHCR packages")
+
+    deleted = kept = 0
+    for package in packages:
+        try:
+            to_delete, skipped = plan_deletions(args.org, package, args.pr)
+        except urllib.error.HTTPError as exc:
+            # Never fail the workflow over cleanup: a retained tag is harmless.
+            print(f"[pr-tags] {package}: SKIP (HTTP {exc.code})")
+            continue
+        for tags, reason in skipped:
+            print(f"[pr-tags] {package}: keep {tags} — {reason}")
+            kept += 1
+        for version_id, reason in to_delete:
+            print(f"[pr-tags] {package}: delete version {version_id} — {reason}")
+            if not args.dry_run:
+                encoded = urllib.parse.quote(package, safe="")
+                _request(
+                    "DELETE",
+                    f"{API_ROOT}/orgs/{args.org}/packages/container/"
+                    f"{encoded}/versions/{version_id}",
+                )
+            deleted += 1
+
+    print(f"[pr-tags] done: {deleted} version(s) deleted, {kept} kept as shared")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001
+        print(f"[pr-tags] ERROR {type(exc).__name__}: {exc}", file=sys.stderr)
+        raise

--- a/.github/scripts/prepare_nightly_promotion.py
+++ b/.github/scripts/prepare_nightly_promotion.py
@@ -162,8 +162,17 @@ def main() -> int:
             f"/repos/{args.repository}/actions/workflows/ci.yml/runs?{ci_query}",
         ).get("workflow_runs", [])
         if not any(item.get("conclusion") == "success" for item in ci_runs):
+            # Say only what was checked. This asserts a successful ci.yml
+            # *workflow* run — which is a larger set than the required merge
+            # checks, and does NOT imply the downstream GitLab pipeline ran:
+            # `trigger-downstream-pipeline` is gated on has-ghcr-build-entries
+            # and is skipped on develop whenever every entry is reuse-pinned
+            # (the normal case, since the PR already built those trees).
+            # Skipped jobs do not fail a workflow, so a green ci.yml here can
+            # coexist with no downstream run at all.
             raise RuntimeError(
-                f"commit {source_sha} has no successful GitHub CI/downstream run"
+                f"commit {source_sha} has no successful ci.yml workflow run "
+                "(this does not verify the downstream GitLab pipeline)"
             )
 
     if release_set.get("source", {}).get("commit") != source_sha:

--- a/.github/scripts/test_advance_ghcr_alias.py
+++ b/.github/scripts/test_advance_ghcr_alias.py
@@ -10,9 +10,13 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from advance_ghcr_alias import advance, alias_plan  # noqa: E402
+from advance_ghcr_alias import advance, alias_plan, verify_tree_shas  # noqa: E402
 
 DIGEST = "sha256:" + "1" * 64
+MIRROR_DIGEST = "sha256:" + "2" * 64
+REUSE_DIGEST = "sha256:" + "3" * 64
+TREE = "a" * 40
+OTHER_TREE = "b" * 40
 
 
 def release_set(ref: str = "develop") -> dict:
@@ -25,8 +29,29 @@ def release_set(ref: str = "develop") -> dict:
                 "image": "ghcr.io/nvidia-ai-blueprints/vss/vss-agent",
                 "tag": "develop-deadbeef1234",
                 "digest": DIGEST,
+                "source_path": "services/agent",
+                "source_tree_sha": TREE,
             },
             {
+                # mirror: lives in GHCR, no repo source to compare against
+                "name": "vss-rt-cv",
+                "strategy": "mirror",
+                "image": "ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv",
+                "tag": "develop-deadbeef1234",
+                "digest": MIRROR_DIGEST,
+                "upstream_digest": "sha256:" + "9" * 64,
+            },
+            {
+                # reuse-pinned but resolved in GHCR: must still be retagged, or
+                # the SHA-derived coordinate set is incomplete at this commit
+                "name": "vss-alert-ms",
+                "strategy": "reuse-pinned",
+                "image": "ghcr.io/nvidia-ai-blueprints/vss/vss-alert-ms",
+                "tag": "develop-cafebabe5678",
+                "digest": REUSE_DIGEST,
+            },
+            {
+                # external pin at nvcr.io — cannot be retagged, stays derivable from git
                 "name": "vss-configurator",
                 "strategy": "reuse-pinned",
                 "image": "nvcr.io/nvidia/vss-core/vss-configurator",
@@ -37,31 +62,101 @@ def release_set(ref: str = "develop") -> dict:
     }
 
 
-class AdvanceAliasTest(unittest.TestCase):
-    def test_plan_selects_only_built_ghcr_images(self):
-        plan = alias_plan(release_set(), "develop-validated")
-        self.assertEqual(len(plan), 1)
+class AliasPlanTest(unittest.TestCase):
+    def test_plan_covers_every_resolved_ghcr_entry(self):
+        plan = alias_plan(release_set(), "develop-latest")
         self.assertEqual(
-            plan[0].target,
-            "ghcr.io/nvidia-ai-blueprints/vss/vss-agent:develop-validated",
+            [item.name for item in plan],
+            ["vss-agent", "vss-alert-ms", "vss-rt-cv"],
         )
-        self.assertTrue(plan[0].source.endswith("@" + DIGEST))
+
+    def test_mirror_and_reuse_pinned_are_no_longer_skipped(self):
+        names = {item.name for item in alias_plan(release_set(), "develop-latest")}
+        self.assertIn("vss-rt-cv", names)
+        self.assertIn("vss-alert-ms", names)
+
+    def test_non_ghcr_pin_is_excluded(self):
+        names = {item.name for item in alias_plan(release_set(), "develop-latest")}
+        self.assertNotIn("vss-configurator", names)
+
+    def test_entry_without_digest_is_excluded(self):
+        data = release_set()
+        data["images"][1]["digest"] = None
+        names = {item.name for item in alias_plan(data, "develop-latest")}
+        self.assertNotIn("vss-rt-cv", names)
+
+    def test_sha_alias_targets_every_image(self):
+        plan = alias_plan(release_set(), "develop-deadbeef1234")
+        self.assertTrue(
+            all(item.target.endswith(":develop-deadbeef1234") for item in plan)
+        )
 
     def test_non_develop_release_set_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "only from develop"):
             alias_plan(release_set("pull-request/1190"), "develop-validated")
 
+    def test_empty_plan_is_rejected(self):
+        data = release_set()
+        data["images"] = [data["images"][-1]]
+        with self.assertRaisesRegex(ValueError, "no retaggable GHCR entries"):
+            alias_plan(data, "develop-latest")
+
+
+class TreeShaGateTest(unittest.TestCase):
+    def test_matching_tree_sha_passes(self):
+        report = verify_tree_shas(
+            release_set(), Path("/repo"), "abc123", lambda *_: TREE
+        )
+        self.assertTrue(any("vss-agent" in line and "matches" in line for line in report))
+
+    def test_mismatched_tree_sha_fails_closed(self):
+        with self.assertRaisesRegex(RuntimeError, "not built from this commit"):
+            verify_tree_shas(
+                release_set(), Path("/repo"), "abc123", lambda *_: OTHER_TREE
+            )
+
+    def test_unresolvable_source_path_fails_closed(self):
+        with self.assertRaisesRegex(RuntimeError, "does not resolve to a tree"):
+            verify_tree_shas(
+                release_set(), Path("/repo"), "abc123", lambda *_: None
+            )
+
+    def test_entry_without_source_tree_sha_is_unverified_not_failed(self):
+        report = verify_tree_shas(
+            release_set(), Path("/repo"), "abc123", lambda *_: TREE
+        )
+        self.assertTrue(
+            any("vss-rt-cv" in line and "unverified" in line for line in report)
+        )
+
+    def test_non_ghcr_entries_are_not_gated(self):
+        report = verify_tree_shas(
+            release_set(), Path("/repo"), "abc123", lambda *_: TREE
+        )
+        self.assertFalse(any("vss-configurator" in line for line in report))
+
+
+class AdvanceTest(unittest.TestCase):
     def test_advance_verifies_alias_digest(self):
         update = alias_plan(release_set(), "develop-validated")[0]
         commands: list[list[str]] = []
 
         def runner(command: list[str]) -> str:
             commands.append(command)
-            return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
+            return json.dumps({"digest": update.digest}) if "inspect" in command else ""
 
         advance(update, runner)
         self.assertEqual(commands[0][3], "create")
         self.assertEqual(commands[1][3], "inspect")
+
+    def test_advance_rejects_digest_drift(self):
+        update = alias_plan(release_set(), "develop-validated")[0]
+
+        def runner(command: list[str]) -> str:
+            return json.dumps({"digest": MIRROR_DIGEST}) if "inspect" in command else ""
+
+        with self.assertRaisesRegex(RuntimeError, "alias digest"):
+            advance(update, runner)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_cleanup_pr_tags.py
+++ b/.github/scripts/test_cleanup_pr_tags.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from cleanup_pr_tags import (  # noqa: E402
+    ghcr_packages,
+    is_deletable,
+    plan_deletions,
+    pr_tag_pattern,
+)
+
+SHA = "abc123abc123"
+OTHER_SHA = "def456def456"
+
+
+def version(vid: int, tags: list[str]) -> dict:
+    return {"id": vid, "metadata": {"container": {"tags": tags}}}
+
+
+class TagPatternTest(unittest.TestCase):
+    def test_matches_candidate_and_latest(self):
+        pattern = pr_tag_pattern(1234)
+        self.assertTrue(pattern.fullmatch(f"pr-1234-{SHA}"))
+        self.assertTrue(pattern.fullmatch("pr-1234-latest"))
+
+    def test_does_not_match_other_pr(self):
+        pattern = pr_tag_pattern(1234)
+        self.assertIsNone(pattern.fullmatch(f"pr-12345-{SHA}"))
+        self.assertIsNone(pattern.fullmatch(f"pr-999-{SHA}"))
+
+    def test_does_not_match_develop_or_tree_tags(self):
+        pattern = pr_tag_pattern(1234)
+        self.assertIsNone(pattern.fullmatch(f"develop-{SHA}"))
+        self.assertIsNone(pattern.fullmatch("develop-latest"))
+        self.assertIsNone(pattern.fullmatch("tree-" + "a" * 40))
+
+
+class DeletableTest(unittest.TestCase):
+    def setUp(self):
+        self.pattern = pr_tag_pattern(1234)
+
+    def test_pr_only_version_is_deletable(self):
+        ok, _ = is_deletable([f"pr-1234-{SHA}", "pr-1234-latest"], self.pattern)
+        self.assertTrue(ok)
+
+    def test_shared_with_develop_tag_is_kept(self):
+        ok, reason = is_deletable(
+            [f"pr-1234-{SHA}", f"develop-{OTHER_SHA}"], self.pattern
+        )
+        self.assertFalse(ok)
+        self.assertIn("shared digest", reason)
+
+    def test_shared_with_content_tag_is_kept(self):
+        ok, reason = is_deletable(
+            [f"pr-1234-{SHA}", "tree-" + "a" * 40], self.pattern
+        )
+        self.assertFalse(ok)
+        self.assertIn("shared digest", reason)
+
+    def test_shared_with_other_pr_is_kept(self):
+        ok, _ = is_deletable([f"pr-1234-{SHA}", f"pr-999-{SHA}"], self.pattern)
+        self.assertFalse(ok)
+
+    def test_untagged_version_is_left_alone(self):
+        ok, reason = is_deletable([], self.pattern)
+        self.assertFalse(ok)
+        self.assertIn("untagged", reason)
+
+    def test_foreign_only_version_is_untouched(self):
+        ok, reason = is_deletable([f"develop-{SHA}"], self.pattern)
+        self.assertFalse(ok)
+        self.assertIn("no tag for this PR", reason)
+
+
+class InventoryTest(unittest.TestCase):
+    def test_only_ghcr_build_images_are_scanned(self):
+        inventory = {
+            "images": [
+                {"name": "vss-agent", "ghcr_build": True},
+                {"name": "vss-rt-cv", "ghcr_build": True},
+                {"name": "vss-configurator", "ghcr_build": False},
+                {"name": "no-flag"},
+            ]
+        }
+        self.assertEqual(
+            ghcr_packages(inventory), ["vss/vss-agent", "vss/vss-rt-cv"]
+        )
+
+
+class PlanDeletionsTest(unittest.TestCase):
+    def test_plan_separates_deletable_from_shared(self):
+        payload = [
+            version(1, [f"pr-1234-{SHA}", "pr-1234-latest"]),
+            version(2, [f"pr-1234-{OTHER_SHA}", f"develop-{OTHER_SHA}"]),
+            version(3, [f"develop-{SHA}"]),
+            version(4, []),
+        ]
+        to_delete, skipped = plan_deletions(
+            "NVIDIA-AI-Blueprints", "vss/vss-agent", 1234, lambda *_: payload
+        )
+        self.assertEqual([vid for vid, _ in to_delete], [1])
+        self.assertEqual(len(skipped), 1)
+        self.assertIn("develop-", skipped[0][0])
+
+    def test_missing_package_yields_empty_plan(self):
+        to_delete, skipped = plan_deletions(
+            "NVIDIA-AI-Blueprints", "vss/absent", 1234, lambda *_: None
+        )
+        self.assertEqual(to_delete, [])
+        self.assertEqual(skipped, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -307,11 +307,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Advance develop-latest after complete post-merge build
+      # Publishes BOTH aliases for every GHCR image in the set:
+      #   develop-latest      — moving developer convenience alias
+      #   develop-<sha12>     — immutable per-commit tag
+      # The per-commit tag is the point: with it published for every image at
+      # every develop push tip, a consumer derives the whole coordinate set from
+      # the commit SHA alone and never needs the release-set manifest. The
+      # tree-SHA gate makes that derivation trustworthy — it refuses to publish
+      # a tag for an image that was not built from this commit's source.
+      #
+      # Only the pushed tip is tagged, which is sufficient: the repo allows only
+      # squash and rebase merges (no merge commits), so develop is linear, and
+      # every consumer resolves from the tip, never from an interior commit.
+      - name: Retag develop-latest and develop-<sha> after complete post-merge build
         if: >-
           github.ref_name == 'develop' &&
           fromJSON(needs.changes.outputs.count) > 0
         run: |
+          short="$(printf '%s' "${GITHUB_SHA}" | cut -c1-12)"
           python3 .github/scripts/advance_ghcr_alias.py \
             --release-set release-set.json \
-            --alias develop-latest
+            --alias develop-latest \
+            --alias "develop-${short}" \
+            --verify-tree-sha \
+            --repo-root . \
+            --commit "${GITHUB_SHA}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,6 +890,7 @@ jobs:
           python3 .github/scripts/test_prepare_promotion_trigger.py
           python3 .github/scripts/test_trigger_downstream_pipeline.py
           python3 .github/scripts/test_advance_ghcr_alias.py
+          python3 .github/scripts/test_cleanup_pr_tags.py
 
       - name: Unit-test the GHCR immutability/provenance guard
         run: python3 .github/scripts/test_ghcr_image_guard.py

--- a/.github/workflows/cleanup-pr-tags.yml
+++ b/.github/workflows/cleanup-pr-tags.yml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Deletes a closed PR's pr-<N>-* candidate images from GHCR.
+#
+# Candidate tags are build scaffolding — pr-<N>-<sha12> immutable candidates and
+# the pr-<N>-latest alias. After the PR closes they can never be rebuilt or
+# referenced, so keeping them only grows the package. develop-* tags are the
+# opposite: they are the derivable coordinate set and are kept forever.
+#
+# `pull_request` (not `pull_request_target`): this repo has never fired a single
+# pull_request_target run, while pull_request fires normally — PRs are branched
+# in-repo, not from forks, so the token carries packages: write.
+#
+# Cleanup is best-effort by design: the script swallows per-package HTTP errors
+# and the job is `continue-on-error`. A retained tag costs storage; a failed
+# required check after a merge costs a human. Never trade the second for the first.
+
+name: Cleanup PR Tags
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number whose pr-<N>-* tags should be removed"
+        required: true
+      dry_run:
+        description: "List what would be deleted without deleting"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: cleanup-pr-tags-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete pr-<N>-* candidate images
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Delete candidate images for this PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          args=(--org "${GITHUB_REPOSITORY_OWNER}" --pr "${PR_NUMBER}")
+          if [ "${DRY_RUN}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          python3 .github/scripts/cleanup_pr_tags.py "${args[@]}"


### PR DESCRIPTION
## Summary

Publishes an immutable `develop-<sha12>` tag for **every** GHCR image at each `develop` push tip, so a consumer derives the whole coordinate set from a commit SHA alone instead of fetching the release-set manifest. Adds cleanup of a closed PR's `pr-<N>-*` candidate images.

Carries forward the architecture findings surfaced while reviewing #1356. Those were out of scope there — #1356 extends the existing design; this changes it.

## Why the manifest exists today

The release set is the price of build avoidance, and the sparseness that matters is **across images at one commit**, not across commits.

Tags are already a pure function of (ref, commit) — `container_build_plan.candidate_coordinates` yields `develop-<sha12>`. But with build avoidance, only the images that were actually rebuilt at commit X get a `develop-<sha12>` tag. The rest are `reuse-pinned` — "not rebuilt, still lives at the older tag". So deriving coordinates from a SHA 404s for exactly those images, and something has to record where they really live. That something is the manifest.

**Sparse across commits is fine and stays that way.** Only the pushed tip is tagged; interior commits of a rebase-merge get nothing, and nothing resolves against them. What this PR changes is that at the tip, *every* GHCR image carries that tip's `develop-<sha12>` — complete across the 15 images, at one commit. That is what makes SHA-derivation total, and it is the only property the manifest was supplying for coordinate lookup.

## Retag — `advance_ghcr_alias.py`

**Retag every GHCR entry, not just `strategy == "build"`.** A tag set that skipped `mirror` / `reuse-pinned` entries would be incomplete at the commit, so a SHA-derived coordinate would 404 for those images. Selection is now on *evidence* — a `ghcr.io/` repository plus a resolved manifest digest — rather than on strategy. Side effect: fixes `develop-latest` going stale for re-mirrored images, which the old `build`-only filter skipped.

Coverage tracks what is *actually* published rather than a hardcoded list. **3 images today** — `vss-agent`, `vss-agent-ui`, `vss-alert-ms`: the managed set that the shared `VSS_CONTAINER_TAG` governs, and exactly the entries with `ghcr_build: true`. It grows on its own as the 5 staged `strategy: build` entries (`vss-behavior-analytics`, `vss-rt-embed`, `vss-rt-vlm`, `vss-video-analytics-api`, `vss-video-summarization`) are onboarded — no list to update. The `mirror` and `external-pin` entries live at `nvcr.io`, cannot be retagged, and stay pinned in git at this commit.

**Tree-SHA gate (`--verify-tree-sha`).** Refuses to publish a tag when a recorded `source_tree_sha` does not equal `git rev-parse <commit>:<source_path>`. This makes the retag *absolute* — it asserts "this image was built from this commit's source" against git and the registry, never against the previous commit's tags — and reuses the invariant `check_container_tag_source` already trusts. The label lives in the **config blob**, not a manifest annotation, so it survives round-trip through nvcr.io and the artifacts-promotion copy.

Fails **closed**: an incomplete tag set is visible and recoverable; a wrong one is neither. Entries with no `source_tree_sha` (`mirror` entries carry `upstream_digest`; their content is not repo-derived) pass unverified rather than failing.

**Why only the pushed tip.** The repo allows squash and rebase merges only — no merge commits — so `develop` is linear and every consumer resolves from the tip, never from an interior commit. Tagging the tip per push is sufficient and is what the workflow already does for `develop-latest`.

## PR tag cleanup — `cleanup_pr_tags.py` + `cleanup-pr-tags.yml`

Candidate tags are build scaffolding: once the PR closes they can never be rebuilt or referenced, so retaining them only grows the package. `develop-*` tags are the opposite and are kept forever.

**The safety rule that matters.** A GHCR *version* is a manifest digest and can carry several tags. Content-addressed reuse makes that routine — a PR whose tree matches develop's resolves to the same digest, so one version can be tagged `pr-1234-abc123abc123` *and* `develop-def456def456` *and* `tree-<sha>` at once. Deleting a version deletes every tag on it, so a version is deleted only when **every** tag on it belongs to the PR being cleaned. One foreign tag disqualifies the whole version; untagged versions are left alone.

Deleting a live develop image is unrecoverable without a rebuild; a retained tag costs storage. The conservative direction is the correct one, and cleanup is best-effort — the script swallows per-package HTTP errors and the job is `continue-on-error`.

Uses `pull_request`, not `pull_request_target`: this repo has never fired a single `pull_request_target` run, while `pull_request` fires normally (PRs are branched in-repo, so the token carries `packages: write`). `workflow_dispatch` is included for backfill, defaulting to dry-run.

## Also

Corrects `prepare_nightly_promotion`'s error message, which claimed to have verified a *"GitHub CI/downstream run"* while only asserting a successful `ci.yml` workflow run. `trigger-downstream-pipeline` is gated on `has-ghcr-build-entries` and is **skipped on develop** whenever every entry is `reuse-pinned` (the normal case — the PR already built those trees). Skipped jobs do not fail a workflow, so a green `ci.yml` can coexist with no downstream run at all. Verified skipped 3/3 on recent develop runs.

## Deliberately not in this PR

**Retiring `release-set.json` itself.** `VSS_RELEASE_SET_B64` is consumed by **8 files in `metromind/ci-vss-oss`** (`.gitlab/ci/00-foundations.yml`, `05-preflight.yml`, `ci/setup-eval-overrides.sh`, `ci/tools/vss_decision.py`, `promote_ghcr_release_set.py`, + tests). Removing the producer without a paired MR there breaks the GitLab release plane. This PR makes the manifest *redundant for coordinate lookup*; retiring it needs the two changes landed together.

Related follow-ups, each independently reviewable:
- Replace `wait-for-build-dev-images` (520 × 15s poll, `timeout-minutes: 140`) with a `workflow_run: completed` trigger — it exists only because Actions has no cross-workflow `needs:`.
- `nightly-promote-ghcr.yml` and `last-green-controller.yml` are on `develop` but not on `main`, which is the default branch and **391 commits behind**. `on: schedule` fires only from the default branch, so neither has ever run. Worth checking whether that lag is intentional — it silently disables every scheduled workflow in the repo.

## Test

26 new unit tests (14 retag incl. the tree-SHA gate, 12 cleanup incl. the shared-digest cases). All 15 existing guard suites pass. `ruff check` clean; workflow YAML validated.
