### PR TITLE
ci: dispatch OSRB review to protected GitLab pipeline

### DIFF
--- a/.github/OSRB_REVIEW.md
+++ b/.github/OSRB_REVIEW.md
@@ -26,6 +26,12 @@ against existing approval evidence. Do not merge while this check is running.
 No further OSRB action is required for the reported dependency changes.
 Normal required checks, CODEOWNERS approval, and maintainer review still apply.
 
+### The review says its verdict is provisional
+
+The reviewer ran a pre-release build of itself, which happens during rollout. Do
+not treat the verdict as final and do not merge on the strength of it. Tell a
+repository maintainer, who will confirm what the check ran against.
+
 ### OSRB Review fails or is inconclusive
 
 1. Read the automated review on the PR.

--- a/.github/OSRB_REVIEW.md
+++ b/.github/OSRB_REVIEW.md
@@ -26,6 +26,14 @@ against existing approval evidence. Do not merge while this check is running.
 No further OSRB action is required for the reported dependency changes.
 Normal required checks, CODEOWNERS approval, and maintainer review still apply.
 
+### OSRB Review passes with notes
+
+The check is green and you can merge. A note means something worth recording
+was found that does not affect approval, most often a package listed in an
+attribution file that no code imports, or a changed container base image whose
+own OSRB record should be confirmed. Fix the attribution gap in this PR if it
+is yours to fix; otherwise raise it with the OSRB owner separately.
+
 ### The review says its verdict is provisional
 
 The reviewer ran a pre-release build of itself, which happens during rollout. Do
@@ -62,6 +70,10 @@ The overview requests attention for:
 
 The complete CSV also retains same-license version updates and removals, but
 those rows do not require OSRB re-engagement by themselves.
+
+Container images that add dependencies without editing a manifest are covered
+too. If your PR changes a Dockerfile base image or installs packages in it, the
+review evaluates those lines even when the CSV is empty.
 
 Changes in how an approved component is used can still require review even when
 its package version and license are unchanged. Examples include static instead

--- a/.github/OSRB_REVIEW.md
+++ b/.github/OSRB_REVIEW.md
@@ -1,0 +1,69 @@
+# License Diff and OSRB Review
+
+Dependency-related pull requests receive two related GitHub checks:
+
+1. **License Diff** creates the public package-change overview and complete CSV.
+2. **OSRB Review** evaluates changes that may require approval and publishes the
+   final result.
+
+Both checks run automatically. Do not manually edit the generated PR comment.
+
+## What developers should do
+
+### License Diff reports no reviewable changes
+
+No OSRB action is required. Continue with the normal code and CODEOWNERS review.
+Same-license version updates and dependency removals remain in the complete CSV
+for traceability, but do not require OSRB re-engagement.
+
+### OSRB Review is running
+
+Wait for it to finish. The protected reviewer is checking the public diff
+against existing approval evidence. Do not merge while this check is running.
+
+### OSRB Review passes
+
+No further OSRB action is required for the reported dependency changes.
+Normal required checks, CODEOWNERS approval, and maintainer review still apply.
+
+### OSRB Review fails or is inconclusive
+
+1. Read the automated review on the PR.
+2. Open the linked **License Diff** Actions run.
+3. Inspect the short overview. Download `license-diff.csv` only when more detail
+   is needed.
+4. Address the reported issue:
+   - correct or remove an unintended dependency;
+   - provide a resolvable public license or component URL;
+   - preserve or add the required third-party notice and license text;
+   - work with the OSRB owner when a new component, license change, or changed
+     use needs approval;
+   - ask a repository maintainer to retry an infrastructure failure.
+5. Push the correction. If no source change was needed, a maintainer can rerun
+   the License Diff workflow.
+
+Do not paste private ticket comments, approval sheets, credentials, or internal
+links into the public PR. The protected reviewer reads that evidence privately
+and publishes only the decision.
+
+## What triggers review
+
+The overview requests attention for:
+
+- a new dependency;
+- a confirmed license change;
+- an old or new license that cannot be resolved.
+
+The complete CSV also retains same-license version updates and removals, but
+those rows do not require OSRB re-engagement by themselves.
+
+Changes in how an approved component is used can still require review even when
+its package version and license are unchanged. Examples include static instead
+of dynamic linking, vendoring source, or moving a build-only dependency into a
+distributed runtime.
+
+## Release-target pull requests
+
+Pull requests targeting `dev/*` or `release/*` are marked not applicable because
+OSRB review is performed on the earlier pull request into the development
+branch.

