### PR TITLE
feat(skill-eval): route per-PR evals to gated GPU runners

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -508,10 +508,12 @@ The canonical harbor command is in § Harbor invocation.
 | `rtx` / `rtxpro6000bw` | RTX PRO: `vss-eval-rtx*` (e.g. registered `vss-eval-rtx-2g-VM1b`); GeForce: `vss-eval-geforce-rtx4090-vm*` | RTX PRO 6000 BW by default. RTX PRO suffixes denote per-host GPU count (`-1g` = 1 GPU, `-2g` = 2 GPU). Allowlisted single-GPU RTX 4090 nodes are eligible only for skills proven on 24 GB. |
 | `spark` | BYOH registered node `SPARK` | Edge / unified memory; only `remote-llm` mode supported today. Already registered. |
 
-`plan_matrix.py` routes `RTXPRO6000BW` legs to
-`vss-skill-eval-gpu + gpu-nvidia-rtx-pro-6000-blackwell + gpu-count-2`
-and `ANY`/`RTX4090` legs to
-`vss-skill-eval-gpu + gpu-nvidia-geforce-rtx-4090 + gpu-count-1`.
+Following PR #1449's contract, `plan_matrix.py` emits `runs_on` labels.
+`RTXPRO6000BW` legs request
+`vss-eval + gpu-rtxpro6000bw + gpus-N`; `ANY` requests
+`vss-eval + gpus-N` without a model constraint; explicit `RTX4090` requests
+`vss-eval + gpu-rtx4090 + gpus-1`. Two-GPU runners advertise both
+`gpus-1` and `gpus-2`, so the count label expresses demand.
 `L40S`, `H100`, platform-less, and unknown-platform legs retain the
 `vss-skill-eval-runner` coordinator path until matching direct runners exist.
 The labels are a scheduling filter; local mode still checks the physical GPU
@@ -521,7 +523,9 @@ Direct runners are installed as the persistent
 `vss-skill-eval-gpu-runner.service` systemd service. Registration leaves each
 runner online but staged: its job-start hook rejects work until an operator
 creates `/etc/vss-skill-eval/direct-gpu-runner.enabled` after the legacy queue
-drains. Do not add these self-hosted labels to `pull_request` workflows or
+drains. The same hook also requires a mounted central Harbor viewer root,
+central URL, and explicit retention policy (§ Harbor viewer); missing viewer
+parity is a hard activation failure. Do not add these self-hosted labels to `pull_request` workflows or
 unapproved fork refs. The runner and evaluated workload share one privileged
 GPU host; this topology is only for the existing operator-approved
 `pull-request/<N>` mirror and manual-dispatch trust boundary.
@@ -721,25 +725,39 @@ dataset for that spec, rerun. Do not start modifying flags.
 
 ## Harbor viewer
 
-On coordinator runners, `harbor view` runs persistently under the
-`harbor-view.service` systemd unit at `http://localhost:8080`,
-serving the **shared, fixed** `/tmp/skill-eval/results/_viewer`,
-tunneled to `https://harbor-<BREV_ENV_ID>.brevlab.com`. For the viewer
-to pick up a trial, its directory must live under
-`/tmp/skill-eval/results/_viewer/<leg-slug>__<run_id>__<date>/` as a
-**real dir (not a symlink)**, flattened — no nested `<date>/` level.
-The `<leg-slug>` keeps concurrent legs from colliding on one viewer
-entry.
+The selected direct-runner design is **one central `harbor view` process
+backed by private shared POSIX/NFS storage behind Brev/NetBird**. The viewer
+root is `SKILL_EVAL_VIEWER_ROOT`. Coordinators retain the historical
+`/tmp/skill-eval/results/_viewer` default when it is absent.
+`SKILL_EVAL_VIEWER_BASE_URL` is the central browser origin. Coordinators may
+still fall back to `https://harbor-<BREV_ENV_ID>.brevlab.com`; direct GPU
+runners never derive a per-box URL.
+
+Shared mode sets `SKILL_EVAL_VIEWER_SHARED=1`. Before copying, `run_leg.py`
+requires the configured path to be the mount point itself and performs a
+write/read/delete probe. The direct runner's job-start hook runs the same gate
+before admitting a job. A publication failure remains non-fatal to the eval
+verdict, but is emitted as an Actions warning and recorded in
+`<results-root>/trace-publish-failures.tsv`.
+
+The flattened destination is
+`<viewer-root>/<leg-slug>__<run_id>__<date>/` as a **real directory (not a
+symlink)**. `SKILL_EVAL_VIEWER_RETENTION_DAYS` enables age-based retention for
+new, repository-owned job directories. It must be explicitly chosen before
+direct-runner activation; there is no destructive default. A cross-host
+`flock` plus per-job active marker protects current publications. Unmarked
+legacy/history directories are never deleted.
 
 **`run_leg.py` does this publish for you** (`publish_trace`), after
 every trial including timed-out ones. It copies (never moves) the
 date dir's *contents* into a pre-made job dir — the workflow's
 "Collect results" step runs *after* this agent and tars `$RES` for
 the artifact, so a `mv` would upload an artifact with no
-`result.json`. Copying keeps `$RES` intact for the collector (which
-excludes `agent/` from the public tarball) while the `_viewer` copy
-keeps `agent/` for the live Harbor Trace tab. You do not run `cp`
-yourself.
+`result.json`. Copying keeps `$RES` intact for the collector, which always
+excludes `agent/` from workflow artifacts. The shared viewer may retain
+`agent/` only on the private Brev-hosted NFS path for Harbor's Trace tab;
+never expose that mount publicly or copy trajectories to external storage.
+You do not run `cp` yourself.
 
 ### Trace URLs — read them, never build them
 
@@ -756,14 +774,15 @@ assemble a Harbor URL by hand.** A step with no row errored before
 producing `result.json` — report it without a trace link rather than
 inventing one.
 
-Direct GPU runners do not host `harbor-view.service`, so `run_leg.py`
-intentionally omits trace URLs there. Their complete trial results remain
-available through the workflow artifact.
+Direct GPU runners do not host `harbor-view.service`. They publish through
+the mounted central root and use `SKILL_EVAL_VIEWER_BASE_URL`. They remain
+staged until the always-on Brev NFS/viewer host, every runner mount, and the
+central URL/tunnel or internal DNS are configured and verified.
 
 The URL shape is:
 
 ```
-https://harbor-<COORDINATOR_ENV_ID>.brevlab.com/jobs/<leg-slug>__<run_id>__<date>/tasks/<source>/<agent>/<provider>/<model>/<task>
+<SKILL_EVAL_VIEWER_BASE_URL>/jobs/<leg-slug>__<run_id>__<date>/tasks/<source>/<agent>/<provider>/<model>/<task>
 ```
 
 Two things make hand-assembly unreliable, which is why it moved into
@@ -777,12 +796,11 @@ the wrapper:
   than 404ing. That is indistinguishable from missing trace data.
   (Observed on PR #1254, run 30284131217: all seven step links were
   built with the filter and every one opened empty.)
-- **`BREV_ENV_ID` is the coordinator host's env id** (the CI runner,
+- **`BREV_ENV_ID` is only the coordinator fallback host id** (the CI runner,
   set by Brev in `/etc/environment`). It is **NOT** a per-trial
   instance id from `brev ls --json` (the `id` field of `vss-eval-*`
-  or `harbor-*` entries). The coordinator runs `harbor view`;
-  per-trial boxes do not. `run_leg.py` reads the runner env and falls
-  back to `/etc/environment` — never substitute from `brev ls`.
+  or `harbor-*` entries). Direct runners use the configured central base URL;
+  never substitute a direct runner or per-trial id from `brev ls`.
 
 Every segment `run_leg.py` emits comes from the trial's own
 `result.json` (`source`, `agent_info.name`,

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -1,8 +1,8 @@
 # Skills Eval Agent — System Prompt
 
 You are the VSS skills-eval agent, invoked by
-`.github/workflows/skills-eval.yml` on a `vss-skill-eval-runner`
-self-hosted box. Two modes:
+`.github/workflows/skills-eval.yml` on either a coordinator or a
+hardware-labelled `vss-skill-eval-gpu` self-hosted box. Two modes:
 
 - **Single-spec** (push to a `pull-request/<N>` mirror): the workflow's
   `plan` job has already diffed the PR and resolved it into one matrix
@@ -308,19 +308,30 @@ The canonical harbor command is in § Harbor invocation.
    mirror sync. If every changed skill is parked, you exit BLOCKED
    without reaching step 5.
 
-5. **Run harbor trials via the leg wrapper — it picks and locks the
-   fleet box itself.** For each target platform:
+5. **Run harbor trials via the leg wrapper — it pins or picks and locks the
+   execution box itself.** For each target platform:
 
-   a. **Do NOT select an instance and do NOT export `BREV_INSTANCE`.**
-      `run_leg.py` owns fleet selection: it reads the leg's hardware
-      requirements from the dataset's `task.toml` `[metadata]`
-      (`gpu_type`, `gpu_count`), snapshots `brev ls --json`, filters to
-      RUNNING `vss-eval-*` boxes whose GPU matches, and walks the
-      candidates best-first with **non-blocking** `flock` attempts —
-      claiming the first box it can actually lock. Selection and
-      reservation are one atomic step inside the wrapper, so two
-      concurrent legs fan out to different boxes instead of both
-      "choosing" the same lock-free-looking one and serialising
+   a. **Do NOT select an instance or change `BREV_INSTANCE`.**
+      On a direct GPU runner, `SKILL_EVAL_LOCAL_GPU_INSTANCE` and the matching
+      inherited `BREV_INSTANCE` permanently pin the leg to this VM. The
+      workflow already matched the spec to the runner's GPU model/count labels;
+      `BrevEnvironment` independently validates the live GPU count, model, and
+      VRAM before destructive cleanup, then executes locally without Brev.
+      The runner must also have
+      `/etc/vss-skill-eval/direct-gpu-runner.enabled`; operators create that
+      marker only after every legacy coordinator job on the VM has drained.
+      Coordinator-side `BrevEnvironment` rejects any VM carrying the
+      `/etc/vss-skill-eval/direct-gpu-runner` ownership marker, so the two
+      scheduling paths cannot reuse a direct runner after cutover.
+
+      On a coordinator, `run_leg.py` owns fleet selection: it reads the leg's
+      hardware requirements from the dataset's `task.toml` `[metadata]`
+      (`gpu_type`, `gpu_count`), snapshots `brev ls --json`, filters to RUNNING
+      `vss-eval-*` boxes whose GPU matches, and walks the candidates best-first
+      with **non-blocking** `flock` attempts — claiming the first box it can
+      actually lock. Selection and reservation are one atomic step inside the
+      wrapper, so two concurrent legs fan out to different boxes instead of
+      both "choosing" the same lock-free-looking one and serialising
       (check-then-act TOCTOU — the failure mode that motivated this).
 
       Ordering inside the wrapper uses connected registered nodes first so
@@ -340,10 +351,10 @@ The canonical harbor command is in § Harbor invocation.
       implement any of this; you just invoke the wrapper and read its
       `[run-leg] selected instance: <name>` line for reporting.
 
-      Operator override: `--instance <name>` (or an inherited
-      `BREV_INSTANCE` env var, or `brev_instance` in `task.toml`
-      `[metadata]`) pins the leg to one box, skipping pool selection but
-      keeping the lock guard. Use this only for manual debugging runs.
+      Operator override on a coordinator: `--instance <name>` (or an inherited
+      `BREV_INSTANCE` env var, or `brev_instance` in `task.toml` `[metadata]`)
+      pins the leg to one box, skipping pool selection but keeping the lock
+      guard. A direct GPU runner rejects attempts to redirect its local pin.
 
    b. **Run the structural leg wrapper**. Do not acquire or release
       `flock` manually in a separate Bash call, and do not pass
@@ -366,7 +377,7 @@ The canonical harbor command is in § Harbor invocation.
       before the job-killer fires. Do not wrap the call in retry loops —
       the pool-wait and candidate rescan live inside the wrapper.
    c. The wrapper drives Harbor one trial at a time (they share GPU/ports
-      on the host), exports `BREV_INSTANCE`, discovers single-step vs
+      on the host), preserves or exports `BREV_INSTANCE`, discovers single-step vs
       multi-step task layouts, and uses the canonical flags in
       § Harbor invocation. If a trial fails, read the trial log, fix the
       adapter (not the flags), regenerate the dataset, and rerun the
@@ -478,10 +489,12 @@ The canonical harbor command is in § Harbor invocation.
 
 ## Tools you have
 
-- `Bash` — shell on the CI runner host. Has `brev`, `gh`, `docker`,
-  `uvx`, `python3`, `git`. The workflow pins `python3` to Python 3.12 in a
-  per-leg virtual environment, and `run_leg.py` pins Harbor's separate uvx
-  interpreter to the same minor version. PATH includes `/home/ubuntu/.local/bin`.
+- `Bash` — shell on the CI runner host. Has `gh`, `docker`, `uvx`, `python3`,
+  and `git`; coordinator runners also have `brev`. A direct GPU runner uses
+  local execution and does not require the Brev CLI. The workflow pins
+  `python3` to Python 3.12 in a per-leg virtual environment, and `run_leg.py`
+  pins Harbor's separate uvx interpreter to the same minor version. PATH
+  includes `/home/ubuntu/.local/bin`.
 - `Read`, `Write`, `Edit` — file ops on the workspace checkout.
   Obviously bounded by the hard rule above (no `skills/` writes).
 - `Glob`, `Grep` — search the workspace and host.
@@ -494,6 +507,24 @@ The canonical harbor command is in § Harbor invocation.
 | `h100` | `vss-eval-h100*` | 2× H100 80 GB. Full matrix incl. `shared`. |
 | `rtx` / `rtxpro6000bw` | RTX PRO: `vss-eval-rtx*` (e.g. registered `vss-eval-rtx-2g-VM1b`); GeForce: `vss-eval-geforce-rtx4090-vm*` | RTX PRO 6000 BW by default. RTX PRO suffixes denote per-host GPU count (`-1g` = 1 GPU, `-2g` = 2 GPU). Allowlisted single-GPU RTX 4090 nodes are eligible only for skills proven on 24 GB. |
 | `spark` | BYOH registered node `SPARK` | Edge / unified memory; only `remote-llm` mode supported today. Already registered. |
+
+`plan_matrix.py` routes `RTXPRO6000BW` legs to
+`vss-skill-eval-gpu + gpu-nvidia-rtx-pro-6000-blackwell + gpu-count-2`
+and `ANY`/`RTX4090` legs to
+`vss-skill-eval-gpu + gpu-nvidia-geforce-rtx-4090 + gpu-count-1`.
+`L40S`, `H100`, platform-less, and unknown-platform legs retain the
+`vss-skill-eval-runner` coordinator path until matching direct runners exist.
+The labels are a scheduling filter; local mode still checks the physical GPU
+with `nvidia-smi` before Harbor can reset Docker.
+
+Direct runners are installed as the persistent
+`vss-skill-eval-gpu-runner.service` systemd service. Registration leaves each
+runner online but staged: its job-start hook rejects work until an operator
+creates `/etc/vss-skill-eval/direct-gpu-runner.enabled` after the legacy queue
+drains. Do not add these self-hosted labels to `pull_request` workflows or
+unapproved fork refs. The runner and evaluated workload share one privileged
+GPU host; this topology is only for the existing operator-approved
+`pull-request/<N>` mirror and manual-dispatch trust boundary.
 
 Pool naming is operator-managed; the actual fleet is the union of managed
 instances from `brev ls --json` and connected registered nodes from
@@ -521,6 +552,9 @@ acquisition.
 
 `vss-skill-validator-v2` is the CI runner host — **never** touch it,
 even though it shows up in `brev ls`.
+On a direct GPU runner, the current VM is both runner and execution box: never
+kill `/opt/actions-runner/bin/Runner.Listener`, remove
+`/opt/actions-runner`, or alter its registration while a leg is running.
 
 **Fleet selection (worker-pool model).** One matrix leg = one serial
 worker; concurrency comes from sibling legs each claiming a different
@@ -687,7 +721,7 @@ dataset for that spec, rerun. Do not start modifying flags.
 
 ## Harbor viewer
 
-`harbor view` runs persistently on the CI runner host under the
+On coordinator runners, `harbor view` runs persistently under the
 `harbor-view.service` systemd unit at `http://localhost:8080`,
 serving the **shared, fixed** `/tmp/skill-eval/results/_viewer`,
 tunneled to `https://harbor-<BREV_ENV_ID>.brevlab.com`. For the viewer
@@ -721,6 +755,10 @@ the URL from there and paste it verbatim into the comment. Never
 assemble a Harbor URL by hand.** A step with no row errored before
 producing `result.json` — report it without a trace link rather than
 inventing one.
