### PR TITLE
Feat/search 2 gpu setup

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -43,9 +43,11 @@ PERCEPTION_TAG="3.3.0-26.07.1"
 BP_PROFILE=bp_developer_search
 
 # GPU IDs reserved for non-LLM/VLM services in this profile.
-RESERVED_DEVICE_IDS='0'
+# 2-GPU layout co-locates RT-VLM with RT-CV on GPU 0, so no GPU is reserved.
+RESERVED_DEVICE_IDS=''
 # GPU IDs treated as shared by dev-profile.sh when deriving LLM/VLM placement.
-FIXED_SHARED_DEVICE_IDS='1'
+# GPU 0: RT-CV + RT-VLM. GPU 1: RT-Embed + LLM.
+FIXED_SHARED_DEVICE_IDS='0,1'
 RT_CV_DEVICE_ID='0'
 RT_EMBED_DEVICE_ID='1'
 

--- a/deploy/docker/developer-profiles/dev-profile-search/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/overrides.env
@@ -22,10 +22,10 @@ HARDWARE_PROFILE=H100
 # =============================================================================
 # Local LLM GPU device. Edge hardware may require device 0.
 LLM_DEVICE_ID='1'
-# Local VLM GPU device. Remote VLM and edge hardware may use device 0.
-VLM_DEVICE_ID='2'
+# Local VLM GPU device. Co-located with RT-CV on GPU 0 for 2-GPU hosts.
+VLM_DEVICE_ID='0'
 # Local RT-VLM device. local uses the VLM device; local_shared follows the shared VLM device; remote and THOR edge use 0.
-RT_VLM_DEVICE_ID='2'
+RT_VLM_DEVICE_ID='0'
 # LLM runtime mode: local_shared when LLM and VLM share one GPU, local for
 # a dedicated local LLM GPU, or remote for an external endpoint.
 LLM_MODE=local_shared
@@ -59,7 +59,7 @@ LLM_MODEL_TYPE=nim
 # Local deployments route the critic VLM through RT-VLM. Keep VLM_NAME aligned
 # with the model id advertised by the RT-VLM /v1/models endpoint.
 # Select the fixed RT-VLM model for the critic, THOR edge base, or remote /v1/models model.
-VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_bf16-final
+VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix
 # Set to none for remote VLM, RT-VLM critic, or disabled search critic.
 VLM_NAME_SLUG=none
 # Extra env file for local VLM container settings.
@@ -166,12 +166,13 @@ RTVI_VLM_IMAGE_TAG="3.2.1"
 RTVI_VLM_ENDPOINT=''
 # Local RT-VLM uses cosmos-reason3; remote VLM uses openai-compat.
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
-# Set per hardware/mode for local RT-VLM by dev-profile.sh.
-RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
+# Set per hardware/mode for local RT-VLM by dev-profile.sh. Fraction leaves room
+# for RT-CV on the shared GPU 0 (H100 local_shared default).
+RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.4'
 # Set to 18000 for RTXPRO4500BW local RT-VLM.
 RTVI_VLM_MAX_MODEL_LEN=''
-# Local RT-VLM checkpoint (Cosmos3 Nano BF16).
-RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final'
+# Local RT-VLM checkpoint (Cosmos3 Nano FP8) to fit alongside RT-CV on a shared GPU.
+RTVI_VLM_MODEL_PATH='ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix'
 # Search critic is request/response over HTTP; no VLM event publishing. Disable
 # Kafka to match the Helm search profile (rtvi.env defaults it on for alerts/LVS).
 RTVI_VLM_KAFKA_ENABLED=false

--- a/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-search/vss-agent/configs/config.yml
@@ -197,8 +197,8 @@ llms:
     temperature: 0.0
     model_kwargs:
       extra_body:
