### PR TITLE
fix(lvs): close HTTP response in generate_captions_stream to fix memory leak

### DIFF
--- a/services/video-summarization/src/rtvi_vlm_client.py
+++ b/services/video-summarization/src/rtvi_vlm_client.py
@@ -370,39 +370,42 @@ class RtviVlmClient:
             timeout=600,
             headers={"x-stream-id": str(req.id)},
         )
-        if resp.status_code != 200:
-            self._raise_rtvi_error("generate_captions", resp)
+        try:
+            if resp.status_code != 200:
+                self._raise_rtvi_error("generate_captions", resp)
 
-        for line in resp.iter_lines(decode_unicode=True):
-            if not line:
-                continue
-            # SSE comment lines (keepalive pings, etc.)
-            if line.startswith(":"):
-                continue
-            # SSE event type lines — skip, we only care about data
-            if line.startswith("event:"):
-                continue
-            # SSE data lines
-            if line.startswith("data:"):
-                data = line[len("data:") :].strip()
-            else:
-                # Unknown line format — skip
-                logger.debug("RTVI SSE unexpected line: %s", line)
-                continue
+            for line in resp.iter_lines(decode_unicode=True):
+                if not line:
+                    continue
+                # SSE comment lines (keepalive pings, etc.)
+                if line.startswith(":"):
+                    continue
+                # SSE event type lines — skip, we only care about data
+                if line.startswith("event:"):
+                    continue
+                # SSE data lines
+                if line.startswith("data:"):
+                    data = line[len("data:") :].strip()
+                else:
+                    # Unknown line format — skip
+                    logger.debug("RTVI SSE unexpected line: %s", line)
+                    continue
 
-            if not data or data == "ping" or data == ": ping":
-                continue
-            if data == "[DONE]":
-                logger.info("RTVI generate_captions_stream: received [DONE]")
-                return
+                if not data or data == "ping" or data == ": ping":
+                    continue
+                if data == "[DONE]":
+                    logger.info("RTVI generate_captions_stream: received [DONE]")
+                    return
 
-            try:
-                chunk = json.loads(data)
-                yield chunk
-            except Exception as e:
-                logger.warning("RTVI SSE parse error: %s, line: %s", e, data)
+                try:
+                    chunk = json.loads(data)
+                    yield chunk
+                except Exception as e:
+                    logger.warning("RTVI SSE parse error: %s, line: %s", e, data)
 
-        logger.info("RTVI generate_captions_stream: stream ended")
+            logger.info("RTVI generate_captions_stream: stream ended")
+        finally:
+            resp.close()
 
     def start_captions(self, **kwargs):
         """Fire-and-forget kickoff for RTVI live-stream captioning.

--- a/services/video-summarization/tests/__init__.py
+++ b/services/video-summarization/tests/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/services/video-summarization/tests/unit/__init__.py
+++ b/services/video-summarization/tests/unit/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/services/video-summarization/tests/unit/test_rtvi_vlm_client.py
+++ b/services/video-summarization/tests/unit/test_rtvi_vlm_client.py
@@ -16,10 +16,6 @@
 """
 Unit tests for RtviVlmClient.generate_captions_stream response cleanup.
 
-Regression tests for NVBug 6542496: streaming HTTP responses were not closed
-after generate_captions_stream completed, causing urllib3 socket objects to
-accumulate and VmSize to grow ~147 MB/hour during stress runs.
-
 Verifies that resp.close() is called on every exit path:
   - Normal termination ([DONE] received)
   - Stream ends without [DONE]
@@ -62,7 +58,7 @@ def _drain(gen):
 
 
 class TestGenerateCaptionsStreamResponseClose:
-    """resp.close() must be called on every exit path (NVBug 6542496)."""
+    """resp.close() must be called on every exit path."""
 
     def _run(self, client, resp):
         client._session.post.return_value = resp
@@ -102,7 +98,11 @@ class TestGenerateCaptionsStreamResponseClose:
     def test_close_called_on_iteration_exception(self):
         client = _make_client()
         resp = _make_resp()
-        resp.iter_lines.return_value = iter(["data: {bad json"])
-        # Drain fully — parse errors are logged, not raised; close must still fire
+
+        def failing_lines():
+            yield "data: {}"
+            raise RuntimeError("stream interrupted")
+
+        resp.iter_lines.return_value = failing_lines()
         self._run(client, resp)
         resp.close.assert_called_once()

