### PR TITLE
Enhanced Spatial AI Data Utils integration

### DIFF
--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -12,7 +12,12 @@ import re
 import sys
 from pathlib import Path
 
-from detect_changed_images import changed_paths, commit_exists, resolve_diff_base
+from detect_changed_images import (
+    changed_paths,
+    commit_exists,
+    paths_changed_under,
+    resolve_diff_base,
+)
 from release_set import load_inventory, validate_release_set
 from update_pr_ghcr_candidates import GitHubApi, download_release_set
 
@@ -22,8 +27,10 @@ DEPLOY_PREFIX = "deploy/"
 # downstream coverage when its source changes -- mirrored and externally pinned
 # components are deployed by the same profiles and break the same evals.
 TRIGGER_FLAG = "trigger_downstream_from_source"
-
-
+SPATIALAI_DATA_UTILS_PATH = "libs/analytics/spatialai-data-utils"
+SPATIALAI_VERSION_SUFFIX_PATTERN = re.compile(
+    r"\.dev[1-9][0-9]*\+t([0-9a-f]{40})\.g([0-9a-f]{12})\.gh\.r[1-9][0-9]*"
+)
 PR_REF_PATTERN = re.compile(r"pull-request/(\d+)")
 
 
@@ -134,6 +141,65 @@ def downstream_variables(release_set: dict) -> dict[str, str]:
     }
 
 
+def downstream_build_type(
+    relevant: bool, spatialai_variables: dict[str, str]
+) -> str:
+    """Choose a lightweight pipeline when SDU reconciliation is the only work."""
+    if spatialai_variables and not relevant:
+        return "spatialai-reconcile"
+    return "ghcr-acceptance"
+
+
+def spatialai_publish_variables(
+    changed: list[str] | None,
+    ref_name: str,
+    version_suffix: str,
+    source_tree_sha: str,
+    source_commit_sha: str,
+    requested: str = "",
+) -> dict[str, str]:
+    """Return the internal publish/reconciliation handoff for SDU.
+
+    PRs validate and build the package in GitHub but never request publication.
+    Every develop run asks internal CI to reconcile the current content-addressed
+    tree with URM. This lets a later merge recover a handoff that was interrupted
+    after an earlier SDU merge. An unavailable diff fails open for the immediate
+    publish decision, matching the GitHub test gate.
+    """
+    if requested not in {"", "true", "false"}:
+        raise ValueError("Spatial AI publish handoff must be true or false")
+    publish = (
+        requested == "true"
+        if requested
+        else ref_name == "develop"
+        and paths_changed_under(changed, SPATIALAI_DATA_UTILS_PATH)
+    )
+    if ref_name != "develop":
+        if publish:
+            raise ValueError("Spatial AI publish handoff is valid only for develop")
+        return {}
+    if not re.fullmatch(r"[0-9a-f]{40}", source_tree_sha):
+        raise ValueError("Spatial AI publish requires a full source tree SHA")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_commit_sha):
+        raise ValueError("Spatial AI publish requires a full source commit SHA")
+    suffix_match = SPATIALAI_VERSION_SUFFIX_PATTERN.fullmatch(version_suffix)
+    if not suffix_match:
+        raise ValueError(
+            "Spatial AI publish requires a GitHub-generated version suffix "
+            "like .dev123+t<40-hex-tree-sha>.gabcdef012345.gh.r1"
+        )
+    if suffix_match.group(1) != source_tree_sha:
+        raise ValueError("Spatial AI version suffix does not identify its source tree")
+    if suffix_match.group(2) != source_commit_sha[:12]:
+        raise ValueError("Spatial AI version suffix does not identify its source commit")
+    return {
+        "SPATIALAI_DATA_UTILS_PUBLISH": "true" if publish else "false",
+        "SPATIALAI_DATA_UTILS_RECONCILE": "true",
+        "SPATIALAI_SOURCE_TREE_SHA": source_tree_sha,
+        "SPATIALAI_PACKAGE_VERSION_SUFFIX": version_suffix,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
@@ -145,6 +211,18 @@ def main() -> int:
     parser.add_argument("--interval-seconds", type=int, default=15)
     parser.add_argument("--release-set", type=Path)
     parser.add_argument("--release-set-output", type=Path)
+    parser.add_argument(
+        "--spatialai-package-version-suffix",
+        default=os.environ.get("SPATIALAI_PACKAGE_VERSION_SUFFIX", ""),
+    )
+    parser.add_argument(
+        "--publish-spatialai-data-utils",
+        default=os.environ.get("SPATIALAI_DATA_UTILS_PUBLISH", ""),
+    )
+    parser.add_argument(
+        "--spatialai-data-utils-tree-sha",
+        default=os.environ.get("SPATIALAI_SOURCE_TREE_SHA", ""),
+    )
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN", "").strip()
@@ -184,11 +262,6 @@ def main() -> int:
             json.dumps(release_set, indent=2, sort_keys=True) + "\n"
         )
 
-    variables = downstream_variables(release_set)
-    with Path(github_env).open("a") as output:
-        output.write("DOWNSTREAM_EXTRA_VARIABLES_JSON<<EOF\n")
-        output.write(json.dumps(variables, separators=(",", ":")) + "\n")
-        output.write("EOF\n")
     has_builds = has_ghcr_build_entries(release_set)
 
     if PR_REF_PATTERN.fullmatch(args.ref_name):
@@ -208,18 +281,51 @@ def main() -> int:
     relevant, gate_reason = downstream_relevant(
         changed, load_inventory(args.repo_root)
     )
+    publish_variables = spatialai_publish_variables(
+        changed,
+        args.ref_name,
+        args.spatialai_package_version_suffix,
+        args.spatialai_data_utils_tree_sha,
+        args.sha,
+        args.publish_spatialai_data_utils,
+    )
+    run_downstream = relevant or bool(publish_variables)
+
+    variables = downstream_variables(release_set)
+    variables.update(publish_variables)
+    variables["BUILD_TYPE"] = downstream_build_type(relevant, publish_variables)
+    with Path(github_env).open("a") as output:
+        output.write("DOWNSTREAM_EXTRA_VARIABLES_JSON<<EOF\n")
+        output.write(json.dumps(variables, separators=(",", ":")) + "\n")
+        output.write("EOF\n")
 
     if github_output:
         with Path(github_output).open("a") as output:
             output.write(
                 f"has_ghcr_build_entries={'true' if has_builds else 'false'}\n"
             )
-            output.write(f"run_downstream={'true' if relevant else 'false'}\n")
+            output.write(f"run_downstream={'true' if run_downstream else 'false'}\n")
+            output.write(
+                "publish_spatialai_data_utils="
+                f"{publish_variables.get('SPATIALAI_DATA_UTILS_PUBLISH', 'false')}\n"
+            )
+            output.write(
+                "spatialai_package_version_suffix="
+                f"{args.spatialai_package_version_suffix if publish_variables else ''}\n"
+            )
+            output.write(
+                "spatialai_data_utils_tree_sha="
+                f"{args.spatialai_data_utils_tree_sha if publish_variables else ''}\n"
+            )
+    if publish_variables.get("SPATIALAI_DATA_UTILS_PUBLISH") == "true":
+        gate_reason += "; merged Spatial AI Data Utils change requests URM publish"
+    elif publish_variables:
+        gate_reason += "; develop run reconciles Spatial AI Data Utils with URM"
     print(
         f"Prepared release set {release_set['release_set_id']} "
         f"for downstream acceptance ({len(release_set['images'])} images, "
         f"GHCR builds: {'yes' if has_builds else 'no'}).\n"
-        f"Downstream gate: {'run' if relevant else 'skip'} "
+        f"Downstream gate: {'run' if run_downstream else 'skip'} "
         f"-- {gate_reason} (base: {base_reason})."
     )
     return 0

--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -223,6 +223,10 @@ def main() -> int:
         "--spatialai-data-utils-tree-sha",
         default=os.environ.get("SPATIALAI_SOURCE_TREE_SHA", ""),
     )
+    parser.add_argument(
+        "--build-type",
+        default=os.environ.get("DOWNSTREAM_BUILD_TYPE", ""),
+    )
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN", "").strip()
@@ -293,7 +297,18 @@ def main() -> int:
 
     variables = downstream_variables(release_set)
     variables.update(publish_variables)
-    variables["BUILD_TYPE"] = downstream_build_type(relevant, publish_variables)
+    # The trigger job unpacks a source archive without `.git`, so it cannot
+    # recompute the gate. It replays the build type decided by the job that
+    # still had the diff instead.
+    build_type = args.build_type or downstream_build_type(
+        relevant, publish_variables
+    )
+    if build_type not in {"ghcr-acceptance", "spatialai-reconcile"}:
+        raise ValueError(
+            "Downstream build type must be ghcr-acceptance or "
+            "spatialai-reconcile"
+        )
+    variables["BUILD_TYPE"] = build_type
     with Path(github_env).open("a") as output:
         output.write("DOWNSTREAM_EXTRA_VARIABLES_JSON<<EOF\n")
         output.write(json.dumps(variables, separators=(",", ":")) + "\n")
@@ -305,6 +320,7 @@ def main() -> int:
                 f"has_ghcr_build_entries={'true' if has_builds else 'false'}\n"
             )
             output.write(f"run_downstream={'true' if run_downstream else 'false'}\n")
