### PR TITLE
feat(ci): build images whose content tag is missing, not just changed ones

### DIFF
--- a/.github/scripts/detect_changed_images.py
+++ b/.github/scripts/detect_changed_images.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Callable
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -159,6 +161,79 @@ def select_images(inventory: dict, changed: list[str] | None) -> tuple[list[dict
     return [], f"0 of {len(buildable)} images changed"
 
 
+def add_missing_content_tags(
+    buildable: list[dict],
+    selected: list[dict],
+    repo: Path,
+    commit: str,
+    probe: Callable[[str], bool | None],
+    owner: str,
+) -> tuple[list[dict], list[str]]:
+    """Add images whose content tag is absent, whatever the path diff said.
+
+    This is what makes "every image at the tip has a tree-<sha>" true by
+    construction rather than by assumption about build history: a missing tag
+    pulls the image into the matrix, the build republishes it, and the
+    post-merge retag finds it.
+    """
+    have = {entry["name"] for entry in selected}
+    added = [
+        entry
+        for entry in buildable
+        if entry["name"] not in have
+        and content_tag_missing(entry, repo, commit, probe, owner)
+    ]
+    if not added:
+        return selected, []
+    names = [entry["name"] for entry in added]
+    return selected + added, names
+
+
+def ghcr_tag_exists(reference: str) -> bool | None:
+    """True/False if the manifest read succeeded, None if it could not be read."""
+    result = subprocess.run(
+        ["docker", "manifest", "inspect", reference],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return True
+    combined = (result.stderr + result.stdout).lower()
+    if "manifest unknown" in combined or "not found" in combined:
+        return False
+    return None  # auth, network, rate limit: unknown, so build
+
+
+def content_tag_missing(
+    entry: dict,
+    repo: Path,
+    commit: str,
+    probe: Callable[[str], bool | None],
+    owner: str,
+) -> bool:
+    """True when this image has no published ``tree-<sha>`` for its current tree.
+
+    A path diff is a *proxy* for "did the content change"; the tree hash IS the
+    content. An image whose tree is unchanged is normally skipped -- but only
+    safely so if the content tag for that tree actually exists, because the
+    post-merge retag sources the candidate set from it.
+
+    Fails **open**: a probe that errors returns None and the image is built.
+    An unreachable registry must never look like "already published" -- a
+    spurious rebuild costs minutes, a spurious skip costs a missing tag that
+    surfaces somewhere else hours later.
+    """
+    source_path = entry.get("source_path")
+    if not source_path:
+        return False
+    result = run_git(repo, "rev-parse", f"{commit}:{source_path}")
+    if result.returncode != 0:
+        return True
+    tree_sha = result.stdout.strip()
+    reference = f"ghcr.io/{owner.lower()}/vss/{entry['name']}:tree-{tree_sha}"
+    return probe(reference) is not True
+
+
 def matrix_entry(entry: dict) -> dict:
     return {
         "name": entry["name"],
@@ -216,6 +291,12 @@ def main() -> int:
     parser.add_argument("--ref-name", required=True)
     parser.add_argument("--before", default="")
     parser.add_argument("--base-branch", default="develop")
+    parser.add_argument(
+        "--owner",
+        default=os.environ.get("GITHUB_REPOSITORY_OWNER", ""),
+        help="GHCR owner; enables the content-tag gap check when set.",
+    )
+    parser.add_argument("--commit", default=os.environ.get("GITHUB_SHA", "HEAD"))
     args = parser.parse_args()
     repo_root = args.repo_root.resolve()
 
@@ -228,6 +309,24 @@ def main() -> int:
         reason += "; diff failed, building everything"
 
     entries, selection_reason = select_images(inventory, changed)
+
+    # A path diff only says the source did not change. It cannot say the content
+    # tag for that source was ever published -- and the post-merge retag sources
+    # the candidate set from tree-<sha>. Pull in any image missing one, so
+    # "every image at the tip has a content tag" holds by construction.
+    if args.owner:
+        buildable = [
+            entry
+            for entry in inventory["images"]
+            if entry.get("strategy") == "build" and entry.get("ghcr_build")
+        ]
+        entries, backfilled = add_missing_content_tags(
+            buildable, entries, repo_root, args.commit, ghcr_tag_exists, args.owner
+        )
+        if backfilled:
+            selection_reason += (
+                f"; no published content tag for {', '.join(backfilled)}"
+            )
     matrix = to_matrix(entries)
     split_matrices = split_build_matrices(entries)
     print(

--- a/.github/scripts/test_detect_changed_images.py
+++ b/.github/scripts/test_detect_changed_images.py
@@ -338,5 +338,67 @@ class SelectImagesTest(unittest.TestCase):
             dci.split_build_matrices(entries)
 
 
+
+BUILDABLE = [
+    {"name": "vss-agent", "source_path": "services/agent",
+     "strategy": "build", "ghcr_build": True},
+    {"name": "vss-agent-ui", "source_path": "services/ui",
+     "strategy": "build", "ghcr_build": True},
+]
+
+
+def _content_repo() -> Path:
+    root = Path(tempfile.mkdtemp())
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    for path in ("services/agent", "services/ui"):
+        d = root / path
+        d.mkdir(parents=True)
+        (d / "f").write_text("x")
+    subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-qm", "init"], check=True)
+    return root
+
+
+class ContentTagGapTest(unittest.TestCase):
+    """A path diff says the source did not change; it cannot say the content
+    tag was ever published. The post-merge retag sources from tree-<sha>, so a
+    missing one must pull the image back into the matrix."""
+
+    def test_missing_content_tag_is_added_to_the_matrix(self):
+        selected, added = dci.add_missing_content_tags(
+            BUILDABLE, [], _content_repo(), "HEAD",
+            lambda ref: "vss-agent:" not in ref, "Org")
+        self.assertEqual(added, ["vss-agent"])
+
+    def test_present_content_tag_is_not_added(self):
+        selected, added = dci.add_missing_content_tags(
+            BUILDABLE, [], _content_repo(), "HEAD", lambda _ref: True, "Org")
+        self.assertEqual(added, [])
+        self.assertEqual(selected, [])
+
+    def test_probe_failure_fails_open_to_building(self):
+        """Unknown must never look like 'already published'."""
+        _, added = dci.add_missing_content_tags(
+            BUILDABLE, [], _content_repo(), "HEAD", lambda _ref: None, "Org")
+        self.assertEqual(added, ["vss-agent", "vss-agent-ui"])
+
+    def test_already_selected_images_are_not_reprobed(self):
+        selected, added = dci.add_missing_content_tags(
+            BUILDABLE, [BUILDABLE[0]], _content_repo(), "HEAD",
+            lambda _ref: None, "Org")
+        self.assertEqual(added, ["vss-agent-ui"])
+        self.assertEqual(len(selected), 2)
+
+    def test_probe_reference_is_the_content_tag(self):
+        seen: list[str] = []
+        dci.add_missing_content_tags(
+            BUILDABLE[:1], [], _content_repo(), "HEAD",
+            lambda ref: seen.append(ref) or True, "Org")
+        self.assertEqual(len(seen), 1)
+        self.assertTrue(seen[0].startswith("ghcr.io/org/vss/vss-agent:tree-"))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -74,7 +74,15 @@ jobs:
       # The content-tag gap check reads GHCR, so the job needs a token. Login
       # before detection, not after: an unauthenticated probe returns "unknown",
       # which fails open and rebuilds everything.
+      #
+      # continue-on-error is load-bearing, not defensive tidiness. A hard-failing
+      # login would stop the job before ghcr_tag_exists could degrade, so a GHCR
+      # outage would block the matrix and the release set entirely -- the exact
+      # opposite of the fail-open posture this check is built on. Letting it fail
+      # leaves detection unauthenticated, every probe returns "unknown", and the
+      # job rebuilds everything. Slower, never wrong.
       - name: Log in to GHCR for the content-tag gap check
+        continue-on-error: true
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ghcr.io

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -71,6 +71,16 @@ jobs:
       # develop pushes, merge-base for PR branches, build-everything on
       # initial/force-push) and is unit-tested in CI. Never diff
       # origin/develop...HEAD on a develop push: that range is always empty.
+      # The content-tag gap check reads GHCR, so the job needs a token. Login
+      # before detection, not after: an unauthenticated probe returns "unknown",
+      # which fails open and rebuilds everything.
+      - name: Log in to GHCR for the content-tag gap check
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Resolve changed images
         id: detect
         run: |


### PR DESCRIPTION
## The gap

The build matrix comes from a **path diff** against the previous commit. That's a proxy for "did the content change" — the tree hash *is* the content — and it can't say whether the content tag for that tree was ever published.

That matters because the post-merge retag sources the candidate set from `tree-<sha>` (#1485). An unchanged image is never in the matrix, so nothing notices its content tag is absent, and the retag is the first thing to look. Today that's a hard failure with no automatic recovery — the image only rebuilds when its source next changes.

## The rule

An image enters the matrix if its source path changed **or** its `tree-<sha>` is absent from GHCR. Skip only when the tree is unchanged **and** the content tag exists.

That makes *"every image at the tip has a content tag"* true **by construction** rather than by assumption about build history: a missing tag pulls the image in, the build republishes it, and the retag finds it. Self-healing on the next push instead of the next source change.

**No digest involved.** The tree hash is the content identity, so "does `tree-<sha>` exist" fully subsumes "is the digest unchanged".

## Fails open

`ghcr_tag_exists` distinguishes three outcomes — published, absent, unreadable — and only *absent* and *unreadable* build:

```python
if result.returncode == 0:            return True    # published → skip
if "manifest unknown" in combined:    return False   # absent     → build
return None                                          # unknown    → build
```

An unreachable registry, auth failure or rate limit must never look like "already published". A spurious rebuild costs minutes; a spurious skip costs a missing tag that surfaces somewhere else hours later. The GHCR login is added **before** detection for the same reason — without it every probe returns unknown and the job rebuilds everything.

## Blast radius

This changes **what gets built**, not just what gets tagged — unlike #1485/#1486, which are additive and revertible by deleting a tag. Worth its own soak.

Mitigations: the check is **opt-in on `--owner`**, so callers without GHCR access keep pure path-diff behaviour and existing tests are unaffected. Worst case on a registry outage is rebuilding all five images, which is the current behaviour when the build contract changes.

## Related

Completes the chain: #1485 (`develop-<sha12>` at every tip) → #1486 (`pr-<N>-<sha12>` on PR branches) → this. With the matrix keyed on content, the candidate set's completeness stops depending on build history.

## Test

18 tests: missing tag added, present tag skipped, probe failure building everything, already-selected images not reprobed, and the probe addressing `tree-<sha>` rather than a candidate tag.
