### PR TITLE
Use fully qualified docker.io image refs in Helm charts.

### DIFF
--- a/deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/templates/warehouse-extra-services.yaml
+++ b/deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/templates/warehouse-extra-services.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       initContainers:
         - name: prepare-ds-config
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - /bin/sh
             - -c

--- a/deploy/helm/industry-profiles/warehouse-operations/warehouse-3d-app/templates/warehouse-extra-services.yaml
+++ b/deploy/helm/industry-profiles/warehouse-operations/warehouse-3d-app/templates/warehouse-extra-services.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       initContainers:
         - name: prepare-ds-config
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - /bin/sh
             - -c

--- a/deploy/helm/industry-profiles/warehouse-operations/warehouse-mv3dt-app/values.yaml
+++ b/deploy/helm/industry-profiles/warehouse-operations/warehouse-mv3dt-app/values.yaml
@@ -158,7 +158,7 @@ infra:
   mosquitto:
     enabled: true
     image:
-      repository: eclipse-mosquitto
+      repository: docker.io/library/eclipse-mosquitto
       tag: "2"
       pullPolicy: IfNotPresent
     port: 1883

--- a/deploy/helm/services/agent/charts/agent/values.yaml
+++ b/deploy/helm/services/agent/charts/agent/values.yaml
@@ -117,7 +117,7 @@ videoIngestTimeouts:
 waitForDependencies:
   enabled: false
   image:
-    repository: busybox
+    repository: docker.io/library/busybox
     tag: "1.37.0"
     pullPolicy: IfNotPresent
   kafkaHost: ""

--- a/deploy/helm/services/alert/values.yaml
+++ b/deploy/helm/services/alert/values.yaml
@@ -67,7 +67,7 @@ tolerations: []
 waitForDependencies:
   enabled: false
   image:
-    repository: busybox
+    repository: docker.io/library/busybox
     tag: "1.37.0"
     pullPolicy: IfNotPresent
   kafkaHost: ""

--- a/deploy/helm/services/analytics/charts/video-analytics-api/values.yaml
+++ b/deploy/helm/services/analytics/charts/video-analytics-api/values.yaml
@@ -41,7 +41,7 @@ tolerations: []
 waitForDependencies:
   enabled: false
   image:
-    repository: busybox
+    repository: docker.io/library/busybox
     tag: "1.37.0"
     pullPolicy: IfNotPresent
   kafkaHost: ""

--- a/deploy/helm/services/bp-configurator/templates/deployment.yaml
+++ b/deploy/helm/services/bp-configurator/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       initContainers:
         {{- if $dataEnabled }}
         - name: prepare-data
-          image: "{{ $initImage.repository | default "busybox" }}:{{ $initImage.tag | default "1.37.0" }}"
+          image: "{{ $initImage.repository | default "docker.io/library/busybox" }}:{{ $initImage.tag | default "1.37.0" }}"
           imagePullPolicy: {{ $initImage.pullPolicy | default "IfNotPresent" }}
           command:
             - /bin/sh
@@ -74,7 +74,7 @@ spec:
         {{- end }}
         {{- if $initEnabled }}
         - name: wait-for-broker
-          image: "{{ $initImage.repository | default "busybox" }}:{{ $initImage.tag | default "1.37.0" }}"
+          image: "{{ $initImage.repository | default "docker.io/library/busybox" }}:{{ $initImage.tag | default "1.37.0" }}"
           imagePullPolicy: {{ $initImage.pullPolicy | default "IfNotPresent" }}
           command:
             - /bin/sh

--- a/deploy/helm/services/bp-configurator/values.yaml
+++ b/deploy/helm/services/bp-configurator/values.yaml
@@ -29,7 +29,7 @@ init:
   maxRetries: 60
   retryIntervalSeconds: 2
   image:
-    repository: busybox
+    repository: docker.io/library/busybox
     tag: "1.37.0"
     pullPolicy: IfNotPresent
 

--- a/deploy/helm/services/calibration-import/templates/job.yaml
+++ b/deploy/helm/services/calibration-import/templates/job.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: calibration-import
-          image: "{{ $image.repository | default "alpine" }}:{{ $image.tag | default "3.24.1" }}"
+          image: "{{ $image.repository | default "docker.io/library/alpine" }}:{{ $image.tag | default "3.24.1" }}"
           imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/deploy/helm/services/calibration-import/values.yaml
+++ b/deploy/helm/services/calibration-import/values.yaml
@@ -13,7 +13,7 @@ name: ""
 useReleaseNamePrefix: null
 
 image:
-  repository: alpine
+  repository: docker.io/library/alpine
   tag: "3.24.1"
   pullPolicy: IfNotPresent
 

