### PR TITLE
feat(agent): add CA-RAG db_query knowledge backend for neo4j/arango/milvus/ES

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config_rag.yml
@@ -203,6 +203,93 @@ functions:
   #       meaning: node_a records are connected to related node_b records.
   # <<< arango_graph reference
 
+  # >>> db_query: reference-only CA-RAG storage query backend (preferred over arango_graph)
+  # Uses NVIDIA context-aware-rag `db_query` via knowledge_retrieval.
+  # Flow: agent LLM authors a native query for the selected db_type → this tool
+  # executes it via CA-RAG (no in-tool NL→query generation).
+  # Install vss-ctx-rag (+ vss-ctx-rag-arango when db_type=arango).
+  # Add carag_db_query to workflow.tool_names and the routing prompt when enabling.
+  #
+  # Select the DB with backend_config.db_type (or CARAG_DB_TYPE):
+  #   neo4j         → Cypher          (default port 7687)
+  #   arango        → AQL             (default port 8529; CA-RAG uses _system DB)
+  #   milvus        → filter expr     (default port 19530)
+  #   elasticsearch → Query DSL JSON  (default port 9200)
+  # Leave db_port empty (quoted "") to use the default for db_type.
+  #
+  # --- Active example (swap schema_description + db_type together) ---
+  # carag_db_query:
+  #   _type: knowledge_retrieval
+  #   backend: db_query
+  #   top_k: 5
+  #   backend_config:
+  #     db_type: ${CARAG_DB_TYPE:-arango}  # neo4j | arango | milvus | elasticsearch
+  #     db_host: ${CARAG_DB_HOST:-127.0.0.1}
+  #     db_port: "${CARAG_DB_PORT:-}"       # empty → default for db_type
+  #     db_user: "${CARAG_DB_USER:-root}"
+  #     db_password: "${CARAG_DB_PASSWORD:-}"
+  #     collection_name: ${CARAG_COLLECTION:-inspection_graph}
+  #     uuid: default
+  #     embedding_enable: false
+  #     # schema_description must match db_type (pick ONE of the examples below).
+  #     schema_description: |
+  #       ArangoDB AQL over collections in _system:
+  #       - inspection_case (case_id)
+  #       - defect (name)
+  #       - image (uri)
+  #       - has_defect edges: inspection_case -> defect
+  #       - has_image edges: inspection_case -> image
+  #       Example:
+  #         FOR c IN inspection_case FILTER c.case_id == @case_id
+  #         FOR v IN 1..1 OUTBOUND c has_image RETURN v.uri
+  #         filters.params: {"case_id": "case_123"}
+  #       Example:
+  #         FOR c IN inspection_case
+  #         FOR d IN 1..1 OUTBOUND c has_defect FILTER d.name == @defect_name
+  #         RETURN c.case_id
+  #         filters.params: {"defect_name": "solder_void"}
+  #
+  # --- Neo4j example (set CARAG_DB_TYPE=neo4j, CARAG_DB_USER=neo4j) ---
+  # # schema_description: |
+  # #   Neo4j Cypher graph:
+  # #   - (:Case {case_id})-[:HAS_IMAGE]->(:Image {uri})
+  # #   - (:Case)-[:HAS_DEFECT]->(:Defect {name})
+  # #   Example:
+  # #     MATCH (c:Case {case_id: $case_id})-[:HAS_IMAGE]->(i:Image)
+  # #     RETURN i.uri
+  # #     filters.params: {"case_id": "case_123"}
+  # #   Example:
+  # #     MATCH (c:Case)-[:HAS_DEFECT]->(d:Defect {name: $defect_name})
+  # #     RETURN c.case_id ORDER BY c.case_id
+  # #     filters.params: {"defect_name": "solder_void"}
+  #
+  # --- Elasticsearch example (set CARAG_DB_TYPE=elasticsearch,
+  # ---   CARAG_COLLECTION=inspection_cases; leave user/password empty) ---
+  # # schema_description: |
+  # #   Elasticsearch index `inspection_cases` documents with fields:
+  # #   - case_id (keyword)
+  # #   - defect_name (keyword)
+  # #   - image_uri (keyword; may be null)
+  # #   Pass an Elasticsearch Query DSL body as `query`.
+  # #   Example (image URI for a case):
+  # #     {"query":{"term":{"case_id":"case_123"}},"_source":["image_uri"]}
+  # #   Example (cases with a defect):
+  # #     {"query":{"term":{"defect_name":"solder_void"}},"_source":["case_id"]}
+  #
+  # --- Milvus example (set CARAG_DB_TYPE=milvus,
+  # ---   CARAG_COLLECTION=inspection_cases; leave user/password empty) ---
+  # # schema_description: |
+  # #   Milvus collection `inspection_cases` with scalar fields:
+  # #   - case_id (string)
+  # #   - defect_name (string)
+  # #   - image_uri (string; may be empty)
+  # #   Pass a Milvus boolean filter expression as `query`.
+  # #   Example (image URI for a case):
+  # #     case_id == "case_123"
+  # #   Example (cases with a defect):
+  # #     defect_name == "solder_void"
+  # <<< db_query reference
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:
@@ -317,6 +404,17 @@ workflow:
       - Skip for operational queries (list/show videos, snapshots, reports).
       - Pass `filters` only when the user names an exact filename; never invent one.
     # <<< frag
+
+    # >>> carag_db_query: enable with functions.carag_db_query + tool_names
+    #   **carag_db_query** - For relationship / structured DB questions over the
+    #   configured store (neo4j / arango / milvus / elasticsearch via db_type).
+    #   - YOU write the native query language for that db_type (Cypher / AQL /
+    #     Milvus filter / ES DSL) using the tool's schema_description.
+    #   - Pass that statement as `query`. Never pass natural language as `query`.
+    #   - Put bind values in `filters.params` ($name for Cypher, @name for AQL).
+    #   - Examples: "What image URI is linked to case_123?",
+    #     "Which inspection cases share the solder_void defect?"
+    # <<< carag_db_query
 
   tool_call_prompt: |
     TOOL CALL RULES:

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config_rag.yml
@@ -263,6 +263,93 @@ functions:
   #       meaning: node_a records are connected to related node_b records.
   # <<< arango_graph reference
 
