### PR TITLE
fix(dev alerts): Disable RTVI VLM kafka on 2d_cv to fix 1970 timestamp issue

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
@@ -184,6 +184,12 @@ RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
 RTVI_VLM_MAX_MODEL_LEN=''
 # Remote VLM uses none; RTXPRO4500BW local alerts/LVS uses the Cosmos3 Nano BF16 path.
 RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final
+# Verification mode (MODE=2d_cv) only. Nothing consumes RT-VLM Kafka output here,
+# and per-clip verification makes RT-VLM publish its own duplicate incidents whose
+# file-relative timestamps Logstash indexes under mdx-vlm-incidents-1970-01-01.
+# Comment out for MODE=2d_vlm: real-time alerts require RT-VLM Kafka publishing.
+# dev-profile.sh comments this out automatically for --mode real-time.
+RTVI_VLM_KAFKA_ENABLED=false
 # Alerts bridge deployment name follows the effective VLM_NAME.
 RTVI_VLM_OPENAI_MODEL_DEPLOYMENT_NAME=${VLM_NAME}
 # Profile path under VSS_APPS_DIR selected by MODE.

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -216,6 +216,25 @@ function set_alerts_ui_subtitle_from_mode() {
   esac
 }
 
+# Alerts RT-VLM Kafka publishing: overrides.env disables it for verification
+# (2d_cv), where nothing consumes the output and RT-VLM would emit duplicate
+# incidents with file-relative timestamps. Real-time (2d_vlm) drives alerts from
+# RT-VLM's Kafka events, so comment the override out and let the rtvi-vlm compose
+# default (true) apply.
+function set_alerts_rtvi_vlm_kafka_from_mode() {
+  local _generated_env="${1}"
+  local _mode
+  _mode="$(get_env_value "${_generated_env}" "MODE")"
+  case "${_mode}" in
+    2d_vlm)
+      if grep -q '^RTVI_VLM_KAFKA_ENABLED=' "${_generated_env}"; then
+        sed -i 's|^RTVI_VLM_KAFKA_ENABLED=|#RTVI_VLM_KAFKA_ENABLED=|' "${_generated_env}"
+        echo "[INFO] Commented out RTVI_VLM_KAFKA_ENABLED for alerts (MODE=2d_vlm → RT-VLM Kafka publishing enabled)"
+      fi
+      ;;
+  esac
+}
+
 # Gets model name from remote API endpoint (works for both LLM and VLM).
 # Auto-select is only safe when the endpoint serves exactly one model
 # (e.g., a deployed NIM). For aggregate endpoints like
