### PR TITLE
feat(vios): add runtime NVStreamer UI base path

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/compose.yml
@@ -36,11 +36,12 @@ services:
     image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
     user: "0:0"
     profiles: ["nvstreamer-alerts"]
-    entrypoint: [ "/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst" ]
+    entrypoint: [ "/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst" ]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:

--- a/deploy/docker/developer-profiles/dev-profile-lvs/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/compose.yml
@@ -30,11 +30,12 @@ services:
     image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
     user: "0:0"
     profiles: ["nvstreamer-lvs"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:

--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml
@@ -59,11 +59,12 @@ services:
     user: "0:0"
     #runtime: nvidia
     profiles: ["nvstreamer-2d-fusion"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:

--- a/deploy/docker/industry-profiles/smartcities/compose.yml
+++ b/deploy/docker/industry-profiles/smartcities/compose.yml
@@ -30,11 +30,12 @@ services:
     image: ${VSS_NVSTREAMER_IMAGE:-nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer}:${NVSTREAMER_IMAGE_TAG}
     user: "0:0"
     profiles: ["nvstreamer-alerts"]
-    entrypoint: [ '/bin/bash', '-c', 'if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst' ]
+    entrypoint: [ '/bin/bash', '-c', 'if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst' ]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     network_mode: "host"
     deploy:
       restart_policy:

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
@@ -56,11 +56,12 @@ services:
     user: "0:0"
     #runtime: nvidia
     profiles: ["nvstreamer-2d"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml
@@ -56,11 +56,12 @@ services:
     user: "0:0"
     runtime: nvidia
     profiles: ["nvstreamer-3d"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
@@ -55,11 +55,12 @@ services:
     user: "0:0"
     runtime: nvidia
     profiles: ["nvstreamer-mv3dt"]
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
     ports:
       - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     deploy:

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/templates/deployment.yaml
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/templates/deployment.yaml
@@ -43,12 +43,14 @@ spec:
         - name: vss-vios-nvstreamer
           image: {{ include "vss-vios-nvstreamer.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
+          command: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
           env:
             - name: ADAPTOR
               value: {{ .Values.env.ADAPTOR | quote }}
             - name: HTTP_PORT
               value: {{ .Values.env.HTTP_PORT | quote }}
+            - name: NVSTREAMER_UI_BASE_PATH
+              value: {{ .Values.env.NVSTREAMER_UI_BASE_PATH | quote }}
             - name: NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES
               value: {{ .Values.env.NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES | quote }}
           ports:

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/values.yaml
@@ -30,6 +30,8 @@ videoMetadataServerUrl: ""   # default: http://<release>-elasticsearch:9200/mdx-
 env:
   ADAPTOR: "streamer"
   HTTP_PORT: "31000"
+  # Public UI/API path. A non-empty value requires the upstream proxy to strip it.
+  NVSTREAMER_UI_BASE_PATH: ""
   NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES: "true"
 
 service:

--- a/services/vios/.claude/sqa/skills/testing/run-bdd-tests.md
+++ b/services/vios/.claude/sqa/skills/testing/run-bdd-tests.md
@@ -75,6 +75,7 @@ Consult `guides/decision-trees.md` if unsure. Common selections:
 | Replay stream | `tests/unit_tests/replay_stream/` | Playback/VOD changes |
 | RTSP proxy | `tests/unit_tests/rtsp_proxy/` | RTSP proxy changes |
 | Stream recorder | `tests/unit_tests/stream_recorder/` | Recording changes |
+| NVStreamer routes | Exact file under `tests/unit_tests/nvstreamer/` | Manual NVStreamer UI/API base-path validation; disabled by default |
 | MCP gateway | `tests/unit_tests/mcp_gateway/` | MCP integration changes |
 | File upload | `tests/file_upload/` | Upload API changes |
 | File download | `tests/file_download/` | Download API changes |
@@ -117,6 +118,33 @@ poetry run pytest tests/unit_tests/sensor_management/ -v \
 # All unit tests against a remote host
 poetry run pytest tests/unit_tests/ -v \
   --base-url http://<HOST>:30888 \
+  --junitxml=reports/junit.xml \
+  --html=reports/report.html \
+  --self-contained-html
+```
+
+### NVStreamer route tests
+
+The two NVStreamer route modules are disabled by default so generic test
+collection and standard CI skip them. To run one manually, set
+`RUN_NVSTREAMER_ROUTE_TESTS=1` and select the exact file matching the active
+deployment. Do not opt in while targeting the whole `nvstreamer/` directory:
+the root and prefixed suites make mutually exclusive assertions.
+
+```bash
+# Direct NVStreamer: NVSTREAMER_UI_BASE_PATH is unset or empty
+RUN_NVSTREAMER_ROUTE_TESTS=1 poetry run pytest \
+  tests/unit_tests/nvstreamer/test_nvstreamer_root_routes.py -v \
+  --base-url http://localhost:31000 \
+  --junitxml=reports/junit.xml \
+  --html=reports/report.html \
+  --self-contained-html
+
+# NVStreamer behind a prefix-stripping proxy:
+# NVSTREAMER_UI_BASE_PATH=/nvstreamer
+RUN_NVSTREAMER_ROUTE_TESTS=1 poetry run pytest \
+  tests/unit_tests/nvstreamer/test_nvstreamer_prefixed_routes.py -v \
+  --base-url http://<HAPROXY_HOST>:<HAPROXY_PORT> \
   --junitxml=reports/junit.xml \
   --html=reports/report.html \
   --self-contained-html

--- a/services/vios/.gitattributes
+++ b/services/vios/.gitattributes
@@ -25,3 +25,4 @@ prebuilts/aarch64/sbsa/libnvbufsurftransform.so.1.0.0 filter=lfs diff=lfs merge=
 ui/**/*.js -filter -diff -merge text=auto
 ui/**/*.js.map -filter -diff -merge text=auto
 ui/**/*.js.LICENSE.txt -filter -diff -merge text=auto
+ui/vios-ui/public/runtime-config.js -filter diff -merge text

--- a/services/vios/build.sh
+++ b/services/vios/build.sh
@@ -720,7 +720,8 @@ build_vios_ui_webroot() {
 
     echo "Staging vios-ui dist into $webroot_dir ..."
     # Remove only the VST UI static files; leave other webroot files intact.
-    rm -rf "$webroot_dir/assets" "$webroot_dir/favicon" "$webroot_dir/index.html"
+    rm -rf "$webroot_dir/assets" "$webroot_dir/favicon" "$webroot_dir/index.html" \
+        "$webroot_dir/runtime-config.js"
     cp -rf "$ui_dir/dist/." "$webroot_dir/" || { echo "[ERROR] Failed to copy vios-ui dist to $webroot_dir"; exit 1; }
 }
 
@@ -808,10 +809,11 @@ clean_generated_artifacts() {
     # Staged vios-ui assets (build_vios_ui_webroot). Never committed — only the
     # .gitkeep placeholders are tracked — so these are safe to drop and are
     # regenerated on the next container build. rm -rf is a no-op if absent.
-    rm -rf webroot/assets webroot/favicon webroot/index.html
+    rm -rf webroot/assets webroot/favicon webroot/index.html webroot/runtime-config.js
     rm -rf deployment/scaling/ingress/vst-ui/assets \
            deployment/scaling/ingress/vst-ui/favicon \
-           deployment/scaling/ingress/vst-ui/index.html
+           deployment/scaling/ingress/vst-ui/index.html \
+           deployment/scaling/ingress/vst-ui/runtime-config.js
 
     # Compiled release output (out/$ARCH/vst_release.tbz2, ...). The container
     # package step may write this as root, so a user-run rm can hit "Permission

--- a/services/vios/deployment/stream-processing/docker-compose/nvstreamer/compose.env
+++ b/services/vios/deployment/stream-processing/docker-compose/nvstreamer/compose.env
@@ -1,5 +1,7 @@
 #Nvstreamer image
 NVSTREAMER_IMAGE=nvcr.io/nvstaging/vss-core/vss-vios-nvstreamer:2.1.0-26.07.1
+# Set only when a proxy exposes this public path and strips it before forwarding.
+NVSTREAMER_UI_BASE_PATH=
 
 NVSTREAMER_CONFIG=./configs
 

--- a/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
@@ -31,11 +31,13 @@ services:
       - "-c"
       - >-
         if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then
-        /home/vst/vst_release/tools/user_additional_install.sh; fi && exec
+        /home/vst/vst_release/tools/user_additional_install.sh; fi &&
+        /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_1}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_1}
     volumes:
@@ -55,11 +57,13 @@ services:
       - "-c"
       - >-
         if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then
-        /home/vst/vst_release/tools/user_additional_install.sh; fi && exec
+        /home/vst/vst_release/tools/user_additional_install.sh; fi &&
+        /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_2}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_2}
     volumes:
@@ -79,11 +83,13 @@ services:
       - "-c"
       - >-
         if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then
-        /home/vst/vst_release/tools/user_additional_install.sh; fi && exec
+        /home/vst/vst_release/tools/user_additional_install.sh; fi &&
+        /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_3}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_3}
     volumes:
@@ -103,11 +109,13 @@ services:
       - "-c"
       - >-
         if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then
-        /home/vst/vst_release/tools/user_additional_install.sh; fi && exec
+        /home/vst/vst_release/tools/user_additional_install.sh; fi &&
+        /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_4}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_4}
     volumes:
