### PR TITLE
fix(lvs): forward scenario/events to CA-RAG and retry empty aggregation results

### DIFF
--- a/services/video-summarization/CLAUDE.md
+++ b/services/video-summarization/CLAUDE.md
@@ -230,6 +230,7 @@ VIA uses extensive environment variable configuration. Key patterns:
 - Database backends selected via `LVS_DATABASE_BACKEND`
 - `KAFKA_ENABLED`: Enables Kafka integration for livestream and file paths
 - `LVS_CAPTION_SOURCE`: Controls caption source for file-path Kafka aggregation (`sse` default, or `db` for Elasticsearch)
+- `LVS_AGGREGATION_EMPTY_RETRIES`: Extra attempts at a CA-RAG aggregation call that returns neither events nor a video summary (default `2`, `0` disables)
 
 ### Logging
 

--- a/services/video-summarization/src/via_stream_handler.py
+++ b/services/video-summarization/src/via_stream_handler.py
@@ -3728,6 +3728,17 @@ This is very important and you must follow this strictly.
             if "params" not in ca_rag_config["functions"]["summarization"]:
                 ca_rag_config["functions"]["summarization"]["params"] = {}
 
+            # scenario and events are always forwarded so the CA-RAG aggregation
+            # LLM has context regardless of enable_vlm_structured_output.
+            if req_info.scenario:
+                ca_rag_config["functions"]["summarization"]["params"][
+                    "scenario"
+                ] = req_info.scenario
+            if req_info.events:
+                ca_rag_config["functions"]["summarization"]["params"][
+                    "events"
+                ] = req_info.events
+
             if not req_info.enable_vlm_structured_output:
                 if req_info.schema:
                     ca_rag_config["functions"]["summarization"]["params"][
@@ -3737,14 +3748,6 @@ This is very important and you must follow this strictly.
                     ca_rag_config["functions"]["summarization"]["params"][
                         "batch_response_method"
                     ] = req_info.batch_response_method
-                if req_info.scenario:
-                    ca_rag_config["functions"]["summarization"]["params"][
-                        "scenario"
-                    ] = req_info.scenario
-                if req_info.events:
-                    ca_rag_config["functions"]["summarization"]["params"][
-                        "events"
-                    ] = req_info.events
                 if req_info.auto_generate_prompt is not None:
                     ca_rag_config["functions"]["summarization"]["params"][
                         "auto_generate_prompt"

--- a/services/video-summarization/src/via_stream_handler.py
+++ b/services/video-summarization/src/via_stream_handler.py
@@ -89,6 +89,12 @@ def _safe_collection_name(stream_id) -> str:
 
 MAX_MILVUS_STRING_LEN = 65535
 
+# Extra attempts at a CA-RAG aggregation call when it returns neither events nor
+# a video summary. The aggregation LLM intermittently samples an unparseable
+# response, which surfaces to the caller as HTTP 200 with total_events=0 and
+# video_summary="". Override with LVS_AGGREGATION_EMPTY_RETRIES; 0 disables.
+DEFAULT_AGGREGATION_EMPTY_RETRIES = 2
+
 
 class RequestInfo:
     """Store information for a request"""
@@ -478,6 +484,8 @@ class ViaStreamHandler:
                 "(sse=use SSE captions for aggregation, db=retrieve from Elastic DB)",
                 self._caption_source,
             )
+
+        self._aggregation_empty_retries = self._read_aggregation_empty_retries()
 
         if not args.disable_ca_rag:
             try:
@@ -2020,7 +2028,9 @@ class ViaStreamHandler:
                 sub_state,
             )
 