-        num_frames_per_second_or_fixed_frames_chunk: 60
-        use_fps_for_chunking: false
+        num_frames_per_second_or_fixed_frames_chunk: 2
+        use_fps_for_chunking: true
         vlm_input_width: 800
         vlm_input_height: 448
 

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1062,14 +1062,15 @@ function process_args() {
         fi
       fi
 
-      # Search deploys a local RT-VLM (critic + video_understanding) that requires a
-      # dedicated GPU unless --use-remote-vlm is provided. On 2-GPU Brev launchables
-      # that GPU is unavailable, so fail fast instead of a broken deployment.
+      # Search deploys a local RT-VLM (critic + video_understanding) that shares GPU 0
+      # with RT-CV, while RT-Embed and the LLM share GPU 1, so two GPUs are the floor
+      # unless --use-remote-vlm is provided. A single-GPU Brev launchable cannot host
+      # that layout, so fail fast instead of a broken deployment.
       if [[ "${profile}" == "search" ]] && [[ -n "${BREV_ENV_ID:-}" ]] && [[ "${vlm_mode}" != "remote" ]]; then
         local _brev_gpu_count
         _brev_gpu_count="$(get_nvidia_smi_gpu_count)"
-        if [[ "${_brev_gpu_count}" =~ ^[0-9]+$ ]] && [[ "${_brev_gpu_count}" -gt 0 ]] && [[ "${_brev_gpu_count}" -le 2 ]]; then
-          echo "[ERROR] Search deploys a local RT-VLM that requires a dedicated GPU, but this Brev environment has ${_brev_gpu_count} GPU(s). Pass --use-remote-vlm with VLM_ENDPOINT_URL to run search here."
+        if [[ "${_brev_gpu_count}" =~ ^[0-9]+$ ]] && [[ "${_brev_gpu_count}" -gt 0 ]] && [[ "${_brev_gpu_count}" -lt 2 ]]; then
+          echo "[ERROR] Search deploys a local RT-VLM and needs at least 2 GPUs, but this Brev environment has ${_brev_gpu_count} GPU(s). Pass --use-remote-vlm with VLM_ENDPOINT_URL to run search here."
           ((_all_good++))
         fi
       fi

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -132,6 +132,8 @@ function get_vlm_slug() {
     nvidia/cosmos-reason1-7b) echo "cosmos-reason1-7b" ;;
     nvidia/cosmos-reason2-8b) echo "cosmos-reason2-8b" ;;
     nvidia/cosmos3-reasoner) echo "cosmos3-reasoner" ;;
+    # No standalone NIM ships this checkpoint; RT-VLM serves it, so there is no slug to select.
+    nvidia/cosmos3-reasoner-fp8) echo "none" ;;
     Qwen/Qwen3-VL-8B-Instruct) echo "qwen3-vl-8b-instruct" ;;
     *) echo "" ;;
   esac
@@ -146,6 +148,7 @@ function get_rtvi_vlm_model_path() {
     nvidia/cosmos-reason1-7b) echo "ngc:nim/nvidia/cosmos-reason1-7b:1.1-fp8-dynamic" ;;
     nvidia/cosmos-reason2-8b) echo "ngc:nim/nvidia/cosmos-reason2-8b:hf-0303" ;;
     nvidia/cosmos3-reasoner) echo "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" ;;
+    nvidia/cosmos3-reasoner-fp8) echo "ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix" ;;
     Qwen/Qwen3-VL-8B-Instruct) echo "git:https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct" ;;
     *) echo "" ;;
   esac
@@ -157,6 +160,7 @@ function get_rtvi_vlm_model_to_use() {
     nvidia/cosmos-reason1-7b) echo "cosmos-reason1" ;;
     nvidia/cosmos-reason2-8b) echo "cosmos-reason2" ;;
     nvidia/cosmos3-reasoner) echo "cosmos-reason3" ;;
+    nvidia/cosmos3-reasoner-fp8) echo "cosmos-reason3" ;;
     Qwen/Qwen3-VL-8B-Instruct) echo "vllm-compatible" ;;
     *) echo "" ;;
   esac
