### PR TITLE
feat(skills): LVS-profile Kubernetes operate via VSS_PUBLIC_URL

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -47,17 +47,21 @@ VSS-based deployments are multi-layer systems. Most skills map to exactly one la
 **Kubernetes runtime endpoint contract.** Operate skills run on the caller's
 host, not inside VSS pods. Supply one public Ingress origin as
 `VSS_PUBLIC_URL` (Helm `global.externalHost` / main Ingress host — e.g.
-`vss.<ip>.nip.io` for **base**, `vss-search.<ip>.nip.io` for **search**).
-Canonical variable mapping, Docker fallbacks, and the no-port-forward rule live
-in
+`vss.<ip>.nip.io` for **base** and **lvs**, `vss-search.<ip>.nip.io` for
+**search**). Canonical variable mapping, Docker fallbacks, and the
+no-port-forward rule live in
 [`vss-build-vision-agent/references/deployment_resolution.md`](vss-build-vision-agent/references/deployment_resolution.md).
-Base quickstart operate uses `/vst` (VIOS) and `/v1` (RT-VLM) on that origin for
-`vss-manage-video-io-storage`, `vss-ask-video`, and `vss-generate-video-report`
-Mode A. Search archive operate uses `/generate` and `/api/v1` via
-`vss-search-archive`. Profile-specific routes also include Alert Bridge, VA-MCP,
-and LVS paths on their respective Ingress hosts. NvStreamer requires a separate
-`VSS_STREAMER_URL`. When `VSS_PUBLIC_URL` is unset, each skill retains its
-documented Docker Compose discovery or `HOST_IP` fallback.
+Base quickstart operate uses `/vst` (VIOS) and Prefix `/v1` (RT-VLM) on that
+origin for `vss-manage-video-io-storage`, `vss-ask-video`, and
+`vss-generate-video-report` Mode A. LVS operate uses Exact `/v1/ready` and
+`/v1/summarize` for `vss-summarize-video` (and report Mode A when LVS is ready),
+plus Exact `/v1/models` / `/v1/chat/completions` for RT-VLM — not a Prefix `/v1`
+and not LVS `/models` or LVS `/openapi.json` through Ingress. Search archive
+operate uses `/generate` and `/api/v1` via `vss-search-archive`. Profile-specific
+routes also include Alert Bridge and VA-MCP on their respective Ingress hosts.
+NvStreamer requires a separate `VSS_STREAMER_URL`. When `VSS_PUBLIC_URL` is
+unset, each skill retains its documented Docker Compose discovery or `HOST_IP`
+fallback.
 
 **Profiles vs. standalone microservices.** A *profile* is a pre-assembled stack of microservices wired together for one workflow. Use **`vss-deploy-profile`** to bring up a whole workflow (`base`, `search`, `lvs`, `alerts`, `warehouse`, `edge`). Use the individual **`vss-deploy-*` / `vss-setup-*`** skills only when you need one microservice on its own.
 

--- a/skills/vss-build-vision-agent/references/deployment_resolution.md
+++ b/skills/vss-build-vision-agent/references/deployment_resolution.md
@@ -15,7 +15,7 @@ A Kubernetes deployment must publish one public Ingress origin, including the
 scheme and any non-default port:
 
 ```bash
-# base profile example
+# base / lvs profile example (same main-host pattern)
 VSS_PUBLIC_URL=https://vss.example.com
 # search profile example
 VSS_PUBLIC_URL=https://vss-search.example.com
@@ -38,7 +38,8 @@ not additional operate inputs:
 | `VSS_VIOS_URL` | `${VSS_PUBLIC_URL}/vst` |
 | `VST_API_BASE` | `${VSS_VIOS_URL}/api/v1` — all VIOS `curl` targets |
 | `AGENT_URL` | `${VSS_PUBLIC_URL}` for Kubernetes operate skills |
-| `VLM_ENDPOINT` | `${VSS_PUBLIC_URL}/v1` when the Ingress exposes RT-VLM (base Helm `vssIngress.vlm.enabled`) — OpenAI-compatible root ending in `/v1` |
+| `VLM_ENDPOINT` | `${VSS_PUBLIC_URL}/v1` when the Ingress exposes RT-VLM (base Prefix `/v1`, or LVS Exact `/v1/models` + `/v1/chat/completions`) — OpenAI-compatible root ending in `/v1` |
+| `LVS_BACKEND_URL` / `VIDEO_SUMMARIZATION_URL` | `${VSS_PUBLIC_URL}` on Kubernetes (origin only — **no** `/v1` suffix); Docker Compose remains `http://${HOST_IP}:38111` |
 | `VSS_STREAMER_URL` | Separate streamer Ingress host (`streamer.<ip>.nip.io`); **not** under `/vst`; search (and other NvStreamer-bearing) profiles only |
 
 Do not make operate skills invent a Brev or nip.io hostname. The deployment
@@ -117,6 +118,54 @@ adds archive search and a separate NvStreamer host:
 | VIOS list/inspect | `GET ${VST_API_BASE}/sensor/list` |
 | NvStreamer HTTP | `${VSS_STREAMER_URL}/api/v1/...` — separate host, no `/vst` prefix |
 