-            agg_response = ctx_mgr.call({"summarization_online": sub_state})
+            agg_response = self._call_aggregation_with_empty_guard(
+                ctx_mgr, "summarization_online", sub_state, req_info.source_id
+            )
 
             if agg_response.get("error"):
                 logger.error(
@@ -3219,6 +3229,97 @@ This is very important and you must follow this strictly.
     # summarize_stream(). The file path never published from
     # _get_aggregated_summary regardless of KAFKA_ENABLED.
 
+    @staticmethod
+    def _read_aggregation_empty_retries() -> int:
+        """Retry budget for aggregation calls that come back empty."""
+        raw = os.environ.get("LVS_AGGREGATION_EMPTY_RETRIES")
+        if raw is None:
+            return DEFAULT_AGGREGATION_EMPTY_RETRIES
+        try:
+            retries = int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid LVS_AGGREGATION_EMPTY_RETRIES=%r, falling back to %d",
+                raw,
+                DEFAULT_AGGREGATION_EMPTY_RETRIES,
+            )
+            return DEFAULT_AGGREGATION_EMPTY_RETRIES
+        if retries < 0:
+            logger.warning(
+                "Negative LVS_AGGREGATION_EMPTY_RETRIES=%d, treating as 0 (no retry)",
+                retries,
+            )
+            return 0
+        return retries
+
+    @staticmethod
+    def _is_empty_aggregation_result(result) -> bool:
+        """True when an aggregation result carries neither events nor a summary.
+
+        A result with an empty ``events`` list but a non-empty ``video_summary``
+        is a legitimate "nothing notable happened" answer, so both fields must be
+        empty before the result is treated as a failed sample. Free-form text
+        that does not parse as JSON is a usable summary as long as it is not blank.
+        """
+        if result is None:
+            return True
+        if isinstance(result, str):
+            if not result.strip():
+                return True
+            try:
+                parsed = json.loads(result)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                return False
+        elif isinstance(result, dict):
+            parsed = result
+        else:
+            return False
+
+        if not isinstance(parsed, dict):
+            return False
+        events = parsed.get("events") or []
+        video_summary = parsed.get("video_summary") or ""
+        return not events and not str(video_summary).strip()
+
+    def _call_aggregation_with_empty_guard(
+        self, ctx_mgr, function_name: str, state: dict, source_id
+    ):
+        """Run a CA-RAG aggregation function, retrying while the result is empty.
+
+        Aggregation reads already-persisted captions and runs an LLM over them,
+        so it holds no state of its own and re-running it is safe. When every
+        attempt comes back empty the last response is returned unchanged, so a
+        genuinely empty aggregation still reaches the caller instead of becoming
+        a new error path.
+        """
+        attempts = self._aggregation_empty_retries + 1
+        response = None
+        for attempt in range(1, attempts + 1):
+            response = ctx_mgr.call({function_name: state})
+            if response.get("error"):
+                return response
+            result = (response.get(function_name, {}) or {}).get("result", "")
+            if not self._is_empty_aggregation_result(result):
+                return response
+            if attempt < attempts:
+                logger.warning(
+                    "%s returned no events and no summary for %s "
+                    "(attempt %d of %d); retrying aggregation",
+                    function_name,
+                    source_id,
+                    attempt,
+                    attempts,
+                )
+            else:
+                logger.warning(
+                    "%s returned no events and no summary for %s after %d attempt(s); "
+                    "returning the empty aggregation",
+                    function_name,
+                    source_id,
+                    attempts,
+                )
+        return response
+
     def _get_aggregated_summary(
         self, req_info: RequestInfo, chunk_responses: list[VlmChunkResponse]
     ):
@@ -3410,7 +3511,12 @@ This is very important and you must follow this strictly.
                                 operation="ctx_rag_call_summarize",
                                 source_id=req_info.source_id,
                             ):
-                                agg_response = req_info._ctx_mgr.call({"summarization": sum_state})
+                                agg_response = self._call_aggregation_with_empty_guard(
+                                    req_info._ctx_mgr,
+                                    "summarization",
+                                    sum_state,
+                                    req_info.source_id,
+                                )
                         if agg_response.get("error"):
                             logger.error(
                                 f"Error for Request ID: {req_info.request_id} "
@@ -3735,9 +3841,7 @@ This is very important and you must follow this strictly.
                     "scenario"
                 ] = req_info.scenario
             if req_info.events:
-                ca_rag_config["functions"]["summarization"]["params"][
-                    "events"
-                ] = req_info.events
+                ca_rag_config["functions"]["summarization"]["params"]["events"] = req_info.events
 
             if not req_info.enable_vlm_structured_output:
                 if req_info.schema:

--- a/services/video-summarization/tests/__init__.py
+++ b/services/video-summarization/tests/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/services/video-summarization/tests/unit/__init__.py
+++ b/services/video-summarization/tests/unit/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/services/video-summarization/tests/unit/test_aggregation_empty_guard.py
+++ b/services/video-summarization/tests/unit/test_aggregation_empty_guard.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the CA-RAG aggregation empty-result guard.
+
+The aggregation LLM intermittently samples an unparseable response, which used to
+surface to the caller as HTTP 200 with total_events=0, events=[] and
+video_summary="". These tests cover the empty-result detection and the bounded
+retry that re-runs aggregation before such a sample reaches the caller.
+"""
+
+import json
+
+import pytest
+
+
+def _make_handler(retries=2):
+    from via_stream_handler import ViaStreamHandler
+
+    handler = ViaStreamHandler.__new__(ViaStreamHandler)
+    handler._aggregation_empty_retries = retries
+    return handler
+
+
+class _FakeCtxMgr:
+    """ctx_mgr stub returning a scripted response per call."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def call(self, state):
+        self.calls.append(state)
+        return self._responses.pop(0)
+
+
+def _response(function_name, result, metadata=None):
+    return {function_name: {"result": result, "metadata": metadata or {}}}
+
+
+def _summary(events=None, video_summary=""):
+    return json.dumps(
+        {
+            "events": events or [],
+            "total_events": len(events or []),
+            "video_summary": video_summary,
+            "uuid": "test-id",
+        }
+    )
+
+
+class TestIsEmptyAggregationResult:
+    """Only results with neither events nor a summary count as empty."""
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            None,
+            "",
+            "   ",
+            _summary(),
+            _summary(video_summary="   "),
+            {"events": [], "total_events": 0, "video_summary": ""},
+        ],
+        ids=[
+            "none",
+            "blank",
+            "whitespace",
+            "no-events-no-summary",
+            "whitespace-summary",
+            "dict-result",
+        ],
+    )
+    def test_empty_results(self, result):
+        handler = _make_handler()
+        assert handler._is_empty_aggregation_result(result) is True
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            _summary(video_summary="A forklift crossed the aisle."),
+            _summary(events=[{"type": "forklift"}]),
+            "A forklift crossed the aisle.",
+            "[]",
+        ],
+        ids=["summary-only", "events-only", "free-text", "non-dict-json"],
+    )
+    def test_non_empty_results(self, result):
+        handler = _make_handler()
+        assert handler._is_empty_aggregation_result(result) is False
+
+
+class TestCallAggregationWithEmptyGuard:
+    """An empty aggregation sample is retried before it reaches the caller."""
+
+    def test_first_non_empty_result_returned_without_retry(self):
+        handler = _make_handler(retries=2)
+        expected = _response("summarization", _summary(video_summary="A busy aisle."))
+        ctx_mgr = _FakeCtxMgr([expected])
+
+        response = handler._call_aggregation_with_empty_guard(
+            ctx_mgr, "summarization", {"start_index": 0, "end_index": 1}, "test-id"
+        )
+
+        assert response is expected
+        assert len(ctx_mgr.calls) == 1
+
+    def test_empty_result_is_retried_until_non_empty(self):
+        handler = _make_handler(retries=2)
+        good = _response("summarization", _summary(video_summary="A forklift tipped over."))
+        ctx_mgr = _FakeCtxMgr([_response("summarization", _summary()), good])
+
+        response = handler._call_aggregation_with_empty_guard(
+            ctx_mgr, "summarization", {"start_index": 0, "end_index": 1}, "test-id"
+        )
+
+        assert response is good
+        assert len(ctx_mgr.calls) == 2
+
+    def test_retries_are_bounded_and_last_response_returned(self):
+        handler = _make_handler(retries=2)
+        last = _response("summarization", _summary())
+        ctx_mgr = _FakeCtxMgr(
+            [_response("summarization", _summary()), _response("summarization", _summary()), last]
+        )
+
+        response = handler._call_aggregation_with_empty_guard(
+            ctx_mgr, "summarization", {"start_index": 0, "end_index": 1}, "test-id"
+        )
+
+        assert response is last
+        assert len(ctx_mgr.calls) == 3
+
+    def test_retries_disabled_makes_a_single_call(self):
+        handler = _make_handler(retries=0)
+        only = _response("summarization", _summary())
+        ctx_mgr = _FakeCtxMgr([only])
+
+        response = handler._call_aggregation_with_empty_guard(
+            ctx_mgr, "summarization", {"start_index": 0, "end_index": 1}, "test-id"
+        )
+
+        assert response is only
+        assert len(ctx_mgr.calls) == 1
+
+    def test_error_response_is_not_retried(self):
+        handler = _make_handler(retries=2)
+        error = {"error": "elasticsearch shard limit exceeded"}
+        ctx_mgr = _FakeCtxMgr([error])
+
+        response = handler._call_aggregation_with_empty_guard(
+            ctx_mgr, "summarization", {"start_index": 0, "end_index": 1}, "test-id"
+        )
+
+        assert response is error
+        assert len(ctx_mgr.calls) == 1
+
+    def test_metadata_comes_from_the_successful_attempt(self):
+        handler = _make_handler(retries=2)
+        good = _response(
+            "summarization_online",
+            _summary(video_summary="A crash near the loading dock."),
+            metadata={"total_tokens": 1234},
+        )
+        ctx_mgr = _FakeCtxMgr([_response("summarization_online", ""), good])
+
+        response = handler._call_aggregation_with_empty_guard(
+            ctx_mgr, "summarization_online", {"uuids": ["test-id"]}, "test-id"
+        )
+
+        assert response["summarization_online"]["metadata"] == {"total_tokens": 1234}
+        assert len(ctx_mgr.calls) == 2
+
+
+class TestReadAggregationEmptyRetries:
+    """LVS_AGGREGATION_EMPTY_RETRIES overrides the default retry budget."""
+
+    def test_default_when_unset(self, monkeypatch):
+        from via_stream_handler import DEFAULT_AGGREGATION_EMPTY_RETRIES, ViaStreamHandler
+
+        monkeypatch.delenv("LVS_AGGREGATION_EMPTY_RETRIES", raising=False)
+        assert (
+            ViaStreamHandler._read_aggregation_empty_retries() == DEFAULT_AGGREGATION_EMPTY_RETRIES
+        )
+
+    @pytest.mark.parametrize("raw,expected", [("0", 0), ("1", 1), ("5", 5)])
+    def test_valid_override(self, monkeypatch, raw, expected):
+        from via_stream_handler import ViaStreamHandler
+
+        monkeypatch.setenv("LVS_AGGREGATION_EMPTY_RETRIES", raw)
+        assert ViaStreamHandler._read_aggregation_empty_retries() == expected
+
+    def test_invalid_value_falls_back_to_default(self, monkeypatch):
+        from via_stream_handler import DEFAULT_AGGREGATION_EMPTY_RETRIES, ViaStreamHandler
+
+        monkeypatch.setenv("LVS_AGGREGATION_EMPTY_RETRIES", "many")
+        assert (
+            ViaStreamHandler._read_aggregation_empty_retries() == DEFAULT_AGGREGATION_EMPTY_RETRIES
+        )
+
+    def test_negative_value_disables_retry(self, monkeypatch):
+        from via_stream_handler import ViaStreamHandler
+
+        monkeypatch.setenv("LVS_AGGREGATION_EMPTY_RETRIES", "-3")
+        assert ViaStreamHandler._read_aggregation_empty_retries() == 0

