### PR TITLE
ci: focus License Diff on OSRB review triggers

### DIFF
--- a/.github/scripts/license_diff_csv.py
+++ b/.github/scripts/license_diff_csv.py
@@ -308,13 +308,19 @@ def diff_requirements(
                 "repository_url": "", "notes": "removed from requirements.txt",
             })
         elif bv != hv and bv and hv:  # pinned == bump on both sides
-            meta = pypi_metadata(name, hv)
+            old_meta = pypi_metadata(name, bv)
+            new_meta = pypi_metadata(name, hv)
+            old_license = old_meta.get("license", "")
+            new_license = new_meta.get("license", "")
+            notes = "requirements.txt version pin changed"
+            if old_license and new_license and old_license != new_license:
+                notes += "; license changed"
             rows.append({
                 "language": "python", "package": name, "change": "updated",
                 "old_version": bv, "new_version": hv,
-                "old_license": "", "new_license": meta.get("license", ""),
-                "repository_url": meta.get("repository_url", ""),
-                "notes": "requirements.txt version pin changed",
+                "old_license": old_license, "new_license": new_license,
+                "repository_url": new_meta.get("repository_url", ""),
+                "notes": notes,
             })
     return rows
 

--- a/.github/scripts/license_diff_summary.py
+++ b/.github/scripts/license_diff_summary.py
@@ -31,6 +31,7 @@ LICENSE_ALIASES = {
     "apache 2": "apache-2.0",
     "apache 2.0": "apache-2.0",
     "apache software license": "apache-2.0",
+    "apache software": "apache-2.0",
     "apache license 2.0": "apache-2.0",
     "mit license": "mit",
     "isc license": "isc",

--- a/.github/scripts/license_diff_summary.py
+++ b/.github/scripts/license_diff_summary.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Render the OSRB-review overview from the complete License Diff CSV.
+
+The input remains the audit record.  The overview contains only changes that
+match OSRB's re-engagement policy: new dependencies, license changes, and
+version updates whose old/new license could not be resolved.  Same-license
+version updates and removals stay in the raw CSV but are omitted from the
+review table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from typing import TextIO
+
+UNKNOWN_LICENSES = {
+    "",
+    "unknown",
+    "unknown license",
+    "n/a",
+    "none",
+    "not found",
+    "see license in",
+}
+
+LICENSE_ALIASES = {
+    "apache 2": "apache-2.0",
+    "apache 2.0": "apache-2.0",
+    "apache software license": "apache-2.0",
+    "apache license 2.0": "apache-2.0",
+    "mit license": "mit",
+    "isc license": "isc",
+    "mozilla public license 2.0": "mpl-2.0",
+    "python software foundation license": "psf-2.0",
+}
+
+
+def normalize_license(value: str) -> str:
+    """Normalize common label variants without guessing ambiguous licenses."""
+    normalized = re.sub(r"\s+", " ", value.strip().lower())
+    return LICENSE_ALIASES.get(normalized, normalized)
+
+
+def license_is_unknown(value: str) -> bool:
+    normalized = normalize_license(value)
+    return normalized in UNKNOWN_LICENSES or normalized.startswith("unknown")
+
+
+def review_category(row: dict[str, str]) -> str | None:
+    """Return the overview category for one raw row, if review is needed."""
+    change = row.get("change", "").strip().lower()
+    if change == "added":
+        return "added"
+    if change != "updated":
+        return None
+
+    old_license = row.get("old_license", "")
+    new_license = row.get("new_license", "")
+    if license_is_unknown(old_license) or license_is_unknown(new_license):
+        return "unresolved"
+    if normalize_license(old_license) != normalize_license(new_license):
+        return "license_changed"
+    return None
+
+
+def classify_rows(rows: list[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
+    grouped: dict[str, list[dict[str, str]]] = {
+        "added": [],
+        "license_changed": [],
+        "unresolved": [],
+        "version_only": [],
+        "removed": [],
+    }
+    for row in rows:
+        category = review_category(row)
+        if category:
+            grouped[category].append(row)
+        elif row.get("change", "").strip().lower() == "removed":
+            grouped["removed"].append(row)
+        elif row.get("change", "").strip().lower() == "updated":
+            grouped["version_only"].append(row)
+    return grouped
+
+
+def markdown_cell(value: str) -> str:
+    value = value.strip()
+    return value.replace("|", "\\|") if value else "—"
+
+
+def _write_table(
+    output: TextIO,
+    rows: list[dict[str, str]],
+    *,
+    license_change: bool = False,
+) -> None:
+    if license_change:
+        print("| Component | Version | License change | Public component or license URL |", file=output)
+        print("|---|---|---|---|", file=output)
+    else:
+        print("| Component | Version | Assessed license | Public component or license URL |", file=output)
+        print("|---|---|---|---|", file=output)
+
+    for row in rows:
+        version = row.get("new_version", "")
+        if row.get("old_version") and row.get("new_version"):
+            version = f"{row['old_version']} → {row['new_version']}"
+        license_value = row.get("new_license", "")
+        if license_change:
+            license_value = f"{row.get('old_license', '')} → {row.get('new_license', '')}"
+        values = [
+            row.get("package", ""),
+            version,
+            license_value,
+            row.get("repository_url", ""),
+        ]
+        print("| " + " | ".join(markdown_cell(value) for value in values) + " |", file=output)
+
+
+def render_summary(rows: list[dict[str, str]], output: TextIO) -> dict[str, int]:
+    grouped = classify_rows(rows)
+    review_rows = (
+        len(grouped["added"])
+        + len(grouped["license_changed"])
+        + len(grouped["unresolved"])
+    )
+    counts = {
+        "raw_rows": len(rows),
+        "review_rows": review_rows,
+        "added_rows": len(grouped["added"]),
+        "license_changed_rows": len(grouped["license_changed"]),
+        "unresolved_rows": len(grouped["unresolved"]),
+        "version_only_rows": len(grouped["version_only"]),
+        "removed_rows": len(grouped["removed"]),
+    }
+
+    print("# OSRB license review overview", file=output)
+    print(file=output)
+    if review_rows:
+        print(f"**{review_rows} change(s) require OSRB attention.**", file=output)
+    else:
+        print("**No changes require OSRB re-engagement.**", file=output)
+    print(file=output)
+    print(
+        f"The complete CSV contains {len(rows)} change(s): "
+        f"{counts['version_only_rows']} same-license version update(s) and "
+        f"{counts['removed_rows']} removal(s) are retained there but omitted below.",
+        file=output,
+    )
+
+    sections = [
+        ("New dependencies", grouped["added"], False),
+        ("License changes", grouped["license_changed"], True),
+        ("Licenses requiring investigation", grouped["unresolved"], True),
+    ]
+    for title, section_rows, license_change in sections:
+        if not section_rows:
+            continue
+        print(file=output)
+        print(f"## {title} ({len(section_rows)})", file=output)
+        print(file=output)
+        _write_table(output, section_rows, license_change=license_change)
+
+    return counts
+
+
+def write_github_output(path: str, counts: dict[str, int]) -> None:
+    with open(path, "a", encoding="utf-8") as output:
+        for name, value in counts.items():
+            print(f"{name}={value}", file=output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default="license-diff.csv")
+    parser.add_argument("--output", default="osrb-summary.md")
+    parser.add_argument("--github-output", help="Optional path supplied by GitHub Actions.")
+    args = parser.parse_args()
+
+    with open(args.input, newline="", encoding="utf-8-sig") as source:
+        rows = list(csv.DictReader(source))
+    with open(args.output, "w", encoding="utf-8") as output:
+        counts = render_summary(rows, output)
+    if args.github_output:
+        write_github_output(args.github_output, counts)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_license_diff_csv.py
+++ b/.github/scripts/test_license_diff_csv.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import importlib.util
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 MODULE_PATH = Path(__file__).with_name("license_diff_csv.py")
@@ -174,6 +175,27 @@ dependencies = [
             },
             set(inventory),
         )
+
+
+class DiffRequirementsTest(unittest.TestCase):
+    @mock.patch.object(license_diff_csv, "pypi_metadata")
+    def test_version_bump_resolves_both_license_versions(self, metadata: mock.Mock) -> None:
+        metadata.side_effect = [
+            {"license": "MIT", "repository_url": "https://example.com/old"},
+            {"license": "MPL-2.0", "repository_url": "https://example.com/new"},
+        ]
+
+        rows = license_diff_csv.diff_requirements(
+            {"demo": "1.0.0"},
+            {"demo": "2.0.0"},
+            set(),
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["old_license"], "MIT")
+        self.assertEqual(rows[0]["new_license"], "MPL-2.0")
+        self.assertEqual(rows[0]["repository_url"], "https://example.com/new")
+        self.assertIn("license changed", rows[0]["notes"])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_license_diff_summary.py
+++ b/.github/scripts/test_license_diff_summary.py
@@ -62,6 +62,17 @@ class ReviewCategoryTest(unittest.TestCase):
             )
         )
 