+### LVS profile public routes
+
+Main host pattern: `vss.<ip>.nip.io` (Helm `dev-profile-lvs`) — same family as
+base, not `vss-search.*`. LVS does **not** mount a Prefix `/v1` the way base
+does. Stock Ingress uses **Exact** paths that split LVS and RT-VLM:
+
+| Capability | Public endpoint |
+|---|---|
+| LVS readiness | `GET ${VSS_PUBLIC_URL}/v1/ready` → video-summarization |
+| LVS summarize | `POST ${VSS_PUBLIC_URL}/v1/summarize` → video-summarization |
+| RT-VLM models / chat | `GET ${VSS_PUBLIC_URL}/v1/models`, `POST ${VSS_PUBLIC_URL}/v1/chat/completions` |
+| VIOS list/inspect/clips | `GET ${VST_API_BASE}/sensor/list`, storage `/url`, … |
+| Agent OpenAPI | `GET ${AGENT_URL}/openapi.json` — **Agent**, not LVS |
+
+Derive the LVS client base as the **origin only**:
+
+```bash
+# Kubernetes — append /v1/ready and /v1/summarize yourself
+LVS_BACKEND_URL="${LVS_BACKEND_URL:-${VSS_PUBLIC_URL%/}}"
+VIDEO_SUMMARIZATION_URL="${LVS_BACKEND_URL}"
+# Docker Compose (unchanged)
+# LVS_BACKEND_URL=http://${HOST_IP}:38111
+```
+
+Do **not** set `LVS_BACKEND_URL=${VSS_PUBLIC_URL}/v1` — that yields `/v1/v1/ready`.
+Do **not** probe bare `${VSS_PUBLIC_URL}/v1` as an LVS or VLM health URL on LVS;
+without a Prefix rule it falls through to the UI catch-all.
+
+**Not on stock LVS Ingress** (Docker `:38111` only): LVS `/models`, LVS
+`/openapi.json`, `/recommended_config`, `/metrics`, and the `/summarize`
+compatibility alias. Public `/openapi.json` is the Agent document — never treat
+it as the LVS schema. On Kubernetes, discover the summarize model via
+`${VSS_PUBLIC_URL}/v1/models` (RT-VLM Exact) or an explicit `VLM_NAME`, and use
+the skill's checked-in `/v1/summarize` contract when live LVS OpenAPI is not
+reachable.
+
+LVS operate skills for the docs walkthrough:
+
+- `vss-manage-video-io-storage` — VIOS via `${VST_API_BASE}`
+- `vss-summarize-video` — Exact `/v1/ready` + `/v1/summarize` on `${VSS_PUBLIC_URL}`
+- `vss-generate-video-report` Mode A — when LVS `/v1/ready` is 200, delegates to
+  `vss-summarize-video`; otherwise VLM-direct
+
+Clip URLs passed into `POST /v1/summarize` must stay as VIOS minted them (LVS
+fetches that URL). Browser/report links may still rewrite `/storage/...` under
+`/vst` using the base-profile rule. Deploy must mint media URLs the LVS pod can
+reach (typically `VST_EXTERNAL_URL` equal to the public origin).
+
 ## Docker Compose
 
 Use `--deployment docker --profile <profile>` for host CLI search. The profile
@@ -169,18 +218,24 @@ AGENT_URL="${VSS_PUBLIC_URL%/}"
 VSS_VIOS_URL="${AGENT_URL}/vst"
 VST_API_BASE="${VSS_VIOS_URL}/api/v1"
 # Resolve VLM_ENDPOINT only with the probe-before-adopt flow above.