+  # >>> db_query: reference-only CA-RAG storage query backend (preferred over arango_graph)
+  # Uses NVIDIA context-aware-rag `db_query` via knowledge_retrieval.
+  # Flow: agent LLM authors a native query for the selected db_type → this tool
+  # executes it via CA-RAG (no in-tool NL→query generation).
+  # Install vss-ctx-rag (+ vss-ctx-rag-arango when db_type=arango).
+  # Add carag_db_query to workflow.tool_names and the routing prompt when enabling.
+  #
+  # Select the DB with backend_config.db_type (or CARAG_DB_TYPE):
+  #   neo4j         → Cypher          (default port 7687)
+  #   arango        → AQL             (default port 8529; CA-RAG uses _system DB)
+  #   milvus        → filter expr     (default port 19530)
+  #   elasticsearch → Query DSL JSON  (default port 9200)
+  # Leave db_port empty (quoted "") to use the default for db_type.
+  #
+  # --- Active example (swap schema_description + db_type together) ---
+  # carag_db_query:
+  #   _type: knowledge_retrieval
+  #   backend: db_query
+  #   top_k: 5
+  #   backend_config:
+  #     db_type: ${CARAG_DB_TYPE:-arango}  # neo4j | arango | milvus | elasticsearch
+  #     db_host: ${CARAG_DB_HOST:-127.0.0.1}
+  #     db_port: "${CARAG_DB_PORT:-}"       # empty → default for db_type
+  #     db_user: "${CARAG_DB_USER:-root}"
+  #     db_password: "${CARAG_DB_PASSWORD:-}"
+  #     collection_name: ${CARAG_COLLECTION:-inspection_graph}
+  #     uuid: default
+  #     embedding_enable: false
+  #     # schema_description must match db_type (pick ONE of the examples below).
+  #     schema_description: |
+  #       ArangoDB AQL over collections in _system:
+  #       - inspection_case (case_id)
+  #       - defect (name)
+  #       - image (uri)
+  #       - has_defect edges: inspection_case -> defect
+  #       - has_image edges: inspection_case -> image
+  #       Example:
+  #         FOR c IN inspection_case FILTER c.case_id == @case_id
+  #         FOR v IN 1..1 OUTBOUND c has_image RETURN v.uri
+  #         filters.params: {"case_id": "case_123"}
+  #       Example:
+  #         FOR c IN inspection_case
+  #         FOR d IN 1..1 OUTBOUND c has_defect FILTER d.name == @defect_name
+  #         RETURN c.case_id
+  #         filters.params: {"defect_name": "solder_void"}
+  #
+  # --- Neo4j example (set CARAG_DB_TYPE=neo4j, CARAG_DB_USER=neo4j) ---
+  # # schema_description: |
+  # #   Neo4j Cypher graph:
+  # #   - (:Case {case_id})-[:HAS_IMAGE]->(:Image {uri})
+  # #   - (:Case)-[:HAS_DEFECT]->(:Defect {name})
+  # #   Example:
+  # #     MATCH (c:Case {case_id: $case_id})-[:HAS_IMAGE]->(i:Image)
+  # #     RETURN i.uri
+  # #     filters.params: {"case_id": "case_123"}
+  # #   Example:
+  # #     MATCH (c:Case)-[:HAS_DEFECT]->(d:Defect {name: $defect_name})
+  # #     RETURN c.case_id ORDER BY c.case_id
+  # #     filters.params: {"defect_name": "solder_void"}
+  #
+  # --- Elasticsearch example (set CARAG_DB_TYPE=elasticsearch,
+  # ---   CARAG_COLLECTION=inspection_cases; leave user/password empty) ---
+  # # schema_description: |
+  # #   Elasticsearch index `inspection_cases` documents with fields:
+  # #   - case_id (keyword)
+  # #   - defect_name (keyword)
+  # #   - image_uri (keyword; may be null)
+  # #   Pass an Elasticsearch Query DSL body as `query`.
+  # #   Example (image URI for a case):
+  # #     {"query":{"term":{"case_id":"case_123"}},"_source":["image_uri"]}
+  # #   Example (cases with a defect):
+  # #     {"query":{"term":{"defect_name":"solder_void"}},"_source":["case_id"]}
+  #
+  # --- Milvus example (set CARAG_DB_TYPE=milvus,
+  # ---   CARAG_COLLECTION=inspection_cases; leave user/password empty) ---
+  # # schema_description: |
+  # #   Milvus collection `inspection_cases` with scalar fields:
+  # #   - case_id (string)
+  # #   - defect_name (string)
+  # #   - image_uri (string; may be empty)
+  # #   Pass a Milvus boolean filter expression as `query`.
+  # #   Example (image URI for a case):
+  # #     case_id == "case_123"
+  # #   Example (cases with a defect):
+  # #     defect_name == "solder_void"
+  # <<< db_query reference
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:
@@ -365,6 +452,17 @@ workflow:
       - Skip for operational queries (list/show videos, snapshots, reports).
       - Pass `filters` only when the user names an exact filename; never invent one.
     # <<< frag
+
+    # >>> carag_db_query: enable with functions.carag_db_query + tool_names
+    #   **carag_db_query** - For relationship / structured DB questions over the
+    #   configured store (neo4j / arango / milvus / elasticsearch via db_type).
+    #   - YOU write the native query language for that db_type (Cypher / AQL /
+    #     Milvus filter / ES DSL) using the tool's schema_description.
+    #   - Pass that statement as `query`. Never pass natural language as `query`.
+    #   - Put bind values in `filters.params` ($name for Cypher, @name for AQL).
+    #   - Examples: "What image URI is linked to case_123?",
+    #     "Which inspection cases share the solder_void defect?"
+    # <<< carag_db_query
 
   tool_call_prompt: |
     - ALWAYS include ALL required parameters when calling tools

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config_rag.yml
@@ -203,6 +203,93 @@ functions:
   #       meaning: node_a records are connected to related node_b records.
   # <<< arango_graph reference
 
