### PR TITLE
fix(ci): fail fast when the companion GHCR build has already failed

### DIFF
--- a/.github/scripts/test_update_pr_ghcr_candidates.py
+++ b/.github/scripts/test_update_pr_ghcr_candidates.py
@@ -24,27 +24,49 @@ class CandidateCommentTest(unittest.TestCase):
         self.assertIsNone(module.pr_number("develop"))
         self.assertIsNone(module.pr_number("pull-request/not-a-number"))
 
-    def test_select_release_set_run_requires_exact_ref_sha_and_success(self):
+    def test_select_release_set_run_requires_exact_ref_and_sha(self):
+        """Exact match only; conclusion is the caller's business, not the selector's."""
         runs = [
-            {
-                "id": 1,
-                "head_sha": "a" * 40,
-                "head_branch": "pull-request/1190",
-                "conclusion": "failure",
-            },
-            {
-                "id": 2,
-                "head_sha": "a" * 40,
-                "head_branch": "pull-request/1190",
-                "conclusion": "success",
-            },
+            {"id": 1, "head_sha": "b" * 40, "head_branch": "pull-request/1190",
+             "conclusion": "success", "created_at": "2026-07-01T00:00:00Z"},
+            {"id": 2, "head_sha": "a" * 40, "head_branch": "develop",
+             "conclusion": "success", "created_at": "2026-07-01T00:00:00Z"},
+        ]
+        self.assertIsNone(
+            module.select_release_set_run(runs, "a" * 40, "pull-request/1190")
+        )
+
+    def test_select_release_set_run_returns_a_failed_run(self):
+        """The whole point: a failed companion run must be visible to the caller.
+
+        Filtering it out here is what made "finished unsuccessfully" look
+        identical to "not created yet", so the poller waited out its budget.
+        """
+        runs = [
+            {"id": 1, "head_sha": "a" * 40, "head_branch": "pull-request/1190",
+             "conclusion": "failure", "created_at": "2026-07-01T00:00:00Z"},
+        ]
+        selected = module.select_release_set_run(runs, "a" * 40, "pull-request/1190")
+        self.assertEqual(selected["id"], 1)
+        self.assertEqual(selected["conclusion"], "failure")
+
+    def test_select_release_set_run_prefers_the_newest_execution(self):
+        """A newer workflow execution supersedes an older one, so a stale
+        failure must not abort a build that is currently running.
+
+        Note this is a distinct execution (new id), not a GitHub re-run.
+        A re-run reuses the id; that case is covered in BuildWaitTest."""
+        runs = [
+            {"id": 1, "head_sha": "a" * 40, "head_branch": "pull-request/1190",
+             "conclusion": "failure", "created_at": "2026-07-01T00:00:00Z"},
+            {"id": 2, "head_sha": "a" * 40, "head_branch": "pull-request/1190",
+             "conclusion": None, "status": "in_progress",
+             "created_at": "2026-07-02T00:00:00Z"},
         ]
         self.assertEqual(
-            module.select_release_set_run(
-                runs, "a" * 40, "pull-request/1190"
-            )["id"],
-            2,
+            module.select_release_set_run(runs, "a" * 40, "pull-request/1190")["id"], 2
         )
+
 
     def test_comment_lists_only_immutable_ghcr_builds(self):
         release_set = {
@@ -292,6 +314,148 @@ class CandidateCommentTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "repeated a page"):
             module.upsert_comment(FakeApi(), "org/repo", 1190, "updated")
 