--- a/services/video-summarization/tests/unit/test_update_ca_rag_config.py
+++ b/services/video-summarization/tests/unit/test_update_ca_rag_config.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for ViaStreamHandler.update_ca_rag_config — scenario/events forwarding.
+
+Verifies that scenario and events are forwarded to the CA-RAG summarization
+params unconditionally, regardless of enable_vlm_structured_output, so that
+the aggregation LLM has context for generating accurate summaries via both
+/summarize and /v1/summarize.
+"""
+
+from threading import RLock
+from unittest.mock import MagicMock
+
+
+def _make_handler(config=None):
+    from via_stream_handler import ViaStreamHandler
+
+    handler = ViaStreamHandler.__new__(ViaStreamHandler)
+    handler._lock = RLock()
+    handler._ca_rag_config = config if config is not None else _base_config()
+    handler._live_stream_info_map = {}
+    return handler
+
+
+def _base_config():
+    return {
+        "context_manager": {"functions": ["summarization"]},
+        "functions": {
+            "summarization": {"tools": {"db": "vector_db", "llm": "llm_tool"}},
+        },
+        "tools": {
+            "vector_db": {"params": {}},
+            "llm_tool": {"params": {}},
+        },
+    }
+
+
+def _make_ri(**overrides):
+    from via_stream_handler import RequestInfo
+
+    ri = RequestInfo()
+    defaults = dict(
+        source_id="test-id",
+        is_live=False,
+        chunk_size=10,
+        summarize_batch_size=None,
+        enable_vlm_structured_output=True,
+        summarize=False,
+        enable_audio=False,
+        user_specified_collection_name=None,
+        custom_metadata=None,
+        delete_external_collection=False,
+        schema=None,
+        batch_response_method=None,
+        scenario=None,
+        events=None,
+        auto_generate_prompt=None,
+        time_metadata_keys=None,
+        summarize_top_p=None,
+        summarize_temperature=None,
+        summarize_max_tokens=None,
+    )
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(ri, k, v)
+    return ri
+
+
+class TestScenarioEventsForwarding:
+    """scenario and events must reach CA-RAG params on every code path."""
+
+    def test_forwarded_when_structured_output_enabled(self):
+        handler = _make_handler()
+        ri = _make_ri(
+            enable_vlm_structured_output=True,
+            scenario="warehouse",
+            events=["forklift", "crash"],
+        )
+        config = handler.update_ca_rag_config(ri)
+        params = config["functions"]["summarization"]["params"]
+        assert params["scenario"] == "warehouse"
+        assert params["events"] == ["forklift", "crash"]
+
+    def test_forwarded_when_structured_output_disabled(self):
+        handler = _make_handler()
+        ri = _make_ri(
+            enable_vlm_structured_output=False,
+            scenario="retail",
+            events=["theft", "slip-and-fall"],
+        )
+        config = handler.update_ca_rag_config(ri)
+        params = config["functions"]["summarization"]["params"]
+        assert params["scenario"] == "retail"
+        assert params["events"] == ["theft", "slip-and-fall"]
+
+    def test_none_scenario_not_forwarded(self):
+        handler = _make_handler()
+        ri = _make_ri(enable_vlm_structured_output=True, scenario=None, events=["crash"])
+        config = handler.update_ca_rag_config(ri)
+        params = config["functions"]["summarization"]["params"]
+        assert "scenario" not in params
+        assert params["events"] == ["crash"]
+
+    def test_none_events_not_forwarded(self):
+        handler = _make_handler()
+        ri = _make_ri(enable_vlm_structured_output=True, scenario="security", events=None)
+        config = handler.update_ca_rag_config(ri)
+        params = config["functions"]["summarization"]["params"]
+        assert params["scenario"] == "security"
+        assert "events" not in params

--- a/services/video-summarization/tests/unit/test_update_ca_rag_config.py
+++ b/services/video-summarization/tests/unit/test_update_ca_rag_config.py
@@ -23,7 +23,6 @@ the aggregation LLM has context for generating accurate summaries via both
 """
 
 from threading import RLock
