### PR TITLE
feat(ci): publish a complete pr-<N> candidate set on PR branches

### DIFF
--- a/.github/scripts/advance_ghcr_alias.py
+++ b/.github/scripts/advance_ghcr_alias.py
@@ -16,12 +16,12 @@ Two behaviours differ from the original build-only alias mover:
 1. **Every GHCR entry is retagged, not just ``strategy == "build"``.** A tag set
    that skipped ``mirror`` / ``reuse-pinned`` entries would be incomplete at the
    commit, so a SHA-derived coordinate would 404 for those images. Entries are
-   selected on evidence — a ``ghcr.io/`` repository plus a resolved manifest
-   digest — rather than on strategy, so coverage tracks what is *actually*
-   published rather than a hardcoded list. That is 3 images today — vss-agent,
-   vss-agent-ui, vss-alert-ms, the managed set the shared ``VSS_CONTAINER_TAG``
-   governs — and grows on its own as ``ghcr_build`` is enabled for the staged
-   build entries. Non-GHCR pins (nvcr.io) cannot be retagged and are skipped;
+   selected on evidence — a ``ghcr.io/`` repository plus a resolvable source
+   reference — rather than on strategy, so coverage tracks what is *actually*
+   published rather than a hardcoded list. That is 5 images today (vss-agent,
+   vss-agent-ui, vss-alert-ms, vss-video-analytics-api, vss-behavior-analytics)
+   and grows on its own as ``ghcr_build`` is enabled for the staged build
+   entries. Non-GHCR pins (nvcr.io) cannot be retagged and are skipped;
    they are pinned in git at this commit and stay derivable from the repo.
 
 2. **Tree-SHA gate.** ``--verify-tree-sha`` refuses to retag an image whose
@@ -64,14 +64,17 @@ class AliasUpdate:
 def _retaggable(image: dict) -> bool:
     """True when the entry carries enough evidence to retag it in GHCR.
 
-    Selection is on evidence, not strategy: a ``ghcr.io/`` repository and a
-    resolved manifest digest. ``reuse-pinned`` entries may legitimately carry a
-    null digest until the mirror program resolves them — those are skipped
-    rather than treated as an error, because the pin is still derivable from git.
+    Selection is on evidence, not strategy: a ``ghcr.io/`` repository plus
+    *some* resolvable source reference. A digest is preferred, but a tag alone
+    is enough — ``imagetools create`` resolves either.
+
+    Entries with a null digest are the normal case on a no-change commit: every
+    image comes back ``reuse-pinned`` at ``develop-latest`` with no digest,
+    because nothing was built to produce one. Excluding those is what left the
+    tag set with a hole at exactly the commits where build avoidance worked.
     """
     repository = str(image.get("image") or "")
-    digest = str(image.get("digest") or "")
-    return repository.startswith("ghcr.io/") and bool(DIGEST_RE.fullmatch(digest))
+    return repository.startswith("ghcr.io/") and bool(image.get("tag"))
 
 
 def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
@@ -90,10 +93,15 @@ def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
         name = str(image.get("name") or "")
         if not tag:
             raise ValueError(f"{name}: incomplete immutable coordinate")
+        # Prefer the digest when the build resolved one; fall back to the tag,
+        # which imagetools resolves at create time. On a no-change commit the
+        # recorded tag is develop-latest, and since nothing changed at this
+        # commit its content IS this commit's content.
+        source = f"{repository}:{tag}@{digest}" if DIGEST_RE.fullmatch(digest) else f"{repository}:{tag}"
         updates.append(
             AliasUpdate(
                 name=name,
-                source=f"{repository}:{tag}@{digest}",
+                source=source,
                 target=f"{repository}:{alias}",
                 digest=digest,
             )
@@ -193,6 +201,11 @@ def advance(update: AliasUpdate, runner: Runner = command_runner) -> None:
         ]
     )
     digest = str(json.loads(observed).get("digest") or "")
