### PR TITLE
Fix/whbp mv3dt

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/configs/ds-mv3dt-tracker-config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/configs/ds-mv3dt-tracker-config.yml
@@ -79,4 +79,4 @@ MultiViewAssociator:
 Communicator:
   communicatorType: 2
   pubSubInfoConfigPath: /tmp/generated/pub_sub_info_config.yml
-  mqttProtoAdaptorConfigPath: configs/config_mqtt.txt
+  mqttProtoAdaptorConfigPath: /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/configs/config_mqtt.txt

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/init-scripts/ds-start-mv3dt.sh
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/init-scripts/ds-start-mv3dt.sh
@@ -11,7 +11,10 @@
 echo "##### RT-DETR + MV3DT pipeline #####"
 
 ARCH="$(uname -m)"
-export LD_PRELOAD="/usr/lib/${ARCH}-linux-gnu/libgomp.so.1:/usr/lib/${ARCH}-linux-gnu/libGLdispatch.so.0"
+# libgomp/libGLdispatch must load first to reserve static TLS; keep any
+# preloads supplied by the image or operator after them.
+MV3DT_PRELOAD="/usr/lib/${ARCH}-linux-gnu/libgomp.so.1:/usr/lib/${ARCH}-linux-gnu/libGLdispatch.so.0"
+export LD_PRELOAD="${MV3DT_PRELOAD}${LD_PRELOAD:+:${LD_PRELOAD}}"
 
 MQTT_HOST=${MQTT_HOST:-mosquitto}
 MQTT_PORT=${MQTT_PORT:-1883}

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/init-scripts/ds-start-mv3dt.sh
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/init-scripts/ds-start-mv3dt.sh
@@ -10,6 +10,9 @@
 
 echo "##### RT-DETR + MV3DT pipeline #####"
 
+ARCH="$(uname -m)"
+export LD_PRELOAD="/usr/lib/${ARCH}-linux-gnu/libgomp.so.1:/usr/lib/${ARCH}-linux-gnu/libGLdispatch.so.0"
+
 MQTT_HOST=${MQTT_HOST:-mosquitto}
 MQTT_PORT=${MQTT_PORT:-1883}
 MQTT_ENDPOINT="${MQTT_HOST}:${MQTT_PORT}"

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/warehouse-mv3dt-app.yml
@@ -292,7 +292,6 @@ services:
       OTEL_SDK_DISABLED: ${OTEL_SDK_DISABLED:-true}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}
       OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
-      LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libgomp.so.1:/usr/lib/x86_64-linux-gnu/libGLdispatch.so.0"
     command: ["./ds-start-mv3dt.sh"]
     depends_on:
       sensor-ms-mv3dt:

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/configs/ds-mv3dt-tracker-config.yml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/configs/ds-mv3dt-tracker-config.yml
@@ -79,4 +79,4 @@ MultiViewAssociator:
 Communicator:
   communicatorType: 2
   pubSubInfoConfigPath: /tmp/generated/pub_sub_info_config.yml
-  mqttProtoAdaptorConfigPath: configs/config_mqtt.txt
+  mqttProtoAdaptorConfigPath: /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/configs/config_mqtt.txt

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/configs/ds-mv3dt-tracker-config.yml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/configs/ds-mv3dt-tracker-config.yml
@@ -1,88 +1,41 @@
 %YAML:1.0
 
 BaseConfig:
-  minDetectorConfidence: 0.027087304322979212
+  minDetectorConfidence: 0.266
+  checkClassMatch: 1
   useBatchNumForFrameId: 1
+
 TargetManagement:
   enableBboxUnClipping: 1
   preserveStreamUpdateOrder: 0
   maxTargetsPerStream: 200
-  minIouDiff4NewTarget: 0.22656630527418112
-  minTrackerConfidence: 0.6957540479571296
-  probationAge: 5
-  maxShadowTrackingAge: 162
-  earlyTerminationAge: 1
+  minIouDiff4NewTarget: 0.33485659954800495
+  minTrackerConfidence: 0.6019478047482886
+  probationAge: 17
+  maxShadowTrackingAge: 131
+  earlyTerminationAge: 7
   maxTrajectoryBufferLength: -1
-  outputTerminatedTracks: 0
-TrajectoryManagement:
-  useUniqueID: 0
-  enableReAssoc: 1
-  minMatchingScore4Overall: 0.9349462651721144
-  minTrackletMatchingScore: 0.2940
-  minMatchingScore4ReidSimilarity: 0
-  matchingScoreWeight4TrackletSimilarity: 0.7981
-  matchingScoreWeight4ReidSimilarity: 0
-  minTrajectoryLength4Projection: 34
-  prepLength4TrajectoryProjection: 58
-  trajectoryProjectionLength: 33
-  maxAngle4TrackletMatching: 67
-  minSpeedSimilarity4TrackletMatching: 0.0574
-  minBboxSizeSimilarity4TrackletMatching: 0.1013
-  maxTrackletMatchingTimeSearchRange: 27
-  trajectoryProjectionProcessNoiseScale: 0.0100
-  trajectoryProjectionMeasurementNoiseScale: 100
-  trackletSpacialSearchRegionScale: 0.0100
-  reidExtractionInterval: 0
+
 DataAssociator:
   dataAssociatorType: 0
   associationMatcherType: 1
