### PR TITLE
Remove dev packages

### DIFF
--- a/deploy/docker/services/vios/nvstreamer/compose.yml
+++ b/deploy/docker/services/vios/nvstreamer/compose.yml
@@ -26,6 +26,7 @@ services:
     user: "0:0"
     entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}

--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -188,6 +188,7 @@ echo "Reinstalling GStreamer plugins and core multimedia libraries..."
 for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
       libv4lconvert0t64 \
+      libjpeg8 libjpeg-turbo8 libpng16-16t64 \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
       libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \

--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -111,17 +111,49 @@ fi
 
 # Keep public Ubuntu repositories as the default. aarch64 packages are served
 # from Ubuntu Ports; no NVIDIA-internal mirror is required or assumed.
-if [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
-  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
-  cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+#
+# VST_APT_MIRROR overrides the archive for deployments that are far from the
+# public mirrors or behind a restricted egress. Download time is dominated by
+# which mirror answers, not by bandwidth: the same 24.6MB fetch measures ~10s
+# against a close mirror and has been observed to take minutes against a slow
+# or stalled one. Point this at an internal mirror to make startup predictable.
+#
+#   VST_APT_MIRROR=http://mirror.example.com/ubuntu           (x86_64)
+#   VST_APT_MIRROR=http://mirror.example.com/ubuntu-ports     (aarch64)
+if [[ "$(uname -m)" == *"aarch64"* ]]; then
+  APT_MIRROR="${VST_APT_MIRROR:-https://ports.ubuntu.com/ubuntu-ports/}"
+else
+  APT_MIRROR="${VST_APT_MIRROR:-}"
+fi
+
+if [[ -n "${APT_MIRROR}" ]]; then
+  # Trailing slash keeps the generated URIs well formed whichever form is passed.
+  [[ "${APT_MIRROR}" == */ ]] || APT_MIRROR="${APT_MIRROR}/"
+fi
+
+if [[ -n "${VST_APT_MIRROR:-}" ]]; then
+  echo "Using APT mirror: ${APT_MIRROR}"
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<EOF
 Types: deb
-URIs: https://ports.ubuntu.com/ubuntu-ports/
+URIs: ${APT_MIRROR}
+Suites: noble noble-updates noble-security
+Components: main universe
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+  # A mirror supersedes whatever the base image shipped; leaving the original
+  # list in place would send half the requests back to the slow archive.
+  rm -f /etc/apt/sources.list
+elif [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
+  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<EOF
+Types: deb
+URIs: ${APT_MIRROR}
 Suites: noble noble-updates
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 Types: deb
-URIs: https://ports.ubuntu.com/ubuntu-ports/
+URIs: ${APT_MIRROR}
 Suites: noble-security
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
@@ -129,19 +161,57 @@ EOF
 fi
 
 # Handle network-level timeouts gracefully without killing dpkg.
+#
+# HTTP pipelining is left at the APT default. Forcing Pipeline-Depth=0 serialises
+# every request and measured ~40% slower on this package set (13s vs 8s for the
+# same 52 packages / 24.6MB). Set VST_APT_PIPELINE_DEPTH=0 to restore the
+# serialised behaviour if a proxy or mirror mishandles pipelined requests.
+#
+# ForceIPv4 stays on: a host with broken IPv6 otherwise waits for the v6 attempt
+# to time out on every connection.
 APT_OPTS=(
   -o Acquire::http::Timeout=30
   -o Acquire::https::Timeout=30
   -o Acquire::Retries=5
   -o DPkg::Lock::Timeout=60
   -o Acquire::ForceIPv4=true
-  -o Acquire::http::Pipeline-Depth=0
   -o Dpkg::Options::=--force-confdef
   -o Dpkg::Options::=--force-confold
 )
+if [[ -n "${VST_APT_PIPELINE_DEPTH:-}" ]]; then
+  APT_OPTS+=(-o "Acquire::http::Pipeline-Depth=${VST_APT_PIPELINE_DEPTH}")
+fi
+
 
 install_packages() {
   apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
+}
+
+# APT already retries individual downloads (Acquire::Retries), but a connection
+# that drops mid-transaction fails the whole install. Retry the install itself so
+# a brief outage does not fail container startup.
+#
+# Deliberately not wrapped in `timeout`: killing apt-get install midway can leave
+# dpkg half-configured, which is worse than a slow start. Repair between attempts
+# instead -- a failed install is exactly what leaves packages unconfigured, and
+# without this the retry fails the same way.
+install_packages_with_retries() {
+  local attempt
+  for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    if install_packages; then
+      return 0
+    fi
+    echo "apt-get install attempt ${attempt}/${MAX_RETRIES} failed."
+    if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+      if is_dpkg_broken; then
+        echo "Repairing incomplete dpkg state before retry..."
+        dpkg --configure -a || true
+      fi
+      echo "Retrying in $((2 * attempt))s..."
+      sleep $((2 * attempt))
+    fi
+  done
+  return 1
 }
 
 refresh_apt_metadata() {
@@ -163,6 +233,19 @@ refresh_apt_metadata() {
   return 1
 }
 
+# A mirror override invalidates the metadata the base image ships, which is
+# indexed against the default archive. Measured: with a mirror configured and the
+# shipped lists in place, apt resolves no download URI at all, so the fast path
+# below would fail and only then refresh. Refresh up front instead of paying for
+# a doomed attempt first.
+if [[ -n "${VST_APT_MIRROR:-}" ]]; then
+  echo "APT mirror configured; refreshing metadata before install."
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata from ${APT_MIRROR}."
+    exit 1
+  fi
+fi
+
 # Reuse the base image's APT metadata first. Refresh only if installation shows
 # it is stale or a package is unavailable, keeping the normal path offline-fast.
 echo "Installing VIOS runtime media packages..."
@@ -176,7 +259,10 @@ if ! install_packages; then
     echo "Repairing incomplete dpkg state..."
     dpkg --configure -a
   fi
-  install_packages
+  if ! install_packages_with_retries; then
+    echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
+    exit 1
+  fi
 fi
 
 # OSRB: strip Intel MediaSDK / QuickSync (QSV) codec libs re-pulled as part of the

--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -24,6 +24,10 @@
 # makes the restart path free.
 set -e  # Exit on any error
 
+# The base image may preload libraries that are restored by this installer.
+# Do not pass unavailable preload paths to apt/dpkg helper processes.
+unset LD_PRELOAD
+
 # Ensure non-interactive mode for apt operations
 export DEBIAN_FRONTEND=noninteractive
 

--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -187,6 +187,7 @@ done
 echo "Reinstalling GStreamer plugins and core multimedia libraries..."
 for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
+      libv4lconvert0t64 \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
       libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \

--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -15,99 +15,101 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Install the media packages VIOS needs at runtime, before launch_vst. The base
+# image ships without them (and deletes the files of the ones that arrive as
+# transitive dependencies), so this script restores them on first start.
+#
+# Keep this idempotent: a retained container does not need an APT transaction on
+# restart. The marker file plus a spot check of the installed libraries is what
+# makes the restart path free.
 set -e  # Exit on any error
 
 # Ensure non-interactive mode for apt operations
 export DEBIAN_FRONTEND=noninteractive
 
-# Generate random timeout to avoid thundering herd problem
-APT_UPDATE_TIMEOUT=$((200 + RANDOM % 101))    # 200-300 seconds for apt-get update
-MAX_RETRIES=3
+FORCE_INSTALL="${VST_FORCE_ADDITIONAL_PACKAGES_INSTALL:-false}"
 
-# Function to check if dpkg is in a broken state
+# Randomized timeout avoids a thundering herd when several replicas (5 nvstreamers
+# plus stream-processing) cold-start against the same mirror at once.
+APT_UPDATE_TIMEOUT="${VST_APT_UPDATE_TIMEOUT:-$((200 + RANDOM % 101))}"
+MAX_RETRIES="${VST_APT_MAX_RETRIES:-3}"
+
+# Runtime libraries only; development packages are intentionally excluded.
+#
+# The four top-level entries are what VIOS actually needs. Everything below them
+# arrives as a transitive dependency, but the base image deletes the files of the
+# ones it already has installed, so they must be listed explicitly for
+# --reinstall to restore them.
+RUNTIME_PACKAGES=(
+  gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+  gstreamer1.0-plugins-ugly gstreamer1.0-libav
+  libopencv-core406t64 libv4lconvert0t64
+  # JPEG and PNG are pruned from the base image and restored here; the packaged
+  # application links them for snapshot and image encoding.
+  libjpeg8 libjpeg-turbo8 libpng16-16t64
+  libvo-aacenc0 libfaad2 libswresample4 libavutil58 libswscale7 libpostproc57
+  libavcodec60 libavformat60 libavfilter9 libde265-0 libx265-199 libx264-164
+  libmpeg2encpp-2.1-0t64 libmpeg2-4 libmpg123-0t64 libbs2b0 libreadline8t64
+  libcdio19t64 libdca0 libdvdnav4 libmjpegutils-2.1-0t64 liba52-0.7.4
+  libdvdread8t64 libsbc1 libzvbi0t64 libmp3lame0 libsidplay1v5 liblrdf0
+  libneon27t64 libflac12t64 libxvidcore4 libvpx9 libopenh264-7
+  # libavcodec/libavformat link these directly. The base image deletes their
+  # files (they arrive as plugins-base/good dependencies), so without an
+  # explicit --reinstall the libav dlopen in LibavWrapper fails and file upload
+  # cannot read duration/codec. libgstlibav.so needs the same set.
+  libogg0 libvorbis0a libvorbisenc2 libopus0 libspeex1 libtheora0 libtwolame0
+  libwebp7 libsharpyuv0
+)
+
+# The marker is keyed on the package list itself, so editing RUNTIME_PACKAGES
+# automatically invalidates markers written by an older revision of this script.
+# Without this, a container that completed an install with a previous list would
+# skip forever and never pick up newly added packages.
+PACKAGE_SET_ID="$(printf '%s\n' "${RUNTIME_PACKAGES[@]}" | md5sum | cut -c1-10)"
+MARKER_FILE="${VST_ADDITIONAL_PACKAGES_MARKER:-/var/lib/vios/additional-packages-installed-${PACKAGE_SET_ID}}"
+
 is_dpkg_broken() {
-  # Check for packages in bad state (Half-installed, Unpacked, Reinst-required)
-  if dpkg -l 2>/dev/null | grep -qE "^[HUR]"; then
-    return 0  # dpkg is broken
-  fi
-
-  # Check dpkg audit for issues
-  if dpkg --audit 2>&1 | grep -q .; then
-    return 0  # dpkg has issues
-  fi
-
-  return 1  # dpkg is healthy
+  dpkg --audit 2>/dev/null | grep -q .
 }
 
-# Function to fix dpkg state
-fix_dpkg() {
-  echo "Fixing dpkg state..."
-
-  # SAFETY: Check if apt/dpkg is already running before touching locks
-  if pgrep -x apt-get >/dev/null 2>&1 || pgrep -x dpkg >/dev/null 2>&1 || pgrep -x apt >/dev/null 2>&1; then
-    echo "Package manager is currently running, cannot safely fix dpkg state"
-    echo "Waiting for package manager to complete..."
-    return 1
-  fi
-
-  # Remove stale lock files (safe now that we checked for running processes)
-  echo "Removing stale lock files..."
-  rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
-
-  # Try to configure any pending packages
-  dpkg --configure -a 2>/dev/null || true
-
-  # Find and remove packages in bad state
-  BAD_PKGS=$(dpkg -l 2>/dev/null | grep -E "^[HUR]" | awk '{print $2}' || true)
-  if [ -n "$BAD_PKGS" ]; then
-    echo "Removing packages in bad state: $BAD_PKGS"
-    for pkg in $BAD_PKGS; do
-      dpkg --remove --force-remove-reinstreq "$pkg" 2>/dev/null || true
+# Sentinels for the package groups this script installs: plugins-bad, libav and
+# libv4lconvert (whose files the base image deletes).
+#
+# Existence alone is not enough. The base image deletes libraries that libav and
+# several plugins link against, which leaves the plugin file on disk but
+# unloadable -- that is exactly how avdec_* silently disappeared while every
+# sentinel still "existed". Check that each one actually resolves.
+runtime_present() {
+  local required match
+  for required in \
+    /usr/lib/*-linux-gnu/libv4lconvert.so.0 \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstvideoparsersbad.so \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstmpegtsmux.so \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstlibav.so; do
+    compgen -G "${required}" >/dev/null || return 1
+    for match in ${required}; do
+      if ldd "${match}" 2>/dev/null | grep -q "not found"; then
+        return 1
+      fi
     done
-  fi
-
-  # Verify fix worked
-  if is_dpkg_broken; then
-    echo "WARNING: dpkg may still have issues after fix attempt"
-    return 1
-  fi
-
-  echo "dpkg state fixed successfully"
-  return 0
+  done
 }
 
-echo "Checking and fixing dpkg state..."
-if ! fix_dpkg; then
-  echo "WARNING: Could not fix dpkg state (package manager may be running)"
-  echo "Proceeding with caution - DPkg::Lock::Timeout will handle lock contention"
+if [[ "${FORCE_INSTALL}" != "true" && -f "${MARKER_FILE}" ]] && runtime_present; then
+  echo "Additional packages already installed; skipping APT."
+  exit 0
 fi
 
-# APT acquire options for robustness and performance
-# These handle network-level timeouts gracefully without killing dpkg
-APT_OPTS="-o Acquire::http::Timeout=30 \
--o Acquire::https::Timeout=30 \
--o Acquire::Retries=5 \
--o DPkg::Lock::Timeout=60 \
--o Acquire::ForceIPv4=true \
--o Acquire::http::Pipeline-Depth=0 \
--o Acquire::http::No-Cache=true \
--o Dpkg::Options::=--force-confdef \
--o Dpkg::Options::=--force-confold"
+if is_dpkg_broken; then
+  echo "Repairing incomplete dpkg state..."
+  dpkg --configure -a
+fi
 
-echo "Starting package installation for Ubuntu 24.04..."
-
-# Optimize APT sources to only include necessary suites and components (HTTPS)
-echo "Configuring APT sources for optimal performance..."
-
-# Detect architecture - only modify sources for aarch64
-ARCH=$(uname -m)
-if [[ "$ARCH" == *"aarch64"* ]]; then
-    # Skip modification if already configured with HTTPS ports.ubuntu.com
-    if [ -f /etc/apt/sources.list.d/ubuntu.sources ] && grep -q "https://ports.ubuntu.com" /etc/apt/sources.list.d/ubuntu.sources; then
-        echo "APT sources already configured with HTTPS ports.ubuntu.com, skipping modification..."
-    else
-        echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
-        cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+# Keep public Ubuntu repositories as the default. aarch64 packages are served
+# from Ubuntu Ports; no NVIDIA-internal mirror is required or assumed.
+if [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
+  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
 Types: deb
 URIs: https://ports.ubuntu.com/ubuntu-ports/
 Suites: noble noble-updates
@@ -120,167 +122,75 @@ Suites: noble-security
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
-    fi
 fi
 
-# Run apt-get update with timeout and retry logic
-echo "Running apt-get update (timeout: ${APT_UPDATE_TIMEOUT}s)..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if timeout ${APT_UPDATE_TIMEOUT}s apt-get update ${APT_OPTS}; then
-    echo "apt-get update completed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "apt-get update attempt $attempt/$MAX_RETRIES failed"
+# Handle network-level timeouts gracefully without killing dpkg.
+APT_OPTS=(
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+  -o Acquire::Retries=5
+  -o DPkg::Lock::Timeout=60
+  -o Acquire::ForceIPv4=true
+  -o Acquire::http::Pipeline-Depth=0
+  -o Dpkg::Options::=--force-confdef
+  -o Dpkg::Options::=--force-confold
+)
 
-      # SAFE lock cleanup: only if locks exist AND no process running
-      if [ -f /var/lib/dpkg/lock-frontend ] || [ -f /var/lib/dpkg/lock ]; then
-        if ! pgrep -x apt-get >/dev/null 2>&1 && ! pgrep -x dpkg >/dev/null 2>&1 && ! pgrep -x apt >/dev/null 2>&1; then
-          echo "Found stale lock files, clearing..."
-          rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
-        else
-          echo "Lock files present but package manager running in another process"
-        fi
-      fi
+install_packages() {
+  apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
+}
 
-      # Clean corrupted apt lists for fresh retry
+refresh_apt_metadata() {
+  local attempt
+  for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    echo "Running apt-get update (attempt ${attempt}/${MAX_RETRIES}, timeout: ${APT_UPDATE_TIMEOUT}s)..."
+    if timeout "${APT_UPDATE_TIMEOUT}" apt-get update "${APT_OPTS[@]}"; then
+      return 0
+    fi
+    echo "apt-get update attempt ${attempt}/${MAX_RETRIES} failed."
+    if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+      # Clear partially fetched or corrupted indexes so the retry starts clean.
       echo "Cleaning apt lists..."
       rm -rf /var/lib/apt/lists/*
-
-      echo "Retrying in $((5 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: apt-get update failed after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
-
-echo "Installing deferred packages (gstreamer1.0-plugins-ugly, gstreamer1.0-libav, libopencv-core406t64)..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install -y ${APT_OPTS} \
-      gstreamer1.0-plugins-ugly \
-      gstreamer1.0-libav \
-      libopencv-core406t64; then
-    echo "Deferred packages installed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
       echo "Retrying in $((2 * attempt))s..."
       sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to install deferred packages after $MAX_RETRIES attempts"
-      exit 1
     fi
+  done
+  return 1
+}
+
+# Reuse the base image's APT metadata first. Refresh only if installation shows
+# it is stale or a package is unavailable, keeping the normal path offline-fast.
+echo "Installing VIOS runtime media packages..."
+if ! install_packages; then
+  echo "Initial install failed; refreshing APT metadata."
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata after ${MAX_RETRIES} attempts."
+    exit 1
   fi
-done
-
-# Reinstall GStreamer plugins and multimedia libraries (batch 1) with retry logic
-echo "Reinstalling GStreamer plugins and core multimedia libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libv4lconvert0t64 \
-      libjpeg8 libjpeg-turbo8 libpng16-16t64 \
-      gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
-      libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
-      libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \
-      libde265-dev libde265-0 libx265-199 libx264-164 libmpeg2encpp-2.1-0 libmpeg2-4 \
-      libmpg123-0 libbs2b0 libreadline8 libcdio19 libdca0 libdvdnav4 libmjpegutils-2.1-0 \
-      liba52-0.7.4 libdvdread8 libsbc1 libzvbi0 libmp3lame0 libsidplay1v5 liblrdf0 libneon27; then
-    echo "GStreamer plugins installed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall GStreamer plugins after $MAX_RETRIES attempts"
-      exit 1
-    fi
+  if is_dpkg_broken; then
+    echo "Repairing incomplete dpkg state..."
+    dpkg --configure -a
   fi
-done
-
-# Reinstall additional codec libraries (batch 2) with retry logic
-echo "Reinstalling additional codec libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libflac12 libxvidcore4; then
-    echo "Codec libraries installed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall codec libraries after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
-
-# Reinstall libvpx and h264 libraries (batch 3) with retry logic
-echo "Reinstalling libvpx and h264 libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libvpx9 libopenh264-7; then
-    echo "libvpx/h264 libraries installed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall libvpx/h264 libraries after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
+  install_packages
+fi
 
 # OSRB: strip Intel MediaSDK / QuickSync (QSV) codec libs re-pulled as part of the
-# gstreamer1.0-plugins-bad reinstall above. VIOS uses NVIDIA NVENC/NVDEC exclusively;
+# gstreamer1.0-plugins-bad install above. VIOS uses NVIDIA NVENC/NVDEC exclusively.
 echo "Removing unused Intel MediaSDK / QSV (patent watchlist) libraries..."
 for libdir in /usr/lib/*-linux-gnu; do
-  rm -f "$libdir"/mfx/libmfx_*_hw64.so* \
-        "$libdir"/libmfx.so* "$libdir"/libmfxhw64.so* "$libdir"/libmfx-tracer.so* \
-        "$libdir"/gstreamer-1.0/libgstmsdk.so* \
-        "$libdir"/gstreamer-1.0/libgstqsv.so* 2>/dev/null || true
-  rm -rf "$libdir"/mfx 2>/dev/null || true
+  rm -f "${libdir}"/mfx/libmfx_*_hw64.so* \
+        "${libdir}"/libmfx.so* "${libdir}"/libmfxhw64.so* "${libdir}"/libmfx-tracer.so* \
+        "${libdir}"/gstreamer-1.0/libgstmsdk.so* \
+        "${libdir}"/gstreamer-1.0/libgstqsv.so*
+  rm -rf "${libdir}"/mfx
 done
 
-# Clean up GStreamer cache
+# Force GStreamer to rebuild its plugin registry so the newly installed plugins
+# are picked up.
 echo "Cleaning up GStreamer cache..."
 rm -rf ~/.cache/gstreamer-1.0/
 
+install -d "$(dirname "${MARKER_FILE}")"
+date --iso-8601=seconds >"${MARKER_FILE}"
 echo "Installation completed successfully!"

--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -156,11 +156,13 @@ for attempt in $(seq 1 $MAX_RETRIES); do
   fi
 done
 
-# Install gstreamer1.0-libav with retry logic
-echo "Installing gstreamer1.0-libav..."
+echo "Installing deferred packages (gstreamer1.0-plugins-ugly, gstreamer1.0-libav, libopencv-core406t64)..."
 for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install -y ${APT_OPTS} gstreamer1.0-libav; then
-    echo "gstreamer1.0-libav installed successfully"
+  if apt-get install -y ${APT_OPTS} \
+      gstreamer1.0-plugins-ugly \
+      gstreamer1.0-libav \
+      libopencv-core406t64; then
+    echo "Deferred packages installed successfully"
     break
   else
     if [ $attempt -lt $MAX_RETRIES ]; then
@@ -175,7 +177,7 @@ for attempt in $(seq 1 $MAX_RETRIES); do
       echo "Retrying in $((2 * attempt))s..."
       sleep $((2 * attempt))
     else
-      echo "ERROR: Failed to install gstreamer1.0-libav after $MAX_RETRIES attempts"
+      echo "ERROR: Failed to install deferred packages after $MAX_RETRIES attempts"
       exit 1
     fi
   fi

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     user: "0:0"
     entrypoint: ["/bin/bash", "-c", "if [ \"${VST_INSTALL_ADDITIONAL_PACKAGES}\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
       - CONTAINER_NAME=vss-vios-streamprocessing
       - ADAPTOR=${VST_ADAPTOR:-vst_rtsp}
@@ -85,6 +86,7 @@ services:
     user: "0:0"
     entrypoint: ["/bin/bash", "-c", "if [ \"${VST_INSTALL_ADDITIONAL_PACKAGES}\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && bash /home/vst/vst_release/tools/apply_turn_config.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
       - CONTAINER_NAME=vss-vios-streamprocessing
       - ADAPTOR=${VST_ADAPTOR:-vst_rtsp}
@@ -152,6 +154,7 @@ services:
     user: "0:0"
     entrypoint: ["/bin/bash", "-c", "if [ \"${VST_INSTALL_ADDITIONAL_PACKAGES}\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && bash /home/vst/vst_release/tools/apply_turn_config.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
       - CONTAINER_NAME=vss-vios-streamprocessing
       - ADAPTOR=${VST_ADAPTOR:-vst_rtsp}
@@ -221,6 +224,7 @@ services:
     user: "0:0"
     entrypoint: ["/bin/bash", "-c", "if [ \"${VST_INSTALL_ADDITIONAL_PACKAGES}\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && bash /home/vst/vst_release/tools/apply_turn_config.sh && exec /home/vst/vst_release/launch_vst"]
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
       - CONTAINER_NAME=vss-vios-streamprocessing
       - ADAPTOR=${VST_ADAPTOR:-vst_rtsp}

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -193,6 +193,7 @@ echo "Reinstalling GStreamer plugins and core multimedia libraries..."
 for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
       libv4lconvert0t64 \
+      libjpeg8 libjpeg-turbo8 libpng16-16t64 \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
       libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -111,17 +111,49 @@ fi
 
 # Keep public Ubuntu repositories as the default. aarch64 packages are served
 # from Ubuntu Ports; no NVIDIA-internal mirror is required or assumed.
-if [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
-  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
-  cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+#
+# VST_APT_MIRROR overrides the archive for deployments that are far from the
+# public mirrors or behind a restricted egress. Download time is dominated by
+# which mirror answers, not by bandwidth: the same 24.6MB fetch measures ~10s
+# against a close mirror and has been observed to take minutes against a slow
+# or stalled one. Point this at an internal mirror to make startup predictable.
+#
+#   VST_APT_MIRROR=http://mirror.example.com/ubuntu           (x86_64)
+#   VST_APT_MIRROR=http://mirror.example.com/ubuntu-ports     (aarch64)
+if [[ "$(uname -m)" == *"aarch64"* ]]; then
+  APT_MIRROR="${VST_APT_MIRROR:-https://ports.ubuntu.com/ubuntu-ports/}"
+else
+  APT_MIRROR="${VST_APT_MIRROR:-}"
+fi
+
+if [[ -n "${APT_MIRROR}" ]]; then
+  # Trailing slash keeps the generated URIs well formed whichever form is passed.
+  [[ "${APT_MIRROR}" == */ ]] || APT_MIRROR="${APT_MIRROR}/"
+fi
+
+if [[ -n "${VST_APT_MIRROR:-}" ]]; then
+  echo "Using APT mirror: ${APT_MIRROR}"
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<EOF
 Types: deb
-URIs: https://ports.ubuntu.com/ubuntu-ports/
+URIs: ${APT_MIRROR}
+Suites: noble noble-updates noble-security
+Components: main universe
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+  # A mirror supersedes whatever the base image shipped; leaving the original
+  # list in place would send half the requests back to the slow archive.
+  rm -f /etc/apt/sources.list
+elif [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
+  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<EOF
+Types: deb
+URIs: ${APT_MIRROR}
 Suites: noble noble-updates
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 Types: deb
-URIs: https://ports.ubuntu.com/ubuntu-ports/
+URIs: ${APT_MIRROR}
 Suites: noble-security
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
@@ -129,19 +161,57 @@ EOF
 fi
 
 # Handle network-level timeouts gracefully without killing dpkg.
+#
+# HTTP pipelining is left at the APT default. Forcing Pipeline-Depth=0 serialises
+# every request and measured ~40% slower on this package set (13s vs 8s for the
+# same 52 packages / 24.6MB). Set VST_APT_PIPELINE_DEPTH=0 to restore the
+# serialised behaviour if a proxy or mirror mishandles pipelined requests.
+#
+# ForceIPv4 stays on: a host with broken IPv6 otherwise waits for the v6 attempt
+# to time out on every connection.
 APT_OPTS=(
   -o Acquire::http::Timeout=30
   -o Acquire::https::Timeout=30
   -o Acquire::Retries=5
   -o DPkg::Lock::Timeout=60
   -o Acquire::ForceIPv4=true
-  -o Acquire::http::Pipeline-Depth=0
   -o Dpkg::Options::=--force-confdef
   -o Dpkg::Options::=--force-confold
 )
+if [[ -n "${VST_APT_PIPELINE_DEPTH:-}" ]]; then
+  APT_OPTS+=(-o "Acquire::http::Pipeline-Depth=${VST_APT_PIPELINE_DEPTH}")
+fi
+
 
 install_packages() {
   apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
+}
+
+# APT already retries individual downloads (Acquire::Retries), but a connection
+# that drops mid-transaction fails the whole install. Retry the install itself so
+# a brief outage does not fail container startup.
+#
+# Deliberately not wrapped in `timeout`: killing apt-get install midway can leave
+# dpkg half-configured, which is worse than a slow start. Repair between attempts
+# instead -- a failed install is exactly what leaves packages unconfigured, and
+# without this the retry fails the same way.
+install_packages_with_retries() {
+  local attempt
+  for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    if install_packages; then
+      return 0
+    fi
+    echo "apt-get install attempt ${attempt}/${MAX_RETRIES} failed."
+    if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+      if is_dpkg_broken; then
+        echo "Repairing incomplete dpkg state before retry..."
+        dpkg --configure -a || true
+      fi
+      echo "Retrying in $((2 * attempt))s..."
+      sleep $((2 * attempt))
+    fi
+  done
+  return 1
 }
 
 refresh_apt_metadata() {
@@ -163,6 +233,19 @@ refresh_apt_metadata() {
   return 1
 }
 
+# A mirror override invalidates the metadata the base image ships, which is
+# indexed against the default archive. Measured: with a mirror configured and the
+# shipped lists in place, apt resolves no download URI at all, so the fast path
+# below would fail and only then refresh. Refresh up front instead of paying for
+# a doomed attempt first.
+if [[ -n "${VST_APT_MIRROR:-}" ]]; then
+  echo "APT mirror configured; refreshing metadata before install."
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata from ${APT_MIRROR}."
+    exit 1
+  fi
+fi
+
 # Reuse the base image's APT metadata first. Refresh only if installation shows
 # it is stale or a package is unavailable, keeping the normal path offline-fast.
 echo "Installing VIOS runtime media packages..."
@@ -176,7 +259,10 @@ if ! install_packages; then
     echo "Repairing incomplete dpkg state..."
     dpkg --configure -a
   fi
-  install_packages
+  if ! install_packages_with_retries; then
+    echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
+    exit 1
+  fi
 fi
 
 # OSRB: strip Intel MediaSDK / QuickSync (QSV) codec libs re-pulled as part of the

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -192,6 +192,7 @@ done
 echo "Reinstalling GStreamer plugins and core multimedia libraries..."
 for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
+      libv4lconvert0t64 \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
       libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -24,6 +24,10 @@
 # makes the restart path free.
 set -e  # Exit on any error
 
+# The base image may preload libraries that are restored by this installer.
+# Do not pass unavailable preload paths to apt/dpkg helper processes.
+unset LD_PRELOAD
+
 # Ensure non-interactive mode for apt operations
 export DEBIAN_FRONTEND=noninteractive
 

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -161,11 +161,13 @@ for attempt in $(seq 1 $MAX_RETRIES); do
   fi
 done
 
-# Install gstreamer1.0-libav with retry logic
-echo "Installing gstreamer1.0-libav..."
+echo "Installing deferred packages (gstreamer1.0-plugins-ugly, gstreamer1.0-libav, libopencv-core406t64)..."
 for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install -y ${APT_OPTS} gstreamer1.0-libav; then
-    echo "gstreamer1.0-libav installed successfully"
+  if apt-get install -y ${APT_OPTS} \
+      gstreamer1.0-plugins-ugly \
+      gstreamer1.0-libav \
+      libopencv-core406t64; then
+    echo "Deferred packages installed successfully"
     break
   else
     if [ $attempt -lt $MAX_RETRIES ]; then
@@ -180,7 +182,7 @@ for attempt in $(seq 1 $MAX_RETRIES); do
       echo "Retrying in $((2 * attempt))s..."
       sleep $((2 * attempt))
     else
-      echo "ERROR: Failed to install gstreamer1.0-libav after $MAX_RETRIES attempts"
+      echo "ERROR: Failed to install deferred packages after $MAX_RETRIES attempts"
       exit 1
     fi
   fi

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -13,106 +15,101 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env bash
+# Install the media packages VIOS needs at runtime, before launch_vst. The base
+# image ships without them (and deletes the files of the ones that arrive as
+# transitive dependencies), so this script restores them on first start.
+#
+# Keep this idempotent: a retained container does not need an APT transaction on
+# restart. The marker file plus a spot check of the installed libraries is what
+# makes the restart path free.
 set -e  # Exit on any error
 
 # Ensure non-interactive mode for apt operations
 export DEBIAN_FRONTEND=noninteractive
 
-# Random initial sleep (0-5 seconds) to stagger container starts
-INITIAL_SLEEP=$((RANDOM % 6))
+FORCE_INSTALL="${VST_FORCE_ADDITIONAL_PACKAGES_INSTALL:-false}"
 
-# Generate random timeout to avoid thundering herd problem
-APT_UPDATE_TIMEOUT=$((200 + RANDOM % 101))    # 200-300 seconds for apt-get update
-MAX_RETRIES=3
+# Randomized timeout avoids a thundering herd when several replicas (5 nvstreamers
+# plus stream-processing) cold-start against the same mirror at once.
+APT_UPDATE_TIMEOUT="${VST_APT_UPDATE_TIMEOUT:-$((200 + RANDOM % 101))}"
+MAX_RETRIES="${VST_APT_MAX_RETRIES:-3}"
 
-echo "Staggering start with ${INITIAL_SLEEP}s delay..."
-sleep ${INITIAL_SLEEP}
+# Runtime libraries only; development packages are intentionally excluded.
+#
+# The four top-level entries are what VIOS actually needs. Everything below them
+# arrives as a transitive dependency, but the base image deletes the files of the
+# ones it already has installed, so they must be listed explicitly for
+# --reinstall to restore them.
+RUNTIME_PACKAGES=(
+  gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+  gstreamer1.0-plugins-ugly gstreamer1.0-libav
+  libopencv-core406t64 libv4lconvert0t64
+  # JPEG and PNG are pruned from the base image and restored here; the packaged
+  # application links them for snapshot and image encoding.
+  libjpeg8 libjpeg-turbo8 libpng16-16t64
+  libvo-aacenc0 libfaad2 libswresample4 libavutil58 libswscale7 libpostproc57
+  libavcodec60 libavformat60 libavfilter9 libde265-0 libx265-199 libx264-164
+  libmpeg2encpp-2.1-0t64 libmpeg2-4 libmpg123-0t64 libbs2b0 libreadline8t64
+  libcdio19t64 libdca0 libdvdnav4 libmjpegutils-2.1-0t64 liba52-0.7.4
+  libdvdread8t64 libsbc1 libzvbi0t64 libmp3lame0 libsidplay1v5 liblrdf0
+  libneon27t64 libflac12t64 libxvidcore4 libvpx9 libopenh264-7
+  # libavcodec/libavformat link these directly. The base image deletes their
+  # files (they arrive as plugins-base/good dependencies), so without an
+  # explicit --reinstall the libav dlopen in LibavWrapper fails and file upload
+  # cannot read duration/codec. libgstlibav.so needs the same set.
+  libogg0 libvorbis0a libvorbisenc2 libopus0 libspeex1 libtheora0 libtwolame0
+  libwebp7 libsharpyuv0
+)
 
-# Function to check if dpkg is in a broken state
+# The marker is keyed on the package list itself, so editing RUNTIME_PACKAGES
+# automatically invalidates markers written by an older revision of this script.
+# Without this, a container that completed an install with a previous list would
+# skip forever and never pick up newly added packages.
+PACKAGE_SET_ID="$(printf '%s\n' "${RUNTIME_PACKAGES[@]}" | md5sum | cut -c1-10)"
+MARKER_FILE="${VST_ADDITIONAL_PACKAGES_MARKER:-/var/lib/vios/additional-packages-installed-${PACKAGE_SET_ID}}"
+
 is_dpkg_broken() {
-  # Check for packages in bad state (Half-installed, Unpacked, Reinst-required)
-  if dpkg -l 2>/dev/null | grep -qE "^[HUR]"; then
-    return 0  # dpkg is broken
-  fi
-
-  # Check dpkg audit for issues
-  if dpkg --audit 2>&1 | grep -q .; then
-    return 0  # dpkg has issues
-  fi
-
-  return 1  # dpkg is healthy
+  dpkg --audit 2>/dev/null | grep -q .
 }
 
-# Function to fix dpkg state
-fix_dpkg() {
-  echo "Fixing dpkg state..."
-
-  # SAFETY: Check if apt/dpkg is already running before touching locks
-  if pgrep -x apt-get >/dev/null 2>&1 || pgrep -x dpkg >/dev/null 2>&1 || pgrep -x apt >/dev/null 2>&1; then
-    echo "Package manager is currently running, cannot safely fix dpkg state"
-    echo "Waiting for package manager to complete..."
-    return 1
-  fi
-
-  # Remove stale lock files (safe now that we checked for running processes)
-  echo "Removing stale lock files..."
-  rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
-
-  # Try to configure any pending packages
-  dpkg --configure -a 2>/dev/null || true
-
-  # Find and remove packages in bad state
-  BAD_PKGS=$(dpkg -l 2>/dev/null | grep -E "^[HUR]" | awk '{print $2}' || true)
-  if [ -n "$BAD_PKGS" ]; then
-    echo "Removing packages in bad state: $BAD_PKGS"
-    for pkg in $BAD_PKGS; do
-      dpkg --remove --force-remove-reinstreq "$pkg" 2>/dev/null || true
+# Sentinels for the package groups this script installs: plugins-bad, libav and
+# libv4lconvert (whose files the base image deletes).
+#
+# Existence alone is not enough. The base image deletes libraries that libav and
+# several plugins link against, which leaves the plugin file on disk but
+# unloadable -- that is exactly how avdec_* silently disappeared while every
+# sentinel still "existed". Check that each one actually resolves.
+runtime_present() {
+  local required match
+  for required in \
+    /usr/lib/*-linux-gnu/libv4lconvert.so.0 \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstvideoparsersbad.so \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstmpegtsmux.so \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstlibav.so; do
+    compgen -G "${required}" >/dev/null || return 1
+    for match in ${required}; do
+      if ldd "${match}" 2>/dev/null | grep -q "not found"; then
+        return 1
+      fi
     done
-  fi
-
-  # Verify fix worked
-  if is_dpkg_broken; then
-    echo "WARNING: dpkg may still have issues after fix attempt"
-    return 1
-  fi
-
-  echo "dpkg state fixed successfully"
-  return 0
+  done
 }
 
-echo "Checking and fixing dpkg state..."
-if ! fix_dpkg; then
-  echo "WARNING: Could not fix dpkg state (package manager may be running)"
-  echo "Proceeding with caution - DPkg::Lock::Timeout will handle lock contention"
+if [[ "${FORCE_INSTALL}" != "true" && -f "${MARKER_FILE}" ]] && runtime_present; then
+  echo "Additional packages already installed; skipping APT."
+  exit 0
 fi
 
-# APT acquire options for robustness and performance
-# These handle network-level timeouts gracefully without killing dpkg
-APT_OPTS="-o Acquire::http::Timeout=30 \
--o Acquire::https::Timeout=30 \
--o Acquire::Retries=5 \
--o DPkg::Lock::Timeout=60 \
--o Acquire::ForceIPv4=true \
--o Acquire::http::Pipeline-Depth=0 \
--o Acquire::http::No-Cache=true \
--o Dpkg::Options::=--force-confdef \
--o Dpkg::Options::=--force-confold"
+if is_dpkg_broken; then
+  echo "Repairing incomplete dpkg state..."
+  dpkg --configure -a
+fi
 
-echo "Starting package installation for Ubuntu 24.04..."
-
-# Optimize APT sources to only include necessary suites and components (HTTPS)
-echo "Configuring APT sources for optimal performance..."
-
-# Detect architecture - only modify sources for aarch64
-ARCH=$(uname -m)
-if [[ "$ARCH" == *"aarch64"* ]]; then
-    # Skip modification if already configured with HTTPS ports.ubuntu.com
-    if [ -f /etc/apt/sources.list.d/ubuntu.sources ] && grep -q "https://ports.ubuntu.com" /etc/apt/sources.list.d/ubuntu.sources; then
-        echo "APT sources already configured with HTTPS ports.ubuntu.com, skipping modification..."
-    else
-        echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
-        cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+# Keep public Ubuntu repositories as the default. aarch64 packages are served
+# from Ubuntu Ports; no NVIDIA-internal mirror is required or assumed.
+if [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
+  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
 Types: deb
 URIs: https://ports.ubuntu.com/ubuntu-ports/
 Suites: noble noble-updates
@@ -125,167 +122,75 @@ Suites: noble-security
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
-    fi
 fi
 
-# Run apt-get update with timeout and retry logic
-echo "Running apt-get update (timeout: ${APT_UPDATE_TIMEOUT}s)..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if timeout ${APT_UPDATE_TIMEOUT}s apt-get update ${APT_OPTS}; then
-    echo "apt-get update completed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "apt-get update attempt $attempt/$MAX_RETRIES failed"
+# Handle network-level timeouts gracefully without killing dpkg.
+APT_OPTS=(
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+  -o Acquire::Retries=5
+  -o DPkg::Lock::Timeout=60
+  -o Acquire::ForceIPv4=true
+  -o Acquire::http::Pipeline-Depth=0
+  -o Dpkg::Options::=--force-confdef
+  -o Dpkg::Options::=--force-confold
+)
 
-      # SAFE lock cleanup: only if locks exist AND no process running
-      if [ -f /var/lib/dpkg/lock-frontend ] || [ -f /var/lib/dpkg/lock ]; then
-        if ! pgrep -x apt-get >/dev/null 2>&1 && ! pgrep -x dpkg >/dev/null 2>&1 && ! pgrep -x apt >/dev/null 2>&1; then
-          echo "Found stale lock files, clearing..."
-          rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
-        else
-          echo "Lock files present but package manager running in another process"
-        fi
-      fi
+install_packages() {
+  apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
+}
 
-      # Clean corrupted apt lists for fresh retry
+refresh_apt_metadata() {
+  local attempt
+  for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    echo "Running apt-get update (attempt ${attempt}/${MAX_RETRIES}, timeout: ${APT_UPDATE_TIMEOUT}s)..."
+    if timeout "${APT_UPDATE_TIMEOUT}" apt-get update "${APT_OPTS[@]}"; then
+      return 0
+    fi
+    echo "apt-get update attempt ${attempt}/${MAX_RETRIES} failed."
+    if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+      # Clear partially fetched or corrupted indexes so the retry starts clean.
       echo "Cleaning apt lists..."
       rm -rf /var/lib/apt/lists/*
-
-      echo "Retrying in $((5 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: apt-get update failed after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
-
-echo "Installing deferred packages (gstreamer1.0-plugins-ugly, gstreamer1.0-libav, libopencv-core406t64)..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install -y ${APT_OPTS} \
-      gstreamer1.0-plugins-ugly \
-      gstreamer1.0-libav \
-      libopencv-core406t64; then
-    echo "Deferred packages installed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
       echo "Retrying in $((2 * attempt))s..."
       sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to install deferred packages after $MAX_RETRIES attempts"
-      exit 1
     fi
+  done
+  return 1
+}
+
+# Reuse the base image's APT metadata first. Refresh only if installation shows
+# it is stale or a package is unavailable, keeping the normal path offline-fast.
+echo "Installing VIOS runtime media packages..."
+if ! install_packages; then
+  echo "Initial install failed; refreshing APT metadata."
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata after ${MAX_RETRIES} attempts."
+    exit 1
   fi
-done
-
-# Reinstall GStreamer plugins and multimedia libraries (batch 1) with retry logic
-echo "Reinstalling GStreamer plugins and core multimedia libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libv4lconvert0t64 \
-      libjpeg8 libjpeg-turbo8 libpng16-16t64 \
-      gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
-      libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
-      libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \
-      libde265-dev libde265-0 libx265-199 libx264-164 libmpeg2encpp-2.1-0 libmpeg2-4 \
-      libmpg123-0 libbs2b0 libreadline8 libcdio19 libdca0 libdvdnav4 libmjpegutils-2.1-0 \
-      liba52-0.7.4 libdvdread8 libsbc1 libzvbi0 libmp3lame0 libsidplay1v5 liblrdf0 libneon27; then
-    echo "GStreamer plugins installed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall GStreamer plugins after $MAX_RETRIES attempts"
-      exit 1
-    fi
+  if is_dpkg_broken; then
+    echo "Repairing incomplete dpkg state..."
+    dpkg --configure -a
   fi
-done
-
-# Reinstall additional codec libraries (batch 2) with retry logic
-echo "Reinstalling additional codec libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libflac12 libxvidcore4; then
-    echo "Codec libraries installed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall codec libraries after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
-
-# Reinstall libvpx and h264 libraries (batch 3) with retry logic
-echo "Reinstalling libvpx and h264 libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libvpx9 libopenh264-7; then
-    echo "libvpx/h264 libraries installed successfully"
-    break
-  else
-    if [ $attempt -lt $MAX_RETRIES ]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall libvpx/h264 libraries after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
+  install_packages
+fi
 
 # OSRB: strip Intel MediaSDK / QuickSync (QSV) codec libs re-pulled as part of the
-# gstreamer1.0-plugins-bad reinstall above. VIOS uses NVIDIA NVENC/NVDEC exclusively;
+# gstreamer1.0-plugins-bad install above. VIOS uses NVIDIA NVENC/NVDEC exclusively.
 echo "Removing unused Intel MediaSDK / QSV (patent watchlist) libraries..."
 for libdir in /usr/lib/*-linux-gnu; do
-  rm -f "$libdir"/mfx/libmfx_*_hw64.so* \
-        "$libdir"/libmfx.so* "$libdir"/libmfxhw64.so* "$libdir"/libmfx-tracer.so* \
-        "$libdir"/gstreamer-1.0/libgstmsdk.so* \
-        "$libdir"/gstreamer-1.0/libgstqsv.so* 2>/dev/null || true
-  rm -rf "$libdir"/mfx 2>/dev/null || true
+  rm -f "${libdir}"/mfx/libmfx_*_hw64.so* \
+        "${libdir}"/libmfx.so* "${libdir}"/libmfxhw64.so* "${libdir}"/libmfx-tracer.so* \
+        "${libdir}"/gstreamer-1.0/libgstmsdk.so* \
+        "${libdir}"/gstreamer-1.0/libgstqsv.so*
+  rm -rf "${libdir}"/mfx
 done
 
-# Clean up GStreamer cache
+# Force GStreamer to rebuild its plugin registry so the newly installed plugins
+# are picked up.
 echo "Cleaning up GStreamer cache..."
 rm -rf ~/.cache/gstreamer-1.0/
 
+install -d "$(dirname "${MARKER_FILE}")"
+date --iso-8601=seconds >"${MARKER_FILE}"
 echo "Installation completed successfully!"

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/templates/deployment.yaml
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/templates/deployment.yaml
@@ -136,6 +136,8 @@ spec:
               value: {{ .Values.env.NVSTREAMER_UI_BASE_PATH | quote }}
             - name: NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES
               value: {{ .Values.env.NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES | quote }}
+            - name: VST_APT_MIRROR
+              value: {{ .Values.env.VST_APT_MIRROR | default "" | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/values.yaml
@@ -37,6 +37,8 @@ env:
   # Public UI/API path. A non-empty value requires the upstream proxy to strip it.
   NVSTREAMER_UI_BASE_PATH: ""
   NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES: "true"
+  # Point APT at an internal/nearby mirror. Empty uses the public archive.
+  VST_APT_MIRROR: ""
 
 service:
   port: 31000

--- a/deploy/helm/services/vios/charts/vios-streamprocessing/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-streamprocessing/values.yaml
@@ -80,6 +80,9 @@ env:
   # Set to "true" to run user_additional_install.sh at startup (installs e.g. libav/ffmpeg for upload media info). Script must exist in image at /home/vst/vst_release/tools/user_additional_install.sh.
   - name: VST_INSTALL_ADDITIONAL_PACKAGES
     value: "true"
+  # Point APT at an internal/nearby mirror. Empty uses the public archive.
+  - name: VST_APT_MIRROR
+    value: ""
   - name: CONTAINER_NAME
     value: vss-vios-streamprocessing
   - name: ADAPTOR

--- a/services/video-summarization/docker/base/user_additional_install.sh
+++ b/services/video-summarization/docker/base/user_additional_install.sh
@@ -14,6 +14,10 @@
 # limitations under the License.
 
 # additional components the user can self install
+# The base image may preload libraries that are restored by this installer.
+# Do not pass unavailable preload paths to apt/dpkg helper processes.
+unset LD_PRELOAD
+
 apt-get update
 #apt-get install -y gstreamer1.0-libav
 #backup librtsp to tmp

--- a/services/vios/cicd_files/aarch64/Dockerfile.app
+++ b/services/vios/cicd_files/aarch64/Dockerfile.app
@@ -17,7 +17,7 @@
 # build.sh always passes this in for you: it builds a base locally, reuses an
 # existing one, or uses a registry image you point it at (base-tag= /
 # image-registry=). One tag works for both x86_64 and arm64 (if it is a multi-arch image).
-ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.07.2
+ARG BASE_IMAGE=vios/vst-base:1.4.0-runtime-26.08.1
 FROM ${BASE_IMAGE}
 
 ARG PKG_LOCATION

--- a/services/vios/cicd_files/aarch64/Dockerfile.app
+++ b/services/vios/cicd_files/aarch64/Dockerfile.app
@@ -17,7 +17,7 @@
 # build.sh always passes this in for you: it builds a base locally, reuses an
 # existing one, or uses a registry image you point it at (base-tag= /
 # image-registry=). One tag works for both x86_64 and arm64 (if it is a multi-arch image).
-ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.07.1
+ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.07.2
 FROM ${BASE_IMAGE}
 
 ARG PKG_LOCATION

--- a/services/vios/cicd_files/aarch64/Dockerfile.base
+++ b/services/vios/cicd_files/aarch64/Dockerfile.base
@@ -26,10 +26,8 @@ RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y --no-install-recommends \
 	libuuid1 \
 	gstreamer1.0-plugins-base \
 	gstreamer1.0-plugins-good \
-	gstreamer1.0-plugins-ugly \
 	gstreamer1.0-plugins-bad \
 	libgstreamer1.0-0 \
-	gstreamer1.0-libav \
 	libgstreamer-plugins-base1.0-0 \
 	libboost-filesystem1.83.0 \
 	libboost-thread1.83.0 \
@@ -40,7 +38,6 @@ RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y --no-install-recommends \
 	libhiredis1.1.0 \
 	libpaho-mqttpp3-1 \
 	libprotobuf32t64 \
-	libopencv-core406t64 \
 	libgrpc++1.51t64 \
 	kmod \
 	&& apt-get clean
@@ -94,6 +91,57 @@ RUN rm -f /usr/lib/aarch64-linux-gnu/mfx/libmfx_h264la_hw64.so*
 RUN rm -f /usr/lib/aarch64-linux-gnu/libswscale.* \
         /usr/lib/aarch64-linux-gnu/libswresample.* \
         /usr/lib/aarch64-linux-gnu/libpostproc.*
+
+# Prune codec libraries and GStreamer codec plugins not selected by VIOS.  Keep
+# the JPEG/PNG and XML dependencies required by the packaged application.
+RUN rm -f /usr/lib/aarch64-linux-gnu/libaom.so* \
+        /usr/lib/aarch64-linux-gnu/libdv.so* \
+        /usr/lib/aarch64-linux-gnu/libflite.so* \
+        /usr/lib/aarch64-linux-gnu/libfluidsynth.so* \
+        /usr/lib/aarch64-linux-gnu/libfreeaptx.so* \
+        /usr/lib/aarch64-linux-gnu/libgme.so* \
+        /usr/lib/aarch64-linux-gnu/libgsm.so* \
+        /usr/lib/aarch64-linux-gnu/libgssdp-1.6.so* \
+        /usr/lib/aarch64-linux-gnu/libinstpatch-1.0.so* \
+        /usr/lib/aarch64-linux-gnu/libjbig.so* \
+        /usr/lib/aarch64-linux-gnu/liblcms2.so* \
+        /usr/lib/aarch64-linux-gnu/libogg.so* \
+        /usr/lib/aarch64-linux-gnu/libOpenEXR*.so* \
+        /usr/lib/aarch64-linux-gnu/libopenjp2.so* \
+        /usr/lib/aarch64-linux-gnu/libopus.so* \
+        /usr/lib/aarch64-linux-gnu/libspandsp.so* \
+        /usr/lib/aarch64-linux-gnu/libspeex.so* \
+        /usr/lib/aarch64-linux-gnu/libSvtAv1Enc.so* \
+        /usr/lib/aarch64-linux-gnu/libtheora*.so* \
+        /usr/lib/aarch64-linux-gnu/libtiff.so* \
+        /usr/lib/aarch64-linux-gnu/libtwolame.so* \
+        /usr/lib/aarch64-linux-gnu/libvo-amrwbenc.so* \
+        /usr/lib/aarch64-linux-gnu/libvorbis*.so* \
+        /usr/lib/aarch64-linux-gnu/libwavpack.so* \
+        /usr/lib/aarch64-linux-gnu/libwebp.so* \
+        /usr/lib/aarch64-linux-gnu/libwebpmux.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstaom.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstcolormanagement.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstdv.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstflite.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstfluidsynthmidi.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstgme.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstgsm.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstogg.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopenaptx.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopenexr.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopenjpeg.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopus.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopusparse.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstspandsp.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstspeex.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstsvtav1.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgsttheora.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgsttwolame.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvoamrwbenc.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvorbis.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwavpack.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwebp.so*
 
 RUN rm -f /usr/lib/aarch64-linux-gnu/liba52* /usr/lib/aarch64-linux-gnu/libcdio.so* /usr/lib/aarch64-linux-gnu/libsidplay.so* \
 		/usr/lib/aarch64-linux-gnu/liblrdf.so*  /usr/lib/aarch64-linux-gnu/libneon.so* \

--- a/services/vios/cicd_files/aarch64/Dockerfile.base
+++ b/services/vios/cicd_files/aarch64/Dockerfile.base
@@ -26,7 +26,6 @@ RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y --no-install-recommends \
 	libuuid1 \
 	gstreamer1.0-plugins-base \
 	gstreamer1.0-plugins-good \
-	gstreamer1.0-plugins-bad \
 	libgstreamer1.0-0 \
 	libgstreamer-plugins-base1.0-0 \
 	libboost-filesystem1.83.0 \
@@ -95,6 +94,8 @@ RUN rm -f /usr/lib/aarch64-linux-gnu/libswscale.* \
 # Prune codec libraries and GStreamer codec plugins not selected by VIOS.  Keep
 # the JPEG/PNG and XML dependencies required by the packaged application.
 RUN rm -f /usr/lib/aarch64-linux-gnu/libaom.so* \
+        /usr/lib/aarch64-linux-gnu/libldacBT_enc.so* \
+        /usr/lib/aarch64-linux-gnu/liblc3.so* \
         /usr/lib/aarch64-linux-gnu/libdv.so* \
         /usr/lib/aarch64-linux-gnu/libflite.so* \
         /usr/lib/aarch64-linux-gnu/libfluidsynth.so* \
@@ -107,6 +108,10 @@ RUN rm -f /usr/lib/aarch64-linux-gnu/libaom.so* \
         /usr/lib/aarch64-linux-gnu/liblcms2.so* \
         /usr/lib/aarch64-linux-gnu/libogg.so* \
         /usr/lib/aarch64-linux-gnu/libOpenEXR*.so* \
+        /usr/lib/aarch64-linux-gnu/libopenmpt.so* \
+        /usr/lib/aarch64-linux-gnu/libmodplug.so* \
+        /usr/lib/aarch64-linux-gnu/libmpcdec.so* \
+        /usr/lib/aarch64-linux-gnu/libWildMidi.so* \
         /usr/lib/aarch64-linux-gnu/libopenjp2.so* \
         /usr/lib/aarch64-linux-gnu/libopus.so* \
         /usr/lib/aarch64-linux-gnu/libspandsp.so* \
@@ -120,28 +125,49 @@ RUN rm -f /usr/lib/aarch64-linux-gnu/libaom.so* \
         /usr/lib/aarch64-linux-gnu/libwavpack.so* \
         /usr/lib/aarch64-linux-gnu/libwebp.so* \
         /usr/lib/aarch64-linux-gnu/libwebpmux.so* \
+        /usr/lib/aarch64-linux-gnu/libsharpyuv.so* \
+        /usr/lib/aarch64-linux-gnu/libavc1394.so* \
+        /usr/lib/aarch64-linux-gnu/librom1394.so* \
+        /usr/lib/aarch64-linux-gnu/libiec61883.so* \
+        /usr/lib/aarch64-linux-gnu/libdc1394.so* \
+        /usr/lib/aarch64-linux-gnu/libcdda_interface.so* \
+        /usr/lib/aarch64-linux-gnu/libcdda_paranoia.so* \
+        /usr/lib/aarch64-linux-gnu/libchromaprint.so* \
+        /usr/lib/aarch64-linux-gnu/libv4lconvert.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstaom.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgst1394.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstcdparanoia.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstchromaprint.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstcolormanagement.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstdv.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstdc1394.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstflite.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstfluidsynthmidi.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstgme.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstgsm.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstlc3.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstldac.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstmidi.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstmodplug.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstogg.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopenaptx.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopenexr.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopenjpeg.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopenmpt.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopus.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstopusparse.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstspandsp.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstspeex.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstsvtav1.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgsttheora.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstteletext.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgsttwolame.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvoamrwbenc.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvorbis.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwavpack.so* \
-        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwebp.so*
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwebp.so* \
+        /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwildmidi.so* \
+        /usr/share/sounds/sf2/TimGM6mb.sf2
 
 RUN rm -f /usr/lib/aarch64-linux-gnu/liba52* /usr/lib/aarch64-linux-gnu/libcdio.so* /usr/lib/aarch64-linux-gnu/libsidplay.so* \
 		/usr/lib/aarch64-linux-gnu/liblrdf.so*  /usr/lib/aarch64-linux-gnu/libneon.so* \

--- a/services/vios/cicd_files/aarch64/Dockerfile.base
+++ b/services/vios/cicd_files/aarch64/Dockerfile.base
@@ -91,8 +91,8 @@ RUN rm -f /usr/lib/aarch64-linux-gnu/libswscale.* \
         /usr/lib/aarch64-linux-gnu/libswresample.* \
         /usr/lib/aarch64-linux-gnu/libpostproc.*
 
-# Prune codec libraries and GStreamer codec plugins not selected by VIOS.  Keep
-# the JPEG/PNG and XML dependencies required by the packaged application.
+# Prune codec libraries and GStreamer codec plugins not selected by VIOS. XML
+# remains in the base image; JPEG/PNG are restored by the optional installer.
 RUN rm -f /usr/lib/aarch64-linux-gnu/libaom.so* \
         /usr/lib/aarch64-linux-gnu/libldacBT_enc.so* \
         /usr/lib/aarch64-linux-gnu/liblc3.so* \
@@ -134,6 +134,8 @@ RUN rm -f /usr/lib/aarch64-linux-gnu/libaom.so* \
         /usr/lib/aarch64-linux-gnu/libcdda_paranoia.so* \
         /usr/lib/aarch64-linux-gnu/libchromaprint.so* \
         /usr/lib/aarch64-linux-gnu/libv4lconvert.so* \
+        /usr/lib/aarch64-linux-gnu/libjpeg.so* \
+        /usr/lib/aarch64-linux-gnu/libpng16.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstaom.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgst1394.so* \
         /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstcdparanoia.so* \

--- a/services/vios/cicd_files/aarch64/Dockerfile.base
+++ b/services/vios/cicd_files/aarch64/Dockerfile.base
@@ -15,9 +15,13 @@
 
 FROM nvcr.io/nvidia/cuda:13.2.0-runtime-ubuntu24.04
 
-RUN apt-get update && apt-get upgrade -y
-
-RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y --no-install-recommends \
+# Keep the index refresh in the same layer as the install. Splitting them lets
+# Docker reuse a cached "apt-get update" while the install runs fresh, and once
+# Ubuntu supersedes a package the cached index points at a .deb that no longer
+# exists on ports.ubuntu.com, failing the build with a 404.
+RUN apt-get update && \
+	apt-get upgrade -y && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	libcurl4 \
 	libxml2 \
 	libssl3t64 \

--- a/services/vios/cicd_files/aarch64/Dockerfile.base
+++ b/services/vios/cicd_files/aarch64/Dockerfile.base
@@ -20,32 +20,35 @@ RUN apt-get update && apt-get upgrade -y
 RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y --no-install-recommends \
 	libcurl4 \
 	libxml2 \
-	libssl-dev \
-	libjsoncpp-dev \
-	sqlite3 \
-	uuid \
+	libssl3t64 \
+	libjsoncpp25 \
+	libsqlite3-0 \
+	libuuid1 \
 	gstreamer1.0-plugins-base \
 	gstreamer1.0-plugins-good \
 	gstreamer1.0-plugins-ugly \
 	gstreamer1.0-plugins-bad \
 	libgstreamer1.0-0 \
 	gstreamer1.0-libav \
-	libgstreamer-plugins-base1.0 \
-	libboost-filesystem-dev \
-	libboost-regex-dev \
-	libboost-thread-dev \
+	libgstreamer-plugins-base1.0-0 \
+	libboost-filesystem1.83.0 \
+	libboost-thread1.83.0 \
 	iptables \
-	librdkafka-dev \
+	librdkafka1 \
 	v4l-utils \
-	libpq-dev \
-	libpqxx-dev \
+	libpqxx-7.8t64 \
 	libhiredis1.1.0 \
-	libpaho-mqttpp-dev \
-	libprotobuf-dev \
-	libopencv-dev \
-	libgrpc++-dev libgrpc-dev \
+	libpaho-mqttpp3-1 \
+	libprotobuf32t64 \
+	libopencv-core406t64 \
+	libgrpc++1.51t64 \
 	kmod \
 	&& apt-get clean
+
+# Kafka producer/consumer load the unversioned name with dlopen(). The runtime
+# package only ships the SONAME; provide the linker-name symlink without
+# installing librdkafka-dev in the release image.
+RUN ln -s /usr/lib/aarch64-linux-gnu/librdkafka.so.1 /usr/lib/aarch64-linux-gnu/librdkafka.so
 
 # To get video driver libraries at runtime (libnvidia-encode.so/libnvcuvid.so)
 ENV NVIDIA_DRIVER_CAPABILITIES=$NVIDIA_DRIVER_CAPABILITIES,video

--- a/services/vios/cicd_files/x86_64/Dockerfile.app
+++ b/services/vios/cicd_files/x86_64/Dockerfile.app
@@ -17,7 +17,7 @@
 # build.sh always passes this in for you: it builds a base locally, reuses an
 # existing one, or uses a registry image you point it at (base-tag= /
 # image-registry=). One tag works for both x86_64 and arm64 (if it is a multi-arch image).
-ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.07.2
+ARG BASE_IMAGE=vios/vst-base:1.4.0-runtime-26.08.1
 FROM ${BASE_IMAGE}
 
 ARG PKG_LOCATION

--- a/services/vios/cicd_files/x86_64/Dockerfile.app
+++ b/services/vios/cicd_files/x86_64/Dockerfile.app
@@ -17,7 +17,7 @@
 # build.sh always passes this in for you: it builds a base locally, reuses an
 # existing one, or uses a registry image you point it at (base-tag= /
 # image-registry=). One tag works for both x86_64 and arm64 (if it is a multi-arch image).
-ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.07.1
+ARG BASE_IMAGE=vios/vst-base:2.1.0-runtime-26.07.2
 FROM ${BASE_IMAGE}
 
 ARG PKG_LOCATION

--- a/services/vios/cicd_files/x86_64/Dockerfile.base
+++ b/services/vios/cicd_files/x86_64/Dockerfile.base
@@ -26,7 +26,6 @@ RUN apt-get update && \
         libuuid1 \
         gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-good \
-        gstreamer1.0-plugins-bad \
         libgstreamer1.0-0 \
         libgstreamer-plugins-base1.0-0 \
         libboost-filesystem1.83.0 \
@@ -95,6 +94,8 @@ RUN rm -f /usr/lib/x86_64-linux-gnu/libswscale.* \
 # Prune codec libraries and GStreamer codec plugins not selected by VIOS.  Keep
 # the JPEG/PNG and XML dependencies required by the packaged application.
 RUN rm -f /usr/lib/x86_64-linux-gnu/libaom.so* \
+        /usr/lib/x86_64-linux-gnu/libldacBT_enc.so* \
+        /usr/lib/x86_64-linux-gnu/liblc3.so* \
         /usr/lib/x86_64-linux-gnu/libdv.so* \
         /usr/lib/x86_64-linux-gnu/libflite.so* \
         /usr/lib/x86_64-linux-gnu/libfluidsynth.so* \
@@ -107,6 +108,10 @@ RUN rm -f /usr/lib/x86_64-linux-gnu/libaom.so* \
         /usr/lib/x86_64-linux-gnu/liblcms2.so* \
         /usr/lib/x86_64-linux-gnu/libogg.so* \
         /usr/lib/x86_64-linux-gnu/libOpenEXR*.so* \
+        /usr/lib/x86_64-linux-gnu/libopenmpt.so* \
+        /usr/lib/x86_64-linux-gnu/libmodplug.so* \
+        /usr/lib/x86_64-linux-gnu/libmpcdec.so* \
+        /usr/lib/x86_64-linux-gnu/libWildMidi.so* \
         /usr/lib/x86_64-linux-gnu/libopenjp2.so* \
         /usr/lib/x86_64-linux-gnu/libopus.so* \
         /usr/lib/x86_64-linux-gnu/libspandsp.so* \
@@ -120,28 +125,49 @@ RUN rm -f /usr/lib/x86_64-linux-gnu/libaom.so* \
         /usr/lib/x86_64-linux-gnu/libwavpack.so* \
         /usr/lib/x86_64-linux-gnu/libwebp.so* \
         /usr/lib/x86_64-linux-gnu/libwebpmux.so* \
+        /usr/lib/x86_64-linux-gnu/libsharpyuv.so* \
+        /usr/lib/x86_64-linux-gnu/libavc1394.so* \
+        /usr/lib/x86_64-linux-gnu/librom1394.so* \
+        /usr/lib/x86_64-linux-gnu/libiec61883.so* \
+        /usr/lib/x86_64-linux-gnu/libdc1394.so* \
+        /usr/lib/x86_64-linux-gnu/libcdda_interface.so* \
+        /usr/lib/x86_64-linux-gnu/libcdda_paranoia.so* \
+        /usr/lib/x86_64-linux-gnu/libchromaprint.so* \
+        /usr/lib/x86_64-linux-gnu/libv4lconvert.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaom.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgst1394.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcdparanoia.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstchromaprint.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcolormanagement.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdv.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdc1394.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstflite.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfluidsynthmidi.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgme.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgsm.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlc3.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstldac.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmidi.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmodplug.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstogg.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenaptx.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenexr.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenjpeg.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenmpt.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopus.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopusparse.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstspandsp.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstspeex.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsvtav1.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttheora.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstteletext.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttwolame.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvoamrwbenc.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvorbis.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwavpack.so* \
-        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwebp.so*
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwebp.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwildmidi.so* \
+        /usr/share/sounds/sf2/TimGM6mb.sf2
 
 RUN rm -f /usr/lib/x86_64-linux-gnu/liba52* /usr/lib/x86_64-linux-gnu/libcdio.so* /usr/lib/x86_64-linux-gnu/libsidplay.so* \
         /usr/lib/x86_64-linux-gnu/liblrdf.so*  /usr/lib/x86_64-linux-gnu/libneon.so* \

--- a/services/vios/cicd_files/x86_64/Dockerfile.base
+++ b/services/vios/cicd_files/x86_64/Dockerfile.base
@@ -26,9 +26,7 @@ RUN apt-get update && \
         libuuid1 \
         gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-good \
-        gstreamer1.0-plugins-ugly \
         gstreamer1.0-plugins-bad \
-        gstreamer1.0-libav \
         libgstreamer1.0-0 \
         libgstreamer-plugins-base1.0-0 \
         libboost-filesystem1.83.0 \
@@ -39,7 +37,6 @@ RUN apt-get update && \
         libcairo2 \
         libpango-1.0-0 \
         libpangocairo-1.0-0 \
-        libopencv-core406t64 \
         libpqxx-7.8t64 \
         libhiredis1.1.0 \
 	libpaho-mqttpp3-1 \

--- a/services/vios/cicd_files/x86_64/Dockerfile.base
+++ b/services/vios/cicd_files/x86_64/Dockerfile.base
@@ -92,6 +92,57 @@ RUN rm -f /usr/lib/x86_64-linux-gnu/libswscale.* \
         /usr/lib/x86_64-linux-gnu/libswresample.* \
         /usr/lib/x86_64-linux-gnu/libpostproc.*
 
+# Prune codec libraries and GStreamer codec plugins not selected by VIOS.  Keep
+# the JPEG/PNG and XML dependencies required by the packaged application.
+RUN rm -f /usr/lib/x86_64-linux-gnu/libaom.so* \
+        /usr/lib/x86_64-linux-gnu/libdv.so* \
+        /usr/lib/x86_64-linux-gnu/libflite.so* \
+        /usr/lib/x86_64-linux-gnu/libfluidsynth.so* \
+        /usr/lib/x86_64-linux-gnu/libfreeaptx.so* \
+        /usr/lib/x86_64-linux-gnu/libgme.so* \
+        /usr/lib/x86_64-linux-gnu/libgsm.so* \
+        /usr/lib/x86_64-linux-gnu/libgssdp-1.6.so* \
+        /usr/lib/x86_64-linux-gnu/libinstpatch-1.0.so* \
+        /usr/lib/x86_64-linux-gnu/libjbig.so* \
+        /usr/lib/x86_64-linux-gnu/liblcms2.so* \
+        /usr/lib/x86_64-linux-gnu/libogg.so* \
+        /usr/lib/x86_64-linux-gnu/libOpenEXR*.so* \
+        /usr/lib/x86_64-linux-gnu/libopenjp2.so* \
+        /usr/lib/x86_64-linux-gnu/libopus.so* \
+        /usr/lib/x86_64-linux-gnu/libspandsp.so* \
+        /usr/lib/x86_64-linux-gnu/libspeex.so* \
+        /usr/lib/x86_64-linux-gnu/libSvtAv1Enc.so* \
+        /usr/lib/x86_64-linux-gnu/libtheora*.so* \
+        /usr/lib/x86_64-linux-gnu/libtiff.so* \
+        /usr/lib/x86_64-linux-gnu/libtwolame.so* \
+        /usr/lib/x86_64-linux-gnu/libvo-amrwbenc.so* \
+        /usr/lib/x86_64-linux-gnu/libvorbis*.so* \
+        /usr/lib/x86_64-linux-gnu/libwavpack.so* \
+        /usr/lib/x86_64-linux-gnu/libwebp.so* \
+        /usr/lib/x86_64-linux-gnu/libwebpmux.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaom.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcolormanagement.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstdv.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstflite.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfluidsynthmidi.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgme.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstgsm.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstogg.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenaptx.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenexr.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopenjpeg.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopus.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstopusparse.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstspandsp.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstspeex.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstsvtav1.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttheora.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgsttwolame.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvoamrwbenc.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvorbis.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwavpack.so* \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwebp.so*
+
 RUN rm -f /usr/lib/x86_64-linux-gnu/liba52* /usr/lib/x86_64-linux-gnu/libcdio.so* /usr/lib/x86_64-linux-gnu/libsidplay.so* \
         /usr/lib/x86_64-linux-gnu/liblrdf.so*  /usr/lib/x86_64-linux-gnu/libneon.so* \
         /usr/lib/x86_64-linux-gnu/libbs2b.so* /usr/lib/x86_64-linux-gnu/libdca.so* /usr/lib/x86_64-linux-gnu/libdvdnav.so* \

--- a/services/vios/cicd_files/x86_64/Dockerfile.base
+++ b/services/vios/cicd_files/x86_64/Dockerfile.base
@@ -20,31 +20,35 @@ RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libcurl4 \
         libxml2 \
-        libssl-dev \
-        libjsoncpp-dev \
-        sqlite3 \
-        uuid \
+        libssl3t64 \
+        libjsoncpp25 \
+        libsqlite3-0 \
+        libuuid1 \
         gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-good \
         gstreamer1.0-plugins-ugly \
         gstreamer1.0-plugins-bad \
         gstreamer1.0-libav \
         libgstreamer1.0-0 \
-        libgstreamer-plugins-base1.0 \
-        libboost-filesystem-dev \
-        libboost-regex-dev \
-        libboost-thread-dev \
-        libyaml-cpp-dev \
+        libgstreamer-plugins-base1.0-0 \
+        libboost-filesystem1.83.0 \
+        libboost-thread1.83.0 \
         gstreamer1.0-tools \
-        libjansson-dev \
-        librdkafka-dev \
-        libcogl-pango-dev \
-        libopencv-dev \
-        libpq-dev \
-        libpqxx-dev \
+        libjansson4 \
+        librdkafka1 \
+        libcairo2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libopencv-core406t64 \
+        libpqxx-7.8t64 \
         libhiredis1.1.0 \
-	libpaho-mqttpp-dev \
+	libpaho-mqttpp3-1 \
         && apt-get clean
+
+# Kafka producer/consumer load the unversioned name with dlopen(). The runtime
+# package only ships the SONAME; provide the linker-name symlink without
+# installing librdkafka-dev in the release image.
+RUN ln -s /usr/lib/x86_64-linux-gnu/librdkafka.so.1 /usr/lib/x86_64-linux-gnu/librdkafka.so
 
 # To get video driver libraries at runtime (libnvidia-encode.so/libnvcuvid.so)
 ENV NVIDIA_DRIVER_CAPABILITIES=$NVIDIA_DRIVER_CAPABILITIES,video,compute,graphics,utility

--- a/services/vios/cicd_files/x86_64/Dockerfile.base
+++ b/services/vios/cicd_files/x86_64/Dockerfile.base
@@ -91,8 +91,8 @@ RUN rm -f /usr/lib/x86_64-linux-gnu/libswscale.* \
         /usr/lib/x86_64-linux-gnu/libswresample.* \
         /usr/lib/x86_64-linux-gnu/libpostproc.*
 
-# Prune codec libraries and GStreamer codec plugins not selected by VIOS.  Keep
-# the JPEG/PNG and XML dependencies required by the packaged application.
+# Prune codec libraries and GStreamer codec plugins not selected by VIOS. XML
+# remains in the base image; JPEG/PNG are restored by the optional installer.
 RUN rm -f /usr/lib/x86_64-linux-gnu/libaom.so* \
         /usr/lib/x86_64-linux-gnu/libldacBT_enc.so* \
         /usr/lib/x86_64-linux-gnu/liblc3.so* \
@@ -134,6 +134,8 @@ RUN rm -f /usr/lib/x86_64-linux-gnu/libaom.so* \
         /usr/lib/x86_64-linux-gnu/libcdda_paranoia.so* \
         /usr/lib/x86_64-linux-gnu/libchromaprint.so* \
         /usr/lib/x86_64-linux-gnu/libv4lconvert.so* \
+        /usr/lib/x86_64-linux-gnu/libjpeg.so* \
+        /usr/lib/x86_64-linux-gnu/libpng16.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaom.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgst1394.so* \
         /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstcdparanoia.so* \

--- a/services/vios/deployment/scaling/ingress/Dockerfile
+++ b/services/vios/deployment/scaling/ingress/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:24.04
+FROM nvcr.io/nvidia/base/ubuntu:24.04
 
 # Install nginx and dependencies.
 # Enforce a minimum version (>= 1.24.0-2ubuntu7.8) rather than an exact pin so the

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
     container_name: streamprocessing-ms-1
     entrypoint: ["/bin/bash", "-c", "if [ \"$$VST_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; fi && exec /home/vst/vst_release/launch_vst"]
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
       - VST_VIDEO_STORAGE_SIZE_MB=${VST_VIDEO_STORAGE_SIZE_MB:-}
       - CONTAINER_NAME=streamprocessing-ms-1

--- a/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
         /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
@@ -61,6 +62,7 @@ services:
         /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
@@ -87,6 +89,7 @@ services:
         /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
@@ -113,6 +116,7 @@ services:
         /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
@@ -139,6 +143,7 @@ services:
         /home/vst/vst_release/tools/configure_nvstreamer_ui.sh && exec
         /home/vst/vst_release/launch_vst
     environment:
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -111,17 +111,49 @@ fi
 
 # Keep public Ubuntu repositories as the default. aarch64 packages are served
 # from Ubuntu Ports; no NVIDIA-internal mirror is required or assumed.
-if [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
-  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
-  cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+#
+# VST_APT_MIRROR overrides the archive for deployments that are far from the
+# public mirrors or behind a restricted egress. Download time is dominated by
+# which mirror answers, not by bandwidth: the same 24.6MB fetch measures ~10s
+# against a close mirror and has been observed to take minutes against a slow
+# or stalled one. Point this at an internal mirror to make startup predictable.
+#
+#   VST_APT_MIRROR=http://mirror.example.com/ubuntu           (x86_64)
+#   VST_APT_MIRROR=http://mirror.example.com/ubuntu-ports     (aarch64)
+if [[ "$(uname -m)" == *"aarch64"* ]]; then
+  APT_MIRROR="${VST_APT_MIRROR:-https://ports.ubuntu.com/ubuntu-ports/}"
+else
+  APT_MIRROR="${VST_APT_MIRROR:-}"
+fi
+
+if [[ -n "${APT_MIRROR}" ]]; then
+  # Trailing slash keeps the generated URIs well formed whichever form is passed.
+  [[ "${APT_MIRROR}" == */ ]] || APT_MIRROR="${APT_MIRROR}/"
+fi
+
+if [[ -n "${VST_APT_MIRROR:-}" ]]; then
+  echo "Using APT mirror: ${APT_MIRROR}"
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<EOF
 Types: deb
-URIs: https://ports.ubuntu.com/ubuntu-ports/
+URIs: ${APT_MIRROR}
+Suites: noble noble-updates noble-security
+Components: main universe
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+  # A mirror supersedes whatever the base image shipped; leaving the original
+  # list in place would send half the requests back to the slow archive.
+  rm -f /etc/apt/sources.list
+elif [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
+  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<EOF
+Types: deb
+URIs: ${APT_MIRROR}
 Suites: noble noble-updates
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 Types: deb
-URIs: https://ports.ubuntu.com/ubuntu-ports/
+URIs: ${APT_MIRROR}
 Suites: noble-security
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
@@ -129,19 +161,57 @@ EOF
 fi
 
 # Handle network-level timeouts gracefully without killing dpkg.
+#
+# HTTP pipelining is left at the APT default. Forcing Pipeline-Depth=0 serialises
+# every request and measured ~40% slower on this package set (13s vs 8s for the
+# same 52 packages / 24.6MB). Set VST_APT_PIPELINE_DEPTH=0 to restore the
+# serialised behaviour if a proxy or mirror mishandles pipelined requests.
+#
+# ForceIPv4 stays on: a host with broken IPv6 otherwise waits for the v6 attempt
+# to time out on every connection.
 APT_OPTS=(
   -o Acquire::http::Timeout=30
   -o Acquire::https::Timeout=30
   -o Acquire::Retries=5
   -o DPkg::Lock::Timeout=60
   -o Acquire::ForceIPv4=true
-  -o Acquire::http::Pipeline-Depth=0
   -o Dpkg::Options::=--force-confdef
   -o Dpkg::Options::=--force-confold
 )
+if [[ -n "${VST_APT_PIPELINE_DEPTH:-}" ]]; then
+  APT_OPTS+=(-o "Acquire::http::Pipeline-Depth=${VST_APT_PIPELINE_DEPTH}")
+fi
+
 
 install_packages() {
   apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
+}
+
+# APT already retries individual downloads (Acquire::Retries), but a connection
+# that drops mid-transaction fails the whole install. Retry the install itself so
+# a brief outage does not fail container startup.
+#
+# Deliberately not wrapped in `timeout`: killing apt-get install midway can leave
+# dpkg half-configured, which is worse than a slow start. Repair between attempts
+# instead -- a failed install is exactly what leaves packages unconfigured, and
+# without this the retry fails the same way.
+install_packages_with_retries() {
+  local attempt
+  for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    if install_packages; then
+      return 0
+    fi
+    echo "apt-get install attempt ${attempt}/${MAX_RETRIES} failed."
+    if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+      if is_dpkg_broken; then
+        echo "Repairing incomplete dpkg state before retry..."
+        dpkg --configure -a || true
+      fi
+      echo "Retrying in $((2 * attempt))s..."
+      sleep $((2 * attempt))
+    fi
+  done
+  return 1
 }
 
 refresh_apt_metadata() {
@@ -163,6 +233,19 @@ refresh_apt_metadata() {
   return 1
 }
 
+# A mirror override invalidates the metadata the base image ships, which is
+# indexed against the default archive. Measured: with a mirror configured and the
+# shipped lists in place, apt resolves no download URI at all, so the fast path
+# below would fail and only then refresh. Refresh up front instead of paying for
+# a doomed attempt first.
+if [[ -n "${VST_APT_MIRROR:-}" ]]; then
+  echo "APT mirror configured; refreshing metadata before install."
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata from ${APT_MIRROR}."
+    exit 1
+  fi
+fi
+
 # Reuse the base image's APT metadata first. Refresh only if installation shows
 # it is stale or a package is unavailable, keeping the normal path offline-fast.
 echo "Installing VIOS runtime media packages..."
@@ -176,7 +259,10 @@ if ! install_packages; then
     echo "Repairing incomplete dpkg state..."
     dpkg --configure -a
   fi
-  install_packages
+  if ! install_packages_with_retries; then
+    echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
+    exit 1
+  fi
 fi
 
 # OSRB: strip Intel MediaSDK / QuickSync (QSV) codec libs re-pulled as part of the

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -162,11 +162,13 @@ for attempt in $(seq 1 $MAX_RETRIES); do
   fi
 done
 
-# Install gstreamer1.0-libav with retry logic
-echo "Installing gstreamer1.0-libav..."
+echo "Installing deferred packages (gstreamer1.0-plugins-ugly, gstreamer1.0-libav, libopencv-core406t64)..."
 for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install -y ${APT_OPTS} gstreamer1.0-libav; then
-    echo "gstreamer1.0-libav installed successfully"
+  if apt-get install -y ${APT_OPTS} \
+      gstreamer1.0-plugins-ugly \
+      gstreamer1.0-libav \
+      libopencv-core406t64; then
+    echo "Deferred packages installed successfully"
     break
   else
     if [[ $attempt -lt $MAX_RETRIES ]]; then
@@ -181,7 +183,7 @@ for attempt in $(seq 1 $MAX_RETRIES); do
       echo "Retrying in $((2 * attempt))s..."
       sleep $((2 * attempt))
     else
-      echo "ERROR: Failed to install gstreamer1.0-libav after $MAX_RETRIES attempts"
+      echo "ERROR: Failed to install deferred packages after $MAX_RETRIES attempts"
       exit 1
     fi
   fi

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -24,6 +24,10 @@
 # makes the restart path free.
 set -e  # Exit on any error
 
+# The base image may preload libraries that are restored by this installer.
+# Do not pass unavailable preload paths to apt/dpkg helper processes.
+unset LD_PRELOAD
+
 # Ensure non-interactive mode for apt operations
 export DEBIAN_FRONTEND=noninteractive
 

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-#
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,105 +15,101 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Install the media packages VIOS needs at runtime, before launch_vst. The base
+# image ships without them (and deletes the files of the ones that arrive as
+# transitive dependencies), so this script restores them on first start.
+#
+# Keep this idempotent: a retained container does not need an APT transaction on
+# restart. The marker file plus a spot check of the installed libraries is what
+# makes the restart path free.
 set -e  # Exit on any error
 
 # Ensure non-interactive mode for apt operations
 export DEBIAN_FRONTEND=noninteractive
 
-# Random initial sleep (0-5 seconds) to stagger container starts
-INITIAL_SLEEP=$((RANDOM % 6))
+FORCE_INSTALL="${VST_FORCE_ADDITIONAL_PACKAGES_INSTALL:-false}"
 
-# Generate random timeout to avoid thundering herd problem
-APT_UPDATE_TIMEOUT=$((200 + RANDOM % 101))    # 200-300 seconds for apt-get update
-MAX_RETRIES=3
+# Randomized timeout avoids a thundering herd when several replicas (5 nvstreamers
+# plus stream-processing) cold-start against the same mirror at once.
+APT_UPDATE_TIMEOUT="${VST_APT_UPDATE_TIMEOUT:-$((200 + RANDOM % 101))}"
+MAX_RETRIES="${VST_APT_MAX_RETRIES:-3}"
 
-echo "Staggering start with ${INITIAL_SLEEP}s delay..."
-sleep ${INITIAL_SLEEP}
+# Runtime libraries only; development packages are intentionally excluded.
+#
+# The four top-level entries are what VIOS actually needs. Everything below them
+# arrives as a transitive dependency, but the base image deletes the files of the
+# ones it already has installed, so they must be listed explicitly for
+# --reinstall to restore them.
+RUNTIME_PACKAGES=(
+  gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+  gstreamer1.0-plugins-ugly gstreamer1.0-libav
+  libopencv-core406t64 libv4lconvert0t64
+  # JPEG and PNG are pruned from the base image and restored here; the packaged
+  # application links them for snapshot and image encoding.
+  libjpeg8 libjpeg-turbo8 libpng16-16t64
+  libvo-aacenc0 libfaad2 libswresample4 libavutil58 libswscale7 libpostproc57
+  libavcodec60 libavformat60 libavfilter9 libde265-0 libx265-199 libx264-164
+  libmpeg2encpp-2.1-0t64 libmpeg2-4 libmpg123-0t64 libbs2b0 libreadline8t64
+  libcdio19t64 libdca0 libdvdnav4 libmjpegutils-2.1-0t64 liba52-0.7.4
+  libdvdread8t64 libsbc1 libzvbi0t64 libmp3lame0 libsidplay1v5 liblrdf0
+  libneon27t64 libflac12t64 libxvidcore4 libvpx9 libopenh264-7
+  # libavcodec/libavformat link these directly. The base image deletes their
+  # files (they arrive as plugins-base/good dependencies), so without an
+  # explicit --reinstall the libav dlopen in LibavWrapper fails and file upload
+  # cannot read duration/codec. libgstlibav.so needs the same set.
+  libogg0 libvorbis0a libvorbisenc2 libopus0 libspeex1 libtheora0 libtwolame0
+  libwebp7 libsharpyuv0
+)
 
-# Function to check if dpkg is in a broken state
+# The marker is keyed on the package list itself, so editing RUNTIME_PACKAGES
+# automatically invalidates markers written by an older revision of this script.
+# Without this, a container that completed an install with a previous list would
+# skip forever and never pick up newly added packages.
+PACKAGE_SET_ID="$(printf '%s\n' "${RUNTIME_PACKAGES[@]}" | md5sum | cut -c1-10)"
+MARKER_FILE="${VST_ADDITIONAL_PACKAGES_MARKER:-/var/lib/vios/additional-packages-installed-${PACKAGE_SET_ID}}"
+
 is_dpkg_broken() {
-  # Check for packages in bad state (Half-installed, Unpacked, Reinst-required)
-  if dpkg -l 2>/dev/null | grep -qE "^[HUR]"; then
-    return 0  # dpkg is broken
-  fi
-
-  # Check dpkg audit for issues
-  if dpkg --audit 2>&1 | grep -q .; then
-    return 0  # dpkg has issues
-  fi
-
-  return 1  # dpkg is healthy
+  dpkg --audit 2>/dev/null | grep -q .
 }
 
-# Function to fix dpkg state
-fix_dpkg() {
-  echo "Fixing dpkg state..."
-
-  # SAFETY: Check if apt/dpkg is already running before touching locks
-  if pgrep -x apt-get >/dev/null 2>&1 || pgrep -x dpkg >/dev/null 2>&1 || pgrep -x apt >/dev/null 2>&1; then
-    echo "Package manager is currently running, cannot safely fix dpkg state"
-    echo "Waiting for package manager to complete..."
-    return 1
-  fi
-
-  # Remove stale lock files (safe now that we checked for running processes)
-  echo "Removing stale lock files..."
-  rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
-
-  # Try to configure any pending packages
-  dpkg --configure -a 2>/dev/null || true
-
-  # Find and remove packages in bad state
-  BAD_PKGS=$(dpkg -l 2>/dev/null | grep -E "^[HUR]" | awk '{print $2}' || true)
-  if [[ -n "$BAD_PKGS" ]]; then
-    echo "Removing packages in bad state: $BAD_PKGS"
-    for pkg in $BAD_PKGS; do
-      dpkg --remove --force-remove-reinstreq "$pkg" 2>/dev/null || true
+# Sentinels for the package groups this script installs: plugins-bad, libav and
+# libv4lconvert (whose files the base image deletes).
+#
+# Existence alone is not enough. The base image deletes libraries that libav and
+# several plugins link against, which leaves the plugin file on disk but
+# unloadable -- that is exactly how avdec_* silently disappeared while every
+# sentinel still "existed". Check that each one actually resolves.
+runtime_present() {
+  local required match
+  for required in \
+    /usr/lib/*-linux-gnu/libv4lconvert.so.0 \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstvideoparsersbad.so \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstmpegtsmux.so \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstlibav.so; do
+    compgen -G "${required}" >/dev/null || return 1
+    for match in ${required}; do
+      if ldd "${match}" 2>/dev/null | grep -q "not found"; then
+        return 1
+      fi
     done
-  fi
-
-  # Verify fix worked
-  if is_dpkg_broken; then
-    echo "WARNING: dpkg may still have issues after fix attempt"
-    return 1
-  fi
-
-  echo "dpkg state fixed successfully"
-  return 0
+  done
 }
 
-echo "Checking and fixing dpkg state..."
-if ! fix_dpkg; then
-  echo "WARNING: Could not fix dpkg state (package manager may be running)"
-  echo "Proceeding with caution - DPkg::Lock::Timeout will handle lock contention"
+if [[ "${FORCE_INSTALL}" != "true" && -f "${MARKER_FILE}" ]] && runtime_present; then
+  echo "Additional packages already installed; skipping APT."
+  exit 0
 fi
 
-# APT acquire options for robustness and performance
-# These handle network-level timeouts gracefully without killing dpkg
-APT_OPTS="-o Acquire::http::Timeout=30 \
--o Acquire::https::Timeout=30 \
--o Acquire::Retries=5 \
--o DPkg::Lock::Timeout=60 \
--o Acquire::ForceIPv4=true \
--o Acquire::http::Pipeline-Depth=0 \
--o Acquire::http::No-Cache=true \
--o Dpkg::Options::=--force-confdef \
--o Dpkg::Options::=--force-confold"
+if is_dpkg_broken; then
+  echo "Repairing incomplete dpkg state..."
+  dpkg --configure -a
+fi
 
-echo "Starting package installation for Ubuntu 24.04..."
-
-# Optimize APT sources to only include necessary suites and components (HTTPS)
-echo "Configuring APT sources for optimal performance..."
-
-# Detect architecture - only modify sources for aarch64
-ARCH=$(uname -m)
-if [[ "$ARCH" == *"aarch64"* ]]; then
-    # Skip modification if already configured with HTTPS ports.ubuntu.com
-    if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]] && grep -q "https://ports.ubuntu.com" /etc/apt/sources.list.d/ubuntu.sources; then
-        echo "APT sources already configured with HTTPS ports.ubuntu.com, skipping modification..."
-    else
-        echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
-        cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+# Keep public Ubuntu repositories as the default. aarch64 packages are served
+# from Ubuntu Ports; no NVIDIA-internal mirror is required or assumed.
+if [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
+  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
 Types: deb
 URIs: https://ports.ubuntu.com/ubuntu-ports/
 Suites: noble noble-updates
@@ -126,168 +122,75 @@ Suites: noble-security
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
-    fi
 fi
 
-# Run apt-get update with timeout and retry logic
-echo "Running apt-get update (timeout: ${APT_UPDATE_TIMEOUT}s)..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if timeout ${APT_UPDATE_TIMEOUT}s apt-get update ${APT_OPTS}; then
-    echo "apt-get update completed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "apt-get update attempt $attempt/$MAX_RETRIES failed"
+# Handle network-level timeouts gracefully without killing dpkg.
+APT_OPTS=(
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+  -o Acquire::Retries=5
+  -o DPkg::Lock::Timeout=60
+  -o Acquire::ForceIPv4=true
+  -o Acquire::http::Pipeline-Depth=0
+  -o Dpkg::Options::=--force-confdef
+  -o Dpkg::Options::=--force-confold
+)
 
-      # SAFE lock cleanup: only if locks exist AND no process running
-      if [[ -f /var/lib/dpkg/lock-frontend ]] || [[ -f /var/lib/dpkg/lock ]]; then
-        if ! pgrep -x apt-get >/dev/null 2>&1 && ! pgrep -x dpkg >/dev/null 2>&1 && ! pgrep -x apt >/dev/null 2>&1; then
-          echo "Found stale lock files, clearing..."
-          rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
-        else
-          echo "Lock files present but package manager running in another process"
-        fi
-      fi
+install_packages() {
+  apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
+}
 
-      # Clean corrupted apt lists for fresh retry
+refresh_apt_metadata() {
+  local attempt
+  for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    echo "Running apt-get update (attempt ${attempt}/${MAX_RETRIES}, timeout: ${APT_UPDATE_TIMEOUT}s)..."
+    if timeout "${APT_UPDATE_TIMEOUT}" apt-get update "${APT_OPTS[@]}"; then
+      return 0
+    fi
+    echo "apt-get update attempt ${attempt}/${MAX_RETRIES} failed."
+    if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+      # Clear partially fetched or corrupted indexes so the retry starts clean.
       echo "Cleaning apt lists..."
       rm -rf /var/lib/apt/lists/*
-
       echo "Retrying in $((2 * attempt))s..."
       sleep $((2 * attempt))
-    else
-      echo "ERROR: apt-get update failed after $MAX_RETRIES attempts"
-      exit 1
     fi
+  done
+  return 1
+}
+
+# Reuse the base image's APT metadata first. Refresh only if installation shows
+# it is stale or a package is unavailable, keeping the normal path offline-fast.
+echo "Installing VIOS runtime media packages..."
+if ! install_packages; then
+  echo "Initial install failed; refreshing APT metadata."
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata after ${MAX_RETRIES} attempts."
+    exit 1
   fi
-done
-
-echo "Installing deferred packages (gstreamer1.0-plugins-ugly, gstreamer1.0-libav, libopencv-core406t64)..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install -y ${APT_OPTS} \
-      gstreamer1.0-plugins-ugly \
-      gstreamer1.0-libav \
-      libopencv-core406t64; then
-    echo "Deferred packages installed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to install deferred packages after $MAX_RETRIES attempts"
-      exit 1
-    fi
+  if is_dpkg_broken; then
+    echo "Repairing incomplete dpkg state..."
+    dpkg --configure -a
   fi
-done
-
-# Reinstall GStreamer plugins and multimedia libraries (batch 1) with retry logic
-echo "Reinstalling GStreamer plugins and core multimedia libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libv4lconvert0t64 \
-      libjpeg8 libjpeg-turbo8 libpng16-16t64 \
-      gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
-      libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
-      libswscale7 libpostproc57 \
-      libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \
-      libde265-dev libde265-0 libx265-199 libx264-164 libmpeg2encpp-2.1-0 libmpeg2-4 \
-      libmpg123-0 libbs2b0 libreadline8 libcdio19 libdca0 libdvdnav4 libmjpegutils-2.1-0 \
-      liba52-0.7.4 libdvdread8 libsbc1 libzvbi0 libmp3lame0 libsidplay1v5 liblrdf0 libneon27; then
-    echo "GStreamer plugins installed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall GStreamer plugins after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
-
-# Reinstall additional codec libraries (batch 2) with retry logic
-echo "Reinstalling additional codec libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libflac12 libxvidcore4; then
-    echo "Codec libraries installed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall codec libraries after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
-
-# Reinstall libvpx and h264 libraries (batch 3) with retry logic
-echo "Reinstalling libvpx and h264 libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libvpx9 libopenh264-7; then
-    echo "libvpx/h264 libraries installed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall libvpx/h264 libraries after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
+  install_packages
+fi
 
 # OSRB: strip Intel MediaSDK / QuickSync (QSV) codec libs re-pulled as part of the
-# gstreamer1.0-plugins-bad reinstall above. VIOS uses NVIDIA NVENC/NVDEC exclusively;
+# gstreamer1.0-plugins-bad install above. VIOS uses NVIDIA NVENC/NVDEC exclusively.
 echo "Removing unused Intel MediaSDK / QSV (patent watchlist) libraries..."
 for libdir in /usr/lib/*-linux-gnu; do
-  rm -f "$libdir"/mfx/libmfx_*_hw64.so* \
-        "$libdir"/libmfx.so* "$libdir"/libmfxhw64.so* "$libdir"/libmfx-tracer.so* \
-        "$libdir"/gstreamer-1.0/libgstmsdk.so* \
-        "$libdir"/gstreamer-1.0/libgstqsv.so* 2>/dev/null || true
-  rm -rf "$libdir"/mfx 2>/dev/null || true
+  rm -f "${libdir}"/mfx/libmfx_*_hw64.so* \
+        "${libdir}"/libmfx.so* "${libdir}"/libmfxhw64.so* "${libdir}"/libmfx-tracer.so* \
+        "${libdir}"/gstreamer-1.0/libgstmsdk.so* \
+        "${libdir}"/gstreamer-1.0/libgstqsv.so*
+  rm -rf "${libdir}"/mfx
 done
 
-# Clean up GStreamer cache
+# Force GStreamer to rebuild its plugin registry so the newly installed plugins
+# are picked up.
 echo "Cleaning up GStreamer cache..."
 rm -rf ~/.cache/gstreamer-1.0/
 
+install -d "$(dirname "${MARKER_FILE}")"
+date --iso-8601=seconds >"${MARKER_FILE}"
 echo "Installation completed successfully!"

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -194,6 +194,7 @@ echo "Reinstalling GStreamer plugins and core multimedia libraries..."
 for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
       libv4lconvert0t64 \
+      libjpeg8 libjpeg-turbo8 libpng16-16t64 \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
       libswscale7 libpostproc57 \

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -193,6 +193,7 @@ done
 echo "Reinstalling GStreamer plugins and core multimedia libraries..."
 for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
+      libv4lconvert0t64 \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
       libswscale7 libpostproc57 \

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -189,6 +189,7 @@ echo "Reinstalling GStreamer plugins and core multimedia libraries..."
 for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
       libv4lconvert0t64 \
+      libjpeg8 libjpeg-turbo8 libpng16-16t64 \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
       libswscale7 libpostproc57 \

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,100 +15,101 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env bash
+# Install the media packages VIOS needs at runtime, before launch_vst. The base
+# image ships without them (and deletes the files of the ones that arrive as
+# transitive dependencies), so this script restores them on first start.
+#
+# Keep this idempotent: a retained container does not need an APT transaction on
+# restart. The marker file plus a spot check of the installed libraries is what
+# makes the restart path free.
 set -e  # Exit on any error
 
 # Ensure non-interactive mode for apt operations
 export DEBIAN_FRONTEND=noninteractive
 
-# Generate random timeout to avoid thundering herd problem
-APT_UPDATE_TIMEOUT=$((200 + RANDOM % 101))    # 200-300 seconds for apt-get update
-MAX_RETRIES=3
+FORCE_INSTALL="${VST_FORCE_ADDITIONAL_PACKAGES_INSTALL:-false}"
 
-# Function to check if dpkg is in a broken state
+# Randomized timeout avoids a thundering herd when several replicas (5 nvstreamers
+# plus stream-processing) cold-start against the same mirror at once.
+APT_UPDATE_TIMEOUT="${VST_APT_UPDATE_TIMEOUT:-$((200 + RANDOM % 101))}"
+MAX_RETRIES="${VST_APT_MAX_RETRIES:-3}"
+
+# Runtime libraries only; development packages are intentionally excluded.
+#
+# The four top-level entries are what VIOS actually needs. Everything below them
+# arrives as a transitive dependency, but the base image deletes the files of the
+# ones it already has installed, so they must be listed explicitly for
+# --reinstall to restore them.
+RUNTIME_PACKAGES=(
+  gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+  gstreamer1.0-plugins-ugly gstreamer1.0-libav
+  libopencv-core406t64 libv4lconvert0t64
+  # JPEG and PNG are pruned from the base image and restored here; the packaged
+  # application links them for snapshot and image encoding.
+  libjpeg8 libjpeg-turbo8 libpng16-16t64
+  libvo-aacenc0 libfaad2 libswresample4 libavutil58 libswscale7 libpostproc57
+  libavcodec60 libavformat60 libavfilter9 libde265-0 libx265-199 libx264-164
+  libmpeg2encpp-2.1-0t64 libmpeg2-4 libmpg123-0t64 libbs2b0 libreadline8t64
+  libcdio19t64 libdca0 libdvdnav4 libmjpegutils-2.1-0t64 liba52-0.7.4
+  libdvdread8t64 libsbc1 libzvbi0t64 libmp3lame0 libsidplay1v5 liblrdf0
+  libneon27t64 libflac12t64 libxvidcore4 libvpx9 libopenh264-7
+  # libavcodec/libavformat link these directly. The base image deletes their
+  # files (they arrive as plugins-base/good dependencies), so without an
+  # explicit --reinstall the libav dlopen in LibavWrapper fails and file upload
+  # cannot read duration/codec. libgstlibav.so needs the same set.
+  libogg0 libvorbis0a libvorbisenc2 libopus0 libspeex1 libtheora0 libtwolame0
+  libwebp7 libsharpyuv0
+)
+
+# The marker is keyed on the package list itself, so editing RUNTIME_PACKAGES
+# automatically invalidates markers written by an older revision of this script.
+# Without this, a container that completed an install with a previous list would
+# skip forever and never pick up newly added packages.
+PACKAGE_SET_ID="$(printf '%s\n' "${RUNTIME_PACKAGES[@]}" | md5sum | cut -c1-10)"
+MARKER_FILE="${VST_ADDITIONAL_PACKAGES_MARKER:-/var/lib/vios/additional-packages-installed-${PACKAGE_SET_ID}}"
+
 is_dpkg_broken() {
-  # Check for packages in bad state (Half-installed, Unpacked, Reinst-required)
-  if dpkg -l 2>/dev/null | grep -qE "^[HUR]"; then
-    return 0  # dpkg is broken
-  fi
-
-  # Check dpkg audit for issues
-  if dpkg --audit 2>&1 | grep -q .; then
-    return 0  # dpkg has issues
-  fi
-
-  return 1  # dpkg is healthy
+  dpkg --audit 2>/dev/null | grep -q .
 }
 
-# Function to fix dpkg state
-fix_dpkg() {
-  echo "Fixing dpkg state..."
-
-  # SAFETY: Check if apt/dpkg is already running before touching locks
-  if pgrep -x apt-get >/dev/null 2>&1 || pgrep -x dpkg >/dev/null 2>&1 || pgrep -x apt >/dev/null 2>&1; then
-    echo "Package manager is currently running, cannot safely fix dpkg state"
-    echo "Waiting for package manager to complete..."
-    return 1
-  fi
-
-  # Remove stale lock files (safe now that we checked for running processes)
-  echo "Removing stale lock files..."
-  rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
-
-  # Try to configure any pending packages
-  dpkg --configure -a 2>/dev/null || true
-
-  # Find and remove packages in bad state
-  BAD_PKGS=$(dpkg -l 2>/dev/null | grep -E "^[HUR]" | awk '{print $2}' || true)
-  if [[ -n "$BAD_PKGS" ]]; then
-    echo "Removing packages in bad state: $BAD_PKGS"
-    for pkg in $BAD_PKGS; do
-      dpkg --remove --force-remove-reinstreq "$pkg" 2>/dev/null || true
+# Sentinels for the package groups this script installs: plugins-bad, libav and
+# libv4lconvert (whose files the base image deletes).
+#
+# Existence alone is not enough. The base image deletes libraries that libav and
+# several plugins link against, which leaves the plugin file on disk but
+# unloadable -- that is exactly how avdec_* silently disappeared while every
+# sentinel still "existed". Check that each one actually resolves.
+runtime_present() {
+  local required match
+  for required in \
+    /usr/lib/*-linux-gnu/libv4lconvert.so.0 \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstvideoparsersbad.so \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstmpegtsmux.so \
+    /usr/lib/*-linux-gnu/gstreamer-1.0/libgstlibav.so; do
+    compgen -G "${required}" >/dev/null || return 1
+    for match in ${required}; do
+      if ldd "${match}" 2>/dev/null | grep -q "not found"; then
+        return 1
+      fi
     done
-  fi
-
-  # Verify fix worked
-  if is_dpkg_broken; then
-    echo "WARNING: dpkg may still have issues after fix attempt"
-    return 1
-  fi
-
-  echo "dpkg state fixed successfully"
-  return 0
+  done
 }
 
-echo "Checking and fixing dpkg state..."
-if ! fix_dpkg; then
-  echo "WARNING: Could not fix dpkg state (package manager may be running)"
-  echo "Proceeding with caution - DPkg::Lock::Timeout will handle lock contention"
+if [[ "${FORCE_INSTALL}" != "true" && -f "${MARKER_FILE}" ]] && runtime_present; then
+  echo "Additional packages already installed; skipping APT."
+  exit 0
 fi
 
-# APT acquire options for robustness and performance
-# These handle network-level timeouts gracefully without killing dpkg
-APT_OPTS="-o Acquire::http::Timeout=30 \
--o Acquire::https::Timeout=30 \
--o Acquire::Retries=5 \
--o DPkg::Lock::Timeout=60 \
--o Acquire::ForceIPv4=true \
--o Acquire::http::Pipeline-Depth=0 \
--o Acquire::http::No-Cache=true \
--o Dpkg::Options::=--force-confdef \
--o Dpkg::Options::=--force-confold"
+if is_dpkg_broken; then
+  echo "Repairing incomplete dpkg state..."
+  dpkg --configure -a
+fi
 
-echo "Starting package installation for Ubuntu 24.04..."
-
-# Optimize APT sources to only include necessary suites and components (HTTPS)
-echo "Configuring APT sources for optimal performance..."
-
-# Detect architecture - only modify sources for aarch64
-ARCH=$(uname -m)
-if [[ "$ARCH" == *"aarch64"* ]]; then
-    # Skip modification if already configured with HTTPS ports.ubuntu.com
-    if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]] && grep -q "https://ports.ubuntu.com" /etc/apt/sources.list.d/ubuntu.sources; then
-        echo "APT sources already configured with HTTPS ports.ubuntu.com, skipping modification..."
-    else
-        echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
-        cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+# Keep public Ubuntu repositories as the default. aarch64 packages are served
+# from Ubuntu Ports; no NVIDIA-internal mirror is required or assumed.
+if [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
+  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
 Types: deb
 URIs: https://ports.ubuntu.com/ubuntu-ports/
 Suites: noble noble-updates
@@ -121,168 +122,75 @@ Suites: noble-security
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
-    fi
 fi
 
-# Run apt-get update with timeout and retry logic
-echo "Running apt-get update (timeout: ${APT_UPDATE_TIMEOUT}s)..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if timeout ${APT_UPDATE_TIMEOUT}s apt-get update ${APT_OPTS}; then
-    echo "apt-get update completed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "apt-get update attempt $attempt/$MAX_RETRIES failed"
+# Handle network-level timeouts gracefully without killing dpkg.
+APT_OPTS=(
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+  -o Acquire::Retries=5
+  -o DPkg::Lock::Timeout=60
+  -o Acquire::ForceIPv4=true
+  -o Acquire::http::Pipeline-Depth=0
+  -o Dpkg::Options::=--force-confdef
+  -o Dpkg::Options::=--force-confold
+)
 
-      # SAFE lock cleanup: only if locks exist AND no process running
-      if [[ -f /var/lib/dpkg/lock-frontend ]] || [[ -f /var/lib/dpkg/lock ]]; then
-        if ! pgrep -x apt-get >/dev/null 2>&1 && ! pgrep -x dpkg >/dev/null 2>&1 && ! pgrep -x apt >/dev/null 2>&1; then
-          echo "Found stale lock files, clearing..."
-          rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
-        else
-          echo "Lock files present but package manager running in another process"
-        fi
-      fi
+install_packages() {
+  apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
+}
 
-      # Clean corrupted apt lists for fresh retry
+refresh_apt_metadata() {
+  local attempt
+  for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    echo "Running apt-get update (attempt ${attempt}/${MAX_RETRIES}, timeout: ${APT_UPDATE_TIMEOUT}s)..."
+    if timeout "${APT_UPDATE_TIMEOUT}" apt-get update "${APT_OPTS[@]}"; then
+      return 0
+    fi
+    echo "apt-get update attempt ${attempt}/${MAX_RETRIES} failed."
+    if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+      # Clear partially fetched or corrupted indexes so the retry starts clean.
       echo "Cleaning apt lists..."
       rm -rf /var/lib/apt/lists/*
-
       echo "Retrying in $((2 * attempt))s..."
       sleep $((2 * attempt))
-    else
-      echo "ERROR: apt-get update failed after $MAX_RETRIES attempts"
-      exit 1
     fi
+  done
+  return 1
+}
+
+# Reuse the base image's APT metadata first. Refresh only if installation shows
+# it is stale or a package is unavailable, keeping the normal path offline-fast.
+echo "Installing VIOS runtime media packages..."
+if ! install_packages; then
+  echo "Initial install failed; refreshing APT metadata."
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata after ${MAX_RETRIES} attempts."
+    exit 1
   fi
-done
-
-echo "Installing deferred packages (gstreamer1.0-plugins-ugly, gstreamer1.0-libav, libopencv-core406t64)..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install -y ${APT_OPTS} \
-      gstreamer1.0-plugins-ugly \
-      gstreamer1.0-libav \
-      libopencv-core406t64; then
-    echo "Deferred packages installed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to install deferred packages after $MAX_RETRIES attempts"
-      exit 1
-    fi
+  if is_dpkg_broken; then
+    echo "Repairing incomplete dpkg state..."
+    dpkg --configure -a
   fi
-done
-
-# Reinstall GStreamer plugins and multimedia libraries (batch 1) with retry logic
-echo "Reinstalling GStreamer plugins and core multimedia libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libv4lconvert0t64 \
-      libjpeg8 libjpeg-turbo8 libpng16-16t64 \
-      gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
-      libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
-      libswscale7 libpostproc57 \
-      libavcodec-dev libavcodec60 libavformat-dev libavformat60 libavfilter-dev libavfilter9 \
-      libde265-dev libde265-0 libx265-199 libx264-164 libmpeg2encpp-2.1-0 libmpeg2-4 \
-      libmpg123-0 libbs2b0 libreadline8 libcdio19 libdca0 libdvdnav4 libmjpegutils-2.1-0 \
-      liba52-0.7.4 libdvdread8 libsbc1 libzvbi0 libmp3lame0 libsidplay1v5 liblrdf0 libneon27; then
-    echo "GStreamer plugins installed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall GStreamer plugins after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
-
-# Reinstall additional codec libraries (batch 2) with retry logic
-echo "Reinstalling additional codec libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libflac12 libxvidcore4; then
-    echo "Codec libraries installed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall codec libraries after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
-
-# Reinstall libvpx and h264 libraries (batch 3) with retry logic
-echo "Reinstalling libvpx and h264 libraries..."
-for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install --reinstall -y ${APT_OPTS} \
-      libvpx9 libopenh264-7; then
-    echo "libvpx/h264 libraries installed successfully"
-    break
-  else
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Attempt $attempt/$MAX_RETRIES failed"
-
-      # Check if dpkg is broken and fix if needed
-      if is_dpkg_broken; then
-        echo "Detected dpkg corruption, attempting fix..."
-        fix_dpkg || echo "WARNING: dpkg fix may not have completed successfully"
-      fi
-
-      echo "Retrying in $((2 * attempt))s..."
-      sleep $((2 * attempt))
-    else
-      echo "ERROR: Failed to reinstall libvpx/h264 libraries after $MAX_RETRIES attempts"
-      exit 1
-    fi
-  fi
-done
+  install_packages
+fi
 
 # OSRB: strip Intel MediaSDK / QuickSync (QSV) codec libs re-pulled as part of the
-# gstreamer1.0-plugins-bad reinstall above. VIOS uses NVIDIA NVENC/NVDEC exclusively;
+# gstreamer1.0-plugins-bad install above. VIOS uses NVIDIA NVENC/NVDEC exclusively.
 echo "Removing unused Intel MediaSDK / QSV (patent watchlist) libraries..."
 for libdir in /usr/lib/*-linux-gnu; do
-  rm -f "$libdir"/mfx/libmfx_*_hw64.so* \
-        "$libdir"/libmfx.so* "$libdir"/libmfxhw64.so* "$libdir"/libmfx-tracer.so* \
-        "$libdir"/gstreamer-1.0/libgstmsdk.so* \
-        "$libdir"/gstreamer-1.0/libgstqsv.so* 2>/dev/null || true
-  rm -rf "$libdir"/mfx 2>/dev/null || true
+  rm -f "${libdir}"/mfx/libmfx_*_hw64.so* \
+        "${libdir}"/libmfx.so* "${libdir}"/libmfxhw64.so* "${libdir}"/libmfx-tracer.so* \
+        "${libdir}"/gstreamer-1.0/libgstmsdk.so* \
+        "${libdir}"/gstreamer-1.0/libgstqsv.so*
+  rm -rf "${libdir}"/mfx
 done
 
-# Clean up GStreamer cache
+# Force GStreamer to rebuild its plugin registry so the newly installed plugins
+# are picked up.
 echo "Cleaning up GStreamer cache..."
 rm -rf ~/.cache/gstreamer-1.0/
 
+install -d "$(dirname "${MARKER_FILE}")"
+date --iso-8601=seconds >"${MARKER_FILE}"
 echo "Installation completed successfully!"

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -157,11 +157,13 @@ for attempt in $(seq 1 $MAX_RETRIES); do
   fi
 done
 
-# Install gstreamer1.0-libav with retry logic
-echo "Installing gstreamer1.0-libav..."
+echo "Installing deferred packages (gstreamer1.0-plugins-ugly, gstreamer1.0-libav, libopencv-core406t64)..."
 for attempt in $(seq 1 $MAX_RETRIES); do
-  if apt-get install -y ${APT_OPTS} gstreamer1.0-libav; then
-    echo "gstreamer1.0-libav installed successfully"
+  if apt-get install -y ${APT_OPTS} \
+      gstreamer1.0-plugins-ugly \
+      gstreamer1.0-libav \
+      libopencv-core406t64; then
+    echo "Deferred packages installed successfully"
     break
   else
     if [[ $attempt -lt $MAX_RETRIES ]]; then
@@ -176,7 +178,7 @@ for attempt in $(seq 1 $MAX_RETRIES); do
       echo "Retrying in $((2 * attempt))s..."
       sleep $((2 * attempt))
     else
-      echo "ERROR: Failed to install gstreamer1.0-libav after $MAX_RETRIES attempts"
+      echo "ERROR: Failed to install deferred packages after $MAX_RETRIES attempts"
       exit 1
     fi
   fi

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -111,17 +111,49 @@ fi
 
 # Keep public Ubuntu repositories as the default. aarch64 packages are served
 # from Ubuntu Ports; no NVIDIA-internal mirror is required or assumed.
-if [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
-  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
-  cat >/etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+#
+# VST_APT_MIRROR overrides the archive for deployments that are far from the
+# public mirrors or behind a restricted egress. Download time is dominated by
+# which mirror answers, not by bandwidth: the same 24.6MB fetch measures ~10s
+# against a close mirror and has been observed to take minutes against a slow
+# or stalled one. Point this at an internal mirror to make startup predictable.
+#
+#   VST_APT_MIRROR=http://mirror.example.com/ubuntu           (x86_64)
+#   VST_APT_MIRROR=http://mirror.example.com/ubuntu-ports     (aarch64)
+if [[ "$(uname -m)" == *"aarch64"* ]]; then
+  APT_MIRROR="${VST_APT_MIRROR:-https://ports.ubuntu.com/ubuntu-ports/}"
+else
+  APT_MIRROR="${VST_APT_MIRROR:-}"
+fi
+
+if [[ -n "${APT_MIRROR}" ]]; then
+  # Trailing slash keeps the generated URIs well formed whichever form is passed.
+  [[ "${APT_MIRROR}" == */ ]] || APT_MIRROR="${APT_MIRROR}/"
+fi
+
+if [[ -n "${VST_APT_MIRROR:-}" ]]; then
+  echo "Using APT mirror: ${APT_MIRROR}"
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<EOF
 Types: deb
-URIs: https://ports.ubuntu.com/ubuntu-ports/
+URIs: ${APT_MIRROR}
+Suites: noble noble-updates noble-security
+Components: main universe
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+  # A mirror supersedes whatever the base image shipped; leaving the original
+  # list in place would send half the requests back to the slow archive.
+  rm -f /etc/apt/sources.list
+elif [[ "$(uname -m)" == *"aarch64"* ]] && ! grep -qr "ports.ubuntu.com" /etc/apt/sources.list.d 2>/dev/null; then
+  echo "Detected aarch64, configuring HTTPS for ports.ubuntu.com..."
+  cat >/etc/apt/sources.list.d/ubuntu.sources <<EOF
+Types: deb
+URIs: ${APT_MIRROR}
 Suites: noble noble-updates
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 Types: deb
-URIs: https://ports.ubuntu.com/ubuntu-ports/
+URIs: ${APT_MIRROR}
 Suites: noble-security
 Components: main universe
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
@@ -129,19 +161,57 @@ EOF
 fi
 
 # Handle network-level timeouts gracefully without killing dpkg.
+#
+# HTTP pipelining is left at the APT default. Forcing Pipeline-Depth=0 serialises
+# every request and measured ~40% slower on this package set (13s vs 8s for the
+# same 52 packages / 24.6MB). Set VST_APT_PIPELINE_DEPTH=0 to restore the
+# serialised behaviour if a proxy or mirror mishandles pipelined requests.
+#
+# ForceIPv4 stays on: a host with broken IPv6 otherwise waits for the v6 attempt
+# to time out on every connection.
 APT_OPTS=(
   -o Acquire::http::Timeout=30
   -o Acquire::https::Timeout=30
   -o Acquire::Retries=5
   -o DPkg::Lock::Timeout=60
   -o Acquire::ForceIPv4=true
-  -o Acquire::http::Pipeline-Depth=0
   -o Dpkg::Options::=--force-confdef
   -o Dpkg::Options::=--force-confold
 )
+if [[ -n "${VST_APT_PIPELINE_DEPTH:-}" ]]; then
+  APT_OPTS+=(-o "Acquire::http::Pipeline-Depth=${VST_APT_PIPELINE_DEPTH}")
+fi
+
 
 install_packages() {
   apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
+}
+
+# APT already retries individual downloads (Acquire::Retries), but a connection
+# that drops mid-transaction fails the whole install. Retry the install itself so
+# a brief outage does not fail container startup.
+#
+# Deliberately not wrapped in `timeout`: killing apt-get install midway can leave
+# dpkg half-configured, which is worse than a slow start. Repair between attempts
+# instead -- a failed install is exactly what leaves packages unconfigured, and
+# without this the retry fails the same way.
+install_packages_with_retries() {
+  local attempt
+  for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    if install_packages; then
+      return 0
+    fi
+    echo "apt-get install attempt ${attempt}/${MAX_RETRIES} failed."
+    if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+      if is_dpkg_broken; then
+        echo "Repairing incomplete dpkg state before retry..."
+        dpkg --configure -a || true
+      fi
+      echo "Retrying in $((2 * attempt))s..."
+      sleep $((2 * attempt))
+    fi
+  done
+  return 1
 }
 
 refresh_apt_metadata() {
@@ -163,6 +233,19 @@ refresh_apt_metadata() {
   return 1
 }
 
+# A mirror override invalidates the metadata the base image ships, which is
+# indexed against the default archive. Measured: with a mirror configured and the
+# shipped lists in place, apt resolves no download URI at all, so the fast path
+# below would fail and only then refresh. Refresh up front instead of paying for
+# a doomed attempt first.
+if [[ -n "${VST_APT_MIRROR:-}" ]]; then
+  echo "APT mirror configured; refreshing metadata before install."
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata from ${APT_MIRROR}."
+    exit 1
+  fi
+fi
+
 # Reuse the base image's APT metadata first. Refresh only if installation shows
 # it is stale or a package is unavailable, keeping the normal path offline-fast.
 echo "Installing VIOS runtime media packages..."
@@ -176,7 +259,10 @@ if ! install_packages; then
     echo "Repairing incomplete dpkg state..."
     dpkg --configure -a
   fi
-  install_packages
+  if ! install_packages_with_retries; then
+    echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
+    exit 1
+  fi
 fi
 
 # OSRB: strip Intel MediaSDK / QuickSync (QSV) codec libs re-pulled as part of the

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -24,6 +24,10 @@
 # makes the restart path free.
 set -e  # Exit on any error
 
+# The base image may preload libraries that are restored by this installer.
+# Do not pass unavailable preload paths to apt/dpkg helper processes.
+unset LD_PRELOAD
+
 # Ensure non-interactive mode for apt operations
 export DEBIAN_FRONTEND=noninteractive
 

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -188,6 +188,7 @@ done
 echo "Reinstalling GStreamer plugins and core multimedia libraries..."
 for attempt in $(seq 1 $MAX_RETRIES); do
   if apt-get install --reinstall -y ${APT_OPTS} \
+      libv4lconvert0t64 \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       libvo-aacenc0 libfaad2 libswresample-dev libswresample4 libavutil-dev libavutil58 \
       libswscale7 libpostproc57 \


### PR DESCRIPTION
## Description
Dev packages in release container causing too many extra dependencies packages to get installed.
This removes 330 such dependencies out of which
26 are GPL licensed.

Approved OSRB bug : https://nvbugspro.nvidia.com/bug/6558907 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