+# LVS client base is the origin (no /v1 suffix):
+LVS_BACKEND_URL="${LVS_BACKEND_URL:-${AGENT_URL}}"
 ```
 
-The public Agent, VIOS (`/vst`), and — when the chart enables it — RT-VLM (`/v1`)
-routes are the supported operate interfaces. Operate skills do not read
-Deployments, ConfigMaps, Services, Secrets, or Helm values, and do not use
-Service DNS, NodePorts, guessed release names, or `kubectl port-forward`.
+The public Agent, VIOS (`/vst`), and — when the chart enables them — RT-VLM and
+LVS Exact `/v1/...` routes are the supported operate interfaces. Operate skills
+do not read Deployments, ConfigMaps, Services, Secrets, or Helm values, and do
+not use Service DNS, NodePorts, guessed release names, `kubectl port-forward`,
+or `kubectl`/`docker exec` into pods.
 
-Private backends (Elasticsearch, RTVI-Embed, RTVI-CV, and RT-VLM when it is
-**not** published under `/v1`) remain agent-side dependencies. Do not expose or
-forward them merely to satisfy host-side operate checks. On the base profile,
-RT-VLM at `${VSS_PUBLIC_URL}/v1` is a supported public operate path for
-`vss-ask-video` and `vss-generate-video-report` Mode A.
+Private backends (Elasticsearch, RTVI-Embed, RTVI-CV, LVS `/models` /
+`/openapi.json` when not published, and RT-VLM when it is **not** on Exact
+`/v1/models`) remain agent-side dependencies. Do not expose or forward them
+merely to satisfy host-side operate checks. On the base profile, RT-VLM at
+`${VSS_PUBLIC_URL}/v1` (Prefix) is a supported public operate path for
+`vss-ask-video` and `vss-generate-video-report` Mode A. On the LVS profile,
+Exact `/v1/ready` and `/v1/summarize` are the supported public operate paths for
+`vss-summarize-video`.
 
 ## Authentication boundary
 

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -3,7 +3,7 @@ name: vss-generate-video-report
 description: Use this skill when producing a VSS analysis report — Mode A per-clip VLM, Mode B incident-range via video-analytics, Mode C SOP compliance via the SOP tools. Not for standalone video summarization, real-time alerts or ad-hoc Q&A.
 license: Apache-2.0
 metadata:
-  version: "3.2.9"
+  version: "3.2.10"
   author: "NVIDIA Video Search and Summarization team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"
@@ -80,7 +80,7 @@ This skill is profile-agnostic for Mode A. A specific profile does **not** have 
 
 ### Endpoint resolution (Kubernetes vs Docker)
 
-When operating against a deployed VSS stack (especially **base** on Helm), resolve
+When operating against a deployed VSS stack (**base** or **lvs** on Helm), resolve
 public endpoints once. Follow
 [`../vss-build-vision-agent/references/deployment_resolution.md`](../vss-build-vision-agent/references/deployment_resolution.md):
 
@@ -90,7 +90,7 @@ if [ -n "${VSS_PUBLIC_URL:-}" ]; then
   VSS_PUBLIC_URL="${VSS_PUBLIC_URL%/}"
   VSS_VIOS_URL="${VSS_PUBLIC_URL}/vst"
   VST_API_BASE="${VSS_VIOS_URL}/api/v1"
-  # Stock base Helm exposes RT-VLM at /v1 (not /vlm/v1).
+  # Base: Prefix /v1 → RT-VLM. LVS: Exact /v1/models + /v1/chat/completions → RT-VLM.
   : "${VLM_ENDPOINT:=${VSS_PUBLIC_URL}/v1}"
 else
   DEPLOYMENT_KIND="docker"
@@ -279,7 +279,21 @@ hosts, download the clip and send inline bytes (same remote-VLM rule as
 
 ## Mode A — Report on a recorded video clip
 
-**If the VSS `lvs` profile is deployed** — `curl -sf --max-time 5 "http://${HOST_IP}:38111/v1/ready"` returns HTTP 200 — run `/vss-summarize-video` to produce the summary, then paste its output into the report template in Step 4 and skip Steps 1–3 (the VLM-direct path). Run Steps 1–3 only when `/v1/ready` is non-200.
+**If the VSS `lvs` profile is deployed** — probe LVS readiness, then hand off:
+
+```bash
+# Kubernetes public Exact path when VSS_PUBLIC_URL is set; Docker host port otherwise.
+if [ -n "${VSS_PUBLIC_URL:-}" ]; then
+  _lvs_ready="${VSS_PUBLIC_URL%/}/v1/ready"
+else
+  _lvs_ready="http://${HOST_IP}:38111/v1/ready"
+fi
+curl -sf --max-time 5 "${_lvs_ready}" >/dev/null
+```
+
+When that returns HTTP 200, run `/vss-summarize-video` to produce the summary,
+then paste its output into the report template in Step 4 and skip Steps 1–3
+(the VLM-direct path). Run Steps 1–3 only when `/v1/ready` is non-200.
 
 ### Step 1 — Resolve Mode A input (A1 clip URL or A2 local-file/base64)
 

--- a/skills/vss-summarize-video/SKILL.md
+++ b/skills/vss-summarize-video/SKILL.md
@@ -3,7 +3,7 @@ name: vss-summarize-video
 description: Summarize recorded video through HITL-gated LVS, with an explicitly approved VLM fallback. Not for reports, archive search, or live RTSP captioning.
 license: Apache-2.0
 metadata:
-  version: "3.2.1"
+  version: "3.2.2"
   author: "NVIDIA Video Search and Summarization team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"
@@ -42,8 +42,8 @@ Load these files only as directed:
   readiness, VIOS preparation, one-request LVS, and VLM fallback commands.
 - [`references/video-summarization-api.md`](references/video-summarization-api.md):
   load before constructing any live LVS operation. Follow its **Runtime
-  OpenAPI Discovery** procedure and treat the deployed `/openapi.json` as
-  authoritative.
+  OpenAPI Discovery** procedure on Docker. On Kubernetes, follow the K8s
+  note there — stock LVS Ingress does not publish LVS `/openapi.json`.
 - [`references/hitl-prompts.md`](references/hitl-prompts.md): load when
   collecting LVS scenario, events, and optional objects of interest.
 - [`references/video-summarization-debugging.md`](references/video-summarization-debugging.md):
@@ -53,6 +53,8 @@ Load these files only as directed:
 - [`references/video-summarization-environment-variables.md`](references/video-summarization-environment-variables.md)
   and `assets/video-summarization.env.example`: use when configuring the
   service environment.
+- [`../vss-build-vision-agent/references/deployment_resolution.md`](../vss-build-vision-agent/references/deployment_resolution.md):
+  Kubernetes `VSS_PUBLIC_URL` contract and LVS Exact `/v1` routes.
 
 ## Core Invariants
 
@@ -71,9 +73,11 @@ Load these files only as directed:
 
 ## Prerequisites
 
-- VSS `lvs` profile on `$HOST_IP` (default port 38111).
+- VSS `lvs` profile reachable either on Docker (`$HOST_IP:38111`) or through
+  the public Ingress (`VSS_PUBLIC_URL` with Exact `/v1/ready`).
 - `curl` and `jq` on the agent host.
-- Network reachability from `vss-lvs` to the final VIOS clip URL.
+- Network reachability from the LVS service to the final VIOS clip URL (Docker:
+  from `vss-lvs`; Kubernetes: deploy must mint a URL the LVS pod can fetch).
 
 The `vss-deploy-profile` skill can deploy the profile. A remote fallback VLM
 must be able to fetch the clip URL; it generally cannot fetch localhost or
@@ -85,15 +89,54 @@ private addresses.
   quality.
 - Private VIOS URLs may be unreachable from remote VLM endpoints.
 - Each user request permits one LVS summarize POST, with no automatic retry.
+- Stock LVS Helm Ingress does not publish LVS `/models`, LVS `/openapi.json`,
+  `/recommended_config`, or `/metrics` — those remain Docker `:38111` only.
+
+## Endpoint resolution (Kubernetes vs Docker)
+
+Resolve endpoints once before probing. Follow
+[`../vss-build-vision-agent/references/deployment_resolution.md`](../vss-build-vision-agent/references/deployment_resolution.md).
+
+```bash
+# Prefer VSS_PUBLIC_URL; accept legacy VSS_ENDPOINT as the same public origin.
+if [ -z "${VSS_PUBLIC_URL:-}" ] && [ -n "${VSS_ENDPOINT:-}" ]; then
+  VSS_PUBLIC_URL="${VSS_ENDPOINT}"
+fi
+
+if [ -n "${VSS_PUBLIC_URL:-}" ]; then
+  DEPLOYMENT_KIND="kubernetes"
+  VSS_PUBLIC_URL="${VSS_PUBLIC_URL%/}"
+  # Origin only — skill appends /v1/ready and /v1/summarize. Never …/v1 here.
+  LVS_BACKEND_URL="${LVS_BACKEND_URL:-${VSS_PUBLIC_URL}}"
+  VIDEO_SUMMARIZATION_URL="${LVS_BACKEND_URL}"
+  VSS_VIOS_URL="${VSS_PUBLIC_URL}/vst"
+  VST_API_BASE="${VSS_VIOS_URL}/api/v1"
+  # LVS Exact /v1/models and /v1/chat/completions → RT-VLM (not Prefix /v1).
+  VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-${VSS_PUBLIC_URL}}}"
+  VLM="${VLM%/v1}"
+else
+  DEPLOYMENT_KIND="docker"
+  LVS_BACKEND_URL="${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}"
+  VIDEO_SUMMARIZATION_URL="${LVS_BACKEND_URL}"
+  VSS_VIOS_URL="http://${HOST_IP:-localhost}:30888/vst"
+  VST_API_BASE="${VSS_VIOS_URL}/api/v1"
+  VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
+  VLM="${VLM%/v1}"
+fi
+```
+
+On Kubernetes, do not use `kubectl port-forward`, Service DNS, NodePorts,
+`docker exec`, or `docker inspect`. Do not set `LVS_BACKEND_URL` to
+`${VSS_PUBLIC_URL}/v1`. Do not treat public `/openapi.json` as the LVS schema
+(that path is Agent on stock Ingress).
 
 ## Routing
 
-Use these defaults unless the corresponding environment variable is set:
-
 | Service | Base URL |
 |---|---|
-| LVS | `${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}` |
-| VLM / RT-VLM | `${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}` |
+| LVS | `${VIDEO_SUMMARIZATION_URL}` (K8s: `${VSS_PUBLIC_URL}`; Docker: `http://${HOST_IP}:38111`) |
+| VLM / RT-VLM | `${VLM}` then append `/v1/...` (K8s: public origin; Docker: `:8018`) |
+| VIOS | `${VST_API_BASE}` |
 
 Strip a trailing `/v1` from the VLM base because this skill appends it. Do not
 scan ports or inspect configuration files to guess endpoints.