+  # >>> db_query: reference-only CA-RAG storage query backend (preferred over arango_graph)
+  # Uses NVIDIA context-aware-rag `db_query` via knowledge_retrieval.
+  # Flow: agent LLM authors a native query for the selected db_type → this tool
+  # executes it via CA-RAG (no in-tool NL→query generation).
+  # Install vss-ctx-rag (+ vss-ctx-rag-arango when db_type=arango).
+  # Add carag_db_query to workflow.tool_names and the routing prompt when enabling.
+  #
+  # Select the DB with backend_config.db_type (or CARAG_DB_TYPE):
+  #   neo4j         → Cypher          (default port 7687)
+  #   arango        → AQL             (default port 8529; CA-RAG uses _system DB)
+  #   milvus        → filter expr     (default port 19530)
+  #   elasticsearch → Query DSL JSON  (default port 9200)
+  # Leave db_port empty (quoted "") to use the default for db_type.
+  #
+  # --- Active example (swap schema_description + db_type together) ---
+  # carag_db_query:
+  #   _type: knowledge_retrieval
+  #   backend: db_query
+  #   top_k: 5
+  #   backend_config:
+  #     db_type: ${CARAG_DB_TYPE:-arango}  # neo4j | arango | milvus | elasticsearch
+  #     db_host: ${CARAG_DB_HOST:-127.0.0.1}
+  #     db_port: "${CARAG_DB_PORT:-}"       # empty → default for db_type
+  #     db_user: "${CARAG_DB_USER:-root}"
+  #     db_password: "${CARAG_DB_PASSWORD:-}"
+  #     collection_name: ${CARAG_COLLECTION:-inspection_graph}
+  #     uuid: default
+  #     embedding_enable: false
+  #     # schema_description must match db_type (pick ONE of the examples below).
+  #     schema_description: |
+  #       ArangoDB AQL over collections in _system:
+  #       - inspection_case (case_id)
+  #       - defect (name)
+  #       - image (uri)
+  #       - has_defect edges: inspection_case -> defect
+  #       - has_image edges: inspection_case -> image
+  #       Example:
+  #         FOR c IN inspection_case FILTER c.case_id == @case_id
+  #         FOR v IN 1..1 OUTBOUND c has_image RETURN v.uri
+  #         filters.params: {"case_id": "case_123"}
+  #       Example:
+  #         FOR c IN inspection_case
+  #         FOR d IN 1..1 OUTBOUND c has_defect FILTER d.name == @defect_name
+  #         RETURN c.case_id
+  #         filters.params: {"defect_name": "solder_void"}
+  #
+  # --- Neo4j example (set CARAG_DB_TYPE=neo4j, CARAG_DB_USER=neo4j) ---
+  # # schema_description: |
+  # #   Neo4j Cypher graph:
+  # #   - (:Case {case_id})-[:HAS_IMAGE]->(:Image {uri})
+  # #   - (:Case)-[:HAS_DEFECT]->(:Defect {name})
+  # #   Example:
+  # #     MATCH (c:Case {case_id: $case_id})-[:HAS_IMAGE]->(i:Image)
+  # #     RETURN i.uri
+  # #     filters.params: {"case_id": "case_123"}
+  # #   Example:
+  # #     MATCH (c:Case)-[:HAS_DEFECT]->(d:Defect {name: $defect_name})
+  # #     RETURN c.case_id ORDER BY c.case_id
+  # #     filters.params: {"defect_name": "solder_void"}
+  #
+  # --- Elasticsearch example (set CARAG_DB_TYPE=elasticsearch,
+  # ---   CARAG_COLLECTION=inspection_cases; leave user/password empty) ---
+  # # schema_description: |
+  # #   Elasticsearch index `inspection_cases` documents with fields:
+  # #   - case_id (keyword)
+  # #   - defect_name (keyword)
+  # #   - image_uri (keyword; may be null)
+  # #   Pass an Elasticsearch Query DSL body as `query`.
+  # #   Example (image URI for a case):
+  # #     {"query":{"term":{"case_id":"case_123"}},"_source":["image_uri"]}
+  # #   Example (cases with a defect):
+  # #     {"query":{"term":{"defect_name":"solder_void"}},"_source":["case_id"]}
+  #
+  # --- Milvus example (set CARAG_DB_TYPE=milvus,
+  # ---   CARAG_COLLECTION=inspection_cases; leave user/password empty) ---
+  # # schema_description: |
+  # #   Milvus collection `inspection_cases` with scalar fields:
+  # #   - case_id (string)
+  # #   - defect_name (string)
+  # #   - image_uri (string; may be empty)
+  # #   Pass a Milvus boolean filter expression as `query`.
+  # #   Example (image URI for a case):
+  # #     case_id == "case_123"
+  # #   Example (cases with a defect):
+  # #     defect_name == "solder_void"
+  # <<< db_query reference
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:
@@ -317,6 +404,17 @@ workflow:
       - Skip for operational queries (list/show videos, snapshots, reports).
       - Pass `filters` only when the user names an exact filename; never invent one.
     # <<< frag
+
+    # >>> carag_db_query: enable with functions.carag_db_query + tool_names
+    #   **carag_db_query** - For relationship / structured DB questions over the
+    #   configured store (neo4j / arango / milvus / elasticsearch via db_type).
+    #   - YOU write the native query language for that db_type (Cypher / AQL /
+    #     Milvus filter / ES DSL) using the tool's schema_description.
+    #   - Pass that statement as `query`. Never pass natural language as `query`.
+    #   - Put bind values in `filters.params` ($name for Cypher, @name for AQL).
+    #   - Examples: "What image URI is linked to case_123?",
+    #     "Which inspection cases share the solder_void defect?"
+    # <<< carag_db_query
 
   tool_call_prompt: |
     TOOL CALL RULES:

--- a/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/configs/vss-agent/config_rag.yml
@@ -263,6 +263,93 @@ functions:
   #       meaning: node_a records are connected to related node_b records.
   # <<< arango_graph reference
 
