### PR TITLE
Update OpenAPI specification in VA-API and license in image creation

### DIFF
--- a/services/analytics/video-analytics-api/docker/Dockerfile
+++ b/services/analytics/video-analytics-api/docker/Dockerfile
@@ -22,5 +22,6 @@ FROM nvcr.io/nvidia/distroless/node:22-v4.0.10 AS node-deploy
 COPY --from=builder --chown=1000:1000 /web-api-core /web-api-core
 COPY --from=builder --chown=1000:1000 /web-api-app /web-api-app
 COPY --chown=1000:1000 ./configs /configs
+COPY --chown=1000:1000 ./3rdParty_Licenses.md /web-api-app/3rdParty_Licenses.md
 WORKDIR /web-api-app
 USER 1000:1000

--- a/services/analytics/video-analytics-api/docker/Dockerfile.dockerignore
+++ b/services/analytics/video-analytics-api/docker/Dockerfile.dockerignore
@@ -1,6 +1,5 @@
 .git*
 Jenkins*
-**/*.md
 readmes/
 test/
 configs/sample-configs/

--- a/services/analytics/video-analytics-api/src/app/specification/openapi.json
+++ b/services/analytics/video-analytics-api/src/app/specification/openapi.json
@@ -10097,7 +10097,6 @@
                     "id",
                     "timeInterval",
                     "end",
-                    "locations",
                     "length",
                     "speedOverTime",
                     "sensor",
@@ -14894,6 +14893,9 @@
                                             "bbox": {
                                                 "$ref": "#/components/schemas/Bbox"
                                             },
+                                            "bbox3d": {
+                                                "$ref": "#/components/schemas/Bbox3d"
+                                            },
                                             "confidence": {
                                                 "type": "number",
                                                 "format": "float"
@@ -15013,14 +15015,22 @@
                                             }
                                         },
                                         "required": [
-                                            "bbox",
                                             "confidence",
                                             "type",
                                             "speed",
-                                            "id",
-                                            "embedding",
-                                            "location",
-                                            "coordinate"
+                                            "id"
+                                        ],
+                                        "anyOf": [
+                                            {
+                                                "required": [
+                                                    "bbox"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "bbox3d"
+                                                ]
+                                            }
                                         ]
                                     }
                                 },
@@ -15311,15 +15321,22 @@
                                             }
                                         },
                                         "required": [
-                                            "bbox",
-                                            "bbox3d",
                                             "confidence",
                                             "type",
                                             "speed",
-                                            "id",
-                                            "embedding",
-                                            "location",
-                                            "coordinate"
+                                            "id"
+                                        ],
+                                        "anyOf": [
+                                            {
+                                                "required": [
+                                                    "bbox"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "bbox3d"
+                                                ]
+                                            }
                                         ]
                                     }
                                 },

--- a/services/analytics/video-analytics-api/test/integration-test/scripts/load_elasticsearch_data_dump.js
+++ b/services/analytics/video-analytics-api/test/integration-test/scripts/load_elasticsearch_data_dump.js
@@ -144,6 +144,9 @@ function postBulk(esUrlParsed, body) {
 
 /**
  * Normalize _source so ES mapping is consistent (e.g. coordinates as float not long).
+ * The warehouse-2D dump contains empty bbox3d placeholders emitted by proto JSON
+ * serialization. Remove those placeholders so the fixture matches the public
+ * contract, where bbox3d is present only when it has 9 or 12 coordinates.
  * Recursively ensures any "coordinates" array is array of floats so ES does not
  * mix long/float and trigger "mapper [locations.coordinates] cannot be changed from type [float] to [long]".
  * Uses a custom stringify for the bulk body so coordinate numbers are emitted as "1.0" not "1".
@@ -159,6 +162,9 @@ function normalizeSource(obj) {
     const out = {};
     for (const key of Object.keys(obj)) {
         const val = obj[key];
+        if (key === 'bbox3d' && Array.isArray(val?.coordinates) && val.coordinates.length === 0) {
+            continue;
+        }
         if (key === 'coordinates' && Array.isArray(val)) {
             out[key] = val.map((v) => (Array.isArray(v) && v.every((n) => typeof n === 'number') ? v.map((n) => Number(n)) : normalizeSource(v)));
         } else if (val !== null && typeof val === 'object') {


### PR DESCRIPTION
…e 'bbox3d' schema reference. Adjust required fields to allow for either 'bbox' or 'bbox3d' in relevant components.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
