### PR TITLE
feat(skill-eval): compute runner labels from the spec in plan_matrix

### DIFF
--- a/.github/skill-eval/plan_matrix.py
+++ b/.github/skill-eval/plan_matrix.py
@@ -24,6 +24,14 @@ A skill whose adapter is missing collapses to a single `missing_adapter`
 leg (that leg's agent commits the one adapter to the PR branch), so N specs
 of an adapterless skill don't race to commit it N times.
 
+Each leg also carries `runs_on`: the runner label set implied by the
+spec's own `resources.platforms.<PLATFORM>` block (see runs_on_labels).
+This resolves the spec -> hardware mapping at PLAN time, where today
+run_leg.py re-derives it at LEG time from `brev ls` under a flock.
+Nothing consumes `runs_on` yet — it is emitted so the mapping can be
+reviewed against current placement before the GPU boxes are registered
+as runners in their own right.
+
 Env:
     PR_BASE        base branch, e.g. develop (diffed as FETCH_HEAD...HEAD)
     MANUAL_SKILLS_FILTER  workflow_dispatch sweep: a skill-dir name or `*`
@@ -66,6 +74,94 @@ SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 # routing.json, …). Skip `evals.json` everywhere a spec is discovered so it
 # never becomes a matrix leg.
 EXCLUDED_SPEC_NAMES = frozenset({"evals.json"})
+
+# --- Runner labels -----------------------------------------------------
+# Every leg carries a `runs_on` label set derived from the spec's own
+# hardware declaration, so the eval job *can* be placed by Actions with
+# `runs-on: ${{ matrix.runs_on }}` once the GPU boxes are registered as
+# runners in their own right. NOTHING CONSUMES THIS YET — skills-eval.yml
+# still pins the coordinator pool and run_leg.py still does fleet
+# selection + flock. This computes and publishes the mapping so it can be
+# reviewed and diffed against today's placement before any runner moves.
+
+# Labels the GPU boxes themselves would carry. Deliberately NOT
+# `vss-skill-eval-runner`: that label is on the coordinator's runner
+# processes, which are not the machines the trials run on.
+BASE_LABELS: tuple[str, ...] = ("self-hosted", "vss-eval")
+
+# `resources.platforms` key -> GPU-type label. `ANY` is GPU-independent
+# and contributes no `gpu-*` label. Keys mirror the PLATFORMS tables in
+# .github/skill-eval/adapters/*/generate.py.
+PLATFORM_LABELS: dict[str, str | None] = {
+    "H100": "gpu-h100",
+    "L40S": "gpu-l40s",
+    "RTXPRO6000BW": "gpu-rtxpro6000bw",
+    "DGX-SPARK": "gpu-dgx-spark",
+    "IGX-THOR": "gpu-igx-thor",
+    "ANY": None,
+}
+
+# run_leg.pool_candidates reads `int(metadata.get("gpu_count", 1) or 0)`:
+# an ABSENT declaration means one GPU, while an explicit 0/null means
+# GPU-independent. Mirror both so a label set places a leg exactly where
+# the runtime selector would have. 15 of the 50 platform entries in
+# skills/*/evals/ omit gpu_count today and rely on this default.
+DEFAULT_GPU_COUNT = 1
+
+
+def _platform_label(platform: str) -> str | None:
+    """GPU-type label for a `resources.platforms` key."""
+    if platform in PLATFORM_LABELS:
+        return PLATFORM_LABELS[platform]
+    # Unknown key: still emit something deterministic, but say so — a
+    # typo'd platform would otherwise produce a label no box carries and
+    # the job would queue until GitHub cancels it at 24 h.
+    slug = re.sub(r"[^a-z0-9]+", "-", platform.lower()).strip("-")
+    print(
+        f"warning: unknown platform {platform!r} — no entry in "
+        f"PLATFORM_LABELS; emitting {'gpu-' + slug if slug else '(none)'}",
+        file=sys.stderr,
+    )
+    return f"gpu-{slug}" if slug else None
+
+
+def _gpu_count(config: dict) -> int:
+    """Declared GPU demand, matching run_leg's coercion exactly."""
+    raw = config.get("gpu_count", DEFAULT_GPU_COUNT)
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        # Explicit null / "" / garbage -> 0, same as run_leg's `or 0`.
+        return 0
+
+
+def runs_on_labels(platform: str, config: dict | None) -> list[str]:
+    """Runner labels for one leg, from the spec's hardware declaration.
+
+    `gpus-N` is a *demand*: the job asks for exactly N. A box advertises
+    every count it can satisfy — a 2-GPU box carries both `gpus-1` and
+    `gpus-2` — which is how pool_candidates' "over-provisioned boxes
+    remain valid" rule survives a static label set.
+
+    `gpu_count: 0` means GPU-independent and drops BOTH the `gpus-*` and
+    the `gpu-*` label, so the leg can land on any box. That mirrors
+    pool_candidates exactly: its type filter is guarded by
+    `if required_count > 0 and required_type`, so a zero-GPU spec ignores
+    the declared platform and "accepts any RUNNING box". 7 of the 50
+    platform entries are zero-GPU today (the ANY specs, and
+    detection-tracking-3d/routing on RTXPRO6000BW) — under labels they
+    stop competing for GPU boxes at all.
+    """
+    labels = list(BASE_LABELS)
+    count = _gpu_count(config) if config is not None else DEFAULT_GPU_COUNT
+    if count <= 0:
+        return labels
+    if platform:
+        label = _platform_label(platform)
+        if label:
+            labels.append(label)
+    labels.append(f"gpus-{count}")
+    return labels
 
 
 def list_changed_files() -> list[str]:
@@ -155,21 +251,40 @@ def list_skill_file_paths(skills_dir: Path | None = None) -> list[str]:
     ]
 
 
