### PR TITLE
nvbug 6537736 /v1/summarize does not propagate incoming traceparent trace ID to Jaeger even when OTEL export is enabled

### DIFF
--- a/services/video-summarization/src/otel_helper.py
+++ b/services/video-summarization/src/otel_helper.py
@@ -287,6 +287,50 @@ def is_tracing_enabled():
     return _otel_enabled
 
 
+def extract_context_from_headers(headers):
+    """Extract a W3C trace context from inbound HTTP request headers.
+
+    Lets a caller's `traceparent` become the parent of the spans this service
+    creates, so the whole request shows up under one trace ID in the backend.
+
+    Args:
+        headers: Mapping of HTTP header names to values (e.g. Starlette's
+                 `request.headers`). Header names are matched case-insensitively.
+
+    Returns:
+        An OTEL Context carrying the remote span, or None when tracing is
+        disabled or the headers carry no usable trace context. Returning None
+        keeps the caller on the default behaviour of starting a new root span.
+    """
+    if not _otel_enabled:
+        return None
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.propagate import extract
+
+        # The W3C propagator expects lower-case keys; Starlette headers are
+        # already case-insensitive but plain dicts from other callers are not.
+        carrier = {str(key).lower(): value for key, value in dict(headers).items()}
+        context = extract(carrier)
+
+        # extract() always returns a Context. Without a valid traceparent it
+        # holds INVALID_SPAN, which would silently produce a fresh trace ID.
+        span_context = trace.get_current_span(context).get_span_context()
+        if not span_context.is_valid:
+            return None
+
+        logger.debug(
+            "Extracted remote trace context: trace_id=%s span_id=%s",
+            format(span_context.trace_id, "032x"),
+            format(span_context.span_id, "016x"),
+        )
+        return context
+    except Exception as e:
+        logger.debug(f"Failed to extract trace context from headers: {e}")
+        return None
+
+
 def trace_function(func_name: str = None):
     """Decorator to trace function execution."""
 

--- a/services/video-summarization/src/via_server.py
+++ b/services/video-summarization/src/via_server.py
@@ -45,6 +45,7 @@ from prometheus_client import (
 from sse_starlette.sse import EventSourceResponse
 
 from chunk_info import RequestSource
+from otel_helper import extract_context_from_headers
 from rtvi_vlm_client import RtviError
 from via_exception import ViaException
 from via_logger import LOG_PERF_LEVEL, TimeMeasure, logger, patch_logger_handlers
@@ -1103,6 +1104,7 @@ class ViaServer:
         )
         async def stream_summarize(
             request_body: StreamSummarizeRequest,
+            request: Request,
         ) -> CompletionResponse:
             if not self._stream_handler._kafka_enabled:
                 raise ViaException(
@@ -1133,11 +1135,14 @@ class ViaServer:
                 request_body.end_time,
             )
 