+  # >>> db_query: reference-only CA-RAG storage query backend (preferred over arango_graph)
+  # Uses NVIDIA context-aware-rag `db_query` via knowledge_retrieval.
+  # Flow: agent LLM authors a native query for the selected db_type → this tool
+  # executes it via CA-RAG (no in-tool NL→query generation).
+  # Install vss-ctx-rag (+ vss-ctx-rag-arango when db_type=arango).
+  # Add carag_db_query to workflow.tool_names and the routing prompt when enabling.
+  #
+  # Select the DB with backend_config.db_type (or CARAG_DB_TYPE):
+  #   neo4j         → Cypher          (default port 7687)
+  #   arango        → AQL             (default port 8529; CA-RAG uses _system DB)
+  #   milvus        → filter expr     (default port 19530)
+  #   elasticsearch → Query DSL JSON  (default port 9200)
+  # Leave db_port empty (quoted "") to use the default for db_type.
+  #
+  # --- Active example (swap schema_description + db_type together) ---
+  # carag_db_query:
+  #   _type: knowledge_retrieval
+  #   backend: db_query
+  #   top_k: 5
+  #   backend_config:
+  #     db_type: ${CARAG_DB_TYPE:-arango}  # neo4j | arango | milvus | elasticsearch
+  #     db_host: ${CARAG_DB_HOST:-127.0.0.1}
+  #     db_port: "${CARAG_DB_PORT:-}"       # empty → default for db_type
+  #     db_user: "${CARAG_DB_USER:-root}"
+  #     db_password: "${CARAG_DB_PASSWORD:-}"
+  #     collection_name: ${CARAG_COLLECTION:-inspection_graph}
+  #     uuid: default
+  #     embedding_enable: false
+  #     # schema_description must match db_type (pick ONE of the examples below).
+  #     schema_description: |
+  #       ArangoDB AQL over collections in _system:
+  #       - inspection_case (case_id)
+  #       - defect (name)
+  #       - image (uri)
+  #       - has_defect edges: inspection_case -> defect
+  #       - has_image edges: inspection_case -> image
+  #       Example:
+  #         FOR c IN inspection_case FILTER c.case_id == @case_id
+  #         FOR v IN 1..1 OUTBOUND c has_image RETURN v.uri
+  #         filters.params: {"case_id": "case_123"}
+  #       Example:
+  #         FOR c IN inspection_case
+  #         FOR d IN 1..1 OUTBOUND c has_defect FILTER d.name == @defect_name
+  #         RETURN c.case_id
+  #         filters.params: {"defect_name": "solder_void"}
+  #
+  # --- Neo4j example (set CARAG_DB_TYPE=neo4j, CARAG_DB_USER=neo4j) ---
+  # # schema_description: |
+  # #   Neo4j Cypher graph:
+  # #   - (:Case {case_id})-[:HAS_IMAGE]->(:Image {uri})
+  # #   - (:Case)-[:HAS_DEFECT]->(:Defect {name})
+  # #   Example:
+  # #     MATCH (c:Case {case_id: $case_id})-[:HAS_IMAGE]->(i:Image)
+  # #     RETURN i.uri
+  # #     filters.params: {"case_id": "case_123"}
+  # #   Example:
+  # #     MATCH (c:Case)-[:HAS_DEFECT]->(d:Defect {name: $defect_name})
+  # #     RETURN c.case_id ORDER BY c.case_id
+  # #     filters.params: {"defect_name": "solder_void"}
+  #
+  # --- Elasticsearch example (set CARAG_DB_TYPE=elasticsearch,
+  # ---   CARAG_COLLECTION=inspection_cases; leave user/password empty) ---
+  # # schema_description: |
+  # #   Elasticsearch index `inspection_cases` documents with fields:
+  # #   - case_id (keyword)
+  # #   - defect_name (keyword)
+  # #   - image_uri (keyword; may be null)
+  # #   Pass an Elasticsearch Query DSL body as `query`.
+  # #   Example (image URI for a case):
+  # #     {"query":{"term":{"case_id":"case_123"}},"_source":["image_uri"]}
+  # #   Example (cases with a defect):
+  # #     {"query":{"term":{"defect_name":"solder_void"}},"_source":["case_id"]}
+  #
+  # --- Milvus example (set CARAG_DB_TYPE=milvus,
+  # ---   CARAG_COLLECTION=inspection_cases; leave user/password empty) ---
+  # # schema_description: |
+  # #   Milvus collection `inspection_cases` with scalar fields:
+  # #   - case_id (string)
+  # #   - defect_name (string)
+  # #   - image_uri (string; may be empty)
+  # #   Pass a Milvus boolean filter expression as `query`.
+  # #   Example (image URI for a case):
+  # #     case_id == "case_123"
+  # #   Example (cases with a defect):
+  # #     defect_name == "solder_void"
+  # <<< db_query reference
+
 llms:
   # --- LLM profiles (selected by LLM_MODEL_TYPE) ---
   nim_llm:
@@ -365,6 +452,17 @@ workflow:
       - Skip for operational queries (list/show videos, snapshots, reports).
       - Pass `filters` only when the user names an exact filename; never invent one.
     # <<< frag
+
+    # >>> carag_db_query: enable with functions.carag_db_query + tool_names
+    #   **carag_db_query** - For relationship / structured DB questions over the
+    #   configured store (neo4j / arango / milvus / elasticsearch via db_type).
+    #   - YOU write the native query language for that db_type (Cypher / AQL /
+    #     Milvus filter / ES DSL) using the tool's schema_description.
+    #   - Pass that statement as `query`. Never pass natural language as `query`.
+    #   - Put bind values in `filters.params` ($name for Cypher, @name for AQL).
+    #   - Examples: "What image URI is linked to case_123?",
+    #     "Which inspection cases share the solder_void defect?"
+    # <<< carag_db_query
 
   tool_call_prompt: |
     - ALWAYS include ALL required parameters when calling tools

--- a/services/agent/packages/vss_agents/src/vss_agents/register_knowledge_layers.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/register_knowledge_layers.py
@@ -38,7 +38,9 @@ from vss_core.knowledge import get_retriever
 
 logger = logging.getLogger(__name__)
 
-BackendType = Literal["frag_api", "es_caption", "frag_lib", "llama_index", "langchain", "arango_graph"]
+BackendType = Literal[
+    "frag_api", "es_caption", "frag_lib", "llama_index", "langchain", "arango_graph", "db_query"
+]
 
 SUMMARIZE_SYSTEM_PROMPT = (
     "You are an analyst summarising retrieved knowledge-base excerpts. "
@@ -72,6 +74,8 @@ class KnowledgeRetrievalConfig(FunctionBaseConfig, name="knowledge_retrieval"):
             "(requires the `nvidia-vss[agent,langchain]` extras); "
             "'arango_graph' = in-process LangChain graph QA over ArangoDB "
             "(requires the `nvidia-vss[arango_graph]` extra); "
+            "'db_query' = CA-RAG storage db_query over neo4j/arango/milvus/elasticsearch "
+            "(requires context-aware-rag 3.1.1rc1 / vss-ctx-rag installed in the agent env); "
             "'es_caption' = BM25 over RT-VLM caption store in Elasticsearch."
         ),
     )
@@ -216,7 +220,8 @@ async def knowledge_retrieval(config: KnowledgeRetrievalConfig, builder: Builder
         f"cited source material rather than general knowledge. Returns up to "
         f"{config.top_k} excerpts by default."
     )