@@ -510,6 +514,7 @@ function usage() {
   echo "                                     - nvidia/cosmos-reason2-8b"
   echo "                                     - nvidia/cosmos3-reasoner          (search: NIM_MODEL_SIZE=nano|super → nvidia/cosmos3-{size}-reasoner;"
   echo "                                                                         base/alerts/lvs: maps to RT-VLM MODEL_PATH + /v1/models basename)"
+  echo "                                     - nvidia/cosmos3-reasoner-fp8      (Cosmos3 Nano FP8 via RT-VLM; smaller footprint for a shared GPU)"
   echo "                                     - Qwen/Qwen3-VL-8B-Instruct"
   echo "                                   • Not accepted for profile=alerts or base on IGX-THOR or AGX-THOR"
   echo "                                   • When --use-remote-vlm is passed, any model name can be passed"
@@ -1051,7 +1056,7 @@ function process_args() {
         fi
         if contains_element "vlm" "${options_provided[@]}"; then
           if [[ -z "$(get_vlm_slug "${vlm}")" ]]; then
-            echo "[ERROR] Invalid VLM model name: ${vlm}. Must be one of: nvidia/cosmos-reason1-7b, nvidia/cosmos-reason2-8b, nvidia/cosmos3-reasoner, Qwen/Qwen3-VL-8B-Instruct"
+            echo "[ERROR] Invalid VLM model name: ${vlm}. Must be one of: nvidia/cosmos-reason1-7b, nvidia/cosmos-reason2-8b, nvidia/cosmos3-reasoner, nvidia/cosmos3-reasoner-fp8, Qwen/Qwen3-VL-8B-Instruct"
             ((_all_good++))
           fi
         fi

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -732,13 +732,16 @@ rm -f "${_out_compose_env_order}" "${_err_compose_env_order}"
 # Search: RT-VLM (vss-rtvi-vlm) is always deployed because it serves both the critic and
 # video_understanding. It is activated via the explicit "rtvi-vlm" compose profile (no vlm_
 # NIM profile) and the agent is wired to it with VLM_NAME_SLUG=none, VLM_MODEL_TYPE=rtvi,
-# VLM_BASE_URL=http://rtvi-vlm:8000. RT_VLM_DEVICE_ID follows the shared/VLM device (2).
+# VLM_BASE_URL=http://rtvi-vlm:8000. RT-VLM shares GPU 0 with RT-CV, so device 0 is in
+# FIXED_SHARED_DEVICE_IDS and VLM_MODE derives to local_shared, which caps RT-VLM at the
+# 0.4 H100 shared fraction so RT-CV keeps its headroom.
 run_dry_run_up_and_check_generated_env "generated.env search default wires RT-VLM" "search" \
   -i 127.0.0.1 -d -- \
-  "VLM_DEVICE_ID" "2" "VLM_NAME_SLUG" "none" "VLM_MODEL_TYPE" "rtvi" \
-  "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_bf16-final" \
-  "VLM_BASE_URL" "http://rtvi-vlm:8000" "RT_VLM_DEVICE_ID" "2" \
-  "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3"
+  "VLM_DEVICE_ID" "0" "VLM_MODE" "local_shared" "VLM_NAME_SLUG" "none" "VLM_MODEL_TYPE" "rtvi" \
+  "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix" \
+  "VLM_BASE_URL" "http://rtvi-vlm:8000" "RT_VLM_DEVICE_ID" "0" \
+  "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" \
+  "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.4"
 _mock_brev_two_gpu_dir="$(mktemp -d)"
 CLEANUP_DIRS+=("${_mock_brev_two_gpu_dir}")
 cat > "${_mock_brev_two_gpu_dir}/nvidia-smi" <<'EOF'
@@ -769,10 +772,12 @@ else
 fi
 EOF
 chmod +x "${_mock_brev_three_gpu_dir}/nvidia-smi"
+# Placement comes from the profile env, not the host GPU count, so a 3-GPU host still
+# co-locates RT-VLM with RT-CV on GPU 0 and leaves GPU 2 unused.
 PATH="${_mock_brev_three_gpu_dir}:${PATH}" BREV_ENV_ID=test-env run_dry_run_up_and_check_generated_env "generated.env search Brev 3 GPU wires RT-VLM" "search" \
   -i 127.0.0.1 -d -- \
-  "VLM_DEVICE_ID" "2" "VLM_NAME_SLUG" "none" "VLM_MODEL_TYPE" "rtvi" \
-  "VLM_BASE_URL" "http://rtvi-vlm:8000" "RT_VLM_DEVICE_ID" "2"
+  "VLM_DEVICE_ID" "0" "VLM_NAME_SLUG" "none" "VLM_MODEL_TYPE" "rtvi" \
+  "VLM_BASE_URL" "http://rtvi-vlm:8000" "RT_VLM_DEVICE_ID" "0"
 
 # --- Setup paths: data directory and selective downloads (assert dry-run output) ---
 _out_setup="$(mktemp)"

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -704,8 +704,8 @@ run_dry_run_up_and_check_generated_env "up base with llm keeps fixed RT-VLM" "ba
 run_negative_test "llm-env-file must exist" 1 up -p base -i 127.0.0.1 --llm-env-file /nonexistent/llm.env -d
 run_negative_test "vlm-env-file must exist" 1 up -p base -i 127.0.0.1 --vlm-env-file ./nonexistent-vlm.env -d
 run_dry_run_test "up alerts real-time mode" up -p alerts -i 127.0.0.1 -m real-time -d
-# L40S forbids local_shared for LLM/VLM; search profile default is local_shared for LLM (device 1 in FIXED_SHARED). Use remote LLM so L40S is allowed.
-LLM_ENDPOINT_URL=http://127.0.0.1:1 run_dry_run_test "up search with L40S (allowed)" up -p search -i 127.0.0.1 -H L40S --use-remote-llm --llm x -d
+# L40S forbids local_shared for LLM/VLM; the search profile shares both GPUs (devices 0,1 in FIXED_SHARED), so LLM and VLM must both be remote for L40S to be allowed.
+LLM_ENDPOINT_URL=http://127.0.0.1:1 VLM_ENDPOINT_URL=http://127.0.0.1:9998 run_dry_run_test "up search with L40S (allowed)" up -p search -i 127.0.0.1 -H L40S --use-remote-llm --llm x --use-remote-vlm --vlm my-remote-vlm -d
 
 _out_compose_env_order="$(mktemp)"
 _err_compose_env_order="$(mktemp)"

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -742,6 +742,23 @@ run_dry_run_up_and_check_generated_env "generated.env search default wires RT-VL
   "VLM_BASE_URL" "http://rtvi-vlm:8000" "RT_VLM_DEVICE_ID" "0" \
   "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" \
   "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.4"
+_mock_brev_one_gpu_dir="$(mktemp -d)"
+CLEANUP_DIRS+=("${_mock_brev_one_gpu_dir}")
+cat > "${_mock_brev_one_gpu_dir}/nvidia-smi" <<'EOF'
+#!/bin/bash
+if [[ "$*" == *"--query-gpu=index"* ]]; then
+  printf '0\n'
+else
+  printf 'NVIDIA RTX PRO 6000 Blackwell\n'
+fi
+EOF
+chmod +x "${_mock_brev_one_gpu_dir}/nvidia-smi"
+# One GPU cannot host RT-CV + RT-VLM and RT-Embed + LLM, so local RT-VLM is rejected.
+PATH="${_mock_brev_one_gpu_dir}:${PATH}" BREV_ENV_ID=test-env run_negative_test "search Brev 1 GPU rejects default local RT-VLM" 1 up -p search -i 127.0.0.1 -d
+PATH="${_mock_brev_one_gpu_dir}:${PATH}" BREV_ENV_ID=test-env VLM_ENDPOINT_URL=http://127.0.0.1:9998 run_dry_run_up_and_check_generated_env "generated.env search Brev 1 GPU allows remote VLM" "search" \
+  -i 127.0.0.1 --use-remote-vlm --vlm my-remote-vlm -d -- \
+  "VLM_MODE" "remote" "RTVI_VLM_MODEL_PATH" "none" "RT_VLM_DEVICE_ID" "0"
+
 _mock_brev_two_gpu_dir="$(mktemp -d)"
 CLEANUP_DIRS+=("${_mock_brev_two_gpu_dir}")
 cat > "${_mock_brev_two_gpu_dir}/nvidia-smi" <<'EOF'
@@ -753,8 +770,11 @@ else
 fi
 EOF
 chmod +x "${_mock_brev_two_gpu_dir}/nvidia-smi"
-# RT-VLM always deploys locally for search, so a 2-GPU Brev is rejected; only --use-remote-vlm avoids it.
-PATH="${_mock_brev_two_gpu_dir}:${PATH}" BREV_ENV_ID=test-env run_negative_test "search Brev 2 GPU rejects default local RT-VLM" 1 up -p search -i 127.0.0.1 -d
+# Two GPUs are enough for a local RT-VLM now that it shares GPU 0 with RT-CV.
+PATH="${_mock_brev_two_gpu_dir}:${PATH}" BREV_ENV_ID=test-env run_dry_run_up_and_check_generated_env "generated.env search Brev 2 GPU wires local RT-VLM" "search" \
+  -i 127.0.0.1 -d -- \
+  "VLM_DEVICE_ID" "0" "VLM_MODE" "local_shared" "VLM_NAME_SLUG" "none" "VLM_MODEL_TYPE" "rtvi" \
+  "VLM_BASE_URL" "http://rtvi-vlm:8000" "RT_VLM_DEVICE_ID" "0"
 PATH="${_mock_brev_two_gpu_dir}:${PATH}" BREV_ENV_ID=test-env VLM_ENDPOINT_URL=http://127.0.0.1:9998 run_dry_run_up_and_check_generated_env "generated.env search Brev 2 GPU allows remote VLM" "search" \
   -i 127.0.0.1 --use-remote-vlm --vlm my-remote-vlm -d -- \
   "VLM_MODE" "remote" "VLM_NAME_SLUG" "none" "VLM_MODEL_TYPE" "rtvi" \

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1480,6 +1480,12 @@ run_dry_run_up_and_check_generated_env "generated.env base --vlm cosmos3-reasone
   "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" \
   "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" "VLM_MODEL_TYPE" "rtvi"
 
+run_dry_run_up_and_check_generated_env "generated.env base --vlm cosmos3-reasoner-fp8 maps to RT-VLM FP8 path+basename" "base" \
+ -i 127.0.0.1 --vlm nvidia/cosmos3-reasoner-fp8 -d -- \
+  "VLM_NAME_SLUG" "none" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix" \
+  "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix" \
+  "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" "VLM_MODEL_TYPE" "rtvi"
+
 run_dry_run_up_and_check_generated_env "generated.env base --vlm Qwen maps to RT-VLM git path+basename" "base" \
  -i 127.0.0.1 --vlm Qwen/Qwen3-VL-8B-Instruct -d -- \
   "VLM_NAME_SLUG" "none" "VLM_NAME" "Qwen3-VL-8B-Instruct" \
@@ -1487,6 +1493,12 @@ run_dry_run_up_and_check_generated_env "generated.env base --vlm Qwen maps to RT
   "RTVI_VLM_MODEL_TO_USE" "vllm-compatible" "VLM_MODEL_TYPE" "rtvi"
 
 # Search routes --vlm through RT-VLM (integrated checkpoint), same as base/lvs; see the base --vlm tests above.
+run_dry_run_up_and_check_generated_env "generated.env search --vlm cosmos3-reasoner-fp8 maps to RT-VLM FP8 path+basename" "search" \
+ -i 127.0.0.1 --vlm nvidia/cosmos3-reasoner-fp8 -d -- \
+  "VLM_NAME_SLUG" "none" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix" \
+  "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix" \
+  "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" "VLM_MODEL_TYPE" "rtvi"
+
 run_dry_run_up_and_check_generated_env "generated.env search --vlm Qwen maps to RT-VLM git path+basename" "search" \
  -i 127.0.0.1 --vlm Qwen/Qwen3-VL-8B-Instruct -d -- \
   "VLM_NAME_SLUG" "none" "VLM_NAME" "Qwen3-VL-8B-Instruct" \

--- a/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-search/configs/vss-agent/config.yml
@@ -197,8 +197,8 @@ llms:
     temperature: 0.0
     model_kwargs:
       extra_body:
-        num_frames_per_second_or_fixed_frames_chunk: 60
-        use_fps_for_chunking: false
+        num_frames_per_second_or_fixed_frames_chunk: 2
+        use_fps_for_chunking: true
         vlm_input_width: 800
         vlm_input_height: 448
 

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -382,7 +382,7 @@ rtvi:
   vss-rtvi-vlm:
     enabled: true
     useSharedNim: false
-    modelPath: "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final"
+    modelPath: "ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix"
     sharedNimPort: "8000"
     waitForKafka:
       enabled: false
@@ -566,7 +566,7 @@ agent:
     # The VLM is served by rtvi-vlm (see rtvi.vss-rtvi-vlm) for both the critic and
     # video_understanding. Model id must match the rtvi-vlm /v1/models advertisement,
     # not the cosmos3-reasoner NIM id.
-    vlmName: nim_nvidia_cosmos3-nano-reasoner_bf16-final
+    vlmName: nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix
     # Search routes VLM calls (critic and video_understanding) through vss-rtvi-vlm.
     # rtviVlmServiceName feeds the RTVI_VLM_BASE_URL env below; leave rtviVlmBaseUrl empty
     # to use the in-cluster service.
@@ -689,7 +689,7 @@ agent:
       - name: LLM_NAME
         value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.llmName ((index $g "llmName") | default "") "nvidia/nvidia-nemotron-nano-9b-v2") }}'
       - name: VLM_NAME