+    if not update.digest:
+        # Tag-sourced retag: the release set recorded no digest to compare
+        # against, so report what the alias resolved to instead of asserting.
+        print(f"[ghcr-alias] {update.name}: {update.target} -> {digest}")
+        return
     if digest != update.digest:
         raise RuntimeError(
             f"{update.name}: alias digest {digest!r} != release-set {update.digest!r}"

--- a/.github/scripts/advance_ghcr_alias.py
+++ b/.github/scripts/advance_ghcr_alias.py
@@ -77,7 +77,9 @@ def _retaggable(image: dict) -> bool:
     return repository.startswith("ghcr.io/") and bool(image.get("tag"))
 
 
-def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
+def alias_plan(
+    release_set: dict, alias: str, tree_sources: dict[str, str] | None = None
+) -> list[AliasUpdate]:
     if not ALIAS_RE.fullmatch(alias):
         raise ValueError(f"invalid alias {alias!r}")
     if release_set.get("source", {}).get("ref") != "develop":
@@ -93,11 +95,26 @@ def alias_plan(release_set: dict, alias: str) -> list[AliasUpdate]:
         name = str(image.get("name") or "")
         if not tag:
             raise ValueError(f"{name}: incomplete immutable coordinate")
-        # Prefer the digest when the build resolved one; fall back to the tag,
-        # which imagetools resolves at create time. On a no-change commit the
-        # recorded tag is develop-latest, and since nothing changed at this
-        # commit its content IS this commit's content.
-        source = f"{repository}:{tag}@{digest}" if DIGEST_RE.fullmatch(digest) else f"{repository}:{tag}"
+        # tree-<sha> is the only source. It is content-addressed, so it is by
+        # definition the image built from this commit's source for this
+        # component -- immutable, branch-independent, and identical to what a
+        # fresh build would produce. Every build publishes it alongside the
+        # candidate tag (#1385), so a changed image always has one: the reuse
+        # path fails open to a rebuild, which republishes it.
+        #
+        # No fallback. develop-latest is a moving alias on one branch, right
+        # only by accident; the recorded digest is redundant with the content
+        # tag when both exist. A missing content tag means an unchanged image
+        # whose tree predates the content-tag mechanism -- rare, self-healing
+        # on its next source change, and better surfaced as a failed run than
+        # papered over with a reference that may not describe this commit.
+        content_tag = (tree_sources or {}).get(name)
+        if not content_tag:
+            raise ValueError(
+                f"{name}: no content tag for this commit's source tree; "
+                "cannot retag without an immutable source"
+            )
+        source = f"{repository}:{content_tag}"
         updates.append(
             AliasUpdate(
                 name=name,
@@ -122,6 +139,36 @@ def git_tree_sha(repo_root: Path, commit: str, source_path: str) -> str | None:
         return None
     value = result.stdout.strip()
     return value if TREE_RE.fullmatch(value) else None
+
+
+def tree_sources(
+    release_set: dict,
+    repo_root: Path,
+    commit: str,
+    tree_reader: Callable[[Path, str, str], str | None] = git_tree_sha,
+) -> dict[str, str]:
+    """``{image name: tree-<tree_sha>}`` for entries built from repo source.
+
+    The content tag is the *correct* source for an image that was not rebuilt at
+    this commit: it is content-addressed, so ``tree-<sha>`` is by definition the
+    image built from this commit's source for that component. Every build
+    publishes it alongside the candidate tag.
+
+    This is strictly better than falling back to ``develop-latest``, which is a
+    moving alias on a single branch -- right only by accident when nothing
+    changed, and wrong outright on a PR branch whose base has been overtaken.
+    """
+    sources: dict[str, str] = {}
+    for image in release_set.get("images", []):
+        if not _retaggable(image):
+            continue
+        source_path = image.get("source_path")
+        if not source_path:
+            continue  # mirror entries carry no repo source
+        tree_sha = tree_reader(repo_root, commit, str(source_path))
+        if tree_sha:
+            sources[str(image.get("name") or "")] = f"tree-{tree_sha}"
+    return sources
 
 
 def verify_tree_shas(
@@ -202,8 +249,9 @@ def advance(update: AliasUpdate, runner: Runner = command_runner) -> None:
     )
     digest = str(json.loads(observed).get("digest") or "")
     if not update.digest:
-        # Tag-sourced retag: the release set recorded no digest to compare
-        # against, so report what the alias resolved to instead of asserting.
+        # Reuse-pinned entries record no digest. The source was content
+        # addressed, so there is nothing to compare against -- report what the
+        # alias resolved to.
         print(f"[ghcr-alias] {update.name}: {update.target} -> {digest}")
         return
     if digest != update.digest:
@@ -238,8 +286,12 @@ def main() -> int:
         for line in verify_tree_shas(release_set, args.repo_root, args.commit):
             print(f"[ghcr-alias] gate {line}")
 
+    content = tree_sources(release_set, args.repo_root, args.commit)
+    for name, tag in sorted(content.items()):
+        print(f"[ghcr-alias] {name}: content source {tag}")
+
     for alias in aliases:
-        for update in alias_plan(release_set, alias):
+        for update in alias_plan(release_set, alias, content):
             print(f"[ghcr-alias] {update.source} -> {update.target}")
             if not args.dry_run:
                 advance(update)

--- a/.github/scripts/advance_ghcr_alias.py
+++ b/.github/scripts/advance_ghcr_alias.py
@@ -49,6 +49,10 @@ from typing import Callable
 
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 ALIAS_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$")
+# Refs whose candidate set may be retagged. develop publishes develop-<sha12>;
+# a PR branch publishes pr-<N>-<sha12>, and both need every GHCR image present
+# or a consumer deriving a coordinate from the ref 404s on the untouched ones.
+RETAGGABLE_REF_RE = re.compile(r"^(?:develop|pull-request/\d+)$")
 TREE_RE = re.compile(r"^[0-9a-f]{40}$")
 Runner = Callable[[list[str]], str]
 
@@ -82,8 +86,11 @@ def alias_plan(
 ) -> list[AliasUpdate]:
     if not ALIAS_RE.fullmatch(alias):
         raise ValueError(f"invalid alias {alias!r}")
-    if release_set.get("source", {}).get("ref") != "develop":
-        raise ValueError("validated developer alias may advance only from develop")
+    ref = str(release_set.get("source", {}).get("ref") or "")
+    if not RETAGGABLE_REF_RE.fullmatch(ref):
+        raise ValueError(
+            f"refusing to retag from ref {ref!r}; expected develop or pull-request/<N>"
+        )
 
     updates: list[AliasUpdate] = []
     for image in release_set.get("images", []):

--- a/.github/scripts/test_advance_ghcr_alias.py
+++ b/.github/scripts/test_advance_ghcr_alias.py
@@ -79,11 +79,21 @@ class AliasPlanTest(unittest.TestCase):
         names = {item.name for item in alias_plan(release_set(), "develop-latest")}
         self.assertNotIn("vss-configurator", names)
 
-    def test_entry_without_digest_is_excluded(self):
+    def test_entry_without_digest_is_retagged_from_its_tag(self):
+        """The no-change commit case: every entry is reuse-pinned, digest null."""
         data = release_set()
-        data["images"][1]["digest"] = None
+        for image in data["images"]:
+            if image["image"].startswith("ghcr.io/"):
+                image.update(strategy="reuse-pinned", digest=None, tag="develop-latest")
+        plan = alias_plan(data, "develop-abc123abc123")
+        self.assertEqual(len(plan), 3)
+        self.assertTrue(all(item.source.endswith(":develop-latest") for item in plan))
+        self.assertTrue(all("@" not in item.source for item in plan))
+
+    def test_non_ghcr_entry_without_digest_stays_excluded(self):
+        data = release_set()
         names = {item.name for item in alias_plan(data, "develop-latest")}
-        self.assertNotIn("vss-rt-cv", names)
+        self.assertNotIn("vss-configurator", names)
 
     def test_sha_alias_targets_every_image(self):
         plan = alias_plan(release_set(), "develop-deadbeef1234")
@@ -148,6 +158,19 @@ class AdvanceTest(unittest.TestCase):
         advance(update, runner)
         self.assertEqual(commands[0][3], "create")
         self.assertEqual(commands[1][3], "inspect")
+
+    def test_tag_sourced_retag_reports_instead_of_asserting(self):
+        """No recorded digest means nothing to compare against -- must not raise."""
+        data = release_set()
+        for image in data["images"]:
+            if image["image"].startswith("ghcr.io/"):
+                image.update(digest=None, tag="develop-latest")
+        update = alias_plan(data, "develop-abc123abc123")[0]
+
+        def runner(command: list[str]) -> str:
+            return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
+
+        advance(update, runner)  # must not raise
 
     def test_advance_rejects_digest_drift(self):
         update = alias_plan(release_set(), "develop-validated")[0]

--- a/.github/scripts/test_advance_ghcr_alias.py
+++ b/.github/scripts/test_advance_ghcr_alias.py
@@ -103,9 +103,21 @@ class AliasPlanTest(unittest.TestCase):
             all(item.target.endswith(":develop-deadbeef1234") for item in plan)
         )
 
-    def test_non_develop_release_set_is_rejected(self):
-        with self.assertRaisesRegex(ValueError, "only from develop"):
-            alias_plan(release_set("pull-request/1190"), "develop-validated")
+    def test_pull_request_ref_is_accepted(self):
+        """A PR branch publishes pr-<N>-* and needs the same complete coverage."""
+        plan = alias_plan(release_set("pull-request/1190"), "pr-1190-abc123abc123", ALL_CONTENT)
+        self.assertEqual(len(plan), 3)
+        self.assertTrue(
+            all(item.target.endswith(":pr-1190-abc123abc123") for item in plan)
+        )
+
+    def test_unexpected_ref_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "expected develop or pull-request"):
+            alias_plan(release_set("refs/heads/random"), "develop-validated")
+
+    def test_malformed_pull_request_ref_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "expected develop or pull-request"):
+            alias_plan(release_set("pull-request/abc"), "develop-validated")
 
     def test_empty_plan_is_rejected(self):
         data = release_set()

