### PR TITLE
fix(skills): fix build vision agent frontmatter

### DIFF
--- a/skills/vss-build-vision-agent/SKILL.md
+++ b/skills/vss-build-vision-agent/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vss-build-vision-agent
-description: Add agent-ready vision capabilities — dense captioning, detection, search, alerting, summarization — to an agent or application through a customizable, self-contained vision stack built on the NVIDIA VSS Blueprint. Use this skill when a developer or agent wants to give their app vision: pick capabilities via guided intake ("build a vision agent", "add vision capabilities") or describe them in natural language ("create a profile for streaming dense captioning", "add agentic search to my base deployment"). Route, compose, configure, and deploy stock base, alerts, LVS, or search developer profiles and lean custom combinations expressed as delta overlays using one current developer profile as the Foundation.
+description: >-
+  Add agent-ready vision capabilities — dense captioning, detection, search, alerting, summarization — to an agent or application through a customizable, self-contained vision stack built on the NVIDIA VSS Blueprint. Use this skill when a developer or agent wants to give their app vision: pick capabilities via guided intake ("build a vision agent", "add vision capabilities") or describe them in natural language ("create a profile for streaming dense captioning", "add agentic search to my base deployment"). Route, compose, configure, and deploy stock base, alerts, LVS, or search developer profiles and lean custom combinations expressed as delta overlays using one current developer profile as the Foundation.
 license: Apache-2.0
 metadata:
   version: "3.2.0"


### PR DESCRIPTION
## Description

Fixes NvBug 6570833.

The `vss-build-vision-agent` description added in #1534 contains `: ` inside an unquoted YAML plain scalar. NemoClaw therefore rejects the `SKILL.md` frontmatter and stops skill installation on `dev-26.08.1` descendants. The failure affects both DGX Spark and Brev 2x RTX PRO 6000 Blackwell Server Edition because both deployment paths install the same skill through the NemoClaw notebook.

Represent the existing description as a folded block scalar (`>-`). This makes the frontmatter valid without changing the parsed description text.

## Testing

- Ruby `YAML.safe_load`: passed
- Parsed-description preservation: passed (713 characters unchanged)
- `git diff --check`: passed
- Skill compliance checker: passed with 0 errors (6 pre-existing warnings)
- Applicable pre-commit hooks and DCO sign-off: passed
- Diff-scoped TruffleHog scan: passed (0 verified or unverified secrets)
- Full-history TruffleHog hook: blocked by unrelated credential-shaped fixtures already present in repository history and local process-inspection restrictions; no finding came from this change

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] The commit includes a DCO `Signed-off-by` trailer.
- [x] Relevant focused validation passes.
- [x] Documentation remains current; this is a YAML syntax-only correction.
- [ ] The full pre-commit suite passes without exclusions (see TruffleHog baseline limitation above).