-        value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.vlmName ((index $g "vlmName") | default "") "nim_nvidia_cosmos3-nano-reasoner_bf16-final") }}'
+        value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.vlmName ((index $g "vlmName") | default "") "nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix") }}'
       - name: EVAL_LLM_JUDGE_NAME
         value: '{{- $g := .Values.global | default dict }}{{- $ln := trim (coalesce .Values.llmName ((index $g "llmName") | default "") "nvidia/nvidia-nemotron-nano-9b-v2") }}{{ coalesce .Values.evalLlmJudgeName $ln }}'
       - name: EVAL_LLM_JUDGE_BASE_URL
@@ -888,6 +888,7 @@ nims:
     replicas: 1
     nimModelSize: 'nano'
     # Empty so the NIM uses its built-in manifest; BF16 pinned via nimModelProfile.
+    # This standalone path stays BF16 while rtvi.vss-rtvi-vlm defaults to the FP8 checkpoint.
     nimModelName: ''
     nimModelProfile: 'e55fdb44f41441032f546360d0dcf61caa8b39fa2852d31124c03953d01e1cb3'
     resources:

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -10,7 +10,7 @@ Semantic video search via Cosmos Embed1 embeddings indexed in Elasticsearch. RT-
 
 - **Four always-on GPU services:** `rtvi-cv` (DeepStream perception), `rtvi-embed` (Cosmos Embed1 embeddings), the **LLM**, and `vss-rtvi-vlm`. Search does not deploy a standalone Cosmos VLM NIM.
 - **RT-VLM serves two consumers.** The Critique agent uses it when `use_critic=true` (default), and `video_understanding` uses it independently.
