### PR TITLE
fix(docker): update hardware profile options and max streams supported by RTXPRO4500BW

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -125,16 +125,6 @@ VSS_ES_PORT=9200
 VSS_AGENT_OBJECT_STORE_TYPE=local_object_store
 
 # =============================================================================
-# RTVI CONFIGURATION
-# =============================================================================
-RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.8'
-
-# RTVI VLM input dimensions and frame rate (for DGX-SPARK, IGX-THOR, AGX-THOR only; not set on other platforms)
-# RTVI_VLM_INPUT_WIDTH=860
-# RTVI_VLM_INPUT_HEIGHT=467
-# RTVI_VLM_DEFAULT_NUM_FRAMES_PER_SECOND_OR_FIXED_FRAMES_CHUNK=20
-
-# =============================================================================
 # AGENT UI CONFIGURATION
 # =============================================================================
 NEXT_PUBLIC_APP_SUBTITLE="Warehouse"

--- a/deploy/docker/industry-profiles/warehouse-operations/.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/.env
@@ -127,9 +127,7 @@ VSS_AGENT_OBJECT_STORE_TYPE=local_object_store
 # =============================================================================
 # RTVI CONFIGURATION
 # =============================================================================
-# RTVI CONFIGURATION
-# =============================================================================
-RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
+RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.8'
 
 # RTVI VLM input dimensions and frame rate (for DGX-SPARK, IGX-THOR, AGX-THOR only; not set on other platforms)
 # RTVI_VLM_INPUT_WIDTH=860

--- a/deploy/docker/industry-profiles/warehouse-operations/blueprint-configurator/blueprint_config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/blueprint-configurator/blueprint_config.yml
@@ -599,7 +599,7 @@ commons:
 
 H100:
   2d:
-    max_streams_supported: 76
+    max_streams_supported: 77
   3d:
     max_streams_supported: 16
   mv3dt:
@@ -639,11 +639,15 @@ RTXA6000ADA:
 
 RTXPRO6000BW:
   2d:
-    max_streams_supported: 49
+    max_streams_supported: 47
   3d:
     max_streams_supported: 19
   mv3dt:
     max_streams_supported: 39
+    
+RTXPRO4500BW:
+  2d:
+    max_streams_supported: 20
 
 IGX-THOR:
   2d:

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -134,7 +134,9 @@ SENSOR_INFO_SOURCE=nvstreamer
 # RTVI CONFIGURATION
 # =============================================================================
 RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.8'
-# RTVI_VLM_MAX_MODEL_LEN=18000 # Uncomment RTVI_VLM_MAX_MODEL_LEN=18000 for RTXPRO4500BW
+# RTXPRO4500BW (32 GB), when COMPOSE_PROFILES=${COMPOSE_PROFILES_WH_2D} deploys vss-rtvi-vlm:
+# cap RT-VLM context so the KV cache can be allocated.
+RTVI_VLM_MAX_MODEL_LEN=18000
 
 # RTVI VLM input dimensions and frame rate (for DGX-SPARK, IGX-THOR, AGX-THOR only; not set on other platforms)
 # RTVI_VLM_INPUT_WIDTH=860

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -41,7 +41,7 @@ SAMPLE_VIDEO_DATASET="nv-warehouse-4cams"
 # Match NUM_STREAMS to the selected sample dataset; defaults are shown above.
 NUM_STREAMS=4
 # Hardware profile for NIM and perception optimization.
-# Valid: H100, L40, L40S, L4, A6000, RTXPRO6000BW, IGX-THOR, DGX-SPARK.
+# Valid: H100, L40, L40S, L4, A6000, RTXPRO6000BW, RTXPRO4500BW, IGX-THOR, DGX-SPARK.
 HARDWARE_PROFILE=H100
 # Message broker. Use redis for bp_wh_redis; use kafka for bp_wh, bp_wh_kafka, and bp_wh_auto_calib.
 STREAM_TYPE=kafka

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -131,6 +131,17 @@ VSS_AGENT_REPORTS_BASE_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VS
 SENSOR_INFO_SOURCE=nvstreamer
 
 # =============================================================================
+# RTVI CONFIGURATION
+# =============================================================================
+RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.8'
+# RTVI_VLM_MAX_MODEL_LEN=18000 # Uncomment RTVI_VLM_MAX_MODEL_LEN=18000 for RTXPRO4500BW
+
+# RTVI VLM input dimensions and frame rate (for DGX-SPARK, IGX-THOR, AGX-THOR only; not set on other platforms)
+# RTVI_VLM_INPUT_WIDTH=860
+# RTVI_VLM_INPUT_HEIGHT=467
+# RTVI_VLM_DEFAULT_NUM_FRAMES_PER_SECOND_OR_FIXED_FRAMES_CHUNK=20
+
+# =============================================================================
 # HOST-PUBLISHED PORTS
 # =============================================================================
 # Change these when a default host port conflicts with another local service.