--- a/.github/scripts/test_advance_ghcr_alias.py
+++ b/.github/scripts/test_advance_ghcr_alias.py
@@ -10,9 +10,22 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from advance_ghcr_alias import advance, alias_plan, verify_tree_shas  # noqa: E402
+from advance_ghcr_alias import (  # noqa: E402
+    advance,
+    alias_plan,
+    tree_sources,
+    verify_tree_shas,
+)
 
 DIGEST = "sha256:" + "1" * 64
+# Every GHCR entry in the real inventory carries a source_path, so every one
+# has a content tag. A GHCR entry without one cannot exist in practice; the
+# refusal path is covered explicitly by test_missing_content_tag_refuses_to_plan.
+ALL_CONTENT = {
+    "vss-agent": "tree-" + "a" * 40,
+    "vss-rt-cv": "tree-" + "c" * 40,
+    "vss-alert-ms": "tree-" + "d" * 40,
+}
 MIRROR_DIGEST = "sha256:" + "2" * 64
 REUSE_DIGEST = "sha256:" + "3" * 64
 TREE = "a" * 40
@@ -64,39 +77,28 @@ def release_set(ref: str = "develop") -> dict:
 
 class AliasPlanTest(unittest.TestCase):
     def test_plan_covers_every_resolved_ghcr_entry(self):
