### PR TITLE
Disable config event generation in warehouse 2d

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/warehouse-2d-app.yml
@@ -181,6 +181,7 @@ services:
       AI_BRIDGE_ENDPOINT: ${AI_BRIDGE_ENDPOINT}
       SENSOR_FILE_PATH: ${SENSOR_FILE_PATH:-$VSS_APPS_DIR/industry-profiles/warehouse-operations/camera_configs/camera_info.json}
       CHECK_SENSOR_IN_CALIBRATION_FILE: false
+      SEND_CONFIG_TO_SDR: false
     env_file:
       - ${BP_CONFIGURATOR_BASE_ENV_FILE:-$VSS_APPS_DIR/industry-profiles/warehouse-operations/.env}
       - ${BP_CONFIGURATOR_ENV_FILE:-$VSS_APPS_DIR/industry-profiles/warehouse-operations/overrides.env}
@@ -190,11 +191,6 @@ services:
       - |
         import os
         import sys
-
-        os.environ["SEND_CONFIG_TO_SDR"] = (
-            os.environ.get("SEND_CONFIG_TO_SDR")
-            or ("false" if os.environ.get("BP_PROFILE") == "bp_wh_auto_calib" else "true")
-        )
         os.execvp(sys.executable, [sys.executable, "entrypoint.py"])
     volumes:
       - $VSS_APPS_DIR:$VSS_APPS_DIR:rw


### PR DESCRIPTION
 Set `SEND_CONFIG_TO_SDR=false` for warehouse 2D vss-configurator 

Warehouse 2D does not require sensor config events to SDR for any profile, so sending them is unnecessary.
