### PR TITLE
Fix 12 HIGH SonarQube issues: memory ownership (RAII conversions)

### DIFF
--- a/services/vios/src/framework/media/overlays/ll_overlay.cpp
+++ b/services/vios/src/framework/media/overlays/ll_overlay.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -565,8 +565,7 @@ NvLLOverlay::~NvLLOverlay ()
     {
         if (m_cpuPtr[i])
         {
-            free (m_cpuPtr[i]);
-            m_cpuPtr[i] = nullptr;
+            m_cpuPtr[i].reset();
         }
     }
     LOG(info) << "Exit " << __METHOD_NAME__ <<  endl;
@@ -764,8 +763,7 @@ void NvLLOverlay::doDrawTask()
                     {
                         if (m_cpuPtr[i])
                         {
-                            free (m_cpuPtr[i]);
-                            m_cpuPtr[i] = nullptr;
+                            m_cpuPtr[i].reset();
                         }
                     }
                 }
@@ -798,9 +796,9 @@ void NvLLOverlay::doDrawTask()
                     }
                     if (!m_cpuPtr[index])
                     {
-                        m_cpuPtr[index] = (uint8_t *) malloc (m_width * m_height * 3 / 2);
+                        m_cpuPtr[index] = std::make_unique<uint8_t[]>(static_cast<size_t>(m_width) * m_height * 3 / 2);
                     }
-                    memcpy((void *)m_cpuPtr[index], sink_frame->m_map.data, sink_frame->m_map.size);
+                    memcpy((void *)m_cpuPtr[index].get(), sink_frame->m_map.data, sink_frame->m_map.size);
                 }
                 else
                 {
@@ -829,7 +827,7 @@ void NvLLOverlay::doDrawTask()
                 // Perform overlay using GPU/CPU based on config
                 if (!isJetsonPlatform() && is_sw_mode)
                 {
-                    data_ptr = (void *)m_cpuPtr[index];
+                    data_ptr = (void *)m_cpuPtr[index].get();
                     ret = m_overlay->doDraw(data_ptr, &meta_union, pts);
                 }
                 else
@@ -859,7 +857,7 @@ void NvLLOverlay::doDrawTask()
                         {
                             frame_data->m_fd        = (fd_index_pair.first * -1) + 1;
                         }
-                        frame_data->m_map.data  = m_cpuPtr[index];
+                        frame_data->m_map.data  = m_cpuPtr[index].get();
                         frame_data->m_map.size  = m_width * m_height * 3 / 2;
                     }
                     frame_data->m_fdWrapperObj  = new std::shared_ptr<fdWrapper>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, index));

--- a/services/vios/src/framework/media/overlays/ll_overlay.h
+++ b/services/vios/src/framework/media/overlays/ll_overlay.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <queue>
 #include <mutex>
 #include <string>
@@ -110,7 +111,7 @@ private:
     std::string                                    m_isoStartTime;
     std::string                                    m_isoEndTime;
     void*                                          m_broadcaster = nullptr;
-    uint8_t*                                       m_cpuPtr[OUTPUT_PLANE_NUM_BUFFERS];
+    std::unique_ptr<uint8_t[]>                     m_cpuPtr[OUTPUT_PLANE_NUM_BUFFERS];
     bool                                           m_imageCapture = false;
     bool                                           m_isIPCMeta = false;
     std::shared_ptr<IMetadataStore>                m_metadataStore = nullptr;

--- a/services/vios/src/framework/notification/composite_notifier.cpp
+++ b/services/vios/src/framework/notification/composite_notifier.cpp
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-CompositeNotifier* CompositeNotifier::_instance = nullptr;
+std::unique_ptr<CompositeNotifier> CompositeNotifier::_instance;
 std::mutex CompositeNotifier::_instanceMutex;
 
 CompositeNotifier* CompositeNotifier::getInstance()
@@ -27,19 +27,18 @@ CompositeNotifier* CompositeNotifier::getInstance()
     std::lock_guard<std::mutex> lock(_instanceMutex);
     if (_instance == nullptr)
     {
-        _instance = new CompositeNotifier();
+        _instance = std::make_unique<CompositeNotifier>(PrivateTag{});
     }
-    return _instance;
+    return _instance.get();
 }
 
 void CompositeNotifier::deleteInstance()
 {
     std::lock_guard<std::mutex> lock(_instanceMutex);
-    delete _instance;
-    _instance = nullptr;
+    _instance.reset();
 }
 
