### PR TITLE
 fix(lvs): EVS structured-prompt guard and compose EVS passthrough

### DIFF
--- a/services/video-summarization/docker/deploy/compose.yaml
+++ b/services/video-summarization/docker/deploy/compose.yaml
@@ -93,6 +93,14 @@ services:
       LVS_LLM_BASE_URL: http://${LVS_LLM_HOST}:${LVS_LLM_PORT}/v1
       LVS_ENABLE_LLM_MERGING: ${LVS_ENABLE_LLM_MERGING:-false}
       LVS_DROP_EMPTY_EVENT_FIELDS: ${LVS_DROP_EMPTY_EVENT_FIELDS:-false}
+      # EVS knobs (typically set on RTVI-VLM). Pass through to LVS so
+      # `_create_vlm_prompt` can append the structured-output schema guard
+      # that prevents grounding/detection JSON CA-RAG cannot ingest.
+      VIA_EVS_SESSION: ${VIA_EVS_SESSION:-}
+      VLM_VIDEO_PRUNING_RATE: ${VLM_VIDEO_PRUNING_RATE:-}
+      VIA_EVS_EVENT_ONLY: ${VIA_EVS_EVENT_ONLY:-}
+      VIA_EVS_TOKEN_BUDGET: ${VIA_EVS_TOKEN_BUDGET:-}
+      VLLM_IGNORE_EOS: ${VLLM_IGNORE_EOS:-}
       ES_HOST: elasticsearch
       ES_PORT: '9200'
       LVS_DATABASE_BACKEND: ${LVS_DATABASE_BACKEND:-elasticsearch_db}
@@ -371,6 +379,24 @@ services:
       RTVI_TIMESTAMP_PROMPT_PREFIX_RTSP_SOURCE: ${RTVI_TIMESTAMP_PROMPT_PREFIX_RTSP_SOURCE:-}
       RTVI_TIMESTAMP_PROMPT_SUFFIX_RTSP_SOURCE: ${RTVI_TIMESTAMP_PROMPT_SUFFIX_RTSP_SOURCE:-}
       RTVI_VIDEO_METADATA_ABSOLUTE_TIMESTAMPS: true
+      # EVS / EVS++ (video pruning + session knobs). Empty defaults keep
+      # stock behavior; set VIA_EVS_SESSION / VLM_VIDEO_PRUNING_RATE in
+      # .env to enable. LVS also receives these for the structured-prompt
+      # schema guard (see via service env above).
+      VLM_VIDEO_PRUNING_RATE: ${VLM_VIDEO_PRUNING_RATE:-}
+      VIA_EVS_SESSION: ${VIA_EVS_SESSION:-}
+      VLLM_EVS_SIMILARITY_THRESHOLD: ${VLLM_EVS_SIMILARITY_THRESHOLD:-}
+      VLLM_NUM_PREPROCESS_WORKERS: ${VLLM_NUM_PREPROCESS_WORKERS:-}
+      VIA_EVS_TOKEN_BUDGET: ${VIA_EVS_TOKEN_BUDGET:-}
+      VIA_EVS_MIN_CLIPS: ${VIA_EVS_MIN_CLIPS:-}
+      VIA_EVS_EVENT_ONLY: ${VIA_EVS_EVENT_ONLY:-}
+      VIA_EVS_EMA_MEMORY_S: ${VIA_EVS_EMA_MEMORY_S:-}
+      VIA_EVS_SPIKE_STD_K: ${VIA_EVS_SPIKE_STD_K:-}
+      VIA_EVS_SETTLING_STD_K: ${VIA_EVS_SETTLING_STD_K:-}
+      VIA_EVS_STD_FLOOR_RATIO: ${VIA_EVS_STD_FLOOR_RATIO:-}
+      VIA_EVS_DOWNWARD_BASELINE_MIN: ${VIA_EVS_DOWNWARD_BASELINE_MIN:-}
+      VIA_EVS_STREAMING_PREFILL: ${VIA_EVS_STREAMING_PREFILL:-}
+      VLLM_IGNORE_EOS: ${VLLM_IGNORE_EOS:-}
     ulimits:
       memlock:
         soft: -1

--- a/services/video-summarization/src/via_stream_handler.py
+++ b/services/video-summarization/src/via_stream_handler.py
@@ -2744,6 +2744,62 @@ class ViaStreamHandler:
             skip_ca_rag=True,
         )
 