+            output.write(f"build_type={variables['BUILD_TYPE']}\n")
             output.write(
                 "publish_spatialai_data_utils="
                 f"{publish_variables.get('SPATIALAI_DATA_UTILS_PUBLISH', 'false')}\n"

--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from detect_changed_images import (
     changed_paths,
     commit_exists,
-    paths_changed_under,
     resolve_diff_base,
 )
 from release_set import load_inventory, validate_release_set
@@ -27,10 +26,6 @@ DEPLOY_PREFIX = "deploy/"
 # downstream coverage when its source changes -- mirrored and externally pinned
 # components are deployed by the same profiles and break the same evals.
 TRIGGER_FLAG = "trigger_downstream_from_source"
-SPATIALAI_DATA_UTILS_PATH = "libs/analytics/spatialai-data-utils"
-SPATIALAI_VERSION_SUFFIX_PATTERN = re.compile(
-    r"\.dev[1-9][0-9]*\+t([0-9a-f]{40})\.g([0-9a-f]{12})\.gh\.r[1-9][0-9]*"
-)
 PR_REF_PATTERN = re.compile(r"pull-request/(\d+)")
 
 
@@ -141,65 +136,6 @@ def downstream_variables(release_set: dict) -> dict[str, str]:
     }
 
 
-def downstream_build_type(
-    relevant: bool, spatialai_variables: dict[str, str]
-) -> str:
-    """Choose a lightweight pipeline when SDU reconciliation is the only work."""
-    if spatialai_variables and not relevant:
-        return "spatialai-reconcile"
-    return "ghcr-acceptance"
-
-
-def spatialai_publish_variables(
-    changed: list[str] | None,
-    ref_name: str,
-    version_suffix: str,
-    source_tree_sha: str,
-    source_commit_sha: str,
-    requested: str = "",
-) -> dict[str, str]:
-    """Return the internal publish/reconciliation handoff for SDU.
-
-    PRs validate and build the package in GitHub but never request publication.
-    Every develop run asks internal CI to reconcile the current content-addressed
-    tree with URM. This lets a later merge recover a handoff that was interrupted
-    after an earlier SDU merge. An unavailable diff fails open for the immediate
-    publish decision, matching the GitHub test gate.
-    """
-    if requested not in {"", "true", "false"}:
-        raise ValueError("Spatial AI publish handoff must be true or false")
-    publish = (
-        requested == "true"
-        if requested
-        else ref_name == "develop"
-        and paths_changed_under(changed, SPATIALAI_DATA_UTILS_PATH)
-    )
-    if ref_name != "develop":
-        if publish:
-            raise ValueError("Spatial AI publish handoff is valid only for develop")
-        return {}
-    if not re.fullmatch(r"[0-9a-f]{40}", source_tree_sha):
-        raise ValueError("Spatial AI publish requires a full source tree SHA")
-    if not re.fullmatch(r"[0-9a-f]{40}", source_commit_sha):
-        raise ValueError("Spatial AI publish requires a full source commit SHA")
-    suffix_match = SPATIALAI_VERSION_SUFFIX_PATTERN.fullmatch(version_suffix)
-    if not suffix_match:
-        raise ValueError(
-            "Spatial AI publish requires a GitHub-generated version suffix "
-            "like .dev123+t<40-hex-tree-sha>.gabcdef012345.gh.r1"
-        )
-    if suffix_match.group(1) != source_tree_sha:
-        raise ValueError("Spatial AI version suffix does not identify its source tree")
-    if suffix_match.group(2) != source_commit_sha[:12]:
-        raise ValueError("Spatial AI version suffix does not identify its source commit")
-    return {
-        "SPATIALAI_DATA_UTILS_PUBLISH": "true" if publish else "false",
-        "SPATIALAI_DATA_UTILS_RECONCILE": "true",
-        "SPATIALAI_SOURCE_TREE_SHA": source_tree_sha,
-        "SPATIALAI_PACKAGE_VERSION_SUFFIX": version_suffix,
-    }
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
@@ -211,22 +147,6 @@ def main() -> int:
     parser.add_argument("--interval-seconds", type=int, default=15)
     parser.add_argument("--release-set", type=Path)
     parser.add_argument("--release-set-output", type=Path)
-    parser.add_argument(
-        "--spatialai-package-version-suffix",
-        default=os.environ.get("SPATIALAI_PACKAGE_VERSION_SUFFIX", ""),
-    )
-    parser.add_argument(
-        "--publish-spatialai-data-utils",
-        default=os.environ.get("SPATIALAI_DATA_UTILS_PUBLISH", ""),
-    )
-    parser.add_argument(
-        "--spatialai-data-utils-tree-sha",
-        default=os.environ.get("SPATIALAI_SOURCE_TREE_SHA", ""),
-    )
-    parser.add_argument(
-        "--build-type",
-        default=os.environ.get("DOWNSTREAM_BUILD_TYPE", ""),
-    )
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN", "").strip()
@@ -285,30 +205,9 @@ def main() -> int:
     relevant, gate_reason = downstream_relevant(
         changed, load_inventory(args.repo_root)
     )
-    publish_variables = spatialai_publish_variables(
-        changed,
-        args.ref_name,
-        args.spatialai_package_version_suffix,
-        args.spatialai_data_utils_tree_sha,
-        args.sha,
-        args.publish_spatialai_data_utils,
-    )
-    run_downstream = relevant or bool(publish_variables)
+    run_downstream = relevant
 
     variables = downstream_variables(release_set)
-    variables.update(publish_variables)
-    # The trigger job unpacks a source archive without `.git`, so it cannot
-    # recompute the gate. It replays the build type decided by the job that
-    # still had the diff instead.
-    build_type = args.build_type or downstream_build_type(
-        relevant, publish_variables
-    )
-    if build_type not in {"ghcr-acceptance", "spatialai-reconcile"}:
-        raise ValueError(
-            "Downstream build type must be ghcr-acceptance or "
-            "spatialai-reconcile"
-        )
-    variables["BUILD_TYPE"] = build_type
     with Path(github_env).open("a") as output:
         output.write("DOWNSTREAM_EXTRA_VARIABLES_JSON<<EOF\n")
         output.write(json.dumps(variables, separators=(",", ":")) + "\n")
@@ -320,23 +219,6 @@ def main() -> int:
                 f"has_ghcr_build_entries={'true' if has_builds else 'false'}\n"
             )
             output.write(f"run_downstream={'true' if run_downstream else 'false'}\n")
-            output.write(f"build_type={variables['BUILD_TYPE']}\n")
-            output.write(
-                "publish_spatialai_data_utils="
-                f"{publish_variables.get('SPATIALAI_DATA_UTILS_PUBLISH', 'false')}\n"
-            )
-            output.write(
-                "spatialai_package_version_suffix="
-                f"{args.spatialai_package_version_suffix if publish_variables else ''}\n"
-            )
-            output.write(
-                "spatialai_data_utils_tree_sha="
-                f"{args.spatialai_data_utils_tree_sha if publish_variables else ''}\n"
-            )
-    if publish_variables.get("SPATIALAI_DATA_UTILS_PUBLISH") == "true":
-        gate_reason += "; merged Spatial AI Data Utils change requests URM publish"
-    elif publish_variables:
-        gate_reason += "; develop run reconciles Spatial AI Data Utils with URM"
     print(
         f"Prepared release set {release_set['release_set_id']} "
         f"for downstream acceptance ({len(release_set['images'])} images, "

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -17,9 +17,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import prepare_downstream_release_set as module  # noqa: E402
 from prepare_downstream_release_set import (  # noqa: E402
     candidate_container_tag,
+    downstream_build_type,
     downstream_relevant,
     downstream_variables,
     pr_merge_base_sha,
+    spatialai_publish_variables,
 )
 
 
@@ -176,9 +178,69 @@ class DownstreamVariablesTest(unittest.TestCase):
             )
             self.assertEqual(
                 output_path.read_text(),
-                "has_ghcr_build_entries=false\nrun_downstream=false\n",
+                "has_ghcr_build_entries=false\n"
+                "run_downstream=false\n"
+                "publish_spatialai_data_utils=false\n"
+                "spatialai_package_version_suffix=\n"
+                "spatialai_data_utils_tree_sha=\n",
             )
             self.assertEqual(json.loads(release_output_path.read_text()), release_set)
+
+    def test_unrelated_develop_run_triggers_lightweight_sdu_reconciliation(self):
+        sha = "a" * 40
+        tree_sha = "b" * 40
+        suffix = f".dev123+t{tree_sha}.g{sha[:12]}.gh.r1"
+        release_set = {
+            "source": {"commit": sha, "ref": "develop"},
+            "release_set_id": "sha256:" + "1" * 64,
+            "images": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            release_path = Path(tmp) / "release-set.json"
+            env_path = Path(tmp) / "github.env"
+            output_path = Path(tmp) / "github.output"
+            release_path.write_text(json.dumps(release_set))
+            argv = [
+                "prepare_downstream_release_set.py",
+                "--sha",
+                sha,
+                "--ref-name",
+                "develop",
+                "--release-set",
+                str(release_path),
+                "--spatialai-package-version-suffix",
+                suffix,
+                "--spatialai-data-utils-tree-sha",
+                tree_sha,
+            ]
+            with mock.patch("sys.argv", argv), mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_ENV": str(env_path),
+                    "GITHUB_OUTPUT": str(output_path),
+                },
+                clear=True,
+            ), mock.patch.object(
+                module, "validate_release_set", return_value=[]
+            ), mock.patch.object(
+                module, "resolve_diff_base", return_value=(sha, "pinned")
+            ), mock.patch.object(
+                module, "changed_paths", return_value=["docs/readme.md"]
+            ), mock.patch.object(
+                module, "load_inventory", return_value={"images": []}
+            ):
+                self.assertEqual(module.main(), 0)
+
+            env_text = env_path.read_text()
+            payload = env_text.split("<<EOF\n", 1)[1].split("\nEOF", 1)[0]
+            variables = json.loads(payload)
+            self.assertEqual(variables["BUILD_TYPE"], "spatialai-reconcile")
+            self.assertEqual(
+                variables["SPATIALAI_DATA_UTILS_RECONCILE"], "true"
+            )
+            self.assertEqual(variables["SPATIALAI_DATA_UTILS_PUBLISH"], "false")
+            self.assertEqual(variables["SPATIALAI_SOURCE_TREE_SHA"], tree_sha)
+            self.assertIn("run_downstream=true\n", output_path.read_text())
 
 
 