-from unittest.mock import MagicMock
 
 
 def _make_handler(config=None):


### PR DESCRIPTION
## Summary

Two independent defects in the CA-RAG aggregation path, both surfacing as empty or degraded summaries.

**1. `scenario` / `events` were dropped before reaching the aggregation LLM**

- They were only forwarded to the CA-RAG summarization params when `enable_vlm_structured_output=False`
- `enable_vlm_structured_output` defaults to `True` and the reported payload never overrides it, so the aggregation LLM received no context about the scenario or the event types being detected
- Confirmed deterministically from LVS debug logs for the same request:
  - without fix: `params={'time_overlap_threshold': 0.1, 'max_events_per_batch': 50, 'kafka_enabled': 'false', 'enable_llm_merging': 'false', 'caption_source': 'sse', 'uuid': ...}`
  - with fix: `params={..., 'caption_source': 'sse', 'scenario': 'warehouse', 'events': ['forklift', 'crash'], 'uuid': ...}`
- Fix moves the forwarding outside the `enable_vlm_structured_output` guard

**2. A single bad aggregation sample surfaced as a fully empty response**

Reproduction on matching hardware (H100 80GB, `cosmos3-nano-reasoner` modelopt-fp8 NIM served locally on GPU) showed roughly 5-10% of requests returning HTTP 200 with `total_events=0`, `events=[]` and `video_summary=""`. Across 40 calls the failures followed no endpoint — an empty result landed on `/summarize` as well as `/v1/summarize` — so this is **not** an endpoint parity defect. Both routes are the same handler behind stacked FastAPI decorators. The aggregation LLM (`nvidia-nemotron-nano-9b-v2` at temperature 0.2) intermittently samples a response that yields nothing parseable.

