### PR TITLE
Fix 141 HIGH SonarQube issues: Type & API safety

### DIFF
--- a/services/vios/include/sensor_control_adaptor.h
+++ b/services/vios/include/sensor_control_adaptor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,7 +94,7 @@ public:
     virtual int setSensorEncodeSettings(shared_ptr<SensorInfo>& sensor, const SensorVideoEncoderSettingsValues& settings) { return -1; };
     virtual int getStreamSettings(shared_ptr<SensorInfo>& sensor, const string& stream_id) { return 0;}
     virtual int setPTZ(shared_ptr<SensorInfo>& sensor, PTZAction, string x, string y) { return 0; };
-    map<PTZAction, ptzRange> getPTZ(shared_ptr<SensorInfo>& sensor) { map<PTZAction, ptzRange>ptz; return ptz; };
+    virtual map<PTZAction, ptzRange> getPTZ(shared_ptr<SensorInfo>& sensor) { map<PTZAction, ptzRange>ptz; return ptz; };
     virtual bool validateCredentials(shared_ptr<SensorInfo>& sensor, const string username, const string password) { return false; }
     virtual VmsErrorCode addSensor(const Json::Value& sensorInfo) { return VmsErrorCode::NoError; }
     virtual bool deleteSensor(shared_ptr<SensorInfo>& sensor) { return true; }

--- a/services/vios/include/sensor_discovery_adaptor.h
+++ b/services/vios/include/sensor_discovery_adaptor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ class ISensorDiscoveryEvent
         virtual int onSensorChanged(SensorInfo& sensorInfo) = 0;
         virtual int onSensorRemoved(const string& sensorInfo) = 0;
 
-        virtual void notifyEvent(const SensorStatus& status, const string& url) {}
+        virtual void notifyEvent(const SensorStatus& status, const string& url, const string& ipc_url = "") {}
         virtual void refreshSensorList() {}
 };
 

--- a/services/vios/src/adaptors/milestone/milestone_vms.cpp
+++ b/services/vios/src/adaptors/milestone/milestone_vms.cpp
@@ -1026,7 +1026,7 @@ int MilestoneVmsVendor::parseCameraInfo(const string& server_url, const string& 
         return -1;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "cameras");
     if (!cur)