@@ -226,6 +288,132 @@ class DownstreamGateTest(unittest.TestCase):
     def test_source_path_prefix_is_not_matched_loosely(self):
         run, _ = downstream_relevant(["services/agent-extras/x.py"], INVENTORY)
         self.assertFalse(run)
+
+
+class SpatialAiPublishGateTest(unittest.TestCase):
+    TREE_SHA = "b" * 40
+    COMMIT_SHA = "a" * 40
+    SUFFIX = ".dev123+t" + TREE_SHA + ".gaaaaaaaaaaaa.gh.r1"
+
+    def variables(self, changed, ref_name="develop", requested=""):
+        return spatialai_publish_variables(
+            changed,
+            ref_name,
+            self.SUFFIX,
+            self.TREE_SHA,
+            self.COMMIT_SHA,
+            requested,
+        )
+
+    def test_develop_change_requests_internal_publish(self):
+        self.assertEqual(
+            self.variables(
+                ["libs/analytics/spatialai-data-utils/release/setup.py"]
+            ),
+            {
+                "SPATIALAI_DATA_UTILS_PUBLISH": "true",
+                "SPATIALAI_DATA_UTILS_RECONCILE": "true",
+                "SPATIALAI_SOURCE_TREE_SHA": self.TREE_SHA,
+                "SPATIALAI_PACKAGE_VERSION_SUFFIX": self.SUFFIX,
+            },
+        )
+
+    def test_pr_change_never_requests_publish(self):
+        self.assertEqual(
+            self.variables(
+                ["libs/analytics/spatialai-data-utils/release/setup.py"],
+                "pull-request/1562",
+            ),
+            {},
+        )
+
+    def test_unrelated_develop_change_reconciles_without_immediate_publish(self):
+        variables = self.variables(["docs/readme.md"])
+        self.assertEqual(variables["SPATIALAI_DATA_UTILS_PUBLISH"], "false")
+        self.assertEqual(variables["SPATIALAI_DATA_UTILS_RECONCILE"], "true")
+        self.assertEqual(variables["SPATIALAI_SOURCE_TREE_SHA"], self.TREE_SHA)
+
+    def test_every_develop_run_can_recover_a_missing_tree(self):
+        self.assertEqual(
+            self.variables(["services/agent/app.py"])[
+                "SPATIALAI_PACKAGE_VERSION_SUFFIX"
+            ],
+            self.SUFFIX,
+        )
+
+    def test_sdu_only_handoff_uses_lightweight_downstream_pipeline(self):
+        self.assertEqual(
+            downstream_build_type(False, self.variables(["docs/readme.md"])),
+            "spatialai-reconcile",
+        )
+        self.assertEqual(
+            downstream_build_type(True, self.variables(["services/agent/app.py"])),
+            "ghcr-acceptance",
+        )
+
+    def test_unavailable_develop_diff_fails_open(self):
+        self.assertEqual(
+            self.variables(None)["SPATIALAI_DATA_UTILS_PUBLISH"],
+            "true",
+        )
+
+    def test_publish_rejects_missing_or_malformed_suffix(self):
+        changed = ["libs/analytics/spatialai-data-utils/README.md"]
+        for suffix in ("", "dev123", ".dev0+g0123456789ab.r1"):
+            with self.subTest(suffix=suffix), self.assertRaisesRegex(
+                ValueError, "version suffix"
+            ):
+                spatialai_publish_variables(
+                    changed,
+                    "develop",
+                    suffix,
+                    self.TREE_SHA,
+                    self.COMMIT_SHA,
+                )
+
+    def test_publish_rejects_tree_or_commit_identity_mismatch(self):
+        changed = ["libs/analytics/spatialai-data-utils/README.md"]
+        for tree_sha, commit_sha, message in (
+            ("c" * 40, self.COMMIT_SHA, "source tree"),
+            (self.TREE_SHA, "c" * 40, "source commit"),
+        ):
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                spatialai_publish_variables(
+                    changed,
+                    "develop",
+                    self.SUFFIX,
+                    tree_sha,
+                    commit_sha,
+                )
+
+    def test_publish_rejects_malformed_full_tree_sha(self):
+        with self.assertRaisesRegex(ValueError, "full source tree SHA"):
+            spatialai_publish_variables(
+                ["libs/analytics/spatialai-data-utils/README.md"],
+                "develop",
+                self.SUFFIX,
+                "b" * 12,
+                self.COMMIT_SHA,
+            )
+
+    def test_explicit_false_keeps_reconciliation_in_handoff_job(self):
+        variables = self.variables(None, requested="false")
+        self.assertEqual(variables["SPATIALAI_DATA_UTILS_PUBLISH"], "false")
+        self.assertEqual(variables["SPATIALAI_DATA_UTILS_RECONCILE"], "true")
+
+    def test_explicit_true_preserves_first_job_decision(self):
+        self.assertEqual(
+            self.variables(["docs/readme.md"], requested="true")[
+                "SPATIALAI_DATA_UTILS_PUBLISH"
+            ],
+            "true",
+        )
+
+    def test_explicit_true_is_rejected_outside_develop(self):
+        with self.assertRaisesRegex(ValueError, "only for develop"):
+            self.variables(None, "pull-request/1562", "true")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -509,5 +509,24 @@ class SpatialAiPublishGateTest(unittest.TestCase):
             self.variables(None, "pull-request/1562", "true")
 
 
