### PR TITLE
Fix SonarQube HIGH: Memory & ownership

### DIFF
--- a/services/vios/src/framework/media/media_pipelines/VideoQueue.h
+++ b/services/vios/src/framework/media/media_pipelines/VideoQueue.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,7 +112,7 @@ class VideoQueue
 {
 public:
     VideoQueue();
-    ~VideoQueue() {}
+    ~VideoQueue() = default;
 
     void push(FrameInfo& frame);
     void pull(FrameInfo& frame);

--- a/services/vios/src/framework/media/media_pipelines/cloud_stream/s3stream_producer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/cloud_stream/s3stream_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -300,17 +300,10 @@ CloudStreamProducer::CloudStreamProducer(const std::string& streamId,
 CloudStreamProducer::~CloudStreamProducer()
 {
     try {
-        stop();
+        CloudStreamProducer::stop();
 
-        if (m_streamInfo) {
-            delete m_streamInfo;
-            m_streamInfo = nullptr;
-        }
-
-        if (m_seekData) {
-            delete m_seekData;
-            m_seekData = nullptr;
-        }
+        m_streamInfo.reset();
+        m_seekData.reset();
 
         LOG(info) << "CloudStreamProducer destroyed for stream: " << m_streamId << endl;
     } catch (const std::exception& e) {
@@ -388,7 +381,7 @@ bool CloudStreamProducer::start()
     }
 
     // Initialize seek data
-    m_seekData = new SeekData{m_pipeline, m_startTime, m_endTime, false, false};
+    m_seekData = std::make_unique<SeekData>(SeekData{m_pipeline, m_startTime, m_endTime, false, false});
 
     // Set pipeline to PAUSED first (for preroll and seeking and then play in asyncDone callback)
     GstStateChangeReturn ret = gst_element_set_state(m_pipeline, GST_STATE_PAUSED);
@@ -659,10 +652,10 @@ bool CloudStreamProducer::createSingleSegmentPipeline()
     }
 
     // Setup stream info for pad-added callback
-    m_streamInfo = new StreamInfo{0, 0, 0.0, this};
+    m_streamInfo = std::make_unique<StreamInfo>(StreamInfo{0, 0, 0.0, this});
 
     // Connect demux pad-added signal for dynamic linking
-    g_signal_connect(m_demux, "pad-added", G_CALLBACK(onPadAdded), m_streamInfo);
+    g_signal_connect(m_demux, "pad-added", G_CALLBACK(onPadAdded), m_streamInfo.get());
 
     // Connect appsink new-sample signal
     g_signal_connect(m_appsink, "new-sample", G_CALLBACK(onNewSample), this);
@@ -788,7 +781,7 @@ bool CloudStreamProducer::createMultiSegmentPipeline()
             size_t segmentIndex;
         };
 
-        SegmentLinkData* linkData = new SegmentLinkData{this, i};
+        SegmentLinkData* linkData = std::make_unique<SegmentLinkData>(SegmentLinkData{this, i}).release();
 
         g_signal_connect_data(demuxer, "pad-added",
             G_CALLBACK(+[](GstElement* demux, GstPad* newPad, gpointer userData) {
@@ -826,7 +819,7 @@ bool CloudStreamProducer::createMultiSegmentPipeline()
             }),
             linkData,
             +[](gpointer data, GClosure* /*closure*/) {
-                delete static_cast<SegmentLinkData*>(data);
+                std::unique_ptr<SegmentLinkData>(static_cast<SegmentLinkData*>(data));
             },
             (GConnectFlags)0
         );
@@ -877,7 +870,7 @@ bool CloudStreamProducer::createMultiSegmentPipeline()
     }
 
     // Setup stream info for first demuxer (to extract framerate/resolution)
-    m_streamInfo = new StreamInfo{0, 0, 0.0, this};
+    m_streamInfo = std::make_unique<StreamInfo>(StreamInfo{0, 0, 0.0, this});
     if (!m_demuxers.empty()) {
         g_signal_connect(m_demuxers[0], "notify::n-video-streams",
             G_CALLBACK(+[](GObject* /*object*/, GParamSpec* /*pspec*/, gpointer userData) {
@@ -885,7 +878,7 @@ bool CloudStreamProducer::createMultiSegmentPipeline()
                 if (info && info->producer) {
                     LOG(info) << "Demuxer detected video streams" << endl;
                 }
-            }), m_streamInfo);
+            }), m_streamInfo.get());
     }
 
     // Connect appsink new-sample signal
@@ -1204,7 +1197,8 @@ bool CloudStreamProducer::createLocalFilePipeline()
                 GstPad* concatSinkPad;  // Pre-requested pad
             };
 
-            SegmentLinkData* linkData = new SegmentLinkData{this, i, concatSinkPads[i]};
+            SegmentLinkData* linkData =
+                std::make_unique<SegmentLinkData>(SegmentLinkData{this, i, concatSinkPads[i]}).release();
 
             g_signal_connect_data(demuxer, "pad-added",
                 G_CALLBACK(+[](GstElement* src, GstPad* newPad, gpointer userData) {
@@ -1239,7 +1233,9 @@ bool CloudStreamProducer::createLocalFilePipeline()
                     g_free(padName);
                 }),
                 linkData,
-                +[](gpointer data, GClosure* /*closure*/) { delete static_cast<SegmentLinkData*>(data); },
+                +[](gpointer data, GClosure* /*closure*/) {
+                    std::unique_ptr<SegmentLinkData>(static_cast<SegmentLinkData*>(data));
+                },
                 (GConnectFlags)0);
         } else {
             // Single file: connect directly to parser
@@ -1309,7 +1305,7 @@ bool CloudStreamProducer::createLocalFilePipeline()
     }
 
     // Setup stream info