Fix adds an empty-result guard that re-runs the CA-RAG aggregation call when the result carries neither events nor a video summary:

- Aggregation reads already-persisted captions and runs an LLM over them, so it holds no state of its own and re-running it is safe
- A result with no events but a non-empty `video_summary` is a legitimate "nothing notable happened" answer and is **not** retried
- Non-JSON free-form text is treated as a usable summary as long as it is not blank
- Error responses are returned immediately without retry, preserving the existing `DependencyError` classification
- When every attempt comes back empty the last response is returned unchanged, so a genuinely empty aggregation is not converted into a new error path
- Applies to both the file path (`summarization`) and the livestream path (`summarization_online`)
- Retry budget defaults to 2, overridable via `LVS_AGGREGATION_EMPTY_RETRIES`; `0` restores the previous single-call behaviour

Note on scoping: fix 1 is a genuine defect but is not the cause of the empty output — it was verified to survive that change. Fix 2 targets the empty-output symptom directly. The bug is best re-scoped to "intermittent empty summarization output with CR3 FP8, both endpoints" rather than endpoint parity.

## Test plan

- [x] `pytest tests/unit/` — 26 passed (4 scenario/events forwarding + 22 aggregation guard)
- [x] Empty-result detection covers: `None`, blank, whitespace-only, no-events-and-no-summary JSON, whitespace-only summary, dict results
- [x] Non-empty detection covers: summary-only, events-only, free-form text, non-dict JSON
- [x] Retry behaviour covers: no retry on first good result, retry until non-empty, bounded retries returning the last response, retries disabled, error responses not retried, metadata taken from the successful attempt
- [x] `LVS_AGGREGATION_EMPTY_RETRIES` parsing covers unset, valid, invalid, and negative values
- [ ] Re-run the 40-call sample (10 per endpoint per build) on `viking-prod-349-au` to confirm the empty-output rate drops
- [ ] Confirm no regression in summarization quality for existing warehouse/retail/security scenarios