-- **Default local layout uses three GPUs.** `RT_CV_DEVICE_ID=0`; `RT_EMBED_DEVICE_ID=1` and `LLM_DEVICE_ID=1`; `RT_VLM_DEVICE_ID=2`. The LLM must leave headroom for RT-Embed on GPU 1.
+- **Default local layout uses two GPUs.** GPU 0 hosts `RT_CV_DEVICE_ID=0` plus `RT_VLM_DEVICE_ID=0`; GPU 1 hosts `RT_EMBED_DEVICE_ID=1` and `LLM_DEVICE_ID=1`. Both GPUs are shared, so RT-VLM must leave headroom for RT-CV and the LLM must leave headroom for RT-Embed.
 - **Remote VLM still uses a local RT-VLM proxy.** `vss-rtvi-vlm` runs in `openai-compat` mode and forwards inference to the selected remote endpoint.
 
 ## What gets deployed
@@ -37,7 +37,7 @@ Container names below are the actual `container_name:` keys from `deploy/docker/
 | LLM | `nvidia/nvidia-nemotron-nano-9b-v2` | `nvidia-nemotron-nano-9b-v2` | NIM (port 30081) |
 | Embed (RT-Embed) | `nvidia/Cosmos-Embed1-448p-anomaly-detection` | — | RT-Embed (port 8017), `MODEL_PATH=git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection` |
 | Perception (RT-CV) | siglip2 v1.1 + RTDETR (warehouse) | — | RT-CV (DeepStream pipeline) |
-| VLM (RT-VLM) | `ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final` (default local checkpoint) | `VLM_NAME_SLUG=none`; activated via the `rtvi-vlm` compose profile | RT-VLM (port 8018) |
+| VLM (RT-VLM) | `ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix` (default local checkpoint; FP8 so it fits alongside RT-CV on GPU 0) | `VLM_NAME_SLUG=none`; activated via the `rtvi-vlm` compose profile | RT-VLM (port 8018) |
 
 ## VLM placement
 
@@ -47,17 +47,17 @@ RT-VLM is always selected with `VLM_MODEL_TYPE=rtvi` and `VLM_NAME_SLUG=none`; t
 User supplied or approved a remote VLM endpoint?     → Path A: RT-VLM remote proxy
    │
    ▼
-DEFAULT — at least 3 GPUs available?                 → Path B: local RT-VLM on GPU 2
+DEFAULT — at least 2 GPUs available?                 → Path B: local RT-VLM on GPU 0
    │
    ▼
-Only 2 GPUs available?                               → Path A: remote VLM required
+Only 1 GPU available?                                → Path A: remote VLM required
 ```
 