+def spec_platform_config(spec_path: str) -> dict[str, dict]:
+    """A spec's `resources.platforms`, mapping key -> its config object.
+
+    Returns {} for anything malformed, platform-less, or unreadable — the
+    plan then emits a single platform-less leg so the agent surfaces the
+    `missing_platforms_declaration` blocker rather than the plan crashing.
+    A non-dict platform value (e.g. `"L40S": null`) yields {} for that key
+    so callers can read defaults off it uniformly.
+    """
+    try:
+        data = json.loads((REPO_ROOT / spec_path).read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    resources = data.get("resources")
+    if not isinstance(resources, dict):
+        return {}
+    platforms = resources.get("platforms")
+    if not isinstance(platforms, dict):
+        return {}
+    return {
+        key: (value if isinstance(value, dict) else {})
+        for key, value in platforms.items()
+    }
+
+
 def spec_platforms(spec_path: str) -> list[str]:
     """Sorted platform keys from a spec's resources.platforms.
 
     One matrix leg is emitted per platform (the slug carries it), so a
-    two-platform spec fans into two legs. A malformed or platform-less
-    spec yields [] — the plan emits a single platform-less leg so the
-    agent surfaces the `missing_platforms_declaration` blocker rather
-    than the plan crashing.
+    two-platform spec fans into two legs.
     """
-    try:
-        data = json.loads((REPO_ROOT / spec_path).read_text())
-        platforms = data.get("resources", {}).get("platforms", {})
-        return sorted(platforms) if isinstance(platforms, dict) else []
-    except (OSError, ValueError):
-        return []
+    return sorted(spec_platform_config(spec_path))
 
 
 def build_matrix(changed: list[str]) -> list[dict]:
@@ -196,7 +311,6 @@ def build_matrix(changed: list[str]) -> list[dict]:
             # else: harness file or unrelated path -> contributes nothing.
 
     # Resolve to a de-duped (skill, spec_path) target set.
-    targets: dict[str, tuple[str, str]] = {}  # spec_path -> (skill, eval_dir, stem) flattened
     target_meta: dict[str, dict] = {}
 
     def add_spec(skill: str, spec_path: str, eval_dir: str, stem: str) -> None:
@@ -239,10 +353,13 @@ def build_matrix(changed: list[str]) -> list[dict]:
                 # name. For a real trial it's skill__spec_stem__platform.
                 "slug": f"{skill}__missing-adapter",
                 "name": f"{skill} · missing-adapter",
+                # Commits an adapter; runs no trial and needs no GPU.
+                "runs_on": list(BASE_LABELS),
             })
             continue
         for meta in sorted(by_skill[skill], key=lambda m: m["spec_path"]):
