### PR TITLE
Remove hard check from auto-calib UI for env requirements

### DIFF
--- a/deploy/docker/services/auto-calibration/ui/compose.yml
+++ b/deploy/docker/services/auto-calibration/ui/compose.yml
@@ -26,7 +26,7 @@ services:
     ipc: host
 
     environment:
-      - API_URL=${VSS_AUTO_CALIBRATION_MS_API_URL:-http://${EXTERNAL_IP:-${HOST_IP:?HOST_IP or EXTERNAL_IP must be set}}:${VSS_AUTO_CALIBRATION_HOST_PORT:?VSS_AUTO_CALIBRATION_HOST_PORT must be set}/v1}
+      - API_URL=${VSS_AUTO_CALIBRATION_MS_API_URL:-http://${EXTERNAL_IP:-${HOST_IP}}:${VSS_AUTO_CALIBRATION_HOST_PORT}/v1}
 
     restart: unless-stopped
 


### PR DESCRIPTION
## Description
Removed hard env var requirement checks on auto-calib UI

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
