### PR TITLE
Update RTVI_VLM_MAX_MODEL_LEN comment for clarity in overrides.env

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -140,9 +140,9 @@ SENSOR_INFO_SOURCE=nvstreamer
 # RTVI CONFIGURATION
 # =============================================================================
 RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.8'
-# RTXPRO4500BW (32 GB), when COMPOSE_PROFILES=${COMPOSE_PROFILES_WH_2D} deploys vss-rtvi-vlm:
+# Uncomment RTVI_VLM_MAX_MODEL_LEN=18000 when using RTXPRO4500BW (32 GB) for COMPOSE_PROFILES=${COMPOSE_PROFILES_WH_2D} which deploys vss-rtvi-vlm:
 # cap RT-VLM context so the KV cache can be allocated.
-RTVI_VLM_MAX_MODEL_LEN=18000
+# RTVI_VLM_MAX_MODEL_LEN=18000
 
 # RTVI VLM input dimensions and frame rate (for DGX-SPARK, IGX-THOR, AGX-THOR only; not set on other platforms)
 # RTVI_VLM_INPUT_WIDTH=860


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
