### PR TITLE
chore(video-summarization): update CA-RAG to 3.1.1rc1

### DIFF
--- a/services/video-summarization/docker/Dockerfile
+++ b/services/video-summarization/docker/Dockerfile
@@ -64,8 +64,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ca-certific
     && rm -rf /var/lib/apt/lists/*
 
 RUN uv pip install \
-    "vss-ctx-rag @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.0" \
-    "vss-ctx-rag-arango @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.0#subdirectory=packages/vss_ctx_rag_arango" \
+    "vss-ctx-rag @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.1rc1" \
+    "vss-ctx-rag-arango @ git+https://github.com/NVIDIA/context-aware-rag.git@3.1.1rc1#subdirectory=packages/vss_ctx_rag_arango" \
     --extra-index-url https://pypi.nvidia.com/ \
     --python-version 3.13 --target /tmp/packages
 


### PR DESCRIPTION
## Description
- Update `vss-ctx-rag` from `3.1.0` to `3.1.1rc1`.
- Update `vss-ctx-rag-arango` from `3.1.0` to `3.1.1rc1`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