@@ -127,11 +135,13 @@ services:
       - "-c"
       - >-
         if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then
-        /home/vst/vst_release/tools/user_additional_install.sh; fi && exec
+        /home/vst/vst_release/tools/user_additional_install.sh; fi &&
+        /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
+      - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_5}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_5}
     volumes:

--- a/services/vios/packaging/configure_nvstreamer_ui.sh
+++ b/services/vios/packaging/configure_nvstreamer_ui.sh
@@ -2,6 +2,18 @@
 
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -euo pipefail
 

--- a/services/vios/packaging/configure_nvstreamer_ui.sh
+++ b/services/vios/packaging/configure_nvstreamer_ui.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+base_path="${NVSTREAMER_UI_BASE_PATH:-}"
+release_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "$base_path" == "/" ]]; then
+    base_path=""
+elif [[ -n "$base_path" ]]; then
+    if [[ ! "$base_path" =~ ^(/[A-Za-z0-9._~-]+)+/?$ ]]; then
+        echo "Invalid NVSTREAMER_UI_BASE_PATH: use an absolute URL path such as /nvstreamer" >&2
+        exit 1
+    fi
+
+    base_path="${base_path%/}"
+    IFS='/' read -ra path_segments <<< "$base_path"
+    for segment in "${path_segments[@]}"; do
+        if [[ "$segment" == "." || "$segment" == ".." ]]; then
+            echo "Invalid NVSTREAMER_UI_BASE_PATH: path traversal segments are not allowed" >&2
+            exit 1
+        fi
+    done
+fi
+
+printf 'window.__VIOS_RUNTIME_CONFIG__ = {"basePath":"%s"};\n' "$base_path" \
+    > "$release_dir/webroot/runtime-config.js"

