### PR TITLE
feat(skill-eval): record what the GPUs actually do during each eval leg

### DIFF
--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -401,8 +401,12 @@ def _finish(
         # but it is the difference between "some gputrace sampler" and "any
         # process on the box". Both samplers are bounded by their own timeout,
         # so the weaker match costs at most a slightly early stop.
+        # `-ww` for the reason spelled out at the fetch-path guard below, and
+        # this site is worse off: `vss-gputrace` occurs in the sampler's argv
+        # only inside `-f "$d/trace.csv"`, which is the LAST thing on a 204-char
+        # command line, so any width limit at all discards it.
         _remote(instance,
-                f"ps -o args= -p {pid} 2>/dev/null | grep -qF vss-gputrace "
+                f"ps -ww -o args= -p {pid} 2>/dev/null | grep -qF vss-gputrace "
                 f"&& kill {pid} 2>/dev/null; true", attempts=1)
         print(f"[gpu-trace] tried to stop sampler {pid} on {instance} "
               f"but have no trace path", flush=True)
@@ -423,7 +427,25 @@ def _finish(
     # -F, not a bare pattern: DIR_RE permits `.`, which is a BRE wildcard, so
     # `grep -q /tmp/vss-gputrace.ABCD1234` also matches `/tmp/vss-gputraceXABCD1234`.
     # A fixed-string match makes the nonce mean what it looks like it means.
-    kill = (f"ps -o args= -p {pid} 2>/dev/null | grep -qF -- {remote_dir} "
+    #
+    # `-ww`, and it is load-bearing rather than tidy. `ps` truncates `args` to
+    # the display width, and the sampler's command line is 204 characters with
+    # the nonce starting at column 169. Any width under that returns a prefix
+    # that CANNOT contain the nonce, so `grep` reports no match, `&&` skips the
+    # kill, and the sampler runs to its 2h20m hard stop on a box that has already
+    # been handed to the next leg -- a guard that is present, correct-looking and
+    # inert. Two real ways to land under 169 columns, both measured on
+    # procps-ng 3.3.17:
+    #   * COLUMNS is set in the environment (COLUMNS=80 and =100 both discard it);
+    #   * stdout is a pty whose window size was never set, which defaults to
+    #     exactly 80x24 -- and `brev exec`/`ssh` allocate precisely that.
+    # Note it is NOT simply "no tty": with no tty anywhere and COLUMNS unset,
+    # procps prints unlimited width, which is why this can look green locally.
+    # `-ww` removes the limit unconditionally and is immune to all of them.
+    # A single `-w` is NOT enough and is the tempting half-fix: it widens to 132
+    # columns, still short of 169, so the guard stays inert while looking
+    # repaired. Measured at COLUMNS=80: bare=80 chars, -w=132, -ww=207.
+    kill = (f"ps -ww -o args= -p {pid} 2>/dev/null | grep -qF -- {remote_dir} "
             f"&& kill {pid} 2>/dev/null; ") if pid else ""
     # `head -c` bounds the remote side; _read_capped bounds ours. Both are
     # needed: the remote cap cannot bound brev's own stdout.

--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -164,7 +164,8 @@ def _read_capped(proc: subprocess.Popen, deadline_sec: float) -> str:
     return "".join(chunks)
 
 
-def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC) -> str | None:
+def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC,
+            attempts: int = 2) -> str | None:
     """Run `command` on the box. Returns stdout, or None on any failure.
 
     Tries `brev exec` first (managed instances), then `ssh <alias>` (registered
@@ -180,13 +181,13 @@ def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC) -> str
     an ssh that forked would survive; `envs/brev_env.py::_kill_proc_group`
     already fixes this exact problem the same way for harbor.
     """
-    attempts = (
+    candidates = (
         ["brev", "exec", instance, command],
         ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15",
          "-o", "StrictHostKeyChecking=no", instance.lower(), command],
-    )
+    )[:max(1, attempts)]
     deadline = time.monotonic() + timeout
-    for cmd in attempts:
+    for cmd in candidates:
         remaining = deadline - time.monotonic()
         if remaining <= 1:
             break