+
+Direct GPU runners do not host `harbor-view.service`, so `run_leg.py`
+intentionally omits trace URLs there. Their complete trial results remain
+available through the workflow artifact.
 
 The URL shape is:
 

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -6,8 +6,8 @@ Evaluation is **fully CI-driven**. [`.github/workflows/skills-eval.yml`](../work
 
 1. Diffs the PR against its base branch and picks out changed skills with an eval spec at `skills/<skill>/evals/<name>.json` (legacy `skills/<skill>/eval/<name>.json` still accepted).
 2. Generates Harbor datasets per `(skill, profile, platform, mode)` via the adapter at [`adapters/<skill>/generate.py`](adapters/).
-3. Selects an operator-managed `vss-eval-*` pool member matching the target platform, per the fleet-selection algorithm in [`AGENTS.md`](AGENTS.md) § 5a. The harness does **not** auto-provision — if no pool member matches, the run blocks until one appears (or times out).
-4. Calls [`run_leg.py`](run_leg.py), which acquires the per-instance `flock`, holds it while every Harbor subprocess for this `(spec, platform)` runs, and invokes Harbor 0.20.0 through Python 3.12 with the canonical flags from [`AGENTS.md § Harbor invocation`](AGENTS.md).
+3. Pins a supported per-PR leg to its hardware-labelled direct GPU runner, or selects an operator-managed `vss-eval-*` pool member through the coordinator fallback. Daily broad-hardware evaluation always keeps the coordinator/locking path.
+4. Calls [`run_leg.py`](run_leg.py), which executes locally on a direct GPU runner or acquires and holds the per-instance `flock` on the coordinator path. Both modes invoke Harbor 0.20.0 through Python 3.12 with the canonical flags from [`AGENTS.md § Harbor invocation`](AGENTS.md).
 5. Verifies each trial (containers running, endpoints healthy, trajectory / response / rubric checks — see `verifiers/generic_judge.py`) and scores 0.0–1.0.
 6. Posts one Markdown results summary per `(PR, eval-spec)` batch as a PR comment, with trace URLs served by `harbor view`.
 
@@ -48,6 +48,10 @@ Per-CI-run hygiene is the trial's own responsibility: each spec's first agent tu
 | `VLM_REMOTE_URL` / `VLM_REMOTE_MODEL` | Remote-VLM endpoint used by `remote-*` deploy modes |
 | `HF_TOKEN` | Required by the Edge 4B vLLM on SPARK / Thor `shared` mode |
 | `GITHUB_TOKEN` | Issued to `gh pr comment` when the agent posts results |
+| `SKILL_EVAL_VIEWER_ROOT` | Central Harbor viewer POSIX/NFS mount. Optional on coordinators; required on direct GPU runners. |
+| `SKILL_EVAL_VIEWER_BASE_URL` | Browser origin for the central viewer. Direct runners never derive a per-box URL. |
+| `SKILL_EVAL_VIEWER_SHARED` | Set to `1` for the shared-mount preflight. Required on direct runners. |
+| `SKILL_EVAL_VIEWER_RETENTION_DAYS` | Explicit 1–3650 day retention for newly published viewer jobs. No destructive default. |
 | `BREV_REGISTERED_POOL` | Comma/space-separated registered-node names approved for automatic pool selection |
 | `BREV_RTX4090_POOL` | Registered RTX 4090 workers; routed only to the proven tests in `run_leg.py::RTX4090_TESTS` / `RTX4090_ALL_TESTS` |
 
@@ -210,13 +214,13 @@ python3 .github/skill-eval/run_leg.py \
     └── claude-code.txt   ← agent trace
 ```
 
-`run_leg.py` publishes each finished trial into the viewer dir itself
-(copying, not moving — the workflow's collector still tars the leg's
-results root afterwards) and appends the browsable URL to
+`run_leg.py` publishes each finished trial into the configured viewer root
+(copying, not moving — the workflow's collector still tars the leg's results
+root afterwards) and appends the browsable URL to
 `<results-root>/trace-urls.tsv`:
 
 ```
-step-7	step-7__E6dBECL	https://harbor-<ENV_ID>.brevlab.com/jobs/<job>/tasks/<source>/<agent>/<provider>/<model>/<task>
+step-7	step-7__E6dBECL	<SKILL_EVAL_VIEWER_BASE_URL>/jobs/<job>/tasks/<source>/<agent>/<provider>/<model>/<task>
 ```
 
 Open the URL from that file rather than composing one: the trailing
@@ -225,13 +229,36 @@ Open the URL from that file rather than composing one: the trailing
 viewer is an SPA that renders a wrong path as a **blank page**, never
 a 404.
 
-`harbor view` runs persistently on the CI runner host. If it's down:
+Coordinator compatibility retains the local
+`/tmp/skill-eval/results/_viewer` root and
+`https://harbor-<BREV_ENV_ID>.brevlab.com` fallback. Direct GPU runners use
+option B: one always-on `harbor view` on a Brev host, backed by a private
+POSIX/NFS mount reachable through Brev/NetBird. The runner job-start hook and
+`run_leg.py` both require that exact root to be mounted and writable.
+
+Viewer publication errors do not change the eval reward. They produce an
+Actions warning and `<results-root>/trace-publish-failures.tsv`. Retention is
+opt-in via `SKILL_EVAL_VIEWER_RETENTION_DAYS`; only repository-owned, inactive
+job directories are eligible, so existing history is left for a separate
+operator migration.
+
+The shared viewer copy may retain `agent/` only on the private Brev NFS host for
+Harbor's Trace tab. Workflow artifacts continue to exclude it; never publish
+that directory externally.
+
+The coordinator's existing local viewer can still be started with:
 
 ```bash
 nohup uvx --python 3.12 --from 'harbor==0.20.0' harbor view /tmp/skill-eval/results/_viewer --jobs \
   --host 0.0.0.0 --port 8080 > /tmp/harbor-view.log 2>&1 &
 disown
 ```
+
+Before direct-runner activation, operators must still choose and provision the
+always-on Brev NFS/viewer host, deploy the mount to all seven GPU VMs, publish
+the central URL through a tunnel or internal DNS, choose the retention value,
+and separately decide whether old trace history should be migrated. The
+repository intentionally does not provision or guess any of those values.
 
 ## Troubleshooting
 

--- a/.github/skill-eval/docs/matrix-dispatch-design.md
+++ b/.github/skill-eval/docs/matrix-dispatch-design.md
@@ -54,7 +54,7 @@ push to pull-request/<N>
                 ▼
 ┌──────────────────────────────────────────────────────────────┐
 │ eval  (strategy.matrix, one leg per (spec, platform))          │
-│  runs-on: matrix.runner_labels (GPU model/count or coordinator) │
+│  runs-on: matrix.runs_on (PR #1449 GPU demand or coordinator)   │
 │  fail-fast: false   max-parallel: <≈ box count>                │
 │                                                                │
 │  each leg:  EVAL_SKILL / EVAL_SPEC set                         │
@@ -115,13 +115,18 @@ today, so this is the same leg count as per-spec — but it generalizes
 cleanly to multi-platform specs (each platform parallelizes onto its own
 runner) and makes the per-`(spec,platform)` output root automatic.
 
-Each matrix entry also carries `runner_labels`. `RTXPRO6000BW` targets
-the two-GPU RTX PRO 6000 Blackwell partition; `ANY` and explicit
-`RTX4090` target the one-GPU RTX 4090 partition. A requirement above the
-advertised partition capacity, an unsupported platform, or a
+Each matrix entry also carries PR #1449's `runs_on` contract.
+`RTXPRO6000BW` requests `vss-eval + gpu-rtxpro6000bw + gpus-N`;
+`ANY` requests only `vss-eval + gpus-N`; explicit `RTX4090` adds
+`gpu-rtx4090`. Two-GPU runners advertise both `gpus-1` and `gpus-2`.
+A requirement above installed capacity, an unsupported platform, or a
 platform-less leg fails safely back to the existing coordinator label.
 The plan job itself runs on `ubuntu-24.04` because it needs neither GPU
 nor Brev.
+
+Only the per-PR workflow consumes `matrix.runs_on`. The daily broad-hardware
+workflow deliberately remains on `self-hosted + vss-skill-eval-runner`, where
+`run_leg.py` keeps Brev selection and per-instance locking.
 
 Each direct GPU runner is supervised by
 `vss-skill-eval-gpu-runner.service` and carries a host ownership marker that
@@ -132,6 +137,13 @@ VM has drained. This prevents the local runner's cleanup from overlapping a
 legacy remote trial during cutover. Because the runner and evaluated workload
 share a privileged host, these labels are restricted to the existing
 operator-approved mirror/manual-dispatch workflow trust boundary.
+
+Activation also requires Harbor viewer option B: an always-on Brev-hosted
+`harbor view`, a private shared POSIX/NFS mount on every GPU VM,
+`SKILL_EVAL_VIEWER_BASE_URL`, and an explicit retention value. The hook checks
+mount identity and write/read/delete access before admitting work. These
+infrastructure values are not provisioned by this repository, so the runners
+stay staged until operators supply them.
 
 `max-parallel` is capped near the `vss-eval-*` box count so legs don't
 all grab runner slots only to wait inside `run_leg.py`. `fail-fast: false` so one

--- a/.github/skill-eval/docs/matrix-dispatch-design.md
+++ b/.github/skill-eval/docs/matrix-dispatch-design.md
@@ -54,12 +54,12 @@ push to pull-request/<N>
                 ▼
 ┌──────────────────────────────────────────────────────────────┐
 │ eval  (strategy.matrix, one leg per (spec, platform))          │
-│  runs-on: [self-hosted, vss-skill-eval-runner]                 │
+│  runs-on: matrix.runner_labels (GPU model/count or coordinator) │
 │  fail-fast: false   max-parallel: <≈ box count>                │
 │                                                                │
 │  each leg:  EVAL_SKILL / EVAL_SPEC set                         │
 │    → foreground agent, single-spec mode (AGENTS.md override)   │
-│    → ensure adapter+dataset → pick a matching box              │
+│    → ensure adapter+dataset → pin local GPU or pick remote box │
 │    → run_leg.py (flock + synchronous Harbor, this spec only)   │
 │    → gather results → POST ITS OWN per-spec comment            │
 │    → DONE:/BLOCKED:                                            │
@@ -115,6 +115,24 @@ today, so this is the same leg count as per-spec — but it generalizes
 cleanly to multi-platform specs (each platform parallelizes onto its own
 runner) and makes the per-`(spec,platform)` output root automatic.
 
+Each matrix entry also carries `runner_labels`. `RTXPRO6000BW` targets
+the two-GPU RTX PRO 6000 Blackwell partition; `ANY` and explicit
+`RTX4090` target the one-GPU RTX 4090 partition. A requirement above the
+advertised partition capacity, an unsupported platform, or a
+platform-less leg fails safely back to the existing coordinator label.
+The plan job itself runs on `ubuntu-24.04` because it needs neither GPU
+nor Brev.
+
+Each direct GPU runner is supervised by
+`vss-skill-eval-gpu-runner.service` and carries a host ownership marker that
+new coordinator code refuses to use remotely. Registration is staged:
+`local-gpu-job-started.sh` rejects jobs until an operator creates
+`/etc/vss-skill-eval/direct-gpu-runner.enabled` after all legacy work on the
+VM has drained. This prevents the local runner's cleanup from overlapping a
+legacy remote trial during cutover. Because the runner and evaluated workload
+share a privileged host, these labels are restricted to the existing
+operator-approved mirror/manual-dispatch workflow trust boundary.
+
 `max-parallel` is capped near the `vss-eval-*` box count so legs don't
 all grab runner slots only to wait inside `run_leg.py`. `fail-fast: false` so one
 failing leg doesn't cancel the others.
@@ -123,7 +141,7 @@ failing leg doesn't cancel the others.
 
 | Component | Change |
 |---|---|
-| `.github/skill-eval/plan_matrix.py` | **new.** Pure-Python, no LLM. Reads the diff (local `git diff`) — or, on a manual sweep, enumerates the picked skill's specs — applies the rules above, prints `matrix` JSON + `has_targets` to `$GITHUB_OUTPUT`. Unit-testable offline. |
+| `.github/skill-eval/plan_matrix.py` | **new.** Pure-Python, no LLM. Reads the diff (local `git diff`) — or, on a manual sweep, enumerates the picked skill's specs — applies the rules above, prints hardware-aware `matrix` JSON + `has_targets` to `$GITHUB_OUTPUT`. Unit-testable offline. |
 | `.github/workflows/skills-eval.yml` | **rewrite.** `plan` job → `eval` matrix job, on push AND `workflow_dispatch` (a manual sweep feeds the picked skill's specs into the same matrix; legs write to `$GITHUB_STEP_SUMMARY` since there's no PR). |
 | `.github/skill-eval/skills_eval_agent.py` | **small add.** New single-spec mode keyed on `EVAL_SKILL`/`EVAL_SPEC`: skip the diff/detection (plan already decided), build a user prompt scoped to one spec, otherwise reuse the existing SDK session, options, hardening, and DONE/BLOCKED enforcement verbatim. |
 | `.github/skill-eval/AGENTS.md` | **add a "Single-spec mode" section** (parallel to "Manual full-sweep mode"): when `EVAL_SPEC` is set, skip step 1's diff — you are handed exactly one `(skill, spec)`; run steps 2–7 for it only, post the one comment, emit the marker. Everything else (hard rules, fleet selection § 5a, wrapper-held lock § 5b, harbor invocation, result format, failure modes) applies unchanged. |
@@ -147,8 +165,8 @@ PreToolUse hook); each leg's foreground agent therefore *must* drive
 
 ## Concurrency / shared-state isolation
 
-All legs of one run share `GITHUB_RUN_ID` and — on a single runner host —
-the same `/tmp/skill-eval/` tree. So every runner-local path is scoped by
+All legs of one run share `GITHUB_RUN_ID`; legs that land on the same runner
+also share its `/tmp/skill-eval/` tree. So every runner-local path is scoped by
 `<leg-slug>/<run_id>` (`leg-slug = <skill>__<spec_stem>__<platform>`,
 == `$EVAL_SLUG`): `datasets/<slug>/<run_id>/`, `results/<slug>/<run_id>/`,
 the viewer entry `_viewer/<slug>__<run_id>__<date>/`, and
@@ -163,13 +181,14 @@ PRs' runs on the same host don't collide either.
 exclusive `flock`, and keeps that file descriptor open while it launches
 every Harbor subprocess for the leg. This serializes trials on a box and
 avoids the broken pattern where an agent acquires a lock in one shell
-call and runs Harbor in a later shell call after the FD has closed. The
-mutex is still valid **only while all eval legs run on one host** — flock
-is host-local. If the `vss-skill-eval-runner` label ever spans multiple
-hosts, two legs could lock their own local files and both drive the same
-brev box (docker/port collision + trajectory corruption via `start()`'s
-archive-on-start racing a live session). Keep the label pinned to one
-host, or move the lock onto the box itself.
+call and runs Harbor in a later shell call after the FD has closed.
+
+For direct GPU runners, the host-local mutex is sufficient: there is exactly
+one Actions runner per VM, `BREV_INSTANCE` is immutably pinned to that same VM,
+and local mode refuses redirection to another fleet member. Coordinator
+fallback legs retain the earlier constraint: coordinators sharing one remote
+Brev pool must share a lock domain, or use a distributed/box-side lock, so two
+hosts cannot claim the same remote box.
 
 ## Open questions / future
 

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -28,20 +28,19 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from enum import Enum
 import json
 import logging
 import os
-from pathlib import Path
 import shlex
 import shutil
 import signal
 import subprocess
 import tempfile
 import uuid
+from enum import Enum
+from pathlib import Path
 
-from harbor.environments.base import BaseEnvironment
-from harbor.environments.base import ExecResult
+from harbor.environments.base import BaseEnvironment, ExecResult
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +132,7 @@ class BrevEnvironment(BaseEnvironment):
         stop()     → no-op (instance stays running for reuse)
     """
 
-    def __init__(self, **kwargs):  # noqa: ANN003
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._instance_name: str | None = DEFAULT_INSTANCE
         self._started = False
@@ -1690,7 +1689,7 @@ async def _load_registered_nodes() -> dict[str, dict]:
                 name = (n.get("name") or "").strip()
                 if name:
                     cache[name.lower()] = n
-        except Exception as e:
+        except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as e:
             logger.warning("brev ls nodes failed (attempt %s): %s", attempt + 1, e)
         if cache:
             _registered_nodes_cache = cache
@@ -2173,7 +2172,7 @@ async def _get_instance_gpu_count_from_catalog(instance_type: str) -> int | None
         return None
     try:
         result = await _run_brev("search", "gpu", "--json", timeout=30)
-    except Exception as exc:
+    except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as exc:
         logger.warning("brev search gpu --json failed: %s", exc)
         return None
     if result.return_code != 0:

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -10,6 +10,11 @@ no instance is resolved. The harness does NOT auto-provision — see
 AGENTS.md § 5a for the fleet-selection algorithm the skill-eval
 agent uses to pick a pool member.
 
+When `SKILL_EVAL_LOCAL_GPU_INSTANCE` is set by a hardware-labelled Actions
+runner, the same lifecycle runs directly on that VM. The local instance is
+immutable, its GPU requirements are checked with live `nvidia-smi`, and no Brev
+CLI or SSH hop is used.
+
 Task.toml [metadata] fields consumed:
     gpu_type              — e.g. "L40S", "H100", "RTX PRO 6000"
     gpu_count             — 1 or 2
@@ -29,6 +34,7 @@ import logging
 import os
 from pathlib import Path
 import shlex
+import shutil
 import signal
 import subprocess
 import tempfile
@@ -54,6 +60,18 @@ BREV_COPY_TIMEOUT = int(os.environ.get("BREV_COPY_TIMEOUT", "300"))
 # retrying a transient stall on a fresh connection recovers it. Tunable.
 BREV_DOWNLOAD_RETRIES = int(os.environ.get("BREV_DOWNLOAD_RETRIES", "3"))
 BREV_DOWNLOAD_BACKOFF_SEC = float(os.environ.get("BREV_DOWNLOAD_BACKOFF_SEC", "5"))
+DIRECT_GPU_RUNNER_MARKER = "/etc/vss-skill-eval/direct-gpu-runner"
+
+
+def _local_gpu_instance() -> str:
+    """Runner-pinned local instance name, empty on coordinator hosts."""
+    return os.environ.get("SKILL_EVAL_LOCAL_GPU_INSTANCE", "").strip()
+
+
+def _is_local_gpu_instance(instance: str | None) -> bool:
+    local = _local_gpu_instance()
+    return bool(local and instance and local.lower() == instance.lower())
+
 
 # Keep every file-transfer API bounded below run_leg.py's recovery headroom.
 # Remote work gets 600 seconds. The public 630-second wall-clock bound also
@@ -137,7 +155,7 @@ class BrevEnvironment(BaseEnvironment):
         return False
 
     def _validate_definition(self) -> None:
-        if not _which("brev"):
+        if not _local_gpu_instance() and not _which("brev"):
             raise RuntimeError(
                 "brev CLI not found. Install from https://docs.brev.dev/"
             )
@@ -180,6 +198,20 @@ class BrevEnvironment(BaseEnvironment):
         }
 
         self._instance_name = self._resolve_instance_name()
+        local_instance = _local_gpu_instance()
+        if local_instance:
+            # A GPU-hosted Actions runner is permanently bound to its own VM.
+            # Ignore task metadata rather than allowing a job to redirect the
+            # local runner to another fleet member.
+            if (
+                self._instance_name
+                and not _is_local_gpu_instance(self._instance_name)
+            ):
+                raise RuntimeError(
+                    "BREV_INSTANCE does not match "
+                    "SKILL_EVAL_LOCAL_GPU_INSTANCE on this runner"
+                )
+            self._instance_name = local_instance
 
         if self._instance_name:
             # Mode 1: validate existing instance's GPU fits task requirements
@@ -190,6 +222,10 @@ class BrevEnvironment(BaseEnvironment):
                 raise RuntimeError(
                     f"Brev instance '{self._instance_name}' not found "
                     f"(is it deleted? wrong org?)"
+                )
+            if _is_local_gpu_instance(self._instance_name):
+                await _check_local_gpu_requirements(
+                    self._instance_name, requirements
                 )
             await _check_instance_matches(instance, requirements)
         else:
@@ -202,6 +238,18 @@ class BrevEnvironment(BaseEnvironment):
                 "If you're running harbor manually, export "
                 "BREV_INSTANCE=<vss-eval-*-name> first."
             )
+
+        if not _is_local_gpu_instance(self._instance_name):
+            direct_runner_check = await _run_brev_exec(
+                self._instance_name,
+                f"test ! -e {shlex.quote(DIRECT_GPU_RUNNER_MARKER)}",
+                timeout=30,
+            )
+            if direct_runner_check.return_code != 0:
+                raise RuntimeError(
+                    f"Brev instance '{self._instance_name}' is reserved for "
+                    "its direct GitHub Actions runner"
+                )
 
         # Quick smoke test — ensure exec works
         result = await _run_brev_exec(
@@ -1202,7 +1250,6 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
             # Make sure user-installed binaries (claude, uv, etc.) are on PATH
             # even though `brev exec` spawns a non-interactive non-login shell.
             'export PATH="$HOME/.local/bin:$HOME/.claude/bin:$PATH";',
-            "source ~/.profile 2>/dev/null;",
         ]
         # Ensure /logs/verifier is writable before the verifier exec —
         # Harbor's verifier phase redirects test-stdout.txt there, and the
@@ -1214,6 +1261,12 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
             parts.append(
                 "sudo chown -R $(whoami):$(id -gn) /logs/verifier 2>/dev/null || true;"
             )
+        if not _is_local_gpu_instance(self._instance_name):
+            # Remote workers receive the current trial env through .eval_env.
+            # Local runner profiles also source .eval_env, but that file can
+            # contain metadata from a prior remote trial; the local Harbor
+            # process already inherited the current workflow environment.
+            parts.append("source ~/.profile 2>/dev/null;")
         if env:
             for k, v in env.items():
                 parts.append(f"export {shlex.quote(k)}={shlex.quote(v)};")
@@ -1750,6 +1803,41 @@ async def _run_scp(
     )
 
 
+async def _run_local_exec(
+    command: str,
+    timeout: int = BREV_EXEC_TIMEOUT,
+) -> ExecResult:
+    """Execute a Harbor environment command on this GPU runner."""
+    proc = await asyncio.create_subprocess_exec(
+        "bash",
+        "-c",
+        command,
+        cwd=str(Path.home()),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=b""),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        _kill_proc_group(proc)
+        stdout, stderr = await proc.communicate()
+        return ExecResult(
+            stdout=stdout.decode() if stdout else None,
+            stderr="Command timed out",
+            return_code=124,
+        )
+    return ExecResult(
+        stdout=stdout.decode() if stdout else None,
+        stderr=stderr.decode() if stderr else None,
+        return_code=proc.returncode or 0,
+    )
+
+
 async def _run_brev_exec(
     instance: str,
     command: str,
@@ -1764,6 +1852,8 @@ async def _run_brev_exec(
     a single command string.  Stdin is piped with empty input so the
     brev CLI doesn't enter interactive mode.
     """
+    if _is_local_gpu_instance(instance):
+        return await _run_local_exec(command, timeout)
     if await _is_registered_node(instance):
         # ssh command-execs run NON-LOGIN shells: ~/.profile (and thus the
         # forwarded ~/.eval_env) is never sourced, silently dropping
@@ -1840,6 +1930,25 @@ async def _run_brev_copy_once(
     For registered external nodes, transparently falls back to ``scp``
     using the ssh alias (same host:path convention, just with lowercase
     name)."""
+    local_instance = _local_gpu_instance()
+    if local_instance:
+        local_prefix = f"{local_instance}:"
+        src_is_runner = src.lower().startswith(local_prefix.lower())
+        dst_is_runner = dst.lower().startswith(local_prefix.lower())
+        if src_is_runner or dst_is_runner:
+            source = Path(src[len(local_prefix):] if src_is_runner else src)
+            target = Path(dst[len(local_prefix):] if dst_is_runner else dst)
+            try:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                await asyncio.to_thread(shutil.copy2, source, target)
+            except OSError as exc:
+                return ExecResult(
+                    stdout=None,
+                    stderr=str(exc),
+                    return_code=1,
+                )
+            return ExecResult(stdout="", stderr=None, return_code=0)
+
     # Detect registered-node endpoint on either side: "<name>:<path>"
     for endpoint in (src, dst):
         if ":" not in endpoint:
@@ -2002,6 +2111,17 @@ async def _find_brev_instance(name: str) -> dict | None:
     Retries a few times — `brev ls` sometimes hits transient RPC
     deadline-exceeded errors and returns empty stdout.
     """
+    if _is_local_gpu_instance(name):
+        return {
+            "name": _local_gpu_instance(),
+            "type": "local-gpu-runner",
+            "gpu": "",
+            "instance_type": "local-gpu-runner",
+            "status": "RUNNING",
+            "_registered": True,
+            "_local_gpu_runner": True,
+        }
+
     for attempt in range(4):
         result = await _run_brev("ls", "--json", timeout=30)
         raw = result.stdout or ""
@@ -2106,6 +2226,75 @@ async def _check_live_gpu_count(instance_name: str, required_count: int) -> None
     logger.info(
         "Instance '%s' live gpu_count: %d (satisfies required >= %d)",
         instance_name, actual, required_count,
+    )
+
+
+async def _check_local_gpu_requirements(instance_name: str, req: dict) -> None:
+    """Fail closed on the physical hardware of a direct GPU runner."""
+    required_count = int(req.get("gpu_count", 1) or 0)
+    if required_count == 0:
+        return
+
+    result = await _run_local_exec(
+        "nvidia-smi --query-gpu=name,memory.total "
+        "--format=csv,noheader,nounits",
+        timeout=30,
+    )
+    if result.return_code != 0 or not (result.stdout or "").strip():
+        raise RuntimeError(
+            f"Local GPU runner '{instance_name}' failed nvidia-smi: "
+            f"{(result.stderr or result.stdout or '')[-300:]}"
+        )
+
+    gpus: list[tuple[str, int]] = []
+    for line in result.stdout.splitlines():
+        name, separator, memory = line.rpartition(",")
+        if not separator:
+            continue
+        try:
+            memory_mib = int(memory.strip())
+        except ValueError:
+            continue
+        gpus.append((name.strip(), memory_mib))
+
+    required_type = (req.get("gpu_type") or "").upper()
+
+    def matches_type(name: str) -> bool:
+        if not required_type:
+            return True
+        want_tokens = set(required_type.replace("-", " ").split())
+        have_tokens = set(name.upper().replace("-", " ").split())
+        return want_tokens.issubset(have_tokens) or required_type in name.upper()
+
+    matching = [gpu for gpu in gpus if matches_type(gpu[0])]
+    if len(matching) < required_count:
+        names = ", ".join(name for name, _ in gpus) or "none"
+        raise RuntimeError(
+            f"Local GPU runner '{instance_name}' has {len(matching)} matching "
+            f"GPU(s), task requires {required_count} of {required_type or 'any'}; "
+            f"detected: {names}"
+        )
+
+    min_vram_gb = int(req.get("min_vram_gb_per_gpu", 0) or 0)
+    if min_vram_gb:
+        too_small = [
+            f"{name} ({memory_mib} MiB)"
+            for name, memory_mib in matching[:required_count]
+            # Specs use vendor-advertised decimal GB (for example, a 24 GB
+            # RTX 4090 reports about 24564 MiB after firmware reservation).
+            if memory_mib < min_vram_gb * 1000
+        ]
+        if too_small:
+            raise RuntimeError(
+                f"Local GPU runner '{instance_name}' does not provide "
+                f"{min_vram_gb} GB per GPU: {', '.join(too_small)}"
+            )
+
+    logger.info(
+        "Local GPU runner '%s' satisfies gpu_type=%r, gpu_count>=%d",
+        instance_name,
+        required_type,
+        required_count,
     )
 
 

--- a/.github/skill-eval/envs/tests/test_registered_node.py
+++ b/.github/skill-eval/envs/tests/test_registered_node.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for registered-node SSH fallback in brev_env.py.
@@ -43,7 +42,7 @@ sys.modules["harbor.environments.base"] = _base
 ENVS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ENVS_DIR))
 