-The default is **Path B**, with RT-CV on GPU 0, RT-Embed + LLM on GPU 1, and RT-VLM on GPU 2. On a two-GPU Brev host, use Path A; `dev-profile.sh` intentionally rejects local RT-VLM there rather than silently overcommitting either GPU.
+The default is **Path B**, with RT-CV + RT-VLM on GPU 0 and RT-Embed + LLM on GPU 1. On a single-GPU Brev host, use Path A; `dev-profile.sh` rejects local RT-VLM there rather than silently overcommitting the only GPU.
 
 ### Path A — RT-VLM proxy to a remote VLM
 
-Triggered when the user provides a VLM endpoint URL, asks for `remote-vlm` / `remote-all`, or approves remote placement because fewer than three GPUs are available. RT-VLM remains local as the media-processing/OpenAI-compatible proxy:
+Triggered when the user provides a VLM endpoint URL, asks for `remote-vlm` / `remote-all`, or approves remote placement because fewer than two GPUs are available. RT-VLM remains local as the media-processing/OpenAI-compatible proxy:
 
 ```bash
 VLM_MODE=remote
@@ -75,26 +75,28 @@ NVIDIA_API_KEY=<key if required>
 
 The resolved compose must include profile `rtvi-vlm` and container `vss-rtvi-vlm`. `VLM_BASE_URL` has no `/v1`; `RTVI_VLM_ENDPOINT` includes `/v1`.
 
-### Path B — Default: local RT-VLM on dedicated GPU 2
+### Path B — Default: local RT-VLM sharing GPU 0 with RT-CV
 
-Use this on a host with at least three free GPUs:
+Use this on a host with at least two free GPUs:
 
 ```bash
 RT_CV_DEVICE_ID=0
 RT_EMBED_DEVICE_ID=1
 LLM_DEVICE_ID=1                                          # LLM shares GPU 1 with RT-Embed