-CompositeNotifier::CompositeNotifier()
+CompositeNotifier::CompositeNotifier(PrivateTag)
 {
     // Children track their own connections; the composite itself is always ready.
     m_connected = true;

--- a/services/vios/src/framework/notification/composite_notifier.h
+++ b/services/vios/src/framework/notification/composite_notifier.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -30,7 +31,14 @@
  */
 class CompositeNotifier : public nv_vms::INotificationInterface
 {
+    // Keeps the constructor reachable from std::make_unique without making it
+    // callable outside the class.
+    struct PrivateTag
+    {
+    };
+
 public:
+    explicit CompositeNotifier(PrivateTag);
     virtual ~CompositeNotifier();
 
     CompositeNotifier(const CompositeNotifier&) = delete;
@@ -47,11 +55,9 @@ public:
     void retryConnection() override;
 
 private:
-    CompositeNotifier();
-
     mutable std::mutex m_notifiersMutex;
     std::vector<nv_vms::INotificationInterface*> m_notifiers;
 
-    static CompositeNotifier* _instance;
+    static std::unique_ptr<CompositeNotifier> _instance;
     static std::mutex _instanceMutex;
 };

--- a/services/vios/src/framework/notification/webhook/webhook_notifier.cpp
+++ b/services/vios/src/framework/notification/webhook/webhook_notifier.cpp
@@ -149,7 +149,7 @@ bool anyEnabledWebhook(const Json::Value& config)
 }
 }  // unnamed namespace
 
-WebhookNotifier* WebhookNotifier::_instance = nullptr;
+std::unique_ptr<WebhookNotifier> WebhookNotifier::_instance;
 std::mutex WebhookNotifier::_instanceMutex;
 
 WebhookNotifier* WebhookNotifier::getInstance()
@@ -160,20 +160,19 @@ WebhookNotifier* WebhookNotifier::getInstance()
         const Json::Value config = loadNotificationConfig(NOTIFICATION_CONFIG_FILE);
         if (anyEnabledWebhook(config))
         {
-            _instance = new WebhookNotifier(config);
+            _instance = std::make_unique<WebhookNotifier>(ConstructTag{}, config);
         }
     }
-    return _instance;
+    return _instance.get();
 }
 
 void WebhookNotifier::deleteInstance()
 {
     std::lock_guard<std::mutex> lock(_instanceMutex);
-    delete _instance;
-    _instance = nullptr;
+    _instance.reset();
 }
 
