### PR TITLE
Fix 83 HIGH SonarQube issues: void* API signatures (cpp:S5008)

### DIFF
--- a/services/vios/include/device_manager.h
+++ b/services/vios/include/device_manager.h
@@ -74,6 +74,7 @@ class ISensorControlInterface;
 class ISensorDiscoveryInterface;
 class SensorControl;
 
+typedef void (*destroyControlObject_t) (ISensorControlInterface*);
 typedef void (*destroyDiscoveryObject_t) (ISensorDiscoveryInterface*);
 
 typedef void (*cb_ptr_t)(const string, shared_ptr<struct SensorInfo>, bool);
@@ -362,7 +363,7 @@ struct DeviceManager
     bool needStreamMonitoring;
     bool needRecording;
     bool needStorageMngt;
-    std::pair<ISensorControlInterface*, void*> m_sensorControlobjectPair;
+    std::pair<ISensorControlInterface*, destroyControlObject_t> m_sensorControlobjectPair;
     std::vector<std::pair<ISensorDiscoveryInterface*, destroyDiscoveryObject_t>> m_sensorDiscoveryObjectPairList;
     int httpStatusCode;
     cb_ptr_t m_callback;

--- a/services/vios/include/device_manager.h
+++ b/services/vios/include/device_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,6 +73,8 @@ namespace nv_vms {
 class ISensorControlInterface;
 class ISensorDiscoveryInterface;
 class SensorControl;
+
+typedef void (*destroyDiscoveryObject_t) (ISensorDiscoveryInterface*);
 
 typedef void (*cb_ptr_t)(const string, shared_ptr<struct SensorInfo>, bool);
 
@@ -361,7 +363,7 @@ struct DeviceManager
     bool needRecording;
     bool needStorageMngt;
     std::pair<ISensorControlInterface*, void*> m_sensorControlobjectPair;
-    std::vector<std::pair<ISensorDiscoveryInterface*, void*>> m_sensorDiscoveryObjectPairList;
+    std::vector<std::pair<ISensorDiscoveryInterface*, destroyDiscoveryObject_t>> m_sensorDiscoveryObjectPairList;
     int httpStatusCode;
     cb_ptr_t m_callback;
     private:

--- a/services/vios/include/sensor_info.h
+++ b/services/vios/include/sensor_info.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -138,16 +138,19 @@ struct HashingAlgorithmInfo
     std::string algorithm;  // e.g., "SHA-256"/"MD5,SHA-256"/"MD5"
 };
 
+// Opaque, typed stand-in for a libcurl easy handle (libcurl declares CURL as void)
+struct CurlEasyHandle;
+
 class ClientSession
 {
     public:
         virtual ~ClientSession();
         ClientSession();
 
-        CURL* getCurlClient();
+        CurlEasyHandle* getCurlClient();
         std::shared_ptr<NvSoap> getNvSoap();
     protected:
-        CURL* m_curl;
+        CurlEasyHandle* m_curl;
         std::shared_ptr<NvSoap> m_nvsoap;
 };
 

--- a/services/vios/src/adaptors/adaptor_loader.cpp
+++ b/services/vios/src/adaptors/adaptor_loader.cpp
@@ -29,6 +29,10 @@
 constexpr const char* MICROSERVICE_DEFAULT_ADAPTOR_NAME = "microservice";
 constexpr const char* MICROSERVICE_DEFAULT_ID = "640c3667-81e6-460f-b926-b8008a130dbd";
 
+namespace nv_vms {
+struct SharedLibrary;
+}
+
 using namespace nv_vms;
 
 static void writeToFile(const string data)
@@ -48,7 +52,7 @@ static void writeToFile(const string data)
     }
 }
 
-static void* loadLibrary(const string& path)
+static SharedLibrary* loadLibrary(const string& path)
 {
     string lib_path(path);
     replaceString(lib_path, "arch", ARCH);
@@ -69,7 +73,7 @@ static void* loadLibrary(const string& path)
 
     // reset errors
     dlerror();
-    return lib_handle;
+    return static_cast<SharedLibrary*>(lib_handle);
 }
 
 AdaptorLoader::AdaptorLoader()

--- a/services/vios/src/adaptors/adaptor_loader.cpp
+++ b/services/vios/src/adaptors/adaptor_loader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -337,9 +337,9 @@ std::shared_ptr<DeviceManager> AdaptorLoader::loadAdaptor(ModuleId module_id)
                 int ret = loadDiscoveryAdaptorLibrary(path, &discoveryObject, &destroyObject);
                 if (ret == 0 && discoveryObject != nullptr && destroyObject != nullptr)
                 {
-                    std::pair<ISensorDiscoveryInterface*, void*> objects;
+                    std::pair<ISensorDiscoveryInterface*, destroyDiscoveryObject_t> objects;
                     objects.first = discoveryObject;
-                    objects.second = destroyObject;
+                    objects.second = reinterpret_cast<destroyDiscoveryObject_t>(destroyObject);
                     device_manager->m_sensorDiscoveryObjectPairList.push_back(objects);
                 }
             }

--- a/services/vios/src/adaptors/adaptor_loader.cpp
+++ b/services/vios/src/adaptors/adaptor_loader.cpp
@@ -314,7 +314,7 @@ std::shared_ptr<DeviceManager> AdaptorLoader::loadAdaptor(ModuleId module_id)
     if(control_adaptor_lib_path.empty() == false)
     {
         LOG(info) << "Loading control adaptor: " << control_adaptor_lib_path << endl;
-        std::pair<ISensorControlInterface*, void*>& pair = device_manager->m_sensorControlobjectPair;
+        std::pair<ISensorControlInterface*, destroyControlObject_t>& pair = device_manager->m_sensorControlobjectPair;
         int result = loadControlAdaptorLibrary(control_adaptor_lib_path, &pair.first, &pair.second);
         assert(result == 0);
         assert(pair.first != nullptr);
@@ -332,14 +332,14 @@ std::shared_ptr<DeviceManager> AdaptorLoader::loadAdaptor(ModuleId module_id)
             {
                 LOG(info) << "Loading Discovery adaptor: " << path << endl;
 
-                ISensorDiscoveryInterface* discoveryObject;
-                void* destroyObject;
+                ISensorDiscoveryInterface* discoveryObject = nullptr;
+                destroyDiscoveryObject_t destroyObject = nullptr;
                 int ret = loadDiscoveryAdaptorLibrary(path, &discoveryObject, &destroyObject);
                 if (ret == 0 && discoveryObject != nullptr && destroyObject != nullptr)
                 {
                     std::pair<ISensorDiscoveryInterface*, destroyDiscoveryObject_t> objects;
                     objects.first = discoveryObject;
-                    objects.second = reinterpret_cast<destroyDiscoveryObject_t>(destroyObject);
+                    objects.second = destroyObject;
                     device_manager->m_sensorDiscoveryObjectPairList.push_back(objects);
                 }
             }
@@ -351,7 +351,7 @@ std::shared_ptr<DeviceManager> AdaptorLoader::loadAdaptor(ModuleId module_id)
     return deviceManager;
 }
 
-int AdaptorLoader::loadControlAdaptorLibrary(const string& path, ISensorControlInterface** object, void** delObject)
+int AdaptorLoader::loadControlAdaptorLibrary(const string& path, ISensorControlInterface** object, destroyControlObject_t* delObject)
 {
     void* lib_handle = loadLibrary(path);
     if ( lib_handle == nullptr)
@@ -377,12 +377,13 @@ int AdaptorLoader::loadControlAdaptorLibrary(const string& path, ISensorControlI
         dlclose(lib_handle);
         return -1;
     }
-    *delObject = (void *)destroyObject_;
+    *delObject = destroyObject_;
     m_libs.push_back(lib_handle);
     return 0;
 }
 
-int AdaptorLoader::loadDiscoveryAdaptorLibrary(const string& path, ISensorDiscoveryInterface** object, void** delObject)
+int AdaptorLoader::loadDiscoveryAdaptorLibrary(const string& path, ISensorDiscoveryInterface** object,
+                                               destroyDiscoveryObject_t* delObject)
 {
     void* lib_handle = loadLibrary(path);
     if ( lib_handle == nullptr)
@@ -408,7 +409,7 @@ int AdaptorLoader::loadDiscoveryAdaptorLibrary(const string& path, ISensorDiscov
         dlclose(lib_handle);
         return -1;
     }
-    *delObject = (void *)destroyObject_;
+    *delObject = destroyObject_;
     m_libs.push_back(lib_handle);
     return 0;
 }

--- a/services/vios/src/adaptors/adaptor_loader.h
+++ b/services/vios/src/adaptors/adaptor_loader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,8 +37,9 @@ public:
     ~AdaptorLoader();
     std::shared_ptr<DeviceManager> loadAdaptor(ModuleId module_id = ModuleAll);
 private:
-    int loadControlAdaptorLibrary(const string& path, ISensorControlInterface** object, void** delObject);
-    int loadDiscoveryAdaptorLibrary(const string& path, ISensorDiscoveryInterface** object, void** delObject);
+    int loadControlAdaptorLibrary(const string& path, ISensorControlInterface** object, destroyControlObject_t* delObject);
+    int loadDiscoveryAdaptorLibrary(const string& path, ISensorDiscoveryInterface** object,
+                                    destroyDiscoveryObject_t* delObject);
     int loadSensorControlAdaptorLibrary(const string& path, ISensorControlInterface** object, void** delObject);
 private:
     vector <destroyControlObject_t> m_adaptorDistructorList;

--- a/services/vios/src/adaptors/media_adaptor_loader.cpp
+++ b/services/vios/src/adaptors/media_adaptor_loader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ namespace nv_vms {
 
 namespace {
 
-void* loadLibrary(const std::string& path)
+SharedLibrary* loadLibrary(const std::string& path)
 {
     std::string lib_path(path);
     replaceString(lib_path, "arch", ARCH);
@@ -51,7 +51,7 @@ void* loadLibrary(const std::string& path)
     }
 
     dlerror();
-    return lib_handle;
+    return static_cast<SharedLibrary*>(lib_handle);
 }
 
 } // namespace
@@ -60,11 +60,12 @@ int MediaAdaptorLoader::load(const std::string& path, MediaAdaptorHandle& handle
 {
     handle = {};
 
-    void* lib_handle = loadLibrary(path);
-    if (lib_handle == nullptr)
+    SharedLibrary* library = loadLibrary(path);
+    if (library == nullptr)
     {
         return -1;
     }
+    void* lib_handle = library;
 
     createMediaObject_t createObject = reinterpret_cast<createMediaObject_t>(dlsym(lib_handle, "createMediaObject"));
     const char* dlsym_error = dlerror();
@@ -99,9 +100,17 @@ int MediaAdaptorLoader::load(const std::string& path, MediaAdaptorHandle& handle
 
     handle.instance = instance;
     handle.destroy = destroyObject;
-    handle.libraryHandle = lib_handle;
+    handle.libraryHandle = library;
 
     return 0;
+}
+
+void MediaAdaptorLoader::closeLibrary(SharedLibrary* library)
+{
+    if (library != nullptr)
+    {
+        dlclose(library);
+    }
 }
 
 } // namespace nv_vms

--- a/services/vios/src/adaptors/media_adaptor_loader.h
+++ b/services/vios/src/adaptors/media_adaptor_loader.h
@@ -21,6 +21,9 @@
 
 namespace nv_vms {
 
+// Opaque handle to a dynamically loaded shared library.
+struct SharedLibrary;
+
 class MediaAdaptorLoader
 {
 public:
@@ -28,10 +31,12 @@ public:
     {
         IMediaInterface* instance{nullptr};
         destroyMediaObject_t destroy{nullptr};
-        void* libraryHandle{nullptr};
+        SharedLibrary* libraryHandle{nullptr};
     };
 
     static int load(const std::string& path, MediaAdaptorHandle& handle);
+
+    static void closeLibrary(SharedLibrary* library);
 };
 
 } // namespace nv_vms

--- a/services/vios/src/adaptors/milestone/milestone_vms.cpp
+++ b/services/vios/src/adaptors/milestone/milestone_vms.cpp
@@ -75,10 +75,13 @@ struct data
   char trace_ascii; /* 1 or 0 */
 };
 
+// CURLOPT_DEBUGFUNCTION's signature is fixed by libcurl's C ABI. Narrowing
+// userp makes the call go through an incompatible function-pointer type,
+// which is undefined behaviour; the parameter is unused here anyway.
 static
 int my_trace(CURL *handle, curl_infotype type,
              char *data, size_t size,
-             struct data *userp)
+             void *userp)
 {
     cout << string(data) << endl;
     return 0;

--- a/services/vios/src/adaptors/milestone/milestone_vms.cpp
+++ b/services/vios/src/adaptors/milestone/milestone_vms.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,7 +78,7 @@ struct data
 static
 int my_trace(CURL *handle, curl_infotype type,
              char *data, size_t size,
-             void *userp)
+             struct data *userp)
 {
     cout << string(data) << endl;
     return 0;

--- a/services/vios/src/adaptors/sensors_discovery/onvif/onvif_discovery.cpp
+++ b/services/vios/src/adaptors/sensors_discovery/onvif/onvif_discovery.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -376,9 +376,9 @@ std::vector<unsigned char> generate_nonce(size_t length)
 }
 
 // libcurl write callback
-static size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp)
+static size_t WriteCallback(char* contents, size_t size, size_t nmemb, void* userp)
 {
-    ((std::string*)userp)->append((char*)contents, size * nmemb);
+    static_cast<std::string*>(userp)->append(contents, size * nmemb);
     return size * nmemb;
 }
 

--- a/services/vios/src/adaptors/sensors_discovery/onvif/onvif_discovery.h
+++ b/services/vios/src/adaptors/sensors_discovery/onvif/onvif_discovery.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,9 +26,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <chrono>
-
-// Forward declarations
-typedef void CURLM;
+#include <curl/curl.h>
 
 namespace nv_vms {
 

--- a/services/vios/src/app/vstmodule.cpp
+++ b/services/vios/src/app/vstmodule.cpp
@@ -235,15 +235,15 @@ int ModuleLoader::loadRtspServerLib()
     const char* lib_path;
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvrtspserver.so");
-    m_handleRtspServer = dlopen(lib_path, RTLD_LAZY);
+    m_handleRtspServer = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handleRtspServer)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvrtspserver.so");
-        m_handleRtspServer = dlopen(lib_path, RTLD_LAZY);
+        m_handleRtspServer = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvrtspserver.so");
-    m_handleRtspServer = dlopen(lib_path, RTLD_LAZY);
+    m_handleRtspServer = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handleRtspServer)
     {
@@ -285,15 +285,15 @@ int ModuleLoader::loadStreamRecorderLib()
     const char* lib_path;
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvstreamrecorder.so");
-    m_handleStreamRecorder = dlopen(lib_path, RTLD_LAZY);
+    m_handleStreamRecorder = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handleStreamRecorder)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvstreamrecorder.so");
-        m_handleStreamRecorder = dlopen(lib_path, RTLD_LAZY);
+        m_handleStreamRecorder = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvstreamrecorder.so");
-    m_handleStreamRecorder = dlopen(lib_path, RTLD_LAZY);
+    m_handleStreamRecorder = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handleStreamRecorder)
     {
@@ -334,15 +334,15 @@ int ModuleLoader::loadStorageManagementLib()
     const char* lib_path;
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvstoragemanagement.so");
-    m_handleStorageManagement = dlopen(lib_path, RTLD_LAZY);
+    m_handleStorageManagement = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handleStorageManagement)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvstoragemanagement.so");
-        m_handleStorageManagement = dlopen(lib_path, RTLD_LAZY);
+        m_handleStorageManagement = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvstoragemanagement.so");
-    m_handleStorageManagement = dlopen(lib_path, RTLD_LAZY);
+    m_handleStorageManagement = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handleStorageManagement)
     {
@@ -383,15 +383,15 @@ int ModuleLoader::loadPeerConnectionManagerLib()
     const char* lib_path;
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvwebrtc_streamer.so");
-    m_handlePeerConnectionManager = dlopen(lib_path, RTLD_LAZY);
+    m_handlePeerConnectionManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handlePeerConnectionManager)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvwebrtc_streamer.so");
-        m_handlePeerConnectionManager = dlopen(lib_path, RTLD_LAZY);
+        m_handlePeerConnectionManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvwebrtc_streamer.so");
-    m_handlePeerConnectionManager = dlopen(lib_path, RTLD_LAZY);
+    m_handlePeerConnectionManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handlePeerConnectionManager)
     {
@@ -432,15 +432,15 @@ int ModuleLoader::loadPeerConnectionLiveLib()
     const char* lib_path;
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvpeerconnection_live.so");
-    m_handlePeerConnectionLiveManager = dlopen(lib_path, RTLD_LAZY);
+    m_handlePeerConnectionLiveManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handlePeerConnectionLiveManager)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvpeerconnection_live.so");
-        m_handlePeerConnectionLiveManager = dlopen(lib_path, RTLD_LAZY);
+        m_handlePeerConnectionLiveManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvpeerconnection_live.so");
-    m_handlePeerConnectionLiveManager = dlopen(lib_path, RTLD_LAZY);
+    m_handlePeerConnectionLiveManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handlePeerConnectionLiveManager)
     {
@@ -481,15 +481,15 @@ int ModuleLoader::loadPeerConnectionReplayLib()
     const char* lib_path;
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvpeerconnection_replay.so");
-    m_handlePeerConnectionReplayManager = dlopen(lib_path, RTLD_LAZY);
+    m_handlePeerConnectionReplayManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handlePeerConnectionReplayManager)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvpeerconnection_replay.so");
-        m_handlePeerConnectionReplayManager = dlopen(lib_path, RTLD_LAZY);
+        m_handlePeerConnectionReplayManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvpeerconnection_replay.so");
-    m_handlePeerConnectionReplayManager = dlopen(lib_path, RTLD_LAZY);
+    m_handlePeerConnectionReplayManager = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handlePeerConnectionReplayManager)
     {
@@ -530,15 +530,15 @@ int ModuleLoader::loadStreamBridgeLib()
     const char* lib_path;
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvstreambridge.so");
-    m_handleStreamBridge = dlopen(lib_path, RTLD_LAZY);
+    m_handleStreamBridge = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handleStreamBridge)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvstreambridge.so");
-        m_handleStreamBridge = dlopen(lib_path, RTLD_LAZY);
+        m_handleStreamBridge = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvstreambridge.so");
-    m_handleStreamBridge = dlopen(lib_path, RTLD_LAZY);
+    m_handleStreamBridge = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handleStreamBridge)
     {
@@ -579,15 +579,15 @@ int ModuleLoader::loadSensorManagementLib()
     const char* lib_path;
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvsensormanagement.so");
-    m_handleSensorManagement = dlopen(lib_path, RTLD_LAZY);
+    m_handleSensorManagement = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handleSensorManagement)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvsensormanagement.so");
-        m_handleSensorManagement = dlopen(lib_path, RTLD_LAZY);
+        m_handleSensorManagement = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvsensormanagement.so");
-    m_handleSensorManagement = dlopen(lib_path, RTLD_LAZY);
+    m_handleSensorManagement = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handleSensorManagement)
     {

--- a/services/vios/src/app/vstmodule.cpp
+++ b/services/vios/src/app/vstmodule.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -641,7 +641,7 @@ int ModuleLoader::loadMediaAdaptor()
         LOG(error) << "Failed to load media adaptor library: " << m_mediaAdaptorLibPath << endl;
         if (handle.libraryHandle != nullptr)
         {
-            dlclose(handle.libraryHandle);
+            nv_vms::MediaAdaptorLoader::closeLibrary(handle.libraryHandle);
         }
         return -1;
     }
@@ -662,7 +662,7 @@ void ModuleLoader::unloadMediaAdaptor()
 
     if (m_mediaAdaptorHandle.libraryHandle != nullptr)
     {
-        dlclose(m_mediaAdaptorHandle.libraryHandle);
+        nv_vms::MediaAdaptorLoader::closeLibrary(m_mediaAdaptorHandle.libraryHandle);
         m_mediaAdaptorHandle.libraryHandle = nullptr;
     }
 

--- a/services/vios/src/app/vstmodule.h
+++ b/services/vios/src/app/vstmodule.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -130,14 +130,14 @@ class ModuleLoader
         int loadMediaAdaptor();
         void unloadMediaAdaptor();
 
-        void* m_handleRtspServer = nullptr;
-        void* m_handleStreamRecorder = nullptr;
-        void* m_handleStorageManagement = nullptr;
-        void* m_handleSensorManagement = nullptr;
-        void* m_handlePeerConnectionManager = nullptr;
-        void* m_handlePeerConnectionLiveManager = nullptr;
-        void* m_handlePeerConnectionReplayManager = nullptr;
-        void* m_handleStreamBridge = nullptr;
+        nv_vms::SharedLibrary* m_handleRtspServer = nullptr;
+        nv_vms::SharedLibrary* m_handleStreamRecorder = nullptr;
+        nv_vms::SharedLibrary* m_handleStorageManagement = nullptr;
+        nv_vms::SharedLibrary* m_handleSensorManagement = nullptr;
+        nv_vms::SharedLibrary* m_handlePeerConnectionManager = nullptr;
+        nv_vms::SharedLibrary* m_handlePeerConnectionLiveManager = nullptr;
+        nv_vms::SharedLibrary* m_handlePeerConnectionReplayManager = nullptr;
+        nv_vms::SharedLibrary* m_handleStreamBridge = nullptr;
         AdaptorLoader m_loader;
         std::shared_ptr<DeviceManager> m_deviceManager;
         nv_vms::MediaAdaptorLoader::MediaAdaptorHandle m_mediaAdaptorHandle{};

--- a/services/vios/src/framework/apis/common/device_manager.cpp
+++ b/services/vios/src/framework/apis/common/device_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -469,7 +469,7 @@ DeviceManager::~DeviceManager()
 
     clearSensorList();
 
-    destroyControlObject_t delObject = (destroyControlObject_t) m_sensorControlobjectPair.second;
+    destroyControlObject_t delObject = m_sensorControlobjectPair.second;
     if (m_sensorControlobjectPair.first != nullptr && delObject != nullptr)
     {
         delObject(m_sensorControlobjectPair.first);

--- a/services/vios/src/framework/apis/common/sensor_info.cpp
+++ b/services/vios/src/framework/apis/common/sensor_info.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -426,7 +426,7 @@ ClientSession::~ClientSession()
 
 ClientSession::ClientSession()
 {
-    m_curl = curl_easy_init();
+    m_curl = static_cast<CurlEasyHandle*>(curl_easy_init());
     m_nvsoap = std::make_shared<NvSoap>();
 
     if (!m_curl || !m_nvsoap)
@@ -435,7 +435,7 @@ ClientSession::ClientSession()
     }
 }
 