--- a/.github/scripts/osrb_check.py
+++ b/.github/scripts/osrb_check.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Publish the public OSRB check around the private downstream pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+GITHUB_API = "https://api.github.com"
+CHECK_NAME = "OSRB Review"
+EXTERNAL_PREFIX = "gitlab-osrb:"
+
+
+class CheckError(RuntimeError):
+    """A GitHub check operation failed."""
+
+
+def token() -> str:
+    value = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not value:
+        raise CheckError("GITHUB_TOKEN is not configured")
+    return value
+
+
+def github(
+    method: str,
+    repo: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(
+        f"{GITHUB_API}/repos/{repo}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token()}",
+            "Content-Type": "application/json",
+            "User-Agent": "vss-osrb-check/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=45) as response:
+            body = response.read()
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read(500).decode("utf-8", errors="replace")
+        raise CheckError(f"{method} GitHub check request returned HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise CheckError(f"{method} GitHub check request failed: {exc.reason}") from exc
+
+
+def find_check(repo: str, sha: str, external_id: str) -> dict[str, Any] | None:
+    name = urllib.parse.quote(CHECK_NAME)
+    checks = github("GET", repo, f"/commits/{sha}/check-runs?check_name={name}")
+    matches = [
+        check
+        for check in checks.get("check_runs", [])
+        if check.get("name") == CHECK_NAME
+        and check.get("external_id") == external_id
+    ]
+    return max(matches, key=lambda check: int(check.get("id", 0)), default=None)
+
+
+def start(repo: str, sha: str, run_url: str, external_id: str) -> None:
+    payload = {
+        "name": CHECK_NAME,
+        "head_sha": sha,
+        "status": "in_progress",
+        "details_url": run_url,
+        "external_id": external_id,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "output": {
+            "title": "Private OSRB review is running",
+            "summary": "The protected downstream compliance pipeline is evaluating this PR.",
+        },
+    }
+    existing = find_check(repo, sha, external_id)
+    if existing:
+        github("PATCH", repo, f"/check-runs/{existing['id']}", payload)
+    else:
+        github("POST", repo, "/check-runs", payload)
+
+
+def complete(
+    repo: str,
+    sha: str,
+    run_url: str,
+    external_id: str,
+    success: bool,
+    summary: str,
+) -> None:
+    check = find_check(repo, sha, external_id)
+    if not check:
+        raise CheckError(f"no {CHECK_NAME!r} check exists for {sha}")
+    github(
+        "PATCH",
+        repo,
+        f"/check-runs/{check['id']}",
+        {
+            "name": CHECK_NAME,
+            "status": "completed",
+            "conclusion": "success" if success else "failure",
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "details_url": run_url,
+            "output": {
+                "title": "OSRB review passed" if success else "OSRB review needs attention",
+                "summary": summary,
+            },
+        },
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("start", "complete", "skip"))
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--external-id", required=True)
+    parser.add_argument("--success", action="store_true")
+    parser.add_argument("--summary", default="")
+    args = parser.parse_args()
+    if not args.external_id.startswith(EXTERNAL_PREFIX):
+        raise CheckError(f"external ID must start with {EXTERNAL_PREFIX!r}")
+    if args.command == "start":
+        start(args.repo, args.sha, args.run_url, args.external_id)
+    elif args.command == "skip":
+        start(args.repo, args.sha, args.run_url, args.external_id)
+        complete(
+            args.repo,
+            args.sha,
+            args.run_url,
+            args.external_id,
+            True,
+            args.summary or "Not applicable for this target branch.",
+        )
+    else:
+        complete(
+            args.repo,
+            args.sha,
+            args.run_url,
+            args.external_id,
+            args.success,
+            args.summary
+            or (
+                "The private OSRB review approved this change."
+                if args.success
+                else "The private OSRB review did not approve this change. See the PR review."
+            ),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/osrb_check.py
+++ b/.github/scripts/osrb_check.py
@@ -23,6 +23,14 @@ class CheckError(RuntimeError):
     """A GitHub check operation failed."""
 
 
+def guide_url(repo: str) -> str:
+    return f"https://github.com/{repo}/blob/main/.github/OSRB_REVIEW.md"
+
+
+def summary_with_guide(repo: str, summary: str) -> str:
+    return f"{summary}\n\n[How to respond to this check]({guide_url(repo)})"
+
+
 def token() -> str:
     value = os.environ.get("GITHUB_TOKEN", "").strip()
     if not value:
@@ -82,7 +90,11 @@ def start(repo: str, sha: str, run_url: str, external_id: str) -> None:
         "started_at": datetime.now(timezone.utc).isoformat(),
         "output": {
             "title": "Private OSRB review is running",
-            "summary": "The protected downstream compliance pipeline is evaluating this PR.",
+            "summary": summary_with_guide(
+                repo,
+                "Wait for this check to finish before merging. "
+                "The protected compliance reviewer is evaluating the public License Diff.",
+            ),
         },
     }
     existing = find_check(repo, sha, external_id)
@@ -115,7 +127,7 @@ def complete(
             "details_url": run_url,
             "output": {
                 "title": "OSRB review passed" if success else "OSRB review needs attention",
-                "summary": summary,
+                "summary": summary_with_guide(repo, summary),
             },
         },
     )

--- a/.github/scripts/osrb_check.py
+++ b/.github/scripts/osrb_check.py
@@ -112,25 +112,25 @@ def complete(
     success: bool,
     summary: str,
 ) -> None:
-    check = find_check(repo, sha, external_id)
-    if not check:
-        raise CheckError(f"no {CHECK_NAME!r} check exists for {sha}")
-    github(
-        "PATCH",
-        repo,
-        f"/check-runs/{check['id']}",
-        {
-            "name": CHECK_NAME,
-            "status": "completed",
-            "conclusion": "success" if success else "failure",
-            "completed_at": datetime.now(timezone.utc).isoformat(),
-            "details_url": run_url,
-            "output": {
-                "title": "OSRB review passed" if success else "OSRB review needs attention",
-                "summary": summary_with_guide(repo, summary),
-            },
+    payload = {
+        "name": CHECK_NAME,
+        "status": "completed",
+        "conclusion": "success" if success else "failure",
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "details_url": run_url,
+        "output": {
+            "title": "OSRB review passed" if success else "OSRB review needs attention",
+            "summary": summary_with_guide(repo, summary),
         },
-    )
+    }
+    check = find_check(repo, sha, external_id)
+    if check:
+        github("PATCH", repo, f"/check-runs/{check['id']}", payload)
+        return
+    # `start` runs first and should have created it. If that call was lost to a
+    # transient API failure, publish the conclusion anyway: a pull request with
+    # no check at all is worse than one showing the gate did not complete.
+    github("POST", repo, "/check-runs", {**payload, "head_sha": sha, "external_id": external_id})
 
 
 def main() -> int:

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest import mock
 
 DIRECTORY = Path(__file__).parent
+WORKFLOW = DIRECTORY.parent / "workflows" / "osrb-review.yml"
 
 
 def load_python(name: str, path: Path):
@@ -50,6 +51,15 @@ class DispatchTests(unittest.TestCase):
 
     def test_check_external_id_is_private_pipeline_scoped(self) -> None:
         self.assertEqual(check.EXTERNAL_PREFIX, "gitlab-osrb:")
+
+    def test_dispatch_passes_canonical_license_diff_run_url(self) -> None:
+        workflow = WORKFLOW.read_text()
+        self.assertIn(
+            '"GITHUB_LICENSE_RUN_URL":"${{ github.event.workflow_run.html_url }}"',
+            workflow,
+        )
+        self.assertIn('LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}', workflow)
+        self.assertIn('--run-url "$LICENSE_RUN_URL"', workflow)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for the public-to-private OSRB dispatch boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+DIRECTORY = Path(__file__).parent
+
+
+def load_python(name: str, path: Path):
+    loader = SourceFileLoader(name, str(path))
+    spec = importlib.util.spec_from_loader(name, loader)
+    assert spec
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+trigger = load_python("trigger_downstream", DIRECTORY / "trigger-downstream-pipeline.sh")
+check = load_python("osrb_check", DIRECTORY / "osrb_check.py")
+
+
+class DispatchTests(unittest.TestCase):
+    def test_extra_variables_are_string_map(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"DOWNSTREAM_EXTRA_VARIABLES_JSON": '{"OSRB_REVIEW":"true","PR":"42"}'},
+            clear=False,
+        ):
+            self.assertEqual(
+                trigger.configured_extra_variables(),
+                {"OSRB_REVIEW": "true", "PR": "42"},
+            )
+
+    def test_extra_variables_reject_non_string_values(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"DOWNSTREAM_EXTRA_VARIABLES_JSON": '{"PR":42}'},
+            clear=False,
+        ), self.assertRaises(SystemExit):
+            trigger.configured_extra_variables()
+
+    def test_check_external_id_is_private_pipeline_scoped(self) -> None:
+        self.assertEqual(check.EXTERNAL_PREFIX, "gitlab-osrb:")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -74,6 +74,11 @@ class DispatchTests(unittest.TestCase):
         self.assertIn('LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}', workflow)
         self.assertIn('--run-url "$LICENSE_RUN_URL"', workflow)
 
+    def test_dispatch_does_not_choose_the_private_pipeline_code_ref(self) -> None:
+        workflow = WORKFLOW.read_text()
+        for variable in ("OSRB_CODE_REF", "OSRB_ALLOW_UNREVIEWED_CODE"):
+            self.assertNotIn(variable, workflow)
+
     def test_github_output_explains_developer_actions(self) -> None:
         guide = DEVELOPER_GUIDE.read_text()
         license_workflow = LICENSE_WORKFLOW.read_text()

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import re
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -73,6 +74,22 @@ class DispatchTests(unittest.TestCase):
         )
         self.assertIn('LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}', workflow)
         self.assertIn('--run-url "$LICENSE_RUN_URL"', workflow)