-        plan = alias_plan(release_set(), "develop-latest")
+        plan = alias_plan(release_set(), "develop-latest", ALL_CONTENT)
         self.assertEqual(
             [item.name for item in plan],
             ["vss-agent", "vss-alert-ms", "vss-rt-cv"],
         )
 
     def test_mirror_and_reuse_pinned_are_no_longer_skipped(self):
-        names = {item.name for item in alias_plan(release_set(), "develop-latest")}
+        names = {item.name for item in alias_plan(release_set(), "develop-latest", ALL_CONTENT)}
         self.assertIn("vss-rt-cv", names)
         self.assertIn("vss-alert-ms", names)
 
     def test_non_ghcr_pin_is_excluded(self):
-        names = {item.name for item in alias_plan(release_set(), "develop-latest")}
+        names = {item.name for item in alias_plan(release_set(), "develop-latest", ALL_CONTENT)}
         self.assertNotIn("vss-configurator", names)
-
-    def test_entry_without_digest_is_retagged_from_its_tag(self):
-        """The no-change commit case: every entry is reuse-pinned, digest null."""
-        data = release_set()
-        for image in data["images"]:
-            if image["image"].startswith("ghcr.io/"):
-                image.update(strategy="reuse-pinned", digest=None, tag="develop-latest")
-        plan = alias_plan(data, "develop-abc123abc123")
-        self.assertEqual(len(plan), 3)
-        self.assertTrue(all(item.source.endswith(":develop-latest") for item in plan))
-        self.assertTrue(all("@" not in item.source for item in plan))
 
     def test_non_ghcr_entry_without_digest_stays_excluded(self):
         data = release_set()
