### PR TITLE
Merge RTSP webhook schema assertions into the lifecycle scenario

### DIFF
--- a/services/vios/test/bdd_tests/features/notification/webhook_notifications.feature
+++ b/services/vios/test/bdd_tests/features/notification/webhook_notifications.feature
@@ -19,20 +19,20 @@ Feature: Webhook notifications for file sensor lifecycle
     And the camera_streaming notification values are valid
     And the camera_streaming notification metadata is valid for the camera type
 
-  # The two RTSP scenarios are skipped unless notification_tests.test_parameters.rtsp_sensor
-  # is set in config.json.
+  # The RTSP scenario is skipped unless notification_tests.test_parameters.rtsp_sensor
+  # is set in config.json. It also carries the camera_streaming schema assertions:
+  # every RTSP scenario adds the same configured URL, and VST rejects a duplicate by
+  # URL regardless of the unique sensor name, so a second scenario adding it again is
+  # rejected with "Sensor exists already".
   Scenario: RTSP sensor lifecycle delivers to rtsp filtered webhook receivers
     When I add the configured RTSP sensor for webhook testing
     Then the rtsp camera_add webhook is received and valid
     And the rtsp camera_streaming webhook is received and valid
-    When I delete the added RTSP webhook test sensor
-    Then the rtsp camera_remove webhook is received and valid
-
-  Scenario: RTSP sensor camera_streaming event carries the complete notification schema
-    When I add the configured RTSP sensor for webhook testing
-    Then the camera_streaming notification has the expected structure
+    And the camera_streaming notification has the expected structure
     And the camera_streaming notification values are valid
     And the camera_streaming notification metadata is valid for the camera type
+    When I delete the added RTSP webhook test sensor
+    Then the rtsp camera_remove webhook is received and valid
 
   Scenario: Unfiltered webhook receiver accepts a file camera event
     When I upload a uniquely named file sensor for webhook testing


### PR DESCRIPTION
* Fold the camera_streaming schema steps into the RTSP lifecycle scenario so the suite adds the configured RTSP sensor once per run.
* Drop the standalone RTSP schema scenario, whose second add of the same URL was rejected with "Sensor exists already".
* Record in the feature file why the RTSP scenario now carries both sets of assertions.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
