### PR TITLE
fix(vios): resolve libcuda via soname for JP 7.2

### DIFF
--- a/services/vios/README.md
+++ b/services/vios/README.md
@@ -77,7 +77,7 @@ Image tags are baked in **at build time**, so configure the registry *before* yo
 | CLI flag (preferred) | Env var equivalent | Default (local-only) |
 | --- | --- | --- |
 | `image-registry=<ref>` | `IMAGE_REGISTRY` | `vios` → `vios/vst-sensor:latest` |
-| `nvstreamer-image=<ref>` | `NVSTREAMER_IMAGE` | `nvstreamer` → `nvstreamer:latest` |
+| `nvstreamer-image=<ref>` | `NVSTREAMER_IMAGE_REGISTRY` | `nvstreamer` → `nvstreamer:latest` |
 | `toolchain-image=<ref>` | `X86_BUILD_IMAGE` (x86) / `AARCH64_CC_IMAGE` (arm64) | `vios-build:x86-24.04-cuda13.0.0` |
 
 ```bash

--- a/services/vios/build.sh
+++ b/services/vios/build.sh
@@ -112,7 +112,7 @@ show_help() {
     echo "  image-registry=<ref>   Override registry/org prefix for module + base images"
     echo "                          (replaces IMAGE_REGISTRY env var; default 'vios')."
     echo "  nvstreamer-image=<ref> Override the full NVStreamer image repository"
-    echo "                          (replaces NVSTREAMER_IMAGE env var; default 'nvstreamer')."
+    echo "                          (replaces NVSTREAMER_IMAGE_REGISTRY env var; default 'nvstreamer')."
     echo "  vst-app            Build k8s based vst-app for all modules and scaling-app"
     echo "  streamprocessing-app Build k8s based streamprocessing-app (sensor, streamprocessing, postgres, ingress)"
     echo "  ingress            Build ingress container needed for scaling-app"
@@ -308,7 +308,7 @@ while [[ "$#" -gt 0 ]]; do
         multiarch) MULTIARCH=1;;
         no-auto-deps) NO_AUTO_DEPS=1;;
         # CLI-flag alternatives to the X86_BUILD_IMAGE / AARCH64_CC_IMAGE /
-        # IMAGE_REGISTRY / NVSTREAMER_IMAGE env vars. Applied AFTER the
+        # IMAGE_REGISTRY / NVSTREAMER_IMAGE_REGISTRY env vars. Applied AFTER the
         # whole arg list is parsed so `arch=arm64 toolchain-image=…` works
         # regardless of arg order. CLI > env > default.
         toolchain-image=*) TOOLCHAIN_IMAGE_OVERRIDE="${1#*=}";;
@@ -334,7 +334,7 @@ if [[ -n "${IMAGE_REGISTRY_OVERRIDE:-}" ]]; then
     IMAGE_REGISTRY="$IMAGE_REGISTRY_OVERRIDE"
 fi
 if [[ -n "${NVSTREAMER_IMAGE_OVERRIDE:-}" ]]; then
-    NVSTREAMER_IMAGE="$NVSTREAMER_IMAGE_OVERRIDE"
+    NVSTREAMER_IMAGE_REGISTRY="$NVSTREAMER_IMAGE_OVERRIDE"
 fi
 
 # Export the resolved toolchain images so the Makefile's `?=` picks them up
@@ -342,6 +342,11 @@ fi
 # this, an env / toolchain-image= override never reaches the containerised
 # `make cc=1` step.
 export AARCH64_CC_IMAGE X86_BUILD_IMAGE
+# The multiarch path re-invokes this script per architecture, so the resolved
+# registries must be in the environment as well; otherwise an `image-registry=`
+# / `nvstreamer-image=` flag would tag the sub-builds with the defaults while
+# the parent pushes the overridden repository.
+export IMAGE_REGISTRY NVSTREAMER_IMAGE_REGISTRY
 
 # Print all variables
 echo "ARCH=$ARCH"
@@ -366,6 +371,7 @@ echo "NO_CACHE=$NO_CACHE"
 echo "BASE_IMAGE=$BASE_IMAGE"
 echo "MODULES=${MODULES[@]}"
 echo "IMAGE_REGISTRY=$IMAGE_REGISTRY"
+echo "NVSTREAMER_IMAGE_REGISTRY=$NVSTREAMER_IMAGE_REGISTRY"
 
 # Default tags for each module
 declare -A DEFAULT_TAGS=(
@@ -382,7 +388,7 @@ declare -A DEFAULT_TAGS=(
     [mcp]="latest"
     [nvstreamer]="latest"
     [vst]="latest"
-    [vst-base]="2.1.0-runtime-26.05.4"
+    [vst-base]="2.1.0-runtime-26.07.1"
 )
 
 # Function to build base image for faster container builds
@@ -1309,13 +1315,25 @@ build_multiarch() {
     fi
 
     # multiarch always pushes to a registry; the bare local default namespace
-    # (e.g. IMAGE_REGISTRY=vios) has no registry host and cannot be pushed.
-    local reg_host="${IMAGE_REGISTRY%%/*}"
-    if [[ "$reg_host" != *.* ]] && [[ "$reg_host" != *:* ]] && [[ "$reg_host" != "localhost" ]]; then
-        echo "[WARN] IMAGE_REGISTRY='$IMAGE_REGISTRY' has no registry host — the push/manifest will"
+    # (e.g. IMAGE_REGISTRY=vios, NVSTREAMER_IMAGE_REGISTRY=nvstreamer) has no
+    # registry host and cannot be pushed.
+    _warn_unpushable() {
+        local var="$1" value="$2" example="$3" host="${2%%/*}"
+        if [[ "$host" == *.* ]] || [[ "$host" == *:* ]] || [[ "$host" == "localhost" ]]; then
+            return 0
+        fi
+        echo "[WARN] $var='$value' has no registry host — the push/manifest will"
         echo "       target Docker Hub or fail. Set a pushable registry and log in first, e.g.:"
-        echo "         export IMAGE_REGISTRY=nvcr.io/rxczgrvsg8nx/vst-dev"
+        echo "         export $var=$example"
         echo "         docker login nvcr.io"
+    }
+    if [[ $BASE_IMAGE -eq 1 ]] || [[ ${#MODULES[@]} -gt 0 ]]; then
+        _warn_unpushable IMAGE_REGISTRY "$IMAGE_REGISTRY" \
+            "nvcr.io/rxczgrvsg8nx/vst-dev"
+    fi
+    if [[ $NVSTREAMER -eq 1 ]]; then
+        _warn_unpushable NVSTREAMER_IMAGE_REGISTRY "$NVSTREAMER_IMAGE_REGISTRY" \
+            "nvcr.io/rxczgrvsg8nx/vst-dev/nvstreamer"
     fi
 
     if [[ $BASE_IMAGE -eq 1 ]]; then
@@ -1381,7 +1399,7 @@ build_multiarch() {
     local -a repos=()
     local m
     for m in "${MODULES[@]}"; do repos+=("$IMAGE_REGISTRY/vst-${m}"); done
-    [[ $NVSTREAMER -eq 1 ]] && repos+=("$NVSTREAMER_IMAGE")
+    [[ $NVSTREAMER -eq 1 ]] && repos+=("$NVSTREAMER_IMAGE_REGISTRY")
 
     # Flags forwarded to each per-arch sub-build.
     local extra=""
@@ -1524,7 +1542,7 @@ if [[ $BUILD_ALL -eq 1 ]]; then
         _mt="${DEFAULT_TAGS[$_m]:-latest}"
         echo "  module    : $IMAGE_REGISTRY/vst-${_m}:${TAG:-$_mt}"
     done
-    echo "  nvstreamer: $NVSTREAMER_IMAGE:${DEFAULT_TAGS[nvstreamer]:-latest}"
+    echo "  nvstreamer: $NVSTREAMER_IMAGE_REGISTRY:${DEFAULT_TAGS[nvstreamer]:-latest}"
     echo ""
     echo "To publish to your registry, set the registry env vars BEFORE running"
     echo "the build (the tag is baked into the image at build time — see the"
@@ -1895,15 +1913,28 @@ else
             print_per_image_build_timing_line "$MODULE_BUILD_START_TIME"
 
             if [[ $PUSH -eq 1 ]]; then
-                # Push in the background so the next module's compile + docker build
-                # overlaps this image's upload. Output is captured per-image and
-                # printed when the push is waited on after the loop.
-                push_log=$(mktemp)
-                echo "Pushing Docker image (background): $imagename"
-                docker push "$imagename" > "$push_log" 2>&1 &
-                PUSH_PIDS+=("$!")
-                PUSH_IMAGES+=("$imagename")
-                PUSH_LOGS+=("$push_log")
+                if [[ $MODULE_COUNT -eq $((${#MODULES[@]} - 1)) ]]; then
+                    # Last image: no further module build is left to overlap with, so
+                    # push in the foreground and let docker report its own per-layer
+                    # progress instead of leaving the user with a silent upload.
+                    echo "Pushing Docker image: $imagename"
+                    if docker push "$imagename"; then
+                        echo -e "Docker push succeeded for image: $imagename"
+                    else
+                        echo -e "[ERROR] Docker push failed for image: $imagename"
+                        exit 1
+                    fi
+                else
+                    # Push in the background so the next module's compile + docker build
+                    # overlaps this image's upload. Output is captured per-image and
+                    # printed when the push is waited on after the loop.
+                    push_log=$(mktemp)
+                    echo "Pushing Docker image (background): $imagename"
+                    docker push "$imagename" > "$push_log" 2>&1 &
+                    PUSH_PIDS+=("$!")
+                    PUSH_IMAGES+=("$imagename")
+                    PUSH_LOGS+=("$push_log")
+                fi
             fi
 
             MODULE_COUNT=$((MODULE_COUNT + 1))

--- a/services/vios/build.sh
+++ b/services/vios/build.sh
@@ -92,10 +92,10 @@ show_help() {
     echo "  all                One-shot: toolchain -> base -> module containers (sensor + streamprocessing"
     echo "                     by default, or whatever module=... lists) -> nvstreamer container."
     echo "  multiarch          Build+push amd64 and arm64 images (per-arch tags) then assemble one"
-    echo "                     multi-arch manifest via 'docker buildx imagetools'. Needs tag=<manifest-tag>"
-    echo "                     (e.g. tag=2.1.0-26.05.4; per-arch tags are derived as -amd64-/-arm64-) and a"
-    echo "                     target (module=<list> and/or nvstreamer). Set IMAGE_REGISTRY to a pushable"
-    echo "                     registry first. amd64 push overlaps the arm64 build."
+    echo "                     multi-arch manifest via 'docker buildx imagetools'. Application targets need"
+    echo "                     tag=<manifest-tag> and module=<list>, nvstreamer, or all. Base images use"
+    echo "                     base-container base-tag=<manifest-tag>. Set IMAGE_REGISTRY to a pushable"
+    echo "                     registry first. Application amd64 push overlaps the arm64 build."
     echo "  multiarch all      Multi-arch equivalent of 'all': builds sensor + streamprocessing + nvstreamer"
     echo "                     for both arches (needs tag=<manifest-tag>). Ingress is separate (already"
     echo "                     multi-arch): ./build.sh container ingress push=1 tag=<tag>."
@@ -153,6 +153,7 @@ show_help() {
     echo "  export IMAGE_REGISTRY=nvcr.io/rxczgrvsg8nx/vst-dev"
     echo "  ./build.sh multiarch tag=2.1.0-26.05.4 module=sensor,streamprocessing"
     echo "  ./build.sh multiarch tag=2.1.0-26.05.4 nvstreamer base-tag=2.1.0-runtime-26.05.4"
+    echo "  ./build.sh multiarch base-container base-tag=2.1.0-runtime-26.05.4"
     echo "  ./build.sh arch=multiarch all tag=2.1.0-26.05.4   # sensor + streamprocessing + nvstreamer, both arches"
     echo "  ./build.sh container ingress push=1 tag=2.1.0-26.05.4   # ingress (already multi-arch), built separately"
     echo ""
@@ -1256,12 +1257,17 @@ fi
 #
 #   ./build.sh multiarch tag=2.1.0-26.05.4 module=sensor,streamprocessing
 #   ./build.sh multiarch tag=2.1.0-26.05.4 nvstreamer base-tag=2.1.0-runtime-26.05.4
+#   ./build.sh multiarch base-container base-tag=2.1.0-runtime-26.05.4
 #
 # Requires IMAGE_REGISTRY to point at a real registry you can push to (e.g.
 # export IMAGE_REGISTRY=nvcr.io/rxczgrvsg8nx/vst-dev), and `docker login`.
 build_multiarch() {
-    # The multi-arch manifest tag is the standard tag= (as everywhere else).
-    if [[ -z "$TAG" ]]; then
+    # Application manifests use tag=; the base image uses base-tag= so the
+    # command matches the existing single-architecture base-container syntax.
+    if [[ $BASE_IMAGE -eq 1 ]] && [[ -z "$BASE_TAG" ]]; then
+        echo "[ERROR] multiarch base-container requires base-tag=<manifest-tag>, e.g. base-tag=2.1.0-runtime-26.05.4"
+        exit 1
+    elif [[ $BASE_IMAGE -eq 0 ]] && [[ -z "$TAG" ]]; then
         echo "[ERROR] multiarch requires tag=<manifest-tag>, e.g. tag=2.1.0-26.05.4"
         exit 1
     fi
@@ -1281,8 +1287,12 @@ build_multiarch() {
         NVSTREAMER=1
     fi
 
-    if [[ ${#MODULES[@]} -eq 0 ]] && [[ $NVSTREAMER -eq 0 ]]; then
-        echo "[ERROR] multiarch needs a target: module=<list>, nvstreamer, and/or 'all'"
+    if [[ $BASE_IMAGE -eq 1 ]] && \
+       { [[ ${#MODULES[@]} -gt 0 ]] || [[ $NVSTREAMER -eq 1 ]] || [[ $BUILD_ALL -eq 1 ]]; }; then
+        echo "[ERROR] multiarch base-container cannot be combined with module=<list>, nvstreamer, or all"
+        exit 1
+    elif [[ $BASE_IMAGE -eq 0 ]] && [[ ${#MODULES[@]} -eq 0 ]] && [[ $NVSTREAMER -eq 0 ]]; then
+        echo "[ERROR] multiarch needs a target: base-container, module=<list>, nvstreamer, and/or 'all'"
         exit 1
     fi
 
@@ -1306,6 +1316,55 @@ build_multiarch() {
         echo "       target Docker Hub or fail. Set a pushable registry and log in first, e.g.:"
         echo "         export IMAGE_REGISTRY=nvcr.io/rxczgrvsg8nx/vst-dev"
         echo "         docker login nvcr.io"
+    fi
+
+    if [[ $BASE_IMAGE -eq 1 ]]; then
+        local base_amd_tag base_arm_tag
+        if [[ "$BASE_TAG" == *-* ]]; then
+            # Insert the architecture before the final release segment:
+            # 2.1.0-runtime-26.07.1 -> 2.1.0-runtime-amd64-26.07.1.
+            base_amd_tag="${BASE_TAG%-*}-amd64-${BASE_TAG##*-}"
+            base_arm_tag="${BASE_TAG%-*}-arm64-${BASE_TAG##*-}"
+        else
+            base_amd_tag="${BASE_TAG}-amd64"
+            base_arm_tag="${BASE_TAG}-arm64"
+        fi
+
+        local base_repo="$IMAGE_REGISTRY/vst-base"
+        local base_extra=""
+        [[ $NO_CACHE -eq 1 ]] && base_extra="no-cache"
+
+        echo "=============================================="
+        echo "multiarch base: $BASE_TAG"
+        echo "  amd64 tag : $base_amd_tag"
+        echo "  arm64 tag : $base_arm_tag"
+        echo "  manifest  : $BASE_TAG"
+        echo "  target    : $base_repo"
+        echo "=============================================="
+
+        # Base images contain no shared compiled object tree, so no make clean
+        # is needed between the architecture-specific Docker builds.
+        # shellcheck disable=SC2086
+        "$0" base-container base-tag="$base_amd_tag" push=1 $base_extra || {
+            echo "[ERROR] amd64 base image build failed"; exit 1; }
+        # shellcheck disable=SC2086
+        "$0" arch=arm64 base-container base-tag="$base_arm_tag" push=1 $base_extra || {
+            echo "[ERROR] arm64 base image build failed"; exit 1; }
+
+        docker buildx imagetools create \
+            --tag "$base_repo:$BASE_TAG" \
+            "$base_repo:$base_arm_tag" \
+            "$base_repo:$base_amd_tag" || {
+                echo "[ERROR] base image manifest creation failed"; exit 1; }
+
+        echo ""
+        echo "================ multiarch base complete ================"
+        echo "  pushed   :"
+        echo "     - $base_repo:$base_amd_tag"
+        echo "     - $base_repo:$base_arm_tag"
+        echo "  manifest : $base_repo:$BASE_TAG"
+        echo "========================================================="
+        return
     fi
 
     # 2.1.0-26.05.4 -> prefix=2.1.0 suffix=26.05.4 -> 2.1.0-<arch>-26.05.4.

--- a/services/vios/cicd_files/aarch64/Dockerfile.app
+++ b/services/vios/cicd_files/aarch64/Dockerfile.app
@@ -17,7 +17,7 @@
 # build.sh always passes this in for you: it builds a base locally, reuses an
 # existing one, or uses a registry image you point it at (base-tag= /
 # image-registry=). One tag works for both x86_64 and arm64 (if it is a multi-arch image).
-ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.05.4
+ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.07.1
 FROM ${BASE_IMAGE}
 
 ARG PKG_LOCATION

--- a/services/vios/cicd_files/x86_64/Dockerfile.app
+++ b/services/vios/cicd_files/x86_64/Dockerfile.app
@@ -17,7 +17,7 @@
 # build.sh always passes this in for you: it builds a base locally, reuses an
 # existing one, or uses a registry image you point it at (base-tag= /
 # image-registry=). One tag works for both x86_64 and arm64 (if it is a multi-arch image).
-ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.05.4
+ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.07.1
 FROM ${BASE_IMAGE}
 
 ARG PKG_LOCATION

--- a/services/vios/src/framework/platform_specific/cudaLoader.cpp
+++ b/services/vios/src/framework/platform_specific/cudaLoader.cpp
@@ -47,26 +47,47 @@ CudaLoader::CudaLoader()
         , m_handleCuda(nullptr)
         , m_handleCudart(nullptr)
 {
+    // The driver library is injected by the container runtime, and where it
+    // lands depends on the host stack: the Jetson CSV mounts used to place it
+    // in /usr/lib/<triplet>, while CDI injection (JetPack 7.2 / R39 OpenRM)
+    // mounts it under /opt/nvidia/l4t-gpu-libs/openrm and only registers it in
+    // the ld cache. Resolve the soname first so any of those layouts works, and
+    // keep the absolute paths as a fallback for images with no ld cache entry.
+    static const char* const cudaCandidates[] = {
+        "libcuda.so.1",
+        "libcuda.so",
+#ifdef AARCH64_PLATFORM
+        "/opt/nvidia/l4t-gpu-libs/openrm/libcuda.so.1",
+        "/usr/lib/aarch64-linux-gnu/nvidia/libcuda.so.1",
+        "/usr/lib/aarch64-linux-gnu/libcuda.so",
+#endif
+    };
     // Version-agnostic cudart lookup: try the bare soname first (resolved via
     // ldconfig / LD_LIBRARY_PATH), then the /usr/local/cuda symlink, then a
     // pinned minor version. This lets any CUDA 13.x runtime base work (13.0,
     // 13.2, future 13.x) without hardcoding a minor-version path.
 #ifdef AARCH64_PLATFORM
-    // Discrete-GPU aarch64 (Thor/SBSA). Not constructed on Jetson/Orin at runtime.
-    m_handleCuda = dlopen("/usr/lib/aarch64-linux-gnu/libcuda.so", RTLD_LAZY);
     static const char* const cudartCandidates[] = {
         "libcudart.so.13",
         "/usr/local/cuda/targets/sbsa-linux/lib/libcudart.so.13",
         "/usr/local/cuda-13.2/targets/sbsa-linux/lib/libcudart.so.13",
     };
 #else
-    m_handleCuda = dlopen("libcuda.so", RTLD_LAZY);
     static const char* const cudartCandidates[] = {
         "libcudart.so.13",
         "/usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.13",
         "/usr/local/cuda-13.2/targets/x86_64-linux/lib/libcudart.so.13",
     };
 #endif
+    for (const char* cand : cudaCandidates)
+    {
+        m_handleCuda = dlopen(cand, RTLD_LAZY);
+        if (m_handleCuda)
+        {
+            break;
+        }
+        LOG(info) << "libcuda not found at " << cand << ": " << dlerror() << endl;
+    }
     for (const char* cand : cudartCandidates)
     {
         m_handleCudart = dlopen(cand, RTLD_LAZY);
@@ -74,12 +95,15 @@ CudaLoader::CudaLoader()
         {
             break;
         }
+        LOG(info) << "libcudart not found at " << cand << ": " << dlerror() << endl;
     }
     if (!m_handleCuda || !m_handleCudart)
     {
         if (g_isGpuPresent)
         {
-            LOG(error) << "Error loading the CUDA libraries" << endl;
+            LOG(error) << "Error loading the CUDA libraries (libcuda: "
+                       << (m_handleCuda ? "ok" : "missing") << ", libcudart: "
+                       << (m_handleCudart ? "ok" : "missing") << ")" << endl;
             m_error = true;
             throw std::runtime_error("An exception occurred, error loading the CUDA libraries");
         }


### PR DESCRIPTION
## Description
- JetPack 7.2 / R39 (Thor) injects `libcuda` under `/opt/nvidia/l4t-gpu-libs/openrm` via CDI and registers it in the ld cache; the previous hardcoded SBSA path `/usr/lib/aarch64-linux-gnu/libcuda.so` does not exist, so `CudaLoader` threw `Error loading the CUDA libraries` at startup.
- `cudaLoader.cpp` now tries `libcuda.so.1` / `libcuda.so` first, then OpenRM and legacy absolute paths, so Thor, DGX Spark/SBSA, and x86 all resolve the driver. Orin is unchanged (`CudaLoader` is only constructed when `!isJetsonPlatform()`).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.