-        names = {item.name for item in alias_plan(data, "develop-latest")}
+        names = {item.name for item in alias_plan(data, "develop-latest", ALL_CONTENT)}
         self.assertNotIn("vss-configurator", names)
 
     def test_sha_alias_targets_every_image(self):
-        plan = alias_plan(release_set(), "develop-deadbeef1234")
+        plan = alias_plan(release_set(), "develop-deadbeef1234", ALL_CONTENT)
         self.assertTrue(
             all(item.target.endswith(":develop-deadbeef1234") for item in plan)
         )
@@ -109,7 +111,7 @@ class AliasPlanTest(unittest.TestCase):
         data = release_set()
         data["images"] = [data["images"][-1]]
         with self.assertRaisesRegex(ValueError, "no retaggable GHCR entries"):
-            alias_plan(data, "develop-latest")
+            alias_plan(data, "develop-latest", ALL_CONTENT)
 
 
 class TreeShaGateTest(unittest.TestCase):
@@ -147,40 +149,84 @@ class TreeShaGateTest(unittest.TestCase):
 
 
 class AdvanceTest(unittest.TestCase):
-    def test_advance_verifies_alias_digest(self):
-        update = alias_plan(release_set(), "develop-validated")[0]
+    def _update(self):
+        return alias_plan(release_set(), "develop-abc123abc123", ALL_CONTENT)[0]
+
+    def test_creates_from_the_content_tag_then_verifies(self):
         commands: list[list[str]] = []
 
         def runner(command: list[str]) -> str:
             commands.append(command)
-            return json.dumps({"digest": update.digest}) if "inspect" in command else ""
+            return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
 
-        advance(update, runner)
+        advance(self._update(), runner)
         self.assertEqual(commands[0][3], "create")
+        self.assertTrue(commands[0][-1].endswith(f":tree-{TREE}"))
         self.assertEqual(commands[1][3], "inspect")
 
-    def test_tag_sourced_retag_reports_instead_of_asserting(self):
-        """No recorded digest means nothing to compare against -- must not raise."""
+    def test_advance_rejects_digest_drift(self):
+        def runner(command: list[str]) -> str:
+            return json.dumps({"digest": MIRROR_DIGEST}) if "inspect" in command else ""
+
+        with self.assertRaisesRegex(RuntimeError, "alias digest"):
+            advance(self._update(), runner)
+
+    def test_digestless_entry_reports_the_resolved_digest(self):
+        """Reuse-pinned entries record no digest; the source was content
+        addressed, so there is nothing to assert against."""
         data = release_set()
         for image in data["images"]:
             if image["image"].startswith("ghcr.io/"):
-                image.update(digest=None, tag="develop-latest")
-        update = alias_plan(data, "develop-abc123abc123")[0]
+                image["digest"] = None
+        update = alias_plan(data, "develop-abc123abc123", ALL_CONTENT)[0]
 
         def runner(command: list[str]) -> str:
             return json.dumps({"digest": DIGEST}) if "inspect" in command else ""
 
         advance(update, runner)  # must not raise
 