-    backend_hint = getattr(retriever.__class__, "tool_description_hint", "") or ""
+    # Prefer instance hint (e.g. db_query appends schema_description) over ClassVar.
+    backend_hint = getattr(retriever, "tool_description_hint", "") or ""
     description = f"{base_description}\n\n{backend_hint}".rstrip()
 
     yield FunctionInfo.create(

--- a/services/agent/packages/vss_core/src/vss_core/knowledge/adapters/db_query.py
+++ b/services/agent/packages/vss_core/src/vss_core/knowledge/adapters/db_query.py
@@ -1,0 +1,459 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CA-RAG ``db_query`` knowledge-retrieval adapter.
+
+Wraps Context-Aware RAG's storage ``db_query`` function
+(https://github.com/NVIDIA/context-aware-rag/tree/3.1.1rc1) so VSS Agent can
+run backend-native queries against neo4j, arango, milvus, or elasticsearch via
+the existing ``knowledge_retrieval`` tool.
+
+Uses CA-RAG's core ``ContextManagerHandler`` + ``db_query`` function only —
+not the optional CA-RAG NAT plugin package.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import field_validator
+from pydantic import model_validator
+
+from vss_core.knowledge.base import BackendAdapter
+from vss_core.knowledge.factory import register_adapter
+from vss_core.knowledge.schema import Chunk
+from vss_core.knowledge.schema import ContentType
+from vss_core.knowledge.schema import RetrievalResult
+
+logger = logging.getLogger(__name__)
+
+DbType = Literal["neo4j", "arango", "milvus", "elasticsearch"]
+
+_CA_RAG_INSTALL_HINT = (
+    "db_query requires context-aware-rag 3.1.1rc1. Install with:\n"
+    '  uv pip install "vss-ctx-rag @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.1rc1"\n'
+    "For ArangoDB also install:\n"
+    '  uv pip install "vss-ctx-rag-arango @ '
+    "git+https://github.com/NVIDIA/context-aware-rag.git@3.1.1rc1"
+    '#subdirectory=packages/vss_ctx_rag_arango"'
+)
+
+_QUERY_LANGUAGE_HINTS: dict[str, str] = {
+    "neo4j": "Cypher",
+    "arango": "AQL",
+    "milvus": "Milvus filter expression (e.g. 'pk > 0')",
+    "elasticsearch": "Elasticsearch Query DSL body (JSON object or JSON string)",
+}
+
+_BIND_PARAM_HINTS: dict[str, str] = {
+    "neo4j": (
+        "Put bind values in `filters.params` and reference them with `$name` in Cypher "
+        '(e.g. query: "MATCH (c:Case {id: $case_id}) RETURN c", '
+        'filters: {"params": {"case_id": "case_123"}}).'
+    ),
+    "arango": (
+        "Put bind values in `filters.params` and reference them with `@name` in AQL "
+        '(e.g. query: "FOR c IN inspection_case FILTER c.case_id == @case_id RETURN c", '
+        'filters: {"params": {"case_id": "case_123"}}).'
+    ),
+    "milvus": (
+        "Pass a Milvus filter expression as `query`. Optional kwargs go in `filters.params` "
+        "(e.g. options supported by the CA-RAG milvus tool)."
+    ),
+    "elasticsearch": (
+        "Pass an Elasticsearch Query DSL object (or JSON string) as `query`. "
+        "Extra search kwargs may go in `filters.params`."
+    ),
+}
+
+_DEFAULT_PORTS: dict[str, str] = {
+    "neo4j": "7687",
+    "arango": "8529",
+    "milvus": "19530",
+    "elasticsearch": "9200",
+}
+
+
+class DbQueryConfig(BaseModel):
+    """Backend config for CA-RAG ``db_query``.
+
+    Select the storage engine with ``db_type``. That choice also determines which
+    native query language the agent must generate for ``query``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    db_type: DbType = Field(
+        default="neo4j",
+        description=(
+            "Storage backend selector for CA-RAG db_query. "
+            "'neo4j' → Cypher; 'arango' → AQL; 'milvus' → filter expression; "
+            "'elasticsearch' → Query DSL JSON. Requires the matching CA-RAG "
+            "storage plugin (arango needs vss-ctx-rag-arango)."
+        ),
+    )
+    db_host: str = Field(default="localhost", description="Database host.")
+    db_port: str = Field(
+        default="",
+        description=(
+            "Database port. When empty, defaults by db_type: "
+            "neo4j=7687, arango=8529, milvus=19530, elasticsearch=9200."
+        ),
+    )
+    db_user: str = Field(default="", description="Database username (empty when unused).")
+    db_password: str = Field(default="", description="Database password (empty when unused).")
+    collection_name: str | None = Field(
+        default=None,
+        description=(
+            "Optional CA-RAG collection/index/graph base name. When omitted, CA-RAG "
+            "derives a default from ``uuid``. For Arango this is the graph base name "
+            "(CA-RAG connects to the `_system` database)."
+        ),
+    )
+    uuid: str = Field(
+        default="default",
+        description="CA-RAG context uuid used for collection namespacing when collection_name is unset.",
+    )
+    schema_description: str = Field(
+        default="",
+        description=(
+            "Schema / query-language hints for the selected db_type, appended to the "
+            "tool description so the agent can author correct native queries."
+        ),
+    )
+    embedding_enable: bool = Field(
+        default=False,
+        description=(
+            "CA-RAG storage tools require an embedding tool at construction time. "
+            "Leave false to use CA-RAG's NullEmbedding (sufficient for query-only use)."
+        ),
+    )
+    embedding_model: str = Field(
+        default="nvidia/llama-3.2-nv-embedqa-1b-v2",
+        description="Embedding model name when embedding_enable=true.",
+    )
+    embedding_base_url: str = Field(
+        default="https://integrate.api.nvidia.com/v1",
+        description="Embedding endpoint base URL when embedding_enable=true.",
+    )
+    embedding_api_key_env: str = Field(
+        default="NVIDIA_API_KEY",
+        description="Env var holding the embedding API key when embedding_enable=true.",
+    )
+
+    @field_validator("db_port", "db_user", "db_password", mode="before")
+    @classmethod
+    def _coerce_optional_str(cls, value: Any) -> str:
+        # YAML/env may yield None or ints (e.g. empty CARAG_DB_USER, port 9200).
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    @model_validator(mode="after")
+    def _apply_default_port(self) -> DbQueryConfig:
+        if not self.db_port:
+            self.db_port = _DEFAULT_PORTS[self.db_type]
+        return self
+
+
+def build_ca_rag_db_query_config(config: DbQueryConfig) -> dict[str, Any]:
+    """Build a minimal CA-RAG ContextManager config with only ``db_query`` enabled."""
+    db_params: dict[str, Any] = {
+        "host": config.db_host,
+        "port": str(config.db_port),
+        "username": config.db_user,
+        "password": config.db_password,
+    }
+    if config.collection_name:
+        db_params["collection_name"] = config.collection_name
+
+    return {
+        "tools": {
+            "nvidia_embedding": {
+                "type": "embedding",
+                "params": {
+                    "enable": config.embedding_enable,
+                    "model": config.embedding_model,
+                    "base_url": config.embedding_base_url,
+                    "api_key": os.environ.get(config.embedding_api_key_env, ""),
+                },
+            },
+            "db": {
+                "type": config.db_type,
+                "params": db_params,
+                "tools": {"embedding": "nvidia_embedding"},
+            },
+        },
+        "functions": {
+            "db_query": {
+                "type": "db_query",
+                "params": {},
+                "tools": {"db": "db"},
+            },
+        },
+        "context_manager": {
+            "functions": ["db_query"],
+            "uuid": config.uuid,
+        },
+    }
+
+
+def _ensure_ca_rag_imports(db_type: DbType) -> None:
+    """Import CA-RAG modules so tool/function registries are populated."""
+    try:
+        import importlib
+
+        importlib.import_module("vss_ctx_rag.functions.storage")
+        importlib.import_module("vss_ctx_rag.tools")
+    except ImportError as exc:
+        raise ImportError(_CA_RAG_INSTALL_HINT) from exc
+
+    if db_type == "arango":
+        try:
+            importlib.import_module("vss_ctx_rag.plugins.arango")
+        except ImportError as exc:
+            raise ImportError(
+                "db_type='arango' requires the vss-ctx-rag-arango plugin.\n" + _CA_RAG_INSTALL_HINT
+            ) from exc
+
+
+def _parse_query(query: str, db_type: DbType) -> str | dict[str, Any]:
+    """Pass through string queries; parse JSON for elasticsearch DSL bodies."""
+    if db_type != "elasticsearch":
+        return query
+    stripped = query.strip()
+    if not stripped.startswith(("{", "[")):
+        return query
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return query
+    if isinstance(parsed, (dict, list)):
+        return parsed  # type: ignore[return-value]
+    return query
+
+
+def _extract_params(filters: dict[str, Any] | None) -> dict[str, Any]:
+    if not filters:
+        return {}
+    params = filters.get("params")
+    if isinstance(params, dict):
+        return params
+    # Allow callers to pass bind params at the top level of filters.
+    return {k: v for k, v in filters.items() if k != "params"}
+
+
+# CA-RAG Milvus query uses output_fields=["*"], which includes dense vectors.
+# Drop them before returning content to the agent (large + unused for filter queries).
+_MILVUS_VECTOR_KEYS = frozenset({"vector", "embedding", "dense_vector"})
+
+
+def _strip_milvus_vectors(value: Any) -> Any:
+    """Remove embedding/vector fields from Milvus query results (recursively)."""
+    if isinstance(value, list):
+        return [_strip_milvus_vectors(item) for item in value]
+    if isinstance(value, dict):
+        cleaned: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in _MILVUS_VECTOR_KEYS:
+                continue
+            if isinstance(key, str) and key.endswith("_vector"):
+                continue
+            cleaned[key] = _strip_milvus_vectors(item)
+        return cleaned
+    return value
+
+
+def _normalise_payload(
+    payload: Any,
+    *,
+    db_type: DbType | None = None,
+) -> tuple[bool, str, dict[str, Any]]:
+    """Return (success, content, metadata) from a CA-RAG db_query response."""
+    if not isinstance(payload, dict):
+        return False, f"Unexpected db_query response type: {type(payload).__name__}", {}
+
+    if "error" in payload and "result" not in payload:
+        return False, str(payload["error"]), {"raw": payload}
+
+    result = payload.get("result", payload)
+    if db_type == "milvus":
+        result = _strip_milvus_vectors(result)
+    try:
+        content = json.dumps(result, default=str, indent=2)
+    except TypeError:
+        content = str(result)
+    # Keep metadata raw without vectors for milvus to avoid huge logs/citations.
+    meta_raw = payload
+    if db_type == "milvus" and isinstance(payload, dict):
+        meta_raw = {**payload, "result": result} if "result" in payload else result
+    return True, content, {"raw": meta_raw}
+
+
+@register_adapter("db_query", config_type=DbQueryConfig)
+class DbQueryAdapter(BackendAdapter):
+    """Execute CA-RAG ``db_query`` against a configured storage backend.
+
+    Natural-language → query translation is the **agent's** job. This adapter
+    only forwards a backend-native query (plus optional bind params) to CA-RAG.
+    """
+
+    def __init__(self, config: DbQueryConfig, handler: Any | None = None) -> None:
+        super().__init__(config)
+        self.collection_name = config.collection_name or ""
+        language = _QUERY_LANGUAGE_HINTS[config.db_type]
+        hint_parts = [
+            "Use this tool for structured / relationship questions over the configured "
+            "database. CA-RAG only executes queries — it does not translate natural language.",
+            f"Configured db_type={config.db_type!r} → YOU must generate valid {language} "
+            "from the user question and pass it as `query`. "
+            "Never pass English/natural language as `query`.",
+            _BIND_PARAM_HINTS[config.db_type],
+            "Read-only queries only.",
+            f"Endpoint: {config.db_host}:{config.db_port}.",
+        ]
+        if config.schema_description.strip():
+            hint_parts.append(
+                "Use this schema when authoring the query:\n" + config.schema_description.strip()
+            )
+        self.tool_description_hint = "\n".join(hint_parts)
+
+        self._handler = handler
+
+        logger.info(
+            "db_query adapter constructed: db_type=%s host=%s:%s uuid=%s",
+            config.db_type,
+            config.db_host,
+            config.db_port,
+            config.uuid,
+        )
+
+    async def _get_handler(self) -> Any:
+        if self._handler is not None:
+            return self._handler
+
+        _ensure_ca_rag_imports(self.config.db_type)
+        from vss_ctx_rag.context_manager.context_manager_handler import ContextManagerHandler
+
+        ca_config = build_ca_rag_db_query_config(self.config)
+        # Avoid ContextManagerHandler.__init__ -> configure() -> asyncio.run(...),
+        # which fails inside NAT's running event loop.
+        handler = ContextManagerHandler.create_minimal(ca_config, process_index=0)
+        await handler.aconfigure(ca_config)
+        self._handler = handler
+        logger.info("db_query CA-RAG handler ready: db_type=%s", self.config.db_type)
+        return handler
+
+    async def retrieve(
+        self,
+        query: str,
+        collection_name: str,
+        top_k: int = 5,
+        filters: dict[str, Any] | None = None,
+    ) -> RetrievalResult:
+        del top_k  # native DB query controls result size; top_k is unused
+        filter_dict = filters if isinstance(filters, dict) else None
+        native_query = _parse_query(query, self.config.db_type)
+        params = _extract_params(filter_dict)
+
+        # Prefer per-call collection override when the backend config left it empty.
+        if collection_name and not self.config.collection_name:
+            # Rebuild is avoided; pass collection hint via params metadata only.
+            params = {**params, "collection_name_hint": collection_name}
+
+        try:
+            handler = await self._get_handler()
+            raw = await handler.call(
+                {
+                    "db_query": {
+                        "query": native_query,
+                        "params": params,
+                    }
+                }
+            )
+        except Exception as exc:
+            logger.exception("db_query retrieve failed")
+            return RetrievalResult(
+                chunks=[],
+                query=query,
+                backend=self.backend_name,
+                success=False,
+                error_message=f"CA-RAG db_query failed: {str(exc)[:200]}",
+            )
+
+        if not isinstance(raw, dict):
+            return RetrievalResult(
+                chunks=[],
+                query=query,
+                backend=self.backend_name,
+                success=False,
+                error_message=f"Unexpected db_query response type: {type(raw).__name__}",
+            )
+
+        if "error" in raw and "db_query" not in raw:
+            return RetrievalResult(
+                chunks=[],
+                query=query,
+                backend=self.backend_name,
+                success=False,
+                error_message=str(raw["error"]),
+            )
+
+        payload = raw.get("db_query", raw)
+        ok, content, metadata = _normalise_payload(payload, db_type=self.config.db_type)
+        if not ok:
+            return RetrievalResult(
+                chunks=[],
+                query=query,
+                backend=self.backend_name,
+                success=False,
+                error_message=content,
+            )
+
+        scope = collection_name or self.collection_name or self.config.db_type
+        chunk = Chunk(
+            chunk_id=f"db_query_{abs(hash(query)) % 10_000_000}",
+            content=content,
+            score=1.0,
+            metadata={
+                "file_name": "db_query",
+                "display_citation": f"[db_query:{self.config.db_type}]",
+                "content_type": ContentType.TEXT,
+                "db_type": self.config.db_type,
+                "collection_name": scope,
+                "source_metadata": metadata,
+            },
+        )
+        return RetrievalResult(
+            chunks=[chunk],
+            query=query,
+            backend=self.backend_name,
+            success=True,
+            total_tokens=len(content.split()),
+            summary=content,
+        )
+
+    async def health_check(self) -> bool:
+        try:
+            await self._get_handler()
+        except Exception:
+            return False
+        return True

--- a/services/agent/packages/vss_core/src/vss_core/knowledge/factory.py
+++ b/services/agent/packages/vss_core/src/vss_core/knowledge/factory.py
@@ -40,6 +40,7 @@ _LAZY_BACKENDS: dict[str, str] = {
     "llama_index": "vss_core.knowledge.adapters.llama_index",
     "langchain": "vss_core.knowledge.adapters.langchain",
     "arango_graph": "vss_core.knowledge.adapters.arango_graph",
+    "db_query": "vss_core.knowledge.adapters.db_query",
 }
 
 

--- a/services/agent/packages/vss_core/tests/unit_test/knowledge_retrieval/test_db_query_adapter.py
+++ b/services/agent/packages/vss_core/tests/unit_test/knowledge_retrieval/test_db_query_adapter.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for vss_core.knowledge.adapters.db_query."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from vss_core.knowledge.adapters.db_query import DbQueryAdapter
+from vss_core.knowledge.adapters.db_query import DbQueryConfig
+from vss_core.knowledge.adapters.db_query import _extract_params
+from vss_core.knowledge.adapters.db_query import _parse_query
+from vss_core.knowledge.adapters.db_query import build_ca_rag_db_query_config
+
+
+class TestDbQueryConfig:
+    def test_defaults(self) -> None:
+        config = DbQueryConfig()
+        assert config.db_type == "neo4j"
+        assert config.db_host == "localhost"
+        assert config.db_port == "7687"  # default port for neo4j
+        assert config.embedding_enable is False
+
+    def test_default_port_follows_db_type(self) -> None:
+        assert DbQueryConfig(db_type="arango").db_port == "8529"
+        assert DbQueryConfig(db_type="milvus").db_port == "19530"
+        assert DbQueryConfig(db_type="elasticsearch").db_port == "9200"
+        assert DbQueryConfig(db_type="arango", db_port="9999").db_port == "9999"
+        assert DbQueryConfig(db_type="arango", db_port=8529).db_port == "8529"  # type: ignore[arg-type]
+
+    def test_rejects_unknown_db_type(self) -> None:
+        with pytest.raises(Exception):
+            DbQueryConfig(db_type="postgres")  # type: ignore[arg-type]
+
+
+class TestBuildCaRagConfig:
+    def test_minimal_neo4j_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NVIDIA_API_KEY", "test-key")
+        config = DbQueryConfig(
+            db_type="neo4j",
+            db_host="graph-db",
+            db_port="7687",
+            db_user="neo4j",
+            db_password="secret",
+            uuid="stream-1",
+        )
+        ca = build_ca_rag_db_query_config(config)
+        assert ca["context_manager"] == {"functions": ["db_query"], "uuid": "stream-1"}
+        assert ca["functions"]["db_query"]["type"] == "db_query"
+        assert ca["tools"]["db"]["type"] == "neo4j"
+        assert ca["tools"]["db"]["params"]["host"] == "graph-db"
+        assert "collection_name" not in ca["tools"]["db"]["params"]
+        assert ca["tools"]["nvidia_embedding"]["params"]["enable"] is False
+        assert ca["tools"]["nvidia_embedding"]["params"]["api_key"] == "test-key"
+
+    def test_collection_name_and_arango(self) -> None:
+        config = DbQueryConfig(
+            db_type="arango",
+            collection_name="example_graphs",
+            embedding_enable=True,
+        )
+        ca = build_ca_rag_db_query_config(config)
+        assert ca["tools"]["db"]["type"] == "arango"
+        assert ca["tools"]["db"]["params"]["collection_name"] == "example_graphs"
+        assert ca["tools"]["nvidia_embedding"]["params"]["enable"] is True
+
+
+class TestParseQueryAndParams:
+    def test_elasticsearch_json_body(self) -> None:
+        body = '{"query": {"match_all": {}}}'
+        parsed = _parse_query(body, "elasticsearch")
+        assert parsed == {"query": {"match_all": {}}}
+
+    def test_non_es_left_as_string(self) -> None:
+        assert _parse_query('{"a": 1}', "neo4j") == '{"a": 1}'
+
+    def test_params_nested_or_flat(self) -> None:
+        assert _extract_params({"params": {"limit": 1}}) == {"limit": 1}
+        assert _extract_params({"limit": 1, "skip": 0}) == {"limit": 1, "skip": 0}
+        assert _extract_params(None) == {}
+
+
+@pytest.mark.asyncio
+async def test_retrieve_success_via_injected_handler() -> None:
+    handler = MagicMock()
+    handler.call = AsyncMock(return_value={"db_query": {"result": [{"n": 42}]}})
+    adapter = DbQueryAdapter(
+        DbQueryConfig(db_type="neo4j", schema_description="Nodes: Person"),
+        handler=handler,
+    )
+    assert "Person" in adapter.tool_description_hint
+    assert "db_type='neo4j'" in adapter.tool_description_hint
+    assert "Cypher" in adapter.tool_description_hint
+    assert "Never pass English" in adapter.tool_description_hint
+
+    result = await adapter.retrieve(
+        query="MATCH (n) RETURN n LIMIT $limit",
+        collection_name="",
+        top_k=5,
+        filters={"params": {"limit": 5}},
+    )
+
+    assert result.success is True
+    assert len(result.chunks) == 1
+    assert "42" in result.chunks[0].content
+    assert result.chunks[0].metadata["db_type"] == "neo4j"
+    handler.call.assert_awaited_once_with(
+        {
+            "db_query": {
+                "query": "MATCH (n) RETURN n LIMIT $limit",
+                "params": {"limit": 5},
+            }
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_surfaces_function_error() -> None:
+    handler = MagicMock()
+    handler.call = AsyncMock(return_value={"db_query": {"error": "bad query"}})
+    adapter = DbQueryAdapter(DbQueryConfig(), handler=handler)
+
+    result = await adapter.retrieve(query="BAD", collection_name="", top_k=1)
+
+    assert result.success is False
+    assert result.error_message == "bad query"
+    assert result.chunks == []
+
+
+@pytest.mark.asyncio
+async def test_retrieve_surfaces_handler_exception() -> None:
+    handler = MagicMock()
+    handler.call = AsyncMock(side_effect=RuntimeError("boom"))
+    adapter = DbQueryAdapter(DbQueryConfig(), handler=handler)
+
+    result = await adapter.retrieve(query="MATCH (n) RETURN n", collection_name="", top_k=1)
+
+    assert result.success is False
+    assert "boom" in (result.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_elasticsearch_query_parsed_to_dict() -> None:
+    handler = MagicMock()
+    handler.call = AsyncMock(return_value={"db_query": {"result": []}})
+    adapter = DbQueryAdapter(DbQueryConfig(db_type="elasticsearch"), handler=handler)
+
+    await adapter.retrieve(
+        query=json.dumps({"query": {"match_all": {}}}),
+        collection_name="events",
+        top_k=3,
+    )
+
+    call_state: dict[str, Any] = handler.call.await_args.args[0]
+    assert call_state["db_query"]["query"] == {"query": {"match_all": {}}}
+
+
+@pytest.mark.asyncio
+async def test_milvus_retrieve_strips_vector_fields() -> None:
+    from vss_core.knowledge.adapters.db_query import _strip_milvus_vectors
+
+    assert _strip_milvus_vectors(
+        [{"case_id": "case_123", "vector": [0.1, 0.2], "embedding": [1.0], "text": "x"}]
+    ) == [{"case_id": "case_123", "text": "x"}]
+
+    handler = MagicMock()
+    handler.call = AsyncMock(
+        return_value={
+            "db_query": {
+                "result": [
+                    {
+                        "case_id": "case_123",
+                        "image_uri": "s3://demo/img.png",
+                        "vector": [0.1] * 8,
+                        "text": "inspection",
+                    }
+                ]
+            }
+        }
+    )
+    adapter = DbQueryAdapter(DbQueryConfig(db_type="milvus"), handler=handler)
+    result = await adapter.retrieve(query='case_id == "case_123"', collection_name="", top_k=1)
+
+    assert result.success is True
+    content = result.chunks[0].content
+    assert "case_123" in content
+    assert "s3://demo/img.png" in content
+    assert "vector" not in content
+    assert "[0.1]" not in content

--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -149,6 +149,12 @@ arango_graph = [
     "langchain-community>=0.3.27",
     "python-arango>=8.2",
 ]
+# CA-RAG db_query (knowledge_retrieval backend=db_query) depends on
+# context-aware-rag 3.1.1rc1. It is not declared as a uv extra here because
+# vss-ctx-rag pins conflict with the agent lock (e.g. python-multipart).
+# Install into the agent image/env the same way LVS does:
+#   uv pip install "vss-ctx-rag @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.1rc1"
+#   uv pip install "vss-ctx-rag-arango @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.1rc1#subdirectory=packages/vss_ctx_rag_arango"
 all = ["nvidia-vss-agents", "nvidia-vss-cli"]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- Add a single `knowledge_retrieval` backend (`backend: db_query` / tool `carag_db_query`) that wraps CA-RAG's built-in `db_query` instead of inventing separate LangChain GraphRAG adapters per database.
- **Why CA-RAG:** context-aware-rag already supports **neo4j, arango, milvus, and elasticsearch** behind one storage `query` API. VSS only needs one adapter + `db_type` selection — no per-DB NAT tool or GraphRAG integration.
- Agent authors the native query language (Cypher / AQL / Milvus filter / ES DSL); the adapter only executes via CA-RAG (no NL→query inside the tool).
- Configs ship as **commented reference** examples for all four DBs under `config_rag.yml` (docker + helm, base + LVS). Enable by uncommenting the function, adding `carag_db_query` to `workflow.tool_names`, and enabling the routing prompt block.

## Justification vs separate adapters
| Approach | Cost |
|---|---|
| Separate adapter per DB (e.g. LangChain `arango_graph` + future neo4j/ES/Milvus) | 4× connection/schema/tool plumbing, divergent behavior |
| **CA-RAG `db_query`** | One backend; swap `db_type` + `schema_description` |

Live smoke (same NL questions → native query → answer) against seeded inspection data — screenshots attached via GitHub (not in the commit):

### ArangoDB (AQL) — `[db_query:arango]`
<img width="1551" height="848" alt="aql_ex" src="https://github.com/user-attachments/assets/7351e85e-155b-4701-9fb4-3cf0bb3e50fd" />

### Neo4j (Cypher) — `[db_query:neo4j]`
<img width="1567" height="861" alt="cypher_ex" src="https://github.com/user-attachments/assets/afe6ee36-049d-4f8e-a92d-edaa7854ca41" />

### Milvus (filter expr) — `[db_query:milvus]`
<img width="1609" height="1008" alt="milvus_ex" src="https://github.com/user-attachments/assets/a905e139-1ed5-4f29-85c8-5b6b47a944e8" />

### Elasticsearch (Query DSL) — `[db_query:elasticsearch]`
<img width="1612" height="1069" alt="es_ex" src="https://github.com/user-attachments/assets/b0606815-64df-4170-b69a-1224416d5fc5" />

## Test plan
- [x] Unit: `pytest packages/vss_core/tests/unit_test/knowledge_retrieval/test_db_query_adapter.py`
- [x] Enable commented `carag_db_query` in `config_rag.yml`; set `CARAG_DB_TYPE` to each of `arango|neo4j|milvus|elasticsearch`
- [x] `nat serve` + `POST /generate` with:
  - "What image URI is linked to case_123?"
  - "Which inspection cases share the solder_void defect?"
- [x] Confirm citations show `[db_query:<db_type>]` and Milvus results omit vector fields