+class WorkflowDependencyGateTest(unittest.TestCase):
+    def test_path_gated_sdu_skip_cannot_disable_downstream_trigger(self):
+        workflow = (
+            Path(__file__).resolve().parents[1] / "workflows/ci.yml"
+        ).read_text()
+        trigger = workflow.split(
+            "\n  trigger-downstream-pipeline:\n", 1
+        )[1].split("\n    runs-on:", 1)[0]
+
+        self.assertNotIn("success() &&", trigger)
+        self.assertIn("!contains(needs.*.result, 'failure')", trigger)
+        self.assertIn("!contains(needs.*.result, 'cancelled')", trigger)
+        self.assertIn("!contains(needs.*.result, 'skipped')", trigger)
+        self.assertIn(
+            "needs.wait-for-build-dev-images.outputs.run-downstream == 'true'",
+            trigger,
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -246,7 +246,6 @@ class WorkflowSeparationTest(unittest.TestCase):
     def test_release_set_preparation_has_no_sdu_transport(self):
         script = Path(module.__file__).read_text()
         self.assertNotIn("SPATIALAI_", script)
-        self.assertNotIn("spatialai-reconcile", script)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -17,11 +17,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import prepare_downstream_release_set as module  # noqa: E402
 from prepare_downstream_release_set import (  # noqa: E402
     candidate_container_tag,
-    downstream_build_type,
     downstream_relevant,
     downstream_variables,
     pr_merge_base_sha,
-    spatialai_publish_variables,
 )
 
 
@@ -179,161 +177,9 @@ class DownstreamVariablesTest(unittest.TestCase):
             self.assertEqual(
                 output_path.read_text(),
                 "has_ghcr_build_entries=false\n"
-                "run_downstream=false\n"
-                "build_type=ghcr-acceptance\n"
-                "publish_spatialai_data_utils=false\n"
-                "spatialai_package_version_suffix=\n"
-                "spatialai_data_utils_tree_sha=\n",
+                "run_downstream=false\n",
             )
             self.assertEqual(json.loads(release_output_path.read_text()), release_set)
-
-    def test_unrelated_develop_run_triggers_lightweight_sdu_reconciliation(self):
-        sha = "a" * 40
-        tree_sha = "b" * 40
-        suffix = f".dev123+t{tree_sha}.g{sha[:12]}.gh.r1"
-        release_set = {
-            "source": {"commit": sha, "ref": "develop"},
-            "release_set_id": "sha256:" + "1" * 64,
-            "images": [],
-        }
-        with tempfile.TemporaryDirectory() as tmp:
-            release_path = Path(tmp) / "release-set.json"
-            env_path = Path(tmp) / "github.env"
-            output_path = Path(tmp) / "github.output"
-            release_path.write_text(json.dumps(release_set))
-            argv = [
-                "prepare_downstream_release_set.py",
-                "--sha",
-                sha,
-                "--ref-name",
-                "develop",
-                "--release-set",
-                str(release_path),
-                "--spatialai-package-version-suffix",
-                suffix,
-                "--spatialai-data-utils-tree-sha",
-                tree_sha,
-            ]
-            with mock.patch("sys.argv", argv), mock.patch.dict(
-                os.environ,
-                {
-                    "GITHUB_ENV": str(env_path),
-                    "GITHUB_OUTPUT": str(output_path),
-                },
-                clear=True,
-            ), mock.patch.object(
-                module, "validate_release_set", return_value=[]
-            ), mock.patch.object(
-                module, "resolve_diff_base", return_value=(sha, "pinned")
-            ), mock.patch.object(
-                module, "changed_paths", return_value=["docs/readme.md"]
-            ), mock.patch.object(
-                module, "load_inventory", return_value={"images": []}
-            ):
-                self.assertEqual(module.main(), 0)
-
-            env_text = env_path.read_text()
-            payload = env_text.split("<<EOF\n", 1)[1].split("\nEOF", 1)[0]
-            variables = json.loads(payload)
-            self.assertEqual(variables["BUILD_TYPE"], "spatialai-reconcile")
-            self.assertEqual(
-                variables["SPATIALAI_DATA_UTILS_RECONCILE"], "true"
-            )
-            self.assertEqual(variables["SPATIALAI_DATA_UTILS_PUBLISH"], "false")
-            self.assertEqual(variables["SPATIALAI_SOURCE_TREE_SHA"], tree_sha)
-            self.assertIn("run_downstream=true\n", output_path.read_text())
-
-    def run_handoff_without_git(self, tmp, *extra_args):
-        """Drive main() the way the trigger job does: an unpacked source tree.
-
-        That job works from a downloaded archive with no ``.git``, so the diff
-        and the gate it feeds cannot be recomputed there. Mocking
-        resolve_diff_base/changed_paths hides exactly that, so this helper
-        leaves both real.
-        """
-        sha = "a" * 40
-        tree_sha = "b" * 40
-        suffix = f".dev123+t{tree_sha}.g{sha[:12]}.gh.r1"
-        release_set = {
-            "source": {"commit": sha, "ref": "develop"},
-            "release_set_id": "sha256:" + "1" * 64,
-            "images": [],
-        }
-        root = Path(tmp)
-        self.assertFalse((root / ".git").exists())
-        (root / "deploy/docker").mkdir(parents=True)
-        (root / "deploy/docker/container-inventory.json").write_text(
-            json.dumps(INVENTORY)
-        )
-        release_path = root / "release-set.json"
-        env_path = root / "github.env"
-        output_path = root / "github.output"
-        release_path.write_text(json.dumps(release_set))
-        argv = [
-            "prepare_downstream_release_set.py",
-            "--sha",
-            sha,
-            "--ref-name",
-            "develop",
-            "--repo-root",
-            str(root),
-            "--before",
-            "c" * 40,
-            "--release-set",
-            str(release_path),
-            "--spatialai-package-version-suffix",
-            suffix,
-            "--spatialai-data-utils-tree-sha",
-            tree_sha,
-            *extra_args,
-        ]
-        previous = Path.cwd()
-        os.chdir(root)
-        try:
-            with mock.patch("sys.argv", argv), mock.patch.dict(
-                os.environ,
-                {
-                    "GITHUB_ENV": str(env_path),
-                    "GITHUB_OUTPUT": str(output_path),
-                    "PATH": os.environ.get("PATH", ""),
-                },
-                clear=True,
-            ), mock.patch.object(
-                module, "validate_release_set", return_value=[]
-            ):
-                self.assertEqual(module.main(), 0)
-        finally:
-            os.chdir(previous)
-        env_text = env_path.read_text()
-        payload = env_text.split("<<EOF\n", 1)[1].split("\nEOF", 1)[0]
-        return json.loads(payload), output_path.read_text()
-
-    def test_trigger_job_replays_the_build_type_decided_upstream(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            variables, output = self.run_handoff_without_git(
-                tmp, "--build-type", "spatialai-reconcile"
-            )
-        self.assertEqual(variables["BUILD_TYPE"], "spatialai-reconcile")
-        self.assertIn("build_type=spatialai-reconcile\n", output)
-        self.assertEqual(
-            variables["SPATIALAI_SOURCE_TREE_SHA"], "b" * 40
-        )
-
-    def test_trigger_job_rejects_an_unknown_replayed_build_type(self):
-        with tempfile.TemporaryDirectory() as tmp, self.assertRaisesRegex(
-            ValueError, "Downstream build type"
-        ):
-            self.run_handoff_without_git(
-                tmp, "--build-type", "spatialai-reconclie"
-            )
-
-    def test_recomputed_build_type_is_unchanged_without_a_handoff(self):
-        # Without the flag the trigger job re-decides from a diff it cannot
-        # resolve, which is why the upstream job has to hand the answer over.
-        with tempfile.TemporaryDirectory() as tmp:
-            variables, output = self.run_handoff_without_git(tmp)
-        self.assertEqual(variables["BUILD_TYPE"], "ghcr-acceptance")
-        self.assertIn("build_type=ghcr-acceptance\n", output)
 
 
 
@@ -383,149 +229,24 @@ class DownstreamGateTest(unittest.TestCase):
         self.assertFalse(run)
 
 
-class SpatialAiPublishGateTest(unittest.TestCase):
-    TREE_SHA = "b" * 40
-    COMMIT_SHA = "a" * 40
-    SUFFIX = ".dev123+t" + TREE_SHA + ".gaaaaaaaaaaaa.gh.r1"
+class WorkflowSeparationTest(unittest.TestCase):
+    def test_sdu_has_an_independent_workflow_and_handoff(self):
+        workflows = Path(__file__).resolve().parents[1] / "workflows"
+        main = (workflows / "ci.yml").read_text()
+        sdu = (workflows / "spatialai-data-utils.yml").read_text()
 
-    def variables(self, changed, ref_name="develop", requested=""):
-        return spatialai_publish_variables(
-            changed,
-            ref_name,
-            self.SUFFIX,
-            self.TREE_SHA,
-            self.COMMIT_SHA,
-            requested,
-        )
+        self.assertNotIn("spatialai-data-utils-test", main)
+        self.assertNotIn("SPATIALAI_PACKAGE_VERSION_SUFFIX", main)
+        self.assertIn("name: Spatial AI Data Utils", sdu)
+        self.assertIn("name: Gate", sdu)
+        self.assertIn("GITHUB_RUN_ID", sdu)
+        self.assertIn("DOWNSTREAM_REF: spatialai-publisher", sdu)
+        self.assertIn('"SPATIALAI_PIPELINE": "true"', sdu)
 
-    def test_develop_change_requests_internal_publish(self):
-        self.assertEqual(
-            self.variables(
-                ["libs/analytics/spatialai-data-utils/release/setup.py"]
-            ),
-            {
-                "SPATIALAI_DATA_UTILS_PUBLISH": "true",
-                "SPATIALAI_DATA_UTILS_RECONCILE": "true",
-                "SPATIALAI_SOURCE_TREE_SHA": self.TREE_SHA,
-                "SPATIALAI_PACKAGE_VERSION_SUFFIX": self.SUFFIX,
-            },
-        )
-
-    def test_pr_change_never_requests_publish(self):
-        self.assertEqual(
-            self.variables(
-                ["libs/analytics/spatialai-data-utils/release/setup.py"],
-                "pull-request/1562",
-            ),
-            {},
-        )
-
-    def test_unrelated_develop_change_reconciles_without_immediate_publish(self):
-        variables = self.variables(["docs/readme.md"])
-        self.assertEqual(variables["SPATIALAI_DATA_UTILS_PUBLISH"], "false")
-        self.assertEqual(variables["SPATIALAI_DATA_UTILS_RECONCILE"], "true")
-        self.assertEqual(variables["SPATIALAI_SOURCE_TREE_SHA"], self.TREE_SHA)
-
-    def test_every_develop_run_can_recover_a_missing_tree(self):
-        self.assertEqual(
-            self.variables(["services/agent/app.py"])[
-                "SPATIALAI_PACKAGE_VERSION_SUFFIX"
-            ],
-            self.SUFFIX,
-        )
-
-    def test_sdu_only_handoff_uses_lightweight_downstream_pipeline(self):
-        self.assertEqual(
-            downstream_build_type(False, self.variables(["docs/readme.md"])),
-            "spatialai-reconcile",
-        )
-        self.assertEqual(
-            downstream_build_type(True, self.variables(["services/agent/app.py"])),
-            "ghcr-acceptance",
-        )
-
-    def test_unavailable_develop_diff_fails_open(self):
-        self.assertEqual(
-            self.variables(None)["SPATIALAI_DATA_UTILS_PUBLISH"],
-            "true",
-        )
-
-    def test_publish_rejects_missing_or_malformed_suffix(self):
-        changed = ["libs/analytics/spatialai-data-utils/README.md"]
-        for suffix in ("", "dev123", ".dev0+g0123456789ab.r1"):
-            with self.subTest(suffix=suffix), self.assertRaisesRegex(
-                ValueError, "version suffix"
-            ):
-                spatialai_publish_variables(
-                    changed,
-                    "develop",
-                    suffix,
-                    self.TREE_SHA,
-                    self.COMMIT_SHA,
-                )
-
-    def test_publish_rejects_tree_or_commit_identity_mismatch(self):
-        changed = ["libs/analytics/spatialai-data-utils/README.md"]
-        for tree_sha, commit_sha, message in (
-            ("c" * 40, self.COMMIT_SHA, "source tree"),
-            (self.TREE_SHA, "c" * 40, "source commit"),
-        ):
-            with self.subTest(message=message), self.assertRaisesRegex(
-                ValueError, message
-            ):
-                spatialai_publish_variables(
-                    changed,
-                    "develop",
-                    self.SUFFIX,
-                    tree_sha,
-                    commit_sha,
-                )
-
-    def test_publish_rejects_malformed_full_tree_sha(self):
-        with self.assertRaisesRegex(ValueError, "full source tree SHA"):
-            spatialai_publish_variables(
-                ["libs/analytics/spatialai-data-utils/README.md"],
-                "develop",
-                self.SUFFIX,
-                "b" * 12,
-                self.COMMIT_SHA,
-            )
-
-    def test_explicit_false_keeps_reconciliation_in_handoff_job(self):
-        variables = self.variables(None, requested="false")
-        self.assertEqual(variables["SPATIALAI_DATA_UTILS_PUBLISH"], "false")
-        self.assertEqual(variables["SPATIALAI_DATA_UTILS_RECONCILE"], "true")
-
-    def test_explicit_true_preserves_first_job_decision(self):
-        self.assertEqual(
-            self.variables(["docs/readme.md"], requested="true")[
-                "SPATIALAI_DATA_UTILS_PUBLISH"
-            ],
-            "true",
-        )
-
-    def test_explicit_true_is_rejected_outside_develop(self):
-        with self.assertRaisesRegex(ValueError, "only for develop"):
-            self.variables(None, "pull-request/1562", "true")
-
-
-class WorkflowDependencyGateTest(unittest.TestCase):
-    def test_path_gated_sdu_skip_cannot_disable_downstream_trigger(self):
-        workflow = (
-            Path(__file__).resolve().parents[1] / "workflows/ci.yml"
-        ).read_text()
-        trigger = workflow.split(
-            "\n  trigger-downstream-pipeline:\n", 1
-        )[1].split("\n    runs-on:", 1)[0]
-
-        self.assertNotIn("success() &&", trigger)
-        self.assertIn("!contains(needs.*.result, 'failure')", trigger)
-        self.assertIn("!contains(needs.*.result, 'cancelled')", trigger)
-        self.assertIn("!contains(needs.*.result, 'skipped')", trigger)
-        self.assertIn(
-            "needs.wait-for-build-dev-images.outputs.run-downstream == 'true'",
-            trigger,
-        )
+    def test_release_set_preparation_has_no_sdu_transport(self):
+        script = Path(module.__file__).read_text()
+        self.assertNotIn("SPATIALAI_", script)
+        self.assertNotIn("spatialai-reconcile", script)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -180,6 +180,7 @@ class DownstreamVariablesTest(unittest.TestCase):
                 output_path.read_text(),
                 "has_ghcr_build_entries=false\n"
                 "run_downstream=false\n"
+                "build_type=ghcr-acceptance\n"
                 "publish_spatialai_data_utils=false\n"
                 "spatialai_package_version_suffix=\n"
                 "spatialai_data_utils_tree_sha=\n",
@@ -241,6 +242,98 @@ class DownstreamVariablesTest(unittest.TestCase):
             self.assertEqual(variables["SPATIALAI_DATA_UTILS_PUBLISH"], "false")
             self.assertEqual(variables["SPATIALAI_SOURCE_TREE_SHA"], tree_sha)
             self.assertIn("run_downstream=true\n", output_path.read_text())
+
+    def run_handoff_without_git(self, tmp, *extra_args):
+        """Drive main() the way the trigger job does: an unpacked source tree.
+
+        That job works from a downloaded archive with no ``.git``, so the diff
+        and the gate it feeds cannot be recomputed there. Mocking
+        resolve_diff_base/changed_paths hides exactly that, so this helper
+        leaves both real.
+        """
+        sha = "a" * 40
+        tree_sha = "b" * 40
+        suffix = f".dev123+t{tree_sha}.g{sha[:12]}.gh.r1"
+        release_set = {
+            "source": {"commit": sha, "ref": "develop"},
+            "release_set_id": "sha256:" + "1" * 64,
+            "images": [],
+        }
+        root = Path(tmp)
+        self.assertFalse((root / ".git").exists())
+        (root / "deploy/docker").mkdir(parents=True)
+        (root / "deploy/docker/container-inventory.json").write_text(
+            json.dumps(INVENTORY)
+        )
+        release_path = root / "release-set.json"
+        env_path = root / "github.env"
+        output_path = root / "github.output"
+        release_path.write_text(json.dumps(release_set))
+        argv = [
+            "prepare_downstream_release_set.py",
+            "--sha",
+            sha,
+            "--ref-name",
+            "develop",
+            "--repo-root",
+            str(root),
+            "--before",
+            "c" * 40,
+            "--release-set",
+            str(release_path),
+            "--spatialai-package-version-suffix",
+            suffix,
+            "--spatialai-data-utils-tree-sha",
+            tree_sha,
+            *extra_args,
+        ]
+        previous = Path.cwd()
+        os.chdir(root)
+        try:
+            with mock.patch("sys.argv", argv), mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_ENV": str(env_path),
+                    "GITHUB_OUTPUT": str(output_path),
+                    "PATH": os.environ.get("PATH", ""),
+                },
+                clear=True,
+            ), mock.patch.object(
+                module, "validate_release_set", return_value=[]
+            ):
+                self.assertEqual(module.main(), 0)
+        finally:
+            os.chdir(previous)
+        env_text = env_path.read_text()
+        payload = env_text.split("<<EOF\n", 1)[1].split("\nEOF", 1)[0]
+        return json.loads(payload), output_path.read_text()
+
+    def test_trigger_job_replays_the_build_type_decided_upstream(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            variables, output = self.run_handoff_without_git(
+                tmp, "--build-type", "spatialai-reconcile"
+            )
+        self.assertEqual(variables["BUILD_TYPE"], "spatialai-reconcile")
+        self.assertIn("build_type=spatialai-reconcile\n", output)
+        self.assertEqual(
+            variables["SPATIALAI_SOURCE_TREE_SHA"], "b" * 40
+        )
+
+    def test_trigger_job_rejects_an_unknown_replayed_build_type(self):
+        with tempfile.TemporaryDirectory() as tmp, self.assertRaisesRegex(
+            ValueError, "Downstream build type"
+        ):
+            self.run_handoff_without_git(
+                tmp, "--build-type", "spatialai-reconclie"
+            )
+
+    def test_recomputed_build_type_is_unchanged_without_a_handoff(self):
+        # Without the flag the trigger job re-decides from a diff it cannot
+        # resolve, which is why the upstream job has to hand the answer over.
+        with tempfile.TemporaryDirectory() as tmp:
+            variables, output = self.run_handoff_without_git(tmp)
+        self.assertEqual(variables["BUILD_TYPE"], "ghcr-acceptance")
+        self.assertIn("build_type=ghcr-acceptance\n", output)
 
 
 

--- a/.github/scripts/test_trigger_downstream_pipeline.py
+++ b/.github/scripts/test_trigger_downstream_pipeline.py
@@ -86,6 +86,27 @@ class ExtraPipelineVariablesTest(unittest.TestCase):
             self.assertEqual(module.main(), 0)
             fetch.assert_not_called()
 
+    def test_explicit_downstream_branches_support_recovery_workflows(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "GITHUB_REF_NAME": "main",
+                "DOWNSTREAM_TARGET_BRANCH": "develop",
+                "DOWNSTREAM_COMPARE_BRANCH": "develop",
+            },
+            clear=True,
+        ):
+            self.assertEqual(module.resolve_branches(), ("develop", "develop"))
+
+    def test_explicit_downstream_branches_must_be_a_pair(self):
+        with mock.patch.dict(
+            os.environ,
+            {"DOWNSTREAM_TARGET_BRANCH": "develop"},
+            clear=True,
+        ):
+            with self.assertRaises(SystemExit):
+                module.resolve_branches()
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/scripts/trigger_downstream_pipeline.py
+++ b/.github/scripts/trigger_downstream_pipeline.py
@@ -334,6 +334,17 @@ def resolve_branches() -> tuple[str, str]:
     to ``GITHUB_REF_NAME`` so downstream consumers always see something
     meaningful.
     """
+    target_override = os.environ.get("DOWNSTREAM_TARGET_BRANCH", "").strip()
+    compare_override = os.environ.get("DOWNSTREAM_COMPARE_BRANCH", "").strip()
+    if target_override or compare_override:
+        if not target_override or not compare_override:
+            emit_error(
+                "DOWNSTREAM_TARGET_BRANCH and DOWNSTREAM_COMPARE_BRANCH must "
+                "be provided together"
+            )
+            raise SystemExit(1)
+        return target_override, compare_override
+
     ref_name = os.environ.get("GITHUB_REF_NAME", "").strip()
     pr_match = re.fullmatch(r"pull-request/(\d+)", ref_name)
     if not pr_match:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,14 @@ name: CI
       - "pull-request/[0-9]+"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Preserve every delivery run on develop/main. A later merge must not cancel
+  # an in-flight SDU handoff before internal CI can publish it. Synthetic PR
+  # mirror branches still cancel stale runs after a newer PR revision arrives.
+  group: >-
+    ${{ github.workflow }}-${{
+      startsWith(github.ref_name, 'pull-request/') && github.ref || github.run_id
+    }}
+  cancel-in-progress: ${{ startsWith(github.ref_name, 'pull-request/') }}
 
 defaults:
   run:
@@ -51,6 +57,7 @@ jobs:
       current-video-analytics-api-image: ${{ steps.current-images.outputs.video }}
       spatialai-data-utils-changed: ${{ steps.changed-paths.outputs.spatialai-data-utils-changed }}
       trigger-from-src-change: ${{ steps.changed-paths.outputs.trigger-from-src-change }}
+      spatialai-data-utils-tree-sha: ${{ steps.changed-paths.outputs.spatialai-data-utils-tree-sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
@@ -69,6 +76,8 @@ jobs:
         run: |
           python3 - <<'PY'
           import os
+          import re
+          import subprocess
           import sys
           from pathlib import Path
 
@@ -102,10 +111,14 @@ jobs:
           if base and paths is None:
               reason += "; diff failed; running Spatial AI Data Utils CI and downstream"
 
-          changed = paths_changed_under(
-              paths,
-              "libs/analytics/spatialai-data-utils",
-          )
+          source_path = "libs/analytics/spatialai-data-utils"
+          changed = paths_changed_under(paths, source_path)
+          tree_sha = subprocess.check_output(
+              ["git", "rev-parse", f"HEAD:{source_path}"],
+              text=True,
+          ).strip()
+          if not re.fullmatch(r"[0-9a-f]{40}", tree_sha):
+              raise RuntimeError(f"invalid Spatial AI source tree SHA: {tree_sha!r}")
           trigger_from_src = any(
               paths_changed_under(paths, folder)
               for folder in DOWNSTREAM_TRIGGER_PATHS
@@ -117,7 +130,11 @@ jobs:
               output.write(
                   f"trigger-from-src-change={str(trigger_from_src).lower()}\n"
               )
-          print(f"Spatial AI Data Utils changed: {changed} ({reason})")
+              output.write(f"spatialai-data-utils-tree-sha={tree_sha}\n")
+          print(
+              f"Spatial AI Data Utils changed: {changed}; "
+              f"tree: {tree_sha} ({reason})"
+          )
           print(f"Downstream trigger from source: {trigger_from_src} ({reason})")
           PY
 
@@ -648,6 +665,8 @@ jobs:
     name: Test (Spatial AI Data Utils)
     needs: prepare-source
     if: needs.prepare-source.outputs.spatialai-data-utils-changed == 'true'
+    outputs:
+      package-version-suffix: ${{ steps.package-version.outputs.suffix }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     defaults:
@@ -724,7 +743,8 @@ jobs:
         id: package-version
         run: |
           short_sha="$(printf '%s' "$GITHUB_SHA" | cut -c1-12)"
-          suffix=".dev${GITHUB_RUN_NUMBER}+g${short_sha}.r${GITHUB_RUN_ATTEMPT}"
+          tree_sha="${{ needs.prepare-source.outputs.spatialai-data-utils-tree-sha }}"
+          suffix=".dev${GITHUB_RUN_NUMBER}+t${tree_sha}.g${short_sha}.gh.r${GITHUB_RUN_ATTEMPT}"
           echo "suffix=${suffix}" >> "$GITHUB_OUTPUT"
           echo "Spatial AI Data Utils version suffix: ${suffix}"
 
@@ -753,62 +773,7 @@ jobs:
           path: libs/analytics/spatialai-data-utils/release/dist/
 
   # ---------------------------------------------------------------------------
-  # Job 5d: Publish the validated Spatial AI Data Utils package to URM
-  # ---------------------------------------------------------------------------
-  spatialai-data-utils-publish:
-    name: Publish Spatial AI Data Utils (URM)
-    needs: spatialai-data-utils-test
-    if: >-
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/develop' &&
-      needs.spatialai-data-utils-test.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-    steps:
-      - name: Download validated Python package
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
-        with:
-          name: spatialai-data-utils-python-package
-          path: dist
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-        with:
-          python-version: "3.13"
-
-      - name: Validate URM credentials
-        env:
-          URM_PYPI_TOKEN: ${{ secrets.SW_MDX_PYPI_LOCAL_DEPLOY_TOKEN }}
-        run: |
-          if [ -z "$URM_PYPI_TOKEN" ]; then
-            echo "::error::SW_MDX_PYPI_LOCAL_DEPLOY_TOKEN is required to publish Spatial AI Data Utils to URM."
-            exit 1
-          fi
-
-      - name: Upload development package to URM Artifactory
-        env:
-          TWINE_REPOSITORY_URL: https://urm.nvidia.com/artifactory/api/pypi/sw-metropolis-pypi-local
-          TWINE_USERNAME: svc-mdx-rw
-          TWINE_PASSWORD: ${{ secrets.SW_MDX_PYPI_LOCAL_DEPLOY_TOKEN }}
-        run: |
-          python -m pip install "twine==6.2.0"
-          python -m twine upload --non-interactive dist/*
-
-      - name: Publish URM package coordinates
-        run: |
-          {
-            echo "### Spatial AI Data Utils package"
-            echo "- **Repository:** \`sw-metropolis-pypi-local\`"
-            echo "- **Package:** \`spatialai-data-utils\`"
-            echo "- **Artifacts:**"
-            find dist -maxdepth 1 -type f -printf '  - `%f`\n' | sort
-            echo "- **URL:** https://urm.nvidia.com/artifactory/sw-metropolis-pypi-local/spatialai-data-utils/"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  # ---------------------------------------------------------------------------
-  # Job 5e: Behavior analytics Docker Compose integration test
+  # Job 5d: Behavior analytics Docker Compose integration test
   # ---------------------------------------------------------------------------
   behavior-analytics-integration-test:
     name: Integration (behavior analytics)
@@ -1449,11 +1414,24 @@ jobs:
   # exact artifact to the downstream trigger job.
   wait-for-build-dev-images:
     name: Wait for Build Dev Images
-    needs: prepare-source
+    needs:
+      - prepare-source
+      - spatialai-data-utils-test
+    if: >-
+      always() &&
+      needs.prepare-source.result == 'success' &&
+      (needs.spatialai-data-utils-test.result == 'success' ||
+       needs.spatialai-data-utils-test.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 140
     outputs:
       trigger-from-new-image: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
+      has-ghcr-build-entries: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
+      run-downstream: ${{ steps.release-set.outputs.run_downstream }}
+      build-type: ${{ steps.release-set.outputs.build_type }}
+      publish-spatialai-data-utils: ${{ steps.release-set.outputs.publish_spatialai_data_utils }}
+      spatialai-package-version-suffix: ${{ steps.release-set.outputs.spatialai_package_version_suffix }}
+      spatialai-data-utils-tree-sha: ${{ steps.release-set.outputs.spatialai_data_utils_tree_sha }}
     permissions:
       actions: read
       contents: read
@@ -1472,11 +1450,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          suffix="${{ needs.spatialai-data-utils-test.outputs.package-version-suffix }}"
+          if [[ -z "${suffix}" ]]; then
+            tree_sha="${{ needs.prepare-source.outputs.spatialai-data-utils-tree-sha }}"
+            short_sha="$(printf '%s' "$GITHUB_SHA" | cut -c1-12)"
+            suffix=".dev${GITHUB_RUN_NUMBER}+t${tree_sha}.g${short_sha}.gh.r${GITHUB_RUN_ATTEMPT}"
+          fi
           python3 .github/scripts/prepare_downstream_release_set.py \
             --attempts 520 \
             --interval-seconds 15 \
             --repo-root . \
             --before "${{ github.event.before }}" \
+            --spatialai-package-version-suffix "${suffix}" \
+            --spatialai-data-utils-tree-sha \
+              "${{ needs.prepare-source.outputs.spatialai-data-utils-tree-sha }}" \
             --release-set-output downstream-release-set.json
 
       - name: Upload downstream release-set handoff
@@ -1524,8 +1511,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'skipped') &&
-      (needs.prepare-source.outputs.trigger-from-src-change == 'true' ||
-       needs.wait-for-build-dev-images.outputs.trigger-from-new-image == 'true')
+      needs.wait-for-build-dev-images.outputs.run-downstream == 'true'
     runs-on: [self-hosted, downstream-pipeline]
     # Holds the runner until the downstream pipeline completes. Must be
     # at least as long as MAX_POLL_DURATION_SECONDS in the poll step
@@ -1569,9 +1555,16 @@ jobs:
       - name: Prepare GHCR release-set handoff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          python3 .github/scripts/prepare_downstream_release_set.py
-          --release-set .downstream-release-set/downstream-release-set.json
+        run: |
+          python3 .github/scripts/prepare_downstream_release_set.py \
+            --release-set .downstream-release-set/downstream-release-set.json \
+            --publish-spatialai-data-utils \
+              "${{ needs.wait-for-build-dev-images.outputs.publish-spatialai-data-utils }}" \
+            --spatialai-package-version-suffix \
+              "${{ needs.wait-for-build-dev-images.outputs.spatialai-package-version-suffix }}" \
+            --spatialai-data-utils-tree-sha \
+              "${{ needs.wait-for-build-dev-images.outputs.spatialai-data-utils-tree-sha }}" \
+            --build-type "${{ needs.wait-for-build-dev-images.outputs.build-type }}"
 
       - name: Trigger pipeline
         id: trigger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,8 @@ name: CI
       - "pull-request/[0-9]+"
 
 concurrency:
-  # Preserve every delivery run on develop/main. A later merge must not cancel
-  # an in-flight SDU handoff before internal CI can publish it. Synthetic PR
-  # mirror branches still cancel stale runs after a newer PR revision arrives.
+  # Preserve every delivery run on develop/main. Synthetic PR mirror branches
+  # still cancel stale runs after a newer PR revision arrives.
   group: >-
     ${{ github.workflow }}-${{
       startsWith(github.ref_name, 'pull-request/') && github.ref || github.run_id
@@ -55,9 +54,7 @@ jobs:
       build-video-analytics-api: ${{ steps.analytics-changes.outputs.video }}
       current-behavior-analytics-image: ${{ steps.current-images.outputs.behavior }}
       current-video-analytics-api-image: ${{ steps.current-images.outputs.video }}
-      spatialai-data-utils-changed: ${{ steps.changed-paths.outputs.spatialai-data-utils-changed }}
       trigger-from-src-change: ${{ steps.changed-paths.outputs.trigger-from-src-change }}
-      spatialai-data-utils-tree-sha: ${{ steps.changed-paths.outputs.spatialai-data-utils-tree-sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
@@ -76,8 +73,6 @@ jobs:
         run: |
           python3 - <<'PY'
           import os
-          import re
-          import subprocess
           import sys
           from pathlib import Path
 
@@ -109,32 +104,16 @@ jobs:
           )
           paths = changed_paths(repo, base) if base else None
           if base and paths is None:
-              reason += "; diff failed; running Spatial AI Data Utils CI and downstream"
+              reason += "; diff failed; running downstream acceptance"
 
-          source_path = "libs/analytics/spatialai-data-utils"
-          changed = paths_changed_under(paths, source_path)
-          tree_sha = subprocess.check_output(
-              ["git", "rev-parse", f"HEAD:{source_path}"],
-              text=True,
-          ).strip()
-          if not re.fullmatch(r"[0-9a-f]{40}", tree_sha):
-              raise RuntimeError(f"invalid Spatial AI source tree SHA: {tree_sha!r}")
           trigger_from_src = any(
               paths_changed_under(paths, folder)
               for folder in DOWNSTREAM_TRIGGER_PATHS
           )
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write(
-                  f"spatialai-data-utils-changed={str(changed).lower()}\n"
-              )
-              output.write(
                   f"trigger-from-src-change={str(trigger_from_src).lower()}\n"
               )
-              output.write(f"spatialai-data-utils-tree-sha={tree_sha}\n")
-          print(
-              f"Spatial AI Data Utils changed: {changed}; "
-              f"tree: {tree_sha} ({reason})"
-          )
           print(f"Downstream trigger from source: {trigger_from_src} ({reason})")
           PY
 
@@ -659,121 +638,7 @@ jobs:
           path: services/analytics/video-analytics-api/test/coverage/
 
   # ---------------------------------------------------------------------------
-  # Job 5c: Spatial AI Data Utils tests and package build
-  # ---------------------------------------------------------------------------
-  spatialai-data-utils-test:
-    name: Test (Spatial AI Data Utils)
-    needs: prepare-source
-    if: needs.prepare-source.outputs.spatialai-data-utils-changed == 'true'
-    outputs:
-      package-version-suffix: ${{ steps.package-version.outputs.suffix }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    defaults:
-      run:
-        working-directory: libs/analytics/spatialai-data-utils
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
-        with:
-          name: source-${{ github.sha }}
-          path: .source-artifact
-
-      - name: Unpack source artifact
-        working-directory: ${{ github.workspace }}
-        run: |
-          find . -mindepth 1 -maxdepth 1 ! -name .source-artifact -exec rm -rf {} +
-          tar -xzf .source-artifact/source.tar.gz --strip-components=1
-          rm -rf .source-artifact
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-        with:
-          python-version: "3.13"
-
-      - name: Install system build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends g++ git
-
-      - name: Install hash-locked Python dependencies
-        run: |
-          python -m pip install --upgrade \
-            "pip==26.1.2" \
-            "pipenv==2026.6.2" \
-            "setuptools==82.0.1" \
-            "wheel==0.47.0"
-          python -m pip install \
-            "meson-python==0.20.0" \
-            "ninja==1.11.1.1" \
-            "Cython==3.0.12"
-          pipenv requirements --dev --hash > .ci-requirements.txt
-          python -m pip install \
-            --require-hashes \
-            --no-deps \
-            --no-cache-dir \
-            -r .ci-requirements.txt
-          python -m pip install "pytest==9.0.3" "pytest-cov==7.1.0"
-
-      - name: Install CPU-only PyTorch and PyTorch3D
-        run: |
-          python -m pip install \
-            --no-cache-dir \
-            "torch==2.10.0+cpu" \
-            --extra-index-url https://download.pytorch.org/whl/cpu
-          git clone --filter=blob:none https://github.com/facebookresearch/pytorch3d.git /tmp/vss-spatialai-pytorch3d
-          git -C /tmp/vss-spatialai-pytorch3d checkout 33824be
-          MAX_JOBS=4 FORCE_CUDA=0 python -m pip install \
-            --no-build-isolation \
-            /tmp/vss-spatialai-pytorch3d
-
-      - name: Install Spatial AI Data Utils test extras
-        run: python -m pip install --no-build-isolation -e './release[eval,viz]'
-
-      - name: Run tests with coverage
-        run: |
-          mkdir -p tests/coverage
-          pytest tests/ -v \
-            --junitxml=tests/coverage/test-results.xml \
-            --cov=spatialai_data_utils \
-            --cov-report=html:tests/coverage \
-            --cov-report=xml:coverage.xml \
-            --cov-report=term-missing
-
-      - name: Compute development package version
-        id: package-version
-        run: |
-          short_sha="$(printf '%s' "$GITHUB_SHA" | cut -c1-12)"
-          tree_sha="${{ needs.prepare-source.outputs.spatialai-data-utils-tree-sha }}"
-          suffix=".dev${GITHUB_RUN_NUMBER}+t${tree_sha}.g${short_sha}.gh.r${GITHUB_RUN_ATTEMPT}"
-          echo "suffix=${suffix}" >> "$GITHUB_OUTPUT"
-          echo "Spatial AI Data Utils version suffix: ${suffix}"
-
-      - name: Build and validate development package
-        env:
-          VERSION_SUFFIX: ${{ steps.package-version.outputs.suffix }}
-        run: |
-          python -m pip install "twine==6.2.0"
-          cd release
-          python setup.py sdist bdist_wheel
-          python -m twine check dist/*
-
-      - name: Upload test and coverage reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
-        if: always()
-        with:
-          name: spatialai-data-utils-test-reports
-          path: |
-            libs/analytics/spatialai-data-utils/tests/coverage/
-            libs/analytics/spatialai-data-utils/coverage.xml
-
-      - name: Upload Python package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
-        with:
-          name: spatialai-data-utils-python-package
-          path: libs/analytics/spatialai-data-utils/release/dist/
-
-  # ---------------------------------------------------------------------------
-  # Job 5d: Behavior analytics Docker Compose integration test
+  # Job 5c: Behavior analytics Docker Compose integration test
   # ---------------------------------------------------------------------------
   behavior-analytics-integration-test:
     name: Integration (behavior analytics)
@@ -821,7 +686,7 @@ jobs:
           ./test.sh warehouse_2d kafka prod
 
   # ---------------------------------------------------------------------------
-  # Job 5f: Video analytics API Docker Compose integration test
+  # Job 5d: Video analytics API Docker Compose integration test
   # ---------------------------------------------------------------------------
   video-analytics-api-integration-test:
     name: Integration (video analytics API)
@@ -1414,24 +1279,14 @@ jobs:
   # exact artifact to the downstream trigger job.
   wait-for-build-dev-images:
     name: Wait for Build Dev Images
-    needs:
-      - prepare-source
-      - spatialai-data-utils-test
-    if: >-
-      always() &&
-      needs.prepare-source.result == 'success' &&
-      (needs.spatialai-data-utils-test.result == 'success' ||
-       needs.spatialai-data-utils-test.result == 'skipped')
+    needs: prepare-source
+    if: needs.prepare-source.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 140
     outputs:
       trigger-from-new-image: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
       has-ghcr-build-entries: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
       run-downstream: ${{ steps.release-set.outputs.run_downstream }}
-      build-type: ${{ steps.release-set.outputs.build_type }}
-      publish-spatialai-data-utils: ${{ steps.release-set.outputs.publish_spatialai_data_utils }}
-      spatialai-package-version-suffix: ${{ steps.release-set.outputs.spatialai_package_version_suffix }}
-      spatialai-data-utils-tree-sha: ${{ steps.release-set.outputs.spatialai_data_utils_tree_sha }}
     permissions:
       actions: read
       contents: read
@@ -1450,20 +1305,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          suffix="${{ needs.spatialai-data-utils-test.outputs.package-version-suffix }}"
-          if [[ -z "${suffix}" ]]; then
-            tree_sha="${{ needs.prepare-source.outputs.spatialai-data-utils-tree-sha }}"
-            short_sha="$(printf '%s' "$GITHUB_SHA" | cut -c1-12)"
-            suffix=".dev${GITHUB_RUN_NUMBER}+t${tree_sha}.g${short_sha}.gh.r${GITHUB_RUN_ATTEMPT}"
-          fi
           python3 .github/scripts/prepare_downstream_release_set.py \
             --attempts 520 \
             --interval-seconds 15 \
             --repo-root . \
             --before "${{ github.event.before }}" \
-            --spatialai-package-version-suffix "${suffix}" \
-            --spatialai-data-utils-tree-sha \
-              "${{ needs.prepare-source.outputs.spatialai-data-utils-tree-sha }}" \
             --release-set-output downstream-release-set.json
 
       - name: Upload downstream release-set handoff
@@ -1497,11 +1343,6 @@ jobs:
       - license-check-ui
       - folder-structure
       - wait-for-build-dev-images
-    # Do not use success() here. wait-for-build-dev-images deliberately uses
-    # always() to survive a skipped, path-gated Spatial AI Data Utils test, but
-    # success() still inherits that transitive skip and would silently disable
-    # every downstream acceptance run where SDU did not change. Check only this
-    # job's direct dependencies, then apply the gate prepared by the wait job.
     if: >-
       !cancelled() &&
       !contains(needs.*.result, 'failure') &&
@@ -1553,14 +1394,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 .github/scripts/prepare_downstream_release_set.py \
-            --release-set .downstream-release-set/downstream-release-set.json \
-            --publish-spatialai-data-utils \
-              "${{ needs.wait-for-build-dev-images.outputs.publish-spatialai-data-utils }}" \
-            --spatialai-package-version-suffix \
-              "${{ needs.wait-for-build-dev-images.outputs.spatialai-package-version-suffix }}" \
-            --spatialai-data-utils-tree-sha \
-              "${{ needs.wait-for-build-dev-images.outputs.spatialai-data-utils-tree-sha }}" \
-            --build-type "${{ needs.wait-for-build-dev-images.outputs.build-type }}"
+            --release-set .downstream-release-set/downstream-release-set.json
 
       - name: Trigger pipeline
         id: trigger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1497,15 +1497,11 @@ jobs:
       - license-check-ui
       - folder-structure
       - wait-for-build-dev-images
-    # Explicit result checks rather than success(): a bare success() also
-    # inherits a skip from anywhere upstream of a direct need, so one skipped
-    # job two hops away silently disables this one.
-    #
-    # The contains() guards require every DIRECT need to have succeeded.
-    # needs.* holds direct dependencies only, so this is narrower than
-    # success() was: if a future direct need rescues itself past a failed
-    # ancestor with always(), that failure no longer blocks here. Nothing
-    # does that today -- add !failure() if one ever should.
+    # Do not use success() here. wait-for-build-dev-images deliberately uses
+    # always() to survive a skipped, path-gated Spatial AI Data Utils test, but
+    # success() still inherits that transitive skip and would silently disable
+    # every downstream acceptance run where SDU did not change. Check only this
+    # job's direct dependencies, then apply the gate prepared by the wait job.
     if: >-
       !cancelled() &&
       !contains(needs.*.result, 'failure') &&

--- a/.github/workflows/spatialai-data-utils.yml
+++ b/.github/workflows/spatialai-data-utils.yml
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Spatial AI Data Utils
+
+"on":
+  push:
+    branches:
+      - main
+      - develop
+      - "pull-request/[0-9]+"
+  workflow_dispatch:
+  schedule:
+    # Reconcile the current develop tree independently of unrelated VSS CI.
+    - cron: "17 3 * * *"
+
+concurrency:
+  group: >-
+    spatialai-data-utils-${{
+      startsWith(github.ref_name, 'pull-request/') && github.ref || github.run_id
+    }}
+  cancel-in-progress: ${{ startsWith(github.ref_name, 'pull-request/') }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  detect:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.metadata.outputs.changed }}
+      source-commit: ${{ steps.metadata.outputs.source-commit }}
+      source-tree-sha: ${{ steps.metadata.outputs.source-tree-sha }}
+      publish: ${{ steps.metadata.outputs.publish }}
+      reconcile: ${{ steps.metadata.outputs.reconcile }}
+      package-version-suffix: ${{ steps.metadata.outputs.package-version-suffix }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # Scheduled/manual recovery always reconciles the current develop tip.
+          ref: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'develop' || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve SDU source identity and change gate
+        id: metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          sys.path.insert(0, ".github/scripts")
+          from detect_changed_images import (
+              changed_paths,
+              paths_changed_under,
+              resolve_diff_base,
+          )
+
+          source_path = "libs/analytics/spatialai-data-utils"
+          event_name = os.environ["EVENT_NAME"]
+          ref_name = os.environ["REF_NAME"]
+          recovery = event_name in {"schedule", "workflow_dispatch"}
+
+          if recovery:
+              changed = False
+              reason = f"{event_name} reconciliation"
+          else:
+              base_branch = ref_name if ref_name in {"main", "develop"} else "develop"
+              base, reason = resolve_diff_base(
+                  Path.cwd(),
+                  event_name,
+                  ref_name,
+                  os.environ.get("BEFORE_SHA", ""),
+                  base_branch,
+              )
+              paths = changed_paths(Path.cwd(), base) if base else None
+              changed = paths_changed_under(paths, source_path)
+
+          commit = subprocess.check_output(
+              ["git", "rev-parse", "HEAD"], text=True
+          ).strip()
+          tree_sha = subprocess.check_output(
+              ["git", "rev-parse", f"HEAD:{source_path}"], text=True
+          ).strip()
+          if not re.fullmatch(r"[0-9a-f]{40}", commit):
+              raise RuntimeError(f"invalid source commit: {commit!r}")
+          if not re.fullmatch(r"[0-9a-f]{40}", tree_sha):
+              raise RuntimeError(f"invalid Spatial AI source tree SHA: {tree_sha!r}")
+
+          # GITHUB_RUN_ID is repository-global. A separate workflow must not use
+          # GITHUB_RUN_NUMBER because that counter has a different namespace
+          # from the legacy monolithic CI workflow.
+          suffix = (
+              f".dev{os.environ['GITHUB_RUN_ID']}+t{tree_sha}."
+              f"g{commit[:12]}.gh.r{os.environ['GITHUB_RUN_ATTEMPT']}"
+          )
+          publish = changed and ref_name == "develop" and not recovery
+          reconcile = recovery or publish
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"changed={str(changed).lower()}\n")
+              output.write(f"source-commit={commit}\n")
+              output.write(f"source-tree-sha={tree_sha}\n")
+              output.write(f"publish={str(publish).lower()}\n")
+              output.write(f"reconcile={str(reconcile).lower()}\n")
+              output.write(f"package-version-suffix={suffix}\n")
+          print(
+              f"Spatial AI Data Utils changed={changed}, publish={publish}, "
+              f"reconcile={reconcile}, tree={tree_sha} ({reason})"
+          )
+          PY
+
+  test:
+    name: Test
+    needs: detect
+    if: needs.detect.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    defaults:
+      run:
+        working-directory: libs/analytics/spatialai-data-utils
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends g++ git
+
+      - name: Install hash-locked Python dependencies
+        run: |
+          python -m pip install --upgrade \
+            "pip==26.1.2" \
+            "pipenv==2026.6.2" \
+            "setuptools==82.0.1" \
+            "wheel==0.47.0"
+          python -m pip install \
+            "meson-python==0.20.0" \
+            "ninja==1.11.1.1" \
+            "Cython==3.0.12"
+          pipenv requirements --dev --hash > .ci-requirements.txt
+          python -m pip install \
+            --require-hashes \
+            --no-deps \
+            --no-cache-dir \
+            -r .ci-requirements.txt
+          python -m pip install "pytest==9.0.3" "pytest-cov==7.1.0"
+
+      - name: Install CPU-only PyTorch and PyTorch3D
+        run: |
+          python -m pip install \
+            --no-cache-dir \
+            "torch==2.10.0+cpu" \
+            --extra-index-url https://download.pytorch.org/whl/cpu
+          git clone --filter=blob:none https://github.com/facebookresearch/pytorch3d.git /tmp/vss-spatialai-pytorch3d
+          git -C /tmp/vss-spatialai-pytorch3d checkout 33824be
+          MAX_JOBS=4 FORCE_CUDA=0 python -m pip install \
+            --no-build-isolation \
+            /tmp/vss-spatialai-pytorch3d
+
+      - name: Install Spatial AI Data Utils test extras
+        run: python -m pip install --no-build-isolation -e './release[eval,viz]'
+
+      - name: Run tests with coverage
+        run: |
+          mkdir -p tests/coverage
+          pytest tests/ -v \
+            --junitxml=tests/coverage/test-results.xml \
+            --cov=spatialai_data_utils \
+            --cov-report=html:tests/coverage \
+            --cov-report=xml:coverage.xml \
+            --cov-report=term-missing
+
+      - name: Build and validate development package
+        env:
+          VERSION_SUFFIX: ${{ needs.detect.outputs.package-version-suffix }}
+        run: |
+          python -m pip install "twine==6.2.0"
+          cd release
+          python setup.py sdist bdist_wheel
+          python -m twine check dist/*
+
+      - name: Upload test and coverage reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        if: always()
+        with:
+          name: spatialai-data-utils-test-reports
+          path: |
+            libs/analytics/spatialai-data-utils/tests/coverage/
+            libs/analytics/spatialai-data-utils/coverage.xml
+
+  gate:
+    name: Gate
+    needs:
+      - detect
+      - test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require tests only for SDU changes
+        env:
+          CHANGED: ${{ needs.detect.outputs.changed }}
+          DETECT_RESULT: ${{ needs.detect.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "${DETECT_RESULT}" != "success" ]]; then
+            echo "SDU change detection failed" >&2
+            exit 1
+          fi
+          if [[ "${CHANGED}" == "true" && "${TEST_RESULT}" != "success" ]]; then
+            echo "SDU changed but tests did not pass (${TEST_RESULT})" >&2
+            exit 1
+          fi
+          echo "SDU gate passed (changed=${CHANGED}, tests=${TEST_RESULT})"
+
+  publish-internal:
+    name: Publish to URM
+    needs:
+      - detect
+      - gate
+    if: needs.detect.outputs.reconcile == 'true' && needs.gate.result == 'success'
+    runs-on: [self-hosted, downstream-pipeline]
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
+      DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
+      DOWNSTREAM_PROJECT_PATH: ${{ secrets.DOWNSTREAM_PROJECT_PATH }}
+      DOWNSTREAM_REF: spatialai-publisher
+      DOWNSTREAM_SUBMODULE_HASH_VARIABLE: VSS_SUBMODULE_HASH
+      DOWNSTREAM_TARGET_BRANCH: develop
+      DOWNSTREAM_COMPARE_BRANCH: develop
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          ref: ${{ needs.detect.outputs.source-commit }}
+          persist-credentials: false
+
+      - name: Prepare SDU publisher handoff
+        env:
+          SOURCE_TREE_SHA: ${{ needs.detect.outputs.source-tree-sha }}
+          PACKAGE_VERSION_SUFFIX: ${{ needs.detect.outputs.package-version-suffix }}
+          PUBLISH: ${{ needs.detect.outputs.publish }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import json
+          import os
+
+          print("DOWNSTREAM_EXTRA_VARIABLES_JSON=" + json.dumps({
+              "SPATIALAI_PIPELINE": "true",
+              "SPATIALAI_DATA_UTILS_PUBLISH": os.environ["PUBLISH"],
+              "SPATIALAI_DATA_UTILS_RECONCILE": "true",
+              "SPATIALAI_SOURCE_TREE_SHA": os.environ["SOURCE_TREE_SHA"],
+              "SPATIALAI_PACKAGE_VERSION_SUFFIX": os.environ["PACKAGE_VERSION_SUFFIX"],
+          }, separators=(",", ":")))
+          PY
+
+      - name: Trigger dedicated SDU publisher
+        id: trigger
+        env:
+          DOWNSTREAM_COMMIT_SHA: ${{ needs.detect.outputs.source-commit }}
+        run: python3 .github/scripts/trigger_downstream_pipeline.py
+
+      - name: Poll publisher pipeline
+        env:
+          DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
+          DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}
+          POLL_INTERVAL_SECONDS: "30"
+          MAX_POLL_DURATION_SECONDS: "2400"
+        run: python3 .github/scripts/poll-downstream-pipeline.py

--- a/libs/analytics/spatialai-data-utils/README.md
+++ b/libs/analytics/spatialai-data-utils/README.md
@@ -295,3 +295,4 @@ Copyright (c) 2020 Jonathon Luiten, licensed under the MIT License. Each
 file in that subtree is dual-licensed `MIT AND Apache-2.0`: the MIT terms
 cover the upstream TrackEval portions; the NVIDIA modifications are
 released under Apache-2.0.
+


### PR DESCRIPTION
- Updated version suffix pattern to include tree SHA and commit SHA for better traceability.
- Introduced a new function to determine the downstream build type based on the relevance of changes.
- Improved validation in `spatialai_publish_variables` to ensure correct SHA matching.
- Modified CI workflow to handle the new tree SHA and updated suffix format for Spatial AI Data Utils.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