-            platforms = spec_platforms(meta["spec_path"]) or [""]
+            platform_config = spec_platform_config(meta["spec_path"])
+            platforms = sorted(platform_config) or [""]
             for platform in platforms:
                 plat_tag = platform or "no-platform"
                 include.append({
@@ -254,6 +371,9 @@ def build_matrix(changed: list[str]) -> list[dict]:
                     "kind": "eval",
                     "slug": f"{skill}__{meta['spec_stem']}__{plat_tag}",
                     "name": f"{skill} · {meta['spec_stem']} · {plat_tag}",
+                    "runs_on": runs_on_labels(
+                        platform, platform_config.get(platform)
+                    ),
                 })
     return include
 
@@ -301,7 +421,11 @@ def emit(include: list[dict]) -> None:
     print(f"has_targets={has_targets}")
     print(f"legs={len(include)}")
     for leg in include:
-        print(f"  - {leg['name']}  [{leg['kind']}]")
+        # runs_on is trace only and nothing consumes it yet, so a leg built
+        # without it must not fail the plan — unlike slug, which is checked
+        # strictly above because downstream paths depend on it.
+        runs_on = " ".join(leg.get("runs_on") or []) or "-"
+        print(f"  - {leg['name']}  [{leg['kind']}]  runs_on={runs_on}")
     print(f"matrix={matrix}")
 
 