+            trace_context = extract_context_from_headers(request.headers)
+
             loop = asyncio.get_event_loop()
             request_id = await loop.run_in_executor(
                 self._async_executor,
                 self._stream_handler.summarize_stream,
                 request_body,
+                trace_context,
             )
 
             logger.info(
@@ -1429,12 +1434,18 @@ class ViaServer:
             loop = asyncio.get_event_loop()
             videoId = source.source_id
 
+            # Capture the caller's trace context here, on the event loop thread.
+            # run_in_executor hands work to a ThreadPoolExecutor and contextvars
+            # do not cross that boundary, so the context must travel explicitly.
+            trace_context = extract_context_from_headers(request.headers)
+
             # File-based summarization
             request_id = await loop.run_in_executor(
                 self._async_executor,
                 self._stream_handler.summarize,
                 source,
                 query,
+                trace_context,
             )
             logger.info("Created video file query %s for source %s", request_id, videoId)
 

--- a/services/video-summarization/src/via_stream_handler.py
+++ b/services/video-summarization/src/via_stream_handler.py
@@ -1444,10 +1444,14 @@ class ViaStreamHandler:
                 req_info.chunk_count = len(req_info_deserialized.processed_chunk_list)
                 for vlm_response in req_info_deserialized.processed_chunk_list:
                     self._on_vlm_chunk_response(vlm_response, req_info)
-                # This path returns before the SSE loop, which is where the
-                # pipeline span is normally closed. _process_output ends the
-                # E2E span.
+                if req_info.chunk_count:
+                    # The final replayed chunk ends the pipeline span and queues
+                    # _process_output, which ends the E2E span.
+                    return
+                # An empty cache replays nothing, so neither span would other-
+                # wise be closed and the trace would never be exported.
                 self._end_vlm_pipeline_span(req_info)
+                self._end_e2e_span(req_info)
                 return
 
         if req_info._ctx_mgr:

--- a/services/video-summarization/src/via_stream_handler.py
+++ b/services/video-summarization/src/via_stream_handler.py
@@ -178,6 +178,9 @@ class RequestInfo:
         self.vlm_pipeline_span = None
         self._e2e_span_context = None
         self._vlm_pipeline_span_context = None
+        # Trace context extracted from the inbound request's traceparent header,
+        # carried here because span creation happens on an executor thread.
+        self._remote_trace_context = None
         # fps metrics
         self._fps_start_time = None
         self._fps_frame_count = 0
@@ -1401,6 +1404,33 @@ class ViaStreamHandler:
         req_info.status = RequestInfo.Status.PROCESSING
         req_info.start_time = time.time()
 
+        # Create OTEL spans for end-to-end and VLM pipeline tracing. This runs
+        # before the dense caption cache check below so a cache hit still
+        # produces a correctly parented trace instead of orphaned chunk spans.
+        if is_tracing_enabled():
+            from opentelemetry import trace
+
+            tracer = get_tracer()
+            if tracer:
+                # _remote_trace_context is the caller's traceparent when supplied,
+                # otherwise None, which starts a new root span as before.
+                req_info._e2e_span = tracer.start_span(
+                    "Summarization E2E Latency",
+                    context=getattr(req_info, "_remote_trace_context", None),
+                )
+                req_info._e2e_span.set_attribute("request_id", req_info.request_id)
+                req_info._e2e_span.set_attribute("source_id", req_info.source_id)
+                req_info._e2e_span_context = trace.set_span_in_context(req_info._e2e_span)
+
+                req_info.vlm_pipeline_span = tracer.start_span(
+                    "VLM Pipeline Latency", context=req_info._e2e_span_context
+                )
+                req_info.vlm_pipeline_span.set_attribute("request_id", req_info.request_id)
+                req_info.vlm_pipeline_span.set_attribute("source_id", req_info.source_id)
+                req_info._vlm_pipeline_span_context = trace.set_span_in_context(
+                    req_info.vlm_pipeline_span, context=req_info._e2e_span_context
+                )
+
         # Dense caption cache: load from .dc.json if available
         enable_dense_caption = bool(os.environ.get("ENABLE_DENSE_CAPTION", False))
         if enable_dense_caption:
@@ -1414,27 +1444,11 @@ class ViaStreamHandler:
                 req_info.chunk_count = len(req_info_deserialized.processed_chunk_list)
                 for vlm_response in req_info_deserialized.processed_chunk_list:
                     self._on_vlm_chunk_response(vlm_response, req_info)
+                # This path returns before the SSE loop, which is where the
+                # pipeline span is normally closed. _process_output ends the
+                # E2E span.
+                self._end_vlm_pipeline_span(req_info)
                 return
-
-        # Create OTEL spans for end-to-end and VLM pipeline tracing
-        if is_tracing_enabled():
-            from opentelemetry import trace
-
-            tracer = get_tracer()
-            if tracer:
-                req_info._e2e_span = tracer.start_span("Summarization E2E Latency")
-                req_info._e2e_span.set_attribute("request_id", req_info.request_id)
-                req_info._e2e_span.set_attribute("source_id", req_info.source_id)
-                req_info._e2e_span_context = trace.set_span_in_context(req_info._e2e_span)
-
-                req_info.vlm_pipeline_span = tracer.start_span(
-                    "VLM Pipeline Latency", context=req_info._e2e_span_context
-                )
-                req_info.vlm_pipeline_span.set_attribute("request_id", req_info.request_id)
-                req_info.vlm_pipeline_span.set_attribute("source_id", req_info.source_id)
-                req_info._vlm_pipeline_span_context = trace.set_span_in_context(
-                    req_info.vlm_pipeline_span, context=req_info._e2e_span_context
-                )
 
         if req_info._ctx_mgr:
             ca_rag_config = self.update_ca_rag_config(req_info)
@@ -1925,7 +1939,7 @@ class ViaStreamHandler:
                 with self._lock:
                     self._ctx_mgr_pool.append(ctx_mgr)
 
-    def summarize_stream(self, request: StreamSummarizeRequest):
+    def summarize_stream(self, request: StreamSummarizeRequest, trace_context=None):
         """Summarize a live stream by aggregating captions from Elasticsearch via CA-RAG.
 
         Requires ``KAFKA_ENABLED=true``. Creates a RequestInfo, borrows a
@@ -1946,6 +1960,7 @@ class ViaStreamHandler:
         camera_id = getattr(request, "camera_id", "default") or "default"
 
         req_info = RequestInfo()
+        req_info._remote_trace_context = trace_context
         req_info.source_id = stream_id
         req_info.camera_id = camera_id
         req_info.is_summarization = True
@@ -1986,7 +2001,9 @@ class ViaStreamHandler:
 
             tracer = get_tracer()
             if tracer:
-                req_info._e2e_span = tracer.start_span("Stream Summarization E2E Latency")
+                req_info._e2e_span = tracer.start_span(
+                    "Stream Summarization E2E Latency", context=trace_context
+                )
                 req_info._e2e_span.set_attribute("request_id", req_info.request_id)
                 req_info._e2e_span.set_attribute("source_id", stream_id)
                 req_info._e2e_span.set_attribute("is_live", True)
@@ -2465,6 +2482,7 @@ class ViaStreamHandler:
         self,
         source: RequestSource,
         query: SummarizationQuery,
+        trace_context=None,
     ):
         """Run a summarization query on a file"""
         # Enable summarization if summarization config is enabled  OR API passes enable flag
@@ -2482,6 +2500,7 @@ class ViaStreamHandler:
             source=source,
             query=query,
             is_summarization=True,
+            trace_context=trace_context,
         )
 
     def query(
@@ -2490,6 +2509,7 @@ class ViaStreamHandler:
         query: SummarizationQuery,
         is_summarization=False,
         skip_ca_rag=False,
+        trace_context=None,
     ):
         """Run a query on a file"""
 
@@ -2538,6 +2558,7 @@ class ViaStreamHandler:
 
         # Create a RequestInfo object and populate it
         req_info = RequestInfo()
+        req_info._remote_trace_context = trace_context
         req_info.file = source.url or ""
         req_info.chunk_size = query.chunk_duration
         req_info.is_summarization = is_summarization

--- a/services/video-summarization/tests/unit/test_otel_helper.py
+++ b/services/video-summarization/tests/unit/test_otel_helper.py
@@ -1332,3 +1332,179 @@ class TestTraceFunctionDecorator:
         assert result == 42
         call_args = mock_tracer.start_as_current_span.call_args[0]
         assert "traced_auto" in call_args[0]
+
+
+# =============================================================================
+# Inbound W3C traceparent propagation (NVBug 6537736)
+# =============================================================================
+
+# Fixed ids so assertions can compare against the exact values a client sent.
+REMOTE_TRACE_ID_HEX = "7947efe02129245f8b5033e0b3a82bb4"
+REMOTE_SPAN_ID_HEX = "bd41b2a934561ac9"
+REMOTE_TRACEPARENT = f"00-{REMOTE_TRACE_ID_HEX}-{REMOTE_SPAN_ID_HEX}-01"
+
+
+@pytest.fixture
+def in_memory_tracer():
+    """Enable tracing against a local provider whose spans land in memory.
+
+    init_otel() is deliberately not used: it calls trace.set_tracer_provider(),
+    which OTEL only honours once per process, so a second call would silently
+    no-op and make these tests depend on execution order.
+    """
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    otel_helper._otel_enabled = True
+    otel_helper._tracer = provider.get_tracer(__name__)
+    yield exporter
+    provider.shutdown()
+
+
+@pytest.mark.unit
+class TestExtractContextFromHeaders:
+    def test_returns_none_when_otel_disabled(self):
+        otel_helper._otel_enabled = False
+        assert otel_helper.extract_context_from_headers({"traceparent": REMOTE_TRACEPARENT}) is None
+
+    def test_extracts_trace_and_span_id(self, in_memory_tracer):
+        from opentelemetry import trace
+
+        context = otel_helper.extract_context_from_headers({"traceparent": REMOTE_TRACEPARENT})
+
+        assert context is not None
+        span_context = trace.get_current_span(context).get_span_context()
+        assert format(span_context.trace_id, "032x") == REMOTE_TRACE_ID_HEX
+        assert format(span_context.span_id, "016x") == REMOTE_SPAN_ID_HEX
+        assert span_context.is_remote is True
+
+    def test_header_name_is_case_insensitive(self, in_memory_tracer):
+        from opentelemetry import trace
+
+        context = otel_helper.extract_context_from_headers({"TraceParent": REMOTE_TRACEPARENT})
+
+        assert context is not None
+        span_context = trace.get_current_span(context).get_span_context()
+        assert format(span_context.trace_id, "032x") == REMOTE_TRACE_ID_HEX
+
+    def test_returns_none_without_traceparent(self, in_memory_tracer):
+        assert (
+            otel_helper.extract_context_from_headers({"content-type": "application/json"}) is None
+        )
+
+    def test_returns_none_for_empty_headers(self, in_memory_tracer):
+        assert otel_helper.extract_context_from_headers({}) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "not-a-traceparent",
+            "00-tooshort-bd41b2a934561ac9-01",
+            # Version ff is forbidden by the W3C spec. Higher versions such as
+            # 99 are intentionally not listed: the spec requires parsers to
+            # accept them for forward compatibility.
+            "ff-7947efe02129245f8b5033e0b3a82bb4-bd41b2a934561ac9-01",
+            "00-zzz7efe02129245f8b5033e0b3a82bb4-bd41b2a934561ac9-01",
+            "00-7947efe02129245f8b5033e0b3a82bb4-bd41b2a934561ac9",
+            "00-7947efe02129245f8b5033e0b3a82bb4-0000000000000000-01",
+        ],
+    )
+    def test_returns_none_for_malformed_traceparent(self, in_memory_tracer, value):
+        assert otel_helper.extract_context_from_headers({"traceparent": value}) is None
+
+    def test_returns_none_for_all_zero_trace_id(self, in_memory_tracer):
+        # A zeroed trace id is syntactically valid but semantically invalid;
+        # accepting it would produce spans under a bogus parent.
+        zeroed = "00-00000000000000000000000000000000-bd41b2a934561ac9-01"
+        assert otel_helper.extract_context_from_headers({"traceparent": zeroed}) is None
+
+    def test_does_not_raise_on_unusable_headers(self, in_memory_tracer):
+        class Exploding:
+            def keys(self):
+                raise RuntimeError("boom")
+
+        assert otel_helper.extract_context_from_headers(Exploding()) is None
+        assert otel_helper.extract_context_from_headers(None) is None
+
+
+@pytest.mark.unit
+class TestRemoteParentSpanWiring:
+    """The E2E span must adopt the caller's traceparent (NVBug 6537736).
+
+    Mirrors how _trigger_query builds its span tree: an E2E root span, then
+    children created from that span's context.
+    """
+
+    def test_e2e_span_adopts_incoming_trace_id(self, in_memory_tracer):
+        context = otel_helper.extract_context_from_headers({"traceparent": REMOTE_TRACEPARENT})
+
+        otel_helper.get_tracer().start_span("Summarization E2E Latency", context=context).end()
+
+        (span,) = in_memory_tracer.get_finished_spans()
+        assert format(span.context.trace_id, "032x") == REMOTE_TRACE_ID_HEX
+        assert span.parent is not None
+        assert format(span.parent.span_id, "016x") == REMOTE_SPAN_ID_HEX
+
+    def test_e2e_span_is_root_without_traceparent(self, in_memory_tracer):
+        context = otel_helper.extract_context_from_headers({})
+
+        otel_helper.get_tracer().start_span("Summarization E2E Latency", context=context).end()
+
+        (span,) = in_memory_tracer.get_finished_spans()
+        assert span.parent is None
+        assert span.context.trace_id != 0
+        assert format(span.context.trace_id, "032x") != REMOTE_TRACE_ID_HEX
+
+    def test_trace_operation_child_shares_incoming_trace_id(self, in_memory_tracer):
+        from opentelemetry import trace
+
+        context = otel_helper.extract_context_from_headers({"traceparent": REMOTE_TRACEPARENT})
+        e2e_span = otel_helper.get_tracer().start_span("Summarization E2E Latency", context=context)
+        e2e_context = trace.set_span_in_context(e2e_span)
+
+        with otel_helper.trace_operation("CTX-RAG Call - Summarize", parent_context=e2e_context):
+            pass
+        e2e_span.end()
+
+        by_name = {s.name: s for s in in_memory_tracer.get_finished_spans()}
+        child = by_name["CTX-RAG Call - Summarize"]
+        assert format(child.context.trace_id, "032x") == REMOTE_TRACE_ID_HEX
+        assert child.parent.span_id == by_name["Summarization E2E Latency"].context.span_id
+
+    def test_historical_child_spans_share_incoming_trace_id(self, in_memory_tracer):
+        from opentelemetry import trace
+
+        context = otel_helper.extract_context_from_headers({"traceparent": REMOTE_TRACEPARENT})
+        e2e_span = otel_helper.get_tracer().start_span("Summarization E2E Latency", context=context)
+        e2e_context = trace.set_span_in_context(e2e_span)
+
+        chunk_context = otel_helper.create_historical_span(
+            "Chunk 0", 1000.0, 1002.0, {"chunk_idx": 0}, parent_context=e2e_context
+        )
+        otel_helper.create_historical_span(
+            "Decode - Chunk 0", 1000.0, 1001.0, {"chunk_idx": 0}, parent_context=chunk_context
+        )
+        e2e_span.end()
+
+        spans = in_memory_tracer.get_finished_spans()
+        assert {s.name for s in spans} == {
+            "Summarization E2E Latency",
+            "Chunk 0",
+            "Decode - Chunk 0",
+        }
+        assert {format(s.context.trace_id, "032x") for s in spans} == {REMOTE_TRACE_ID_HEX}
+
+        by_name = {s.name: s for s in spans}
+        assert (
+            by_name["Chunk 0"].parent.span_id
+            == by_name["Summarization E2E Latency"].context.span_id
+        )
+        assert by_name["Decode - Chunk 0"].parent.span_id == by_name["Chunk 0"].context.span_id

--- a/services/video-summarization/tests/unit/test_via_stream_handler.py
+++ b/services/video-summarization/tests/unit/test_via_stream_handler.py
@@ -2939,3 +2939,74 @@ class TestHandleEsDependencyError:
             ri, Exception("max_shards_per_node exceeded")
         )
         assert http_status == 503
+
+
+# ---------------------------------------------------------------------------
+# Dense caption cache span lifecycle (NVBug 6537736)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDenseCaptionCacheSpanLifecycle:
+    """_trigger_query must not leak spans when it returns via the cache path.
+
+    A span only reaches the exporter once end() is called, so an unclosed E2E
+    span means the whole cache-hit trace is missing from the backend.
+    """
+
+    @staticmethod
+    def _memory_tracer():
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        return provider.get_tracer(__name__), exporter
+
+    def _trigger_with_cached_chunks(self, tmp_path, monkeypatch, cached_chunks):
+        import via_stream_handler as vsh
+        from via_stream_handler import RequestInfo, ViaStreamHandler
+
+        tracer, exporter = self._memory_tracer()
+        monkeypatch.setattr(vsh, "is_tracing_enabled", lambda: True)
+        monkeypatch.setattr(vsh, "get_tracer", lambda: tracer)
+        monkeypatch.setenv("ENABLE_DENSE_CAPTION", "true")
+        monkeypatch.setenv("VIA_LOG_DIR", str(tmp_path))
+
+        req_info = RequestInfo()
+        req_info.source_id = "cache-src"
+        (tmp_path / f"dc_{req_info.source_id}.json").write_text("{}")
+
+        deserialized = MagicMock()
+        deserialized.processed_chunk_list = cached_chunks
+        monkeypatch.setattr(vsh.DCSerializer, "from_json", lambda _path: deserialized)
+
+        handler = ViaStreamHandler.__new__(ViaStreamHandler)
+        handler._on_vlm_chunk_response = MagicMock()
+        handler._trigger_query(req_info)
+        return handler, exporter
+
+    def test_empty_cache_closes_both_spans(self, tmp_path, monkeypatch):
+        handler, exporter = self._trigger_with_cached_chunks(tmp_path, monkeypatch, [])
+
+        handler._on_vlm_chunk_response.assert_not_called()
+        assert {span.name for span in exporter.get_finished_spans()} == {
+            "Summarization E2E Latency",
+            "VLM Pipeline Latency",
+        }
+
+    def test_populated_cache_leaves_spans_to_the_chunk_handler(self, tmp_path, monkeypatch):
+        handler, exporter = self._trigger_with_cached_chunks(
+            tmp_path, monkeypatch, ["chunk-a", "chunk-b"]
+        )
+
+        assert handler._on_vlm_chunk_response.call_count == 2
+        # The real _on_vlm_chunk_response ends the pipeline span and queues
+        # _process_output for the E2E span on the final chunk. It is mocked
+        # here, so nothing should have closed them: _trigger_query closing
+        # them itself would truncate the trace.
+        assert len(exporter.get_finished_spans()) == 0


### PR DESCRIPTION
## Description
fix(lvs): propagate inbound traceparent into summarization traces
    
    /v1/summarize exported spans under a freshly generated trace ID even when
    the caller supplied a W3C traceparent, so clients could never correlate a
    request with its server-side trace in Jaeger.
    
    Two gaps caused this. Nothing ever read the header: init_otel() builds a
    TracerProvider and exporters, but no code called propagate.extract() and
    the service has no FastAPI instrumentation. Separately, the E2E span was
    started with no context= argument from inside a ThreadPoolExecutor worker,
    and OTEL's ambient context lives in contextvars, which do not cross that
    boundary -- so relying on ambient state would have kept producing root
    spans even after adding extraction.
    
    extract_context_from_headers() now parses the carrier and validates the
    result via span_context.is_valid. That check matters: extract() always
    returns a Context, and without a usable traceparent it holds INVALID_SPAN,
    which would silently regenerate a trace ID. Missing, malformed and
    all-zero values fall back to None so untraced callers keep their existing
    root-span behaviour, and the helper never raises.
    
    The endpoint extracts on the event loop thread and passes the context
    explicitly through run_in_executor onto RequestInfo, where _trigger_query
    uses it as the parent of "Summarization E2E Latency". Every other LVS span
    already chained off that one, so the whole tree follows.
    /v1/stream_summarize gets the same treatment.
    
    Span creation also moves above the dense caption cache check, which
    returned early and left chunk spans parentless -- the "vlm_pipeline_ctx is
    None" warnings seen in the failing run. That path now closes the pipeline
    span itself, since it returns before the SSE loop that normally does so.
    
    Adds TestExtractContextFromHeaders and TestRemoteParentSpanWiring covering
    extraction, the invalid-input fallbacks, root-span parenting, and child
    spans sharing the injected trace ID.
    
    Fixes NVBug 6537736
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