+
+    def test_workflow_supplies_every_variable_the_helpers_require(self) -> None:
+        """The poller reads DOWNSTREAM_PROJECT_PATH even when given a project id.
+
+        ci.yml supplies the shared downstream variables at job level, so both
+        the trigger and the poll step inherit them. Setting them per step is
+        what left the poller a variable short.
+        """
+        workflow = WORKFLOW.read_text()
+        required: set[str] = set()
+        for helper in ("trigger-downstream-pipeline.sh", "poll-downstream-pipeline.py"):
+            required.update(
+                re.findall(r'require_env\(\s*"([A-Z0-9_]+)"', (DIRECTORY / helper).read_text())
+            )
+        missing = sorted(name for name in required if name not in workflow)
+        self.assertEqual(missing, [], f"workflow never sets {missing}")
 
     def test_dispatch_does_not_choose_the_private_pipeline_code_ref(self) -> None:
         workflow = WORKFLOW.read_text()

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -75,6 +75,26 @@ class DispatchTests(unittest.TestCase):
         self.assertIn('LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}', workflow)
         self.assertIn('--run-url "$LICENSE_RUN_URL"', workflow)
 
+    def test_check_is_created_before_anything_that_can_fail(self) -> None:
+        """A failure before the check exists would be an invisible fail-open.
+
+        `workflow_run` jobs are not listed in the pull request, so if no check
+        run is created the gate simply does not happen and nothing says so.
+        """
+        workflow = WORKFLOW.read_text()
+        steps = re.findall(r"^      - name: (.+)$", workflow, re.M)
+        self.assertEqual(steps[1], "Start OSRB check", steps)
+
+        start_block = workflow.split("- name: Start OSRB check", 1)[1]
+        start_block = start_block.split("- name:", 1)[0]
+        self.assertNotIn("if:", start_block, "Start OSRB check must be unconditional")
+
+    def test_dispatch_job_wiring_is_exercised_in_ci(self) -> None:
+        self.assertIn(
+            "python3 .github/scripts/test_osrb_dispatch.py",
+            (DIRECTORY.parent / "workflows" / "ci.yml").read_text(),
+        )
+
     def test_workflow_supplies_every_variable_the_helpers_require(self) -> None:
         """The poller reads DOWNSTREAM_PROJECT_PATH even when given a project id.
 

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -14,6 +14,8 @@ from unittest import mock
 
 DIRECTORY = Path(__file__).parent
 WORKFLOW = DIRECTORY.parent / "workflows" / "osrb-review.yml"
+LICENSE_WORKFLOW = DIRECTORY.parent / "workflows" / "license-diff.yml"
+DEVELOPER_GUIDE = DIRECTORY.parent / "OSRB_REVIEW.md"
 
 
 def load_python(name: str, path: Path):
@@ -52,6 +54,17 @@ class DispatchTests(unittest.TestCase):
     def test_check_external_id_is_private_pipeline_scoped(self) -> None:
         self.assertEqual(check.EXTERNAL_PREFIX, "gitlab-osrb:")
 
+    def test_check_links_to_public_developer_instructions(self) -> None:
+        repo = "NVIDIA-AI-Blueprints/video-search-and-summarization"
+        self.assertEqual(
+            check.guide_url(repo),
+            f"https://github.com/{repo}/blob/main/.github/OSRB_REVIEW.md",
+        )
+        self.assertIn(
+            "[How to respond to this check]",
+            check.summary_with_guide(repo, "Review passed."),
+        )
+
     def test_dispatch_passes_canonical_license_diff_run_url(self) -> None:
         workflow = WORKFLOW.read_text()
         self.assertIn(
@@ -60,6 +73,14 @@ class DispatchTests(unittest.TestCase):
         )
         self.assertIn('LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}', workflow)
         self.assertIn('--run-url "$LICENSE_RUN_URL"', workflow)
+
+    def test_github_output_explains_developer_actions(self) -> None:
+        guide = DEVELOPER_GUIDE.read_text()
+        license_workflow = LICENSE_WORKFLOW.read_text()
+        self.assertIn("### OSRB Review fails or is inconclusive", guide)
+        self.assertIn("Do not paste private ticket comments", guide)
+        self.assertIn("### What to do", license_workflow)
+        self.assertIn("Developer instructions", license_workflow)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -89,6 +89,33 @@ class DispatchTests(unittest.TestCase):
         start_block = start_block.split("- name:", 1)[0]
         self.assertNotIn("if:", start_block, "Start OSRB check must be unconditional")
 
+    def test_every_path_resolves_the_check(self) -> None:
+        """No branch may leave the check stuck in_progress with nothing to close it."""
+        workflow = WORKFLOW.read_text()
+        complete_block = workflow.split("- name: Complete OSRB check", 1)[1]
+        self.assertIn("if: always()\n", complete_block)
+        self.assertNotIn("always() && steps.pr.outputs.skip", complete_block)
+
+        mark_block = workflow.split("- name: Mark release-branch review as not applicable", 1)[1]
+        mark_block = mark_block.split("- name:", 1)[0]
+        self.assertIn("continue-on-error: true", mark_block)
+
+    def test_complete_publishes_even_when_the_check_was_never_started(self) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        def fake_github(method: str, repo: str, path: str, payload: dict | None = None):
+            calls.append((method, path, payload))
+            return {"check_runs": []} if method == "GET" else {}
+
+        with mock.patch.object(check, "github", fake_github):
+            check.complete("owner/repo", "deadbeef", "https://run", "gitlab-osrb:1", False, "why")
+
+        self.assertEqual([call[0] for call in calls], ["GET", "POST"])
+        created = calls[1][2] or {}
+        self.assertEqual(created["head_sha"], "deadbeef")
+        self.assertEqual(created["conclusion"], "failure")
+        self.assertEqual(created["external_id"], "gitlab-osrb:1")
+
     def test_dispatch_job_wiring_is_exercised_in_ci(self) -> None:
         self.assertIn(
             "python3 .github/scripts/test_osrb_dispatch.py",

--- a/.github/scripts/trigger-downstream-pipeline.sh
+++ b/.github/scripts/trigger-downstream-pipeline.sh
@@ -37,6 +37,24 @@ def require_env(name: str) -> str:
     return value
 
 
+def configured_extra_variables() -> dict[str, str]:
+    """Parse optional generic GitLab variables without logging their values."""
+    raw = os.environ.get("DOWNSTREAM_EXTRA_VARIABLES_JSON", "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        emit_error("DOWNSTREAM_EXTRA_VARIABLES_JSON is not valid JSON")
+        raise SystemExit(1) from exc
+    if not isinstance(parsed, dict) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in parsed.items()
+    ):
+        emit_error("DOWNSTREAM_EXTRA_VARIABLES_JSON must be a string-to-string object")
+        raise SystemExit(1)
+    return parsed
+
+
 def api_base_url(raw_url: str) -> str:
     base = raw_url.rstrip("/")
     if not base.endswith("/api/v4"):
@@ -365,7 +383,7 @@ def main() -> int:
             add_mask(segment)
 
         target_branch, compare_branch = resolve_branches()
-        extra_variables: dict[str, str] = {}
+        extra_variables = configured_extra_variables()
         if launchable_notebook_changed():
             extra_variables[LAUNCHABLE_NOTEBOOK_TRIGGER_VARIABLE] = "true"
 
@@ -402,8 +420,8 @@ def main() -> int:
         print(f"  {variable_name}={commit_sha}")
         print(f"  VSS_TARGET_BRANCH={target_branch}")
         print(f"  VSS_COMPARE_BRANCH={compare_branch}")
-        for key, value in extra_variables.items():
-            print(f"  {key}={value}")
+        for key in extra_variables:
+            print(f"  passed variable: {key}")
 
         sha_short = pipeline_sha[:8] if pipeline_sha else ""
         commit_sha_short = commit_sha[:8] if commit_sha else ""
@@ -420,8 +438,8 @@ def main() -> int:
             summary_lines.append(f"- **VSS_TARGET_BRANCH:** `{target_branch}`")
         if compare_branch:
             summary_lines.append(f"- **VSS_COMPARE_BRANCH:** `{compare_branch}`")
-        for key, value in extra_variables.items():
-            summary_lines.append(f"- **{key}:** `{value}`")
+        for key in extra_variables:
+            summary_lines.append(f"- Passed variable: **{key}**")
         if pipeline_created_at:
             summary_lines.append(f"- **Created at:** {pipeline_created_at}")
         write_summary("\n".join(summary_lines))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,7 +684,29 @@ jobs:
         run: python3 .github/scripts/check_no_patented_codecs.py --from-deploy vss-agent
 
   # ---------------------------------------------------------------------------
-  # Job 12: Trigger downstream pipeline and poll it to completion
+  # Job 12: OSRB dispatch wiring
+  # ---------------------------------------------------------------------------
+  # The OSRB Review workflow itself runs on `workflow_run` from the default
+  # branch, so a pull request never executes its own copy. These tests are the
+  # only pre-merge signal on that wiring: they assert the workflow supplies
+  # every variable the downstream helpers require, keeps the private code-ref
+  # choice out of the public repo, and creates the check before anything that
+  # can fail.
+  osrb-dispatch:
+    name: OSRB Dispatch Wiring
+    needs: prepare-source
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Unit-test the OSRB dispatch boundary
+        run: python3 .github/scripts/test_osrb_dispatch.py
+
+  # ---------------------------------------------------------------------------
+  # Job 13: Trigger downstream pipeline and poll it to completion
   # ---------------------------------------------------------------------------
   trigger-downstream-pipeline:
     name: Trigger Downstream Pipeline

--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -149,6 +149,7 @@ jobs:
           BASE: ${{ steps.ctx.outputs.base }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          GUIDE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/main/.github/OSRB_REVIEW.md
         run: |
           set -euo pipefail
           marker='<!-- license-diff-osrb -->'
@@ -156,7 +157,7 @@ jobs:
             echo "$marker"
             echo "## License Diff for OSRB"
             echo
-            echo "**${ROWS}** changed packages require OSRB review (vs \`${BASE}\`)."
+            echo "**${ROWS}** package changes were detected (vs \`${BASE}\`)."
             echo "Download the full CSV directly: [\`license-diff.csv\`](${ARTIFACT_URL}) (or browse the [workflow run](${RUN_URL}))."
             echo
             cat diff-table.md
@@ -168,8 +169,13 @@ jobs:
             echo '```'
             echo "</details>"
             echo
-            echo "_The trusted **OSRB Review** follow-up sends this artifact to the protected compliance pipeline."
-            echo "It approves already-cleared changes or blocks with the missing evidence. CODEOWNERS remains the final merge gate._"
+            echo "### What to do"
+            echo
+            echo "Wait for the **OSRB Review** check. If it passes, no further OSRB action is required."
+            echo "If it fails or is inconclusive, read the automated PR review and correct the reported issue before pushing an update."
+            echo "Do not paste private approval evidence into this public PR."
+            echo
+            echo "[Developer instructions](${GUIDE_URL}) · CODEOWNERS remains the final merge gate."
           } > comment.md
           existing=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
             --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id")

--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -168,7 +168,8 @@ jobs:
             echo '```'
             echo "</details>"
             echo
-            echo "_This check is informational. CODEOWNERS still gates merge — get approval from \`@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers\` for the touched lockfile/manifest paths._"
+            echo "_The trusted **OSRB Review** follow-up sends this artifact to the protected compliance pipeline."
+            echo "It approves already-cleared changes or blocks with the missing evidence. CODEOWNERS remains the final merge gate._"
           } > comment.md
           existing=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
             --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id")
@@ -181,10 +182,9 @@ jobs:
             echo "$payload" | gh api -X POST "repos/${REPO}/issues/${PR}/comments" --input - > /dev/null
           fi
 
-      - name: Fail when license diff is non-empty
+      - name: Hand off non-empty diff to OSRB Review
         if: steps.ctx.outputs.skip != 'true' && steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
         env:
           ROWS: ${{ steps.gen.outputs.rows }}
         run: |
-          echo "::error title=License diff non-empty::${ROWS} packages changed; requires OSRB review."
-          exit 1
+          echo "::notice title=OSRB review queued::${ROWS} package changes will be evaluated by the trusted OSRB Review workflow."

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -130,10 +130,10 @@ jobs:
         run: |
           set -euo pipefail
           success=()
-          summary="The protected downstream OSRB review did not approve this change. See the PR review."
+          summary="This change needs attention. Read the automated PR review and linked License Diff, then correct the dependency or work with the OSRB owner before pushing an update."
           if [[ "$TRIGGER_OUTCOME" == "success" && "$POLL_OUTCOME" == "success" ]]; then
             success=(--success)
-            summary="The protected downstream OSRB review approved this change."
+            summary="The reported dependency changes passed OSRB review. No further OSRB action is required; normal required checks and CODEOWNERS review still apply."
           fi
           python3 .github/scripts/osrb_check.py complete \
             --repo "$REPO" \

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -93,6 +93,11 @@ jobs:
           DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
           DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
           DOWNSTREAM_PROJECT_PATH: ${{ secrets.DOWNSTREAM_PROJECT_PATH }}
+          # A standing ref, because the private project's normal jobs are
+          # opt-out gated and a trigger against its default branch would start
+          # a full build. That ref is maintainer-protected and points at
+          # reviewed code; which code the review runs is decided entirely
+          # there, so this dispatcher must never send a code-ref override.
           DOWNSTREAM_REF: osrb-review-trigger
           DOWNSTREAM_SUBMODULE_HASH_VARIABLE: GITHUB_MIRROR_SHA
           GITHUB_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -38,6 +38,10 @@ jobs:
       LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}
       SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
       EXTERNAL_ID: gitlab-osrb:${{ github.event.workflow_run.id }}
+      # Job level, as in ci.yml: the trigger and the poller both need these.
+      DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
+      DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
+      DOWNSTREAM_PROJECT_PATH: ${{ secrets.DOWNSTREAM_PROJECT_PATH }}
 
     steps:
       - name: Checkout trusted dispatch implementation
@@ -90,9 +94,6 @@ jobs:
         id: trigger
         continue-on-error: true
         env:
-          DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
-          DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
-          DOWNSTREAM_PROJECT_PATH: ${{ secrets.DOWNSTREAM_PROJECT_PATH }}
           # A standing ref, because the private project's normal jobs are
           # opt-out gated and a trigger against its default branch would start
           # a full build. That ref is maintainer-protected and points at
@@ -118,8 +119,6 @@ jobs:
         id: poll
         continue-on-error: true
         env:
-          DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
-          DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
           DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
           DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}
           POLL_INTERVAL_SECONDS: "30"

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       REPO: ${{ github.repository }}
       HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}
       SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
       EXTERNAL_ID: gitlab-osrb:${{ github.event.workflow_run.id }}
 
@@ -70,7 +70,7 @@ jobs:
           python3 .github/scripts/osrb_check.py skip \
             --repo "$REPO" \
             --sha "$HEAD_SHA" \
-            --run-url "$RUN_URL" \
+            --run-url "$LICENSE_RUN_URL" \
             --external-id "$EXTERNAL_ID" \
             --summary "PR targets ${{ steps.pr.outputs.base }}; OSRB was already enforced on the develop-targeted PR."
 
@@ -82,7 +82,7 @@ jobs:
           python3 .github/scripts/osrb_check.py start \
             --repo "$REPO" \
             --sha "$HEAD_SHA" \
-            --run-url "$RUN_URL" \
+            --run-url "$LICENSE_RUN_URL" \
             --external-id "$EXTERNAL_ID"
 
       - name: Trigger private OSRB pipeline
@@ -103,6 +103,7 @@ jobs:
             "GITHUB_REPOSITORY":"${{ github.repository }}",
             "GITHUB_PR_NUMBER":"${{ steps.pr.outputs.number }}",
             "GITHUB_LICENSE_RUN_ID":"${{ github.event.workflow_run.id }}",
+            "GITHUB_LICENSE_RUN_URL":"${{ github.event.workflow_run.html_url }}",
             "GITHUB_OSRB_RUN_URL":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
         run: |
           python3 .github/scripts/trigger-downstream-pipeline.sh
@@ -137,7 +138,7 @@ jobs:
           python3 .github/scripts/osrb_check.py complete \
             --repo "$REPO" \
             --sha "$HEAD_SHA" \
-            --run-url "$RUN_URL" \
+            --run-url "$LICENSE_RUN_URL" \
             --external-id "$EXTERNAL_ID" \
             --summary "$summary" \
             "${success[@]}"

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -50,6 +50,20 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      # First, so the check exists before anything that can fail. Otherwise a
+      # failure here leaves no check on the commit at all, and `workflow_run`
+      # jobs are not listed in the pull request, so the gate would silently not
+      # happen. Idempotent, which also lets the release-branch path reuse it.
+      - name: Start OSRB check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/osrb_check.py start \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --run-url "$LICENSE_RUN_URL" \
+            --external-id "$EXTERNAL_ID"
+
       - name: Resolve source PR
         id: pr
         env:
@@ -77,17 +91,6 @@ jobs:
             --run-url "$LICENSE_RUN_URL" \
             --external-id "$EXTERNAL_ID" \
             --summary "PR targets ${{ steps.pr.outputs.base }}; OSRB was already enforced on the develop-targeted PR."
-
-      - name: Start OSRB check
-        if: steps.pr.outputs.skip != 'true'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          python3 .github/scripts/osrb_check.py start \
-            --repo "$REPO" \
-            --sha "$HEAD_SHA" \
-            --run-url "$LICENSE_RUN_URL" \
-            --external-id "$EXTERNAL_ID"
 
       - name: Trigger private OSRB pipeline
         if: steps.pr.outputs.skip != 'true'
@@ -134,10 +137,15 @@ jobs:
         run: |
           set -euo pipefail
           success=()
-          summary="This change needs attention. Read the automated PR review and linked License Diff, then correct the dependency or work with the OSRB owner before pushing an update."
           if [[ "$TRIGGER_OUTCOME" == "success" && "$POLL_OUTCOME" == "success" ]]; then
             success=(--success)
             summary="The reported dependency changes passed OSRB review. No further OSRB action is required; normal required checks and CODEOWNERS review still apply."
+          elif [[ "$TRIGGER_OUTCOME" != "success" && "$TRIGGER_OUTCOME" != "failure" ]]; then
+            # The review was never dispatched, so this says nothing about the
+            # dependencies themselves. Distinguish it from a real finding.
+            summary="The OSRB gate could not run, so these dependency changes were not reviewed. Ask a repository maintainer to rerun License Diff; do not merge on the strength of this check."
+          else
+            summary="This change needs attention. Read the automated PR review and linked License Diff, then correct the dependency or work with the OSRB owner before pushing an update."
           fi
           python3 .github/scripts/osrb_check.py complete \
             --repo "$REPO" \

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -81,7 +81,11 @@ jobs:
           esac
 
       - name: Mark release-branch review as not applicable
+        id: mark
         if: steps.pr.outputs.skip == 'true'
+        # Failing here must not abort before the completion step, or the check
+        # would stay in_progress with nothing left to resolve it.
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -128,21 +132,28 @@ jobs:
           MAX_POLL_DURATION_SECONDS: "2400"
         run: python3 .github/scripts/poll-downstream-pipeline.py
 
+      # Unconditional, so every path that created the check also resolves it.
       - name: Complete OSRB check
-        if: always() && steps.pr.outputs.skip != 'true'
+        if: always()
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SKIP: ${{ steps.pr.outputs.skip }}
+          MARK_OUTCOME: ${{ steps.mark.outcome }}
           TRIGGER_OUTCOME: ${{ steps.trigger.outcome }}
           POLL_OUTCOME: ${{ steps.poll.outcome }}
         run: |
           set -euo pipefail
+          # The release-branch path already completed the check itself.
+          if [[ "$SKIP" == "true" && "$MARK_OUTCOME" == "success" ]]; then
+            exit 0
+          fi
           success=()
           if [[ "$TRIGGER_OUTCOME" == "success" && "$POLL_OUTCOME" == "success" ]]; then
             success=(--success)
             summary="The reported dependency changes passed OSRB review. No further OSRB action is required; normal required checks and CODEOWNERS review still apply."
-          elif [[ "$TRIGGER_OUTCOME" != "success" && "$TRIGGER_OUTCOME" != "failure" ]]; then
-            # The review was never dispatched, so this says nothing about the
-            # dependencies themselves. Distinguish it from a real finding.
+          elif [[ "$TRIGGER_OUTCOME" != "success" ]]; then
+            # No verdict was ever produced, so this says nothing about the
+            # dependencies themselves. Do not word it like a finding.
             summary="The OSRB gate could not run, so these dependency changes were not reviewed. Ask a repository maintainer to rerun License Diff; do not merge on the strength of this check."
           else
             summary="This change needs attention. Read the automated PR review and linked License Diff, then correct the dependency or work with the OSRB owner before pushing an update."

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Trusted follow-up to License Diff. `workflow_run` loads this workflow and its
+# scripts from the default branch, not from the PR mirror. It creates the
+# public check, then triggers and polls the isolated private GitLab pipeline.
+# Internal compliance systems and credentials are used only in that pipeline.
+name: OSRB Review
+
+on:
+  workflow_run:
+    workflows: ["License Diff"]
+    types: [completed]
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: osrb-review-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  review:
+    name: Trigger private OSRB review
+    if: startsWith(github.event.workflow_run.head_branch, 'pull-request/')
+    runs-on: [self-hosted, downstream-pipeline]
+    timeout-minutes: 45
+    env:
+      REPO: ${{ github.repository }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+      EXTERNAL_ID: gitlab-osrb:${{ github.event.workflow_run.id }}
+
+    steps:
+      - name: Checkout trusted dispatch implementation
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Resolve source PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          pr="${HEAD_BRANCH##pull-request/}"
+          base="$(gh pr view "$pr" --repo "$REPO" --json baseRefName --jq .baseRefName)"
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          case "$base" in
+            dev/*|release/*) echo "skip=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "skip=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Mark release-branch review as not applicable
+        if: steps.pr.outputs.skip == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/osrb_check.py skip \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --run-url "$RUN_URL" \
+            --external-id "$EXTERNAL_ID" \
+            --summary "PR targets ${{ steps.pr.outputs.base }}; OSRB was already enforced on the develop-targeted PR."
+
+      - name: Start OSRB check
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/osrb_check.py start \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --run-url "$RUN_URL" \
+            --external-id "$EXTERNAL_ID"
+
+      - name: Trigger private OSRB pipeline
+        if: steps.pr.outputs.skip != 'true'
+        id: trigger
+        continue-on-error: true
+        env:
+          DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
+          DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
+          DOWNSTREAM_PROJECT_PATH: ${{ secrets.DOWNSTREAM_PROJECT_PATH }}
+          DOWNSTREAM_REF: osrb-review-trigger
+          DOWNSTREAM_SUBMODULE_HASH_VARIABLE: GITHUB_MIRROR_SHA
+          GITHUB_SHA: ${{ github.event.workflow_run.head_sha }}
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
+          GITHUB_TOKEN: ${{ github.token }}
+          DOWNSTREAM_EXTRA_VARIABLES_JSON: >-
+            {"OSRB_REVIEW":"true",
+            "GITHUB_REPOSITORY":"${{ github.repository }}",
+            "GITHUB_PR_NUMBER":"${{ steps.pr.outputs.number }}",
+            "GITHUB_LICENSE_RUN_ID":"${{ github.event.workflow_run.id }}",
+            "GITHUB_OSRB_RUN_URL":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
+        run: |
+          python3 .github/scripts/trigger-downstream-pipeline.sh
+
+      - name: Poll private OSRB pipeline
+        if: steps.pr.outputs.skip != 'true' && steps.trigger.outcome == 'success'
+        id: poll
+        continue-on-error: true
+        env:
+          DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
+          DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
+          DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
+          DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}
+          POLL_INTERVAL_SECONDS: "30"
+          MAX_POLL_DURATION_SECONDS: "2400"
+        run: python3 .github/scripts/poll-downstream-pipeline.py
+
+      - name: Complete OSRB check
+        if: always() && steps.pr.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TRIGGER_OUTCOME: ${{ steps.trigger.outcome }}
+          POLL_OUTCOME: ${{ steps.poll.outcome }}
+        run: |
+          set -euo pipefail
+          success=()
+          summary="The protected downstream OSRB review did not approve this change. See the PR review."
+          if [[ "$TRIGGER_OUTCOME" == "success" && "$POLL_OUTCOME" == "success" ]]; then
+            success=(--success)
+            summary="The protected downstream OSRB review approved this change."
+          fi
+          python3 .github/scripts/osrb_check.py complete \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --run-url "$RUN_URL" \
+            --external-id "$EXTERNAL_ID" \
+            --summary "$summary" \
+            "${success[@]}"
+          [[ "$TRIGGER_OUTCOME" == "success" && "$POLL_OUTCOME" == "success" ]]


### PR DESCRIPTION
## Summary
- add a trusted default-branch dispatcher for completed License Diff runs
- keep private compliance systems and credentials outside the public repository
- create and complete a public `OSRB Review` check while the protected review runs
- pass the source License Diff run ID and canonical Actions URL to the protected reviewer
- link the public check to the License Diff evidence instead of the follow-up dispatcher run
- allow the existing downstream helper to pass generic variables without logging their values
- explain the required developer action directly in the License Diff comment and OSRB Review check
- add a public developer guide at `.github/OSRB_REVIEW.md`
- rebase the implementation onto the latest `main`

## Public data boundary
The public workflow exposes only the PR identity, source commit, public License Diff run, and final review result. It does not publish private approval evidence or service details.

## Merge order
1. Merge and activate the protected reviewer.
2. Protect and update its standing trigger ref, then validate one end-to-end test.
3. Merge this PR into `main` after approval and green CI.
4. Sync this dispatcher and developer guide from `main` into `develop`.

PR #1528, which adds the focused License Diff overview, is already merged into `develop`.

## Test plan
- [x] rebase onto current `main` with no conflicts
- [x] `python3 .github/scripts/test_osrb_dispatch.py` — 6 tests
- [x] `ruff check .github/scripts/osrb_check.py .github/scripts/test_osrb_dispatch.py .github/scripts/trigger-downstream-pipeline.sh`
- [x] parse both edited workflows as YAML
- [x] confirm the trigger receives `DOWNSTREAM_PROJECT_PATH` and passes the resolved numeric project ID to the poller
- [x] verify all review threads are resolved
- [ ] repository CI on the latest commit
- [ ] protected reviewer approval and merge
- [ ] protected trigger setup and end-to-end handoff

The `workflow_run` dispatcher executes from the default branch, so the handoff starts applying to subsequent PRs only after this workflow lands.