--- a/.github/skill-eval/tests/test_plan_matrix.py
+++ b/.github/skill-eval/tests/test_plan_matrix.py
@@ -4,7 +4,7 @@
 """Unit tests for plan_matrix.build_matrix — the diff -> dispatch rules.
 
 The filesystem-touching helpers (specs_for_skill / adapter_exists /
-spec_platforms) are stubbed so the assertions don't drift as the real
+spec_platform_config) are stubbed so the assertions don't drift as the real
 skills/ tree gains or loses specs.
 
 Run:
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import importlib.util
 import os
-import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -73,24 +72,147 @@ class SkillFilePaths(unittest.TestCase):
             )
 
 
+class RunsOnLabels(unittest.TestCase):
+    """Spec hardware declaration -> runner label set.
+
+    Parity target is run_leg.pool_candidates, which reads
+    `int(metadata.get("gpu_count", 1) or 0)` and guards its GPU-type
+    filter with `if required_count > 0 and required_type`.
+    """
+
+    def test_single_gpu_platform(self):
+        self.assertEqual(
+            plan_matrix.runs_on_labels("L40S", {"gpu_count": 1}),
+            ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"],
+        )
+
+    def test_two_gpu_platform(self):
+        self.assertEqual(
+            plan_matrix.runs_on_labels("RTXPRO6000BW", {"gpu_count": 2}),
+            ["self-hosted", "vss-eval", "gpu-rtxpro6000bw", "gpus-2"],
+        )
+
+    def test_absent_gpu_count_defaults_to_one(self):
+        """pool_candidates' `metadata.get("gpu_count", 1)` default."""
+        self.assertEqual(
+            plan_matrix.runs_on_labels("L40S", {"modes": ["remote-all"]}),
+            ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"],
+        )
+        self.assertEqual(
+            plan_matrix.runs_on_labels("L40S", None),
+            ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"],
+        )
+
+    def test_zero_gpu_count_drops_the_platform_label_too(self):
+        """GPU-independent legs must not be pinned to a GPU box.
+
+        pool_candidates only applies its type filter when
+        `required_count > 0`, so a zero-GPU spec accepts any RUNNING box
+        regardless of the platform it names. Emitting `gpu-rtxpro6000bw`
+        here would be *more* restrictive than today's placement.
+        """
+        self.assertEqual(
+            plan_matrix.runs_on_labels("RTXPRO6000BW", {"gpu_count": 0}),
+            ["self-hosted", "vss-eval"],
+        )
+        self.assertEqual(
+            plan_matrix.runs_on_labels("ANY", {"gpu_count": 0}),
+            ["self-hosted", "vss-eval"],
+        )
+
+    def test_null_or_garbage_gpu_count_is_zero(self):
+        """pool_candidates' trailing `or 0` on a present-but-falsy value."""
+        for raw in (None, "", "two"):
+            self.assertEqual(
+                plan_matrix.runs_on_labels("L40S", {"gpu_count": raw}),
+                ["self-hosted", "vss-eval"],
+                raw,
+            )
+
+    def test_any_platform_carries_no_gpu_type_label(self):
+        self.assertEqual(
+            plan_matrix.runs_on_labels("ANY", {"gpu_count": 1}),
+            ["self-hosted", "vss-eval", "gpus-1"],
+        )
+
+    def test_unknown_platform_falls_back_to_a_normalised_slug(self):
+        self.assertEqual(
+            plan_matrix.runs_on_labels("GB200 NVL", {"gpu_count": 1}),
+            ["self-hosted", "vss-eval", "gpu-gb200-nvl", "gpus-1"],
+        )
+
+    def test_every_known_platform_has_a_label(self):
+        for platform in ("H100", "L40S", "RTXPRO6000BW", "DGX-SPARK", "IGX-THOR"):
+            labels = plan_matrix.runs_on_labels(platform, {"gpu_count": 1})
+            self.assertEqual(len(labels), 4, platform)
+            self.assertTrue(labels[2].startswith("gpu-"), platform)
+
+
+class RealSpecCorpus(unittest.TestCase):
+    """Every spec in skills/ must yield a well-formed label set.
+
+    Unlike BuildMatrix this reads the real tree on purpose: the point is
+    that no spec on disk produces a label a runner could never carry.
+    """
+
+    def setUp(self):
+        self.specs = sorted(
+            p for p in (plan_matrix.REPO_ROOT / "skills").glob("*/eval*/*.json")
+            if p.name not in plan_matrix.EXCLUDED_SPEC_NAMES
+        )
+        if not self.specs:
+            self.skipTest("no specs on disk")
+
+    def test_every_platform_entry_yields_valid_labels(self):
+        seen = 0
+        for spec in self.specs:
+            rel = str(spec.relative_to(plan_matrix.REPO_ROOT))
+            for platform, config in plan_matrix.spec_platform_config(rel).items():
+                labels = plan_matrix.runs_on_labels(platform, config)
+                seen += 1
+                # GitHub matches labels case-insensitively; keep the emitted
+                # form strictly lowercase so box registration is unambiguous.
+                for label in labels:
+                    self.assertRegex(label, r"^[a-z0-9][a-z0-9-]*$", f"{rel} {label}")
+                self.assertEqual(labels[:2], list(plan_matrix.BASE_LABELS), rel)
+                self.assertLessEqual(
+                    sum(1 for x in labels if x.startswith("gpu-")), 1, rel
+                )
+                self.assertLessEqual(
+                    sum(1 for x in labels if x.startswith("gpus-")), 1, rel
+                )
+        self.assertGreater(seen, 0)
+
+    def test_a_gpu_type_label_never_appears_without_a_count(self):
+        """The zero-GPU parity rule, asserted across the real corpus."""
+        for spec in self.specs:
+            rel = str(spec.relative_to(plan_matrix.REPO_ROOT))
+            for platform, config in plan_matrix.spec_platform_config(rel).items():
+                labels = plan_matrix.runs_on_labels(platform, config)
+                if any(x.startswith("gpu-") for x in labels):
+                    self.assertTrue(
+                        any(x.startswith("gpus-") for x in labels), f"{rel} {platform}"
+                    )
+
+
 class BuildMatrix(unittest.TestCase):
     def setUp(self):
         self._orig_specs = plan_matrix.specs_for_skill
         self._orig_adapter = plan_matrix.adapter_exists
