### PR TITLE
fix(alerts MS): Add LFS to alert ms build configs

### DIFF
--- a/deploy/docker/container-inventory.json
+++ b/deploy/docker/container-inventory.json
@@ -56,6 +56,7 @@
       "source_path": "services/alert",
       "context": "services/alert",
       "dockerfile": "services/alert/Dockerfile",
+      "lfs_include": "services/alert/warmup/*",
       "platforms": ["linux/amd64", "linux/arm64"],
       "compose_image_names": ["vss-alert-ms", "vss-alert-verification"],
       "tag_variables": ["VSS_ALERT_TAG"],


### PR DESCRIPTION
## Description
LFS for warmup files was missing from the build config causing failed VLM warmups

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
