### PR TITLE
fix(agent): derive version from release tags only, not nightly/dev tags

### DIFF
--- a/services/agent/packages/vss_agents/pyproject.toml
+++ b/services/agent/packages/vss_agents/pyproject.toml
@@ -5,6 +5,11 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 raw-options.root = "../../../.."
+# Keep in sync with services/agent/pyproject.toml [tool.hatch.version].
+raw-options.git_describe_command = [
+  "git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*",
+]
+raw-options.version_scheme = "no-guess-dev"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/agent/packages/vss_cli/pyproject.toml
+++ b/services/agent/packages/vss_cli/pyproject.toml
@@ -5,6 +5,11 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 raw-options.root = "../../../.."
+# Keep in sync with services/agent/pyproject.toml [tool.hatch.version].
+raw-options.git_describe_command = [
+  "git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*",
+]
+raw-options.version_scheme = "no-guess-dev"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/agent/packages/vss_core/pyproject.toml
+++ b/services/agent/packages/vss_core/pyproject.toml
@@ -5,6 +5,11 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 raw-options.root = "../../../.."
+# Keep in sync with services/agent/pyproject.toml [tool.hatch.version].
+raw-options.git_describe_command = [
+  "git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*",
+]
+raw-options.version_scheme = "no-guess-dev"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -5,6 +5,14 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 raw-options.root = "../.."
+# Derive the version from release tags only. The repo also carries nightly-*,
+# dev-*, and develop-<sha> tags; a SHA-shaped one is not PEP 440-parseable and
+# fails the build for every package in the workspace.
+raw-options.git_describe_command = [
+  "git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*",
+]
+# Report distance from the last release instead of guessing the next one.
+raw-options.version_scheme = "no-guess-dev"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
## Problem

`SonarQube Scan (agent)` is failing on **`develop` and every open PR** since ~11:50Z on 2026-07-30. The other three matrix legs (skills / alert / ui) are green because only the `agent` leg builds the Python workspace.

```
ValueError: Error getting the version from source `vcs`:
Can't parse version from tag 'nightly-6e4cada'
(tag_regex='^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$', tag_prefix='')
```

Examples: [develop run 30544796309](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/30544796309) · [PR #1477 run 30541658788](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/30541658788)

## Root cause

All four agent packages use `[tool.hatch.version] source = "vcs"`, which lets `git describe` pick **any** tag reachable from HEAD. The repo carries three tag families and only one of them is a version:

| Family | Example | A version? |
|---|---|---|
| release | `v3.2.1` | yes |
| nightly | `nightly-20260725`, **`nightly-6e4cada`** | no |
| dev / per-push | `dev-26.07.4`, `develop-<sha>` | no |

`nightly-6e4cada` landed on `6e4cadad8`, one commit behind the develop tip, so describe now returns `nightly-6e4cada-1-g257022eae`. The default `tag_regex` strips the `nightly-` prefix and is left with `6e4cada`, which is not a PEP 440 version — hard failure.

Date-shaped nightly tags happened to parse (`nightly-20260725` → version `20260725`), which is why this only surfaced now. Those were already producing junk versions like `26.7.5.dev88` off `dev-26.07.4`.

`ci.yml` was immune only because it pins `SETUPTOOLS_SCM_PRETEND_VERSION`. `sonarqube.yml` does not — and neither does a developer running `uv sync` locally, which fails on `develop` right now.

## Fix

Restrict describe to release tags in all four `pyproject.toml` files, so a non-release tag can never become the version base:

```toml
raw-options.git_describe_command = [
  "git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*",
]
raw-options.version_scheme = "no-guess-dev"
```

`no-guess-dev` reports distance from the last release instead of inventing the next one — the default `guess-next-dev` would claim `3.2.2.dev418` while the tree is heading for 3.3.0. **That second line is separable** if reviewers prefer the default scheme; drop it and versions become `3.2.2.dev418+g257022eae`.

## Verification

At develop `257022eae`, `hatchling version` in each package:

| Package | Before | After |
|---|---|---|
| `services/agent` | `ValueError` | `3.2.1.post1.dev418+g257022eae` |
| `packages/vss_core` | `ValueError` | `3.2.1.post1.dev418+g257022eae` |
| `packages/vss_agents` | `ValueError` | `3.2.1.post1.dev418+g257022eae` |
| `packages/vss_cli` | `ValueError` | `3.2.1.post1.dev418+g257022eae` |

`git describe --dirty --tags --long` returns `nightly-6e4cada-1-g257022eae`; with `--match v[0-9]*` it returns `v3.2.1-418-g257022eae`.

Docker builds are unaffected — `services/agent/docker/Dockerfile` pins `SETUPTOOLS_SCM_PRETEND_VERSION`.

## Follow-ups (not in this PR)

1. **The `nightly-6e4cada` tag is still there.** This PR makes builds immune to it, but deleting or renaming it (`nightly-20260730`) would also unblock everything and is worth doing regardless.
2. **Stop minting SHA-shaped nightly tags.** `prepare_nightly_promotion.py` takes the tag from the release-set's image build tag, so a SHA-shaped image tag becomes a SHA-shaped git tag. There is no `git tag` push anywhere in `.github/`, so the tagger lives outside GH Actions — worth confirming who owns it, possibly related to #1446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