--- a/deploy/helm/services/infra/charts/broker-health-check/values.yaml
+++ b/deploy/helm/services/infra/charts/broker-health-check/values.yaml
@@ -23,7 +23,7 @@ redisHost: ""   # default: <release>-redis
 redisPort: "6379"
 
 image:
-  repository: busybox
+  repository: docker.io/library/busybox
   tag: "1.37.0"
   pullPolicy: IfNotPresent
 

--- a/deploy/helm/services/infra/charts/elasticsearch/values.yaml
+++ b/deploy/helm/services/infra/charts/elasticsearch/values.yaml
@@ -30,7 +30,7 @@ persistence:
     size: 5Gi
 
 volumeInit:
-  image: busybox
+  image: docker.io/library/busybox
   tag: "1.37.0"
 
 gpu:
@@ -52,7 +52,7 @@ init:
   # Empty: inherits elasticsearch.nodeSelector from the Job template coalesce.
   nodeSelector: {}
   image:
-    repository: alpine
+    repository: docker.io/library/alpine
     tag: "3.24.1"
     pullPolicy: IfNotPresent
   backoffLimit: 10

--- a/deploy/helm/services/infra/charts/kafka/values.yaml
+++ b/deploy/helm/services/infra/charts/kafka/values.yaml
@@ -15,7 +15,7 @@
 
 replicas: 1
 image:
-  repository: confluentinc/cp-kafka
+  repository: docker.io/confluentinc/cp-kafka
   tag: "8.3.0"
   pullPolicy: IfNotPresent
 nodeId: "1"
@@ -88,7 +88,7 @@ topicJob:
 # Prometheus kafka-exporter sidecar deployment
 exporter:
   enabled: false
-  image: danielqsj/kafka-exporter:latest
+  image: docker.io/danielqsj/kafka-exporter:latest
   port: 9308
   nodeSelector: {}
   resources: {}

--- a/deploy/helm/services/infra/charts/kibana/values.yaml
+++ b/deploy/helm/services/infra/charts/kibana/values.yaml
@@ -47,7 +47,7 @@ init:
   # Selects packaged NDJSON under configs/objects/{alerts,search,lvs,warehouse-2d,warehouse-3d,warehouse-mv3dt}.ndjson
   objectsBundle: ""
   image:
-    repository: alpine
+    repository: docker.io/library/alpine
     tag: "3.24.1"
     pullPolicy: IfNotPresent
   backoffLimit: 10

--- a/deploy/helm/services/infra/charts/logstash/templates/deployment.yaml
+++ b/deploy/helm/services/infra/charts/logstash/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-kafka
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
               done
               echo "Kafka is ready."
         - name: wait-for-elasticsearch
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c

--- a/deploy/helm/services/infra/charts/mosquitto/values.yaml
+++ b/deploy/helm/services/infra/charts/mosquitto/values.yaml
@@ -17,7 +17,7 @@ enabled: false
 global: {}
 replicas: 1
 image:
-  repository: eclipse-mosquitto
+  repository: docker.io/library/eclipse-mosquitto
   tag: "2"
   pullPolicy: IfNotPresent
 port: 1883

--- a/deploy/helm/services/infra/charts/redis/values.yaml
+++ b/deploy/helm/services/infra/charts/redis/values.yaml
@@ -17,7 +17,7 @@ enabled: false
 global: {}
 replicas: 1
 image:
-  repository: redis
+  repository: docker.io/library/redis
   tag: 8.6.2-alpine
   pullPolicy: IfNotPresent
 # Optional container command/args override (used by alerts profile to load Redis modules for JSON.SET support).

--- a/deploy/helm/services/infra/values.yaml
+++ b/deploy/helm/services/infra/values.yaml
@@ -26,7 +26,7 @@ phoenix:
   useReleaseNamePrefix: false
   replicas: 1
   image:
-    repository: arizephoenix/phoenix
+    repository: docker.io/arizephoenix/phoenix
     tag: "19.8.0"
     pullPolicy: IfNotPresent
   phoenixHost: "0.0.0.0"
@@ -46,7 +46,7 @@ redis:
   enabled: false
   replicas: 1
   image:
-    repository: redis
+    repository: docker.io/library/redis
     tag: 8.6.2-alpine
     pullPolicy: IfNotPresent
   port: 6379
@@ -63,7 +63,7 @@ mosquitto:
   enabled: false
   replicas: 1
   image:
