### PR TITLE
feat(skill-eval): time each leg phase so a silent gap is readable

### DIFF
--- a/.github/skill-eval/leg_timing.py
+++ b/.github/skill-eval/leg_timing.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Elapsed-time heartbeat and per-phase wall time for one skill-eval leg.
+
+A leg's log lines carry no clock. `skills_eval_agent` runs `run_leg.py` through
+a Bash tool that surfaces captured output only once the tool returns, so a
+132-minute leg reaches the Actions log as a single undated block: run
+30733390364 spent 130.3 of 132 minutes inside one gap, and 103.5 of 108 in
+another leg, with no way to tell a lock wait from a slow deploy.
+
+Two cheap answers, both here. A heartbeat stamps elapsed time and the current
+phase into the same stream, so every neighbouring line can be placed to within
+HEARTBEAT_SEC even though the whole block arrives at once. Each phase's wall
+time is written next to the results, where the workflow's existing collect step
+already uploads it, so the split can be aggregated across legs instead of read
+by eye.
+
+TIMING MUST NEVER CHANGE A VERDICT. Every write here is best effort and a
+failure to record is logged and swallowed. `leg_log` swallows its own
+exceptions because one of these calls sits in `run_leg.main`'s finally, where
+raising would replace Harbor's exit code with a logging failure.
+
+WHAT THIS DELIBERATELY DOES NOT DO is sample the network. Harbor runs the
+workload on a remote Brev box via `envs.brev_env:BrevEnvironment` while the
+wrapper runs on the coordinator, so any counter read here describes the wrong
+machine: a box downloading model weights for ten minutes would show up as a
+quiet link. Measuring the transfer needs remote sampling of the kind
+`gpu_trace.py` does, and is a follow-up once these timings show whether that
+time is where we think it is.
+
+STATE IS MODULE-LEVEL and single-writer by design. `run_leg.main` is the only
+writer; the heartbeat thread only reads `_CURRENT_PHASE`, and it is joined
+before `_PHASES` is serialised. Read the label through `current_phase()` rather
+than importing the global, which would copy it once and never see a change.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import math
+import os
+import threading
+import time
+from pathlib import Path
+
+
+MAX_HEARTBEAT_SEC = 3600.0
+
+
+def _heartbeat_interval() -> float:
+    """Seconds between heartbeats, clamped so a typo cannot spin or break a leg."""
+    raw = os.environ.get("RUN_LEG_HEARTBEAT_SEC", "60")
+    try:
+        interval = float(raw)
+    except ValueError:
+        print(
+            f"[run-leg] ignoring RUN_LEG_HEARTBEAT_SEC={raw!r}, using 60s",
+            flush=True,
+        )
+        return 60.0
+    # float() accepts "inf" and "1e999", and max(1.0, inf) is inf, which then
+    # reaches Thread.join(timeout=...) in main()'s finally and raises
+    # OverflowError: timestamp out of range for platform time_t. That would
+    # replace the leg's verdict with an instrumentation traceback, which is the
+    # one thing this file must never do. NaN is safe by luck (max returns 1.0),
+    # which is not a reason to leave it to luck.
+    if not math.isfinite(interval):
+        print(
+            f"[run-leg] ignoring non-finite RUN_LEG_HEARTBEAT_SEC={raw!r}, using 60s",
+            flush=True,
+        )
+        return 60.0
+    # Below a second it busy-loops, filling the log and the very disk this is
+    # here to measure. Above an hour it is not a heartbeat.
+    return min(max(interval, 1.0), MAX_HEARTBEAT_SEC)
+
+
+HEARTBEAT_SEC = _heartbeat_interval()
+PHASE_TIMINGS_NAME = "phase-timings.json"
+_LEG_T0 = time.monotonic()
+_PHASES: list[dict] = []
+_CURRENT_PHASE = "startup"
+
+
+def leg_log(message: str) -> None:
+    """Instrumentation output, which must never become the leg's outcome.
+
+    A print can raise: a closed or backpressured pipe gives BrokenPipeError,
+    and one of these calls sits in main()'s finally, where an exception would
+    replace Harbor's exit code with a logging failure.
+    """
+    with contextlib.suppress(Exception):
+        print(f"[run-leg] {message}", flush=True)
+
+
+def leg_elapsed() -> float:
+    """Seconds since this leg started, the clock all timing lines share."""
+    return time.monotonic() - _LEG_T0
+
+
+def record_phase(name: str, started_s: float, ended_s: float) -> None:
+    _PHASES.append(
+        {
+            "phase": name,
+            "start_s": round(started_s, 1),
+            "end_s": round(ended_s, 1),
+            "seconds": round(ended_s - started_s, 1),
+        }
+    )
+
+
+def set_phase(name: str) -> None:
+    """Point the heartbeat at what the leg is doing right now.
+
+    Needed where the phase's recorded NAME depends on how it ends, which
+    `phase()` cannot express because it has to name the phase before the body
+    runs. The lock wait is `lock-wait`, `lock-wait-timeout` or
+    `lock-wait-failed` depending on its outcome, so it sets its own label.
+    """
+    global _CURRENT_PHASE
+    _CURRENT_PHASE = name
+
+
+def current_phase() -> str:
+    """The label the heartbeat is reporting right now.
+
+    An accessor rather than a bare global, because `from leg_timing import
+    _CURRENT_PHASE` binds the value once and then never changes: a caller
+    saving the label to restore it later would restore whatever it happened to
+    be at import time, which is always "startup".
+    """
+    return _CURRENT_PHASE
+
+
+@contextlib.contextmanager
+def phase(name: str):
+    """Time one named phase and mark its boundaries in the log."""
+    global _CURRENT_PHASE
+    previous = _CURRENT_PHASE
+    started = leg_elapsed()
+    # Label flips after the begin line and before the end line, so a tick
+    # landing on a boundary cannot report a phase the log has not opened yet.
+    leg_log(f"t+{started:.0f}s phase begin: {name}")
+    _CURRENT_PHASE = name
+    try:
+        yield
+    finally:
+        ended = leg_elapsed()
+        record_phase(name, started, ended)
+        # Restore BEFORE the end line, mirroring the begin side. Logging first
+        # left a window in which a heartbeat could claim the leg was still in a
+        # phase the log had already closed.
+        _CURRENT_PHASE = previous
+        leg_log(f"t+{ended:.0f}s phase end: {name} ({ended - started:.0f}s)")
+
+
+def _heartbeat(stop: threading.Event) -> None:
+    """Emit elapsed time and the current phase until asked to stop.
+
+    The first tick fires immediately rather than after a full interval. A leg
+    that dies inside its first HEARTBEAT_SEC would otherwise produce no timing
+    line at all, and "no output" is exactly the symptom this exists to remove.
+    """
+    while not stop.is_set():
+        # Checked before every emission, not only after the wait. A leg short
+        # enough to finish before this thread is first scheduled would
+        # otherwise log "still in <phase>" about work that had already ended.
+        leg_log(f"t+{leg_elapsed():.0f}s still in {_CURRENT_PHASE}")
+        if stop.wait(HEARTBEAT_SEC):
+            return
+
+
+def start_heartbeat() -> tuple[threading.Thread, threading.Event]:
+    """Start the elapsed-time heartbeat. Daemon, so it cannot hold exit."""
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=_heartbeat,
+        args=(stop,),
+        name="run-leg-heartbeat",
+        daemon=True,
+    )
+    thread.start()
+    return thread, stop
+
+
+def write_phase_timings(results_root: Path) -> None:
+    """Drop the phase split next to the results, and summarise it in the log.
+
+    The workflow's existing "Collect results for workflow artifact" step
+    uploads whatever is under results_root, so this needs no workflow change
+    to reach the artifact.
+    """
+    if not _PHASES:
+        return
+    summary = " ".join(f"{entry['phase']}={entry['seconds']:.0f}s" for entry in _PHASES)
+    leg_log(f"phase summary: {summary}")
+    payload = {
+        "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "slug": os.environ.get("EVAL_SLUG", ""),
+        "total_s": round(leg_elapsed(), 1),
+        "phases": _PHASES,
+    }
+    # Written to a sibling then renamed. This runs in main()'s finally, which
+    # is exactly where a second signal can arrive during a cancellation, and a
+    # write interrupted partway leaves truncated JSON at the real path. A
+    # reader cannot tell that from a leg that genuinely recorded nothing, so it
+    # is worse than the missing file. os.replace is atomic within a directory,
+    # so the artifact is either the previous state or the complete new one.
+    destination = results_root / PHASE_TIMINGS_NAME
+    scratch_path = destination.with_name(f"{PHASE_TIMINGS_NAME}.partial")
+    try:
+        results_root.mkdir(parents=True, exist_ok=True)
+        scratch_path.write_text(
+            json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+        )
+        os.replace(scratch_path, destination)
+    except OSError as exc:
+        leg_log(f"could not write {PHASE_TIMINGS_NAME}: {exc!r}")
+        # Never leave the half-written sibling behind to be collected as an
+        # artifact in its own right.
+        with contextlib.suppress(OSError):
+            scratch_path.unlink()

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -37,8 +37,16 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.parse
+
+# Self-contained instrumentation with its own module state. Split out because
+# this file is long enough that a reader looking for the lock or the Harbor
+# command should not have to scroll past it. Read the phase label through
+# leg_timing.current_phase(); importing the global copies it once.
+import leg_timing
+from leg_timing import HEARTBEAT_SEC, leg_log, phase
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_EVAL_PYTHON_VERSION = (3, 12)
@@ -55,6 +63,7 @@ RTX4090_TESTS: dict[str, frozenset[str]] = {}
 # (AGENTS.md § Harbor viewer). Fixed path — the viewer is started once for
 # the host, not per leg, so every leg publishes its trials in here.
 VIEWER_ROOT = Path("/tmp/skill-eval/results/_viewer")
