### PR TITLE
Fix remote VLM mode for RTVI Helm deployments

### DIFF
--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/templates/deployment.yaml
@@ -188,8 +188,15 @@ spec:
                   name: {{ $hfTokName }}
                   key: {{ $hfTokKey }}
             {{- end }}
+            {{- if .Values.useSharedNim }}
+            # Shared-NIM mode uses the OpenAI-compatible VIA endpoint rather than
+            # the integrated Cosmos pipeline.
+            - name: VLM_MODEL_TO_USE
+              value: "openai-compat"
+            {{- end }}
+            {{- $useSharedNim := .Values.useSharedNim }}
             {{- range .Values.env }}
-            {{- if or (eq $hfTokName "") (ne .name "HF_TOKEN") }}
+            {{- if and (or (eq $hfTokName "") (ne .name "HF_TOKEN")) (or (not $useSharedNim) (ne .name "VLM_MODEL_TO_USE")) }}
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}


### PR DESCRIPTION
## Summary

- force RTVI-VLM to use the OpenAI-compatible VIA client when useSharedNim is enabled
- ignore profile-local VLM_MODEL_TO_USE values in shared-NIM mode
- preserve the integrated cosmos-reason3 pipeline for local deployments

## Validation

- rendered dev-profile-base with remote VLM settings: MODEL_PATH=none, remote VIA endpoint, VLM_MODEL_TO_USE=openai-compat
- rendered the local base profile: integrated model path and VLM_MODEL_TO_USE=cosmos-reason3
- ran git diff --check