--- a/services/vios/packaging/package_vms.sh
+++ b/services/vios/packaging/package_vms.sh
@@ -135,6 +135,7 @@ add_common_files() {
 	mappings+=("prebuilts/${ARCH}/libnvutils.so=${PACKAGE_DIR}/prebuilts/${ARCH}/libnvutils.so")
 	mappings+=("prebuilts/${ARCH}/libnvdatabase.so=${PACKAGE_DIR}/prebuilts/${ARCH}/libnvdatabase.so")
 	mappings+=("packaging/user_additional_install.sh=${PACKAGE_DIR}/tools/user_additional_install.sh")
+	mappings+=("packaging/configure_nvstreamer_ui.sh=${PACKAGE_DIR}/tools/configure_nvstreamer_ui.sh")
 	mappings+=("prebuilts/${ARCH}/libnvsystemmonitoring.so=${PACKAGE_DIR}/prebuilts/${ARCH}/libnvsystemmonitoring.so")
 	mappings+=("prebuilts/${ARCH}/libnvvideo_source.so=${PACKAGE_DIR}/prebuilts/${ARCH}/libnvvideo_source.so")
 	mappings+=("prebuilts/${ARCH}/libnvoverlays.so=${PACKAGE_DIR}/prebuilts/${ARCH}/libnvoverlays.so")

--- a/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/__init__.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/__init__.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/__init__.py
@@ -1,2 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_prefixed_routes.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_prefixed_routes.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Public-route tests for NVStreamer behind a prefix-stripping proxy."""
 

--- a/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_prefixed_routes.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_prefixed_routes.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public-route tests for NVStreamer behind a prefix-stripping proxy."""
+
+import re
+from urllib.parse import urljoin
+
+import requests
+
+from ..unit_test_utils import api_get, validate_list_response
+
+PREFIX = "/nvstreamer"
+
+
+def _timeout(unit_test_params: dict) -> int:
+    return unit_test_params.get("timeout", 30)
+
+
+def test_exact_prefix_redirects_to_trailing_slash(
+    api_config: dict, unit_test_params: dict
+) -> None:
+    response = requests.get(
+        f'{api_config["base_url"]}{PREFIX}',
+        allow_redirects=False,
+        verify=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    assert response.status_code == 308
+    assert response.headers["Location"] == f"{PREFIX}/"
+
+
+def test_prefixed_ui_config_and_asset_load(
+    api_config: dict, unit_test_params: dict
+) -> None:
+    index = api_get(
+        api_config["base_url"],
+        f"{PREFIX}/",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    assert index.status_code == 200
+
+    config = api_get(
+        api_config["base_url"],
+        f"{PREFIX}/runtime-config.js",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    assert config.status_code == 200
+    assert '"basePath":"/nvstreamer"' in config.text
+
+    match = re.search(r'src="([^"]+\.js)"', index.text)
+    assert match is not None
+    asset_url = urljoin(f'{api_config["base_url"]}{PREFIX}/', match.group(1))
+    asset = requests.get(
+        asset_url,
+        verify=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    assert asset.status_code == 200
+
+
+def test_prefixed_rest_api_is_available(
+    api_config: dict, unit_test_params: dict
+) -> None:
+    response = api_get(
+        api_config["base_url"],
+        f"{PREFIX}/api/v1/live/streams",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    validate_list_response(response)

--- a/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_prefixed_routes.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_prefixed_routes.py
@@ -3,14 +3,20 @@
 
 """Public-route tests for NVStreamer behind a prefix-stripping proxy."""
 
+import os
 import re
 from urllib.parse import urljoin
 
+import pytest
 import requests
 
 from ..unit_test_utils import api_get, validate_list_response
 
 PREFIX = "/nvstreamer"
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_NVSTREAMER_ROUTE_TESTS") != "1",
+    reason="Set RUN_NVSTREAMER_ROUTE_TESTS=1 to run disabled NVStreamer route tests",
+)
 
 
 def _timeout(unit_test_params: dict) -> int:

--- a/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_root_routes.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_root_routes.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Direct-port routing tests for NVStreamer root mode."""
 

--- a/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_root_routes.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_root_routes.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct-port routing tests for NVStreamer root mode."""
+
+from ..unit_test_utils import api_get, validate_list_response
+
+
+def _timeout(unit_test_params: dict) -> int:
+    return unit_test_params.get("timeout", 30)
+
+
+def test_root_mode_serves_ui_and_root_config(
+    api_config: dict, unit_test_params: dict
+) -> None:
+    index = api_get(
+        api_config["base_url"],
+        "/",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    assert index.status_code == 200
+
+    config = api_get(
+        api_config["base_url"],
+        "/runtime-config.js",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    assert config.status_code == 200
+    assert '"basePath":""' in config.text
+
+
+def test_root_mode_serves_unprefixed_api(
+    api_config: dict, unit_test_params: dict
+) -> None:
+    response = api_get(
+        api_config["base_url"],
+        "/api/v1/live/streams",
+        verify_ssl=api_config.get("verify_ssl", False),
+        timeout=_timeout(unit_test_params),
+    )
+    validate_list_response(response)
+
+
+def test_root_mode_does_not_add_nvstreamer_prefix(
+    api_config: dict, unit_test_params: dict
+) -> None:
+    for path in ("/nvstreamer/", "/nvstreamer/api/v1/live/streams"):
+        response = api_get(
+            api_config["base_url"],
+            path,
+            verify_ssl=api_config.get("verify_ssl", False),
+            timeout=_timeout(unit_test_params),
+        )
+        assert response.status_code == 404, f"{path} returned {response.status_code}"
+
+
+def test_root_mode_health_probes_remain_available(
+    api_config: dict, unit_test_params: dict
+) -> None:
+    for path in ("/v1/ready", "/v1/live", "/v1/startup"):
+        response = api_get(
+            api_config["base_url"],
+            path,
+            verify_ssl=api_config.get("verify_ssl", False),
+            timeout=_timeout(unit_test_params),
+        )
+        assert response.status_code == 200, f"{path} returned {response.status_code}"

--- a/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_root_routes.py
+++ b/services/vios/test/bdd_tests/tests/unit_tests/nvstreamer/test_nvstreamer_root_routes.py
@@ -3,7 +3,16 @@
 
 """Direct-port routing tests for NVStreamer root mode."""
 
+import os
+
+import pytest
+
 from ..unit_test_utils import api_get, validate_list_response
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_NVSTREAMER_ROUTE_TESTS") != "1",
+    reason="Set RUN_NVSTREAMER_ROUTE_TESTS=1 to run disabled NVStreamer route tests",
+)
 
 
 def _timeout(unit_test_params: dict) -> int:

--- a/services/vios/ui/vios-ui/index.html
+++ b/services/vios/ui/vios-ui/index.html
@@ -18,12 +18,12 @@ limitations under the License.
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <link rel="icon" type="image/png" href="/favicon/favicon-16x16.png" />
+        <link rel="icon" type="image/png" href="./favicon/favicon-16x16.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>VSS VIOS</title>
     </head>
     <body>
         <div id="root"></div>
-        <script type="module" src="/src/main.tsx"></script>
+        <script type="module" src="/src/bootstrap.ts"></script>
     </body>
 </html>

--- a/services/vios/ui/vios-ui/public/runtime-config.js
+++ b/services/vios/ui/vios-ui/public/runtime-config.js
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+window.__VIOS_RUNTIME_CONFIG__ = {
+    basePath: null,
+};

--- a/services/vios/ui/vios-ui/public/runtime-config.js
+++ b/services/vios/ui/vios-ui/public/runtime-config.js
@@ -1,6 +1,18 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 window.__VIOS_RUNTIME_CONFIG__ = {
     basePath: null,

--- a/services/vios/ui/vios-ui/src/bootstrap.ts
+++ b/services/vios/ui/vios-ui/src/bootstrap.ts
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (typeof document !== 'undefined') {
+    const runtimeConfigUrl = new URL('./runtime-config.js', document.baseURI).href;
+
+    void import(/* @vite-ignore */ runtimeConfigUrl)
+        .catch(() => undefined)
+        .then(() => import('./main'));
+}

--- a/services/vios/ui/vios-ui/src/components/videoPlayer/VideoPlayer.tsx
+++ b/services/vios/ui/vios-ui/src/components/videoPlayer/VideoPlayer.tsx
@@ -72,6 +72,7 @@ import BitrateSparkline from './videoPlayerUtils/BitrateSparkline';
 import Analytics from './videoPlayerUtils/analytics/Analytics';
 import { useShowEvents, useEventImages } from './videoPlayerUtils/ShowEvents';
 import useVSTUIStore from '../../services/StateManagement';
+import { toWebSocketUrl } from '../../utils/runtimeConfig';
 
 const FALLBACK_START_TIME = '1970-01-01T00:00:00.000Z';
 const DEFAULT_QUALITY = 'auto';
@@ -323,18 +324,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ sensor, streamType, videoElem
             setConnectionPhase('initial');
         };
 
-        let wsEndpoint = config.liveStreamEndpoint.startsWith('https')
-            ? config.liveStreamEndpoint.replace('https', 'wss')
-            : config.liveStreamEndpoint.replace('http', 'ws');
-
-        let proxy = window.location.pathname;
-        if (proxy !== '/' && proxy.length > 0) {
-            if (proxy[proxy.length - 1] === '/') {
-                proxy = proxy.slice(0, -1);
-            }
-            // Add the proxy path to the endpoint with proper / separator
-            wsEndpoint = `${wsEndpoint}${wsEndpoint.endsWith('/') ? '' : '/'}${proxy}`;
-        }
+        const wsEndpoint = toWebSocketUrl(config.liveStreamEndpoint);
 
         const webStreamerConfig: AppConfig = {
             inboundStreamVideoElementId: videoElementId,

--- a/services/vios/ui/vios-ui/src/config.tsx
+++ b/services/vios/ui/vios-ui/src/config.tsx
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import { Config } from './interfaces/interfaces';
+import { appendBasePath, getPublicBasePath } from './utils/runtimeConfig';
 
 const isDevelopment = () => {
     return process.env.NODE_ENV === 'development';
@@ -24,16 +25,23 @@ const getPort = () => {
     return isDevelopment() ? '30000' : window.location.port;
 };
 
+const getViosOrigin = () => {
+    return isDevelopment()
+        ? `${window.location.protocol}//${window.location.hostname}:${getPort()}`
+        : window.location.origin;
+};
+
 const mdatWebAPIDefaultPort = '8081';
 const analyticsUIServerDefaultPort = '8003';
+const viosEndpoint = appendBasePath(getViosOrigin(), getPublicBasePath());
 
 const config: Config = {
-    sensorManagementEndpoint: `${window.location.protocol}//${window.location.hostname}:${getPort()}`,
-    streamRecorderEndpoint: `${window.location.protocol}//${window.location.hostname}:${getPort()}`,
-    storageManagementEndpoint: `${window.location.protocol}//${window.location.hostname}:${getPort()}`,
-    liveStreamEndpoint: `${window.location.protocol}//${window.location.hostname}:${getPort()}`,
-    replayStreamEndpoint: `${window.location.protocol}//${window.location.hostname}:${getPort()}`,
-    streambridgeEndpoint: `${window.location.protocol}//${window.location.hostname}:${getPort()}`,
+    sensorManagementEndpoint: viosEndpoint,
+    streamRecorderEndpoint: viosEndpoint,
+    storageManagementEndpoint: viosEndpoint,
+    liveStreamEndpoint: viosEndpoint,
+    replayStreamEndpoint: viosEndpoint,
+    streambridgeEndpoint: viosEndpoint,
 
     mdatWebApiEndpoint: `${window.location.protocol}//${window.location.hostname}:${mdatWebAPIDefaultPort}`,
     analyticsUIServerEndpoint: `${window.location.protocol}//${window.location.hostname}:${analyticsUIServerDefaultPort}`,

--- a/services/vios/ui/vios-ui/src/features/sensorManagement/sensorVideoDownload/SensorVideoDownload.tsx
+++ b/services/vios/ui/vios-ui/src/features/sensorManagement/sensorVideoDownload/SensorVideoDownload.tsx
@@ -223,17 +223,6 @@ const SensorVideoDownloadCard: React.FC = () => {
             url += `&container=${encodeURIComponent(container.trim())}`;
         }
 
-        let proxy = window.location.pathname;
-        if (proxy !== '/' && proxy.length > 0) {
-            if (proxy[proxy.length - 1] === '/') {
-                proxy = proxy.slice(0, -1);
-            }
-            const emdxEndpoint = useVSTUIStore.getState().emdxEndpoint;
-            if (!emdxEndpoint || (emdxEndpoint && !url.includes(emdxEndpoint))) {
-                url = url.replace('/api', `${proxy}/api`);
-            }
-        }
-
         return url;
     }, [selectedSensor, selectedStartTime, selectedEndTime, useConfiguration, videoConfig, container]);
 

--- a/services/vios/ui/vios-ui/src/pages/common/experimentalPages/StreamAutomation.tsx
+++ b/services/vios/ui/vios-ui/src/pages/common/experimentalPages/StreamAutomation.tsx
@@ -33,6 +33,7 @@ import useVSTUIStore from '../../../services/StateManagement';
 import { Sensor } from '../../../interfaces/interfaces';
 import StreamManager, { StreamConfig, StreamType, ErrorType } from 'vst-streaming-lib';
 import config from '../../../config';
+import { toWebSocketUrl } from '../../../utils/runtimeConfig';
 
 interface StreamResult {
     sensorId: string;
@@ -186,19 +187,8 @@ export const StreamAutomation: React.FC = () => {
                     streamConfig.startTime = '2020-12-01T12:00:20.000Z';
                 }
 
-                let wsEndpoint = (streamType === StreamType.Live ? config.liveStreamEndpoint : config.replayStreamEndpoint).startsWith(
-                    'https'
-                )
-                    ? (streamType === StreamType.Live ? config.liveStreamEndpoint : config.replayStreamEndpoint).replace('https', 'wss')
-                    : (streamType === StreamType.Live ? config.liveStreamEndpoint : config.replayStreamEndpoint).replace('http', 'ws');
-
-                let proxy = window.location.pathname;
-                if (proxy !== '/' && proxy.length > 0) {
-                    if (proxy[proxy.length - 1] === '/') {
-                        proxy = proxy.slice(0, -1);
-                    }
-                    wsEndpoint = `${wsEndpoint}${wsEndpoint.endsWith('/') ? '' : '/'}${proxy}`;
-                }
+                const endpoint = streamType === StreamType.Live ? config.liveStreamEndpoint : config.replayStreamEndpoint;
+                const wsEndpoint = toWebSocketUrl(endpoint);
 
                 streamManagerRef.current.updateConfig({
                     inboundStreamVideoElementId: videoElementId,

--- a/services/vios/ui/vios-ui/src/pages/common/experimentalPages/TokkioExperience.tsx
+++ b/services/vios/ui/vios-ui/src/pages/common/experimentalPages/TokkioExperience.tsx
@@ -34,6 +34,7 @@ import StreamManager, { ErrorType } from 'vst-streaming-lib';
 import React from 'react';
 import { StreamType } from 'vst-streaming-lib';
 import appConfig from '../../../config';
+import { toWebSocketUrl } from '../../../utils/runtimeConfig';
 
 // Updated styled components
 const VideoContainer = styled(Box)(({ theme }) => ({
@@ -101,17 +102,7 @@ const Webrtc: FC = () => {
         streamManager.current = new StreamManager();
         if (streamManager.current) {
             const streambridgeEndpoint = appConfig.streambridgeEndpoint;
-            let wsEndpoint = streambridgeEndpoint.startsWith('https')
-                ? streambridgeEndpoint.replace('https', 'wss')
-                : streambridgeEndpoint.replace('http', 'ws');
-
-            let proxy = window.location.pathname;
-            if (proxy !== '/' && proxy.length > 0) {
-                if (proxy[proxy.length - 1] === '/') {
-                    proxy = proxy.slice(0, -1);
-                }
-                wsEndpoint = `${wsEndpoint}${wsEndpoint.endsWith('/') ? '' : '/'}${proxy}`;
-            }
+            const wsEndpoint = toWebSocketUrl(streambridgeEndpoint);
 
             streamManager.current.updateConfig({
                 inboundStreamVideoElementId: 'tokkio-avatar-stream',

--- a/services/vios/ui/vios-ui/src/services/Axios.tsx
+++ b/services/vios/ui/vios-ui/src/services/Axios.tsx
@@ -14,38 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import useVSTUIStore from './StateManagement';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 
 const nvAxios = axios.create({
     timeout: 60000,
 });
-
-// Add a request interceptor
-nvAxios.interceptors.request.use(
-    (config: InternalAxiosRequestConfig) => {
-        // Do something before request is sent
-        let proxy = window.location.pathname;
-        if (proxy !== '/' && proxy.length > 0) {
-            if (proxy[proxy.length - 1] === '/') {
-                proxy = proxy.slice(0, -1);
-            }
-            const emdxEndpoint = useVSTUIStore.getState().emdxEndpoint;
-            // If URL exists and either:
-            // 1. There is no EMDX endpoint configured, or
-            // 2. EMDX endpoint exists but URL doesn't contain it
-            // Then replace /api with {proxy}/api in the URL to handle proxy deployments
-            if (config.url && (!emdxEndpoint || (emdxEndpoint && !config.url.includes(emdxEndpoint)))) {
-                config.url = config.url.replace('/api', `${proxy}/api`);
-            }
-        }
-        return config;
-    },
-    (error: AxiosError) => {
-        // Do something with request error
-        return Promise.reject(error);
-    }
-);
 
 // Add a response interceptor
 nvAxios.interceptors.response.use(

--- a/services/vios/ui/vios-ui/src/utils/runtimeConfig.ts
+++ b/services/vios/ui/vios-ui/src/utils/runtimeConfig.ts
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface ViosRuntimeConfig {
+    basePath?: unknown;
+}
+
+declare global {
+    interface Window {
+        __VIOS_RUNTIME_CONFIG__?: ViosRuntimeConfig;
+    }
+}
+
+const hasTraversalSegment = (path: string): boolean => {
+    return path.split('/').some(segment => {
+        try {
+            const decodedSegment = decodeURIComponent(segment);
+            return decodedSegment === '.' || decodedSegment === '..';
+        } catch {
+            return true;
+        }
+    });
+};
+
+const hasControlCharacter = (value: string): boolean => {
+    return Array.from(value).some(character => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return codePoint < 0x20 || codePoint === 0x7f;
+    });
+};
+
+export const normalizeBasePath = (value: string): string | null => {
+    if (value === '' || value === '/') {
+        return '';
+    }
+
+    if (
+        value !== value.trim() ||
+        !value.startsWith('/') ||
+        hasControlCharacter(value) ||
+        value.includes('?') ||
+        value.includes('#') ||
+        value.includes('\\') ||
+        hasTraversalSegment(value)
+    ) {
+        return null;
+    }
+
+    return value.replace(/\/+$/, '');
+};
+
+export const inferBasePath = (documentBaseUri: string): string => {
+    const documentPath = new URL(documentBaseUri).pathname;
+    const documentDirectory = documentPath.endsWith('/')
+        ? documentPath
+        : documentPath.slice(0, documentPath.lastIndexOf('/') + 1);
+
+    return normalizeBasePath(documentDirectory) ?? '';
+};
+
+export const resolveBasePath = (configuredValue: unknown, documentBaseUri: string): string => {
+    if (typeof configuredValue === 'string') {
+        const normalizedPath = normalizeBasePath(configuredValue);
+        if (normalizedPath !== null) {
+            return normalizedPath;
+        }
+    }
+
+    return inferBasePath(documentBaseUri);
+};
+
+export const getPublicBasePath = (): string => {
+    const configuredValue = window.__VIOS_RUNTIME_CONFIG__?.basePath;
+    if (typeof configuredValue === 'string' && normalizeBasePath(configuredValue) === null) {
+        // Runtime configuration is public deployment input. Fall back safely instead of
+        // allowing an invalid path to redirect requests to another origin.
+        console.warn(`Ignoring invalid VIOS UI base path: ${configuredValue}`);
+    }
+
+    return resolveBasePath(configuredValue, document.baseURI);
+};
+
+export const appendBasePath = (origin: string, basePath: string): string => {
+    const normalizedPath = normalizeBasePath(basePath);
+    if (normalizedPath === null) {
+        throw new Error(`Invalid VIOS UI base path: ${basePath}`);
+    }
+
+    return `${origin.replace(/\/+$/, '')}${normalizedPath}`;
+};
+
+export const toWebSocketUrl = (httpUrl: string): string => {
+    const protocol = new URL(httpUrl).protocol;
+    if (protocol === 'https:') {
+        return httpUrl.replace(/^https:/, 'wss:');
+    }
+    if (protocol === 'http:') {
+        return httpUrl.replace(/^http:/, 'ws:');
+    }
+
+    throw new Error(`Unsupported VIOS endpoint protocol: ${protocol}`);
+};


### PR DESCRIPTION
## Description

- Adds runtime-configurable NVSTREAMER_UI_BASE_PATH support for NVStreamer UI assets, REST APIs, and WebSocket endpoints behind a prefix-stripping proxy.
- Preserves existing root-path behavior when unset and adds Python BDD coverage for both prefixed and root deployments.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