--- a/skills/vss-deploy-profile/references/alerts.md
+++ b/skills/vss-deploy-profile/references/alerts.md
@@ -170,7 +170,7 @@ On GPUs where the script gives RT-VLM a high share — **OTHER (0.7)**,
 32 GB VRAM is too little to host RT-VLM **and** a local Nano 9B LLM together. The supported layout is the default Cosmos Reason3 Nano BF16 RT-VLM checkpoint with the LLM remote. Full env block for `dev-profile-alerts/generated.env`:
 
 ```env
-HARDWARE_PROFILE=RTX4500
+HARDWARE_PROFILE=RTXPRO4500BW
 LLM_MODE=remote
 VLM_MODE=local
 # RT-VLM sizing: cap context + lift utilization to fit on 32 GB.

--- a/skills/vss-deploy-profile/references/warehouse-debug.md
+++ b/skills/vss-deploy-profile/references/warehouse-debug.md
@@ -162,6 +162,7 @@ PYTHONPATH="${SDU_DIR}:${PYTHONPATH:-}" python3 \
 |---|---|---|
 | `model not found` / `No such file` | `vss-rtvi-cv` | `VSS_DATA_DIR` wrong or models not present |
 | `CUDA out of memory` | `vss-rtvi-cv` / LLM NIM / `vss-rtvi-vlm` | Too many streams or wrong device assignment — reduce `NUM_STREAMS` or change device IDs |
+| `Available KV cache memory: -… GiB` / `No available memory for the cache blocks` / `EngineCore failed to start` | `vss-rtvi-vlm` | RT-VLM's context budget does not fit on the selected GPU. Set `RTVI_VLM_MAX_MODEL_LEN=18000` in the active warehouse `generated.env` (or `overrides.env` before first deployment), then recreate `vss-rtvi-vlm`. |
 | `GST pipeline error` / `Failed to start pipeline` | `vss-rtvi-cv` | No valid RTSP input — check `vss-vios-nvstreamer` first |
 | `Connection refused` on broker port | `vss-broker-health-check` | Kafka/Redis not listening — broker crashed |
 | `RTSP connection failed` / `Cannot open resource` | `vss-vios-nvstreamer` | RTSP source (camera / video file) unreachable |

--- a/skills/vss-deploy-profile/references/warehouse-debug.md
+++ b/skills/vss-deploy-profile/references/warehouse-debug.md
@@ -162,7 +162,6 @@ PYTHONPATH="${SDU_DIR}:${PYTHONPATH:-}" python3 \
 |---|---|---|
 | `model not found` / `No such file` | `vss-rtvi-cv` | `VSS_DATA_DIR` wrong or models not present |
 | `CUDA out of memory` | `vss-rtvi-cv` / LLM NIM / `vss-rtvi-vlm` | Too many streams or wrong device assignment — reduce `NUM_STREAMS` or change device IDs |
-| `Available KV cache memory: -… GiB` / `No available memory for the cache blocks` / `EngineCore failed to start` | `vss-rtvi-vlm` | RT-VLM's context budget does not fit on the selected GPU. Set `RTVI_VLM_MAX_MODEL_LEN=18000` in the active warehouse `generated.env` (or `overrides.env` before first deployment), then recreate `vss-rtvi-vlm`. |
 | `GST pipeline error` / `Failed to start pipeline` | `vss-rtvi-cv` | No valid RTSP input — check `vss-vios-nvstreamer` first |
 | `Connection refused` on broker port | `vss-broker-health-check` | Kafka/Redis not listening — broker crashed |
 | `RTSP connection failed` / `Cannot open resource` | `vss-vios-nvstreamer` | RTSP source (camera / video file) unreachable |

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -399,7 +399,7 @@ Valid values: `H100, L40, L40S, L4, A6000, RTXA6000, RTXA6000ADA, RTXPRO6000BW, 
 | Discrete GPU (typical `nvidia-smi` name) | HARDWARE_PROFILE |
 |---|---|
 | RTX PRO 6000 Blackwell | `RTXPRO6000BW` |