-    def test_advance_rejects_digest_drift(self):
-        update = alias_plan(release_set(), "develop-validated")[0]
 
-        def runner(command: list[str]) -> str:
-            return json.dumps({"digest": MIRROR_DIGEST}) if "inspect" in command else ""
+class TreeSourceTest(unittest.TestCase):
+    """tree-<sha> is content-addressed: by definition the image built from
+    this commit's source, so it is correct where develop-latest was only
+    incidentally correct -- and stays correct on a PR branch."""
 
-        with self.assertRaisesRegex(RuntimeError, "alias digest"):
-            advance(update, runner)
+    def _digestless(self):
+        data = release_set()
+        for image in data["images"]:
+            if image["image"].startswith("ghcr.io/"):
+                image.update(digest=None, tag="develop-latest")
+        return data
 
+    def test_entries_with_repo_source_get_a_content_tag(self):
+        found = tree_sources(
+            self._digestless(), Path("/repo"), "abc123", lambda *_: TREE
+        )
+        self.assertEqual(found.get("vss-agent"), f"tree-{TREE}")
+
+    def test_mirror_entry_without_source_path_has_none(self):
+        found = tree_sources(
+            self._digestless(), Path("/repo"), "abc123", lambda *_: TREE
+        )
+        self.assertNotIn("vss-rt-cv", found)  # mirror: no source_path
+
+    def test_plan_prefers_the_content_tag_over_the_moving_alias(self):
+        data = self._digestless()
+        plan = {i.name: i.source for i in alias_plan(data, "develop-abc123abc123", ALL_CONTENT)}
+        self.assertTrue(plan["vss-agent"].endswith(":" + ALL_CONTENT["vss-agent"]))
+
+    def test_content_tag_is_the_only_source_even_when_a_digest_exists(self):
+        """One source rule, no tiers: a fresh build's content tag and its
+        candidate tag are the same manifest, so there is nothing to choose."""
+        data = release_set()  # vss-agent has a real digest
+        plan = {i.name: i.source for i in alias_plan(data, "develop-latest", ALL_CONTENT)}
+        self.assertTrue(plan["vss-agent"].endswith(":" + ALL_CONTENT["vss-agent"]))
+
+    def test_missing_content_tag_refuses_to_plan(self):
+        """No fallback: a reference that may not describe this commit is worse
+        than a failed run."""
+        with self.assertRaisesRegex(ValueError, "no content tag"):
+            alias_plan(release_set(), "develop-latest", {})
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -569,15 +569,11 @@ jobs:
           retention-days: 90
 
       - name: Set up Buildx for post-merge alias publication
-        if: >-
-          github.ref_name == 'develop' &&
-          fromJSON(needs.changes.outputs.count) > 0
+        if: github.ref_name == 'develop'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Log in to GHCR for post-merge publication
-        if: >-
-          github.ref_name == 'develop' &&
-          fromJSON(needs.changes.outputs.count) > 0
+        if: github.ref_name == 'develop'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ghcr.io
@@ -597,9 +593,7 @@ jobs:
       # squash and rebase merges (no merge commits), so develop is linear, and
       # every consumer resolves from the tip, never from an interior commit.
       - name: Retag develop-latest and develop-<sha> after complete post-merge build
-        if: >-
-          github.ref_name == 'develop' &&
-          fromJSON(needs.changes.outputs.count) > 0
+        if: github.ref_name == 'develop'
         run: |
           short="$(printf '%s' "${GITHUB_SHA}" | cut -c1-12)"
           python3 .github/scripts/advance_ghcr_alias.py \

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -569,11 +569,9 @@ jobs:
           retention-days: 90
 
       - name: Set up Buildx for post-merge alias publication
-        if: github.ref_name == 'develop'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Log in to GHCR for post-merge publication
-        if: github.ref_name == 'develop'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ghcr.io
@@ -592,14 +590,24 @@ jobs:
       # Only the pushed tip is tagged, which is sufficient: the repo allows only
       # squash and rebase merges (no merge commits), so develop is linear, and
       # every consumer resolves from the tip, never from an interior commit.