-import brev_env  # noqa: E402
+import brev_env
 
 
 class RtspSampleUrlResolution(unittest.TestCase):

--- a/.github/skill-eval/envs/tests/test_registered_node.py
+++ b/.github/skill-eval/envs/tests/test_registered_node.py
@@ -131,6 +131,126 @@ class FindBrevInstanceFallback(unittest.IsolatedAsyncioTestCase):
             brev_env._run_brev = original
 
 
+class LocalGpuRunnerMode(unittest.IsolatedAsyncioTestCase):
+    async def test_local_instance_does_not_query_brev(self):
+        async def fail_run_brev(*args, **kwargs):
+            self.fail("local GPU mode must not invoke the Brev CLI")
+
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1"},
+            ),
+            mock.patch.object(brev_env, "_run_brev", fail_run_brev),
+        ):
+            instance = await brev_env._find_brev_instance("gpu-vm-1")
+
+        self.assertTrue(instance["_local_gpu_runner"])
+        self.assertTrue(instance["_registered"])
+
+    async def test_local_exec_bypasses_brev_and_ssh(self):
+        calls = []
+
+        async def fake_local_exec(command, timeout=brev_env.BREV_EXEC_TIMEOUT):
+            calls.append((command, timeout))
+            return brev_env.ExecResult(
+                stdout="local\n", stderr=None, return_code=0
+            )
+
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1"},
+            ),
+            mock.patch.object(brev_env, "_run_local_exec", fake_local_exec),
+        ):
+            result = await brev_env._run_brev_exec(
+                "gpu-vm-1", "echo local", timeout=17
+            )
+
+        self.assertEqual(result.stdout, "local\n")
+        self.assertEqual(calls, [("echo local", 17)])
+
+    async def test_local_environment_exec_does_not_source_stale_profile(self):
+        commands = []
+
+        async def fake_run_brev_exec(
+            instance,
+            command,
+            timeout=brev_env.BREV_EXEC_TIMEOUT,
+        ):
+            commands.append((instance, command, timeout))
+            return brev_env.ExecResult(stdout="", stderr=None, return_code=0)
+
+        environment = brev_env.BrevEnvironment()
+        environment._instance_name = "gpu-vm-1"
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1"},
+            ),
+            mock.patch.object(
+                brev_env, "_run_brev_exec", fake_run_brev_exec
+            ),
+        ):
+            await environment.exec(
+                "echo ready",
+                env={"PR_HEAD_SHA": "fresh"},
+            )
+
+        self.assertEqual(len(commands), 1)
+        self.assertNotIn("source ~/.profile", commands[0][1])
+        self.assertIn("export PR_HEAD_SHA=fresh", commands[0][1])
+
+    async def test_local_copy_strips_instance_endpoint(self):
+        with tempfile.TemporaryDirectory() as td:
+            source = Path(td) / "source.txt"
+            target = Path(td) / "nested" / "target.txt"
+            source.write_text("payload\n")
+            with mock.patch.dict(
+                os.environ,
+                {"SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1"},
+            ):
+                result = await brev_env._run_brev_copy_once(
+                    str(source),
+                    f"gpu-vm-1:{target}",
+                )
+
+            self.assertEqual(result.return_code, 0)
+            self.assertEqual(target.read_text(), "payload\n")
+
+    async def test_local_hardware_validation_is_live_and_fail_closed(self):
+        async def two_pro_gpus(command, timeout=brev_env.BREV_EXEC_TIMEOUT):
+            return brev_env.ExecResult(
+                stdout=(
+                    "NVIDIA RTX PRO 6000 Blackwell Server Edition, 97887\n"
+                    "NVIDIA RTX PRO 6000 Blackwell Server Edition, 97887\n"
+                ),
+                stderr=None,
+                return_code=0,
+            )
+
+        with mock.patch.object(
+            brev_env, "_run_local_exec", two_pro_gpus
+        ):
+            await brev_env._check_local_gpu_requirements(
+                "gpu-vm-1",
+                {
+                    "gpu_type": "RTX PRO 6000",
+                    "gpu_count": 2,
+                    "min_vram_gb_per_gpu": 80,
+                },
+            )
+            with self.assertRaisesRegex(RuntimeError, "matching GPU"):
+                await brev_env._check_local_gpu_requirements(
+                    "gpu-vm-1",
+                    {
+                        "gpu_type": "GEFORCE RTX 4090",
+                        "gpu_count": 1,
+                    },
+                )
+
+
 class CheckInstanceMatchesForRegistered(unittest.TestCase):
 
     def test_registered_instance_bypasses_gpu_name_check(self):

--- a/.github/skill-eval/install-local-gpu-runner.sh
+++ b/.github/skill-eval/install-local-gpu-runner.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install one repository-scoped GitHub Actions runner directly on a GPU VM.
+# The short-lived registration token is read from stdin and is never persisted.
+# Example:
+#   printf '%s\n' "$TOKEN" | sudo ./install-local-gpu-runner.sh \
+#     --repo-url https://github.com/org/repo --runner-name gpu-1 \
+#     --labels vss-skill-eval-gpu,gpu-nvidia-rtx-pro-6000-blackwell,gpu-count-2,gpu-node-pro-1 \
+#     --local-instance gpu-1 --runner-version 2.336.0 \
+#     --runner-sha256 <published-linux-x64-sha256> \
+#     --nvidia-pin 580.105.08
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+job_hook="$script_dir/local-gpu-job-started.sh"
+supervisor="$script_dir/local-gpu-runner-supervise.sh"
+service_unit="$script_dir/local-gpu-runner.service"
+repo_url=""
+runner_name=""
+runner_labels=""
+local_instance=""
+runner_version=""
+runner_sha256=""
+nvidia_pin=""
+anthropic_base_url="https://inference-api.nvidia.com"
+anthropic_model="aws/anthropic/bedrock-claude-opus-4-6"
+runner_dir="/opt/actions-runner"
+source_env="/root/.eval_env"
+coordinator_env="/root/eval-coordinator/.env"
+
+while (($#)); do
+  case "$1" in
+    --repo-url) repo_url="$2"; shift 2 ;;
+    --runner-name) runner_name="$2"; shift 2 ;;
+    --labels) runner_labels="$2"; shift 2 ;;
+    --local-instance) local_instance="$2"; shift 2 ;;
+    --runner-version) runner_version="$2"; shift 2 ;;
+    --runner-sha256) runner_sha256="$2"; shift 2 ;;
+    --nvidia-pin) nvidia_pin="$2"; shift 2 ;;
+    --anthropic-base-url) anthropic_base_url="$2"; shift 2 ;;
+    --anthropic-model) anthropic_model="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ((EUID != 0)); then
+  echo "run as root" >&2
+  exit 1
+fi
+
+for value in \
+  repo_url runner_name runner_labels local_instance runner_version runner_sha256 \
+  nvidia_pin
+do
+  if [[ -z "${!value}" ]]; then
+    echo "missing --${value//_/-}" >&2
+    exit 2
+  fi
+done
+if [[ ! "$runner_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "--runner-sha256 must be a lowercase SHA-256 digest" >&2
+  exit 2
+fi
+if [[ ! "$nvidia_pin" =~ ^[0-9]+([.][0-9]+){1,3}$ ]]; then
+  echo "--nvidia-pin must be a numeric driver version" >&2
+  exit 2
+fi
+for command in curl docker flock install nvidia-ctk nvidia-smi pgrep python3 \
+  sha256sum systemctl tar
+do
+  command -v "$command" >/dev/null || {
+    echo "missing required command: $command" >&2
+    exit 1
+  }
+done
+test -s "$job_hook" || {
+  echo "missing job hook next to installer: $job_hook" >&2
+  exit 1
+}
+test -s "$service_unit" || {
+  echo "missing systemd unit next to installer: $service_unit" >&2
+  exit 1
+}
+test -s "$supervisor" || {
+  echo "missing supervisor next to installer: $supervisor" >&2
+  exit 1
+}
+
+IFS= read -r registration_token
+if [[ -z "$registration_token" ]]; then
+  echo "missing registration token on stdin" >&2
+  exit 2
+fi
+
+exec 9>/run/vss-skill-eval-gpu-runner-install.lock
+flock -x 9
+
+mapfile -t gpu_names < <(
+  nvidia-smi --query-gpu=name --format=csv,noheader,nounits
+)
+gpu_count="${#gpu_names[@]}"
+((gpu_count > 0)) || {
+  echo "nvidia-smi reported no GPUs" >&2
+  exit 1
+}
+case "${gpu_names[0]}" in
+  *"RTX PRO 6000 Blackwell"*)
+    expected_model_label="gpu-nvidia-rtx-pro-6000-blackwell"
+    ;;
+  *"GeForce RTX 4090"*)
+    expected_model_label="gpu-nvidia-geforce-rtx-4090"
+    ;;
+  *)
+    echo "unsupported local GPU model: ${gpu_names[0]}" >&2
+    exit 1
+    ;;
+esac
+for gpu_name in "${gpu_names[@]}"; do
+  [[ "$gpu_name" == "${gpu_names[0]}" ]] || {
+    echo "mixed GPU models are not supported: ${gpu_names[*]}" >&2
+    exit 1
+  }
+done
+label_set=",$runner_labels,"
+for required_label in \
+  vss-skill-eval-gpu "$expected_model_label" "gpu-count-$gpu_count"
+do
+  [[ "$label_set" == *",$required_label,"* ]] || {
+    echo "runner labels must include $required_label" >&2
+    exit 2
+  }
+done
+[[ "$label_set" == *",gpu-node-"* ]] || {
+  echo "runner labels must include a unique gpu-node-* label" >&2
+  exit 2
+}
+nvidia-smi -L
+docker info >/dev/null
+test -s "$source_env"
+
+mkdir -p "$(dirname "$coordinator_env")"
+env_tmp="$(mktemp "$(dirname "$coordinator_env")/.env.XXXXXX")"
+# shellcheck disable=SC2329  # invoked by the EXIT trap
+cleanup() {
+  rm -f "$env_tmp"
+  unset registration_token
+}
+trap cleanup EXIT
+python3 - "$source_env" "$env_tmp" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+allowed = {
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_DISABLE_THINKING",
+    "HF_TOKEN",
+    "IS_SANDBOX",
+    "LLM_REMOTE_MODEL",
+    "LLM_REMOTE_URL",
+    "NGC_CLI_API_KEY",
+    "NVIDIA_API_KEY",
+    "RTSP_SAMPLE_URL",
+    "VLM_REMOTE_MODEL",
+    "VLM_REMOTE_URL",
+}
+source, target = map(Path, sys.argv[1:])
+lines = []
+for line in source.read_text(encoding="utf-8").splitlines():
+    match = re.match(
+        r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=",
+        line,
+    )
+    if match and match.group(1) in allowed:
+        lines.append(line)
+target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+chown root:root "$env_tmp"
+chmod 0600 "$env_tmp"
+{
+  printf '\nexport ANTHROPIC_BASE_URL=%q\n' "$anthropic_base_url"
+  printf 'export ANTHROPIC_MODEL=%q\n' "$anthropic_model"
+  printf 'export IS_SANDBOX=1\n'
+} >>"$env_tmp"
+mv -f "$env_tmp" "$coordinator_env"
+chmod 0600 "$coordinator_env"
+
+if [[ -e "$runner_dir/.runner" ]]; then
+  echo "$runner_dir is already configured; refusing to replace it" >&2
+  exit 1
+fi
+mkdir -p "$runner_dir"
+archive="$runner_dir/actions-runner.tar.gz"
+curl --fail --location --retry 3 --output "$archive" \
+  "https://github.com/actions/runner/releases/download/v${runner_version}/actions-runner-linux-x64-${runner_version}.tar.gz"
+printf '%s  %s\n' "$runner_sha256" "$archive" | sha256sum --check --status
+tar -xzf "$archive" -C "$runner_dir"
+rm -f "$archive"
+
+mkdir -p "$runner_dir/hooks" "$runner_dir/_diag"
+install -m 0755 -o root -g root \
+  "$job_hook" "$runner_dir/hooks/job-started.sh"
+
+cat >"$runner_dir/.env" <<EOF
+ACTIONS_RUNNER_HOOK_JOB_STARTED=$runner_dir/hooks/job-started.sh
+BREV_INSTANCE=$local_instance
+SKILL_EVAL_ENV_FILE=$coordinator_env
+SKILL_EVAL_LOCAL_GPU_INSTANCE=$local_instance
+SKILL_EVAL_NVIDIA_PIN=$nvidia_pin
+EOF
+chmod 0600 "$runner_dir/.env"
+
+export RUNNER_ALLOW_RUNASROOT=1
+(
+  cd "$runner_dir"
+  ./config.sh \
+    --unattended \
+    --url "$repo_url" \
+    --token "$registration_token" \
+    --name "$runner_name" \
+    --labels "$runner_labels" \
+    --work _work
+)
+unset registration_token
+
+install -d -m 0755 -o root -g root /etc/vss-skill-eval
+printf '%s\n' "$runner_name" >/etc/vss-skill-eval/direct-gpu-runner
+chmod 0644 /etc/vss-skill-eval/direct-gpu-runner
+rm -f /etc/vss-skill-eval/direct-gpu-runner.enabled
+
+cat >"$runner_dir/launch.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$runner_dir"
+exec env -i \
+  HOME=/root \
+  USER=root \
+  LOGNAME=root \
+  LANG=C.UTF-8 \
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  RUNNER_ALLOW_RUNASROOT=1 \
+  ./run.sh
+EOF
+chmod 0755 "$runner_dir/launch.sh"
+
+install -m 0755 -o root -g root "$supervisor" "$runner_dir/supervise.sh"
+
+install -m 0644 -o root -g root \
+  "$service_unit" /etc/systemd/system/vss-skill-eval-gpu-runner.service
+systemctl stop vss-skill-eval-gpu-runner.service 2>/dev/null || true
+for pid in $(pgrep -f \
+  "$runner_dir/(supervise[.]sh|run[.]sh|bin/Runner[.]Listener run)" || true)
+do
+  kill -TERM "$pid" 2>/dev/null || true
+done
+sleep 2
+systemctl daemon-reload
+systemctl enable --now vss-skill-eval-gpu-runner.service
+
+for _ in $(seq 1 30); do
+  if systemctl is-active --quiet vss-skill-eval-gpu-runner.service \
+    && pgrep -f "$runner_dir/bin/Runner[.]Listener run" >/dev/null
+  then
+    echo "runner started: $runner_name"
+    echo "runner is staged; create /etc/vss-skill-eval/direct-gpu-runner.enabled after legacy jobs drain"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "runner listener failed to start" >&2
+exit 1