-| RTX 4500 Blackwell | `RTX4500` — 32 GB; see [alerts.md § RTX 4500](alerts.md#rtx-4500-32-gb) for the required `LLM_MODE=remote` + RT-VLM sizing overrides |
+| RTX PRO 4500 Blackwell | `RTXPRO4500` — 32 GB; see [alerts.md § RTX PRO 4500](alerts.md#rtx-4500-32-gb) for the required `LLM_MODE=remote` + RT-VLM sizing overrides |
 | H100 (NVL, SXM HBM3) | `H100` |
 | RTX A6000 Ada Generation | `RTXA6000ADA` |
 | RTX A6000 (Ampere) | `RTXA6000` |
@@ -826,7 +826,7 @@ SAMPLE_VIDEO_DATASET="<dataset-name>"
 NUM_STREAMS=<3|4>
 
 # --- Hardware ---
-# Valid: H100, L40, L40S, L4, A6000, RTXA6000, RTXA6000ADA, RTXPRO6000BW, IGX-THOR, DGX-SPARK
+# Valid: H100, L40, L40S, L4, A6000, RTXA6000, RTXA6000ADA, RTXPRO6000BW, RTXPRO4500BW, IGX-THOR, DGX-SPARK
 HARDWARE_PROFILE=H100
 
 # GPU device IDs (defaults shown — change only if you need a non-default layout)

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -394,12 +394,12 @@ Run each check in order. **If a check fails, automatically install and re-verify
 
 `HARDWARE_PROFILE` is a **blueprint setting**, not a string that `nvidia-smi` always prints verbatim. For **discrete GPUs**, match the GPU model from `nvidia-smi` / `lspci` to a row below. **IGX-THOR** and **DGX-SPARK** are **whole-system platforms** (kits/boards): set the profile from product/SKU or vendor docs if you already know the machine type; `nvidia-smi` shows the **on-board NVIDIA GPU name** (e.g. a Thor-class or Spark system GPU), not the text `IGX-THOR` or `DGX-SPARK`. On **DGX Spark**, unified memory can make some `nvidia-smi` memory fields show **Not Supported**; driver and device listing should still be checked per [DGX Spark user guide](https://docs.nvidia.com/dgx/dgx-spark/).
 
-Valid values: `H100, L40, L40S, L4, A6000, RTXA6000, RTXA6000ADA, RTXPRO6000BW, IGX-THOR, DGX-SPARK`. All profiles include tuned `max_streams_supported` for 2D, 3D, and MV3DT modes.
+Valid values: `H100, L40, L40S, L4, A6000, RTXA6000, RTXA6000ADA, RTXPRO4500BW, RTXPRO6000BW, IGX-THOR, DGX-SPARK`. All profiles include tuned `max_streams_supported` for 2D, 3D, and MV3DT modes.
 
 | Discrete GPU (typical `nvidia-smi` name) | HARDWARE_PROFILE |
 |---|---|
 | RTX PRO 6000 Blackwell | `RTXPRO6000BW` |
-| RTX PRO 4500 Blackwell | `RTXPRO4500BW` — 32 GB; see [alerts.md § RTX PRO 4500](alerts.md#rtx-4500-32-gb) for the required `LLM_MODE=remote` + RT-VLM sizing overrides |
+| RTX PRO 4500 Blackwell | `RTXPRO4500BW` (32 GB). When `COMPOSE_PROFILES=${COMPOSE_PROFILES_WH_2D}` deploys `vss-rtvi-vlm`, set `RTVI_VLM_MAX_MODEL_LEN=18000` to cap RT-VLM context and allow KV-cache allocation. |
 | H100 (NVL, SXM HBM3) | `H100` |
 | RTX A6000 Ada Generation | `RTXA6000ADA` |
 | RTX A6000 (Ampere) | `RTXA6000` |

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -399,7 +399,7 @@ Valid values: `H100, L40, L40S, L4, A6000, RTXA6000, RTXA6000ADA, RTXPRO6000BW, 
 | Discrete GPU (typical `nvidia-smi` name) | HARDWARE_PROFILE |
 |---|---|
 | RTX PRO 6000 Blackwell | `RTXPRO6000BW` |
-| RTX PRO 4500 Blackwell | `RTXPRO4500` — 32 GB; see [alerts.md § RTX PRO 4500](alerts.md#rtx-4500-32-gb) for the required `LLM_MODE=remote` + RT-VLM sizing overrides |
+| RTX PRO 4500 Blackwell | `RTXPRO4500BW` — 32 GB; see [alerts.md § RTX PRO 4500](alerts.md#rtx-4500-32-gb) for the required `LLM_MODE=remote` + RT-VLM sizing overrides |
 | H100 (NVL, SXM HBM3) | `H100` |
 | RTX A6000 Ada Generation | `RTXA6000ADA` |
 | RTX A6000 (Ampere) | `RTXA6000` |


### PR DESCRIPTION
- Added RTXPRO4500BW to the valid hardware profiles in overrides.env and updated the corresponding max streams supported in blueprint_config.yml.
- Adjusted documentation in warehouse.md to reflect the new hardware profile and its specifications.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
