### PR TITLE
ci(skills-eval): start nightly sweep at 21:00 PT for a morning-fresh report

### DIFF
--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -16,7 +16,17 @@ on:
   # deliberately no per-PR `push:` trigger, because a full GPU sweep is far
   # too heavy to run on every pull-request mirror push.
   schedule:
-    - cron: "30 1 * * *"
+    # Start at 21:00 PT (was 01:30 PT). The old start ran the ~8h sweep to a
+    # ~10:10 PT close — AFTER the 09:00 PT dashboard check — so the report was
+    # always a day stale. Runtime has also crept ~1.5h recently (6.5h -> 8h),
+    # so a late start hugs the deadline. Starting at 21:00 PT closes by ~07:50
+    # PT even if the sweep grows to 10h (~21:50 actual start + ~50m queue lag
+    # + 10h), leaving ~1.5h of buffer before the 09:00 PT check. Keep the PT
+    # timezone so the start tracks DST rather than drifting against Pacific.
+    # NB: this only buys headroom — if runtime keeps growing unbounded, no
+    # start time is safe; the durable fixes are shortening the sweep and/or
+    # push-based dashboard ingest.
+    - cron: "0 21 * * *"
       timezone: "America/Los_Angeles"
   # On-demand sweep. The "Run workflow" button only appears when
   # `workflow_dispatch:` is configured on the repo's default branch (`main`),


### PR DESCRIPTION
## Problem
The daily skills-eval sweep starts at **01:30 PT** and runs ~8h, so it closes **~10:10 PT** — *after* the 09:00 PT dashboard refresh/check. The dashboard is therefore a day stale every morning. Runtime has also crept ~1.5h recently (6.5h → 8h), so a late start hugs the deadline.

## Change
Start the sweep at **21:00 PT** (`cron: "0 21 * * *"`), timezone unchanged (`America/Los_Angeles`).

With ~50m scheduler queue lag the sweep begins ~21:50 PT and closes **~05:50–07:50 PT** across an 8–10h runtime — before ~08:00 PT even in the worst case, leaving **~1.5h of buffer** ahead of the 09:00 PT check.

| Start (PT) | Actual start | Close @8h | Close @9h | Close @10h |
|---|---|---|---|---|
| 01:30 (old) | ~02:20 | 10:20 | 11:20 | 12:20 |
| **21:00 (new)** | ~21:50 | 05:50 | 06:50 | 07:50 |

## Notes
- Timezone stays `America/Los_Angeles` so the start tracks DST rather than drifting against Pacific.
- The `schedule:` trigger is read from `main` (this file); the job still checks out and evaluates `develop`, unchanged.
- This buys headroom, not a permanent fix — if runtime keeps growing unbounded, no start time is safe. Durable fixes: shorten the sweep and/or push-based dashboard ingest.
