### PR TITLE
Enhance add_sensor function with retry logic and error handling

### DIFF
--- a/services/analytics/vss-configurator/app/sensor_config_manager.py
+++ b/services/analytics/vss-configurator/app/sensor_config_manager.py
@@ -256,7 +256,7 @@ def fetch_sensor_data_from_msb(delay=60, timeout=5) -> Optional[List[Dict]]:
             time.sleep(delay) 
             continue
 
-def add_sensor(sensor_info: Sensor, delay=30):
+def add_sensor(sensor_info: Sensor, delay=5, max_retries=10):
     logger.debug(f"Adding sensor: {sensor_info.name} to VMS endpoint: {CONFIG['VST_CAMERA_ADD_ENDPOINT']}")
     headers = {"Content-Type": "application/json"}
     sensor_data = {
@@ -269,23 +269,38 @@ def add_sensor(sensor_info: Sensor, delay=30):
         sensor_data["tags"] = f"{sensor_info.region}|{sensor_info.group_id}"
         logger.debug(f"Sensor tags set: {sensor_data['tags']}")
 
-    while True:
+    import random
+    for attempt in range(1, max_retries + 1):
         try:
-            logger.debug(f"Sending POST request to add sensor: {sensor_data['name']}")
+            logger.debug(f"Sending POST request to add sensor: {sensor_data['name']} (attempt {attempt}/{max_retries})")
             response = requests.post(CONFIG['VST_CAMERA_ADD_ENDPOINT'], json=sensor_data, headers=headers, timeout=5)
             if response and response.status_code == 200:
                 logger.info(f"Successfully added sensor: {sensor_data['name']}")
                 logger.debug(f"VMS response: {response.text}")
                 return
-            logger.warning(f"Error adding sensor {sensor_data['name']}. Received status code {response.status_code} from VMS. Retrying in {delay} seconds...")
+            # 409 or a body containing "already" means the sensor is registered — treat as success.
+            if response and (response.status_code == 409 or "already" in response.text.lower()):
+                logger.info(f"Sensor {sensor_data['name']} already exists in VMS — treating as success.")
+                return
+            logger.warning(
+                f"Error adding sensor {sensor_data['name']}. "
+                f"Status {response.status_code} from VMS (attempt {attempt}/{max_retries})."
+            )
             logger.debug(f"VMS error response: {response.text if response else 'No response'}")
         except Exception as e:
-            logger.warning(
-                f"VST sensor add API unreachable Retrying in {delay} seconds..."
+            logger.warning(f"VST sensor add API unreachable (attempt {attempt}/{max_retries}): {repr(e)}")
+
+        if attempt >= max_retries:
+            logger.error(
+                f"Giving up on sensor {sensor_data['name']} after {max_retries} attempts. "
+                "It will not be registered with VMS."
             )
-            logger.debug(f"Exception details: {repr(e)}")
-            time.sleep(delay)
-            continue
+            return
+
+        # Exponential backoff with jitter, applied on every retry path.
+        sleep_time = min(delay * (2 ** (attempt - 1)), 120) + random.uniform(0, 2)
+        logger.info(f"Retrying sensor {sensor_data['name']} in {sleep_time:.1f} seconds...")
+        time.sleep(sleep_time)
 
 def fetch_calibration_from_api(delay):
     """Fetch calibration data from configured API endpoint."""

--- a/services/analytics/vss-configurator/tests/test_sensor_config_manager_api.py
+++ b/services/analytics/vss-configurator/tests/test_sensor_config_manager_api.py
@@ -223,3 +223,82 @@ def test_groups_with_mapping_returns_list(client, sample_sensor_mapping, monkeyp
     assert isinstance(data, list)
     assert "r1|g1" in data
     assert "r2|g1" in data
+
+
+# ---------------------------------------------------------------------------
+# add_sensor() unit tests — covers the hot-loop / duplicate-block bug fixes
+# ---------------------------------------------------------------------------
+
+def _make_sensor(name="cam-1", url="rtsp://host/1"):
+    from utils.sensor_mapping import Sensor
+    return Sensor(name=name, url=url, group_id="g1", region="r1")
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Patch time.sleep so tests don't actually wait."""
+    monkeypatch.setattr("sensor_config_manager.time.sleep", lambda _: None)
+
+
+def test_add_sensor_200_returns_immediately(safe_calibration_dir_for_api, no_sleep):
+    """add_sensor returns after a single 200 response without sleeping."""
+    import sensor_config_manager as mod
+    ok = MagicMock(status_code=200, text="ok")
+    with patch("sensor_config_manager.requests.post", return_value=ok) as mock_post:
+        mod.add_sensor(_make_sensor(), delay=5, max_retries=3)
+    assert mock_post.call_count == 1
+
+
+def test_add_sensor_409_treated_as_success(safe_calibration_dir_for_api, no_sleep):
+    """HTTP 409 (already exists) is treated as success and does NOT retry."""
+    import sensor_config_manager as mod
+    conflict = MagicMock(status_code=409, text="sensor already exists")
+    with patch("sensor_config_manager.requests.post", return_value=conflict) as mock_post:
+        mod.add_sensor(_make_sensor(), delay=5, max_retries=10)
+    # Must exit on the first 409 — must NOT spin 10 times
+    assert mock_post.call_count == 1
+
+
+def test_add_sensor_already_in_body_treated_as_success(safe_calibration_dir_for_api, no_sleep):
+    """A 400 response whose body contains 'already' is treated as success."""
+    import sensor_config_manager as mod
+    conflict = MagicMock(status_code=400, text='{"message":"Sensor already registered"}')
+    with patch("sensor_config_manager.requests.post", return_value=conflict) as mock_post:
+        mod.add_sensor(_make_sensor(), delay=5, max_retries=10)
+    assert mock_post.call_count == 1
+
+
+def test_add_sensor_non200_retries_then_gives_up(safe_calibration_dir_for_api, no_sleep):
+    """A persistent non-200 (not duplicate) causes bounded retries then returns."""
+    import sensor_config_manager as mod
+    bad = MagicMock(status_code=500, text="internal error")
+    max_retries = 4
+    with patch("sensor_config_manager.requests.post", return_value=bad) as mock_post:
+        mod.add_sensor(_make_sensor(), delay=1, max_retries=max_retries)
+    # Must have tried exactly max_retries times and then given up (not looped forever)
+    assert mock_post.call_count == max_retries
+
+
+def test_add_sensor_exception_retries_then_gives_up(safe_calibration_dir_for_api, no_sleep):
+    """Repeated connection errors cause bounded retries then return (no infinite loop)."""
+    import sensor_config_manager as mod
+    max_retries = 3
+    with patch("sensor_config_manager.requests.post", side_effect=ConnectionError("refused")) as mock_post:
+        mod.add_sensor(_make_sensor(), delay=1, max_retries=max_retries)
+    assert mock_post.call_count == max_retries
+
+
+def test_add_sensor_sleep_called_on_non200_not_exception(safe_calibration_dir_for_api):
+    """Sleep is called between retries even when VMS responds (not just on exceptions).
+
+    This directly tests defect #1: before the fix, sleep was only in the except
+    branch so non-200 responses from a reachable VMS caused ~3 ms hot-looping.
+    """
+    import sensor_config_manager as mod
+    bad = MagicMock(status_code=500, text="error")
+    sleep_calls = []
+    with patch("sensor_config_manager.requests.post", return_value=bad):
+        with patch("sensor_config_manager.time.sleep", side_effect=lambda t: sleep_calls.append(t)):
+            mod.add_sensor(_make_sensor(), delay=1, max_retries=3)
+    # Sleep must have been called between the first two attempts (at minimum)
+    assert len(sleep_calls) >= 1, "time.sleep must be called on the non-200 retry path"


### PR DESCRIPTION
The add_sensor() function had two control-flow defects that caused Sparse4D
to receive zero active sources when any camera was already registered in VMS:

1. time.sleep(delay) was only inside the except branch, so when VMS was
   reachable and returned a non-200 response, the loop retried immediately
   every ~3 ms instead of the logged 30-second interval.

2. The only success exit was status_code == 200. A duplicate camera never
   returns 200, so add_sensor() blocked forever on the first duplicate,
   preventing all subsequent cameras from being registered.

Fix:
- Move sleep outside the except branch so all retry paths wait correctly
- Treat HTTP 409 and "already exists" response body as idempotent success
- Replace unbounded while-True with bounded exponential backoff and jitter
  (max_retries=10, capped at 120s per sleep)
- Add six regression tests covering all fixed scenarios