### PR TITLE
Use down command using env files instead of compose project

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -294,7 +294,11 @@ docker compose -f compose.yml \
 4. **Stop the stack**
 
 ```bash
-docker compose -p mdx down -v --remove-orphans
+docker compose -f compose.yml \
+  --env-file containers.env \
+  --env-file industry-profiles/warehouse-operations/.env \
+  --env-file industry-profiles/warehouse-operations/overrides.env \
+  down -v --remove-orphans
 ```
 
 5. **Data / backup cleanup**


### PR DESCRIPTION
## Description
Changed the warehouse down command in deploy docker docs

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
