### PR TITLE
feat(skill-eval): correlate agent activity with hardware utilization

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -681,14 +681,13 @@ The `<leg-slug>` keeps concurrent legs from colliding on one viewer
 entry.
 
 **`run_leg.py` does this publish for you** (`publish_trace`), after
-every trial including timed-out ones. It copies (never moves) the
-date dir's *contents* into a pre-made job dir — the workflow's
+every trial that produced a `result.json`. It copies (never moves) the
+date dir's sanitized contents into a pre-made job dir — the workflow's
 "Collect results" step runs *after* this agent and tars `$RES` for
 the artifact, so a `mv` would upload an artifact with no
-`result.json`. Copying keeps `$RES` intact for the collector (which
-excludes `agent/` from the public tarball) while the `_viewer` copy
-keeps `agent/` for the live Harbor Trace tab. You do not run `cp`
-yourself.
+`result.json`. Raw `agent/` directories are ephemeral inputs to the
+allowlisted hardware timeline and are excluded from both the `_viewer`
+copy and the public tarball. You do not run `cp` yourself.
 
 ### Trace URLs — read them, never build them
 

--- a/.github/skill-eval/agent_timeline/README.md
+++ b/.github/skill-eval/agent_timeline/README.md
@@ -1,0 +1,14 @@
+# Agent Hardware Timeline
+
+This directory will contain the stacked prototype that correlates skill-eval
+agent and tool activity with the GPU telemetry introduced by PR #1516.
+
+The draft compares three representations generated from one canonical,
+ephemeral correlation model:
+
+- a Perfetto-compatible trace;
+- a self-contained HTML timeline;
+- OpenTelemetry trace and metric records.
+
+Raw agent trajectories remain ephemeral. Only allowlisted, sanitized timeline
+fields are eligible for workflow artifacts.

--- a/.github/skill-eval/agent_timeline/README.md
+++ b/.github/skill-eval/agent_timeline/README.md
@@ -1,14 +1,48 @@
 # Agent Hardware Timeline
 
-This directory will contain the stacked prototype that correlates skill-eval
-agent and tool activity with the GPU telemetry introduced by PR #1516.
+This prototype correlates skill-eval agent steps and tool calls with the GPU
+telemetry introduced by PR #1516 and aggregate CPU/RAM telemetry sampled over
+the same Harbor invocation.
 
-The draft compares three representations generated from one canonical,
-ephemeral correlation model:
+One sanitized canonical model produces four files under
+`<results-root>/timeline/<invocation>/`:
 
-- a Perfetto-compatible trace;
-- a self-contained HTML timeline;
-- OpenTelemetry trace and metric records.
+- `timeline.perfetto.json` — Chrome Trace Event JSON, loadable in
+  `https://ui.perfetto.dev`;
+- `timeline.html` — a self-contained, dependency-free timeline for direct
+  artifact viewing;
+- `timeline.otlp.jsonl` — one OTLP trace export request and one OTLP metrics
+  export request, each on its own line;
+- `timeline.json` — the canonical model used to compare and refine the three
+  representations.
 
-Raw agent trajectories remain ephemeral. Only allowlisted, sanitized timeline
-fields are eligible for workflow artifacts.
+The GPU, system, and agent clocks are normalized to Unix microseconds. GPU and
+system samples are aligned to the coordinator's invocation start, avoiding
+remote clock and timezone skew (`nvidia-smi` emits timezone-free wall-clock
+values). Every hardware sample is annotated with the active agent step when one
+spans that timestamp.
+
+## Collection boundary
+
+The system sampler reads fixed aggregate numeric counters from `/proc/stat`,
+`/proc/meminfo`, and `/proc/loadavg`. It does not inspect processes, command
+lines, environments, containers, network payloads, or files.
+
+The full trajectory is an ephemeral input. After all sanitized outputs are
+written, its per-trial `agent/` directory is removed before the trial is copied
+to the persistent Harbor viewer. Published timeline artifacts use an allowlist:
+
+- step timing and source (`agent`/`user`);
+- tool name;
+- for shell calls, known executable names only;
+- aggregate numeric GPU, CPU, load, RAM, and swap metrics;
+- non-secret run/spec/platform identity.
+
+Messages, observations, tool arguments, raw commands, tool-call IDs, file
+contents, and environment values are never copied. The workflow continues to
+exclude each trial's `agent/` directory from public artifacts.
+
+Both samplers are default-on, hard-bounded by the Harbor timeout, and
+best-effort. Set `EVAL_GPU_TRACE=0` or `EVAL_SYSTEM_TRACE=0` to disable one.
+Telemetry startup, collection, rendering, and write failures never alter the
+evaluation result.