@@ -109,8 +152,9 @@ not inspect the body.
 
 If LVS is unavailable, ask:
 
-> The VSS `lvs` profile isn't running on `$HOST_IP`. Shall I deploy it now
-> using `/vss-deploy-profile -p lvs`? Reply `no` to stop here; I can use the
+> The VSS `lvs` profile isn't reachable
+> (`${VSS_PUBLIC_URL:-$HOST_IP:38111}`). Shall I deploy it now using
+> `/vss-deploy-profile -p lvs`? Reply `no` to stop here; I can use the
 > lower-quality VLM-only fallback only if you explicitly ask for it.
 
 - Deployment approved or pre-authorized: invoke `vss-deploy-profile`, re-probe,
@@ -129,9 +173,13 @@ Load the end-to-end and API references. Run the LVS readiness probe before
 preparing the clip. Also probe VLM `/v1/models` so an approved fallback can be
 validated, but do not infer against it while LVS is ready.
 
-Discover model IDs from the selected service. Honor `${VLM_NAME}` only if it
-exactly matches an advertised ID; otherwise use the sole advertised ID. If
-multiple IDs exist and no valid preference selects one, report them and stop.
+Discover model IDs from the selected service:
+
+- **Docker:** honor `${VLM_NAME}` only if it matches an id from LVS `GET /models`;
+  otherwise use the sole advertised LVS id.
+- **Kubernetes:** LVS `/models` is not on Ingress. Prefer `${VLM_NAME}` when set;
+  otherwise take the sole id from Exact `GET ${VLM}/v1/models` (RT-VLM). If
+  multiple ids exist and no valid preference selects one, report them and stop.
 
 A non-200 LVS readiness result after warmup is the only unavailability signal.
 An empty summary, empty events, missing optional fields, or empty readiness