+
+class BuildWaitTest(unittest.TestCase):
+    """The defect: a failed companion build was invisible, so the poller
+    retried 520 times over ~130 minutes for a run that would never appear."""
+
+    SHA = "f" * 40
+    REF = "pull-request/1190"
+
+    def _api(self, *pages):
+        api = mock.Mock()
+        api.request.side_effect = [{"workflow_runs": p} for p in pages]
+        return api
+
+    def _run(self, **kw):
+        base = {"id": 7, "run_number": 7, "run_attempt": 1,
+                "head_sha": self.SHA, "head_branch": self.REF,
+                "created_at": "2026-07-01T00:00:00Z", "html_url": "https://x/7"}
+        base.update(kw)
+        return base
+
+    def test_query_does_not_filter_on_success(self):
+        """Guards the fix itself. Asking GitHub only for successful runs is
+        what made a failed companion build indistinguishable from an absent
+        one, so the query must stay unfiltered by status."""
+        api = self._api([self._run(status="completed", conclusion="success")])
+        with mock.patch.object(module, "download_release_set_artifact",
+                               return_value={"ok": True}):
+            module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
+        url = api.request.call_args[0][1]
+        self.assertIn("head_sha=", url)
+        self.assertNotIn("status=", url)
+        self.assertIn("branch=", url)
+
+    def test_failed_companion_run_raises_immediately_without_sleeping(self):
+        api = self._api([self._run(status="completed", conclusion="failure")])
+        with mock.patch.object(module.time, "sleep") as slept:
+            with self.assertRaises(RuntimeError) as ctx:
+                module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
+        slept.assert_not_called()
+        self.assertIn("failure", str(ctx.exception))
+        self.assertIn("7", str(ctx.exception))
+        self.assertEqual(api.request.call_count, 1)
+
+    def test_every_terminal_non_success_conclusion_fails_immediately(self):
+        for conclusion in ("cancelled", "timed_out", "startup_failure",
+                           "stale", "neutral", "skipped"):
+            with self.subTest(conclusion=conclusion):
+                api = self._api([self._run(status="completed",
+                                           conclusion=conclusion)])
+                with mock.patch.object(module.time, "sleep") as slept:
+                    with self.assertRaises(RuntimeError) as ctx:
+                        module.download_release_set(
+                            api, "o/r", self.SHA, self.REF, 520, 15)
+                slept.assert_not_called()
+                self.assertIn(conclusion, str(ctx.exception))
+
+    def test_action_required_keeps_polling(self):
+        """Approval can resume the same run, so this is not terminal."""
+        api = self._api(
+            [self._run(status="completed", conclusion="action_required")],
+            [self._run(status="completed", conclusion="success")],
+        )
+        with mock.patch.object(module.time, "sleep"), mock.patch.object(
+            module, "download_release_set_artifact", return_value={"ok": True}
+        ):
+            self.assertEqual(
+                module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15),
+                {"ok": True},
+            )
+
+    def test_in_flight_github_rerun_is_not_aborted(self):
+        """A GitHub re-run reuses the run id and resets status to in_progress
+        while `conclusion` may still read stale. Interpreting a conclusion on a
+        non-completed run would abort somebody's retry."""
+        api = self._api(
+            [self._run(run_attempt=2, status="in_progress", conclusion="failure")],
+            [self._run(run_attempt=2, status="completed", conclusion="success")],
+        )
+        with mock.patch.object(module.time, "sleep") as slept, mock.patch.object(
+            module, "download_release_set_artifact", return_value={"ok": True}
+        ):
+            out = module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
+        self.assertEqual(out, {"ok": True})
+        self.assertEqual(slept.call_count, 1)
+
+    def test_in_progress_keeps_waiting_then_succeeds(self):
+        api = self._api(
+            [self._run(status="in_progress", conclusion=None)],
+            [self._run(status="completed", conclusion="success")],
+        )
+        with mock.patch.object(module.time, "sleep") as slept, mock.patch.object(
+            module, "download_release_set_artifact", return_value={"ok": True}
+        ) as dl:
+            out = module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
+        self.assertEqual(out, {"ok": True})
+        self.assertEqual(slept.call_count, 1)
+        dl.assert_called_once()
+
+    def test_still_in_progress_at_the_final_attempt_times_out(self):
+        """Guards the reset at the end of the loop: a non-terminal run on the
+        last attempt must not be mistaken for a usable one."""
+        api = mock.Mock()
+        api.request.return_value = {
+            "workflow_runs": [self._run(status="in_progress", conclusion=None)]
+        }
+        with mock.patch.object(module.time, "sleep") as slept, mock.patch.object(
+            module, "download_release_set_artifact"
+        ) as dl:
+            with self.assertRaises(RuntimeError) as ctx:
+                module.download_release_set(api, "o/r", self.SHA, self.REF, 3, 15)
+        self.assertEqual(api.request.call_count, 3)
+        self.assertEqual(slept.call_count, 2)
+        dl.assert_not_called()
+        self.assertIn("3 polling attempts", str(ctx.exception))
+
+    def test_absent_run_still_exhausts_its_budget(self):
+        """Waiting is correct while the run does not exist yet. Note CI also
+        triggers on `main`, where Build Dev Images never runs at all, so an
+        absent run is not always transient."""
+        api = mock.Mock()
+        api.request.return_value = {"workflow_runs": []}
+        with mock.patch.object(module.time, "sleep") as slept:
+            with self.assertRaises(RuntimeError):
+                module.download_release_set(api, "o/r", self.SHA, self.REF, 3, 15)
+        self.assertEqual(api.request.call_count, 3)
+        self.assertEqual(slept.call_count, 2)
+
+    def test_older_failure_does_not_abort_a_newer_running_execution(self):
+        api = self._api([
+            self._run(id=1, run_number=1, status="completed", conclusion="failure",
+                      created_at="2026-07-01T00:00:00Z"),
+            self._run(id=2, run_number=2, status="in_progress", conclusion=None,
+                      created_at="2026-07-02T00:00:00Z"),
+        ], [
+            self._run(id=2, run_number=2, status="completed", conclusion="success",
+                      created_at="2026-07-02T00:00:00Z"),
+        ])
+        with mock.patch.object(module.time, "sleep"), mock.patch.object(
+            module, "download_release_set_artifact", return_value={"ok": True}
+        ):
+            out = module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
+        self.assertEqual(out, {"ok": True})
 
 if __name__ == "__main__":
     module.enforce_memory_ceiling()