@@ -1314,6 +1333,7 @@ function state_up() {
   fi
   if [[ "${profile}" == "alerts" ]]; then
     set_alerts_ui_subtitle_from_mode "${_generated_env}"
+    set_alerts_rtvi_vlm_kafka_from_mode "${_generated_env}"
     # Alerts VLM mode uses a different explicit service list than CV mode.
     if [[ "${mode_env}" == "2d_vlm" ]]; then
       set_env_var "COMPOSE_PROFILES" "\${COMPOSE_PROFILES_VLM}"

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1488,12 +1488,35 @@ run_dry_run_up_and_check_generated_env "generated.env base local VLM uses RT-VLM
 run_dry_run_up_and_check_generated_env "generated.env MODE for alerts" "alerts" \
  -i 127.0.0.1 -m verification -d -- \
   "MODE" "2d_cv" \
-  "NEXT_PUBLIC_APP_SUBTITLE" '"Vision (Alerts - CV)"'
+  "NEXT_PUBLIC_APP_SUBTITLE" '"Vision (Alerts - CV)"' \
+  "RTVI_VLM_KAFKA_ENABLED" "false"
 
 run_dry_run_up_and_check_generated_env "generated.env alerts UI subtitle follows real-time MODE" "alerts" \
  -i 127.0.0.1 -m real-time -d -- \
   "MODE" "2d_vlm" \
   "NEXT_PUBLIC_APP_SUBTITLE" '"Vision (Alerts - VLM)"'
+
+# Real-time alerts are driven by RT-VLM's Kafka events, so the verification-only
+# RTVI_VLM_KAFKA_ENABLED=false override must be commented out for MODE=2d_vlm.
+_alerts_gen_env="$(generated_env_path "alerts")"
+_alerts_gen_env_backup=""
+if [[ -f "${_alerts_gen_env}" ]]; then
+  _alerts_gen_env_backup="$(mktemp)"
+  cp "${_alerts_gen_env}" "${_alerts_gen_env_backup}"
+  CLEANUP_RESTORES+=("${_alerts_gen_env_backup}|${_alerts_gen_env}")
+fi
+if timeout "${TEST_TIMEOUT}" "$DEV_PROFILE" up -p alerts -i 127.0.0.1 -m real-time -d > /dev/null 2>&1 \
+  && ! grep -q '^RTVI_VLM_KAFKA_ENABLED=' "${_alerts_gen_env}" \
+  && grep -Eq '^#[[:space:]]*RTVI_VLM_KAFKA_ENABLED=' "${_alerts_gen_env}"; then
+  echo "PASS: alerts real-time comments out RTVI_VLM_KAFKA_ENABLED so RT-VLM publishes to Kafka"
+  ((TESTS_PASSED++)) || true
+else
+  echo "FAIL: alerts real-time should comment out RTVI_VLM_KAFKA_ENABLED (verification-only override)"
+  ((TESTS_FAILED++)) || true
+fi
+if [[ -n "${_alerts_gen_env_backup}" && -f "${_alerts_gen_env_backup}" ]]; then
+  mv "${_alerts_gen_env_backup}" "${_alerts_gen_env}"
+fi
 
 _alerts_overrides_env="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env"
 _alerts_overrides_env_backup="$(mktemp)"

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values-verification.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values-verification.yaml
@@ -89,7 +89,7 @@ rtvi:
       - name: VLM_MODEL_TO_USE
         value: "cosmos-reason3"
       - name: KAFKA_ENABLED
-        value: "true"
+        value: "false"
       - name: KAFKA_INCIDENT_TOPIC
         value: "mdx-vlm-incidents"
       - name: ERROR_MESSAGE_TOPIC

--- a/skills/vss-deploy-profile/references/alerts.md
+++ b/skills/vss-deploy-profile/references/alerts.md
@@ -13,6 +13,8 @@ Real-time alert generation and verification on RTSP / live video. VLM is **alway
 
 Switch modes by editing `MODE` in `dev-profile-alerts/generated.env` (`MODE=2d_cv` or `MODE=2d_vlm`) and re-resolving the compose. Update `NEXT_PUBLIC_APP_SUBTITLE` in the same file so the UI label matches the deployed mode.
 
+> **Also flip `RTVI_VLM_KAFKA_ENABLED` when switching modes by hand.** `overrides.env` ships `RTVI_VLM_KAFKA_ENABLED=false`, which is correct for verification (`2d_cv`) only: nothing consumes RT-VLM's Kafka output there, and leaving it on makes RT-VLM publish duplicate incidents whose file-relative timestamps land in `mdx-vlm-incidents-1970-01-01`. Real-time (`2d_vlm`) drives alerts from those Kafka events, so comment the line out for `2d_vlm` and let the compose default (`true`) apply. `dev-profile.sh` does this automatically for `--mode real-time`; only manual `generated.env` edits need it.
+
 ## What's different from `base` and `lvs`
 
 - **VLM is RT-VLM with the integrated Cosmos Reason3 Nano BF16 checkpoint.** Default `RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final`, `RTVI_VLM_MODEL_TO_USE=cosmos-reason3`. No standalone `cosmos-reason2-8b` NIM service is started.

--- a/skills/vss-manage-alerts/SKILL.md
+++ b/skills/vss-manage-alerts/SKILL.md
@@ -123,6 +123,8 @@ passes, detect the mode per Step 1.
 
 **Switching modes** uses the `vss-deploy-profile` teardown + deploy flow with the other `-m` flag (VLM → CV adds the CV pipeline; CV → VLM tears it down). `rtvi-vlm` runs in both modes.
 
+**`RTVI_VLM_KAFKA_ENABLED` is mode-specific.** `overrides.env` ships `RTVI_VLM_KAFKA_ENABLED=false` for verification (`2d_cv`), where nothing consumes RT-VLM's Kafka output and leaving it on makes RT-VLM publish duplicate incidents that Logstash indexes under `mdx-vlm-incidents-1970-01-01`. Real-time (`2d_vlm`) alerts depend on RT-VLM publishing to Kafka, so the line must be commented out in that mode — `dev-profile.sh` does this automatically for `-m real-time`. If a real-time deployment produces no alerts, check that this override is not still active in `generated.env`.
+
 ---
 
 ## Step 1 — Detect the Currently Deployed Mode


### PR DESCRIPTION
## Description
  Prevents duplicate VLM incidents from being indexed with Unix epoch (1970-01-01) timestamps in Alerts verification mode.

  - Disables RT-VLM Kafka publishing in verification (2d_cv), where its output is unused and produces duplicate incidents with file-relative timestamps.
  - Keeps Kafka publishing enabled for real-time (2d_vlm), where alerts depend on it.
  - Adds automated coverage for both modes and updates deployment documentation.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