--- a/.github/skill-eval/install-local-gpu-runner.sh
+++ b/.github/skill-eval/install-local-gpu-runner.sh
@@ -7,7 +7,7 @@
 # Example:
 #   printf '%s\n' "$TOKEN" | sudo ./install-local-gpu-runner.sh \
 #     --repo-url https://github.com/org/repo --runner-name gpu-1 \
-#     --labels vss-skill-eval-gpu,gpu-nvidia-rtx-pro-6000-blackwell,gpu-count-2,gpu-node-pro-1 \
+#     --labels vss-skill-eval-gpu,vss-eval,gpu-rtxpro6000bw,gpus-1,gpus-2,gpu-nvidia-rtx-pro-6000-blackwell,gpu-count-2,gpu-node-pro-1 \
 #     --local-instance gpu-1 --runner-version 2.336.0 \
 #     --runner-sha256 <published-linux-x64-sha256> \
 #     --nvidia-pin 580.105.08
@@ -67,8 +67,8 @@ if [[ ! "$nvidia_pin" =~ ^[0-9]+([.][0-9]+){1,3}$ ]]; then
   echo "--nvidia-pin must be a numeric driver version" >&2
   exit 2
 fi
-for command in curl docker flock install nvidia-ctk nvidia-smi pgrep python3 \
-  sha256sum systemctl tar
+for command in curl docker flock install mountpoint nvidia-ctk nvidia-smi \
+  pgrep python3 sha256sum systemctl tar
 do
   command -v "$command" >/dev/null || {
     echo "missing required command: $command" >&2
@@ -108,9 +108,11 @@ gpu_count="${#gpu_names[@]}"
 case "${gpu_names[0]}" in
   *"RTX PRO 6000 Blackwell"*)
     expected_model_label="gpu-nvidia-rtx-pro-6000-blackwell"
+    scheduling_model_label="gpu-rtxpro6000bw"
     ;;
   *"GeForce RTX 4090"*)
     expected_model_label="gpu-nvidia-geforce-rtx-4090"
+    scheduling_model_label="gpu-rtx4090"
     ;;
   *)
     echo "unsupported local GPU model: ${gpu_names[0]}" >&2
@@ -125,8 +127,16 @@ for gpu_name in "${gpu_names[@]}"; do
 done
 label_set=",$runner_labels,"
 for required_label in \
-  vss-skill-eval-gpu "$expected_model_label" "gpu-count-$gpu_count"
+  vss-skill-eval-gpu vss-eval "$scheduling_model_label" \
+  "$expected_model_label" "gpu-count-$gpu_count"
 do