+
 
 # Harbor phase budgets. Adapters set the task's base agent timeout to the same
 # 600-second base used by Harbor for environment build and verification; these
@@ -1323,7 +1332,8 @@ def run_invocations(
 
         cmd = build_harbor_command(invocation, results_root, model, base_url, agent)
         started_at = time.time() - 1.0
-        rc = run_command(cmd, env, harbor_timeout_sec)
+        with phase(f"harbor:{invocation.include_task_name}"):
+            rc = run_command(cmd, env, harbor_timeout_sec)
         # Publish before the rc checks below: a timed-out (rc=124) trial
         # returns early, and its partial trace is exactly what needs reading.
         try:
@@ -1399,6 +1409,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return args
 
 
+def _terminate(signum: int, _frame) -> None:
+    """Turn SIGTERM into an unwinding exit so cleanup actually runs.
+
+    Python converts only SIGINT into an exception; SIGTERM keeps SIG_DFL and
+    terminates the interpreter without unwinding, so no `finally` and no
+    context-manager exit fires. That matters here because `skills-eval.yml`
+    sets `cancel-in-progress: true`: every push to a pull request SIGTERMs the
+    in-flight legs, up to `max-parallel` of them at once. Without this, a
+    cancelled leg never reaches the phase-timing write in main()'s finally, so
+    it produces no artifact at all -- and a leg cancelled after an hour in the
+    lock queue is one of the most informative things this feature can record.
+    """
+    raise SystemExit(128 + signum)
+
+
 def main(argv: list[str] | None = None) -> int:
     actual_python = sys.version_info[:2]
     if actual_python != SKILL_EVAL_PYTHON_VERSION:
@@ -1409,7 +1434,20 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+    with contextlib.suppress(ValueError, OSError):
+        # ValueError if not on the main thread; never fatal either way.
+        signal.signal(signal.SIGTERM, _terminate)
     args = parse_args(argv or sys.argv[1:])
+    # Instrumentation must not be able to fail the leg, and starting a thread
+    # can: a runner at its thread limit raises RuntimeError here. Losing the
+    # heartbeat costs visibility, while raising costs the whole leg, so this
+    # degrades to no heartbeat and says so.
+    heartbeat: threading.Thread | None = None
+    stop_heartbeat: threading.Event | None = None
+    try:
+        heartbeat, stop_heartbeat = leg_timing.start_heartbeat()
+    except Exception as exc:  # noqa: BLE001 - telemetry is never load-bearing
+        leg_log(f"heartbeat unavailable ({exc!r}); leg continues without it")
     try:
         invocations = discover_invocations(args.dataset_root)
         print(f"[run-leg] discovered {len(invocations)} harbor invocation(s)", flush=True)
@@ -1439,10 +1477,29 @@ def main(argv: list[str] | None = None) -> int:
             candidates_fn = (  # noqa: E731
                 lambda: pool_candidates(metadata, args.spec_stem)
             )
+        # Timed either side of the lock: the wait for a free box is the leg's
+        # least visible cost and the one the pickup analysis most needs split
+        # out from the Harbor run itself.
+        lock_wait_started = leg_timing.leg_elapsed()
+        lock_acquired = False
+        # The heartbeat's LABEL, not just the recorded interval. The lock wait
+        # is the longest gap a leg can have -- 16 minutes in the run that
+        # motivated this, and bounded only by lock_timeout_sec -- and it ran
+        # entirely under the label "startup", so every tick during the one
+        # phase the log most needed to name reported the wrong thing.
+        outer_phase = leg_timing.current_phase()
+        leg_timing.set_phase("lock-wait")
         try:
             with hold_pool_lock(
                 candidates_fn, args.lock_dir, effective_lock_timeout
             ) as instance:
+                lock_acquired = True
+                leg_timing.record_phase(
+                    "lock-wait", lock_wait_started, leg_timing.leg_elapsed()
+                )
+                # The wait is over the moment the lock is held; the Harbor
+                # phases below set their own labels.
+                leg_timing.set_phase(outer_phase)
                 return run_invocations(
                     invocations,
                     instance,
@@ -1454,11 +1511,37 @@ def main(argv: list[str] | None = None) -> int:
                     work_deadline,
                 )
         except LockTimeoutError:
+            leg_timing.record_phase(
+                "lock-wait-timeout", lock_wait_started, leg_timing.leg_elapsed()
+            )
             if effective_lock_timeout < args.lock_timeout_sec:
                 raise LegDeadlineError(
                     "whole-leg deadline expired while reserving room for Harbor"
                 )
             raise
+        except BaseException:
+            # Every exit from the lock gets a phase, including the ones nobody
+            # expects: an invalid instance name raises ValueError, a bad lock
+            # dir raises OSError. A leg that died selecting a box still spent
+            # that time, and an artifact with no lock interval is
+            # indistinguishable from one where the wait was zero.
+            #
+            # BaseException, not Exception, and the difference is the common
+            # case rather than an exotic one. `skills-eval.yml` sets
+            # cancel-in-progress, so a push cancels in-flight legs, and a
+            # cancellation arriving during the lock wait raises
+            # KeyboardInterrupt. Catching only Exception dropped the wait from
+            # the artifact for precisely the legs that spent longest in it.
+            if not lock_acquired:
+                leg_timing.record_phase(
+                    "lock-wait-failed", lock_wait_started, leg_timing.leg_elapsed()
+                )
+            raise
+        finally:
+            # Every exit restores the label, including the ones that raise past
+            # the resets above. A stuck "lock-wait" would misreport the rest of
+            # the leg for as long as it ran.
+            leg_timing.set_phase(outer_phase)
     except LockTimeoutError:
         target = args.instance or f"pool ({args.platform or 'platform'})"
         print(f"BLOCKED: lock timeout on {target}", flush=True)
@@ -1469,6 +1552,20 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # noqa: BLE001
         print(f"FATAL: run_leg failed: {exc!r}", file=sys.stderr)
         return 1
+    finally:
+        if stop_heartbeat is not None:
+            stop_heartbeat.set()
+        # Joined, not just signalled. A daemon still writing to stdout while
+        # the interpreter tears down its buffered streams is how a clean leg
+        # turns into a fatal abort at exit.
+        if heartbeat is not None:
+            heartbeat.join(timeout=HEARTBEAT_SEC + 5)
+        # This whole block runs on the return path of a leg that already has
+        # its outcome. Nothing here may replace it.
+        try:
+            leg_timing.write_phase_timings(args.results_root)
+        except Exception as exc:  # noqa: BLE001
+            leg_log(f"phase timing write failed: {exc!r}")
 
 
 if __name__ == "__main__":

--- a/.github/skill-eval/tests/test_leg_timing.py
+++ b/.github/skill-eval/tests/test_leg_timing.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for leg_timing.py.
+
+Run:
+    python3 .github/skill-eval/tests/test_leg_timing.py
+
+This module's contract is "record the leg's shape, and under no circumstance
+change its verdict", so the cases that matter are the ones that fail when a
+safety property is removed. The tests that drive that contract THROUGH
+run_leg.main -- the lock-wait label, SIGTERM unwinding, a heartbeat that cannot
+start -- live in test_run_leg.py, because they are about the wiring rather than
+about this module.
+
+Mutations confirmed to fail this suite:
+  * log the phase-end line before restoring the label
+  * wait a full interval before the first heartbeat tick
+  * write the artifact in place instead of renaming it into position
+  * drop the `if not _PHASES` guard so an empty run writes a file
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import leg_timing  # noqa: E402 - must follow the sys.path insert above
+
+
+class PhaseTimings(unittest.TestCase):
+    """The leg's own log has no clock, so these lines are the only clock."""
+
+    def setUp(self):
+        self._saved = list(leg_timing._PHASES)
+        leg_timing._PHASES.clear()
+
+    def tearDown(self):
+        leg_timing._PHASES[:] = self._saved
+
+    def test_phase_records_name_and_duration(self):
+        with leg_timing.phase("harbor:step-1"):
+            pass
+
+        self.assertEqual(len(leg_timing._PHASES), 1)
+        entry = leg_timing._PHASES[0]
+        self.assertEqual(entry["phase"], "harbor:step-1")
+        self.assertGreaterEqual(entry["seconds"], 0.0)
+        self.assertGreaterEqual(entry["end_s"], entry["start_s"])
+
+    def test_phase_records_even_when_the_body_raises(self):
+        # A leg that dies mid-Harbor is exactly the one worth timing.
+        with self.assertRaises(RuntimeError):
+            with leg_timing.phase("harbor:step-1"):
+                raise RuntimeError("harbor died")
+
+        self.assertEqual([e["phase"] for e in leg_timing._PHASES], ["harbor:step-1"])
+
+    def test_phase_restores_the_previous_phase_for_the_heartbeat(self):
+        with leg_timing.phase("outer"):
+            with leg_timing.phase("inner"):
+                self.assertEqual(leg_timing._CURRENT_PHASE, "inner")
+            self.assertEqual(leg_timing._CURRENT_PHASE, "outer")
+
+    def test_write_phase_timings_lands_next_to_the_results(self):
+        leg_timing.record_phase("lock-wait", 0.0, 7412.0)
+        leg_timing.record_phase("harbor:step-1", 7412.0, 8192.0)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            results_root = Path(tmp) / "results" / "slug" / "12345"
+            leg_timing.write_phase_timings(results_root)
+            payload = json.loads(
+                (results_root / leg_timing.PHASE_TIMINGS_NAME).read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(
+            [(e["phase"], e["seconds"]) for e in payload["phases"]],
+            [("lock-wait", 7412.0), ("harbor:step-1", 780.0)],
+        )
+
+    def test_write_phase_timings_is_a_no_op_without_phases(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results_root = Path(tmp) / "results"
+            leg_timing.write_phase_timings(results_root)
+            self.assertFalse(results_root.exists())
+
+    def test_write_phase_timings_never_fails_the_leg(self):
+        # Best effort by design: a read-only results root must not turn a
+        # green leg red over bookkeeping.
+        leg_timing.record_phase("lock-wait", 0.0, 1.0)
+        with mock.patch.object(
+            Path, "mkdir", side_effect=OSError("read-only file system")
+        ):
+            leg_timing.write_phase_timings(Path("/nonexistent/results"))
+
+    def test_heartbeat_stops_and_does_not_outlive_the_leg(self):
+        with mock.patch.object(leg_timing, "HEARTBEAT_SEC", 0.01):
+            thread, stop = leg_timing.start_heartbeat()
+            self.assertTrue(thread.daemon)
+            stop.set()
+            thread.join(timeout=5)
+        self.assertFalse(thread.is_alive())
+
+    def _ticks(self, seconds: float) -> list[str]:
+        emitted: list[str] = []
+        with mock.patch.object(leg_timing, "HEARTBEAT_SEC", 0.01), \
+                mock.patch.object(leg_timing, "leg_log", emitted.append):
+            thread, stop = leg_timing.start_heartbeat()
+            time.sleep(seconds)
+            stop.set()
+            thread.join(timeout=5)
+        return emitted
+
+    def test_the_first_tick_does_not_wait_a_whole_interval(self):
+        """A leg that dies inside one HEARTBEAT_SEC produced no timing line at
+        all, so the shortest legs -- the ones that failed fast -- were exactly
+        the ones with nothing to read."""
+        with mock.patch.object(leg_timing, "HEARTBEAT_SEC", 3600), \
+                mock.patch.object(leg_timing, "leg_log", (emitted := []).append):
+            thread, stop = leg_timing.start_heartbeat()
+            time.sleep(0.2)
+            stop.set()
+            thread.join(timeout=5)
+        self.assertTrue(emitted, "no heartbeat before the first full interval")
+
+    def test_the_label_is_restored_before_the_end_line_is_logged(self):
+        """The begin side flips the label after its line, so the end side must
+        restore before its own. Logging first left a window where a tick could
+        claim the leg was still in a phase the log had already closed."""
+        outer = leg_timing._CURRENT_PHASE
+        at_log: list[tuple[str, str]] = []
+        with mock.patch.object(leg_timing, "leg_log",
+            lambda m: at_log.append((m, leg_timing._CURRENT_PHASE)),
+        ):
+            with leg_timing.phase("harbor:step-1"):
+                pass
+        labels_at_end = [p for m, p in at_log if "phase end" in m]
+        self.assertEqual(
+            labels_at_end, [outer],
+            "the end line was logged while the label still named the closed phase",
+        )
+
+    def test_every_tick_names_the_phase_the_leg_is_actually_in(self):
+        leg_timing.set_phase("startup")
+        try:
+            leg_timing.set_phase("lock-wait")
+            ticks = self._ticks(0.1)
+        finally:
+            leg_timing.set_phase("startup")
+        self.assertTrue(ticks)
+        for line in ticks:
+            self.assertIn("lock-wait", line)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -13,11 +13,18 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import signal
+import subprocess
 import sys
 import tempfile
 import time
 import unittest
 from unittest import mock
+
+# run_leg imports its sibling `leg_timing`, and spec_from_file_location does
+# not put the loaded file's directory on sys.path the way running it as a
+# script does.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 _SPEC = importlib.util.spec_from_file_location(
     "run_leg", Path(__file__).resolve().parents[1] / "run_leg.py"
@@ -25,6 +32,8 @@ _SPEC = importlib.util.spec_from_file_location(
 run_leg = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = run_leg
 _SPEC.loader.exec_module(run_leg)
+
+import leg_timing  # noqa: E402 - must follow the sys.path insert above
 
 
 class DiscoverInvocations(unittest.TestCase):
@@ -1182,6 +1191,256 @@ class HoldPoolLock(unittest.TestCase):
                 fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             finally:
                 probe.close()
+
+
+class TheHeartbeatNamesTheRightPhase(unittest.TestCase):
+    """The lock wait is the longest gap a leg can have, and it was the one
+    phase the heartbeat could not name: `record_phase` was called directly, so
+    the recorded interval said `lock-wait` while every tick during it said
+    `startup`."""
+
+    def test_the_lock_wait_is_labelled_while_it_is_being_waited_on(self):
+        seen: list[str] = []
+
+        @contextlib.contextmanager
+        def fake_lock(*_args, **_kwargs):
+            seen.append(leg_timing._CURRENT_PHASE)
+            yield "vss-eval-box-1"
+
+        with mock.patch.object(run_leg, "hold_pool_lock", fake_lock):
+            with self.assertRaises(SystemExit):
+                self._run_main_far_enough()
+        self.assertEqual(
+            seen, ["lock-wait"],
+            "the heartbeat would report 'startup' for the whole wait",
+        )
+
+    def test_the_label_is_restored_when_the_lock_raises(self):
+        """A stuck `lock-wait` misreports every later tick for the rest of the
+        leg, which is worse than the missing label it replaced."""
+        @contextlib.contextmanager
+        def exploding_lock(*_args, **_kwargs):
+            raise OSError("bad lock dir")
+            yield  # pragma: no cover
+
+        before = leg_timing._CURRENT_PHASE
+        with mock.patch.object(run_leg, "hold_pool_lock", exploding_lock):
+            with contextlib.suppress(BaseException):
+                self._run_main_far_enough()
+        self.assertEqual(leg_timing._CURRENT_PHASE, before)
+
+    def _run_main_far_enough(self):
+        """Drive main() to the lock and no further."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = Path(tmp) / "dataset" / "platform" / "step-1"
+            dataset.mkdir(parents=True)
+            (dataset / "task.toml").write_text("step_count = 1\n", encoding="utf-8")
+            with mock.patch.object(
+                run_leg, "SKILL_EVAL_PYTHON_VERSION", sys.version_info[:2]
+            ), mock.patch.object(
+                run_leg, "run_invocations", side_effect=SystemExit(0)
+            ), mock.patch.object(leg_timing, "start_heartbeat",
+                                 return_value=(mock.Mock(), mock.Mock())):
+                run_leg.main([
+                    "--dataset-root", str(Path(tmp) / "dataset"),
+                    "--results-root", str(Path(tmp) / "results"),
+                    "--scratch", str(Path(tmp) / "scratch"),
+                    "--spec-stem", "spec",
+                    "--platform", "L40S",
+                ])
+
+
+class InstrumentationNeverChangesTheVerdict(unittest.TestCase):
+    """The one property the whole feature rests on, pinned through main()."""
+
+    def _argv(self, tmp: str) -> list[str]:
+        return [
+            "--dataset-root", str(Path(tmp) / "dataset"),
+            "--results-root", str(Path(tmp) / "results"),
+            "--scratch", str(Path(tmp) / "scratch"),
+            "--spec-stem", "spec",
+            "--platform", "L40S",
+        ]
+
+    def setUp(self):
+        # main() gates on the interpreter; that gate is not what these pin, and
+        # the suite should pass under whichever python a reviewer has to hand.
+        patcher = mock.patch.object(
+            run_leg, "SKILL_EVAL_PYTHON_VERSION", sys.version_info[:2]
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self._saved_phases = list(leg_timing._PHASES)
+        leg_timing._PHASES.clear()
+        self.addCleanup(lambda: leg_timing._PHASES.__setitem__(slice(None), self._saved_phases))
+
+    def _dataset(self, tmp: str) -> None:
+        task_dir = Path(tmp) / "dataset" / "chain" / "l40s"
+        task_dir.mkdir(parents=True)
+        (task_dir / "task.toml").write_text("step_count = 1\n")
+
+    @contextlib.contextmanager
+    def _held_lock(self):
+        with mock.patch.object(run_leg, "hold_pool_lock") as lock:
+            lock.return_value.__enter__.return_value = "box-a"
+            lock.return_value.__exit__.return_value = False
+            yield lock
+
+    def test_exit_code_survives_a_failing_phase_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._dataset(tmp)
+            with self._held_lock(), \
+                 mock.patch.object(run_leg, "run_invocations", return_value=42), \
+                 mock.patch.object(leg_timing, "write_phase_timings", side_effect=RuntimeError("boom")
+                 ):
+                self.assertEqual(run_leg.main(self._argv(tmp)), 42)
+
+    def test_instrumentation_logging_swallows_a_broken_pipe(self):
+        # BrokenPipeError on a closed stdout is the realistic version of this.
+        # Scoped to the instrumentation path on purpose: run_leg's pre-existing
+        # FATAL prints are unprotected too, but that predates this change and
+        # widening the assertion here would quietly claim otherwise.
+        with mock.patch("builtins.print", side_effect=BrokenPipeError("closed")):
+            leg_timing.leg_log("must not raise")
+            with leg_timing.phase("harbor:step-1"):
+                pass
+            leg_timing.write_phase_timings(Path("/nonexistent"))
+
+        self.assertEqual(leg_timing._PHASES[-1]["phase"], "harbor:step-1")
+
+    def test_a_lock_failure_that_is_not_a_timeout_still_records_the_wait(self):
+        # An invalid instance name raises ValueError inside hold_pool_lock.
+        # Without a phase, the artifact cannot distinguish "died selecting a
+        # box after 40 minutes" from "never waited at all".
+        with tempfile.TemporaryDirectory() as tmp:
+            self._dataset(tmp)
+            with mock.patch.object(
+                run_leg, "hold_pool_lock", side_effect=ValueError("invalid name")
+            ):
+                self.assertEqual(run_leg.main(self._argv(tmp)), 1)
+
+        self.assertEqual(
+            [e["phase"] for e in leg_timing._PHASES], ["lock-wait-failed"]
+        )
+
+    def test_a_dead_heartbeat_thread_does_not_fail_the_leg(self):
+        """The name used to contradict the body: it asserted RuntimeError
+        escaped, inside a class asserting the opposite invariant, so scanning
+        the names said the property held while the test proved it did not.
+
+        A runner at its thread limit is the case. Losing the heartbeat costs
+        visibility; raising costs the leg, and the leg is worth more."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._dataset(tmp)
+            with self._held_lock(), \
+                 mock.patch.object(run_leg, "run_invocations", return_value=0), \
+                 mock.patch.object(
+                     run_leg.threading.Thread,
+                     "start",
+                     side_effect=RuntimeError("no threads"),
+                 ):
+                self.assertEqual(run_leg.main(self._argv(tmp)), 0)
+
+    def test_sigterm_unwinds_so_a_cancelled_leg_still_writes_its_timings(self):
+        """Python turns only SIGINT into an exception. SIGTERM keeps SIG_DFL
+        and kills the interpreter without unwinding, so main()'s finally never
+        runs and a cancelled leg produced no artifact at all. `skills-eval.yml`
+        sets cancel-in-progress, so this is the normal way a leg ends.
+
+        In a subprocess on purpose. Delivering a real SIGTERM in-process means
+        that if the handler is ever removed, the signal takes the whole test
+        runner down instead of failing this one test, and a suite that dies is
+        harder to read than a suite that reports.
+        """
+        driver = """
+import importlib.util, os, signal, sys
+from contextlib import contextmanager
+# run_leg imports its sibling leg_timing, and loading by path does not put the
+# file's directory on sys.path the way running it as a script does.
+sys.path.insert(0, os.path.dirname(os.path.abspath(sys.argv[1])))
+spec = importlib.util.spec_from_file_location("run_leg", sys.argv[1])
+run_leg = importlib.util.module_from_spec(spec)
+sys.modules["run_leg"] = run_leg
+spec.loader.exec_module(run_leg)
+
+@contextmanager
+def lock_then_sigterm(*a, **k):
+    os.kill(os.getpid(), signal.SIGTERM)
+    yield "box"
+
+run_leg.hold_pool_lock = lock_then_sigterm
+run_leg.SKILL_EVAL_PYTHON_VERSION = sys.version_info[:2]
+run_leg.main(sys.argv[2:])
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._dataset(tmp)
+            script = Path(tmp) / "driver.py"
+            script.write_text(driver, encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, str(script),
+                 str(Path(__file__).resolve().parents[1] / "run_leg.py"),
+                 *self._argv(tmp)],
+                capture_output=True, text=True, timeout=60,
+            )
+            written = Path(tmp) / "results" / leg_timing.PHASE_TIMINGS_NAME
+            self.assertTrue(
+                written.exists(),
+                f"SIGTERM killed the leg before it recorded anything "
+                f"(rc={completed.returncode}): {completed.stderr[-400:]}",
+            )
+            self.assertEqual(
+                [e["phase"] for e in json.loads(written.read_text())["phases"]],
+                ["lock-wait-failed"],
+            )
+        # 128+SIGTERM, the conventional code, reached by unwinding rather than
+        # by the default terminating action.
+        self.assertEqual(completed.returncode, 128 + signal.SIGTERM)
+
+    def test_the_artifact_is_replaced_atomically(self):
+        """This write runs in main()'s finally, which is where a second signal
+        during a cancellation lands. A partial write leaves truncated JSON at
+        the real path, and a reader cannot tell that from a leg that recorded
+        nothing, so it is worse than no file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            results = Path(tmp) / "results"
+            results.mkdir()
+            destination = results / leg_timing.PHASE_TIMINGS_NAME
+            destination.write_text('{"phases": ["previous"]}\n', encoding="utf-8")
+            with mock.patch.object(leg_timing, "_PHASES",
+                [{"phase": "lock-wait", "start_s": 0.0, "end_s": 1.0, "seconds": 1.0}],
+            ), mock.patch.object(
+                run_leg.os, "replace", side_effect=OSError("interrupted")
+            ):
+                leg_timing.write_phase_timings(results)
+            # The previous artifact survives intact rather than being truncated.
+            self.assertEqual(
+                json.loads(destination.read_text())["phases"], ["previous"]
+            )
+            self.assertEqual(
+                list(results.glob("*.partial")), [],
+                "a half-written sibling was left to be collected as an artifact",
+            )
+
+    def test_a_cancelled_lock_wait_is_still_recorded(self):
+        """`skills-eval.yml` sets cancel-in-progress, so a push cancels
+        in-flight legs and the cancellation lands as KeyboardInterrupt. Under
+        `except Exception` the wait was dropped from the artifact for exactly
+        the legs that had spent longest in it."""
+        @contextlib.contextmanager
+        def cancelled_lock(*_args, **_kwargs):
+            raise KeyboardInterrupt
+            yield  # pragma: no cover
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self._dataset(tmp)
+            with mock.patch.object(run_leg, "hold_pool_lock", cancelled_lock), \
+                 mock.patch.object(leg_timing, "_PHASES", []) as phases:
+                with contextlib.suppress(KeyboardInterrupt):
+                    run_leg.main(self._argv(tmp))
+        self.assertEqual(
+            [entry["phase"] for entry in phases], ["lock-wait-failed"],
+            "a cancelled lock wait left no interval in the artifact",
+        )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,7 @@ jobs:
         run: |
           uvx --python 3.12 --from "pytest==9.1.1" pytest \
             .github/skill-eval/tests/test_adapter_agent_timeout.py \
+            .github/skill-eval/tests/test_leg_timing.py \
             .github/skill-eval/tests/test_python_runtime_contract.py \
             .github/skill-eval/tests/test_skills_eval_agent_protocol.py \
             .github/skill-eval/envs/tests/test_cancellation_recovery.py \
@@ -434,6 +435,8 @@ jobs:
             .github/skill-eval/tests/test_run_leg.py::RunCommand \
             .github/skill-eval/tests/test_run_leg.py::ProcessGroupShutdown \
             .github/skill-eval/tests/test_run_leg.py::RunInvocations \
+            .github/skill-eval/tests/test_run_leg.py::TheHeartbeatNamesTheRightPhase \
+            .github/skill-eval/tests/test_run_leg.py::InstrumentationNeverChangesTheVerdict \
             -q
 
       - name: Upload coverage report


### PR DESCRIPTION
## Why

A skill-eval leg reaches the Actions log as one undated block. `skills_eval_agent` runs `run_leg.py` through a Bash tool that surfaces captured output only when the tool returns, so the wrapper's existing log lines all arrive together with no clock on them.

From run `30733390364`:

```
detection-tracking-3d · deploy       130.3 of 132 min = one silent gap
stored_video_summarization_harbor    103.5 of 108 min = one silent gap
```

Both gaps begin right after `[tool] Bash :: python3 .github/skill-eval/run_leg.py ...`. From outside there is no way to tell a lock wait from a slow image pull from the agent working.

That gap is blocking a decision. We are weighing whether to pre-download and mount model weights on the runners, and nobody can say whether download time is even a material share of a leg, because we emit nothing while it runs.

## What

No behaviour change. Two additions to `run_leg.py`, and no workflow change.

**A heartbeat** prints elapsed leg time and the current phase every `HEARTBEAT_SEC` (default 60, env-overridable). Because captured output is replayed in order, every existing log line can now be placed to within one heartbeat even though the block still arrives at once. That is why the elapsed time is carried in the text rather than left to the log's own line timestamps, which do not exist for captured output. The first tick fires immediately rather than after a full interval, so a leg that dies inside the first minute still emits a timing line.

**Per-phase wall time** written to `phase-timings.json` under the results root. The workflow's existing "Collect results for workflow artifact" step already uploads that directory. Phases are the lock wait and each Harbor invocation, which is the split the queue-time question turns on.

```json
{"run_id": "...", "slug": "...", "total_s": 8192.0,
 "phases": [{"phase": "lock-wait", "start_s": 0.0, "end_s": 7412.0, "seconds": 7412.0},
            {"phase": "harbor:step-1", "start_s": 7412.0, "end_s": 8192.0, "seconds": 780.0}]}
```

The lock wait sets the heartbeat's **label** as well as its recorded interval. It calls `record_phase` directly rather than going through `phase()`, because its recorded name depends on how it ends (`lock-wait`, `lock-wait-timeout`, `lock-wait-failed`). An earlier revision therefore left the label at `startup` for the whole wait: the longest gap a leg can have, 16 minutes in the run above and bounded only by `lock_timeout_sec`, was the one phase every tick named wrongly.

## Layout

The instrumentation lives in its own module, `leg_timing.py`, rather than inline. It is self-contained, carries its own state, and `run_leg.py` is long enough that a reader looking for the lock or the Harbor command should not have to scroll past it. That file grows by 98 lines instead of 278.

Callers read the label through `leg_timing.current_phase()` rather than importing the global, which would bind once at import and never see a change.

The tests split on the same seam. `test_leg_timing.py` covers the module on its own; `test_run_leg.py` keeps the cases that drive the contract *through* `main()` (the lock-wait label, SIGTERM unwinding, a heartbeat that cannot start), because those are about the wiring rather than the module.

## Cancellation is the normal exit

`skills-eval.yml` sets `cancel-in-progress`, so every push SIGTERMs the in-flight legs. Three things follow, and without them the legs that cancel after the longest waits are exactly the ones that record nothing:

- **SIGTERM is converted into an unwinding exit.** Python turns only SIGINT into an exception; SIGTERM keeps `SIG_DFL` and kills the interpreter without running any `finally`, so the timing write never happened at all.
- **The lock wait is recorded on `BaseException`**, not `Exception`, so a `KeyboardInterrupt` mid-wait still leaves its interval in the artifact.
- **The artifact is written to a sibling and renamed.** This write runs in `main()`'s `finally`, which is where a second signal lands, and a partial write leaves truncated JSON that a reader cannot distinguish from a leg that recorded nothing.

## Safety

Timing must never change a verdict, so every write is best effort:

- `leg_log` swallows its own exceptions; a `print` can raise `BrokenPipeError`, and one of these calls sits in `main()`'s `finally`
- the heartbeat is started inside a guard, so a runner at its thread limit loses visibility rather than the leg
- the heartbeat thread is a daemon and cannot hold exit
- an unwritable results root logs and continues, leaving no partial sibling
- phases are recorded even when the body raises, since a leg that dies mid-Harbor is exactly the one worth timing
- `HEARTBEAT_SEC` is clamped to `[1, 3600]` and rejects non-finite values: `float()` accepts `"inf"` and `"1e999"`, and `max(1.0, inf)` is `inf`, which reaches `Thread.join(timeout=...)` and raises `OverflowError`
- the phase label is restored *before* the end line is logged, and the stop event is checked before every tick, so no line can claim a phase that has already closed

No new dependency; `threading` is stdlib.

## Scope

This times the leg. It deliberately **does not sample the network**, which an earlier revision of this PR did.

The workload runs on a remote Brev box via `envs.brev_env:BrevEnvironment` while this wrapper runs on the coordinator, so any counter read here describes the wrong machine: a box downloading model weights for ten minutes shows up as a quiet link. Measuring the transfer needs remote sampling of the kind `gpu_trace.py` does over `brev exec`, and is a follow-up once these timings show whether that time is where we think it is.

Separating an NGC pull from a weight download *inside* a Harbor invocation needs instrumentation in the deploy path, and is also a follow-up.

## Tests

```
python3 .github/skill-eval/tests/test_run_leg.py
```

69 tests in the file, 15 covering this change, each mutation-checked. Reverting the immediate first tick, the lock-wait label, either label restore, the end-line ordering, the `BaseException` catch, the guarded heartbeat start, the SIGTERM handler, or the atomic rename each fails a dedicated test.

CI runs `test_run_leg.py` by explicit class rather than by file, so this PR adds `test_leg_timing.py` and the two remaining new classes to that list in `ci.yml`. Without that none of these 15 tests execute in CI, including `InstrumentationNeverChangesTheVerdict`, which pins the one invariant the feature rests on. Verified against the step's exact invocation: 79 passed.

The SIGTERM case runs in a subprocess on purpose: delivered in-process, a removed handler would take the whole test runner down instead of failing one test.

`test_a_dead_heartbeat_thread_does_not_fail_the_leg` previously asserted the opposite of its own name, inside a class asserting the opposite invariant. It now pins the behaviour the name describes.

Three failures in `test_run_leg.py` predate this change (RTX 4090 pool capability tables) and are unrelated. Verified by running the suite on `develop`: same 3 failures.