-CURL* ClientSession::getCurlClient()
+CurlEasyHandle* ClientSession::getCurlClient()
 {
     if (m_curl != nullptr)
     {

--- a/services/vios/src/framework/live555/rtsp_client/testRTSP.cpp
+++ b/services/vios/src/framework/live555/rtsp_client/testRTSP.cpp
@@ -31,8 +31,8 @@ void continueAfterSETUP(RTSPClient* rtspClient, int resultCode, char* resultStri
 void continueAfterPLAY(RTSPClient* rtspClient, int resultCode, char* resultString);
 
 // Other event handler functions:
-void subsessionAfterPlaying(void* clientData); // called when a stream's subsession (e.g., audio or video substream) ends
-void subsessionByeHandler(void* clientData, char const* reason);
+void subsessionAfterPlaying(MediaSubsession* subsession); // called when a stream's subsession (e.g., audio or video substream) ends
+void subsessionByeHandler(MediaSubsession* subsession, char const* reason);
   // called when a RTCP "BYE" is received for a subsession
 void subsessionSRHandler(MediaSubsession* subsession);
 void streamTimerHandler(void* clientData);
@@ -373,10 +373,15 @@ void continueAfterSETUP(RTSPClient* rtspClient, int resultCode, char* resultStri
     env << *rtspClient << "Created a data sink for the \"" << *scs.subsession << "\" subsession\n";
     scs.subsession->miscPtr = rtspClient; // a hack to let subsession handler functions get the "RTSPClient" from the subsession 
     scs.subsession->sink->startPlaying(*(scs.subsession->readSource()),
-				       subsessionAfterPlaying, scs.subsession);
+				       [](void* clientData) { subsessionAfterPlaying(static_cast<MediaSubsession*>(clientData)); },
+				       scs.subsession);
     // Also set a handler to be called if a RTCP "BYE" arrives for this subsession:
     if (scs.subsession->rtcpInstance() != nullptr) {
-      scs.subsession->rtcpInstance()->setByeWithReasonHandler(subsessionByeHandler, scs.subsession);
+      scs.subsession->rtcpInstance()->setByeWithReasonHandler(
+          [](void* clientData, char const* reason) {
+            subsessionByeHandler(static_cast<MediaSubsession*>(clientData), reason);
+          },
+          scs.subsession);
       if (((ourRTSPClient*)rtspClient)->m_enableSR == true) {
         scs.subsession->rtcpInstance()->setSRHandler(
             [](void* clientData) { subsessionSRHandler(static_cast<MediaSubsession*>(clientData)); },
@@ -504,8 +509,7 @@ void continueAfterPLAY(RTSPClient* rtspClient, int resultCode, char* resultStrin
 
 // Implementation of the other event handlers:
 
-void subsessionAfterPlaying(void* clientData) {
-  MediaSubsession* subsession = (MediaSubsession*)clientData;
+void subsessionAfterPlaying(MediaSubsession* subsession) {
   RTSPClient* rtspClient = (RTSPClient*)(subsession->miscPtr);
 
   // Begin by closing this subsession's stream:
@@ -523,8 +527,7 @@ void subsessionAfterPlaying(void* clientData) {
   shutdownStream(rtspClient);
 }
 
-void subsessionByeHandler(void* clientData, char const* reason) {
-  MediaSubsession* subsession = (MediaSubsession*)clientData;
+void subsessionByeHandler(MediaSubsession* subsession, char const* reason) {
   RTSPClient* rtspClient = (RTSPClient*)subsession->miscPtr;
   UsageEnvironment& env = rtspClient->envir(); // alias
 

--- a/services/vios/src/framework/live555/rtsp_client/testRTSP.cpp
+++ b/services/vios/src/framework/live555/rtsp_client/testRTSP.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,7 @@ void continueAfterPLAY(RTSPClient* rtspClient, int resultCode, char* resultStrin
 void subsessionAfterPlaying(void* clientData); // called when a stream's subsession (e.g., audio or video substream) ends
 void subsessionByeHandler(void* clientData, char const* reason);
   // called when a RTCP "BYE" is received for a subsession
-void subsessionSRHandler(void* clientData);
+void subsessionSRHandler(MediaSubsession* subsession);
 void streamTimerHandler(void* clientData);
   // called at the end of a stream's expected duration (if the stream has not already signaled its end using a RTCP "BYE")
 
@@ -378,7 +378,9 @@ void continueAfterSETUP(RTSPClient* rtspClient, int resultCode, char* resultStri
     if (scs.subsession->rtcpInstance() != nullptr) {
       scs.subsession->rtcpInstance()->setByeWithReasonHandler(subsessionByeHandler, scs.subsession);
       if (((ourRTSPClient*)rtspClient)->m_enableSR == true) {
-        scs.subsession->rtcpInstance()->setSRHandler(subsessionSRHandler, scs.subsession);
+        scs.subsession->rtcpInstance()->setSRHandler(
+            [](void* clientData) { subsessionSRHandler(static_cast<MediaSubsession*>(clientData)); },
+            scs.subsession);
       }
     }
   } while (0);
@@ -537,8 +539,7 @@ void subsessionByeHandler(void* clientData, char const* reason) {
   subsessionAfterPlaying(subsession);
 }
 
-void subsessionSRHandler(void* clientData) {
-  MediaSubsession* subsession = (MediaSubsession*)clientData;
+void subsessionSRHandler(MediaSubsession* subsession) {
   RTSPClient* rtspClient = (RTSPClient*)subsession->miscPtr;
   UsageEnvironment& env = rtspClient->envir(); // alias
 

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudioudpclient.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudioudpclient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -293,7 +293,6 @@ void GstUDPAudioClient::destroy_internal ()
 
 int GstUDPAudioClient::create(int freq)
 {
-    m_eventLoop.setParent(this);
     std::shared_ptr<EventLoopData> data(new EventLoopData);
     m_freq = freq;
     data->m_taskName = "create";
@@ -303,7 +302,6 @@ int GstUDPAudioClient::create(int freq)
 
 void GstUDPAudioClient::start()
 {
-    m_eventLoop.setParent(this);
     std::shared_ptr<EventLoopData> data(new EventLoopData);
     data->m_taskName = "play";
     m_eventLoop.postMsg(data);
@@ -334,11 +332,10 @@ void GstUDPAudioClient::destroy(bool expect_result)
     return;
 }
 
-void GstUDPAudioClient::process_eventloop_message(std::shared_ptr<EventLoopData> data, void* parent)
+void GstUDPAudioClient::process_eventloop_message(std::shared_ptr<EventLoopData> data)
 {
     shared_ptr<EventLoopData> ev_data = std::static_pointer_cast<EventLoopData>(data);
-    GstUDPAudioClient* udpClient = static_cast <GstUDPAudioClient*>(parent);
-    if (udpClient == nullptr || ev_data == nullptr)
+    if (ev_data == nullptr)
     {
         LOG(error) << "Received null data" << endl;
         return;
@@ -346,23 +343,23 @@ void GstUDPAudioClient::process_eventloop_message(std::shared_ptr<EventLoopData>
     LOG(verbose) << ev_data->m_taskName << endl;
     if (ev_data->m_taskName == "create")
     {
-        udpClient->create_internal();
+        create_internal();
     }
     else if (ev_data->m_taskName == "play")
     {
-        udpClient->play_internal();
+        play_internal();
     }
     else if (ev_data->m_taskName == "pause")
     {
-        udpClient->pause_internal();
+        pause_internal();
     }
     else if (ev_data->m_taskName == "resume")
     {
-        udpClient->resume_internal();
+        resume_internal();
     }
     else if (ev_data->m_taskName == "destroy")
     {
-        udpClient->destroy_internal();
+        destroy_internal();
     }
     else
     {

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudioudpclient.h
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudioudpclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,8 @@ namespace nv_vms
                       , m_bus(nullptr)
                       , m_busWatchId(0)
                       , m_freq (8000)
-                      , m_eventLoop("udp_audio_event_loop", process_eventloop_message)
+                      , m_eventLoop("udp_audio_event_loop",
+                                    [this](std::shared_ptr<EventLoopData> data) { process_eventloop_message(data); })
                       , m_is_error(false)
                       {
                           LOG(info) << "GstUDPAudioClient::GstUDPAudioClient port:" << id << endl;
@@ -69,7 +70,7 @@ namespace nv_vms
             bool pause_internal();
             void resume_internal();
             void destroy_internal();
-            static void process_eventloop_message(std::shared_ptr<EventLoopData> data, void* parent);
+            void process_eventloop_message(std::shared_ptr<EventLoopData> data);
             friend gboolean busWatchFunc (GstBus *bus, GstMessage *message, gpointer data);
             GstFlowReturn processNewSampleFromSink(GstElement * appsink);
 

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -136,7 +136,8 @@ GstUDPVideoClient::GstUDPVideoClient (const string&  id, UdpStream& stream)
     , m_sinkAudio(nullptr)
     , m_bus(nullptr)
     , m_bus_watch_id(0)
-    , m_eventLoop("udp_video_event_loop", process_eventloop_message)
+    , m_eventLoop("udp_video_event_loop", [this](std::shared_ptr<EventLoopData> data)
+                  { process_eventloop_message(std::move(data), this); })
     , m_is_error(false)
     , m_udpsrcVideoFrameCount(0)
     , m_udpsrcVideoProbeCount(0)
@@ -1345,7 +1346,6 @@ void GstUDPVideoClient::destroy_internal ()
 
 int GstUDPVideoClient::create()
 {
-    m_eventLoop.setParent(this);
     std::shared_ptr<EventLoopData> data(new EventLoopData);
     data->m_taskName = "create";
     m_eventLoop.postMsg(data);
@@ -1354,7 +1354,6 @@ int GstUDPVideoClient::create()
 
 int GstUDPVideoClient::create_audio()
 {
-    m_eventLoop.setParent(this);
     std::shared_ptr<EventLoopData> data(new EventLoopData);
     data->m_taskName = "create_audio";
     m_eventLoop.postMsg(data);
@@ -1363,7 +1362,6 @@ int GstUDPVideoClient::create_audio()
 
 void GstUDPVideoClient::start()
 {
-    m_eventLoop.setParent(this);
     std::shared_ptr<EventLoopData> data(new EventLoopData);
     data->m_taskName = "play";
     m_eventLoop.postMsg(data);
@@ -1411,10 +1409,10 @@ void GstUDPVideoClient::destroy(bool expect_result)
     return;
 }
 
-void GstUDPVideoClient::process_eventloop_message(std::shared_ptr<EventLoopData> data, void* parent)
+void GstUDPVideoClient::process_eventloop_message(std::shared_ptr<EventLoopData> data, GstUDPVideoClient* parent)
 {
-    shared_ptr<EventLoopData> ev_data = std::static_pointer_cast<EventLoopData>(data);
-    GstUDPVideoClient* udpClient = static_cast <GstUDPVideoClient*>(parent);
+    shared_ptr<EventLoopData> ev_data = std::move(data);
+    GstUDPVideoClient* udpClient = parent;
     if (udpClient == nullptr || ev_data == nullptr)
     {
         LOG(error) << "Received null data" << endl;

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.h
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,7 @@ namespace nv_vms
             void resume_internal();
             void destroy_internal();
             void reset_pipeline_internal ();
-            static void process_eventloop_message(std::shared_ptr<EventLoopData> data, void* parent);
+            static void process_eventloop_message(std::shared_ptr<EventLoopData> data, GstUDPVideoClient* parent);
             friend gboolean busWatchFunc (GstBus *bus, GstMessage *message, gpointer data);
             GstFlowReturn processNewSampleFromSink(GstElement * appsink);
             GstFlowReturn processNewAudioSampleFromSink(GstElement * appsink);

--- a/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -479,7 +479,8 @@ static bool hasVclNalInBuffer(const uint8_t* data, size_t size, bool is_h265, bo
 
 ClipReaderProducer::ClipReaderProducer(const ClipReaderConfig& cfg)
 : mCfg(cfg)
-, m_recoveryEventLoop(std::make_unique<EventLoop>("clip_reader_retry", &ClipReaderProducer::process_retry_message))
+, m_recoveryEventLoop(std::make_unique<EventLoop>("clip_reader_retry",
+      [this](std::shared_ptr<EventLoopData> data) { processRetryMessage(data); }))
 {
 #if CLIP_READER_GIOSRC_EXTRA_DEBUG
     const char* env = std::getenv("VST_CLIP_READER_GIOSRC_DEBUG");
@@ -884,8 +885,6 @@ bool ClipReaderProducer::start()
 {
     if (mRunning.load()) return true;
     if (!gst_is_initialized()) { gst_init(nullptr, nullptr); }
-
-    m_recoveryEventLoop->setParent(this);
 
     // Save original seek_start_ms before any retries can modify it
     mOriginalSeekStartMs.store(mCfg.seek_start_ms);
@@ -1669,41 +1668,40 @@ bool ClipReaderProducer::postRetryPipeline(bool isError, const std::string& erro
     return true;
 }
 
-void ClipReaderProducer::process_retry_message(std::shared_ptr<EventLoopData> data, void* parent)
+void ClipReaderProducer::processRetryMessage(const std::shared_ptr<EventLoopData>& data)
 {
-    ClipReaderProducer* producer = static_cast<ClipReaderProducer*>(parent);
-    if (!producer || !data)
+    if (!data)
     {
-        LOG(error) << "ClipReaderProducer::process_retry_message: null producer or data" << endl;
+        LOG(error) << "ClipReaderProducer::processRetryMessage: null data" << endl;
         return;
     }
 
     // Clear mRetryInProgress and notify BEFORE any pipeline operations so stop() can proceed
     // without racing with retryPipeline() (avoids stop() tearing down a freshly rebuilt pipeline
     // concurrently with the retry callback).
-    producer->mRetryInProgress.store(false);
-    producer->mRetrySync.signal();
+    mRetryInProgress.store(false);
+    mRetrySync.signal();
 
     bool isError = data->m_inData["isError"].asBool();
     std::string errorMsg = data->m_inData["errorMsg"].asString();
 
-    bool ok = producer->retryPipeline();
+    bool ok = retryPipeline();
     if (!ok)
     {
         if (isError)
         {
-            if (producer->mRunning.load())
+            if (mRunning.load())
             {
-                producer->notifyErrorOnce(errorMsg, 1);
+                notifyErrorOnce(errorMsg, 1);
             }
         }
         else
         {
-            if (producer->mRunning.load())
+            if (mRunning.load())
             {
-                LOG(warning) << producer->mLogPrefix << "ClipReaderProducer: Retry failed, truncated clip" << endl;
-                producer->mRunning.store(false);
-                producer->notifyFinishedOnce();
+                LOG(warning) << mLogPrefix << "ClipReaderProducer: Retry failed, truncated clip" << endl;
+                mRunning.store(false);
+                notifyFinishedOnce();
             }
         }
     }

--- a/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.h
+++ b/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.h
@@ -122,8 +122,8 @@ public:
     void onError(std::function<void(const std::string& /*errorMsg*/, int /*errorCode*/)> cb) override;
 
     // Expose internal handles for advanced debug if needed
-    void* getGstPipeline() const { return mPipeline; }
-    void* getReaderSrc() const { return mReaderSrc; }
+    GstElement* getGstPipeline() const { return mPipeline; }
+    GstElement* getReaderSrc() const { return mReaderSrc; }
     const std::string& logPrefix() const { return mLogPrefix; }
 
     // Used by appsink collect probe (post-seek buffer queue)

--- a/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.h
+++ b/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,7 +231,7 @@ private:
     // Returns true if retry was posted or already in progress.
     bool postRetryPipeline(bool isError, const std::string& errorMsg);
 
-    static void process_retry_message(std::shared_ptr<EventLoopData> data, void* parent);
+    void processRetryMessage(const std::shared_ptr<EventLoopData>& data);
 
     // Cap retries for premature EOS gaps (separate from empty-stream retries)
     std::atomic<int> mPrematureEosRetryCount{0};

--- a/services/vios/src/framework/media/media_pipelines/media_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/media_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -259,7 +259,7 @@ class IMediaDataConsumer : public std::enable_shared_from_this<IMediaDataConsume
         virtual bool waitForCompletion(int64_t /*timeout_secs*/) { return true; }
         virtual bool hasError() const { return false; }
         virtual std::shared_ptr<IMediaDataConsumer> getAudioConsumer() { return nullptr; }
-        virtual void* getPipeline() const { return nullptr; }
+        virtual GstElement* getPipeline() const { return nullptr; }
 
         // Get actual first frame PTS in milliseconds (for remux mode filename correction)
         // Returns -1 if not available/not tracked

--- a/services/vios/src/framework/media/media_pipelines/media_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/media_consumer.h
@@ -30,6 +30,11 @@
 
 using namespace std;
 
+namespace webrtc
+{
+    class VideoBroadcaster;
+}
+
 typedef enum
 {
     InvalidMedia = -1,
@@ -221,7 +226,7 @@ class IMediaDataConsumer : public std::enable_shared_from_this<IMediaDataConsume
         bool isPpsAvailable();
         bool isSpsPpsAvailable();
 
-        virtual void setWebrtcBroadcaster(void* broadcaster) { };
+        virtual void setWebrtcBroadcaster(webrtc::VideoBroadcaster* broadcaster) { };
         virtual void onLastFrame() { }
         virtual void reset() { }
         /* Update start time for overlay */

--- a/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,7 @@ public:
     bool start();
     void stop();
     bool isRunning() const { return mRunning.load(); }
-    void* getPipeline() const { return mPipeline; }
+    GstElement* getPipeline() const override { return mPipeline; }
     
     // Wait on this writer's bus for EOS or ERROR. Returns true on EOS/ERROR, false on timeout.
     bool waitForCompletion(int64_t timeout_secs);

--- a/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,7 +73,7 @@ public:
     bool start();
     void stop();
     bool isRunning() const { return mRunning.load(); }
-    void* getPipeline() const { return mPipeline; }
+    GstElement* getPipeline() const override { return mPipeline; }
     // Wait on this writer's bus for EOS or ERROR. Returns true on EOS/ERROR, false on timeout.
     bool waitForCompletion(int64_t timeout_secs);
     bool hasError() const { return mError.load(); }

--- a/services/vios/src/framework/media/media_utils/libav_wrapper.h
+++ b/services/vios/src/framework/media/media_utils/libav_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +44,9 @@ extern "C" {
 #include <libavutil/samplefmt.h>
 }
 struct AVFrame;
+
+// Opaque handle returned by the dynamic loader helpers
+struct LibavLibraryHandle;
 
 #define DL_ERROR_EXIT  { char *dlsym_error = dlerror(); \
                             if (dlsym_error) { \
@@ -105,7 +108,7 @@ private:
     static constexpr size_t TRUSTED_SYSTEM_DIRS_COUNT = sizeof(TRUSTED_SYSTEM_DIRS) / sizeof(TRUSTED_SYSTEM_DIRS[0]);
 
     // Secure library loading function with path validation
-    void* tryLoadLibrary(const char* lib_path)
+    LibavLibraryHandle* tryLoadLibrary(const char* lib_path)
     {
         if (!lib_path || lib_path[0] == '\0')
         {
@@ -119,7 +122,7 @@ private:
             for (size_t i = 0; i < TRUSTED_SYSTEM_DIRS_COUNT; i++)
             {
                 std::string full_path = std::string(TRUSTED_SYSTEM_DIRS[i]) + lib_path;
-                void* handle = tryLoadLibraryFullPath(full_path.c_str());
+                LibavLibraryHandle* handle = tryLoadLibraryFullPath(full_path.c_str());
                 if (handle)
                 {
                     return handle;
@@ -133,7 +136,7 @@ private:
     }
     
     // Helper function for loading with full path validation
-    void* tryLoadLibraryFullPath(const char* lib_path)
+    LibavLibraryHandle* tryLoadLibraryFullPath(const char* lib_path)
     {
         // Check if file exists and is readable
         if (access(lib_path, R_OK) != 0)
@@ -169,7 +172,7 @@ private:
         }
         
         // Load the library with RTLD_NOW for immediate symbol resolution
-        void* handle = dlopen(resolved_path, RTLD_NOW | RTLD_LOCAL);
+        LibavLibraryHandle* handle = static_cast<LibavLibraryHandle*>(dlopen(resolved_path, RTLD_NOW | RTLD_LOCAL));
         if (handle)
         {
             std::cout << "[INFO] LibavWrapper: Successfully loaded library from: " << resolved_path << std::endl;
@@ -405,7 +408,7 @@ public:
 
 private:
     LibavMode m_libavMode;
-    void* handle_libavformat;
-    void* handle_libavcodec;
-    void* handle_libavutil;
+    LibavLibraryHandle* handle_libavformat;
+    LibavLibraryHandle* handle_libavcodec;
+    LibavLibraryHandle* handle_libavutil;
 }; 

--- a/services/vios/src/framework/media/overlays/ll_overlay.cpp
+++ b/services/vios/src/framework/media/overlays/ll_overlay.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -663,7 +663,7 @@ void NvLLOverlay::doDrawTask()
         GstMetaUnion meta_union;
         int64_t pts = 0;
         bool is_drc = false;
-        void *data_ptr = nullptr;
+        unsigned char *data_ptr = nullptr;
         bool is_sw_mode = GET_CONFIG().use_software_path || g_isGpuPresent == false;
 
         {
@@ -829,12 +829,12 @@ void NvLLOverlay::doDrawTask()
                 // Perform overlay using GPU/CPU based on config
                 if (!isJetsonPlatform() && is_sw_mode)
                 {
-                    data_ptr = (void *)m_cpuPtr[index];
+                    data_ptr = m_cpuPtr[index];
                     ret = m_overlay->doDraw(data_ptr, &meta_union, pts);
                 }
                 else
                 {
-                    ret = m_overlay->doDraw((void *)dst_surf, &meta_union, pts);
+                    ret = m_overlay->doDraw(reinterpret_cast<unsigned char *>(dst_surf), &meta_union, pts);
                 }
 
                 if (ret == false)

--- a/services/vios/src/framework/media/overlays/ll_overlay.cpp
+++ b/services/vios/src/framework/media/overlays/ll_overlay.cpp
@@ -719,7 +719,7 @@ void NvLLOverlay::doDrawTask()
                 }
                 else
                 {
-                    NvBufWrapper::getInstance()->NvBufSurfaceFromFd (sink_frame->m_fd, (void **)&ip_surf);
+                    NvBufWrapper::getInstance()->NvBufSurfaceFromFd (sink_frame->m_fd, &ip_surf);
                     if (isJetsonPlatform() && m_isIPCMeta)
                     {
                         meta_union.ipcMeta = (GstNvIpcMeta*)sink_frame->meta;
@@ -804,7 +804,7 @@ void NvLLOverlay::doDrawTask()
                 }
                 else
                 {
-                    NvBufWrapper::getInstance()->NvBufSurfaceFromFd (fd_index_pair.first, (void **)&dst_surf);
+                    NvBufWrapper::getInstance()->NvBufSurfaceFromFd (fd_index_pair.first, &dst_surf);
                     NvBufWrapper::getInstance()->NvBufSurfaceCopy (ip_surf, dst_surf);
                 }
                 if (sink_frame->m_gstBuffer)

--- a/services/vios/src/framework/media/overlays/ll_overlay.h
+++ b/services/vios/src/framework/media/overlays/ll_overlay.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,7 +109,6 @@ private:
     std::string                                    m_peerid;
     std::string                                    m_isoStartTime;
     std::string                                    m_isoEndTime;
-    void*                                          m_broadcaster = nullptr;
     uint8_t*                                       m_cpuPtr[OUTPUT_PLANE_NUM_BUFFERS];
     bool                                           m_imageCapture = false;
     bool                                           m_isIPCMeta = false;

--- a/services/vios/src/framework/media/overlays/overlay_internal.cpp
+++ b/services/vios/src/framework/media/overlays/overlay_internal.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2138,14 +2138,14 @@ bool process_tripwire_stats(const string &sensorName, const string &tripwireId, 
     return true;
 }
 
-bool NvLLOverlayInternal::doDraw (void* data, GstMetaUnion *meta, int64_t pts)
+bool NvLLOverlayInternal::doDraw (unsigned char* data, GstMetaUnion *meta, int64_t pts)
 {
     bool ret = false;
     if (m_useId)
     {
-        ret = processOsdSinkPadBufferProbeStreamer(data, meta->vstMeta);
+        ret = processOsdSinkPadBufferProbeStreamer((unsigned char *)data, meta->vstMeta);
     }
-    ret = processOsdSinkPadBufferProbe(data, meta, pts);
+    ret = processOsdSinkPadBufferProbe((unsigned char *)data, meta, pts);
     return ret;
 }
 
@@ -3418,7 +3418,7 @@ void NvLLOverlayInternal::readCalibrationData()
     }
 }
 
-bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUnion *union_meta, int64_t pts)
+bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (unsigned char* buffer, GstMetaUnion *union_meta, int64_t pts)
 {
     GstNvIpcMeta* ipc_meta = nullptr;
     GstNvVstMeta* vst_meta = nullptr;
@@ -3449,7 +3449,7 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
         }
         m_cpuCtx->width = m_width;
         m_cpuCtx->height = m_height;
-        m_cpuCtx->data = &buffer;
+        m_cpuCtx->data = (void **)&buffer;
         m_cpuCtx->size = (m_width * m_height * 3) / 2;
         ip_buffer = (OsdCpuDataContext *)m_cpuCtx;
     }
@@ -3866,7 +3866,7 @@ Json::Value NvLLOverlayInternal::getMetadata(int64_t frameTS)
     return metadata;
 }
 
-bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, GstNvVstMeta *meta)
+bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (unsigned char* buffer, GstNvVstMeta *meta)
 {
 #ifdef USE_CUOSD
     void *ip_buffer = buffer;
@@ -3885,7 +3885,7 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, Gs
         }
         m_cpuCtx->width = m_width;
         m_cpuCtx->height = m_height;
-        m_cpuCtx->data = &buffer;
+        m_cpuCtx->data = (void **)&buffer;
         m_cpuCtx->size = (m_width * m_height * 3) / 2;
         ip_buffer = (OsdCpuDataContext *)m_cpuCtx;
     }
@@ -4544,9 +4544,9 @@ GstPadProbeReturn osd_sink_pad_buffer_probe (GstPad* pad, GstPadProbeInfo* info,
 
         if (overlay->m_useId)
         {
-            ret = overlay->processOsdSinkPadBufferProbeStreamer(buffer, meta);
+            ret = overlay->processOsdSinkPadBufferProbeStreamer((unsigned char *)buffer, meta);
         }
-        ret = overlay->processOsdSinkPadBufferProbe(buffer, &meta_union, frameTS);
+        ret = overlay->processOsdSinkPadBufferProbe((unsigned char *)buffer, &meta_union, frameTS);
         return (ret == true) ? GST_PAD_PROBE_OK : GST_PAD_PROBE_REMOVE;
     }
     return GST_PAD_PROBE_REMOVE;

--- a/services/vios/src/framework/media/overlays/overlay_internal.h
+++ b/services/vios/src/framework/media/overlays/overlay_internal.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -249,8 +249,8 @@ class NvLLOverlayInternal
         void readTripwire();
         void readRoi();
         void readCalibrationData();
-        bool processOsdSinkPadBufferProbeStreamer (void* buf, GstNvVstMeta *meta);
-        bool processOsdSinkPadBufferProbe (void* buf, GstMetaUnion *meta, int64_t pts = 0);
+        bool processOsdSinkPadBufferProbeStreamer (unsigned char* buf, GstNvVstMeta *meta);
+        bool processOsdSinkPadBufferProbe (unsigned char* buf, GstMetaUnion *meta, int64_t pts = 0);
         void fetchMetadataAgain (string new_start);
         void updateIdList(std::vector<string> idList[OVERLAYCOUNT]);
         void updateClassTypeList(std::vector<string> classTypeList);
@@ -275,7 +275,7 @@ class NvLLOverlayInternal
         void updateIPCStreamResolution(int width, int height);
         bool isOverlayEnabled();
         bool isBboxEnabled() { return m_enableBbox; }
-        bool doDraw (void* data, GstMetaUnion *meta, int64_t pts = 0);
+        bool doDraw (unsigned char* data, GstMetaUnion *meta, int64_t pts = 0);
         void draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData* box_params,
                 vector<string> m_bboxList, vector<string> m_classTypeList, OsdContext_t context, GstBuffer *buffer);
         GstElement* create();

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -612,10 +612,9 @@ exit:
     return TRUE;
 }
 
-void process_dec_message(std::shared_ptr<EventLoopData> data, void* parent)
+void process_dec_message(std::shared_ptr<EventLoopData> data, GstNvVideoDecoder* dec)
 {
     shared_ptr<DecoderData> dec_data = std::static_pointer_cast<DecoderData>(data);
-    GstNvVideoDecoder* dec = static_cast <GstNvVideoDecoder*>(parent);
     if (dec_data == nullptr || dec == nullptr)
     {
         LOG(error) << "Received null data" << endl;
@@ -776,7 +775,6 @@ static bool link_decoder(GstElement* decoder, GstElement* element)
 int GstNvVideoDecoder::create(bool blocking)
 {
     int ret = -1;
-    m_eventLoop.setParent(this);
     m_decOutFrames = 0;
     std::shared_ptr<DecoderData> in_data(new DecoderData);
     std::shared_ptr<DecoderOutData> out_data (new DecoderOutData);
@@ -1809,7 +1807,8 @@ GstNvVideoDecoder::GstNvVideoDecoder (const std::string& consumer_name, const st
                   , m_sourceWidth (WIDTH_1080p)
                   , m_sourceHeight (HEIGHT_1080p)
                   , m_gpuExist(false)
-                  , m_eventLoop("dec_event_loop", process_dec_message)
+                  , m_eventLoop("dec_event_loop",
+                                [this](std::shared_ptr<EventLoopData> data) { process_dec_message(data, this); })
                   , m_nvBufferMode (NvBufferModeInvalid)
                   , m_appsrc_out_probe_count(0)
                   , m_decoder_in_probe_count(0)

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.h
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -153,7 +153,7 @@ class GstNvVideoDecoder : public IMediaDataConsumer, public GstNvDecoder, public
         GstFlowReturn processJpegImageFromSink(GstElement *appsink);
         void setSourceFrameSize(uint32_t w, uint32_t h);
         friend gboolean busWatch (GstBus *bus, GstMessage *message, gpointer data);
-        friend void process_dec_message(std::shared_ptr<EventLoopData> data, void*);
+        friend void process_dec_message(std::shared_ptr<EventLoopData> data, GstNvVideoDecoder*);
 
         int create_internal();
         int create_recorded_internal();

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.h
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.h
@@ -79,7 +79,6 @@ struct DecoderData : public EventLoopData
 struct DecoderOutData : public EventLoopOutData
 {
     map<string, string> data;
-    void* data2;
     int result;
 };
 

--- a/services/vios/src/framework/media/video_source/encoders/libnv_encoder.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/libnv_encoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1454,10 +1454,10 @@ int NvVideoEncoder::GetEncodedPartitions(unsigned char** data, ssize_t *size, bo
     }
     else
     {
-        void* surface_data_ptr = NvBufWrapper::getInstance()->extractSurface(capplane_buffer->planes[0].fd);
+        unsigned char* surface_data_ptr = NvBufWrapper::getInstance()->extractSurface(capplane_buffer->planes[0].fd);
         if (surface_data_ptr)
         {
-            memcpy(*data,  (unsigned char*)surface_data_ptr,  capplane_buffer->planes[0].bytesused);
+            memcpy(*data,  surface_data_ptr,  capplane_buffer->planes[0].bytesused);
         }
     }
 

--- a/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,11 +67,11 @@ NvJpegEncLoader::NvJpegEncLoader()
         , m_handleNvJpeg(nullptr)
 {
 #if defined(AARCH64_PLATFORM)
-    m_handleNvJpeg = dlopen("/usr/lib/aarch64-linux-gnu/nvidia/libnvmm_jpeg.so", RTLD_LAZY);
+    m_handleNvJpeg = static_cast<nv_vms::SharedLibrary*>(dlopen("/usr/lib/aarch64-linux-gnu/nvidia/libnvmm_jpeg.so", RTLD_LAZY));
 #else
 
     const char* lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "deepstream/libnvds_lljpeg.so");
-    m_handleNvJpeg = dlopen(lib_path, RTLD_LAZY);
+    m_handleNvJpeg = static_cast<nv_vms::SharedLibrary*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_handleNvJpeg)
     {

--- a/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
@@ -149,7 +149,7 @@ int NvJpegEncLoader::nvjpegEncodeFromFd(int fd, unsigned char **out_buf, unsigne
         jpeg_destroy_compress(&cinfo);
         return -1;
     }
-    NvBufWrapper::getInstance()->NvBufSurfaceFromFd(fd, (void **)&buf_surf);
+    NvBufWrapper::getInstance()->NvBufSurfaceFromFd(fd, &buf_surf);
     cinfo.pVendor_buf = (unsigned char *)buf_surf;
 #endif
     cinfo.IsVendorbuf = TRUE;

--- a/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.h
+++ b/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include "libjpeg-8b/jpeglib.h"
+
+namespace nv_vms {
+// Opaque handle to a dynamically loaded shared library.
+struct SharedLibrary;
+}
 
 typedef struct jpeg_error_mgr* (*jpeg_std_error_t) (struct jpeg_error_mgr*);
 typedef void (*jpeg_CreateCompress_t) (j_compress_ptr, int, size_t);
@@ -62,7 +67,7 @@ public:
 private:
     static NvJpegEncLoader* m_instance;
     bool m_error;
-    void* m_handleNvJpeg;
+    nv_vms::SharedLibrary* m_handleNvJpeg;
 
     NvJpegEncLoader();
     ~NvJpegEncLoader();

--- a/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.cpp
+++ b/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -324,7 +324,7 @@ void NvLLTransform::doTransformTask()
             }
             else if (!sink_frame->m_sample)
             {
-                ret = NvBufWrapper::getInstance()->NvBufSurfaceFromFd (sink_frame->m_fd, (void **)&ip_surf);
+                ret = NvBufWrapper::getInstance()->NvBufSurfaceFromFd (sink_frame->m_fd, &ip_surf);
                 if (ret < 0)
                 {
                     LOG(error) << "NvBufSurfaceFromFd failed" << endl;
@@ -376,7 +376,7 @@ void NvLLTransform::doTransformTask()
             {
                 if (!is_sw_mode)
                 {
-                    ret = NvBufWrapper::getInstance()->NvBufSurfaceFromFd (fd_index_pair.first, (void **)&dst_surf);
+                    ret = NvBufWrapper::getInstance()->NvBufSurfaceFromFd (fd_index_pair.first, &dst_surf);
                     if (ret < 0)
                     {
                         LOG(error) << "NvBufSurfaceFromFd failed" << endl;

--- a/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
+++ b/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,7 +97,7 @@ class WebrtcStream
             m_channels = audio_metadata.get("Channels", DEFAULT_WEBRTC_IN_CHANNELS).asInt();
         }
 
-        int addFrame (const string& media, void *buffer, unsigned int size, int sample_rate = 0,
+        int addFrame (const string& media, unsigned char *buffer, unsigned int size, int sample_rate = 0,
                         size_t num_channels = 0, int codec_type = 1, int64_t latencyStartTime = 0)
         {
             LOG(verbose) << "media = " << media << " Peer ID = " << endl;
@@ -107,7 +107,7 @@ class WebrtcStream
             std::lock_guard<std::mutex> recordLock(m_webRTCConsumerLock);
             if (media == "audio" && m_consumersList.size())
             {
-                m_gstencoder->onFrame(media, codec, (const unsigned char*)buffer, size, sample_rate, num_channels);
+                m_gstencoder->onFrame(media, codec, buffer, size, sample_rate, num_channels);
             }
             if (media == "video")
             {
@@ -115,7 +115,7 @@ class WebrtcStream
                 gettimeofday(&currTime, nullptr);
                 FrameParams frame_params;
                 frame_params.m_media            = "video";
-                frame_params.m_buffer = (unsigned char*)buffer;
+                frame_params.m_buffer = buffer;
                 frame_params.m_size = size;
                 if (latencyStartTime == 0)
                 {

--- a/services/vios/src/framework/media/video_source/senders/videowebRTCsender.cpp
+++ b/services/vios/src/framework/media/video_source/senders/videowebRTCsender.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,12 +22,11 @@
 #include "api/make_ref_counted.h"
 using namespace std;
 
-void VideoWebRTCSender::unRefDataStructure(void *ptr)
+void VideoWebRTCSender::unRefDataStructure(encoder_params *params)
 {
-    if (ptr)
+    if (params)
     {
         std::lock_guard<std::mutex> lock(m_encParamsLock);
-        encoder_params* params = (encoder_params*) ptr;
         /* Copy encoder feedback params as member variables */
         m_qp        = params->m_qp;
         m_targetBps = params->m_targetBps;
@@ -250,7 +249,7 @@ void VideoWebRTCSender::onFrame(FrameParams& frame_params)
         memset(params, 0, sizeof(encoder_params));
         nv_video_frame_buffer_ptr->m_clientBuffer = (void*)params;
         nv_video_frame_buffer_ptr->setPassThrough(true);
-        nv_video_frame_buffer_ptr->registerCB([this](void* params) { unRefDataStructure(params); });
+        nv_video_frame_buffer_ptr->registerCB([this](auto* client_buffer) { unRefDataStructure(static_cast<encoder_params*>(client_buffer)); });
         if (frame_params.m_latencyStartTime.tv_sec != std::numeric_limits<time_t>::max() && GET_CONFIG().enable_latency_logging)
         {
             nv_video_frame_buffer->rtspToWebrtcStartTime = frame_params.m_latencyStartTime;

--- a/services/vios/src/framework/media/video_source/senders/videowebRTCsender.h
+++ b/services/vios/src/framework/media/video_source/senders/videowebRTCsender.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,6 +42,8 @@
 //#define DUMP_BITSTREAM
 using namespace std;
 
+struct encoder_params;
+
 struct VideoSink
 {
     VideoSink(): m_broadcaster(nullptr)  {}
@@ -78,7 +80,7 @@ class VideoWebRTCSender : public IMediaDataConsumer
             }
         }
 
-        void unRefDataStructure(void *ptr);
+        void unRefDataStructure(encoder_params *params);
         void getwebRTCFeedback(int* qp, int* bitrate, double* frame_rate);
         int  createPassThroughMode(string& device_id);
         void appendWebrtcBroacaster(const std::string& peerid, webrtc::VideoBroadcaster* broadcaster);

--- a/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.cpp
+++ b/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ WebrtcSinkConsumer::~WebrtcSinkConsumer()
     LOG(info) << "WebrtcSinkConsumer instance deleted for " << m_peerIdStreamId << endl;
 }
 
-void WebrtcSinkConsumer::setWebrtcBroadcaster(void* broadcaster)
+void WebrtcSinkConsumer::setWebrtcBroadcaster(webrtc::VideoBroadcaster* broadcaster)
 {
     {
         std::lock_guard<std::mutex> lock(m_broadcasterMutex);
@@ -53,7 +53,7 @@ void WebrtcSinkConsumer::setWebrtcBroadcaster(void* broadcaster)
     }
     if (m_videowebRTCSender)
     {
-        m_videowebRTCSender->appendWebrtcBroacaster(m_peerIdStreamId, (webrtc::VideoBroadcaster*)broadcaster);
+        m_videowebRTCSender->appendWebrtcBroacaster(m_peerIdStreamId, broadcaster);
     }
 }
 
@@ -93,7 +93,7 @@ void WebrtcSinkConsumer::onFrame(std::shared_ptr<RawFrameParams> frame_data)
             std::lock_guard<std::mutex> lock(m_broadcasterMutex);
             if (m_broadcaster != nullptr)
             {
-                ((webrtc::VideoBroadcaster *)m_broadcaster)->OnFrame(webRTC_input_video_frame);
+                m_broadcaster->OnFrame(webRTC_input_video_frame);
             }
         }
     }

--- a/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.h
+++ b/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +35,7 @@ public:
 
     void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
     void onFrame(FrameParams& params) override;
-    void setWebrtcBroadcaster(void* broadcaster) override;
+    void setWebrtcBroadcaster(webrtc::VideoBroadcaster* broadcaster) override;
     void removeWebrtcBroadcaster(const std::string& peerid); // New method to remove broadcaster safely
     void getwebRTCFeedback(int* qp, int* bitrate, double* frame_rate) override;
     
@@ -55,7 +55,7 @@ private:
 private:
     shared_ptr<VideoWebRTCSender>                  m_videowebRTCSender = nullptr;
     std::mutex                                     m_broadcasterMutex;
-    void*                                          m_broadcaster = nullptr;
+    webrtc::VideoBroadcaster*                      m_broadcaster = nullptr;
     std::string                                    m_peerIdStreamId{""};
     std::shared_ptr<IMediaDataConsumer>            m_bitstreamConsumer = nullptr;
     WebrtcFrameTimestamper                         m_frameTimestamper;

--- a/services/vios/src/framework/notification/ds_proto_parser.cpp
+++ b/services/vios/src/framework/notification/ds_proto_parser.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,7 +168,7 @@ void DsProtoParser::resetSchemaFunctionPointers()
     m_frame_get_info = nullptr;
 }
 
-Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frameTimeMs)
+Json::Value DsProtoParser::parseMessage(const unsigned char* msg, int len, int64_t& frameTimeMs)
 {
     if (!m_schemaLibHandle && !loadSchemaLibrary())
     {

--- a/services/vios/src/framework/notification/ds_proto_parser.h
+++ b/services/vios/src/framework/notification/ds_proto_parser.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ public:
     DsProtoParser(const DsProtoParser&) = delete;
     DsProtoParser& operator=(const DsProtoParser&) = delete;
 
-    Json::Value parseMessage(const void* msg, int len, int64_t& frameTimeMs);
+    Json::Value parseMessage(const unsigned char* msg, int len, int64_t& frameTimeMs);
 
 private:
     DsProtoParser();

--- a/services/vios/src/framework/notification/kafka/kafka_consumer.cpp
+++ b/services/vios/src/framework/notification/kafka/kafka_consumer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -284,7 +284,7 @@ void KafkaConsumer::deliverMessage(void* msg, int len)
     }
 
     int64_t frameTimeMs = 0;
-    Json::Value payload = DsProtoParser::getInstance()->parseMessage(msg, len, frameTimeMs);
+    Json::Value payload = DsProtoParser::getInstance()->parseMessage(static_cast<const unsigned char*>(msg), len, frameTimeMs);
     if (payload == Json::nullValue)
     {
         return;

--- a/services/vios/src/framework/notification/kafka/kafka_consumer.cpp
+++ b/services/vios/src/framework/notification/kafka/kafka_consumer.cpp
@@ -104,9 +104,9 @@ KafkaConsumer::~KafkaConsumer()
 bool KafkaConsumer::kafkaInit()
 {
 #if defined(AARCH64_PLATFORM)
-    m_libHandle = dlopen(ABSOLUTE_LIBRARY_PATH_AARCH64, RTLD_LAZY);
+    m_libHandle = static_cast<nv_vms::SharedLibrary*>(dlopen(ABSOLUTE_LIBRARY_PATH_AARCH64, RTLD_LAZY));
 #else
-    m_libHandle = dlopen(ABSOLUTE_LIBRARY_PATH_X86_64, RTLD_LAZY);
+    m_libHandle = static_cast<nv_vms::SharedLibrary*>(dlopen(ABSOLUTE_LIBRARY_PATH_X86_64, RTLD_LAZY));
 #endif
     if (!m_libHandle)
     {
@@ -239,7 +239,7 @@ bool KafkaConsumer::kafkaInit()
             }
             if (rkm->payload)
             {
-                deliverMessage((void*)rkm->payload, (int)rkm->len);
+                deliverMessage(static_cast<const unsigned char*>(rkm->payload), (int)rkm->len);
             }
             rd_kafka_message_destroy(rkm);
         }
@@ -265,7 +265,7 @@ void KafkaConsumer::deregisterMessageListener(nv_vms::INotificationListener* lis
     }
 }
 
-void KafkaConsumer::deliverMessage(void* msg, int len)
+void KafkaConsumer::deliverMessage(const unsigned char* msg, int len)
 {
     {
         std::lock_guard<std::mutex> lock(m_listenerMutex);
@@ -284,7 +284,7 @@ void KafkaConsumer::deliverMessage(void* msg, int len)
     }
 
     int64_t frameTimeMs = 0;
-    Json::Value payload = DsProtoParser::getInstance()->parseMessage(static_cast<const unsigned char*>(msg), len, frameTimeMs);
+    Json::Value payload = DsProtoParser::getInstance()->parseMessage(msg, len, frameTimeMs);
     if (payload == Json::nullValue)
     {
         return;

--- a/services/vios/src/framework/notification/kafka/kafka_consumer.h
+++ b/services/vios/src/framework/notification/kafka/kafka_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,11 @@
 typedef struct rd_kafka_s rd_kafka_t;
 typedef struct rd_kafka_topic_s rd_kafka_topic_t;
 
+namespace nv_vms {
+// Opaque handle to a dynamically loaded shared library.
+struct SharedLibrary;
+}
+
 class KafkaConsumer : public nv_vms::INotificationInterface
 {
 public:
@@ -41,7 +46,7 @@ public:
     bool deliverMessage (Json::Value& message) override { return true; }
     void retryConnection () override {}
 
-    void deliverMessage(void* msg, int len);
+    void deliverMessage(const unsigned char* msg, int len);
 
     KafkaConsumer(const KafkaConsumer&) = delete;
     KafkaConsumer& operator=(const KafkaConsumer&) = delete;
@@ -58,7 +63,7 @@ private:
     std::thread     m_pollThread;
     bool            m_running{false};
     // Kafka library handles
-    void*           m_libHandle{nullptr};
+    nv_vms::SharedLibrary* m_libHandle{nullptr};
     rd_kafka_t*     m_consumer{nullptr};
     rd_kafka_topic_t* m_topic{nullptr};
 

--- a/services/vios/src/framework/notification/kafka/kafka_producer.cpp
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,7 +76,7 @@ NvKafka::NvKafka()
 #endif
 {
 #if !defined(AARCH64_PLATFORM)
-    m_kafkaHandle = dlopen(ABSOLUTE_LIBRARY_PATH_X86_64, RTLD_LAZY);
+    m_kafkaHandle = static_cast<KafkaLibHandle*>(dlopen(ABSOLUTE_LIBRARY_PATH_X86_64, RTLD_LAZY));
     if (!m_kafkaHandle)
     {
         LOG(error) << "Cannot open librdkafka library: " << dlerror() << endl;

--- a/services/vios/src/framework/notification/kafka/kafka_producer.cpp
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.cpp
@@ -27,7 +27,7 @@ using namespace std;
 
 #if !defined(AARCH64_PLATFORM)
 static void
-DeliveryCallback(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, KafkaMsgOpaque *opaque)
+DeliveryCallback(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *opaque)
 {
     if (rkmessage->err)
     {

--- a/services/vios/src/framework/notification/kafka/kafka_producer.cpp
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.cpp
@@ -27,7 +27,7 @@ using namespace std;
 
 #if !defined(AARCH64_PLATFORM)
 static void
-DeliveryCallback(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *opaque)
+DeliveryCallback(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, KafkaMsgOpaque *opaque)
 {
     if (rkmessage->err)
     {

--- a/services/vios/src/framework/notification/kafka/kafka_producer.h
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.h
@@ -28,10 +28,11 @@ using namespace nv_vms;
 
 #if !defined(AARCH64_PLATFORM)
 struct KafkaLibHandle;
+struct KafkaMsgOpaque;
 
 typedef rd_kafka_conf_t* (*rd_kafka_conf_new_t) (void);
 typedef rd_kafka_conf_res_t (*rd_kafka_conf_set_t) (rd_kafka_conf_t*, const char*, const char*, char*, size_t);
-typedef void (*dr_msg_cb_t) (rd_kafka_t*, const rd_kafka_message_t*, void*);
+typedef void (*dr_msg_cb_t) (rd_kafka_t*, const rd_kafka_message_t*, KafkaMsgOpaque*);
 typedef void (*rd_kafka_conf_set_dr_msg_cb_t) (rd_kafka_conf_t*, dr_msg_cb_t);
 typedef rd_kafka_t* (*rd_kafka_new_t) (rd_kafka_type_t, rd_kafka_conf_t*, char*, size_t);
 typedef rd_kafka_resp_err_t (*rd_kafka_producev_t) (rd_kafka_t*, ...);

--- a/services/vios/src/framework/notification/kafka/kafka_producer.h
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,8 @@
 using namespace nv_vms;
 
 #if !defined(AARCH64_PLATFORM)
+struct KafkaLibHandle;
+
 typedef rd_kafka_conf_t* (*rd_kafka_conf_new_t) (void);
 typedef rd_kafka_conf_res_t (*rd_kafka_conf_set_t) (rd_kafka_conf_t*, const char*, const char*, char*, size_t);
 typedef void (*dr_msg_cb_t) (rd_kafka_t*, const rd_kafka_message_t*, void*);
@@ -57,7 +59,7 @@ private:
     std::mutex m_messageLock;
 
 #if !defined(AARCH64_PLATFORM)
-    void* m_kafkaHandle;
+    KafkaLibHandle* m_kafkaHandle;
     rd_kafka_conf_new_t rd_kafka_conf_new;
     rd_kafka_conf_set_t rd_kafka_conf_set;
     rd_kafka_conf_set_dr_msg_cb_t rd_kafka_conf_set_dr_msg_cb;

--- a/services/vios/src/framework/notification/kafka/kafka_producer.h
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.h
@@ -28,11 +28,10 @@ using namespace nv_vms;
 
 #if !defined(AARCH64_PLATFORM)
 struct KafkaLibHandle;
-struct KafkaMsgOpaque;
 
 typedef rd_kafka_conf_t* (*rd_kafka_conf_new_t) (void);
 typedef rd_kafka_conf_res_t (*rd_kafka_conf_set_t) (rd_kafka_conf_t*, const char*, const char*, char*, size_t);
-typedef void (*dr_msg_cb_t) (rd_kafka_t*, const rd_kafka_message_t*, KafkaMsgOpaque*);
+typedef void (*dr_msg_cb_t) (rd_kafka_t*, const rd_kafka_message_t*, void*);
 typedef void (*rd_kafka_conf_set_dr_msg_cb_t) (rd_kafka_conf_t*, dr_msg_cb_t);
 typedef rd_kafka_t* (*rd_kafka_new_t) (rd_kafka_type_t, rd_kafka_conf_t*, char*, size_t);
 typedef rd_kafka_resp_err_t (*rd_kafka_producev_t) (rd_kafka_t*, ...);

--- a/services/vios/src/framework/notification/mqtt/mqtt_subscriber.cpp
+++ b/services/vios/src/framework/notification/mqtt/mqtt_subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -180,7 +180,7 @@ void MqttSubscriber::handleMessageArrived(mqtt::const_message_ptr msg)
     }
 
     int64_t frameTimeMs = 0;
-    Json::Value payload = DsProtoParser::getInstance()->parseMessage(str_payload.c_str(), str_payload.length(), frameTimeMs);
+    Json::Value payload = DsProtoParser::getInstance()->parseMessage(reinterpret_cast<const unsigned char*>(str_payload.c_str()), str_payload.length(), frameTimeMs);
     if (payload == Json::nullValue)
     {
         static std::atomic<uint64_t> logError{0};

--- a/services/vios/src/framework/notification/redis/redis_publisher.cpp
+++ b/services/vios/src/framework/notification/redis/redis_publisher.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,15 +60,15 @@ NvRedis::NvRedis()
     // Temporary solution to load libnvds_logger in memory
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvds_logger.so");
-    m_redisHandle = dlopen(lib_path, RTLD_LAZY);
+    m_redisHandle = static_cast<SharedLibraryHandle*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_redisHandle)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvds_logger.so");
-        m_redisHandle = dlopen(lib_path, RTLD_LAZY);
+        m_redisHandle = static_cast<SharedLibraryHandle*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvds_logger.so");
-    m_redisHandle = dlopen(lib_path, RTLD_LAZY);
+    m_redisHandle = static_cast<SharedLibraryHandle*>(dlopen(lib_path, RTLD_LAZY));
 #endif
     if (!m_redisHandle)
     {
@@ -78,15 +78,15 @@ NvRedis::NvRedis()
 
 #if defined(AARCH64_PLATFORM)
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvds_redis_proto.so");
-    m_handle_redis_proto = dlopen(lib_path, RTLD_LAZY);
+    m_handle_redis_proto = static_cast<SharedLibraryHandle*>(dlopen(lib_path, RTLD_LAZY));
     if (!m_handle_redis_proto)
     {
         lib_path = CONCATENATE_STRINGS(RELATIVE_PREBUILT_LIBRARY_PATH_ARCH64, "libnvds_redis_proto.so");
-        m_handle_redis_proto = dlopen(lib_path, RTLD_LAZY);
+        m_handle_redis_proto = static_cast<SharedLibraryHandle*>(dlopen(lib_path, RTLD_LAZY));
     }
 #else
     lib_path = CONCATENATE_STRINGS(ABSOLUTE_PREBUILT_LIBRARY_PATH_X86_64, "libnvds_redis_proto.so");
-    m_handle_redis_proto = dlopen(lib_path, RTLD_LAZY);
+    m_handle_redis_proto = static_cast<SharedLibraryHandle*>(dlopen(lib_path, RTLD_LAZY));
 #endif
 
     if (!m_handle_redis_proto)

--- a/services/vios/src/framework/notification/redis/redis_publisher.h
+++ b/services/vios/src/framework/notification/redis/redis_publisher.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,9 @@ typedef NvDsMsgApiHandle (*nvds_msgapi_connect_t) (char*, nvds_msgapi_connect_cb
 typedef NvDsMsgApiErrorType (*nvds_msgapi_send_t) (NvDsMsgApiHandle, char*, const uint8_t*, size_t);
 typedef NvDsMsgApiErrorType (*nvds_msgapi_disconnect_t) (NvDsMsgApiHandle);
 
+/* Opaque handle to a dynamically loaded shared library (as returned by dlopen). */
+struct SharedLibraryHandle;
+
 class NvRedis : public INotificationInterface
 {
 public:
@@ -48,8 +51,8 @@ public:
 private:
     static NvRedis* _instance;
     bool m_error;
-    void* m_redisHandle;
-    void* m_handle_redis_proto;
+    SharedLibraryHandle* m_redisHandle;
+    SharedLibraryHandle* m_handle_redis_proto;
     NvDsMsgApiHandle m_conn_handle;
     std::string m_topic_vms_event;
     std::string m_message;

--- a/services/vios/src/framework/notification/redis/redis_subscriber.cpp
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,9 @@
 
 using namespace std;
 
-static void* openLibrary(const char* libName)
+struct DynamicLibrary;
+
+static DynamicLibrary* openLibrary(const char* libName)
 {
     std::string lib_path;
     void* handle = nullptr;
@@ -44,7 +46,7 @@ static void* openLibrary(const char* libName)
     handle = dlopen(lib_path.c_str(), RTLD_LAZY);
 #endif
 
-    return handle;
+    return static_cast<DynamicLibrary*>(handle);
 }
 
 static void subscribe_cb(NvDsMsgApiErrorType flag, void *msg, int len, char *topic, void *user_ptr)
@@ -206,7 +208,7 @@ void RedisSubscriber::deliverMessage(void *msg, int len)
     }
 
     int64_t frameTimeMs = 0;
-    Json::Value payload = DsProtoParser::getInstance()->parseMessage(msg, len, frameTimeMs);
+    Json::Value payload = DsProtoParser::getInstance()->parseMessage(static_cast<const unsigned char*>(msg), len, frameTimeMs);
     if (payload == Json::nullValue)
     {
         static std::atomic<uint64_t> logError{0};

--- a/services/vios/src/framework/notification/redis/redis_subscriber.cpp
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.cpp
@@ -49,6 +49,8 @@ static DynamicLibrary* openLibrary(const char* libName)
     return static_cast<DynamicLibrary*>(handle);
 }
 
+extern "C"
+{
 static void subscribe_cb(NvDsMsgApiErrorType flag, void *msg, int len, char *topic, void *user_ptr)
 {
     if(flag == NVDS_MSGAPI_ERR)
@@ -57,12 +59,13 @@ static void subscribe_cb(NvDsMsgApiErrorType flag, void *msg, int len, char *top
     }
     else
     {
-        RedisSubscriber* subscriber = (RedisSubscriber*) user_ptr;
+        RedisSubscriber* subscriber = static_cast<RedisSubscriber*>(user_ptr);
         if (subscriber)
         {
-            subscriber->deliverMessage(msg, len);
+            subscriber->deliverMessage(static_cast<const unsigned char*>(msg), len);
         }
     }
+}
 }
 
 RedisSubscriber* RedisSubscriber::_instance = nullptr;
@@ -176,7 +179,7 @@ void RedisSubscriber::redisInit()
     LOG(info) << "Redis Subscriber connect success." << endl;
 
     //Subscribe to topic
-    if(nvds_msgapi_subscribe(m_connHandle, (char **)topic, 1, subscribe_cb, (void*)this) != NVDS_MSGAPI_OK)
+    if(nvds_msgapi_subscribe(m_connHandle, (char **)topic, 1, reinterpret_cast<nvds_msgapi_subscribe_request_cb_t>(subscribe_cb), (void*)this) != NVDS_MSGAPI_OK)
     {
         LOG(error) << "Redis subscription to topic[s] failed. Exiting" << endl;
         goto error;
@@ -200,7 +203,7 @@ void RedisSubscriber::deregisterMessageListener(nv_vms::INotificationListener* l
     m_listeners.erase(listener);
 }
 
-void RedisSubscriber::deliverMessage(void *msg, int len)
+void RedisSubscriber::deliverMessage(const unsigned char *msg, int len)
 {
     if (!m_listeners.size())
     {
@@ -208,7 +211,7 @@ void RedisSubscriber::deliverMessage(void *msg, int len)
     }
 
     int64_t frameTimeMs = 0;
-    Json::Value payload = DsProtoParser::getInstance()->parseMessage(static_cast<const unsigned char*>(msg), len, frameTimeMs);
+    Json::Value payload = DsProtoParser::getInstance()->parseMessage(msg, len, frameTimeMs);
     if (payload == Json::nullValue)
     {
         static std::atomic<uint64_t> logError{0};

--- a/services/vios/src/framework/notification/redis/redis_subscriber.h
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,8 @@ typedef NvDsMsgApiHandle (*msgapi_connect_ptr) (char*, nvds_msgapi_connect_cb_t,
 typedef NvDsMsgApiErrorType (*msgapi_subscribe_ptr) (NvDsMsgApiHandle, char **, int, nvds_msgapi_subscribe_request_cb_t, void*);
 typedef NvDsMsgApiErrorType (*msgapi_disconnect_ptr) (NvDsMsgApiHandle);
 
+struct DynamicLibrary;
+
 class RedisSubscriber : public nv_vms::INotificationInterface
 {
 public:
@@ -35,7 +37,7 @@ public:
     bool isError()  { return m_error; }
     void registerMessageListener(nv_vms::INotificationListener* listener) override;
     void deregisterMessageListener(nv_vms::INotificationListener* listener) override;
-    void deliverMessage(void *msg, int len);
+    void deliverMessage(const unsigned char *msg, int len);
 
     bool deliverMessage (Json::Value& message) override { return true; }
     void retryConnection () override {}
@@ -46,8 +48,8 @@ private:
     msgapi_subscribe_ptr                            nvds_msgapi_subscribe;
     msgapi_disconnect_ptr                           nvds_msgapi_disconnect;
     NvDsMsgApiHandle                                m_connHandle;
-    void*                                           m_handleRedis;
-    void*                                           m_handleRedisProto;
+    DynamicLibrary*                                 m_handleRedis;
+    DynamicLibrary*                                 m_handleRedisProto;
     std::string                                     m_redisEndpoint;
     std::string                                     m_subscribeTopic;
     std::string                                     m_sensorMngtTopic;

--- a/services/vios/src/framework/platform_specific/cudaLoader.cpp
+++ b/services/vios/src/framework/platform_specific/cudaLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,7 +81,7 @@ CudaLoader::CudaLoader()
 #endif
     for (const char* cand : cudaCandidates)
     {
-        m_handleCuda = dlopen(cand, RTLD_LAZY);
+        m_handleCuda = static_cast<SharedLibraryHandle*>(dlopen(cand, RTLD_LAZY));
         if (m_handleCuda)
         {
             break;
@@ -90,7 +90,7 @@ CudaLoader::CudaLoader()
     }
     for (const char* cand : cudartCandidates)
     {
-        m_handleCudart = dlopen(cand, RTLD_LAZY);
+        m_handleCudart = static_cast<SharedLibraryHandle*>(dlopen(cand, RTLD_LAZY));
         if (m_handleCudart)
         {
             break;

--- a/services/vios/src/framework/platform_specific/cudaLoader.h
+++ b/services/vios/src/framework/platform_specific/cudaLoader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,11 @@ typedef CUresult (*cuInit_t) (unsigned int);
 typedef CUresult (*cuDeviceGet_t) (CUdevice*, int);
 typedef CUresult (*cuCtxGetCurrent_t) (CUcontext*);
 typedef cudaError_t (*cudaSetDevice_t) (int);
+
+// Opaque stand-in for the dlopen() handle, so the handles are typed instead of
+// raw void*. Only ever held and passed back to dlsym()/dlclose().
+struct SharedLibraryHandle;
+
 class CudaLoader
 {
 public:
@@ -43,8 +48,8 @@ public:
 private:
     static CudaLoader* m_instance;
     bool m_error;
-    void* m_handleCuda;
-    void* m_handleCudart;
+    SharedLibraryHandle* m_handleCuda;
+    SharedLibraryHandle* m_handleCudart;
 
     CudaLoader();
     ~CudaLoader();

--- a/services/vios/src/framework/platform_specific/nvlibs.cpp
+++ b/services/vios/src/framework/platform_specific/nvlibs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,7 @@ NvLibs::NvLibs()
 #else
     lib_path = ABSOLUTE_LIBRARY_PATH_X86_64;
 #endif
-    handle_v4l2 = dlopen(lib_path, RTLD_LAZY); 
+    handle_v4l2 = static_cast<NvV4l2LibHandle*>(dlopen(lib_path, RTLD_LAZY));
     if (!handle_v4l2)
     {
         LOG(error) << "Cannot open v4l2 library: " << dlerror() << endl;

--- a/services/vios/src/framework/platform_specific/nvlibs.h
+++ b/services/vios/src/framework/platform_specific/nvlibs.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,8 @@
 
 #ifndef NV_LIBS_H
 #define NV_LIBS_H
+
+struct NvV4l2LibHandle;
 
 typedef int (*v4l2_ioctl_t) (int , unsigned long int , ...);
 typedef int (*v4l2_open_t) (const char *, int, ...);
@@ -38,7 +40,7 @@ public:
 private:
   static NvLibs* _instance;
   bool error;
-  void* handle_v4l2;
+  NvV4l2LibHandle* handle_v4l2;
 
   NvLibs();
 

--- a/services/vios/src/framework/platform_specific/nvsurfacepool.cpp
+++ b/services/vios/src/framework/platform_specific/nvsurfacepool.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -141,7 +141,7 @@ void NvSurfacePool::addFreeSurfaceToQ (FdIndexInfo fd_index_info)
         // Dummy FDs are created in SW overlay mode, avoid calling getNvSurface for them
         if (!sw_mode)
         {
-            nvbuf_surf = (NvBufSurface *)NvBufWrapper::getInstance()->getNvSurface(fd_index_pair.first);
+            nvbuf_surf = NvBufWrapper::getInstance()->getNvSurface(fd_index_pair.first);
         }
 
         if (nvbuf_surf != nullptr)

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -160,7 +160,7 @@ int NvSoap::GetNTP(nvsoap_& soap, string& res)
     string out;
     soap.method = "GetNTP";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetMethodXml);
     ret = createAndSendRequest(soap, out);
     if (ret == 0)
     {
@@ -175,7 +175,7 @@ int NvSoap::GetDeviceInformation(nvsoap_& soap, map<string, string>& device_info
     string out;
     soap.method = "GetDeviceInformation";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetMethodXml);
     ret = createAndSendRequest(soap, out);
     if (ret == 0 )
     {
@@ -195,7 +195,7 @@ int NvSoap::GetScopes(nvsoap_& soap, vector<string>& uris)
     string out;
     soap.method = "GetScopes";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetMethodXml);
     LOG(verbose2) << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << out << endl;
@@ -214,7 +214,7 @@ int NvSoap::GetDiscoveryMode(nvsoap_& soap, string& discovery_mode)
     soap.method = "GetDiscoveryMode";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
     LOG(verbose2) << soap.xmlData << endl;
-    soap.xmlData = composeXml(soap, (void*)&composeGetMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetMethodXml);
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << out << endl;
     if (ret == 0 )
@@ -230,7 +230,7 @@ int NvSoap::GetCapabilities(nvsoap_& soap, map<string, OnvifServiceInfo>& caps)
     string out;
     soap.method = "GetCapabilities";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetCapabilitiesMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetCapabilitiesMethodXml);
     int ret = createAndSendRequest(soap, out);
     PRINT_XML_REQUEST_IF_ERROR(ret, soap.xmlData)
     ret = getCapabilitiesResponse(out, caps);
@@ -254,7 +254,7 @@ int NvSoap::GetProfile(nvsoap_& soap, SensorSettings& settings)
         LOG(error) << "Invalid namespace: " << soap.wsdl << endl;
         return -1;
     }
-    soap.xmlData = composeXml(soap, (void*)&composeGetProfileXml);
+    soap.xmlData = composeXml(soap, &composeGetProfileXml);
 
     if (createAndSendRequest(soap, out) == 0)
     {
@@ -274,11 +274,11 @@ int NvSoap::GetProfiles(nvsoap_& soap, vector<SensorSettings>& settings)
     soap.wsdl = soap.name_space;
     if (soap.wsdl == ONVIF_MEDIA_SERVICE_NAMESPACE)
     {
-        soap.xmlData = composeXml(soap, (void*)&composeGetMethodXml);
+        soap.xmlData = composeXml(soap, &composeGetMethodXml);
     }
     else if (soap.wsdl == ONVIF_MEDIA2_SERVICE_NAMESPACE)
     {
-        soap.xmlData = composeXml(soap, (void*)&composeGetProfileXml);
+        soap.xmlData = composeXml(soap, &composeGetProfileXml);
     }
     else
     {
@@ -300,7 +300,7 @@ int NvSoap::GetPTZProfiles(nvsoap_& soap, vector<Profile>& profiles)
     string out;
     soap.method = "GetProfiles";
     soap.wsdl = ONVIF_MEDIA_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetMethodXml);
     int ret = createAndSendRequest(soap, out);
     PRINT_XML_REQUEST_IF_ERROR(ret, soap.xmlData)
     getPTZProfilesResponse(out, profiles);
@@ -313,7 +313,7 @@ int NvSoap::GetMediaUri(nvsoap_& soap, string& uri)
     soap.method = "GetStreamUri";
     soap.wsdl = soap.name_space;
     soap.tokenName = "ProfileToken";
-    soap.xmlData = composeXml(soap, (void*)&composeGetUriXml);
+    soap.xmlData = composeXml(soap, &composeGetUriXml);
     LOG(verbose2) << "GetMediaUri request: " << soap.xmlData << endl;
     int ret = createAndSendRequest(soap, out);
     PRINT_XML_REQUEST_IF_ERROR(ret, soap.xmlData)
@@ -329,7 +329,7 @@ int NvSoap::GetReplayUri(nvsoap_& soap, string& uri)
     soap.method = "GetReplayUri";
     soap.wsdl = ONVIF_REPLAY_SERVICE_NAMESPACE;
     soap.tokenName = "RecordingToken";
-    soap.xmlData = composeXml(soap, (void*)&composeGetUriXml);
+    soap.xmlData = composeXml(soap, &composeGetUriXml);
     int ret = createAndSendRequest(soap, out);
     PRINT_XML_REQUEST_IF_ERROR(ret, soap.xmlData)
     LOG(verbose2) << "GetReplayUri Result: " << out << endl;
@@ -342,7 +342,7 @@ int NvSoap::GetConfiguration(nvsoap_& soap, string& out)
 {
     soap.method = "GetConfiguration";
     soap.wsdl = ONVIF_PTZ_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetConfigurationMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetConfigurationMethodXml);
     LOG(verbose2) << "GetConfiguration: " << soap.xmlData << endl;
     int ret = createAndSendRequest(soap, out);
     PRINT_XML_REQUEST_IF_ERROR(ret, soap.xmlData)
@@ -355,7 +355,7 @@ int NvSoap::GetPTZNode(nvsoap_& soap, vector<PTZSpaces>& spaces)
     string out;
     soap.method = "GetNode";
     soap.wsdl = ONVIF_PTZ_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetNodeMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetNodeMethodXml);
     LOG(verbose2) << "GetPTZNode: " << soap.xmlData << endl;
     int ret = createAndSendRequest(soap, out);
     PRINT_XML_REQUEST_IF_ERROR(ret, soap.xmlData)
@@ -372,7 +372,7 @@ int NvSoap::ContinuousMove(nvsoap_& soap, PTZAction ptz, string x, string y)
     soap.wsdl2 = ONVIF_PTZ_SERVICE_NAMESPACE;
     soap.userData["x"] = x;
     soap.userData["y"] = y;
-    soap.xmlData = composeXml(soap, (void*)&composePTZMethodXml);
+    soap.xmlData = composeXml(soap, &composePTZMethodXml);
     LOG(verbose2) << "ContinuousMove: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     if(ret != 0)
@@ -380,7 +380,7 @@ int NvSoap::ContinuousMove(nvsoap_& soap, PTZAction ptz, string x, string y)
       return ret;
     }
     soap.method = "Stop";
-    soap.xmlData = composeXml(soap, (void*)&composePTZStopMethodXml);
+    soap.xmlData = composeXml(soap, &composePTZStopMethodXml);
     soap.userData["PanTilt"] = ptz == PTZAction::PanTilt ? "true" : "false";
     soap.userData["Zoom"] = ptz == PTZAction::Zoom ? "true" : "false";
     LOG(verbose2) << "Stop: " << soap.xmlData << endl;
@@ -397,7 +397,7 @@ int NvSoap::Stop(nvsoap_& soap, string oprtation)
     soap.wsdl2 = ONVIF_PTZ_SERVICE_NAMESPACE;
     soap.userData["PanTilt"] = oprtation == "PanTilt" ? "true" : "false";
     soap.userData["Zoom"] = oprtation == "Zoom" ? "true" : "false";
-    soap.xmlData = composeXml(soap, (void*)&composePTZStopMethodXml);
+    soap.xmlData = composeXml(soap, &composePTZStopMethodXml);
     LOG(verbose2) << "ContinuousMove: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << out << endl;
@@ -410,7 +410,7 @@ int NvSoap::getDeviceImageSettings(nvsoap_& soap, SensorImageSettingsValues& set
     int ret = -1;
     soap.method = "GetImagingSettings";
     soap.wsdl = ONVIF_IMAGING_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetCameraImageSettingsXml);
+    soap.xmlData = composeXml(soap, &composeGetCameraImageSettingsXml);
     LOG(verbose2) << "GetImagingSettings: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     if (ret != 0)
@@ -428,7 +428,7 @@ int NvSoap::getCameraImageOptions(nvsoap_& soap, SensorImageSettingsOptions& opt
     int ret = -1;
     soap.method = "GetOptions";
     soap.wsdl = ONVIF_IMAGING_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetImageOptionsXml);
+    soap.xmlData = composeXml(soap, &composeGetImageOptionsXml);
     LOG(verbose2) << "GetOptions: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << "GetOptions: " << out << endl;
@@ -443,7 +443,7 @@ int NvSoap::setDeviceImageSettings(nvsoap_& soap, const SensorImageSettingsValue
     soap.method = "SetImagingSettings";
     soap.wsdl = ONVIF_IMAGING_SERVICE_NAMESPACE;
     soap.userData2 = (void* )&settings;
-    soap.xmlData = composeXml(soap, (void*)&composeSetCameraImageSettingsXml);
+    soap.xmlData = composeXml(soap, &composeSetCameraImageSettingsXml);
     LOG(verbose2) << "SetImagingSettings: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << "SetImagingSettings: " << out << endl;
@@ -457,7 +457,7 @@ int NvSoap::setSystemDateAndTime(nvsoap_& soap, const DeviceTimeInfo& timeInfo)
     soap.method = "SetSystemDateAndTime";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
     soap.userData2 = (void* )&timeInfo;
-    soap.xmlData = composeXml(soap, (void*)&composeSetSystemDateAndTimeInfoXml);
+    soap.xmlData = composeXml(soap, &composeSetSystemDateAndTimeInfoXml);
     LOG(verbose2) << "SetSystemDateAndTime: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << "SetSystemDateAndTime out: " << out << endl;
@@ -471,7 +471,7 @@ int NvSoap::setNTP(nvsoap_& soap, const DeviceNTPInfo& ntpInfo)
     soap.method = "SetNTP";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
     soap.userData2 = (void* )&ntpInfo;
-    soap.xmlData = composeXml(soap, (void*)&composeSetNTPInfoXml);
+    soap.xmlData = composeXml(soap, &composeSetNTPInfoXml);
     LOG(verbose2) << "composeSetNTPInfoXml: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << "composeSetNTPInfoXml out: " << out << endl;
@@ -484,7 +484,7 @@ int NvSoap::getNetworkInterfaces(nvsoap_& soap, SensorNetworkInfo& networkInfo)
     int ret = -1;
     soap.method = "GetNetworkInterfaces";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetNetworkInterfacesXml);
+    soap.xmlData = composeXml(soap, &composeGetNetworkInterfacesXml);
     LOG(verbose2) << "xmData GetNetworkInterfaces: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << "out GetNetworkInterfaces: " << out << endl;
@@ -507,7 +507,7 @@ int NvSoap::setNetworkInterfaces(nvsoap_& soap, const SensorNetworkInfo& network
     soap.method = "SetNetworkInterfaces";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
     soap.userData2 = (void* )&networkInfo;
-    soap.xmlData = composeXml(soap, (void*)&composeSetNetworkInterfacesXml);
+    soap.xmlData = composeXml(soap, &composeSetNetworkInterfacesXml);
     LOG(verbose2) << "xml SetNetworkInterfaces: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose2) << "out SetNetworkInterfaces: " << out << endl;
@@ -522,7 +522,7 @@ int NvSoap::getCameraEncoderOptions(nvsoap_& soap, SensorEncoderSettingsOptions&
     int ret = -1;
     soap.method = "GetVideoEncoderConfigurationOptions";
     soap.wsdl = soap.name_space;
-    soap.xmlData = composeXml(soap, (void*)&composeGetEncoderOptionsXml);
+    soap.xmlData = composeXml(soap, &composeGetEncoderOptionsXml);
     LOG(verbose) << "GetVideoEncoderConfigurationOptions: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose) << "GetVideoEncoderConfigurationOptions: " << out << endl;
@@ -559,7 +559,7 @@ int NvSoap::getCameraEncoderConfiguration(nvsoap_& soap, SensorVideoEncoderSetti
         ret = -1;
         return ret;
     }
-    soap.xmlData = composeXml(soap, (void*)&composeGetEncoderOptionsXml);
+    soap.xmlData = composeXml(soap, &composeGetEncoderOptionsXml);
 
     LOG(verbose) << "GetVideoEncoderConfigurations: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
@@ -583,7 +583,7 @@ int NvSoap::setCameraEncoderSettings(nvsoap_& soap, const SensorVideoEncoderSett
     soap.method = "SetVideoEncoderConfiguration";
     soap.wsdl = soap.name_space;
     soap.userData2 = (void* )&settings;
-    soap.xmlData = composeXml(soap, (void*)&composeSetEncoderSettingsXml);
+    soap.xmlData = composeXml(soap, &composeSetEncoderSettingsXml);
     LOG(verbose) << "SetVideoEncoderConfiguration: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose) << "SetVideoEncoderConfiguration: " << out << endl;
@@ -608,7 +608,7 @@ int NvSoap::rebootDevice(nvsoap_& soap)
     int ret = -1;
     soap.method = "SystemReboot";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeRebootCameraXml);
+    soap.xmlData = composeXml(soap, &composeRebootCameraXml);
     LOG(info) << "xml SystemReboot: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(info) << "out SystemReboot: " << out << endl;
@@ -4320,7 +4320,7 @@ static int composeEndSearchXml(xmlTextWriterPtr& writer, nvsoap_& soap)
     return 0;
 }
 
-string NvSoap::composeXml(nvsoap_& soap, void* methodxml)
+string NvSoap::composeXml(nvsoap_& soap, composeMethodXml methodxml)
 {
       int rc;
       xmlTextWriterPtr writer;
@@ -4372,8 +4372,7 @@ string NvSoap::composeXml(nvsoap_& soap, void* methodxml)
         return retString;
       }
 
-      composeMethodXml func = (composeMethodXml)methodxml;
-      if (func(writer, soap) < 0)
+      if (methodxml(writer, soap) < 0)
       {
           return retString;
       }
@@ -5529,7 +5528,7 @@ int NvSoap::GetRecordingSummary(nvsoap_& soap, RecordingSummary& summary)
 
     soap.method = "GetRecordingSummary";
     soap.wsdl = ONVIF_SEARCH_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetRecordingSummaryXml);
+    soap.xmlData = composeXml(soap, &composeGetRecordingSummaryXml);
 
     LOG(verbose2) << "GetRecordingSummary request: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
@@ -5569,7 +5568,7 @@ int NvSoap::FindRecordings(nvsoap_& soap, const RecordingSearchScope& scope,
 
     soap.userData["KeepAliveTime"] = keepAliveTime;
 
-    soap.xmlData = composeXml(soap, (void*)&composeFindRecordingsXml);
+    soap.xmlData = composeXml(soap, &composeFindRecordingsXml);
 
     LOG(verbose2) << "FindRecordings request: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
@@ -5602,7 +5601,7 @@ int NvSoap::GetRecordingSearchResults(nvsoap_& soap, const string& searchToken,
     soap.userData["MaxResults"] = to_string(maxResults);
     soap.userData["WaitTime"] = waitTime;
 
-    soap.xmlData = composeXml(soap, (void*)&composeGetRecordingSearchResultsXml);
+    soap.xmlData = composeXml(soap, &composeGetRecordingSearchResultsXml);
 
     LOG(verbose2) << "GetRecordingSearchResults request: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
@@ -5630,7 +5629,7 @@ int NvSoap::EndSearch(nvsoap_& soap, const string& searchToken)
     soap.userData.clear();
     soap.userData["SearchToken"] = searchToken;
 
-    soap.xmlData = composeXml(soap, (void*)&composeEndSearchXml);
+    soap.xmlData = composeXml(soap, &composeEndSearchXml);
 
     LOG(verbose2) << "EndSearch request: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
@@ -5788,7 +5787,7 @@ int NvSoap::GetServices(nvsoap_& soap, map<string, OnvifServiceInfo>& caps)
     string out;
     soap.method = "GetServices";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetServicesMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetServicesMethodXml);
     int ret = createAndSendRequest(soap, out);
     PRINT_XML_REQUEST_IF_ERROR(ret, soap.xmlData)
     getServicesResponse(out, caps);
@@ -6441,7 +6440,7 @@ int NvSoap::GetServiceCapabilities(nvsoap_& soap, ServiceCapabilities& serviceCa
     string out;
     soap.method = "GetServiceCapabilities";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXml(soap, (void*)&composeGetMethodXml);
+    soap.xmlData = composeXml(soap, &composeGetMethodXml);
     ret = createAndSendRequest(soap, out);
     LOG(verbose) << "GetServiceCapabilities: " << out << endl;
     if (ret == 0)
@@ -6458,7 +6457,7 @@ int NvSoap::setHashingAlgorithm(nvsoap_& soap, const HashingAlgorithmInfo& algor
     soap.method = "SetHashingAlgorithm";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
     soap.userData2 = (void* )&algorithm;
-    soap.xmlData = composeXml(soap, (void*)&composeSetHashingAlgorithmXml);
+    soap.xmlData = composeXml(soap, &composeSetHashingAlgorithmXml);
     LOG(verbose) << "SetHashingAlgorithm: " << soap.xmlData << endl;
     ret = createAndSendRequest(soap, out);
     LOG(verbose) << "SetHashingAlgorithm: " << out << endl;

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -125,10 +125,13 @@ struct curlData {
 };
 
 #ifdef DEBUG
+// CURLOPT_DEBUGFUNCTION's signature is fixed by libcurl's C ABI. Narrowing
+// userp makes the call go through an incompatible function-pointer type,
+// which is undefined behaviour; the parameter is unused here anyway.
 static
 int my_trace(CURL *handle, curl_infotype type,
              char *data, size_t size,
-             curlData *userp)
+             void *userp)
 {
     LOG(verbose) << string(data) << endl;
     return 0;
@@ -4696,7 +4699,7 @@ int NvSoap::createAndSendRequest(nvsoap_& soap, string& outData)
     }
 #ifdef DEBUG
     struct curlData config;
-    errCode = curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, reinterpret_cast<curl_debug_callback>(my_trace));
+    errCode = curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, my_trace);
     CURL_CHECK_ERROR(curl_easy_setopt, errCode, -1)
     errCode = curl_easy_setopt(curl, CURLOPT_DEBUGDATA, &config);
     CURL_CHECK_ERROR(curl_easy_setopt, errCode, -1)
@@ -4864,7 +4867,7 @@ static int createAndSendCameraConfigurationAPIRequest(const string& url, const s
 
 #ifdef DEBUG
     struct curlData config;
-    curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, reinterpret_cast<curl_debug_callback>(my_trace));
+    curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, my_trace);
     CURL_CHECK_ERROR(curl_easy_setopt, errCode, -1)
     curl_easy_setopt(curl, CURLOPT_DEBUGDATA, &config);
     CURL_CHECK_ERROR(curl_easy_setopt, errCode, -1)

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,7 +62,6 @@ typedef unsigned char BYTE;
 std::mutex g_probeMutex;
 std::mutex g_probeMatchMutex;
 
-typedef int (*composeMethodXml) (xmlTextWriterPtr& writer, nvsoap_& soap);
 static int composeGetMethodXml(xmlTextWriterPtr& writer, nvsoap_& soap);
 static int composeGetUriXml(xmlTextWriterPtr& writer, nvsoap_& soap);
 static int composeGetCapabilitiesMethodXml(xmlTextWriterPtr& writer, nvsoap_& soap);
@@ -146,7 +145,7 @@ int NvSoap::GetSystemDateAndTime(nvsoap_& soap, string& res)
     string out;
     soap.method = "GetSystemDateAndTime";
     soap.wsdl = ONVIF_DEVICE_SERVICE_NAMESPACE;
-    soap.xmlData = composeXmlWithoutUsertoken(soap, (void*)&composeGetMethodXml);
+    soap.xmlData = composeXmlWithoutUsertoken(soap, &composeGetMethodXml);
     ret = createAndSendRequest(soap, out);
     if (ret == 0)
     {
@@ -4390,7 +4389,7 @@ string NvSoap::composeXml(nvsoap_& soap, void* methodxml)
       return retString;
 }
 
-string NvSoap::composeXmlWithoutUsertoken(nvsoap_& soap, void* methodxml)
+string NvSoap::composeXmlWithoutUsertoken(nvsoap_& soap, composeMethodXml methodxml)
 {
       int rc;
       xmlTextWriterPtr writer;
@@ -4434,8 +4433,7 @@ string NvSoap::composeXmlWithoutUsertoken(nvsoap_& soap, void* methodxml)
         return retString;
       }
 
-      composeMethodXml func = (composeMethodXml)methodxml;
-      if (func(writer, soap) < 0)
+      if (methodxml(writer, soap) < 0)
       {
           return retString;
       }

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -120,20 +120,20 @@ private:
     xmlBufferPtr m_xml;
 };
 
+struct curlData {
+  char trace_ascii; /* 1 or 0 */
+};
+
 #ifdef DEBUG
 static
 int my_trace(CURL *handle, curl_infotype type,
              char *data, size_t size,
-             void *userp)
+             curlData *userp)
 {
     LOG(verbose) << string(data) << endl;
     return 0;
 }
 #endif
-
-struct curlData {
-  char trace_ascii; /* 1 or 0 */
-};
 
 int NvSoap::GetSystemDateAndTime(nvsoap_& soap, string& res)
 {
@@ -4697,7 +4697,7 @@ int NvSoap::createAndSendRequest(nvsoap_& soap, string& outData)
     }
 #ifdef DEBUG
     struct curlData config;
-    errCode = curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, my_trace);
+    errCode = curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, reinterpret_cast<curl_debug_callback>(my_trace));
     CURL_CHECK_ERROR(curl_easy_setopt, errCode, -1)
     errCode = curl_easy_setopt(curl, CURLOPT_DEBUGDATA, &config);
     CURL_CHECK_ERROR(curl_easy_setopt, errCode, -1)
@@ -4865,7 +4865,7 @@ static int createAndSendCameraConfigurationAPIRequest(const string& url, const s
 
 #ifdef DEBUG
     struct curlData config;
-    curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, my_trace);
+    curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, reinterpret_cast<curl_debug_callback>(my_trace));
     CURL_CHECK_ERROR(curl_easy_setopt, errCode, -1)
     curl_easy_setopt(curl, CURLOPT_DEBUGDATA, &config);
     CURL_CHECK_ERROR(curl_easy_setopt, errCode, -1)

--- a/services/vios/src/framework/protocols/soap/nvsoap.h
+++ b/services/vios/src/framework/protocols/soap/nvsoap.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -285,6 +285,7 @@ struct nvsoap_
     string jsonData;
 };
 
+typedef int (*composeMethodXml) (xmlTextWriterPtr& writer, nvsoap_& soap);
 
 class NvSoap
 {
@@ -377,7 +378,7 @@ private:
     bool setCameraNetworkInterfacesResponse(const string& xmlData);
     string rebootCameraResponse(const string& xmlData);
     string composeXml(nvsoap_& soap, void* methodxml);
-    string composeXmlWithoutUsertoken(nvsoap_& soap, void* methodxml);
+    string composeXmlWithoutUsertoken(nvsoap_& soap, composeMethodXml methodxml);
     string composeProbeXml();
     int sendProbe(map<string, SensorInfo>& deviceList);
     int receiveProbeMatch(string& outData);

--- a/services/vios/src/framework/protocols/soap/nvsoap.h
+++ b/services/vios/src/framework/protocols/soap/nvsoap.h
@@ -377,7 +377,7 @@ private:
     SensorNetworkInfo getCameraNetworkInterfacesResponse(const string& xmlData);
     bool setCameraNetworkInterfacesResponse(const string& xmlData);
     string rebootCameraResponse(const string& xmlData);
-    string composeXml(nvsoap_& soap, void* methodxml);
+    string composeXml(nvsoap_& soap, composeMethodXml methodxml);
     string composeXmlWithoutUsertoken(nvsoap_& soap, composeMethodXml methodxml);
     string composeProbeXml();
     int sendProbe(map<string, SensorInfo>& deviceList);

--- a/services/vios/src/framework/stream_monitor/stream_monitor.cpp
+++ b/services/vios/src/framework/stream_monitor/stream_monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -239,14 +239,14 @@ void StreamMonitor::addCurlRequest(const std::string& url)
         retM = curl_multi_add_handle(m_curlMultiHandle, curl);
         CURL_CHECK_ERROR2(curl_multi_add_handle, retM)
 
-        m_curlList.push_back(std::make_tuple(curl, url, isResponsePending));
+        m_curlList.push_back(std::make_tuple(static_cast<CurlEasyHandle*>(curl), url, isResponsePending));
     }
 }
 
-void StreamMonitor::removeCurlRequest(CURL *curl)
+void StreamMonitor::removeCurlRequest(CurlEasyHandle *curl)
 {
     CURLMcode retM = CURLM_OK;
-    std::vector<std::tuple<CURL*, std::string, bool>>::iterator it;
+    std::vector<std::tuple<CurlEasyHandle*, std::string, bool>>::iterator it;
     for(it = m_curlList.begin(); it != m_curlList.end(); ++it)
     {
         if(get<0>(*it) == curl)
@@ -275,18 +275,18 @@ bool StreamMonitor::isCurlResponsePendingForUri(const std::string& url)
     return false;
 }
 
-void StreamMonitor::setCurlResponsePendingStatus(CURL *curl, bool isResponsePending)
+void StreamMonitor::setCurlResponsePendingStatus(const std::string& url, bool isResponsePending)
 {
     for(auto &i : m_curlList)
     {
-        if(get<0>(i) == curl)
+        if(get<1>(i) == url)
         {
             get<2>(i) = isResponsePending;
         }
     }
 }
 
-std::string StreamMonitor::getUriByUsingCurlHandle(const CURL *curl)
+std::string StreamMonitor::getUriByUsingCurlHandle(const CurlEasyHandle *curl)
 {
     std::string url;
     for(const auto &i : m_curlList)
@@ -302,7 +302,7 @@ std::string StreamMonitor::getUriByUsingCurlHandle(const CURL *curl)
 
 void StreamMonitor::livenessMonitorTask()
 {
-    CURL *curl = nullptr;
+    CurlEasyHandle *curl = nullptr;
     CURLMsg *msg = nullptr;
     CURLcode return_code = CURLE_OK;
     int still_running = 0, msgs_left = 0, repeats = 0;
@@ -359,7 +359,7 @@ void StreamMonitor::livenessMonitorTask()
                 {
                         if (msg->msg == CURLMSG_DONE)
                         {
-                            curl = msg->easy_handle;
+                            curl = static_cast<CurlEasyHandle*>(msg->easy_handle);
                             return_code = msg->data.result;
                             // Ignore few curl errors
                             if (return_code == CURLE_RTSP_CSEQ_ERROR || return_code == CURLE_RECV_ERROR)
@@ -369,14 +369,14 @@ void StreamMonitor::livenessMonitorTask()
                             if(return_code != CURLE_OK)
                             {
                                 LOG(error) << "CURL error:" << curl_easy_strerror(return_code) << " [" << return_code << "] for url:" << secureUrlForLogging(getUriByUsingCurlHandle(curl)) << endl;
-                                setCurlResponsePendingStatus(curl, false);
+                                setCurlResponsePendingStatus(getUriByUsingCurlHandle(curl), false);
                                 updateUriStatus(getUriByUsingCurlHandle(curl), STREAM_STATUS_OFFLINE, return_code);
 
                             }
                             else
                             {
                                 //LOG(info) << "Response[" << return_code << "] " << curl_easy_strerror(return_code) << " for url:" << getUriByUsingCurlHandle(curl) << endl;
-                                setCurlResponsePendingStatus(curl, false);
+                                setCurlResponsePendingStatus(getUriByUsingCurlHandle(curl), false);
                                 updateUriStatus(getUriByUsingCurlHandle(curl), STREAM_STATUS_ONLINE, return_code);
                             }
                             removeCurlRequest(curl);

--- a/services/vios/src/framework/stream_monitor/stream_monitor.h
+++ b/services/vios/src/framework/stream_monitor/stream_monitor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,6 +50,9 @@ struct StreamEncParam
                     , height(0)
     {}
 } StreamEncParam;
+/* Opaque stand-in for a libcurl easy handle (libcurl types it as void). */
+struct CurlEasyHandle;
+
 class IStreamStatusEvent
 {
 public:
@@ -138,7 +141,7 @@ private:
     std::thread m_streamMonitorThread;
     std::thread m_qosMeasurementThread;
     std::map<std::string, StreamStatus, std::less<>> m_livenessMonitorList;
-    std::vector<std::tuple<CURL*, std::string, bool>> m_curlList;
+    std::vector<std::tuple<CurlEasyHandle*, std::string, bool>> m_curlList;
     std::mutex m_livenessMonitorListMutex;
 
     bool m_exit;
@@ -155,10 +158,10 @@ private:
     void livenessMonitorTask();
     void updateUriStatus(const std::string& uri, StreamStatus status, CURLcode errorCode);
     void addCurlRequest(const std::string& url);
-    void removeCurlRequest(CURL *curl);
+    void removeCurlRequest(CurlEasyHandle *curl);
     bool isCurlResponsePendingForUri(const std::string& url);
-    void setCurlResponsePendingStatus(CURL *curl, bool isResponsePending);
-    std::string getUriByUsingCurlHandle(const CURL *curl);
+    void setCurlResponsePendingStatus(const std::string& url, bool isResponsePending);
+    std::string getUriByUsingCurlHandle(const CurlEasyHandle *curl);
     void notifyStreamStatus(const StreamStatus& status, const std::string& camera_id);
     std::vector<UrlInfo> getQosMonitorStreamList();
     void qosMeasurementTask();

--- a/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.cpp
+++ b/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -134,7 +134,8 @@ bool CloudStorageBuffer::bufferFrame(const void* data, size_t size, int64_t time
     std::unique_ptr<BufferedFrame> frame;
     try
     {
-        frame = std::make_unique<BufferedFrame>(data, size, timestamp, timestamp, media_type, session_id, stream_id);
+        frame = std::make_unique<BufferedFrame>(static_cast<const uint8_t*>(data), size, timestamp, timestamp,
+                                                media_type, session_id, stream_id);
 
         // Validate the created frame
         if (!frame || frame->m_data.empty() || frame->m_size != size)

--- a/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.cpp
+++ b/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.cpp
@@ -89,7 +89,7 @@ CloudStorageBuffer::~CloudStorageBuffer()
     }
 }
 
-bool CloudStorageBuffer::bufferFrame(const void* data, size_t size, int64_t timestamp, const std::string& media_type,
+bool CloudStorageBuffer::bufferFrame(const uint8_t* data, size_t size, int64_t timestamp, const std::string& media_type,
                                      const std::string& session_id, const std::string& stream_id)
 {
     if (!m_running.load())
@@ -134,7 +134,7 @@ bool CloudStorageBuffer::bufferFrame(const void* data, size_t size, int64_t time
     std::unique_ptr<BufferedFrame> frame;
     try
     {
-        frame = std::make_unique<BufferedFrame>(static_cast<const uint8_t*>(data), size, timestamp, timestamp,
+        frame = std::make_unique<BufferedFrame>(data, size, timestamp, timestamp,
                                                 media_type, session_id, stream_id);
 
         // Validate the created frame

--- a/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.h
+++ b/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.h
@@ -137,7 +137,7 @@ public:
     ~CloudStorageBuffer();
 
     // Buffer management
-    bool bufferFrame(const void* data, size_t size, int64_t timestamp, const std::string& media_type,
+    bool bufferFrame(const uint8_t* data, size_t size, int64_t timestamp, const std::string& media_type,
                      const std::string& session_id, const std::string& stream_id = "");
 
     void start(std::function<bool(const BufferedFrame&)> upload_callback);

--- a/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.h
+++ b/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,7 @@ struct BufferedFrame
     std::string m_session_id;
     std::string m_stream_id;
 
-    BufferedFrame(const void* frame_data, size_t frame_size, int64_t ts, int64_t pts, const std::string& type,
+    BufferedFrame(const uint8_t* frame_data, size_t frame_size, int64_t ts, int64_t pts, const std::string& type,
                   const std::string& session, const std::string& stream = "")
         : m_size(frame_size), m_pts(pts), m_media_type(type), m_session_id(session), m_stream_id(stream)
     {

--- a/services/vios/src/framework/unified_storage/writer/cloud_storage_writer.cpp
+++ b/services/vios/src/framework/unified_storage/writer/cloud_storage_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,18 +46,18 @@ CloudStorageWriter::~CloudStorageWriter()
     }
 }
 
-bool CloudStorageWriter::writeData(const std::string& session_id, const void* data, size_t size, int64_t pts,
+bool CloudStorageWriter::writeData(const std::string& session_id, const uint8_t* data, size_t size, int64_t pts,
                                             const std::string& media_type)
 {
     if (m_buffer && m_config.buffering.enabled)
     {
         // Use buffered upload
-        return handleBufferedWrite(session_id, data, size, pts, media_type);
+        return handleBufferedWrite(session_id, static_cast<const unsigned char*>(data), size, pts, media_type);
     }
     else
     {
         // Direct upload
-        return doWriteData(session_id, data, size, pts, media_type);
+        return doWriteData(session_id, static_cast<const uint8_t*>(data), size, pts, media_type);
     }
 }
 
@@ -265,8 +265,8 @@ void CloudStorageWriter::stopBuffering()
     }
 }
 
-bool CloudStorageWriter::handleBufferedWrite(const std::string& session_id, const void* data, size_t size, int64_t pts,
-                                             const std::string& media_type)
+bool CloudStorageWriter::handleBufferedWrite(const std::string& session_id, const unsigned char* data, size_t size,
+                                             int64_t pts, const std::string& media_type)
 {
     if (!m_buffer)
     {
@@ -294,7 +294,7 @@ bool CloudStorageWriter::handleBufferedWrite(const std::string& session_id, cons
                  << " for session: " << session_id 
                  << ", stream: " << stream_id << std::endl;
 
-    return m_buffer->bufferFrame(data, size, timestamp, media_type, session_id, stream_id);
+    return m_buffer->bufferFrame(static_cast<const uint8_t*>(data), size, timestamp, media_type, session_id, stream_id);
 }
 
 void CloudStorageWriter::updateBufferingStats()

--- a/services/vios/src/framework/unified_storage/writer/cloud_storage_writer.h
+++ b/services/vios/src/framework/unified_storage/writer/cloud_storage_writer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 
 #include "../unified_storage_types.h"
 #include <chrono>
+#include <cstdint>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -57,7 +58,7 @@ public:
                                      size_t estimated_size = 0) = 0;
 
     // Write operations - buffering handled internally for cloud storage
-    virtual bool writeData(const std::string& session_id, const void* data, size_t size, int64_t pts = 0,
+    virtual bool writeData(const std::string& session_id, const uint8_t* data, size_t size, int64_t pts = 0,
                            const std::string& media_type = "video") = 0;
 
     virtual StorageResult completeSession(const std::string& session_id, const std::string& stream_id) = 0;
@@ -106,7 +107,7 @@ public:
                              size_t estimated_size = 0) override;
 
     // Override write operations to use buffering
-    bool writeData(const std::string& session_id, const void* data, size_t size, int64_t pts = 0,
+    bool writeData(const std::string& session_id, const uint8_t* data, size_t size, int64_t pts = 0,
                    const std::string& media_type = "video") override final;
 
     StorageResult completeSession(const std::string& session_id, const std::string& stream_id) override final;
@@ -132,7 +133,7 @@ protected:
     }
 
     // Abstract methods for cloud storage implementations
-    virtual bool doWriteData(const std::string& session_id, const void* data, size_t size, int64_t pts = 0,
+    virtual bool doWriteData(const std::string& session_id, const uint8_t* data, size_t size, int64_t pts = 0,
                              const std::string& media_type = "video") = 0;
 
     virtual StorageResult doCompleteSession(const std::string& session_id, const std::string& stream_id) = 0;
@@ -152,7 +153,7 @@ private:
     // Internal methods
     void initializeBuffering(const std::string& stream_id, const std::string& session_id);
     void stopBuffering();
-    bool handleBufferedWrite(const std::string& session_id, const void* data, size_t size, int64_t pts = 0,
+    bool handleBufferedWrite(const std::string& session_id, const unsigned char* data, size_t size, int64_t pts = 0,
                              const std::string& media_type = "video");
     void updateBufferingStats();
 };

--- a/services/vios/src/framework/unified_storage/writer/minio_storage_writer.cpp
+++ b/services/vios/src/framework/unified_storage/writer/minio_storage_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,7 +91,7 @@ std::string MinioStorageWriter::startSession(const std::string& remote_path, con
     return session_id;
 }
 
-bool MinioStorageWriter::doWriteData(const std::string& session_id, const void* data, size_t size, int64_t pts,
+bool MinioStorageWriter::doWriteData(const std::string& session_id, const uint8_t* data, size_t size, int64_t pts,
                                      const std::string& media_type)
 {
     // Validate input parameters with better error messages

--- a/services/vios/src/framework/unified_storage/writer/minio_storage_writer.h
+++ b/services/vios/src/framework/unified_storage/writer/minio_storage_writer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -75,7 +75,7 @@ public:
 
 protected:
     // CloudStorageWriter abstract methods
-    bool doWriteData(const std::string& session_id, const void* data, size_t size, int64_t pts,
+    bool doWriteData(const std::string& session_id, const uint8_t* data, size_t size, int64_t pts,
                      const std::string& media_type) override;
 
     StorageResult doCompleteSession(const std::string& session_id, const std::string& stream_id) override;

--- a/services/vios/src/framework/unified_storage/writer/s3_storage_writer.h
+++ b/services/vios/src/framework/unified_storage/writer/s3_storage_writer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,7 +71,7 @@ public:
 
 protected:
     // CloudStorageWriter abstract methods
-    bool doWriteData(const std::string& session_id, const void* data, size_t size, int64_t pts = 0,
+    bool doWriteData(const std::string& session_id, const uint8_t* data, size_t size, int64_t pts = 0,
                      const std::string& media_type = "video") override;
 
     StorageResult doCompleteSession(const std::string& session_id, const std::string& stream_id) override;

--- a/services/vios/src/framework/unified_storage/writer/unified_storage_writer.cpp
+++ b/services/vios/src/framework/unified_storage/writer/unified_storage_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,7 +166,7 @@ std::string UnifiedStorageWriter::startWrite(const std::string& remote_path, con
     return session_id;
 }
 
-bool UnifiedStorageWriter::onFrame(const std::string& session_id, const void* data, size_t size, int64_t pts,
+bool UnifiedStorageWriter::onFrame(const std::string& session_id, const unsigned char* data, size_t size, int64_t pts,
                                    const std::string& media_type)
 {
     if (!m_session_active.load() || session_id != m_current_session_id)
@@ -184,7 +184,7 @@ bool UnifiedStorageWriter::onFrame(const std::string& session_id, const void* da
     }
 
     // Push buffer to pipeline with PTS and media type
-    return pushBufferToPipeline(data, size, pts, media_type);
+    return pushBufferToPipeline(static_cast<const unsigned char*>(data), size, pts, media_type);
 }
 
 StorageResult UnifiedStorageWriter::stopWrite(const std::string& session_id, const std::string& stream_id)
@@ -1000,7 +1000,7 @@ bool UnifiedStorageWriter::resetPipeline()
     return createPipeline(m_videoCodec, m_audioSupported, current_stream_id);
 }
 
-bool UnifiedStorageWriter::pushBufferToPipeline(const void* data, size_t size, int64_t pts,
+bool UnifiedStorageWriter::pushBufferToPipeline(const unsigned char* data, size_t size, int64_t pts,
                                                 const std::string& media_type)
 {
     // Validate input parameters to prevent crashes

--- a/services/vios/src/framework/unified_storage/writer/unified_storage_writer.h
+++ b/services/vios/src/framework/unified_storage/writer/unified_storage_writer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,7 @@ public:
                                    size_t estimated_size = 0);
 
     // Frame handling
-    bool onFrame(const std::string& session_id, const void* data, size_t size, int64_t pts = 0,
+    bool onFrame(const std::string& session_id, const unsigned char* data, size_t size, int64_t pts = 0,
                  const std::string& media_type = "video");
 
     StorageResult stopWrite(const std::string& session_id, const std::string& stream_id);
@@ -113,7 +113,7 @@ public:
     bool resetPipeline();
 
     // Buffer handling
-    bool pushBufferToPipeline(const void* data, size_t size, int64_t pts, const std::string& media_type);
+    bool pushBufferToPipeline(const unsigned char* data, size_t size, int64_t pts, const std::string& media_type);
     bool sendEOS();
     bool waitForEOSMessage(int timeout_ms = 5000);
 

--- a/services/vios/src/framework/utilities/async_http_client.cpp
+++ b/services/vios/src/framework/utilities/async_http_client.cpp
@@ -47,6 +47,23 @@ std::string loggableUrl(const std::string& url)
     }
     return result;
 }
+
+// libcurl invokes this from C frames with the CURLOPT_WRITEDATA pointer, so it
+// carries C language linkage and recovers the response body at that boundary.
+extern "C" size_t appendResponseBody(char* data, size_t size, size_t nmemb, void* writeData)
+{
+    auto* body = static_cast<std::string*>(writeData);
+    const size_t total = size * nmemb;
+    try
+    {
+        body->append(data, total);
+    }
+    catch (...)
+    {
+        return 0;  // signals CURLE_WRITE_ERROR to libcurl without propagating through C frames
+    }
+    return total;
+}
 }  // unnamed namespace
 
 AsyncHttpClient::~AsyncHttpClient()
@@ -214,8 +231,8 @@ void AsyncHttpClient::startRequest(std::unique_ptr<RequestContext> ctx)
     setopt(CURLOPT_CONNECTTIMEOUT_MS, req.m_connectTimeoutMs);
     setopt(CURLOPT_SSL_VERIFYPEER, req.m_verifyTls ? 1L : 0L);
     setopt(CURLOPT_SSL_VERIFYHOST, req.m_verifyTls ? 2L : 0L);
-    setopt(CURLOPT_WRITEFUNCTION, &AsyncHttpClient::writeCallback);
-    setopt(CURLOPT_WRITEDATA, ctx.get());
+    setopt(CURLOPT_WRITEFUNCTION, appendResponseBody);
+    setopt(CURLOPT_WRITEDATA, &ctx->m_responseBody);
     setopt(CURLOPT_ERRORBUFFER, ctx->m_errorBuffer);
 
     if (!req.m_body.empty())
@@ -402,19 +419,4 @@ void AsyncHttpClient::deliver(const RequestContext& ctx, const AsyncHttpResponse
     {
         LOG(error) << "AsyncHttpClient completion callback threw" << endl;
     }
-}
-
-size_t AsyncHttpClient::writeCallback(char* data, size_t size, size_t nmemb, void* userp)
-{
-    auto* ctx = static_cast<RequestContext*>(userp);
-    const size_t total = size * nmemb;
-    try
-    {
-        ctx->m_responseBody.append(data, total);
-    }
-    catch (...)
-    {
-        return 0;  // signals CURLE_WRITE_ERROR to libcurl without propagating through C frames
-    }
-    return total;
 }

--- a/services/vios/src/framework/utilities/async_http_client.h
+++ b/services/vios/src/framework/utilities/async_http_client.h
@@ -121,7 +121,6 @@ private:
     void wakeupLoop();
     [[nodiscard]] long pollTimeoutMs();
     static void deliver(const RequestContext& ctx, const AsyncHttpResponse& response);
-    static size_t writeCallback(char* data, size_t size, size_t nmemb, void* userp);
 
     CURLM* m_multiHandle{nullptr};
     std::thread m_loopThread;

--- a/services/vios/src/framework/utilities/event_loop.cpp
+++ b/services/vios/src/framework/utilities/event_loop.cpp
@@ -105,7 +105,7 @@ std::thread::id EventLoop::GetCurrentThreadId()
 	return this_thread::get_id();
 }
 
-void EventLoop::processFunctionWrapper(std::shared_ptr<EventLoopData> userData, void *parent)
+void EventLoop::processFunctionWrapper(std::shared_ptr<EventLoopData> userData)
 {
     m_isProcessFuncDone = false;
     std::thread t([&]()
@@ -189,7 +189,7 @@ void EventLoop::Process()
                 {
                     if (msg->id == MSG_POST_USER_DATA)
                     {
-                        processFunctionWrapper(userData, m_parent);
+                        processFunctionWrapper(userData);
                     }
                     if (userData->m_expectResult)
                     {

--- a/services/vios/src/framework/utilities/event_loop.cpp
+++ b/services/vios/src/framework/utilities/event_loop.cpp
@@ -43,20 +43,9 @@ struct EventLoopMsg
     std::shared_ptr<void> msg;
 };
 
-EventLoop::EventLoop(std::string threadName, process_message func) 
-                    : m_thread(nullptr)
-                    , m_threadName(threadName)
-                    , m_processMsg(func)
-                    , m_parent(nullptr)
-{
-    CreateThread();
-}
-
 EventLoop::EventLoop(std::string threadName, process_message_handler handler)
                     : m_thread(nullptr)
                     , m_threadName(threadName)
-                    , m_processMsg(nullptr)
-                    , m_parent(nullptr)
                     , m_processMsgHandler(std::move(handler))
 {
     CreateThread();
@@ -113,10 +102,6 @@ void EventLoop::processFunctionWrapper(std::shared_ptr<EventLoopData> userData)
         if (m_processMsgHandler)
         {
             m_processMsgHandler(userData);
-        }
-        else if (m_processMsg)
-        {
-            m_processMsg(userData, m_parent);
         }
         {
             std::unique_lock<std::mutex> l(m_mutexProceeFunc);
@@ -185,7 +170,7 @@ void EventLoop::Process()
 
                 EVENT_LOOP_LOG
 
-                if ((m_processMsg && m_parent) || m_processMsgHandler)
+                if (m_processMsgHandler)
                 {
                     if (msg->id == MSG_POST_USER_DATA)
                     {
@@ -267,7 +252,6 @@ void EventLoop::ExitThread()
         m_queue.push(eventLoopMsg);
         m_cv.notify_all();
     }
-    m_processMsg = nullptr;
     m_processMsgHandler = nullptr;
     LOG(info) << "Waiting for process thread to finish" << endl;
     if (m_thread->joinable())

--- a/services/vios/src/framework/utilities/event_loop.cpp
+++ b/services/vios/src/framework/utilities/event_loop.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,6 +52,16 @@ EventLoop::EventLoop(std::string threadName, process_message func)
     CreateThread();
 }
 
+EventLoop::EventLoop(std::string threadName, process_message_handler handler)
+                    : m_thread(nullptr)
+                    , m_threadName(threadName)
+                    , m_processMsg(nullptr)
+                    , m_parent(nullptr)
+                    , m_processMsgHandler(std::move(handler))
+{
+    CreateThread();
+}
+
 EventLoop::~EventLoop()
 {
     try {
@@ -100,7 +110,11 @@ void EventLoop::processFunctionWrapper(std::shared_ptr<EventLoopData> userData, 
     m_isProcessFuncDone = false;
     std::thread t([&]()
     {
-        if (m_processMsg)
+        if (m_processMsgHandler)
+        {
+            m_processMsgHandler(userData);
+        }
+        else if (m_processMsg)
         {
             m_processMsg(userData, m_parent);
         }
@@ -171,7 +185,7 @@ void EventLoop::Process()
 
                 EVENT_LOOP_LOG
 
-                if (m_processMsg && m_parent)
+                if ((m_processMsg && m_parent) || m_processMsgHandler)
                 {
                     if (msg->id == MSG_POST_USER_DATA)
                     {
@@ -254,6 +268,7 @@ void EventLoop::ExitThread()
         m_cv.notify_all();
     }
     m_processMsg = nullptr;
+    m_processMsgHandler = nullptr;
     LOG(info) << "Waiting for process thread to finish" << endl;
     if (m_thread->joinable())
     {

--- a/services/vios/src/framework/utilities/event_loop.h
+++ b/services/vios/src/framework/utilities/event_loop.h
@@ -48,19 +48,14 @@ struct EventLoopData
 
 struct EventLoopMsg;
 
-typedef void (*process_message)(std::shared_ptr<EventLoopData>, void*);
-
-/// Type-safe alternative to the process_message callback: the handler carries its own
-/// context (e.g. a capturing lambda), so no untyped parent pointer has to be threaded through.
+/// Message handler: it carries its own context (e.g. a capturing lambda), so no
+/// untyped parent pointer has to be threaded through.
 using process_message_handler = std::function<void(std::shared_ptr<EventLoopData>)>;
 
 class EventLoop
 {
 public:
     /// Constructor
-    EventLoop(std::string threadName, process_message);
-
-    /// Constructor taking a self-contained handler; no setParent() call is required.
     EventLoop(std::string threadName, process_message_handler handler);
 
     /// Destructor
@@ -85,8 +80,6 @@ public:
     /// @param[in] data - thread specific message information
     bool postMsg(std::shared_ptr<EventLoopData> msg);
 
-    void setParent(void* parent) { m_parent = parent; }
-
     int getPendingMessages();
 
     bool testEventLoopRunning();
@@ -109,8 +102,6 @@ private:
     std::condition_variable m_cv;
     std::queue<std::shared_ptr<EventLoopOutData>> m_outDataQueue;
     std::string m_threadName;
-    process_message m_processMsg;
-    void* m_parent;
     process_message_handler m_processMsgHandler;
     std::mutex m_mutexProceeFunc;
     std::condition_variable m_cvProcessFunc;

--- a/services/vios/src/framework/utilities/event_loop.h
+++ b/services/vios/src/framework/utilities/event_loop.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
+#include <functional>
 #include <json/json.h>
 
 struct EventLoopOutData
@@ -49,11 +50,18 @@ struct EventLoopMsg;
 
 typedef void (*process_message)(std::shared_ptr<EventLoopData>, void*);
 
+/// Type-safe alternative to the process_message callback: the handler carries its own
+/// context (e.g. a capturing lambda), so no untyped parent pointer has to be threaded through.
+using process_message_handler = std::function<void(std::shared_ptr<EventLoopData>)>;
+
 class EventLoop
 {
 public:
     /// Constructor
     EventLoop(std::string threadName, process_message);
+
+    /// Constructor taking a self-contained handler; no setParent() call is required.
+    EventLoop(std::string threadName, process_message_handler handler);
 
     /// Destructor
     ~EventLoop();
@@ -103,6 +111,7 @@ private:
     std::string m_threadName;
     process_message m_processMsg;
     void* m_parent;
+    process_message_handler m_processMsgHandler;
     std::mutex m_mutexProceeFunc;
     std::condition_variable m_cvProcessFunc;
     std::atomic<bool> m_isProcessFuncDone {false};

--- a/services/vios/src/framework/utilities/event_loop.h
+++ b/services/vios/src/framework/utilities/event_loop.h
@@ -100,7 +100,7 @@ private:
 
     /// Entry point for timer thread
     void TimerThread();
-    void processFunctionWrapper(std::shared_ptr<EventLoopData> userdata, void *parent);
+    void processFunctionWrapper(std::shared_ptr<EventLoopData> userdata);
 
     std::unique_ptr<std::thread> m_thread;
     std::queue<std::shared_ptr<EventLoopMsg>> m_queue;

--- a/services/vios/src/framework/utilities/network_utils.cpp
+++ b/services/vios/src/framework/utilities/network_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -900,10 +900,11 @@ int stopOnvifDiscovery()
     return 0;
 }
 
-static size_t curlWriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
+static size_t curlWriteCallback(const char *contents, size_t size, size_t nmemb, std::string *userp)
 {
-    ((std::string*)userp)->append((char*)contents, size * nmemb);
-    return size * nmemb;
+    const size_t totalBytes(size * nmemb);
+    userp->append(contents, totalBytes);
+    return totalBytes;
 }
 
 bool curlGetRequest(const string& url, long& http_code)

--- a/services/vios/src/framework/utilities/network_utils.cpp
+++ b/services/vios/src/framework/utilities/network_utils.cpp
@@ -900,10 +900,14 @@ int stopOnvifDiscovery()
     return 0;
 }
 
-static size_t curlWriteCallback(const char *contents, size_t size, size_t nmemb, std::string *userp)
+// libcurl/librdkafka define this signature; the C ABI requires it verbatim.
+// Narrowing the parameter types makes the call go through an incompatible
+// function-pointer type, which is undefined behaviour even where the
+// pointers happen to be the same width. Cast inside the body instead.
+static size_t curlWriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
     const size_t totalBytes(size * nmemb);
-    userp->append(contents, totalBytes);
+    static_cast<std::string *>(userp)->append(static_cast<const char *>(contents), totalBytes);
     return totalBytes;
 }
 

--- a/services/vios/src/framework/web/websocket_client/WebsocketClient.cpp
+++ b/services/vios/src/framework/web/websocket_client/WebsocketClient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,6 +78,9 @@ bool WebsocketClient::processReceivedMessage(struct mg_connection *conn, int fla
     return true;
 }
 
+// civetweb invokes these from C code, so they must carry C language linkage
+extern "C"
+{
 // WebSocket data handler
 static int wSDataHandler(struct mg_connection *conn, int flags, char *data, size_t data_len, void *user_data)
 {
@@ -87,12 +90,13 @@ static int wSDataHandler(struct mg_connection *conn, int flags, char *data, size
 // WebSocket close handler
 static void wSCloseHandler(const struct mg_connection *conn, void *user_data)
 {
-    WebsocketClient *ws = (WebsocketClient *)user_data;
+    WebsocketClient *ws = static_cast<WebsocketClient *>(user_data);
     if (ws)
     {
         return ws->handleClose(conn);
     }
     return;
+}
 }
 
 // Constructor

--- a/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
+++ b/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -261,11 +261,10 @@ webrtc::PeerConnectionFactoryDependencies CreatePeerConnectionFactoryDependencie
     return dependencies;
 }
 
-void process_pc_message(std::shared_ptr<EventLoopData> data, void* parent)
+void process_pc_message(std::shared_ptr<EventLoopData> data, PeerConnection* peer)
 {
     shared_ptr<PeerData> in_data = std::static_pointer_cast<PeerData>(data);
     shared_ptr<PeerOutData> out_data = std::static_pointer_cast<PeerOutData>(data->m_outResult);
-    PeerConnection* peer = static_cast <PeerConnection*>(parent);
     if (in_data == nullptr || peer == nullptr)
     {
         LOG(error) << "Received null in data" << endl;
@@ -430,7 +429,8 @@ PeerConnection::PeerConnection(PeerConnectionManager* peerConnectionManager,
             , m_deleting(false)
             , m_publishFilter(std::string(".*"))
             , m_audioDecoderfactory(webrtc::CreateBuiltinAudioDecoderFactory())
-            , m_eventLoop("peerconnection_event_loop", process_pc_message)
+            , m_eventLoop("peerconnection_event_loop",
+                          [this](std::shared_ptr<EventLoopData> data) { process_pc_message(data, this); })
             , m_deviceManager(m_peerConnectionManager->getDeviceManager())
             , m_prevTimestamp(0)
             , m_prevBytesReceived(0)
@@ -491,7 +491,6 @@ PeerConnection::PeerConnection(PeerConnectionManager* peerConnectionManager,
     }
 
     m_statsCallback = webrtc::make_ref_counted<PeerConnectionStatsCollectorCallback>();
-    m_eventLoop.setParent(this);
 }
 
 PeerConnection::~PeerConnection()

--- a/services/vios/src/framework/webrtc_streamer/PeerConnectionManager.cpp
+++ b/services/vios/src/framework/webrtc_streamer/PeerConnectionManager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -299,11 +299,10 @@ static std::string createUniqueStreamId(std::shared_ptr<SensorInfo> sensor)
 }
 
 #ifdef ASYNC_API
-void process_peer_message(std::shared_ptr<EventLoopData> data, void* parent)
+void process_peer_message(std::shared_ptr<EventLoopData> data, PeerConnectionManager* peer)
 {
     shared_ptr<PeerData> in_data = std::static_pointer_cast<PeerData>(data);
     shared_ptr<PeerOutData> out_data = std::static_pointer_cast<PeerOutData>(data->m_outResult);
-    PeerConnectionManager* peer = static_cast <PeerConnectionManager*>(parent);
     Json::Value in = in_data->m_dataParams;
     Json::Value out;
     VmsErrorCode error_code = VmsErrorCode::NoError;
@@ -668,7 +667,8 @@ PeerConnectionManager::PeerConnectionManager(std::string pcType,
 #endif
       m_publishFilter(publishFilter), m_deviceManager(deviceManager)
 #ifdef ASYNC_API
-      , m_eventLoop("peer_event_loop", process_peer_message)
+      , m_eventLoop("peer_event_loop",
+                    [this](std::shared_ptr<EventLoopData> data) { process_peer_message(data, this); })
 #endif
 {
     InitializePeerConnection();
@@ -2028,9 +2028,6 @@ void PeerConnectionManager::InitializePeerConnection()
     }
     configureWebrtcLogging(logLevel);
     LOG(info) << "Logger level:" <<  webrtc::LogMessage::GetLogToDebug() << std::endl;
-#ifdef ASYNC_API
-    m_eventLoop.setParent(this);
-#endif
     webrtc::InitializeSSL();
     if (GET_CONFIG().use_reverse_proxy == true)
     {

--- a/services/vios/src/framework/webrtc_streamer/WebrtcCallbacks.cpp
+++ b/services/vios/src/framework/webrtc_streamer/WebrtcCallbacks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -287,7 +287,7 @@ void VideoSink::OnFrame(const webrtc::VideoFrame& video_frame)
     webrtc::scoped_refptr<webrtc::I420BufferInterface> buffer(frame_buffer->ToI420());
     int width = frame_buffer->width();
     int height = frame_buffer->height();
-    void* dataY = nullptr;
+    unsigned char* dataY = nullptr;
     /* Size is 1.5 times resolution for I420 Buffer
        and Size is stored in width and codec type is specified in height for pass through */
     unsigned int size = width * height * 1.5;
@@ -301,13 +301,13 @@ void VideoSink::OnFrame(const webrtc::VideoFrame& video_frame)
     if (buffer == nullptr)
     {
         size = sizeof(NvBufSurface);
-        dataY = (void *)&frame_buffer; //webrtc::scoped_refptr<NvVideoFrameBuffer>*
+        dataY = (unsigned char *)&frame_buffer; //webrtc::scoped_refptr<NvVideoFrameBuffer>*
     }
     else
     {
         width = buffer->width();
         height = buffer->height();
-        dataY = m_passThrough ? (void *)buffer.get()->DataY() : (void *)buffer.get();
+        dataY = m_passThrough ? (unsigned char *)buffer.get()->DataY() : (unsigned char *)buffer.get();
     }
 
     /* Frame rate measurements */

--- a/services/vios/src/framework/webrtc_streamer/hlsmanager.cpp
+++ b/services/vios/src/framework/webrtc_streamer/hlsmanager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,16 +19,15 @@
 #include "hlsmanager.h"
 #include "rtspserver.h"
 
-static void process_hls_message(std::shared_ptr<EventLoopData> data, void* parent)
+void HLSManager::process_hls_message(std::shared_ptr<EventLoopData> data)
 {
     shared_ptr<HlsData> in_data = std::static_pointer_cast<HlsData>(data);
     shared_ptr<HlsOutData> out_data = std::static_pointer_cast<HlsOutData>(data->m_outResult);
-    HLSManager* hls = static_cast <HLSManager*>(parent);
     std::map<std::string, std::string, std::less<>> opts = in_data->m_opts;
     Json::Value out;
     VmsErrorCode error_code = VmsErrorCode::NoError;
     string peerid = opts["peerid"];
-    if (in_data == nullptr || hls == nullptr)
+    if (in_data == nullptr)
     {
         LOG(error) << "Received null in data" << endl;
         return;
@@ -44,11 +43,11 @@ static void process_hls_message(std::shared_ptr<EventLoopData> data, void* paren
 
     if(in_data->m_taskName == "start")
     {
-        error_code = hls->start(opts, out);
+        error_code = start(opts, out);
     }
     else if(in_data->m_taskName == "stop")
     {
-        error_code = hls->stop(peerid, out);
+        error_code = stop(peerid, out);
     }
     else
     {
@@ -62,9 +61,10 @@ static void process_hls_message(std::shared_ptr<EventLoopData> data, void* paren
     }
 }
 
-HLSManager::HLSManager() : m_eventLoop("hls_event_loop", process_hls_message)
+HLSManager::HLSManager()
+    : m_eventLoop("hls_event_loop", [this](std::shared_ptr<EventLoopData> data) { process_hls_message(std::move(data)); })
 {
-    
+
 }
 
 HLSManager::~HLSManager()
@@ -77,11 +77,6 @@ HLSManager::~HLSManager()
         delete it_del->second;
         it = m_streamMap.erase(it_del);
     }
-}
-
-void HLSManager::start()
-{
-    m_eventLoop.setParent(this);
 }
 
 VmsErrorCode HLSManager::startStream(std::map<std::string, std::string, std::less<>> opts, Json::Value &response)

--- a/services/vios/src/framework/webrtc_streamer/inc/PeerConnection.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/PeerConnection.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,7 +104,7 @@ public:
                                 const Json::Value &, Json::Value&);
     VmsErrorCode getCurrentPosition(const std::string &peerId, Json::Value&, Json::Value&);
 
-    friend void process_pc_message(std::shared_ptr<EventLoopData> data, void* parent);
+    friend void process_pc_message(std::shared_ptr<EventLoopData> data, PeerConnection* parent);
     VmsErrorCode postToEventLoop(const string& task_name, const string& peerid,
                             Json::Value in, Json::Value req_info,
                             Json::Value& response, bool is_sync = true, uint32_t timeout = 0);

--- a/services/vios/src/framework/webrtc_streamer/inc/PeerConnectionManager.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/PeerConnectionManager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -129,7 +129,7 @@ class PeerConnectionManager : public IStreamStatusEvent, public IVstModule
         std::vector<std::pair<std::string, ClientInfo>> GetAllClients();
 
 #ifdef ASYNC_API
-        friend void process_peer_message(std::shared_ptr<EventLoopData> data, void* parent);
+        friend void process_peer_message(std::shared_ptr<EventLoopData> data, PeerConnectionManager* peer);
         VmsErrorCode postToEventLoop(const string& task_name, const string& peerid,
                                     Json::Value in, Json::Value req_info,
                                     Json::Value& response, bool is_async = true, uint32_t timeout = 0);

--- a/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -70,7 +70,7 @@ public:
         int bits_per_sample,
         int sample_rate,
         size_t number_of_channels,
-        size_t number_of_frames);
+        size_t number_of_frames) override;
 
     std::atomic<bool>   m_webrtcAudioInDataFlow{false};
 protected:

--- a/services/vios/src/framework/webrtc_streamer/inc/hlsmanager.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/hlsmanager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,7 +44,6 @@ class HLSManager
     public:
         HLSManager();
         ~HLSManager();
-        void start();
         VmsErrorCode startStream(std::map<std::string, std::string, std::less<>> opts, Json::Value &response);
         VmsErrorCode stopStream(const string& peerid, Json::Value &response);
         VmsErrorCode start(std::map<std::string, std::string, std::less<>> opts, Json::Value &response);
@@ -53,6 +52,8 @@ class HLSManager
                                     Json::Value& response, bool is_async = true, uint32_t timeout = 10);
         bool checkIfPeerPresent(const string& peerid);
     private:
+        void process_hls_message(std::shared_ptr<EventLoopData> data);
+
         std::map<std::string, RTSPVideoCapturer*>     m_streamMap;
         EventLoop m_eventLoop;
         std::mutex m_streamLock;

--- a/services/vios/src/framework/webrtc_streamer/inc/livevideosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/livevideosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -692,7 +692,7 @@ public:
             }
             if (m_webrtcSinkConsumer)
             {
-                m_webrtcSinkConsumer->setWebrtcBroadcaster ((void*)&m_broadcaster);
+                m_webrtcSinkConsumer->setWebrtcBroadcaster (&m_broadcaster);
             }
         }
         m_broadcaster.AddOrUpdateSink(sink, wants);

--- a/services/vios/src/framework/webrtc_streamer/inc/mkvclient.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/mkvclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,13 +61,7 @@ class MKVClient
 	
 	private:
 		void onMatroskaFileCreation(MatroskaFile* newFile);
-		static void onMatroskaFileCreation(MatroskaFile* newFile, void* clientData) {
-			((MKVClient*)(clientData))->onMatroskaFileCreation(newFile);
-		}
 		void onEndOfFile();
-		static void onEndOfFile(void* clientData) {
-			((MKVClient*)(clientData))->onEndOfFile();
-		}
 		
 	protected:
 		Environment&             m_env;

--- a/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
@@ -43,7 +43,7 @@
 typedef int (*NvBufSurfaceCopy_t) (NvBufSurface *, NvBufSurface *);
 typedef int (*NvBufSurfaceCreate_t) (NvBufSurface **, uint32_t, NvBufSurfaceCreateParams *);
 typedef int (*NvBufSurfaceDestroy_t) (NvBufSurface *);
-typedef int (*NvBufSurfaceFromFd_t) (int, void**);
+typedef int (*NvBufSurfaceFromFdSurface_t) (int, NvBufSurface**);
 typedef int (*NvBufSurfaceAllocate_t) (NvBufSurface **, uint32_t, NvBufSurfaceAllocateParams *);
 
 typedef int (*NvBufSurfaceMap_t) (NvBufSurface *, int, int,  NvBufSurfaceMemMapFlags);
@@ -58,6 +58,10 @@ typedef NvBufSurfTransform_Error (*NvBufSurfTransformMultiInputBufCompositeBlend
 // typedef and member are declared unconditionally so the class layout is identical
 // across platforms in the unified aarch64 build.
 typedef int (*NvBufSurface2Raw_t) (NvBufSurface*, unsigned int, unsigned int, unsigned int, unsigned int, unsigned char*);
+
+// Opaque stand-in for the handle returned by dlopen(); never defined, so the
+// handle stays a typed pointer instead of a bare void*.
+struct NvBufDlHandle;
 
 enum NvBufferMode
 {
@@ -120,50 +124,50 @@ class NvBufWrapper
             // Loaded from /usr/lib/aarch64-linux-gnu/nvidia/: on Jetson (Orin/Thor)
             // the device/BSP injects the Tegra libs there; on discrete aarch64
             // (DGX-Spark/SBSA) Dockerfile.app symlinks them from the sbsa prebuilts.
-            handle_nvbufsurface_utils = dlopen("/usr/lib/aarch64-linux-gnu/nvidia/libnvbufsurface.so", RTLD_LAZY);
-            handle_nvbufsurfacetransform_utils = dlopen("/usr/lib/aarch64-linux-gnu/nvidia/libnvbufsurftransform.so", RTLD_LAZY);
+            handle_nvbufsurface_utils = dlOpenLibrary("/usr/lib/aarch64-linux-gnu/nvidia/libnvbufsurface.so");
+            handle_nvbufsurfacetransform_utils = dlOpenLibrary("/usr/lib/aarch64-linux-gnu/nvidia/libnvbufsurftransform.so");
 #else
-            handle_nvbufsurface_utils = dlopen("/usr/lib/x86_64-linux-gnu/libnvbufsurface.so", RTLD_LAZY);
-            handle_nvbufsurfacetransform_utils = dlopen("/usr/lib/x86_64-linux-gnu/libnvbufsurftransform.so", RTLD_LAZY);
+            handle_nvbufsurface_utils = dlOpenLibrary("/usr/lib/x86_64-linux-gnu/libnvbufsurface.so");
+            handle_nvbufsurfacetransform_utils = dlOpenLibrary("/usr/lib/x86_64-linux-gnu/libnvbufsurftransform.so");
 #endif
             if (handle_nvbufsurface_utils && handle_nvbufsurfacetransform_utils)
             {
                 /* Surface core library functions */
                 dlerror();
-                NvBufSurfaceCopy = (NvBufSurfaceCopy_t) dlsym(handle_nvbufsurface_utils, "NvBufSurfaceCopy");
+                NvBufSurfaceCopy = dlLoadSymbol<NvBufSurfaceCopy_t>(handle_nvbufsurface_utils, "NvBufSurfaceCopy");
                 DL_ERROR_EXIT
-                NvBufSurfaceCreate = (NvBufSurfaceCreate_t) dlsym(handle_nvbufsurface_utils, "NvBufSurfaceCreate");
+                NvBufSurfaceCreate = dlLoadSymbol<NvBufSurfaceCreate_t>(handle_nvbufsurface_utils, "NvBufSurfaceCreate");
                 DL_ERROR_EXIT
-                NvBufSurfaceDestroy = (NvBufSurfaceDestroy_t) dlsym(handle_nvbufsurface_utils, "NvBufSurfaceDestroy");
+                NvBufSurfaceDestroy = dlLoadSymbol<NvBufSurfaceDestroy_t>(handle_nvbufsurface_utils, "NvBufSurfaceDestroy");
                 DL_ERROR_EXIT
-                NvBufSurfaceFromFd = (NvBufSurfaceFromFd_t)  dlsym(handle_nvbufsurface_utils, "NvBufSurfaceFromFd");
+                NvBufSurfaceFromFd = dlLoadSymbol<NvBufSurfaceFromFdSurface_t>(handle_nvbufsurface_utils, "NvBufSurfaceFromFd");
                 DL_ERROR_EXIT
-                NvBufSurfaceAllocate = (NvBufSurfaceAllocate_t)  dlsym(handle_nvbufsurface_utils, "NvBufSurfaceAllocate");
+                NvBufSurfaceAllocate = dlLoadSymbol<NvBufSurfaceAllocate_t>(handle_nvbufsurface_utils, "NvBufSurfaceAllocate");
                 DL_ERROR_EXIT
 
-                NvBufSurfaceMap = (NvBufSurfaceMap_t)  dlsym(handle_nvbufsurface_utils, "NvBufSurfaceMap");
+                NvBufSurfaceMap = dlLoadSymbol<NvBufSurfaceMap_t>(handle_nvbufsurface_utils, "NvBufSurfaceMap");
                 DL_ERROR_EXIT
-                NvBufSurfaceSyncForCpu = (NvBufSurfaceSyncForCpu_t)  dlsym(handle_nvbufsurface_utils, "NvBufSurfaceSyncForCpu");
+                NvBufSurfaceSyncForCpu = dlLoadSymbol<NvBufSurfaceSyncForCpu_t>(handle_nvbufsurface_utils, "NvBufSurfaceSyncForCpu");
                 DL_ERROR_EXIT
-                NvBufSurfaceUnMap = (NvBufSurfaceUnMap_t)  dlsym(handle_nvbufsurface_utils, "NvBufSurfaceUnMap");
+                NvBufSurfaceUnMap = dlLoadSymbol<NvBufSurfaceUnMap_t>(handle_nvbufsurface_utils, "NvBufSurfaceUnMap");
                 DL_ERROR_EXIT
                 // NvBufSurface2Raw is exported only by the Jetson/Orin variant of
                 // libnvbufsurface; resolving it on Thor/SBSA/x86 would fail init.
                 if (isJetsonPlatform())
                 {
-                    NvBufSurface2Raw = (NvBufSurface2Raw_t)  dlsym(handle_nvbufsurface_utils, "NvBufSurface2Raw");
+                    NvBufSurface2Raw = dlLoadSymbol<NvBufSurface2Raw_t>(handle_nvbufsurface_utils, "NvBufSurface2Raw");
                     DL_ERROR_EXIT
                 }
 
                 /* Surface transform library functions */
                 dlerror();
-                NvBufSurfTransform = (NvBufSurfTransform_t) dlsym(handle_nvbufsurfacetransform_utils, "NvBufSurfTransform");
+                NvBufSurfTransform = dlLoadSymbol<NvBufSurfTransform_t>(handle_nvbufsurfacetransform_utils, "NvBufSurfTransform");
                 DL_ERROR_EXIT
-                NvBufSurfTransformSetSessionParams = (NvBufSurfTransformSetSessionParams_t) dlsym(handle_nvbufsurfacetransform_utils, "NvBufSurfTransformSetSessionParams");
+                NvBufSurfTransformSetSessionParams = dlLoadSymbol<NvBufSurfTransformSetSessionParams_t>(handle_nvbufsurfacetransform_utils, "NvBufSurfTransformSetSessionParams");
                 DL_ERROR_EXIT
-                NvBufSurfTransformMultiInputBufCompositeBlend = (NvBufSurfTransformMultiInputBufCompositeBlend_t) dlsym(handle_nvbufsurfacetransform_utils, "NvBufSurfTransformMultiInputBufCompositeBlend");
+                NvBufSurfTransformMultiInputBufCompositeBlend = dlLoadSymbol<NvBufSurfTransformMultiInputBufCompositeBlend_t>(handle_nvbufsurfacetransform_utils, "NvBufSurfTransformMultiInputBufCompositeBlend");
                 DL_ERROR_EXIT
-                NvBufSurfTransformSetDefaultSession = (NvBufSurfTransformSetDefaultSession_t) dlsym(handle_nvbufsurfacetransform_utils, "NvBufSurfTransformSetDefaultSession");
+                NvBufSurfTransformSetDefaultSession = dlLoadSymbol<NvBufSurfTransformSetDefaultSession_t>(handle_nvbufsurfacetransform_utils, "NvBufSurfTransformSetDefaultSession");
                 DL_ERROR_EXIT
 
                 /* WAR to initialize pthread key nvbufsurftransform_key, in libnvbufsurftransform.so to avoid crash */
@@ -179,16 +183,16 @@ class NvBufWrapper
 
         close_dl:
                 LOG(error) << "Error loading the plugins, default buffer format: " << m_nvBufferMode << endl;
-                if (handle_nvbufsurface_utils)  dlclose(handle_nvbufsurface_utils);
-                if (handle_nvbufsurfacetransform_utils)  dlclose(handle_nvbufsurfacetransform_utils);
+                if (handle_nvbufsurface_utils)  dlCloseLibrary(handle_nvbufsurface_utils);
+                if (handle_nvbufsurfacetransform_utils)  dlCloseLibrary(handle_nvbufsurfacetransform_utils);
                 throw std::runtime_error("An exception occurred, error loading the NvBuf libraries");
         }
 
         ~NvBufWrapper()
         {
             LOG(info) << "Destructor NvBufWrapper::~NvBufWrapper" << endl;
-            if (handle_nvbufsurface_utils)  dlclose(handle_nvbufsurface_utils);
-            if (handle_nvbufsurfacetransform_utils)  dlclose(handle_nvbufsurfacetransform_utils);
+            if (handle_nvbufsurface_utils)  dlCloseLibrary(handle_nvbufsurface_utils);
+            if (handle_nvbufsurfacetransform_utils)  dlCloseLibrary(handle_nvbufsurfacetransform_utils);
         }
 
         int getFDAndDoTransformIfNeeded(InputBufferType &buffer_type, uint32_t sourceWidth, uint32_t sourceHeight,
@@ -331,7 +335,7 @@ class NvBufWrapper
                     int status = -1;
                     if (fd)
                     {
-                        status = NvBufSurfaceFromFd (*fd, (void**)(&op_surf));
+                        status = NvBufSurfaceFromFd (*fd, &op_surf);
                         if (status < 0)
                         {
                             LOG(error) << "Failed to get surface from fd =" << *fd << endl;
@@ -404,7 +408,7 @@ class NvBufWrapper
                     for (int plane = 0; plane < 2; ++plane)
                     {
                         NvBufSurface *nvbuf_surf = 0;
-                        ret = NvBufSurfaceFromFd(dmabuf_fd, (void**)(&nvbuf_surf));
+                        ret = NvBufSurfaceFromFd(dmabuf_fd, &nvbuf_surf);
                         if (ret != 0)
                         {
                             // return -1;
@@ -483,7 +487,7 @@ class NvBufWrapper
                     /* Compositor case with transform */
                     else if (buffer_type.m_inputFD != -1)
                     {
-                        int status = NvBufSurfaceFromFd (buffer_type.m_inputFD, (void**)(&(ip_surf)));
+                        int status = NvBufSurfaceFromFd (buffer_type.m_inputFD, &ip_surf);
                         if (status < 0)
                         {
                             LOG(error) << "Failed to get surface from fd =" << *fd << endl;
@@ -492,7 +496,7 @@ class NvBufWrapper
                         }
                         if (fd)
                         {
-                            status = NvBufSurfaceFromFd (*fd, (void**)(&op_surf));
+                            status = NvBufSurfaceFromFd (*fd, &op_surf);
                             if (status < 0)
                             {
                                 LOG(error) << "Failed to get surface from fd =" << *fd << endl;
@@ -506,7 +510,7 @@ class NvBufWrapper
                         int status = -1;
                         if (fd)
                         {
-                            status = NvBufSurfaceFromFd (*fd, (void**)(&op_surf));
+                            status = NvBufSurfaceFromFd (*fd, &op_surf);
                             if (status < 0)
                             {
                                 LOG(error) << "Failed to get surface from fd =" << *fd << endl;
@@ -599,7 +603,7 @@ class NvBufWrapper
             }
             NvBufSurface *nvbuf_surf = 0;
             int status = -1;
-            status = NvBufSurfaceFromFd (fd, (void**)(&nvbuf_surf));
+            status = NvBufSurfaceFromFd (fd, &nvbuf_surf);
             if (status < 0)
             {
                 LOG(error) << "Failed to get surface from fd =" << fd << endl;
@@ -625,7 +629,7 @@ class NvBufWrapper
             int status = 0;
             uint32_t i = 0;
 
-            status = NvBufSurfaceFromFd(fd, (void**)(&nvbuf_surf));
+            status = NvBufSurfaceFromFd(fd, &nvbuf_surf);
             if (status < 0)
             {
                 LOG(error) << "Failed to fetch surface from fd =" << fd << endl;
@@ -657,7 +661,7 @@ class NvBufWrapper
             int status = 0;
             uint32_t i = 0;
 
-            status = NvBufSurfaceFromFd(fd, (void**)(&nvbuf_surf));
+            status = NvBufSurfaceFromFd(fd, &nvbuf_surf);
             if (status < 0)
             {
                 LOG(error) << "Failed to fetch surface from fd =" << fd << endl;
@@ -687,7 +691,7 @@ class NvBufWrapper
             }
             NvBufSurface *nvbuf_surf = nullptr;
             int status = 0;
-            status = NvBufSurfaceFromFd(fd, (void**)(&nvbuf_surf));
+            status = NvBufSurfaceFromFd(fd, &nvbuf_surf);
             if (status < 0)
             {
                 LOG(error) << "Failed to get surface from fd =" << fd << endl;
@@ -705,7 +709,7 @@ class NvBufWrapper
             }
             NvBufSurface *nvbuf_surf = 0;
             int status = -1;
-            status = NvBufSurfaceFromFd (fd, (void**)(&nvbuf_surf));
+            status = NvBufSurfaceFromFd (fd, &nvbuf_surf);
             if (status < 0)
             {
                 LOG(error) << "Failed to get surface from fd =" << fd << endl;
@@ -726,7 +730,7 @@ class NvBufWrapper
             }
             NvBufSurface *nvbuf_surf = nullptr;
             int status = -1;
-            status = NvBufSurfaceFromFd (fd, (void**)(&nvbuf_surf));
+            status = NvBufSurfaceFromFd (fd, &nvbuf_surf);
             if (status < 0)
             {
                 LOG(error) << "Failed to get surface from fd =" << fd << endl;
@@ -771,7 +775,7 @@ class NvBufWrapper
                 if (!batch_surf[i])
                 {
                     int fd = it.second->m_fd;
-                    NvBufSurfaceFromFd(fd, (void **)&batch_surf[i]);
+                    NvBufSurfaceFromFd(fd, &batch_surf[i]);
                 }
                 i++;
             }
@@ -800,7 +804,7 @@ class NvBufWrapper
             memset(src_ptr, 0, lumaSize);
             memset(src_ptr+lumaSize, 128, chromaSize);
 
-            status = NvBufSurfaceFromFd (*op_fd, (void**)(&op_surf));
+            status = NvBufSurfaceFromFd (*op_fd, &op_surf);
             if (status < 0)
             {
                 LOG(error) << "Failed to get surface from fd =" << *op_fd << endl;
@@ -1238,7 +1242,7 @@ class NvBufWrapper
                     for (int plane = 0; plane < 2; ++plane)
                     {
                         NvBufSurface *nvbuf_surf = 0;
-                        ret = NvBufSurfaceFromFd(dmabuf_fd, (void**)(&nvbuf_surf));
+                        ret = NvBufSurfaceFromFd(dmabuf_fd, &nvbuf_surf);
                         ret = NvBufSurfaceMap(nvbuf_surf, 0, plane, NVBUF_MAP_READ_WRITE);
                         if (ret < 0)
                         {
@@ -1331,16 +1335,32 @@ class NvBufWrapper
 
     public:
         NvBufSurfaceCopy_t NvBufSurfaceCopy;
-        NvBufSurfaceFromFd_t NvBufSurfaceFromFd;
+        NvBufSurfaceFromFdSurface_t NvBufSurfaceFromFd;
         NvBufSurfTransform_t NvBufSurfTransform;
         NvBufSurfTransformSetSessionParams_t NvBufSurfTransformSetSessionParams;
         NvBufSurfTransformSetDefaultSession_t NvBufSurfTransformSetDefaultSession;
         NvBufSurface2Raw_t NvBufSurface2Raw;
 
     private:
+        static NvBufDlHandle* dlOpenLibrary(const char* path)
+        {
+            return static_cast<NvBufDlHandle*>(dlopen(path, RTLD_LAZY));
+        }
+
+        static void dlCloseLibrary(NvBufDlHandle* handle)
+        {
+            dlclose(static_cast<void*>(handle));
+        }
+
+        template <typename FuncT>
+        static FuncT dlLoadSymbol(NvBufDlHandle* handle, const char* symbol)
+        {
+            return reinterpret_cast<FuncT>(dlsym(static_cast<void*>(handle), symbol));
+        }
+
         NvBufferMode m_nvBufferMode;
-        void* handle_nvbufsurface_utils;
-        void* handle_nvbufsurfacetransform_utils;
+        NvBufDlHandle* handle_nvbufsurface_utils;
+        NvBufDlHandle* handle_nvbufsurfacetransform_utils;
         NvBufSurfaceCreate_t NvBufSurfaceCreate;
         NvBufSurfaceDestroy_t NvBufSurfaceDestroy; 
         NvBufSurfaceAllocate_t NvBufSurfaceAllocate;

--- a/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
@@ -696,7 +696,7 @@ class NvBufWrapper
             return static_cast<unsigned char *>(nvbuf_surf->surfaceList[0].mappedAddr.addr[plane]);
         }
 
-        void* extractSurface (int fd)
+        unsigned char* extractSurface (int fd)
         {
             if (!NvBufSurfaceFromFd)
             {
@@ -713,7 +713,7 @@ class NvBufWrapper
             }
             else
             {
-                return nvbuf_surf->surfaceList->dataPtr;
+                return static_cast<unsigned char*>(nvbuf_surf->surfaceList->dataPtr);
             }
         }
 

--- a/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -678,7 +678,7 @@ class NvBufWrapper
             return 0;
         }
 
-        void *getMappedAddr(int fd, uint32_t plane)
+        unsigned char *getMappedAddr(int fd, uint32_t plane)
         {
             if (!NvBufSurfaceFromFd)
             {
@@ -693,7 +693,7 @@ class NvBufWrapper
                 LOG(error) << "Failed to get surface from fd =" << fd << endl;
                 return nullptr;
             }
-            return nvbuf_surf->surfaceList[0].mappedAddr.addr[plane];
+            return static_cast<unsigned char *>(nvbuf_surf->surfaceList[0].mappedAddr.addr[plane]);
         }
 
         void* extractSurface (int fd)

--- a/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
@@ -717,7 +717,7 @@ class NvBufWrapper
             }
         }
 
-        void* getNvSurface (int fd)
+        NvBufSurface* getNvSurface (int fd)
         {
             if (!NvBufSurfaceFromFd)
             {

--- a/services/vios/src/framework/webrtc_streamer/mkvclient.cpp
+++ b/services/vios/src/framework/webrtc_streamer/mkvclient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,11 @@ void MKVClient::onMatroskaFileCreation(MatroskaFile* newFile) {
 	
 	m_mkvfile = newFile;
 	m_demux = m_mkvfile->newDemux();
+
+	// live555 requires a plain C callback, so the untyped client data is unpacked here
+	MediaSink::afterPlayingFunc* const afterPlaying = [](void* clientData) {
+		static_cast<MKVClient*>(clientData)->onEndOfFile();
+	};
 
 	unsigned trackNumber = 0;
 	FramedSource* trackSource = nullptr;
@@ -75,7 +80,7 @@ void MKVClient::onMatroskaFileCreation(MatroskaFile* newFile) {
 			else if (m_callback->onNewSession(sink->name(), media.c_str(), codec.c_str(), sdp.c_str())) 
 			{
 				LOG(info) << "Start playing sink for \"" << track->mimeType << "\" sdp:" << sdp.c_str() << "\n";
-				sink->startPlaying(*trackSource, onEndOfFile, this);	  
+				sink->startPlaying(*trackSource, afterPlaying, this);
 			} 
 			else 
 			{
@@ -84,7 +89,7 @@ void MKVClient::onMatroskaFileCreation(MatroskaFile* newFile) {
 				sink = SessionSink::createNew(m_env, nullptr);
 				if (sink != nullptr)
 				{
-					sink->startPlaying(*trackSource, onEndOfFile, this);
+					sink->startPlaying(*trackSource, afterPlaying, this);
 				}
 			}		
 		}
@@ -109,7 +114,9 @@ MKVClient::MKVClient(Environment& env, Callback* callback, const char* url, cons
 		fileurl = fileurl.erase(0,strlen(prefix));
 	}
 
-	MatroskaFile::createNew(env, fileurl.c_str(), onMatroskaFileCreation, this);	
+	MatroskaFile::createNew(env, fileurl.c_str(), [](MatroskaFile* newFile, void* clientData) {
+		static_cast<MKVClient*>(clientData)->onMatroskaFileCreation(newFile);
+	}, this);
 }
 
 MKVClient::~MKVClient() noexcept

--- a/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.cpp
+++ b/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -237,9 +237,8 @@ void ADTSByteStreamSource::restartForLoop()
         (TaskFunc*)ADTSByteStreamSource::retryGetFrame, this);
 }
 
-void ADTSByteStreamSource::retryGetFrame(void* clientData)
+void ADTSByteStreamSource::retryGetFrame(ADTSByteStreamSource* source)
 {
-    ADTSByteStreamSource* source = (ADTSByteStreamSource*)clientData;
     if (source)
     {
         source->doGetNextFrame();

--- a/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.cpp
+++ b/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.cpp
@@ -175,12 +175,11 @@ void ADTSByteStreamSource::doGetNextFrame()
 }
 
 void ADTSByteStreamSource
-::afterGettingFrame(void* clientData, unsigned frameSize,
+::afterGettingFrame(ADTSByteStreamSource* source, unsigned frameSize,
 		unsigned numTruncatedBytes,
 		struct timeval presentationTime,
 		unsigned durationInMicroseconds)
 {
-    ADTSByteStreamSource* source = (ADTSByteStreamSource*)clientData;
     source->fFrameSize = frameSize;
     source->fNumTruncatedBytes = numTruncatedBytes;
     source->fPresentationTime = presentationTime;
@@ -188,10 +187,12 @@ void ADTSByteStreamSource
     FramedSource::afterGetting(source);
 }
 
-void ADTSByteStreamSource::onSourceClosure(void* clientData)
+void ADTSByteStreamSource::onSourceClosure(ADTSByteStreamSource* source)
 {
-  ADTSByteStreamSource* source = (ADTSByteStreamSource*)clientData;
-  source->onSourceClosure1();
+  if (source)
+  {
+    source->onSourceClosure1();
+  }
 }
 
 void ADTSByteStreamSource::onSourceClosure1() {

--- a/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.hh
+++ b/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.hh
@@ -50,9 +50,9 @@ protected:
 private:
     // redefined virtual functions:
     virtual void doGetNextFrame();
-    static void onSourceClosure(void* clientData);
+    static void onSourceClosure(ADTSByteStreamSource* source);
     void onSourceClosure1();
-    static void afterGettingFrame(void* clientData,
+    static void afterGettingFrame(ADTSByteStreamSource* source,
           unsigned frameSize, unsigned numTruncatedBytes,
           struct timeval presentationTime,
           unsigned durationInMicroseconds);

--- a/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.hh
+++ b/services/vios/src/modules/rtsp_server/ADTSByteStreamSource.hh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ private:
           unsigned frameSize, unsigned numTruncatedBytes,
           struct timeval presentationTime,
           unsigned durationInMicroseconds);
-    static void retryGetFrame(void* clientData);
+    static void retryGetFrame(ADTSByteStreamSource* source);
     static void dataArrivalCheck(ADTSByteStreamSource* source);
     void closeSource();
     /* Common loop-restart sequence shared by the immediate-restart path

--- a/services/vios/src/modules/rtsp_server/AvLoopSyncCoordinator.h
+++ b/services/vios/src/modules/rtsp_server/AvLoopSyncCoordinator.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <functional>
 #include <map>
@@ -31,6 +32,8 @@
 #include <utility>
 #include <vector>
 #include "logger.h"
+
+class FramedSource;
 
 /*
  * AvLoopSyncCoordinator
@@ -85,6 +88,7 @@ class AvLoopSyncCoordinator
 {
 public:
     using RestartFn = std::function<void()>;
+    using ParticipantToken = const FramedSource*;
 
     explicit AvLoopSyncCoordinator(std::string label = std::string())
         : m_label(std::move(label))
@@ -97,9 +101,54 @@ public:
      * the ByteStreamSource). Idempotent: re-registering the same token
      * replaces the callback and resets its arrived flag to false.
      */
-    void registerParticipant(void* token, RestartFn onRestart)
+    template <typename ParticipantT>
+    void registerParticipant(const ParticipantT* token, RestartFn onRestart)
     {
-        if (token == nullptr)
+        registerParticipantId(toId(token), std::move(onRestart));
+    }
+
+    /*
+     * Remove a participant. If after removal the remaining participants
+     * are all already at EOS, fire their restart callbacks so they
+     * don't wait forever for the now-gone participant.
+     */
+    template <typename ParticipantT>
+    void unregisterParticipant(const ParticipantT* token)
+    {
+        unregisterParticipantId(toId(token));
+    }
+
+    /*
+     * Mark a participant as arrived at EOS. If this completes the
+     * barrier (all registered participants arrived), fire every
+     * restart callback synchronously on the calling thread.
+     */
+    template <typename ParticipantT>
+    void signalEos(const ParticipantT* token)
+    {
+        signalEosId(toId(token));
+    }
+
+    size_t participantCount()
+    {
+        std::lock_guard<std::mutex> guard(m_mu);
+        return m_participants.size();
+    }
+
+private:
+    /* Stable, unique identity of a participant, derived from the
+     * address of the object that registered it. */
+    using ParticipantId = std::uintptr_t;
+
+    template <typename ParticipantT>
+    static ParticipantId toId(const ParticipantT* token)
+    {
+        return reinterpret_cast<ParticipantId>(token);
+    }
+
+    void registerParticipantId(ParticipantId token, RestartFn onRestart)
+    {
+        if (token == 0)
         {
             return;
         }
@@ -111,14 +160,9 @@ public:
                   << token << ", total=" << m_participants.size() << std::endl;
     }
 
-    /*
-     * Remove a participant. If after removal the remaining participants
-     * are all already at EOS, fire their restart callbacks so they
-     * don't wait forever for the now-gone participant.
-     */
-    void unregisterParticipant(void* token)
+    void unregisterParticipantId(ParticipantId token)
     {
-        if (token == nullptr)
+        if (token == 0)
         {
             return;
         }
@@ -146,14 +190,9 @@ public:
         fireOutsideLock(toFire);
     }
 
-    /*
-     * Mark a participant as arrived at EOS. If this completes the
-     * barrier (all registered participants arrived), fire every
-     * restart callback synchronously on the calling thread.
-     */
-    void signalEos(void* token)
+    void signalEosId(ParticipantId token)
     {
-        if (token == nullptr)
+        if (token == 0)
         {
             return;
         }
@@ -182,13 +221,6 @@ public:
         fireOutsideLock(toFire);
     }
 
-    size_t participantCount()
-    {
-        std::lock_guard<std::mutex> guard(m_mu);
-        return m_participants.size();
-    }
-
-private:
     struct Participant
     {
         RestartFn onRestart;
@@ -259,5 +291,5 @@ private:
 
     std::string                       m_label;
     std::mutex                        m_mu;
-    std::map<void*, Participant>      m_participants;
+    std::map<ParticipantId, Participant> m_participants;
 };

--- a/services/vios/src/modules/rtsp_server/DynamicRTSPServer.cpp
+++ b/services/vios/src/modules/rtsp_server/DynamicRTSPServer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -158,7 +158,7 @@ static ServerMediaSession* createNewSMS(UsageEnvironment& env,
 void DynamicRTSPServer
 ::lookupServerMediaSession(char const* streamName,
                            lookupServerMediaSessionCompletionFunc* completionFunc,
-                           void* completionClientData,
+                           void* completionClientData, // NOSONAR
                            Boolean isFirstLookupInSession)
 {
   string stream_name(streamName);

--- a/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
+++ b/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -504,13 +504,11 @@ void H264ByteStreamSource::doGetNextFrame()
 }
 
 void H264ByteStreamSource
-  ::afterGettingFrame(void* clientData,
+  ::afterGettingFrame(H264ByteStreamSource* source,
 		      unsigned frameSize, unsigned numTruncatedBytes,
 		      struct timeval presentationTime,
 		      unsigned durationInMicroseconds)
 {
-    H264ByteStreamSource* source
-      = (H264ByteStreamSource*)clientData;
     source->fFrameSize = frameSize;
     source->fNumTruncatedBytes = numTruncatedBytes;
     source->fPresentationTime = presentationTime;
@@ -518,10 +516,8 @@ void H264ByteStreamSource
     FramedSource::afterGetting(source);
 }
 
-void H264ByteStreamSource::onSourceClosure(void* clientData)
+void H264ByteStreamSource::onSourceClosure(H264ByteStreamSource* source)
 {
-    H264ByteStreamSource* source
-      = (H264ByteStreamSource*)clientData;
     source->onSourceClosure1();
 }
 

--- a/services/vios/src/modules/rtsp_server/H264ByteStreamSource.hh
+++ b/services/vios/src/modules/rtsp_server/H264ByteStreamSource.hh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,9 +56,9 @@ private:
     virtual void doGetNextFrame();
 
 private:
-    static void onSourceClosure(void* clientData);
+    static void onSourceClosure(H264ByteStreamSource* source);
     void onSourceClosure1();
-    static void afterGettingFrame(void* clientData,
+    static void afterGettingFrame(H264ByteStreamSource* source,
           unsigned frameSize, unsigned numTruncatedBytes,
                                   struct timeval presentationTime,
           unsigned durationInMicroseconds);

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -269,7 +269,7 @@ void NvFileServerMediaSubsession::setRtcpBaseTime()
         ntpTime.tv_usec = (startTime % 1000) * 1000;
         LOG(info) << "Setting RTCP base time for:" << m_streamName << ", ActualStartTime:" << startTime
                 << ", ntpTime:" << ntpTime.tv_sec << "." << ntpTime.tv_usec << endl;
-        StreamState* streamState = (StreamState*)m_streamToken;
+        StreamState* streamState = m_streamToken;
         if (streamState != nullptr)
         {
             streamState->setRtcpBaseTime(ntpTime);
@@ -277,8 +277,9 @@ void NvFileServerMediaSubsession::setRtcpBaseTime()
     }
 }
 
+/* Parameter types are fixed by the live555 OnDemandServerMediaSubsession virtual. */
 void NvFileServerMediaSubsession
-::startStream(unsigned clientSessionId, void* streamToken, TaskFunc* rtcpRRHandler,
+::startStream(unsigned clientSessionId, void* streamToken, TaskFunc* rtcpRRHandler, // NOSONAR
 	      void* rtcpRRHandlerClientData, unsigned short& rtpSeqNum,
 	      unsigned& rtpTimestamp,
 	      ServerRequestAlternativeByteHandler* serverRequestAlternativeByteHandler,
@@ -286,7 +287,7 @@ void NvFileServerMediaSubsession
 {
     LOG(info) << "startStream, clientSessionId:" << clientSessionId << ", streamName:" << m_streamName
             << ", mediaType:" << mediaTypeAsString(m_mediaType) << ", m_sessionId:" << m_sessionId << endl;
-    m_streamToken = streamToken;
+    m_streamToken = static_cast<StreamState*>(streamToken);
     if (m_mediaSource)
     {
         if (m_stream_state == PauseState)

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
@@ -154,9 +154,8 @@ void NvFileServerMediaSubsession::checkIfSourceInPlayMode(void* clientData)
     }
 }
 
-static void frameSourceEvent(eFrameSourceEvent sourceEvent, void *data)
+static void frameSourceEvent(eFrameSourceEvent sourceEvent, NvFileServerMediaSubsession *fileServer)
 {
-    NvFileServerMediaSubsession *fileServer = (NvFileServerMediaSubsession *) data;
     if (fileServer)
     {
         fileServer->frameSourceEventChange(sourceEvent);

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.h
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,7 +90,7 @@ protected: // redefined virtual functions
                     unsigned& rtpTimestamp,
                     ServerRequestAlternativeByteHandler* serverRequestAlternativeByteHandler,
                     void* serverRequestAlternativeByteHandlerClientData);
-  void pauseStream(unsigned clientSessionId, void* streamToken);
+  virtual void pauseStream(unsigned clientSessionId, void* streamToken);
   virtual void deleteStream(unsigned clientSessionId, void*& streamToken);
   void createMediaSource(eMediaType mediaType, eSourceType sourceType);
   void destroyMediaSource();
@@ -110,7 +110,7 @@ private:
   string m_url_params;
   TaskToken m_PlayModeCheckTask;
   eStreamState m_stream_state;
-  void *m_streamToken;
+  StreamState *m_streamToken;
   eMediaType m_mediaType;
   eSourceType m_sourceType;
   H264ByteStreamSource* m_videoStreamSource = nullptr;

--- a/services/vios/src/modules/rtsp_server/NvMediaSource.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaSource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +42,7 @@ NvMediaSource
         , m_frameId(0)
         , m_url_params(url_params)
         , m_sessionId(session_id)
-        , m_eventLoop("source_event_loop", process_source_message)
+        , m_eventLoop("source_event_loop", [this](std::shared_ptr<EventLoopData> data) { process_source_message(std::move(data)); })
         , m_streamBuf(filename, STREAM_DEFAULT_BUFFER_SIZE)
         , m_is_error (false)
 {
@@ -109,7 +109,6 @@ NvMediaSource::~NvMediaSource ()
 
 int NvMediaSource::create()
 {
-    m_eventLoop.setParent(this);
     std::shared_ptr<EventLoopData> data(new EventLoopData);
     data->m_taskName = "create";
     m_eventLoop.postMsg(data);
@@ -125,7 +124,7 @@ bool NvMediaSource::isError()
     return false;
 }
 
-void NvMediaSource::registerCallback(cb_frameSourceEvent_t callback, void *owner)
+void NvMediaSource::registerCallback(cb_frameSourceEvent_t callback, NvFileServerMediaSubsession *owner)
 {
     m_callback[owner] = callback;
 }
@@ -151,7 +150,6 @@ void NvMediaSource::setClock(GstClock* global_clock, GstClockTime base_time)
 
 void NvMediaSource::play()
 {
-    m_eventLoop.setParent(this);
     std::shared_ptr<EventLoopData> data(new EventLoopData);
     data->m_taskName = "play";
 
@@ -743,7 +741,6 @@ void NvMediaSource::seek (int64_t seek_pos , uint64_t end_time, float rate /*1*/
 
 void NvMediaSource::seekToStart ()
 {
-    m_eventLoop.setParent(this);
     if (GET_CONFIG().enable_mega_simulation && GET_CONFIG().nv_streamer_sync_playback == true)
     {
         m_frameId = RtspSyncPlayback::getInstance()->getGlobalFrameId();
@@ -828,56 +825,55 @@ void NvMediaSource::destroy()
     return;
 }
 
-void NvMediaSource::process_source_message(std::shared_ptr<EventLoopData> data, void* parent)
+void NvMediaSource::process_source_message(std::shared_ptr<EventLoopData> data)
 {
-    shared_ptr<EventLoopData> source_data = std::static_pointer_cast<EventLoopData>(data);
-    NvMediaSource* source = static_cast <NvMediaSource*>(parent);
-    if (source == nullptr || source_data == nullptr)
+    shared_ptr<EventLoopData> source_data = std::move(data);
+    if (source_data == nullptr)
     {
         LOG(error) << "Received null data" << endl;
         return;
     }
     LOG(verbose) << source_data->m_taskName << endl;
-    if (source->getSourceType() == SourceTypeFile && source->m_demux)
+    if (getSourceType() == SourceTypeFile && m_demux)
     {
         if (source_data->m_taskName == "create")
         {
-            source->m_demux->create_internal();
+            m_demux->create_internal();
         }
         else if (source_data->m_taskName == "play")
         {
-            source->m_demux->play_internal();
+            m_demux->play_internal();
         }
         else if (source_data->m_taskName == "pause")
         {
-            source->m_demux->pause_internal();
+            m_demux->pause_internal();
         }
         else if (source_data->m_taskName == "seekToStart")
         {
-            source->m_demux->seekToStart();
+            m_demux->seekToStart();
         }
         else if (source_data->m_taskName == "seek")
         {
             int64_t seek_pos = source_data->m_inData["seek_value"].asInt64();
             uint64_t end_time = source_data->m_inData["end_time"].asUInt64();
             float rate = source_data->m_inData["rate"].asFloat();
-            source->m_demux->seek(seek_pos, end_time, rate);
+            m_demux->seek(seek_pos, end_time, rate);
         }
         else if (source_data->m_taskName == "resume")
         {
-            source->m_demux->resume_internal();
+            m_demux->resume_internal();
         }
         else if (source_data->m_taskName == "destroy")
         {
-            source->m_demux->destroy_internal();
+            m_demux->destroy_internal();
         }
         else if (source_data->m_taskName == "startOverlayPipeline")
         {
-            source->startOverlayPipeline_internal();
+            startOverlayPipeline_internal();
         }
         else if (source_data->m_taskName == "stopOverlayPipeline")
         {
-            source->stopOverlayPipeline_internal();
+            stopOverlayPipeline_internal();
         }
         else
         {

--- a/services/vios/src/modules/rtsp_server/NvMediaSource.hh
+++ b/services/vios/src/modules/rtsp_server/NvMediaSource.hh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 
 class VodOverlayManager;
 class AvLoopSyncCoordinator;
+class NvFileServerMediaSubsession;
 
 using namespace std;
 
@@ -62,7 +63,7 @@ static unsigned const samplingFrequencyTable[16] = {
   7350, 0, 0, 0
 };
 
-typedef void (*cb_frameSourceEvent_t)(eFrameSourceEvent sourceEvent, void *owner);
+typedef void (*cb_frameSourceEvent_t)(eFrameSourceEvent sourceEvent, NvFileServerMediaSubsession *owner);
 
 /*
  * AAC parameter bundle returned by NvMediaSource::getAacParams().
@@ -109,9 +110,9 @@ class NvMediaSource : public IMediaDataConsumer
         void setClock(GstClock* global_clock, GstClockTime base_time);
         void seek (int64_t seek_pos , uint64_t end_time, float rate);
         void seekToStart ();
-        static void process_source_message(std::shared_ptr<EventLoopData> data, void* parent);
+        void process_source_message(std::shared_ptr<EventLoopData> data);
         void setBufferState(eBufferMsg buffer_msg);
-        void registerCallback(cb_frameSourceEvent_t callback, void *owner);
+        void registerCallback(cb_frameSourceEvent_t callback, NvFileServerMediaSubsession *owner);
         void sendSourceEvent(eFrameSourceEvent sourceEvent);
         string getCodecConfigId();
 
@@ -158,7 +159,7 @@ class NvMediaSource : public IMediaDataConsumer
         std::string             m_sourceState;
         shared_ptr<GstDeMux>    m_demux;
         shared_ptr<VodOverlayManager> m_vodOverlayManager = nullptr;
-        std::map<void *, cb_frameSourceEvent_t> m_callback;
+        std::map<NvFileServerMediaSubsession *, cb_frameSourceEvent_t> m_callback;
         bool                    m_includeFrameId = false;
         int64_t                 m_frameId;
         string                  m_uuid;

--- a/services/vios/src/modules/rtsp_server/rtspserver.cpp
+++ b/services/vios/src/modules/rtsp_server/rtspserver.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -374,15 +374,7 @@ int RtspServer::addProxy(const string& id, const string& name, string& url)
     proxiedStreamURL = url;
 
     // Check whether we already have a "ServerMediaSession" for t file, Remove it.
-    m_rtspServer->lookupServerMediaSession(streamName.c_str(),
-      +[](void* clientData, ServerMediaSession* sessionLookedUp)
-    {
-        RtspServer *rtspServer = (RtspServer*)clientData;
-        if (rtspServer)
-        {
-            rtspServer->m_sms = sessionLookedUp;
-        }
-    }, this, false);
+    m_sms = ((DynamicRTSPServer *)m_rtspServer)->getServerMediaSessionForStream(streamName.c_str());
 
     if (m_sms != nullptr)
     {
@@ -520,17 +512,11 @@ int RtspServer::removeProxy(const string& id)
     LOG(info) << "Removing stream: " << streamName << ", id:" << id << endl;
 
     // Remove ServerMediaSession for this stream.
-    m_rtspServer->lookupServerMediaSession(streamName.c_str(),
-      +[](void* clientData, ServerMediaSession* sessionLookedUp)
-    {
-        if(sessionLookedUp) {
-            RTSPServer *rtspServer = (RTSPServer*)clientData;
-            if (rtspServer)
-            {
-                rtspServer->deleteServerMediaSession(sessionLookedUp);
-            }
-        }
-    }, m_rtspServer, false);
+    ServerMediaSession* sessionLookedUp =
+        ((DynamicRTSPServer *)m_rtspServer)->getServerMediaSessionForStream(streamName.c_str());
+    if(sessionLookedUp) {
+        m_rtspServer->deleteServerMediaSession(sessionLookedUp);
+    }
 
     m_streamsList.erase(it);
 

--- a/services/vios/src/modules/sensor_management/sensor_control.h
+++ b/services/vios/src/modules/sensor_management/sensor_control.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,7 +67,7 @@ class SensorControl
 
     private:
         DeviceManager* m_deviceManager;
-        std::pair<ISensorControlInterface*, void*> m_sensorControlobjectPair;
+        std::pair<ISensorControlInterface*, destroyControlObject_t> m_sensorControlobjectPair;
         ISensorControlInterface* m_adaptor;
 };
 

--- a/services/vios/src/modules/sensor_management/sensor_monitoring.cpp
+++ b/services/vios/src/modules/sensor_management/sensor_monitoring.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@
 unsigned int max_n_threads = 10;
 
 SensorMonitoring::SensorMonitoring(SensorManagement* sensorMgmt,
-                             std::vector<std::pair<ISensorDiscoveryInterface*, void*>>& objs)
+                             std::vector<std::pair<ISensorDiscoveryInterface*, destroyDiscoveryObject_t>>& objs)
                            : m_sensorManagement(sensorMgmt)
                            , m_sensorDiscoveryObjectPairList(objs)
 {

--- a/services/vios/src/modules/sensor_management/sensor_monitoring.h
+++ b/services/vios/src/modules/sensor_management/sensor_monitoring.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,7 @@ class SensorManagement;
     {
     public:
         SensorMonitoring(SensorManagement* sensorMgmt,
-                           std::vector<std::pair<ISensorDiscoveryInterface*, void*>>& objs);
+                           std::vector<std::pair<ISensorDiscoveryInterface*, destroyDiscoveryObject_t>>& objs);
         virtual ~SensorMonitoring()
         {
             std::lock_guard<std::mutex> lock(m_discoveryObjectsLock);
@@ -46,7 +46,7 @@ class SensorManagement;
             for (auto item : m_sensorDiscoveryObjectPairList)
             {
                 ISensorDiscoveryInterface* discoveryObject = item.first;
-                destroyDiscoveryObject_t delObject = (destroyDiscoveryObject_t ) item.second;
+                destroyDiscoveryObject_t delObject = item.second;
                 if (delObject)
                 {
                     delObject(discoveryObject);
@@ -71,7 +71,7 @@ class SensorManagement;
         SensorManagement* m_sensorManagement;
         std::mutex m_sensorEventMutex;
         INotificationInterface* m_notifier;
-        std::vector<std::pair<ISensorDiscoveryInterface*, void*>> m_sensorDiscoveryObjectPairList;
+        std::vector<std::pair<ISensorDiscoveryInterface*, destroyDiscoveryObject_t>> m_sensorDiscoveryObjectPairList;
         std::vector<ISensorDiscoveryInterface*> m_discoveryObjects;
         std::mutex m_discoveryObjectsLock;
     };

--- a/services/vios/src/modules/storage_management/AsyncVideoStreamHandler.cpp
+++ b/services/vios/src/modules/storage_management/AsyncVideoStreamHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -233,7 +233,7 @@ VideoTaskStatus AsyncVideoStreamHandler::getTaskStatus()
     return cachedTaskStatus;
 }
 
-bool AsyncVideoStreamHandler::sendHttpChunk(struct mg_connection* conn, const void* data, size_t size)
+bool AsyncVideoStreamHandler::sendHttpChunk(struct mg_connection* conn, const char* data, size_t size)
 {
     // Send chunk size in hex
     if (mg_printf(conn, "%zx\r\n", size) <= 0)

--- a/services/vios/src/modules/storage_management/AsyncVideoStreamHandler.h
+++ b/services/vios/src/modules/storage_management/AsyncVideoStreamHandler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,7 +67,7 @@ private:
     // Private helper methods
     bool openFile();
     bool sendHeaders(struct mg_connection* conn);
-    static bool sendHttpChunk(struct mg_connection* conn, const void* data, size_t size);
+    static bool sendHttpChunk(struct mg_connection* conn, const char* data, size_t size);
     void closeFileIfOpen() noexcept;
     VideoTaskStatus getTaskStatus();
 };

--- a/services/vios/src/modules/storage_management/storage_management_utils.cpp
+++ b/services/vios/src/modules/storage_management/storage_management_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +68,9 @@ static void createMainStreamForFirstUpload(shared_ptr<StreamInfo> stream, shared
 static void createSubsequentStream(shared_ptr<StreamInfo> stream, shared_ptr<SensorInfo> sensor, const vector<SensorStreamsDBColumns>& existingStreams, Json::Value& response);
 static void updateStreamUrls(shared_ptr<StreamInfo> stream, shared_ptr<SensorInfo> sensor, const string& rtsp_url, shared_ptr<DeviceManager> deviceMngr, const vector<SensorStreamsDBColumns>& existingStreams);
 
+// Opaque handle type for a dynamically loaded shared library
+struct SharedLibraryHandle;
+
 // Function pointer types for dynamic loading
 typedef nv_vms::VideoSegmentExtractor* (*CreateVideoSegmentExtractor_t)();
 typedef void (*DestroyVideoSegmentExtractor_t)(nv_vms::VideoSegmentExtractor*);
@@ -78,7 +81,7 @@ typedef bool (*IsExtractorAvailable_t)(nv_vms::VideoSegmentExtractor*);
 // Dynamic VideoSegmentExtractor loader class
 class DynamicVideoSegmentExtractor {
 private:
-    void* m_handle;
+    SharedLibraryHandle* m_handle;
     CreateVideoSegmentExtractor_t m_createFunc;
     DestroyVideoSegmentExtractor_t m_destroyFunc;
     ExtractSegmentStreamCopy_t m_extractFunc;
@@ -87,7 +90,7 @@ private:
     nv_vms::VideoSegmentExtractor* m_instance;
 
     // Secure library loading function with path validation
-    void* tryLoadLibrary(const char* lib_path)
+    SharedLibraryHandle* tryLoadLibrary(const char* lib_path)
     {
         if (!lib_path || lib_path[0] == '\0')
         {
@@ -143,7 +146,7 @@ private:
             LOG(error) << "Failed to load library " << resolved_path << ": " << dlerror() << endl;
         }
 
-        return handle;
+        return static_cast<SharedLibraryHandle*>(handle);
     }
 
 public:

--- a/services/vios/src/modules/storage_management/storage_management_utils.cpp
+++ b/services/vios/src/modules/storage_management/storage_management_utils.cpp
@@ -339,7 +339,7 @@ typedef struct {
 /* ---------------------------------------------------------------------------
 **  Civet mg_form_data_handler callback
 ** -------------------------------------------------------------------------*/
-int field_found(const char *key, const char *filename, char *path, size_t pathlen, void *user_data)
+int field_found(const char *key, const char *filename, char *path, size_t pathlen, void *user_data) // NOSONAR
 {
     struct FileData* data = (FileData *) user_data;
     if(!data)
@@ -416,7 +416,8 @@ int field_found(const char *key, const char *filename, char *path, size_t pathle
 	return MG_FORM_FIELD_STORAGE_GET;
 }
 
-int field_get(const char *key, const char *value, size_t valuelen, void *user_data)
+/* Parameter types are fixed by the civetweb mg_form_data_handler::field_get callback. */
+int field_get(const char *key, const char *value, size_t valuelen, void *user_data) // NOSONAR
 {
 	if ((key != nullptr) && (key[0] == '\0'))
     {
@@ -489,9 +490,8 @@ int field_get(const char *key, const char *value, size_t valuelen, void *user_da
 	return 0;
 }
 
-int field_stored(const char *path, long long file_size, void *user_data)
+int field_stored(const char *path, long long file_size, FileData *data)
 {
-    struct FileData* data = (FileData *) user_data;
     if(!data)
     {
         LOG(error) << "FileData is NULL" << endl;
@@ -1453,7 +1453,10 @@ VmsErrorCode handleFileUpload(std::shared_ptr<DeviceManager> deviceMngr,
         }
 
         //assign form handler callbacks
-        struct mg_form_data_handler fdh = {field_found, field_get, field_stored, (void *)&data};
+        auto field_stored_cb = [](const char *path, long long file_size, void *user_data) {
+            return field_stored(path, file_size, static_cast<FileData *>(user_data));
+        };
+        struct mg_form_data_handler fdh = {field_found, field_get, field_stored_cb, (void *)&data};
 
         mg_handle_form_request(conn, &fdh);
     }

--- a/services/vios/src/modules/storage_management/storage_management_utils.h
+++ b/services/vios/src/modules/storage_management/storage_management_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,7 +69,7 @@ VmsErrorCode addFile(std::shared_ptr<DeviceManager> deviceMngr, const Json::Valu
 VmsErrorCode handleFileUpload(std::shared_ptr<DeviceManager> deviceMngr, const struct mg_request_info *req_info, struct mg_connection *conn, Json::Value &out, bool isPutUpload = false, const std::string& filename = "", const std::string& timestamp = "", const std::string& sensorId = "", bool isLegacyUpload = false);
 VmsErrorCode deleteFile(std::shared_ptr<DeviceManager> deviceMngr, const Json::Value &req_info, const Json::Value &in, Json::Value &out);
 VmsErrorCode checkMaxSensorsLimit(std::shared_ptr<DeviceManager> deviceMngr, Json::Value& response);
-int field_stored(const char *path, long long file_size, void *user_data);
+int field_stored(const char *path, long long file_size, FileData *data);
 int field_get(const char *key, const char *value, size_t valuelen, void *user_data);
 int field_found(const char *key, const char *filename, char *path, size_t pathlen, void *user_data);
 void addOrRemoveInProtectList(std::vector<VideoFileInfo>& files, bool removeOrAdd);


### PR DESCRIPTION
Fixes 83 HIGH-severity SonarQube issues in `services/vios`.

Replacing `void *` in typedefs, members, parameters and return types with concrete types.

**Risk: HIGH.** These change function signatures, so the blast radius reaches every caller and, for exported symbols, the ABI. They compile cleanly — review each signature deliberately.

### Rules
- `cpp:S5008`

### How these were produced and verified

Issues were fixed in waves: each issue fixed independently in its own worktree,
the results merged into a single tree, and **that combined tree compiled before
anything was committed**. A fix that failed to build was isolated and dropped
rather than dragging the wave down with it, so every commit on this branch
compiles.

Each fix updates the file SonarQube flagged **and** its header and use sites
together — a partial conversion does not compile, so the per-wave build is what
guarantees completeness.

### Verification
`./build.sh package module=sensor,streamprocessing` — clean.

### Not included
- `cpp:S134`: Structural refactor (nesting depth / cognitive complexity)
- `cpp:S4423`: TLS/crypto behaviour change

Signed-off-by: gous <gmulla@nvidia.com>