+    @staticmethod
+    def _is_evs_enabled() -> bool:
+        """Return True when EVS / EVS++ is active for this LVS process.
+
+        EVS is considered enabled when ``VIA_EVS_SESSION`` is truthy, or when
+        ``VLM_VIDEO_PRUNING_RATE`` is set to a value in ``(0, 1)``. These env
+        vars are normally set on RTVI-VLM; they must also be passed through to
+        LVS for this prompt guard to take effect.
+        """
+        if os.environ.get("VIA_EVS_SESSION", "").strip().lower() in (
+            "true",
+            "1",
+            "yes",
+            "on",
+        ):
+            return True
+        rate_str = os.environ.get("VLM_VIDEO_PRUNING_RATE", "").strip()
+        if not rate_str:
+            return False
+        try:
+            rate = float(rate_str)
+        except ValueError:
+            return False
+        return 0.0 < rate < 1.0
+
+    @staticmethod
+    def _evs_structured_output_constraints() -> str:
+        """Extra constraints that keep EVS/CR3 outputs CA-RAG-parseable.
+
+        Under EVS, Cosmos Reason often emits grounding/detection JSON
+        (``bbox_2d`` / ``label`` / trajectories / ``no visible …``) instead of
+        timeline events. CA-RAG then silently drops those docs. This text is
+        appended to the VLM prompt when EVS is enabled and structured output
+        is requested.
+        """
+        return (
+            "EVS/output-format constraints (mandatory): "
+            "Output ONLY a JSON array of timeline event objects. "
+            "Each object MUST contain exactly these keys: "
+            "'start_time', 'end_time', 'type', 'description' "
+            "(all mandatory; description must be non-empty prose). "
+            "Do NOT emit grounding/detection schemas: never use "
+            "bbox_2d, box_2d, point_2d, trajector, trajectory, "
+            "label-only objects, category/clothing/location entity fields, "
+            "or bare numeric values. "
+            "Do NOT emit negative findings such as "
+            "'no visible smoke or flames' / 'no anomalies' as standalone "
+            "objects or free-form prose. "
+            "If none of the requested event types are present, return one "
+            "event with type chosen from the allowed list (prefer "
+            "'normal activity' when available) covering the chunk time "
+            "range and a brief scene description in 'description'. "
+            "Do not wrap the array in an object, do not prefix with "
+            "'Assistant', and do not include any text outside the JSON array."
+        )
+
     def _create_vlm_prompt(
         self,
         prompt: str,
@@ -2762,6 +2818,10 @@ class ViaStreamHandler:
         - LVS_PROMPT_VLM_INSTRUCTION: Override the instruction section
         - LVS_PROMPT_VLM_CONSTRAINTS: Add additional constraints (empty by default)
         - LVS_PROMPT_VLM_STRUCTURED_OUTPUT: Override output format and JSON template
+
+        When EVS is enabled (``VIA_EVS_SESSION`` or ``VLM_VIDEO_PRUNING_RATE``),
+        additional constraints are appended automatically to discourage
+        grounding/detection JSON that CA-RAG cannot ingest.
 
         Template variables available for substitution in custom prompts:
         - {scenario}: The scenario parameter
@@ -2844,6 +2904,12 @@ This is very important and you must follow this strictly.
         structured_output = (
             env_structured_output if env_structured_output else default_structured_output
         )
+
+        # Under EVS, CR3 often drifts into grounding JSON; reinforce event schema.
+        if self._is_evs_enabled():
+            evs_guard = self._evs_structured_output_constraints()
+            constraints = f"{constraints}\n\n{evs_guard}".strip() if constraints else evs_guard
+            logger.info("EVS enabled: appending structured-output schema guard to VLM prompt")
 
         # Helper function for safe template variable substitution
         # Uses str.replace() instead of .format() to handle literal braces in JSON

--- a/services/video-summarization/tests/unit/test_evs_structured_prompt_guard.py
+++ b/services/video-summarization/tests/unit/test_evs_structured_prompt_guard.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for EVS structured-output prompt guard in _create_vlm_prompt."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_handler():
+    from via_stream_handler import ViaStreamHandler
+
+    return ViaStreamHandler.__new__(ViaStreamHandler)
+
+
+def _clear_prompt_overrides():
+    for key in (
+        "LVS_PROMPT_VLM_ROLE",
+        "LVS_PROMPT_VLM_INSTRUCTION",
+        "LVS_PROMPT_VLM_CONSTRAINTS",
+        "LVS_PROMPT_VLM_STRUCTURED_OUTPUT",
+    ):
+        os.environ.pop(key, None)
+
+
+@pytest.mark.unit
+class TestEvsStructuredPromptGuard:
+    def test_evs_session_appends_schema_guard(self):
+        handler = _make_handler()
+        with patch.dict(
+            os.environ,
+            {"VIA_EVS_SESSION": "true", "VLM_VIDEO_PRUNING_RATE": ""},
+            clear=False,
+        ):
+            _clear_prompt_overrides()
+            result = handler._create_vlm_prompt(
+                "ignored", True, [], ["fire", "normal activity"], "warehouse"
+            )
+            assert "bbox_2d" in result
+            assert "EVS/output-format constraints" in result
+            assert "normal activity" in result
+
+    def test_evs_pruning_rate_appends_schema_guard(self):
+        handler = _make_handler()
+        with patch.dict(
+            os.environ,
+            {"VIA_EVS_SESSION": "false", "VLM_VIDEO_PRUNING_RATE": "0.5"},
+            clear=False,
+        ):
+            _clear_prompt_overrides()
+            result = handler._create_vlm_prompt("ignored", True, [], ["theft"], "warehouse")
+            assert "EVS/output-format constraints" in result
+            assert "Do NOT emit grounding/detection schemas" in result
+
+    def test_evs_guard_not_added_when_evs_disabled(self):
+        handler = _make_handler()
+        with patch.dict(
+            os.environ,
+            {"VIA_EVS_SESSION": "false", "VLM_VIDEO_PRUNING_RATE": "0"},
+            clear=False,
+        ):
+            _clear_prompt_overrides()
+            result = handler._create_vlm_prompt("ignored", True, [], ["theft"], "warehouse")
+            assert "EVS/output-format constraints" not in result
+
+    def test_evs_guard_appended_to_existing_constraints(self):
+        handler = _make_handler()
+        with patch.dict(
+            os.environ,
+            {
+                "VIA_EVS_SESSION": "true",
+                "LVS_PROMPT_VLM_CONSTRAINTS": "Keep answers concise.",
+            },
+            clear=False,
+        ):
+            result = handler._create_vlm_prompt("ignored", True, [], ["fire"], "warehouse")
+            assert "Keep answers concise." in result
+            assert "EVS/output-format constraints" in result
+
+    def test_is_evs_enabled_helpers(self):
+        handler = _make_handler()
+        with patch.dict(os.environ, {"VIA_EVS_SESSION": "true"}, clear=False):
+            assert handler._is_evs_enabled() is True
+        with patch.dict(
+            os.environ,
+            {"VIA_EVS_SESSION": "false", "VLM_VIDEO_PRUNING_RATE": "0.9"},
+            clear=False,
+        ):
+            assert handler._is_evs_enabled() is True
+        with patch.dict(
+            os.environ,
+            {"VIA_EVS_SESSION": "false", "VLM_VIDEO_PRUNING_RATE": "0"},
+            clear=False,
+        ):
+            assert handler._is_evs_enabled() is False


### PR DESCRIPTION
## Summary
- When EVS is enabled (`VIA_EVS_SESSION` or `VLM_VIDEO_PRUNING_RATE`), append a structured-output schema guard to VLM prompts so Cosmos Reason does not emit grounding/detection JSON that CA-RAG silently drops.
- Pass EVS env knobs through to both the `via` (LVS) and in-stack `rtvi-vlm` services in `services/video-summarization/docker/deploy/compose.yaml` so EVS can be enabled from `.env`.
- Add unit coverage for the EVS detection helpers and prompt-guard append behavior.

## Test plan
- [x] Unit: `pytest services/video-summarization/tests/unit/test_evs_structured_prompt_guard.py -vv`
- [x] Compose: set `VIA_EVS_SESSION=true` and `VLM_VIDEO_PRUNING_RATE=0.5` in `.env`; confirm both `via` and `rtvi-vlm` containers see the vars (`docker exec … env | rg VIA_EVS|VLM_VIDEO_PRUNING`)
- [x] Smoke EVS file summarize; verify LVS logs show fewer/zero `Dropping event with empty description` / `Skipping invalid event` vs ungarded EVS run
- [x] Confirm stock path (EVS unset) is unchanged — no schema-guard text appended to prompts