### PR TITLE
ci(skills-eval): pin daily runs to nightly commit

### DIFF
--- a/.github/scripts/resolve-skills-eval-ref.sh
+++ b/.github/scripts/resolve-skills-eval-ref.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Resolve the source ref for the daily skills evaluation.
+#
+# Usage: resolve-skills-eval-ref.sh [YYYYMMDD]
+#
+# Environment overrides keep the policy easy to adjust without coupling it to
+# the workflow:
+#   SKILLS_EVAL_REMOTE          Git remote or URL (default: origin)
+#   SKILLS_EVAL_TAG_PREFIX      Daily tag prefix (default: nightly-)
+#   SKILLS_EVAL_FALLBACK_BRANCH Fallback branch (default: develop)
+#   SKILLS_EVAL_TIMEZONE        Timezone used for today's date
+#                               (default: UTC, matching the tag publisher)
+#
+# Prints the commit SHA behind either the exact daily tag or fallback branch.
+
+set -euo pipefail
+
+remote="${SKILLS_EVAL_REMOTE:-origin}"
+tag_prefix="${SKILLS_EVAL_TAG_PREFIX:-nightly-}"
+fallback_branch="${SKILLS_EVAL_FALLBACK_BRANCH:-develop}"
+timezone="${SKILLS_EVAL_TIMEZONE:-UTC}"
+date_suffix="${1:-$(TZ="$timezone" date +%Y%m%d)}"
+
+if [[ ! "$date_suffix" =~ ^[0-9]{8}$ ]]; then
+  printf 'error: expected date in YYYYMMDD form, got %q\n' "$date_suffix" >&2
+  exit 64
+fi
+
+tag="${tag_prefix}${date_suffix}"
+tag_ref="refs/tags/${tag}"
+
+# Resolve a remote ref to a commit SHA. For an annotated tag, ls-remote returns
+# both the tag-object SHA and a ^{} entry; prefer the latter (peeled commit).
+resolve_remote_commit() {
+  local ref="$1"
+  local result direct_sha="" peeled_sha="" sha remote_ref resolved_sha
+
+  result="$(git ls-remote --exit-code "$remote" "$ref" "${ref}^{}")" || return $?
+  while read -r sha remote_ref; do
+    if [[ "$remote_ref" == "${ref}^{}" ]]; then
+      peeled_sha="$sha"
+    elif [[ "$remote_ref" == "$ref" ]]; then
+      direct_sha="$sha"
+    fi
+  done <<< "$result"
+
+  resolved_sha="${peeled_sha:-$direct_sha}"
+  if [[ ! "$resolved_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    printf 'error: remote returned an invalid SHA for %s: %q\n' \
+      "$ref" "$resolved_sha" >&2
+    return 65
+  fi
+  printf '%s\n' "$resolved_sha"
+}
+
+if resolved_ref="$(resolve_remote_commit "$tag_ref")"; then
+  printf 'skills eval ref: using daily tag %s commit %s\n' \
+    "$tag" "$resolved_ref" >&2
+else
+  status=$?
+  # git-ls-remote reserves status 2 for a successful remote query with no
+  # matching ref. Authentication, transport, and other failures must fail the
+  # workflow rather than silently evaluating a different revision.
+  if [[ "$status" -ne 2 ]]; then
+    printf 'error: could not query %s for %s (git ls-remote exit %d)\n' \
+      "$remote" "$tag_ref" "$status" >&2
+    exit "$status"
+  fi
+
+  fallback_ref="refs/heads/${fallback_branch}"
+  if resolved_ref="$(resolve_remote_commit "$fallback_ref")"; then
+    :
+  else
+    status=$?
+    printf 'error: could not resolve fallback branch %s from %s (git ls-remote exit %d)\n' \
+      "$fallback_branch" "$remote" "$status" >&2
+    exit "$status"
+  fi
+
+  printf 'skills eval ref: %s is unavailable; using %s commit %s\n' \
+    "$tag" "$fallback_branch" "$resolved_ref" >&2
+fi
+
+# Both successful paths converge here and emit exactly one final ref.
+printf '%s\n' "$resolved_ref"

--- a/.github/scripts/test_resolve_skills_eval_ref.py
+++ b/.github/scripts/test_resolve_skills_eval_ref.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for resolve-skills-eval-ref.sh."""
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("resolve-skills-eval-ref.sh")
+
+
+def run(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+class ResolveSkillsEvalRefTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        root = Path(self.tempdir.name)
+        self.remote = root / "remote.git"
+        self.worktree = root / "worktree"
+
+        run("git", "init", "--bare", str(self.remote), cwd=root)
+        run("git", "init", "-b", "develop", str(self.worktree), cwd=root)
+        run("git", "config", "user.name", "Skills Eval Test", cwd=self.worktree)
+        run("git", "config", "user.email", "skills-eval@example.com", cwd=self.worktree)
+        (self.worktree / "fixture.txt").write_text("fixture\n", encoding="utf-8")
+        run("git", "add", "fixture.txt", cwd=self.worktree)
+        run("git", "commit", "-m", "test fixture", cwd=self.worktree)
+        run("git", "remote", "add", "origin", str(self.remote), cwd=self.worktree)
+        run("git", "push", "-u", "origin", "develop", cwd=self.worktree)
+        self.develop_sha = run(
+            "git", "rev-parse", "HEAD", cwd=self.worktree
+        ).stdout.strip()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def resolve(self, date_suffix: str) -> subprocess.CompletedProcess[str]:
+        return run(str(SCRIPT), date_suffix, cwd=self.worktree)
+
+    def test_resolves_exact_annotated_daily_tag_to_commit_sha(self) -> None:
+        run(
+            "git",
+            "tag",
+            "-a",
+            "nightly-20260806",
+            "-m",
+            "nightly fixture",
+            cwd=self.worktree,
+        )
+        run("git", "push", "origin", "nightly-20260806", cwd=self.worktree)
+
+        result = self.resolve("20260806")
+
+        self.assertEqual(result.stdout.strip(), self.develop_sha)
+        self.assertIn("using daily tag", result.stderr)
+
+    def test_falls_back_to_develop_commit_sha_when_tag_is_absent(self) -> None:
+        # A neighboring daily tag must not be treated as today's exact tag.
+        run("git", "tag", "nightly-20260806", cwd=self.worktree)
+        run("git", "push", "origin", "nightly-20260806", cwd=self.worktree)
+
+        result = self.resolve("20260807")
+
+        self.assertEqual(result.stdout.strip(), self.develop_sha)
+        self.assertIn("is unavailable", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -72,12 +72,43 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------
+  # resolve-ref — choose one ref for the rest of the workflow. Scheduled runs
+  # prefer the commit behind nightly-YYYYMMDD (UTC date) and fall back to
+  # develop's SHA.
+  # Manual runs preserve the branch/tag selected in the workflow dispatch UI.
+  # ---------------------------------------------------------------------
+  resolve_ref:
+    name: Resolve eval ref
+    runs-on: [self-hosted, vss-skill-eval-runner]
+    timeout-minutes: 15
+    outputs:
+      ref: ${{ github.event_name == 'schedule' && steps.resolve.outputs.ref || github.ref }}
+    steps:
+      - name: Checkout resolver
+        if: github.event_name == 'schedule'
+        uses: actions/checkout@v4
+        with:
+          # Scheduled workflows run from the default branch. This checkout
+          # loads the resolver script from that same commit. Plan and eval
+          # check out its result.
+          fetch-depth: 1
+
+      - name: Resolve latest daily ref
+        if: github.event_name == 'schedule'
+        id: resolve
+        run: |
+          resolved_ref="$(.github/scripts/resolve-skills-eval-ref.sh)"
+          printf 'ref=%s\n' "$resolved_ref" >> "$GITHUB_OUTPUT"
+          printf 'Resolved skills eval ref: %s\n' "$resolved_ref" >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
   # plan — enumerate every skill into the dispatch matrix (full sweep:
   # DAILY_RUN=1 -> plan_matrix.py list_skill_file_paths()).
   # Lightweight: gh + python3, no GPU, no brev, no flock.
   # ---------------------------------------------------------------------
   plan:
     name: Plan eval matrix
+    needs: resolve_ref
     runs-on: [self-hosted, vss-skill-eval-runner]
     timeout-minutes: 15
     outputs:
@@ -87,11 +118,9 @@ jobs:
       - name: Checkout mirror head
         uses: actions/checkout@v4
         with:
-          # The scheduled nightly fires from the DEFAULT branch (main) but must
-          # EVALUATE develop, where active skill/harness work lands. Schedule ->
-          # develop; workflow_dispatch -> the ref picked in the dropdown
-          # (github.ref) so on-demand runs can still target any branch.
-          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
+          # Scheduled runs receive the commit behind nightly-YYYYMMDD (UTC) or
+          # the develop fallback SHA. Manual runs retain the dispatched ref.
+          ref: ${{ needs.resolve_ref.outputs.ref }}
           fetch-depth: 0   # plan diffs the cumulative head...base range
 
       - name: Set up skill-eval Python
@@ -110,7 +139,7 @@ jobs:
   # ---------------------------------------------------------------------
   eval:
     name: ${{ matrix.name }}
-    needs: plan
+    needs: [resolve_ref, plan]
     if: needs.plan.outputs.has_targets == 'true'
     runs-on: [self-hosted, vss-skill-eval-runner]
     strategy:
@@ -134,9 +163,9 @@ jobs:
       - name: Checkout mirror head
         uses: actions/checkout@v4
         with:
-          # Match the plan job: nightly evaluates develop; dispatch uses the
-          # chosen ref. Both jobs must check out the same tree.
-          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
+          # Match the plan job exactly. Every leg consumes the same immutable
+          # ref selected once by resolve_ref.
+          ref: ${{ needs.resolve_ref.outputs.ref }}
           fetch-depth: 0   # agent needs full history to fetch + commit to the contributor's branch (§ 3c)
 
       - name: Set up skill-eval Python
@@ -200,10 +229,10 @@ jobs:
           python3 -c 'import os, sys; expected = tuple(map(int, os.environ["SKILL_EVAL_PYTHON_VERSION"].split("."))); assert sys.version_info[:2] == expected, sys.version'
           # Pin the box-side repo sync to the SHA the runner actually checked
           # out — NOT github.sha. On a scheduled run github.sha is the default
-          # branch (main) tip, but the checkout above is develop; using it here
-          # would make BrevEnvironment._sync_repo_to_pr_head deploy main's code
-          # while the harness ran develop. git rev-parse HEAD = the checked-out
-          # commit (develop on the nightly, the dispatch ref otherwise), so both
+          # branch (main) tip, but the checkout above is the resolved ref; using
+          # github.sha here would make BrevEnvironment._sync_repo_to_pr_head
+          # deploy main's code while the harness ran another revision.
+          # git rev-parse HEAD = the commit selected by resolve_ref, so both
           # code sources stay on the same tree.
           export PR_HEAD_SHA="$(git rev-parse HEAD)"
           export PR_REPO="${{ github.repository }}"


### PR DESCRIPTION
## Summary

Updates the scheduled Skills Eval Daily workflow to evaluate a stable commit associated with the UTC-dated nightly tag.

## Behavior

For scheduled runs:

1. Derive `nightly-YYYYMMDD` using the current UTC date.
2. Resolve the tag to its underlying commit SHA.
3. If the exact tag is unavailable, resolve the current `develop` commit SHA.
4. Pass the resolved SHA as the ref for all downstream jobs, ensuring matrix planning and every evaluation leg use the same commit.

Manual workflow dispatches continue using the branch or tag selected in the GitHub UI.

Resolving to a SHA ensures the entire run remains pinned to one commit even if a lightweight nightly tag is moved later.

## Implementation

- Adds a modular `resolve-skills-eval-ref.sh` resolver.
- Handles lightweight and annotated tags, including peeling annotated tags to their commit SHA.
- Fails on authentication or transport errors rather than silently falling back.
- Records the selected tag/branch and resolved SHA in the workflow logs.
- Loads the resolver from the same default-branch commit as the scheduled workflow.

## Validation

- Nightly annotated tag resolves to its underlying commit SHA.
- Missing exact nightly tag falls back to the `develop` commit SHA.
- A neighboring nightly tag is not selected.
- Bash syntax and workflow ref-routing checks pass.

## Follow-up recommendation

The nightly tag publisher should create annotated tags and protect the `nightly-*` namespace against updates or deletion. Annotated tags improve traceability; protection provides immutability.