-        self._orig_platforms = plan_matrix.spec_platforms
+        self._orig_platforms = plan_matrix.spec_platform_config
         self._orig_isfile = plan_matrix.Path.is_file
 
         plan_matrix.specs_for_skill = lambda s: FAKE_SPECS.get(s, [])
         plan_matrix.adapter_exists = lambda s: s in SKILLS_WITH_ADAPTERS
         # One platform per spec by default; overridden in the multi test.
-        plan_matrix.spec_platforms = lambda p: ["L40S"]
+        plan_matrix.spec_platform_config = lambda p: {"L40S": {"gpu_count": 1}}
         # All explicitly-changed spec paths in these tests "exist".
         plan_matrix.Path.is_file = lambda self: True  # type: ignore
 
     def tearDown(self):
         plan_matrix.specs_for_skill = self._orig_specs
         plan_matrix.adapter_exists = self._orig_adapter
-        plan_matrix.spec_platforms = self._orig_platforms
+        plan_matrix.spec_platform_config = self._orig_platforms
         plan_matrix.Path.is_file = self._orig_isfile
 
     def _stems(self, include):
@@ -144,6 +266,34 @@ class BuildMatrix(unittest.TestCase):
         self.assertEqual(len(inc), 1)
         self.assertEqual(inc[0]["kind"], "missing_adapter")
         self.assertEqual(inc[0]["slug"], "vss-no-adapter__missing-adapter")
+        # Commits an adapter, runs no trial — must not claim a GPU.
+        self.assertEqual(inc[0]["runs_on"], ["self-hosted", "vss-eval"])
+
+    def test_every_leg_carries_runs_on(self):
+        inc = plan_matrix.build_matrix([
+            "skills/vss-summarize-video/SKILL.md",
+            "skills/vss-no-adapter/SKILL.md",
+        ])
+        self.assertTrue(inc)
+        for leg in inc:
+            self.assertIn("runs_on", leg)
+            self.assertEqual(leg["runs_on"][:2], ["self-hosted", "vss-eval"])
+
+    def test_runs_on_tracks_the_spec_declaration(self):
+        plan_matrix.spec_platform_config = lambda p: {
+            "L40S": {"gpu_count": 1},
+            "RTXPRO6000BW": {"gpu_count": 2},
+        }
+        inc = plan_matrix.build_matrix(["skills/vss-search-archive/evals/search.json"])
+        self.assertEqual(
+            {leg["platform"]: leg["runs_on"] for leg in inc},
+            {
+                "L40S": ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"],
+                "RTXPRO6000BW": [
+                    "self-hosted", "vss-eval", "gpu-rtxpro6000bw", "gpus-2",
+                ],
+            },
+        )
 
     def test_slug_carries_platform(self):
         inc = plan_matrix.build_matrix(["skills/vss-search-archive/evals/search.json"])
@@ -152,7 +302,10 @@ class BuildMatrix(unittest.TestCase):
         self.assertEqual(inc[0]["slug"], "vss-search-archive__search__L40S")
 
     def test_multi_platform_spec_fans_into_one_leg_per_platform(self):
