### PR TITLE
Fix alerts eval Kafka container name

### DIFF
--- a/skills/vss-deploy-dense-captioning/SKILL.md
+++ b/skills/vss-deploy-dense-captioning/SKILL.md
@@ -246,7 +246,7 @@ and 26.05 compatibility notes live in
   documented in [`references/kafka-workflows.md`](references/kafka-workflows.md).
 - Kafka validation: trust the live `vss-rtvi-vlm` environment for topic names.
   In a full VSS alerts real-time profile, use the existing VSS Kafka container
-  `mdx-kafka` for CLI checks and final incident-consumer commands. For
+  `kafka` for CLI checks and final incident-consumer commands. For
   standalone validation, use a broker that advertises `${HOST_IP}:9092`; never
   stop or replace a pre-existing broker without user confirmation.
 

--- a/skills/vss-deploy-dense-captioning/evals/alerts_profile_api.json
+++ b/skills/vss-deploy-dense-captioning/evals/alerts_profile_api.json
@@ -14,7 +14,7 @@
   },
   "expects": [
     {
-      "query": "Deploy the VSS **alerts** profile in `real-time` mode on `{{platform}}` via `/vss-deploy-profile -p alerts -m real-time`. Run autonomously.\n\n**Environment & prerequisites:** A GPU host matching `{{platform}}` with Docker + NVIDIA Container Toolkit, `NGC_CLI_API_KEY`, remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`, `LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`, `VLM_REMOTE_MODEL`), and `RTSP_SAMPLE_URL` for a reachable RTSP sample video stream. The eval harness predeploys the full VSS `alerts` profile in `real-time` mode with remote LLM + remote VLM placement before this task starts; this task tests the RT-VLM microservice directly at http://localhost:8018. Required after predeploy: `rtvi-vlm` healthy on port 8018, `mdx-kafka` running, source-backed RT-VLM Kafka topics visible in the live container env (`KAFKA_TOPIC=mdx-vlm`, `KAFKA_INCIDENT_TOPIC=mdx-vlm-incidents`, `ERROR_MESSAGE_TOPIC=vision-llm-errors` unless the deployment explicitly overrides them), and the RTSP sample stream from `RTSP_SAMPLE_URL` reachable from the host. Precheck the stream with `ffprobe`, `gst-discoverer-1.0`, or an equivalent RTSP probe before registering it, and require the probe to discover a video stream/caps entry.",
+      "query": "Deploy the VSS **alerts** profile in `real-time` mode on `{{platform}}` via `/vss-deploy-profile -p alerts -m real-time`. Run autonomously.\n\n**Environment & prerequisites:** A GPU host matching `{{platform}}` with Docker + NVIDIA Container Toolkit, `NGC_CLI_API_KEY`, remote LLM/VLM endpoint env vars (`LLM_REMOTE_URL`, `LLM_REMOTE_MODEL`, `VLM_REMOTE_URL`, `VLM_REMOTE_MODEL`), and `RTSP_SAMPLE_URL` for a reachable RTSP sample video stream. The eval harness predeploys the full VSS `alerts` profile in `real-time` mode with remote LLM + remote VLM placement before this task starts; this task tests the RT-VLM microservice directly at http://localhost:8018. Required after predeploy: `rtvi-vlm` healthy on port 8018, `kafka` running, source-backed RT-VLM Kafka topics visible in the live container env (`KAFKA_TOPIC=mdx-vlm`, `KAFKA_INCIDENT_TOPIC=mdx-vlm-incidents`, `ERROR_MESSAGE_TOPIC=vision-llm-errors` unless the deployment explicitly overrides them), and the RTSP sample stream from `RTSP_SAMPLE_URL` reachable from the host. Precheck the stream with `ffprobe`, `gst-discoverer-1.0`, or an equivalent RTSP probe before registering it, and require the probe to discover a video stream/caps entry.",
       "checks": [
         "The agent verified `RTSP_SAMPLE_URL` is set and non-empty in the harness environment before probing or registering the RTSP sample stream.",
         "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
@@ -35,14 +35,14 @@
         "The agent successfully called text-only `POST http://localhost:8018/v1/chat/completions` with a messages array and model.",
         "The agent called text-only `POST http://localhost:8018/v1/completions` only to verify the documented legacy behavior, and treated HTTP 400 as expected on current 26.05 builds.",
         "`docker ps --format '{{.Names}}' | grep -qx vss-rtvi-vlm` returns exit 0.",
-        "`docker ps --format '{{.Names}}' | grep -qx mdx-kafka` returns exit 0.",
+        "`docker ps --format '{{.Names}}' | grep -qx kafka` returns exit 0.",
         "The agent verified `RTSP_SAMPLE_URL` is set and non-empty in the harness environment before probing or registering the RTSP sample stream.",
         "The agent prechecked the configured `RTSP_SAMPLE_URL` with `ffprobe`, `gst-discoverer-1.0`, or an equivalent RTSP probe before calling `/v1/streams/add`, verified the probe discovered a video stream/caps entry, and would fail fast with a clear message if the stream was unreachable or reported an unknown/non-video media type.",
         "The agent called `POST http://localhost:8018/v1/streams/add` with `liveStreamUrl` exactly matching the configured `RTSP_SAMPLE_URL` and a description containing `rt-vlm-eval`.",
         "The agent parsed the RT-VLM stream id from the `results[0].id` field returned by `/v1/streams/add`, not from `.streams[0].id`.",
         "The agent called `DELETE http://localhost:8018/v1/streams/delete/<stream_id>` for the temporary `rt-vlm-eval` stream before finishing.",
         "`curl -sf --max-time 15 http://localhost:8018/v1/streams/get-stream-info` returns exit 0 and the response does not contain `rt-vlm-eval`.",
-        "The final reply includes a Kafka incident-consumer command using `docker exec` against `mdx-kafka` and `kafka-console-consumer`, with the incident topic derived from the live `KAFKA_INCIDENT_TOPIC` env or the source-backed alerts/profile default `mdx-vlm-incidents`.",
+        "The final reply includes a Kafka incident-consumer command using `docker exec` against the running `kafka` container and `kafka-console-consumer`, with the incident topic derived from the live `KAFKA_INCIDENT_TOPIC` env or the source-backed alerts/profile default `mdx-vlm-incidents`.",
         "The agent did not reference or try to run `tests/kafka/test_kafka_consumer.py`."
       ]
     }

--- a/skills/vss-deploy-dense-captioning/references/integrate-rt-vlm.md
+++ b/skills/vss-deploy-dense-captioning/references/integrate-rt-vlm.md
@@ -222,7 +222,7 @@ The `nv.VisionLLM` and `nv.Incident` protobuf schemas are the contract between R
 
 ```bash
 docker exec kafka kafka-get-offsets --bootstrap-server 127.0.0.1:9092 --topic mdx-vlm-captions
-docker exec mdx-kafka kafka-console-consumer \
+docker exec kafka kafka-console-consumer \
   --bootstrap-server 127.0.0.1:9092 --topic mdx-vlm-captions \
   --from-beginning --timeout-ms 5000 --max-messages 5 \
   --property print.headers=true --property print.key=true --property print.value=false

--- a/skills/vss-deploy-dense-captioning/references/kafka-workflows.md
+++ b/skills/vss-deploy-dense-captioning/references/kafka-workflows.md
@@ -66,18 +66,17 @@ Source-backed topic sets:
 
 Always confirm the live container before validating Kafka, because these env vars
 are fixed at RT-VLM container start. In a full VSS alerts real-time profile, the
-Kafka container is `mdx-kafka`; use that exact container name in consumer
-commands and final proof snippets. Do not shorten it to `kafka`, even if another
-container with that name exists. Run this shared setup once before the topic
-checks and consumer snippets below:
+Kafka container is `kafka`; use that exact container name in consumer commands
+and final proof snippets. Run this shared setup once before the topic checks and
+consumer snippets below:
 ```bash
 if [ -z "${KAFKA_CONTAINER:-}" ]; then
-  if docker ps --format '{{.Names}}' | grep -qx mdx-kafka; then
+  if docker ps --format '{{.Names}}' | grep -qx kafka; then
+    KAFKA_CONTAINER=kafka
+  elif docker ps --format '{{.Names}}' | grep -qx mdx-kafka; then
     KAFKA_CONTAINER=mdx-kafka
   elif docker ps --format '{{.Names}}' | grep -qx rtvi-vlm-kafka; then
     KAFKA_CONTAINER=rtvi-vlm-kafka
-  elif docker ps --format '{{.Names}}' | grep -qx kafka; then
-    KAFKA_CONTAINER=kafka
   else
     KAFKA_CONTAINER=rtvi-vlm-kafka
   fi
@@ -327,11 +326,11 @@ done
 ```
 
 For a full VSS alerts real-time profile, the incident-topic proof should include
-`mdx-kafka` explicitly. Skip this block for standalone RT-VLM; use the
+`kafka` explicitly. Skip this block for standalone RT-VLM; use the
 `kafka_cli` consumer above instead.
 
 ```bash
-docker exec mdx-kafka kafka-console-consumer \
+docker exec kafka kafka-console-consumer \
   --bootstrap-server 127.0.0.1:9092 \
   --topic "${INCIDENT_TOPIC:-mdx-vlm-incidents}" \
   --from-beginning \


### PR DESCRIPTION
## Summary
- align the dense-captioning alerts eval with the deployed `kafka` container name
- update final incident-consumer guidance and examples
- retain legacy and standalone Kafka container detection as fallbacks

## Test plan
- [x] Validate `alerts_profile_api.json`
- [x] Run dense-captioning skill compliance check
- [x] Run `git diff --check`