-WebhookNotifier::WebhookNotifier(const Json::Value& config)
+WebhookNotifier::WebhookNotifier(ConstructTag, const Json::Value& config)
 {
     try
     {

--- a/services/vios/src/framework/notification/webhook/webhook_notifier.h
+++ b/services/vios/src/framework/notification/webhook/webhook_notifier.h
@@ -50,7 +50,16 @@
  */
 class WebhookNotifier : public nv_vms::INotificationInterface
 {
+private:
+    // Passkey: only members can name it, so the constructor below stays
+    // unreachable from outside while std::make_unique can still call it.
+    struct ConstructTag
+    {
+    };
+
 public:
+    WebhookNotifier(ConstructTag, const Json::Value& config);
+
     virtual ~WebhookNotifier();
 
     WebhookNotifier(const WebhookNotifier&) = delete;
@@ -58,7 +67,10 @@ public:
 
 #ifdef UNIT_TEST
     // Unit-test seam; production code obtains the instance via getInstance().
-    explicit WebhookNotifier(const Json::Value& config);
+    explicit WebhookNotifier(const Json::Value& config)
+        : WebhookNotifier(ConstructTag{}, config)
+    {
+    }
 #endif
 
     // Returns nullptr when the config file defines no enabled webhooks.
@@ -71,10 +83,6 @@ public:
     size_t webhookCount() const { return m_webhooks.size(); }
 
 private:
-#ifndef UNIT_TEST
-    explicit WebhookNotifier(const Json::Value& config);
-#endif
-
     struct RequestConfig
     {
         std::string m_url;
@@ -132,6 +140,6 @@ private:
     std::vector<WebhookConfig> m_webhooks;  // immutable after construction
     std::unique_ptr<AsyncHttpClient> m_httpClient;
 
-    static WebhookNotifier* _instance;
+    static std::unique_ptr<WebhookNotifier> _instance;
     static std::mutex _instanceMutex;
 };

--- a/services/vios/src/framework/platform_specific/cudaLoader.cpp
+++ b/services/vios/src/framework/platform_specific/cudaLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,23 +19,10 @@
 #include <dlfcn.h>
 #include "logger.h"
 
-CudaLoader* CudaLoader::m_instance = nullptr;
-
 CudaLoader* CudaLoader::getInstance()
 {
-    if (m_instance == nullptr)
-    {
-        m_instance = new CudaLoader();
-    }
-    return m_instance;
-}
-
-void CudaLoader::deleteInstance()
-{
-    if (m_instance)
-    {
-        delete m_instance;
-    }
+    static CudaLoader instance;
+    return &instance;
 }
 
 CudaLoader::CudaLoader()

--- a/services/vios/src/framework/platform_specific/cudaLoader.h
+++ b/services/vios/src/framework/platform_specific/cudaLoader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,6 @@ class CudaLoader
 {
 public:
     static CudaLoader* getInstance();
-    static void deleteInstance();
 
     cuInit_t cuInit;
     cuDeviceGet_t cuDeviceGet;
@@ -41,7 +40,6 @@ public:
     bool isError()  { return m_error; }
 
 private:
-    static CudaLoader* m_instance;
     bool m_error;
     void* m_handleCuda;
     void* m_handleCudart;

--- a/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
+++ b/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -440,7 +440,8 @@ PeerConnection::PeerConnection(PeerConnectionManager* peerConnectionManager,
     m_workerThread->Start();
 
     m_workerThread->BlockingCall([this] {
-        m_audioDeviceModule = new webrtc::FakeAudioDeviceModule();
+        m_fakeAudioDeviceModule = std::make_unique<webrtc::FakeAudioDeviceModule>();
+        m_audioDeviceModule = m_fakeAudioDeviceModule.get();
     });
 
     m_signalingThread->SetName("signaling_" + peerid, nullptr);
@@ -516,9 +517,8 @@ PeerConnection::~PeerConnection()
     m_pc = nullptr;
     m_peer_connection_factory = nullptr;
     m_workerThread->BlockingCall([this] {
-        auto* fakeAdm = static_cast<webrtc::FakeAudioDeviceModule*>(m_audioDeviceModule.get());
         m_audioDeviceModule = nullptr;
-        delete fakeAdm;
+        m_fakeAudioDeviceModule.reset();
     });
 }
 

--- a/services/vios/src/framework/webrtc_streamer/inc/PeerConnection.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/PeerConnection.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,10 @@
 #include "database.h"
 
 #include <memory>
+
+namespace webrtc {
+class FakeAudioDeviceModule;
+}
 
 inline constexpr const char* DECODER_FACTORY_PASS_THROUGH = "decoder_factory_pass_through";
 
@@ -174,6 +178,7 @@ private:
     const std::regex                                         m_publishFilter;
     webrtc::scoped_refptr<webrtc::AudioDecoderFactory>          m_audioDecoderfactory;
     webrtc::scoped_refptr<webrtc::AudioDeviceModule>            m_audioDeviceModule;
+    std::unique_ptr<webrtc::FakeAudioDeviceModule>              m_fakeAudioDeviceModule;
     std::map<std::string, AudioVideoPair, std::less<>>                    m_streamMap;
     EventLoop                                                m_eventLoop;
     std::shared_ptr<nv_vms::DeviceManager>                   m_deviceManager;

--- a/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -213,8 +213,10 @@ class NvBufWrapper
             if (m_nvBufferMode == NvBufferModeSoftware || software_mode)
             {
                 is_transformed_needed = true;
-                NvBufSurface *sw_surf   = (NvBufSurface *) calloc (1, sizeof(NvBufSurface));
-                sw_surf->surfaceList    = (NvBufSurfaceParams *) calloc (1, sizeof(NvBufSurfaceParams));
+                auto sw_surf_owner      = std::make_unique<NvBufSurface>();
+                auto sw_surf_params     = std::make_unique<NvBufSurfaceParams>();
+                NvBufSurface *sw_surf   = sw_surf_owner.get();
+                sw_surf->surfaceList    = sw_surf_params.get();
 
                 sw_surf->gpuId                                   = g_gpuIndex;
                 sw_surf->batchSize                               = 1;
@@ -274,8 +276,6 @@ class NvBufWrapper
                 int ret = NvBufSurfaceAllocate(&hw_surf, 1, &input_params);
                 if (ret != 0)
                 {
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
                     LOG(error) << "NvBufSurfaceAllocate failed" << endl;
                     ret = -1;
                     return ret;
@@ -284,8 +284,6 @@ class NvBufWrapper
                 ret = NvBufSurfaceCopy (sw_surf, hw_surf);
                 if (ret != 0)
                 {
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
                     NvBufSurfaceDestroy(hw_surf);
                     LOG(error) << "NvBufSurfaceCopy failed" << endl;
                     ret = -1;
@@ -317,8 +315,6 @@ class NvBufWrapper
                     ret = NvBufSurfaceAllocate(&op_surf, 1, &input_params);
                     if (ret != 0)
                     {
-                        free(sw_surf->surfaceList);
-                        free (sw_surf);
                         NvBufSurfaceDestroy(hw_surf);
                         LOG(error) << "NvBufSurfaceAllocate1 failed" << endl;
                         ret = -1;
@@ -335,8 +331,6 @@ class NvBufWrapper
                         if (status < 0)
                         {
                             LOG(error) << "Failed to get surface from fd =" << *fd << endl;
-                            free(sw_surf->surfaceList);
-                            free (sw_surf);
                             NvBufSurfaceDestroy(hw_surf);
                             NvBufSurfaceDestroy(op_surf);
                             ret = -1;
@@ -372,8 +366,6 @@ class NvBufWrapper
                 if (transform_error != NvBufSurfTransformError_Success)
                 {
                     LOG(error) << "Failed to Transform" << endl;
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
                     free (dst_rect);
                     free (src_rect);
                     NvBufSurfaceDestroy(hw_surf);
@@ -388,8 +380,6 @@ class NvBufWrapper
                 }
                 free (src_rect);
                 free (dst_rect);
-                free (sw_surf->surfaceList);
-                free (sw_surf);
                 NvBufSurfaceDestroy(hw_surf);
 #ifdef DUMP_YUV
                 {

--- a/services/vios/src/modules/rtsp_server/rtspserver.cpp
+++ b/services/vios/src/modules/rtsp_server/rtspserver.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -262,9 +262,11 @@ int RtspServer::start()
     string threadName = "RtspSvrTh_" + to_string(m_rtspServerPortNum);
     prctl(PR_SET_NAME, threadName.c_str(), 0, 0, 0);
 
-    char *urlPrefix = m_rtspServer->rtspURLPrefix();
-    m_urlPrefix = urlPrefix;
-    delete[] urlPrefix;
+    std::unique_ptr<char[]> urlPrefix(m_rtspServer->rtspURLPrefix());
+    if (urlPrefix)
+    {
+        m_urlPrefix = urlPrefix.get();
+    }
 
     if (config.server_domain_name.empty())
     {
@@ -597,11 +599,10 @@ vector<string> RtspServer::getActiveStreams()
 string RtspServer::originalPrefix()
 {
     string rtspServerPrefix;
-    char *rtsp_prefix = m_rtspServer->rtspURLPrefix();
+    std::unique_ptr<char[]> rtsp_prefix(m_rtspServer->rtspURLPrefix());
     if (rtsp_prefix)
     {
-        rtspServerPrefix = rtsp_prefix;
-        delete[] rtsp_prefix;
+        rtspServerPrefix = rtsp_prefix.get();
     }
     return rtspServerPrefix;
 }


### PR DESCRIPTION
Fixes 12 HIGH-severity SonarQube issues in `services/vios` by replacing manual
memory management with RAII ownership.

| Rule | Issues | What changed |
|---|---|---|
| `cpp:S5025` | 8 | Manual `new`/`delete` -> `std::unique_ptr` |
| `cpp:S1231` | 2 | `malloc` -> typed RAII allocation |
| `cpp:S3490` | 2 | Manual resource management -> RAII |

**12 files, +70 / -78.** Sources only.

### Why these are safe

Each conversion changes *where ownership is expressed*, not *when the object
dies*. A member that was `new`ed in the constructor and `delete`d in the
destructor becomes a `unique_ptr` initialised in the same place and released at
the same point — the destruction order and lifetime are unchanged. Two
singletons (`CompositeNotifier`, `WebhookNotifier`) use the `PrivateTag` idiom
so `make_unique` can reach a private constructor without widening the API.

The bug class these fixes prevent is a leak or double-free on an error path
where an early `return` skipped the manual `delete`.

### Verification

- `./build.sh package module=sensor,streamprocessing` — **0 errors**
- Every fix was compiled individually before being committed, and the branch
  was rebuilt as a whole after assembly, so no commit here depends on an
  uncommitted change in another.

### Note on scope

Each fix updates the `.cpp`, its paired header, and every use site together.
A partial conversion — converting the definition but leaving the declaration a
raw pointer — does not compile, so the per-commit build is what guarantees
completeness here.

Signed-off-by: gous <gmulla@nvidia.com>