### PR TITLE
fix(skill-eval): publish reaper test pid atomically to fix flaky read

### DIFF
--- a/.github/skill-eval/envs/tests/test_cancellation_recovery.py
+++ b/.github/skill-eval/envs/tests/test_cancellation_recovery.py
@@ -329,7 +329,11 @@ import time
 pid = os.fork()
 if pid == 0:
     os.setsid()
-    Path(sys.argv[1]).write_text(str(os.getpid()))
+    # Publish the pid atomically. write_text() creates a zero-length file
+    # before the bytes land, so a waiter that gates on exists() can read ''.
+    tmp = Path(sys.argv[1] + ".tmp")
+    tmp.write_text(str(os.getpid()))
+    os.replace(tmp, sys.argv[1])
     while True:
         time.sleep(1)
 while not Path(sys.argv[1]).exists():


### PR DESCRIPTION
Fixes the intermittent `Test (pytest)` failure in the **Skill eval harness contracts** step.

## Symptom

```
RemoteAgentReapTest::test_exact_and_startup_reapers_kill_detached_marked_groups_only
.github/skill-eval/envs/tests/test_cancellation_recovery.py:387
ValueError: invalid literal for int() with base 10: ''
```

Seen on PR #1524 ([job](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/30842811796/job/91784323929), `1 failed, 60 passed ... in 0.98s`). That PR touches 0 Python files — the race is pre-existing, introduced by `2a2cad499` (#1517).

## Root cause

`Path.write_text()` is `open(w)` + `write()` + `close()`. The `open(w)` publishes a **zero-length file immediately**; the pid bytes only land on the later `write()`.

Two waiters gate on `Path.exists()`, and both can therefore observe an empty file:

- inside `_TREE_SCRIPT`, the fork parent waiting for its grandchild;
- the test itself, which does `assertTrue(child_file.exists())` and then `int(child_file.read_text())`.

Existence is not content, so the second one raises `int('')`.

## Fix

Write to a sibling temp file and `os.replace()` it into place. The rename is atomic within the directory, so the pid file becomes visible only once complete — which makes **both** existing `exists()` checks correct, rather than adding retry logic to one of them.

## Verification

A harness mirroring the two sides of the race:

| writer | empty reads |
|---|---|
| `write_text()` (current) | **1545 / 3000** |
| `os.replace()` (this PR) | **0 / 3000** |

- Full file as CI runs it (`uvx --python 3.12 --from pytest==9.1.1`): `18 passed, 2 subtests passed`.
- The previously-flaky test stressed **25/25 pass**.

Note the flake is genuinely intermittent — `Test (pytest)` is green on `develop` for 7 consecutive runs on this same code, which is why it slipped through.