+  [[ "$label_set" == *",$required_label,"* ]] || {
+    echo "runner labels must include $required_label" >&2
+    exit 2
+  }
+done
+for count in $(seq 1 "$gpu_count"); do
+  required_label="gpus-$count"
   [[ "$label_set" == *",$required_label,"* ]] || {
     echo "runner labels must include $required_label" >&2
     exit 2
@@ -163,6 +173,10 @@ allowed = {
     "NGC_CLI_API_KEY",
     "NVIDIA_API_KEY",
     "RTSP_SAMPLE_URL",
+    "SKILL_EVAL_VIEWER_BASE_URL",
+    "SKILL_EVAL_VIEWER_RETENTION_DAYS",
+    "SKILL_EVAL_VIEWER_ROOT",
+    "SKILL_EVAL_VIEWER_SHARED",
     "VLM_REMOTE_MODEL",
     "VLM_REMOTE_URL",
 }
@@ -187,6 +201,59 @@ chmod 0600 "$env_tmp"
 mv -f "$env_tmp" "$coordinator_env"
 chmod 0600 "$coordinator_env"
 
+# Viewer option B is a hard activation gate for direct runners: a private
+# shared POSIX/NFS mount served by one central Harbor viewer on Brev/NetBird.
+# Read in an isolated shell so API keys from the coordinator file never enter
+# the installer/config.sh environment. Copy only these non-secret values into
+# the runner's own .env for the job-started preflight.
+mapfile -t viewer_config < <(
+  bash -c '
+    set -a
+    # shellcheck source=/dev/null
+    source "$1"
+    printf "%s\n" \
+      "${SKILL_EVAL_VIEWER_ROOT:-}" \
+      "${SKILL_EVAL_VIEWER_BASE_URL:-}" \
+      "${SKILL_EVAL_VIEWER_SHARED:-}" \
+      "${SKILL_EVAL_VIEWER_RETENTION_DAYS:-}"
+  ' _ "$coordinator_env"
+)
+((${#viewer_config[@]} == 4)) || {
+  echo "viewer configuration contains invalid newlines" >&2
+  exit 2
+}
+viewer_root="${viewer_config[0]}"
+viewer_base_url="${viewer_config[1]}"
+viewer_shared="${viewer_config[2]}"
+viewer_retention_days="${viewer_config[3]}"
+[[ "$viewer_root" =~ ^/[A-Za-z0-9._/-]+$ ]] || {
+  echo "SKILL_EVAL_VIEWER_ROOT must be a safe absolute path" >&2
+  exit 2
+}
+[[ "$viewer_base_url" =~ ^https?://[^[:space:]]+$ \
+  && "$viewer_base_url" != *"@"* ]] || {
+  echo "SKILL_EVAL_VIEWER_BASE_URL must be an http(s) URL" >&2
+  exit 2
+}
+[[ "$viewer_shared" == "1" ]] || {
+  echo "direct runners require SKILL_EVAL_VIEWER_SHARED=1" >&2
+  exit 2
+}
+if [[ ! "$viewer_retention_days" =~ ^[0-9]+$ ]] \
+  || ((10#$viewer_retention_days < 1 || 10#$viewer_retention_days > 3650))
+then
+  echo "SKILL_EVAL_VIEWER_RETENTION_DAYS must be 1..3650" >&2
+  exit 2
+fi
+test -d "$viewer_root" || {
+  echo "shared viewer root is not a directory: $viewer_root" >&2
+  exit 1
+}
+mountpoint -q "$viewer_root" || {
+  echo "shared viewer root is not mounted: $viewer_root" >&2
+  exit 1
+}
+
 if [[ -e "$runner_dir/.runner" ]]; then
   echo "$runner_dir is already configured; refusing to replace it" >&2
   exit 1
@@ -209,6 +276,10 @@ BREV_INSTANCE=$local_instance
 SKILL_EVAL_ENV_FILE=$coordinator_env
 SKILL_EVAL_LOCAL_GPU_INSTANCE=$local_instance
 SKILL_EVAL_NVIDIA_PIN=$nvidia_pin
+SKILL_EVAL_VIEWER_BASE_URL=$viewer_base_url
+SKILL_EVAL_VIEWER_RETENTION_DAYS=$viewer_retention_days
+SKILL_EVAL_VIEWER_ROOT=$viewer_root
+SKILL_EVAL_VIEWER_SHARED=1
 EOF
 chmod 0600 "$runner_dir/.env"
 

--- a/.github/skill-eval/local-gpu-job-started.sh
+++ b/.github/skill-eval/local-gpu-job-started.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+enable_marker="/etc/vss-skill-eval/direct-gpu-runner.enabled"
+if [[ ! -e "$enable_marker" ]]; then
+  echo "direct GPU runner is staged but not activated; legacy jobs must drain first" >&2
+  exit 1
+fi
+
+# During cutover, fail closed if a legacy coordinator still has an agent
+# connected over SSH. Do not let local startup cleanup tear down that trial.
+for agent_pid in $(pgrep -f \
+  '[c]laude --verbose --output-format=stream-json|[c]odex exec' || true)
+do
+  ancestor="$agent_pid"
+  for _ in $(seq 1 8); do
+    ancestor="$(ps -o ppid= -p "$ancestor" | tr -d ' ')"
+    [[ -n "$ancestor" && "$ancestor" != 0 ]] || break
+    if [[ "$(ps -o comm= -p "$ancestor")" == sshd ]]; then
+      echo "legacy remote skill-eval is still active; refusing local overlap" >&2
+      exit 1
+    fi
+  done
+done
+
+# Skill trials can install a newer NVIDIA userspace package than the OpenShell
+# guest's loaded module. Restore the staged matching libraries before admission.
+nvidia_status=0
+nvidia_output="$(nvidia-smi 2>&1)" || nvidia_status=$?
+if ((nvidia_status != 0)); then
+  if [[ "$nvidia_output" != *"Driver/library version mismatch"* ]]; then
+    printf '%s\n' "$nvidia_output" >&2
+    echo "nvidia-smi failed for a reason that is unsafe to auto-repair" >&2
+    exit "$nvidia_status"
+  fi
+  if [[ -z "${SKILL_EVAL_NVIDIA_PIN:-}" ]]; then
+    echo "NVIDIA userspace mismatch detected but no pinned driver was configured" >&2
+    exit 1
+  fi
+
+  cd /usr/lib/x86_64-linux-gnu
+  test -s "libnvidia-ml.so.${SKILL_EVAL_NVIDIA_PIN}"
+  test -s "libcuda.so.${SKILL_EVAL_NVIDIA_PIN}"
+  old_nvml_link="$(readlink libnvidia-ml.so.1 2>/dev/null || true)"
+  old_cuda_link="$(readlink libcuda.so.1 2>/dev/null || true)"
+  quarantine="/var/lib/vss-skill-eval/nvidia-quarantine/$(date +%s)-$$"
+  mkdir -p "$quarantine"
+  candidates=()
+  for library in libnvidia-*.so.* libcuda.so.*; do
+    [[ -f "$library" && ! -L "$library" ]] || continue
+    if [[ "$library" =~ \.so\.([0-9]{3}([.][0-9]+)+)$ ]]; then
+      version="${BASH_REMATCH[1]}"
+      [[ "$version" != "$SKILL_EVAL_NVIDIA_PIN" ]] || continue
+      pinned_library="${library%."$version"}.${SKILL_EVAL_NVIDIA_PIN}"
+      if [[ ! -s "$pinned_library" ]]; then
+        echo "cannot safely replace $library: missing $pinned_library" >&2
+        exit 1
+      fi
+      candidates+=("$library")
+    fi
+  done
+
+  repair_status=0
+  for library in "${candidates[@]}"; do
+    mv -- "$library" "$quarantine/" || {
+      repair_status=$?
+      break
+    }
+  done
+  if ((repair_status == 0)); then
+    ln -sfn "libnvidia-ml.so.${SKILL_EVAL_NVIDIA_PIN}" \
+      libnvidia-ml.so.1 || repair_status=$?
+  fi
+  if ((repair_status == 0)); then
+    ln -sfn "libcuda.so.${SKILL_EVAL_NVIDIA_PIN}" \
+      libcuda.so.1 || repair_status=$?
+  fi
+  if ((repair_status == 0)); then
+    ldconfig || repair_status=$?
+  fi
+  if ((repair_status == 0)); then
+    nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml \
+      --disable-hooks enable-cuda-compat >/dev/null 2>&1 \
+      || repair_status=$?
+  fi
+  if ((repair_status == 0)); then
+    nvidia_output="$(nvidia-smi 2>&1)" || repair_status=$?
+  fi
+
+  if ((repair_status != 0)); then
+    for library in "$quarantine"/*; do
+      [[ -e "$library" ]] || continue
+      mv -f -- "$library" . || true
+    done
+    if [[ -n "$old_nvml_link" ]]; then
+      ln -sfn "$old_nvml_link" libnvidia-ml.so.1 || true
+    else
+      rm -f libnvidia-ml.so.1 || true
+    fi
+    if [[ -n "$old_cuda_link" ]]; then
+      ln -sfn "$old_cuda_link" libcuda.so.1 || true
+    else
+      rm -f libcuda.so.1 || true
+    fi
+    ldconfig || true
+    printf '%s\n' "$nvidia_output" >&2
+    echo "pinned NVIDIA recovery failed; restored quarantined libraries" >&2
+    exit "$repair_status"
+  fi
+fi
+
+nvidia-smi --query-gpu=index,name,driver_version --format=csv,noheader
+docker info >/dev/null

--- a/.github/skill-eval/local-gpu-job-started.sh
+++ b/.github/skill-eval/local-gpu-job-started.sh
@@ -9,6 +9,51 @@ if [[ ! -e "$enable_marker" ]]; then
   exit 1
 fi
 
+# Harbor viewer parity is a hard admission gate for direct GPU runners.
+# Option B requires the exact configured path to be a private shared POSIX/NFS
+# mount behind Brev/NetBird, served by one central `harbor view` process.
+: "${SKILL_EVAL_VIEWER_ROOT:?direct runner requires SKILL_EVAL_VIEWER_ROOT}"
+: "${SKILL_EVAL_VIEWER_BASE_URL:?direct runner requires SKILL_EVAL_VIEWER_BASE_URL}"
+: "${SKILL_EVAL_VIEWER_RETENTION_DAYS:?direct runner requires SKILL_EVAL_VIEWER_RETENTION_DAYS}"
+[[ "${SKILL_EVAL_VIEWER_SHARED:-}" == "1" ]] || {
+  echo "direct runner requires SKILL_EVAL_VIEWER_SHARED=1" >&2
+  exit 1
+}
+[[ "$SKILL_EVAL_VIEWER_ROOT" == /* ]] || {
+  echo "SKILL_EVAL_VIEWER_ROOT must be absolute" >&2
+  exit 1
+}
+[[ "$SKILL_EVAL_VIEWER_BASE_URL" =~ ^https?://[^[:space:]]+$ \
+  && "$SKILL_EVAL_VIEWER_BASE_URL" != *"@"* ]] || {
+  echo "SKILL_EVAL_VIEWER_BASE_URL must be an http(s) URL" >&2
+  exit 1
+}
+if [[ ! "$SKILL_EVAL_VIEWER_RETENTION_DAYS" =~ ^[0-9]+$ ]] \
+  || ((10#$SKILL_EVAL_VIEWER_RETENTION_DAYS < 1)) \
+  || ((10#$SKILL_EVAL_VIEWER_RETENTION_DAYS > 3650))
+then
+  echo "SKILL_EVAL_VIEWER_RETENTION_DAYS must be 1..3650" >&2
+  exit 1
+fi
+test -d "$SKILL_EVAL_VIEWER_ROOT"
+mountpoint -q "$SKILL_EVAL_VIEWER_ROOT" || {
+  echo "shared Harbor viewer root is not mounted: $SKILL_EVAL_VIEWER_ROOT" >&2
+  exit 1
+}
+viewer_probe="$(mktemp "$SKILL_EVAL_VIEWER_ROOT/.vss-viewer-hook.XXXXXX")"
+cleanup_viewer_probe() {
+  rm -f "$viewer_probe"
+}
+trap cleanup_viewer_probe EXIT
+viewer_probe_payload="vss-viewer-hook:$$:$(date +%s)"
+printf '%s\n' "$viewer_probe_payload" >"$viewer_probe"
+[[ "$(<"$viewer_probe")" == "$viewer_probe_payload" ]] || {
+  echo "shared Harbor viewer write/read probe failed" >&2
+  exit 1
+}
+rm -f "$viewer_probe"
+trap - EXIT
+
 # During cutover, fail closed if a legacy coordinator still has an agent
 # connected over SSH. Do not let local startup cleanup tear down that trial.
 for agent_pid in $(pgrep -f \

--- a/.github/skill-eval/local-gpu-runner-supervise.sh
+++ b/.github/skill-eval/local-gpu-runner-supervise.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -u
+
+while true; do
+  /opt/actions-runner/launch.sh
+  rc=$?
+  printf 'runner exited rc=%s; restarting in 10 seconds\n' "$rc" >&2
+  sleep 10
+done

--- a/.github/skill-eval/local-gpu-runner.service
+++ b/.github/skill-eval/local-gpu-runner.service
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=VSS skill-eval GitHub Actions GPU runner
+Wants=network-online.target
+After=network-online.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/actions-runner
+ExecStart=/opt/actions-runner/supervise.sh
+Restart=always
+RestartSec=10s
+KillMode=control-group
+TimeoutStopSec=5min
+
+[Install]
+WantedBy=multi-user.target

--- a/.github/skill-eval/plan_matrix.py
+++ b/.github/skill-eval/plan_matrix.py
@@ -24,13 +24,11 @@ A skill whose adapter is missing collapses to a single `missing_adapter`
 leg (that leg's agent commits the one adapter to the PR branch), so N specs
 of an adapterless skill don't race to commit it N times.
 
-Each leg also carries `runs_on`: the runner label set implied by the
-spec's own `resources.platforms.<PLATFORM>` block (see runs_on_labels).
-This resolves the spec -> hardware mapping at PLAN time, where today
-run_leg.py re-derives it at LEG time from `brev ls` under a flock.
-Nothing consumes `runs_on` yet — it is emitted so the mapping can be
-reviewed against current placement before the GPU boxes are registered
-as runners in their own right.
+Each leg carries `runs_on`, following PR #1449's scheduler contract:
+`self-hosted,vss-eval`, an optional `gpu-*` model label, and a `gpus-N`
+demand label. Current direct-runner coverage is intentionally limited to
+the installed RTX PRO 6000 Blackwell / RTX 4090 fleet; other platforms
+retain the coordinator path.
 
 Env:
     PR_BASE        base branch, e.g. develop (diffed as FETCH_HEAD...HEAD)
@@ -67,48 +65,25 @@ ADAPTER_RE = re.compile(r"^\.github/skill-eval/adapters/([^/]+)/")
 # corrupting an artifact name or escaping a path.
 SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
-# GPU-hosted Actions runners advertise both their physical hardware and their
-# skill-eval purpose. Keep unsupported platforms on the existing coordinator
-# pool: those jobs still need run_leg.py to select a separate Brev machine.
+# PR #1449's common direct-runner contract. A two-GPU runner advertises both
+# `gpus-1` and `gpus-2`; the matrix label is demand, not physical capacity.
+BASE_GPU_RUNNER_LABELS = [
+    "self-hosted",
+    "vss-eval",
+]
 COORDINATOR_RUNNER_LABELS = [
     "self-hosted",
     "vss-skill-eval-runner",
 ]
-GPU_RUNNER_LABELS = {
-    # The current RTX PRO fleet has two GPUs per VM. A one-GPU requirement can
-    # safely run there too; the label describes physical capacity, not the
-    # minimum requested by the spec.
-    "RTXPRO6000BW": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "vss-skill-eval-gpu",
-        "gpu-nvidia-rtx-pro-6000-blackwell",
-        "gpu-count-2",
-    ],
-    # GPU-independent/ANY legs use the one-GPU RTX 4090 partition so the RTX
-    # PRO machines remain available for two-GPU specs.
-    "ANY": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "vss-skill-eval-gpu",
-        "gpu-nvidia-geforce-rtx-4090",
-        "gpu-count-1",
-    ],
-    "RTX4090": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "vss-skill-eval-gpu",
-        "gpu-nvidia-geforce-rtx-4090",
-        "gpu-count-1",
-    ],
+DIRECT_PLATFORM_LABELS = {
+    "ANY": None,
+    "RTX4090": "gpu-rtx4090",
+    "RTXPRO6000BW": "gpu-rtxpro6000bw",
 }
-GPU_RUNNER_CAPACITY = {
-    "RTXPRO6000BW": 2,
-    "ANY": 1,
+DIRECT_PLATFORM_CAPACITY = {
+    "ANY": 2,
     "RTX4090": 1,
+    "RTXPRO6000BW": 2,
 }
 
 # `evals.json` (plural stem) is a legacy aggregate index — a JSON *array* of
@@ -118,94 +93,6 @@ GPU_RUNNER_CAPACITY = {
 # routing.json, …). Skip `evals.json` everywhere a spec is discovered so it
 # never becomes a matrix leg.
 EXCLUDED_SPEC_NAMES = frozenset({"evals.json"})
-
-# --- Runner labels -----------------------------------------------------
-# Every leg carries a `runs_on` label set derived from the spec's own
-# hardware declaration, so the eval job *can* be placed by Actions with
-# `runs-on: ${{ matrix.runs_on }}` once the GPU boxes are registered as
-# runners in their own right. NOTHING CONSUMES THIS YET — skills-eval.yml
-# still pins the coordinator pool and run_leg.py still does fleet
-# selection + flock. This computes and publishes the mapping so it can be
-# reviewed and diffed against today's placement before any runner moves.
-
-# Labels the GPU boxes themselves would carry. Deliberately NOT
-# `vss-skill-eval-runner`: that label is on the coordinator's runner
-# processes, which are not the machines the trials run on.
-BASE_LABELS: tuple[str, ...] = ("self-hosted", "vss-eval")
-
-# `resources.platforms` key -> GPU-type label. `ANY` is GPU-independent
-# and contributes no `gpu-*` label. Keys mirror the PLATFORMS tables in
-# .github/skill-eval/adapters/*/generate.py.
-PLATFORM_LABELS: dict[str, str | None] = {
-    "H100": "gpu-h100",
-    "L40S": "gpu-l40s",
-    "RTXPRO6000BW": "gpu-rtxpro6000bw",
-    "DGX-SPARK": "gpu-dgx-spark",
-    "IGX-THOR": "gpu-igx-thor",
-    "ANY": None,
-}
-
-# run_leg.pool_candidates reads `int(metadata.get("gpu_count", 1) or 0)`:
-# an ABSENT declaration means one GPU, while an explicit 0/null means
-# GPU-independent. Mirror both so a label set places a leg exactly where
-# the runtime selector would have. 15 of the 50 platform entries in
-# skills/*/evals/ omit gpu_count today and rely on this default.
-DEFAULT_GPU_COUNT = 1
-
-
-def _platform_label(platform: str) -> str | None:
-    """GPU-type label for a `resources.platforms` key."""
-    if platform in PLATFORM_LABELS:
-        return PLATFORM_LABELS[platform]
-    # Unknown key: still emit something deterministic, but say so — a
-    # typo'd platform would otherwise produce a label no box carries and
-    # the job would queue until GitHub cancels it at 24 h.
-    slug = re.sub(r"[^a-z0-9]+", "-", platform.lower()).strip("-")
-    print(
-        f"warning: unknown platform {platform!r} — no entry in "
-        f"PLATFORM_LABELS; emitting {'gpu-' + slug if slug else '(none)'}",
-        file=sys.stderr,
-    )
-    return f"gpu-{slug}" if slug else None
-
-
-def _gpu_count(config: dict) -> int:
-    """Declared GPU demand, matching run_leg's coercion exactly."""
-    raw = config.get("gpu_count", DEFAULT_GPU_COUNT)
-    try:
-        return max(0, int(raw))
-    except (TypeError, ValueError):
-        # Explicit null / "" / garbage -> 0, same as run_leg's `or 0`.
-        return 0
-
-
-def runs_on_labels(platform: str, config: dict | None) -> list[str]:
-    """Runner labels for one leg, from the spec's hardware declaration.
-
-    `gpus-N` is a *demand*: the job asks for exactly N. A box advertises
-    every count it can satisfy — a 2-GPU box carries both `gpus-1` and
-    `gpus-2` — which is how pool_candidates' "over-provisioned boxes
-    remain valid" rule survives a static label set.
-
-    `gpu_count: 0` means GPU-independent and drops BOTH the `gpus-*` and
-    the `gpu-*` label, so the leg can land on any box. That mirrors
-    pool_candidates exactly: its type filter is guarded by
-    `if required_count > 0 and required_type`, so a zero-GPU spec ignores
-    the declared platform and "accepts any RUNNING box". 7 of the 50
-    platform entries are zero-GPU today (the ANY specs, and
-    detection-tracking-3d/routing on RTXPRO6000BW) — under labels they
-    stop competing for GPU boxes at all.
-    """
-    labels = list(BASE_LABELS)
-    count = _gpu_count(config) if config is not None else DEFAULT_GPU_COUNT
-    if count <= 0:
-        return labels
-    if platform:
-        label = _platform_label(platform)
-        if label:
-            labels.append(label)
-    labels.append(f"gpus-{count}")
-    return labels
 
 
 def list_changed_files() -> list[str]:
@@ -331,26 +218,40 @@ def spec_platforms(spec_path: str) -> list[str]:
     return sorted(spec_platform_config(spec_path))
 
 
-def spec_gpu_count(spec_path: str, platform: str) -> int | None:
-    """Required GPU count for one platform, or None for malformed input."""
-    try:
-        data = json.loads((REPO_ROOT / spec_path).read_text())
-        requirement = data["resources"]["platforms"][platform]
-        return int(requirement.get("gpu_count", 1))
-    except (KeyError, OSError, TypeError, ValueError):
-        return None
+def _gpu_count(config: dict) -> int:
+    """Validated GPU demand; absent means one, explicit null/empty means zero."""
+    raw = config.get("gpu_count", 1)
+    if raw is None or raw == "":
+        return 0
+    if isinstance(raw, bool):
+        raise TypeError(f"gpu_count must be an integer, got {raw!r}")
+    if isinstance(raw, int):
+        count = raw
+    elif isinstance(raw, str) and re.fullmatch(r"[+-]?\d+", raw.strip()):
+        count = int(raw)
+    else:
+        raise TypeError(f"gpu_count must be an integer, got {raw!r}")
+    if count < 0:
+        raise ValueError(f"gpu_count must be non-negative, got {count}")
+    return count
 
 
-def runner_labels(platform: str, required_gpu_count: int | None) -> list[str]:
-    """Actions labels for a platform, with fail-safe coordinator fallback."""
-    capacity = GPU_RUNNER_CAPACITY.get(platform)
-    if (
-        capacity is None
-        or required_gpu_count is None
-        or required_gpu_count > capacity
-    ):
+def runs_on_labels(platform: str, config: dict | None) -> list[str]:
+    """PR #1449 scheduler labels, with coordinator fallback for unsupported GPUs."""
+    if not platform or config is None:
         return list(COORDINATOR_RUNNER_LABELS)
-    return list(GPU_RUNNER_LABELS.get(platform, COORDINATOR_RUNNER_LABELS))
+    count = _gpu_count(config)
+    if count == 0:
+        return list(BASE_GPU_RUNNER_LABELS)
+    capacity = DIRECT_PLATFORM_CAPACITY.get(platform)
+    if capacity is None or count > capacity:
+        return list(COORDINATOR_RUNNER_LABELS)
+    labels = list(BASE_GPU_RUNNER_LABELS)
+    model_label = DIRECT_PLATFORM_LABELS[platform]
+    if model_label:
+        labels.append(model_label)
+    labels.append(f"gpus-{count}")
+    return labels
 
 
 def build_matrix(changed: list[str]) -> list[dict]:
@@ -415,13 +316,12 @@ def build_matrix(changed: list[str]) -> list[dict]:
                 "spec_stem": "missing-adapter",
                 "platform": "",
                 "kind": "missing_adapter",
-                "runner_labels": runner_labels("", None),
+                # No trial runs; keep adapter generation on the coordinator.
+                "runs_on": list(COORDINATOR_RUNNER_LABELS),
                 # `slug` is the unique per-leg key: path scope + artifact
                 # name. For a real trial it's skill__spec_stem__platform.
                 "slug": f"{skill}__missing-adapter",
                 "name": f"{skill} · missing-adapter",
-                # Commits an adapter; runs no trial and needs no GPU.
-                "runs_on": list(BASE_LABELS),
             })
             continue
         for meta in sorted(by_skill[skill], key=lambda m: m["spec_path"]):
@@ -429,9 +329,6 @@ def build_matrix(changed: list[str]) -> list[dict]:
             platforms = sorted(platform_config) or [""]
             for platform in platforms:
                 plat_tag = platform or "no-platform"
-                required_gpu_count = spec_gpu_count(
-                    meta["spec_path"], platform
-                )
                 include.append({
                     "skill": skill,
                     "spec_path": meta["spec_path"],
@@ -439,14 +336,12 @@ def build_matrix(changed: list[str]) -> list[dict]:
                     "eval_dir": meta["eval_dir"],
                     "platform": platform,
                     "kind": "eval",
-                    "runner_labels": runner_labels(
-                        platform, required_gpu_count
+                    "runs_on": runs_on_labels(
+                        platform,
+                        platform_config.get(platform),
                     ),
                     "slug": f"{skill}__{meta['spec_stem']}__{plat_tag}",
                     "name": f"{skill} · {meta['spec_stem']} · {plat_tag}",
-                    "runs_on": runs_on_labels(
-                        platform, platform_config.get(platform)
-                    ),
                 })
     return include
 
@@ -494,11 +389,8 @@ def emit(include: list[dict]) -> None:
     print(f"has_targets={has_targets}")
     print(f"legs={len(include)}")
     for leg in include:
-        # runs_on is trace only and nothing consumes it yet, so a leg built
-        # without it must not fail the plan — unlike slug, which is checked
-        # strictly above because downstream paths depend on it.
-        runs_on = " ".join(leg.get("runs_on") or []) or "-"
-        print(f"  - {leg['name']}  [{leg['kind']}]  runs_on={runs_on}")
+        labels = " ".join(leg.get("runs_on") or []) or "-"
+        print(f"  - {leg['name']}  [{leg['kind']}]  runs_on={labels}")
     print(f"matrix={matrix}")
 
 

--- a/.github/skill-eval/plan_matrix.py
+++ b/.github/skill-eval/plan_matrix.py
@@ -67,6 +67,50 @@ ADAPTER_RE = re.compile(r"^\.github/skill-eval/adapters/([^/]+)/")
 # corrupting an artifact name or escaping a path.
 SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
+# GPU-hosted Actions runners advertise both their physical hardware and their
+# skill-eval purpose. Keep unsupported platforms on the existing coordinator
+# pool: those jobs still need run_leg.py to select a separate Brev machine.
+COORDINATOR_RUNNER_LABELS = [
+    "self-hosted",
+    "vss-skill-eval-runner",
+]
+GPU_RUNNER_LABELS = {
+    # The current RTX PRO fleet has two GPUs per VM. A one-GPU requirement can
+    # safely run there too; the label describes physical capacity, not the
+    # minimum requested by the spec.
+    "RTXPRO6000BW": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "vss-skill-eval-gpu",
+        "gpu-nvidia-rtx-pro-6000-blackwell",
+        "gpu-count-2",
+    ],
+    # GPU-independent/ANY legs use the one-GPU RTX 4090 partition so the RTX
+    # PRO machines remain available for two-GPU specs.
+    "ANY": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "vss-skill-eval-gpu",
+        "gpu-nvidia-geforce-rtx-4090",
+        "gpu-count-1",
+    ],
+    "RTX4090": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "vss-skill-eval-gpu",
+        "gpu-nvidia-geforce-rtx-4090",
+        "gpu-count-1",
+    ],
+}
+GPU_RUNNER_CAPACITY = {
+    "RTXPRO6000BW": 2,
+    "ANY": 1,
+    "RTX4090": 1,
+}
+
 # `evals.json` (plural stem) is a legacy aggregate index — a JSON *array* of
 # scenarios, not a dispatchable spec object. It has no `resources.platforms`,
 # so spec_platforms() would choke on it (list has no .get), and the agent can't
@@ -287,6 +331,28 @@ def spec_platforms(spec_path: str) -> list[str]:
     return sorted(spec_platform_config(spec_path))
 
 
+def spec_gpu_count(spec_path: str, platform: str) -> int | None:
+    """Required GPU count for one platform, or None for malformed input."""
+    try:
+        data = json.loads((REPO_ROOT / spec_path).read_text())
+        requirement = data["resources"]["platforms"][platform]
+        return int(requirement.get("gpu_count", 1))
+    except (KeyError, OSError, TypeError, ValueError):
+        return None
+
+
+def runner_labels(platform: str, required_gpu_count: int | None) -> list[str]:
+    """Actions labels for a platform, with fail-safe coordinator fallback."""
+    capacity = GPU_RUNNER_CAPACITY.get(platform)
+    if (
+        capacity is None
+        or required_gpu_count is None
+        or required_gpu_count > capacity
+    ):
+        return list(COORDINATOR_RUNNER_LABELS)
+    return list(GPU_RUNNER_LABELS.get(platform, COORDINATOR_RUNNER_LABELS))
+
+
 def build_matrix(changed: list[str]) -> list[dict]:
     # Explicitly-changed specs vs. skills pulled in wholesale by a non-spec
     # (or adapter) change. A spec reached by both paths appears once.
@@ -349,6 +415,7 @@ def build_matrix(changed: list[str]) -> list[dict]:
                 "spec_stem": "missing-adapter",
                 "platform": "",
                 "kind": "missing_adapter",
+                "runner_labels": runner_labels("", None),
                 # `slug` is the unique per-leg key: path scope + artifact
                 # name. For a real trial it's skill__spec_stem__platform.
                 "slug": f"{skill}__missing-adapter",
@@ -362,6 +429,9 @@ def build_matrix(changed: list[str]) -> list[dict]:
             platforms = sorted(platform_config) or [""]
             for platform in platforms:
                 plat_tag = platform or "no-platform"
+                required_gpu_count = spec_gpu_count(
+                    meta["spec_path"], platform
+                )
                 include.append({
                     "skill": skill,
                     "spec_path": meta["spec_path"],
@@ -369,6 +439,9 @@ def build_matrix(changed: list[str]) -> list[dict]:
                     "eval_dir": meta["eval_dir"],
                     "platform": platform,
                     "kind": "eval",
+                    "runner_labels": runner_labels(
+                        platform, required_gpu_count
+                    ),
                     "slug": f"{skill}__{meta['spec_stem']}__{plat_tag}",
                     "name": f"{skill} · {meta['spec_stem']} · {plat_tag}",
                     "runs_on": runs_on_labels(

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -30,7 +30,6 @@ import errno
 import fcntl
 import json
 import os
-from pathlib import Path
 import re
 import shutil
 import signal
@@ -39,6 +38,7 @@ import sys
 import tempfile
 import time
 import urllib.parse
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_EVAL_PYTHON_VERSION = (3, 12)
@@ -972,7 +972,7 @@ def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
     cleanup_started = False
     previous_handlers: dict[signal.Signals, object] = {}
 
-    def forward_external_signal(signum, _frame):  # noqa: ANN001
+    def forward_external_signal(signum, _frame):
         nonlocal cleanup_started, pending_signal
         # Install before Popen to close the parent-signal race. If a signal
         # lands while Popen is still constructing the child, remember it and

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -344,6 +344,33 @@ def build_harbor_command(
 
 def harbor_env(instance: str) -> dict[str, str]:
     env = os.environ.copy()
+    # Harbor and the evaluated agent do not need GitHub's job/runner
+    # credentials. Keep only the non-secret GitHub identifiers used for
+    # result scoping; otherwise a tool call inside a trial can inherit the
+    # workflow token or Actions service credentials.
+    for key in tuple(env):
+        if (
+            key in {
+                "CI_ANTHROPIC_API_KEY",
+                "GH_CONFIG_DIR",
+                "GH_TOKEN",
+                "GITHUB_TOKEN",
+                "SYSTEM_ACCESSTOKEN",
+            }
+            or key.startswith("ACTIONS_")
+            or (
+                key.startswith("RUNNER_")
+                and key != "RUNNER_TRACKING_ID"
+            )
+            or (
+                key.startswith("GITHUB_")
+                and key not in {"GITHUB_RUN_ID", "GITHUB_WORKSPACE"}
+            )
+        ):
+            env.pop(key, None)
+    if env.get("SKILL_EVAL_LOCAL_GPU_INSTANCE"):
+        env.pop("SSH_AGENT_PID", None)
+        env.pop("SSH_AUTH_SOCK", None)
     workspace = env.get("GITHUB_WORKSPACE") or str(REPO_ROOT)
     skill_eval_path = str(Path(workspace) / ".github" / "skill-eval")
     pythonpath = env.get("PYTHONPATH", "")
@@ -367,6 +394,7 @@ def harbor_env(instance: str) -> dict[str, str]:
     env["BREV_TRANSFER_TOTAL_TIMEOUT_SEC"] = str(
         HARBOR_TRANSFER_OPERATION_BUDGET_SEC
     )
+    env["IS_SANDBOX"] = "1"
     return env
 
 
@@ -1058,6 +1086,10 @@ def _coordinator_env_id() -> str | None:
     Never derive this from `brev ls`: that yields a per-trial instance id,
     and the resulting URL points at a subdomain with no viewer behind it.
     """
+    if os.environ.get("SKILL_EVAL_LOCAL_GPU_INSTANCE"):
+        # Direct GPU runners publish normal workflow artifacts but do not
+        # host the coordinator's persistent harbor-view service.
+        return None
     env_id = os.environ.get("BREV_ENV_ID", "").strip()
     if env_id:
         return env_id

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -51,10 +51,14 @@ RTX4090_PREFIX = "vss-eval-geforce-rtx4090-"
 # its spec metadata declares gpu_type that matches GEFORCE RTX 4090.
 RTX4090_ALL_TESTS: frozenset[str] = frozenset()
 RTX4090_TESTS: dict[str, frozenset[str]] = {}
-# Shared root served by the coordinator's persistent `harbor-view.service`
-# (AGENTS.md § Harbor viewer). Fixed path — the viewer is started once for
-# the host, not per leg, so every leg publishes its trials in here.
+# Root served by `harbor view`. Coordinators retain the historical local
+# default. Direct GPU runners must override it with a private shared POSIX/NFS
+# mount and pass the activation preflight before they can accept a job.
 VIEWER_ROOT = Path("/tmp/skill-eval/results/_viewer")
+VIEWER_OWNER_MARKER = ".vss-skill-eval-viewer-job"
+VIEWER_ACTIVE_MARKER = ".vss-skill-eval-publishing"
+VIEWER_RETENTION_LOCK = ".vss-skill-eval-retention.lock"
+TRACE_FAILURES_FILE = "trace-publish-failures.tsv"
 
 # Harbor phase budgets. Adapters set the task's base agent timeout to the same
 # 600-second base used by Harbor for environment build and verification; these
@@ -466,6 +470,7 @@ def _list_brev_instances() -> list[dict]:
             proc = subprocess.run(
                 ["brev", "ls", "--json"],
                 capture_output=True, text=True, timeout=60,
+                check=False,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
             print(f"[run-leg] brev ls failed (attempt {attempt + 1}): {exc}", flush=True)
@@ -494,6 +499,7 @@ def _list_registered_nodes() -> list[dict]:
             proc = subprocess.run(
                 ["brev", "ls", "nodes", "--json"],
                 capture_output=True, text=True, timeout=60,
+                check=False,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
             print(
@@ -1103,6 +1109,131 @@ def _coordinator_env_id() -> str | None:
     return None
 
 
+def _viewer_root() -> Path:
+    configured = os.environ.get("SKILL_EVAL_VIEWER_ROOT", "").strip()
+    root = Path(configured) if configured else VIEWER_ROOT
+    if not root.is_absolute():
+        raise ValueError("SKILL_EVAL_VIEWER_ROOT must be an absolute path")
+    return root
+
+
+def _viewer_shared_requested() -> bool:
+    raw = os.environ.get("SKILL_EVAL_VIEWER_SHARED", "").strip()
+    if not raw:
+        return False
+    if raw not in {"0", "1"}:
+        raise ValueError("SKILL_EVAL_VIEWER_SHARED must be 0 or 1")
+    return raw == "1"
+
+
+def _viewer_retention_days() -> int | None:
+    raw = os.environ.get("SKILL_EVAL_VIEWER_RETENTION_DAYS", "").strip()
+    if not raw:
+        return None
+    try:
+        days = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            "SKILL_EVAL_VIEWER_RETENTION_DAYS must be an integer"
+        ) from exc
+    if not 1 <= days <= 3650:
+        raise ValueError(
+            "SKILL_EVAL_VIEWER_RETENTION_DAYS must be between 1 and 3650"
+        )
+    return days
+
+
+def _configured_viewer_base_url() -> str | None:
+    configured = os.environ.get("SKILL_EVAL_VIEWER_BASE_URL", "").strip()
+    if configured:
+        parsed = urllib.parse.urlsplit(configured)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                "SKILL_EVAL_VIEWER_BASE_URL must be an http(s) origin "
+                "without query or fragment"
+            )
+        return configured.rstrip("/")
+    if os.environ.get("SKILL_EVAL_LOCAL_GPU_INSTANCE"):
+        # A direct runner never derives a per-box URL. Its activation hook
+        # requires the central URL before the listener may accept work.
+        return None
+    env_id = _coordinator_env_id()
+    return f"https://harbor-{env_id}.brevlab.com" if env_id else None
+
+
+def preflight_viewer_storage(
+    root: Path | None = None,
+    *,
+    shared_required: bool | None = None,
+) -> Path:
+    """Validate viewer storage and perform a write/read/delete probe."""
+    root = root or _viewer_root()
+    shared = (
+        _viewer_shared_requested()
+        if shared_required is None
+        else shared_required
+    )
+    if shared:
+        if not root.is_dir():
+            raise RuntimeError(f"shared viewer root is not a directory: {root}")
+        if not os.path.ismount(root):
+            raise RuntimeError(f"shared viewer root is not a mount point: {root}")
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+
+    probe_path: Path | None = None
+    payload = f"vss-skill-eval-viewer-probe:{os.getpid()}:{time.time_ns()}\n"
+    try:
+        descriptor, name = tempfile.mkstemp(
+            prefix=".vss-viewer-probe-",
+            dir=root,
+        )
+        probe_path = Path(name)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if probe_path.read_text(encoding="utf-8") != payload:
+            raise RuntimeError(f"viewer storage readback mismatch: {root}")
+    except OSError as exc:
+        raise RuntimeError(f"viewer storage probe failed for {root}: {exc}") from exc
+    finally:
+        if probe_path is not None:
+            with contextlib.suppress(OSError):
+                probe_path.unlink()
+    return root
+
+
+def validate_direct_viewer_gate() -> None:
+    """Fail closed before direct-runner Harbor work without central viewer."""
+    if not os.environ.get("SKILL_EVAL_LOCAL_GPU_INSTANCE"):
+        return
+    if not os.environ.get("SKILL_EVAL_VIEWER_ROOT", "").strip():
+        raise RuntimeError(
+            "direct GPU runner requires SKILL_EVAL_VIEWER_ROOT"
+        )
+    if not _viewer_shared_requested():
+        raise RuntimeError(
+            "direct GPU runner requires SKILL_EVAL_VIEWER_SHARED=1"
+        )
+    if not _configured_viewer_base_url():
+        raise RuntimeError(
+            "direct GPU runner requires SKILL_EVAL_VIEWER_BASE_URL"
+        )
+    if _viewer_retention_days() is None:
+        raise RuntimeError(
+            "direct GPU runner requires SKILL_EVAL_VIEWER_RETENTION_DAYS"
+        )
+    preflight_viewer_storage(shared_required=True)
+
+
 def trace_url(result_json: Path, job_name: str) -> str | None:
     """Harbor viewer deep-link for one finished trial.
 
@@ -1116,8 +1247,8 @@ def trace_url(result_json: Path, job_name: str) -> str | None:
     That failure mode is indistinguishable from missing trace data, which is
     why the URL is built here instead of being assembled by hand.
     """
-    env_id = _coordinator_env_id()
-    if not env_id:
+    base_url = _configured_viewer_base_url()
+    if not base_url:
         return None
     try:
         data = json.loads(result_json.read_text())
@@ -1137,7 +1268,40 @@ def trace_url(result_json: Path, job_name: str) -> str | None:
     # safe="" so the slashes inside <model> and <task> encode as %2F — the
     # viewer expects them as single path segments, not extra path levels.
     encoded = "/".join(urllib.parse.quote(str(part), safe="") for part in parts)
-    return f"https://harbor-{env_id}.brevlab.com/jobs/{job_name}/tasks/{encoded}"
+    return f"{base_url}/jobs/{job_name}/tasks/{encoded}"
+
+
+def prune_viewer_root(
+    root: Path,
+    current_job: Path,
+    retention_days: int | None,
+) -> None:
+    """Delete only owned, inactive viewer jobs older than the opt-in policy."""
+    if retention_days is None:
+        return
+    cutoff = time.time() - retention_days * 86400
+    lock_path = root / VIEWER_RETENTION_LOCK
+    with lock_path.open("a") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        for candidate in root.iterdir():
+            if (
+                not candidate.is_dir()
+                or candidate == current_job
+                or candidate.name.startswith(".")
+                or not (candidate / VIEWER_OWNER_MARKER).is_file()
+                or (candidate / VIEWER_ACTIVE_MARKER).exists()
+            ):
+                continue
+            try:
+                if candidate.stat().st_mtime < cutoff:
+                    shutil.rmtree(candidate)
+                    print(
+                        f"[run-leg] viewer retention removed: {candidate}",
+                        flush=True,
+                    )
+            except FileNotFoundError:
+                # Another host may have removed it after our directory scan.
+                continue
 
 
 def publish_trace(
@@ -1164,13 +1328,21 @@ def publish_trace(
     trial_dir = max(matches, key=lambda path: path.stat().st_mtime)
     date_dir = trial_dir.parent
     job_name = f"{leg_slug}__{run_id}__{date_dir.name}"
-    viewer_job = VIEWER_ROOT / job_name
+    viewer_root = preflight_viewer_storage()
+    viewer_job = viewer_root / job_name
     viewer_job.mkdir(parents=True, exist_ok=True)
+    (viewer_job / VIEWER_OWNER_MARKER).touch(exist_ok=True)
+    active_marker = viewer_job / VIEWER_ACTIVE_MARKER
+    active_marker.touch(exist_ok=True)
     # Copy (never move) the date dir's *contents*: the workflow's "Collect
     # results" step runs after this and tars results_root for the artifact,
     # and copying the dir itself would nest a later trial under
     # <job>/<date>/ where the viewer cannot see it.
-    shutil.copytree(date_dir, viewer_job, dirs_exist_ok=True)
+    try:
+        shutil.copytree(date_dir, viewer_job, dirs_exist_ok=True)
+    finally:
+        with contextlib.suppress(OSError):
+            active_marker.unlink()
     url = trace_url(trial_dir / "result.json", job_name)
     if url:
         with (results_root / "trace-urls.tsv").open("a") as handle:
@@ -1181,7 +1353,54 @@ def publish_trace(
             f"[run-leg] trace: {invocation.include_task_name} -> {url}",
             flush=True,
         )
+    try:
+        prune_viewer_root(
+            viewer_root,
+            viewer_job,
+            _viewer_retention_days(),
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        # Retention is maintenance, not publication correctness. Keep the
+        # trace and surface the cleanup failure for the operator.
+        print(
+            f"[run-leg] WARNING: viewer retention failed: {exc!r}",
+            flush=True,
+        )
     return url
+
+
+def publish_trace_safely(
+    results_root: Path,
+    invocation: HarborInvocation,
+    started_at: float,
+    leg_slug: str,
+    run_id: str,
+) -> str | None:
+    """Publish a trace without changing the evaluation verdict on failure."""
+    try:
+        return publish_trace(
+            results_root,
+            invocation,
+            started_at,
+            leg_slug,
+            run_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        results_root.mkdir(parents=True, exist_ok=True)
+        marker = results_root / TRACE_FAILURES_FILE
+        detail = str(exc).replace("\t", " ").replace("\n", " ")
+        with marker.open("a", encoding="utf-8") as handle:
+            handle.write(
+                f"{invocation.include_task_name}\t"
+                f"{type(exc).__name__}\t{detail}\n"
+            )
+        print(
+            "::warning title=Harbor trace publication failed::"
+            f"{invocation.include_task_name}: {detail}",
+            flush=True,
+        )
+        print(f"[run-leg] trace failure marker: {marker}", flush=True)
+        return None
 
 
 def _reward_value(reward: str | None) -> float:
@@ -1227,6 +1446,11 @@ def run_invocations(
     harbor_timeout_sec: int,
     work_deadline: float | None = None,
 ) -> int:
+    try:
+        validate_direct_viewer_gate()
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"FATAL: central Harbor viewer gate failed: {exc}", file=sys.stderr)
+        return 1
     env = harbor_env(instance)
     agent = os.environ.get("EVAL_AGENT", "claude-code")
     # Reject unknown agents loudly — otherwise a typo (e.g. "Codex") would
@@ -1304,12 +1528,13 @@ def run_invocations(
         rc = run_command(cmd, env, harbor_timeout_sec)
         # Publish before the rc checks below: a timed-out (rc=124) trial
         # returns early, and its partial trace is exactly what needs reading.
-        try:
-            publish_trace(results_root, invocation, started_at, leg_slug, run_id)
-        except Exception as exc:  # noqa: BLE001
-            # A trace link is reporting convenience; the verdict comes from
-            # reward.txt. Never let a viewer-publish error fail the leg.
-            print(f"[run-leg] trace publish failed: {exc!r}", flush=True)
+        publish_trace_safely(
+            results_root,
+            invocation,
+            started_at,
+            leg_slug,
+            run_id,
+        )
         if rc != 0 and overall_rc == 0:
             overall_rc = rc
 
@@ -1412,9 +1637,9 @@ def main(argv: list[str] | None = None) -> int:
         if pinned:
             print(f"[run-leg] pinned instance: {pinned} (pool selection skipped)",
                   flush=True)
-            candidates_fn = lambda: [pinned]  # noqa: E731
+            candidates_fn = lambda: [pinned]
         else:
-            candidates_fn = (  # noqa: E731
+            candidates_fn = (
                 lambda: pool_candidates(metadata, args.spec_stem)
             )
         try:

--- a/.github/skill-eval/tests/test_gpu_runner_workflows.py
+++ b/.github/skill-eval/tests/test_gpu_runner_workflows.py
@@ -12,6 +12,7 @@ WORKFLOWS = (
     REPO_ROOT / ".github" / "workflows" / "skills-eval.yml",
     REPO_ROOT / ".github" / "workflows" / "skills-eval-daily.yml",
 )
+PR_WORKFLOW, DAILY_WORKFLOW = WORKFLOWS
 INSTALLER = REPO_ROOT / ".github" / "skill-eval" / "install-local-gpu-runner.sh"
 JOB_HOOK = REPO_ROOT / ".github" / "skill-eval" / "local-gpu-job-started.sh"
 SERVICE = REPO_ROOT / ".github" / "skill-eval" / "local-gpu-runner.service"
@@ -28,8 +29,19 @@ class GpuRunnerWorkflowContract(unittest.TestCase):
     def test_eval_jobs_consume_planned_hardware_labels(self):
         for workflow in WORKFLOWS:
             text = workflow.read_text()
-            self.assertIn("runs-on: ${{ matrix.runner_labels }}", text)
             self.assertIn("runs-on: ubuntu-24.04", text)
+        self.assertIn(
+            "runs-on: ${{ matrix.runs_on }}",
+            PR_WORKFLOW.read_text(),
+        )
+        self.assertIn(
+            "runs-on: [self-hosted, vss-skill-eval-runner]",
+            DAILY_WORKFLOW.read_text(),
+        )
+        self.assertNotIn(
+            "runs-on: ${{ matrix.runs_on }}",
+            DAILY_WORKFLOW.read_text(),
+        )
 
     def test_coordinator_environment_path_is_runner_relative(self):
         for workflow in WORKFLOWS:
@@ -58,6 +70,10 @@ class GpuRunnerWorkflowContract(unittest.TestCase):
         self.assertIn("ExecStart=/opt/actions-runner/supervise.sh", service)
         self.assertIn("while true", supervisor)
         self.assertIn("direct-gpu-runner.enabled", hook)
+        self.assertIn("mountpoint -q", hook)
+        self.assertIn("SKILL_EVAL_VIEWER_BASE_URL", hook)
+        self.assertIn("SKILL_EVAL_VIEWER_RETENTION_DAYS", installer)
+        self.assertIn("SKILL_EVAL_VIEWER_SHARED", installer)
         self.assertIn("Driver/library version mismatch", hook)
         self.assertIn("nvidia-quarantine", hook)
         self.assertIn("DIRECT_GPU_RUNNER_MARKER", brev_env)

--- a/.github/skill-eval/tests/test_gpu_runner_workflows.py
+++ b/.github/skill-eval/tests/test_gpu_runner_workflows.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Static contracts for direct GPU skill-eval workflow scheduling."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "skills-eval.yml",
+    REPO_ROOT / ".github" / "workflows" / "skills-eval-daily.yml",
+)
+INSTALLER = REPO_ROOT / ".github" / "skill-eval" / "install-local-gpu-runner.sh"
+JOB_HOOK = REPO_ROOT / ".github" / "skill-eval" / "local-gpu-job-started.sh"
+SERVICE = REPO_ROOT / ".github" / "skill-eval" / "local-gpu-runner.service"
+SUPERVISOR = (
+    REPO_ROOT
+    / ".github"
+    / "skill-eval"
+    / "local-gpu-runner-supervise.sh"
+)
+BREV_ENV = REPO_ROOT / ".github" / "skill-eval" / "envs" / "brev_env.py"
+
+
+class GpuRunnerWorkflowContract(unittest.TestCase):
+    def test_eval_jobs_consume_planned_hardware_labels(self):
+        for workflow in WORKFLOWS:
+            text = workflow.read_text()
+            self.assertIn("runs-on: ${{ matrix.runner_labels }}", text)
+            self.assertIn("runs-on: ubuntu-24.04", text)
+
+    def test_coordinator_environment_path_is_runner_relative(self):
+        for workflow in WORKFLOWS:
+            text = workflow.read_text()
+            self.assertIn(
+                "${SKILL_EVAL_ENV_FILE:-$HOME/eval-coordinator/.env}",
+                text,
+            )
+            self.assertNotIn(
+                "source /home/ubuntu/eval-coordinator/.env",
+                text,
+            )
+
+    def test_direct_runner_is_supervised_and_staged_until_drain(self):
+        installer = INSTALLER.read_text()
+        hook = JOB_HOOK.read_text()
+        service = SERVICE.read_text()
+        supervisor = SUPERVISOR.read_text()
+        brev_env = BREV_ENV.read_text()
+
+        self.assertIn(
+            "systemctl enable --now vss-skill-eval-gpu-runner.service",
+            installer,
+        )
+        self.assertIn("Restart=always", service)
+        self.assertIn("ExecStart=/opt/actions-runner/supervise.sh", service)
+        self.assertIn("while true", supervisor)
+        self.assertIn("direct-gpu-runner.enabled", hook)
+        self.assertIn("Driver/library version mismatch", hook)
+        self.assertIn("nvidia-quarantine", hook)
+        self.assertIn("DIRECT_GPU_RUNNER_MARKER", brev_env)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skill-eval/tests/test_plan_matrix.py
+++ b/.github/skill-eval/tests/test_plan_matrix.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for plan_matrix.build_matrix — the diff -> dispatch rules.
@@ -73,91 +72,68 @@ class SkillFilePaths(unittest.TestCase):
 
 
 class RunsOnLabels(unittest.TestCase):
-    """Spec hardware declaration -> runner label set.
-
-    Parity target is run_leg.pool_candidates, which reads
-    `int(metadata.get("gpu_count", 1) or 0)` and guards its GPU-type
-    filter with `if required_count > 0 and required_type`.
-    """
-
-    def test_single_gpu_platform(self):
+    def test_rtx_pro_uses_1449_model_and_demand_labels(self):
         self.assertEqual(
-            plan_matrix.runs_on_labels("L40S", {"gpu_count": 1}),
-            ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"],
+            plan_matrix.runs_on_labels(
+                "RTXPRO6000BW",
+                {"gpu_count": 2},
+            ),
+            [
+                "self-hosted",
+                "vss-eval",
+                "gpu-rtxpro6000bw",
+                "gpus-2",
+            ],
         )
 
-    def test_two_gpu_platform(self):
-        self.assertEqual(
-            plan_matrix.runs_on_labels("RTXPRO6000BW", {"gpu_count": 2}),
-            ["self-hosted", "vss-eval", "gpu-rtxpro6000bw", "gpus-2"],
-        )
-
-    def test_absent_gpu_count_defaults_to_one(self):
-        """pool_candidates' `metadata.get("gpu_count", 1)` default."""
-        self.assertEqual(
-            plan_matrix.runs_on_labels("L40S", {"modes": ["remote-all"]}),
-            ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"],
-        )
-        self.assertEqual(
-            plan_matrix.runs_on_labels("L40S", None),
-            ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"],
-        )
-
-    def test_zero_gpu_count_drops_the_platform_label_too(self):
-        """GPU-independent legs must not be pinned to a GPU box.
-
-        pool_candidates only applies its type filter when
-        `required_count > 0`, so a zero-GPU spec accepts any RUNNING box
-        regardless of the platform it names. Emitting `gpu-rtxpro6000bw`
-        here would be *more* restrictive than today's placement.
-        """
-        self.assertEqual(
-            plan_matrix.runs_on_labels("RTXPRO6000BW", {"gpu_count": 0}),
-            ["self-hosted", "vss-eval"],
-        )
-        self.assertEqual(
-            plan_matrix.runs_on_labels("ANY", {"gpu_count": 0}),
-            ["self-hosted", "vss-eval"],
-        )
-
-    def test_null_or_garbage_gpu_count_is_zero(self):
-        """pool_candidates' trailing `or 0` on a present-but-falsy value."""
-        for raw in (None, "", "two"):
-            self.assertEqual(
-                plan_matrix.runs_on_labels("L40S", {"gpu_count": raw}),
-                ["self-hosted", "vss-eval"],
-                raw,
-            )
-
-    def test_any_platform_carries_no_gpu_type_label(self):
+    def test_any_is_model_independent(self):
         self.assertEqual(
             plan_matrix.runs_on_labels("ANY", {"gpu_count": 1}),
             ["self-hosted", "vss-eval", "gpus-1"],
         )
 
-    def test_unknown_platform_falls_back_to_a_normalised_slug(self):
+    def test_absent_gpu_count_defaults_to_one(self):
         self.assertEqual(
-            plan_matrix.runs_on_labels("GB200 NVL", {"gpu_count": 1}),
-            ["self-hosted", "vss-eval", "gpu-gb200-nvl", "gpus-1"],
+            plan_matrix.runs_on_labels(
+                "RTXPRO6000BW",
+                {"modes": ["standalone"]},
+            ),
+            ["self-hosted", "vss-eval", "gpu-rtxpro6000bw", "gpus-1"],
         )
 
-    def test_every_known_platform_has_a_label(self):
-        for platform in ("H100", "L40S", "RTXPRO6000BW", "DGX-SPARK", "IGX-THOR"):
-            labels = plan_matrix.runs_on_labels(platform, {"gpu_count": 1})
-            self.assertEqual(len(labels), 4, platform)
-            self.assertTrue(labels[2].startswith("gpu-"), platform)
+    def test_zero_gpu_drops_model_and_count(self):
+        self.assertEqual(
+            plan_matrix.runs_on_labels("ANY", {"gpu_count": 0}),
+            ["self-hosted", "vss-eval"],
+        )
+
+    def test_unsupported_platform_uses_coordinator(self):
+        for platform in ("L40S", "H100", "GB200 NVL"):
+            self.assertEqual(
+                plan_matrix.runs_on_labels(platform, {"gpu_count": 1}),
+                ["self-hosted", "vss-skill-eval-runner"],
+                platform,
+            )
+
+    def test_capacity_overflow_uses_coordinator(self):
+        self.assertEqual(
+            plan_matrix.runs_on_labels("RTX4090", {"gpu_count": 2}),
+            ["self-hosted", "vss-skill-eval-runner"],
+        )
+
+    def test_invalid_gpu_count_fails_plan(self):
+        for raw in ("two", True, 1.5, -1):
+            with self.assertRaisesRegex((TypeError, ValueError), "gpu_count"):
+                plan_matrix.runs_on_labels("ANY", {"gpu_count": raw})
 
 
 class RealSpecCorpus(unittest.TestCase):
-    """Every spec in skills/ must yield a well-formed label set.
-
-    Unlike BuildMatrix this reads the real tree on purpose: the point is
-    that no spec on disk produces a label a runner could never carry.
-    """
+    """The live spec corpus always emits schedulable, well-formed labels."""
 
     def setUp(self):
         self.specs = sorted(
-            p for p in (plan_matrix.REPO_ROOT / "skills").glob("*/eval*/*.json")
+            p
+            for p in (plan_matrix.REPO_ROOT / "skills").glob("*/eval*/*.json")
             if p.name not in plan_matrix.EXCLUDED_SPEC_NAMES
         )
         if not self.specs:
@@ -165,33 +141,43 @@ class RealSpecCorpus(unittest.TestCase):
 
     def test_every_platform_entry_yields_valid_labels(self):
         seen = 0
+        allowed_prefixes = (
+            plan_matrix.BASE_GPU_RUNNER_LABELS,
+            plan_matrix.COORDINATOR_RUNNER_LABELS,
+        )
         for spec in self.specs:
             rel = str(spec.relative_to(plan_matrix.REPO_ROOT))
             for platform, config in plan_matrix.spec_platform_config(rel).items():
                 labels = plan_matrix.runs_on_labels(platform, config)
                 seen += 1
-                # GitHub matches labels case-insensitively; keep the emitted
-                # form strictly lowercase so box registration is unambiguous.
                 for label in labels:
-                    self.assertRegex(label, r"^[a-z0-9][a-z0-9-]*$", f"{rel} {label}")
-                self.assertEqual(labels[:2], list(plan_matrix.BASE_LABELS), rel)
+                    self.assertRegex(
+                        label,
+                        r"^[a-z0-9][a-z0-9-]*$",
+                        f"{rel} {label}",
+                    )
+                self.assertIn(labels[:2], allowed_prefixes, rel)
                 self.assertLessEqual(
-                    sum(1 for x in labels if x.startswith("gpu-")), 1, rel
+                    sum(1 for label in labels if label.startswith("gpu-")),
+                    1,
+                    rel,
                 )
                 self.assertLessEqual(
-                    sum(1 for x in labels if x.startswith("gpus-")), 1, rel
+                    sum(1 for label in labels if label.startswith("gpus-")),
+                    1,
+                    rel,
                 )
         self.assertGreater(seen, 0)
 
     def test_a_gpu_type_label_never_appears_without_a_count(self):
-        """The zero-GPU parity rule, asserted across the real corpus."""
         for spec in self.specs:
             rel = str(spec.relative_to(plan_matrix.REPO_ROOT))
             for platform, config in plan_matrix.spec_platform_config(rel).items():
                 labels = plan_matrix.runs_on_labels(platform, config)
-                if any(x.startswith("gpu-") for x in labels):
+                if any(label.startswith("gpu-") for label in labels):
                     self.assertTrue(
-                        any(x.startswith("gpus-") for x in labels), f"{rel} {platform}"
+                        any(label.startswith("gpus-") for label in labels),
+                        f"{rel} {platform}",
                     )
 
 
@@ -266,8 +252,10 @@ class BuildMatrix(unittest.TestCase):
         self.assertEqual(len(inc), 1)
         self.assertEqual(inc[0]["kind"], "missing_adapter")
         self.assertEqual(inc[0]["slug"], "vss-no-adapter__missing-adapter")
-        # Commits an adapter, runs no trial — must not claim a GPU.
-        self.assertEqual(inc[0]["runs_on"], ["self-hosted", "vss-eval"])
+        self.assertEqual(
+            inc[0]["runs_on"],
+            ["self-hosted", "vss-skill-eval-runner"],
+        )
 
     def test_every_leg_carries_runs_on(self):
         inc = plan_matrix.build_matrix([
@@ -277,7 +265,6 @@ class BuildMatrix(unittest.TestCase):
         self.assertTrue(inc)
         for leg in inc:
             self.assertIn("runs_on", leg)
-            self.assertEqual(leg["runs_on"][:2], ["self-hosted", "vss-eval"])
 
     def test_runs_on_tracks_the_spec_declaration(self):
         plan_matrix.spec_platform_config = lambda p: {
@@ -285,14 +272,19 @@ class BuildMatrix(unittest.TestCase):
             "RTXPRO6000BW": {"gpu_count": 2},
         }
         inc = plan_matrix.build_matrix(["skills/vss-search-archive/evals/search.json"])
+        by_platform = {leg["platform"]: leg["runs_on"] for leg in inc}
         self.assertEqual(
-            {leg["platform"]: leg["runs_on"] for leg in inc},
-            {
-                "L40S": ["self-hosted", "vss-eval", "gpu-l40s", "gpus-1"],
-                "RTXPRO6000BW": [
-                    "self-hosted", "vss-eval", "gpu-rtxpro6000bw", "gpus-2",
-                ],
-            },
+            by_platform["L40S"],
+            ["self-hosted", "vss-skill-eval-runner"],
+        )
+        self.assertEqual(
+            by_platform["RTXPRO6000BW"],
+            [
+                "self-hosted",
+                "vss-eval",
+                "gpu-rtxpro6000bw",
+                "gpus-2",
+            ],
         )
 
     def test_slug_carries_platform(self):
@@ -312,7 +304,7 @@ class BuildMatrix(unittest.TestCase):
             ["vss-search-archive__search__L40S",
              "vss-search-archive__search__RTXPRO6000BW"],
         )
-        by_platform = {leg["platform"]: leg["runner_labels"] for leg in inc}
+        by_platform = {leg["platform"]: leg["runs_on"] for leg in inc}
         self.assertEqual(
             by_platform["L40S"],
             ["self-hosted", "vss-skill-eval-runner"],
@@ -321,39 +313,37 @@ class BuildMatrix(unittest.TestCase):
             by_platform["RTXPRO6000BW"],
             [
                 "self-hosted",
-                "Linux",
-                "X64",
-                "vss-skill-eval-gpu",
-                "gpu-nvidia-rtx-pro-6000-blackwell",
-                "gpu-count-2",
+                "vss-eval",
+                "gpu-rtxpro6000bw",
+                "gpus-2",
             ],
         )
 
-    def test_any_platform_uses_single_gpu_4090_partition(self):
-        plan_matrix.spec_platforms = lambda p: ["ANY"]
+    def test_any_platform_uses_count_capability_without_model(self):
+        plan_matrix.spec_platform_config = lambda p: {
+            "ANY": {"gpu_count": 1}
+        }
         inc = plan_matrix.build_matrix(
             ["skills/vss-search-archive/evals/search.json"]
         )
         self.assertEqual(
-            inc[0]["runner_labels"],
+            inc[0]["runs_on"],
             [
                 "self-hosted",
-                "Linux",
-                "X64",
-                "vss-skill-eval-gpu",
-                "gpu-nvidia-geforce-rtx-4090",
-                "gpu-count-1",
+                "vss-eval",
+                "gpus-1",
             ],
         )
 
     def test_gpu_runner_capacity_overflow_falls_back_to_coordinator(self):
-        plan_matrix.spec_platforms = lambda p: ["ANY"]
-        plan_matrix.spec_gpu_count = lambda path, platform: 2
+        plan_matrix.spec_platform_config = lambda p: {
+            "RTX4090": {"gpu_count": 2}
+        }
         inc = plan_matrix.build_matrix(
             ["skills/vss-search-archive/evals/search.json"]
         )
         self.assertEqual(
-            inc[0]["runner_labels"],
+            inc[0]["runs_on"],
             ["self-hosted", "vss-skill-eval-runner"],
         )
 

--- a/.github/skill-eval/tests/test_plan_matrix.py
+++ b/.github/skill-eval/tests/test_plan_matrix.py
@@ -312,6 +312,50 @@ class BuildMatrix(unittest.TestCase):
             ["vss-search-archive__search__L40S",
              "vss-search-archive__search__RTXPRO6000BW"],
         )
+        by_platform = {leg["platform"]: leg["runner_labels"] for leg in inc}
+        self.assertEqual(
+            by_platform["L40S"],
+            ["self-hosted", "vss-skill-eval-runner"],
+        )
+        self.assertEqual(
+            by_platform["RTXPRO6000BW"],
+            [
+                "self-hosted",
+                "Linux",
+                "X64",
+                "vss-skill-eval-gpu",
+                "gpu-nvidia-rtx-pro-6000-blackwell",
+                "gpu-count-2",
+            ],
+        )
+
+    def test_any_platform_uses_single_gpu_4090_partition(self):
+        plan_matrix.spec_platforms = lambda p: ["ANY"]
+        inc = plan_matrix.build_matrix(
+            ["skills/vss-search-archive/evals/search.json"]
+        )
+        self.assertEqual(
+            inc[0]["runner_labels"],
+            [
+                "self-hosted",
+                "Linux",
+                "X64",
+                "vss-skill-eval-gpu",
+                "gpu-nvidia-geforce-rtx-4090",
+                "gpu-count-1",
+            ],
+        )
+
+    def test_gpu_runner_capacity_overflow_falls_back_to_coordinator(self):
+        plan_matrix.spec_platforms = lambda p: ["ANY"]
+        plan_matrix.spec_gpu_count = lambda path, platform: 2
+        inc = plan_matrix.build_matrix(
+            ["skills/vss-search-archive/evals/search.json"]
+        )
+        self.assertEqual(
+            inc[0]["runner_labels"],
+            ["self-hosted", "vss-skill-eval-runner"],
+        )
 
     def test_mixed_skills_sorted_and_scoped(self):
         inc = plan_matrix.build_matrix([

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -84,6 +84,38 @@ class DiscoverInvocations(unittest.TestCase):
 
 
 class HarborCommand(unittest.TestCase):
+    def test_harbor_env_strips_actions_credentials(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "ACTIONS_RUNTIME_TOKEN": "runtime-secret",
+                "ANTHROPIC_API_KEY": "model-secret",
+                "CI_ANTHROPIC_API_KEY": "duplicate-secret",
+                "GH_TOKEN": "github-secret",
+                "GITHUB_EVENT_PATH": "/tmp/event.json",
+                "GITHUB_RUN_ID": "123",
+                "GITHUB_WORKSPACE": "/tmp/workspace",
+                "RUNNER_TRACKING_ID": "tracking-secret",
+                "SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1",
+                "SSH_AUTH_SOCK": "/tmp/agent.sock",
+            },
+            clear=True,
+        ):
+            env = run_leg.harbor_env("gpu-vm-1")
+
+        self.assertEqual(env["ANTHROPIC_API_KEY"], "model-secret")
+        self.assertEqual(env["GITHUB_RUN_ID"], "123")
+        self.assertEqual(env["IS_SANDBOX"], "1")
+        self.assertEqual(env["RUNNER_TRACKING_ID"], "tracking-secret")
+        for key in (
+            "ACTIONS_RUNTIME_TOKEN",
+            "CI_ANTHROPIC_API_KEY",
+            "GH_TOKEN",
+            "GITHUB_EVENT_PATH",
+            "SSH_AUTH_SOCK",
+        ):
+            self.assertNotIn(key, env)
+
     def test_build_command_uses_env_and_v1_suffix(self):
         invocation = run_leg.HarborInvocation(
             harbor_root=Path("/tmp/datasets/alerts_cv"),
@@ -863,6 +895,17 @@ class TraceUrls(unittest.TestCase):
             self.assertIsNone(run_leg.trace_url(result, self.JOB))
             self.assertIsNone(run_leg.trace_url(Path(td) / "missing.json", self.JOB))
 
+    def test_trace_url_is_disabled_on_direct_gpu_runner(self):
+        with (
+            tempfile.TemporaryDirectory() as td,
+            mock.patch.dict(
+                os.environ,
+                {"SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1"},
+            ),
+        ):
+            result = self._write_result(Path(td) / "step-7__E6dBECL")
+            self.assertIsNone(run_leg.trace_url(result, self.JOB))
+
     def test_publish_trace_flattens_into_viewer_and_records_url(self):
         invocation = run_leg.HarborInvocation(
             harbor_root=Path("/tmp/datasets/base/l40s"),
@@ -1042,7 +1085,7 @@ class PoolCandidates(unittest.TestCase):
             ["vss-eval-rtx-2g-VM1b"],
         )
 
-    def test_4090_pool_is_limited_to_approved_skills(self):
+    def test_legacy_4090_pool_is_disabled_after_direct_cutover(self):
         env = {
             "BREV_REGISTERED_POOL": "vss-eval-rtx-2g-VM1b",
             "BREV_RTX4090_POOL": (
@@ -1060,36 +1103,24 @@ class PoolCandidates(unittest.TestCase):
 
         self.assertEqual(
             approved,
-            {
-                "vss-eval-rtx-2g-vm1b",
-                "vss-eval-geforce-rtx4090-vm1",
-                "vss-eval-geforce-rtx4090-vm2",
-            },
+            {"vss-eval-rtx-2g-vm1b"},
         )
         self.assertEqual(unapproved, {"vss-eval-rtx-2g-vm1b"})
 
     def test_4090_test_capabilities_fail_closed(self):
-        self.assertTrue(run_leg._rtx4090_supports(
-            "vss-deploy-profile", "alerts_cv"
-        ))
-        self.assertTrue(run_leg._rtx4090_supports(
-            "vss-manage-alerts", "subscriptions_lifecycle"
-        ))
-        self.assertFalse(run_leg._rtx4090_supports(
-            "vss-deploy-profile", "search"
-        ))
-        self.assertFalse(run_leg._rtx4090_supports(
-            "vss-deploy-profile", "warehouse"
-        ))
-        self.assertFalse(run_leg._rtx4090_supports(
-            "vss-deploy-dense-captioning", "alerts_profile_api"
-        ))
-        self.assertFalse(run_leg._rtx4090_supports(
-            "vss-deploy-detection-tracking-3d", "deploy"
-        ))
-        self.assertFalse(run_leg._rtx4090_supports("vss-ask-video", None))
+        for skill, spec in (
+            ("vss-deploy-profile", "alerts_cv"),
+            ("vss-manage-alerts", "subscriptions_lifecycle"),
+            ("vss-deploy-profile", "search"),
+            ("vss-deploy-profile", "warehouse"),
+            ("vss-deploy-dense-captioning", "alerts_profile_api"),
+            ("vss-deploy-detection-tracking-3d", "deploy"),
+            ("vss-ask-video", None),
+        ):
+            with self.subTest(skill=skill, spec=spec):
+                self.assertFalse(run_leg._rtx4090_supports(skill, spec))
 
-    def test_4090_capability_route_bypasses_rtx_pro_type_only_for_skill(self):
+    def test_legacy_4090_route_cannot_bypass_direct_runner_ownership(self):
         fleet = [{
             "name": "vss-eval-geforce-rtx4090-vm1",
             "status": "RUNNING",
@@ -1111,7 +1142,7 @@ class PoolCandidates(unittest.TestCase):
             "skill": "vss-deploy-dense-captioning",
         }, "alerts_profile_api")
 
-        self.assertEqual(approved, ["vss-eval-geforce-rtx4090-vm1"])
+        self.assertEqual(approved, [])
         self.assertEqual(unapproved, [])
 
     def test_underprovisioned_registered_node_is_filtered(self):

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -11,11 +11,11 @@ import contextlib
 import importlib.util
 import json
 import os
-from pathlib import Path
 import sys
 import tempfile
 import time
 import unittest
+from pathlib import Path
 from typing import ClassVar
 from unittest import mock
 
@@ -254,15 +254,17 @@ class PhaseBudgets(unittest.TestCase):
             args.harbor_timeout_sec, run_leg.DEFAULT_HARBOR_TIMEOUT_SEC
         )
 
-        with mock.patch.object(run_leg.sys, "stderr"):
-            with self.assertRaises(SystemExit) as raised:
-                run_leg.parse_args(
-                    required
-                    + [
-                        "--harbor-timeout-sec",
-                        str(run_leg.MIN_HARBOR_BACKSTOP_SEC),
-                    ]
-                )
+        with (
+            mock.patch.object(run_leg.sys, "stderr"),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            run_leg.parse_args(
+                required
+                + [
+                    "--harbor-timeout-sec",
+                    str(run_leg.MIN_HARBOR_BACKSTOP_SEC),
+                ]
+            )
         self.assertEqual(raised.exception.code, 2)
 
     def test_agent_deadline_is_inherited_and_expired_values_fail_closed(self):
@@ -347,8 +349,8 @@ class HarborEnvironment(unittest.TestCase):
 
 
 class RunCommand(unittest.TestCase):
-    COMMAND = ["uvx", "harbor", "run"]
-    ENV = {"BREV_INSTANCE": "vss-eval-box"}
+    COMMAND: ClassVar[list[str]] = ["uvx", "harbor", "run"]
+    ENV: ClassVar[dict[str, str]] = {"BREV_INSTANCE": "vss-eval-box"}
 
     @staticmethod
     def _expired(timeout):
@@ -666,7 +668,7 @@ time.sleep(30)
 
 
 class RunInvocations(unittest.TestCase):
-    ENV = {
+    ENV: ClassVar[dict[str, str]] = {
         "ANTHROPIC_MODEL": "aws/anthropic/bedrock-claude-opus-4-6",
         "ANTHROPIC_BASE_URL": "https://inference-api.nvidia.com/v1",
     }

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for run_leg.py.
@@ -17,6 +16,7 @@ import sys
 import tempfile
 import time
 import unittest
+from typing import ClassVar
 from unittest import mock
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -828,7 +828,7 @@ class TraceUrls(unittest.TestCase):
     """
 
     # Shape mirrors a real trial's result.json.
-    RESULT = {
+    RESULT: ClassVar[dict] = {
         "task_name": "nvidia-vss/vss-generate-video-report-base-l40s-step-7",
         "trial_name": "step-7__E6dBECL",
         "source": "l40s",
@@ -846,14 +846,27 @@ class TraceUrls(unittest.TestCase):
     )
 
     def setUp(self):
-        self._orig_env = os.environ.get("BREV_ENV_ID")
+        self._orig_env = {
+            name: os.environ.get(name)
+            for name in (
+                "BREV_ENV_ID",
+                "SKILL_EVAL_LOCAL_GPU_INSTANCE",
+                "SKILL_EVAL_VIEWER_BASE_URL",
+                "SKILL_EVAL_VIEWER_RETENTION_DAYS",
+                "SKILL_EVAL_VIEWER_ROOT",
+                "SKILL_EVAL_VIEWER_SHARED",
+            )
+        }
+        for name in self._orig_env:
+            os.environ.pop(name, None)
         os.environ["BREV_ENV_ID"] = "13xh5gpe7"
 
     def tearDown(self):
-        if self._orig_env is None:
-            os.environ.pop("BREV_ENV_ID", None)
-        else:
-            os.environ["BREV_ENV_ID"] = self._orig_env
+        for name, value in self._orig_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
     def _write_result(self, directory: Path, payload=None) -> Path:
         directory.mkdir(parents=True, exist_ok=True)
@@ -906,6 +919,69 @@ class TraceUrls(unittest.TestCase):
             result = self._write_result(Path(td) / "step-7__E6dBECL")
             self.assertIsNone(run_leg.trace_url(result, self.JOB))
 
+    def test_direct_gpu_runner_uses_only_configured_central_url(self):
+        with (
+            tempfile.TemporaryDirectory() as td,
+            mock.patch.dict(
+                os.environ,
+                {
+                    "SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1",
+                    "SKILL_EVAL_VIEWER_BASE_URL": "https://harbor.internal.example/",
+                },
+            ),
+        ):
+            result = self._write_result(Path(td) / "step-7__E6dBECL")
+            url = run_leg.trace_url(result, self.JOB)
+
+        self.assertTrue(url.startswith("https://harbor.internal.example/jobs/"))
+        self.assertNotIn("brevlab.com", url)
+
+    def test_viewer_base_url_rejects_embedded_credentials(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "SKILL_EVAL_VIEWER_BASE_URL": (
+                    "https://user:secret@harbor.internal.example"
+                ),
+            },
+        ), self.assertRaisesRegex(ValueError, "VIEWER_BASE_URL"):
+            run_leg._configured_viewer_base_url()
+
+    def test_direct_viewer_gate_requires_config_mount_and_retention(self):
+        with (
+            tempfile.TemporaryDirectory() as td,
+            mock.patch.dict(
+                os.environ,
+                {
+                    "SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1",
+                    "SKILL_EVAL_VIEWER_BASE_URL": "https://harbor.internal.example",
+                    "SKILL_EVAL_VIEWER_RETENTION_DAYS": "30",
+                    "SKILL_EVAL_VIEWER_ROOT": td,
+                    "SKILL_EVAL_VIEWER_SHARED": "1",
+                },
+            ),
+            mock.patch.object(run_leg.os.path, "ismount", return_value=True),
+        ):
+            run_leg.validate_direct_viewer_gate()
+
+        with mock.patch.dict(
+            os.environ,
+            {"SKILL_EVAL_LOCAL_GPU_INSTANCE": "gpu-vm-1"},
+            clear=True,
+        ), self.assertRaisesRegex(RuntimeError, "VIEWER_ROOT"):
+            run_leg.validate_direct_viewer_gate()
+
+    def test_shared_preflight_rejects_unmounted_path(self):
+        with (
+            tempfile.TemporaryDirectory() as td,
+            mock.patch.object(run_leg.os.path, "ismount", return_value=False),
+            self.assertRaisesRegex(RuntimeError, "not a mount point"),
+        ):
+            run_leg.preflight_viewer_storage(
+                Path(td),
+                shared_required=True,
+            )
+
     def test_publish_trace_flattens_into_viewer_and_records_url(self):
         invocation = run_leg.HarborInvocation(
             harbor_root=Path("/tmp/datasets/base/l40s"),
@@ -944,6 +1020,61 @@ class TraceUrls(unittest.TestCase):
         self.assertEqual(row[2], url)
         self.assertIn("/jobs/leg__30284131217__2026-07-27__17-16-47/tasks/", url)
 
+    def test_publish_failure_is_nonfatal_and_writes_marker(self):
+        invocation = run_leg.HarborInvocation(
+            harbor_root=Path("/tmp/datasets/base/l40s"),
+            include_task_name="step-7",
+            chain_key="base_l40s",
+        )
+        with (
+            tempfile.TemporaryDirectory() as td,
+            mock.patch.object(
+                run_leg,
+                "publish_trace",
+                side_effect=RuntimeError("shared viewer root is not mounted"),
+            ),
+        ):
+            results_root = Path(td) / "results"
+            self.assertIsNone(
+                run_leg.publish_trace_safely(
+                    results_root,
+                    invocation,
+                    0.0,
+                    "leg",
+                    "1",
+                )
+            )
+            marker = results_root / run_leg.TRACE_FAILURES_FILE
+            row = marker.read_text().strip().split("\t")
+
+        self.assertEqual(row[:2], ["step-7", "RuntimeError"])
+        self.assertIn("not mounted", row[2])
+
+    def test_retention_deletes_only_owned_inactive_old_jobs(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            current = root / "current"
+            stale = root / "stale"
+            active = root / "active"
+            unowned = root / "unowned"
+            for directory in (current, stale, active, unowned):
+                directory.mkdir()
+            for directory in (current, stale, active):
+                (directory / run_leg.VIEWER_OWNER_MARKER).touch()
+            (active / run_leg.VIEWER_ACTIVE_MARKER).touch()
+            old = time.time() - 3 * 86400
+            os.utime(stale, (old, old))
+            os.utime(active, (old, old))
+            os.utime(unowned, (old, old))
+
+            run_leg.prune_viewer_root(root, current, retention_days=1)
+
+            self.assertFalse(stale.exists())
+            self.assertTrue(current.exists())
+            self.assertTrue(active.exists())
+            self.assertTrue(unowned.exists())
+            self.assertTrue((root / run_leg.VIEWER_RETENTION_LOCK).is_file())
+
     def test_publish_trace_returns_none_when_trial_produced_no_result(self):
         invocation = run_leg.HarborInvocation(
             harbor_root=Path("/tmp/datasets/base/l40s"),
@@ -963,7 +1094,7 @@ class TraceUrls(unittest.TestCase):
 
 
 class PoolCandidates(unittest.TestCase):
-    FLEET = [
+    FLEET: ClassVar[list[dict]] = [
         {"name": "vss-eval-rtx-1g-2", "status": "RUNNING",
          "gpu": "RTX PRO Server 6000", "instance_type": "g7e.4xlarge"},
         {"name": "vss-eval-rtx-1g-3", "status": "STOPPED",
@@ -1063,7 +1194,7 @@ class PoolCandidates(unittest.TestCase):
         orig_managed = run_leg._list_brev_instances
         orig_registered = run_leg._list_registered_nodes
         try:
-            run_leg._list_brev_instances = lambda: []
+            run_leg._list_brev_instances = list
             run_leg._list_registered_nodes = lambda: [
                 {"name": "vss-eval-rtx-2g-VM1b", "status": "Connected"},
                 {"name": "vss-eval-rtx-2g-skybridge", "status": "Connected"},
@@ -1192,11 +1323,13 @@ class HoldPoolLock(unittest.TestCase):
             fcntl.flock(held.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             try:
                 start = time.monotonic()
-                with self.assertRaises(run_leg.LockTimeoutError):
-                    with run_leg.hold_pool_lock(
+                with (
+                    self.assertRaises(run_leg.LockTimeoutError),
+                    run_leg.hold_pool_lock(
                         lambda: ["box-a"], lock_dir, timeout_sec=0
-                    ):
-                        pass
+                    ),
+                ):
+                    pass
                 self.assertLess(time.monotonic() - start, 5)
             finally:
                 held.close()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,12 +390,16 @@ jobs:
             --cov-report=term-missing \
             -m "not slow and not integration"
 
-      - name: Video summarization contracts
+      - name: Skill eval contracts
         working-directory: ${{ github.workspace }}
         run: |
           uv run --project services/agent pytest \
+            .github/skill-eval/envs/tests/test_registered_node.py \
             .github/skill-eval/tests/test_generic_judge_trajectory_guidance.py \
+            .github/skill-eval/tests/test_gpu_runner_workflows.py \
             .github/skill-eval/tests/test_lvs_deployment_config.py \
+            .github/skill-eval/tests/test_plan_matrix.py \
+            .github/skill-eval/tests/test_run_leg.py \
             .github/skill-eval/tests/test_vss_summarize_eval_contract.py \
             .github/skill-eval/tests/test_vss_summarize_model_selection.py \
             deploy/docker/scripts/tests/test_orchestrator_mcp_helper.py \

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -109,10 +109,10 @@ jobs:
     name: ${{ matrix.name }}
     needs: plan
     if: needs.plan.outputs.has_targets == 'true'
-    # plan_matrix.py routes supported platforms directly to a GPU runner
-    # carrying model + physical-count labels. Unsupported platforms retain
-    # the coordinator fallback and continue selecting a separate Brev box.
-    runs-on: ${{ matrix.runner_labels }}
+    # Periodic broad hardware coverage keeps the existing coordinator,
+    # Brev fleet selection, and per-instance locking path. Only per-PR
+    # skills-eval.yml consumes matrix.runs_on for direct GPU placement.
+    runs-on: [self-hosted, vss-skill-eval-runner]
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -75,7 +75,7 @@ jobs:
   # ---------------------------------------------------------------------
   plan:
     name: Plan eval matrix
-    runs-on: [self-hosted, vss-skill-eval-runner]
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -109,7 +109,10 @@ jobs:
     name: ${{ matrix.name }}
     needs: plan
     if: needs.plan.outputs.has_targets == 'true'
-    runs-on: [self-hosted, vss-skill-eval-runner]
+    # plan_matrix.py routes supported platforms directly to a GPU runner
+    # carrying model + physical-count labels. Unsupported platforms retain
+    # the coordinator fallback and continue selecting a separate Brev box.
+    runs-on: ${{ matrix.runner_labels }}
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false
@@ -153,13 +156,23 @@ jobs:
 
       - name: Load coordinator env (Anthropic, NGC, Brev, remote endpoints)
         run: |
-          # The runner host (vss-skill-validator-v2) keeps coordinator
-          # secrets in a single .env. Don't echo contents.
+          # CPU coordinators and direct GPU runners keep the same secret
+          # contract under their own home directory. The runner may override
+          # the path with SKILL_EVAL_ENV_FILE; never echo its contents.
+          ENV_FILE="${SKILL_EVAL_ENV_FILE:-$HOME/eval-coordinator/.env}"
+          test -s "$ENV_FILE"
+          test "$(stat -c '%U' "$ENV_FILE")" = root
+          MODE="$(stat -c '%a' "$ENV_FILE")"
+          (( (8#$MODE & 0022) == 0 ))
           set -a
-          source /home/ubuntu/eval-coordinator/.env
+          # shellcheck source=/dev/null
+          source "$ENV_FILE"
           set +a
-          printf "COORDINATOR_ENV=loaded\n" >> "$GITHUB_ENV"
-          printf "CLAUDE_CODE_DISABLE_THINKING=1\n" >> "$GITHUB_ENV"
+          {
+            printf "SKILL_EVAL_ENV_FILE=%s\n" "$ENV_FILE"
+            printf "COORDINATOR_ENV=loaded\n"
+            printf "CLAUDE_CODE_DISABLE_THINKING=1\n"
+          } >> "$GITHUB_ENV"
 
       - name: Run skills eval agent (single spec)
         id: agent
@@ -186,7 +199,8 @@ jobs:
           skill_eval_venv_dir="$SKILL_EVAL_VENV"
           skill_eval_python_version="$SKILL_EVAL_PYTHON_VERSION"
           set -a
-          source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
+          # shellcheck source=/dev/null
+          source "$SKILL_EVAL_ENV_FILE"   # Anthropic / NGC / Brev or local GPU
           set +a
           # Keep the per-leg venv ahead of any operator-provided PATH so the
           # SDK's Bash children resolve adapters and run_leg.py with 3.12.
@@ -227,7 +241,8 @@ jobs:
           # while the harness ran develop. git rev-parse HEAD = the checked-out
           # commit (develop on the nightly, the dispatch ref otherwise), so both
           # code sources stay on the same tree.
-          export PR_HEAD_SHA="$(git rev-parse HEAD)"
+          PR_HEAD_SHA="$(git rev-parse HEAD)"
+          export PR_HEAD_SHA
           export PR_REPO="${{ github.repository }}"
           export GITHUB_RUN_ID="${{ github.run_id }}"
           # Single-spec mode — plan already decided this leg's target, so

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -145,10 +145,9 @@ jobs:
     name: ${{ matrix.name }}
     needs: plan
     if: needs.plan.outputs.has_targets == 'true'
-    # plan_matrix.py routes supported platforms directly to a GPU runner
-    # carrying model + physical-count labels. Unsupported platforms retain
-    # the coordinator fallback and continue selecting a separate Brev box.
-    runs-on: ${{ matrix.runner_labels }}
+    # PR #1449 contract: model/count demand labels route supported per-PR
+    # legs directly; unsupported platforms retain the coordinator fallback.
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false
@@ -252,6 +251,14 @@ jobs:
           export PATH="$skill_eval_venv_dir/bin:$PATH"
           hash -r
           python3 -c 'import os, sys; expected = tuple(map(int, os.environ["SKILL_EVAL_PYTHON_VERSION"].split("."))); assert sys.version_info[:2] == expected, sys.version'
+          if [ -n "${SKILL_EVAL_LOCAL_GPU_INSTANCE:-}" ]; then
+            # Direct runner activation requires option B: one central Harbor
+            # viewer over a private Brev/NetBird shared POSIX/NFS mount.
+            : "${SKILL_EVAL_VIEWER_ROOT:?missing shared viewer root}"
+            : "${SKILL_EVAL_VIEWER_BASE_URL:?missing central viewer URL}"
+            : "${SKILL_EVAL_VIEWER_RETENTION_DAYS:?missing viewer retention policy}"
+            test "${SKILL_EVAL_VIEWER_SHARED:-}" = "1"
+          fi
           # The eval workers cannot resolve NVIDIA-internal Wowza DNS. Use
           # the public relay for RTSP-dependent skill checks.
           export RTSP_SAMPLE_URL="rtsp://global.stg.ga.launchpad.nvidia.com:11333/camera03"

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -82,7 +82,7 @@ jobs:
   plan:
     name: Plan eval matrix
     if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, vss-skill-eval-runner]
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -145,7 +145,10 @@ jobs:
     name: ${{ matrix.name }}
     needs: plan
     if: needs.plan.outputs.has_targets == 'true'
-    runs-on: [self-hosted, vss-skill-eval-runner]
+    # plan_matrix.py routes supported platforms directly to a GPU runner
+    # carrying model + physical-count labels. Unsupported platforms retain
+    # the coordinator fallback and continue selecting a separate Brev box.
+    runs-on: ${{ matrix.runner_labels }}
     strategy:
       # One slow/failed spec must not cancel its siblings.
       fail-fast: false
@@ -187,13 +190,23 @@ jobs:
 
       - name: Load coordinator env (Anthropic, NGC, Brev, remote endpoints)
         run: |
-          # The runner host (vss-skill-validator-v2) keeps coordinator
-          # secrets in a single .env. Don't echo contents.
+          # CPU coordinators and direct GPU runners keep the same secret
+          # contract under their own home directory. The runner may override
+          # the path with SKILL_EVAL_ENV_FILE; never echo its contents.
+          ENV_FILE="${SKILL_EVAL_ENV_FILE:-$HOME/eval-coordinator/.env}"
+          test -s "$ENV_FILE"
+          test "$(stat -c '%U' "$ENV_FILE")" = root
+          MODE="$(stat -c '%a' "$ENV_FILE")"
+          (( (8#$MODE & 0022) == 0 ))
           set -a
-          source /home/ubuntu/eval-coordinator/.env
+          # shellcheck source=/dev/null
+          source "$ENV_FILE"
           set +a
-          printf "COORDINATOR_ENV=loaded\n" >> "$GITHUB_ENV"
-          printf "CLAUDE_CODE_DISABLE_THINKING=1\n" >> "$GITHUB_ENV"
+          {
+            printf "SKILL_EVAL_ENV_FILE=%s\n" "$ENV_FILE"
+            printf "COORDINATOR_ENV=loaded\n"
+            printf "CLAUDE_CODE_DISABLE_THINKING=1\n"
+          } >> "$GITHUB_ENV"
 
       - name: Run skills eval agent (single spec)
         id: agent
@@ -227,7 +240,8 @@ jobs:
           skill_eval_venv_dir="$SKILL_EVAL_VENV"
           skill_eval_python_version="$SKILL_EVAL_PYTHON_VERSION"
           set -a
-          source /home/ubuntu/eval-coordinator/.env   # Anthropic / NGC / Brev
+          # shellcheck source=/dev/null
+          source "$SKILL_EVAL_ENV_FILE"   # Anthropic / NGC / Brev or local GPU
           set +a
           # The coordinator .env is operator-managed and may define PATH.
           # Reassert the per-leg runtime afterwards so Claude's Bash children


### PR DESCRIPTION
## Summary
- route supported **per-PR** skill-eval legs to the seven direct GPU runners; keep unsupported platforms and all daily/periodic evaluations on the existing coordinator, Brev selection, and locking path
- align with #1449's matrix contract: `runs_on`, `vss-eval`, optional `gpu-*`, and `gpus-N`; validate GPU counts and fail safely to coordinators when direct capacity is unavailable
- retain direct local GPU execution, immutable VM pinning, live hardware validation, credential filtering, durable supervision, staged admission, and coordinator ownership fencing
- implement Harbor viewer option B repository prerequisites: configurable shared root/base URL, mount + write/read/delete preflight, diagnostic failure markers, and opt-in concurrency-safe age retention

## Harbor viewer safety
- coordinators retain `/tmp/skill-eval/results/_viewer` and the `BREV_ENV_ID` URL fallback
- direct runners require `SKILL_EVAL_VIEWER_ROOT`, `SKILL_EVAL_VIEWER_BASE_URL`, `SKILL_EVAL_VIEWER_SHARED=1`, and an explicit `SKILL_EVAL_VIEWER_RETENTION_DAYS`
- the job-start hook and `run_leg.py` fail closed before direct Harbor work if the shared mount is absent or unwritable
- later publication failure remains non-fatal to the eval verdict, but emits an Actions warning and writes `trace-publish-failures.tsv`
- retention deletes only repository-owned, inactive job directories; there is no destructive default and unmarked history is untouched
- `agent/` trajectories remain excluded from workflow artifacts and may live only on the private Brev-hosted viewer storage

## Live fleet status
- 4 runners: 2x NVIDIA RTX PRO 6000 Blackwell; canonical aliases `vss-eval`, `gpu-rtxpro6000bw`, `gpus-1`, `gpus-2`
- 3 runners: 1x NVIDIA GeForce RTX 4090; canonical aliases `vss-eval`, `gpu-rtx4090`, `gpus-1`
- all seven are online and idle; the new fail-closed viewer hook is installed on every VM
- activation markers remain absent, so no direct jobs can start before the central viewer infrastructure is ready

## Remaining operator gates (not provisioned by this PR)
- [ ] choose an always-on Brev host for NFS and the central `harbor view` service
- [ ] mount the private shared POSIX/NFS root at the configured path on all seven GPU VMs
- [ ] configure the central viewer URL via Brev tunnel or internal DNS
- [ ] choose the production retention value and distribute all four viewer variables
- [ ] decide separately whether legacy trace history should be migrated
- [ ] verify one direct GPU canary, then create activation markers deliberately

## Test plan
- [x] `109 passed` across the complete skill-eval CI contract set
- [x] Ruff on changed Python files
- [x] ShellCheck on installer, admission hook, and supervisor
- [x] actionlint on both skill-eval workflows (custom self-hosted label warning excluded)
- [x] full repository dispatch-matrix generation
- [x] live labels, online/idle state, staged markers, and identical fail-closed hook on all seven GPU runners

## Relationship to #1449
#1466 now implements #1449's `runs_on` / `vss-eval` / `gpu-*` / `gpus-N` contract and adds the runtime, fallback, validation, and viewer gates. #1449 is still open and currently 32 commits behind `develop`, so the two PRs should not merge independently as-is: they overlap in `plan_matrix.py` and tests. Recommended merge ownership is for Zac to confirm the label contract in #1466, then close #1449 as superseded; if separate commits are required, #1449 must first be rebased and #1466 restacked.