+    def test_classifier_derived_apache_label_does_not_create_false_drift(self) -> None:
+        self.assertIsNone(
+            summary.review_category(
+                row(
+                    "updated",
+                    old_license="Apache Software License",
+                    new_license="Apache Software",
+                )
+            )
+        )
+
     def test_license_change_requires_review(self) -> None:
         self.assertEqual(
             summary.review_category(

--- a/.github/scripts/test_license_diff_summary.py
+++ b/.github/scripts/test_license_diff_summary.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the OSRB license-diff overview."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("license_diff_summary.py")
+MODULE_SPEC = importlib.util.spec_from_file_location("license_diff_summary", MODULE_PATH)
+assert MODULE_SPEC is not None and MODULE_SPEC.loader is not None
+summary = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(summary)
+
+
+def row(
+    change: str,
+    *,
+    package: str = "demo",
+    old_version: str = "1.0",
+    new_version: str = "2.0",
+    old_license: str = "MIT",
+    new_license: str = "MIT",
+) -> dict[str, str]:
+    return {
+        "language": "python",
+        "package": package,
+        "change": change,
+        "old_version": old_version,
+        "new_version": new_version,
+        "old_license": old_license,
+        "new_license": new_license,
+        "repository_url": f"https://example.com/{package}",
+        "notes": "",
+    }
+
+
+class ReviewCategoryTest(unittest.TestCase):
+    def test_addition_requires_review(self) -> None:
+        self.assertEqual(
+            summary.review_category(
+                row("added", old_version="", old_license="", new_license="Apache-2.0")
+            ),
+            "added",
+        )
+
+    def test_same_license_version_update_does_not_require_review(self) -> None:
+        self.assertIsNone(summary.review_category(row("updated")))
+
+    def test_equivalent_license_labels_do_not_create_false_drift(self) -> None:
+        self.assertIsNone(
+            summary.review_category(
+                row(
+                    "updated",
+                    old_license="Apache Software License",
+                    new_license="Apache-2.0",
+                )
+            )
+        )
+
+    def test_license_change_requires_review(self) -> None:
+        self.assertEqual(
+            summary.review_category(
+                row("updated", old_license="MIT", new_license="GPL-3.0")
+            ),
+            "license_changed",
+        )
+
+    def test_unresolved_license_comparison_requires_review(self) -> None:
+        self.assertEqual(
+            summary.review_category(row("updated", old_license="", new_license="MIT")),
+            "unresolved",
+        )
+
+    def test_removal_does_not_require_review(self) -> None:
+        self.assertIsNone(
+            summary.review_category(
+                row("removed", new_version="", new_license="")
+            )
+        )
+
+
+class RenderSummaryTest(unittest.TestCase):
+    def test_overview_keeps_raw_counts_but_hides_non_actionable_rows(self) -> None:
+        rows = [
+            row("added", package="new-dep", old_version="", old_license=""),
+            row("updated", package="version-only"),
+            row(
+                "updated",
+                package="relicensed",
+                old_license="MIT",
+                new_license="MPL-2.0",
+            ),
+            row("removed", package="deleted", new_version="", new_license=""),
+        ]
+        output = io.StringIO()
+
+        counts = summary.render_summary(rows, output)
+        rendered = output.getvalue()
+
+        self.assertEqual(counts["raw_rows"], 4)
+        self.assertEqual(counts["review_rows"], 2)
+        self.assertEqual(counts["version_only_rows"], 1)
+        self.assertEqual(counts["removed_rows"], 1)
+        self.assertIn("new-dep", rendered)
+        self.assertIn("relicensed", rendered)
+        self.assertNotIn("| version-only |", rendered)
+        self.assertNotIn("| deleted |", rendered)
+
+    def test_markdown_escapes_table_separators(self) -> None:
+        self.assertEqual(summary.markdown_cell("MIT OR Apache | custom"), "MIT OR Apache \\| custom")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,7 @@ jobs:
           uv run --no-sync pytest packages/vss_core/tests/unit_test packages/vss_cli/tests/unit_test -W error::RuntimeWarning -W error::ResourceWarning \
             --cov=packages/vss_core/src --cov=packages/vss_cli/src --cov-fail-under=80 --cov-report=xml:coverage-lib.xml -m "not slow and not integration"
           uv run --no-sync python ../../.github/scripts/test_license_diff_csv.py
+          uv run --no-sync python ../../.github/scripts/test_license_diff_summary.py
           rm -rf dist
           uv build --package nvidia-vss-core
           uv build --package nvidia-vss-cli

--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -84,58 +84,50 @@ jobs:
           echo "--- csv preview (rows=${row_count}) ---"
           head -n 30 license-diff.csv || true
 
-      - name: Upload CSV artifact
+      - name: Render OSRB review overview
+        id: overview
+        if: steps.ctx.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          python .github/scripts/license_diff_summary.py \
+            --input license-diff.csv \
+            --output osrb-summary.md \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload review evidence
         id: upload
         if: always() && steps.ctx.outputs.skip != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: license-diff
-          path: license-diff.csv
+          path: |
+            license-diff.csv
+            osrb-summary.md
           if-no-files-found: warn
-
-      - name: Render markdown table
-        id: render
-        if: always() && steps.ctx.outputs.skip != 'true' && steps.gen.outputs.rows != ''
-        run: |
-          set -euo pipefail
-          python3 - <<'PY' > diff-table.md
-          import csv
-          rows = list(csv.DictReader(open("license-diff.csv")))
-          print("| language | package | change | old_version | new_version | old_license | new_license | repository_url |")
-          print("|----------|---------|--------|-------------|-------------|-------------|-------------|----------------|")
-          for row in rows:
-              cells = [
-                  row["language"], row["package"], row["change"],
-                  row["old_version"], row["new_version"],
-                  row["old_license"], row["new_license"],
-                  row["repository_url"],
-              ]
-              print("| " + " | ".join(c.replace("|", "\\|") for c in cells) + " |")
-          PY
 
       - name: Write step summary
         if: always()
         env:
           SKIP: ${{ steps.ctx.outputs.skip }}
-          ROWS: ${{ steps.gen.outputs.rows }}
           BASE: ${{ steps.ctx.outputs.base }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
         run: |
           set -euo pipefail
           {
-            echo "## License Diff for OSRB"
-            echo
             if [[ "${SKIP}" == "true" ]]; then
+              echo "## License Diff for OSRB"
+              echo
               echo "Skipped: PR targets a release branch (\`dev/*\` or \`release/*\`)."
               echo "License Diff already enforced on the develop-targeted PR; running again here only adds noise."
             elif [[ ! -f license-diff.csv ]]; then
-              echo "No CSV produced."
-            elif [[ "${ROWS:-0}" -le 0 ]]; then
-              echo "No package version or license changes detected."
-            else
-              echo "Compared HEAD against \`${BASE}\`."
-              echo "**${ROWS}** changed packages require OSRB review. Full CSV is attached as the **license-diff** artifact."
+              echo "## License Diff for OSRB"
               echo
-              cat diff-table.md
+              echo "No CSV produced."
+            else
+              cat osrb-summary.md
+              echo
+              echo "Compared HEAD against \`${BASE}\`."
+              echo "Download the complete \`license-diff.csv\` from the [license-diff artifact](${ARTIFACT_URL})."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -145,7 +137,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ steps.ctx.outputs.pr }}
-          ROWS: ${{ steps.gen.outputs.rows }}
+          RAW_ROWS: ${{ steps.gen.outputs.rows }}
           BASE: ${{ steps.ctx.outputs.base }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
@@ -154,12 +146,10 @@ jobs:
           marker='<!-- license-diff-osrb -->'
           {
             echo "$marker"
-            echo "## License Diff for OSRB"
+            cat osrb-summary.md
             echo
-            echo "**${ROWS}** changed packages require OSRB review (vs \`${BASE}\`)."
-            echo "Download the full CSV directly: [\`license-diff.csv\`](${ARTIFACT_URL}) (or browse the [workflow run](${RUN_URL}))."
-            echo
-            cat diff-table.md
+            echo "Compared against \`${BASE}\`. The complete CSV retains all **${RAW_ROWS}** changes."
+            echo "Review the [GitHub Actions run](${RUN_URL}) or download the [\`license-diff\` artifact](${ARTIFACT_URL})."
             echo
             echo "<details><summary>Raw CSV (inline)</summary>"
             echo
@@ -181,10 +171,10 @@ jobs:
             echo "$payload" | gh api -X POST "repos/${REPO}/issues/${PR}/comments" --input - > /dev/null
           fi
 
-      - name: Fail when license diff is non-empty
-        if: steps.ctx.outputs.skip != 'true' && steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
+      - name: Fail when OSRB re-engagement is required
+        if: steps.ctx.outputs.skip != 'true' && steps.overview.outputs.review_rows != '' && steps.overview.outputs.review_rows != '0'
         env:
-          ROWS: ${{ steps.gen.outputs.rows }}
+          REVIEW_ROWS: ${{ steps.overview.outputs.review_rows }}
         run: |
-          echo "::error title=License diff non-empty::${ROWS} packages changed; requires OSRB review."
+          echo "::error title=OSRB review required::${REVIEW_ROWS} package changes require OSRB attention."
           exit 1

--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -132,7 +132,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Post or update PR comment
-        if: always() && steps.ctx.outputs.skip != 'true' && steps.gen.outputs.rows != '' && steps.gen.outputs.rows != '0'
+        if: always() && steps.ctx.outputs.skip != 'true' && steps.gen.outputs.rows != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- add a short OSRB overview for new dependencies, confirmed license changes, and unresolved license comparisons
- keep every dependency change in the complete CSV artifact for investigation
- stop blocking on same-license version updates and removals
- normalize equivalent license metadata labels to avoid false OSRB triggers
- link the overview to the GitHub Actions run and artifact
- resolve both old and new license metadata for pinned requirements updates
- refresh the PR summary on zero-change reruns so old warnings are cleared

## Test plan
- [x] `python3 .github/scripts/test_license_diff_csv.py`
- [x] `python3 .github/scripts/test_license_diff_summary.py`
- [x] regression test for classifier-derived Apache metadata
- [x] `ruff check` on the changed Python scripts
- [x] parse the changed workflow YAML files
- [ ] repository CI on the latest commit