### PR TITLE
fix(skill-eval): decouple phase timeouts

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -637,16 +637,17 @@ Notes that have burned prior runs:
 - **Timeout budgets** cover cold-box realities. Every adapter-generated
   `task.toml` MUST set `[agent] timeout_sec = 600.0`; without that explicit
   base, Harbor treats the agent timeout as unbounded and
-  `--agent-timeout-multiplier` is a no-op. Keep the section and multipliers
-  verbatim:
+  `--agent-timeout-multiplier` is a no-op. `run_leg.py` owns four independent
+  absolute phase limits and derives Harbor's CLI multipliers from the pinned
+  Harbor 0.20 bases; do not modify the generated command flags:
   - `--environment-build-timeout-multiplier 3.0` → 1800s env start.
     Massedcompute L40S provisioning can exceed 10 min; 600s fires
     `EnvironmentStartTimeoutError` before the box is READY.
-  - `--agent-timeout-multiplier 6.0` → 3600s (1 h) per trial. Cold
-    `/vss-deploy-profile` (esp. `lvs` / `alerts_*` pulling local NIMs)
-    plus follow-on ingest / multi-step work overran the old 30-min
-    ceiling and harbor logged `NonZeroAgentExitCodeError` (exit 124).
-    Only this multiplier is 6.0 — it's the trial-work budget.
+  - `--agent-setup-timeout-multiplier 1.0` → 360s agent installation/setup.
+  - `--agent-timeout-multiplier 12.0` → 7200s (2 h) per trial. A legitimate
+    cold `/vss-deploy-profile` can spend more than an hour downloading and
+    starting local NIMs before follow-on ingest or checks begin. Preserved
+    caches improve the common path but are not a correctness prerequisite.
   - `--verifier-timeout-multiplier 3.0` → 1800s verify. `generic_judge.py`
     runs a judge per check (4-6 on specs like `vss-manage-video-io-storage`),
     which compounds past 600s and raises `VerifierTimeoutError`.
@@ -664,13 +665,13 @@ real failure: the wrapper exits 4, see § Output requirements).
 Don't background the trial (`run_in_background`, `&`/`nohup`/`disown`):
 the harness blocks those and raises the Bash timeout cap so the long
 foreground wrapper call is not auto-backgrounded into a pollable task.
-`run_leg.py` applies a 12000s (200 min) hard backstop to each internal Harbor
-subprocess: 7560s for environment build + agent setup + agent + verifier,
+`run_leg.py` applies a 15600s (260 min) hard backstop to each internal Harbor
+subprocess: 11160s for environment build + agent setup + agent + verifier,
 2520s for four bounded artifact-transfer/recovery windows, and 1920s of
 scheduling/non-transfer teardown headroom. `brev_env.py` caps each transfer's
 active work at 600s and its total process-reap wall time at 630s, so that
 recovery term is real rather than aspirational. The normal
-3600s agent deadline should fire first; the outer backstop is emergency-only
+7200s agent deadline should fire first; the outer backstop is emergency-only
 and requests SIGINT before bounded TERM/KILL escalation. The agent publishes a
 12-hour SDK deadline inside the 14-hour job and an earlier 11.5-hour Harbor
 deadline, reserving 30 minutes for result inspection, the PR comment, and the

--- a/.github/skill-eval/docs/matrix-dispatch-design.md
+++ b/.github/skill-eval/docs/matrix-dispatch-design.md
@@ -21,7 +21,7 @@ serially inside a single `uvx harbor run` loop. Two problems:
    failure" (one agent burned its turn budget on `sleep && tail` before a
    cold-box trial finished, then exited with no `DONE:`/`BLOCKED:`).
 2. **One slow/failed spec blocks the rest.** Serial dispatch means a spec
-   that hits the 1 h agent ceiling delays every spec behind it; a crash
+   that hits the 2 h agent ceiling delays every spec behind it; a crash
    mid-loop can drop later specs entirely.
 
 ## Core idea
@@ -135,7 +135,7 @@ PreToolUse hook); each leg's foreground agent therefore *must* drive
 ## Unchanged on purpose
 
 - Per-leg agent logic: adapter autogeneration, adapter auto-commit flow, harbor flags