--- a/services/video-summarization/tests/unit/test_rtvi_vlm_client.py
+++ b/services/video-summarization/tests/unit/test_rtvi_vlm_client.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for RtviVlmClient.generate_captions_stream response cleanup.
+
+Regression tests for NVBug 6542496: streaming HTTP responses were not closed
+after generate_captions_stream completed, causing urllib3 socket objects to
+accumulate and VmSize to grow ~147 MB/hour during stress runs.
+
+Verifies that resp.close() is called on every exit path:
+  - Normal termination ([DONE] received)
+  - Stream ends without [DONE]
+  - Non-200 HTTP status (error path)
+  - Exception raised during line iteration
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rtvi_vlm_client import RtviVlmClient
+
+
+def _make_client():
+    """Create an RtviVlmClient bypassing __init__ health checks."""
+    with patch.object(RtviVlmClient, "__init__", lambda self, *a, **k: None):
+        client = RtviVlmClient(None)
+    client._base_url = "http://fake-rtvi:8000"
+    client._session = MagicMock()
+    client._model_info = SimpleNamespace(id="test-model")
+    return client
+
+
+def _make_resp(status_code=200, lines=None):
+    """Build a mock requests.Response with iter_lines() returning `lines`."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = ""
+    if lines is not None:
+        resp.iter_lines.return_value = iter(lines)
+    return resp
+
+
+def _drain(gen):
+    """Exhaust a generator, collecting all yielded items."""
+    return list(gen)
+
+
+class TestGenerateCaptionsStreamResponseClose:
+    """resp.close() must be called on every exit path (NVBug 6542496)."""
+
+    def _run(self, client, resp):
+        client._session.post.return_value = resp
+        gen = client.generate_captions_stream(
+            file_id="test-uuid",
+            model="test-model",
+            url="http://example.com/video.mp4",
+        )
+        try:
+            _drain(gen)
+        except Exception:
+            pass
+        return resp
+
+    def test_close_called_after_done_marker(self):
+        client = _make_client()
+        chunk = json.dumps(
+            {"id": "c1", "chunk_responses": [{"chunk_id": 0, "content": "hello"}]}
+        )
+        resp = _make_resp(lines=[f"data: {chunk}", "data: [DONE]"])
+        self._run(client, resp)
+        resp.close.assert_called_once()
+
+    def test_close_called_when_stream_ends_without_done(self):
+        client = _make_client()
+        resp = _make_resp(lines=[])
+        self._run(client, resp)
+        resp.close.assert_called_once()
+
+    def test_close_called_on_non_200_status(self):
+        client = _make_client()
+        resp = _make_resp(status_code=500)
+        resp.text = json.dumps({"code": "InternalError", "message": "boom"})
+        self._run(client, resp)
+        resp.close.assert_called_once()
+
+    def test_close_called_on_iteration_exception(self):
+        client = _make_client()
+        resp = _make_resp()
+        resp.iter_lines.return_value = iter(["data: {bad json"])
+        # Drain fully — parse errors are logged, not raised; close must still fire
+        self._run(client, resp)
+        resp.close.assert_called_once()


### PR DESCRIPTION
## Summary

- **Root cause**: `RtviVlmClient.generate_captions_stream` opened a streaming HTTP POST to RTVI-VLM but never called `resp.close()` on any exit path. Over thousands of back-to-back file summarizations, abandoned `urllib3.HTTPResponse` objects and their underlying OS socket/TCP buffers accumulated, causing VmSize to grow ~147 MB/hour.
- **Fix**: Wrap the streaming response body in `try/finally: resp.close()` in `services/video-summarization/src/rtvi_vlm_client.py`, mirroring the pattern already used in `start_captions()` in the same class.
- **Tests**: New regression test file `tests/unit/test_rtvi_vlm_client.py` with 4 tests covering all exit paths (normal `[DONE]`, stream-end without `[DONE]`, non-200 status, iteration exception).


## Test plan

- [x] Run `pytest services/video-summarization/tests/unit/test_rtvi_vlm_client.py` — all 4 tests must pass
- [x] Verify no regression in file summarization latency or correctness
