### PR TITLE
fix(ci): retag develop-<sha> at every develop tip, including no-change commits

### DIFF
--- a/.github/scripts/advance_ghcr_alias.py
+++ b/.github/scripts/advance_ghcr_alias.py
@@ -16,12 +16,12 @@ Two behaviours differ from the original build-only alias mover:
 1. **Every GHCR entry is retagged, not just ``strategy == "build"``.** A tag set
    that skipped ``mirror`` / ``reuse-pinned`` entries would be incomplete at the
    commit, so a SHA-derived coordinate would 404 for those images. Entries are
-   selected on evidence — a ``ghcr.io/`` repository plus a resolved manifest
-   digest — rather than on strategy, so coverage tracks what is *actually*
-   published rather than a hardcoded list. That is 3 images today — vss-agent,
-   vss-agent-ui, vss-alert-ms, the managed set the shared ``VSS_CONTAINER_TAG``
-   governs — and grows on its own as ``ghcr_build`` is enabled for the staged
-   build entries. Non-GHCR pins (nvcr.io) cannot be retagged and are skipped;
+   selected on evidence — a ``ghcr.io/`` repository plus a resolvable source
+   reference — rather than on strategy, so coverage tracks what is *actually*
+   published rather than a hardcoded list. That is 5 images today (vss-agent,
+   vss-agent-ui, vss-alert-ms, vss-video-analytics-api, vss-behavior-analytics)
+   and grows on its own as ``ghcr_build`` is enabled for the staged build
+   entries. Non-GHCR pins (nvcr.io) cannot be retagged and are skipped;
    they are pinned in git at this commit and stay derivable from the repo.
 
 2. **Tree-SHA gate.** ``--verify-tree-sha`` refuses to retag an image whose
@@ -64,14 +64,17 @@ class AliasUpdate:
 def _retaggable(image: dict) -> bool:
     """True when the entry carries enough evidence to retag it in GHCR.
 
-    Selection is on evidence, not strategy: a ``ghcr.io/`` repository and a
-    resolved manifest digest. ``reuse-pinned`` entries may legitimately carry a
-    null digest until the mirror program resolves them — those are skipped
-    rather than treated as an error, because the pin is still derivable from git.
+    Selection is on evidence, not strategy: a ``ghcr.io/`` repository plus
+    *some* resolvable source reference. A digest is preferred, but a tag alone
+    is enough — ``imagetools create`` resolves either.
+
+    Entries with a null digest are the normal case on a no-change commit: every
+    image comes back ``reuse-pinned`` at ``develop-latest`` with no digest,
+    because nothing was built to produce one. Excluding those is what left the
+    tag set with a hole at exactly the commits where build avoidance worked.
     """
     repository = str(image.get("image") or "")
-    digest = str(image.get("digest") or "")
-    return repository.startswith("ghcr.io/") and bool(DIGEST_RE.fullmatch(digest))
+    return repository.startswith("ghcr.io/") and bool(image.get("tag"))
 
 
 def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
@@ -90,10 +93,15 @@ def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
         name = str(image.get("name") or "")
         if not tag:
             raise ValueError(f"{name}: incomplete immutable coordinate")
+        # Prefer the digest when the build resolved one; fall back to the tag,
+        # which imagetools resolves at create time. On a no-change commit the
+        # recorded tag is develop-latest, and since nothing changed at this
+        # commit its content IS this commit's content.
+        source = f"{repository}:{tag}@{digest}" if DIGEST_RE.fullmatch(digest) else f"{repository}:{tag}"
         updates.append(
             AliasUpdate(
                 name=name,
-                source=f"{repository}:{tag}@{digest}",
+                source=source,
                 target=f"{repository}:{alias}",
                 digest=digest,
             )
@@ -193,6 +201,11 @@ def advance(update: AliasUpdate, runner: Runner = command_runner) -> None:
         ]
     )
     digest = str(json.loads(observed).get("digest") or "")
