### PR TITLE
Fix SonarQube HIGH: destructor bugs (cpp:S1048)

### DIFF
--- a/services/vios/src/framework/stream_monitor/stream_monitor.cpp
+++ b/services/vios/src/framework/stream_monitor/stream_monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -473,8 +473,18 @@ public:
     }
     virtual ~QosMeasurementRecord()
     {
-        LOG(info) << "~QosMeasurementRecord - " << m_fName << endl;
-        stopQoS();
+        try
+        {
+            LOG(info) << "~QosMeasurementRecord - " << m_fName << endl;
+            stopQoS();
+        }
+        catch (const std::exception& e)
+        {
+            LOG(error) << "~QosMeasurementRecord - exception: " << e.what() << endl;
+        }
+        catch (...)
+        {
+        }
     }
 
     void startQoS(const string& url, RTPSource* rtpSrcProxy)

--- a/services/vios/src/framework/webrtc_streamer/inc/livevideosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/livevideosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,8 +101,14 @@ public:
 
     virtual ~VideoSource()
     {
-        this->Stop();
-        LOG(info) << __func__ << endl;
+        try {
+            this->Stop();
+            LOG(info) << __func__ << endl;
+        } catch (const std::exception& e) {
+            try { LOG(error) << "Exception in ~VideoSource: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
+        } catch (...) {
+            try { LOG(error) << "Unknown exception in ~VideoSource" << endl; } catch (...) { (void)std::current_exception(); }
+        }
     }
     void Start()
     {

--- a/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.cpp
+++ b/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,15 +87,21 @@ ADTSByteStreamSource
 
 ADTSByteStreamSource::~ADTSByteStreamSource()
 {
-    LOG(info) << "~ ::ADTSByteStreamSource streamName:" << m_streamName << endl;
-    envir().taskScheduler().unscheduleDelayedTask(m_DataArrivalCheckTask);
-    /* Unregister from the AV-loop-sync coordinator. If we were parked
-     * at EOS waiting on the video side, this also releases the video
-     * side so it doesn't deadlock waiting for a now-gone audio. */
-    if (m_avLoopSync)
-    {
-        m_avLoopSync->unregisterParticipant(this);
-        m_avLoopSync.reset();
+    try {
+        LOG(info) << "~ ::ADTSByteStreamSource streamName:" << m_streamName << endl;
+        envir().taskScheduler().unscheduleDelayedTask(m_DataArrivalCheckTask);
+        /* Unregister from the AV-loop-sync coordinator. If we were parked
+         * at EOS waiting on the video side, this also releases the video
+         * side so it doesn't deadlock waiting for a now-gone audio. */
+        if (m_avLoopSync)
+        {
+            m_avLoopSync->unregisterParticipant(this);
+            m_avLoopSync.reset();
+        }
+    } catch (const std::exception& e) {
+        try { LOG(error) << "Exception in ~ADTSByteStreamSource: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
+    } catch (...) {
+        try { LOG(error) << "Unknown exception in ~ADTSByteStreamSource" << endl; } catch (...) { (void)std::current_exception(); }
     }
 }
 

--- a/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
+++ b/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -192,21 +192,32 @@ H264ByteStreamSource
 
 H264ByteStreamSource::~H264ByteStreamSource()
 {
-    LOG(info) << __METHOD_NAME__ << ", sourceState:" << m_sourceState <<  endl;
+    try
+    {
+        LOG(info) << __METHOD_NAME__ << ", sourceState:" << m_sourceState <<  endl;
 
-    if (m_DataArrivalCheckTask)
-    {
-        envir().taskScheduler().unscheduleDelayedTask(m_DataArrivalCheckTask);
+        if (m_DataArrivalCheckTask)
+        {
+            envir().taskScheduler().unscheduleDelayedTask(m_DataArrivalCheckTask);
+        }
+        /* Unregister from the AV-loop-sync coordinator. If we were parked
+         * at EOS waiting on the audio side, this also releases the audio
+         * side so it doesn't deadlock waiting for a now-gone video. */
+        if (m_avLoopSync)
+        {
+            m_avLoopSync->unregisterParticipant(this);
+            m_avLoopSync.reset();
+        }
+        LOG(info) << "Exiting ~H264ByteStreamSource(), m_sessionId:" << m_sessionId << endl;
     }
-    /* Unregister from the AV-loop-sync coordinator. If we were parked
-     * at EOS waiting on the audio side, this also releases the audio
-     * side so it doesn't deadlock waiting for a now-gone video. */
-    if (m_avLoopSync)
+    catch (const std::exception& e)
     {
-        m_avLoopSync->unregisterParticipant(this);
-        m_avLoopSync.reset();
+        try { LOG(error) << "Exception in ~H264ByteStreamSource: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
     }
-    LOG(info) << "Exiting ~H264ByteStreamSource(), m_sessionId:" << m_sessionId << endl;
+    catch (...)
+    {
+        try { LOG(error) << "Unknown exception in ~H264ByteStreamSource" << endl; } catch (...) { (void)std::current_exception(); }
+    }
 }
 
 void H264ByteStreamSource::setStreamScale(float scaleFactor)


### PR DESCRIPTION
## Destructor bugs (cpp:S1048)

Destructors must not throw — an exception escaping a destructor during stack
unwinding calls `std::terminate`.

Automated SonarQube fixes (HIGH impact severity), one squashed commit per module.
Every module was compiled before its commit.

**Deliberately NOT included:** the 38 TLS/crypto findings in this severity band
(`cpp:S4423`, `cpp:S4830`, `cpp:S5527`, `cpp:S5542`). Those disable
certificate/hostname verification and pin crypto modes; "fixing" them literally
would break connections to self-signed and IP-addressed cameras and could make
existing ciphertext undecryptable. They need a product decision on device
compatibility, and are recorded as deferred in the campaign report.

> Review commit-by-commit; use `git diff -w`.
> Generated by the SonarQube fix agent. Draft until reviewed.