--- a/.github/scripts/update_pr_ghcr_candidates.py
+++ b/.github/scripts/update_pr_ghcr_candidates.py
@@ -179,17 +179,45 @@ class GitHubApi:
         return json.loads(body) if content_type == "application/json" else body
 
 
+#: Conclusions that mean the companion build will never produce a release set.
+#: Anything else (None while queued or in progress, or a value we do not
+#: recognise) is treated as "keep waiting", so an unfamiliar conclusion can only
+#: cost time, never a false failure.
+#: ``action_required`` is deliberately absent: approval can resume the same run.
+TERMINAL_FAILURE_CONCLUSIONS = frozenset(
+    {"failure", "cancelled", "timed_out", "startup_failure", "stale",
+     "neutral", "skipped"}
+)
+
+
 def select_release_set_run(
     runs: list[dict[str, Any]], sha: str, ref_name: str
 ) -> dict[str, Any] | None:
-    for run in runs:
-        if (
-            run.get("head_sha") == sha
-            and run.get("head_branch") == ref_name
-            and run.get("conclusion") == "success"
-        ):
-            return run
-    return None
+    """Newest Build Dev Images run for this exact commit and ref, any conclusion.
+
+    Deliberately not filtered to successes. The caller has to tell three states
+    apart: not created yet, still running, and finished unsuccessfully. Filtering
+    here collapsed the last two into "keep polling", so a failed companion build
+    was indistinguishable from one that had not started and the caller waited out
+    its whole budget against a run that would never appear.
+
+    Newest wins so that a rerun supersedes the attempt it replaced.
+    """
+    matches = [
+        run
+        for run in runs
+        if run.get("head_sha") == sha and run.get("head_branch") == ref_name
+    ]
+    if not matches:
+        return None
+    return max(
+        matches,
+        key=lambda run: (
+            str(run.get("created_at") or ""),
+            run.get("run_number") or 0,
+            run.get("id") or 0,
+        ),
+    )
 
 
 def download_release_set(
@@ -201,7 +229,7 @@ def download_release_set(
     interval_seconds: int,
 ) -> dict[str, Any]:
     query = urllib.parse.urlencode(
-        {"head_sha": sha, "status": "success", "per_page": 20}
+        {"head_sha": sha, "branch": ref_name, "per_page": 100}
     )
     run: dict[str, Any] | None = None
     for attempt in range(1, attempts + 1):
@@ -211,16 +239,39 @@ def download_release_set(
         )
         run = select_release_set_run(payload.get("workflow_runs", []), sha, ref_name)
         if run is not None:
-            break
+            status = run.get("status")
+            conclusion = run.get("conclusion")
+            if status != "completed":
+                # Queued, in progress, or a re-run in flight. A GitHub re-run
+                # reuses the run id and resets status, so an earlier failure
+                # must not abort the attempt that replaced it.
+                conclusion = None
+            if conclusion == "success":
+                break
+            if conclusion in TERMINAL_FAILURE_CONCLUSIONS:
+                # Fail now rather than polling out the budget. The companion run
+                # has finished and will never publish a release set.
+                raise RuntimeError(
+                    f"GHCR build run {run.get('id')} for {sha[:12]} on {ref_name} "
+                    f"concluded {conclusion!r}; it will not produce a release set. "
+                    f"See {run.get('html_url') or 'the Build Dev Images run'}."
+                )
+            # Present but not finished: keep waiting.
         if attempt < attempts:
+            state = "not ready" if run is None else f"{run.get('status')}"
             print(
-                f"GHCR build run for {sha[:12]} is not ready; "
+                f"GHCR build run for {sha[:12]} is {state}; "
                 f"retrying in {interval_seconds}s ({attempt}/{attempts})",
                 flush=True,
             )
             time.sleep(interval_seconds)
+        run = None
     if run is None:
-        raise RuntimeError(f"no successful GHCR build run found for {sha}")
+        raise RuntimeError(
+            f"no GHCR build run for {sha} on {ref_name} reached a successful "
+            f"conclusion after {attempts} polling attempts at "
+            f"{interval_seconds}s intervals"
+        )
 
     return download_release_set_artifact(api, repository, int(run["id"]))
 


### PR DESCRIPTION
## Description

**This is not about test failures.** The bridge already stops on the first blocking downstream failure and already ignores `allow_failure: true` jobs — that part works. This is one layer earlier: **you cannot run tests at all if the images never got built, and nothing noticed the build had died.**

`Wait for Build Dev Images` could not tell *"the build hasn't finished"* from *"the build failed"*, so a failed companion build was invisible and the job polled out its whole budget waiting for an artifact that was never coming.

### Measured

Four runs between 2026-07-23 and 07-29 did this. 520 polls at 15s, ~132 minutes each, roughly **9 hours of delayed verdicts**, each ending on:

```
GHCR build run for f2da3e71421a is not ready; retrying in 15s (519/520)
RuntimeError: no successful GHCR build run found for f2da3e71421a
```

The information was available on the first poll.

### Cause

Two filters, either of which alone would have caused it:

- the workflow-runs query asked for `status=success`
- `select_release_set_run` additionally required `conclusion == "success"`

So a failed run and a nonexistent one both came back as `None`, and the caller could only conclude "keep waiting."

### Change

`select_release_set_run` now returns the newest run matching `head_sha` + `head_branch` regardless of conclusion, and the caller distinguishes three cases:

| Companion run | Behaviour |
|---|---|
| `completed` + `success` | proceed |
| `completed` + `failure`/`cancelled`/`timed_out`/`startup_failure`/`stale`/`neutral`/`skipped` | **raise now**, naming run id, conclusion and URL |
| anything else | keep polling |

A conclusion is only interpreted once `status == "completed"`. **A GitHub re-run reuses the run id and resets status while the old conclusion may still read stale** — without that gate this would abort somebody's retry. `action_required` also keeps polling, since approval can resume the same run. An unrecognised conclusion keeps polling too, so an unfamiliar value can cost time but never cause a false failure.

The query is now scoped by `branch` and pages at 100, so a busy SHA cannot evict the relevant run.

### Impact, stated honestly

**This is a latency fix and does not change pass rate.** Those four runs still fail — roughly 130 minutes sooner. The frequency is four occurrences in one seven-day sample, so treat the ~9 hours as indicative rather than a rate.

One operational note: fail-fast removes the accidental 130-minute window in which someone could manually re-run the build and rescue the still-polling job. Recovery becomes re-run Build Dev Images, then re-run the wait job.

### Tests

24 pass. New coverage in `BuildWaitTest`, including the two that guard the change itself:

- `test_query_does_not_filter_on_success` — asserts the request contains `head_sha=` and `branch=` and **not** `status=`, so the fix cannot be silently undone
- `test_in_flight_github_rerun_is_not_aborted` — same run id, `run_attempt: 2`, `in_progress` with a stale `failure` conclusion, must not raise
- every terminal non-success conclusion fails immediately, asserting `sleep` was never called
- still-in-progress at the final attempt times out without downloading an artifact
- an older failed execution does not abort a newer running one

## Checklist

- [x] Every commit is DCO sign-off'd
- [x] `test_update_pr_ghcr_candidates.py` already runs in `ci.yml`, so the new behaviour is gated
- [x] No other caller of `select_release_set_run`; `prepare_nightly_promotion.py` imports only `download_release_set_artifact` and is unaffected
- [x] Nothing in either repo depends on the old error string