-VLM_DEVICE_ID=2
-RT_VLM_DEVICE_ID=2
+VLM_DEVICE_ID=0                                          # RT-VLM shares GPU 0 with RT-CV
+RT_VLM_DEVICE_ID=0
 LLM_MODE=local_shared
-VLM_MODE=local
-VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_bf16-final
+VLM_MODE=local_shared
+VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix
 VLM_NAME_SLUG=none
 VLM_MODEL_TYPE=rtvi
 VLM_PORT=8018
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
-RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final
-RTVI_VLLM_GPU_MEMORY_UTILIZATION=<hardware-derived value>
+RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix
+RTVI_VLLM_GPU_MEMORY_UTILIZATION=<hardware-derived value>  # 0.4 on H100/RTX PRO 6000 in local_shared
 ```
+
+`VLM_MODE` derives to `local_shared` rather than `local` because `VLM_DEVICE_ID=0` is listed in `FIXED_SHARED_DEVICE_IDS`. That is what selects the shared-GPU memory fraction, so do not hand-set `VLM_MODE=local` here — it would let RT-VLM claim the fraction meant for a dedicated GPU and starve RT-CV.
 
 The resolved compose must include profile `rtvi-vlm` and container `vss-rtvi-vlm`. Use `RTVI_VLLM_GPU_MEMORY_UTILIZATION`, not `NIM_KVCACHE_PERCENT`, to size RT-VLM.
 
@@ -202,14 +204,14 @@ That's it. No compose-file tweak required for the default Cosmos-Embed1 deployme
 
 > **Verifying under load.** Watch `docker logs vss-rtvi-embed` and `nvidia-smi -l 5` on GPU 1 while pushing `NUM_STREAMS=16` of test video. If RT-Embed's resident memory exceeds ~12 GB, raise the budget (e.g. 12 → 15 GB → recompute LLM `NIM_KVCACHE_PERCENT`). If the LLM OOMs at startup, it usually means RT-Embed grabbed more than 10 GB before the LLM allocated; constrain RT-Embed by lowering `NUM_STREAMS` or `RTVI_EMBED_NUM_VLM_PROCS` (10 → 4).
 
-RT-VLM uses dedicated GPU 2 in the default search layout, so its budget is independent of the RT-CV stream count. Size it with `RTVI_VLLM_GPU_MEMORY_UTILIZATION`; continue to size the LLM + RT-Embed pair on GPU 1 with the table above.
+RT-VLM shares GPU 0 with RT-CV in the default search layout, so its budget and the RT-CV stream count now compete for the same device. Size RT-VLM with `RTVI_VLLM_GPU_MEMORY_UTILIZATION` (0.4 on H100 / RTX PRO 6000 in `local_shared`) and leave the remainder for RT-CV; continue to size the LLM + RT-Embed pair on GPU 1 with the table above. If RT-CV fails to build engines or drops streams, lower the RT-VLM fraction before touching `NUM_STREAMS`.
 
 ## Hard rules
 
 - **RT-VLM must always be reachable.** Disabling Critique does not remove this requirement because `video_understanding` still uses RT-VLM.
-- **Default local search requires three GPUs.** On a two-GPU host, use the remote-proxy path for the VLM. L40S (48 GB) may also require a quantized or remote LLM because the LLM shares GPU 1 with RT-Embed.
+- **Default local search requires two GPUs.** On a single-GPU host, use the remote-proxy path for the VLM. L40S (48 GB) may also require a quantized or remote LLM because the LLM shares GPU 1 with RT-Embed.
 - **Edge platforms (DGX Spark / Thor) are not supported for `search` yet** — track upstream blueprint for support. Use SBSA image tags (`-sbsa-`) when they land.
-- **`RESERVED_DEVICE_IDS` and `FIXED_SHARED_DEVICE_IDS` come from defaults** in `dev-profile-search/.env` (`'0'` and `'1'` respectively). They tell `dev-profile.sh` which devices not to reassign — the skill works at the env-file level, so leave them as-is unless changing the layout meaningfully (e.g. swapping which GPU hosts RT-CV vs RT-Embed).
+- **`RESERVED_DEVICE_IDS` and `FIXED_SHARED_DEVICE_IDS` come from defaults** in `dev-profile-search/.env` (`''` and `'0,1'` respectively). Nothing is reserved because both GPUs are shared, and listing both devices as shared is what makes the LLM and RT-VLM derive `local_shared` memory fractions. The skill works at the env-file level, so leave them as-is unless changing the layout meaningfully (e.g. swapping which GPU hosts RT-CV vs RT-Embed).
 - **`/v1` quirk** — `LLM_BASE_URL` / `VLM_BASE_URL` have no `/v1` (the client appends it). In remote-proxy mode, `RTVI_VLM_ENDPOINT` does include `/v1`.
 
 ## Key capabilities


### PR DESCRIPTION
## Description

Moves the search developer profile from a 3-GPU to a 2-GPU layout: RT-VLM now
shares GPU 0 with RT-CV, and RT-Embed shares GPU 1 with the LLM. Fitting RT-VLM
onto a shared GPU requires the FP8 Cosmos3 Nano checkpoint
(`modelopt-fp8-final_format_fix`) at a 0.4 vLLM memory fraction.
- **Docker:** 2-GPU device map, FP8 checkpoint as the search default, and
  FPS-based frame chunking for `video_understanding`.
- **New `--vlm nvidia/cosmos3-reasoner-fp8`:** makes the FP8 default reversible
  per-deploy. `nvidia/cosmos3-reasoner` still resolves to BF16, so the base,
  alerts and lvs profiles are unchanged.
- **Brev:** the guard now admits 2-GPU hosts and rejects only single-GPU ones.
- **Helm:** search moves to the same FP8 checkpoint for parity with Docker. GPU
  allocation is unchanged there — each component keeps a dedicated GPU.
- **Tests:** 1/2/3-GPU Brev coverage, FP8 `--vlm` cases for base and search, and
  the L40S case updated to require a remote VLM (shared GPU 0 makes `vlm_mode`
  derive to `local_shared`, which L40S rejects).
- **Docs:** `skills/vss-deploy-profile/references/search.md` rewritten for the
  new layout.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
