### PR TITLE
fix(ci): stop prepare-source fetching 414 MB of unused Git LFS data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,12 @@ jobs:
       # starts stripping fixtures the analytics integration jobs depend on.
       - name: Verify LFS exclusion boundaries
         run: |
-          vios='repo/services/vios/prebuilts/aarch64/aws/libaws-c-auth.so'
+          # Must be a regular file, not a symlink: git archive stores a symlink's
+          # target text, so libaws-c-auth.so (mode 120000, content
+          # "libaws-c-auth.so.1.0.0") would never match the pointer signature and
+          # would fail this step for every run. All 126 vios LFS pointers are
+          # regular files; this is the resolved target of that symlink.
+          vios='repo/services/vios/prebuilts/aarch64/aws/libaws-c-auth.so.1.0.0'
           keep='repo/services/analytics/behavior-analytics/tests/integration/expected_output/smart_city/mdx-behavior-data.json'
           if ! tar -xzOf source.tar.gz "$vios" | head -c 64 | grep -q '^version https://git-lfs'; then
             echo "::error::$vios is not an LFS pointer; lfs.fetchexclude is not taking effect"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,36 @@ jobs:
 
       - name: Package tracked source
         run: |
-          git archive --format=tar.gz --prefix=repo/ -o source.tar.gz HEAD
+          # actions/checkout above runs with lfs:false, but `git archive` applies
+          # checkout-side conversion (ident, then smudge/process), so it fetches
+          # the repo's entire ~989 MB of LFS payload on every run. 414 MB of that
+          # is services/vios, which no current consumer of this artifact reads.
+          #
+          # lfs.fetchexclude makes git-lfs pass those paths through as pointer
+          # text rather than fetching them. Scoped to this one command with -c,
+          # so nothing under .git is mutated and the services/analytics fixtures
+          # the integration jobs do read are still smudged normally.
+          git -c lfs.fetchexclude='services/vios/**' \
+            archive --format=tar.gz --prefix=repo/ -o source.tar.gz HEAD
           git ls-files > tracked-files.txt
           ls -lh source.tar.gz
+
+      # Assert the exclusion did what we think, in both directions. Without this
+      # a silent change in git-lfs behaviour either stops saving anything, or
+      # starts stripping fixtures the analytics integration jobs depend on.
+      - name: Verify LFS exclusion boundaries
+        run: |
+          vios='repo/services/vios/prebuilts/aarch64/aws/libaws-c-auth.so'
+          keep='repo/services/analytics/behavior-analytics/tests/integration/expected_output/smart_city/mdx-behavior-data.json'
+          if ! tar -xzOf source.tar.gz "$vios" | head -c 64 | grep -q '^version https://git-lfs'; then
+            echo "::error::$vios is not an LFS pointer; lfs.fetchexclude is not taking effect"
+            exit 1
+          fi
+          if tar -xzOf source.tar.gz "$keep" | head -c 64 | grep -q '^version https://git-lfs'; then
+            echo "::error::$keep is a pointer; the exclusion over-matched and analytics fixtures would break"
+            exit 1
+          fi
+          echo "vios excluded as pointers, analytics fixtures smudged"
 
       - name: Upload source artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2


### PR DESCRIPTION
## What is wrong

`prepare-source` takes a **median of 134 s** and **20 jobs** wait on it via `needs:`. Almost all of that is fetching Git LFS objects that no current consumer of the source artifact reads.

`actions/checkout` runs with `lfs:false`, but **`git archive` applies checkout-side conversion** (ident, then smudge/process), so it fetches everything anyway.

## What it costs

- Run 30594276379: the step took **179 s**, and **147 LFS `Downloading` lines span 176 s of it, 98%**.
- **149 pointer-bearing paths, 147 unique OIDs, ~988.8 MB** on a cold cache.
- **414.3 MB across 126 files is `services/vios`**, and `grep -n vios .github/workflows/ci.yml` returns nothing.
- **373** runs in the trailing 7 days.

## The fix

`lfs.fetchexclude` makes git-lfs pass those paths through as pointer text rather than fetching them. Scoped to the single command with `-c`, so nothing under `.git` is mutated and the `services/analytics` fixtures the two integration jobs read are still smudged normally.

A follow-up step asserts **both** directions: a vios member must be a pointer, an analytics fixture must not. The failure mode is silent either way, so without it a future git-lfs change could quietly stop saving anything, or quietly strip fixtures those jobs depend on.

## Measured result

From the mirror run on this branch (30647797334), against four consecutive `develop` runs as baseline:

| | Before | After |
|---|---|---|
| `Package tracked source` | **134 s** (p50, n=175) | **80 s** |
| `source-<sha>` artifact | **258 MiB** (stable across 4 runs) | **117 MiB** |
| Mirror run | | 40 success, 7 skipped, **0 failures** |

**-40% on the step, -55% on the artifact.** Net saving is **49 s per run** after the 5 s the new assertion step costs, so roughly **5.1 h/week** off the front of the pipeline with 20 jobs starting sooner.

The 80 s is what the arithmetic predicts, which is the useful confirmation: vios is **41.8%** of the LFS payload, so `134 x (1 - 0.418) = 78 s` expected against **80 s** observed. Two earlier drafts of this description said "well under 60 s" and "44%"; both were optimistic and are corrected above to the measured **80 s** and **40%**.

## Scope and risk

Deliberately **vios only**. The other ~546 MB is `services/analytics` fixtures that are genuinely consumed; relocating those needs a different approach and would be a separate PR.

To be precise about the claim: no *current source-artifact consumer* uses the vios LFS payload. Real byte consumers exist elsewhere in the repo, `services/vios/test/bdd_tests/.../test_upload_lifecycle.py:43` and `services/vios/packaging/package_vms.sh:160`, but neither reads this tarball. If either is ever pointed at it, it would receive pointer text.

This **fixes zero failures** and does not move the merge gate, which is 7 required contexts of which 3 are SonarQube. It is a latency change only.

## Review

Reviewed by Codex (gpt-5.6-sol, ultra), which confirmed `git archive` applies smudge rather than clean via a controlled Git 2.50.1 test, and rejected an earlier `.git/info/attributes` approach: its `-diff -merge` matched all **3,184** tracked vios paths rather than the 126 pointer files, and that file survives `git clean` and checkout, so it would persist on a reused self-hosted workspace.

Greptile caught that the first version of the assertion pointed at `libaws-c-auth.so`, which is a symlink (mode 120000). `git archive` stores a symlink's target text, so the check would have failed on every run and blocked all 20 dependents. Fixed in `deb9334be` to assert on the resolved target; all 126 vios LFS pointers are regular files.