### PR TITLE
docs: add external user agent guidance routers

### DIFF
--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -25,6 +25,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shlex
 import signal
 import subprocess
@@ -52,6 +53,12 @@ BREV_COPY_TIMEOUT = int(os.environ.get("BREV_COPY_TIMEOUT", "300"))
 # retrying a transient stall on a fresh connection recovers it. Tunable.
 BREV_DOWNLOAD_RETRIES = int(os.environ.get("BREV_DOWNLOAD_RETRIES", "3"))
 BREV_DOWNLOAD_BACKOFF_SEC = float(os.environ.get("BREV_DOWNLOAD_BACKOFF_SEC", "5"))
+
+VSS_REPO_CWD = '"$HOME/video-search-and-summarization"'
+CLAUDE_PRINT_RE = re.compile(
+    r"(^|[|;&]\s*)claude(?:\s+[^|;&]*)?\s--print(?:\s|$)",
+    re.DOTALL,
+)
 
 # Public relay used by the RT-VLM test suite. Operators can override it for
 # isolated environments, but the eval remains runnable without extra CI
@@ -263,13 +270,11 @@ class BrevEnvironment(BaseEnvironment):
         # already (harbor's per-trial copy-back), so this archive is just
         # box-side history.
         #
-        # Why archive only, not also per-trial cwd: harbor's claude-code
-        # agent (vendor cache) invokes `claude --print` with no cwd
-        # override, so all trials share `cwd=/home/shadeform` and the
-        # project key is `-home-shadeform`. Forcing a per-trial cwd would
-        # require forking harbor — out of scope. Empty-on-start is
-        # sufficient for the harbor mapper's "exactly one session dir"
-        # heuristic to produce a clean per-trial trajectory.
+        # Harbor's claude-code agent does not pass a cwd. Our exec() wrapper
+        # starts the actual `claude --print` command from the synced repo root
+        # so repository CLAUDE.md/AGENTS.md guidance can load, but every trial
+        # still uses the same repo cwd/project key on a warm box. Empty-on-start
+        # keeps harbor's "exactly one session dir" trajectory mapper clean.
         archive_cmd = (
             "ts=$(date +%Y%m%d-%H%M%S); "
             "PROJ=/logs/agent/sessions/projects; "
@@ -1009,6 +1014,12 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
                 parts.append(f"export {shlex.quote(k)}={shlex.quote(v)};")
         if cwd:
             parts.append(f"cd {shlex.quote(cwd)};")
+        elif _is_claude_code_agent_command(command):
+            # Harbor's installed claude-code agent invokes `claude --print`
+            # without a cwd, which otherwise starts from $HOME and misses the
+            # checked-out repo's CLAUDE.md/AGENTS.md guidance. The repo is
+            # synced in start() before agent setup/execution reaches exec().
+            parts.append(f"cd {VSS_REPO_CWD};")
         parts.append(command)
 
         inner_cmd = " ".join(parts)
@@ -1018,7 +1029,6 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
         # real install commands (not substrings like `command -v apk`)
         # and wrap them with sudo; everything else runs as the normal
         # user so that file ownership stays consistent with brev copy.
-        import re
         needs_root = (
             user == "root" or user == 0
             # Match package-manager INSTALL actions at word boundaries,
@@ -1046,6 +1056,11 @@ echo "synced $REPO to $(git rev-parse --short HEAD)"
 def _which(cmd: str) -> bool:
     import shutil
     return shutil.which(cmd) is not None
+
+
+def _is_claude_code_agent_command(command: str) -> bool:
+    """Return True for Harbor's Claude Code agent rollout command."""
+    return bool(CLAUDE_PRINT_RE.search(command))
 
 
 def _stray_agent_reap_command() -> str:

--- a/.github/skill-eval/envs/tests/test_registered_node.py
+++ b/.github/skill-eval/envs/tests/test_registered_node.py
@@ -269,5 +269,46 @@ class ClaudeTaskScratchCleanup(unittest.TestCase):
         self.assertNotIn("rm -rf {} + 2>/dev/null", cmd)
 
 
+class ClaudeAgentWorkingDirectory(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.exec_calls = []
+
+        async def fake_run_brev_exec(instance, command, timeout=brev_env.BREV_EXEC_TIMEOUT):
+            self.exec_calls.append((instance, command, timeout))
+            return brev_env.ExecResult(stdout="", stderr=None, return_code=0)
+
+        self.original_exec = brev_env._run_brev_exec
+        brev_env._run_brev_exec = fake_run_brev_exec
+
+    async def asyncTearDown(self):
+        brev_env._run_brev_exec = self.original_exec
+
+    async def test_claude_print_command_defaults_to_repo_root(self):
+        env = brev_env.BrevEnvironment()
+        env._instance_name = "vss-eval-test"
+
+        await env.exec(
+            'printf "%s" "$PROMPT" | claude --verbose '
+            "--output-format=stream-json --permission-mode=bypassPermissions "
+            "--print 2>&1 | tee /logs/agent/claude-code.txt"
+        )
+
+        self.assertIn(
+            'cd "$HOME/video-search-and-summarization";',
+            self.exec_calls[0][1],
+        )
+
+    async def test_non_claude_command_does_not_default_to_repo_root(self):
+        env = brev_env.BrevEnvironment()
+        env._instance_name = "vss-eval-test"
+
+        await env.exec("echo harbor-ready")
+
+        self.assertNotIn(
+            'cd "$HOME/video-search-and-summarization";',
+            self.exec_calls[0][1],
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Repository-wide guidance for coding agents working in NVIDIA VSS.
+Always-on router for coding agents working in NVIDIA VSS.
 
 ## Always On
 
@@ -8,25 +8,22 @@ Repository-wide guidance for coding agents working in NVIDIA VSS.
   links.
 - Follow `CONTRIBUTING.md` for licensing, DCO sign-off, branch, PR, and test
   expectations.
-- Keep this file as a router. Put source, Docker, Kubernetes, and component
-  specifics in the nearest nested guide or README.
+- Load only the scoped guide that matches the task; avoid reading unrelated
+  deployment, service, skill, or tooling trees.
 - Do not commit secrets, generated runtime data, local `.env` files, logs, model
   downloads, or scratch artifacts.
 - Preserve SPDX headers and existing third-party license notices.
 
 ## Scoped Routing
 
-- Source code changes: read `services/AGENTS.md`, then the nearest service
-  `README.md` or existing service-specific `AGENTS.md`.
-- Docker Compose deployment changes: read `deploy/AGENTS.md` and
-  `deploy/docker/AGENTS.md`.
-- Kubernetes or Helm deployment changes: read `deploy/AGENTS.md` and
-  `deploy/helm/AGENTS.md`.
-- Shared libraries: start with the nearest `README.md` under `libs/`.
-- Utility scripts or data tools: start with the nearest `README.md` under
-  `tools/`.
-- Agent skills under `skills/` are product artifacts; read the target
-  `SKILL.md` and only the references it names.
+| Task area | Read next |
+|---|---|
+| Source services | `services/AGENTS.md`, then the nearest service guide |
+| Docker Compose deployment | `deploy/AGENTS.md`, then `deploy/docker/AGENTS.md` |
+| Kubernetes or Helm deployment | `deploy/AGENTS.md`, then `deploy/helm/AGENTS.md` |
+| Shared libraries | Nearest `README.md` under `libs/` |
+| Utility scripts or data tools | Nearest `README.md` under `tools/` |
+| Agent skills | Target `SKILL.md` and only the references it names |
 
 ## Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+Repository-wide guidance for coding agents working in NVIDIA VSS.
+
+## Always On
+
+- Start with `README.md` for the blueprint overview and public documentation
+  links.
+- Follow `CONTRIBUTING.md` for licensing, DCO sign-off, branch, PR, and test
+  expectations.
+- Keep this file as a router. Put source, Docker, Kubernetes, and component
+  specifics in the nearest nested guide or README.
+- Do not commit secrets, generated runtime data, local `.env` files, logs, model
+  downloads, or scratch artifacts.
+- Preserve SPDX headers and existing third-party license notices.
+
+## Scoped Routing
+
+- Source code changes: read `services/AGENTS.md`, then the nearest service
+  `README.md` or existing service-specific `AGENTS.md`.
+- Docker Compose deployment changes: read `deploy/AGENTS.md` and
+  `deploy/docker/AGENTS.md`.
+- Kubernetes or Helm deployment changes: read `deploy/AGENTS.md` and
+  `deploy/helm/AGENTS.md`.
+- Shared libraries: start with the nearest `README.md` under `libs/`.
+- Utility scripts or data tools: start with the nearest `README.md` under
+  `tools/`.
+- Agent skills under `skills/` are product artifacts; read the target
+  `SKILL.md` and only the references it names.
+
+## Validation
+
+- Always run `git diff --check` before committing.
+- Choose focused validation for the paths changed; do not run deployment or
+  hardware-heavy checks unless the task explicitly requires them.
+- Report commands run and any checks skipped because prerequisites were not
+  available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+Compatibility shim for Claude Code and other tools that load `CLAUDE.md`.
+
+This repository's agent guidance lives in `AGENTS.md`. Read and follow
+`AGENTS.md` first, then load only the scoped guide it routes you to for the
+current task.
+
+Do not duplicate or override repository guidance here; keep this file as a
+thin pointer so `AGENTS.md` remains the source of truth.

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -1,24 +1,21 @@
 # AGENTS.md
 
-Scoped guidance for deployment assets under `deploy/`.
+Router for deployment assets under `deploy/`.
 
 ## Scope
 
-- This file routes deployment changes. Read the Docker or Helm nested guide
-  before editing those trees.
-- Keep deployment guidance focused on external-user operation, not internal
-  automation behavior.
+- Read only the deployment surface that matches the task unless a service
+  contract change requires both Docker and Helm.
+- Keep guidance focused on external-user operation.
 
 ## Routing
 
-- Docker Compose: read `deploy/docker/AGENTS.md` and `deploy/docker/README.md`.
-- Kubernetes or Helm: read `deploy/helm/AGENTS.md` and the nearest chart
-  `README.md`.
-- Service image, port, environment, health, volume, or dependency changes often
-  require both Docker and Helm updates.
-- Developer profiles and industry profiles are user-facing bundles. Preserve
-  their documented intent and avoid moving settings across profile boundaries
-  unless the task asks for it.
+| Task area | Read next |
+|---|---|
+| Docker Compose | `deploy/docker/AGENTS.md` |
+| Kubernetes or Helm | `deploy/helm/AGENTS.md` |
+| Service image, port, env, health, volume, or dependency contract | Matching Docker and Helm surfaces |
+| Developer or industry profile behavior | The target profile README, values/env files, and compose/chart entrypoint |
 
 ## Deployment Rules
 
@@ -34,8 +31,6 @@ Scoped guidance for deployment assets under `deploy/`.
 
 ## Validation
 
-- Validate only the affected deployment surface:
-  - Docker Compose changes: follow `deploy/docker/AGENTS.md`.
-  - Helm changes: follow `deploy/helm/AGENTS.md`.
+- Validate only the affected deployment surface.
 - If validation needs Docker, Helm, GPUs, credentials, or NGC access that are
   unavailable, say exactly which check was skipped.

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+Scoped guidance for deployment assets under `deploy/`.
+
+## Scope
+
+- This file routes deployment changes. Read the Docker or Helm nested guide
+  before editing those trees.
+- Keep deployment guidance focused on external-user operation, not internal
+  automation behavior.
+
+## Routing
+
+- Docker Compose: read `deploy/docker/AGENTS.md` and `deploy/docker/README.md`.
+- Kubernetes or Helm: read `deploy/helm/AGENTS.md` and the nearest chart
+  `README.md`.
+- Service image, port, environment, health, volume, or dependency changes often
+  require both Docker and Helm updates.
+- Developer profiles and industry profiles are user-facing bundles. Preserve
+  their documented intent and avoid moving settings across profile boundaries
+  unless the task asks for it.
+
+## Deployment Rules
+
+- Prefer existing profile helpers, values files, and documented environment
+  variables over ad hoc one-off commands.
+- Do not commit generated values, rendered manifests, local data directories,
+  logs, downloaded models, resolved secrets, or `.env` files containing secrets.
+- Keep public endpoints and host-facing variables browser- or client-reachable;
+  do not replace them with container-internal names unless the setting is
+  explicitly internal.
+- When a source service contract changes, update deployment wiring and docs in
+  the same change.
+
+## Validation
+
+- Validate only the affected deployment surface:
+  - Docker Compose changes: follow `deploy/docker/AGENTS.md`.
+  - Helm changes: follow `deploy/helm/AGENTS.md`.
+- If validation needs Docker, Helm, GPUs, credentials, or NGC access that are
+  unavailable, say exactly which check was skipped.

--- a/deploy/docker/AGENTS.md
+++ b/deploy/docker/AGENTS.md
@@ -1,20 +1,23 @@
 # AGENTS.md
 
-Scoped guidance for Docker Compose deployment assets.
+Router for Docker Compose deployment assets.
 
 ## Scope
 
 - Applies to `deploy/docker/**`: root Compose, shared services, developer
   profiles, industry profiles, helper scripts, and Docker deployment docs.
-- Use this file as a router. Profile-specific details live in the relevant
-  profile files and README sections.
+- Profile-specific details live in the relevant profile files and README
+  sections.
 
 ## First Reads
 
-- `deploy/docker/README.md` for the external Docker deployment workflow.
-- `deploy/docker/compose.yml` for the top-level include structure.
-- The nearest profile `.env`, `overrides.env`, `compose.yml`, and README before
-  changing a profile.
+| Task area | Read next |
+|---|---|
+| General Docker workflow | `deploy/docker/README.md` |
+| Top-level include behavior | `deploy/docker/compose.yml` |
+| Developer profile | Target profile `.env`, `overrides.env`, `compose.yml`, and README |
+| Industry profile | Target profile `.env`, `compose.yml`, and README |
+| Helper script | Script help text and nearest README |
 
 ## Rules
 
@@ -34,5 +37,4 @@ Scoped guidance for Docker Compose deployment assets.
 - For Compose edits, render the affected stack with the documented env layers
   and run `docker compose config --quiet` when Docker Compose is available.
 - For helper-script edits, run `bash -n` and any documented dry-run/help path.
-- Do not start GPU-heavy or credentialed stacks unless the task explicitly asks
-  for runtime validation.
+- Do not start GPU-heavy or credentialed stacks unless explicitly asked.

--- a/deploy/docker/AGENTS.md
+++ b/deploy/docker/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+Scoped guidance for Docker Compose deployment assets.
+
+## Scope
+
+- Applies to `deploy/docker/**`: root Compose, shared services, developer
+  profiles, industry profiles, helper scripts, and Docker deployment docs.
+- Use this file as a router. Profile-specific details live in the relevant
+  profile files and README sections.
+
+## First Reads
+
+- `deploy/docker/README.md` for the external Docker deployment workflow.
+- `deploy/docker/compose.yml` for the top-level include structure.
+- The nearest profile `.env`, `overrides.env`, `compose.yml`, and README before
+  changing a profile.
+
+## Rules
+
+- Run Compose from `deploy/docker` unless a script documents another working
+  directory.
+- Prefer `deploy/docker/scripts/dev-profile.sh` for developer-profile flows.
+- Treat checked-in profile defaults as source and generated/runtime env files
+  as local state.
+- Do not edit generated resolved Compose output as source.
+- Keep service profile keys canonical; do not invent aggregate profile names.
+- If a service image, port, env var, volume, readiness endpoint, or dependency
+  changes, check whether the matching Helm chart also needs an update.
+
+## Validation
+
+- Always run `git diff --check -- deploy/docker`.
+- For Compose edits, render the affected stack with the documented env layers
+  and run `docker compose config --quiet` when Docker Compose is available.
+- For helper-script edits, run `bash -n` and any documented dry-run/help path.
+- Do not start GPU-heavy or credentialed stacks unless the task explicitly asks
+  for runtime validation.

--- a/deploy/helm/AGENTS.md
+++ b/deploy/helm/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Scoped guidance for Kubernetes and Helm deployment assets.
+Router for Kubernetes and Helm deployment assets.
 
 ## Scope
 
@@ -11,10 +11,11 @@ Scoped guidance for Kubernetes and Helm deployment assets.
 
 ## First Reads
 
-- The nearest `Chart.yaml`, `values.yaml`, and chart `README.md`.
-- Parent profile chart values when editing a subchart consumed by a profile.
-- Matching Docker Compose service/profile files when changing shared deployment
-  behavior.
+| Task area | Read next |
+|---|---|
+| Single chart change | Nearest `Chart.yaml`, `values.yaml`, and chart README |
+| Subchart consumed by a profile | Parent profile values and chart README |
+| Shared service contract | Matching Docker Compose service/profile files |
 
 ## Rules
 

--- a/deploy/helm/AGENTS.md
+++ b/deploy/helm/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+Scoped guidance for Kubernetes and Helm deployment assets.
+
+## Scope
+
+- Applies to `deploy/helm/**`: service charts, developer-profile charts,
+  industry-profile charts, values files, templates, and chart docs.
+- More specific chart READMEs and values files are the source of truth for a
+  chart's public configuration.
+
+## First Reads
+
+- The nearest `Chart.yaml`, `values.yaml`, and chart `README.md`.
+- Parent profile chart values when editing a subchart consumed by a profile.
+- Matching Docker Compose service/profile files when changing shared deployment
+  behavior.
+
+## Rules
+
+- Keep values user-facing and stable. Prefer adding documented values over
+  hardcoding deployment-specific names, hosts, image tags, or credentials.
+- Do not commit rendered manifests, live-cluster state, kubeconfigs, secrets, or
+  generated values files.
+- Preserve chart boundaries: shared service charts should not depend on a
+  single developer or industry profile unless the chart already does so.
+- Keep Docker and Helm behavior aligned for service contracts: images, ports,
+  env vars, probes, volumes, dependencies, and public endpoints.
+
+## Validation
+
+- Always run `git diff --check -- deploy/helm`.
+- Run `helm lint` or `helm template` for each affected chart when Helm is
+  available.
+- If a profile chart consumes a changed service chart, validate the profile
+  chart too.

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -1,27 +1,26 @@
 # AGENTS.md
 
-Scoped guidance for source code under `services/`.
+Router for source code under `services/`.
 
 ## Scope
 
-- This file routes service changes. More specific `AGENTS.md` or `CLAUDE.md`
-  files under a service take precedence for that service.
-- Prefer the service README and local package metadata over assumptions from
-  other services.
+- More specific `AGENTS.md` or `CLAUDE.md` files under a service take
+  precedence.
+- Read the target service guide only; do not load sibling service context unless
+  the change crosses that service boundary.
 
 ## Routing
 
-- Agent service: read `services/agent/AGENTS.md` and
-  `services/agent/README.md`.
-- Behavior analytics: read `services/analytics/behavior-analytics/AGENTS.md`.
-- Video analytics API: read `services/analytics/video-analytics-api/AGENTS.md`.
-- UI: read `services/ui/README.md` and `services/ui/CONTRIBUTING.md`.
-- Long video summarization: read `services/video-summarization/README.md`.
-- VIOS: read `services/vios/README.md`.
-- RT video intelligence services: read the nearest README under
-  `services/rtvi/`.
-- Alert, SDRC, and configurator services: start with the nearest service
-  README before changing code.
+| Path | Read next |
+|---|---|
+| `services/agent/**` | `services/agent/AGENTS.md` |
+| `services/analytics/behavior-analytics/**` | `services/analytics/behavior-analytics/AGENTS.md` |
+| `services/analytics/video-analytics-api/**` | `services/analytics/video-analytics-api/AGENTS.md` |
+| `services/ui/**` | `services/ui/README.md` and `services/ui/CONTRIBUTING.md` |
+| `services/video-summarization/**` | `services/video-summarization/README.md` |
+| `services/vios/**` | `services/vios/README.md` |
+| `services/rtvi/**` | Nearest README under `services/rtvi/` |
+| Other service paths | Nearest service README |
 
 ## Source Rules
 
@@ -38,5 +37,5 @@ Scoped guidance for source code under `services/`.
 
 - Run the narrowest service-level test or lint command documented by the
   service guide.
-- For cross-service behavior, validate each touched service plus the deployment
+- For cross-service behavior, validate each touched service and the deployment
   config that wires them together.

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+Scoped guidance for source code under `services/`.
+
+## Scope
+
+- This file routes service changes. More specific `AGENTS.md` or `CLAUDE.md`
+  files under a service take precedence for that service.
+- Prefer the service README and local package metadata over assumptions from
+  other services.
+
+## Routing
+
+- Agent service: read `services/agent/AGENTS.md` and
+  `services/agent/README.md`.
+- Behavior analytics: read `services/analytics/behavior-analytics/AGENTS.md`.
+- Video analytics API: read `services/analytics/video-analytics-api/AGENTS.md`.
+- UI: read `services/ui/README.md` and `services/ui/CONTRIBUTING.md`.
+- Long video summarization: read `services/video-summarization/README.md`.
+- VIOS: read `services/vios/README.md`.
+- RT video intelligence services: read the nearest README under
+  `services/rtvi/`.
+- Alert, SDRC, and configurator services: start with the nearest service
+  README before changing code.
+
+## Source Rules
+
+- Keep service boundaries intact. Shared deployment wiring belongs under
+  `deploy/`; service runtime code belongs under its service directory.
+- Preserve each service's package manager, formatter, test runner, and language
+  conventions.
+- Update tests and API/spec docs when behavior, schemas, endpoints, or public
+  configuration change.
+- Do not hardcode hostnames, ports, credentials, or model names when the service
+  already supports configuration.
+
+## Validation
+
+- Run the narrowest service-level test or lint command documented by the
+  service guide.
+- For cross-service behavior, validate each touched service plus the deployment
+  config that wires them together.


### PR DESCRIPTION
## Summary
- Add a root `AGENTS.md` as an always-on router for repository-wide guidance.
- Add scoped routers for `services/`, `deploy/`, `deploy/docker/`, and `deploy/helm/`.
- Keep guidance focused on external-user source, Docker Compose, and Kubernetes/Helm workflows; detailed context stays in nearest READMEs/component guides.

## Validation
- `git diff --cached --check`
- Scanned new router files for Harbor/eval-specific language.

## Notes
- This intentionally avoids Harbor/skills-eval-specific nested guidance.
- Existing service-specific guides are preserved and linked rather than replaced.