-  checkClassMatch: 1
-  minMatchingScore4Overall: 0.4
-  minMatchingScore4SizeSimilarity: 0.4
-  minMatchingScore4Iou: 0.1393522182207021
-  minMatchingScore4VisualSimilarity: 0.0520394823204932
-  matchingScoreWeight4SizeSimilarity: 0.104589699500018
-  matchingScoreWeight4Iou: 0.7844652139368062
-  matchingScoreWeight4VisualSimilarity: 0.9294872869302965
-  tentativeDetectorConfidence: 0.70167245554449
-  minMatchingScore4TentativeIou: 0.1768733030811293
-  minMatchingScore4PeerAssocIou: 0.2
+  minMatchingScore4Overall: 0.5082953005836124
+  minMatchingScore4SizeSimilarity: 0.009643993655030297
+  minMatchingScore4Iou: 0.11557371329518315
+  matchingScoreWeight4SizeSimilarity: 0.5084913673983223
+  matchingScoreWeight4Iou: 0.3494256836722713
+  tentativeDetectorConfidence: 0.7745249596202076
+  minMatchingScore4TentativeIou: 0.42388480686796887
+  minMatchingScore4PeerAssocIou: 0.6955557941537551
+
 StateEstimator:
-  stateEstimatorType: 3
-  processNoiseVar4Loc: 6497.75224242603
-  processNoiseVar4Vel: 8035.858212054732
-  measurementNoiseVar4Detector: 100.0000
-  measurementNoiseVar4Tracker: 883.5847350922555
-ObjectModelProjection:
-  minPoseConfidence: 0.925
-  outputFootLocation: 1
-  outputVisibility: 1
-  outputConvexHull: 0
-  cameraModelFilepath:
-    Camera: /tmp/camInfo/Camera.yml
-    Camera_01: /tmp/camInfo/Camera_01.yml
-    Camera_02: /tmp/camInfo/Camera_02.yml
-    Camera_03: /tmp/camInfo/Camera_03.yml
-  objectModelType: 0
-VisualTracker:
-  visualTrackerType: 0
-  useColorNames: 1
-  useHog: 1
-  featureImgSizeLevel: 5
-  featureFocusOffsetFactor_y: -0.10525549278780495
-  filterLr: 0.025008995723548734
-  filterChannelWeightsLr: 0.09460260509799209
-  gaussianSigma: 0.44967391866177786
-MultiViewAssociator:
-  multiViewAssociatorType: 1
-  maxPeerToPredDistance4Fusion: 3.0
-  minPeerTrackletMatchScore: 0.3
-  minPeerVisibility4Fusion: 0.15
-  recentlyActiveAge: 178
-Communicator:
-  communicatorType: 2
-  pubSubInfoConfigPath: /tmp/generated/pub_sub_info_config.yml
-  mqttProtoAdaptorConfigPath: configs/config_mqtt.txt
+  stateEstimatorType: 4
+  processNoiseVar4Loc: 56.29654177092754
+  processNoiseVar4Size: 96.07257407264093
+  processNoiseVar4Vel: 84.56030088053706
+  measurementNoiseVar4Detector: 78.43805173471176
+  measurementNoiseVar4Tracker: 82.2705749896136
+
 PoseEstimator:
   poseEstimatorType: 1
   useVPICropScaler: 1
@@ -98,3 +51,32 @@ PoseEstimator:
   onnxFile: /opt/storage/BodyPose3DNet/bodypose3dnet_accuracy.onnx
   modelEngineFile: /opt/storage/BodyPose3DNet/bodypose3dnet_accuracy.onnx_b1_gpu0_fp16.engine
   poseInferenceInterval: -1
+
+ObjectModelProjection:
+  outputFootLocation: 1
+  minPoseConfidence: 0.95
+  cameraModelFilepath:
+    Camera: /tmp/camInfo/Camera.yml
+    Camera_01: /tmp/camInfo/Camera_01.yml
+    Camera_02: /tmp/camInfo/Camera_02.yml
+    Camera_03: /tmp/camInfo/Camera_03.yml
+  objectModelType: 0
+
+MultiViewAssociator:
+  multiViewAssociatorType: 1
+  enableLatePeerReAssoc: 1
+  enableIDCorrection: 0
+  enableSeeThrough: 1
+  maxPeerTrackletSize: 30
+  recentlyActiveAge: 150
+  minCommonFrames4MatchScore: 15
+  minPeerTrackletMatchScore: 0.5
+  minPeerVisibility4Fusion: 0.1
+  maxPeerToPredDistance4Fusion: 2.0
+  maxTrackletMatchingTimeSearchRange: 5
+  maxPeerFrameDiff4NoDet: 5
+
+Communicator:
+  communicatorType: 2
+  pubSubInfoConfigPath: /tmp/generated/pub_sub_info_config.yml
+  mqttProtoAdaptorConfigPath: configs/config_mqtt.txt

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/configs/ds-pgie-config.yml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/configs/ds-pgie-config.yml
@@ -14,24 +14,23 @@
 # limitations under the License.
 
 class-attrs-all:
-  pre-cluster-threshold: 0.5
-  topk: 20
-
-class-attrs-0:
-  pre-cluster-threshold: 0.5
-  topk: 20
-class-attrs-1:
-  pre-cluster-threshold: 0.85
-class-attrs-2:
-  pre-cluster-threshold: 0.85
-class-attrs-3:
-  pre-cluster-threshold: 0.85
-class-attrs-4:
-  pre-cluster-threshold: 0.9
-class-attrs-5:
-  pre-cluster-threshold: 0.5
-class-attrs-6:
-  pre-cluster-threshold: 0.5
+  pre-cluster-threshold: 0.25
+  topk: 15
+# class-attrs-0:
+#   pre-cluster-threshold: 0.5
+#   topk: 20
+# class-attrs-1:
+#   pre-cluster-threshold: 0.85
+# class-attrs-2:
+#   pre-cluster-threshold: 0.85
+# class-attrs-3:
+#   pre-cluster-threshold: 0.85
+# class-attrs-4:
+#   pre-cluster-threshold: 0.9
+# class-attrs-5:
+#   pre-cluster-threshold: 0.5
+# class-attrs-6:
+#   pre-cluster-threshold: 0.5
 
 property:
   # 1=DBSCAN, 2=NMS, 3= DBSCAN+NMS Hybrid, 4 = None(No clustering)

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/init-scripts/ds-start-mv3dt.sh
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/init-scripts/ds-start-mv3dt.sh
@@ -11,7 +11,10 @@
 echo "##### RT-DETR + MV3DT pipeline #####"
 
 ARCH="$(uname -m)"
-export LD_PRELOAD="/usr/lib/${ARCH}-linux-gnu/libgomp.so.1:/usr/lib/${ARCH}-linux-gnu/libGLdispatch.so.0"
+# libgomp/libGLdispatch must load first to reserve static TLS; keep any
+# preloads supplied by the image or operator after them.
+MV3DT_PRELOAD="/usr/lib/${ARCH}-linux-gnu/libgomp.so.1:/usr/lib/${ARCH}-linux-gnu/libGLdispatch.so.0"
+export LD_PRELOAD="${MV3DT_PRELOAD}${LD_PRELOAD:+:${LD_PRELOAD}}"
 
 MQTT_HOST=${MQTT_HOST:-mosquitto}
 MQTT_PORT=${MQTT_PORT:-1883}

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/init-scripts/ds-start-mv3dt.sh
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/files/warehouse-standalone-mv3dt/deepstream/init-scripts/ds-start-mv3dt.sh
@@ -10,7 +10,10 @@
 
 echo "##### RT-DETR + MV3DT pipeline #####"
 
-MQTT_HOST=${MQTT_HOST:-localhost}
+ARCH="$(uname -m)"
+export LD_PRELOAD="/usr/lib/${ARCH}-linux-gnu/libgomp.so.1:/usr/lib/${ARCH}-linux-gnu/libGLdispatch.so.0"
+
+MQTT_HOST=${MQTT_HOST:-mosquitto}
 MQTT_PORT=${MQTT_PORT:-1883}
 MQTT_ENDPOINT="${MQTT_HOST}:${MQTT_PORT}"
 cd /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app


### PR DESCRIPTION
## Description

Fixes warehouse MV3DT DeepStream startup and aligns helm standalone configs with the docker path.

- Sync helm `warehouse-standalone-mv3dt` tracker and PGIE configs with the docker accuracy-tuned settings so compose and helm ship the same association/pose and detector thresholds.
- Make `LD_PRELOAD` arch-safe via `uname -m` in both docker and helm `ds-start-mv3dt.sh`, and remove the hardcoded x86 preload from the compose service env (avoids invalid paths on SBSA/aarch64).
- Default helm `MQTT_HOST` to `mosquitto` so the start-script fallback matches the chart `mv3dtMqttHost` helper.
- Use an absolute `mqttProtoAdaptorConfigPath` in docker and helm tracker configs. A relative `configs/config_mqtt.txt` failed to load under the tracker adaptor, so `set-threaded` defaulted to enabled and `mosquitto_loop_start()` returned `INVAL`, leaving DeepStream at `Active sources : 0`.

Related: NVBug [6525220](https://nvbugspro.nvidia.com/bug/6525220) (MQTT communicator / zero-FPS symptom; this PR addresses the absolute-path load path and the SBSA `LD_PRELOAD` secondary finding for warehouse MV3DT).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