-    repository: eclipse-mosquitto
+    repository: docker.io/library/eclipse-mosquitto
     tag: "2"
     pullPolicy: IfNotPresent
   port: 1883

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset-standalone-2d.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset-standalone-2d.yaml
@@ -55,7 +55,7 @@ spec:
       initContainers:
         {{- if .Values.downloadNgcAppData }}
         - name: wait-for-ngc-app-data
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -78,7 +78,7 @@ spec:
               mountPath: /opt/storage
         {{- else }}
         - name: wait-for-warehouse-videos
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -135,7 +135,7 @@ spec:
         {{- end }}
         {{- if eq (.Values.standaloneWarehouse.streamType | default "none") "kafka" }}
         - name: wait-for-kafka
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -155,7 +155,7 @@ spec:
               echo "Kafka is ready."
         {{- end }}
         - name: ensure-trt-cache
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset-standalone-3d.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset-standalone-3d.yaml
@@ -56,7 +56,7 @@ spec:
       initContainers:
         {{- if .Values.downloadNgcAppData }}
         - name: wait-for-ngc-app-data
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -79,7 +79,7 @@ spec:
               mountPath: /opt/storage
         {{- else }}
         - name: wait-for-warehouse-videos
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -136,7 +136,7 @@ spec:
         {{- end }}
         {{- if eq ($sw.streamType | default "none") "kafka" }}
         - name: wait-for-kafka
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -156,7 +156,7 @@ spec:
               echo "Kafka is ready."
         {{- end }}
         - name: ensure-trt-cache
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset-standalone-mv3dt.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset-standalone-mv3dt.yaml
@@ -57,7 +57,7 @@ spec:
       initContainers:
         {{- if .Values.downloadNgcAppData }}
         - name: wait-for-ngc-app-data
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -80,7 +80,7 @@ spec:
               mountPath: /models-data
         {{- else }}
         - name: wait-for-warehouse-models
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -101,7 +101,7 @@ spec:
               mountPath: /models-data
         {{- end }}
         - name: prepare-mv3dt-models
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -123,7 +123,7 @@ spec:
               mountPath: /opt/storage
         {{- if eq ($sw.streamType | default "none") "kafka" }}
         - name: wait-for-kafka
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
         {{- end }}
         {{- if $engineCacheEnabled }}
         - name: prepare-engine-cache
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -109,7 +109,7 @@ spec:
               mountPath: /wdm-scripts
         {{- if $waitForKafka }}
         - name: wait-for-kafka
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c
@@ -265,7 +265,7 @@ spec:
               mountPath: /models-data
         {{- end }}
         - name: wait-for-kafka
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           command:
             - sh
             - -c

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
       initContainers:
         {{- if $waitKafka }}
         - name: wait-for-kafka
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -97,7 +97,7 @@ spec:
         {{- end }}
         {{- if .Values.clearCachedEnginesOnStart }}
         - name: clear-rtvi-trt-cache
-          image: busybox:1.37.0
+          image: docker.io/library/busybox:1.37.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/templates/deployment.yaml
@@ -21,7 +21,7 @@
 {{- $kafkaBs := .Values.kafkaBootstrapServers | default (printf "%s:9092" $kafkaH) }}
 {{- $wfk := .Values.waitForKafka | default dict }}
 {{- $wfkImg := $wfk.image | default dict }}
-{{- $wfkRepo := $wfkImg.repository | default "confluentinc/cp-kafka" }}
+{{- $wfkRepo := $wfkImg.repository | default "docker.io/confluentinc/cp-kafka" }}
 {{- $wfkTag := $wfkImg.tag | default "8.3.0" }}
 {{- $wfkTopics := $wfk.topics | default (list "mdx-vlm" "mdx-vlm-incidents") }}
 apiVersion: apps/v1

--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/values.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/values.yaml
@@ -55,7 +55,7 @@ kafkaBootstrapServers: ""
 waitForKafka:
   enabled: true
   image:
-    repository: confluentinc/cp-kafka
+    repository: docker.io/confluentinc/cp-kafka
     tag: "8.3.0"
   imagePullPolicy: IfNotPresent
   timeoutSeconds: 1200

--- a/deploy/helm/services/vios/charts/vios-postgres/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-postgres/values.yaml
@@ -17,7 +17,7 @@
 enabled: false
 global: {}
 image:
-  repository: postgres
+  repository: docker.io/library/postgres
   tag: 17.10-alpine
   pullPolicy: IfNotPresent
 replicas: 1
@@ -41,7 +41,7 @@ postgresCm:
 initContainer:
   fixPermissions:
     enabled: true
-    image: busybox:1.37.0
+    image: docker.io/library/busybox:1.37.0
     runAsUser: 0
 securityContext:
   runAsUser: 1000


### PR DESCRIPTION
Short image names can resolve ambiguously across registries; pin public images to docker.io (including library/) so pulls are explicit and reproducible.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