@@ -141,7 +189,7 @@ stdout must not trigger fallback.
 
 Execute VIOS API operations directly as part of this workflow; do not invoke a
 separate skill. Follow **Prepare the video through VIOS** in the end-to-end
-reference.
+reference (uses `${VST_API_BASE}`).
 
 1. List sensors and reuse the exact requested recording when present.
 2. If absent and the exact local file is available, upload it through the VIOS
@@ -150,9 +198,14 @@ reference.
 3. Poll the returned stream's timelines and obtain the complete minimum start
    and maximum end time.
 4. Generate a fresh temporary MP4 URL for that full interval with audio
-   disabled.
-5. If LVS was selected, verify one-byte reachability from `vss-lvs` using the
-   Python range probe in the reference.
+   disabled. Pass that minted URL into LVS **as returned** (after stripping a
+   doubled `http://` scheme if present). Do not rewrite it for browser Ingress
+   paths before `POST /v1/summarize`.
+5. If LVS was selected, verify one-byte reachability:
+   - **Docker:** `docker exec vss-lvs` Python range probe in the reference.
+   - **Kubernetes:** bounded Range GET of the minted URL from the agent host
+     (no `docker exec` / `kubectl exec`). Deploy must mint a URL the LVS pod
+     can fetch.
 
 Require the exact recording, full timeline, and fresh clip URL before
 continuing. When the source file is available, compare VIOS timeline duration
@@ -164,7 +217,8 @@ an arbitrary `/tmp` video, alternate recording, local HTTP server, NvStreamer,
 or RTSP source unless the user explicitly requested that source.
 
 Do not use the `vss-lvs` container's lightweight `curl` shim for reachability;
-it can write the entire video into tool output. Use the one-byte Python probe.
+it can write the entire video into tool output. Use the one-byte Python probe
+on Docker.
 
 ### Stage 3: Collect LVS Settings
 
@@ -185,12 +239,19 @@ specific settings.
 
 ### Stage 4: Discover the Contract and Submit Once
 
-Fetch `/openapi.json` from the same LVS instance immediately before building
-the operation. Confirm `/v1/summarize`, inspect its live JSON schema, and use
-that schema rather than a hardcoded or source-tree copy.
+Prefer `POST /v1/summarize`; `/summarize` is only a Docker compatibility alias
+and is **not** on stock LVS Ingress.
 
-Prefer `POST /v1/summarize`; `/summarize` is only a compatibility alias. Build
-the request with the selected model, fresh VIOS URL, exact HITL values,
+- **Docker:** fetch `/openapi.json` from the same LVS instance immediately
+  before building the operation. Confirm `/v1/summarize`, inspect its live JSON
+  schema, and use that schema rather than a hardcoded copy. Discover the model
+  via LVS `GET /models`.
+- **Kubernetes:** do not fetch public `/openapi.json` (Agent) or LVS `/models`
+  (not published). Confirm the request against the checked-in summarize
+  contract in the API reference, resolve the model as in Stage 1, and POST
+  Exact `/v1/summarize` on `${VIDEO_SUMMARIZATION_URL}`.
+
+Build the request with the selected model, fresh VIOS URL, exact HITL values,
 `chunk_duration: 10`, and `seed: 1`. Include `objects_of_interest` only when
 provided.
 
@@ -200,7 +261,8 @@ workflow. RT-VLM owns frame sampling; remote Docker LVS configures five fixed
 frames per chunk for endpoints with that image limit.
 
 Use the one-request implementation in the end-to-end reference. Preserve its
-HTTP status and complete body in files. After that POST:
+HTTP status and complete body in files. Keep a long client timeout (at least
+300s; Ingress allows up to 600s). After that POST:
 
 - On curl or HTTP failure, report the exact failure and saved response.
 - If `choices[0].message.content` cannot be parsed, report the exact body.
@@ -253,6 +315,8 @@ re-voice either backend's content.
 | Readiness stdout is empty | Use the HTTP status; a 200 body may be empty. |
 | Summary and events are empty | Inspect saved `usage.total_chunks_processed`; do not retry. |
 | VLM returns `<think>` | Remove reasoning through `</think>` when rendering. |
+| K8s `/openapi.json` looks like Agent | Expected — do not use it as LVS schema. |
+| K8s `/models` 404 / HTML | Expected — use Exact `/v1/models` (RT-VLM) or `VLM_NAME`. |
 
 Use the debugging reference for deeper diagnostics and the deployment
 reference for logs or configuration. Match image tags to the host: `3.3.0-rc2` on
@@ -262,8 +326,11 @@ x86/Jetson Thor and `3.3.0-rc2-sbsa` on SBSA/DGX Spark/Grace.
 
 For direct API questions such as models, readiness, recommended configuration,
 metrics, schemas, or 422 responses, use the API reference instead of the
-recorded-video workflow. For deployment, restart, teardown, backend selection,
-or service logs, prefer `vss-deploy-profile` and use the deployment reference.
+recorded-video workflow. On Kubernetes, only Exact `/v1/ready` and
+`/v1/summarize` are public for LVS; other LVS admin routes need Docker
+`:38111` or a chart change. For deployment, restart, teardown, backend
+selection, or service logs, prefer `vss-deploy-profile` and use the deployment
+reference.
 
 ## Cross-reference
 