-    m_streamInfo = new StreamInfo{0, 0, 0.0, this};
+    m_streamInfo = std::make_unique<StreamInfo>(StreamInfo{0, 0, 0.0, this});
 
     // Monitor concat's active-pad to track which file is currently playing
     if (m_concat) {
@@ -2033,7 +2029,7 @@ gboolean CloudStreamProducer::busWatch(GstBus* bus, GstMessage* msg, gpointer us
 
         case GST_MESSAGE_ASYNC_DONE: {
             // Pipeline is prerolled and ready for seeking
-            SeekData* seekData = producer->m_seekData;
+            SeekData* seekData = producer->m_seekData.get();
             if (!seekData->seekDone && seekData->pausedStateReached) {
                 LOG(info) << "Pipeline ready for seeking" << endl;
 

--- a/services/vios/src/framework/media/media_pipelines/gstmux.h
+++ b/services/vios/src/framework/media/media_pipelines/gstmux.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,12 +88,10 @@ class GstMux : public IMediaDataConsumer
         m_recordingStopped = false;
         m_fpsDisplay.reset(new FPSDisplay());
         m_checkStatusScheduler = make_unique<Bosma::Scheduler>(1);
-        setConsumerMediaType(MediaTypeAudioVideo);
+        IMediaDataConsumer::setConsumerMediaType(MediaTypeAudioVideo);
         m_videoQueue.setRecordingState(m_recordingState);
     }
-    ~GstMux()
-    {
-    }
+    ~GstMux() = default;
 
     int create(shared_ptr<StreamInfo> stream, GAsyncQueue* qErrorDeviceID, bool recreate_muxer = false);
     void destroy();

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.h
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,7 +81,7 @@ class GstNvAudioDecoder : public IMediaDataConsumer, public GstNvDecoder
             {
                 m_audioData.m_audioCodec = opts.at("audio_codec");
             }
-            setConsumerMediaType(MediaTypeAudio);
+            IMediaDataConsumer::setConsumerMediaType(MediaTypeAudio);
         }
         ~GstNvAudioDecoder ()
         {

--- a/services/vios/src/framework/media/media_pipelines/gstnvdecodebin.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvdecodebin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -453,10 +453,7 @@ NvDecodeBin::NvDecodeBin(DecoderBase* parent, const string codec)
     m_useNvV4l2Dec = NvHwDetection::getInstance()->m_useNvV4l2Dec;
 }
 
-NvDecodeBin::~NvDecodeBin()
-{
-
-}
+NvDecodeBin::~NvDecodeBin() = default;
 
 GstElement* NvDecodeBin::create(bool is_image_capture)
 {

--- a/services/vios/src/framework/media/media_pipelines/gstnvdecoder.h
+++ b/services/vios/src/framework/media/media_pipelines/gstnvdecoder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +21,8 @@
 class GstNvDecoder
 {
     public:
-        GstNvDecoder () {}
-        ~GstNvDecoder () {}
+        GstNvDecoder () = default;
+        ~GstNvDecoder () = default;
 
         virtual int create(bool blocking = false) { return 0; }
         virtual void destroy(bool expect_result) = 0;

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoencodeout.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoencodeout.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,9 +32,7 @@ NvVideoEncodeOut::NvVideoEncodeOut() :
 {
 }
 
-NvVideoEncodeOut::~NvVideoEncodeOut()
-{
-}
+NvVideoEncodeOut::~NvVideoEncodeOut() = default;
 
 GstElement* NvVideoEncodeOut::create(const string& file_name)
 {

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoencoder.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoencoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -453,13 +453,13 @@ static void gst_buffer_object_free_cb(gpointer data, GstMiniObject *obj)
     if (!encoder)
     {
         LOG(error) << "gst_buffer_object_free_cb: consumer is null" << endl;
-        free(buffer_data);
+        delete buffer_data;
         return;
     }
 
     encoder->freeVideoFrameData(buffer_data->m_decoderFd);
 
-    free (buffer_data);
+    delete buffer_data;
 }
 
 void GstNvVideoEncoder::freeVideoFrameData(int fd)
@@ -601,7 +601,7 @@ int GstNvVideoEncoder::onFrame(FrameParams& frame_params, const string& codec, i
     if (is_zero_copy)
     {
         mem = gst_buffer_peek_memory (gstbuffer, 0);
-        struct WebrtcVideoDecoderBufferData* buffer_data = (WebrtcVideoDecoderBufferData*) malloc(sizeof (WebrtcVideoDecoderBufferData));
+        WebrtcVideoDecoderBufferData* buffer_data = new WebrtcVideoDecoderBufferData();
         buffer_data->m_videoEncInstance = this;
         buffer_data->m_decoderFd = buf_surf->surfaceList[0].bufferDesc;
         gst_mini_object_weak_ref(GST_MINI_OBJECT(mem), (GstMiniObjectNotify)gst_buffer_object_free_cb, (void*)buffer_data);

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1243,7 +1243,7 @@ void GstUDPVideoClient::play_internal ()
     LOG (info) << "Exit - play Gstreamer GstUDPVideoClient pipeline" << endl;   
 
     m_videoDataWatchDog = make_unique<Bosma::Scheduler>(1);
-    m_videoDataWatchDog->interval(VIDEO_DATA_WATCH_DOG_SCHEDULER_INTERVAL, [=]() {
+    m_videoDataWatchDog->interval(VIDEO_DATA_WATCH_DOG_SCHEDULER_INTERVAL, [this]() {
         checkVideoDataFlowStatus();
     });
 }

--- a/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -508,7 +508,7 @@ ClipReaderProducer::ClipReaderProducer(const ClipReaderConfig& cfg)
 ClipReaderProducer::~ClipReaderProducer()
 {
     try {
-        stop();
+        ClipReaderProducer::stop();
         teardown();
         LOG(info) << mLogPrefix << "~ClipReaderProducer destructor" << endl;
     } catch (const std::exception& e) {

--- a/services/vios/src/framework/media/media_pipelines/media_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/media_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,11 +104,7 @@ struct _RawFrameParams
             gst_caps_unref (m_caps);
             m_caps = nullptr;
         }
-        if (m_fdWrapperObj)
-        {
-            delete (m_fdWrapperObj);
-            m_fdWrapperObj = nullptr;
-        }
+        m_fdWrapperObj.reset();
     }
 
     string     m_streamId;
@@ -137,7 +133,7 @@ struct _RawFrameParams
     void *meta = nullptr;
     int64_t pts = 0;
 
-    std::shared_ptr<fdWrapper>*       m_fdWrapperObj = nullptr;
+    std::unique_ptr<std::shared_ptr<fdWrapper>> m_fdWrapperObj;
     EncoderMsgType m_encoderMsgType = Buffer;
     std::atomic<bool> m_eos;
 } typedef RawFrameParams;

--- a/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,7 +60,7 @@ RemuxWriterConsumer::RemuxWriterConsumer(const RemuxWriterConfig& cfg)
 RemuxWriterConsumer::~RemuxWriterConsumer()
 {
     try {
-        stop();
+        RemuxWriterConsumer::stop();
         teardown();
     } catch (const std::exception& e) {
         try { LOG(error) << "Exception in ~RemuxWriterConsumer: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
@@ -368,7 +368,7 @@ void RemuxWriterConsumer::attachProbes()
     // Attach EOS enforcement probe on mux sink (for end_time_ms)
     if (mMux && mCfg.end_time_ms != std::numeric_limits<int64_t>::max())
     {
-        MuxProbeCtx* mctx = new MuxProbeCtx();
+        auto mctx = std::make_unique<MuxProbeCtx>();
         mctx->end_ms = mCfg.end_time_ms;
         mctx->mux = mMux;
         mctx->videoSrc = mVideoAppsrc ? GST_APP_SRC(mVideoAppsrc) : nullptr;
@@ -410,7 +410,7 @@ void RemuxWriterConsumer::attachProbes()
                                         }
                                     }
                                     return GST_PAD_PROBE_OK;
-                                }, mctx, (GDestroyNotify)+[](gpointer data) { delete static_cast<MuxProbeCtx*>(data); });
+                                }, mctx.release(), (GDestroyNotify)+[](gpointer data) { std::unique_ptr<MuxProbeCtx>(static_cast<MuxProbeCtx*>(data)); });
 
                             g_value_reset(&item);
                             done = TRUE;  // First video pad is enough

--- a/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -280,7 +280,7 @@ TranscodeWriterConsumer::TranscodeWriterConsumer(const TranscodeWriterConfig& cf
 TranscodeWriterConsumer::~TranscodeWriterConsumer()
 {
     try {
-        stop();
+        TranscodeWriterConsumer::stop();
         teardown();
     } catch (const std::exception& e) {
         try { LOG(error) << "Exception in ~TranscodeWriterConsumer: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }

--- a/services/vios/src/framework/media/media_utils/OverlayDataTypes.h
+++ b/services/vios/src/framework/media/media_utils/OverlayDataTypes.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,38 +104,6 @@ struct OverlayBBoxParams
                         , m_enableHalos(false)
                         , m_overlayClassTypeList()
     { }
-
-    OverlayBBoxParams(const OverlayBBoxParams& params)
-    {
-        this->m_bboxColor = params.m_bboxColor;
-        this->m_bboxDebug = params.m_bboxDebug;
-        this->m_bboxDebugFontSize = params.m_bboxDebugFontSize;
-        this->m_bboxOpacity = params.m_bboxOpacity;
-        this->m_bboxThickness = params.m_bboxThickness;
-        this->m_enableTripwire = params.m_enableTripwire;
-        this->m_enableROI = params.m_enableROI;
-        this->m_enableBbox = params.m_enableBbox;
-        this->m_enableSensorNameText = params.m_enableSensorNameText;
-        this->m_sensorNameTextPosX = params.m_sensorNameTextPosX;
-        this->m_sensorNameTextPosY = params.m_sensorNameTextPosY;
-        this->m_proximityClass = params.m_proximityClass;
-        this->m_entrantClass = params.m_entrantClass;
-        this->m_proximityAreaFactor = params.m_proximityAreaFactor;
-        this->m_proximityAnimation = params.m_proximityAnimation;
-        this->m_colorCode = params.m_colorCode;
-        this->m_enableGodsEyeView = params.m_enableGodsEyeView;
-        this->m_enablePose = params.m_enablePose;
-        this->m_enableBboxId = params.m_enableBboxId;
-        this->m_bboxIdPosition = params.m_bboxIdPosition;
-        this->m_bboxIdColor = params.m_bboxIdColor;
-        this->m_bboxIdBgColor = params.m_bboxIdBgColor;
-        this->m_enableHalos = params.m_enableHalos;
-        this->m_overlayClassTypeList = params.m_overlayClassTypeList;
-        for (uint32_t i = 0; i < OVERLAYCOUNT; ++i)
-        {
-            this->m_overlayIdList[i] = params.m_overlayIdList[i];
-        }
-    }
 };
 
 typedef struct _searchParams
@@ -145,7 +113,7 @@ typedef struct _searchParams
                                             , m_end_time(endTime)
                                             , m_sensor_id(sensor_id)
                 {}
-    _searchParams() {}
+    _searchParams() = default;
     std::string     m_start_time;
     std::string     m_end_time;
     std::string     m_sensor_id;

--- a/services/vios/src/framework/media/media_utils/gst_utils.cpp
+++ b/services/vios/src/framework/media/media_utils/gst_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1827,20 +1827,19 @@ error:
     return (ret == 0) ? result : Json::nullValue;
 }
 
-GstDummyUdpPipeline* GstDummyUdpPipeline::m_instance = nullptr;
+std::unique_ptr<GstDummyUdpPipeline> GstDummyUdpPipeline::m_instance;
 GstDummyUdpPipeline* GstDummyUdpPipeline::getInstance()
 {
     if (m_instance == nullptr)
     {
-        m_instance = new GstDummyUdpPipeline();
+        m_instance = std::make_unique<GstDummyUdpPipeline>();
     }
-    return m_instance;
+    return m_instance.get();
 }
 
 void GstDummyUdpPipeline::deleteInstance()
 {
-    delete m_instance;
-    m_instance = nullptr;
+    m_instance.reset();
 }
 
 GstDummyUdpPipeline::~GstDummyUdpPipeline()

--- a/services/vios/src/framework/media/media_utils/gst_utils.h
+++ b/services/vios/src/framework/media/media_utils/gst_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 #include <json/json.h>
 #include <algorithm>
 #include <climits>
+#include <memory>
 #include <sstream>
 
 inline constexpr int DEFAUL_KEY_FRAME_INTERVAL = 30;
@@ -228,9 +229,12 @@ class GstTranscode : public GstNvElements
         string m_inAudioCaps;
     } TranscodeParam;
 
-    GstTranscode()
-    {
-    }
+    GstTranscode() = default;
+
+    GstTranscode(const GstTranscode&) = delete;
+    GstTranscode& operator=(const GstTranscode&) = delete;
+    GstTranscode(GstTranscode&&) = delete;
+    GstTranscode& operator=(GstTranscode&&) = delete;
 
     ~GstTranscode()
     {
@@ -314,7 +318,7 @@ bool muxElementaryStream(const std::string& elementaryFilePath, const std::strin
 class GstDummyUdpPipeline
 {
 public:
-    GstDummyUdpPipeline() {}
+    GstDummyUdpPipeline() = default;
     ~GstDummyUdpPipeline();
     static GstDummyUdpPipeline* getInstance();
     static void deleteInstance();
@@ -323,7 +327,7 @@ public:
     void stopAllUdpPipelines();
 
 private:
-    static GstDummyUdpPipeline*                                          m_instance;
+    static std::unique_ptr<GstDummyUdpPipeline>                          m_instance;
     std::mutex                                                      m_pipelineMapMutex;
     std::unordered_map<std::string, std::shared_ptr<gstElements> >  m_udpPipelines;
 

--- a/services/vios/src/framework/media/media_utils/libav_wrapper.h
+++ b/services/vios/src/framework/media/media_utils/libav_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -353,6 +353,11 @@ public:
         if (handle_libavcodec) dlclose(handle_libavcodec);
         if (handle_libavutil) dlclose(handle_libavutil);
     }
+
+    LibavWrapper(const LibavWrapper&) = delete;
+    LibavWrapper& operator=(const LibavWrapper&) = delete;
+    LibavWrapper(LibavWrapper&&) = delete;
+    LibavWrapper& operator=(LibavWrapper&&) = delete;
 
     LibavMode getLibavMode() const
     {

--- a/services/vios/src/framework/media/media_utils/mm_utils.h
+++ b/services/vios/src/framework/media/media_utils/mm_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,11 +168,6 @@ struct FrameSize
     {}
     FrameSize (uint32_t w, uint32_t h) : m_width(w), m_height(h)
     {}
-    void operator=(const FrameSize& size)
-    {
-        this->m_width = size.m_width;
-        this->m_height = size.m_height;
-    }
     int getPixels() { return m_width * m_height; }
     FrameSize minimum(FrameSize size)
     {

--- a/services/vios/src/framework/media/metadata/LiveMetadataStore.cpp
+++ b/services/vios/src/framework/media/metadata/LiveMetadataStore.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,7 @@ LiveMetadataStore::LiveMetadataStore(const std::string& sensorName, bool startLi
             {
                 auto tmp = std::make_unique<NotificationListener>(this);
                 m_notificationConsumer->registerMessageListener(tmp.get());
-                m_notificationListener = tmp.release();
+                m_notificationListener = std::move(tmp);
             }
         }
         catch(const std::exception& e)
@@ -65,13 +65,9 @@ LiveMetadataStore::~LiveMetadataStore()
 {
     if (m_notificationConsumer && m_notificationListener)
     {
-        m_notificationConsumer->deregisterMessageListener(m_notificationListener);
+        m_notificationConsumer->deregisterMessageListener(m_notificationListener.get());
     }
-    if (m_notificationListener)
-    {
-        delete m_notificationListener;
-        m_notificationListener = nullptr;
-    }
+    m_notificationListener.reset();
     m_metaWait.signal();
 }
 

--- a/services/vios/src/framework/media/overlays/halo_safety.cpp
+++ b/services/vios/src/framework/media/overlays/halo_safety.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -370,13 +370,9 @@ void HaloSafetyCommandListener::listenerThread()
 // HaloSafetyManager Implementation
 // =============================================================================
 
-HaloSafetyManager::HaloSafetyManager()
-{
-}
+HaloSafetyManager::HaloSafetyManager() = default;
 
-HaloSafetyManager::~HaloSafetyManager()
-{
-}
+HaloSafetyManager::~HaloSafetyManager() = default;
 
 bool HaloSafetyManager::checkHalosData(const std::string& obj_type, const std::string& proximity_class,
                                        bool& draw_halo_text, const std::string& metadata_object_id)
@@ -555,10 +551,10 @@ static OSD_ColorParams getHaloTextColor(const std::string& color)
 void HaloSafetyManager::drawHaloText(const Point& left_top, const Point& right_bottom,
                                      const std::string& text, OsdContext_t context, GstBuffer* buffer)
 {
-    OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+    OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
     if (text_params != nullptr)
     {
-        char* cstr = (char*)calloc(text.size() + 1, sizeof(char));
+        char* cstr = g_try_new0(char, text.size() + 1);
         if (cstr != nullptr)
         {
             strncpy(cstr, text.c_str(), text.size());

--- a/services/vios/src/framework/media/overlays/ll_overlay.cpp
+++ b/services/vios/src/framework/media/overlays/ll_overlay.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -563,11 +563,7 @@ NvLLOverlay::~NvLLOverlay ()
     m_surfacePool.reset();
     for (int i = 0; i < OUTPUT_PLANE_NUM_BUFFERS; i++)
     {
-        if (m_cpuPtr[i])
-        {
-            free (m_cpuPtr[i]);
-            m_cpuPtr[i] = nullptr;
-        }
+        m_cpuPtr[i].reset();
     }
     LOG(info) << "Exit " << __METHOD_NAME__ <<  endl;
 }
@@ -762,11 +758,7 @@ void NvLLOverlay::doDrawTask()
                     m_surfacePool->m_surfacesAllocated = false;
                     for (int i = 0; i < OUTPUT_PLANE_NUM_BUFFERS; i++)
                     {
-                        if (m_cpuPtr[i])
-                        {
-                            free (m_cpuPtr[i]);
-                            m_cpuPtr[i] = nullptr;
-                        }
+                        m_cpuPtr[i].reset();
                     }
                 }
                 LOG(info) << "Allocating surfaces of resolution = " << m_width << " x " << m_height << endl;
@@ -798,9 +790,9 @@ void NvLLOverlay::doDrawTask()
                     }
                     if (!m_cpuPtr[index])
                     {
-                        m_cpuPtr[index] = (uint8_t *) malloc (m_width * m_height * 3 / 2);
+                        m_cpuPtr[index] = std::make_unique<uint8_t[]>(m_width * m_height * 3 / 2);
                     }
-                    memcpy((void *)m_cpuPtr[index], sink_frame->m_map.data, sink_frame->m_map.size);
+                    memcpy((void *)m_cpuPtr[index].get(), sink_frame->m_map.data, sink_frame->m_map.size);
                 }
                 else
                 {
@@ -829,7 +821,7 @@ void NvLLOverlay::doDrawTask()
                 // Perform overlay using GPU/CPU based on config
                 if (!isJetsonPlatform() && is_sw_mode)
                 {
-                    data_ptr = (void *)m_cpuPtr[index];
+                    data_ptr = (void *)m_cpuPtr[index].get();
                     ret = m_overlay->doDraw(data_ptr, &meta_union, pts);
                 }
                 else
@@ -859,10 +851,10 @@ void NvLLOverlay::doDrawTask()
                         {
                             frame_data->m_fd        = (fd_index_pair.first * -1) + 1;
                         }
-                        frame_data->m_map.data  = m_cpuPtr[index];
+                        frame_data->m_map.data  = m_cpuPtr[index].get();
                         frame_data->m_map.size  = m_width * m_height * 3 / 2;
                     }
-                    frame_data->m_fdWrapperObj  = new std::shared_ptr<fdWrapper>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, index));
+                    frame_data->m_fdWrapperObj  = std::make_unique<std::shared_ptr<fdWrapper>>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, index));
                     frame_data->m_sourceWidth   = m_overlay->m_width;
                     frame_data->m_sourceHeight  = m_overlay->m_height;
                     frame_data->m_targetWidth   = m_overlay->m_width;

--- a/services/vios/src/framework/media/overlays/overlay_internal.cpp
+++ b/services/vios/src/framework/media/overlays/overlay_internal.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -753,7 +753,7 @@ void NvLLOverlayInternal::draw_bbox_id_cuosd(const Point& left_top, const Point&
     const int bottom = right_bottom.y;
     const int right = right_bottom.x;
 
-    OSD_TextParams* text_params = static_cast<OSD_TextParams*>(malloc(sizeof(OSD_TextParams)));
+    OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
     if (!text_params)
     {
         LOG(error) << "Failed to allocate OSD_TextParams for bbox id" << endl;
@@ -761,7 +761,7 @@ void NvLLOverlayInternal::draw_bbox_id_cuosd(const Point& left_top, const Point&
     }
 
     const string text = object_id;
-    char* cstr = static_cast<char*>(calloc(text.size() + 1, sizeof(char)));
+    char* cstr = g_try_new0(char, text.size() + 1);
     if (cstr)
     {
         strncpy(cstr, text.c_str(), text.size());
@@ -771,7 +771,7 @@ void NvLLOverlayInternal::draw_bbox_id_cuosd(const Point& left_top, const Point&
     else
     {
         LOG(error) << "Failed to allocate memory for overlay object id text" << endl;
-        free(text_params);
+        g_free(text_params);
         return;
     }
 
@@ -955,7 +955,7 @@ int NvLLOverlayInternal::draw_3d_bbox(const vector<Point2D>& corners2d, const st
         clamp_point(x1, y1, m_sourceWidth, m_sourceHeight);
         clamp_point(x2, y2, m_sourceWidth, m_sourceHeight);
 
-        OSD_LineParams* line_params = (OSD_LineParams*)malloc(sizeof(OSD_LineParams));
+        OSD_LineParams* line_params = g_try_new0(OSD_LineParams, 1);
         if (line_params)
         {
             Point start = interpolateCoordinate(x1, y1, m_sourceWidth, m_sourceHeight, m_width, m_height);
@@ -979,7 +979,7 @@ int NvLLOverlayInternal::draw_3d_bbox(const vector<Point2D>& corners2d, const st
             }
 
             draw_line_cuosd(line_params, box_params, context, buffer, output_color);
-            free(line_params);
+            g_free(line_params);
         }
     }
 
@@ -1016,11 +1016,11 @@ int NvLLOverlayInternal::draw_3d_bbox(const vector<Point2D>& corners2d, const st
         ss << object_id << "," << obj_type << "," << std::fixed << std::setprecision(2) << confidence;
         string label_text = ss.str();
 
-        OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+        OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
         if (text_params != nullptr)
         {
             // Use safe strncpy with explicit bounds checking
-            char* cstr = (char*)calloc(label_text.size() + 1, sizeof(char));
+            char* cstr = g_try_new0(char, label_text.size() + 1);
             if (cstr != nullptr)
             {
                 strncpy(cstr, label_text.c_str(), label_text.size());
@@ -1252,7 +1252,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
         }
 
         /* Assign bounding box coordinates */
-        OSD_RectParams* rect_params = (OSD_RectParams*)malloc(sizeof(OSD_RectParams));
+        OSD_RectParams* rect_params = g_try_new0(OSD_RectParams, 1);
         Point left_top = {}, right_bottom = {};
         if (rect_params)
         {
@@ -1311,16 +1311,13 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
             int bottom = right_bottom.y;
 
             // Display coordinates above each bbox.
-            OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+            OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
             if (text_params)
             {
                 string text = to_string(left) + "    " + to_string(top);
-                // Use safe strncpy with explicit bounds checking
-                char* cstr = (char*)calloc(text.size() + 1, sizeof(char));
+                char* cstr = strdup(text.c_str());
                 if (cstr)
                 {
-                    strncpy(cstr, text.c_str(), text.size());
-                    cstr[text.size()] = '\0';  // Guarantee null termination
                     text_params->text = cstr;
                 }
                 else
@@ -1352,12 +1349,12 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
 
             // Display retail name & confidence under bbox.
             {
-                OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+                OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
                 if (text_params)
                 {
                     string text = obj_type + "    " + to_string(confidence);
                     // Use safe strncpy with explicit bounds checking
-                    char* cstr = (char*)calloc(text.size() + 1, sizeof(char));
+                    char* cstr = g_try_new0(char, text.size() + 1);
                     if (cstr)
                     {
                         strncpy(cstr, text.c_str(), text.size());
@@ -1522,7 +1519,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
         if (box_params->m_overlay.m_proximityAnimation == "circleOnly" ||
             box_params->m_overlay.m_proximityAnimation == "circleAndLine")
         {
-            OSD_CircleParams* circle_params = (OSD_CircleParams*)malloc(sizeof(OSD_CircleParams));
+            OSD_CircleParams* circle_params = g_try_new0(OSD_CircleParams, 1);
             if (circle_params)
             {
                 // Use the bottom face center for the circle
@@ -1588,7 +1585,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                 }
                 else
                 {
-                    free(circle_params);
+                    g_free(circle_params);
                 }
             }
         }
@@ -1597,7 +1594,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
         if (box_params->m_overlay.m_proximityAnimation == "ellipseOnly" ||
             box_params->m_overlay.m_proximityAnimation == "ellipseAndLine")
         {
-            OSD_EllipseParams* ellipse_params = (OSD_EllipseParams*)malloc(sizeof(OSD_EllipseParams));
+            OSD_EllipseParams* ellipse_params = g_try_new0(OSD_EllipseParams, 1);
             if (ellipse_params)
             {
                 // Check if we have bbox3d coordinates in the original JSON
@@ -1853,7 +1850,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                     }
                     else
                     {
-                        free(ellipse_params);
+                        g_free(ellipse_params);
                     }
                 }
             }
@@ -1914,7 +1911,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                 if (entrantStates.find(entrantId) != entrantStates.end())
                 {
                     // Draw line between bottom face centers
-                    OSD_LineParams* line_params = (OSD_LineParams*)malloc(sizeof(OSD_LineParams));
+                    OSD_LineParams* line_params = g_try_new0(OSD_LineParams, 1);
                     if (line_params)
                     {
                         // Use the bottom face centers for both proximity and entrant objects
@@ -1937,7 +1934,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                         }
                         else
                         {
-                            free(line_params);
+                            g_free(line_params);
                             continue;
                         }
 
@@ -1958,15 +1955,12 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                         int text_y = ((start.y + end.y) / 2) - 2; // Offset above the line
 
                         // Create text parameters
-                        OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+                        OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
                         if (text_params != nullptr)
                         {
-                            // Use safe strncpy with explicit bounds checking
-                            char* cstr = (char*)calloc(distance_text.size() + 1, sizeof(char));
+                            char* cstr = strdup(distance_text.c_str());
                             if (cstr != nullptr)
                             {
-                                strncpy(cstr, distance_text.c_str(), distance_text.size());
-                                cstr[distance_text.size()] = '\0';  // Guarantee null termination
                                 text_params->text = cstr;
                             }
                             else
@@ -1996,7 +1990,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                                 GET_OSD_INSTANCE()->osd_add_metadata(context, &meta);
                             }
                         }
-                        free (line_params);
+                        g_free(line_params);
                         line_params = nullptr;
                     }
                 }
@@ -2205,7 +2199,7 @@ void NvLLOverlayInternal::readTripwire()
                 {
                     if (tripwire.wires[j])
                     {
-                        free(tripwire.wires[j]);
+                        g_free(tripwire.wires[j]);
                         tripwire.wires[j] = nullptr;
                     }
                 }
@@ -2213,7 +2207,7 @@ void NvLLOverlayInternal::readTripwire()
                 {
                     if (tripwire.endpoints[j])
                     {
-                        free(tripwire.endpoints[j]);
+                        g_free(tripwire.endpoints[j]);
                         tripwire.endpoints[j] = nullptr;
                     }
                 }
@@ -2221,7 +2215,7 @@ void NvLLOverlayInternal::readTripwire()
                 {
                     if (tripwire.direction[j])
                     {
-                        free(tripwire.direction[j]);
+                        g_free(tripwire.direction[j]);
                         tripwire.direction[j] = nullptr;
                     }
                 }
@@ -2247,15 +2241,15 @@ void NvLLOverlayInternal::readTripwire()
                     tripwire.direction_count = tripwire.endpoints_count = tripwire.wires_count = 0;
                     for (uint32_t j = 0; j < MAX_LINES; j++)
                     {
-                        tripwire.wires[j] = (OSD_LineParams *)malloc(sizeof(OSD_LineParams));
+                        tripwire.wires[j] = g_new0(OSD_LineParams, 1);
                     }
                     for (uint32_t j = 0; j < MAX_POINTS; j++)
                     {
-                        tripwire.endpoints[j] = (OSD_PointParams *)malloc(sizeof(OSD_PointParams));
+                        tripwire.endpoints[j] = g_new0(OSD_PointParams, 1);
                     }
                     for (uint32_t j = 0; j < MAX_ARROWS; j++)
                     {
-                        tripwire.direction[j] = (OSD_ArrowParams *)malloc(sizeof(OSD_ArrowParams));
+                        tripwire.direction[j] = g_new0(OSD_ArrowParams, 1);
                     }
 
                     Json::Value wire = tripwire_details[i].get("wire", Json::Value::null);
@@ -2408,13 +2402,12 @@ void NvLLOverlayInternal::drawTripwire(GstBuffer* buffer)
         }
         if (tripwire.stats.size())
         {
-            OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+            OSD_TextParams* text_params=g_try_new0(OSD_TextParams, 1);
             if (text_params != nullptr)
             {
-                char* cstr = (char*)malloc(tripwire.stats.size() + 1);
+                char* cstr = strdup(tripwire.stats.c_str());
                 if (cstr != nullptr)
                 {
-                    strcpy(cstr, tripwire.stats.c_str());
                     text_params->text = cstr;
                 }
 
@@ -2501,7 +2494,7 @@ void NvLLOverlayInternal::readRoi()
                 {
                     if (roi.lines[j])
                     {
-                        free(roi.lines[j]);
+                        g_free(roi.lines[j]);
                         roi.lines[j] = nullptr;
                     }
                 }
@@ -2509,7 +2502,7 @@ void NvLLOverlayInternal::readRoi()
                 {
                     if (roi.endpoints[j])
                     {
-                        free(roi.endpoints[j]);
+                        g_free(roi.endpoints[j]);
                         roi.endpoints[j] = nullptr;
                     }
                 }
@@ -2535,11 +2528,11 @@ void NvLLOverlayInternal::readRoi()
                     roi.lines_count = roi.endpoints_count = 0;
                     for (uint32_t j = 0; j < MAX_LINES; j++)
                     {
-                        roi.lines[j] = (OSD_LineParams *)malloc(sizeof(OSD_LineParams));
+                        roi.lines[j] = g_new0(OSD_LineParams, 1);
                     }
                     for (uint32_t j = 0; j < MAX_POINTS; j++)
                     {
-                        roi.endpoints[j] = (OSD_PointParams *)malloc(sizeof(OSD_PointParams));
+                        roi.endpoints[j] = g_new0(OSD_PointParams, 1);
                     }
                     Json::Value roi_coord = roi_details[i].get("coordinates", Json::Value::null);
                     if (roi_details[i].get("id", Json::Value::null) != Json::Value::null)
@@ -2687,13 +2680,12 @@ void NvLLOverlayInternal::drawRoi(GstBuffer* buffer)
         }
         if (roi.stats.size())
         {
-            OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+            OSD_TextParams* text_params=g_try_new0(OSD_TextParams, 1);
             if (text_params != nullptr)
             {
-                char* cstr = (char*)malloc(roi.stats.size() + 1);
+                char* cstr = strdup(roi.stats.c_str());
                 if (cstr != nullptr)
                 {
-                    strcpy(cstr, roi.stats.c_str());
                     text_params->text = cstr;
                 }
 
@@ -3445,13 +3437,13 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
     {
         if (!m_cpuCtx)
         {
-            m_cpuCtx = new OsdCpuDataContext();
+            m_cpuCtx = std::make_unique<OsdCpuDataContext>();
         }
         m_cpuCtx->width = m_width;
         m_cpuCtx->height = m_height;
         m_cpuCtx->data = &buffer;
         m_cpuCtx->size = (m_width * m_height * 3) / 2;
-        ip_buffer = (OsdCpuDataContext *)m_cpuCtx;
+        ip_buffer = m_cpuCtx.get();
     }
 #endif
     string frameTimestamp;
@@ -3516,7 +3508,7 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
                 Point left_top = {}, right_bottom = {};
 
                 /* Assign bounding box coordinates */
-                OSD_RectParams* rect_params = (OSD_RectParams*)malloc(sizeof(OSD_RectParams));
+                OSD_RectParams* rect_params = g_try_new0(OSD_RectParams, 1);
 
                 if (rect_params)
                 {
@@ -3560,13 +3552,12 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
 
     if (m_enableSensorNameText)
     {
-        OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+        OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
         if (text_params != nullptr)
         {
-            char* cstr = (char*)malloc(m_sensorName.size() + 1);
+            char* cstr = strdup(m_sensorName.c_str());
             if (cstr != nullptr)
             {
-                strcpy(cstr, m_sensorName.c_str());
                 text_params->text = cstr;
             }
 
@@ -3601,14 +3592,13 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
         if (m_bboxParams.m_overlay.m_bboxDebug)
         {
 #ifdef USE_CUOSD
-            OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+            OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
             if (text_params != nullptr)
             {
                 string text = getUTCtoLocalISOTime(frameTS);
-                char* cstr = (char*)malloc(text.size() + 1);
+                char* cstr = strdup(text.c_str());
                 if (cstr != nullptr)
                 {
-                    strcpy(cstr, text.c_str());
                     text_params->text = cstr;
                 }
 
@@ -3768,7 +3758,7 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
 #ifdef USE_CUOSD
     if (m_bboxParams.m_overlay.m_bboxDebug)
     {
-        OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+        OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
         int font_size = interpolateFontSize(m_sourceWidth, m_width);
         if (text_params != nullptr)
         {
@@ -3777,10 +3767,9 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
             {
                 text = text + "  #objects: " + to_string(num_objects);
             }
-            char* cstr = (char*)malloc(text.size() + 1);
+            char* cstr = strdup(text.c_str());
             if (cstr != nullptr)
             {
-                strcpy(cstr, text.c_str());
                 text_params->text = cstr;
             }
 
@@ -3810,15 +3799,14 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
         // Display latency of the frame;
         if (m_bboxParams.m_isLive)
         {
-            OSD_TextParams* text_params_latency = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+            OSD_TextParams* text_params_latency = g_try_new0(OSD_TextParams, 1);
             if (text_params_latency != nullptr)
             {
                 int64_t current_time_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
                 string text = "Latency: " + to_string((current_time_ns - stored_frame_TS) / 1000000) + "ms";
-                char* cstr = (char*)malloc(text.size() + 1);
+                char* cstr = strdup(text.c_str());
                 if (cstr != nullptr)
                 {
-                    strcpy(cstr, text.c_str());
                     text_params_latency->text = cstr;
                 }
 
@@ -3881,13 +3869,13 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, Gs
     {
         if (!m_cpuCtx)
         {
-            m_cpuCtx = new OsdCpuDataContext();
+            m_cpuCtx = std::make_unique<OsdCpuDataContext>();
         }
         m_cpuCtx->width = m_width;
         m_cpuCtx->height = m_height;
         m_cpuCtx->data = &buffer;
         m_cpuCtx->size = (m_width * m_height * 3) / 2;
-        ip_buffer = (OsdCpuDataContext *)m_cpuCtx;
+        ip_buffer = m_cpuCtx.get();
     }
 #endif
 
@@ -3904,15 +3892,14 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, Gs
     if (m_bboxParams.m_overlay.m_bboxDebug)
     {
 #ifdef USE_CUOSD
-        OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+        OSD_TextParams* text_params=g_try_new0(OSD_TextParams, 1);
         if (text_params != nullptr)
         {
             string time_str = getRelativeTimeUsingFrameId(frameTS, m_bboxParams.m_frameRate);
             string text = "id:" + to_string(frameTS) + string(" ts: ") + time_str ;
-            char* cstr = (char*)malloc(text.size() + 1);
+            char* cstr = strdup(text.c_str());
             if (cstr != nullptr)
             {
-                strcpy(cstr, text.c_str());
                 text_params->text = cstr;
             }
 
@@ -4041,7 +4028,7 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, Gs
     if (m_bboxParams.m_overlay.m_bboxDebug)
     {
 #ifdef USE_CUOSD
-        OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+        OSD_TextParams* text_params=g_try_new0(OSD_TextParams, 1);
         if (text_params != nullptr)
         {
             string text = to_string(frameTS) + "   " + to_string(elasticFrameId) + "  " + match_check;
@@ -4049,10 +4036,9 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, Gs
             {
                 text = text + "  #objects: " + to_string(num_objects);
             }
-            char* cstr = (char*)malloc(text.size() + 1);
+            char* cstr = strdup(text.c_str());
             if (cstr != nullptr)
             {
-                strcpy(cstr, text.c_str());
                 text_params->text = cstr;
             }
 
@@ -4089,24 +4075,10 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, Gs
     return true;
 }
 
-NvOsdLibs* NvOsdLibs::_instance = nullptr;
-
 NvOsdLibs* NvOsdLibs::getInstance()
 {
-    if (_instance == nullptr)
-    {
-        _instance = new NvOsdLibs();
-    }
-    return _instance;
-}
-
-void NvOsdLibs::deleteInstance()
-{
-    if (_instance)
-    {
-        delete _instance;
-        _instance = nullptr;  // Reset to nullptr after deletion
-    }
+    static NvOsdLibs instance;
+    return &instance;
 }
 
 NvOsdLibs::NvOsdLibs()
@@ -4209,10 +4181,6 @@ void NvLLOverlayInternal::updateIPCStreamResolution(int width, int height)
 {
     m_ipcSourceWidth  = width;
     m_ipcSourceHeight = height;
-}
-
-NvLLOverlayInternal::NvLLOverlayInternal()
-{
 }
 
 void NvLLOverlayInternal::enableOverlay(OverlayParams& params, bool use_frameid, bool wait_for_es_query)
@@ -4421,7 +4389,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (tripwire.wires[j])
                 {
-                    free(tripwire.wires[j]);
+                    g_free(tripwire.wires[j]);
                     tripwire.wires[j] = nullptr;
                 }
             }
@@ -4429,7 +4397,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (tripwire.endpoints[j])
                 {
-                    free(tripwire.endpoints[j]);
+                    g_free(tripwire.endpoints[j]);
                     tripwire.endpoints[j] = nullptr;
                 }
             }
@@ -4437,7 +4405,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (tripwire.direction[j])
                 {
-                    free(tripwire.direction[j]);
+                    g_free(tripwire.direction[j]);
                     tripwire.direction[j] = nullptr;
                 }
             }
@@ -4450,7 +4418,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (roi.lines[j])
                 {
-                    free(roi.lines[j]);
+                    g_free(roi.lines[j]);
                     roi.lines[j] = nullptr;
                 }
             }
@@ -4458,7 +4426,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (roi.endpoints[j])
                 {
-                    free(roi.endpoints[j]);
+                    g_free(roi.endpoints[j]);
                     roi.endpoints[j] = nullptr;
                 }
             }
@@ -4488,11 +4456,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
         osd_ctx = nullptr;
     }
 #if !defined(AARCH64_PLATFORM)
-    if (m_cpuCtx)
-    {
-        delete m_cpuCtx;
-        m_cpuCtx = nullptr;
-    }
+    m_cpuCtx.reset();
 #endif
     m_calibrationData.clear();
     activeObjectCorners.clear();
@@ -5296,15 +5260,12 @@ void NvLLOverlayInternal::draw_pose_cuosd(const std::vector<float>& keypoints,
     {
         Point text_pos = interpolateCoordinate(x, y, m_sourceWidth, m_sourceHeight, m_width, m_height);
 
-        OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+        OSD_TextParams* text_params = g_try_new0(OSD_TextParams, 1);
         if (text_params)
         {
-            // Use safe strncpy with explicit bounds checking
-            char* cstr = (char*)calloc(action_label.size() + 1, sizeof(char));
+            char* cstr = g_strdup(action_label.c_str());
             if (cstr)
             {
-                strncpy(cstr, action_label.c_str(), action_label.size());
-                cstr[action_label.size()] = '\0';  // Guarantee null termination
                 text_params->text = cstr;
             }
             else
@@ -5319,7 +5280,7 @@ void NvLLOverlayInternal::draw_pose_cuosd(const std::vector<float>& keypoints,
 
             // Add error checking for strdup
             const char* font_type_str = GET_CONFIG().overlay_text_font_type.c_str();
-            text_params->font_type = strdup(font_type_str);
+            text_params->font_type = g_strdup(font_type_str);
             if (!text_params->font_type)
             {
                 LOG(error) << "Failed to duplicate font type string" << endl;
@@ -5349,9 +5310,9 @@ void NvLLOverlayInternal::draw_pose_cuosd(const std::vector<float>& keypoints,
                 // Clean up if we failed to allocate text
                 if (text_params->font_type)
                 {
-                    free(text_params->font_type);
+                    g_free(text_params->font_type);
                 }
-                free(text_params);
+                g_free(text_params);
             }
         }
         else
@@ -5369,7 +5330,7 @@ void NvLLOverlayInternal::draw_ellipse_around_2d_bbox(const Point& left_top, con
     right   = right_bottom.x;
     bottom  = right_bottom.y;
 
-    OSD_EllipseParams* ellipse_params = (OSD_EllipseParams*)malloc(sizeof(OSD_EllipseParams));
+    OSD_EllipseParams* ellipse_params = g_try_new0(OSD_EllipseParams, 1);
     if (ellipse_params)
     {
         // Calculate the midpoint of the bottom line of the 2D box

--- a/services/vios/src/framework/media/video_segment_extractor/VideoSegmentExtractor.cpp
+++ b/services/vios/src/framework/media/video_segment_extractor/VideoSegmentExtractor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@
  #include <filesystem>
  #include <iomanip>
  #include <chrono>
+ #include <memory>
  
  // Enable detailed logging
  #define LOG_INFO(msg) std::cout << "[INFO] " << msg << std::endl
@@ -542,7 +543,7 @@ extern "C" {
     // Create VideoSegmentExtractor instance
     nv_vms::VideoSegmentExtractor* createVideoSegmentExtractor() {
         try {
-            return new nv_vms::VideoSegmentExtractor();
+            return std::make_unique<nv_vms::VideoSegmentExtractor>().release();
         } catch (const std::exception& e) {
             LOG_ERROR("Failed to create VideoSegmentExtractor: " << e.what());
             return nullptr;
@@ -551,9 +552,7 @@ extern "C" {
     
     // Destroy VideoSegmentExtractor instance
     void destroyVideoSegmentExtractor(nv_vms::VideoSegmentExtractor* extractor) {
-        if (extractor) {
-            delete extractor;
-        }
+        std::unique_ptr<nv_vms::VideoSegmentExtractor> owner(extractor);
     }
     
     // Extract video segment using stream copy

--- a/services/vios/src/framework/media/video_source/core/CommonVideoSource.h
+++ b/services/vios/src/framework/media/video_source/core/CommonVideoSource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,6 +93,11 @@ public:
 
     CommonVideoSource(const std::string &uri, const std::map<std::string, std::string, std::less<>> &opts);
     virtual ~CommonVideoSource(); // Custom destructor for pimpl-like pattern
+
+    CommonVideoSource(const CommonVideoSource&) = delete;
+    CommonVideoSource& operator=(const CommonVideoSource&) = delete;
+    CommonVideoSource(CommonVideoSource&&) = delete;
+    CommonVideoSource& operator=(CommonVideoSource&&) = delete;
 
     // Public interface methods
     VmsErrorCode controlStreamFileVideoSource(const std::string& action, const std::string& seek_value);

--- a/services/vios/src/framework/media/video_source/decoders/decoderpool.h
+++ b/services/vios/src/framework/media/video_source/decoders/decoderpool.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,7 @@ class DecoderPool
             static DecoderPool instance;
             return &instance;
         }
-        ~DecoderPool() {}
+        ~DecoderPool() = default;
 
         dec_map getDecoderPool()
         {

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1830,12 +1830,12 @@ GstNvVideoDecoder::GstNvVideoDecoder (const std::string& consumer_name, const st
         m_vodDebugFile.open(file_name, ios::out | ios::app);
     }
     m_playbackWD = make_unique<Bosma::Scheduler>(1);
-    m_playbackWD->interval(SCHEDULER_WD_INTERVAL, [=]()
+    m_playbackWD->interval(SCHEDULER_WD_INTERVAL, [this]()
     {
         /* Reset playstate to not playing, it will be set again in appsink callback*/
         m_playbackState.store(STATE_NOT_PLAYING);
     });
-    setConsumerMediaType(MediaTypeAudioVideo);
+    IMediaDataConsumer::setConsumerMediaType(MediaTypeAudioVideo);
 
     if (m_perfLogging)
     {

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.h
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,7 +110,7 @@ class GstNvVideoDecoder : public IMediaDataConsumer, public GstNvDecoder, public
                     m_decStats.printTotalStats();
                     m_decStats.clearQueue();
                 }
-                destroy(true);
+                GstNvVideoDecoder::destroy(true);
                 LOG(info) << "Decoder instance is deleted "<< m_peerid << endl;
             } catch (const std::exception& e) {
                 try { LOG(error) << "Exception in ~GstNvVideoDecoder: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }

--- a/services/vios/src/framework/media/video_source/encoders/image_encoder.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/image_encoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -328,11 +328,11 @@ void ImageEnc::hwEncode(uint64_t fd, std::shared_ptr<RawFrameParams> frameData)
     }
 
     unsigned long out_buf_size = 0;
-    unsigned char *out_buf = nullptr;
 
     // Extra 512 Kbytes are required for some case encoded bitstream exceeds input buffer size
     out_buf_size = (frameData->m_targetWidth * frameData->m_targetHeight * 3/2) + (512 << 10) ;
-    out_buf = (unsigned char *)malloc(out_buf_size);
+    std::vector<unsigned char> out_buf_storage(out_buf_size);
+    unsigned char *out_buf = out_buf_storage.data();
     if (NvJpegEncLoader::getInstance()->nvjpegEncodeFromFd(fd, &out_buf, out_buf_size) == 0)
     {
         LOG(info) << "HW jpeg conversion success" << endl;
@@ -340,8 +340,6 @@ void ImageEnc::hwEncode(uint64_t fd, std::shared_ptr<RawFrameParams> frameData)
     else
     {
         LOG(error) << "HW jpeg conversion failed" << endl;
-        free(out_buf);
-        out_buf = nullptr;
         m_stop = true;
         return;
     }
@@ -354,9 +352,6 @@ void ImageEnc::hwEncode(uint64_t fd, std::shared_ptr<RawFrameParams> frameData)
     std::string().swap(image_buf);
     m_stop = true;
     m_imgBufferWait.notify_all();
-
-    free(out_buf);
-    out_buf = nullptr;
 }
 
 int ImageEnc::create(string sourceWidth, string sourceHeight, string resizeWidth, string resizeHeight)

--- a/services/vios/src/framework/media/video_source/encoders/libnv_encoder.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/libnv_encoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,21 +89,17 @@ std::unordered_map<std::string, uint32_t> stringToPresetIDMap =
         {"slow"       , 7 }
 };
 
-NvVideoEncoder::NvVideoEncoder()
-{
-}
-
 NvVideoEncoder::~NvVideoEncoder()
 {
     // Ensure cleanup of allocated resources
     if (capturePlane != nullptr)
     {
-        free(capturePlane);
+        delete capturePlane;
         capturePlane = nullptr;
     }
     if (outputPlane != nullptr)
     {
-        free(outputPlane);
+        delete outputPlane;
         outputPlane = nullptr;
     }
 }
@@ -113,13 +109,13 @@ void NvVideoEncoder::Init()
     int ret = 0;
     if (capturePlane == nullptr)
     {
-        capturePlane = (v4l2Planes_ *)(malloc(sizeof(v4l2Planes_)));
+        capturePlane = new v4l2Planes_();
         capturePlane->plane_name = "Capture Plane";
         InitPlane(capturePlane);
     }
     if (outputPlane == nullptr)
     {
-        outputPlane = (v4l2Planes_ *)(malloc(sizeof(v4l2Planes_)));
+        outputPlane = new v4l2Planes_();
         outputPlane->plane_name = "Output Plane";
         InitPlane(outputPlane);
     }
@@ -181,13 +177,13 @@ void NvVideoEncoder::Deinit()
 
     if (capturePlane != nullptr)
     {
-        free(capturePlane);
+        delete capturePlane;
         capturePlane = nullptr;
     }
 
     if (outputPlane != nullptr)
     {
-        free(outputPlane);
+        delete outputPlane;
         outputPlane = nullptr;
     }
 
@@ -588,11 +584,11 @@ int NvVideoEncoder::reqbufs(struct v4l2Planes_ * currentPlane, uint32_t num)
         if (reqbuf.count)
         {
             currentPlane->buffer_count = reqbuf.count;
-            currentPlane->buffers  = (NvBuffer ** )malloc(reqbuf.count*sizeof(NvBuffer *));
+            currentPlane->buffers  = new NvBuffer *[reqbuf.count]();
 
             for (uint32_t i = 0; i < reqbuf.count; i++)
             {
-                currentPlane->buffers[i] = (NvBuffer *)malloc(sizeof(NvBuffer));
+                currentPlane->buffers[i] = new NvBuffer();
                 InitNvBuffer(currentPlane->buffers[i], currentPlane->buf_type,
                         currentPlane->memory_type, currentPlane->n_planes,
                         currentPlane->planefmts, i);
@@ -602,9 +598,9 @@ int NvVideoEncoder::reqbufs(struct v4l2Planes_ * currentPlane, uint32_t num)
         {
             for (uint32_t i = 0; i < currentPlane->num_buffers; i++)
             {
-                free(currentPlane->buffers[i]);
+                delete currentPlane->buffers[i];
             }
-            free(currentPlane->buffers);
+            delete[] currentPlane->buffers;
             currentPlane->buffers = nullptr;
         }
         currentPlane->num_buffers = reqbuf.count;
@@ -1446,7 +1442,7 @@ int NvVideoEncoder::GetEncodedPartitions(unsigned char** data, ssize_t *size, bo
         LOG(error) << "capplane_buffer is NULL" << endl;
         return -1;
     }
-    *data = (uint8_t* )malloc(capplane_buffer->planes[0].bytesused);
+    *data = new uint8_t[capplane_buffer->planes[0].bytesused];
     *size =  capplane_buffer->planes[0].bytesused;
     if (isJetsonPlatform())
     {

--- a/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 
 #include "nvjpegenc_loader.h"
 #include <dlfcn.h>
+#include <vector>
 #include "logger.h"
 #include "nvbufwrapper.h"
 
@@ -30,23 +31,10 @@ constexpr int JPEG_DEFAULT_QUALITY = 75;
 #endif
 #define ROUND_UP_4(num)  (((num) + 3) & ~3)
 
-NvJpegEncLoader* NvJpegEncLoader::m_instance = nullptr;
-
 NvJpegEncLoader* NvJpegEncLoader::getInstance()
 {
-    if (m_instance == nullptr)
-    {
-        m_instance = new NvJpegEncLoader();
-    }
-    return m_instance;
-}
-
-void NvJpegEncLoader::deleteInstance()
-{
-    if (m_instance)
-    {
-        delete m_instance;
-    }
+    static NvJpegEncLoader _instance;
+    return &_instance;
 }
 
 NvJpegEncLoader::NvJpegEncLoader()
@@ -191,6 +179,7 @@ int NvJpegEncLoader::nvjpegEncodeFromFd(int fd, unsigned char **out_buf, unsigne
 int NvJpegEncLoader::nvjpegEncodeFromBuffer(unsigned char* buffer, uint32_t width, uint32_t height, unsigned char **out_buf, unsigned long &out_buf_size)
 {
     unsigned char **line[3];
+    std::vector<unsigned char *> line_storage[MAX_CHANNELS];
 
     uint32_t comp_height[MAX_CHANNELS];
     uint32_t comp_width[MAX_CHANNELS];
@@ -262,8 +251,8 @@ int NvJpegEncLoader::nvjpegEncodeFromBuffer(unsigned char* buffer, uint32_t widt
     {
         cinfo.comp_info[i].h_samp_factor = h_samp[i];
         cinfo.comp_info[i].v_samp_factor = v_samp[i];
-        line[i] = (unsigned char **) malloc(v_max_samp * DCTSIZE *
-                sizeof(unsigned char *));
+        line_storage[i].resize(v_max_samp * DCTSIZE);
+        line[i] = line_storage[i].data();
     }
 
     for (i = 0; i < channels; i++)
@@ -302,10 +291,6 @@ int NvJpegEncLoader::nvjpegEncodeFromBuffer(unsigned char* buffer, uint32_t widt
     }
 
     jpeg_finish_compress(&cinfo);
-    for (i = 0; i < channels; i++)
-    {
-        free(line[i]);
-    }
     LOG(info) << "Succesfully encoded Buffer" << endl;
 
     /* Destroy */

--- a/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ NvEncoderVideoConsumer::NvEncoderVideoConsumer(const std::string& consumer_name,
     m_encoderProcessThread = std::thread(&NvEncoderVideoConsumer::encoderProcessThread, this);
     m_transcodeStats.clear();
     // Performance tracking element name is now set in base constructor
-    setConsumerType (encoder);
+    IMediaDataConsumer::setConsumerType (encoder);
 
     /* Initialize encoder with default resolution */
     if (NvHwDetection::getInstance()->m_useNvV4l2Enc == true)
@@ -375,7 +375,7 @@ void NvEncoderVideoConsumer::encoderProcessThread()
                 }
                 if (output_buffer)
                 {
-                    free (output_buffer);
+                    delete[] output_buffer;
                     output_buffer = nullptr;
                 }
             }
@@ -578,7 +578,7 @@ void NvEncoderVideoConsumer::encoderProcessThread()
         }
         if (output_buffer)
         {
-            free (output_buffer);
+            delete[] output_buffer;
             output_buffer = nullptr;
         }
         {

--- a/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.cpp
+++ b/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -220,22 +220,19 @@ void NvCompositor::doCompositeTask()
             {
                 // Create layout rectangles array for custom layout
                 size_t buffer_count = nv_buffer_list.size();
-                NvBufSurfTransformRect* dstCompRect = nullptr;
-                
+
                 // Check if we should use custom layout
                 if (m_gridLayout.isCustom && !m_gridLayout.tiles.empty()) {
-                    dstCompRect = new NvBufSurfTransformRect[buffer_count];
-                    calculateCustomLayout(dstCompRect, buffer_count, target_width, target_height);
-                    
+                    std::vector<NvBufSurfTransformRect> dstCompRect(buffer_count);
+                    calculateCustomLayout(dstCompRect.data(), buffer_count, target_width, target_height);
+
                     NvBufWrapper::getInstance()->doComposition(
-                        &fd_index_pair.first, 
-                        nv_buffer_list, 
-                        m_sourceFrameSize.m_width, 
-                        m_sourceFrameSize.m_height, 
-                        dstCompRect, 
+                        &fd_index_pair.first,
+                        nv_buffer_list,
+                        m_sourceFrameSize.m_width,
+                        m_sourceFrameSize.m_height,
+                        dstCompRect.data(),
                         buffer_count);
-                        
-                    delete[] dstCompRect;
                 } else {
                     // Use default layout
                     NvBufWrapper::getInstance()->doComposition(
@@ -254,7 +251,7 @@ void NvCompositor::doCompositeTask()
                     frame_data->m_targetWidth = target_width;
                     frame_data->m_targetHeight = target_height;
                     frame_data->m_isTransformed = false;
-                    frame_data->m_fdWrapperObj = new std::shared_ptr<fdWrapper>(
+                    frame_data->m_fdWrapperObj = std::make_unique<std::shared_ptr<fdWrapper>>(
                         std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, -1));
                     
                     m_consumer->onFrame(frame_data);

--- a/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.cpp
+++ b/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,16 +94,8 @@ NvLLTransform::~NvLLTransform ()
         m_surfacePool->freeSurfacesAndDataStructure(false);
     }
     m_surfacePool.reset();
-    if (m_swSurf != nullptr)
-    {
-        if (m_swSurf->surfaceList != nullptr)
-        {
-            free(m_swSurf->surfaceList);
-            m_swSurf->surfaceList = nullptr;
-        }
-        free(m_swSurf);
-        m_swSurf = nullptr;
-    }
+    m_swSurf.reset();
+    m_swSurfaceList.reset();
     LOG(info) << "Exit " << __METHOD_NAME__ <<  endl;
 }
 
@@ -391,20 +383,18 @@ void NvLLTransform::doTransformTask()
                     config_params.cuda_stream  = nullptr;
                     NvBufWrapper::getInstance()->NvBufSurfTransformSetSessionParams (&config_params);
 
-                    NvBufSurfTransformRect *src_rect = nullptr, *dst_rect = nullptr;
+                    NvBufSurfTransformRect src_rect = {}, dst_rect = {};
                     NvBufSurfTransformParams transform_params = {0};
-                    src_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-                    dst_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-                    src_rect->top                       = 0;
-                    src_rect->left                      = 0;
-                    src_rect->width                     = sink_frame->m_sourceWidth;
-                    src_rect->height                    = sink_frame->m_sourceHeight;
-                    dst_rect->top                       = 0;
-                    dst_rect->left                      = 0;
-                    dst_rect->width                     = sink_frame->m_targetWidth;
-                    dst_rect->height                    = sink_frame->m_targetHeight;
-                    transform_params.src_rect           = src_rect;
-                    transform_params.dst_rect           = dst_rect;
+                    src_rect.top                        = 0;
+                    src_rect.left                       = 0;
+                    src_rect.width                      = sink_frame->m_sourceWidth;
+                    src_rect.height                     = sink_frame->m_sourceHeight;
+                    dst_rect.top                        = 0;
+                    dst_rect.left                       = 0;
+                    dst_rect.width                      = sink_frame->m_targetWidth;
+                    dst_rect.height                     = sink_frame->m_targetHeight;
+                    transform_params.src_rect           = &src_rect;
+                    transform_params.dst_rect           = &dst_rect;
                     transform_params.transform_flag     = NVBUFSURF_TRANSFORM_FILTER;
                     transform_params.transform_flip     = NvBufSurfTransform_None;
                     transform_params.transform_filter   = NvBufSurfTransformInter_Default;
@@ -413,13 +403,9 @@ void NvLLTransform::doTransformTask()
                     if (transform_error != NvBufSurfTransformError_Success)
                     {
                         LOG(error) << "Transform failure" << endl;
-                        free (dst_rect);
-                        free (src_rect);
                         is_error = true;
                         goto error;
                     }
-                    free (dst_rect);
-                    free (src_rect);
                 }
 
                 if (NvHwDetection::getInstance()->m_useNvV4l2Enc == true || (m_consumer && m_consumer->getConsumerType() != ConsumerType::webrtcConsumer))
@@ -440,7 +426,7 @@ void NvLLTransform::doTransformTask()
                         {
                             // case 1.2 hw mode full
                             frame_data->m_fd            = fd_index_pair.first;
-                            frame_data->m_fdWrapperObj  = new std::shared_ptr<fdWrapper>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, fd_index_pair.second));
+                            frame_data->m_fdWrapperObj  = std::make_unique<std::shared_ptr<fdWrapper>>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, fd_index_pair.second));
                             frame_data->m_sourceWidth   = sink_frame->m_targetWidth;
                             frame_data->m_sourceHeight  = sink_frame->m_targetHeight;
                         }
@@ -583,24 +569,13 @@ void NvLLTransform::doTransformTask()
                         // Create the NvBufSurface for webrtc SW buffer storage
                         if (!m_swSurf)
                         {
-                            m_swSurf = (NvBufSurface *) calloc (1, sizeof(NvBufSurface));
-                            if (!m_swSurf)
-                            {
-                                LOG(error) << "Allocate SW surface failed" << endl;
-                                is_error = true;
-                                goto error;
-                            }
-                            m_swSurf->surfaceList = (NvBufSurfaceParams *) calloc (1, sizeof(NvBufSurfaceParams));
-                            if (!m_swSurf->surfaceList)
-                            {
-                                LOG(error) << "Allocate SW surfaceList failed" << endl;
-                                is_error = true;
-                                goto error;
-                            }
+                            m_swSurf = std::make_unique<NvBufSurface>();
+                            m_swSurfaceList = std::make_unique<NvBufSurfaceParams>();
+                            m_swSurf->surfaceList = m_swSurfaceList.get();
                         }
 
                         // For SW transform : Init the NvBufSurface data from the webrtc I420 buffer created
-                        ret = NvBufWrapper::getInstance()->getSwNvBufSurface(yuv_buffer, m_swSurf);
+                        ret = NvBufWrapper::getInstance()->getSwNvBufSurface(yuv_buffer, m_swSurf.get());
                         if (ret < 0)
                         {
                             LOG(error) << "Get SW NvBufSurface failed" << endl;
@@ -609,7 +584,7 @@ void NvLLTransform::doTransformTask()
                         }
 
                         // For SW transform : Copy from HW I420 -> SW I420
-                        ret = NvBufWrapper::getInstance()->NvBufSurfaceCopy (dst_surf, m_swSurf);
+                        ret = NvBufWrapper::getInstance()->NvBufSurfaceCopy (dst_surf, m_swSurf.get());
                         if (ret < 0)
                         {
                             LOG(error) << "NvBufSurfaceCopy failed" << endl;

--- a/services/vios/src/framework/media/video_source/producers/ipcproducerpool.h
+++ b/services/vios/src/framework/media/video_source/producers/ipcproducerpool.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ class IPCProducerPool
             static IPCProducerPool instance;
             return &instance;
         }
-        ~IPCProducerPool() {}
+        ~IPCProducerPool() = default;
 
         ipc_producer_map getVideoSenderPool()
         {

--- a/services/vios/src/framework/media/video_source/producers/native_stream_monitor.h
+++ b/services/vios/src/framework/media/video_source/producers/native_stream_monitor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,32 +18,31 @@
 #pragma once
 
 #include<iostream>
+#include <memory>
 #include "logger.h"
 #include "nativestreamproducer.h"
 
 class NativeStreamMonitor
 {
 private:
-    static NativeStreamMonitor* m_pInstance;
-    NativeStreamMonitor() { }
+    struct PrivateTag { };
+    static std::unique_ptr<NativeStreamMonitor> m_pInstance;
 
 public:
+    explicit NativeStreamMonitor(PrivateTag) { }
+
     static NativeStreamMonitor* getInstance()
     {
         if(m_pInstance == nullptr)
         {
-            m_pInstance  = new NativeStreamMonitor();
+            m_pInstance  = std::make_unique<NativeStreamMonitor>(PrivateTag{});
         }
-        return m_pInstance;
+        return m_pInstance.get();
     }
 
     static void deleteInstance()
     {
-        if(m_pInstance != nullptr)
-        {
-            delete m_pInstance;
-            m_pInstance = nullptr;
-        }
+        m_pInstance.reset();
     }
     ~NativeStreamMonitor();
 

--- a/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
+++ b/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -221,10 +221,10 @@ class WebrtcStream
 class WebrtcStreamProducer : public IMediaDataProducer
 {
     private:
-        WebrtcStreamProducer () {}
+        WebrtcStreamProducer () = default;
 
     public:
-        ~WebrtcStreamProducer ()  {}
+        ~WebrtcStreamProducer ()  = default;
 
         static WebrtcStreamProducer* getInstance()
         {

--- a/services/vios/src/framework/media/video_source/senders/videosenderpool.h
+++ b/services/vios/src/framework/media/video_source/senders/videosenderpool.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ class VideoSenderPool
             static VideoSenderPool instance;
             return &instance;
         }
-        ~VideoSenderPool() {}
+        ~VideoSenderPool() = default;
 
         video_sender_map getVideoSenderPool()
         {

--- a/services/vios/src/framework/media/video_source/senders/videowebRTCsender.cpp
+++ b/services/vios/src/framework/media/video_source/senders/videowebRTCsender.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,12 +27,12 @@ void VideoWebRTCSender::unRefDataStructure(void *ptr)
     if (ptr)
     {
         std::lock_guard<std::mutex> lock(m_encParamsLock);
-        encoder_params* params = (encoder_params*) ptr;
+        encoder_params* params = static_cast<encoder_params*>(ptr);
         /* Copy encoder feedback params as member variables */
         m_qp        = params->m_qp;
         m_targetBps = params->m_targetBps;
         m_fps       = params->m_frameRate;
-        free (params);
+        delete params;
     }
 }
 
@@ -40,7 +40,7 @@ VideoWebRTCSender::VideoWebRTCSender (const std::string& consumer_name, const st
                     IMediaDataConsumer(consumer_name), m_uri(uri)
 {
     m_fpsDisplay = std::make_unique<FPSDisplay>();
-    setConsumerMediaType(MediaTypeVideo);
+    IMediaDataConsumer::setConsumerMediaType(MediaTypeVideo);
 }
 
 VideoWebRTCSender::VideoWebRTCSender (const std::string& consumer_name, double frame_rate, bool enable_frame_sync)
@@ -48,7 +48,7 @@ VideoWebRTCSender::VideoWebRTCSender (const std::string& consumer_name, double f
 {
     LOG(info) << "VideoWebRTCSender::VideoWebRTCSender m_frameRate:" << m_frameRate << endl;
     m_fpsDisplay = std::make_unique<FPSDisplay>();
-    setConsumerMediaType(MediaTypeVideo);
+    IMediaDataConsumer::setConsumerMediaType(MediaTypeVideo);
     if (frame_rate != 0)
     {
         m_idealFrameSendInterval = (1000/m_frameRate);
@@ -59,7 +59,7 @@ VideoWebRTCSender::VideoWebRTCSender (const std::string& consumer_name, double f
 VideoWebRTCSender::VideoWebRTCSender (const std::string& consumer_name) : IMediaDataConsumer(consumer_name)
 {
     m_fpsDisplay = std::make_unique<FPSDisplay>();
-    setConsumerMediaType(MediaTypeVideo);
+    IMediaDataConsumer::setConsumerMediaType(MediaTypeVideo);
 }
 
 int VideoWebRTCSender::createPassThroughMode(std::string& device_id)
@@ -246,8 +246,7 @@ void VideoWebRTCSender::onFrame(FrameParams& frame_params)
         memcpy(nv_video_frame_buffer_ptr->m_encodedData,  content.data(),  content.size());
         nv_video_frame_buffer->codecName = frame_params.m_codec;
 
-        encoder_params* params = (encoder_params*)malloc(sizeof(encoder_params));
-        memset(params, 0, sizeof(encoder_params));
+        encoder_params* params = new encoder_params{};
         nv_video_frame_buffer_ptr->m_clientBuffer = (void*)params;
         nv_video_frame_buffer_ptr->setPassThrough(true);
         nv_video_frame_buffer_ptr->registerCB([this](void* params) { unRefDataStructure(params); });

--- a/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.cpp
+++ b/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@
 WebrtcSinkConsumer::WebrtcSinkConsumer(const std::string& consumer_name) : IMediaDataConsumer(consumer_name)
 {
     m_videowebRTCSender = std::make_shared<VideoWebRTCSender>("VideoWebRTCSender");
-    setConsumerType (ConsumerType::webrtcConsumer);
+    IMediaDataConsumer::setConsumerType (ConsumerType::webrtcConsumer);
 }
 
 WebrtcSinkConsumer::WebrtcSinkConsumer(const std::string& consumer_name, string peer_id, double frame_rate,
@@ -33,7 +33,7 @@ WebrtcSinkConsumer::WebrtcSinkConsumer(const std::string& consumer_name, string 
         : IMediaDataConsumer(consumer_name), m_peerIdStreamId (peer_id)
 {
     m_videowebRTCSender = std::make_shared<VideoWebRTCSender>("VideoWebRTCSender", frame_rate, enable_frame_sync);
-    setConsumerType (ConsumerType::webrtcConsumer);
+    IMediaDataConsumer::setConsumerType (ConsumerType::webrtcConsumer);
 }
 
 WebrtcSinkConsumer::~WebrtcSinkConsumer()

--- a/services/vios/src/framework/notification/composite_notifier.cpp
+++ b/services/vios/src/framework/notification/composite_notifier.cpp
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-CompositeNotifier* CompositeNotifier::_instance = nullptr;
+std::unique_ptr<CompositeNotifier> CompositeNotifier::_instance;
 std::mutex CompositeNotifier::_instanceMutex;
 
 CompositeNotifier* CompositeNotifier::getInstance()
@@ -27,19 +27,18 @@ CompositeNotifier* CompositeNotifier::getInstance()
     std::lock_guard<std::mutex> lock(_instanceMutex);
     if (_instance == nullptr)
     {
-        _instance = new CompositeNotifier();
+        _instance = std::make_unique<CompositeNotifier>(PrivateTag{});
     }
-    return _instance;
+    return _instance.get();
 }
 
 void CompositeNotifier::deleteInstance()
 {
     std::lock_guard<std::mutex> lock(_instanceMutex);
-    delete _instance;
-    _instance = nullptr;
+    _instance.reset();
 }
 
-CompositeNotifier::CompositeNotifier()
+CompositeNotifier::CompositeNotifier(PrivateTag)
 {
     // Children track their own connections; the composite itself is always ready.
     m_connected = true;

--- a/services/vios/src/framework/notification/ds_proto_parser.cpp
+++ b/services/vios/src/framework/notification/ds_proto_parser.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,9 @@
 #include "ds_proto_parser.h"
 #include "logger.h"
 #include "utils.h"
+#include <cstdlib>
 #include <dlfcn.h>
+#include <memory>
 #include <vector>
 
 constexpr const char* ABSOLUTE_LIBRARY_PATH_2D_X86_64 = "/home/vst/vst_release/prebuilts/x86_64/libnvds_schema_2d.so";
@@ -181,6 +183,8 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
         return Json::nullValue;
     }
 
+    using CStringPtr = std::unique_ptr<char, decltype(&std::free)>;
+
     Json::Value payload;
     try {
         if (!m_frame_new || !m_frame_parse || !m_frame_get_sensorid ||
@@ -198,9 +202,8 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
         }
 
         // SensorId
-        char* sensorid = m_frame_get_sensorid(frame);
-        payload["sensorId"] = sensorid ? sensorid : "";
-        free(sensorid);
+        CStringPtr sensorid(m_frame_get_sensorid(frame), std::free);
+        payload["sensorId"] = sensorid ? sensorid.get() : "";
 
         // Timestamp
         frameTimeMs = 0;
@@ -215,13 +218,11 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
             void* obj = m_frame_get_object(frame, i);
             Json::Value objJson;
             // id, type, confidence
-            char* id = m_object_get_id(obj);
-            char* type = m_object_get_type(obj);
-            objJson["id"] = id ? id : "";
-            objJson["type"] = type ? type : "";
+            CStringPtr id(m_object_get_id(obj), std::free);
+            CStringPtr type(m_object_get_type(obj), std::free);
+            objJson["id"] = id ? id.get() : "";
+            objJson["type"] = type ? type.get() : "";
             objJson["confidence"] = m_object_get_confidence(obj);
-            if (id) free(id);
-            if (type) free(type);
             // 3D or 2D bbox
             if (m_data2d)
             {
@@ -261,9 +262,8 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
                 // Add pose type
                 if (m_object_get_pose_type)
                 {
-                    char* poseType = m_object_get_pose_type(obj);
-                    poseJson["type"] = poseType ? poseType : "";
-                    if (poseType) free(poseType);
+                    CStringPtr poseType(m_object_get_pose_type(obj), std::free);
+                    poseJson["type"] = poseType ? poseType.get() : "";
                 }
 
                 // Add keypoints as an array of keypoint objects, size = keypointCount
@@ -311,22 +311,20 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
                     if (actionsCount > 0)
                     {
                         // For compatibility with overlay_internal.cpp, use the first action as primary
-                        char* primaryActionType = m_object_get_pose_action_type(obj, 0);
+                        CStringPtr primaryActionType(m_object_get_pose_action_type(obj, 0), std::free);
                         float primaryActionConfidence = m_object_get_pose_action_confidence(obj, 0);
-                        poseJson["action"] = primaryActionType ? primaryActionType : "";
+                        poseJson["action"] = primaryActionType ? primaryActionType.get() : "";
                         poseJson["action_confidence"] = primaryActionConfidence;
-                        if (primaryActionType) free(primaryActionType);
 
                         // Also add all actions as an array for completeness
                         Json::Value actionsArray = Json::arrayValue;
                         for (int i = 0; i < actionsCount; i++)
                         {
-                            char* actionType = m_object_get_pose_action_type(obj, i);
+                            CStringPtr actionType(m_object_get_pose_action_type(obj, i), std::free);
                             float actionConfidence = m_object_get_pose_action_confidence(obj, i);
                             Json::Value actionJson;
-                            actionJson["type"] = actionType ? actionType : "";
+                            actionJson["type"] = actionType ? actionType.get() : "";
                             actionJson["confidence"] = actionConfidence;
-                            if (actionType) free(actionType);
                             actionsArray.append(actionJson);
                         }
                         poseJson["actions"] = actionsArray;
@@ -351,29 +349,30 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
             std::vector<char*> values(infoSize, nullptr);
             int infoCount = m_frame_get_info(frame, keys.data(), values.data(), infoSize);
 
+            std::vector<CStringPtr> infoOwners;
+            infoOwners.reserve(static_cast<size_t>(infoSize) * 2);
+            for (int i = 0; i < infoSize; i++)
+            {
+                infoOwners.emplace_back(keys[i], std::free);
+                infoOwners.emplace_back(values[i], std::free);
+            }
+
             Json::Value perCameraPayloads = Json::arrayValue;
             for (int i = 0; i < infoCount; i++)
             {
                 if (!keys[i] || !values[i])
                 {
-                    free(keys[i]);
-                    free(values[i]);
                     continue;
                 }
                 std::time_t epochMs = isoToEpoch(std::string(values[i]));
                 if (epochMs == 0)
                 {
-                    free(keys[i]);
-                    free(values[i]);
                     continue;
                 }
                 Json::Value cameraPayload = payload;
                 cameraPayload["sensorId"] = std::string(keys[i]);
                 cameraPayload["epocTime"] = static_cast<int64_t>(epochMs);
                 perCameraPayloads.append(cameraPayload);
-
-                free(keys[i]);
-                free(values[i]);
             }
 
             if (perCameraPayloads.size() > 0)

--- a/services/vios/src/framework/notification/ds_schema_2d_c_api.cpp
+++ b/services/vios/src/framework/notification/ds_schema_2d_c_api.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +20,13 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <memory>
 #include <google/protobuf/timestamp.pb.h>
 
 extern "C" {
 
 void* nv_frame_new() {
-    return new nv::Frame();
+    return std::make_unique<nv::Frame>().release();
 }
 
 bool nv_frame_parse(void* frame, const void* data, size_t len) {
@@ -34,18 +35,12 @@ bool nv_frame_parse(void* frame, const void* data, size_t len) {
 
 char* nv_frame_get_sensorid(void* frame) {
     std::string id = static_cast<nv::Frame*>(frame)->sensorid();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(id.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, id.c_str(), id.size());
-        cstr[id.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(id.c_str());  // Will be nullptr if allocation failed
 }
 
 void nv_frame_destroy(void* frame) {
-    delete static_cast<nv::Frame*>(frame);
+    std::unique_ptr<nv::Frame> owner(static_cast<nv::Frame*>(frame));
 }
 
 // Get timestamp in epoch ms, returns 0 if not present
@@ -71,25 +66,13 @@ void* nv_frame_get_object(void* frame, int idx) {
 // Object-level getters
 const char* nv_object_get_id(void* obj) {
     std::string id = static_cast<nv::Object*>(obj)->id();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(id.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, id.c_str(), id.size());
-        cstr[id.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(id.c_str());  // Will be nullptr if allocation failed
 }
 const char* nv_object_get_type(void* obj) {
     std::string type = static_cast<nv::Object*>(obj)->type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(type.c_str());  // Will be nullptr if allocation failed
 }
 float nv_object_get_confidence(void* obj) {
     return static_cast<nv::Object*>(obj)->confidence();
@@ -112,14 +95,8 @@ bool nv_object_has_pose(void* obj) {
 }
 char* nv_object_get_pose_type(void* obj) {
     std::string type = static_cast<nv::Object*>(obj)->pose().type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(type.c_str());  // Will be nullptr if allocation failed
 }
 int nv_object_get_pose_keypoints_count(void* obj) {
     return static_cast<nv::Object*>(obj)->pose().keypoints_size();
@@ -141,14 +118,8 @@ int nv_object_get_pose_actions_count(void* obj) {
 }
 char* nv_object_get_pose_action_type(void* obj, int idx) {
     std::string type = static_cast<nv::Object*>(obj)->pose().actions(idx).type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(type.c_str());  // Will be nullptr if allocation failed
 }
 float nv_object_get_pose_action_confidence(void* obj, int idx) {
     return static_cast<nv::Object*>(obj)->pose().actions(idx).confidence();

--- a/services/vios/src/framework/notification/ds_schema_3d_c_api.cpp
+++ b/services/vios/src/framework/notification/ds_schema_3d_c_api.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +20,13 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <memory>
 #include <google/protobuf/timestamp.pb.h>
 
 extern "C" {
 
 void* nv_frame_new() {
-    return new nv::Frame();
+    return std::make_unique<nv::Frame>().release();
 }
 
 bool nv_frame_parse(void* frame, const void* data, size_t len) {
@@ -34,18 +35,12 @@ bool nv_frame_parse(void* frame, const void* data, size_t len) {
 
 char* nv_frame_get_sensorid(void* frame) {
     std::string id = static_cast<nv::Frame*>(frame)->sensorid();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(id.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, id.c_str(), id.size());
-        cstr[id.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(id.c_str());  // Will be nullptr if allocation failed
 }
 
 void nv_frame_destroy(void* frame) {
-    delete static_cast<nv::Frame*>(frame);
+    std::unique_ptr<nv::Frame> owner(static_cast<nv::Frame*>(frame));
 }
 
 // Get timestamp in epoch ms, returns 0 if not present
@@ -71,25 +66,13 @@ void* nv_frame_get_object(void* frame, int idx) {
 // Object-level getters
 const char* nv_object_get_id(void* obj) {
     std::string id = static_cast<nv::Object*>(obj)->id();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(id.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, id.c_str(), id.size());
-        cstr[id.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(id.c_str());  // Will be nullptr if allocation failed
 }
 const char* nv_object_get_type(void* obj) {
     std::string type = static_cast<nv::Object*>(obj)->type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(type.c_str());  // Will be nullptr if allocation failed
 }
 float nv_object_get_confidence(void* obj) {
     return static_cast<nv::Object*>(obj)->confidence();
@@ -115,14 +98,8 @@ bool nv_object_has_pose(void* obj) {
 }
 char* nv_object_get_pose_type(void* obj) {
     std::string type = static_cast<nv::Object*>(obj)->pose().type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(type.c_str());  // Will be nullptr if allocation failed
 }
 int nv_object_get_pose_keypoints_count(void* obj) {
     return static_cast<nv::Object*>(obj)->pose().keypoints_size();
@@ -144,14 +121,8 @@ int nv_object_get_pose_actions_count(void* obj) {
 }
 char* nv_object_get_pose_action_type(void* obj, int idx) {
     std::string type = static_cast<nv::Object*>(obj)->pose().actions(idx).type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller releases the returned buffer with free()
+    return strdup(type.c_str());  // Will be nullptr if allocation failed
 }
 float nv_object_get_pose_action_confidence(void* obj, int idx) {
     return static_cast<nv::Object*>(obj)->pose().actions(idx).confidence();

--- a/services/vios/src/framework/notification/kafka/kafka_producer.cpp
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,27 +41,23 @@ DeliveryCallback(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *opaq
 }
 #endif
 
-NvKafka* NvKafka::_instance = nullptr;
+std::unique_ptr<NvKafka> NvKafka::_instance;
 
 NvKafka* NvKafka::getInstance()
 {
     if (_instance == nullptr)
     {
-        _instance = new NvKafka();
+        _instance = std::make_unique<NvKafka>(PrivateTag{});
     }
-    return _instance;
+    return _instance.get();
 }
 
 void NvKafka::deleteInstance()
 {
-    if (_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    _instance.reset();
 }
 
-NvKafka::NvKafka()
+NvKafka::NvKafka(PrivateTag)
         : m_error(false)
 #if !defined(AARCH64_PLATFORM)
         , m_kafkaHandle(nullptr)

--- a/services/vios/src/framework/notification/mqtt/mqtt_subscriber.cpp
+++ b/services/vios/src/framework/notification/mqtt/mqtt_subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,27 +26,10 @@
 using namespace std;
 #define MQTT_WAIT_TIMEOUT (10 * 1000)   // 10 seconds
 
-MqttSubscriber* MqttSubscriber::_instance = nullptr;
-std::mutex MqttSubscriber::m_instanceMutex;
-
 MqttSubscriber* MqttSubscriber::getInstance()
 {
-    std::lock_guard<std::mutex> lock(m_instanceMutex);
-    if (_instance == nullptr)
-    {
-        _instance = new MqttSubscriber();
-    }
-    return _instance;
-}
-
-void MqttSubscriber::deleteInstance()
-{
-    std::lock_guard<std::mutex> lock(m_instanceMutex);
-    if (_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    static MqttSubscriber instance;
+    return &instance;
 }
 
 MqttSubscriber::MqttSubscriber()

--- a/services/vios/src/framework/notification/redis/redis_publisher.cpp
+++ b/services/vios/src/framework/notification/redis/redis_publisher.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,27 +28,23 @@
 
 using namespace std;
 
-NvRedis* NvRedis::_instance = nullptr;
+std::unique_ptr<NvRedis> NvRedis::_instance;
 
 NvRedis* NvRedis::getInstance()
 {
     if (_instance == nullptr)
     {
-        _instance = new NvRedis();
+        _instance = std::make_unique<NvRedis>(PrivateTag{});
     }
-    return _instance;
+    return _instance.get();
 }
 
 void NvRedis::deleteInstance()
 {
-    if (_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    _instance.reset();
 }
 
-NvRedis::NvRedis()
+NvRedis::NvRedis(PrivateTag)
       : nvds_msgapi_connect(nullptr)
       , nvds_msgapi_send(nullptr)
       , m_error(false)

--- a/services/vios/src/framework/notification/redis/redis_subscriber.cpp
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,24 +63,10 @@ static void subscribe_cb(NvDsMsgApiErrorType flag, void *msg, int len, char *top
     }
 }
 
-RedisSubscriber* RedisSubscriber::_instance = nullptr;
-
 RedisSubscriber* RedisSubscriber::getInstance()
 {
-    if (_instance == nullptr)
-    {
-        _instance = new RedisSubscriber();
-    }
-    return _instance;
-}
-
-void RedisSubscriber::deleteInstance()
-{
-    if (_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    static RedisSubscriber instance;
+    return &instance;
 }
 
 RedisSubscriber::RedisSubscriber()
@@ -145,7 +131,10 @@ error:
 
 RedisSubscriber::~RedisSubscriber()
 {
-    nvds_msgapi_disconnect(m_connHandle);
+    if (nvds_msgapi_disconnect)
+    {
+        nvds_msgapi_disconnect(m_connHandle);
+    }
     if (m_handleRedis)
     {
         dlclose(m_handleRedis);

--- a/services/vios/src/framework/notification/webhook/webhook_notifier.cpp
+++ b/services/vios/src/framework/notification/webhook/webhook_notifier.cpp
@@ -149,7 +149,7 @@ bool anyEnabledWebhook(const Json::Value& config)
 }
 }  // unnamed namespace
 
-WebhookNotifier* WebhookNotifier::_instance = nullptr;
+std::unique_ptr<WebhookNotifier> WebhookNotifier::_instance;
 std::mutex WebhookNotifier::_instanceMutex;
 
 WebhookNotifier* WebhookNotifier::getInstance()
@@ -160,20 +160,19 @@ WebhookNotifier* WebhookNotifier::getInstance()
         const Json::Value config = loadNotificationConfig(NOTIFICATION_CONFIG_FILE);
         if (anyEnabledWebhook(config))
         {
-            _instance = new WebhookNotifier(config);
+            _instance = std::make_unique<WebhookNotifier>(config, PrivateTag{});
         }
     }
-    return _instance;
+    return _instance.get();
 }
 
 void WebhookNotifier::deleteInstance()
 {
     std::lock_guard<std::mutex> lock(_instanceMutex);
-    delete _instance;
-    _instance = nullptr;
+    _instance.reset();
 }
 
-WebhookNotifier::WebhookNotifier(const Json::Value& config)
+WebhookNotifier::WebhookNotifier(const Json::Value& config, PrivateTag)
 {
     try
     {

--- a/services/vios/src/framework/platform_specific/cudaLoader.cpp
+++ b/services/vios/src/framework/platform_specific/cudaLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,23 +19,10 @@
 #include <dlfcn.h>
 #include "logger.h"
 
-CudaLoader* CudaLoader::m_instance = nullptr;
-
 CudaLoader* CudaLoader::getInstance()
 {
-    if (m_instance == nullptr)
-    {
-        m_instance = new CudaLoader();
-    }
-    return m_instance;
-}
-
-void CudaLoader::deleteInstance()
-{
-    if (m_instance)
-    {
-        delete m_instance;
-    }
+    static CudaLoader instance;
+    return &instance;
 }
 
 CudaLoader::CudaLoader()

--- a/services/vios/src/framework/platform_specific/nvlibs.cpp
+++ b/services/vios/src/framework/platform_specific/nvlibs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,15 +31,10 @@
 #define ABSOLUTE_LIBRARY_PATH_X86_64 "/usr/lib/x86_64-linux-gnu/libv4l2.so.0"
 #define ABSOLUTE_LIBRARY_PATH_ARCH64 "/usr/lib/aarch64-linux-gnu/libv4l2.so.0"
 
-NvLibs* NvLibs::_instance = NULL;
-
 NvLibs* NvLibs::getInstance()
 {
-    if(_instance == NULL)
-    {
-        _instance = new NvLibs();
-    }
-    return _instance;
+    static NvLibs instance;
+    return &instance;
 }
 
 NvLibs::NvLibs()
@@ -72,13 +67,17 @@ NvLibs::NvLibs()
         {
             LOG(error) << "Cannot load symbol 'v4l2_ioctl_': " << dlsym_error << endl;
             dlclose(handle_v4l2);
+            handle_v4l2 = nullptr;
         }
     }
 }
 
 NvLibs::~NvLibs()
 {
-    dlclose(handle_v4l2);
+    if (handle_v4l2)
+    {
+        dlclose(handle_v4l2);
+    }
 }
 
 bool NvLibs::isV4l2EncPresent()

--- a/services/vios/src/framework/platform_specific/nvsurfacepool.h
+++ b/services/vios/src/framework/platform_specific/nvsurfacepool.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,8 +30,8 @@ struct _FdIndexInfo
 class NvSurfacePool
 {
 public:
-    NvSurfacePool() {};
-    ~NvSurfacePool() {};
+    NvSurfacePool() = default;
+    ~NvSurfacePool() = default;
     FD_Index_Pair getFreeFd(bool is_drc, unsigned int target_width, unsigned int target_height, bool need_allocations);
 
     bool allocateSurfaces    (int num_surfaces, unsigned int target_width, unsigned int target_height, bool need_allocations,
@@ -63,6 +63,10 @@ public:
     { 
         m_fd = fd; m_index = index;
     }
+    fdWrapper (const fdWrapper&) = delete;
+    fdWrapper& operator= (const fdWrapper&) = delete;
+    fdWrapper (fdWrapper&&) = delete;
+    fdWrapper& operator= (fdWrapper&&) = delete;
     ~fdWrapper ()
     {
         try {

--- a/services/vios/src/framework/utilities/async_http_client.h
+++ b/services/vios/src/framework/utilities/async_http_client.h
@@ -101,6 +101,8 @@ private:
         std::string m_responseBody;
         char m_errorBuffer[CURL_ERROR_SIZE]{};
 
+        RequestContext() = default;
+
         ~RequestContext()
         {
             if (m_headerList != nullptr)
@@ -108,6 +110,11 @@ private:
                 curl_slist_free_all(m_headerList);
             }
         }
+
+        RequestContext(const RequestContext&) = delete;
+        RequestContext& operator=(const RequestContext&) = delete;
+        RequestContext(RequestContext&&) = delete;
+        RequestContext& operator=(RequestContext&&) = delete;
     };
 
     using Clock = std::chrono::steady_clock;

--- a/services/vios/src/framework/utilities/cmdline_parser.cpp
+++ b/services/vios/src/framework/utilities/cmdline_parser.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,17 +26,12 @@
 using namespace std;
 using namespace nv_vms;
 
-/* Null, because instance will be initialized on demand. */
-CmdLineParser* CmdLineParser::m_instance = 0;
-
 CmdLineParser* CmdLineParser::getInstance()
 {
-    if (m_instance == 0)
-    {
-        m_instance = new CmdLineParser();
-    }
+    /* Instance is initialized on demand and destroyed at exit. */
+    static CmdLineParser instance;
 
-    return m_instance;
+    return &instance;
 }
 
 static void

--- a/services/vios/src/framework/utilities/cmdline_parser.h
+++ b/services/vios/src/framework/utilities/cmdline_parser.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,8 +29,6 @@ namespace nv_vms {
 class CmdLineParser
 {
     private:
-        /* Here will be the instance stored. */
-        static CmdLineParser* m_instance;
         std::string m_adaptorConfigFilePath;
         std::string m_vmsConfigFilePath;
         std::string m_onvifFilePath;
@@ -47,7 +45,7 @@ class CmdLineParser
                          , m_rtspStreamsFilePath(RTSP_STREAMS_FILE)
         {
         }
-        ~CmdLineParser () {}
+        ~CmdLineParser () = default;
 
     public:
         int parseCommandLine (int argc, char *argv[]);

--- a/services/vios/src/framework/utilities/event_loop.cpp
+++ b/services/vios/src/framework/utilities/event_loop.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,7 +98,7 @@ std::thread::id EventLoop::GetCurrentThreadId()
 void EventLoop::processFunctionWrapper(std::shared_ptr<EventLoopData> userData, void *parent)
 {
     m_isProcessFuncDone = false;
-    std::thread t([&]()
+    std::thread t([this, &userData]()
     {
         if (m_processMsg)
         {

--- a/services/vios/src/framework/utilities/event_loop.h
+++ b/services/vios/src/framework/utilities/event_loop.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +32,7 @@ struct EventLoopOutData
     std::condition_variable m_outDataWait;
     std::shared_ptr<void> m_outData;
     uint32_t m_timeout = 0;
-    virtual ~EventLoopOutData() {}
+    virtual ~EventLoopOutData() = default;
 };
 struct EventLoopData
 {
@@ -42,7 +42,7 @@ struct EventLoopData
     std::atomic<bool> m_error {false};
     std::shared_ptr<EventLoopOutData> m_outResult;
     Json::Value m_inData;
-    virtual ~EventLoopData() {}
+    virtual ~EventLoopData() = default;
 };
 
 struct EventLoopMsg;

--- a/services/vios/src/framework/utilities/fps_display.h
+++ b/services/vios/src/framework/utilities/fps_display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,7 @@ class FPSDisplay
             m_fpsCaptureIntervalSecs = DEFAULT_FPS_CAPTURE_INTERVAL_SEC * 1000 * 1000;
             m_fpsPublishIntervalSecs = DEFAULT_FPS_PUBLISH_INTERVAL_SEC * 1000 * 1000;
         }
-        ~FPSDisplay(){ }
+        ~FPSDisplay() = default;
 
         void       displayFPS           (unsigned long pts_in_ms, string peerId_streamId);
         double     getAvgFPS            () { return m_avgFPS; }

--- a/services/vios/src/framework/utilities/gmainloop_manager.h
+++ b/services/vios/src/framework/utilities/gmainloop_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,11 @@ public:
             g_main_loop_unref(m_loop);
         }
     }
+
+    GMainLoopManager(const GMainLoopManager&) = delete;
+    GMainLoopManager& operator=(const GMainLoopManager&) = delete;
+    GMainLoopManager(GMainLoopManager&&) = delete;
+    GMainLoopManager& operator=(GMainLoopManager&&) = delete;
 
     void run()
     {

--- a/services/vios/src/framework/utilities/logger.cpp
+++ b/services/vios/src/framework/utilities/logger.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,15 +45,11 @@ void Logger::setRedirect(bool flag)
     std::lock_guard<std::mutex> lock(m_LogLock);
     if (flag)
     {
-        m_redirect = new CoutToString(m_stringBuffer.rdbuf());
+        m_redirect = std::make_unique<CoutToString>(m_stringBuffer.rdbuf());
     }
     else
     {
-        if (m_redirect)
-        {
-            delete m_redirect;
-            m_redirect = nullptr;
-        }
+        m_redirect.reset();
     }
 }
 

--- a/services/vios/src/framework/utilities/logger.h
+++ b/services/vios/src/framework/utilities/logger.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <streambuf>
 #include <atomic>
+#include <memory>
 #include <string.h>
 
 #include "utils.h"
@@ -73,6 +74,11 @@ struct CoutToString
         std::cout.rdbuf( old );
     }
 
+    CoutToString( const CoutToString & ) = delete;
+    CoutToString & operator=( const CoutToString & ) = delete;
+    CoutToString( CoutToString && ) = delete;
+    CoutToString & operator=( CoutToString && ) = delete;
+
 private:
     std::streambuf * old;
 };
@@ -92,11 +98,7 @@ class Logger {
 
         ~Logger ()
         {
-            if (m_redirect)
-            {
-                delete m_redirect;
-                m_redirect = nullptr;
-            }
+            m_redirect.reset();
             m_stringBuffer.clear();
             m_fileStream.close ();
             m_qosStream.close();
@@ -114,7 +116,7 @@ class Logger {
         /* here user's file logging preference will be stored */
         bool m_enableFileLog;
 
-        CoutToString *m_redirect;
+        std::unique_ptr<CoutToString> m_redirect;
         std::stringstream m_stringBuffer;
         std::mutex m_LogLock;
 

--- a/services/vios/src/framework/utilities/network_utils.cpp
+++ b/services/vios/src/framework/utilities/network_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,8 +71,12 @@ struct curlData {
 class AutoDestroyXml
 {
 public:
-    AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
+    explicit AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
     ~AutoDestroyXml() { xmlBufferFree(m_xml); }
+    AutoDestroyXml(const AutoDestroyXml&) = delete;
+    AutoDestroyXml& operator=(const AutoDestroyXml&) = delete;
+    AutoDestroyXml(AutoDestroyXml&&) = delete;
+    AutoDestroyXml& operator=(AutoDestroyXml&&) = delete;
 private:
     xmlBufferPtr m_xml;
 };

--- a/services/vios/src/framework/utilities/profiler.h
+++ b/services/vios/src/framework/utilities/profiler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,6 +78,10 @@ public:
         }
         caller = std::string("\"") + caller_ + std::string("\"");
     }
+    MeasureExecutionTime(const MeasureExecutionTime&) = delete;
+    MeasureExecutionTime& operator=(const MeasureExecutionTime&) = delete;
+    MeasureExecutionTime(MeasureExecutionTime&&) = delete;
+    MeasureExecutionTime& operator=(MeasureExecutionTime&&) = delete;
     ~MeasureExecutionTime()
     {
         const auto duration=std::chrono::steady_clock::now() - begin;

--- a/services/vios/src/framework/utilities/signal_handler.h
+++ b/services/vios/src/framework/utilities/signal_handler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <cstdlib>
 #include <cxxabi.h>
+#include <memory>
 #include "logger.h"
 
 // Initialize the static member variable
@@ -29,7 +30,7 @@ struct sigaction sigact;
 class SignalHandler
 {
 public:
-    SignalHandler() {}
+    SignalHandler() = default;
     SignalHandler(void (*handler)(int))
     {
         signal(SIGINT, handler);
@@ -65,6 +66,13 @@ private:
         // Do any cleaning up chores here
     }
 
+    // deleter for buffers handed back by backtrace_symbols()/__cxa_demangle(),
+    // whose contract mandates release through std::free()
+    struct CFree
+    {
+        void operator()(void* ptr) const noexcept { std::free(ptr); } // NOSONAR - mandated by the C API contract
+    };
+
     static void dumpstack(unsigned int max_frames = 63)
     {
         LOG(error) << "stack trace:" << endl;
@@ -80,12 +88,9 @@ private:
         }
 
         // resolve addresses into strings containing "filename(function+address)",
-        // this array must be free()-ed
-        char** symbollist = backtrace_symbols(addrlist, addrlen);
-
-        // allocate string which will be filled with the demangled function name
-        size_t funcnamesize = 256;
-        char* funcname = (char*)malloc(funcnamesize);
+        // this array is owned by the caller and released by CFree
+        std::unique_ptr<char*, CFree> symbollist_owner(backtrace_symbols(addrlist, addrlen));
+        char** symbollist = symbollist_owner.get();
 
         // iterate over the returned symbol lines. skip the first, it is the
         // address of this function.
@@ -118,11 +123,10 @@ private:
                 // offset in [begin_offset, end_offset). now apply
                 // __cxa_demangle():
                 int status;
-                char* ret = abi::__cxa_demangle(begin_name, funcname, &funcnamesize, &status);
+                std::unique_ptr<char, CFree> funcname(abi::__cxa_demangle(begin_name, nullptr, nullptr, &status));
                 if (status == 0)
                 {
-                    funcname = ret;
-                    LOG(error) << symbollist[i] << " : " << funcname << "+" << begin_offset << endl;
+                    LOG(error) << symbollist[i] << " : " << funcname.get() << "+" << begin_offset << endl;
                 }
                 else
                 {
@@ -136,8 +140,6 @@ private:
                 LOG(error) << " " << symbollist[i] << endl;
             }
         }
-        free(funcname);
-        free(symbollist);
         return;
     }
 

--- a/services/vios/src/framework/utilities/stats.h
+++ b/services/vios/src/framework/utilities/stats.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,10 +33,7 @@ struct LatencyStats
                     , m_maxLatency(0)
     {
     }
-    ~LatencyStats()
-    {
-
-    }
+    ~LatencyStats() = default;
     void clear()
     {
         m_totalFrames = 0;
@@ -53,8 +50,8 @@ struct LatencyStats
 class CodecStats : public LatencyStats
 {
     public:
-        CodecStats() {}
-        ~CodecStats() {}
+        CodecStats() = default;
+        ~CodecStats() = default;
         void startProcessing();
         void finishProcessing();
         void clearQueue();
@@ -174,6 +171,6 @@ class Stats
         std::mutex                                       m_timeStampQueueMutex;
 
         /* Private constructor to prevent instancing. */
-        Stats () {}
-        ~Stats () {}
+        Stats () = default;
+        ~Stats () = default;
 };

--- a/services/vios/src/framework/utilities/utils.cpp
+++ b/services/vios/src/framework/utilities/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,6 +55,7 @@
 #include <ifaddrs.h>
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <regex>
 
 #include<boost/algorithm/string.hpp>
@@ -1724,14 +1725,13 @@ Json::Value stringToJson(string in)
 {
     Json::Value out;
     Json::CharReaderBuilder builder;
-    Json::CharReader* reader = builder.newCharReader();
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
     std::string errors;
 
     reader->parse(in.c_str(),
                 in.c_str() + in.size(),
                 &out,
                 &errors);
-    delete reader;
     return out;
 }
 

--- a/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
+++ b/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -440,7 +440,8 @@ PeerConnection::PeerConnection(PeerConnectionManager* peerConnectionManager,
     m_workerThread->Start();
 
     m_workerThread->BlockingCall([this] {
-        m_audioDeviceModule = new webrtc::FakeAudioDeviceModule();
+        m_fakeAudioDeviceModule = std::make_unique<webrtc::FakeAudioDeviceModule>();
+        m_audioDeviceModule = m_fakeAudioDeviceModule.get();
     });
 
     m_signalingThread->SetName("signaling_" + peerid, nullptr);
@@ -516,9 +517,8 @@ PeerConnection::~PeerConnection()
     m_pc = nullptr;
     m_peer_connection_factory = nullptr;
     m_workerThread->BlockingCall([this] {
-        auto* fakeAdm = static_cast<webrtc::FakeAudioDeviceModule*>(m_audioDeviceModule.get());
         m_audioDeviceModule = nullptr;
-        delete fakeAdm;
+        m_fakeAudioDeviceModule.reset();
     });
 }
 
@@ -1332,7 +1332,7 @@ PeerConnection::call(const Json::Value& req_info, const Json::Value &in, Json::V
         rtcoptions.offer_to_receive_audio = 1;
         std::promise<const webrtc::SessionDescriptionInterface *> localpromise;
         std::string sdp;
-        m_pc->CreateAnswer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp), rtcoptions);
+        m_pc->CreateAnswer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp).get(), rtcoptions);
 
         // waiting for answer
         std::future<const webrtc::SessionDescriptionInterface *> localfuture = localpromise.get_future();
@@ -2486,7 +2486,7 @@ VmsErrorCode PeerConnection::createOffer(const Json::Value& in, Json::Value &off
     std::promise<const webrtc::SessionDescriptionInterface *> localpromise;
     std::string sdp;
 
-    m_pc->CreateOffer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp), rtcoptions);
+    m_pc->CreateOffer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp).get(), rtcoptions);
 
     std::future<const webrtc::SessionDescriptionInterface *> localfuture = localpromise.get_future();
     if (localfuture.wait_for(std::chrono::milliseconds(5000)) == std::future_status::ready)
@@ -2955,7 +2955,7 @@ VmsErrorCode PeerConnection::getAnswer(const Json::Value& in, Json::Value& answe
     rtcoptions.offer_to_receive_audio = 1;
     std::promise<const webrtc::SessionDescriptionInterface *> localpromise;
     std::string sdp;
-    m_pc->CreateAnswer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp), rtcoptions);
+    m_pc->CreateAnswer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp).get(), rtcoptions);
 
     // waiting for answer
     std::future<const webrtc::SessionDescriptionInterface *> localfuture = localpromise.get_future();

--- a/services/vios/src/framework/webrtc_streamer/PeerConnectionManager.cpp
+++ b/services/vios/src/framework/webrtc_streamer/PeerConnectionManager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <utility>
 #include <functional>
+#include <memory>
 #include <math.h>
 
 #include "rtc_base/logging.h"
@@ -132,14 +133,14 @@ extern "C" void* createPeerConnectionManagerObject()
 {
     std::string publishFilter(".*");
     webrtc::AudioDeviceModule::AudioLayer audioLayer = webrtc::AudioDeviceModule::kPlatformDefaultAudio;
-    return static_cast<void*>(static_cast<IVstModule*>(
-        new PeerConnectionManager("", audioLayer, publishFilter, ModuleLoader::getInstance()->getDeviceManagerObject())));
+    auto pcm = std::make_unique<PeerConnectionManager>(
+        "", audioLayer, publishFilter, ModuleLoader::getInstance()->getDeviceManagerObject());
+    return static_cast<void*>(static_cast<IVstModule*>(pcm.release()));
 }
 
 extern "C" void deletePeerConnectionManagerObject(IVstModule* object)
 {
-    PeerConnectionManager* pcm = static_cast<PeerConnectionManager*>(object);
-    delete pcm;
+    const std::unique_ptr<PeerConnectionManager> pcm(static_cast<PeerConnectionManager*>(object));
 }
 
 // character to remove from url to make webrtc label
@@ -664,7 +665,8 @@ PeerConnectionManager::PeerConnectionManager(std::string pcType,
 #ifdef HAVE_SOUND
       m_audioDeviceModule(webrtc::AudioDeviceModule::Create(audioLayer, m_taskQueueFactory.get())),
 #else
-      m_audioDeviceModule(new webrtc::FakeAudioDeviceModule()),
+      m_fakeAudioDeviceModule(std::make_unique<webrtc::FakeAudioDeviceModule>()),
+      m_audioDeviceModule(m_fakeAudioDeviceModule.get()),
 #endif
       m_publishFilter(publishFilter), m_deviceManager(deviceManager)
 #ifdef ASYNC_API
@@ -705,13 +707,7 @@ PeerConnectionManager::~PeerConnectionManager()
     {
         m_peerConnMonitoringThread.join();
     }
-#ifdef HAVE_SOUND
     m_audioDeviceModule = nullptr;
-#else
-    auto* fakeAdm = static_cast<webrtc::FakeAudioDeviceModule*>(m_audioDeviceModule.get());
-    m_audioDeviceModule = nullptr;
-    delete fakeAdm;
-#endif
     webrtc::CleanupSSL();
 }
 
@@ -929,7 +925,7 @@ VmsErrorCode PeerConnectionManager::createOffer(unordered_map<string, string> ur
         rtcoptions.offer_to_receive_audio = 0;
         std::promise<const webrtc::SessionDescriptionInterface *> promise;
         std::string sdp;
-        rtcPeerConnection->CreateOffer(vst_webrtc::CreateSessionDescriptionObserver::Create(rtcPeerConnection.get(), promise, sdp), rtcoptions);
+        rtcPeerConnection->CreateOffer(vst_webrtc::CreateSessionDescriptionObserver::Create(rtcPeerConnection.get(), promise, sdp).get(), rtcoptions);
 
         // waiting for offer
         std::future<const webrtc::SessionDescriptionInterface *> future = promise.get_future();

--- a/services/vios/src/framework/webrtc_streamer/fileaudiocapturer.cpp
+++ b/services/vios/src/framework/webrtc_streamer/fileaudiocapturer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,5 @@ FileAudioSource::FileAudioSource(webrtc::scoped_refptr<webrtc::AudioDecoderFacto
 	LOG(info) << "FileAudioSource " << uri ;					
 }
 
-FileAudioSource::~FileAudioSource()  { 
-}
+FileAudioSource::~FileAudioSource() = default;
 #endif

--- a/services/vios/src/framework/webrtc_streamer/hlsmanager.cpp
+++ b/services/vios/src/framework/webrtc_streamer/hlsmanager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -70,13 +70,7 @@ HLSManager::HLSManager() : m_eventLoop("hls_event_loop", process_hls_message)
 HLSManager::~HLSManager()
 {
     LOG(info) << "Destroy HLS stream map" << endl;
-    std::map<std::string, RTSPVideoCapturer*>::iterator it;
-    for (it = m_streamMap.begin();  it != m_streamMap.end();)
-    {
-        std::map<std::string, RTSPVideoCapturer*>::iterator it_del = it;
-        delete it_del->second;
-        it = m_streamMap.erase(it_del);
-    }
+    m_streamMap.clear();
 }
 
 void HLSManager::start()
@@ -130,14 +124,14 @@ VmsErrorCode HLSManager::start(std::map<std::string, std::string, std::less<>> o
     RTSPVideoCapturer* capture = nullptr;
     {
         std::lock_guard<std::mutex> peerlock(m_streamLock);
-        std::map<std::string, RTSPVideoCapturer*>::iterator it = m_streamMap.find(peerid);
+        auto it = m_streamMap.find(peerid);
         if(it == m_streamMap.end())
         {
             capture = RTSPVideoCapturer::Create(out_url, opts);
             if (capture)
             {
                 url_path = capture->getUrlsPath();
-                m_streamMap[peerid] = capture;
+                m_streamMap[peerid] = std::unique_ptr<RTSPVideoCapturer>(capture);
             }
         }
         else
@@ -167,10 +161,9 @@ VmsErrorCode HLSManager::start(std::map<std::string, std::string, std::less<>> o
         if (capture)
         {
             std::lock_guard<std::mutex> peerlock(m_streamLock);
-            std::map<std::string, RTSPVideoCapturer*>::iterator it = m_streamMap.find(peerid);
+            auto it = m_streamMap.find(peerid);
             if(it != m_streamMap.end())
             {
-                delete it->second;
                 m_streamMap.erase(it);
             }
         }
@@ -187,10 +180,9 @@ VmsErrorCode HLSManager::stop(const string peerid, Json::Value &response)
 {
     std::lock_guard<std::mutex> peerlock(m_streamLock);
     LOG(info) << "Stoping HLS streamimg " << peerid << endl;
-    std::map<std::string, RTSPVideoCapturer*>::iterator it = m_streamMap.find(peerid);
+    auto it = m_streamMap.find(peerid);
     if(it != m_streamMap.end())
     {
-        delete it->second;
         m_streamMap.erase(it);
     }
     else
@@ -204,7 +196,7 @@ bool HLSManager::checkIfPeerPresent(const string& peerid)
 {
     std::lock_guard<std::mutex> peerlock(m_streamLock);
     bool peer_present = false;
-    std::map<std::string, RTSPVideoCapturer*>::iterator it = m_streamMap.find(peerid);
+    auto it = m_streamMap.find(peerid);
     if(it != m_streamMap.end())
     {
         peer_present = true;

--- a/services/vios/src/framework/webrtc_streamer/inc/IWebrtcConnection.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/IWebrtcConnection.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,8 +24,8 @@
 class IWebrtcConnection
 {
 public:
-    IWebrtcConnection() {}
-    virtual ~IWebrtcConnection() {}
+    IWebrtcConnection() = default;
+    virtual ~IWebrtcConnection() = default;
 
     virtual nv_vms::VmsErrorCode post(const std::string& task_name, const std::string& peerid,
                             Json::Value in, Json::Value req_info, Json::Value& response,

--- a/services/vios/src/framework/webrtc_streamer/inc/VideoFilter.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/VideoFilter.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "pc/video_track_source.h"
+#include "api/make_ref_counted.h"
 template<class T>
 class VideoFilter : public webrtc::VideoTrackSource {
 public:
@@ -35,7 +36,7 @@ public:
 		if (!source) {
 			return nullptr;
 		}
-		return new webrtc::RefCountedObject<VideoFilter>(std::move(source));
+		return webrtc::make_ref_counted<VideoFilter>(std::move(source));
 	}
 
 protected:

--- a/services/vios/src/framework/webrtc_streamer/inc/VideoScaler.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/VideoScaler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,9 +94,7 @@ public:
         }
     }
 
-    virtual ~VideoScaler()
-    {
-    }
+    ~VideoScaler() override = default;
 
     void OnFrame(const webrtc::VideoFrame &frame) override
     {

--- a/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "api/make_ref_counted.h"
 #include "api/peer_connection_interface.h"
 #include "Scheduler.h"
 #include "webrtcstreamproducer.h"
@@ -84,9 +85,9 @@ protected:
 class SetSessionDescriptionObserver : public webrtc::SetSessionDescriptionObserver
 {
     public:
-        static SetSessionDescriptionObserver* Create(webrtc::PeerConnectionInterface* pc, std::promise<const webrtc::SessionDescriptionInterface*> & promise, std::string &sdp)
+        static webrtc::scoped_refptr<SetSessionDescriptionObserver> Create(webrtc::PeerConnectionInterface* pc, std::promise<const webrtc::SessionDescriptionInterface*> & promise, std::string &sdp)
         {
-            return new webrtc::RefCountedObject<SetSessionDescriptionObserver>(pc, promise, sdp);
+            return webrtc::make_ref_counted<SetSessionDescriptionObserver>(pc, promise, sdp);
         }
         virtual void OnSuccess();
         virtual void OnFailure(webrtc::RTCError error);
@@ -102,9 +103,9 @@ class SetSessionDescriptionObserver : public webrtc::SetSessionDescriptionObserv
 class CreateSessionDescriptionObserver : public webrtc::CreateSessionDescriptionObserver
 {
     public:
-        static CreateSessionDescriptionObserver* Create(webrtc::PeerConnectionInterface* pc, std::promise<const webrtc::SessionDescriptionInterface*> & promise, std::string &sdp)
+        static webrtc::scoped_refptr<CreateSessionDescriptionObserver> Create(webrtc::PeerConnectionInterface* pc, std::promise<const webrtc::SessionDescriptionInterface*> & promise, std::string &sdp)
         {
-            return new webrtc::RefCountedObject<CreateSessionDescriptionObserver>(pc,promise, sdp);
+            return webrtc::make_ref_counted<CreateSessionDescriptionObserver>(pc,promise, sdp);
         }
         virtual void OnSuccess(webrtc::SessionDescriptionInterface* desc);
         virtual void OnFailure(webrtc::RTCError error);
@@ -120,7 +121,7 @@ class CreateSessionDescriptionObserver : public webrtc::CreateSessionDescription
 class PeerConnectionStatsCollectorCallback : public webrtc::RTCStatsCollectorCallback
 {
     public:
-        PeerConnectionStatsCollectorCallback() {}
+        PeerConnectionStatsCollectorCallback() = default;
         void clearReport() { m_report.clear(); }
         Json::Value getReport() { return m_report; }
         std::string getTransportID() { return m_transportId; }

--- a/services/vios/src/framework/webrtc_streamer/inc/liveaudiosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/liveaudiosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@
 #include <thread>
 #include <mutex>
 #include <queue>
+#include <vector>
 #include <cctype>
 
 #include "environment.h"
@@ -153,9 +154,9 @@ public:
                 }
 
                 int maxDecodedBufferSize = m_decoder->PacketDuration(buffer, size) * m_channel * sizeof(int16_t);
-                int16_t *decoded = new int16_t[maxDecodedBufferSize];
+                std::vector<int16_t> decoded(maxDecodedBufferSize);
                 webrtc::AudioDecoder::SpeechType speech_type;
-                int decodedBufferSize = m_decoder->Decode(buffer, size, m_freq, maxDecodedBufferSize, decoded, &speech_type);
+                int decodedBufferSize = m_decoder->Decode(buffer, size, m_freq, maxDecodedBufferSize, decoded.data(), &speech_type);
                 LOG(verbose) << "LiveAudioSource::onData size:" << size << " decodedBufferSize:" << decodedBufferSize << " maxDecodedBufferSize: " << maxDecodedBufferSize << " channels: " << m_channel;
                 if (decodedBufferSize > 0)
                 {
@@ -168,10 +169,9 @@ public:
                 {
                     LOG(error) << "LiveAudioSource::onData error:Decode Audio failed";
                 }
-                delete[] decoded;
                 while (m_buffer.size() > segmentLength * m_channel)
                 {
-                    int16_t *outbuffer = new int16_t[segmentLength * m_channel];
+                    std::vector<int16_t> outbuffer(segmentLength * m_channel);
                     for (unsigned int i = 0; i < segmentLength * m_channel; ++i)
                     {
                         uint16_t value = m_buffer.front();
@@ -181,9 +181,8 @@ public:
                     std::lock_guard<std::mutex> lock(m_sink_lock);
                     for (auto *sink : m_sinks)
                     {
-                        sink->OnData(outbuffer, 16, m_freq, m_channel, segmentLength);
+                        sink->OnData(outbuffer.data(), 16, m_freq, m_channel, segmentLength);
                     }
-                    delete[] outbuffer;
                 }
 
                 m_previmagets = sourcets;

--- a/services/vios/src/framework/webrtc_streamer/inc/mkvclient.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/mkvclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +54,11 @@ class MKVClient
 	public:
 		MKVClient(Environment& env, Callback* callback, const char* path, const std::map<std::string,std::string, std::less<>> & opts, int verbosityLevel=1);
 		virtual ~MKVClient() noexcept;
+
+		MKVClient(const MKVClient&) = delete;
+		MKVClient& operator=(const MKVClient&) = delete;
+		MKVClient(MKVClient&&) = delete;
+		MKVClient& operator=(MKVClient&&) = delete;
 
 		void stop() {
 			m_env.stop();

--- a/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -184,6 +184,11 @@ class NvBufWrapper
                 throw std::runtime_error("An exception occurred, error loading the NvBuf libraries");
         }
 
+        NvBufWrapper(const NvBufWrapper&) = delete;
+        NvBufWrapper& operator=(const NvBufWrapper&) = delete;
+        NvBufWrapper(NvBufWrapper&&) = delete;
+        NvBufWrapper& operator=(NvBufWrapper&&) = delete;
+
         ~NvBufWrapper()
         {
             LOG(info) << "Destructor NvBufWrapper::~NvBufWrapper" << endl;
@@ -213,8 +218,10 @@ class NvBufWrapper
             if (m_nvBufferMode == NvBufferModeSoftware || software_mode)
             {
                 is_transformed_needed = true;
-                NvBufSurface *sw_surf   = (NvBufSurface *) calloc (1, sizeof(NvBufSurface));
-                sw_surf->surfaceList    = (NvBufSurfaceParams *) calloc (1, sizeof(NvBufSurfaceParams));
+                NvBufSurface sw_surf_storage = {};
+                NvBufSurfaceParams sw_surf_params = {};
+                NvBufSurface *sw_surf   = &sw_surf_storage;
+                sw_surf->surfaceList    = &sw_surf_params;
 
                 sw_surf->gpuId                                   = g_gpuIndex;
                 sw_surf->batchSize                               = 1;
@@ -274,8 +281,6 @@ class NvBufWrapper
                 int ret = NvBufSurfaceAllocate(&hw_surf, 1, &input_params);
                 if (ret != 0)
                 {
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
                     LOG(error) << "NvBufSurfaceAllocate failed" << endl;
                     ret = -1;
                     return ret;
@@ -284,8 +289,6 @@ class NvBufWrapper
                 ret = NvBufSurfaceCopy (sw_surf, hw_surf);
                 if (ret != 0)
                 {
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
                     NvBufSurfaceDestroy(hw_surf);
                     LOG(error) << "NvBufSurfaceCopy failed" << endl;
                     ret = -1;
@@ -317,8 +320,6 @@ class NvBufWrapper
                     ret = NvBufSurfaceAllocate(&op_surf, 1, &input_params);
                     if (ret != 0)
                     {
-                        free(sw_surf->surfaceList);
-                        free (sw_surf);
                         NvBufSurfaceDestroy(hw_surf);
                         LOG(error) << "NvBufSurfaceAllocate1 failed" << endl;
                         ret = -1;
@@ -335,8 +336,6 @@ class NvBufWrapper
                         if (status < 0)
                         {
                             LOG(error) << "Failed to get surface from fd =" << *fd << endl;
-                            free(sw_surf->surfaceList);
-                            free (sw_surf);
                             NvBufSurfaceDestroy(hw_surf);
                             NvBufSurfaceDestroy(op_surf);
                             ret = -1;
@@ -350,10 +349,9 @@ class NvBufWrapper
                 config_params.cuda_stream  = nullptr;
                 NvBufSurfTransformSetSessionParams (&config_params);
 
-                NvBufSurfTransformRect *src_rect = nullptr, *dst_rect = nullptr;
+                NvBufSurfTransformRect src_rect_storage = {}, dst_rect_storage = {};
+                NvBufSurfTransformRect *src_rect = &src_rect_storage, *dst_rect = &dst_rect_storage;
                 NvBufSurfTransformParams transform_params = {0};
-                src_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-                dst_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
                 src_rect->top                       = 0;
                 src_rect->left                      = 0;
                 src_rect->width                     = sourceWidth;
@@ -372,10 +370,6 @@ class NvBufWrapper
                 if (transform_error != NvBufSurfTransformError_Success)
                 {
                     LOG(error) << "Failed to Transform" << endl;
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
-                    free (dst_rect);
-                    free (src_rect);
                     NvBufSurfaceDestroy(hw_surf);
                     NvBufSurfaceDestroy(op_surf);
                     ret = -1;
@@ -386,10 +380,6 @@ class NvBufWrapper
                     *fd = op_surf->surfaceList->bufferDesc;
                     *ret_transform = is_transformed_needed;
                 }
-                free (src_rect);
-                free (dst_rect);
-                free (sw_surf->surfaceList);
-                free (sw_surf);
                 NvBufSurfaceDestroy(hw_surf);
 #ifdef DUMP_YUV
                 {
@@ -449,8 +439,10 @@ class NvBufWrapper
                 }
                 if (is_transformed_needed)
                 {
-                    NvBufSurfTransformRect *src_rect          = nullptr;
-                    NvBufSurfTransformRect *dst_rect          = nullptr;
+                    NvBufSurfTransformRect src_rect_storage   = {};
+                    NvBufSurfTransformRect dst_rect_storage   = {};
+                    NvBufSurfTransformRect *src_rect          = &src_rect_storage;
+                    NvBufSurfTransformRect *dst_rect          = &dst_rect_storage;
                     NvBufSurfaceCreateParams buf_params       = {0};
                     NvBufSurfTransformParams transform_params = {0};
                     NvBufSurface *op_surf                     = nullptr;
@@ -516,9 +508,6 @@ class NvBufWrapper
                         }
                         ip_surf = (NvBufSurface*)buffer_type.m_inputBuffer;
                     }
-                    src_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-                    dst_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-
                     src_rect->top    = 0;
                     src_rect->left   = 0;
                     src_rect->width  = sourceWidth;
@@ -544,8 +533,6 @@ class NvBufWrapper
                         {
                             LOG(error) << "Failed to destroy surface" << endl;
                         }
-                        free (src_rect);
-                        free (dst_rect);
                         ret = -1;
                         return ret;
                     }
@@ -557,8 +544,6 @@ class NvBufWrapper
                     {
                         *ret_transform = is_transformed_needed;
                     }
-                    free (src_rect);
-                    free (dst_rect);
                 }
                 else
                 {
@@ -1163,8 +1148,10 @@ class NvBufWrapper
             compositeParam.params.composite_blend_filter = NvBufSurfTransformInter_Algo3;
 
             size_t alloc_size = (sizeof(NvBufSurfTransformRect) * list_size);
-            compositeParam.dst_comp_rect = static_cast<NvBufSurfTransformRect*> (malloc(alloc_size));
-            compositeParam.src_comp_rect = static_cast<NvBufSurfTransformRect*> (malloc(alloc_size));
+            auto dst_comp_rect = std::make_unique<NvBufSurfTransformRect[]> (list_size);
+            auto src_comp_rect = std::make_unique<NvBufSurfTransformRect[]> (list_size);
+            compositeParam.dst_comp_rect = dst_comp_rect.get();
+            compositeParam.src_comp_rect = src_comp_rect.get();
 
             // Use safe memory copy with bounds validation
             size_t src_size = sizeof(dstCompRect);
@@ -1172,8 +1159,6 @@ class NvBufWrapper
             {
                 LOG(error) << "Buffer overflow prevented: alloc_size(" << alloc_size 
                           << ") > src_size(" << src_size << ")" << endl;
-                free(compositeParam.dst_comp_rect);
-                free(compositeParam.src_comp_rect);
                 return;  // Early return from void function
             }
             memmove(compositeParam.dst_comp_rect, &dstCompRect[0], alloc_size);
@@ -1261,14 +1246,6 @@ class NvBufWrapper
                 }
 #endif
             NvBufWrapper::getInstance()->destroyFd(blk_surface_fd);
-            if (compositeParam.src_comp_rect)
-            {
-                free(compositeParam.src_comp_rect);
-            }
-            if (compositeParam.dst_comp_rect)
-            {
-                free(compositeParam.dst_comp_rect);
-            }
         }
 
         int getSwNvBufSurface(webrtc::scoped_refptr<webrtc::I420Buffer> buffer, NvBufSurface* sw_surf)

--- a/services/vios/src/framework/webrtc_streamer/inc/nvgstudpvideocapturer.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvgstudpvideocapturer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,8 @@
  */
 
 #pragma once
+#include <memory>
+
 #include "rtc_base/ref_counted_object.h"
 
 #include "nvgstudpvideosource.h"
@@ -28,7 +30,7 @@ class NvGstUDPVideoCapturer : public NvGstUDPVideoSource
 	
 		static NvGstUDPVideoCapturer* Create(const std::string & url, const std::map<std::string, std::string, std::less<>> & opts)
 		{
-			return new NvGstUDPVideoCapturer(url, opts);
+			return std::make_unique<NvGstUDPVideoCapturer>(url, opts).release();
 		}
 		void controlStreamCapturer(const std::string&, const std::string&);
 		void switchStreamCapturer(std::string url, const std::map<std::string, std::string, std::less<>> &opts);

--- a/services/vios/src/framework/webrtc_streamer/inc/nvgstudpvideosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvgstudpvideosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,7 @@ class VideoDataConsumer : public IMediaDataConsumer
         VideoDataConsumer () : IMediaDataConsumer("VideoDataConsumer")
         {
         }
-        ~VideoDataConsumer () {}
+        ~VideoDataConsumer () = default;
         FrameSize qualityToFrameSize(const string& quality)
         {
             FrameSize size;

--- a/services/vios/src/framework/webrtc_streamer/inc/nvgstvideocapturer.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvgstvideocapturer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "mkvclient.h"
 
 #include "nvgstvideosource.h"
@@ -29,7 +31,7 @@ class NvGstVideoCapturer : public NvGstVideoSource
 	
 		static NvGstVideoCapturer* Create(const std::string & url, const std::map<std::string, std::string, std::less<>> & opts)
 		{
-			return new NvGstVideoCapturer(url, opts);
+			return std::make_unique<NvGstVideoCapturer>(url, opts).release();
 		}
 		VmsErrorCode controlStreamCapturer(const std::string&, const std::string&);
 		void startPlayback();

--- a/services/vios/src/framework/webrtc_streamer/inc/rtspvideocapturer.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/rtspvideocapturer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "rtspconnectionclient.h"
 #include "livevideosource.h"
 
@@ -37,7 +39,7 @@ class RTSPVideoCapturer : public LiveVideoSource<RTSPConnection>
 
 		static RTSPVideoCapturer* Create(const std::string & url, const std::map<std::string, std::string, std::less<>> & opts)
 		{
-			return new RTSPVideoCapturer(url, opts);
+			return std::make_unique<RTSPVideoCapturer>(url, opts).release();
 		}
 		
 		void getDecoderStats(LatencyStats& stats);

--- a/services/vios/src/framework/webrtc_streamer/inc/udpclient.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/udpclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,14 +30,6 @@ namespace nv_vms
                      , m_audioFreq(8000)
                      , m_videoCodec("h264")
         {}
-        UdpStream (const UdpStream& obj)
-        {
-            this->m_audioPort = obj.m_audioPort;
-            this->m_videoPort = obj.m_videoPort;
-            this->m_type = obj.m_type;
-            this->m_audioFreq = obj.m_audioFreq;
-            this->m_videoCodec = obj.m_videoCodec;
-        }
         unsigned int m_videoPort;
         unsigned int m_audioPort;
         string m_type;
@@ -56,7 +48,7 @@ namespace nv_vms
             UdpClient(const string& id, UdpStream& stream) : m_id(id)
                                                            , m_udpStream(stream)
             {}
-            virtual ~UdpClient() {}
+            virtual ~UdpClient() = default;
 
             virtual int create() { return -1; };
             virtual int create(int freq) { return -1; };

--- a/services/vios/src/framework/webrtc_streamer/inc/videosinkinfo.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/videosinkinfo.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,8 +25,8 @@
 
 struct DecoderStats : public LatencyStats
 {
-    DecoderStats() {}
-    ~DecoderStats() {}
+    DecoderStats() = default;
+    ~DecoderStats() = default;
     std::queue<int64_t> qTimestamp;
     std::mutex   m_queueLock;
     std::condition_variable  m_qTsCond;

--- a/services/vios/src/framework/webrtc_streamer/inc/webrtcDataChannel.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/webrtcDataChannel.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 #include "datachannellistenerinterface.h"
 #include <thread>
 #include <string>
+#include <memory>
 
 using namespace std;
 
@@ -114,22 +115,31 @@ protected:
 
 class WebrtcDataChannel
 {
+	struct PrivateTag
+	{
+	};
+
 public:
+	explicit WebrtcDataChannel(PrivateTag)
+	{
+		LOG(verbose) << __PRETTY_FUNCTION__ << endl;
+	}
+	~WebrtcDataChannel()
+	{
+		LOG(info) << __PRETTY_FUNCTION__ << endl;
+	}
+
 	static WebrtcDataChannel *getInstance()
 	{
 		if (m_instance == nullptr)
 		{
-			m_instance = new WebrtcDataChannel();
+			m_instance = std::make_unique<WebrtcDataChannel>(PrivateTag{});
 		}
-		return m_instance;
+		return m_instance.get();
 	}
 	static void deleteDataChannelInstance()
 	{
-		if (m_instance != nullptr)
-		{
-			delete m_instance;
-			m_instance = nullptr;
-		}
+		m_instance.reset();
 	}
 
 	void addChannelObserver(std::string clientId, webrtc::scoped_refptr<webrtc::DataChannelInterface> channel);
@@ -142,15 +152,7 @@ public:
 	void deRegisterListener(IDataChannelListener *listener);
 
 private:
-	WebrtcDataChannel()
-	{
-		LOG(verbose) << __PRETTY_FUNCTION__ << endl;
-	}
-	~WebrtcDataChannel()
-	{
-		LOG(info) << __PRETTY_FUNCTION__ << endl;
-	}
-	static WebrtcDataChannel *m_instance;
+	static std::unique_ptr<WebrtcDataChannel> m_instance;
 
 	std::map<std::string, std::shared_ptr<WebrtcDataChannelOberver>> m_channelObserverMap;
 	std::mutex m_channelMapMutex;

--- a/services/vios/src/framework/webrtc_streamer/rtspaudiocapturer.cpp
+++ b/services/vios/src/framework/webrtc_streamer/rtspaudiocapturer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,8 +37,7 @@ RTSPAudioSource::RTSPAudioSource(webrtc::scoped_refptr<webrtc::AudioDecoderFacto
 				: LiveAudioSource(audioDecoderFactory, uri, opts, false) {
 }
 
-RTSPAudioSource::~RTSPAudioSource()  { 
-}
+RTSPAudioSource::~RTSPAudioSource() = default;
 
 
 #endif

--- a/services/vios/src/framework/webrtc_streamer/rtspvideocapturer.cpp
+++ b/services/vios/src/framework/webrtc_streamer/rtspvideocapturer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,9 +36,7 @@ RTSPVideoCapturer::RTSPVideoCapturer(const std::string & uri, const std::map<std
 	LOG(verbose) << "RTSPVideoCapturer " << uri ;
 }
 
-RTSPVideoCapturer::~RTSPVideoCapturer()
-{
-}
+RTSPVideoCapturer::~RTSPVideoCapturer() = default;
 
 void RTSPVideoCapturer::getDecoderStats(LatencyStats& stats)
 {

--- a/services/vios/src/framework/webrtc_streamer/sensordatamanager.cpp
+++ b/services/vios/src/framework/webrtc_streamer/sensordatamanager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -364,9 +364,7 @@ SensorDataManager::SensorDataManager(shared_ptr<SensorManagement> sensorMgmt) : 
 {
 }
 
-SensorDataManager::~SensorDataManager()
-{
-}
+SensorDataManager::~SensorDataManager() = default;
 
 VmsErrorCode SensorDataManager::startStream(std::map<std::string, std::string, std::less<>> opts, Json::Value &response)
 {

--- a/services/vios/src/modules/storage_management/VideoGeneratorTaskManager.cpp
+++ b/services/vios/src/modules/storage_management/VideoGeneratorTaskManager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,9 +27,7 @@
 #include <cctype>
 #include <chrono>
 
-VideoGeneratorTaskManager::VideoGeneratorTaskManager()
-{
-}
+VideoGeneratorTaskManager::VideoGeneratorTaskManager() = default;
 
 VideoGeneratorTaskManager::~VideoGeneratorTaskManager() noexcept
 {

--- a/services/vios/src/modules/storage_management/storage_management.cpp
+++ b/services/vios/src/modules/storage_management/storage_management.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,12 +81,12 @@ bool StorageManagement::m_isStorageCapacityInitialized = false;
 extern "C" void* createStorageManagementObject()
 {
     std::shared_ptr<DeviceManager> deviceManager = ModuleLoader::getInstance()->getDeviceManagerObject();
-    return new StorageManagement(ModuleLoader::getInstance()->getDeviceType(), ModuleLoader::getInstance()->getDeviceId(), deviceManager);
+    return std::make_unique<StorageManagement>(ModuleLoader::getInstance()->getDeviceType(), ModuleLoader::getInstance()->getDeviceId(), deviceManager).release();
 }
 
 extern "C" void deleteStorageManagementObject(StorageManagement* object)
 {
-    delete object;
+    const std::unique_ptr<StorageManagement> storageManagement(object);
 }
 
 StorageManagement::StorageManagement(const string deviceType, const string deviceId, std::shared_ptr<DeviceManager> deviceMngr)
@@ -109,7 +109,7 @@ StorageManagement::StorageManagement(const string deviceType, const string devic
         const uint64_t frequency = config.storage_monitoring_frequency_secs;
         std::chrono::seconds seconds (frequency);
         m_storage = make_unique<Bosma::Scheduler>(AGING_POLICY_THREAD_COUNT);
-        m_storage->interval(seconds, [=]() {
+        m_storage->interval(seconds, [this]() {
             StorageMonitorTask();
         });
         LOG(info) << "Aging policy enabled (enable_aging_policy=" << config.enable_aging_policy << ")" << endl;
@@ -134,7 +134,7 @@ StorageManagement::StorageManagement(const string deviceType, const string devic
 
     std::chrono::seconds prometheus_interval (5);
     m_monitoring = make_unique<Bosma::Scheduler>(1);
-    m_monitoring->interval(prometheus_interval, [=]() {
+    m_monitoring->interval(prometheus_interval, [this]() {
         sendCurrentUsedStorageSizeToPrometheus();
     });
 
@@ -1620,7 +1620,7 @@ VmsErrorCode StorageManagement::getFileListSensorIdBased(const string &sensorId,
                 try
                 {
                     Json::CharReaderBuilder builder;
-                    Json::CharReader* reader = builder.newCharReader();
+                    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
                     Json::Value metadata;
                     string errors;
 
@@ -1630,7 +1630,6 @@ VmsErrorCode StorageManagement::getFileListSensorIdBased(const string &sensorId,
                         &metadata,
                         &errors
                     );
-                    delete reader;
 
                     if (parsingSuccessful && !metadata.isNull())
                     {
@@ -3725,7 +3724,7 @@ VmsErrorCode StorageManagement::listLocalFiles(const Json::Value& req_info, cons
                 try
                 {
                     Json::CharReaderBuilder builder;
-                    Json::CharReader* reader = builder.newCharReader();
+                    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
                     Json::Value metadata;
                     string errors;
 
@@ -3735,7 +3734,6 @@ VmsErrorCode StorageManagement::listLocalFiles(const Json::Value& req_info, cons
                         &metadata,
                         &errors
                     );
-                    delete reader;
 
                     if (parsingSuccessful && !metadata.isNull())
                     {

--- a/services/vios/src/modules/storage_management/storage_management_utils.cpp
+++ b/services/vios/src/modules/storage_management/storage_management_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,6 +151,11 @@ public:
                                    m_destroyFunc(nullptr), m_extractFunc(nullptr),
                                    m_getErrorFunc(nullptr), m_isAvailableFunc(nullptr),
                                    m_instance(nullptr) {}
+
+    DynamicVideoSegmentExtractor(const DynamicVideoSegmentExtractor&) = delete;
+    DynamicVideoSegmentExtractor& operator=(const DynamicVideoSegmentExtractor&) = delete;
+    DynamicVideoSegmentExtractor(DynamicVideoSegmentExtractor&&) = delete;
+    DynamicVideoSegmentExtractor& operator=(DynamicVideoSegmentExtractor&&) = delete;
 
     ~DynamicVideoSegmentExtractor() {
         cleanup();

--- a/services/vios/src/modules/webrtc_live/LivePeerConnection.cpp
+++ b/services/vios/src/modules/webrtc_live/LivePeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,13 +33,13 @@ extern "C" void* createPeerConnectionLiveManagerObject()
     std::shared_ptr<DeviceManager> deviceManager = ModuleLoader::getInstance()->getDeviceManagerObject();
     std::shared_ptr<PeerConnectionManager> pcm = std::make_shared<PeerConnectionManager>("live", audioLayer, publishFilter, deviceManager);
 
-    return static_cast<void*>(static_cast<IVstModule*>(new LivePeerConnection(pcm, deviceManager)));
+    auto pcm_live = std::make_unique<LivePeerConnection>(pcm, deviceManager);
+    return static_cast<void*>(static_cast<IVstModule*>(pcm_live.release()));
 }
 
 extern "C" void deletePeerConnectionLiveManagerObject(IVstModule* object)
 {
-    LivePeerConnection* pcm_live = static_cast<LivePeerConnection*>(object);
-    delete pcm_live;
+    std::unique_ptr<LivePeerConnection> pcm_live(static_cast<LivePeerConnection*>(object));
 }
 
 LivePeerConnection::LivePeerConnection(std::shared_ptr<PeerConnectionManager> peerConnectionManager,

--- a/services/vios/src/modules/webrtc_replay/ReplayPeerConnection.cpp
+++ b/services/vios/src/modules/webrtc_replay/ReplayPeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,13 +32,13 @@ extern "C" void* createPeerConnectionReplayManagerObject()
     std::shared_ptr<DeviceManager> deviceManager = ModuleLoader::getInstance()->getDeviceManagerObject();
     std::shared_ptr<PeerConnectionManager> pcm = std::make_shared<PeerConnectionManager>("replay", audioLayer, publishFilter, deviceManager);
 
-    return static_cast<void*>(static_cast<IVstModule*>(new ReplayPeerConnection(pcm, deviceManager)));
+    auto pcm_live = std::make_unique<ReplayPeerConnection>(pcm, deviceManager);
+    return static_cast<void*>(static_cast<IVstModule*>(pcm_live.release()));
 }
 
 extern "C" void deletePeerConnectionReplayManagerObject(IVstModule* object)
 {
-    ReplayPeerConnection* pcm_live = static_cast<ReplayPeerConnection*>(object);
-    delete pcm_live;
+    std::unique_ptr<ReplayPeerConnection> pcm_live(static_cast<ReplayPeerConnection*>(object));
 }
 
 ReplayPeerConnection::ReplayPeerConnection(std::shared_ptr<PeerConnectionManager> peerConnectionManager,


### PR DESCRIPTION
## Memory & ownership

Manual memory management, C-style allocation, and special member functions -> RAII / smart pointers / rule-of-zero.

Automated SonarQube fixes (HIGH impact severity), one squashed commit per module.

**Rules:** `cpp:S5025`, `cpp:S1231`, `cpp:S3490`, `cpp:S3624`, `cpp:S5019`, `cpp:S1699`, `cpp:S5506`
**Results:** {'fixed': 311, 'failed': 170}
**Commits:** 8

Every module was compiled via `cd services/vios && ./build.sh package module=streamprocessing,sensor` before its commit; a failing module is reverted and its issues marked failed.

> Review **commit-by-commit** - each commit is one module. Use `git diff -w`: some rules cause reindentation that dwarfs the real change.

> Generated by the SonarQube fix agent. Draft until reviewed.