### PR TITLE
fix(lvs): reject unsupported purpose values in GET /files with 422 

### DIFF
--- a/services/video-summarization/src/via_server.py
+++ b/services/video-summarization/src/via_server.py
@@ -497,16 +497,12 @@ class ViaServer:
         )
         async def list_video_files(
             purpose: Annotated[
-                str,
+                Purpose,
                 Query(
-                    description="Only return files with the given purpose.",
-                    max_length=36,
-                    pattern=r"^[a-zA-Z]*$",
+                    description="Only return files with the given purpose. Must be 'vision'.",
                 ),
             ],
         ) -> ListFilesResponse:
-            if purpose != "vision":
-                return {"data": [], "object": "list"}
             try:
                 rtvi_resp = self._stream_handler._vlm_pipeline.list_files(purpose)
             except Exception as e:
@@ -1910,3 +1906,4 @@ if __name__ == "__main__":
 
     server = ViaServer(args)
     server.run()
+


### PR DESCRIPTION
## Summary

- `GET /files?purpose=notvision` (and any alphabetic non-`vision` string) previously returned HTTP 200 with `{"data":[],"object":"list"}` instead of a validation error
- Root cause: `list_video_files` accepted `purpose` as a bare `str` with only an alphabetic regex, then silently short-circuited non-`vision` values
- Fix: replace `str` + regex + manual `if purpose != "vision"` check with the `Purpose` enum already used by the `add_file` endpoint — FastAPI now rejects invalid values with HTTP 422 / `InvalidParameters`

Fixes NVBug 6536983.

## Test plan

- [x] `GET /files?purpose=vision` → 200 (existing behaviour preserved)
- [x] `GET /files?purpose=notvision` → 422 `InvalidParameters`
- [x] `GET /files?purpose=audio` → 422 `InvalidParameters`
- [x] `GET /files?purpose=Vision` → 422 `InvalidParameters` (case-sensitive enum)
- [x] `GET /files?purpose=vision1` → 422 `InvalidParameters` (existing; digits still rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)