--- a/services/vios/src/adaptors/milestone/milestone_vms.cpp
+++ b/services/vios/src/adaptors/milestone/milestone_vms.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -815,7 +815,7 @@ static string getCurrentStatusResult(const string& xmlData, vector<SensorStatus>
         return result;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cursor = xmlDocGetRootElement(doc);
     if (cursor == nullptr)
     {

--- a/services/vios/src/adaptors/milestone/milestone_vms.cpp
+++ b/services/vios/src/adaptors/milestone/milestone_vms.cpp
@@ -64,7 +64,7 @@ extern "C" void destroyObject( MilestoneVmsVendor* object )
 class AutoDestroyXml
 {
 public:
-    AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
+    explicit AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
     ~AutoDestroyXml() { xmlBufferFree(m_xml); }
 private:
     xmlBufferPtr m_xml;
@@ -747,7 +747,7 @@ static string getToken(const string& xmlData)
         return token;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cursor = xmlDocGetRootElement(doc);
     if (cursor == nullptr)
     {
@@ -781,7 +781,7 @@ static string getStartStatusSessionResult(const string& xmlData)
         return result;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cursor = xmlDocGetRootElement(doc);
     if (cursor == nullptr)
     {
@@ -874,7 +874,7 @@ map<string, string> getEventResult(const string& xmlData)
         return result;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cursor = xmlDocGetRootElement(doc);
     if (cursor == nullptr)
     {

--- a/services/vios/src/adaptors/onvif/onvif_client.cpp
+++ b/services/vios/src/adaptors/onvif/onvif_client.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -795,7 +795,7 @@ bool OnvifClient::isServerOnline(const string & url)
     return true;
 }
 
- map<PTZAction, ptzRange> OnvifClient::getPTZ(shared_ptr<SensorInfo> sensor)
+ map<PTZAction, ptzRange> OnvifClient::getPTZ(shared_ptr<SensorInfo>& sensor)
  {
     map<PTZAction, ptzRange> ptz;
     if (sensor != nullptr && sensor->streams.size() > 0)

--- a/services/vios/src/adaptors/onvif/onvif_client.h
+++ b/services/vios/src/adaptors/onvif/onvif_client.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,7 @@ public:
     int synchronizeSensorTime(shared_ptr<SensorInfo>& sensor);
     bool isServerOnline(const string & url);
     int setPTZ(shared_ptr<SensorInfo>& sensor, PTZAction, string x, string y);
-    map<PTZAction, ptzRange> getPTZ(shared_ptr<SensorInfo> sensor);
+    map<PTZAction, ptzRange> getPTZ(shared_ptr<SensorInfo>& sensor) override;
     bool validateCredentials(shared_ptr<SensorInfo>& sensor, const string username, const string password);
     int getNetworkInfo(shared_ptr<SensorInfo>& sensor, SensorNetworkInfo& networkInfo);
     int setNetworkInfo(shared_ptr<SensorInfo>& sensor, const SensorNetworkInfo& networkInfo, bool& rebootNeeded);

--- a/services/vios/src/app/server.h
+++ b/services/vios/src/app/server.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,7 @@ static const std::vector<std::string> g_deprecatedApis = {
 class VmsServer
 {
 public:
-    VmsServer(ModuleId module_id = ModuleAll);
+    explicit VmsServer(ModuleId module_id = ModuleAll);
     ~VmsServer();
     int start();
     void start_webrtc();

--- a/services/vios/src/framework/apis/common/vst_common.cpp
+++ b/services/vios/src/framework/apis/common/vst_common.cpp
@@ -973,7 +973,7 @@ namespace vst_common
             if (0 == EVP_EncryptUpdate(ctx_,
                                     (unsigned char *)out.data(),
                                     &resultLength,
-                                    (unsigned char *)in.data(),
+                                    reinterpret_cast<const unsigned char *>(in.data()),
                                     in.size()))
             {
                 return false;
@@ -984,7 +984,7 @@ namespace vst_common
             if (0 == EVP_DecryptUpdate(ctx_,
                                     (unsigned char *)out.data(),
                                     &resultLength,
-                                    (unsigned char *)in.data(),
+                                    reinterpret_cast<const unsigned char *>(in.data()),
                                     in.size()))
             {
                 return false;

--- a/services/vios/src/framework/apis/common/vst_common.cpp
+++ b/services/vios/src/framework/apis/common/vst_common.cpp
@@ -942,7 +942,7 @@ namespace vst_common
         if (0 == dir_)
         {
             if (0 == EVP_EncryptFinal_ex(ctx_,
-                                        (unsigned char *)out.data(),
+                                        reinterpret_cast<unsigned char *>(out.data()),
                                         &resultLength))
             {
                 return false;
@@ -951,7 +951,7 @@ namespace vst_common
         else
         {
             if (0 == EVP_DecryptFinal_ex(ctx_,
-                                        (unsigned char *)out.data(),
+                                        reinterpret_cast<unsigned char *>(out.data()),
                                         &resultLength))
             {
                 return false;
@@ -971,7 +971,7 @@ namespace vst_common
         if (0 == dir_)
         {
             if (0 == EVP_EncryptUpdate(ctx_,
-                                    (unsigned char *)out.data(),
+                                    reinterpret_cast<unsigned char *>(out.data()),
                                     &resultLength,
                                     reinterpret_cast<const unsigned char *>(in.data()),
                                     in.size()))
@@ -982,7 +982,7 @@ namespace vst_common
         else
         {
             if (0 == EVP_DecryptUpdate(ctx_,
-                                    (unsigned char *)out.data(),
+                                    reinterpret_cast<unsigned char *>(out.data()),
                                     &resultLength,
                                     reinterpret_cast<const unsigned char *>(in.data()),
                                     in.size()))

--- a/services/vios/src/framework/apis/common/vst_common.cpp
+++ b/services/vios/src/framework/apis/common/vst_common.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -788,9 +788,9 @@ namespace vst_common
 
         /* Set the country code and common name. */
         string common_name = getRandomCommonName();
-        X509_NAME_add_entry_by_txt(name, "C",  MBSTRING_ASC, (unsigned char *)"US",        -1, -1, 0);
-        X509_NAME_add_entry_by_txt(name, "O",  MBSTRING_ASC, (unsigned char *)"NVIDIA", -1, -1, 0);
-        X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char *)(common_name.c_str()), -1, -1, 0);
+        X509_NAME_add_entry_by_txt(name, "C",  MBSTRING_ASC, reinterpret_cast<const unsigned char *>("US"),        -1, -1, 0);
+        X509_NAME_add_entry_by_txt(name, "O",  MBSTRING_ASC, reinterpret_cast<const unsigned char *>("NVIDIA"), -1, -1, 0);
+        X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char *>(common_name.c_str()), -1, -1, 0);
 
         /* Now set the issuer name. */
         X509_set_issuer_name(x509, name);

--- a/services/vios/src/framework/apis/websocket_apis.h
+++ b/services/vios/src/framework/apis/websocket_apis.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ using namespace nv_vms;
 class WebsocketApis
 {
     public:
-        WebsocketApis(std::shared_ptr<DeviceManager> deviceMngr);
+        explicit WebsocketApis(std::shared_ptr<DeviceManager> deviceMngr);
         typedef std::function<VmsErrorCode(const Json::Value &, const Json::Value &, Json::Value &, struct mg_connection *conn)> httpFunction;
         const std::map<std::string,WebsocketServerRequestHandler::httpFunction, std::less<>> getWebsocketApis() { return m_func; };
         void addRequestHandler(std::map<std::string, httpFunction, std::less<>>& func);

--- a/services/vios/src/framework/database/include/database_schema.h
+++ b/services/vios/src/framework/database/include/database_schema.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -305,7 +305,7 @@ namespace nv_vms
 
         LocalDeviceDetailsDBColumns() : id_value(""), name_value(""), location_value("") {}
 
-        LocalDeviceDetailsDBColumns(string &id) : id_value(id), name_value(name), location_value(location) {}
+        explicit LocalDeviceDetailsDBColumns(string &id) : id_value(id), name_value(name), location_value(location) {}
 
         void printInfo()
         {
@@ -763,7 +763,7 @@ namespace nv_vms
         {
         }
 
-        _VideoFileInfo(const VideoRecordDBColumns &row)
+        explicit _VideoFileInfo(const VideoRecordDBColumns &row)
         {
             this->m_filePath = row.filepath_value;
             this->m_startTime = row.start_time_value;

--- a/services/vios/src/framework/database/postgresql/postgresql_helper.cpp
+++ b/services/vios/src/framework/database/postgresql/postgresql_helper.cpp
@@ -3293,7 +3293,7 @@ std::vector<VideoFileInfo> Postgresql::getNextFileList(std::string streamId, int
             LOG(info) << "File FPS = " << rows[i].filefps_value << endl;
             LOG(info) << "File object name = " << object_id << endl;
             
-                next_file_list.push_back(rows[i]);
+                next_file_list.push_back(VideoFileInfo(rows[i]));
         }
         else
         {

--- a/services/vios/src/framework/live555/rtsp_client/rtspconnectionclient.cpp
+++ b/services/vios/src/framework/live555/rtsp_client/rtspconnectionclient.cpp
@@ -458,7 +458,7 @@ void RTSPConnection::RTSPClientConnection::sessionByeHandler(char const* reason)
   LOG(info) << ":Received RTCP \"BYE\"" << endl;
   if (reason != nullptr) {
     LOG(info) << " (reason:\"" << reason << "\")";
-    delete[] (char*)reason;
+    delete[] reason;
   }
 
   envir().taskScheduler().unscheduleDelayedTask(m_DataArrivalTimeoutTask);

--- a/services/vios/src/framework/live555/rtsp_client/rtspconnectionclient.cpp
+++ b/services/vios/src/framework/live555/rtsp_client/rtspconnectionclient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -336,11 +336,11 @@ void RTSPConnection::RTSPClientConnection::sendNextCommand()
 		else
 		{
 			std::string updated_endTime;
-			char *absEndTime = nullptr;
+			const char *absEndTime = nullptr;
 			if (!m_endTime.empty())
 			{
 				m_endTime = getUpdatedTime (m_endTime, m_framerate);
-				absEndTime = (char*)m_endTime.c_str();
+				absEndTime = m_endTime.c_str();
 				LOG(info) << "Updated End Time:" << updated_endTime << endl;
 			}
 			// no more subsession to SETUP, send PLAY

--- a/services/vios/src/framework/live555/rtsp_client/testRTSP.cpp
+++ b/services/vios/src/framework/live555/rtsp_client/testRTSP.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -529,7 +529,7 @@ void subsessionByeHandler(void* clientData, char const* reason) {
   env << *rtspClient << "Received RTCP \"BYE\"";
   if (reason != nullptr) {
     env << " (reason:\"" << reason << "\")";
-    delete[] (char*)reason;
+    delete[] reason;
   }
   env << " on \"" << *subsession << "\" subsession\n";
 

--- a/services/vios/src/framework/live555/rtsp_client/testRTSP.h
+++ b/services/vios/src/framework/live555/rtsp_client/testRTSP.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -142,7 +142,7 @@ public:
         m_env.mainloop();
     }
 
-    videoClient(char const* rtspURL)
+    explicit videoClient(char const* rtspURL)
       : m_env(m_stop)
     {
         LOG(info) << "videoClient" << endl;

--- a/services/vios/src/framework/media/media_pipelines/cloud_stream/s3stream_producer.h
+++ b/services/vios/src/framework/media/media_pipelines/cloud_stream/s3stream_producer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -102,6 +102,10 @@ public:
     // IMediaDataProducer Interface Implementation
     // ========================================================================
     
+    // Keep the base class registerConsumer overloads visible (e.g. the
+    // time-range variant) so they are not hidden by the overloads below.
+    using IMediaDataProducer::registerConsumer;
+
     /**
      * @brief Register a consumer to receive data from this producer
      * @param consumer The consumer to register

--- a/services/vios/src/framework/media/media_pipelines/gstmux.h
+++ b/services/vios/src/framework/media/media_pipelines/gstmux.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,7 +73,7 @@ class GstMux;
 class GstMux : public IMediaDataConsumer
 {
    public:
-    GstMux(RecordState record_state)
+    explicit GstMux(RecordState record_state)
         : IMediaDataConsumer("GstMux"),
           m_totalFileSize(0),
           m_isError(false),

--- a/services/vios/src/framework/media/media_pipelines/gstmux.h
+++ b/services/vios/src/framework/media/media_pipelines/gstmux.h
@@ -117,7 +117,8 @@ class GstMux : public IMediaDataConsumer
     bool isPlaying();
     bool isAudioSupported();
     void checkStatus();
-    virtual void onFrame(FrameParams& params);
+    using IMediaDataConsumer::onFrame;
+    void onFrame(FrameParams& params) override;
     GstMux* getSelf()
     {
         return this;

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.h
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudiodecoder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -102,7 +102,8 @@ class GstNvAudioDecoder : public IMediaDataConsumer, public GstNvDecoder
         void updateAudioDataIfRequired();
         std::list<webrtc::AudioTrackSinkInterface *> getWebrtcBroacasterList() { return m_sinks; }
 
-        virtual void onFrame(FrameParams& params);
+        using IMediaDataConsumer::onFrame;
+        void onFrame(FrameParams& params) override;
         
         vector<uint16_t>                             m_audioBuffer;
         std::mutex                                   m_sinkLock;

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudioudpclient.h
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudioudpclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,11 +56,12 @@ namespace nv_vms
             ~GstUDPAudioClient () { LOG(info) << "~GstUDPAudioClient" << endl; }
 
             // UdpClient interfaces
-            int create (int freq);
-            void destroy (bool expect_result);
-            void start ();
+            using UdpClient::create;
+            int create (int freq) override;
+            void destroy (bool expect_result) override;
+            void start () override;
 
-            void pause ();
+            void pause () override;
             void resume ();
             bool isCreated() { return m_pipeline != nullptr; }
             int create_internal();

--- a/services/vios/src/framework/media/media_pipelines/gstnvdecodebin.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvdecodebin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -307,14 +307,14 @@ GstPadProbeReturn NvDecodeBin::padProbeCB (GstPad * pad, GstPadProbeInfo * info)
     /* remove unlinks automatically */
     gst_bin_remove (GST_BIN (m_decodeBin), m_decoder);
     m_decoder = nullptr;
-    gchar *element_name;
+    const gchar *element_name;
     if (m_useNvV4l2Dec == false || m_playBackSpeed < 0)
     {
-        element_name = (gchar *)SW_AV_DECODER;
+        element_name = SW_AV_DECODER;
     }
     else
     {
-        element_name = (gchar *)NV_V4L2_DECODER;
+        element_name = NV_V4L2_DECODER;
     }
     m_decoder = gst_element_factory_make (element_name, nullptr);
     LOG(info) << "Selecting decoder element: " << element_name << endl;

--- a/services/vios/src/framework/media/media_pipelines/gstnvimageencode.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvimageencode.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -295,7 +295,7 @@ void NvImageEncode::onFrame(const unsigned char *buffer, ssize_t size)
     /* Map the Gst Buffer to write the data */
     gst_buffer_map (gstbuffer, &map, GST_MAP_WRITE);
 
-    memcpy (map.data, (uint8_t*)buffer, size);
+    memcpy (map.data, buffer, size);
     map.size = size;
 
     /* Unmap the Gst Buffer */

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoencoder.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoencoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -486,7 +486,7 @@ int GstNvVideoEncoder::onFrame(FrameParams& frame_params, const string& codec, i
     std::string caps_string;
     int width, height, max_framerate;
     webrtc::scoped_refptr<NvVideoFrameBuffer> frame_buffer = nullptr;
-    webrtc::scoped_refptr<webrtc::I420BufferInterface> i420_buffer = nullptr;
+    webrtc::scoped_refptr<const webrtc::I420BufferInterface> i420_buffer = nullptr;
 
     if (buffer == nullptr || size == 0)
     {
@@ -514,7 +514,7 @@ int GstNvVideoEncoder::onFrame(FrameParams& frame_params, const string& codec, i
     max_framerate = GET_CONFIG().webrtc_in_max_framerate;
     if (size == sizeof(NvBufSurface))
     {
-        frame_buffer = webrtc::scoped_refptr<NvVideoFrameBuffer>(*((webrtc::scoped_refptr<NvVideoFrameBuffer>*)buffer));
+        frame_buffer = *reinterpret_cast<const webrtc::scoped_refptr<NvVideoFrameBuffer>*>(buffer);
         buf_surf = (NvBufSurface *)frame_buffer->m_decodedData;
         width = buf_surf->surfaceList[0].width;
         height = buf_surf->surfaceList[0].height;
@@ -533,7 +533,7 @@ int GstNvVideoEncoder::onFrame(FrameParams& frame_params, const string& codec, i
     }
     else
     {
-        i420_buffer = (webrtc::I420BufferInterface*)buffer;
+        i420_buffer = reinterpret_cast<const webrtc::I420BufferInterface*>(buffer);
         width  = i420_buffer->width ();
         height = i420_buffer->height();
     }

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.h
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,6 +40,7 @@ namespace nv_vms
             ~GstUDPVideoClient ();
 
             // UdpClient interfaces
+            using UdpClient::create;
             int create ();
             int create_audio();
             void destroy (bool expect_result);

--- a/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.h
+++ b/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,6 +103,8 @@ class ClipReaderProducer : public IMediaDataProducer
 public:
     explicit ClipReaderProducer(const ClipReaderConfig& cfg);
     virtual ~ClipReaderProducer();
+
+    using IMediaDataProducer::registerConsumer;
 
     void registerConsumer(std::shared_ptr<IMediaDataConsumer> consumer,
                           const std::string& identifier = "") override;

--- a/services/vios/src/framework/media/media_pipelines/media_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/media_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -186,7 +186,7 @@ class IMediaDataConsumer : public std::enable_shared_from_this<IMediaDataConsume
         }
 
         // Constructor with consumer name - preferred way
-        IMediaDataConsumer(const std::string& consumerName) : m_consumerName(consumerName)
+        explicit IMediaDataConsumer(const std::string& consumerName) : m_consumerName(consumerName)
         {
             m_transcodeStats.setElementName(m_consumerName);
         }

--- a/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.h
@@ -112,6 +112,7 @@ private:
     public:
         explicit AudioAppSrcConsumer(RemuxWriterConsumer* owner) 
             : IMediaDataConsumer("RemuxAudioConsumer"), mOwner(owner) {}
+        using IMediaDataConsumer::onFrame;
         void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
     private:
         RemuxWriterConsumer* mOwner;

--- a/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,6 +51,7 @@ public:
     virtual ~RemuxWriterConsumer();
 
     // IMediaDataConsumer (video path)
+    using IMediaDataConsumer::onFrame;
     void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
 
     // Lifecycle

--- a/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,6 +67,7 @@ public:
     virtual ~TranscodeWriterConsumer();
 
     // IMediaDataConsumer (video path)
+    using IMediaDataConsumer::onFrame;
     void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
 
     // Lifecycle
@@ -123,6 +124,7 @@ private:
     {
     public:
         explicit AudioAppSrcConsumer(TranscodeWriterConsumer* owner) : IMediaDataConsumer("AudioAppSrcConsumer"), mOwner(owner) {}
+        using IMediaDataConsumer::onFrame;
         void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
     private:
         TranscodeWriterConsumer* mOwner;

--- a/services/vios/src/framework/media/media_utils/mm_utils.cpp
+++ b/services/vios/src/framework/media/media_utils/mm_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -390,7 +390,7 @@ int64_t parseSeiFrameId(const unsigned char *buffer, ssize_t size, int64_t& pts_
         ssize_t sei_uuid_index = nal_start_code_size + 1;
         if (size >= sei_uuid_index)
         {
-            uint8_t *uuid_buf  = (uint8_t *)&buffer[sei_uuid_index];
+            const uint8_t *uuid_buf  = &buffer[sei_uuid_index];
             uuid_str = hexBytesToString(uuid_buf, UUID_STANDARD_SIZE);
             if (uuid_str.find(SEI_CUSTOM_META_UUID) == string::npos && uuid_str.find(MEGA_SEI_CUSTOM_META_UUID) == string::npos)
             {
@@ -412,14 +412,17 @@ int64_t parseSeiFrameId(const unsigned char *buffer, ssize_t size, int64_t& pts_
         /* Parse the actual payload frameId + time */
         if (size >= seiPayload_index)
         {
-            uint8_t *seiPayload  = (uint8_t *)&buffer[seiPayload_index];
+            const uint8_t *seiPayload  = reinterpret_cast<const uint8_t *>(&buffer[seiPayload_index]);
             vect_sei_payload.assign(seiPayload, seiPayload + size - 1);
 #ifdef ENABLE_EMULATION_PREVENTATION_BYTE_SUPPORT
             checkAndRemoveEmulationPrevByte(vect_sei_payload);
 #endif
             if (uuid_str.find(SEI_CUSTOM_META_UUID) != string::npos)
             {
-                for (size_t i = 0; i < vect_sei_payload.size(); i++)
+                /* Copy at most sizeof(FrameInfoSeiPayload) bytes, the payload can be larger */
+                const size_t copy_size = vect_sei_payload.size() < sizeof(FrameInfoSeiPayload) ?
+                                         vect_sei_payload.size() : sizeof(FrameInfoSeiPayload);
+                for (size_t i = 0; i < copy_size; i++)
                 {
                     frameInfo_ptr[i] = vect_sei_payload[i];
                 }
@@ -966,7 +969,7 @@ int getMediaInformation (const string& filename, Json::Value &media_info, bool m
         // Local file path, add file:// prefix
         uri_string = string("file://") + filename;
     }
-    gchar *uri = (gchar *) uri_string.c_str();
+    const gchar *uri = uri_string.c_str();
 
     discoverer = gst_discoverer_new (4 * GST_SECOND, &err);
     if (err != nullptr)

--- a/services/vios/src/framework/media/overlays/halo_safety.h
+++ b/services/vios/src/framework/media/overlays/halo_safety.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,7 +80,7 @@ public:
      * @brief Constructor
      * @param port UDP port to listen on (default: 12345)
      */
-    HaloSafetyCommandListener(int port = 12345);
+    explicit HaloSafetyCommandListener(int port = 12345);
 
     /**
      * @brief Destructor - automatically stops listener if running

--- a/services/vios/src/framework/media/overlays/ll_overlay.h
+++ b/services/vios/src/framework/media/overlays/ll_overlay.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,7 @@ public:
     ~NvLLOverlay();
 
     void doDrawTask();
+    using IMediaDataConsumer::onFrame;
     void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
     void setConsumer(std::shared_ptr<IMediaDataConsumer> consumer);
     std::string getUri() { return m_uri; }

--- a/services/vios/src/framework/media/overlays/overlay_internal.cpp
+++ b/services/vios/src/framework/media/overlays/overlay_internal.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -3253,8 +3253,7 @@ void NvLLOverlayInternal::readCalibrationData()
     LOG(info) << "Recentering: " << recentering << endl;
 
     {
-        std::lock_guard<std::mutex> guard_id(m_idLock);
-        std::lock_guard<std::mutex> guard_classType(m_classTypeLock);
+        std::scoped_lock guard(m_idLock, m_classTypeLock);
         if (find(m_idList[BBOX].begin(), m_idList[BBOX].end(), "none") != m_idList[BBOX].end() &&
             find(m_classTypeList.begin(), m_classTypeList.end(), "none") != m_classTypeList.end())
         {

--- a/services/vios/src/framework/media/overlays/overlay_internal.h
+++ b/services/vios/src/framework/media/overlays/overlay_internal.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,7 +80,9 @@ struct Point2D
     float x;
     float y;
     
-    Point2D(float _x = 0, float _y = 0) 
+    Point2D()
+        : x(0), y(0) {}
+    Point2D(float _x, float _y)
         : x(_x), y(_y) {}
 };
 

--- a/services/vios/src/framework/media/overlays/overlay_internal.h
+++ b/services/vios/src/framework/media/overlays/overlay_internal.h
@@ -92,7 +92,9 @@ struct Point3D
     float y;
     float z;
     
-    Point3D(float _x = 0, float _y = 0, float _z = 0) 
+    Point3D()
+        : x(0), y(0), z(0) {}
+    Point3D(float _x, float _y, float _z)
         : x(_x), y(_y), z(_z) {}
 };
 

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -411,7 +411,7 @@ void GstNvVideoDecoder::pushBufferToDecoder(const unsigned char *buffer, ssize_t
     /* Map the Gst Buffer to write the data */
     gst_buffer_map (gstbuffer, &map, GST_MAP_WRITE);
 
-    memcpy (map.data, (uint8_t*)buffer, size);
+    memcpy (map.data, buffer, size);
     map.size = size;
 
     /* Unmap the Gst Buffer */

--- a/services/vios/src/framework/media/video_source/encoders/image_encoder.h
+++ b/services/vios/src/framework/media/video_source/encoders/image_encoder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@
 class ImageEnc : public IMediaDataConsumer
 {
 public:
-    ImageEnc(const std::string& consumer_name);
+    explicit ImageEnc(const std::string& consumer_name);
     ImageEnc(const std::string& consumer_name, const std::map<std::string, std::string, std::less<>> &opts);
     ~ImageEnc();
 

--- a/services/vios/src/framework/media/video_source/encoders/image_encoder.h
+++ b/services/vios/src/framework/media/video_source/encoders/image_encoder.h
@@ -29,6 +29,7 @@ public:
     ImageEnc(const std::string& consumer_name, const std::map<std::string, std::string, std::less<>> &opts);
     ~ImageEnc();
 
+    using IMediaDataConsumer::onFrame;
     void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
     std::string getImageBuffer();
     GstFlowReturn processJpegImageFromSink(GstElement *appsink);

--- a/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.h
+++ b/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.h
@@ -37,6 +37,7 @@ class NvEncoderVideoConsumer : public IMediaDataConsumer
         NvEncoderVideoConsumer (const std::string& consumer_name, double frame_rate, std::string peerId_streamId, bool enable_frame_sync = false);
         ~NvEncoderVideoConsumer ();
         void stopEncoder();
+        using IMediaDataConsumer::onFrame;
         void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
         void onLastFrame()override;
         void reset() override;

--- a/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.h
+++ b/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.h
@@ -88,7 +88,7 @@ class NvEncoderVideoConsumer : public IMediaDataConsumer
 class EncoderQueue
 {
 public:
-    EncoderQueue(NvEncoderVideoConsumer* consumer);
+    explicit EncoderQueue(NvEncoderVideoConsumer* consumer);
     ~EncoderQueue();
 
     void push(std::shared_ptr<RawFrameParams> frame_data);

--- a/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.h
+++ b/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,7 @@ class EncoderQueue;
 class NvEncoderVideoConsumer : public IMediaDataConsumer
 {
     public:
-        NvEncoderVideoConsumer (const std::string& consumer_name);
+        explicit NvEncoderVideoConsumer (const std::string& consumer_name);
         NvEncoderVideoConsumer (const std::string& consumer_name, double frame_rate, std::string peerId_streamId, bool enable_frame_sync = false);
         ~NvEncoderVideoConsumer ();
         void stopEncoder();

--- a/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.h
+++ b/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.h
@@ -86,6 +86,7 @@ public:
     using IMediaDataConsumer::onFrame;
     void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
     void setConsumer(std::shared_ptr<IMediaDataConsumer> consumer);
+    using IMediaDataConsumer::setOriginalFrameSize;
     void setOriginalFrameSize() override;
     void setFrameRate(string frame_rate);
     

--- a/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.h
+++ b/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,7 +78,7 @@ struct GridLayout {
 class NvCompositor : public IMediaDataConsumer
 {
 public:
-    NvCompositor(const GridLayout& gridLayout); // Constructor that extracts URLs from GridLayout
+    explicit NvCompositor(const GridLayout& gridLayout); // Constructor that extracts URLs from GridLayout
     ~NvCompositor();
 
     void doCompositeTask();

--- a/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.h
+++ b/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.h
@@ -83,6 +83,7 @@ public:
 
     void doCompositeTask();
     void setTargetFrameSize (FrameSize& target_size);
+    using IMediaDataConsumer::onFrame;
     void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
     void setConsumer(std::shared_ptr<IMediaDataConsumer> consumer);
     void setOriginalFrameSize() override;

--- a/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.h
+++ b/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,7 @@ using namespace std;
 class NvLLTransform : public IMediaDataConsumer
 {
 public:
-    NvLLTransform(const std::string& consumer_name);
+    explicit NvLLTransform(const std::string& consumer_name);
     ~NvLLTransform();
 
     void doTransformTask();

--- a/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.h
+++ b/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.h
@@ -37,6 +37,7 @@ public:
     ~NvLLTransform();
 
     void doTransformTask();
+    using IMediaDataConsumer::onFrame;
     void onFrame(std::shared_ptr<RawFrameParams> frame_data) override;
     void setConsumer(std::shared_ptr<IMediaDataConsumer> consumer);
     void stopTransform();

--- a/services/vios/src/framework/media/video_source/producers/gstnvipcproducer.h
+++ b/services/vios/src/framework/media/video_source/producers/gstnvipcproducer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ static std::map<State, GstState> gstStateMap =
 class NvIPCProducer
 {
     public:
-        NvIPCProducer (const string& stream_id);
+        explicit NvIPCProducer (const string& stream_id);
         ~NvIPCProducer ();
 
         int create();

--- a/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
+++ b/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -461,6 +461,8 @@ class WebrtcStreamProducer : public IMediaDataProducer
         {
             return getConsumerCount() > 0;
         }
+
+        using IMediaDataProducer::registerConsumer;
 
         void registerConsumer(std::shared_ptr<IMediaDataConsumer> consumer, const std::string& identifier = "") override
         {

--- a/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
+++ b/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
@@ -136,6 +136,18 @@ class WebrtcStream
             return 0;
         }
 
+        void addAudioFrame (const unsigned char *buffer, unsigned int size, int sample_rate = 0,
+                        size_t num_channels = 0)
+        {
+            LOG(verbose) << "media = audio Peer ID = " << endl;
+
+            std::lock_guard<std::mutex> recordLock(m_webRTCConsumerLock);
+            if (m_consumersList.size())
+            {
+                m_gstencoder->onFrame("audio", "pcm", buffer, size, sample_rate, num_channels);
+            }
+        }
+
         void addConsumer (shared_ptr<IMediaDataConsumer> consumer)
         {
             std::lock_guard<std::mutex> lock(m_webRTCConsumerLock);

--- a/services/vios/src/framework/media/video_source/senders/videowebRTCsender.cpp
+++ b/services/vios/src/framework/media/video_source/senders/videowebRTCsender.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -333,7 +333,7 @@ void VideoWebRTCSender::dump_input_stream(const unsigned char *buffer, ssize_t s
     }
     else if (m_dumpFile.is_open())
     {
-        m_dumpFile.write((char*)buffer, size);
+        m_dumpFile.write(reinterpret_cast<const char*>(buffer), size);
         LOG(info) << "contant data: " << size << "frame count : " << m_frameCount << endl;
         m_frameCount ++;
     }

--- a/services/vios/src/framework/media/video_source/senders/videowebRTCsender.h
+++ b/services/vios/src/framework/media/video_source/senders/videowebRTCsender.h
@@ -83,7 +83,8 @@ class VideoWebRTCSender : public IMediaDataConsumer
         int  createPassThroughMode(string& device_id);
         void appendWebrtcBroacaster(const std::string& peerid, webrtc::VideoBroadcaster* broadcaster);
         void removeWebrtcBroacaster(const std::string& peerid);
-        virtual void onFrame(FrameParams& params);
+        using IMediaDataConsumer::onFrame;
+        void onFrame(FrameParams& params) override;
         void checkEarlyFramesAndSynchronize();
 
         void resume(const std::string& peerid);

--- a/services/vios/src/framework/media/video_source/senders/videowebRTCsender.h
+++ b/services/vios/src/framework/media/video_source/senders/videowebRTCsender.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,7 +54,7 @@ class VideoWebRTCSender : public IMediaDataConsumer
     public:
         VideoWebRTCSender (const std::string& consumer_name, const std::string& uri);
         VideoWebRTCSender (const std::string& consumer_name, double frame_rate, bool enable_frame_sync = false);
-        VideoWebRTCSender (const std::string& consumer_name);
+        explicit VideoWebRTCSender (const std::string& consumer_name);
         ~VideoWebRTCSender ()
         {
             try {

--- a/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.h
+++ b/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ class
 WebrtcSinkConsumer : public IMediaDataConsumer
 {
 public:
-    WebrtcSinkConsumer(const std::string& consumer_name);
+    explicit WebrtcSinkConsumer(const std::string& consumer_name);
     WebrtcSinkConsumer(const std::string& consumer_name, string peer_id, double frame_rate, 
                     const std::map<std::string, std::string, std::less<>> &opts, bool enable_frame_sync = false);
     ~WebrtcSinkConsumer();

--- a/services/vios/src/framework/notification/redis/redis_publisher.cpp
+++ b/services/vios/src/framework/notification/redis/redis_publisher.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -159,6 +159,7 @@ NvRedis::~NvRedis()
 void NvRedis::redis_init()
 {
     string payload_key;
+    char redis_config_file[] = REDIS_CONFIG_FILE;
     m_topic_vms_event = GET_CONFIG().message_broker_topic;
     m_redisEndpoint = getRedisServerEndpoint();
 
@@ -180,8 +181,8 @@ void NvRedis::redis_init()
     }
 
     LOG(info) << "Radis server address:port= " << m_redisEndpoint << endl;
-    m_conn_handle = nvds_msgapi_connect((char*)m_redisEndpoint.c_str(),
-                                        nullptr, (char*)REDIS_CONFIG_FILE);
+    m_conn_handle = nvds_msgapi_connect(m_redisEndpoint.data(),
+                                        nullptr, redis_config_file);
     if (!m_conn_handle)
     {
         LOG(error) << "Redis Connect failed. Exiting" << endl;

--- a/services/vios/src/framework/notification/redis/redis_publisher.cpp
+++ b/services/vios/src/framework/notification/redis/redis_publisher.cpp
@@ -227,7 +227,7 @@ bool NvRedis::sendToRedis(std::string& payload)
         return false;
     }
 
-    int ret = nvds_msgapi_send(m_conn_handle, (char*)m_topic_vms_event.c_str(),
+    int ret = nvds_msgapi_send(m_conn_handle, m_topic_vms_event.data(),
                             (const uint8_t*) payload.c_str(), payload.size());
     if(ret == 0)
     {

--- a/services/vios/src/framework/notification/redis/redis_subscriber.cpp
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,12 +160,13 @@ RedisSubscriber::~RedisSubscriber()
 void RedisSubscriber::redisInit()
 {
     m_subscribeTopic = GET_CONFIG().message_broker_topic_consumer;
-    const char *topic[] = {m_subscribeTopic.c_str()};
+    char *topic[] = {m_subscribeTopic.data()};
+    char connectConfig[] = "";
 
     m_redisEndpoint = getRedisServerEndpoint();
     // Connect to Redis server
-    m_connHandle = nvds_msgapi_connect((char*)m_redisEndpoint.c_str(),
-                                        nullptr, (char*)"");
+    m_connHandle = nvds_msgapi_connect(m_redisEndpoint.data(),
+                                        nullptr, connectConfig);
     if (!m_connHandle)
     {
         LOG(error) << "Redis Subscriber Connect failed. Exiting" << endl;
@@ -174,7 +175,7 @@ void RedisSubscriber::redisInit()
     LOG(info) << "Redis Subscriber connect success." << endl;
 
     //Subscribe to topic
-    if(nvds_msgapi_subscribe(m_connHandle, (char **)topic, 1, subscribe_cb, (void*)this) != NVDS_MSGAPI_OK)
+    if(nvds_msgapi_subscribe(m_connHandle, topic, 1, subscribe_cb, (void*)this) != NVDS_MSGAPI_OK)
     {
         LOG(error) << "Redis subscription to topic[s] failed. Exiting" << endl;
         goto error;

--- a/services/vios/src/framework/notification/redis/redis_subscriber.cpp
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.cpp
@@ -175,7 +175,7 @@ void RedisSubscriber::redisInit()
     LOG(info) << "Redis Subscriber connect success." << endl;
 
     //Subscribe to topic
-    if(nvds_msgapi_subscribe(m_connHandle, topic, 1, subscribe_cb, (void*)this) != NVDS_MSGAPI_OK)
+    if(nvds_msgapi_subscribe(m_connHandle, topic, 1, subscribe_cb, static_cast<void*>(this)) != NVDS_MSGAPI_OK)
     {
         LOG(error) << "Redis subscription to topic[s] failed. Exiting" << endl;
         goto error;

--- a/services/vios/src/framework/protocols/grpc/nvgrpc.h
+++ b/services/vios/src/framework/protocols/grpc/nvgrpc.h
@@ -138,7 +138,7 @@ private:
 class GrpcClient
 {
 public:
-    GrpcClient(std::shared_ptr<Channel> channel)
+    explicit GrpcClient(std::shared_ptr<Channel> channel)
         : m_stub(VstGrpcServer::NewStub(channel)) {}
     GrpcClient();
 

--- a/services/vios/src/framework/protocols/grpc/nvgrpc.h
+++ b/services/vios/src/framework/protocols/grpc/nvgrpc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,7 @@ using vstserver::IceCandidate;
 class  GrpcUdpService final : public VstGrpcServer::Service
 {
 public:
-    GrpcUdpService(std::shared_ptr<nv_vms::DeviceManager> deviceMngr): m_deviceManager(deviceMngr)
+    explicit GrpcUdpService(std::shared_ptr<nv_vms::DeviceManager> deviceMngr): m_deviceManager(deviceMngr)
     {}
 
     ~GrpcUdpService()

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -6198,7 +6198,7 @@ RecordingSummary NvSoap::getRecordingSummaryResponse(const string& xmlData)
         return summary;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
 
     // Find GetRecordingSummaryResponse node
@@ -6249,7 +6249,7 @@ string NvSoap::getFindRecordingsResponse(const string& xmlData)
         return searchToken;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
 
     // Find FindRecordingsResponse node
@@ -6280,7 +6280,7 @@ RecordingSearchResults NvSoap::getRecordingSearchResultsResponse(const string& x
         return results;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
 
     // Find GetRecordingSearchResultsResponse node
@@ -6303,7 +6303,7 @@ RecordingSearchResults NvSoap::getRecordingSearchResultsResponse(const string& x
             while (node != nullptr)
             {
                 if (node->type == XML_ELEMENT_NODE &&
-                    xmlStrcmp(node->name, BAD_CAST "RecordingInformation") == 0)
+                    xmlStrcmp(node->name, reinterpret_cast<const xmlChar *>("RecordingInformation")) == 0)
                 {
                     RecordingInformation recInfo;
 
@@ -6375,7 +6375,7 @@ RecordingSearchResults NvSoap::getRecordingSearchResultsResponse(const string& x
                     while (trackSearchNode != nullptr)
                     {
                         if (trackSearchNode->type == XML_ELEMENT_NODE &&
-                            xmlStrcmp(trackSearchNode->name, BAD_CAST "Track") == 0)
+                            xmlStrcmp(trackSearchNode->name, (const xmlChar *)"Track") == 0)
                         {
                             RecordingTrack track;
 

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -115,7 +115,7 @@ namespace
 class AutoDestroyXml
 {
 public:
-    AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
+    explicit AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
     ~AutoDestroyXml() { xmlBufferFree(m_xml); }
 private:
     xmlBufferPtr m_xml;
@@ -730,7 +730,7 @@ bool NvSoap::getProbeResponse(const string& xmlData, SensorInfo& sensor)
         return false;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar *>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if(cursor)
     {
@@ -988,7 +988,7 @@ void NvSoap::getDeviceInformationResponse(const string& xmlData, map<string, str
         return;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if (cursor)
     {
@@ -1046,7 +1046,7 @@ int NvSoap::getCapabilitiesResponse(const string& xmlData, map<string, OnvifServ
         return -1;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     xmlNodePtr cur = findNode(doc, cursor, ONVIF_MEDIA_SERVICE);
     if (cur)
@@ -1395,7 +1395,7 @@ void NvSoap::getProfilesResponse(const string& xmlData, vector<SensorSettings>& 
         return;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if(cursor)
     {
@@ -1720,7 +1720,7 @@ string NvSoap::getUriResponse(const string& xmlData)
         return value;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "Uri");
     if (!cur)

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -1663,7 +1663,7 @@ void NvSoap::getPTZProfilesResponse(const string& xmlData, vector<Profile>& prof
 
     Profile profile;
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if(cursor)
     {
@@ -1782,7 +1782,7 @@ vector<PTZSpaces> NvSoap::getPTZNodeResponse(const string& xmlData)
         return spaces;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if(cursor)
     {
@@ -1873,7 +1873,7 @@ SensorImageSettingsValues NvSoap::getCameraGetImageSettingsResponse(const string
         return values;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "ImagingSettings");
     if (cur)
@@ -2045,7 +2045,7 @@ SensorImageSettingsOptions NvSoap::getCameraGetImageOptionResponse(const string&
         return options;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "ImagingOptions");
     if (cur)

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -5696,7 +5696,7 @@ void NvSoap::getServicesResponse(const string& xmlData, map<string, OnvifService
         return;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if(cursor)
     {
@@ -5809,7 +5809,7 @@ SensorEncoderSettingsOptions NvSoap::getVideoEncoderConfigurationOptionsMedia2Re
         return options;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if(cursor)
     {
@@ -6140,7 +6140,7 @@ ServiceCapabilities NvSoap::getServiceCapabilitiesResponse(const string& xmlData
     }
 
     Token token;
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
 
     // Find the Security node

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -6009,7 +6009,7 @@ SensorVideoEncoderSettingsValues NvSoap::getVideoEncoderConfigurationsMedia2Resp
     }
 
     Token token;
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "Configurations");
     if (cur)

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -1122,7 +1122,7 @@ void NvSoap::getProfileResponse(const string& xmlData, SensorSettings& setting, 
     SensorVideoEncoderSettingsValues& encoderValues = setting.encoderValues;
     MultiCast& multiCast = setting.multiCast;
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if(cursor)
     {
@@ -2557,7 +2557,7 @@ string NvSoap::rebootCameraResponse(const string& xmlData)
         return rebootMessage;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "Message");
     if (cur)
@@ -2685,7 +2685,7 @@ SensorEncoderSettingsOptions NvSoap::getVideoEncoderConfigurationOptionsMediaRes
 
     VideoEncoderConfigurationsOptions option;
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "Options");
     if (cur)
@@ -2926,7 +2926,7 @@ static void getCameraPositionResult(const string& xmlData, SensorPosition& posit
         return;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cursor = xmlDocGetRootElement(doc);
     if (cursor == nullptr)
     {

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -814,7 +814,7 @@ void NvSoap::getSystemDateAndTimeResponse(const string& xmlData, string& respons
         return;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if (cursor)
     {
@@ -901,7 +901,7 @@ void NvSoap::getNTPResponse(const string& xmlData, string& response)
         return;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if (cursor)
     {
@@ -2334,7 +2334,7 @@ bool NvSoap::setCameraNetworkInterfacesResponse(const string& xmlData)
         return false;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar *>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "RebootNeeded");
     if (cur)
@@ -2359,7 +2359,7 @@ SensorNetworkInfo NvSoap::getCameraNetworkInterfacesResponse(const string& xmlDa
         return networkInfo;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "NetworkInterfaces");
     if (cur)
@@ -2797,7 +2797,7 @@ SensorVideoEncoderSettingsValues NvSoap::getVideoEncoderConfigurationMediaRespon
     }
 
     Token token;
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     cur = xmlDocGetRootElement(doc);
     cur = findNode(doc, cur, "Configuration");
     if (cur)

--- a/services/vios/src/framework/stream_monitor/stream_monitor.h
+++ b/services/vios/src/framework/stream_monitor/stream_monitor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,6 +90,9 @@ public:
     std::string getSourceIdentifier() const override;
     size_t getConsumerCount() const override;
     bool hasConsumers() const override;
+    // Keep the base class registerConsumer overloads visible (e.g. the
+    // media-type variant) so they are not hidden by the ones declared here.
+    using IMediaDataProducer::registerConsumer;
     void registerConsumer(std::shared_ptr<IMediaDataConsumer> consumer, const std::string& identifier = "") override;
     // Overloaded registerConsumer for time-range playback
     void registerConsumer(std::shared_ptr<IMediaDataConsumer> consumer, const std::string& identifier, const std::string& startTime, const std::string& endTime) override;

--- a/services/vios/src/framework/unified_storage/manager/cloud_manager.h
+++ b/services/vios/src/framework/unified_storage/manager/cloud_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,7 @@ struct CloudManagerConfig
     } request;
     
     CloudManagerConfig() = default;
-    CloudManagerConfig(CloudStorageType type) : storageType(type)
+    explicit CloudManagerConfig(CloudStorageType type) : storageType(type)
     {
     }
 };

--- a/services/vios/src/framework/unified_storage/manager/unified_storage_manager.h
+++ b/services/vios/src/framework/unified_storage/manager/unified_storage_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ struct BucketResult
     std::chrono::milliseconds duration;
     
     BucketResult() : success(false), duration(0) {}
-    BucketResult(bool success, const std::string& message = "") 
+    explicit BucketResult(bool success, const std::string& message = "")
         : success(success), message(message), duration(0) {}
 };
 
@@ -62,7 +62,7 @@ struct DeleteResult
     std::chrono::milliseconds duration;
     
     DeleteResult() : success(false), deletedSize(0), duration(0) {}
-    DeleteResult(bool success, const std::string& message = "") 
+    explicit DeleteResult(bool success, const std::string& message = "")
         : success(success), message(message), deletedSize(0), duration(0) {}
 };
 
@@ -105,7 +105,7 @@ struct MultiDeleteResult
 class UnifiedStorageManager
 {
 public:
-    UnifiedStorageManager(StorageType type);
+    explicit UnifiedStorageManager(StorageType type);
     virtual ~UnifiedStorageManager();
 
     // Core interface

--- a/services/vios/src/framework/unified_storage/reader/cloud_reader.h
+++ b/services/vios/src/framework/unified_storage/reader/cloud_reader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -146,7 +146,7 @@ struct AsyncDownloadSession
     {
     }
     
-    AsyncDownloadSession(const std::string& id) : sessionId(id), startTime(std::chrono::system_clock::now()),
+    explicit AsyncDownloadSession(const std::string& id) : sessionId(id), startTime(std::chrono::system_clock::now()),
                                                  completedTasks(0), successfulDownloads(0), failedDownloads(0),
                                                  totalBytesDownloaded(0), isCompleted(false) {}
 };

--- a/services/vios/src/framework/unified_storage/reader/unified_storage_reader.h
+++ b/services/vios/src/framework/unified_storage/reader/unified_storage_reader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +35,7 @@ class CloudReader;
 class UnifiedStorageReader
 {
 public:
-    UnifiedStorageReader(StorageType type);
+    explicit UnifiedStorageReader(StorageType type);
     virtual ~UnifiedStorageReader();
 
     // Core interface

--- a/services/vios/src/framework/unified_storage/unified_storage_types.h
+++ b/services/vios/src/framework/unified_storage/unified_storage_types.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,7 +83,7 @@ struct BucketInfo
     BucketInfo() : objectCount(0), totalSize(0)
     {
     }
-    BucketInfo(const std::string& name) : name(name), objectCount(0), totalSize(0)
+    explicit BucketInfo(const std::string& name) : name(name), objectCount(0), totalSize(0)
     {
     }
 };
@@ -116,7 +116,7 @@ struct CloudResult {
     std::chrono::milliseconds duration{0};
     
     CloudResult() = default;
-    CloudResult(bool success, const std::string& message = "") 
+    explicit CloudResult(bool success, const std::string& message = "")
         : success(success), message(message) {}
 };
 
@@ -135,7 +135,7 @@ struct StorageResult
     std::chrono::milliseconds duration;
     
     StorageResult() : success(false), bytes_written(0), bytes_read(0), duration(0) {}
-    StorageResult(bool success, const std::string& message = "") 
+    explicit StorageResult(bool success, const std::string& message = "") 
         : success(success), message(message), bytes_written(0), bytes_read(0), duration(0) {}
 };
 
@@ -152,7 +152,7 @@ struct CloudListResult : public CloudResult {
     std::string nextMarker;
     
     CloudListResult() = default;
-    CloudListResult(bool success, const std::string& message = "") 
+    explicit CloudListResult(bool success, const std::string& message = "")
         : CloudResult(success, message) {}
 };
  
@@ -256,7 +256,7 @@ struct FileListResult : public StorageResult
     std::string nextMarker;             // Marker for pagination
     
     FileListResult() : totalSize(0), count(0), isTruncated(false) {}
-    FileListResult(bool success, const std::string& message = "") 
+    explicit FileListResult(bool success, const std::string& message = "")
         : StorageResult(success, message), totalSize(0), count(0), isTruncated(false) {}
 };
  

--- a/services/vios/src/framework/unified_storage/writer/unified_storage_writer.h
+++ b/services/vios/src/framework/unified_storage/writer/unified_storage_writer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,7 @@ class UnifiedStorageWriter
 {
 public:
 
-    UnifiedStorageWriter(StorageType type);
+    explicit UnifiedStorageWriter(StorageType type);
     virtual ~UnifiedStorageWriter();
 
     // Independent interface

--- a/services/vios/src/framework/utilities/logger.h
+++ b/services/vios/src/framework/utilities/logger.h
@@ -64,7 +64,7 @@ enum Level {
 
 struct CoutToString
 {
-    CoutToString( std::streambuf * new_buffer ) 
+    explicit CoutToString( std::streambuf * new_buffer )
         : old( std::cout.rdbuf( new_buffer ) )
     { }
 

--- a/services/vios/src/framework/utilities/logger.h
+++ b/services/vios/src/framework/utilities/logger.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -264,18 +264,21 @@ class Logger {
             return m_logStream.str();
         }
 #endif
-        void log_qos(string format, ...)
+        void log_qos(string text)
         {
-            va_list args;
+            m_qosStream << text;
+            m_qosStream.flush();
+        }
+
+        template <typename... Args>
+        void log_qos(string format, Args... args)
+        {
             const int max_len = VA_ARG_MAX_BUFFER_LENGTH;
             char buffer[max_len] = { 0 };
 
-            // retrieve the variable arguments (last named parameter before ... must be used for va_start)
-            va_start(args, format);
-            
             // Safe formatted output with bounds checking and null termination
-            int written = vsnprintf(buffer, max_len, format.c_str(), args);
-            
+            int written = snprintf(buffer, max_len, format.c_str(), args...);
+
             // Ensure null termination and handle potential truncation
             if (written >= max_len)
             {
@@ -284,27 +287,30 @@ class Logger {
             else if (written < 0)
             {
                 buffer[0] = '\0';  // Handle encoding error
-                LOG(error) << "Error in vsnprintf" << endl;
+                LOG(error) << "Error in snprintf" << endl;
             }
 
             m_qosStream << buffer;
             m_qosStream.flush();
-
-            va_end(args);
         }
 
-        void log_color(string color, string format, ...)
+        template <typename... Args>
+        void log_color(string color, string format, Args... args)
         {
-            va_list args;
             const int max_len = VA_ARG_MAX_BUFFER_LENGTH;
             char buffer[max_len] = { 0 };
 
-            // retrieve the variable arguments (last named parameter before ... must be used for va_start)
-            va_start(args, format);
-            
             // Safe formatted output with bounds checking and null termination
-            int written = vsnprintf(buffer, max_len, format.c_str(), args);
-            
+            int written;
+            if constexpr (sizeof...(args) == 0)
+            {
+                written = snprintf(buffer, max_len, "%s", format.c_str());
+            }
+            else
+            {
+                written = snprintf(buffer, max_len, format.c_str(), args...);
+            }
+
             // Ensure null termination and handle potential truncation
             if (written >= max_len)
             {
@@ -332,7 +338,6 @@ class Logger {
                     std::cout << buffer << endl;
                 }
             }
-            va_end(args);
         }
 };
 } // nv_logger

--- a/services/vios/src/framework/utilities/network_utils.cpp
+++ b/services/vios/src/framework/utilities/network_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,7 +71,7 @@ struct curlData {
 class AutoDestroyXml
 {
 public:
-    AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
+    explicit AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
     ~AutoDestroyXml() { xmlBufferFree(m_xml); }
 private:
     xmlBufferPtr m_xml;
@@ -250,7 +250,7 @@ static bool getProbeResponse(const string& xmlData, SensorInfo& sensor)
         return false;
     }
 
-    doc = xmlParseDoc(BAD_CAST xmlData.c_str());
+    doc = xmlParseDoc(reinterpret_cast<const xmlChar*>(xmlData.c_str()));
     xmlNodePtr cursor = xmlDocGetRootElement(doc);
     if(cursor)
     {

--- a/services/vios/src/framework/utilities/signal_handler.h
+++ b/services/vios/src/framework/utilities/signal_handler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ class SignalHandler
 {
 public:
     SignalHandler() {}
-    SignalHandler(void (*handler)(int))
+    explicit SignalHandler(void (*handler)(int))
     {
         signal(SIGINT, handler);
         signal(SIGTERM, handler);

--- a/services/vios/src/framework/web/http_server/HttpServerRequestHandler.cpp
+++ b/services/vios/src/framework/web/http_server/HttpServerRequestHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -369,19 +369,24 @@ class RequestHandler : public CivetHandler
         return (method != HTTP_METHOD_POST && method != HTTP_METHOD_PUT && method != HTTP_METHOD_PATCH);
     }
     
-    bool handleGet(CivetServer *server, struct mg_connection *conn)
+    using CivetHandler::handleGet;
+    using CivetHandler::handlePost;
+    using CivetHandler::handlePut;
+    using CivetHandler::handleDelete;
+
+    bool handleGet(CivetServer *server, struct mg_connection *conn) override
     {
         return handle(server, conn);
     }
-    bool handlePost(CivetServer *server, struct mg_connection *conn)
+    bool handlePost(CivetServer *server, struct mg_connection *conn) override
     {
         return handle(server, conn);
     }
-    bool handlePut(CivetServer *server, struct mg_connection *conn)
+    bool handlePut(CivetServer *server, struct mg_connection *conn) override
     {
         return handle(server, conn);
     }
-    bool handleDelete(CivetServer *server, struct mg_connection *conn)
+    bool handleDelete(CivetServer *server, struct mg_connection *conn) override
     {
         return handle(server, conn);
     }

--- a/services/vios/src/framework/web/http_server/HttpServerRequestHandler.h
+++ b/services/vios/src/framework/web/http_server/HttpServerRequestHandler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +41,7 @@ class HttpServerRequestHandler
     public:
         typedef std::function<VmsErrorCode(const Json::Value &, const Json::Value &, Json::Value &, struct mg_connection *conn)> httpFunction;
 
-        HttpServerRequestHandler(std::shared_ptr<CivetServer> m_civetServer);
+        explicit HttpServerRequestHandler(std::shared_ptr<CivetServer> m_civetServer);
 
         void addRequestHandler(std::map<std::string,httpFunction, std::less<>>& func);
         

--- a/services/vios/src/framework/web/webServer.cpp
+++ b/services/vios/src/framework/web/webServer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,8 @@
 class VstPrefixRedirectHandler : public CivetHandler
 {
 public:
+    using CivetHandler::handleGet;
+
     bool handleGet(CivetServer *server, struct mg_connection *conn) override
     {
         const struct mg_request_info *req_info = mg_get_request_info(conn);

--- a/services/vios/src/framework/web/websocket_server/WebsocketServerRequestHandler.cpp
+++ b/services/vios/src/framework/web/websocket_server/WebsocketServerRequestHandler.cpp
@@ -34,8 +34,9 @@ bool WebsocketServerRequestHandler::handleConnection(CivetServer *server, const 
     std::string queryParamName = "connectionId";
     std::string connectionId = EMPTY_STRING;
     const char* queryParam = queryParamName.c_str();
-    struct mg_connection *connection = const_cast<struct mg_connection *>(conn);
-    if(!CivetServer::getParam(connection, queryParam, connectionId))
+    const struct mg_request_info *requestInfo = mg_get_request_info(conn);
+    const char *queryString = (requestInfo != nullptr) ? requestInfo->query_string : nullptr;
+    if(queryString == nullptr || !CivetServer::getParam(queryString, strlen(queryString), queryParam, connectionId))
     {
         LOG(error) << "Query param not found" << endl;
         return false;

--- a/services/vios/src/framework/web/websocket_server/WebsocketServerRequestHandler.cpp
+++ b/services/vios/src/framework/web/websocket_server/WebsocketServerRequestHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -117,7 +117,7 @@ bool WebsocketServerRequestHandler::handleData(CivetServer *server, struct mg_co
 void WebsocketServerRequestHandler::handleClose(CivetServer *server, const struct mg_connection *conn)
 {
     Json::Value temp_json;
-    m_callbackMap["/event/disconnect"](temp_json, temp_json, (struct mg_connection *)conn);
+    m_callbackMap["/event/disconnect"](temp_json, temp_json, const_cast<struct mg_connection *>(conn));
     return GET_WEBSOCKET_INSTANCE()->removeConnection(conn);
 }
 

--- a/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
+++ b/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1339,12 +1339,13 @@ PeerConnection::call(const Json::Value& req_info, const Json::Value &in, Json::V
         if (localfuture.wait_for(std::chrono::milliseconds(5000)) == std::future_status::ready)
         {
             // answer with the created answer
-            webrtc::SessionDescriptionInterface *descInterface = const_cast<webrtc::SessionDescriptionInterface *>(localfuture.get());
+            const webrtc::SessionDescriptionInterface *descInterface = localfuture.get();
             if (descInterface)
             {
                 if (GET_CONFIG().use_reverse_proxy == true /*&& m_peerConnectionManager->isRpStunAvailable() == false*/)
                 {
-                    string sdpLite = m_observer->getSdpWithIceLite(descInterface, m_peerid, m_clientPublicIpAddr);
+                    std::unique_ptr<webrtc::SessionDescriptionInterface> liteDesc = descInterface->Clone();
+                    string sdpLite = m_observer->getSdpWithIceLite(liteDesc.get(), m_peerid, m_clientPublicIpAddr);
                     if (sdpLite.empty() == false)
                     {
                         sdp = sdpLite;
@@ -2492,12 +2493,13 @@ VmsErrorCode PeerConnection::createOffer(const Json::Value& in, Json::Value &off
     if (localfuture.wait_for(std::chrono::milliseconds(5000)) == std::future_status::ready)
     {
         // answer with the created offer
-        webrtc::SessionDescriptionInterface *desc = const_cast<webrtc::SessionDescriptionInterface *>(localfuture.get());
+        const webrtc::SessionDescriptionInterface *desc = localfuture.get();
         if (desc)
         {
             if (GET_CONFIG().use_reverse_proxy == true /*&& m_peerConnectionManager->isRpStunAvailable() == false*/)
             {
-                string sdpLite = m_observer->getSdpWithIceLite(desc, m_peerid, m_clientPublicIpAddr);
+                std::unique_ptr<webrtc::SessionDescriptionInterface> mutableDesc = desc->Clone();
+                string sdpLite = m_observer->getSdpWithIceLite(mutableDesc.get(), m_peerid, m_clientPublicIpAddr);
                 if (sdpLite.empty() == false)
                 {
                     sdp = sdpLite;
@@ -2962,12 +2964,13 @@ VmsErrorCode PeerConnection::getAnswer(const Json::Value& in, Json::Value& answe
     if (localfuture.wait_for(std::chrono::milliseconds(5000)) == std::future_status::ready)
     {
         // answer with the created answer
-        webrtc::SessionDescriptionInterface *descInterface = const_cast<webrtc::SessionDescriptionInterface *>(localfuture.get());
+        const webrtc::SessionDescriptionInterface *localDesc = localfuture.get();
+        std::unique_ptr<webrtc::SessionDescriptionInterface> descInterface = localDesc ? localDesc->Clone() : nullptr;
         if (descInterface)
         {
             if (GET_CONFIG().use_reverse_proxy == true /*&& m_peerConnectionManager->isRpStunAvailable() == false*/)
             {
-                string sdpLite = m_observer->getSdpWithIceLite(descInterface, m_peerid, m_clientPublicIpAddr);
+                string sdpLite = m_observer->getSdpWithIceLite(descInterface.get(), m_peerid, m_clientPublicIpAddr);
                 if (sdpLite.empty() == false)
                 {
                     sdp = sdpLite;

--- a/services/vios/src/framework/webrtc_streamer/WebrtcCallbacks.cpp
+++ b/services/vios/src/framework/webrtc_streamer/WebrtcCallbacks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -383,7 +383,7 @@ void AudioSink::OnData(const void* audio_data,
         }
     }
     size_t streamSizeBytes = (bits_per_sample / 8) * number_of_channels * number_of_frames;
-    m_producer->addFrame ("audio", (unsigned char *)audio_data, streamSizeBytes, sample_rate, number_of_channels);
+    m_producer->addAudioFrame (static_cast<const unsigned char *>(audio_data), streamSizeBytes, sample_rate, number_of_channels);
     m_webrtcAudioInDataFlow = true;
 }
 

--- a/services/vios/src/framework/webrtc_streamer/inc/VideoFilter.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/VideoFilter.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ protected:
   SourceState state() const override { 
 	  return kLive; 
   }
-  bool GetStats(Stats* stats) override {
+  bool GetStats(webrtc::VideoTrackSourceInterface::Stats* stats) override {
       bool result = false;
       T* source =  m_source.get();
       if (source) {

--- a/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,11 +66,13 @@ public:
 
     virtual ~AudioSink();
 
-    virtual void OnData(const void* audio_data,
+    using webrtc::AudioTrackSinkInterface::OnData;
+
+    void OnData(const void* audio_data,
         int bits_per_sample,
         int sample_rate,
         size_t number_of_channels,
-        size_t number_of_frames);
+        size_t number_of_frames) override;
 
     std::atomic<bool>   m_webrtcAudioInDataFlow{false};
 protected:

--- a/services/vios/src/framework/webrtc_streamer/inc/WebrtcStreamStats.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/WebrtcStreamStats.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,7 @@ private:
 
     void stopLogging();
 public:
-    WebrtcStreamStats(std::string peerId);
+    explicit WebrtcStreamStats(std::string peerId);
     ~WebrtcStreamStats();
 
     void createLogFile();

--- a/services/vios/src/framework/webrtc_streamer/inc/nvgstudpaudiosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvgstudpaudiosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,7 +63,8 @@ class AudioDataConsumer : public IMediaDataConsumer
             m_freq = freq;
             m_bitsPerSample = bitsPerSample;
         }
-        void onFrame(FrameParams& params)
+        using IMediaDataConsumer::onFrame;
+        void onFrame(FrameParams& params) override
         {
             uint16_t segment_length       = m_freq / 100;
             uint16_t total_segment_length = m_channel * segment_length;

--- a/services/vios/src/framework/webrtc_streamer/inc/nvgstudpvideosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvgstudpvideosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,7 +84,8 @@ class VideoDataConsumer : public IMediaDataConsumer
             return m_videoSinkList.size();
         }
 
-        void onFrame(FrameParams& params)
+        using IMediaDataConsumer::onFrame;
+        void onFrame(FrameParams& params) override
         {
             std::lock_guard<std::mutex> lock(m_videoSinkLock);
             m_sourceWidth  = params.m_width;

--- a/services/vios/src/framework/webrtc_streamer/inc/screencapturer.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/screencapturer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +42,7 @@
 
 class DesktopCapturer : public webrtc::VideoSourceInterface<webrtc::VideoFrame>, public webrtc::DesktopCapturer::Callback  {
 	public:
-		DesktopCapturer(const std::map<std::string,std::string> & opts) : m_width(0), m_height(0) {
+		explicit DesktopCapturer(const std::map<std::string,std::string> & opts) : m_width(0), m_height(0) {
 			if (opts.find("width") != opts.end()) {
 				m_width = std::stoi(opts.at("width"));
 			}	

--- a/services/vios/src/framework/webrtc_streamer/inc/sensordatamanager.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/sensordatamanager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,7 +110,7 @@ class MetaDataSchedule
 class SensorDataManager
 {
     public:
-        SensorDataManager(shared_ptr<SensorManagement> sensorMgmt);
+        explicit SensorDataManager(shared_ptr<SensorManagement> sensorMgmt);
         ~SensorDataManager();
         VmsErrorCode startStream(std::map<std::string, std::string, std::less<>> opts, Json::Value &response);
         VmsErrorCode stopStream(const string& sensor_id, Json::Value &response);

--- a/services/vios/src/modules/rtsp_server/DynamicRTSPServer.cpp
+++ b/services/vios/src/modules/rtsp_server/DynamicRTSPServer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,9 +59,9 @@ DynamicRTSPServer::~DynamicRTSPServer()
     LOG(info) << "~DynamicRTSPServer" << endl;
 }
 
-void DynamicRTSPServer::cleanup()
+void DynamicRTSPServer::cleanupAndDestroy()
 {
-    LOG(info) << "DynamicRTSPServer::cleanup()" << endl;
+    LOG(info) << "DynamicRTSPServer::cleanupAndDestroy()" << endl;
 
     std::vector<std::string> streamNames;
     {
@@ -84,7 +84,7 @@ void DynamicRTSPServer::cleanup()
     {
         removeServerMediaSession(name.c_str());
     }
-    LOG(info) << "DynamicRTSPServer::cleanup() - deleted streams" << endl;
+    LOG(info) << "DynamicRTSPServer::cleanupAndDestroy() - deleted streams" << endl;
     delete this;
 }
 

--- a/services/vios/src/modules/rtsp_server/DynamicRTSPServer.hh
+++ b/services/vios/src/modules/rtsp_server/DynamicRTSPServer.hh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,12 +29,13 @@ public:
   static DynamicRTSPServer* createNew(UsageEnvironment& env, Port ourPort,
 				      UserAuthenticationDatabase* authDatabase,
 				      unsigned reclamationTestSeconds = 65);
-  void cleanup();
+  void cleanupAndDestroy();
   ServerMediaSession* getServerMediaSessionForStream(char const* streamName);
   void deleteServerMediaSessionForStream(char const* streamName);
   std::vector<std::string> getActiveStreams();
   void setVodServer(bool isVodServer) { m_isVodServer = isVodServer; }
   bool isVodServer() { return m_isVodServer; }
+  using GenericMediaServer::lookupServerMediaSession;
 
 protected:
   DynamicRTSPServer(UsageEnvironment& env, int ourSocketIPv4, int ourSocketIPv6, Port ourPort,

--- a/services/vios/src/modules/rtsp_server/NvMediaSource.hh
+++ b/services/vios/src/modules/rtsp_server/NvMediaSource.hh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -147,7 +147,8 @@ class NvMediaSource : public IMediaDataConsumer
         void stopOverlayPipeline_internal();
 
         //IMediaDataConsumer virtual function
-        virtual void onFrame(FrameParams& params);
+        using IMediaDataConsumer::onFrame;
+        virtual void onFrame(FrameParams& params) override;
         virtual eMediaType getConsumerMediaType() { return m_mediaType; }
         virtual void setConsumerMediaType(eMediaType media_type) { m_mediaType = media_type; }
 

--- a/services/vios/src/modules/rtsp_server/VodOverlayManager.hh
+++ b/services/vios/src/modules/rtsp_server/VodOverlayManager.hh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,7 @@ class NvMediaSource;
 class VodOverlayManager
 {
 public:
-    VodOverlayManager(NvMediaSource* mediaSource);
+    explicit VodOverlayManager(NvMediaSource* mediaSource);
     ~VodOverlayManager() = default;
 
     void startOverlayPipeline();

--- a/services/vios/src/modules/rtsp_server/rtspserver.cpp
+++ b/services/vios/src/modules/rtsp_server/rtspserver.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -197,7 +197,7 @@ RtspServer::~RtspServer()
 
     if (m_rtspServer != nullptr)
     {
-        ((DynamicRTSPServer *)m_rtspServer)->cleanup();
+        ((DynamicRTSPServer *)m_rtspServer)->cleanupAndDestroy();
         m_rtspServer = nullptr;
     }
     LOG(info) << "Exited RTSP Server" << endl;

--- a/services/vios/src/modules/rtsp_server/rtspserver.h
+++ b/services/vios/src/modules/rtsp_server/rtspserver.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,7 +62,7 @@ typedef struct _StreamDetails
 class RtspServer
 {
     public:
-        RtspServer(u_int16_t port);
+        explicit RtspServer(u_int16_t port);
         ~RtspServer();
         int16_t getPort() { return m_rtspServerPortNum; }
         std::string createProxy(const string& id, const string& name, const string& url);

--- a/services/vios/src/modules/sensor_management/sensor_control.h
+++ b/services/vios/src/modules/sensor_management/sensor_control.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ struct SensorContollerLoader
 class SensorControl
 {
     public:
-        SensorControl(DeviceManager* deviceMngr);
+        explicit SensorControl(DeviceManager* deviceMngr);
         ~SensorControl();
 
         int connect();

--- a/services/vios/src/modules/sensor_management/sensor_management.h
+++ b/services/vios/src/modules/sensor_management/sensor_management.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,7 @@ namespace nv_vms
     public:
         IVstModule* createSensorManagementObject();
         void deleteSensorManagementObject(IVstModule* object);
-        SensorManagement(std::shared_ptr<DeviceManager> deviceMngr);
+        explicit SensorManagement(std::shared_ptr<DeviceManager> deviceMngr);
         ~SensorManagement();
         std::shared_ptr<DeviceManager> getDeviceManagerObject();
         std::shared_ptr<SensorManagement> getptr() { return std::shared_ptr<SensorManagement>(this); }

--- a/services/vios/src/modules/sensor_management/sensor_monitoring.h
+++ b/services/vios/src/modules/sensor_management/sensor_monitoring.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,7 +63,7 @@ class SensorManagement;
         int onSensorFound(SensorInfo& sensorInfo);
         int onSensorChanged(SensorInfo& sensorInfo);
         int onSensorRemoved(const string& sensor_id);
-        void notifyEvent(const SensorStatus& status, const string& url, const string &ipc_url = "");
+        void notifyEvent(const SensorStatus& status, const string& url, const string &ipc_url = "") override;
         void refreshSensorList();
         void addAndRegisterDiscoveryObject(ISensorDiscoveryInterface* discoveryObject);
         void removeAndDeRegisterDiscoveryObject(ISensorDiscoveryInterface* discoveryObject);

--- a/services/vios/src/modules/stream_recorder/streamrecorder.h
+++ b/services/vios/src/modules/stream_recorder/streamrecorder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -150,7 +150,7 @@ inline constexpr const char* KILL_ERROR_WATCH_THREAD = "KILL_ERROR_WATCH_THREAD"
             RecordScheduleStatus m_isRunning;
             std::unique_ptr<Bosma::Scheduler> m_scheduler;
 
-            schedule_(std::unique_ptr<Bosma::Scheduler> bosma_scheduler_ptr)
+            explicit schedule_(std::unique_ptr<Bosma::Scheduler> bosma_scheduler_ptr)
             {
                 m_scheduler = std::move(bosma_scheduler_ptr);
                 m_isRunning = RecordScheduleOFF;


### PR DESCRIPTION
Fixes 141 HIGH-severity SonarQube issues in `services/vios`.

const-removing casts, implicit conversions, hidden inherited functions and multi-mutex locking.

### Rules
- `cpp:S859`
- `cpp:S1709`
- `cpp:S1242`
- `cpp:S923`
- `cpp:S5524`

### How these were produced and verified

Issues were fixed in waves: each issue fixed independently in its own worktree,
the results merged into a single tree, and **that combined tree compiled before
anything was committed**. A fix that failed to build was isolated and dropped
rather than dragging the wave down with it, so every commit on this branch
compiles.

Each fix updates the file SonarQube flagged **and** its header and use sites
together — a partial conversion does not compile, so the per-wave build is what
guarantees completeness.

### Verification
`./build.sh package module=sensor,streamprocessing` — clean.

### Not included
- `cpp:S134`: Structural refactor (nesting depth / cognitive complexity)
- `cpp:S4423`: TLS/crypto behaviour change

Signed-off-by: gous <gmulla@nvidia.com>