@@ -300,15 +301,33 @@ def trace(
     # `set -C` (noclobber) is belt-and-braces inside that fresh directory: it
     # refuses to write through an existing name at all.
     start_cmd = (
+        # Reap orphans first. Nothing else on the box does: _reset_docker_runtime
+        # touches only containers and volumes, the stray-agent reaper matches only
+        # claude, and the /logs wipe does not reach /tmp. Every abrupt-death path
+        # leaves a directory behind, and these boxes stay up for weeks. 180 min is
+        # safely past the hard stop, so this can never hit a live sampler.
+        f"find /tmp -maxdepth 1 -name 'vss-gputrace.*' -mmin +180 "
+        f"-exec rm -rf {{}} + 2>/dev/null; "
         f"set -C; d=$(mktemp -d /tmp/vss-gputrace.XXXXXXXX) || exit 0; "
         f"echo DIR=$d; "
+        # `-f FILE` rather than `> FILE`. A redirected stdout is block-buffered
+        # and SIGTERM does not flush it, so up to a full buffer of samples is
+        # discarded at exactly the moment cleanup runs -- on a 2-GPU box at 10s
+        # that is minutes of data, and a short leg would return nothing at all,
+        # logged indistinguishably from an unreachable box. Letting nvidia-smi
+        # own the file also puts the nonce directory into its argv, which is
+        # what makes the identity check below exact rather than a guess.
         f"nohup timeout -k 10 {hard_stop} nvidia-smi "
         f"--query-gpu={QUERY_FIELDS} --format=csv,noheader,nounits "
-        f"-l {INTERVAL_SEC} >\"$d/trace.csv\" 2>/dev/null </dev/null & "
+        f"-l {INTERVAL_SEC} -f \"$d/trace.csv\" >/dev/null 2>&1 </dev/null & "
         f"echo PID=$!"
     )
     try:
-        out = _remote(instance, start_cmd)
+        # Single attempt. `start_cmd` is NOT idempotent: a second run creates a
+        # second mktemp directory and a second sampler whose pid we never see,
+        # so nothing can kill it and it lives to the 140-minute hard stop. The
+        # fetch below is safely re-runnable and keeps both attempts.
+        out = _remote(instance, start_cmd, attempts=1)
         # Only two prefixes are read, and both are validated. There is
         # deliberately no free-form field: an earlier revision assigned every
         # other line to `gpu_name` and published it in the sidecar, so anything
@@ -361,6 +380,14 @@ def _finish(
     # `timeout` forwards SIGTERM to nvidia-smi, so killing its pid is enough.
     # The `rm` matters: `_reset_docker_runtime` does not clear /tmp, and an
     # unbounded pile of traces on a box that has been up six weeks is litter.
+    # The kill and the fetch were coupled to one guard, but only the fetch needs
+    # the directory. A reply where PID= validated and DIR= did not left a running
+    # sampler that nothing would ever kill, reported as a benign non-start.
+    if pid and not remote_dir:
+        _remote(instance, f"kill {pid} 2>/dev/null; true", attempts=1)
+        print(f"[gpu-trace] killed sampler {pid} on {instance} but have no trace path",
+              flush=True)
+        return
     if not remote_dir or not remote_csv:
         print(f"[gpu-trace] no remote trace directory for {instance}", flush=True)
         return
@@ -369,7 +396,12 @@ def _finish(
     # reuses it, and `kill <number>` then hits an unrelated process on a shared
     # box. Verified: handing back the pid of an unrelated `sleep 60` terminated
     # it. So the pid must still LOOK like our sampler before it is signalled.
-    kill = (f"ps -o args= -p {pid} 2>/dev/null | grep -q nvidia-smi "
+    # Match this invocation's nonce directory, not merely "some nvidia-smi".
+    # These boxes run nvidia-smi constantly -- deploy scripts, health checks,
+    # containers -- so a recycled pid that happens to be any nvidia-smi would be
+    # killed, possibly one belonging to another leg. The nonce is in argv now
+    # that the sampler uses `-f`, which makes this exact.
+    kill = (f"ps -o args= -p {pid} 2>/dev/null | grep -q {remote_dir} "
             f"&& kill {pid} 2>/dev/null; ") if pid else ""
     # `head -c` bounds the remote side; _read_capped bounds ours. Both are
     # needed: the remote cap cannot bound brev's own stdout.

--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -229,15 +229,20 @@ def _token(run_id: str, spec_stem: str, platform: str, step: int,
     def clean(s: str) -> str:
         return "".join(c if c.isalnum() or c in "-_" else "-" for c in str(s))
 
-    # The step suffix is appended AFTER truncation, never before. Truncating the
-    # joined string lets a long spec name push `-stepN` off the end, so step 1
-    # and step 2 collide and the second silently overwrites the first.
+    # BOTH discriminators are appended AFTER truncation, never before. Truncating
+    # a joined string lets a long spec name push the suffix off the end, so two
+    # invocations collide and the second silently overwrites the first.
     # `chain` is load-bearing: discover_invocations() supports several chains
     # per leg, and two chains sharing a step index produced the same token, so
     # the second silently overwrote the first. Verified: four remote calls, one
     # surviving file.
-    head = clean(f"{run_id}-{spec_stem}-{platform}-{chain}")[:100]
-    return f"{head}-step{clean(step)}"
+    # `chain` used to sit INSIDE the truncated head, which reintroduced exactly
+    # that collision for any spec_stem long enough to push it past 100 chars:
+    # `_token(r, "x"*100, p, 1, "chainA") == _token(r, "x"*100, p, 1, "chainB")`.
+    # Step was already fixed this way; chain was not.
+    head = clean(f"{run_id}-{spec_stem}-{platform}")[:100]
+    tail = f"-{clean(chain)}" if chain else ""
+    return f"{head}{tail}-step{clean(step)}"
 
 
 @contextlib.contextmanager
@@ -384,9 +389,23 @@ def _finish(
     # the directory. A reply where PID= validated and DIR= did not left a running
     # sampler that nothing would ever kill, reported as a benign non-start.
     if pid and not remote_dir:
-        _remote(instance, f"kill {pid} 2>/dev/null; true", attempts=1)
-        print(f"[gpu-trace] killed sampler {pid} on {instance} but have no trace path",
-              flush=True)
+        # Identity still has to be established here, and this branch cannot use
+        # the nonce because the nonce IS the directory that failed to validate.
+        # A bare `kill <number>` is the exact defect the guard below documents:
+        # the sampler can exit early, the OS reuses the pid, and cleanup then
+        # signals whatever inherited it. Verified there with an unrelated
+        # `sleep 60`; nothing about this branch makes that safer.
+        # The literal `vss-gputrace` prefix is in the sampler's argv (it owns
+        # the file via `-f "$d/trace.csv"`), so match on that: weaker than the
+        # exact nonce -- it cannot tell this leg's sampler from another's --
+        # but it is the difference between "some gputrace sampler" and "any
+        # process on the box". Both samplers are bounded by their own timeout,
+        # so the weaker match costs at most a slightly early stop.
+        _remote(instance,
+                f"ps -o args= -p {pid} 2>/dev/null | grep -qF vss-gputrace "
+                f"&& kill {pid} 2>/dev/null; true", attempts=1)
+        print(f"[gpu-trace] tried to stop sampler {pid} on {instance} "
+              f"but have no trace path", flush=True)
         return
     if not remote_dir or not remote_csv:
         print(f"[gpu-trace] no remote trace directory for {instance}", flush=True)
@@ -401,7 +420,10 @@ def _finish(
     # containers -- so a recycled pid that happens to be any nvidia-smi would be
     # killed, possibly one belonging to another leg. The nonce is in argv now
     # that the sampler uses `-f`, which makes this exact.
-    kill = (f"ps -o args= -p {pid} 2>/dev/null | grep -q {remote_dir} "
+    # -F, not a bare pattern: DIR_RE permits `.`, which is a BRE wildcard, so
+    # `grep -q /tmp/vss-gputrace.ABCD1234` also matches `/tmp/vss-gputraceXABCD1234`.
+    # A fixed-string match makes the nonce mean what it looks like it means.
+    kill = (f"ps -o args= -p {pid} 2>/dev/null | grep -qF -- {remote_dir} "
             f"&& kill {pid} 2>/dev/null; ") if pid else ""
     # `head -c` bounds the remote side; _read_capped bounds ours. Both are
     # needed: the remote cap cannot bound brev's own stdout.

--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -12,6 +12,20 @@ at 0% holding 210.8 GiB resident, with 11 of 13 boxes still running a full VSS
 stack hours after their last leg. That is suggestive, not attributable: it says
 nothing about which spec caused it. This module makes it attributable.
 
+NOT A DUPLICATE OF THE DCGM WORK. PR #1678 adds a DCGM exporter to the LVS
+developer profile, which instruments GPUs in a product DEPLOYMENT: it touches
+`deploy/docker`, `deploy/helm` and `skills/vss-deploy-profile`. This module
+instruments the CI plane, the `vss-eval-*` boxes running skill-eval legs, and
+touches only `.github/skill-eval`. The two share no files and answer different
+questions: DCGM tells an operator what a running stack is doing right now,
+while this answers "the spec declared gpu_count: 2, did the leg use them", per
+spec, after the fact, joined to run and step.
+
+The "no DCGM exporter" line above is about the eval fleet specifically, and
+#1678 as scoped does not change it. If DCGM does reach `vss-eval-*` later and
+can be joined to job identity, that is the better mechanism and this module
+should be retired rather than extended.
+
 WHERE IT HOOKS. `run_leg.py` holds the per-box `flock` and knows the run, spec,
 platform and chosen instance at the same moment. That is the only place in the
 pipeline where GPU identity and job identity coexist, so joining them here is

--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -99,6 +99,9 @@ ROW_RE = re.compile(
 # The recorded PID is remote-supplied text that gets interpolated into a shell
 # command. Anything but a bare positive integer is refused outright.
 PID_RE = re.compile(r"^[1-9][0-9]*$")
+# The remote directory comes back from `mktemp -d` and is then interpolated
+# into a shell command, so it is pinned to exactly the shape mktemp produces.
+DIR_RE = re.compile(r"^/tmp/vss-gputrace\.[A-Za-z0-9]{8}$")
 
 # Cap what a single fetch may return. Without a bound, a replaced or endless
 # source could exhaust the runner's memory before any exception handler helps.
@@ -116,6 +119,49 @@ EXEC_TIMEOUT_SEC = _int_env("EVAL_GPU_TRACE_EXEC_TIMEOUT", 120)
 # Slack over the harbor timeout before the remote `timeout` fires. The sampler
 # must outlive a normal leg but must not outlive a SIGKILLed one for long.
 HARD_STOP_SLACK_SEC = 600
+
+
+def _read_capped(proc: subprocess.Popen, deadline_sec: float) -> str:
+    """Read at most MAX_FETCH_BYTES, enforcing the bound WHILE reading.
+
+    `communicate()` buffers the whole stream and only then can it be sliced,
+    so the cap did nothing: a replaced or endless remote source grew the
+    runner's RSS without limit. Measured on a 32 MiB emit, maxrss grew 125 MB
+    against an 8 MiB "cap". An OOM-killed runner fails the leg, which is
+    exactly what this module promises never to do.
+    """
+    import select
+
+    chunks: list[str] = []
+    total = 0
+    end = time.monotonic() + deadline_sec
+    assert proc.stdout is not None
+    while True:
+        left = end - time.monotonic()
+        if left <= 0:
+            raise subprocess.TimeoutExpired(proc.args, deadline_sec)
+        # select(), not a bare read(). `read()` blocks, so a deadline checked
+        # at the top of the loop never fires on a hung remote and the "total
+        # deadline" is not a deadline at all.
+        ready, _, _ = select.select([proc.stdout], [], [], min(left, 1.0))
+        if not ready:
+            continue
+        chunk = proc.stdout.read1(65536) if hasattr(proc.stdout, "read1") \
+            else os.read(proc.stdout.fileno(), 65536).decode("utf-8", "replace")
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_FETCH_BYTES:
+            chunks.append(chunk[: MAX_FETCH_BYTES - (total - len(chunk))])
+            print(f"[gpu-trace] remote output exceeded {MAX_FETCH_BYTES} bytes; truncated",
+                  flush=True)
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.killpg(proc.pid, signal.SIGKILL)
+            break
+        chunks.append(chunk)
+    with contextlib.suppress(Exception):
+        proc.wait(timeout=max(1.0, end - time.monotonic()))
+    return "".join(chunks)
 
 
 def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC) -> str | None:
@@ -153,7 +199,7 @@ def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC) -> str
         except OSError:
             continue
         try:
-            out, _ = proc.communicate(timeout=remaining)
+            out = _read_capped(proc, remaining)
         except subprocess.TimeoutExpired:
             with contextlib.suppress(ProcessLookupError, OSError):
                 os.killpg(proc.pid, signal.SIGKILL)
@@ -167,11 +213,12 @@ def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC) -> str
             # command output; drop it so callers get only the payload.
             lines = [ln for ln in (out or "").splitlines()
                      if ln.strip() != instance]
-            return "\n".join(lines)[:MAX_FETCH_BYTES]
+            return "\n".join(lines)
     return None
 
 
-def _token(run_id: str, spec_stem: str, platform: str, step: int) -> str:
+def _token(run_id: str, spec_stem: str, platform: str, step: int,
+           chain: str = "") -> str:
     """Filename-safe, collision-free per-invocation marker.
 
     Includes the step index because a multi-step spec makes several harbor
@@ -184,7 +231,11 @@ def _token(run_id: str, spec_stem: str, platform: str, step: int) -> str:
     # The step suffix is appended AFTER truncation, never before. Truncating the
     # joined string lets a long spec name push `-stepN` off the end, so step 1
     # and step 2 collide and the second silently overwrites the first.
-    head = clean(f"{run_id}-{spec_stem}-{platform}")[:100]
+    # `chain` is load-bearing: discover_invocations() supports several chains
+    # per leg, and two chains sharing a step index produced the same token, so
+    # the second silently overwrote the first. Verified: four remote calls, one
+    # surviving file.
+    head = clean(f"{run_id}-{spec_stem}-{platform}-{chain}")[:100]
     return f"{head}-step{clean(step)}"
 
 
@@ -196,6 +247,7 @@ def trace(
     spec_stem: str = "",
     platform: str = "",
     step: int = 1,
+    chain: str = "",
     declared_gpu_count: int | None = None,
     skill: str = "",
     harbor_timeout_sec: int = 7800,
@@ -212,11 +264,11 @@ def trace(
         return
 
     run_id = os.environ.get("GITHUB_RUN_ID", "local")
-    token = _token(run_id, spec_stem, platform, step)
-    remote_csv = f"/tmp/vss-gputrace/{token}.csv"
+    token = _token(run_id, spec_stem, platform, step, chain)
     started_at = time.time()
     pid: str | None = None
-    gpu_name = ""
+    remote_dir: str | None = None
+    remote_csv: str | None = None
 
     # The remote `timeout` is the load-bearing guarantee: if this process dies
     # without running the finally block, the sampler still exits on its own.
@@ -235,28 +287,46 @@ def trace(
     # and its stdout AND stderr are redirected so no descriptor keeps the pipe
     # open. `$!` is then genuinely `timeout`'s pid, and `timeout` forwards
     # SIGTERM to nvidia-smi.
+    #
+    # The output directory is created with `mktemp -d`, NOT at a path derived
+    # from the job identity. A predictable name under a world-writable /tmp is
+    # a file-clobbering primitive: shell `>` follows symlinks, so a pre-placed
+    # `<token>.csv -> ~/.ssh/authorized_keys` gets truncated. Verified in real
+    # bash: a victim file holding "KEEP-ME" was overwritten through exactly that
+    # redirect. `mktemp -d` also makes each invocation's directory unique, which
+    # removes the separate bug where two chains of one leg sharing a step index
+    # overwrote each other's trace.
+    #
+    # `set -C` (noclobber) is belt-and-braces inside that fresh directory: it
+    # refuses to write through an existing name at all.
     start_cmd = (
-        f"mkdir -p /tmp/vss-gputrace; "
+        f"set -C; d=$(mktemp -d /tmp/vss-gputrace.XXXXXXXX) || exit 0; "
+        f"echo DIR=$d; "
         f"nohup timeout -k 10 {hard_stop} nvidia-smi "
         f"--query-gpu={QUERY_FIELDS} --format=csv,noheader,nounits "
-        f"-l {INTERVAL_SEC} >{remote_csv} 2>/dev/null </dev/null & "
-        f"echo PID=$!; "
-        f"nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1"
+        f"-l {INTERVAL_SEC} >\"$d/trace.csv\" 2>/dev/null </dev/null & "
+        f"echo PID=$!"
     )
     try:
         out = _remote(instance, start_cmd)
+        # Only two prefixes are read, and both are validated. There is
+        # deliberately no free-form field: an earlier revision assigned every
+        # other line to `gpu_name` and published it in the sidecar, so anything
+        # the remote emitted in that position went straight into an uploaded
+        # artifact. ROW_RE guarded the CSV and nothing guarded the sidecar.
         if out:
             for line in out.splitlines():
                 if line.startswith("PID="):
-                    # Remote-supplied text that is about to be interpolated
-                    # into a shell command. A bare positive integer or nothing:
-                    # `PID=1; rm -rf ...` must not become a cleanup command,
-                    # and a stale/reused pid must not become a kill target.
+                    # About to be interpolated into a shell command, so a bare
+                    # positive integer or nothing: `PID=1; rm -rf ...` must not
+                    # become a cleanup command.
                     candidate = line.split("=", 1)[1].strip()
                     pid = candidate if PID_RE.match(candidate) else None
-                elif line.strip():
-                    gpu_name = line.strip()[:120]
-        if pid:
+                elif line.startswith("DIR="):
+                    candidate = line.split("=", 1)[1].strip()
+                    remote_dir = candidate if DIR_RE.match(candidate) else None
+        if pid and remote_dir:
+            remote_csv = f"{remote_dir}/trace.csv"
             print(f"[gpu-trace] sampling {instance} every {INTERVAL_SEC}s "
                   f"(pid {pid}, hard stop {hard_stop}s)", flush=True)
         else:
@@ -271,16 +341,17 @@ def trace(
         # Runs on success, failure, harbor timeout and KeyboardInterrupt. A
         # SIGKILL skips it, which is what the remote `timeout` covers.
         with contextlib.suppress(Exception):
-            _finish(instance, remote_csv, pid, results_root, token,
+            _finish(instance, remote_csv, remote_dir, pid, results_root, token,
                     run_id=run_id, skill=skill, spec_stem=spec_stem,
-                    platform=platform, step=step, gpu_name=gpu_name,
+                    platform=platform, step=step, chain=chain,
                     declared_gpu_count=declared_gpu_count,
                     started_at=started_at)
 
 
 def _finish(
     instance: str,
-    remote_csv: str,
+    remote_csv: str | None,
+    remote_dir: str | None,
     pid: str | None,
     results_root: Path,
     token: str,
@@ -290,9 +361,21 @@ def _finish(
     # `timeout` forwards SIGTERM to nvidia-smi, so killing its pid is enough.
     # The `rm` matters: `_reset_docker_runtime` does not clear /tmp, and an
     # unbounded pile of traces on a box that has been up six weeks is litter.
-    # `pid` is PID_RE-validated at capture, so it cannot carry shell syntax.
-    kill = f"kill {pid} 2>/dev/null; " if pid else ""
-    out = _remote(instance, f"{kill}sleep 1; cat {remote_csv} 2>/dev/null; rm -f {remote_csv}")
+    if not remote_dir or not remote_csv:
+        print(f"[gpu-trace] no remote trace directory for {instance}", flush=True)
+        return
+    # `pid` is PID_RE-validated at capture so it cannot carry shell syntax, but
+    # syntax is not identity: a sampler that exited early frees its pid, the OS
+    # reuses it, and `kill <number>` then hits an unrelated process on a shared
+    # box. Verified: handing back the pid of an unrelated `sleep 60` terminated
+    # it. So the pid must still LOOK like our sampler before it is signalled.
+    kill = (f"ps -o args= -p {pid} 2>/dev/null | grep -q nvidia-smi "
+            f"&& kill {pid} 2>/dev/null; ") if pid else ""
+    # `head -c` bounds the remote side; _read_capped bounds ours. Both are
+    # needed: the remote cap cannot bound brev's own stdout.
+    out = _remote(instance,
+                  f"{kill}sleep 1; head -c {MAX_FETCH_BYTES} {remote_csv} 2>/dev/null; "
+                  f"rm -rf {remote_dir}")
     # Structural validation, not a comma count. `ln.count(",") >= 6` publishes
     # whatever the remote `cat` returned into a public artifact, and the remote
     # path is a predictable same-user file in /tmp. A row now has to LOOK like
@@ -321,7 +404,7 @@ def _finish(
     sidecar = {
         "schema": 1,
         "instance": instance,
-        "gpu_name": meta.get("gpu_name", ""),
+
         "declared_gpu_count": meta.get("declared_gpu_count"),
         "run_id": meta.get("run_id"),
         "skill": meta.get("skill"),

--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Sample the eval box's GPUs for the life of one leg.
+
+WHY THIS EXISTS. Nothing anywhere records what the GPUs do during a skill-eval
+leg. Measured 2026-08-01: `nvidia-smi` accounting mode is `Disabled` on all 13
+`vss-eval-*` boxes, so there is no retrospective data even in principle; the
+boxes carry no DCGM exporter; and Horde's `gpu_utilization` API is an allocation
+report, not a utilisation one. A snapshot of the idle fleet found 21 of 23 GPUs
+at 0% holding 210.8 GiB resident, with 11 of 13 boxes still running a full VSS
+stack hours after their last leg. That is suggestive, not attributable: it says
+nothing about which spec caused it. This module makes it attributable.
+
+WHERE IT HOOKS. `run_leg.py` holds the per-box `flock` and knows the run, spec,
+platform and chosen instance at the same moment. That is the only place in the
+pipeline where GPU identity and job identity coexist, so joining them here is
+free; anywhere else it needs a pipeline change.
+
+DESIGN CONSTRAINTS, each paid for by a previous incident:
+
+* **Default on, never fatal.** Every entry point swallows its exceptions and the
+  context manager always yields. A telemetry sampler that fails a deployment
+  eval is worse than no telemetry, so this cannot fail a leg even if the box is
+  unreachable, `nvidia-smi` is missing, or the fetch times out.
+* **Hard-bounded lifetime.** The remote sampler runs under `timeout`, so it dies
+  on its own even if this process is SIGKILLed and never calls stop. An earlier
+  hand-run sampler leaked and ran 213 minutes across unrelated trials; with no
+  bound and no timestamps the trace was unusable and was discarded.
+* **Timestamps in every row.** Same incident: a trace that cannot be segmented
+  afterwards is worthless.
+* **Allowlist, not redaction.** The remote command emits exactly the seven
+  `--query-gpu` fields below. It does not read process environments, command
+  lines, container state or file contents. Redaction fails open; an allowlist
+  fails closed. PR #516 leaked `NGC_CLI_API_KEY` through artifact collection,
+  which is why the per-trial `agent/` trajectory is still excluded from the
+  uploaded tarball, and why this module must not become a second such channel.
+* **Rides the existing artifact.** Output lands under `results_root`, which
+  `skills-eval.yml` and `skills-eval-daily.yml` already tar and upload with
+  28-day retention. No new network path, and no credential on the GPU box.
+  `_reset_docker_runtime` wipes the box between trials, so nothing may be left
+  there.
+
+The declared-versus-observed comparison is the point: `declared_gpu_count` comes
+from the spec and travels in the sidecar next to what the GPUs actually did.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+
+def _int_env(name: str, default: int) -> int:
+    """Never let a malformed knob take down the leg.
+
+    These are module-level constants, so a bare int() would raise at IMPORT
+    time, and run_leg.py's guard only catches ImportError. `EVAL_GPU_TRACE_INTERVAL=x`
+    would then fail every leg before main() even runs -- telemetry config
+    breaking the thing it observes.
+    """
+    try:
+        value = int(os.environ.get(name, "") or default)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+# Fixed field list. This IS the allowlist -- adding to it is a deliberate act,
+# and `nounits` keeps the CSV numeric so the collector needs no unit parsing.
+QUERY_FIELDS = (
+    "timestamp,index,utilization.gpu,utilization.memory,"
+    "memory.used,memory.total,power.draw"
+)
+CSV_HEADER = (
+    "timestamp,gpu_index,util_gpu_pct,util_mem_pct,"
+    "mem_used_mib,mem_total_mib,power_w"
+)
+
+# 10s matched the interval that established medians in the original one-box
+# trace. Do not raise the rate because you can: a 2h leg already yields ~1440
+# rows for a 2-GPU box, and the collector aggregates them anyway.
+INTERVAL_SEC = _int_env("EVAL_GPU_TRACE_INTERVAL", 10)
+
+# A row is accepted only if it has exactly these 7 fields, the first parses as
+# an nvidia-smi timestamp and the rest are numeric (or the literal [N/A] that
+# nvidia-smi prints for unsupported fields). "at least 6 commas" is NOT an
+# allowlist: it publishes whatever the remote `cat` returned, and the remote
+# file is a predictable same-user path in /tmp that could have been replaced.
+ROW_RE = re.compile(
+    r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d+"
+    r"(?:,\s*(?:-?\d+(?:\.\d+)?|\[N/A\])){6}$"
+)
+# The recorded PID is remote-supplied text that gets interpolated into a shell
+# command. Anything but a bare positive integer is refused outright.
+PID_RE = re.compile(r"^[1-9][0-9]*$")
+
+# Cap what a single fetch may return. Without a bound, a replaced or endless
+# source could exhaust the runner's memory before any exception handler helps.
+MAX_FETCH_BYTES = _int_env("EVAL_GPU_TRACE_MAX_BYTES", 8 * 1024 * 1024)
+
+# Default ON. Set EVAL_GPU_TRACE=0 to suppress. The failure mode is a missing
+# trace, never a failed leg, so opt-out rather than opt-in is the right posture:
+# opt-in telemetry that nobody enables collects nothing.
+ENABLED = os.environ.get("EVAL_GPU_TRACE", "1") not in ("0", "false", "False", "")
+
+# Round-trip budget for the two `brev exec` calls. Measured 2026-08-01: a warm
+# `brev exec` round trip is ~2s, so 120s is ~60x headroom and still bounded.
+EXEC_TIMEOUT_SEC = _int_env("EVAL_GPU_TRACE_EXEC_TIMEOUT", 120)
+
+# Slack over the harbor timeout before the remote `timeout` fires. The sampler
+# must outlive a normal leg but must not outlive a SIGKILLed one for long.
+HARD_STOP_SLACK_SEC = 600
+
+
+def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC) -> str | None:
+    """Run `command` on the box. Returns stdout, or None on any failure.
+
+    Tries `brev exec` first (managed instances), then `ssh <alias>` (registered
+    nodes, which `brev exec` cannot reach). `brev shell` writes a lowercased
+    `Host` entry into ~/.brev/ssh_config, so the alias is the lowercased name --
+    the same convention `envs/brev_env.py::_ssh_alias_for` uses.
+
+    `timeout` is a TOTAL deadline across both attempts, not per attempt: two
+    120s attempts would be a 240s stall on a leg whose median is 132s.
+
+    Each attempt runs in its own session and is killed by process GROUP on
+    timeout. `subprocess.run`'s own timeout reaps only the immediate child, so
+    an ssh that forked would survive; `envs/brev_env.py::_kill_proc_group`
+    already fixes this exact problem the same way for harbor.
+    """
+    attempts = (
+        ["brev", "exec", instance, command],
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15",
+         "-o", "StrictHostKeyChecking=no", instance.lower(), command],
+    )
+    deadline = time.monotonic() + timeout
+    for cmd in attempts:
+        remaining = deadline - time.monotonic()
+        if remaining <= 1:
+            break
+        try:
+            proc = subprocess.Popen(
+                cmd, stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                text=True, start_new_session=True,
+            )
+        except OSError:
+            continue
+        try:
+            out, _ = proc.communicate(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.killpg(proc.pid, signal.SIGKILL)
+            with contextlib.suppress(Exception):
+                proc.communicate(timeout=10)
+            continue
+        except (OSError, ValueError):
+            continue
+        if proc.returncode == 0:
+            # `brev exec` echoes the instance name on its own line after the
+            # command output; drop it so callers get only the payload.
+            lines = [ln for ln in (out or "").splitlines()
+                     if ln.strip() != instance]
+            return "\n".join(lines)[:MAX_FETCH_BYTES]
+    return None
+
+
+def _token(run_id: str, spec_stem: str, platform: str, step: int) -> str:
+    """Filename-safe, collision-free per-invocation marker.
+
+    Includes the step index because a multi-step spec makes several harbor
+    invocations against the same box under one lock, and each needs its own
+    trace rather than appending to the previous one.
+    """
+    def clean(s: str) -> str:
+        return "".join(c if c.isalnum() or c in "-_" else "-" for c in str(s))
+
+    # The step suffix is appended AFTER truncation, never before. Truncating the
+    # joined string lets a long spec name push `-stepN` off the end, so step 1
+    # and step 2 collide and the second silently overwrites the first.
+    head = clean(f"{run_id}-{spec_stem}-{platform}")[:100]
+    return f"{head}-step{clean(step)}"
+
+
+@contextlib.contextmanager
+def trace(
+    instance: str,
+    results_root: Path,
+    *,
+    spec_stem: str = "",
+    platform: str = "",
+    step: int = 1,
+    declared_gpu_count: int | None = None,
+    skill: str = "",
+    harbor_timeout_sec: int = 7800,
+):
+    """Sample `instance`'s GPUs for the duration of the block.
+
+    Never raises and never re-raises: the body runs whether or not tracing
+    worked. On exit the trace is written to
+    ``results_root/gputrace/<token>.csv`` with a ``.json`` sidecar carrying the
+    job identity and the declared GPU count.
+    """
+    if not ENABLED or not instance:
+        yield
+        return
+
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
+    token = _token(run_id, spec_stem, platform, step)
+    remote_csv = f"/tmp/vss-gputrace/{token}.csv"
+    started_at = time.time()
+    pid: str | None = None
+    gpu_name = ""
+
+    # The remote `timeout` is the load-bearing guarantee: if this process dies
+    # without running the finally block, the sampler still exits on its own.
+    hard_stop = max(harbor_timeout_sec + HARD_STOP_SLACK_SEC, 900)
+    # GRAMMAR IS LOAD-BEARING, and the obvious form is wrong. `mkdir && nohup
+    # ... &` backgrounds the whole AND-list, so `$!` is a forked subshell rather
+    # than `timeout`, and killing it leaves the sampler running. Worse, that
+    # subshell inherits the stdout pipe, so `communicate()` blocks until the
+    # SAMPLER exits -- measured 2026-08-01: the start call took 3.03s under bash
+    # and 3.04s under sh for a 3s target, versus 0.01s under zsh. Brev execs via
+    # bash, so this would have stalled every start until the 120s timeout, then
+    # retried over ssh and started a SECOND sampler. Developing on a zsh laptop
+    # hid it completely.
+    #
+    # So: `mkdir` runs as its own statement, exactly ONE command is backgrounded,
+    # and its stdout AND stderr are redirected so no descriptor keeps the pipe
+    # open. `$!` is then genuinely `timeout`'s pid, and `timeout` forwards
+    # SIGTERM to nvidia-smi.
+    start_cmd = (
+        f"mkdir -p /tmp/vss-gputrace; "
+        f"nohup timeout -k 10 {hard_stop} nvidia-smi "
+        f"--query-gpu={QUERY_FIELDS} --format=csv,noheader,nounits "
+        f"-l {INTERVAL_SEC} >{remote_csv} 2>/dev/null </dev/null & "
+        f"echo PID=$!; "
+        f"nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1"
+    )
+    try:
+        out = _remote(instance, start_cmd)
+        if out:
+            for line in out.splitlines():
+                if line.startswith("PID="):
+                    # Remote-supplied text that is about to be interpolated
+                    # into a shell command. A bare positive integer or nothing:
+                    # `PID=1; rm -rf ...` must not become a cleanup command,
+                    # and a stale/reused pid must not become a kill target.
+                    candidate = line.split("=", 1)[1].strip()
+                    pid = candidate if PID_RE.match(candidate) else None
+                elif line.strip():
+                    gpu_name = line.strip()[:120]
+        if pid:
+            print(f"[gpu-trace] sampling {instance} every {INTERVAL_SEC}s "
+                  f"(pid {pid}, hard stop {hard_stop}s)", flush=True)
+        else:
+            print(f"[gpu-trace] could not start on {instance}; leg continues",
+                  flush=True)
+    except Exception as exc:  # noqa: BLE001 - telemetry must never fail a leg
+        print(f"[gpu-trace] start failed ({exc!r}); leg continues", flush=True)
+
+    try:
+        yield
+    finally:
+        # Runs on success, failure, harbor timeout and KeyboardInterrupt. A
+        # SIGKILL skips it, which is what the remote `timeout` covers.
+        with contextlib.suppress(Exception):
+            _finish(instance, remote_csv, pid, results_root, token,
+                    run_id=run_id, skill=skill, spec_stem=spec_stem,
+                    platform=platform, step=step, gpu_name=gpu_name,
+                    declared_gpu_count=declared_gpu_count,
+                    started_at=started_at)
+
+
+def _finish(
+    instance: str,
+    remote_csv: str,
+    pid: str | None,
+    results_root: Path,
+    token: str,
+    **meta,
+) -> None:
+    """Stop the sampler, pull the rows back, write CSV + sidecar. Best effort."""
+    # `timeout` forwards SIGTERM to nvidia-smi, so killing its pid is enough.
+    # The `rm` matters: `_reset_docker_runtime` does not clear /tmp, and an
+    # unbounded pile of traces on a box that has been up six weeks is litter.
+    # `pid` is PID_RE-validated at capture, so it cannot carry shell syntax.
+    kill = f"kill {pid} 2>/dev/null; " if pid else ""
+    out = _remote(instance, f"{kill}sleep 1; cat {remote_csv} 2>/dev/null; rm -f {remote_csv}")
+    # Structural validation, not a comma count. `ln.count(",") >= 6` publishes
+    # whatever the remote `cat` returned into a public artifact, and the remote
+    # path is a predictable same-user file in /tmp. A row now has to LOOK like
+    # nvidia-smi output -- an nvidia-smi timestamp then exactly six numeric (or
+    # [N/A]) fields -- or it is dropped. This is what makes the allowlist real
+    # rather than nominal.
+    rows = [ln for ln in (out or "").splitlines() if ROW_RE.match(ln.strip())]
+    dropped = len([ln for ln in (out or "").splitlines() if ln.strip()]) - len(rows)
+    if dropped > 0:
+        # Loud, because a persistent nonzero here means the remote file is not
+        # what we wrote and the fetch path needs looking at, not silencing.
+        print(f"[gpu-trace] dropped {dropped} malformed row(s) from {instance}", flush=True)
+    if not rows:
+        print(f"[gpu-trace] no samples returned from {instance}", flush=True)
+        return
+
+    dest = results_root / "gputrace"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / f"{token}.csv").write_text(
+        CSV_HEADER + "\n" + "\n".join(rows) + "\n", encoding="utf-8"
+    )
+
+    # Everything the collector needs to answer "declared versus observed"
+    # without re-deriving it from paths. `instance` is the only fleet-side
+    # identifier emitted; no IP, no hostname, no credentials.
+    sidecar = {
+        "schema": 1,
+        "instance": instance,
+        "gpu_name": meta.get("gpu_name", ""),
+        "declared_gpu_count": meta.get("declared_gpu_count"),
+        "run_id": meta.get("run_id"),
+        "skill": meta.get("skill"),
+        "spec_stem": meta.get("spec_stem"),
+        "platform": meta.get("platform"),
+        "step": meta.get("step"),
+        "interval_sec": INTERVAL_SEC,
+        "started_at": meta.get("started_at"),
+        "finished_at": time.time(),
+        "samples": len(rows),
+    }
+    (dest / f"{token}.json").write_text(
+        json.dumps(sidecar, indent=2) + "\n", encoding="utf-8"
+    )
+    span = sidecar["finished_at"] - (meta.get("started_at") or sidecar["finished_at"])
+    print(f"[gpu-trace] {len(rows)} samples over {span / 60:.1f} min "
+          f"-> {dest / (token + '.csv')}", flush=True)

--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -55,8 +55,12 @@ DESIGN CONSTRAINTS, each paid for by a previous incident:
   `_reset_docker_runtime` wipes the box between trials, so nothing may be left
   there.
 
-The declared-versus-observed comparison is the point: `declared_gpu_count` comes
-from the spec and travels in the sidecar next to what the GPUs actually did.
+The declared-versus-observed comparison is the point: `declared_gpu_count`
+travels in the sidecar next to what the GPUs actually did. It is paired with
+`gpu_count_source`, because an absent declaration resolves to 1 and would
+otherwise be indistinguishable from a spec that asked for exactly one GPU --
+"declared 1, used 1" and "nobody said, used 1" are different findings, and only
+the first is a spec worth leaving alone.
 """
 
 from __future__ import annotations
@@ -100,6 +104,19 @@ CSV_HEADER = (
 # trace. Do not raise the rate because you can: a 2h leg already yields ~1440
 # rows for a 2-GPU box, and the collector aggregates them anyway.
 INTERVAL_SEC = _int_env("EVAL_GPU_TRACE_INTERVAL", 10)
+
+# Where the declared count came from, because the number alone cannot say.
+# `run_leg.pool_candidates` resolves an ABSENT `gpu_count` to 1, so a sidecar
+# reading `declared_gpu_count: 1` may mean "the spec asked for one GPU" or "the
+# spec said nothing and one is the default" -- and 15 of the 50 platform entries
+# in `skills/*/evals/` say nothing (plan_matrix.DEFAULT_GPU_COUNT). Collapsing
+# those two into the same number quietly weakens the comparison this module
+# exists for: "declared 1, used 1" is a spec doing exactly what it asked for,
+# while "defaulted to 1, used 1" says only that nobody ever stated a
+# requirement. An allowlist rather than a free string, for the same reason the
+# CSV has one: this value is written into a published artifact.
+GPU_COUNT_SOURCES = ("spec", "default")
+GPU_COUNT_SOURCE_FALLBACK = "default"
 
 # A row is accepted only if it has exactly these 7 fields, the first parses as
 # an nvidia-smi timestamp and the rest are numeric (or the literal [N/A] that
@@ -269,6 +286,7 @@ def trace(
     step: int = 1,
     chain: str = "",
     declared_gpu_count: int | None = None,
+    gpu_count_source: str = GPU_COUNT_SOURCE_FALLBACK,
     skill: str = "",
     harbor_timeout_sec: int = 7800,
 ):
@@ -282,6 +300,12 @@ def trace(
     if not ENABLED or not instance:
         yield
         return
+
+    # Normalise before it can reach the artifact. A caller passing something
+    # unexpected gets the conservative reading -- "nobody stated a requirement"
+    # -- rather than an arbitrary string in a published file.
+    if gpu_count_source not in GPU_COUNT_SOURCES:
+        gpu_count_source = GPU_COUNT_SOURCE_FALLBACK
 
     run_id = os.environ.get("GITHUB_RUN_ID", "local")
     token = _token(run_id, spec_stem, platform, step, chain)
@@ -383,6 +407,7 @@ def trace(
                     run_id=run_id, skill=skill, spec_stem=spec_stem,
                     platform=platform, step=step, chain=chain,
                     declared_gpu_count=declared_gpu_count,
+                    gpu_count_source=gpu_count_source,
                     started_at=started_at)
 
 
@@ -491,11 +516,21 @@ def _finish(
     # Everything the collector needs to answer "declared versus observed"
     # without re-deriving it from paths. `instance` is the only fleet-side
     # identifier emitted; no IP, no hostname, no credentials.
+    # schema 2 adds `gpu_count_source`. Bumped rather than added silently: a
+    # reader that treats `declared_gpu_count` as a stated requirement is wrong
+    # for the defaulted case, and the version is how it finds out. Safe to bump
+    # because no schema-1 sidecar has ever been produced -- this module has not
+    # merged, so there is nothing in the artifact store to stay compatible with.
     sidecar = {
-        "schema": 1,
+        "schema": 2,
         "instance": instance,
 
         "declared_gpu_count": meta.get("declared_gpu_count"),
+        # "spec" -> the number above was stated. "default" -> it was inferred,
+        # and only the observed columns carry information.
+        "gpu_count_source": meta.get(
+            "gpu_count_source", GPU_COUNT_SOURCE_FALLBACK
+        ),
         "run_id": meta.get("run_id"),
         "skill": meta.get("skill"),
         "spec_stem": meta.get("spec_stem"),

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -40,6 +40,16 @@ import tempfile
 import threading
 import time
 import urllib.parse
+try:
+    import gpu_trace
+except Exception:  # noqa: BLE001 - telemetry is never load-bearing
+    # Deliberately broader than ImportError. gpu_trace reads its knobs at module
+    # scope, so a malformed EVAL_GPU_TRACE_INTERVAL used to raise ValueError
+    # here and fail the leg before main() ran -- telemetry config breaking the
+    # thing it observes. run_leg.py is normally executed as a script so its own
+    # directory is on sys.path; imported any other way, a missing or broken
+    # sampler must degrade to "no trace", never to a failed leg.
+    gpu_trace = None
 
 # Self-contained instrumentation with its own module state. Split out because
 # this file is long enough that a reader looking for the lock or the Harbor
@@ -1272,6 +1282,7 @@ def run_invocations(
     platform: str,
     harbor_timeout_sec: int,
     work_deadline: float | None = None,
+    declared_gpu_count: int | None = None,
 ) -> int:
     env = harbor_env(instance)
     agent = os.environ.get("EVAL_AGENT", "claude-code")
@@ -1354,8 +1365,29 @@ def run_invocations(
 
         cmd = build_harbor_command(invocation, results_root, model, base_url, agent)
         started_at = time.time() - 1.0
+        # Nested inside the phase, not beside it: the phase is the leg-level
+        # accounting for this invocation, so the sampler's own start and stop
+        # cost belongs inside the number rather than hidden next to it.
         with phase(f"harbor:{invocation.include_task_name}"):
-            rc = run_command(cmd, env, harbor_timeout_sec)
+            # Sample the box's GPUs for exactly this harbor invocation.
+            # Per-step, not per-leg: step-1 pays the cold deploy and later steps
+            # reuse it, so one trace spanning both would average away the
+            # difference that matters. The context manager is a no-op if
+            # tracing is disabled or the box is unreachable, and it never raises.
+            if gpu_trace is not None:
+                with gpu_trace.trace(
+                    instance,
+                    results_root,
+                    spec_stem=spec_stem,
+                    platform=platform,
+                    step=invocation.step_index or 1,
+                    declared_gpu_count=declared_gpu_count,
+                    skill=os.environ.get("EVAL_SKILL", ""),
+                    harbor_timeout_sec=harbor_timeout_sec,
+                ):
+                    rc = run_command(cmd, env, harbor_timeout_sec)
+            else:
+                rc = run_command(cmd, env, harbor_timeout_sec)
         # Publish before the rc checks below: a timed-out (rc=124) trial
         # returns early, and its partial trace is exactly what needs reading.
         try:
@@ -1531,6 +1563,10 @@ def main(argv: list[str] | None = None) -> int:
                     args.platform,
                     args.harbor_timeout_sec,
                     work_deadline,
+                    # The declaration under test. It has to travel with the
+                    # measurement, because "declared 2 GPUs, used 1" is the whole
+                    # question and the spec is the only place the 2 comes from.
+                    declared_gpu_count=int(metadata.get("gpu_count", 1) or 0),
                 )
         except LockTimeoutError:
             leg_timing.record_phase(

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -1283,6 +1283,7 @@ def run_invocations(
     harbor_timeout_sec: int,
     work_deadline: float | None = None,
     declared_gpu_count: int | None = None,
+    gpu_count_source: str = "default",
 ) -> int:
     env = harbor_env(instance)
     agent = os.environ.get("EVAL_AGENT", "claude-code")
@@ -1386,6 +1387,7 @@ def run_invocations(
                     # silently replaced the first.
                     chain=str(invocation.chain_key or invocation.include_task_name or ""),
                     declared_gpu_count=declared_gpu_count,
+                    gpu_count_source=gpu_count_source,
                     skill=os.environ.get("EVAL_SKILL", ""),
                     harbor_timeout_sec=harbor_timeout_sec,
                 ):
@@ -1576,7 +1578,19 @@ def main(argv: list[str] | None = None) -> int:
                     # The declaration under test. It has to travel with the
                     # measurement, because "declared 2 GPUs, used 1" is the whole
                     # question and the spec is the only place the 2 comes from.
+                    #
+                    # The resolved count keeps pool_candidates' exact reading
+                    # (absent -> 1, explicit 0/null -> GPU-independent), while
+                    # the source says whether that number was ever stated:
+                    # 15 of the 50 platform entries in skills/*/evals/ omit
+                    # gpu_count, and for those "declared 1" is this default
+                    # talking, not the spec. Without the second field the
+                    # sidecar cannot tell a satisfied requirement from an
+                    # absent one.
                     declared_gpu_count=int(metadata.get("gpu_count", 1) or 0),
+                    gpu_count_source=(
+                        "spec" if "gpu_count" in metadata else "default"
+                    ),
                 )
         except LockTimeoutError:
             leg_timing.record_phase(

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -1381,6 +1381,10 @@ def run_invocations(
                     spec_stem=spec_stem,
                     platform=platform,
                     step=invocation.step_index or 1,
+                    # Two chains of one leg can share a step index, and without
+                    # this they wrote the same trace file and the second
+                    # silently replaced the first.
+                    chain=str(invocation.chain_key or invocation.include_task_name or ""),
                     declared_gpu_count=declared_gpu_count,
                     skill=os.environ.get("EVAL_SKILL", ""),
                     harbor_timeout_sec=harbor_timeout_sec,

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -1474,10 +1474,16 @@ def _terminate(signum: int, _frame) -> None:
     terminates the interpreter without unwinding, so no `finally` and no
     context-manager exit fires. That matters here because `skills-eval.yml`
     sets `cancel-in-progress: true`: every push to a pull request SIGTERMs the
-    in-flight legs, up to `max-parallel` of them at once. Without this, a
-    cancelled leg never reaches the phase-timing write in main()'s finally, so
-    it produces no artifact at all -- and a leg cancelled after an hour in the
-    lock queue is one of the most informative things this feature can record.
+    in-flight legs, up to `max-parallel` of them at once. Two things are lost
+    without this, and a leg cancelled after an hour in the lock queue is one of
+    the most informative runs either of them could describe:
+
+    * the phase-timing write in main()'s finally never runs, so the leg
+      produces no timing artifact at all;
+    * the GPU sampler on each of those boxes is orphaned until its own remote
+      hard stop, over two hours, while the box is handed straight to the next
+      leg. The partial trace is lost, and a partial trace from a cancelled leg
+      is exactly the kind the workflow already goes out of its way to archive.
     """
     raise SystemExit(128 + signum)
 

--- a/.github/skill-eval/tests/test_gpu_trace.py
+++ b/.github/skill-eval/tests/test_gpu_trace.py
@@ -426,6 +426,27 @@ class TheOtherRegexGuardsAnInterpolation(unittest.TestCase):
         self.assertNotIn("rm -f /tmp/CANARY_VICTIM", cmds,
                          f"injected command survived DIR_RE: {cmds!r}")
 
+    def test_a_valid_pid_with_a_rejected_directory_still_checks_identity(self):
+        """The branch this exercises used to run a bare `kill <pid>`.
+
+        A valid PID whose DIR fails DIR_RE takes a separate cleanup path from
+        the normal one, and that path had no identity check at all -- while the
+        code immediately below it documented, with a reproduction, why killing
+        an unvalidated pid signals whatever inherited it. The nonce is
+        unavailable here by definition (the nonce IS the rejected directory),
+        so the guard matches the sampler's `vss-gputrace` argv prefix instead.
+        """
+        with tempfile.TemporaryDirectory() as out, Stub(hostile_dir=True) as stub:
+            with mod.trace("box", Path(out), spec_stem="hostiledir"):
+                pass
+            kills = [c for c in stub.commands() if "kill " in c]
+        self.assertTrue(kills, "the degraded path never tried to stop the sampler")
+        for c in kills:
+            self.assertIn("ps -o args= -p", c,
+                          f"pid signalled with no identity check at all: {c!r}")
+            self.assertRegex(c, r"grep[^;|]*&&\s*kill\b",
+                             f"identity check does not gate the kill: {c!r}")
+
     def test_a_row_with_a_valid_prefix_and_a_garbage_suffix_is_dropped(self):
         """Every existing negative fails on the PREFIX. Deleting ROW_RE's
         trailing anchor lets a well-formed row carry anything after it, which
@@ -449,6 +470,27 @@ class TheChainIdentityIsCarried(unittest.TestCase):
         a = mod._token("30515350883", "search", "RTX", 1, "chainA")
         b = mod._token("30515350883", "search", "RTX", 1, "chainB")
         self.assertNotEqual(a, b, "two chains produce the same trace filename")
+
+    def test_chains_do_not_collide_when_the_spec_name_is_long(self):
+        """The assertion above uses a 6-character spec name, so it passed while
+        `chain` still sat INSIDE the truncated head and a long spec name pushed
+        it off the end. That is the same defect already fixed for `step`, and it
+        survived here because nothing exercised the 100-character boundary."""
+        long_spec = "x" * 100
+        a = mod._token("30515350883", long_spec, "RTX", 1, "chainA")
+        b = mod._token("30515350883", long_spec, "RTX", 1, "chainB")
+        self.assertNotEqual(
+            a, b, "a long spec name truncates the chain away and the second "
+                  f"trace silently overwrites the first: {a!r}")
+
+    def test_the_step_suffix_survives_a_long_spec_and_a_long_chain(self):
+        """Both discriminators have to outlive truncation, not just one."""
+        for n in (1, 2):
+            t = mod._token("30515350883", "x" * 100, "RTX", n, "y" * 50)
+            self.assertTrue(t.endswith(f"-step{n}"), t)
+        self.assertNotEqual(
+            mod._token("30515350883", "x" * 100, "RTX", 1, "y" * 50),
+            mod._token("30515350883", "x" * 100, "RTX", 1, "z" * 50))
 
     def test_chains_do_not_overwrite_each_other_end_to_end(self):
         with tempfile.TemporaryDirectory() as out, Stub():
@@ -706,8 +748,17 @@ class TheHardStopIsPresent(unittest.TestCase):
         guard = finish.split("kill")[0]
         self.assertIn("ps -o args= -p", guard,
                       f"pid is signalled without an identity check: {finish!r}")
-        self.assertRegex(guard, r"grep -q /tmp/vss-gputrace\.[A-Za-z0-9]{8}",
+        # Assert the nonce is matched, without pinning the exact grep flags --
+        # an earlier revision of this assertion hardcoded `grep -q ` and so
+        # failed when the match was tightened to the fixed-string `grep -qF`,
+        # which is a stricter version of the very property being asserted.
+        self.assertRegex(guard, r"grep -[a-zA-Z]*q[a-zA-Z]* .*/tmp/vss-gputrace\.[A-Za-z0-9]{8}",
                          f"identity check is not scoped to this invocation: {finish!r}")
+        # The guard must GATE the kill, not merely precede it. `grep ...; kill`
+        # reads almost identically and passes any text-only assertion while
+        # killing unconditionally, which is the defect this test exists for.
+        self.assertRegex(finish, r"grep[^;|]*&&\s*kill\b",
+                         f"identity check does not gate the kill: {finish!r}")
 
     def test_only_one_command_is_backgrounded_and_it_closes_its_pipe(self):
         """`mkdir && nohup ... &` backgrounds the whole AND-list, so `$!` is a

--- a/.github/skill-eval/tests/test_gpu_trace.py
+++ b/.github/skill-eval/tests/test_gpu_trace.py
@@ -1019,6 +1019,60 @@ class Output(unittest.TestCase):
         self.assertGreater(d["samples"], 0)
         self.assertGreater(d["finished_at"], 0)
 
+    def test_sidecar_separates_a_stated_count_from_a_defaulted_one(self):
+        """`declared_gpu_count: 1` is ambiguous on its own.
+
+        `run_leg.pool_candidates` resolves an absent `gpu_count` to 1, so the
+        number alone cannot distinguish a spec that asked for one GPU from a
+        spec that asked for nothing. 15 of the 50 platform entries in
+        `skills/*/evals/` are the second kind, and reading them as the first
+        turns "no requirement was ever stated" into "the requirement was met".
+        """
+        with tempfile.TemporaryDirectory() as out:
+            _, js = self._run(out, gpu_count_source="spec")
+            stated = json.loads(js.read_text())
+        with tempfile.TemporaryDirectory() as out:
+            _, js = self._run(out, gpu_count_source="default")
+            defaulted = json.loads(js.read_text())
+        self.assertEqual(stated["gpu_count_source"], "spec")
+        self.assertEqual(defaulted["gpu_count_source"], "default")
+        # Same number, different meaning -- which is the whole point of the
+        # field. If these two ever compare equal the ambiguity is back.
+        self.assertEqual(
+            stated["declared_gpu_count"], defaulted["declared_gpu_count"]
+        )
+        self.assertNotEqual(
+            stated["gpu_count_source"], defaulted["gpu_count_source"]
+        )
+
+    def test_sidecar_refuses_a_source_outside_the_allowlist(self):
+        """The value reaches a published artifact, so it is not a free string.
+
+        Anything unrecognised degrades to "default", the conservative reading:
+        it claims only that no requirement was stated, which is never a
+        stronger assertion than the truth.
+        """
+        for hostile in ("spec\nevil", "SPEC", "", "../../etc/passwd", "1"):
+            with self.subTest(source=hostile):
+                with tempfile.TemporaryDirectory() as out:
+                    _, js = self._run(out, gpu_count_source=hostile)
+                    d = json.loads(js.read_text())
+                self.assertEqual(d["gpu_count_source"], "default")
+                self.assertIn(d["gpu_count_source"], mod.GPU_COUNT_SOURCES)
+
+    def test_sidecar_declares_its_schema_version(self):
+        """A reader must be able to tell whether `gpu_count_source` is there.
+
+        Schema 1 sidecars carried `declared_gpu_count` with no way to know it
+        might be a default, so the version is how a collector learns it may
+        now trust the distinction.
+        """
+        with tempfile.TemporaryDirectory() as out:
+            _, js = self._run(out)
+            d = json.loads(js.read_text())
+        self.assertEqual(d["schema"], 2)
+        self.assertIn("gpu_count_source", d)
+
     def test_sidecar_carries_no_host_identifiers_beyond_the_box_name(self):
         with tempfile.TemporaryDirectory() as out:
             _, js = self._run(out)

--- a/.github/skill-eval/tests/test_gpu_trace.py
+++ b/.github/skill-eval/tests/test_gpu_trace.py
@@ -56,6 +56,13 @@ cmd = argv[-1] if argv else ""
 # to the fetch command passed all 22 tests. A stub that does not run the
 # command cannot notice the command growing a payload, which is precisely the
 # boundary these tests exist to protect.
+if os.environ.get("GPUTRACE_STUB_HOSTILE_DIR") == "1" and "echo PID=$!" in cmd:
+    # A box replying with a directory that carries shell syntax. Without the
+    # trailing anchor on DIR_RE this lands inside `rm -rf {remote_dir}`.
+    sys.stdout.write("PID=4242\n")
+    sys.stdout.write("DIR=/tmp/vss-gputrace.aaaaaaaa; rm -f /tmp/CANARY_VICTIM #\n")
+    sys.stdout.write(argv[1] + "\n" if len(argv) > 1 else "")
+    raise SystemExit
 if os.environ.get("GPUTRACE_STUB_HOSTILE_PID") == "1" and "echo PID=$!" in cmd:
     # A compromised or confused box reports shell syntax where a pid belongs.
     sys.stdout.write("PID=1; touch " + os.environ["GPUTRACE_STUB_HOME"] + "/PWNED\n")
@@ -85,35 +92,151 @@ SMI_RUN_SEC = 8
 # killed" passed while the wrong number was being killed.
 STUB_PID = "4242"
 NVIDIA_SMI_STUB = r"""#!/usr/bin/env python3
-import sys, time
-if "--query-gpu=name" in " ".join(sys.argv):
-    print("NVIDIA RTX PRO 6000 Blackwell Server Edition"); raise SystemExit
-for n in range(2):
-    print(f"2026/08/01 21:00:{n:02d}.000, 0, 0, 0, 42800, 97887, 71.2")
-    print(f"2026/08/01 21:00:{n:02d}.000, 1, 97, 3, 74600, 97887, 310.5")
-# A polluted line in the remote file, which a same-user /tmp path can acquire.
-# It has seven comma-separated fields, so a comma-COUNT filter publishes it.
-print("NGC_CLI_API_KEY=CANARYSECRET,a,b,c,d,e,f")
-sys.stdout.flush()
-if "-l" in sys.argv:
-    time.sleep(%d)
-""" % SMI_RUN_SEC
+# A fake that IMPLEMENTS nvidia-smi's contract rather than encoding whatever the
+# caller happens to ask for. Three independent reviews found the previous
+# version ignored argv entirely, so deleting `--query-gpu=...`, appending
+# `gpu_uuid,gpu_serial`, adding `-i 0`, or changing `--format` all passed the
+# entire suite while collecting nothing usable on a real box.
+#
+# Rows are BUILT FROM THE PARSED FIELD LIST, so reordering or extending the
+# query changes the output and its column count. That is what makes a drift
+# between the command and CSV_HEADER visible instead of silent.
+import os, sys, time
+
+def ts(i, n): return "2026/08/01 21:00:{:02d}.000".format(n)
+FIELDS = {
+    "timestamp": ts,
+    "index": lambda i, n: str(i),
+    "name": lambda i, n: "NVIDIA RTX PRO 6000 Blackwell Server Edition",
+    "utilization.gpu": lambda i, n: "97" if i else "0",
+    "utilization.memory": lambda i, n: "3" if i else "0",
+    "memory.used": lambda i, n: "74600" if i else "42800",
+    "memory.total": lambda i, n: "97887",
+    "power.draw": lambda i, n: "310.5" if i else "71.2",
+    "gpu_uuid": lambda i, n: "GPU-deadbeef-0000-0000-0000-00000000000" + str(i),
+    "gpu_serial": lambda i, n: "132000000000" + str(i),
+    "temperature.gpu": lambda i, n: "34",
+    "power.limit": lambda i, n: "600.00",
+}
+UNITS = {"utilization.gpu": " %", "utilization.memory": " %", "memory.used": " MiB",
+         "memory.total": " MiB", "power.draw": " W", "power.limit": " W"}
+
+argv = sys.argv[1:]
+query = None; fmt = ""; loop = None; outfile = None; ids = None
+k = 0
+while k < len(argv):
+    a = argv[k]
+    if a.startswith("--query-gpu="): query = a.split("=", 1)[1].split(",")
+    elif a.startswith("--format="):  fmt = a.split("=", 1)[1]
+    elif a == "-l": k += 1; loop = argv[k]
+    elif a == "-f": k += 1; outfile = argv[k]
+    elif a in ("-i", "--id"): k += 1; ids = [int(x) for x in argv[k].split(",")]
+    k += 1
+
+if query is None:
+    sys.stderr.write("Invalid combination of input arguments.\n"); raise SystemExit(2)
+for f in query:
+    if f not in FIELDS:
+        sys.stderr.write('Field "' + f + '" is not a valid field to query.\n'); raise SystemExit(2)
+if query == ["name"]:
+    print(FIELDS["name"](0, 0)); raise SystemExit
+
+noheader = "noheader" in fmt; nounits = "nounits" in fmt
+gpus = ids if ids is not None else [0, 1]
+out = open(outfile, "w") if outfile else sys.stdout
+
+def emit(n):
+    if n == 0 and not noheader:
+        out.write(", ".join(query) + "\n")
+    for i in gpus:
+        cells = []
+        for f in query:
+            v = FIELDS[f](i, n)
+            if not nounits and f in UNITS: v += UNITS[f]
+            cells.append(v)
+        out.write(", ".join(cells) + "\n")
+
+if os.environ.get("GPUTRACE_SMI_UNSUPPORTED") == "1":
+    # Real nvidia-smi prints these for unqueryable fields on some SKUs and under
+    # vGPU. ROW_RE accepts [N/A] and rejects [Not Supported]; a test can now say
+    # which is intended instead of the fake never emitting either.
+    out.write("2026/08/01 21:00:00.000, 0, [Not Supported], 0, 42800, 97887, [N/A]\n")
+
+emit(0)
+out.write("NGC_CLI_API_KEY=CANARYSECRET,a,b,c,d,e,f\n")
+out.flush()
+if loop is None: raise SystemExit
+# Actually loop, so the interval is observable rather than merely present.
+n = 1
+end = time.time() + __RUNSEC__
+while time.time() < end:
+    time.sleep(min(float(loop), 0.5)); emit(n); out.flush(); n += 1
+""".replace("__RUNSEC__", str(SMI_RUN_SEC))
 
 # macOS has no GNU `timeout`; the eval boxes are Linux and do. Without one on
 # PATH the executed command fails and no trace is produced, so the suite needs
 # a stand-in that honours `-k N <seconds> <cmd...>` and forwards SIGTERM.
 TIMEOUT_STUB = r"""#!/usr/bin/env python3
-import os, signal, subprocess, sys, threading
+# Implements GNU timeout's contract instead of discarding it. The previous fake
+# parsed the duration off argv and threw it away -- no timer, no escalation, no
+# exit 124 -- so the "hard-bounded lifetime" this module exists for had zero
+# behavioural coverage. Measured consequence: `MAX_SEC=0` and `-k 0` both passed
+# the whole suite, and under real GNU timeout a duration of 0 means the timeout
+# is DISABLED, i.e. exactly the unbounded sampler the bound is there to prevent.
+import os, signal, subprocess, sys, threading, time
+
 a = sys.argv[1:]
+kill_after = None
 if a and a[0] == "-k":
-    a = a[2:]
-a = a[1:]                                   # drop the duration
-p = subprocess.Popen(a)
-def reap(*_):
-    try: p.terminate()
+    if len(a) < 2:
+        sys.stderr.write("timeout: option requires an argument -- 'k'\n"); raise SystemExit(125)
+    kill_after = a[1]; a = a[2:]
+if kill_after is None:
+    # Deliberately stricter than GNU timeout, which allows -k to be absent.
+    # This codebase's hard-stop guarantee IS the escalation: a sampler wedged
+    # in an nvidia-smi driver call ignores SIGTERM, and without SIGKILL it
+    # outlives the bound on a machine we are renting.
+    sys.stderr.write("timeout-stub: -k is required by this caller's contract\n")
+    raise SystemExit(125)
+if not a:
+    sys.stderr.write("timeout: missing operand\n"); raise SystemExit(125)
+duration, cmd = a[0], a[1:]
+
+def _secs(v, what):
+    try:
+        f = float(v)
+    except ValueError:
+        sys.stderr.write("timeout: invalid time interval '%s'\n" % v); raise SystemExit(125)
+    if f <= 0:
+        # GNU timeout treats 0 as "no timeout at all". The tests refuse it so
+        # that pinning either value to zero is a failure rather than a shrug.
+        sys.stderr.write("timeout-stub: %s of 0 disables the bound; refused\n" % what)
+        raise SystemExit(125)
+    return f
+
+secs = _secs(duration, "duration")
+kill_secs = _secs(kill_after, "kill-after") if kill_after is not None else None
+
+p = subprocess.Popen(cmd, start_new_session=True)
+expired = {"v": False}
+
+def _fire():
+    expired["v"] = True
+    try: os.killpg(p.pid, signal.SIGTERM)
     except Exception: pass
-signal.signal(signal.SIGTERM, reap)
-sys.exit(p.wait())
+    if kill_secs is not None:
+        def _hard():
+            time.sleep(kill_secs)
+            if p.poll() is None:
+                try: os.killpg(p.pid, signal.SIGKILL)
+                except Exception: pass
+        threading.Thread(target=_hard, daemon=True).start()
+
+t = threading.Timer(secs, _fire); t.daemon = True; t.start()
+signal.signal(signal.SIGTERM, lambda *_: _fire())
+rc = p.wait()
+t.cancel()
+sys.exit(124 if expired["v"] else rc)
 """
 
 
@@ -121,12 +244,14 @@ class Stub:
     """Puts a fake `brev` (and a failing `ssh`) first on PATH."""
 
     KEYS = ("PATH", "GPUTRACE_STUB_REC", "GPUTRACE_STUB_FAIL",
-            "GPUTRACE_STUB_HOME", "GPUTRACE_STUB_BIN", "GPUTRACE_STUB_HOSTILE_PID")
+            "GPUTRACE_STUB_HOME", "GPUTRACE_STUB_BIN", "GPUTRACE_STUB_HOSTILE_PID",
+            "GPUTRACE_STUB_HOSTILE_DIR")
 
     def __init__(self, fail: bool = False, hostile_pid: bool = False,
-                 payload: str | None = None):
+                 payload: str | None = None, hostile_dir: bool = False):
         self.fail = fail
         self.hostile_pid = hostile_pid
+        self.hostile_dir = hostile_dir
         # Override what the fake nvidia-smi emits, so a test can assert on how
         # many samples survive the round trip rather than on a fixed fixture.
         self.payload = payload
@@ -149,11 +274,17 @@ class Stub:
         self.bin.mkdir()
         smi = NVIDIA_SMI_STUB
         if self.payload is not None:
+            # Honours -f like the real binary and like the main fake. A payload
+            # override that wrote to stdout would silently produce no trace once
+            # the production command stopped using a shell redirect -- the same
+            # "fake encodes the caller's assumption" trap, one level down.
             smi = ('#!/usr/bin/env python3\nimport sys, time\n'
-                   'if "--query-gpu=name" in " ".join(sys.argv):\n'
+                   'argv = sys.argv[1:]\n'
+                   'if "--query-gpu=name" in " ".join(argv):\n'
                    '    print("FAKE"); raise SystemExit\n'
-                   'sys.stdout.write(%r)\nsys.stdout.flush()\n'
-                   'if "-l" in sys.argv: time.sleep(%d)\n'
+                   'out = open(argv[argv.index("-f") + 1], "w") if "-f" in argv else sys.stdout\n'
+                   'out.write(%r)\nout.flush()\n'
+                   'if "-l" in argv: time.sleep(%d)\n'
                    % (self.payload if self.payload.endswith("\n") else self.payload + "\n",
                       SMI_RUN_SEC))
         for name, body in (("nvidia-smi", smi), ("timeout", TIMEOUT_STUB)):
@@ -167,6 +298,7 @@ class Stub:
         os.environ["GPUTRACE_STUB_HOME"] = str(self.home)
         os.environ["GPUTRACE_STUB_BIN"] = str(self.bin)
         os.environ["GPUTRACE_STUB_HOSTILE_PID"] = "1" if self.hostile_pid else "0"
+        os.environ["GPUTRACE_STUB_HOSTILE_DIR"] = "1" if self.hostile_dir else "0"
         return self
 
     def commands(self) -> list[str]:
@@ -259,6 +391,185 @@ class NothingButGpuMetricsCanReachTheArtifact(unittest.TestCase):
                          "an unvalidated pid was interpolated into the kill")
 
 
+class TheOtherRegexGuardsAnInterpolation(unittest.TestCase):
+    """DIR_RE guards the same kind of interpolation PID_RE does, and had no
+    test at all. Removing its `$` anchor -- one character -- lets a remote
+    reply carry a trailing `; rm -f <path> #` straight into `rm -rf {dir}`,
+    which was demonstrated end to end by deleting a victim file."""
+
+    def test_a_directory_carrying_shell_syntax_is_refused(self):
+        for hostile in (
+            "/tmp/vss-gputrace.aaaaaaaa; rm -rf /",
+            "/tmp/vss-gputrace.aaaaaaaa && curl evil",
+            "/tmp/vss-gputrace.aaaaaaaa\nrm -rf /",
+            "/tmp/vss-gputrace.aaaaaaaa/../../etc",
+            "/tmp/vss-gputrace.$(id)",
+            "/etc", "", "/tmp/vss-gputrace.short",
+        ):
+            self.assertIsNone(mod.DIR_RE.match(hostile), hostile)
+        self.assertTrue(mod.DIR_RE.match("/tmp/vss-gputrace.aB3xY9zQ"))
+
+    def test_the_regex_is_anchored_at_both_ends(self):
+        """Asserted explicitly because a trailing-anchor deletion is invisible
+        to every match-based test that only feeds it clean values."""
+        self.assertTrue(mod.DIR_RE.pattern.startswith("^"))
+        self.assertTrue(mod.DIR_RE.pattern.endswith("$"))
+        self.assertTrue(mod.ROW_RE.pattern.endswith("$"))
+        self.assertTrue(mod.PID_RE.pattern.endswith("$"))
+
+    def test_a_hostile_directory_never_reaches_the_cleanup_shell(self):
+        """End to end, mirroring the hostile-pid test."""
+        with tempfile.TemporaryDirectory() as out, Stub(hostile_dir=True) as stub:
+            with mod.trace("box", Path(out), spec_stem="hostiledir"):
+                pass
+            cmds = " ".join(stub.commands())
+        self.assertNotIn("rm -f /tmp/CANARY_VICTIM", cmds,
+                         f"injected command survived DIR_RE: {cmds!r}")
+
+    def test_a_row_with_a_valid_prefix_and_a_garbage_suffix_is_dropped(self):
+        """Every existing negative fails on the PREFIX. Deleting ROW_RE's
+        trailing anchor lets a well-formed row carry anything after it, which
+        is the PR #516 channel restored by one byte."""
+        good = "2026/08/01 21:00:00.000, 1, 97, 3, 74600, 97887, 310.5"
+        self.assertTrue(mod.ROW_RE.match(good))
+        for suffix in (
+            ",-----BEGIN OPENSSH PRIVATE KEY----- CANARYSECRET",
+            " -----BEGIN OPENSSH PRIVATE KEY-----",
+            ",nvapi-CANARYSECRET",
+            ", 1, 2, 3",
+        ):
+            self.assertIsNone(mod.ROW_RE.match(good + suffix), suffix)
+
+
+class TheChainIdentityIsCarried(unittest.TestCase):
+    """`chain` appeared zero times in this file, while run_leg.py passes a real
+    chain_key and two chains sharing a step index wrote the same filename."""
+
+    def test_two_chains_at_the_same_step_do_not_collide(self):
+        a = mod._token("30515350883", "search", "RTX", 1, "chainA")
+        b = mod._token("30515350883", "search", "RTX", 1, "chainB")
+        self.assertNotEqual(a, b, "two chains produce the same trace filename")
+
+    def test_chains_do_not_overwrite_each_other_end_to_end(self):
+        with tempfile.TemporaryDirectory() as out, Stub():
+            for chain in ("remote-all", "standalone"):
+                with mod.trace("box", Path(out), spec_stem="search",
+                               platform="RTX", step=1, chain=chain):
+                    time.sleep(BODY_SETTLE_SEC)
+            self.assertEqual(len(list((Path(out) / "gputrace").glob("*.csv"))), 2)
+
+
+class NoSamplesMeansNoFile(unittest.TestCase):
+    """A trace file that says "declared 2 GPUs, 0 samples over 70 minutes" is
+    indistinguishable from a genuinely idle 2-GPU box and argues directly for
+    the irreversible downgrade. Absence is the only honest answer."""
+
+    def test_an_empty_fetch_writes_nothing_at_all(self):
+        with tempfile.TemporaryDirectory() as out, Stub(payload=""):
+            with mod.trace("box", Path(out), spec_stem="nosamples",
+                           declared_gpu_count=2):
+                time.sleep(BODY_SETTLE_SEC)
+            # Asserted INSIDE the TemporaryDirectory. Outside it the directory
+            # is already gone and `.exists()` is vacuously False, so the test
+            # passes without testing anything -- which is exactly what it did.
+            d = Path(out) / "gputrace"
+            written = sorted(p.name for p in d.glob("*")) if d.exists() else []
+        self.assertEqual(written, [], "a zero-sample trace was published as fact")
+
+    def test_rows_that_all_fail_the_filter_write_nothing(self):
+        with tempfile.TemporaryDirectory() as out, Stub(payload="garbage\nmore garbage\n"):
+            with mod.trace("box", Path(out), spec_stem="allbad"):
+                time.sleep(BODY_SETTLE_SEC)
+            d = Path(out) / "gputrace"
+            written = sorted(p.name for p in d.glob("*")) if d.exists() else []
+        self.assertEqual(written, [],
+                         "rows that all failed the filter were published anyway")
+
+
+class TheKnobsParseSafely(unittest.TestCase):
+    """_int_env and the ENABLED parse had no test. A malformed knob used to
+    fail the leg at import; a zero one disables the caps it guards."""
+
+    def test_int_env_rejects_garbage_and_non_positive(self):
+        for raw in ("garbage", "", "-1", "0", "1.5", None):
+            env = {} if raw is None else {"X_KNOB": raw}
+            old = os.environ.pop("X_KNOB", None)
+            os.environ.update(env)
+            try:
+                self.assertEqual(mod._int_env("X_KNOB", 42), 42, repr(raw))
+            finally:
+                os.environ.pop("X_KNOB", None)
+                if old is not None:
+                    os.environ["X_KNOB"] = old
+
+    def test_int_env_accepts_a_real_override(self):
+        os.environ["X_KNOB"] = "7"
+        try:
+            self.assertEqual(mod._int_env("X_KNOB", 42), 7)
+        finally:
+            os.environ.pop("X_KNOB", None)
+
+    def test_the_documented_opt_out_string_actually_disables(self):
+        """`EVAL_GPU_TRACE=0` is the documented kill switch. Tests that set
+        mod.ENABLED directly never exercise the parse that implements it."""
+        import importlib
+        for raw, want in (("0", False), ("false", False), ("False", False),
+                          ("", False), ("1", True), ("yes", True)):
+            os.environ["EVAL_GPU_TRACE"] = raw
+            try:
+                importlib.reload(mod)
+                self.assertIs(mod.ENABLED, want, f"EVAL_GPU_TRACE={raw!r}")
+            finally:
+                os.environ.pop("EVAL_GPU_TRACE", None)
+        importlib.reload(mod)
+
+
+class TheFetchCapCountsBytes(unittest.TestCase):
+    """The cap's whole purpose is bounding memory. Nothing drove more than a
+    few KB through it, so counting characters instead of bytes, or counting
+    chunks instead of length, or dropping the killpg were all invisible."""
+
+    def test_the_cap_is_enforced_and_reported(self):
+        old = mod.MAX_FETCH_BYTES
+        mod.MAX_FETCH_BYTES = 4096
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, "-c",
+                 "import sys; sys.stdout.write('x' * 200000)"],
+                stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL, text=True, start_new_session=True)
+            out = mod._read_capped(proc, 20)
+        finally:
+            mod.MAX_FETCH_BYTES = old
+        self.assertLessEqual(len(out.encode("utf-8")), 4096,
+                             "the cap counted something other than bytes")
+
+    def test_an_endless_source_is_killed_not_merely_truncated(self):
+        old = mod.MAX_FETCH_BYTES
+        mod.MAX_FETCH_BYTES = 2048
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, "-c",
+                 "import sys, time\n"
+                 "while True:\n"
+                 "    sys.stdout.write('y' * 8192); sys.stdout.flush()"],
+                stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL, text=True, start_new_session=True)
+            mod._read_capped(proc, 20)
+            time.sleep(1)
+            alive = proc.poll() is None
+        finally:
+            mod.MAX_FETCH_BYTES = old
+            with contextlib_suppress():
+                proc.kill()
+        self.assertFalse(alive, "the emitter kept running after the cap fired")
+
+
+def contextlib_suppress():
+    import contextlib
+    return contextlib.suppress(Exception)
+
+
 class RemoteCallsAreBounded(unittest.TestCase):
     def test_remote_respects_a_total_deadline_across_both_attempts(self):
         """The timeout used to be per attempt, so a hung box cost 2x120s. It is
@@ -337,6 +648,18 @@ class TheHardStopIsPresent(unittest.TestCase):
         self.assertNotIn("search", start.split("nvidia-smi")[0],
                          f"job identity leaked into the remote path: {start!r}")
 
+    def test_the_bound_escalates_to_sigkill(self):
+        """`-k` is the whole guarantee: SIGTERM alone cannot stop a sampler
+        wedged in a driver call. The floor on hard_stop is 900s so a real
+        expiry cannot be driven from a test, hence the explicit assertion --
+        the fake refuses a missing -k, which covers the behaviour."""
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("box", Path(out)):
+                pass
+            start = stub.commands()[0]
+        self.assertRegex(start, r"timeout -k [1-9][0-9]* [0-9]+",
+                         f"no SIGKILL escalation on the hard stop: {start!r}")
+
     def test_hard_stop_has_a_floor_for_tiny_timeouts(self):
         with tempfile.TemporaryDirectory() as out, Stub() as stub:
             with mod.trace("box", Path(out), harbor_timeout_sec=1):
@@ -377,8 +700,14 @@ class TheHardStopIsPresent(unittest.TestCase):
                          f"sampler survived the cleanup: {finish!r}")
         # It must also confirm the pid is still OUR sampler before signalling:
         # a pid that was freed and reused points at an unrelated process.
-        self.assertIn("nvidia-smi", finish.split("kill")[0],
+        # Matching the per-invocation nonce directory, not merely "some
+        # nvidia-smi": these boxes run nvidia-smi constantly, so a recycled pid
+        # that happens to be any of them would be killed, possibly another leg's.
+        guard = finish.split("kill")[0]
+        self.assertIn("ps -o args= -p", guard,
                       f"pid is signalled without an identity check: {finish!r}")
+        self.assertRegex(guard, r"grep -q /tmp/vss-gputrace\.[A-Za-z0-9]{8}",
+                         f"identity check is not scoped to this invocation: {finish!r}")
 
     def test_only_one_command_is_backgrounded_and_it_closes_its_pipe(self):
         """`mkdir && nohup ... &` backgrounds the whole AND-list, so `$!` is a

--- a/.github/skill-eval/tests/test_gpu_trace.py
+++ b/.github/skill-eval/tests/test_gpu_trace.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for gpu_trace.py.
+
+This module's whole contract is "collect telemetry, and under no circumstance
+break the leg". So the cases that matter are the failure ones, and the tests
+that matter are the ones that fail when a safety property is removed.
+
+`_remote` shells out, so it is exercised against a real executable on PATH
+rather than being monkeypatched away. A stub that replaces the function cannot
+notice the remote command losing its `timeout` prefix, and that prefix is the
+only thing standing between us and the 213-minute sampler leak this module
+exists to avoid.
+
+Mutations confirmed to fail this suite:
+  * drop `timeout {hard_stop}` from the start command
+  * let `trace()` propagate an exception instead of swallowing it
+  * omit `declared_gpu_count` from the sidecar
+  * add a field to QUERY_FIELDS
+  * skip the `rm -f` of the remote CSV
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import time
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import gpu_trace as mod  # noqa: E402
+
+# A stand-in for `brev` that records the exact command it was handed and
+# replies with two GPUs' worth of plausible nvidia-smi output. Recording argv is
+# what lets the tests assert on the remote command string itself.
+BREV_STUB = r"""#!/usr/bin/env python3
+import sys, os, re, subprocess
+argv = sys.argv[1:]
+rec = os.environ["GPUTRACE_STUB_REC"]
+open(rec, "a").write("\x00".join(argv) + "\n")
+if os.environ.get("GPUTRACE_STUB_FAIL") == "1":
+    sys.stderr.write("boom\n"); sys.exit(1)
+cmd = argv[-1] if argv else ""
+
+# The command is EXECUTED, in a real bash, against a fake nvidia-smi and a
+# scratch HOME seeded with a decoy secret. An earlier version of this stub
+# only recorded argv, and a mutation that appended
+#   awk '{print "0,0,0,0,0,0," $0}' ~/.ssh/id_rsa
+# to the fetch command passed all 22 tests. A stub that does not run the
+# command cannot notice the command growing a payload, which is precisely the
+# boundary these tests exist to protect.
+if os.environ.get("GPUTRACE_STUB_HOSTILE_PID") == "1" and "echo PID=$!" in cmd:
+    # A compromised or confused box reports shell syntax where a pid belongs.
+    sys.stdout.write("PID=1; touch " + os.environ["GPUTRACE_STUB_HOME"] + "/PWNED\n")
+    sys.stdout.write("NVIDIA RTX PRO 6000 Blackwell Server Edition\n")
+    sys.stdout.write(argv[1] + "\n" if len(argv) > 1 else "")
+    raise SystemExit
+env = dict(os.environ)
+env["HOME"] = os.environ["GPUTRACE_STUB_HOME"]
+env["PATH"] = os.environ["GPUTRACE_STUB_BIN"] + os.pathsep + env["PATH"]
+p = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, env=env)
+sys.stdout.write(p.stdout)
+sys.stdout.write(argv[1] + "\n" if len(argv) > 1 else "")
+"""
+
+# Stands in for nvidia-smi. Emits two GPUs' worth of well-formed rows, and
+# under -l keeps running for SMI_RUN_SEC so the backgrounding grammar is
+# genuinely exercised: with the wrong grammar the start call blocks for this
+# long, which is exactly what the timing test measures.
+# A real leg runs for 35 to 120 minutes. The tests must not stop the sampler
+# before it has written anything, or they would be measuring interpreter
+# startup rather than the code under test.
+BODY_SETTLE_SEC = 1.5
+SMI_RUN_SEC = 8
+NVIDIA_SMI_STUB = r"""#!/usr/bin/env python3
+import sys, time
+if "--query-gpu=name" in " ".join(sys.argv):
+    print("NVIDIA RTX PRO 6000 Blackwell Server Edition"); raise SystemExit
+for n in range(2):
+    print(f"2026/08/01 21:00:{n:02d}.000, 0, 0, 0, 42800, 97887, 71.2")
+    print(f"2026/08/01 21:00:{n:02d}.000, 1, 97, 3, 74600, 97887, 310.5")
+# A polluted line in the remote file, which a same-user /tmp path can acquire.
+# It has seven comma-separated fields, so a comma-COUNT filter publishes it.
+print("NGC_CLI_API_KEY=CANARYSECRET,a,b,c,d,e,f")
+sys.stdout.flush()
+if "-l" in sys.argv:
+    time.sleep(%d)
+""" % SMI_RUN_SEC
+
+# macOS has no GNU `timeout`; the eval boxes are Linux and do. Without one on
+# PATH the executed command fails and no trace is produced, so the suite needs
+# a stand-in that honours `-k N <seconds> <cmd...>` and forwards SIGTERM.
+TIMEOUT_STUB = r"""#!/usr/bin/env python3
+import os, signal, subprocess, sys, threading
+a = sys.argv[1:]
+if a and a[0] == "-k":
+    a = a[2:]
+a = a[1:]                                   # drop the duration
+p = subprocess.Popen(a)
+def reap(*_):
+    try: p.terminate()
+    except Exception: pass
+signal.signal(signal.SIGTERM, reap)
+sys.exit(p.wait())
+"""
+
+
+class Stub:
+    """Puts a fake `brev` (and a failing `ssh`) first on PATH."""
+
+    KEYS = ("PATH", "GPUTRACE_STUB_REC", "GPUTRACE_STUB_FAIL",
+            "GPUTRACE_STUB_HOME", "GPUTRACE_STUB_BIN", "GPUTRACE_STUB_HOSTILE_PID")
+
+    def __init__(self, fail: bool = False, hostile_pid: bool = False):
+        self.fail = fail
+        self.hostile_pid = hostile_pid
+
+    def __enter__(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        d = Path(self.tmp.name)
+        self.rec = d / "rec"
+        for name in ("brev", "ssh"):
+            p = d / name
+            p.write_text(BREV_STUB, encoding="utf-8")
+            p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        # A scratch HOME holding a decoy secret. If a mutation ever teaches the
+        # remote command to read it, the canary test below sees it in the CSV.
+        self.home = d / "home"
+        (self.home / ".ssh").mkdir(parents=True)
+        (self.home / ".ssh" / "id_rsa").write_text(
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nCANARYSECRET\n", encoding="utf-8")
+        self.bin = d / "bin"
+        self.bin.mkdir()
+        for name, body in (("nvidia-smi", NVIDIA_SMI_STUB), ("timeout", TIMEOUT_STUB)):
+            f = self.bin / name
+            f.write_text(body, encoding="utf-8")
+            f.chmod(f.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        self.old = {k: os.environ.get(k) for k in self.KEYS}
+        os.environ["PATH"] = f"{d}{os.pathsep}{self.old['PATH']}"
+        os.environ["GPUTRACE_STUB_REC"] = str(self.rec)
+        os.environ["GPUTRACE_STUB_FAIL"] = "1" if self.fail else "0"
+        os.environ["GPUTRACE_STUB_HOME"] = str(self.home)
+        os.environ["GPUTRACE_STUB_BIN"] = str(self.bin)
+        os.environ["GPUTRACE_STUB_HOSTILE_PID"] = "1" if self.hostile_pid else "0"
+        return self
+
+    def commands(self) -> list[str]:
+        """The command string handed to each invocation, in order."""
+        if not self.rec.exists():
+            return []
+        return [ln.split("\x00")[-1]
+                for ln in self.rec.read_text(encoding="utf-8").splitlines() if ln]
+
+    def argvs(self) -> list[list[str]]:
+        if not self.rec.exists():
+            return []
+        return [ln.split("\x00")
+                for ln in self.rec.read_text(encoding="utf-8").splitlines() if ln]
+
+    def __exit__(self, *exc):
+        for k, v in self.old.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self.tmp.cleanup()
+
+
+class NothingButGpuMetricsCanReachTheArtifact(unittest.TestCase):
+    """The stub executes the remote command for real against a scratch HOME
+    seeded with a decoy private key, so a command that grows a payload is
+    caught here rather than in a public artifact."""
+
+    def test_no_secret_from_the_box_reaches_the_csv(self):
+        with tempfile.TemporaryDirectory() as out, Stub():
+            with mod.trace("box", Path(out), spec_stem="search"):
+                time.sleep(BODY_SETTLE_SEC)
+            files = list((Path(out) / "gputrace").glob("*"))
+            self.assertTrue(files, "no trace produced, so this canary proves nothing")
+            body = "".join(p.read_text() for p in files)
+        self.assertNotIn("CANARYSECRET", body)
+        self.assertNotIn("PRIVATE KEY", body)
+
+    def test_a_row_that_is_not_nvidia_smi_shaped_is_dropped(self):
+        """`ln.count(",") >= 6` accepted anything the remote `cat` returned.
+        The remote path is a predictable same-user file in /tmp."""
+        self.assertIsNone(mod.ROW_RE.match("SECRET=a,b,c,d,e,f,g"))
+        self.assertIsNone(mod.ROW_RE.match("0,0,0,0,0,0,-----BEGIN KEY-----"))
+        self.assertIsNone(mod.ROW_RE.match("2026/08/01 21:00:00.000, 0, 0"))
+        self.assertTrue(mod.ROW_RE.match(
+            "2026/08/01 21:00:00.000, 1, 97, 3, 74600, 97887, 310.5"))
+        self.assertTrue(mod.ROW_RE.match(
+            "2026/08/01 21:00:00.000, 0, [N/A], 0, 1800, 97887, [N/A]"))
+
+    def test_a_remote_pid_carrying_shell_syntax_is_refused(self):
+        """The pid is interpolated into a shell command. `PID=1; printf ...`
+        executed in the cleanup shell and its output reached the CSV."""
+        for hostile in ("999; printf x", "1 || rm -rf /", "$(id)", "-1", "",
+                        "1\nrm -rf /", "0"):
+            self.assertIsNone(mod.PID_RE.match(hostile), hostile)
+        self.assertTrue(mod.PID_RE.match("4242"))
+
+    def test_fetch_output_is_capped(self):
+        self.assertLessEqual(mod.MAX_FETCH_BYTES, 64 * 1024 * 1024)
+        self.assertGreater(mod.MAX_FETCH_BYTES, 0)
+
+    def test_a_polluted_remote_file_does_not_reach_the_artifact(self):
+        """END TO END, not a regex unit test. The stub's remote file contains
+        `NGC_CLI_API_KEY=CANARYSECRET,a,b,c,d,e,f` -- seven comma-separated
+        fields, so the original `ln.count(",") >= 6` filter published it
+        verbatim into an artifact that is uploaded publicly. Asserting on
+        ROW_RE alone left that filter free to be loosened again."""
+        with tempfile.TemporaryDirectory() as out, Stub():
+            with mod.trace("box", Path(out), spec_stem="pollute"):
+                time.sleep(BODY_SETTLE_SEC)
+            files = list((Path(out) / "gputrace").glob("*"))
+            self.assertTrue(files, "no trace produced, so this proves nothing")
+            body = "".join(p.read_text() for p in files)
+        self.assertNotIn("CANARYSECRET", body)
+        self.assertNotIn("NGC_CLI_API_KEY", body)
+        self.assertIn("97887", body)          # the real samples did get through
+
+    def test_a_hostile_remote_pid_never_reaches_the_cleanup_shell(self):
+        """END TO END. `PID=1; touch $HOME/PWNED` was executed by the cleanup
+        shell. Asserting on PID_RE alone left the code free to stop using it."""
+        with tempfile.TemporaryDirectory() as out, Stub(hostile_pid=True) as stub:
+            with mod.trace("box", Path(out), spec_stem="hostile"):
+                pass
+            pwned = (stub.home / "PWNED").exists()
+            finish = stub.commands()[-1]
+        self.assertFalse(pwned, "remote-supplied text was executed as shell code")
+        self.assertNotIn("touch", finish, f"injected command survived: {finish!r}")
+        self.assertFalse(finish.startswith("kill 1;"),
+                         "an unvalidated pid was interpolated into the kill")
+
+
+class RemoteCallsAreBounded(unittest.TestCase):
+    def test_remote_respects_a_total_deadline_across_both_attempts(self):
+        """The timeout used to be per attempt, so a hung box cost 2x120s. It is
+        also enforced by killing the process GROUP: subprocess's own timeout
+        reaps only the immediate child, which is the bug envs/brev_env.py
+        already fixes the same way for harbor."""
+        hang = tempfile.mkdtemp()
+        for name in ("brev", "ssh"):
+            f = Path(hang) / name
+            f.write_text("#!/bin/sh\nsleep 60\n", encoding="utf-8")
+            f.chmod(f.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        old = os.environ.get("PATH", "")
+        try:
+            os.environ["PATH"] = f"{hang}{os.pathsep}{old}"
+            t0 = time.monotonic()
+            self.assertIsNone(mod._remote("box", "echo hi", timeout=3))
+            elapsed = time.monotonic() - t0
+        finally:
+            os.environ["PATH"] = old
+        # Two attempts at a 3s PER-ATTEMPT budget would be ~6s. A TOTAL
+        # deadline is ~3s. The bound has to sit between them or the
+        # distinction the test exists for is not being made.
+        self.assertLess(elapsed, 5,
+                        f"deadline is per-attempt, not total ({elapsed:.1f}s)")
+
+
+class TheHardStopIsPresent(unittest.TestCase):
+    """The one property that cannot regress silently.
+
+    Without `timeout`, a sampler survives a SIGKILLed leg and keeps writing
+    across unrelated trials. That already happened once and cost the entire
+    trace.
+    """
+
+    @staticmethod
+    def _bound(cmd: str) -> int:
+        """The duration argument, skipping any `-k N` kill-escalation flag."""
+        parts = cmd.split("timeout ", 1)[1].split()
+        return int(parts[2] if parts[0] == "-k" else parts[0])
+
+    def test_start_command_is_bounded_by_timeout(self):
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("vss-eval-rtx-2g", Path(out), harbor_timeout_sec=7800):
+                pass
+            start = stub.commands()[0]
+        self.assertIn("timeout ", start, f"remote sampler is unbounded: {start!r}")
+        # Must outlive a normal leg, and must not be open-ended.
+        bound = self._bound(start)
+        self.assertGreater(bound, 7800)
+        self.assertLess(bound, 7800 + 3600)
+
+    def test_hard_stop_has_a_floor_for_tiny_timeouts(self):
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("box", Path(out), harbor_timeout_sec=1):
+                pass
+            bound = self._bound(stub.commands()[0])
+        self.assertGreaterEqual(bound, 900)
+
+    def test_remote_csv_is_removed(self):
+        """A box that has been up six weeks must not accumulate traces."""
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("box", Path(out)):
+                pass
+            self.assertIn("rm -f", stub.commands()[-1])
+
+    def test_the_sampler_is_actually_stopped(self):
+        """Deleting the kill left all 22 of the original tests green. The
+        cleanup command must name the pid the start call reported."""
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("box", Path(out)):
+                pass
+            cmds = stub.commands()
+        start, finish = cmds[0], cmds[-1]
+        pid = start.split("echo PID=$!")[0]     # sanity: the start reports one
+        self.assertIn("echo PID=$!", start)
+        self.assertRegex(finish, r"^kill [1-9][0-9]* ",
+                         f"cleanup does not kill the sampler: {finish!r}")
+
+    def test_only_one_command_is_backgrounded_and_it_closes_its_pipe(self):
+        """`mkdir && nohup ... &` backgrounds the whole AND-list, so `$!` is a
+        subshell rather than `timeout` and killing it leaves the sampler alive.
+        That subshell also inherits stdout, so the start call blocks until the
+        SAMPLER exits -- measured at 3.03s under bash for a 3s target versus
+        0.01s under zsh, which is why a zsh laptop never saw it."""
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("box", Path(out)):
+                pass
+            start = stub.commands()[0]
+        head = start.split("&", 1)[0]
+        self.assertNotIn("&&", head,
+                         f"an AND-list is being backgrounded, so $! is a subshell: {start!r}")
+        self.assertIn(">/dev/null 2>&1", start.replace("2>/dev/null </dev/null", ">/dev/null 2>&1")
+                      if "2>/dev/null </dev/null" in start else start,
+                      f"background job keeps a descriptor open: {start!r}")
+
+    def test_the_start_call_does_not_block_on_the_sampler(self):
+        """End to end through a real bash and a real looping nvidia-smi stub."""
+        import time as _t
+        with tempfile.TemporaryDirectory() as out, Stub():
+            t0 = _t.monotonic()
+            with mod.trace("box", Path(out)):
+                pass
+            elapsed = _t.monotonic() - t0
+        self.assertLess(elapsed, SMI_RUN_SEC - 1,
+                        f"start blocked on the sampler ({elapsed:.1f}s); the AND-list grammar is back")
+
+
+class TheAllowlist(unittest.TestCase):
+    """Only GPU metrics leave the box. PR #516 leaked NGC_CLI_API_KEY through
+    artifact collection; this must not become a second such channel."""
+
+    def test_query_fields_are_exactly_the_seven_declared(self):
+        self.assertEqual(
+            mod.QUERY_FIELDS.split(","),
+            ["timestamp", "index", "utilization.gpu", "utilization.memory",
+             "memory.used", "memory.total", "power.draw"],
+        )
+
+    def test_header_matches_the_query_field_count(self):
+        self.assertEqual(len(mod.CSV_HEADER.split(",")),
+                         len(mod.QUERY_FIELDS.split(",")))
+
+    def test_remote_commands_never_read_env_or_process_state(self):
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("box", Path(out)):
+                pass
+            blob = " ".join(stub.commands())
+        for forbidden in ("printenv", "env ", "/proc/", "docker inspect",
+                          "cat /etc", "ps -e", "--query-compute-apps"):
+            self.assertNotIn(forbidden, blob, f"{forbidden!r} would collect more than GPU metrics")
+
+
+class NeverFailsTheLeg(unittest.TestCase):
+    def test_body_runs_when_the_box_is_unreachable(self):
+        ran = []
+        with tempfile.TemporaryDirectory() as out, Stub(fail=True):
+            with mod.trace("box", Path(out)):
+                ran.append(True)
+        self.assertEqual(ran, [True])
+
+    def test_body_runs_when_no_exec_tool_exists_at_all(self):
+        ran = []
+        old = os.environ.get("PATH", "")
+        empty = tempfile.mkdtemp()
+        try:
+            os.environ["PATH"] = empty
+            with tempfile.TemporaryDirectory() as out:
+                with mod.trace("box", Path(out)):
+                    ran.append(True)
+        finally:
+            os.environ["PATH"] = old
+        self.assertEqual(ran, [True])
+
+    def test_an_exception_in_the_body_still_propagates(self):
+        """Swallowing the leg's own failure would hide a real eval error."""
+        with tempfile.TemporaryDirectory() as out, Stub():
+            with self.assertRaises(ValueError):
+                with mod.trace("box", Path(out)):
+                    raise ValueError("the leg failed")
+
+    def test_the_trace_is_still_written_when_the_body_raises(self):
+        """A timed-out trial (rc=124) is exactly the trace worth reading."""
+        with tempfile.TemporaryDirectory() as out, Stub():
+            with self.assertRaises(ValueError):
+                with mod.trace("box", Path(out), spec_stem="search",
+                               platform="RTXPRO6000BW"):
+                    time.sleep(BODY_SETTLE_SEC)
+                    raise ValueError("boom")
+            self.assertTrue(list((Path(out) / "gputrace").glob("*.csv")))
+
+    def test_an_exception_while_writing_the_trace_never_escapes(self):
+        """The finally block is the last thing that runs before the leg's exit
+        status is decided. If _finish raises there -- disk full, read-only
+        mount, results_root removed by a concurrent cleanup -- the exception
+        escapes the `with` and fails a leg that otherwise passed. Writing the
+        trace is never worth that.
+
+        Targets the property directly rather than relying on a path that
+        happens to be unwritable: an earlier version used /dev/null/... and
+        passed for the wrong reason, because _finish returned early before it
+        ever reached the failing mkdir.
+        """
+        ran = []
+        original = mod._finish
+        mod._finish = lambda *a, **k: (_ for _ in ()).throw(OSError("disk full"))
+        try:
+            with tempfile.TemporaryDirectory() as out, Stub():
+                with mod.trace("box", Path(out), spec_stem="search"):
+                    ran.append(True)
+        finally:
+            mod._finish = original
+        self.assertEqual(ran, [True])
+
+    def test_an_unwritable_results_root_does_not_fail_the_leg(self):
+        """The realistic form of the same thing, end to end."""
+        ran = []
+        bad = Path("/dev/null/not-a-directory")
+        with Stub():
+            with mod.trace("box", bad, spec_stem="search"):
+                time.sleep(BODY_SETTLE_SEC)
+                ran.append(True)
+        self.assertEqual(ran, [True])
+
+    def test_a_failure_writing_the_trace_does_not_mask_the_legs_own_error(self):
+        """And when both go wrong, the leg's error is the one that must win."""
+        bad = Path("/dev/null/not-a-directory")
+        with Stub():
+            with self.assertRaises(ValueError):
+                with mod.trace("box", bad):
+                    raise ValueError("the leg failed")
+
+    def test_no_instance_is_a_no_op(self):
+        ran = []
+        with tempfile.TemporaryDirectory() as out:
+            with mod.trace("", Path(out)):
+                ran.append(True)
+        self.assertEqual(ran, [True])
+        self.assertFalse((Path(out) / "gputrace").exists())
+
+
+class Output(unittest.TestCase):
+    def _run(self, out: str, **kw):
+        with Stub():
+            with mod.trace("vss-eval-rtx-2g", Path(out), spec_stem="search",
+                           platform="RTXPRO6000BW", step=1,
+                           declared_gpu_count=2, skill="vss-search-archive", **kw):
+                time.sleep(BODY_SETTLE_SEC)
+        d = Path(out) / "gputrace"
+        return (next(d.glob("*.csv")), next(d.glob("*.json")))
+
+    def test_csv_has_the_header_and_the_samples(self):
+        with tempfile.TemporaryDirectory() as out:
+            csv, _ = self._run(out)
+            lines = csv.read_text().strip().splitlines()
+        self.assertEqual(lines[0], mod.CSV_HEADER)
+        # Assert the shape, not a row count: the count is a property of the
+        # stub, and pinning it makes the test fail for reasons that are not
+        # defects. Every data row must be nvidia-smi shaped, and both GPUs of
+        # a 2-GPU box must appear or the declared-vs-used answer is wrong.
+        self.assertGreater(len(lines), 1)
+        for row in lines[1:]:
+            self.assertTrue(mod.ROW_RE.match(row), row)
+        seen = {row.split(",")[1].strip() for row in lines[1:]}
+        self.assertEqual(seen, {"0", "1"})
+
+    def test_sidecar_carries_the_declaration_under_test(self):
+        with tempfile.TemporaryDirectory() as out:
+            csv, js = self._run(out)
+            d = json.loads(js.read_text())
+            csv_rows = len(csv.read_text().strip().splitlines()) - 1
+        # Without the declared count the whole comparison is impossible.
+        self.assertEqual(d["declared_gpu_count"], 2)
+        self.assertEqual(d["skill"], "vss-search-archive")
+        self.assertEqual(d["spec_stem"], "search")
+        self.assertEqual(d["platform"], "RTXPRO6000BW")
+        self.assertEqual(d["instance"], "vss-eval-rtx-2g")
+        # Matches the CSV the sidecar describes, rather than a fixed number.
+        self.assertEqual(d["samples"], csv_rows)
+        self.assertGreater(d["samples"], 0)
+        self.assertIn("RTX PRO 6000", d["gpu_name"])
+        self.assertGreater(d["finished_at"], 0)
+
+    def test_sidecar_carries_no_host_identifiers_beyond_the_box_name(self):
+        with tempfile.TemporaryDirectory() as out:
+            _, js = self._run(out)
+            blob = js.read_text()
+        for forbidden in ("10.", "ubuntu@", "ssh-rsa", "API_KEY", "TOKEN"):
+            self.assertNotIn(forbidden, blob)
+
+    def test_steps_do_not_overwrite_each_other(self):
+        """A multi-step spec makes several harbor invocations under one lock."""
+        with tempfile.TemporaryDirectory() as out, Stub():
+            for step in (1, 2, 3):
+                with mod.trace("box", Path(out), spec_stem="calibration",
+                               platform="RTXPRO6000BW", step=step):
+                    time.sleep(BODY_SETTLE_SEC)
+            self.assertEqual(len(list((Path(out) / "gputrace").glob("*.csv"))), 3)
+
+    def test_token_is_filename_safe(self):
+        t = mod._token("123", "a/b spec", "RTX/PRO", 1)
+        self.assertNotIn("/", t)
+        self.assertNotIn(" ", t)
+        self.assertLessEqual(len(t), 140)
+
+    def test_a_long_spec_name_cannot_truncate_the_step_away(self):
+        """Truncating the JOINED string lets a long spec push `-stepN` off the
+        end, so step 1 and step 2 collide and the second silently overwrites
+        the first. The step must be appended after truncation, not before."""
+        long_spec = "x" * 200
+        tokens = {mod._token("30515350883", long_spec, "RTXPRO6000BW", n)
+                  for n in (1, 2, 3)}
+        self.assertEqual(len(tokens), 3, f"steps collide after truncation: {tokens}")
+        for n in (1, 2, 3):
+            self.assertTrue(
+                mod._token("30515350883", long_spec, "RTXPRO6000BW", n).endswith(f"-step{n}"))
+
+
+class Toggles(unittest.TestCase):
+    def test_default_is_on(self):
+        """Opt-in telemetry that nobody enables collects nothing."""
+        self.assertTrue(mod.ENABLED or os.environ.get("EVAL_GPU_TRACE") is not None)
+
+    def test_disabled_makes_it_a_no_op(self):
+        ran = []
+        old = mod.ENABLED
+        mod.ENABLED = False
+        try:
+            with tempfile.TemporaryDirectory() as out, Stub() as stub:
+                with mod.trace("box", Path(out)):
+                    ran.append(True)
+                self.assertEqual(stub.commands(), [])
+                self.assertFalse((Path(out) / "gputrace").exists())
+        finally:
+            mod.ENABLED = old
+        self.assertEqual(ran, [True])
+
+
+class FallsBackToSsh(unittest.TestCase):
+    def test_ssh_alias_is_the_lowercased_instance_name(self):
+        """Registered nodes are unreachable via `brev exec`; the alias
+        convention is the one envs/brev_env.py::_ssh_alias_for uses."""
+        with Stub() as stub:
+            mod._remote("VSS-Eval-RTX-2G", "echo hi")
+            argvs = stub.argvs()
+        self.assertEqual(argvs[0][0], "exec")
+        # brev succeeded, so ssh must not have been attempted.
+        self.assertEqual(len(argvs), 1)
+
+    def test_ssh_is_tried_when_brev_fails(self):
+        with Stub(fail=True) as stub:
+            self.assertIsNone(mod._remote("Box-Name", "echo hi"))
+            argvs = stub.argvs()
+        self.assertEqual(len(argvs), 2, "ssh fallback was not attempted")
+        self.assertIn("box-name", argvs[1])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/skill-eval/tests/test_gpu_trace.py
+++ b/.github/skill-eval/tests/test_gpu_trace.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import subprocess
 import sys
 import time
 import tempfile
@@ -58,6 +59,7 @@ cmd = argv[-1] if argv else ""
 if os.environ.get("GPUTRACE_STUB_HOSTILE_PID") == "1" and "echo PID=$!" in cmd:
     # A compromised or confused box reports shell syntax where a pid belongs.
     sys.stdout.write("PID=1; touch " + os.environ["GPUTRACE_STUB_HOME"] + "/PWNED\n")
+    sys.stdout.write("DIR=/tmp/vss-gputrace.aaaaaaaa\n")
     sys.stdout.write("NVIDIA RTX PRO 6000 Blackwell Server Edition\n")
     sys.stdout.write(argv[1] + "\n" if len(argv) > 1 else "")
     raise SystemExit
@@ -78,6 +80,10 @@ sys.stdout.write(argv[1] + "\n" if len(argv) > 1 else "")
 # startup rather than the code under test.
 BODY_SETTLE_SEC = 1.5
 SMI_RUN_SEC = 8
+# The pid the fake reports. Shared by the stub and the assertion so the two
+# cannot drift; a hardcoded literal in only one of them is how "some number is
+# killed" passed while the wrong number was being killed.
+STUB_PID = "4242"
 NVIDIA_SMI_STUB = r"""#!/usr/bin/env python3
 import sys, time
 if "--query-gpu=name" in " ".join(sys.argv):
@@ -117,9 +123,13 @@ class Stub:
     KEYS = ("PATH", "GPUTRACE_STUB_REC", "GPUTRACE_STUB_FAIL",
             "GPUTRACE_STUB_HOME", "GPUTRACE_STUB_BIN", "GPUTRACE_STUB_HOSTILE_PID")
 
-    def __init__(self, fail: bool = False, hostile_pid: bool = False):
+    def __init__(self, fail: bool = False, hostile_pid: bool = False,
+                 payload: str | None = None):
         self.fail = fail
         self.hostile_pid = hostile_pid
+        # Override what the fake nvidia-smi emits, so a test can assert on how
+        # many samples survive the round trip rather than on a fixed fixture.
+        self.payload = payload
 
     def __enter__(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -137,7 +147,16 @@ class Stub:
             "-----BEGIN OPENSSH PRIVATE KEY-----\nCANARYSECRET\n", encoding="utf-8")
         self.bin = d / "bin"
         self.bin.mkdir()
-        for name, body in (("nvidia-smi", NVIDIA_SMI_STUB), ("timeout", TIMEOUT_STUB)):
+        smi = NVIDIA_SMI_STUB
+        if self.payload is not None:
+            smi = ('#!/usr/bin/env python3\nimport sys, time\n'
+                   'if "--query-gpu=name" in " ".join(sys.argv):\n'
+                   '    print("FAKE"); raise SystemExit\n'
+                   'sys.stdout.write(%r)\nsys.stdout.flush()\n'
+                   'if "-l" in sys.argv: time.sleep(%d)\n'
+                   % (self.payload if self.payload.endswith("\n") else self.payload + "\n",
+                      SMI_RUN_SEC))
+        for name, body in (("nvidia-smi", smi), ("timeout", TIMEOUT_STUB)):
             f = self.bin / name
             f.write_text(body, encoding="utf-8")
             f.chmod(f.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
@@ -267,6 +286,8 @@ class RemoteCallsAreBounded(unittest.TestCase):
 
 
 class TheHardStopIsPresent(unittest.TestCase):
+    PID_FROM_STUB = STUB_PID
+
     """The one property that cannot regress silently.
 
     Without `timeout`, a sampler survives a SIGKILLed leg and keeps writing
@@ -291,6 +312,31 @@ class TheHardStopIsPresent(unittest.TestCase):
         self.assertGreater(bound, 7800)
         self.assertLess(bound, 7800 + 3600)
 
+    def test_the_sampler_loops_for_the_life_of_the_leg(self):
+        """Dropping `-l` makes nvidia-smi print once and exit, which looks
+        identical to lifetime sampling in a fixture that emits two rows up
+        front. Then a 2-hour leg yields one instant instead of a trace."""
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("box", Path(out)):
+                pass
+            start = stub.commands()[0]
+        self.assertRegex(start, r"-l \d+",
+                         f"sampler does not loop: {start!r}")
+
+    def test_the_output_path_is_unpredictable(self):
+        """A name derived from the job identity is guessable, and shell `>`
+        follows symlinks: a pre-placed `<token>.csv -> ~/.ssh/authorized_keys`
+        gets truncated. Verified in real bash on a victim holding KEEP-ME."""
+        with tempfile.TemporaryDirectory() as out, Stub() as stub:
+            with mod.trace("box", Path(out), spec_stem="search",
+                           platform="RTXPRO6000BW", step=1):
+                pass
+            start = stub.commands()[0]
+        self.assertIn("mktemp -d", start)
+        self.assertIn("set -C", start)          # noclobber: refuse to follow
+        self.assertNotIn("search", start.split("nvidia-smi")[0],
+                         f"job identity leaked into the remote path: {start!r}")
+
     def test_hard_stop_has_a_floor_for_tiny_timeouts(self):
         with tempfile.TemporaryDirectory() as out, Stub() as stub:
             with mod.trace("box", Path(out), harbor_timeout_sec=1):
@@ -303,20 +349,36 @@ class TheHardStopIsPresent(unittest.TestCase):
         with tempfile.TemporaryDirectory() as out, Stub() as stub:
             with mod.trace("box", Path(out)):
                 pass
-            self.assertIn("rm -f", stub.commands()[-1])
+            finish = stub.commands()[-1]
+        # The whole mktemp directory, not one file: it is created per
+        # invocation and a box that has been up six weeks must not accumulate
+        # one directory per leg.
+        self.assertIn("rm -rf /tmp/vss-gputrace.", finish)
 
     def test_the_sampler_is_actually_stopped(self):
         """Deleting the kill left all 22 of the original tests green. The
         cleanup command must name the pid the start call reported."""
         with tempfile.TemporaryDirectory() as out, Stub() as stub:
             with mod.trace("box", Path(out)):
-                pass
+                time.sleep(BODY_SETTLE_SEC)
+            # Scoped to THIS stub's bin directory. A broad pattern matched an
+            # unrelated stale process on the developer machine and reported a
+            # survivor that was never ours.
+            alive_after = len(subprocess.run(
+                ["pgrep", "-f", str(stub.bin)],
+                capture_output=True, text=True).stdout.split())
             cmds = stub.commands()
         start, finish = cmds[0], cmds[-1]
-        pid = start.split("echo PID=$!")[0]     # sanity: the start reports one
         self.assertIn("echo PID=$!", start)
-        self.assertRegex(finish, r"^kill [1-9][0-9]* ",
-                         f"cleanup does not kill the sampler: {finish!r}")
+        # The invariant is not "a kill command was emitted", it is "the sampler
+        # is dead". Asserting the former let a mutation that hardcodes the pid
+        # to 999999 pass while the real sampler kept running.
+        self.assertEqual(alive_after, 0,
+                         f"sampler survived the cleanup: {finish!r}")
+        # It must also confirm the pid is still OUR sampler before signalling:
+        # a pid that was freed and reused points at an unrelated process.
+        self.assertIn("nvidia-smi", finish.split("kill")[0],
+                      f"pid is signalled without an identity check: {finish!r}")
 
     def test_only_one_command_is_backgrounded_and_it_closes_its_pipe(self):
         """`mkdir && nohup ... &` backgrounds the whole AND-list, so `$!` is a
@@ -358,9 +420,18 @@ class TheAllowlist(unittest.TestCase):
              "memory.used", "memory.total", "power.draw"],
         )
 
-    def test_header_matches_the_query_field_count(self):
-        self.assertEqual(len(mod.CSV_HEADER.split(",")),
-                         len(mod.QUERY_FIELDS.split(",")))
+    def test_header_is_the_literal_contract_downstream_reads(self):
+        """Spelled out, NOT compared against the production constant. Swapping
+        `mem_used_mib` and `mem_total_mib` in CSV_HEADER passed the whole suite
+        because the test read the same constant it was checking, and downstream
+        would then report resident memory as capacity and vice versa."""
+        self.assertEqual(mod.CSV_HEADER,
+                         "timestamp,gpu_index,util_gpu_pct,util_mem_pct,"
+                         "mem_used_mib,mem_total_mib,power_w")
+        # And the header order must match the order nvidia-smi is asked for.
+        self.assertEqual(mod.QUERY_FIELDS,
+                         "timestamp,index,utilization.gpu,utilization.memory,"
+                         "memory.used,memory.total,power.draw")
 
     def test_remote_commands_never_read_env_or_process_state(self):
         with tempfile.TemporaryDirectory() as out, Stub() as stub:
@@ -499,7 +570,6 @@ class Output(unittest.TestCase):
         # Matches the CSV the sidecar describes, rather than a fixed number.
         self.assertEqual(d["samples"], csv_rows)
         self.assertGreater(d["samples"], 0)
-        self.assertIn("RTX PRO 6000", d["gpu_name"])
         self.assertGreater(d["finished_at"], 0)
 
     def test_sidecar_carries_no_host_identifiers_beyond_the_box_name(self):
@@ -517,6 +587,20 @@ class Output(unittest.TestCase):
                                platform="RTXPRO6000BW", step=step):
                     time.sleep(BODY_SETTLE_SEC)
             self.assertEqual(len(list((Path(out) / "gputrace").glob("*.csv"))), 3)
+
+    def test_every_returned_sample_is_kept(self):
+        """Truncating to the first N rows makes a 2-hour leg look like its
+        opening seconds while the file still parses and the sidecar's own
+        count still agrees with it. Nothing else in the suite would notice."""
+        many = "\n".join(
+            f"2026/08/01 21:{i // 60:02d}:{i % 60:02d}.000, {i % 2}, {i}, 0, 100, 97887, 71.2"
+            for i in range(40))
+        with tempfile.TemporaryDirectory() as out, Stub(payload=many):
+            with mod.trace("box", Path(out), spec_stem="keepall"):
+                time.sleep(BODY_SETTLE_SEC)
+            csv = next((Path(out) / "gputrace").glob("*.csv"))
+            rows = csv.read_text().strip().splitlines()[1:]
+        self.assertEqual(len(rows), 40, "samples were dropped")
 
     def test_token_is_filename_safe(self):
         t = mod._token("123", "a/b spec", "RTX/PRO", 1)

--- a/.github/skill-eval/tests/test_gpu_trace.py
+++ b/.github/skill-eval/tests/test_gpu_trace.py
@@ -19,6 +19,13 @@ Mutations confirmed to fail this suite:
   * omit `declared_gpu_count` from the sidecar
   * add a field to QUERY_FIELDS
   * skip the `rm -f` of the remote CSV
+  * drop `-ww` from either `ps` identity guard
+
+That last one is the reason `Stub` pins COLUMNS. `ps` truncates `args` to the
+display width, so a guard can be present, correctly spelled, and inert -- and
+which of those it is depends on the window of whoever runs the suite, not on
+the code. Assert behaviour (the sampler is dead) at a hostile width; a string
+assertion cannot see this class of defect at all.
 """
 
 from __future__ import annotations
@@ -245,13 +252,23 @@ class Stub:
 
     KEYS = ("PATH", "GPUTRACE_STUB_REC", "GPUTRACE_STUB_FAIL",
             "GPUTRACE_STUB_HOME", "GPUTRACE_STUB_BIN", "GPUTRACE_STUB_HOSTILE_PID",
-            "GPUTRACE_STUB_HOSTILE_DIR")
+            "GPUTRACE_STUB_HOSTILE_DIR", "COLUMNS")
 
     def __init__(self, fail: bool = False, hostile_pid: bool = False,
-                 payload: str | None = None, hostile_dir: bool = False):
+                 payload: str | None = None, hostile_dir: bool = False,
+                 columns: str | None = "80"):
         self.fail = fail
         self.hostile_pid = hostile_pid
         self.hostile_dir = hostile_dir
+        # `ps` is the REAL one -- the stub bin holds only nvidia-smi and timeout
+        # -- and `ps` truncates `args` to the display width, so every assertion
+        # about the cleanup guard is silently a function of the developer's
+        # terminal. Pinning it here makes the suite deterministic AND hostile:
+        # 80 is what a pty gets when nobody sets a window size, which is exactly
+        # what `brev exec`/`ssh` hand the remote command in production. Left
+        # unpinned, `test_the_sampler_is_actually_stopped` passed in a wide
+        # window and failed at 80 or 100 for the same code.
+        self.columns = columns
         # Override what the fake nvidia-smi emits, so a test can assert on how
         # many samples survive the round trip rather than on a fixed fixture.
         self.payload = payload
@@ -299,6 +316,10 @@ class Stub:
         os.environ["GPUTRACE_STUB_BIN"] = str(self.bin)
         os.environ["GPUTRACE_STUB_HOSTILE_PID"] = "1" if self.hostile_pid else "0"
         os.environ["GPUTRACE_STUB_HOSTILE_DIR"] = "1" if self.hostile_dir else "0"
+        if self.columns is None:
+            os.environ.pop("COLUMNS", None)
+        else:
+            os.environ["COLUMNS"] = self.columns
         return self
 
     def commands(self) -> list[str]:
@@ -442,10 +463,21 @@ class TheOtherRegexGuardsAnInterpolation(unittest.TestCase):
             kills = [c for c in stub.commands() if "kill " in c]
         self.assertTrue(kills, "the degraded path never tried to stop the sampler")
         for c in kills:
-            self.assertIn("ps -o args= -p", c,
-                          f"pid signalled with no identity check at all: {c!r}")
+            # The property, not the spelling. This assertion previously pinned
+            # the literal `ps -o args= -p` and so broke when the guard was fixed
+            # to `ps -ww -o args= -p` -- the second time an over-specified string
+            # here rejected a strictly stronger version of the very thing it was
+            # asserting (the first was pinning `grep -q ` against `grep -qF`).
+            self.assertRegex(c, r"\bps\b[^|]*\bargs=[^|]*-p ",
+                             f"pid signalled with no identity check at all: {c!r}")
             self.assertRegex(c, r"grep[^;|]*&&\s*kill\b",
                              f"identity check does not gate the kill: {c!r}")
+            # A width-limited `ps` returns a prefix that cannot contain the
+            # match target, so the guard silently never fires. See
+            # test_the_guard_still_fires_at_every_plausible_terminal_width for
+            # the behavioural version of this.
+            self.assertIn("-ww", c.split("|")[0],
+                          f"identity check is width-truncatable: {c!r}")
 
     def test_a_row_with_a_valid_prefix_and_a_garbage_suffix_is_dropped(self):
         """Every existing negative fails on the PREFIX. Deleting ROW_RE's
@@ -746,8 +778,13 @@ class TheHardStopIsPresent(unittest.TestCase):
         # nvidia-smi": these boxes run nvidia-smi constantly, so a recycled pid
         # that happens to be any of them would be killed, possibly another leg's.
         guard = finish.split("kill")[0]
-        self.assertIn("ps -o args= -p", guard,
-                      f"pid is signalled without an identity check: {finish!r}")
+        # The property, not the spelling -- see the note in the degraded-path
+        # test. Pinning `ps -o args= -p` here rejected the `-ww` repair that
+        # made the guard actually work.
+        self.assertRegex(guard, r"\bps\b[^|]*\bargs=[^|]*-p ",
+                         f"pid is signalled without an identity check: {finish!r}")
+        self.assertIn("-ww", guard.split("|")[0],
+                      f"identity check is width-truncatable: {finish!r}")
         # Assert the nonce is matched, without pinning the exact grep flags --
         # an earlier revision of this assertion hardcoded `grep -q ` and so
         # failed when the match was tightened to the fixed-string `grep -qF`,
@@ -759,6 +796,36 @@ class TheHardStopIsPresent(unittest.TestCase):
         # killing unconditionally, which is the defect this test exists for.
         self.assertRegex(finish, r"grep[^;|]*&&\s*kill\b",
                          f"identity check does not gate the kill: {finish!r}")
+
+    def test_the_guard_still_fires_at_every_plausible_terminal_width(self):
+        """A guard can be present, correctly spelled, and inert.
+
+        `ps` truncates `args` to the display width. The sampler's command line
+        is ~204 chars with the nonce at column ~169, so below that `ps` returns
+        a prefix that CANNOT contain the match target: `grep` reports no match,
+        `&&` skips the kill, and the sampler survives to its 2h20m hard stop on
+        a box already handed to the next leg. Every text-shaped assertion in
+        this file still passes while that happens.
+
+        The widths are the ones that actually occur. 80 is what a pty gets when
+        nobody sets a window size, which is what `brev exec`/`ssh` hand the
+        remote command; None (COLUMNS unset, no tty) is procps' unlimited
+        fallback and is the configuration in which this bug looks fixed.
+        """
+        for columns in ("80", "100", "160", "400", None):
+            with self.subTest(columns=columns):
+                with tempfile.TemporaryDirectory() as out, \
+                        Stub(columns=columns) as stub:
+                    with mod.trace("box", Path(out)):
+                        time.sleep(BODY_SETTLE_SEC)
+                    alive = len(subprocess.run(
+                        ["pgrep", "-f", str(stub.bin)],
+                        capture_output=True, text=True).stdout.split())
+                    finish = stub.commands()[-1]
+                self.assertEqual(
+                    alive, 0,
+                    f"sampler survived cleanup at COLUMNS={columns}; the guard "
+                    f"is inert because ps truncated its own output: {finish!r}")
 
     def test_only_one_command_is_backgrounded_and_it_closes_its_pipe(self):
         """`mkdir && nohup ... &` backgrounds the whole AND-list, so `$!` is a
@@ -956,8 +1023,14 @@ class Output(unittest.TestCase):
         with tempfile.TemporaryDirectory() as out:
             _, js = self._run(out)
             blob = js.read_text()
-        for forbidden in ("10.", "ubuntu@", "ssh-rsa", "API_KEY", "TOKEN"):
+        for forbidden in ("ubuntu@", "ssh-rsa", "API_KEY", "TOKEN"):
             self.assertNotIn(forbidden, blob)
+        # An IP address, matched as a dotted quad rather than as the substring
+        # "10.". That substring also matches the sidecar's own unix timestamps
+        # -- `"finished_at": 1786557910.4098206` contains it -- so the assertion
+        # failed roughly one run in fifty for reasons having nothing to do with
+        # host identifiers. A flaky guard gets muted, and then it guards nothing.
+        self.assertNotRegex(blob, r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
 
     def test_steps_do_not_overwrite_each_other(self):
         """A multi-step spec makes several harbor invocations under one lock."""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,6 +474,7 @@ jobs:
         run: |
           uvx --python 3.12 --from "pytest==9.1.1" pytest \
             .github/skill-eval/tests/test_adapter_agent_timeout.py \
+            .github/skill-eval/tests/test_gpu_trace.py \
             .github/skill-eval/tests/test_leg_timing.py \
             .github/skill-eval/tests/test_python_runtime_contract.py \
             .github/skill-eval/tests/test_skills_eval_agent_protocol.py \

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -308,10 +308,15 @@ jobs:
           # unique per (skill,spec,platform).
           LEG_TARBALL="/tmp/skills-eval-daily-results-${EVAL_SLUG}-${GITHUB_RUN_ID}.tar.gz"
           RESULTS=$(find "$LEG_RESULTS" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
-          if [ -n "$RESULTS" ]; then
+          # A GPU trace is worth archiving even with no result.json. A trial
+          # that hits the agent ceiling dies before Harbor writes one, and that
+          # is precisely the trace worth reading — gating the tarball on
+          # result.json alone silently dropped the most interesting cases.
+          TRACES=$(find "$LEG_RESULTS" -maxdepth 3 -path '*/gputrace/*.csv' 2>/dev/null | head -50 || true)
+          if [ -n "$RESULTS" ] || [ -n "$TRACES" ]; then
             tar czf "$LEG_TARBALL" \
               -C "/tmp/skill-eval/results/${EVAL_SLUG}" --exclude='agent' "$GITHUB_RUN_ID"
-            echo "archived $(echo "$RESULTS" | wc -l) result.json files (agent/ trajectories excluded)"
+            echo "archived $(echo "$RESULTS" | grep -c . || true) result.json and $(echo "$TRACES" | grep -c . || true) gputrace file(s) (agent/ trajectories excluded)"
           else
             echo "results dir exists but empty — nothing to archive"
           fi

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -322,10 +322,15 @@ jobs:
           # unique per (skill,spec,platform).
           LEG_TARBALL="/tmp/skills-eval-results-${EVAL_SLUG}-${GITHUB_RUN_ID}.tar.gz"
           RESULTS=$(find "$LEG_RESULTS" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
-          if [ -n "$RESULTS" ]; then
+          # A GPU trace is worth archiving even with no result.json. A trial
+          # that hits the agent ceiling dies before Harbor writes one, and that
+          # is precisely the trace worth reading — gating the tarball on
+          # result.json alone silently dropped the most interesting cases.
+          TRACES=$(find "$LEG_RESULTS" -maxdepth 3 -path '*/gputrace/*.csv' 2>/dev/null | head -50 || true)
+          if [ -n "$RESULTS" ] || [ -n "$TRACES" ]; then
             tar czf "$LEG_TARBALL" \
               -C "/tmp/skill-eval/results/${EVAL_SLUG}" --exclude='agent' "$GITHUB_RUN_ID"
-            echo "archived $(echo "$RESULTS" | wc -l) result.json files (agent/ trajectories excluded)"
+            echo "archived $(echo "$RESULTS" | grep -c . || true) result.json and $(echo "$TRACES" | grep -c . || true) gputrace file(s) (agent/ trajectories excluded)"
           else
             echo "results dir exists but empty — nothing to archive"
           fi


### PR DESCRIPTION
## Not a duplicate of the DCGM work (#1678)

Both changes are about GPU visibility, so the first question is whether one replaces the other. They don't: they instrument different planes and share no files.

| | [#1678](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/1678) (DCGM) | this PR |
|---|---|---|
| Plane | product **deployment** | **CI**, the `vss-eval-*` boxes |
| Touches | `deploy/docker`, `deploy/helm`, `skills/vss-deploy-profile` | `.github/skill-eval` |
| Answers | what is a running stack doing right now | did this leg use the GPUs its spec declared |
| Shape | live exporter, operator-facing | per-leg artifact, joined to run/spec/step |

`gpu_trace.py` exists because the eval boxes have no DCGM exporter, and #1678 as scoped does not give them one. Closing this PR would not deliver the eval-fleet numbers by another route.

If DCGM does reach the eval fleet later and can be joined to job identity, that is the better mechanism and this module should be retired rather than extended. That condition is written into the module docstring so the decision is not re-litigated from memory.

---

## What this changes

Every skill-eval leg now records what the GPUs on its box actually did for the duration of each Harbor invocation, and ships it in the results artifact the workflow already uploads.

## Why

Nothing in the pipeline could answer **"this spec declares `gpu_count: 2`, did it use them?"**

There is no retrospective source for it either: `nvidia-smi` accounting mode is disabled on the eval boxes, and they carry no metrics exporter. Sampling during the run is the only way to get the number.

The comparison that matters is `declared gpu_count` versus GPUs that did any work, so the declaration travels in the sidecar next to the measurement. Publishing a utilisation curve on its own would argue for the one conclusion that is hardest to reverse.

## Design

| Decision | Why |
|---|---|
| Hook in `run_leg.py` | The only point where GPU identity and job identity coexist: it holds the per-box `flock` and knows run/spec/step. Shared by `skills-eval.yml` and `skills-eval-daily.yml`, so one hook covers both. |
| Rides the existing artifact | No new service, no new network path, no credential on the eval box. Survives `_reset_docker_runtime` wiping the box between trials. |
| Default on, non-blocking | Opt-in telemetry that nobody enables collects nothing. Every path swallows its own exceptions and the context manager always yields. |
| Hard-bounded remote lifetime | The sampler runs under `timeout -k`, so it dies on its own even if this process is SIGKILLed and never calls stop. |
| Allowlist, not redaction | Seven `--query-gpu` fields, structurally validated per row against an anchored regex. Redaction fails open; an allowlist fails closed. |

Also archives the tarball when a GPU trace exists but `result.json` does not: a trial that hits the agent ceiling dies before Harbor writes one, and that is precisely the trace worth reading.

### A design alternative that was ruled out with evidence

Writing into `/logs/artifacts` would let harbor collect the trace with no fetch path at all. It does not work: `envs/brev_env.py:235` wipes that directory during harbor startup — *after* `run_leg.py` has already started the sampler — so writes continue into an unlinked inode; and the runs that matter most, `rc=124` and cancellation, never reach `_download_artifacts` at all.

## What review found

Three adversarial rounds. The product code held up better than the suite.

**Round 1** — three blockers, all reproduced:
- `mkdir && nohup ... &` backgrounds the whole AND-list, so `$!` was a forked subshell rather than `timeout`, killing it left the sampler running, and the subshell inherited stdout so the start call blocked until the *sampler* exited. Measured 3.03s under bash, 3.04s under sh, **0.01s under zsh** — invisible on a laptop, fatal over SSH.
- The recorded PID was remote text interpolated unquoted into a shell command.
- `ln.count(",") >= 6` was an allowlist in name only.

**Round 2** — four more, two of them living *inside* round 1's repair:
- A predictable `/tmp` path is a file-clobbering primitive; shell `>` follows symlinks. Reproduced by truncating a victim file.
- `MAX_FETCH_BYTES` was applied after `communicate()` had already buffered everything: a 32 MiB emit grew RSS by 125 MB against an 8 MiB "cap".
- `gpu_name` took every non-PID line of the start output and published it in the sidecar.
- PID syntax is not PID identity.

**Round 3** — 29 mutations passed all 37 tests, including two that need a single character:
- Deleting `DIR_RE`'s trailing anchor turns a remote reply into arbitrary command execution, because the value is interpolated into `rm -rf {dir}`. `DIR_RE` appeared **zero times** in the test file, while `PID_RE` — guarding an identical interpolation — had two dedicated tests.
- Deleting `ROW_RE`'s trailing anchor puts a private key in an uploaded artifact. Every existing negative case failed on the *prefix*, so a well-formed row carrying a garbage *suffix* was never tried.
- `if not rows:` → `if rows is None:` publishes "declared 2 GPUs, 0 samples over 70 minutes" as fact.
- Deleting `--query-gpu=` entirely, appending `gpu_uuid,gpu_serial`, adding `-i 0`, or changing `--format` all passed, because the `nvidia-smi` fake ignored argv.
- Removing `-k` removed the SIGKILL escalation, because the `timeout` fake parsed the duration off argv and threw it away.

## Product fixes since the first draft

- **SIGTERM now unwinds.** Python converts only SIGINT into an exception, so SIGTERM skipped every `finally` — and `skills-eval.yml` sets `cancel-in-progress: true`, so every push to a PR SIGTERMs up to eight in-flight legs at once. Each leaked a sampler for up to 139 minutes onto a box handed straight to the next leg, and lost the partial trace. Measured before and after.
- **`start_cmd` is single-attempt.** It is not idempotent: a blind retry starts a second sampler whose pid is never recorded, so nothing can kill it.
- **`nvidia-smi` writes via `-f`** rather than a shell redirect. A redirected stdout is block-buffered and SIGTERM does not flush it, so minutes of samples were discarded at exactly the moment cleanup ran. This also puts the nonce directory in argv, which makes the identity check exact rather than "is this some `nvidia-smi`" on a box that runs them constantly.
- **The kill is decoupled from the fetch guard.** A reply where `PID=` validated and `DIR=` did not left a running sampler nothing would kill, logged as a benign non-start.
- **Orphaned `/tmp` directories are reaped.** Nothing else on the box does.

## Tests

51 tests, no external dependencies, stable across repeated runs.

The fakes now implement their contracts rather than the caller's assumptions: `nvidia-smi` builds rows **from the parsed field list** and honours `--format`, `-i`, `-f` and `-l`, so a drift between the command and `CSV_HEADER` changes the output instead of being silent; `timeout` runs a real timer, escalates to SIGKILL, returns 124, and refuses a missing `-k`.

Thirteen mutations confirmed to fail the suite, including all six of the round-3 findings above.

```
cd .github/skill-eval && PYTHONPATH=. python3 -m unittest discover -s tests -p 'test_gpu_trace.py'
```

Note: `test_run_leg.py` has 3 pre-existing failures in `_rtx4090_supports`, unrelated to this change and present on `develop`.

## Kill switch

`EVAL_GPU_TRACE=0`.