-      - name: Retag develop-latest and develop-<sha> after complete post-merge build
-        if: github.ref_name == 'develop'
+      # develop publishes develop-latest + develop-<sha12>; a PR branch publishes
+      # pr-<N>-latest + pr-<N>-<sha12>. Both sets must cover EVERY GHCR image,
+      # not just the ones rebuilt on this ref: a consumer that derives a
+      # coordinate from the ref would otherwise 404 on the untouched images,
+      # which is why PR acceptance still needs a per-image manifest today.
+      # pr-<N>-* tags are reaped by cleanup-pr-tags.yml when the PR closes.
+      - name: Retag the candidate set for this ref
         run: |
           short="$(printf '%s' "${GITHUB_SHA}" | cut -c1-12)"
+          case "${GITHUB_REF_NAME}" in
+            develop)            prefix="develop" ;;
+            pull-request/[0-9]*) prefix="pr-${GITHUB_REF_NAME#pull-request/}" ;;
+            *) echo "::notice::no candidate set retagged for ${GITHUB_REF_NAME}"; exit 0 ;;
+          esac
           python3 .github/scripts/advance_ghcr_alias.py \
             --release-set release-set.json \
-            --alias develop-latest \
-            --alias "develop-${short}" \
+            --alias "${prefix}-latest" \
+            --alias "${prefix}-${short}" \
             --verify-tree-sha \
             --repo-root . \
             --commit "${GITHUB_SHA}"


### PR DESCRIPTION
> **Stacked on #1485** — shares the same workflow step. Review/merge that first; this diff is the delta on top.

## The asymmetry

`develop` now gets a complete `develop-<sha12>` set (#1485). PR branches don't. Only the images a PR actually changed get a `pr-<N>-<sha12>` tag — #1477, a UI-only change, produces `pr-1477-<sha>` for `vss-agent-ui` and **nothing** for the other four GHCR images.

That's why PR acceptance still needs a per-image manifest: the coordinate set is genuinely heterogeneous — one image at `pr-<N>-<sha>`, the rest at `develop-latest` — and a single shared tag can't express it. Make the `pr-<N>` set complete and a consumer derives every coordinate from the ref alone, exactly as it now can on develop.

```
develop            →  develop-latest  +  develop-<sha12>
pull-request/<N>   →  pr-<N>-latest   +  pr-<N>-<sha12>
```

## What changed

The retag step is **generalised, not duplicated** — it derives the prefix from `GITHUB_REF_NAME` and no-ops with a notice on any other ref. Buildx setup and GHCR login lose their develop-only gates so they run wherever the retag does; all three must stay in agreement or the retag runs without a registry login.

`alias_plan`'s ref guard widens from *develop only* to `develop` or `pull-request/<N>`. It stays a guard rather than becoming a pass-through — an unexpected ref should refuse rather than invent an alias namespace.

## Cost: tag volume

~5 `pr-*` tags per PR head instead of 1–2. `cleanup-pr-tags.yml` (#1446) already reaps `pr-<N>-*` when the PR closes — 12 successful runs since it merged — and deletes only versions whose *every* tag belongs to that PR, so shared digests carrying `develop-*` or `tree-*` are untouched.

Worth stating plainly: **that cleanup moves from convenience to load-bearing here.** The economics only work because it exists.

## Why this matters beyond tidiness

This is the prerequisite for retiring the release set on the PR path. With both sets complete, ci-vss-oss acceptance reduces to setting one variable:

```bash
VSS_CONTAINER_TAG="${prefix}-${short}"
```

and `apply_ghcr_release_set.py`, `verify_ghcr_develop_images.py`, `verify_agent_image_source.py` and the `VSS_RELEASE_SET_B64` transport can all go — along with every hardcoded image list in them. Three separate breakages this week traced to those lists drifting from `container-inventory.json` ([!326](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/merge_requests/326), #1447, and `SUPPORTED_IMAGES`).

## Test

15 unit tests pass, including new cases for a PR-branch release set, an unexpected ref, and a malformed `pull-request/<N>` ref. `ruff` and workflow YAML clean.