-        plan_matrix.spec_platforms = lambda p: ["L40S", "RTXPRO6000BW"]
+        plan_matrix.spec_platform_config = lambda p: {
+            "L40S": {"gpu_count": 1},
+            "RTXPRO6000BW": {"gpu_count": 2},
+        }
         inc = plan_matrix.build_matrix(["skills/vss-search-archive/evals/search.json"])
         self.assertEqual(
             sorted(leg["slug"] for leg in inc),


### PR DESCRIPTION
## What

Every matrix leg now carries `runs_on` — the runner label set implied by the spec's own `resources.platforms.<PLATFORM>` block:

```json
{"include": [{"name": "…", "slug": "…",
              "runs_on": ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"]}]}
```

**Nothing consumes it yet.** `skills-eval.yml` still pins the coordinator pool and `run_leg.py` still does fleet selection + flock. This is emit-only on purpose, so the mapping can be reviewed and diffed against today's placement before any GPU box is registered as a runner in its own right.

## Why here

The spec already declares its hardware, and that declaration is readable at **plan** time — no dataset, no `brev ls`, no box. `spec_platforms()` was already parsing the exact object and discarding everything but the keys:

```python
platforms = data.get("resources", {}).get("platforms", {})
return sorted(platforms) if isinstance(platforms, dict) else []
```

So the spec stays the source of truth for hardware; only the *resolution point* moves — from leg-time runtime matching to plan-time label computation, with Actions doing the placement.

## Mapping, with `pool_candidates` as the parity target

| spec | label | rationale |
|---|---|---|
| `platforms.L40S` | `gpu-l40s` | keys mirror the `PLATFORMS` tables in `adapters/*/generate.py` |
| `platforms.ANY` | *(none)* | GPU-independent |
| `gpu_count: N` | `gpus-N` | a **demand**. A box advertises every count it can satisfy — a 2-GPU box carries `gpus-1` *and* `gpus-2` — which is how "over-provisioned boxes remain valid" (#929) survives a static label set |
| `gpu_count: 0` | *(neither)* | `pool_candidates` guards its type filter with `if required_count > 0 and required_type`, so a zero-GPU spec already accepts any RUNNING box. Emitting a GPU label here would be **more** restrictive than today |
| absent | `gpus-1` | matches `int(metadata.get("gpu_count", 1) or 0)`. 15 of the 50 platform entries rely on this default |

## Over the real tree

50 legs collapse to four label sets:

```
18  self-hosted vss-eval gpu-l40s gpus-1
14  self-hosted vss-eval gpu-rtxpro6000bw gpus-2
11  self-hosted vss-eval gpu-rtxpro6000bw gpus-1
 7  self-hosted vss-eval
```

Those 7 are the zero-GPU legs — the `ANY` specs plus `detection-tracking-3d/routing`. Under labels they stop competing for GPU boxes entirely, which the runtime selector cannot express. That's a throughput win available the moment anything consumes the field.

## Two findings from the survey

**No spec declares `gpu_type`** — 0 of 50. `_rtx4090_supports()` routes on "spec metadata declares `gpu_type`", so that path is dead code, consistent with `RTX4090_TESTS` and `RTX4090_ALL_TESTS` both being empty frozensets. Nothing to preserve when the label model lands.

**Unknown platform keys now warn.** A typo'd platform would otherwise emit a label no box carries, and the job would queue until GitHub cancels it at 24 h. It still emits a deterministic slug, but says so on stderr.

## Incidental

`spec_platforms` is refactored onto a new `spec_platform_config`, which also hardens the malformed-spec path: a non-dict document or `resources` block previously raised `AttributeError` straight past the `except (OSError, ValueError)`. There is such a file on disk — the legacy list-shaped `evals.json`. Tests stub the new helper.

Also fixes two pre-existing `ruff` findings in the touched files (unused `targets` local, unused `sys` import). Both confirmed present on `develop`.

## Tests

- `RunsOnLabels` — each mapping rule, plus both `pool_candidates` coercion quirks (absent → 1, present-but-falsy → 0).
- `RealSpecCorpus` — reads the real tree on purpose: every spec on disk yields lowercase-safe labels, base labels first, at most one `gpu-*` and one `gpus-*`, and **never a GPU-type label without a count** (the zero-GPU parity rule).
- `BuildMatrix` — every leg carries `runs_on`; `missing_adapter` legs get base labels only (they commit an adapter, run no trial).

33 passed, `ruff` clean.

Note: `test_plan_matrix.py` is not in `ci.yml`'s hand-listed pytest set, so these run locally only — same gap as `test_run_leg.py`.

## Sequencing

This is step 1 of moving placement to Actions. It is independently reviewable and mergeable: no runner is re-registered, no workflow changes, no behaviour changes. Step 2 would be registering one GPU box with these labels and flipping `runs-on: ${{ matrix.runs_on }}` for that one platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