--- a/.github/skill-eval/agent_timeline/__init__.py
+++ b/.github/skill-eval/agent_timeline/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Sanitized agent and hardware timeline generation."""
+
+from .timeline import generate
+
+__all__ = ["generate"]

--- a/.github/skill-eval/agent_timeline/timeline.py
+++ b/.github/skill-eval/agent_timeline/timeline.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Correlate ephemeral agent trajectories with allowlisted hardware samples."""
+
+from __future__ import annotations
+
+import csv
+import contextlib
+import datetime as dt
+import hashlib
+import html
+import json
+import math
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9_.:/ -]+")
+SAFE_TOKEN_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+METADATA_FIELDS = frozenset({
+    "run_id", "skill", "spec_stem", "platform", "step", "chain", "agent",
+    "model", "instance",
+})
+SAFE_EXECUTABLES = frozenset({
+    "apt", "apt-get", "awk", "bash", "brev", "cargo", "cmake", "curl",
+    "docker", "find", "git", "go", "grep", "helm", "jq", "kubectl", "make",
+    "ninja", "node", "npm", "nvidia-smi", "pip", "pip3", "pytest", "python",
+    "python3", "rg", "sed", "sh", "tar", "terraform", "uv", "uvx", "wget",
+})
+SHELL_WRAPPERS = frozenset({"command", "env", "nohup", "sudo", "time", "timeout"})
+METRIC_UNITS = {
+    "gpu.utilization": "%",
+    "gpu.memory.utilization": "%",
+    "gpu.memory.used": "MiB",
+    "gpu.memory.total": "MiB",
+    "gpu.power": "W",
+    "cpu.user": "%",
+    "cpu.system": "%",
+    "cpu.iowait": "%",
+    "cpu.idle": "%",
+    "cpu.steal": "%",
+    "system.load.1m": "1",
+    "system.load.5m": "1",
+    "system.load.15m": "1",
+    "memory.used": "MiB",
+    "memory.available": "MiB",
+    "memory.total": "MiB",
+    "swap.used": "MiB",
+    "swap.total": "MiB",
+}
+
+
+def _safe_name(value: Any, default: str = "unknown", limit: int = 96) -> str:
+    cleaned = SAFE_NAME_RE.sub("", str(value or "")).strip()
+    return cleaned[:limit] or default
+
+
+def _timestamp_us(value: Any) -> int | None:
+    if isinstance(value, (int, float)):
+        number = float(value)
+        if not math.isfinite(number) or number <= 0:
+            return None
+        # Contemporary Unix values are approximately 1e18 ns, 1e15 us,
+        # 1e12 ms, and 1e9 s. Keep the thresholds between those ranges:
+        # treating 1.7e15 microseconds as nanoseconds shifts events to 1970.
+        if number > 1e17:
+            return int(number / 1_000)
+        if number > 1e14:
+            return int(number)
+        if number > 1e11:
+            return int(number * 1_000)
+        return int(number * 1_000_000)
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return int(parsed.timestamp() * 1_000_000)
+    except ValueError:
+        return None
+
+
+def _command_summary(command: Any) -> str:
+    """Return only allowlisted executable names; arguments never survive."""
+    words = re.findall(r"[A-Za-z0-9_./+-]+", str(command or ""))
+    found: list[str] = []
+    for word in words:
+        executable = word.rsplit("/", 1)[-1].lower()
+        if executable in SHELL_WRAPPERS:
+            continue
+        if executable in SAFE_EXECUTABLES and executable not in found:
+            found.append(executable)
+    return " + ".join(found[:4]) if found else "shell"
+
+
+def _load_trajectory(path: Path) -> list[dict[str, Any]]:
+    if path.suffix == ".jsonl":
+        rows = []
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict):
+                rows.append(value)
+        return rows
+    value = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    if isinstance(value, dict) and isinstance(value.get("steps"), list):
+        return [row for row in value["steps"] if isinstance(row, dict)]
+    return []
+
+
+def _legacy_calls(step: dict[str, Any]) -> list[dict[str, Any]]:
+    message = step.get("message")
+    if not isinstance(message, str):
+        return []
+    try:
+        decoded = json.loads(message)
+    except json.JSONDecodeError:
+        return []
+    content = ((decoded.get("message") or {}).get("content")
+               if isinstance(decoded, dict) else None)
+    if not isinstance(content, list):
+        return []
+    calls = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "tool_use":
+            calls.append({
+                "function_name": item.get("name"),
+                "arguments": item.get("input") or {},
+            })
+    return calls
+
+
+def _agent_events(
+    path: Path, started_us: int, finished_us: int
+) -> tuple[list[dict], list[dict]]:
+    rows = _load_trajectory(path)
+    parsed: list[tuple[int, dict[str, Any]]] = []
+    for row in rows:
+        timestamp = _timestamp_us(row.get("timestamp"))
+        if timestamp is not None and started_us <= timestamp <= finished_us:
+            parsed.append((timestamp, row))
+    parsed.sort(key=lambda item: item[0])
+
+    spans: list[dict] = []
+    instants: list[dict] = []
+    for index, (start_us, row) in enumerate(parsed):
+        next_us = parsed[index + 1][0] if index + 1 < len(parsed) else finished_us
+        end_us = max(start_us + 1, min(next_us, finished_us))
+        source_value = str(row.get("source") or "").lower()
+        source = source_value if source_value in {"agent", "user"} else "event"
+        span_id = f"step-{index + 1}"
+        spans.append({
+            "id": span_id,
+            "name": f"{source} step",
+            "source": source,
+            "start_us": start_us,
+            "end_us": end_us,
+        })
+        calls = row.get("tool_calls")
+        if not isinstance(calls, list):
+            calls = _legacy_calls(row)
+        for call_index, call in enumerate(calls):
+            if not isinstance(call, dict):
+                continue
+            tool = _safe_name(call.get("function_name"), "tool", 48)
+            arguments = call.get("arguments")
+            if not isinstance(arguments, dict):
+                arguments = {}
+            label = tool
+            if tool.lower() in {"bash", "shell"}:
+                label = f"{tool}: {_command_summary(arguments.get('command'))}"
+            instants.append({
+                "id": f"{span_id}-tool-{call_index + 1}",
+                "name": label,
+                "tool": tool,
+                "timestamp_us": start_us + call_index,
+                "step_id": span_id,
+            })
+    return spans, instants
+
+
+def _sidecar(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _gpu_metrics(csv_path: Path, sidecar: dict[str, Any]) -> list[dict]:
+    with csv_path.open(encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    if not rows:
+        return []
+    raw_times = []
+    for row in rows:
+        try:
+            stamp = dt.datetime.strptime(
+                row["timestamp"].strip(), "%Y/%m/%d %H:%M:%S.%f"
+            ).replace(tzinfo=dt.timezone.utc)
+            raw_times.append(int(stamp.timestamp() * 1_000_000))
+        except (KeyError, ValueError):
+            raw_times.append(None)
+    first = next((value for value in raw_times if value is not None), None)
+    started = _timestamp_us(sidecar.get("started_at"))
+    offset = (started - first) if first is not None and started is not None else 0
+    mapping = {
+        "util_gpu_pct": "gpu.utilization",
+        "util_mem_pct": "gpu.memory.utilization",
+        "mem_used_mib": "gpu.memory.used",
+        "mem_total_mib": "gpu.memory.total",
+        "power_w": "gpu.power",
+    }
+    metrics = []
+    for row, timestamp in zip(rows, raw_times):
+        if timestamp is None:
+            continue
+        try:
+            gpu_index = int(float(row["gpu_index"]))
+        except (KeyError, ValueError):
+            continue
+        for column, name in mapping.items():
+            try:
+                value = float(row[column])
+            except (KeyError, ValueError):
+                continue
+            if math.isfinite(value):
+                metrics.append({
+                    "timestamp_us": timestamp + offset,
+                    "name": name,
+                    "value": value,
+                    "unit": METRIC_UNITS[name],
+                    "attributes": {"gpu_index": gpu_index},
+                })
+    return metrics
+
+
+def _system_metrics(csv_path: Path, sidecar: dict[str, Any]) -> list[dict]:
+    mapping = {
+        "cpu_user_pct": "cpu.user",
+        "cpu_system_pct": "cpu.system",
+        "cpu_iowait_pct": "cpu.iowait",
+        "cpu_idle_pct": "cpu.idle",
+        "cpu_steal_pct": "cpu.steal",
+        "load_1m": "system.load.1m",
+        "load_5m": "system.load.5m",
+        "load_15m": "system.load.15m",
+        "mem_used_mib": "memory.used",
+        "mem_available_mib": "memory.available",
+        "mem_total_mib": "memory.total",
+        "swap_used_mib": "swap.used",
+        "swap_total_mib": "swap.total",
+    }
+    rows: list[dict[str, str]] = []
+    with csv_path.open(encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    raw_times: list[int | None] = []
+    for row in rows:
+        try:
+            raw_times.append(int(row["timestamp_ns"]) // 1_000)
+        except (KeyError, ValueError):
+            raw_times.append(None)
+    first = next((value for value in raw_times if value is not None), None)
+    started = _timestamp_us(sidecar.get("started_at"))
+    offset = (started - first) if first is not None and started is not None else 0
+
+    metrics = []
+    for row, timestamp_us in zip(rows, raw_times):
+        if timestamp_us is None:
+            continue
+        for column, name in mapping.items():
+            try:
+                value = float(row[column])
+            except (KeyError, ValueError):
+                continue
+            if math.isfinite(value):
+                metrics.append({
+                    "timestamp_us": timestamp_us + offset,
+                    "name": name,
+                    "value": value,
+                    "unit": METRIC_UNITS[name],
+                    "attributes": {},
+                })
+    return metrics
+
+
+def _active_step(spans: list[dict], timestamp_us: int) -> str:
+    for span in spans:
+        if span["start_us"] <= timestamp_us < span["end_us"]:
+            return span["id"]
+    return ""
+
+
+def _summary(metrics: list[dict]) -> dict[str, Any]:
+    grouped: dict[str, list[float]] = {}
+    for metric in metrics:
+        grouped.setdefault(metric["name"], []).append(metric["value"])
+    aggregates = {
+        name: {
+            "samples": len(values),
+            "min": round(min(values), 3),
+            "mean": round(sum(values) / len(values), 3),
+            "max": round(max(values), 3),
+            "unit": METRIC_UNITS.get(name, "1"),
+        }
+        for name, values in sorted(grouped.items())
+    }
+    gpu_samples: dict[tuple[int, int], dict[str, float]] = {}
+    for metric in metrics:
+        if metric["name"] not in {"gpu.utilization", "gpu.memory.used"}:
+            continue
+        key = (
+            metric["timestamp_us"],
+            int(metric.get("attributes", {}).get("gpu_index", 0)),
+        )
+        gpu_samples.setdefault(key, {})[metric["name"]] = metric["value"]
+    idle_resident = [
+        row for row in gpu_samples.values()
+        if row.get("gpu.utilization", 100) < 5 and row.get("gpu.memory.used", 0) > 1024
+    ]
+    signals = {
+        "gpu_idle_with_resident_memory_samples": len(idle_resident),
+        "gpu_idle_with_resident_memory_pct": round(
+            100 * len(idle_resident) / len(gpu_samples), 2
+        ) if gpu_samples else 0.0,
+    }
+    return {"metrics": aggregates, "waste_signals": signals}
+
+
+def _perfetto(model: dict[str, Any]) -> dict[str, Any]:
+    origin = model["bounds"]["start_us"]
+    events: list[dict[str, Any]] = [
+        {"name": "process_name", "ph": "M", "pid": 1, "tid": 0,
+         "args": {"name": "Agent activity"}},
+        {"name": "process_name", "ph": "M", "pid": 2, "tid": 0,
+         "args": {"name": "Hardware metrics"}},
+        {"name": "trace_origin_unix_us", "ph": "i", "s": "g", "pid": 1,
+         "tid": 0, "ts": 0, "args": {"unix_us": str(origin)}},
+    ]
+    for span in model["spans"]:
+        events.append({
+            "name": span["name"], "cat": "agent", "ph": "X", "pid": 1,
+            "tid": 1, "ts": span["start_us"] - origin,
+            "dur": max(1, span["end_us"] - span["start_us"]),
+            "args": {"step_id": span["id"], "source": span["source"]},
+        })
+    for event in model["instants"]:
+        events.append({
+            "name": event["name"], "cat": "tool", "ph": "i", "s": "t",
+            "pid": 1, "tid": 2, "ts": event["timestamp_us"] - origin,
+            "args": {"step_id": event["step_id"], "tool": event["tool"]},
+        })
+    for metric in model["metrics"]:
+        track = metric["name"]
+        gpu = metric.get("attributes", {}).get("gpu_index")
+        if gpu is not None:
+            track = f"gpu.{gpu}.{track.removeprefix('gpu.')}"
+        events.append({
+            "name": track, "cat": "metric", "ph": "C", "pid": 2, "tid": 1,
+            "ts": metric["timestamp_us"] - origin,
+            "args": {"value": metric["value"], "unit": metric["unit"],
+                     "active_step": metric.get("active_step", "")},
+        })
+    return {"traceEvents": events, "displayTimeUnit": "ms"}
+
+
+def _otlp_lines(model: dict[str, Any]) -> list[str]:
+    seed = json.dumps(model["metadata"], sort_keys=True).encode()
+    trace_id = hashlib.sha256(seed).hexdigest()[:32]
+    resource = {
+        "attributes": [
+            {"key": key, "value": {"stringValue": str(value)}}
+            for key, value in sorted(model["metadata"].items())
+            if value not in (None, "")
+        ]
+    }
+    spans = []
+    for index, span in enumerate(model["spans"] + [
+        {
+            "id": event["id"], "name": event["name"],
+            "start_us": event["timestamp_us"], "end_us": event["timestamp_us"] + 1,
+        } for event in model["instants"]
+    ]):
+        span_id = hashlib.sha256(f"{trace_id}:{index}".encode()).hexdigest()[:16]
+        spans.append({
+            "traceId": trace_id,
+            "spanId": span_id,
+            "name": span["name"],
+            "kind": 1,
+            "startTimeUnixNano": str(span["start_us"] * 1_000),
+            "endTimeUnixNano": str(span["end_us"] * 1_000),
+            "attributes": [{
+                "key": "skill_eval.event_id",
+                "value": {"stringValue": span["id"]},
+            }],
+        })
+    trace_request = {
+        "resourceSpans": [{
+            "resource": resource,
+            "scopeSpans": [{"scope": {"name": "vss.skill_eval.timeline"}, "spans": spans}],
+        }]
+    }
+
+    grouped: dict[str, list[dict]] = {}
+    for metric in model["metrics"]:
+        attributes = [
+            {"key": key, "value": {"intValue": str(value)}}
+            for key, value in sorted(metric.get("attributes", {}).items())
+        ]
+        if metric.get("active_step"):
+            attributes.append({
+                "key": "skill_eval.active_step",
+                "value": {"stringValue": metric["active_step"]},
+            })
+        grouped.setdefault(metric["name"], []).append({
+            "timeUnixNano": str(metric["timestamp_us"] * 1_000),
+            "asDouble": metric["value"],
+            "attributes": attributes,
+        })
+    metric_request = {
+        "resourceMetrics": [{
+            "resource": resource,
+            "scopeMetrics": [{
+                "scope": {"name": "vss.skill_eval.timeline"},
+                "metrics": [{
+                    "name": name,
+                    "unit": METRIC_UNITS.get(name, "1"),
+                    "gauge": {"dataPoints": points},
+                } for name, points in sorted(grouped.items())],
+            }],
+        }]
+    }
+    return [
+        json.dumps(trace_request, separators=(",", ":")),
+        json.dumps(metric_request, separators=(",", ":")),
+    ]
+
+
+def _html(model: dict[str, Any]) -> str:
+    start = model["bounds"]["start_us"]
+    end = max(start + 1, model["bounds"]["end_us"])
+    width, height = 1400, 390
+    left, right = 170, 20
+
+    def x(timestamp: int) -> float:
+        return left + (timestamp - start) * (width - left - right) / (end - start)
+
+    colors = {"agent": "#76b900", "user": "#5b8def", "event": "#888"}
+    svg = [
+        f'<svg viewBox="0 0 {width} {height}" role="img" '
+        'aria-label="Agent and hardware timeline">',
+        '<rect width="100%" height="100%" fill="#11151a"/>',
+    ]
+    tracks = [("Agent steps", 45), ("Tool calls", 105), ("GPU utilization", 180),
+              ("CPU utilization", 255), ("Memory used", 330)]
+    for label, y in tracks:
+        svg.append(f'<text x="8" y="{y}" fill="#d5dbe3">{html.escape(label)}</text>')
+        svg.append(f'<line x1="{left}" x2="{width-right}" y1="{y}" y2="{y}" '
+                   'stroke="#35404c"/>')
+    for span in model["spans"]:
+        sx, ex = x(span["start_us"]), x(span["end_us"])
+        color = colors.get(span["source"], colors["event"])
+        svg.append(
+            f'<rect x="{sx:.2f}" y="25" width="{max(1, ex-sx):.2f}" height="28" '
+            f'fill="{color}" opacity=".75"><title>{html.escape(span["id"])}: '
+            f'{html.escape(span["name"])}</title></rect>'
+        )
+    for event in model["instants"]:
+        ex = x(event["timestamp_us"])
+        svg.append(
+            f'<circle cx="{ex:.2f}" cy="105" r="5" fill="#f5a623"><title>'
+            f'{html.escape(event["name"])} ({html.escape(event["step_id"])})'
+            '</title></circle>'
+        )
+
+    def polyline(name: str, y: int, maximum: float, color: str) -> None:
+        points = [
+            (x(metric["timestamp_us"]),
+             y - min(max(metric["value"], 0), maximum) * 55 / maximum)
+            for metric in model["metrics"] if metric["name"] == name
+        ]
+        if points:
+            joined = " ".join(f"{px:.2f},{py:.2f}" for px, py in points)
+            svg.append(f'<polyline points="{joined}" fill="none" stroke="{color}" '
+                       'stroke-width="2"/>')
+
+    polyline("gpu.utilization", 225, 100, "#76b900")
+    polyline("cpu.user", 300, 100, "#5b8def")
+    memory = [m["value"] for m in model["metrics"] if m["name"] == "memory.used"]
+    polyline("memory.used", 375, max(memory) if memory else 1, "#d66efd")
+    svg.append("</svg>")
+
+    rows = []
+    for name, values in model["summary"]["metrics"].items():
+        rows.append(
+            "<tr>" + "".join(
+                f"<td>{html.escape(str(value))}</td>"
+                for value in (
+                    name, values["samples"], values["min"], values["mean"],
+                    values["max"], values["unit"],
+                )
+            ) + "</tr>"
+        )
+    return """<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Skill-eval agent hardware timeline</title>
+<style>
+body{font:14px system-ui,sans-serif;background:#0b0e11;color:#e8edf2;margin:24px}
+h1{font-size:22px} .meta{color:#9eabb8} svg{width:100%;border:1px solid #35404c}
+table{border-collapse:collapse;width:100%;margin-top:18px}th,td{padding:6px 10px;
+border-bottom:1px solid #303943;text-align:right}th:first-child,td:first-child{text-align:left}
+code{color:#9dccff}
+</style></head><body>
+<h1>Skill-eval agent hardware timeline</h1>
+<p class="meta">Hover timeline marks for sanitized labels. Raw commands, arguments,
+messages, observations, environments, and file contents are intentionally absent.</p>
+""" + "".join(svg) + """
+<h2>Metric summary</h2>
+<table><thead><tr><th>Metric</th><th>Samples</th><th>Min</th><th>Mean</th>
+<th>Max</th><th>Unit</th></tr></thead><tbody>""" + "".join(rows) + """
+</tbody></table>
+<h2>Waste signal</h2><p><code>GPU idle &lt;5% with &gt;1 GiB resident:</code> """ + \
+        html.escape(str(model["summary"]["waste_signals"][
+            "gpu_idle_with_resident_memory_pct"])) + "% of paired samples</p></body></html>\n"
+
+
+def generate(
+    results_root: Path,
+    *,
+    include_task_name: str,
+    trace_token: str,
+    started_at: float,
+    finished_at: float,
+    metadata: dict[str, Any] | None = None,
+) -> Path | None:
+    """Generate all comparison formats from one sanitized canonical model."""
+    candidates = [
+        path for path in results_root.glob(
+            f"*/{include_task_name}__*/agent/trajectory.json*"
+        ) if path.stat().st_mtime >= started_at - 2
+    ]
+    trajectory = max(candidates, key=lambda path: path.stat().st_mtime) \
+        if candidates else None
+    started_us = int(started_at * 1_000_000)
+    finished_us = int(finished_at * 1_000_000)
+    try:
+        spans, instants = _agent_events(
+            trajectory, started_us, finished_us
+        ) if trajectory else ([], [])
+
+        metrics: list[dict] = []
+        gpu_csv = results_root / "gputrace" / f"{trace_token}.csv"
+        if gpu_csv.exists():
+            metrics.extend(_gpu_metrics(
+                gpu_csv, _sidecar(gpu_csv.with_suffix(".json"))
+            ))
+        system_csv = results_root / "systemtrace" / f"{trace_token}.csv"
+        if system_csv.exists():
+            metrics.extend(_system_metrics(
+                system_csv, _sidecar(system_csv.with_suffix(".json"))
+            ))
+        metrics.sort(key=lambda item: (item["timestamp_us"], item["name"]))
+        for metric in metrics:
+            metric["active_step"] = _active_step(spans, metric["timestamp_us"])
+
+        all_times = (
+            [span["start_us"] for span in spans] +
+            [span["end_us"] for span in spans] +
+            [metric["timestamp_us"] for metric in metrics]
+        )
+        start_us = min(all_times) if all_times else started_us
+        end_us = max(all_times) if all_times else finished_us
+        supplied_metadata = metadata or {}
+        safe_metadata = {
+            key: _safe_name(supplied_metadata[key], "", 128)
+            for key in sorted(METADATA_FIELDS)
+            if key in supplied_metadata and supplied_metadata[key] not in (None, "")
+        }
+        model = {
+            "schema": 1,
+            "metadata": safe_metadata,
+            "bounds": {"start_us": start_us, "end_us": max(start_us + 1, end_us)},
+            "spans": spans,
+            "instants": instants,
+            "metrics": metrics,
+            "summary": _summary(metrics),
+            "privacy": {
+                "source_trajectory": "ephemeral",
+                "published_fields": "allowlist",
+                "raw_commands_included": False,
+            },
+        }
+        outputs = {
+            "timeline.json": json.dumps(model, indent=2) + "\n",
+            "timeline.perfetto.json": (
+                json.dumps(_perfetto(model), separators=(",", ":")) + "\n"
+            ),
+            "timeline.html": _html(model),
+            "timeline.otlp.jsonl": "\n".join(_otlp_lines(model)) + "\n",
+        }
+        timeline_root = results_root / "timeline"
+        timeline_root.mkdir(parents=True, exist_ok=True)
+        token = SAFE_TOKEN_RE.sub("-", str(trace_token))[:160].strip(".-") or "trace"
+        dest = timeline_root / token
+        # Stage outside results_root so even an abrupt process death cannot
+        # leave a partial timeline.* set for the artifact collector to archive.
+        # The parent is the same filesystem, preserving atomic directory rename.
+        temporary = Path(tempfile.mkdtemp(
+            prefix=f".timeline-{token}.", dir=results_root.parent
+        ))
+        try:
+            for filename, content in outputs.items():
+                (temporary / filename).write_text(content, encoding="utf-8")
+            if dest.exists():
+                shutil.rmtree(dest)
+            os.replace(temporary, dest)
+        finally:
+            with contextlib.suppress(OSError):
+                shutil.rmtree(temporary)
+        return dest
+    finally:
+        # Deletion is independent of rendering success. A malformed trajectory
+        # or unwritable output must not turn raw messages and tool results into
+        # a persistent viewer retention path.
+        if trajectory is not None:
+            with contextlib.suppress(OSError):
+                shutil.rmtree(trajectory.parent)

--- a/.github/skill-eval/agent_timeline/timeline.py
+++ b/.github/skill-eval/agent_timeline/timeline.py
@@ -277,7 +277,25 @@ def _system_metrics(csv_path: Path, sidecar: dict[str, Any]) -> list[dict]:
     for row, timestamp_us in zip(rows, raw_times):
         if timestamp_us is None:
             continue
+        # The sampler's first row primes /proc/stat and therefore carries
+        # five CPU percentages set to zero. Treating that as a measurement
+        # says the host is simultaneously 0% busy and 0% idle, and skews every
+        # short trace. Keep that row's instantaneous load/memory values, but
+        # omit CPU percentages until a real counter delta exists.
+        try:
+            cpu_total = sum(float(row[column]) for column in (
+                "cpu_user_pct", "cpu_system_pct", "cpu_iowait_pct",
+                "cpu_idle_pct", "cpu_steal_pct",
+            ))
+        except (KeyError, ValueError):
+            cpu_total = None
         for column, name in mapping.items():
+            if (
+                name.startswith("cpu.")
+                and cpu_total is not None
+                and cpu_total < 50.0
+            ):
+                continue
             try:
                 value = float(row[column])
             except (KeyError, ValueError):

--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -161,6 +161,8 @@ def _read_capped(proc: subprocess.Popen, deadline_sec: float) -> str:
         chunks.append(chunk)
     with contextlib.suppress(Exception):
         proc.wait(timeout=max(1.0, end - time.monotonic()))
+    with contextlib.suppress(Exception):
+        proc.stdout.close()
     return "".join(chunks)
 
 
@@ -208,7 +210,18 @@ def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC,
                 proc.communicate(timeout=10)
             continue
         except (OSError, ValueError):
+            # A failed read must not leave the transport (or a descendant ssh)
+            # alive until the remote deadline. Telemetry owns this process.
+            if proc.poll() is None:
+                with contextlib.suppress(ProcessLookupError, OSError):
+                    os.killpg(proc.pid, signal.SIGKILL)
+                with contextlib.suppress(Exception):
+                    proc.wait(timeout=10)
             continue
+        finally:
+            with contextlib.suppress(Exception):
+                if proc.stdout is not None:
+                    proc.stdout.close()
         if proc.returncode == 0:
             # `brev exec` echoes the instance name on its own line after the
             # command output; drop it so callers get only the payload.

--- a/.github/skill-eval/gpu_trace.py
+++ b/.github/skill-eval/gpu_trace.py
@@ -183,11 +183,23 @@ def _remote(instance: str, command: str, timeout: int = EXEC_TIMEOUT_SEC,
     an ssh that forked would survive; `envs/brev_env.py::_kill_proc_group`
     already fixes this exact problem the same way for harbor.
     """
-    candidates = (
-        ["brev", "exec", instance, command],
-        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15",
-         "-o", "StrictHostKeyChecking=no", instance.lower(), command],
-    )[:max(1, attempts)]
+    brev = ["brev", "exec", instance, command]
+    ssh = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15",
+           "-o", "StrictHostKeyChecking=no", instance.lower(), command]
+    # Sampler startup is deliberately single-attempt because it is not safe to
+    # replay after an ambiguous timeout. Registered external nodes cannot use
+    # `brev exec`, so putting brev first with attempts=1 guaranteed that both
+    # samplers collected nothing on that pool. The coordinator already carries
+    # the operator-controlled registered-node allowlists; use them to choose
+    # the one viable transport before applying the attempt cap.
+    registered = {
+        name.lower()
+        for variable in ("BREV_REGISTERED_POOL", "BREV_RTX4090_POOL")
+        for name in re.split(r"[\s,]+", os.environ.get(variable, "").strip())
+        if name
+    }
+    candidates = ((ssh, brev) if instance.lower() in registered
+                  else (brev, ssh))[:max(1, attempts)]
     deadline = time.monotonic() + timeout
     for cmd in candidates:
         remaining = deadline - time.monotonic()

--- a/.github/skill-eval/plan_matrix.py
+++ b/.github/skill-eval/plan_matrix.py
@@ -35,8 +35,9 @@ as runners in their own right.
 Env:
     PR_BASE        base branch, e.g. develop (diffed as FETCH_HEAD...HEAD)
     MANUAL_SKILLS_FILTER  workflow_dispatch sweep: a skill-dir name or `*`
-                   (all skills) — enumerates those specs instead of diffing,
-                   so the matrix fans per-(spec, platform) like a push
+                          (all skills) — enumerates those specs instead of
+                          diffing, so the matrix fans like a push
+    MANUAL_SPEC_FILTER    optional spec stem for a one-spec manual proof
     CHANGED_FILES  optional newline-separated override (tests / local)
     GITHUB_OUTPUT  optional; when set, key=value lines are appended here
 """
@@ -205,7 +206,25 @@ def list_changed_files() -> list[str]:
             sorted(p.name for p in (REPO_ROOT / "skills").iterdir() if p.is_dir())
             if manual == "*" else [manual]
         )
-        return [sp for sk in skills for sp, _, _ in specs_for_skill(sk)]
+        specs = [entry for sk in skills for entry in specs_for_skill(sk)]
+        spec_filter = os.environ.get("MANUAL_SPEC_FILTER", "").strip()
+        if spec_filter:
+            if manual == "*":
+                raise ValueError(
+                    "MANUAL_SPEC_FILTER requires one explicit skill, not '*'"
+                )
+            if not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_-]*", spec_filter):
+                raise ValueError(
+                    f"unsafe MANUAL_SPEC_FILTER {spec_filter!r}: expected a "
+                    "spec filename stem ([A-Za-z0-9_-])"
+                )
+            specs = [entry for entry in specs if entry[2] == spec_filter]
+            if not specs:
+                raise ValueError(
+                    f"MANUAL_SPEC_FILTER {spec_filter!r}: no matching spec "
+                    f"under skills/{manual}/evals or skills/{manual}/eval"
+                )
+        return [spec_path for spec_path, _, _ in specs]
 
     base = os.environ["PR_BASE"]
     subprocess.run(

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -50,6 +50,16 @@ except Exception:  # noqa: BLE001 - telemetry is never load-bearing
     # sampler must degrade to "no trace", never to a failed leg.
     gpu_trace = None
 
+try:
+    import system_trace
+except Exception:  # noqa: BLE001 - telemetry is never load-bearing
+    system_trace = None
+
+try:
+    import agent_timeline
+except Exception:  # noqa: BLE001 - reporting is never load-bearing
+    agent_timeline = None
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STEP_COUNT_RE = re.compile(r"^\s*step_count\s*=\s*(\d+)\s*$", re.MULTILINE)
 SAFE_PART_RE = re.compile(r"[^A-Za-z0-9_-]+")
@@ -691,11 +701,23 @@ def publish_trace(
     job_name = f"{leg_slug}__{run_id}__{date_dir.name}"
     viewer_job = VIEWER_ROOT / job_name
     viewer_job.mkdir(parents=True, exist_ok=True)
+    # Raw agent data is intentionally ephemeral. Remove anything retained by
+    # an older copy before refreshing this viewer job, and exclude all agent
+    # directories from the copy itself. The second guard matters when timeline
+    # generation failed before it could clean the source trial.
+    for agent_dir in viewer_job.rglob("agent"):
+        if agent_dir.is_dir():
+            shutil.rmtree(agent_dir)
     # Copy (never move) the date dir's *contents*: the workflow's "Collect
     # results" step runs after this and tars results_root for the artifact,
     # and copying the dir itself would nest a later trial under
     # <job>/<date>/ where the viewer cannot see it.
-    shutil.copytree(date_dir, viewer_job, dirs_exist_ok=True)
+    shutil.copytree(
+        date_dir,
+        viewer_job,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns("agent"),
+    )
     url = trace_url(trial_dir / "result.json", job_name)
     if url:
         with (results_root / "trace-urls.tsv").open("a") as handle:
@@ -707,6 +729,39 @@ def publish_trace(
             flush=True,
         )
     return url
+
+
+def _remove_ephemeral_agent_data(
+    results_root: Path, invocation: HarborInvocation
+) -> None:
+    """Remove raw agent directories for this task before publish/archive."""
+    for agent_dir in results_root.glob(
+        f"*/{invocation.include_task_name}__*/agent"
+    ):
+        with contextlib.suppress(OSError):
+            shutil.rmtree(agent_dir)
+
+
+def _enter_telemetry(
+    stack: contextlib.ExitStack, manager: object, label: str
+) -> None:
+    """Enter an optional telemetry manager without affecting the eval."""
+    try:
+        stack.enter_context(manager)  # type: ignore[arg-type]
+    except Exception as exc:  # noqa: BLE001 - telemetry is never load-bearing
+        print(f"[run-leg] {label} startup failed: {exc!r}; leg continues", flush=True)
+
+
+def _telemetry_token(
+    run_id: str, spec_stem: str, platform: str, step: int, chain: str
+) -> str:
+    if gpu_trace is not None:
+        token_builder = getattr(gpu_trace, "_token", None)
+        if callable(token_builder):
+            return token_builder(run_id, spec_stem, platform, step, chain)
+    head = _safe_part(f"{run_id}-{spec_stem}-{platform}")[:100]
+    tail = f"-{_safe_part(chain)}" if chain else ""
+    return f"{head}{tail}-step{step}"
 
 
 def _reward_value(reward: str | None) -> float:
@@ -801,29 +856,78 @@ def run_invocations(
 
         cmd = build_harbor_command(invocation, results_root, model, base_url, agent)
         started_at = time.time() - 1.0
+        step = invocation.step_index or 1
+        chain = str(invocation.chain_key or invocation.include_task_name or "")
         # Sample the box's GPUs for exactly this harbor invocation. Per-step,
         # not per-leg: step-1 pays the cold deploy and later steps reuse it, so
         # one trace spanning both would average away the difference that
         # matters. The context manager is a no-op if tracing is disabled or the
         # box is unreachable, and it never raises.
-        if gpu_trace is not None:
-            with gpu_trace.trace(
-                instance,
-                results_root,
-                spec_stem=spec_stem,
-                platform=platform,
-                step=invocation.step_index or 1,
-                # Two chains of one leg can share a step index, and without
-                # this they wrote the same trace file and the second silently
-                # replaced the first.
-                chain=str(invocation.chain_key or invocation.include_task_name or ""),
-                declared_gpu_count=declared_gpu_count,
-                skill=os.environ.get("EVAL_SKILL", ""),
-                harbor_timeout_sec=harbor_timeout_sec,
-            ):
-                rc = run_command(cmd, env, harbor_timeout_sec)
-        else:
+        with contextlib.ExitStack() as telemetry:
+            if gpu_trace is not None:
+                _enter_telemetry(telemetry, gpu_trace.trace(
+                    instance,
+                    results_root,
+                    spec_stem=spec_stem,
+                    platform=platform,
+                    step=step,
+                    # Two chains of one leg can share a step index, and without
+                    # this they wrote the same trace file and the second silently
+                    # replaced the first.
+                    chain=chain,
+                    declared_gpu_count=declared_gpu_count,
+                    skill=os.environ.get("EVAL_SKILL", ""),
+                    harbor_timeout_sec=harbor_timeout_sec,
+                ), "GPU telemetry")
+            if system_trace is not None:
+                _enter_telemetry(telemetry, system_trace.trace(
+                    instance,
+                    results_root,
+                    spec_stem=spec_stem,
+                    platform=platform,
+                    step=step,
+                    chain=chain,
+                    skill=os.environ.get("EVAL_SKILL", ""),
+                    harbor_timeout_sec=harbor_timeout_sec,
+                ), "system telemetry")
             rc = run_command(cmd, env, harbor_timeout_sec)
+        finished_at = time.time()
+
+        # The trajectory is consumed only as an ephemeral source. The generated
+        # comparison contains allowlisted labels and aggregate numeric metrics:
+        # no messages, observations, command arguments, environments, or file
+        # contents. Failure is reporting-only and cannot change the eval verdict.
+        if agent_timeline is not None:
+            try:
+                trace_token = _telemetry_token(
+                    run_id, spec_stem, platform, step, chain
+                )
+                timeline_dir = agent_timeline.generate(
+                    results_root,
+                    include_task_name=invocation.include_task_name,
+                    trace_token=trace_token,
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    metadata={
+                        "run_id": run_id,
+                        "skill": os.environ.get("EVAL_SKILL", ""),
+                        "spec_stem": spec_stem,
+                        "platform": platform,
+                        "step": step,
+                        "chain": chain,
+                        "agent": agent,
+                        "model": model,
+                        "instance": instance,
+                    },
+                )
+                if timeline_dir:
+                    print(f"[run-leg] hardware timeline: {timeline_dir}", flush=True)
+            except Exception as exc:  # noqa: BLE001
+                print(f"[run-leg] timeline generation failed: {exc!r}", flush=True)
+            finally:
+                _remove_ephemeral_agent_data(results_root, invocation)
+        else:
+            _remove_ephemeral_agent_data(results_root, invocation)
         # Publish before the rc checks below: a timed-out (rc=124) trial
         # returns early, and its partial trace is exactly what needs reading.
         try:

--- a/.github/skill-eval/system_trace.py
+++ b/.github/skill-eval/system_trace.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Best-effort CPU and memory sampling for one skill-eval invocation.
+
+Only fixed numeric fields from Linux's procfs accounting interfaces are read.
+Process lists, command lines, environments, file contents, and per-process
+metrics are deliberately excluded from the collection boundary.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import shlex
+import time
+from pathlib import Path
+
+import gpu_trace
+
+
+INTERVAL_SEC = gpu_trace._int_env("EVAL_SYSTEM_TRACE_INTERVAL", 10)
+MAX_FETCH_BYTES = gpu_trace._int_env("EVAL_SYSTEM_TRACE_MAX_BYTES", 8 * 1024 * 1024)
+ENABLED = os.environ.get("EVAL_SYSTEM_TRACE", "1") not in ("0", "false", "False", "")
+HARD_STOP_SLACK_SEC = 600
+
+CSV_HEADER = (
+    "timestamp_ns,cpu_count,cpu_user_pct,cpu_system_pct,cpu_iowait_pct,"
+    "cpu_idle_pct,cpu_steal_pct,load_1m,load_5m,load_15m,mem_used_mib,"
+    "mem_available_mib,mem_total_mib,swap_used_mib,swap_total_mib"
+)
+ROW_RE = re.compile(
+    r"^[1-9][0-9]{15,19}(?:,-?\d+(?:\.\d+)?){14}$"
+)
+DIR_RE = re.compile(r"^/tmp/vss-systrace\.[A-Za-z0-9]{8}$")
+
+# This constant is passed directly to ``python3 -c``. It reads only aggregate
+# numeric counters from three fixed kernel interfaces and writes a fixed-width
+# numeric CSV. No job-controlled value is interpolated into it.
+SAMPLER = r"""
+import os, sys, time
+
+out = open(sys.argv[1], "w", buffering=1)
+previous = None
+
+def cpu():
+    cells = open("/proc/stat", encoding="ascii").readline().split()
+    values = [int(v) for v in cells[1:9]]
+    return values
+
+def memory():
+    wanted = {"MemTotal", "MemAvailable", "SwapTotal", "SwapFree"}
+    values = {}
+    with open("/proc/meminfo", encoding="ascii") as handle:
+        for line in handle:
+            key, _, rest = line.partition(":")
+            if key in wanted:
+                values[key] = int(rest.split()[0])
+    return values
+
+while True:
+    now = time.time_ns()
+    current = cpu()
+    mem = memory()
+    load = open("/proc/loadavg", encoding="ascii").readline().split()[:3]
+    percentages = [0.0] * 5
+    if previous is not None:
+        delta = [max(0, a - b) for a, b in zip(current, previous)]
+        total = sum(delta) or 1
+        user = delta[0] + delta[1]
+        system = delta[2] + delta[5] + delta[6]
+        percentages = [
+            100.0 * user / total,
+            100.0 * system / total,
+            100.0 * delta[4] / total,
+            100.0 * delta[3] / total,
+            100.0 * delta[7] / total,
+        ]
+    previous = current
+    total_mib = mem.get("MemTotal", 0) / 1024.0
+    available_mib = mem.get("MemAvailable", 0) / 1024.0
+    swap_total_mib = mem.get("SwapTotal", 0) / 1024.0
+    swap_free_mib = mem.get("SwapFree", 0) / 1024.0
+    row = [
+        now, os.cpu_count() or 0, *percentages, *[float(v) for v in load],
+        max(0.0, total_mib - available_mib), available_mib, total_mib,
+        max(0.0, swap_total_mib - swap_free_mib), swap_total_mib,
+    ]
+    out.write(",".join(str(round(v, 3)) if isinstance(v, float) else str(v)
+                       for v in row) + "\n")
+    time.sleep(%INTERVAL%)
+""".replace("%INTERVAL%", str(INTERVAL_SEC))
+
+
+@contextlib.contextmanager
+def trace(
+    instance: str,
+    results_root: Path,
+    *,
+    spec_stem: str = "",
+    platform: str = "",
+    step: int = 1,
+    chain: str = "",
+    skill: str = "",
+    harbor_timeout_sec: int = 7800,
+):
+    """Sample aggregate CPU and memory counters without ever failing the leg."""
+    if not ENABLED or not instance:
+        yield
+        return
+
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
+    token = gpu_trace._token(run_id, spec_stem, platform, step, chain)
+    started_at = time.time()
+    hard_stop = max(harbor_timeout_sec + HARD_STOP_SLACK_SEC, 900)
+    pid: str | None = None
+    remote_dir: str | None = None
+    script = shlex.quote(SAMPLER)
+    start_cmd = (
+        "find /tmp -maxdepth 1 -name 'vss-systrace.*' -mmin +180 "
+        "-exec rm -rf {} + 2>/dev/null; "
+        "set -C; d=$(mktemp -d /tmp/vss-systrace.XXXXXXXX) || exit 0; "
+        "echo DIR=$d; "
+        f"nohup timeout -k 10 {hard_stop} python3 -c {script} \"$d/trace.csv\" "
+        ">/dev/null 2>&1 </dev/null & echo PID=$!"
+    )
+    try:
+        out = gpu_trace._remote(instance, start_cmd, attempts=1)
+        for line in (out or "").splitlines():
+            if line.startswith("PID="):
+                candidate = line.split("=", 1)[1].strip()
+                pid = candidate if gpu_trace.PID_RE.match(candidate) else None
+            elif line.startswith("DIR="):
+                candidate = line.split("=", 1)[1].strip()
+                remote_dir = candidate if DIR_RE.match(candidate) else None
+        if not (pid and remote_dir):
+            print(f"[system-trace] could not start on {instance}; leg continues",
+                  flush=True)
+    except Exception as exc:  # noqa: BLE001 - telemetry is never load-bearing
+        print(f"[system-trace] start failed ({exc!r}); leg continues", flush=True)
+
+    try:
+        yield
+    finally:
+        with contextlib.suppress(Exception):
+            _finish(
+                instance, remote_dir, pid, results_root, token,
+                run_id=run_id, skill=skill, spec_stem=spec_stem,
+                platform=platform, step=step, chain=chain,
+                started_at=started_at,
+            )
+
+
+def _finish(
+    instance: str,
+    remote_dir: str | None,
+    pid: str | None,
+    results_root: Path,
+    token: str,
+    **meta,
+) -> None:
+    """Stop, validate, and persist aggregate samples. Best effort."""
+    if pid and not remote_dir:
+        gpu_trace._remote(
+            instance,
+            f"ps -o args= -p {pid} 2>/dev/null | grep -qF vss-systrace "
+            f"&& kill {pid} 2>/dev/null; true",
+            attempts=1,
+        )
+        return
+    if not remote_dir:
+        return
+
+    kill = (
+        f"ps -o args= -p {pid} 2>/dev/null | grep -qF -- {remote_dir} "
+        f"&& kill {pid} 2>/dev/null; "
+    ) if pid else ""
+    out = gpu_trace._remote(
+        instance,
+        f"{kill}sleep 1; head -c {MAX_FETCH_BYTES} "
+        f"{remote_dir}/trace.csv 2>/dev/null; rm -rf {remote_dir}",
+    )
+    rows = [line.strip() for line in (out or "").splitlines()
+            if ROW_RE.match(line.strip())]
+    if not rows:
+        return
+
+    dest = results_root / "systemtrace"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / f"{token}.csv").write_text(
+        CSV_HEADER + "\n" + "\n".join(rows) + "\n", encoding="utf-8"
+    )
+    sidecar = {
+        "schema": 1,
+        "instance": instance,
+        "run_id": meta.get("run_id"),
+        "skill": meta.get("skill"),
+        "spec_stem": meta.get("spec_stem"),
+        "platform": meta.get("platform"),
+        "step": meta.get("step"),
+        "interval_sec": INTERVAL_SEC,
+        "started_at": meta.get("started_at"),
+        "finished_at": time.time(),
+        "samples": len(rows),
+    }
+    (dest / f"{token}.json").write_text(
+        json.dumps(sidecar, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"[system-trace] {len(rows)} samples -> {dest / (token + '.csv')}",
+          flush=True)

--- a/.github/skill-eval/tests/test_agent_timeline.py
+++ b/.github/skill-eval/tests/test_agent_timeline.py
@@ -214,6 +214,27 @@ class Sanitization(unittest.TestCase):
             )
         self.assertEqual(metrics[0]["timestamp_us"], 1_785_618_000_000_000)
 
+    def test_system_priming_row_does_not_report_impossible_zero_cpu(self):
+        with tempfile.TemporaryDirectory() as td:
+            csv_path = Path(td) / "system.csv"
+            csv_path.write_text(
+                "timestamp_ns,cpu_count,cpu_user_pct,cpu_system_pct,"
+                "cpu_iowait_pct,cpu_idle_pct,cpu_steal_pct,load_1m,load_5m,"
+                "load_15m,mem_used_mib,mem_available_mib,mem_total_mib,"
+                "swap_used_mib,swap_total_mib\n"
+                "1785621600000000000,16,0,0,0,0,0,1,2,3,100,900,1000,0,0\n"
+                "1785621610000000000,16,20,5,1,74,0,1,2,3,110,890,1000,0,0\n"
+            )
+            metrics = mod._system_metrics(
+                csv_path, {"started_at": 1_785_618_000.0}
+            )
+        cpu = [metric for metric in metrics if metric["name"].startswith("cpu.")]
+        memory = [metric for metric in metrics if metric["name"] == "memory.used"]
+        self.assertEqual(len(cpu), 5)
+        self.assertEqual({metric["timestamp_us"] for metric in cpu},
+                         {1_785_618_010_000_000})
+        self.assertEqual(len(memory), 2)
+
     def test_metadata_is_field_allowlisted_not_merely_redacted(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/.github/skill-eval/tests/test_agent_timeline.py
+++ b/.github/skill-eval/tests/test_agent_timeline.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for sanitized multi-format agent/hardware timelines."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent_timeline import timeline as mod  # noqa: E402
+
+
+class TimelineFixture(unittest.TestCase):
+    def _generate(self, root: Path) -> Path:
+        trial = root / "2026-08-01__21-00-00" / "step-1__trial" / "agent"
+        trial.mkdir(parents=True)
+        trajectory = {
+            "steps": [
+                {
+                    "timestamp": "2026-08-01T21:00:00Z",
+                    "source": "agent",
+                    "message": "SECRET_MESSAGE",
+                    "tool_calls": [{
+                        "tool_call_id": "toolu_secret_id",
+                        "function_name": "Bash",
+                        "arguments": {
+                            "command": (
+                                "API_KEY=CANARYSECRET curl -H "
+                                "'Authorization: Bearer CANARYSECRET' "
+                                "https://private.invalid/run"
+                            )
+                        },
+                        "observation": {"body": "CANARY_OBSERVATION"},
+                    }],
+                },
+                {
+                    "timestamp": "2026-08-01T21:00:10Z",
+                    "source": "user",
+                    "message": "CANARY_USER_PROMPT",
+                },
+            ]
+        }
+        (trial / "trajectory.json").write_text(json.dumps(trajectory))
+
+        token = "run-search-rtx-chain-step1"
+        gpu = root / "gputrace"
+        gpu.mkdir()
+        (gpu / f"{token}.csv").write_text(
+            "timestamp,gpu_index,util_gpu_pct,util_mem_pct,mem_used_mib,"
+            "mem_total_mib,power_w\n"
+            "2026/08/01 21:00:00.000,0,0,2,4096,97887,70\n"
+            "2026/08/01 21:00:10.000,0,95,40,50000,97887,320\n"
+        )
+        epoch = dt.datetime(
+            2026, 8, 1, 21, 0, tzinfo=dt.timezone.utc
+        ).timestamp()
+        (gpu / f"{token}.json").write_text(json.dumps({
+            "started_at": epoch,
+            "finished_at": epoch + 20,
+        }))
+
+        system = root / "systemtrace"
+        system.mkdir()
+        header = (
+            "timestamp_ns,cpu_count,cpu_user_pct,cpu_system_pct,cpu_iowait_pct,"
+            "cpu_idle_pct,cpu_steal_pct,load_1m,load_5m,load_15m,mem_used_mib,"
+            "mem_available_mib,mem_total_mib,swap_used_mib,swap_total_mib\n"
+        )
+        timestamp_ns = int(epoch * 1_000_000_000)
+        (system / f"{token}.csv").write_text(
+            header + f"{timestamp_ns},32,12,4,1,83,0,1,2,3,8000,56000,64000,0,0\n"
+        )
+
+        result = mod.generate(
+            root,
+            include_task_name="step-1",
+            trace_token=token,
+            started_at=epoch - 1,
+            finished_at=epoch + 20,
+            metadata={
+                "skill": "search",
+                "spec_stem": "spec",
+                "unsafe": "<script>CANARY_METADATA</script>",
+            },
+        )
+        self.assertIsNotNone(result)
+        return result
+
+    def test_generates_all_three_comparison_formats(self):
+        with tempfile.TemporaryDirectory() as td:
+            dest = self._generate(Path(td))
+            names = {path.name for path in dest.iterdir()}
+        self.assertEqual(names, {
+            "timeline.json",
+            "timeline.perfetto.json",
+            "timeline.html",
+            "timeline.otlp.jsonl",
+        })
+
+    def test_raw_trajectory_content_cannot_reach_any_output(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            dest = self._generate(root)
+            output = "\n".join(path.read_text() for path in dest.iterdir())
+            retained_agent_dirs = list(root.glob("*/*/agent"))
+        for secret in (
+            "CANARYSECRET", "SECRET_MESSAGE", "CANARY_OBSERVATION",
+            "CANARY_USER_PROMPT", "private.invalid", "toolu_secret_id",
+        ):
+            self.assertNotIn(secret, output)
+        self.assertIn("Bash: curl", output)
+        self.assertEqual(retained_agent_dirs, [])
+
+    def test_canonical_model_correlates_samples_to_agent_steps(self):
+        with tempfile.TemporaryDirectory() as td:
+            dest = self._generate(Path(td))
+            model = json.loads((dest / "timeline.json").read_text())
+        self.assertEqual(model["spans"][0]["id"], "step-1")
+        first_gpu = next(
+            metric for metric in model["metrics"]
+            if metric["name"] == "gpu.utilization"
+        )
+        self.assertEqual(first_gpu["active_step"], "step-1")
+        first_cpu = next(
+            metric for metric in model["metrics"]
+            if metric["name"] == "cpu.user"
+        )
+        self.assertEqual(first_cpu["active_step"], "step-1")
+        self.assertGreater(
+            model["summary"]["waste_signals"][
+                "gpu_idle_with_resident_memory_pct"
+            ],
+            0,
+        )
+        self.assertFalse(model["privacy"]["raw_commands_included"])
+
+    def test_perfetto_and_otlp_outputs_have_expected_envelopes(self):
+        with tempfile.TemporaryDirectory() as td:
+            dest = self._generate(Path(td))
+            perfetto = json.loads((dest / "timeline.perfetto.json").read_text())
+            otlp = [
+                json.loads(line)
+                for line in (dest / "timeline.otlp.jsonl").read_text().splitlines()
+            ]
+        self.assertTrue(any(event["ph"] == "X" for event in perfetto["traceEvents"]))
+        self.assertTrue(any(event["ph"] == "C" for event in perfetto["traceEvents"]))
+        self.assertIn("resourceSpans", otlp[0])
+        self.assertIn("resourceMetrics", otlp[1])
+        self.assertTrue(
+            otlp[0]["resourceSpans"][0]["scopeSpans"][0]["spans"][0][
+                "startTimeUnixNano"
+            ].isdigit()
+        )
+
+    def test_html_is_self_contained(self):
+        with tempfile.TemporaryDirectory() as td:
+            dest = self._generate(Path(td))
+            page = (dest / "timeline.html").read_text()
+        self.assertIn("<svg", page)
+        self.assertNotIn('src="http', page)
+        self.assertNotIn('href="http', page)
+
+
+class Sanitization(unittest.TestCase):
+    def test_command_summary_is_fail_closed(self):
+        self.assertEqual(
+            mod._command_summary(
+                "TOKEN=secret sudo docker compose up && curl https://private"
+            ),
+            "docker + curl",
+        )
+        self.assertEqual(mod._command_summary("/secret/custom-tool --token x"), "shell")
+
+    def test_legacy_encoded_tool_calls_are_supported_without_messages(self):
+        step = {
+            "message": json.dumps({
+                "message": {
+                    "content": [{
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "input": {"command": "python3 secret.py"},
+                    }]
+                }
+            })
+        }
+        calls = mod._legacy_calls(step)
+        self.assertEqual(calls[0]["function_name"], "Bash")
+        self.assertEqual(mod._command_summary(calls[0]["arguments"]["command"]), "python3")
+
+    def test_timestamp_units_are_normalized_without_epoch_shift(self):
+        expected = 1_785_618_000_000_000
+        self.assertEqual(mod._timestamp_us(expected * 1_000), expected)
+        self.assertEqual(mod._timestamp_us(expected), expected)
+        self.assertEqual(mod._timestamp_us(expected // 1_000), expected)
+        self.assertEqual(mod._timestamp_us(expected / 1_000_000), expected)
+
+    def test_system_clock_is_aligned_to_coordinator_start(self):
+        with tempfile.TemporaryDirectory() as td:
+            csv_path = Path(td) / "system.csv"
+            csv_path.write_text(
+                "timestamp_ns,cpu_user_pct\n"
+                "1785621600000000000,12.5\n"
+            )
+            metrics = mod._system_metrics(
+                csv_path, {"started_at": 1_785_618_000.0}
+            )
+        self.assertEqual(metrics[0]["timestamp_us"], 1_785_618_000_000_000)
+
+    def test_metadata_is_field_allowlisted_not_merely_redacted(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            epoch = dt.datetime(
+                2026, 8, 1, 21, 0, tzinfo=dt.timezone.utc
+            ).timestamp()
+            dest = mod.generate(
+                root,
+                include_task_name="step-1",
+                trace_token="trace",
+                started_at=epoch,
+                finished_at=epoch + 1,
+                metadata={"skill": "search", "arbitrary": "CANARYSECRET"},
+            )
+            model = json.loads((dest / "timeline.json").read_text())
+        self.assertEqual(model["metadata"], {"skill": "search"})
+        self.assertNotIn("CANARYSECRET", json.dumps(model))
+
+    def test_render_failure_still_deletes_raw_agent_directory(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            agent = root / "2026-08-01" / "step-1__trial" / "agent"
+            agent.mkdir(parents=True)
+            (agent / "trajectory.json").write_text(json.dumps({
+                "steps": [{
+                    "timestamp": "2026-08-01T21:00:00Z",
+                    "source": "agent",
+                    "message": "CANARYSECRET",
+                }]
+            }))
+            epoch = dt.datetime(
+                2026, 8, 1, 21, 0, tzinfo=dt.timezone.utc
+            ).timestamp()
+            with mock.patch.object(mod, "_html", side_effect=OSError("full")):
+                with self.assertRaisesRegex(OSError, "full"):
+                    mod.generate(
+                        root,
+                        include_task_name="step-1",
+                        trace_token="trace",
+                        started_at=epoch - 1,
+                        finished_at=epoch + 1,
+                    )
+            self.assertFalse(agent.exists())
+
+    def test_no_result_or_trajectory_still_generates_archivable_outputs(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            dest = mod.generate(
+                root,
+                include_task_name="step-1",
+                trace_token="timeout-step1",
+                started_at=1_785_618_000.0,
+                finished_at=1_785_618_010.0,
+            )
+            names = {path.name for path in dest.iterdir()}
+        self.assertEqual(names, {
+            "timeline.json",
+            "timeline.perfetto.json",
+            "timeline.html",
+            "timeline.otlp.jsonl",
+        })
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/skill-eval/tests/test_gpu_trace.py
+++ b/.github/skill-eval/tests/test_gpu_trace.py
@@ -1039,6 +1039,22 @@ class FallsBackToSsh(unittest.TestCase):
         self.assertEqual(len(argvs), 2, "ssh fallback was not attempted")
         self.assertIn("box-name", argvs[1])
 
+    def test_registered_node_uses_ssh_for_single_attempt_startup(self):
+        old = os.environ.get("BREV_REGISTERED_POOL")
+        os.environ["BREV_REGISTERED_POOL"] = "other-box, VSS-Eval-RTX-2G-VM2b"
+        try:
+            with Stub() as stub:
+                mod._remote("vss-eval-rtx-2g-VM2b", "echo hi", attempts=1)
+                argvs = stub.argvs()
+        finally:
+            if old is None:
+                os.environ.pop("BREV_REGISTERED_POOL", None)
+            else:
+                os.environ["BREV_REGISTERED_POOL"] = old
+        self.assertEqual(len(argvs), 1)
+        self.assertEqual(argvs[0][0], "-o")
+        self.assertIn("vss-eval-rtx-2g-vm2b", argvs[0])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/skill-eval/tests/test_plan_matrix.py
+++ b/.github/skill-eval/tests/test_plan_matrix.py
@@ -445,6 +445,46 @@ class ListChangedFiles(unittest.TestCase):
             if orig_changed is not None:
                 os.environ["CHANGED_FILES"] = orig_changed
 
+    def test_manual_spec_filter_selects_exactly_one_spec(self):
+        orig_specs = plan_matrix.specs_for_skill
+        orig_changed = os.environ.pop("CHANGED_FILES", None)
+        plan_matrix.specs_for_skill = lambda _skill: [
+            ("skills/vss-deploy-profile/evals/base.json", "evals", "base"),
+            ("skills/vss-deploy-profile/evals/search.json", "evals", "search"),
+        ]
+        os.environ["MANUAL_SKILLS_FILTER"] = "vss-deploy-profile"
+        os.environ["MANUAL_SPEC_FILTER"] = "base"
+        try:
+            files = plan_matrix.list_changed_files()
+        finally:
+            plan_matrix.specs_for_skill = orig_specs
+            os.environ.pop("MANUAL_SKILLS_FILTER", None)
+            os.environ.pop("MANUAL_SPEC_FILTER", None)
+            if orig_changed is not None:
+                os.environ["CHANGED_FILES"] = orig_changed
+
+        self.assertEqual(
+            files, ["skills/vss-deploy-profile/evals/base.json"]
+        )
+
+    def test_manual_spec_filter_fails_loud_when_missing(self):
+        orig_specs = plan_matrix.specs_for_skill
+        orig_changed = os.environ.pop("CHANGED_FILES", None)
+        plan_matrix.specs_for_skill = lambda _skill: [
+            ("skills/vss-deploy-profile/evals/base.json", "evals", "base"),
+        ]
+        os.environ["MANUAL_SKILLS_FILTER"] = "vss-deploy-profile"
+        os.environ["MANUAL_SPEC_FILTER"] = "does-not-exist"
+        try:
+            with self.assertRaises(ValueError):
+                plan_matrix.list_changed_files()
+        finally:
+            plan_matrix.specs_for_skill = orig_specs
+            os.environ.pop("MANUAL_SKILLS_FILTER", None)
+            os.environ.pop("MANUAL_SPEC_FILTER", None)
+            if orig_changed is not None:
+                os.environ["CHANGED_FILES"] = orig_changed
+
 
 class EmitSlugSafety(unittest.TestCase):
     def test_emit_rejects_unsafe_slug(self):

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -8,6 +8,7 @@ Run:
 """
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import json
 import os
@@ -264,6 +265,9 @@ class TraceUrls(unittest.TestCase):
             results_root = root / "results" / "leg" / "30284131217"
             trial = results_root / "2026-07-27__17-16-47" / "step-7__E6dBECL"
             self._write_result(trial)
+            agent_dir = trial / "agent"
+            agent_dir.mkdir()
+            (agent_dir / "trajectory.json").write_text("CANARYSECRET")
             viewer_root = root / "_viewer"
             orig_viewer = run_leg.VIEWER_ROOT
             run_leg.VIEWER_ROOT = viewer_root
@@ -278,6 +282,7 @@ class TraceUrls(unittest.TestCase):
             # Flattened: the trial sits at the job's top level, with no
             # intervening <date>/ level for the viewer to miss.
             self.assertTrue((job_dir / "step-7__E6dBECL" / "result.json").is_file())
+            self.assertFalse((job_dir / "step-7__E6dBECL" / "agent").exists())
             self.assertFalse((job_dir / "2026-07-27__17-16-47").exists())
             # Copy, not move — the workflow collector still tars results_root.
             self.assertTrue((trial / "result.json").is_file())
@@ -305,6 +310,49 @@ class TraceUrls(unittest.TestCase):
                 run_leg.publish_trace(results_root, invocation, 0.0, "leg", "1")
             )
             self.assertFalse((results_root / "trace-urls.tsv").exists())
+
+    def test_ephemeral_cleanup_removes_only_matching_task_agent_dirs(self):
+        invocation = run_leg.HarborInvocation(
+            harbor_root=Path("/tmp/datasets/base/l40s"),
+            include_task_name="step-1",
+            chain_key="base_l40s",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            matching = root / "date" / "step-1__trial" / "agent"
+            other = root / "date" / "step-2__trial" / "agent"
+            matching.mkdir(parents=True)
+            other.mkdir(parents=True)
+
+            run_leg._remove_ephemeral_agent_data(root, invocation)
+
+            self.assertFalse(matching.exists())
+            self.assertTrue(other.exists())
+
+
+class TelemetryIsolation(unittest.TestCase):
+    def test_startup_failure_does_not_escape_or_poison_other_managers(self):
+        exited = []
+
+        @contextlib.contextmanager
+        def working():
+            try:
+                yield
+            finally:
+                exited.append(True)
+
+        @contextlib.contextmanager
+        def broken():
+            raise OSError("telemetry unavailable")
+            yield  # pragma: no cover
+
+        with contextlib.ExitStack() as stack:
+            run_leg._enter_telemetry(stack, working(), "working")
+            run_leg._enter_telemetry(stack, broken(), "broken")
+            body_ran = True
+
+        self.assertTrue(body_ran)
+        self.assertEqual(exited, [True])
 
 
 class PoolCandidates(unittest.TestCase):

--- a/.github/skill-eval/tests/test_system_trace.py
+++ b/.github/skill-eval/tests/test_system_trace.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for aggregate CPU and memory sampling."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import system_trace as mod  # noqa: E402
+
+
+ROW = (
+    "1785618000000000000,32,12.5,4.5,1.0,81.5,0.5,1.2,1.1,1.0,"
+    "8192.0,57344.0,65536.0,0.0,0.0"
+)
+
+
+class Output(unittest.TestCase):
+    def _remote(self, calls: list[str], hostile: bool = False):
+        def run(_instance, command, **_kwargs):
+            calls.append(command)
+            if "echo PID=$!" in command:
+                return "DIR=/tmp/vss-systrace.aB3xY9zQ\nPID=4242"
+            return ("API_KEY=CANARYSECRET,1,2,3,4,5,6,7,8,9,10,11,12,13,14\n"
+                    if hostile else "") + ROW
+        return run
+
+    def test_writes_only_validated_numeric_rows_and_sidecar(self):
+        calls: list[str] = []
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(
+            mod.gpu_trace, "_remote", side_effect=self._remote(calls, hostile=True)
+        ):
+            with mod.trace(
+                "vss-eval-rtx-1g", Path(td), spec_stem="search",
+                platform="RTX", skill="vss-search",
+            ):
+                pass
+            csv_path = next((Path(td) / "systemtrace").glob("*.csv"))
+            json_path = next((Path(td) / "systemtrace").glob("*.json"))
+            body = csv_path.read_text()
+            sidecar = json.loads(json_path.read_text())
+        self.assertIn(mod.CSV_HEADER, body)
+        self.assertIn(ROW, body)
+        self.assertNotIn("CANARYSECRET", body)
+        self.assertEqual(sidecar["samples"], 1)
+        self.assertEqual(sidecar["skill"], "vss-search")
+
+    def test_remote_sampler_reads_only_fixed_aggregate_interfaces(self):
+        calls: list[str] = []
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(
+            mod.gpu_trace, "_remote", side_effect=self._remote(calls)
+        ):
+            with mod.trace("box", Path(td)):
+                pass
+        start = calls[0]
+        for expected in ("/proc/stat", "/proc/meminfo", "/proc/loadavg"):
+            self.assertIn(expected, start)
+        for forbidden in (
+            "/proc/self", "/proc/[", "environ", "cmdline", "printenv",
+            "docker inspect", "ps -e",
+        ):
+            self.assertNotIn(forbidden, start)
+        self.assertIn("timeout -k 10", start)
+        self.assertIn("mktemp -d /tmp/vss-systrace.", start)
+
+    def test_cleanup_checks_pid_identity_and_removes_remote_directory(self):
+        calls: list[str] = []
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(
+            mod.gpu_trace, "_remote", side_effect=self._remote(calls)
+        ):
+            with mod.trace("box", Path(td)):
+                pass
+        finish = calls[-1]
+        self.assertIn("ps -o args= -p 4242", finish)
+        self.assertIn("grep -qF -- /tmp/vss-systrace.aB3xY9zQ", finish)
+        self.assertRegex(finish, r"grep[^;]+&& kill 4242")
+        self.assertIn("rm -rf /tmp/vss-systrace.aB3xY9zQ", finish)
+
+
+class FailureIsolation(unittest.TestCase):
+    def test_sampler_failure_never_prevents_the_body(self):
+        ran = []
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(
+            mod.gpu_trace, "_remote", side_effect=OSError("unreachable")
+        ):
+            with mod.trace("box", Path(td)):
+                ran.append(True)
+        self.assertEqual(ran, [True])
+
+    def test_body_exception_still_propagates(self):
+        replies = iter([
+            "DIR=/tmp/vss-systrace.aB3xY9zQ\nPID=4242",
+            ROW,
+        ])
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(
+            mod.gpu_trace, "_remote", side_effect=lambda *_a, **_k: next(replies)
+        ):
+            with self.assertRaisesRegex(ValueError, "leg failed"):
+                with mod.trace("box", Path(td)):
+                    raise ValueError("leg failed")
+
+
+class Guards(unittest.TestCase):
+    def test_row_shape_is_exact(self):
+        self.assertTrue(mod.ROW_RE.match(ROW))
+        self.assertIsNone(mod.ROW_RE.match(ROW + ",1"))
+        self.assertIsNone(mod.ROW_RE.match("SECRET," + ROW))
+
+    def test_remote_directory_shape_is_exact(self):
+        self.assertTrue(mod.DIR_RE.match("/tmp/vss-systrace.aB3xY9zQ"))
+        self.assertIsNone(
+            mod.DIR_RE.match("/tmp/vss-systrace.aB3xY9zQ; rm -rf /")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -234,9 +234,11 @@ jobs:
             echo "no results dir for this leg — blocked before running a trial (expected for blocker outcomes)"
             exit 0
           fi
-          # Exclude per-trial agent/ trajectory subdirs from the tarball
-          # (NOT from the on-disk tree the Harbor viewer serves). Those
-          # files capture every tool_use/tool_result verbatim, so a `.env`
+          # Exclude per-trial agent/ trajectory subdirs from the tarball as a
+          # defense in depth. run_leg consumes and removes current trajectories
+          # before publishing, and its persistent viewer copy excludes agent/
+          # unconditionally. Those files capture every tool_use/tool_result
+          # verbatim, so a `.env`
           # read or `docker compose config` dump would otherwise carry
           # secret values into the public artifact (PR #516 leaked
           # NGC_CLI_API_KEY this way). Reward / judge / result.json — what
@@ -249,15 +251,16 @@ jobs:
           # unique per (skill,spec,platform).
           LEG_TARBALL="/tmp/skills-eval-daily-results-${EVAL_SLUG}-${GITHUB_RUN_ID}.tar.gz"
           RESULTS=$(find "$LEG_RESULTS" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
-          # A GPU trace is worth archiving even with no result.json. A trial
-          # that hits the agent ceiling dies before Harbor writes one, and that
-          # is precisely the trace worth reading — gating the tarball on
-          # result.json alone silently dropped the most interesting cases.
-          TRACES=$(find "$LEG_RESULTS" -maxdepth 3 -path '*/gputrace/*.csv' 2>/dev/null | head -50 || true)
-          if [ -n "$RESULTS" ] || [ -n "$TRACES" ]; then
+          # Hardware telemetry is worth archiving even with no result.json. A
+          # trial that hits the agent ceiling dies before Harbor writes one,
+          # and that partial timeline is precisely the trace worth reading.
+          TELEMETRY=$(find "$LEG_RESULTS" -maxdepth 3 \
+            \( -path '*/gputrace/*.csv' -o -path '*/systemtrace/*.csv' \
+               -o -path '*/timeline/*/timeline.*' \) 2>/dev/null | head -100 || true)
+          if [ -n "$RESULTS" ] || [ -n "$TELEMETRY" ]; then
             tar czf "$LEG_TARBALL" \
               -C "/tmp/skill-eval/results/${EVAL_SLUG}" --exclude='agent' "$GITHUB_RUN_ID"
-            echo "archived $(echo "$RESULTS" | grep -c . || true) result.json and $(echo "$TRACES" | grep -c . || true) gputrace file(s) (agent/ trajectories excluded)"
+            echo "archived $(echo "$RESULTS" | grep -c . || true) result.json and $(echo "$TELEMETRY" | grep -c . || true) telemetry file(s) (agent/ trajectories excluded)"
           else
             echo "results dir exists but empty — nothing to archive"
           fi

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -257,9 +257,11 @@ jobs:
             echo "no results dir for this leg — blocked before running a trial (expected for blocker outcomes)"
             exit 0
           fi
-          # Exclude per-trial agent/ trajectory subdirs from the tarball
-          # (NOT from the on-disk tree the Harbor viewer serves). Those
-          # files capture every tool_use/tool_result verbatim, so a `.env`
+          # Exclude per-trial agent/ trajectory subdirs from the tarball as a
+          # defense in depth. run_leg consumes and removes current trajectories
+          # before publishing, and its persistent viewer copy excludes agent/
+          # unconditionally. Those files capture every tool_use/tool_result
+          # verbatim, so a `.env`
           # read or `docker compose config` dump would otherwise carry
           # secret values into the public artifact (PR #516 leaked
           # NGC_CLI_API_KEY this way). Reward / judge / result.json — what
@@ -272,15 +274,16 @@ jobs:
           # unique per (skill,spec,platform).
           LEG_TARBALL="/tmp/skills-eval-results-${EVAL_SLUG}-${GITHUB_RUN_ID}.tar.gz"
           RESULTS=$(find "$LEG_RESULTS" -maxdepth 3 -name "result.json" 2>/dev/null | head -50 || true)
-          # A GPU trace is worth archiving even with no result.json. A trial
-          # that hits the agent ceiling dies before Harbor writes one, and that
-          # is precisely the trace worth reading — gating the tarball on
-          # result.json alone silently dropped the most interesting cases.
-          TRACES=$(find "$LEG_RESULTS" -maxdepth 3 -path '*/gputrace/*.csv' 2>/dev/null | head -50 || true)
-          if [ -n "$RESULTS" ] || [ -n "$TRACES" ]; then
+          # Hardware telemetry is worth archiving even with no result.json. A
+          # trial that hits the agent ceiling dies before Harbor writes one,
+          # and that partial timeline is precisely the trace worth reading.
+          TELEMETRY=$(find "$LEG_RESULTS" -maxdepth 3 \
+            \( -path '*/gputrace/*.csv' -o -path '*/systemtrace/*.csv' \
+               -o -path '*/timeline/*/timeline.*' \) 2>/dev/null | head -100 || true)
+          if [ -n "$RESULTS" ] || [ -n "$TELEMETRY" ]; then
             tar czf "$LEG_TARBALL" \
               -C "/tmp/skill-eval/results/${EVAL_SLUG}" --exclude='agent' "$GITHUB_RUN_ID"
-            echo "archived $(echo "$RESULTS" | grep -c . || true) result.json and $(echo "$TRACES" | grep -c . || true) gputrace file(s) (agent/ trajectories excluded)"
+            echo "archived $(echo "$RESULTS" | grep -c . || true) result.json and $(echo "$TELEMETRY" | grep -c . || true) telemetry file(s) (agent/ trajectories excluded)"
           else
             echo "results dir exists but empty — nothing to archive"
           fi

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -39,6 +39,11 @@ on:
         required: false
         default: "*"
         type: string
+      spec:
+        description: "Optional spec filename stem when evaluating one skill (for example `base`)."
+        required: false
+        default: ""
+        type: string
 
 # Authenticate as github-actions[bot] for all GitHub operations (gh pr
 # comment + git push of the adapter commit to the contributor's branch).
@@ -125,6 +130,7 @@ jobs:
           # the old behavior — never blank, which would fall through to the
           # diff path and silently produce an empty matrix.
           MANUAL_SKILLS_FILTER: ${{ github.event_name == 'workflow_dispatch' && (inputs.skills || '*') || '' }}
+          MANUAL_SPEC_FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.spec || '' }}
         run: python3 .github/skill-eval/plan_matrix.py
 
   # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- stack on #1516 and correlate skill-eval agent/tool activity with GPU, CPU, and memory telemetry
- compare Perfetto, self-contained HTML, and OpenTelemetry timeline outputs from one canonical event model
- keep full-fidelity source traces ephemeral and publish only sanitized, allowlisted artifacts

## Dependency
- [ ] #1516 must land first; this draft intentionally targets its `feat/eval-gpu-trace` branch

## Test plan
- [ ] validate correlation and clock alignment with synthetic trajectories and hardware samples
- [ ] open the generated Perfetto trace in Perfetto UI
- [ ] inspect the standalone HTML timeline without network access
- [ ] validate emitted OTLP JSONL records against the documented schema
- [ ] verify secrets and raw trajectory content cannot enter published artifacts