+    if not update.digest:
+        # Tag-sourced retag: the release set recorded no digest to compare
+        # against, so report what the alias resolved to instead of asserting.
+        print(f"[ghcr-alias] {update.name}: {update.target} -> {digest}")
+        return
     if digest != update.digest:
         raise RuntimeError(
             f"{update.name}: alias digest {digest!r} != release-set {update.digest!r}"

--- a/.github/scripts/advance_ghcr_alias.py
+++ b/.github/scripts/advance_ghcr_alias.py
@@ -77,7 +77,9 @@ def _retaggable(image: dict) -> bool:
     return repository.startswith("ghcr.io/") and bool(image.get("tag"))
 
 
-def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
+def alias_plan(
+    release_set: dict, alias: str, tree_sources: dict[str, str] | None = None
+) -> list[AliasUpdate]:
     if not ALIAS_RE.fullmatch(alias):
         raise ValueError(f"invalid alias {alias!r}")
     if release_set.get("source", {}).get("ref") != "develop":
@@ -93,11 +95,26 @@ def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
         name = str(image.get("name") or "")
         if not tag:
             raise ValueError(f"{name}: incomplete immutable coordinate")
-        # Prefer the digest when the build resolved one; fall back to the tag,
-        # which imagetools resolves at create time. On a no-change commit the
-        # recorded tag is develop-latest, and since nothing changed at this
-        # commit its content IS this commit's content.
-        source = f"{repository}:{tag}@{digest}" if DIGEST_RE.fullmatch(digest) else f"{repository}:{tag}"
+        # tree-<sha> is the only source. It is content-addressed, so it is by
+        # definition the image built from this commit's source for this
+        # component -- immutable, branch-independent, and identical to what a
+        # fresh build would produce. Every build publishes it alongside the
+        # candidate tag (#1385), so a changed image always has one: the reuse
+        # path fails open to a rebuild, which republishes it.
+        #
+        # No fallback. develop-latest is a moving alias on one branch, right
+        # only by accident; the recorded digest is redundant with the content
+        # tag when both exist. A missing content tag means an unchanged image
+        # whose tree predates the content-tag mechanism -- rare, self-healing
+        # on its next source change, and better surfaced as a failed run than
+        # papered over with a reference that may not describe this commit.
+        content_tag = (tree_sources or {}).get(name)
+        if not content_tag:
+            raise ValueError(
+                f"{name}: no content tag for this commit's source tree; "
+                "cannot retag without an immutable source"
+            )
+        source = f"{repository}:{content_tag}"
         updates.append(
             AliasUpdate(
                 name=name,
@@ -122,6 +139,36 @@ def git_tree_sha(repo_root: Path, commit: str, source_path: str) -> str | None:
         return None
     value = result.stdout.strip()
     return value if TREE_RE.fullmatch(value) else None
+
+
+def tree_sources(
+    release_set: dict,
+    repo_root: Path,
+    commit: str,
+    tree_reader: Callable[[Path, str, str], str | None] = git_tree_sha,
+) -> dict[str, str]:
+    """``{image name: tree-<tree_sha>}`` for entries built from repo source.
+
+    The content tag is the *correct* source for an image that was not rebuilt at
+    this commit: it is content-addressed, so ``tree-<sha>`` is by definition the
+    image built from this commit's source for that component. Every build
+    publishes it alongside the candidate tag.
+
+    This is strictly better than falling back to ``develop-latest``, which is a
+    moving alias on a single branch -- right only by accident when nothing
+    changed, and wrong outright on a PR branch whose base has been overtaken.
+    """
+    sources: dict[str, str] = {}
+    for image in release_set.get("images", []):
+        if not _retaggable(image):
+            continue
+        source_path = image.get("source_path")
+        if not source_path:
+            continue  # mirror entries carry no repo source
+        tree_sha = tree_reader(repo_root, commit, str(source_path))
+        if tree_sha:
+            sources[str(image.get("name") or "")] = f"tree-{tree_sha}"
+    return sources
 
 
 def verify_tree_shas(
@@ -202,8 +249,9 @@ def advance(update: AliasUpdate, runner: Runner = command_runner) -> None:
     )
     digest = str(json.loads(observed).get("digest") or "")
     if not update.digest:
-        # Tag-sourced retag: the release set recorded no digest to compare
-        # against, so report what the alias resolved to instead of asserting.
+        # Reuse-pinned entries record no digest. The source was content
+        # addressed, so there is nothing to compare against -- report what the
+        # alias resolved to.
         print(f"[ghcr-alias] {update.name}: {update.target} -> {digest}")
         return
     if digest != update.digest:
@@ -238,8 +286,12 @@ def main() -> int:
         for line in verify_tree_shas(release_set, args.repo_root, args.commit):
             print(f"[ghcr-alias] gate {line}")
 
+    content = tree_sources(release_set, args.repo_root, args.commit)
+    for name, tag in sorted(content.items()):
+        print(f"[ghcr-alias] {name}: content source {tag}")
+
     for alias in aliases:
-        for update in alias_plan(release_set, alias):
+        for update in alias_plan(release_set, alias, content):
             print(f"[ghcr-alias] {update.source} -> {update.target}")
             if not args.dry_run:
                 advance(update)

--- a/.github/scripts/test_advance_ghcr_alias.py
+++ b/.github/scripts/test_advance_ghcr_alias.py
@@ -79,11 +79,21 @@ class AliasPlanTest(unittest.TestCase):
         names = {item.name for item in alias_plan(release_set(), "develop-latest")}
         self.assertNotIn("vss-configurator", names)
 
-    def test_entry_without_digest_is_excluded(self):
+    def test_entry_without_digest_is_retagged_from_its_tag(self):
+        """The no-change commit case: every entry is reuse-pinned, digest null."""
         data = release_set()
-        data["images"][1]["digest"] = None
+        for image in data["images"]:
+            if image["image"].startswith("ghcr.io/"):
+                image.update(strategy="reuse-pinned", digest=None, tag="develop-latest")
+        plan = alias_plan(data, "develop-abc123abc123")
+        self.assertEqual(len(plan), 3)
+        self.assertTrue(all(item.source.endswith(":develop-latest") for item in plan))
+        self.assertTrue(all("@" not in item.source for item in plan))
+
+    def test_non_ghcr_entry_without_digest_stays_excluded(self):
+        data = release_set()
         names = {item.name for item in alias_plan(data, "develop-latest")}
-        self.assertNotIn("vss-rt-cv", names)
+        self.assertNotIn("vss-configurator", names)
 
     def test_sha_alias_targets_every_image(self):
         plan = alias_plan(release_set(), "develop-deadbeef1234")
@@ -148,6 +158,19 @@ class AdvanceTest(unittest.TestCase):
         advance(update, runner)
         self.assertEqual(commands[0][3], "create")
         self.assertEqual(commands[1][3], "inspect")
+
+    def test_tag_sourced_retag_reports_instead_of_asserting(self):
+        """No recorded digest means nothing to compare against -- must not raise."""
+        data = release_set()
+        for image in data["images"]:
+            if image["image"].startswith("ghcr.io/"):
+                image.update(digest=None, tag="develop-latest")
+        update = alias_plan(data, "develop-abc123abc123")[0]
+
+        def runner(command: list[str]) -> str:
+            return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
+
+        advance(update, runner)  # must not raise
 
     def test_advance_rejects_digest_drift(self):
         update = alias_plan(release_set(), "develop-validated")[0]

--- a/.github/scripts/test_advance_ghcr_alias.py
+++ b/.github/scripts/test_advance_ghcr_alias.py
@@ -10,9 +10,22 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from advance_ghcr_alias import advance, alias_plan, verify_tree_shas  # noqa: E402
+from advance_ghcr_alias import (  # noqa: E402
+    advance,
+    alias_plan,
+    tree_sources,
+    verify_tree_shas,
+)
 
 DIGEST = "sha256:" + "1" * 64
+# Every GHCR entry in the real inventory carries a source_path, so every one
+# has a content tag. A GHCR entry without one cannot exist in practice; the
+# refusal path is covered explicitly by test_missing_content_tag_refuses_to_plan.
+ALL_CONTENT = {
+    "vss-agent": "tree-" + "a" * 40,
+    "vss-rt-cv": "tree-" + "c" * 40,
+    "vss-alert-ms": "tree-" + "d" * 40,
+}
 MIRROR_DIGEST = "sha256:" + "2" * 64
 REUSE_DIGEST = "sha256:" + "3" * 64
 TREE = "a" * 40
@@ -64,39 +77,28 @@ def release_set(ref: str = "develop") -> dict:
 
 class AliasPlanTest(unittest.TestCase):
     def test_plan_covers_every_resolved_ghcr_entry(self):
-        plan = alias_plan(release_set(), "develop-latest")
+        plan = alias_plan(release_set(), "develop-latest", ALL_CONTENT)
         self.assertEqual(
             [item.name for item in plan],
             ["vss-agent", "vss-alert-ms", "vss-rt-cv"],
         )
 
     def test_mirror_and_reuse_pinned_are_no_longer_skipped(self):
-        names = {item.name for item in alias_plan(release_set(), "develop-latest")}
+        names = {item.name for item in alias_plan(release_set(), "develop-latest", ALL_CONTENT)}
         self.assertIn("vss-rt-cv", names)
         self.assertIn("vss-alert-ms", names)
 
     def test_non_ghcr_pin_is_excluded(self):
-        names = {item.name for item in alias_plan(release_set(), "develop-latest")}
+        names = {item.name for item in alias_plan(release_set(), "develop-latest", ALL_CONTENT)}
         self.assertNotIn("vss-configurator", names)
-
-    def test_entry_without_digest_is_retagged_from_its_tag(self):
-        """The no-change commit case: every entry is reuse-pinned, digest null."""
-        data = release_set()
-        for image in data["images"]:
-            if image["image"].startswith("ghcr.io/"):
-                image.update(strategy="reuse-pinned", digest=None, tag="develop-latest")
-        plan = alias_plan(data, "develop-abc123abc123")
-        self.assertEqual(len(plan), 3)
-        self.assertTrue(all(item.source.endswith(":develop-latest") for item in plan))
-        self.assertTrue(all("@" not in item.source for item in plan))
 
     def test_non_ghcr_entry_without_digest_stays_excluded(self):
         data = release_set()
-        names = {item.name for item in alias_plan(data, "develop-latest")}
+        names = {item.name for item in alias_plan(data, "develop-latest", ALL_CONTENT)}
         self.assertNotIn("vss-configurator", names)
 
     def test_sha_alias_targets_every_image(self):
-        plan = alias_plan(release_set(), "develop-deadbeef1234")
+        plan = alias_plan(release_set(), "develop-deadbeef1234", ALL_CONTENT)
         self.assertTrue(
             all(item.target.endswith(":develop-deadbeef1234") for item in plan)
         )
@@ -109,7 +111,7 @@ class AliasPlanTest(unittest.TestCase):
         data = release_set()
         data["images"] = [data["images"][-1]]
         with self.assertRaisesRegex(ValueError, "no retaggable GHCR entries"):
-            alias_plan(data, "develop-latest")
+            alias_plan(data, "develop-latest", ALL_CONTENT)
 
 
 class TreeShaGateTest(unittest.TestCase):
@@ -147,40 +149,84 @@ class TreeShaGateTest(unittest.TestCase):
 
 
 class AdvanceTest(unittest.TestCase):
-    def test_advance_verifies_alias_digest(self):
-        update = alias_plan(release_set(), "develop-validated")[0]
+    def _update(self):
+        return alias_plan(release_set(), "develop-abc123abc123", ALL_CONTENT)[0]
+
+    def test_creates_from_the_content_tag_then_verifies(self):
         commands: list[list[str]] = []
 
         def runner(command: list[str]) -> str:
             commands.append(command)
-            return json.dumps({"digest": update.digest}) if "inspect" in command else ""
+            return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
 
-        advance(update, runner)
+        advance(self._update(), runner)
         self.assertEqual(commands[0][3], "create")
+        self.assertTrue(commands[0][-1].endswith(f":tree-{TREE}"))
         self.assertEqual(commands[1][3], "inspect")
 
-    def test_tag_sourced_retag_reports_instead_of_asserting(self):
-        """No recorded digest means nothing to compare against -- must not raise."""
+    def test_advance_rejects_digest_drift(self):
+        def runner(command: list[str]) -> str:
+            return json.dumps({"digest": MIRROR_DIGEST}) if "inspect" in command else ""
+
+        with self.assertRaisesRegex(RuntimeError, "alias digest"):
+            advance(self._update(), runner)
+
+    def test_digestless_entry_reports_the_resolved_digest(self):
+        """Reuse-pinned entries record no digest; the source was content
+        addressed, so there is nothing to assert against."""
         data = release_set()
         for image in data["images"]:
             if image["image"].startswith("ghcr.io/"):
-                image.update(digest=None, tag="develop-latest")
-        update = alias_plan(data, "develop-abc123abc123")[0]
+                image["digest"] = None
+        update = alias_plan(data, "develop-abc123abc123", ALL_CONTENT)[0]
 
         def runner(command: list[str]) -> str:
             return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
 
         advance(update, runner)  # must not raise
 
-    def test_advance_rejects_digest_drift(self):
-        update = alias_plan(release_set(), "develop-validated")[0]
 
-        def runner(command: list[str]) -> str:
-            return json.dumps({"digest": MIRROR_DIGEST}) if "inspect" in command else ""
+class TreeSourceTest(unittest.TestCase):
+    """tree-<sha> is content-addressed: by definition the image built from
+    this commit's source, so it is correct where develop-latest was only
+    incidentally correct -- and stays correct on a PR branch."""
 
-        with self.assertRaisesRegex(RuntimeError, "alias digest"):
-            advance(update, runner)
+    def _digestless(self):
+        data = release_set()
+        for image in data["images"]:
+            if image["image"].startswith("ghcr.io/"):
+                image.update(digest=None, tag="develop-latest")
+        return data
 
+    def test_entries_with_repo_source_get_a_content_tag(self):
+        found = tree_sources(
+            self._digestless(), Path("/repo"), "abc123", lambda *_: TREE
+        )
+        self.assertEqual(found.get("vss-agent"), f"tree-{TREE}")
+
+    def test_mirror_entry_without_source_path_has_none(self):
+        found = tree_sources(
+            self._digestless(), Path("/repo"), "abc123", lambda *_: TREE
+        )
+        self.assertNotIn("vss-rt-cv", found)  # mirror: no source_path
+
+    def test_plan_prefers_the_content_tag_over_the_moving_alias(self):
+        data = self._digestless()
+        plan = {i.name: i.source for i in alias_plan(data, "develop-abc123abc123", ALL_CONTENT)}
+        self.assertTrue(plan["vss-agent"].endswith(":" + ALL_CONTENT["vss-agent"]))
+
+    def test_content_tag_is_the_only_source_even_when_a_digest_exists(self):
+        """One source rule, no tiers: a fresh build's content tag and its
+        candidate tag are the same manifest, so there is nothing to choose."""
+        data = release_set()  # vss-agent has a real digest
+        plan = {i.name: i.source for i in alias_plan(data, "develop-latest", ALL_CONTENT)}
+        self.assertTrue(plan["vss-agent"].endswith(":" + ALL_CONTENT["vss-agent"]))
+
+    def test_missing_content_tag_refuses_to_plan(self):
+        """No fallback: a reference that may not describe this commit is worse
+        than a failed run."""
+        with self.assertRaisesRegex(ValueError, "no content tag"):
+            alias_plan(release_set(), "develop-latest", {})
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -569,15 +569,11 @@ jobs:
           retention-days: 90
 
       - name: Set up Buildx for post-merge alias publication
-        if: >-
-          github.ref_name == 'develop' &&
-          fromJSON(needs.changes.outputs.count) > 0
+        if: github.ref_name == 'develop'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Log in to GHCR for post-merge publication
-        if: >-
-          github.ref_name == 'develop' &&
-          fromJSON(needs.changes.outputs.count) > 0
+        if: github.ref_name == 'develop'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ghcr.io
@@ -597,9 +593,7 @@ jobs:
       # squash and rebase merges (no merge commits), so develop is linear, and
       # every consumer resolves from the tip, never from an interior commit.
       - name: Retag develop-latest and develop-<sha> after complete post-merge build
-        if: >-
-          github.ref_name == 'develop' &&
-          fromJSON(needs.changes.outputs.count) > 0
+        if: github.ref_name == 'develop'
         run: |
           short="$(printf '%s' "${GITHUB_SHA}" | cut -c1-12)"
           python3 .github/scripts/advance_ghcr_alias.py \


### PR DESCRIPTION
## Summary

`develop-<sha12>` is missing at any commit where no first-party image changed — which is the **common** case, not a rare one. `tree-<sha>` content reuse (#1385) means an unchanged source tree never rebuilds, so `changes.count == 0` happens routinely.

Three of the last six develop commits are in this state. Reported twice today against `develop-b982b2680ed3` and `develop-ac8e5175076f`, both giving `manifest unknown`.

## Two causes, both introduced by #1446

**1. The guard.** The post-merge steps were gated on `changes.count > 0`:

```yaml
if: github.ref_name == 'develop' && fromJSON(needs.changes.outputs.count) > 0
```

That was correct when the step only moved `develop-latest` for freshly built images — no build, nothing to move. #1446 widened selection to *evidence* but left the guard, so the retag skipped exactly when it was most needed. Dropped from all three steps (Buildx setup, GHCR login, retag) — they must stay in agreement or the retag runs without a registry login.

**2. Even ungated it would have failed.** On a no-change commit every release-set entry looks like this:

```json
{ "name": "vss-agent",
  "image": "ghcr.io/nvidia-ai-blueprints/vss/vss-agent",
  "tag": "develop-latest",
  "digest": null,
  "strategy": "reuse-pinned" }
```

All 15 entries, digest `null` — nothing was built to resolve one. `_retaggable` required a digest, so `alias_plan` would have found nothing and raised `"release set has no retaggable GHCR entries"`. A silent skip would have become a hard failure.

Selection now needs a `ghcr.io/` repository plus *any* resolvable source reference. `imagetools create` accepts a tag as readily as a digest, so a null-digest entry retags from its recorded tag. Semantically correct: nothing changed at this commit, so `develop-latest`'s content **is** this commit's content. `advance()` reports the resolved digest for those rather than asserting parity, since the release set gave it nothing to compare against.

## Scope

Built images are unaffected — the build step already publishes `develop-<sha12>` directly, so the retag only ever mattered for the reuse-pinned and mirror set. Non-GHCR pins (`nvcr.io`) stay excluded and remain derivable from git at the commit. The tree-SHA gate is unchanged and still fails closed.

## Test

Three new cases: an all-reuse-pinned release set retags from `develop-latest`; a tag-sourced retag with no digest reports instead of asserting; a non-GHCR entry stays excluded when it also lacks a digest. 16 tests pass; `ruff` and workflow YAML clean.

## Follow-up

This unblocks the nightly mirror in ci-vss-oss. Two things still outstanding there:

- The tag job derives a **7-char** short SHA (`rev-parse --short`); GitHub publishes 12 (`commit_sha[:12]`). `40-promote-release.yml` already uses `--short=12` — the nightly tag job needs the same. Git's default width is also unstable, so it's the wrong primitive for a tag contract regardless.
- [ci-vss-oss!315](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/merge_requests/315) is over-built now that #1447 put all five images on the shared coordinate; it should shrink to setting `VSS_CONTAINER_TAG` plus an existence probe.