-  (incl. `--agent-timeout-multiplier 6.0` = 1 h), result-comment format,
+  (incl. `--agent-timeout-multiplier 12.0` = 2 h), result-comment format,
   per-trial metric extraction, failure-mode handling, no `skills/` writes,
   no instance lifecycle calls.
 - The drop of harness-side profile pre-deploy / `active-deploy.txt`

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -56,34 +56,39 @@ RTX4090_TESTS: dict[str, frozenset[str]] = {}
 # the host, not per leg, so every leg publishes its trials in here.
 VIEWER_ROOT = Path("/tmp/skill-eval/results/_viewer")
 
-# Harbor phase budgets. Adapters set the task's base agent timeout to the same
-# 600-second base used by Harbor for environment build and verification; these
-# multipliers are also passed on the command line below. Keep the outer process
-# backstop strictly beyond every phase plus recovery time so Harbor gets a
-# chance to record the real phase outcome, download logs, and stop the Brev
-# environment before this wrapper intervenes.
-HARBOR_BASE_PHASE_TIMEOUT_SEC = 600
-HARBOR_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER = 3.0
-HARBOR_AGENT_TIMEOUT_MULTIPLIER = 6.0
-HARBOR_VERIFIER_TIMEOUT_MULTIPLIER = 3.0
-HARBOR_ENVIRONMENT_BUILD_BUDGET_SEC = int(
-    HARBOR_BASE_PHASE_TIMEOUT_SEC
-    * HARBOR_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER
+# Harbor phase policy is expressed as four independent absolute timeouts.
+# Harbor 0.20's CLI transports those values as phase-specific multipliers over
+# separate task/default bases, so derive that encoding here rather than making
+# a shared base the source of truth. Adapters explicitly emit the 600-second
+# agent base; the other three bases are pinned defaults in Harbor 0.20.0.
+HARBOR_ENVIRONMENT_BUILD_BASE_TIMEOUT_SEC = 600
+HARBOR_AGENT_SETUP_BASE_TIMEOUT_SEC = 360
+HARBOR_AGENT_BASE_TIMEOUT_SEC = 600
+HARBOR_VERIFIER_BASE_TIMEOUT_SEC = 600
+
+HARBOR_ENVIRONMENT_BUILD_TIMEOUT_SEC = 30 * 60
+HARBOR_AGENT_SETUP_TIMEOUT_SEC = 6 * 60
+HARBOR_AGENT_TIMEOUT_SEC = 2 * 60 * 60
+HARBOR_VERIFIER_TIMEOUT_SEC = 30 * 60
+
+HARBOR_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER = (
+    HARBOR_ENVIRONMENT_BUILD_TIMEOUT_SEC
+    / HARBOR_ENVIRONMENT_BUILD_BASE_TIMEOUT_SEC
 )
-# Harbor applies a separate six-minute ceiling while installing/configuring
-# the selected agent, before the task's [agent] timeout begins.
-HARBOR_AGENT_SETUP_BUDGET_SEC = 360
-HARBOR_AGENT_BUDGET_SEC = int(
-    HARBOR_BASE_PHASE_TIMEOUT_SEC * HARBOR_AGENT_TIMEOUT_MULTIPLIER
+HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER = (
+    HARBOR_AGENT_SETUP_TIMEOUT_SEC / HARBOR_AGENT_SETUP_BASE_TIMEOUT_SEC
 )
-HARBOR_VERIFIER_BUDGET_SEC = int(
-    HARBOR_BASE_PHASE_TIMEOUT_SEC * HARBOR_VERIFIER_TIMEOUT_MULTIPLIER
+HARBOR_AGENT_TIMEOUT_MULTIPLIER = (
+    HARBOR_AGENT_TIMEOUT_SEC / HARBOR_AGENT_BASE_TIMEOUT_SEC
+)
+HARBOR_VERIFIER_TIMEOUT_MULTIPLIER = (
+    HARBOR_VERIFIER_TIMEOUT_SEC / HARBOR_VERIFIER_BASE_TIMEOUT_SEC
 )
 HARBOR_PHASE_BUDGET_SEC = (
-    HARBOR_ENVIRONMENT_BUILD_BUDGET_SEC
-    + HARBOR_AGENT_SETUP_BUDGET_SEC
-    + HARBOR_AGENT_BUDGET_SEC
-    + HARBOR_VERIFIER_BUDGET_SEC
+    HARBOR_ENVIRONMENT_BUILD_TIMEOUT_SEC
+    + HARBOR_AGENT_SETUP_TIMEOUT_SEC
+    + HARBOR_AGENT_TIMEOUT_SEC
+    + HARBOR_VERIFIER_TIMEOUT_SEC
 )
 # brev_env.py caps each upload/download API, including active work and process
 # reaping, to this duration. These VSS tasks serially perform no more than four
@@ -98,15 +103,18 @@ HARBOR_CLEANUP_RECOVERY_HEADROOM_SEC = (
 MIN_HARBOR_BACKSTOP_SEC = (
     HARBOR_PHASE_BUDGET_SEC + HARBOR_CLEANUP_RECOVERY_HEADROOM_SEC
 )
-# Stay strictly above the minimum rather than making the validation boundary
-# itself the default.  The round 200-minute backstop leaves another 32 minutes
-# for scheduling jitter and bounded teardown that does not transfer files.
-DEFAULT_HARBOR_TIMEOUT_SEC = 12_000
+# Derive the default rather than maintaining a second phase-budget literal.
+# Preserve 32 minutes beyond the strict minimum for scheduling jitter and
+# bounded teardown that does not transfer files.
+HARBOR_BACKSTOP_ADDITIONAL_HEADROOM_SEC = 32 * 60
+DEFAULT_HARBOR_TIMEOUT_SEC = (
+    MIN_HARBOR_BACKSTOP_SEC + HARBOR_BACKSTOP_ADDITIONAL_HEADROOM_SEC
+)
 
 # A single remote agent command must not be killed by Brev before Harbor's own
 # agent deadline can fire and drive normal artifact/environment cleanup.
 MIN_BREV_EXEC_TIMEOUT_SEC = (
-    HARBOR_AGENT_BUDGET_SEC + HARBOR_TRANSFER_OPERATION_BUDGET_SEC
+    HARBOR_AGENT_TIMEOUT_SEC + HARBOR_TRANSFER_OPERATION_BUDGET_SEC
 )
 
 # Emergency-only escalation after the outer backstop. SIGINT gives Harbor's
@@ -244,10 +252,10 @@ def validate_harbor_timeout_sec(timeout_sec: int) -> int:
         raise ValueError(
             "harbor timeout must be greater than "
             f"{MIN_HARBOR_BACKSTOP_SEC}s: environment "
-            f"{HARBOR_ENVIRONMENT_BUILD_BUDGET_SEC}s + agent setup "
-            f"{HARBOR_AGENT_SETUP_BUDGET_SEC}s + agent "
-            f"{HARBOR_AGENT_BUDGET_SEC}s + verifier "
-            f"{HARBOR_VERIFIER_BUDGET_SEC}s + cleanup/recovery "
+            f"{HARBOR_ENVIRONMENT_BUILD_TIMEOUT_SEC}s + agent setup "
+            f"{HARBOR_AGENT_SETUP_TIMEOUT_SEC}s + agent "
+            f"{HARBOR_AGENT_TIMEOUT_SEC}s + verifier "
+            f"{HARBOR_VERIFIER_TIMEOUT_SEC}s + cleanup/recovery "
             f"{HARBOR_CLEANUP_RECOVERY_HEADROOM_SEC}s"
         )
     return timeout_sec
@@ -330,6 +338,8 @@ def build_harbor_command(
         str(HARBOR_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER),
         "--agent-timeout-multiplier",
         str(HARBOR_AGENT_TIMEOUT_MULTIPLIER),
+        "--agent-setup-timeout-multiplier",
+        str(HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER),
         "--verifier-timeout-multiplier",
         str(HARBOR_VERIFIER_TIMEOUT_MULTIPLIER),
         "--max-retries",

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -127,6 +127,10 @@ class HarborCommand(unittest.TestCase):
             str(run_leg.HARBOR_AGENT_TIMEOUT_MULTIPLIER),
         )
         self.assertEqual(
+            cmd[cmd.index("--agent-setup-timeout-multiplier") + 1],
+            str(run_leg.HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER),
+        )
+        self.assertEqual(
             cmd[cmd.index("--verifier-timeout-multiplier") + 1],
             str(run_leg.HARBOR_VERIFIER_TIMEOUT_MULTIPLIER),
         )
@@ -169,11 +173,17 @@ class HarborCommand(unittest.TestCase):
 
 class PhaseBudgets(unittest.TestCase):
     def test_default_backstop_exceeds_all_phases_and_recovery_headroom(self):
-        self.assertEqual(run_leg.HARBOR_ENVIRONMENT_BUILD_BUDGET_SEC, 1800)
-        self.assertEqual(run_leg.HARBOR_AGENT_SETUP_BUDGET_SEC, 360)
-        self.assertEqual(run_leg.HARBOR_AGENT_BUDGET_SEC, 3600)
-        self.assertEqual(run_leg.HARBOR_VERIFIER_BUDGET_SEC, 1800)
-        self.assertEqual(run_leg.HARBOR_PHASE_BUDGET_SEC, 7560)
+        self.assertEqual(run_leg.HARBOR_ENVIRONMENT_BUILD_TIMEOUT_SEC, 1800)
+        self.assertEqual(run_leg.HARBOR_AGENT_SETUP_TIMEOUT_SEC, 360)
+        self.assertEqual(run_leg.HARBOR_AGENT_TIMEOUT_SEC, 7200)
+        self.assertEqual(run_leg.HARBOR_VERIFIER_TIMEOUT_SEC, 1800)
+        self.assertEqual(
+            run_leg.HARBOR_ENVIRONMENT_BUILD_TIMEOUT_MULTIPLIER, 3.0
+        )
+        self.assertEqual(run_leg.HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER, 1.0)
+        self.assertEqual(run_leg.HARBOR_AGENT_TIMEOUT_MULTIPLIER, 12.0)
+        self.assertEqual(run_leg.HARBOR_VERIFIER_TIMEOUT_MULTIPLIER, 3.0)
+        self.assertEqual(run_leg.HARBOR_PHASE_BUDGET_SEC, 11160)
         self.assertEqual(run_leg.HARBOR_TRANSFER_OPERATION_BUDGET_SEC, 630)
         self.assertEqual(run_leg.HARBOR_RECOVERY_TRANSFER_OPERATION_COUNT, 4)
         self.assertEqual(run_leg.HARBOR_CLEANUP_RECOVERY_HEADROOM_SEC, 2520)
@@ -182,13 +192,19 @@ class PhaseBudgets(unittest.TestCase):
             run_leg.HARBOR_PHASE_BUDGET_SEC
             + run_leg.HARBOR_CLEANUP_RECOVERY_HEADROOM_SEC,
         )
-        self.assertEqual(run_leg.MIN_HARBOR_BACKSTOP_SEC, 10080)
-        self.assertEqual(run_leg.DEFAULT_HARBOR_TIMEOUT_SEC, 12000)
+        self.assertEqual(run_leg.MIN_HARBOR_BACKSTOP_SEC, 13680)
+        self.assertEqual(run_leg.HARBOR_BACKSTOP_ADDITIONAL_HEADROOM_SEC, 1920)
+        self.assertEqual(
+            run_leg.DEFAULT_HARBOR_TIMEOUT_SEC,
+            run_leg.MIN_HARBOR_BACKSTOP_SEC
+            + run_leg.HARBOR_BACKSTOP_ADDITIONAL_HEADROOM_SEC,
+        )
+        self.assertEqual(run_leg.DEFAULT_HARBOR_TIMEOUT_SEC, 15600)
         self.assertEqual(run_leg.HARBOR_SIGINT_GRACE_SEC, 1380)
         self.assertEqual(run_leg.HARBOR_SHUTDOWN_GRACE_SEC, 1420)
         self.assertEqual(
             run_leg.invocation_reserve_sec(run_leg.DEFAULT_HARBOR_TIMEOUT_SEC),
-            13480,
+            17080,
         )
         self.assertGreater(
             run_leg.DEFAULT_HARBOR_TIMEOUT_SEC,
@@ -196,8 +212,9 @@ class PhaseBudgets(unittest.TestCase):
         )
         self.assertGreater(
             run_leg.MIN_BREV_EXEC_TIMEOUT_SEC,
-            run_leg.HARBOR_AGENT_BUDGET_SEC,
+            run_leg.HARBOR_AGENT_TIMEOUT_SEC,
         )
+        self.assertEqual(run_leg.MIN_BREV_EXEC_TIMEOUT_SEC, 7830)
 
     def test_timeout_validation_rejects_boundary_and_accepts_default(self):
         with self.assertRaisesRegex(ValueError, "cleanup/recovery"):
@@ -282,7 +299,7 @@ class HarborEnvironment(unittest.TestCase):
             int(env["BREV_EXEC_TIMEOUT"]), run_leg.MIN_BREV_EXEC_TIMEOUT_SEC
         )
         self.assertGreater(
-            int(env["BREV_EXEC_TIMEOUT"]), run_leg.HARBOR_AGENT_BUDGET_SEC
+            int(env["BREV_EXEC_TIMEOUT"]), run_leg.HARBOR_AGENT_TIMEOUT_SEC
         )
         self.assertEqual(
             int(env["BREV_TRANSFER_TOTAL_TIMEOUT_SEC"]),

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -118,10 +118,10 @@ jobs:
       max-parallel: 8
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     # Per-leg cap. One spec, but a multi-step spec runs step-1..N as
-    # sequential harbor invocations, each up to the 1 h agent ceiling
-    # (AGENTS.md `--agent-timeout-multiplier 6.0`). A timeout stops the
+    # sequential harbor invocations, each up to the 2 h agent ceiling
+    # (AGENTS.md `--agent-timeout-multiplier 12.0`). A timeout stops the
     # remaining chain; successful steps normally finish well below their
-    # 200-minute emergency backstop. AGENTS.md's box-lock wait
+    # 260-minute emergency backstop. AGENTS.md's box-lock wait
     # (flock -w 21000 ≈ 5.8 h) is kept strictly under this 840 m ceiling so a
     # lock-starved leg emits `BLOCKED: lock timeout`
     # before the job-killer fires (a 43200 s / 12 h wait would be

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -154,10 +154,10 @@ jobs:
       max-parallel: 8
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     # Per-leg cap. One spec, but a multi-step spec runs step-1..N as
-    # sequential harbor invocations, each up to the 1 h agent ceiling
-    # (AGENTS.md `--agent-timeout-multiplier 6.0`). A timeout stops the
+    # sequential harbor invocations, each up to the 2 h agent ceiling
+    # (AGENTS.md `--agent-timeout-multiplier 12.0`). A timeout stops the
     # remaining chain; successful steps normally finish well below their
-    # 200-minute emergency backstop. AGENTS.md's box-lock wait
+    # 260-minute emergency backstop. AGENTS.md's box-lock wait
     # (run_leg.py --lock-timeout-sec
     # 21000 ≈ 5.8 h) is kept strictly under this 840 m ceiling so a
     # lock-starved leg emits `BLOCKED: lock timeout`


### PR DESCRIPTION
## Description

Make the skill-eval timeout policy four independent absolute phase limits:

- environment build: 1,800 seconds
- agent setup: 360 seconds
- agent execution: 7,200 seconds
- verification: 1,800 seconds

Harbor 0.20 exposes these through phase-specific multipliers, so `run_leg.py` now derives the CLI encoding (`3.0 / 1.0 / 12.0 / 3.0`) from the four limits instead of treating a shared 600-second base as policy.

The outer watchdog is now derived as well: 11,160 seconds of phase time + 2,520 seconds of bounded artifact recovery + the existing 1,920-second scheduling/teardown margin = 15,600 seconds. The Brev remote-command floor follows the agent limit automatically and becomes 7,830 seconds.

This lets a legitimate cold VSS startup survive beyond one hour without making cache preservation a correctness requirement. It keeps the emergency watchdog strictly outside Harbor's normal timeout, verifier, artifact collection, and cleanup path fixed by #1517.

Documentation and workflow comments now describe the four limits and the 260-minute emergency backstop.

## Validation

- `60 passed, 2 subtests passed` using the exact Python 3.12 skill-eval harness contract from CI
- pre-commit hooks passed, including TruffleHog, SPDX headers, and DCO
- both modified workflow files parse as valid YAML
- Harbor 0.20.0 CLI confirms `--agent-setup-timeout-multiplier` support
- broader `test_run_leg.py`: 47 passed; its 3 RTX4090 routing failures reproduce unchanged on `develop` and are unrelated to this patch

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