@@ -272,5 +339,6 @@ or service logs, prefer `vss-deploy-profile` and use the deployment reference.
   ordered workflow.
 - `vss-search-archive`: search archived video.
 - `vss-query-analytics`: query stored incidents and events.
+- `vss-generate-video-report`: Mode A delegates here when LVS `/v1/ready` is 200.
 
 bump:3

--- a/skills/vss-summarize-video/references/end-to-end-example.md
+++ b/skills/vss-summarize-video/references/end-to-end-example.md
@@ -2,6 +2,7 @@
 
 Use these implementations with the ordered stages in `SKILL.md`.
 
+- [Resolve endpoints](#resolve-endpoints)
 - [Probe readiness](#probe-readiness)
 - [Prepare the video through VIOS](#prepare-the-video-through-vios)
 - [Submit one LVS request](#submit-one-lvs-request)
@@ -10,15 +11,40 @@ Use these implementations with the ordered stages in `SKILL.md`.
 Do not run a direct VLM fallback when LVS is ready, and do not rerun the LVS
 POST with broader events when the response is empty.
 
+### Resolve endpoints
+
+Run once before any probe. Docker keeps host ports; Kubernetes uses
+`VSS_PUBLIC_URL` (LVS client base = origin, **no** `/v1` suffix).
+
+```bash
+if [ -z "${VSS_PUBLIC_URL:-}" ] && [ -n "${VSS_ENDPOINT:-}" ]; then
+  VSS_PUBLIC_URL="${VSS_ENDPOINT}"
+fi
+
+if [ -n "${VSS_PUBLIC_URL:-}" ]; then
+  DEPLOYMENT_KIND="kubernetes"
+  VSS_PUBLIC_URL="${VSS_PUBLIC_URL%/}"
+  LVS_BACKEND_URL="${LVS_BACKEND_URL:-${VSS_PUBLIC_URL}}"
+  VIDEO_SUMMARIZATION_URL="${LVS_BACKEND_URL}"
+  VST_API_BASE="${VSS_PUBLIC_URL}/vst/api/v1"
+  VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-${VSS_PUBLIC_URL}}}"
+  VLM="${VLM%/v1}"
+else
+  DEPLOYMENT_KIND="docker"
+  LVS_BACKEND_URL="${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}"
+  VIDEO_SUMMARIZATION_URL="${LVS_BACKEND_URL}"
+  VST_API_BASE="http://${HOST_IP:-localhost}:30888/vst/api/v1"
+  VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
+  VLM="${VLM%/v1}"
+fi
+
+LVS_REQUEST=/tmp/vss-summarize-video-request.json
+LVS_RESPONSE=/tmp/vss-summarize-video-response.json
+```
+
 ### Probe readiness
 
 ```bash
-VIDEO_SUMMARIZATION_URL=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
-LVS_REQUEST=/tmp/vss-summarize-video-request.json
-LVS_RESPONSE=/tmp/vss-summarize-video-response.json
-VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
-VLM="${VLM%/v1}"
-
 vlm_code=$(curl -s -o /dev/null -w '%{http_code}' \
   --connect-timeout 3 --max-time 10 "$VLM/v1/models")
 [ "$vlm_code" = "200" ] || echo "VLM not reachable (HTTP $vlm_code)"
@@ -56,7 +82,7 @@ with the exact requested local file and upload it directly. Preserve the
 returned stream ID, full timeline, and fresh MP4 URL for later stages.
 
 ```bash
-VIOS_API="http://${HOST_IP:-localhost}:30888/vst/api/v1"
+VIOS_API="${VST_API_BASE:-http://${HOST_IP:-localhost}:30888/vst/api/v1}"
 SOURCE_FILE=/path/to/video.mp4
 FILENAME=$(basename "$SOURCE_FILE")
 UPLOAD_TIMESTAMP=2025-01-01T00:00:00.000Z
@@ -95,11 +121,14 @@ CLIP=$(jq -er '.videoUrl | sub("^http://http://"; "http://")' \
   /tmp/vios-clip-url.json)
 ```
 
-When LVS is selected, verify the URL from inside `vss-lvs` without writing the
-video body into tool output:
+When LVS is selected, verify the URL is fetchable without writing the video
+body into tool output.
+
+**Docker** — probe from inside `vss-lvs`:
 
 ```bash
-docker exec vss-lvs python3 -c '
+if [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ]; then
+  docker exec vss-lvs python3 -c '
 import sys
 import urllib.request
 request = urllib.request.Request(sys.argv[1], headers={"Range": "bytes=0-0"})
@@ -107,18 +136,27 @@ with urllib.request.urlopen(request, timeout=30) as response:
     response.read(1)
     print(response.status)
 ' "$CLIP"
+fi
+```
+
+**Kubernetes** — no `docker exec` / `kubectl exec`. Probe from the agent host
+with a bounded Range GET. The URL passed to LVS must remain the minted VIOS
+URL (deploy should set `VST_EXTERNAL_URL` to the public origin so the LVS pod
+can fetch it):
+
+```bash
+if [ "${DEPLOYMENT_KIND:-docker}" = "kubernetes" ]; then
+  curl -fsS --connect-timeout 5 --max-time 60 --range 0-0 -o /dev/null "$CLIP" \
+    || { echo "CLIP not reachable from agent host: $CLIP"; return 1 2>/dev/null || exit 1; }
+fi
 ```
 
 ### Submit one LVS request
 
-Assume video preparation established `$CLIP` and `$DURATION`. Discover the
-live schema and model, then issue exactly one summarize request.
+Assume video preparation established `$CLIP` and `$DURATION`. Resolve the model,
+then issue exactly one summarize request.
 
 ```bash
-VIDEO_SUMMARIZATION_URL=${LVS_BACKEND_URL:-http://${HOST_IP:-localhost}:38111}
-LVS_REQUEST=/tmp/vss-summarize-video-request.json
-LVS_RESPONSE=/tmp/vss-summarize-video-response.json
-
 # HITL (required, before the curl): collect the Stage 3 scenario/events and
 # wait for the user's reply. Substitute their values (or the `defaults` opt-in)
 # into $SCENARIO, $EVENTS_JSON, and $OBJECTS_JSON below. Do not run the curl
@@ -126,16 +164,30 @@ LVS_RESPONSE=/tmp/vss-summarize-video-response.json
 SCENARIO='warehouse monitoring'            # or whatever the user gave
 EVENTS_JSON='["notable activity"]'         # jq-compatible JSON array
 OBJECTS_JSON=''                            # '' to omit, else '["cars","trucks"]'
-LVS_OPENAPI=/tmp/vss-lvs-openapi.json
-curl -fsS "$VIDEO_SUMMARIZATION_URL/openapi.json" > "$LVS_OPENAPI"
-jq -e '.paths["/v1/summarize"].post.requestBody.content["application/json"].schema' \
-  "$LVS_OPENAPI" >/dev/null
-LVS_MODEL=$(curl -fsS "$VIDEO_SUMMARIZATION_URL/models" | jq -er --arg preferred "${VLM_NAME:-}" '
-  [.data[]?.id | select(type == "string" and length > 0)] | unique as $ids
-  | if $preferred != "" and ($ids | index($preferred)) != null then $preferred
-    elif ($ids | length) == 1 then $ids[0]
-    else empty end
-') || { echo "Set VLM_NAME to an advertised model id"; return 1 2>/dev/null || exit 1; }
+
+# --- Model discovery ---
+# Docker: LVS GET /models (authoritative for summarize).
+# Kubernetes: LVS /models is not on Ingress — use Exact RT-VLM /v1/models
+# (or VLM_NAME when set).
+if [ "${DEPLOYMENT_KIND:-docker}" = "kubernetes" ]; then
+  LVS_MODEL=$(curl -fsS "$VLM/v1/models" | jq -er --arg preferred "${VLM_NAME:-}" '
+    [.data[]?.id | select(type == "string" and length > 0)] | unique as $ids
+    | if $preferred != "" and ($ids | index($preferred)) != null then $preferred
+      elif ($ids | length) == 1 then $ids[0]
+      else empty end
+  ') || { echo "Set VLM_NAME to an advertised RT-VLM model id"; return 1 2>/dev/null || exit 1; }
+else
+  LVS_OPENAPI=/tmp/vss-lvs-openapi.json
+  curl -fsS "$VIDEO_SUMMARIZATION_URL/openapi.json" > "$LVS_OPENAPI"
+  jq -e '.paths["/v1/summarize"].post.requestBody.content["application/json"].schema' \
+    "$LVS_OPENAPI" >/dev/null
+  LVS_MODEL=$(curl -fsS "$VIDEO_SUMMARIZATION_URL/models" | jq -er --arg preferred "${VLM_NAME:-}" '
+    [.data[]?.id | select(type == "string" and length > 0)] | unique as $ids
+    | if $preferred != "" and ($ids | index($preferred)) != null then $preferred
+      elif ($ids | length) == 1 then $ids[0]
+      else empty end
+  ') || { echo "Set VLM_NAME to an advertised model id"; return 1 2>/dev/null || exit 1; }
+fi
 
 jq -n --arg url "$CLIP" \
       --arg model "$LVS_MODEL" \
@@ -152,6 +204,7 @@ jq -n --arg url "$CLIP" \
   > "$LVS_REQUEST"
 
 # Exactly one summarize POST. Save the raw body for parsing and diagnosis.
+# Keep a long timeout — LVS chunk→VLM→aggregate can exceed 50s; Ingress allows 600s.
 LVS_HTTP_CODE=$(curl -sS --max-time 300 -o "$LVS_RESPONSE" -w '%{http_code}' \
   -X POST "$VIDEO_SUMMARIZATION_URL/v1/summarize" \
   -H "Content-Type: application/json" \
@@ -185,8 +238,6 @@ Run this only after LVS remains unavailable and the user explicitly approves
 the lower-quality fallback. `$CLIP` must be reachable from the VLM endpoint.
 
 ```bash
-VLM="${VLM_BASE_URL:-${RTVI_VLM_BASE_URL:-http://${HOST_IP:-localhost}:8018}}"
-VLM="${VLM%/v1}"
 VLM_MODEL=$(curl -fsS "$VLM/v1/models" | jq -er --arg preferred "${VLM_NAME:-}" '
   [.data[]?.id | select(type == "string" and length > 0)] | unique as $ids
   | if $preferred != "" and ($ids | index($preferred)) != null then $preferred

--- a/skills/vss-summarize-video/references/hitl-prompts.md
+++ b/skills/vss-summarize-video/references/hitl-prompts.md
@@ -63,9 +63,15 @@ canonical defaults rather than guessing.
 
 **Request:**
 
+On Docker, discover the live schema and model from the LVS host port. On
+Kubernetes, skip LVS `/openapi.json` / `/models` (not on Ingress) and use the
+model / request construction from
+[`end-to-end-example.md`](end-to-end-example.md) instead.
+
 ```bash
 LVS_REQUEST=/tmp/vss-summarize-video-request.json
 LVS_RESPONSE=/tmp/vss-summarize-video-response.json
+# Docker default; on Kubernetes set LVS_BACKEND_URL=${VSS_PUBLIC_URL%/} (origin only).
 LVS_BASE=${LVS_BACKEND_URL:-http://localhost:38111}
 LVS_OPENAPI=/tmp/vss-lvs-openapi.json
 curl -fsS "$LVS_BASE/openapi.json" > "$LVS_OPENAPI"

--- a/skills/vss-summarize-video/references/video-summarization-api.md
+++ b/skills/vss-summarize-video/references/video-summarization-api.md
@@ -2,27 +2,33 @@
 
 This reference explains the video summarization API workflows used by
 `vss-summarize-video`. The tables and examples below are illustrative guidance
-only for live calls. The running service's `/openapi.json` is authoritative
-because its image version may expose a newer or different schema.
+only for live calls. On **Docker**, the running service's `/openapi.json` is
+authoritative because its image version may expose a newer or different schema.
+On **Kubernetes**, stock LVS Ingress does not publish that document — use the
+checked-in contract here plus Exact public routes (see Runtime OpenAPI
+Discovery).
 
 Use `/v1/summarize` for new file-summarization examples. `/summarize` is still
-present with the same request and response schema as a compatibility route.
+present on Docker with the same request and response schema as a compatibility
+route; it is not on stock LVS Ingress.
 
 ## Setup
 
 The OpenAPI spec declares a relative server URL (`/`), so `BASE_URL` is
-deployment-specific. For the VSS developer `lvs` profile, the default external
-URL is:
+deployment-specific:
 
 ```bash
+# Docker Compose (default)
 export BASE_URL="${LVS_BACKEND_URL:-http://localhost:38111}"
+# Kubernetes operate — origin only (skill appends /v1/ready and /v1/summarize)
+# export BASE_URL="${VSS_PUBLIC_URL%/}"
 ```
 
 ## Runtime OpenAPI Discovery
 
-Before constructing or issuing any live API operation, fetch the schema from
-the same service instance that will receive the request. The bootstrap
-`/openapi.json` fetch and health probes are the only exceptions.
+Before constructing or issuing any live API operation on **Docker**, fetch the
+schema from the same service instance that will receive the request. The
+bootstrap `/openapi.json` fetch and health probes are the only exceptions.
 
 ```bash
 LVS_OPENAPI=/tmp/vss-lvs-openapi.json
@@ -31,8 +37,15 @@ curl -fsS --connect-timeout 3 --max-time 15 \
 jq -e '.openapi and (.paths | type == "object")' "$LVS_OPENAPI" >/dev/null
 ```
 
-Use the runtime document to confirm the operation exists and inspect its
-request body before building a payload. For example:
+**Kubernetes:** stock LVS Ingress does **not** publish LVS `/openapi.json` or
+LVS `/models`. Public `/openapi.json` is the **Agent** document — do not treat
+it as the LVS schema. On Kubernetes, confirm `POST /v1/summarize` against the
+checked-in contract in this reference, resolve `model` from Exact
+`${VSS_PUBLIC_URL}/v1/models` (RT-VLM) or `VLM_NAME`, and call Exact
+`${BASE_URL}/v1/ready` / `${BASE_URL}/v1/summarize` only.
+
+Use the runtime document (Docker) to confirm the operation exists and inspect
+its request body before building a payload. For example:
 
 ```bash
 OPERATION_PATH=/v1/summarize


### PR DESCRIPTION
## Summary
- Wire `vss-summarize-video` and `vss-generate-video-report` Mode A to the shared `VSS_PUBLIC_URL` contract so LVS operate works on Kubernetes public Ingress (Exact `/v1` for LVS + Exact `/v1` for RT-VLM) without `kubectl port-forward` or `docker exec`.
- Document LVS public routes in `deployment_resolution.md` / `skills/README.md`, including that stock LVS Ingress does not expose LVS `/openapi.json` or `/models` — use the checked-in schema and RT-VLM Exact `/v1/models` instead.
- Keep Docker Compose host-port paths (`:38111`, `:8000`, `:30888`) and Docker-only discovery/`docker exec` probes gated behind `DEPLOYMENT_KIND=docker`.

## Test plan
- [x] Live LVS Helm smoke: upload `warehouse_sample.mp4` via VIOS on `${VSS_PUBLIC_URL}/vst`
- [x] Live summarize (custom + default scenario) via Exact `POST /v1/summarize` — 21 chunks, real events
- [x] Live report Mode A (custom + default) — LVS readiness path, clip URL rewritten to `${VSS_PUBLIC_URL}/vst/storage/...`
- [ ] Harbor / skills-check CI green on this PR
- [ ] Spot-check Docker LVS path still uses host ports and live OpenAPI/`docker exec` (no K8s regressions)