### PR TITLE
Fix 105 HIGH SonarQube issues: Misc C++ cleanups

### DIFF
--- a/services/vios/include/sensor_control_adaptor.h
+++ b/services/vios/include/sensor_control_adaptor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,6 +105,9 @@ public:
     void setCacheSensorList(std::vector<shared_ptr<SensorInfo>> list) { m_cacheSensorList = list; }
     std::vector<shared_ptr<SensorInfo>> getCacheSensorList() { return m_cacheSensorList; }
 protected:
+    const AdaptorInfo& adaptorInfo() const { return m_adaptorInfo; }
+    std::vector<shared_ptr<SensorInfo>>& cacheSensorList() { return m_cacheSensorList; }
+private:
     AdaptorInfo m_adaptorInfo;
     std::vector<shared_ptr<SensorInfo>> m_cacheSensorList;
 };

--- a/services/vios/include/sensor_discovery_adaptor.h
+++ b/services/vios/include/sensor_discovery_adaptor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,8 +36,16 @@ class ISensorDiscoveryEvent
         virtual int onSensorChanged(SensorInfo& sensorInfo) = 0;
         virtual int onSensorRemoved(const string& sensorInfo) = 0;
 
-        virtual void notifyEvent(const SensorStatus& status, const string& url) {}
-        virtual void refreshSensorList() {}
+        virtual void notifyEvent(const SensorStatus& status, const string& url)
+        {
+            // Optional hook: listeners that do not track sensor status changes ignore the event.
+            (void)status;
+            (void)url;
+        }
+        virtual void refreshSensorList()
+        {
+            // Optional hook: only listeners that maintain a cached sensor list override this.
+        }
 };
 
 class ISensorDiscoveryInterface

--- a/services/vios/include/sensor_info.h
+++ b/services/vios/include/sensor_info.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -146,7 +146,7 @@ class ClientSession
 
         CURL* getCurlClient();
         std::shared_ptr<NvSoap> getNvSoap();
-    protected:
+    private:
         CURL* m_curl;
         std::shared_ptr<NvSoap> m_nvsoap;
 };

--- a/services/vios/include/vms_media_interface.h
+++ b/services/vios/include/vms_media_interface.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,10 @@ public:
     virtual int fetchSnapshot(const SnapshotRequest& req, SnapshotResponse& out) = 0;
     virtual int fetchClip(const ClipRequest& req, ClipResponse& out) = 0;
 
-    virtual void close() {}
+    virtual void close()
+    {
+        // Optional hook: adaptors holding no persistent connection need no teardown.
+    }
 };
 
 extern "C" IMediaInterface* createMediaObject();

--- a/services/vios/src/adaptors/milestone/milestone_vms.cpp
+++ b/services/vios/src/adaptors/milestone/milestone_vms.cpp
@@ -947,7 +947,7 @@ static int refreshToken(const string& baseurl, const string& username, const str
 int MilestoneVmsVendor::connect()
 {
     LOG(info) << __METHOD_NAME__ << endl;
-    int ret = refreshToken(m_adaptorInfo.m_url, m_adaptorInfo.m_user, m_adaptorInfo.m_password, m_token);
+    int ret = refreshToken(adaptorInfo().m_url, adaptorInfo().m_user, adaptorInfo().m_password, m_token);
     if (ret == 0 && m_deviceEventCB != nullptr && m_cameraEvent == nullptr)
     {
        //m_cameraEvent.reset(new MSCameraEvents(m_deviceManager, m_token, m_deviceEventCB));
@@ -959,14 +959,14 @@ int MilestoneVmsVendor::getSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sens
 {
     LOG(info) << __FUNCTION__ << endl;
     int ret = -1;
-    const string & url = m_adaptorInfo.m_url + string(":") + string("80") + string ("/rcserver/systeminfo.xml");
+    const string & url = adaptorInfo().m_url + string(":") + string("80") + string ("/rcserver/systeminfo.xml");
     string xmlData;
     const string username = ""; //nv_user
     const string password = ""; //nv_password
     ret = createAndSendRequest(url, SOAP_AUTH_NTLM, username, password, "", xmlData);
     if (ret == 0)
     {
-        ret = parseCameraInfo(m_adaptorInfo.m_url, xmlData, sensors);
+        ret = parseCameraInfo(adaptorInfo().m_url, xmlData, sensors);
     }
     return ret;
 }
@@ -1040,8 +1040,8 @@ int MilestoneVmsVendor::parseCameraInfo(const string& server_url, const string& 
         if (cur != nullptr)
         {
             shared_ptr<SensorInfo> sensor(new SensorInfo);
-            sensor->user = m_adaptorInfo.m_user;
-            sensor->password = m_adaptorInfo.m_password;
+            sensor->user = adaptorInfo().m_user;
+            sensor->password = adaptorInfo().m_password;
             sensor->type = SENSOR_TYPE_RTSP;  // Set sensor type for Milestone VMS cameras
             sensor->updateSensorStatus(SensorStatusOnline);  // Initialize sensor status as online
             shared_ptr<StreamInfo> stream(new StreamInfo);

--- a/services/vios/src/adaptors/milestone/milestone_vms.h
+++ b/services/vios/src/adaptors/milestone/milestone_vms.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +42,11 @@ class ICameraStatusEvent
 {
     public:
         virtual void onDeviceEvent(const SensorStatus& status) = 0;
-        virtual void notifyEvent(const SensorStatus& status, const string& camera_ip){}
+        virtual void notifyEvent(const SensorStatus& status, const string& camera_ip)
+        {
+            // Optional notification hook: implementers that only care about onDeviceEvent()
+            // intentionally leave this as a no-op.
+        }
 };
 
 

--- a/services/vios/src/adaptors/onvif/onvif_client.cpp
+++ b/services/vios/src/adaptors/onvif/onvif_client.cpp
@@ -218,7 +218,7 @@ static int GetSensorInfo(shared_ptr<SensorInfo>& sensor)
 
 bool OnvifClient::isSensorExists(const string& id)
 {
-    for (auto sensor : m_cacheSensorList)
+    for (auto sensor : cacheSensorList())
     {
         if(sensor->id == id)
         {
@@ -230,7 +230,7 @@ bool OnvifClient::isSensorExists(const string& id)
 
 std::shared_ptr<SensorInfo> OnvifClient::getSensor(const string& id)
 {
-    for (auto sensor : m_cacheSensorList)
+    for (auto sensor : cacheSensorList())
     {
         if(sensor->id == id)
         {
@@ -353,13 +353,13 @@ int OnvifClient::fetchSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sensors)
         return ret;
     }
 
-    soap.user = m_adaptorInfo.m_user;
-    soap.password = m_adaptorInfo.m_password;
+    soap.user = adaptorInfo().m_user;
+    soap.password = adaptorInfo().m_password;
     soap.curl = clientSession->getCurlClient();
     soap.authMethod = AUTH_METHOD_USERNAME_TOKEN;
     clientSession->getNvSoap()->getHttpErrorCode(); // reset code value
     vector<SensorSettings> settings;
-    soap.url = m_adaptorInfo.m_url +  string(":") + m_adaptorInfo.m_port + string("/onvif/device_service");
+    soap.url = adaptorInfo().m_url +  string(":") + adaptorInfo().m_port + string("/onvif/device_service");
     soap.device_url = soap.url;
     map<string, OnvifServiceInfo> caps;
     OnvifServiceInfo serviceInfo;
@@ -428,13 +428,13 @@ int OnvifClient::fetchSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sensors)
             sensor = getSensor(s.token.profileToken);
             sensor->streams.clear();
         }
-        sensor->user =  m_adaptorInfo.m_user;
-        sensor->password = m_adaptorInfo.m_password;
+        sensor->user =  adaptorInfo().m_user;
+        sensor->password = adaptorInfo().m_password;
         sensor->id = sensor->sensorId = stream->id = s.token.profileToken;
         // Set sensor URL to MMS device URL (needed for MMS mode)
         sensor->url = soap.device_url;
         // Extract and set IP from MMS device URL (needed for duplicate detection in database layer)
-        sensor->ip = m_adaptorInfo.m_ipaddress;
+        sensor->ip = adaptorInfo().m_ipaddress;
         // Set sensor type to MMS_ONVIF for MMS sensors, For onvif sensors, type is set in discovery_adaptor
         sensor->type = SENSOR_TYPE_MMS_ONVIF;
         // Populate serviceUrls with MMS device capabilities (avoid redundant getDeviceCapabilities calls)
@@ -505,10 +505,10 @@ int OnvifClient::fetchSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sensors)
         }
         {
             nvsoap_ in;
-            in.url = HTTPS + string("://") + m_adaptorInfo.m_ipaddress;
+            in.url = HTTPS + string("://") + adaptorInfo().m_ipaddress;
             in.token = stream->id;
-            in.user = m_adaptorInfo.m_user;
-            in.password = m_adaptorInfo.m_password;
+            in.user = adaptorInfo().m_user;
+            in.password = adaptorInfo().m_password;
             in.curl = clientSession->getCurlClient();
             clientSession->getNvSoap()->getCameraPostionsValues(in, sensor->position);
         }
@@ -537,11 +537,11 @@ int OnvifClient::connect()
     int result = -1;
     string url;
     int online_sensors = 0;
-    if (m_adaptorInfo.m_type == TYPE_VST)
+    if (adaptorInfo().m_type == TYPE_VST)
     {
         int max_sensors = GET_CONFIG().max_sensors_supported;
         std::vector<shared_ptr<SensorInfo>>::iterator it;
-        for (it = m_cacheSensorList.begin(); it != m_cacheSensorList.end();)
+        for (it = cacheSensorList().begin(); it != cacheSensorList().end();)
         {
             auto sensor =  *it;
             bool is_sensor_offline = false;
@@ -582,7 +582,7 @@ int OnvifClient::connect()
             if(online_sensors >= max_sensors)
             {
                 LOG(warning) << "Max sensor limit is reached, so deleting extra sensor: " << sensor->name << endl;
-                it = m_cacheSensorList.erase(it);
+                it = cacheSensorList().erase(it);
                 continue;
             }
             else
@@ -612,10 +612,10 @@ int OnvifClient::connect()
             return result;
         }
         /* TBD, about ONVIF endpoints, getting input from vms_config.json file */
-        url = m_adaptorInfo.m_url +  string(":") + m_adaptorInfo.m_port + string("/onvif/device_service");
+        url = adaptorInfo().m_url +  string(":") + adaptorInfo().m_port + string("/onvif/device_service");
         nvsoap_ soap;
-        soap.user = m_adaptorInfo.m_user;
-        soap.password = m_adaptorInfo.m_password;
+        soap.user = adaptorInfo().m_user;
+        soap.password = adaptorInfo().m_password;
         soap.url = soap.device_url = url;
         soap.curl = clientSession->getCurlClient();
         soap.authMethod = AUTH_METHOD_USERNAME_TOKEN;
@@ -673,7 +673,7 @@ int OnvifClient::getSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sensors)
     std::shared_ptr<NvSoap> nvsoap;
     nvsoap_ soap;
     std::shared_ptr<ClientSession> clientSession;
-    if (m_adaptorInfo.m_type == TYPE_VST)
+    if (adaptorInfo().m_type == TYPE_VST)
     {
         for (uint32_t i = 0; i < sensors.size(); i++)
         {
@@ -730,7 +730,7 @@ int OnvifClient::getSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sensors)
             }
         }
     }
-    else if (m_adaptorInfo.m_type == TYPE_MMS)
+    else if (adaptorInfo().m_type == TYPE_MMS)
     {
         response = fetchSensorStreamInfo(sensors);
     }
@@ -748,7 +748,7 @@ int OnvifClient::getSensorStreamInfo(shared_ptr<SensorInfo>& sensor)
         return -1;
     }
     vector<shared_ptr<StreamInfo>> streams;
-    if (m_adaptorInfo.m_type == TYPE_VST)
+    if (adaptorInfo().m_type == TYPE_VST)
     {
         if (sensor->url.empty())
         {

--- a/services/vios/src/adaptors/remote_device/remote_device.cpp
+++ b/services/vios/src/adaptors/remote_device/remote_device.cpp
@@ -75,7 +75,7 @@ void RemoteDevice::syncSensorStatus()
 {
     std::vector<shared_ptr<SensorInfo>>::iterator it;
     set<pair<string, string>> remoteIds;
-    for (auto sensor : m_cacheSensorList)
+    for (auto sensor : cacheSensorList())
     {
         if (sensor.get() && sensor->isRemoteSensor)
         {
@@ -150,7 +150,7 @@ void RemoteDevice::syncSensorStatus(pair<string, string> sensorInfo)
     response = object->m_response;
     if (response.isObject())
     {
-        for (auto sensor : m_cacheSensorList)
+        for (auto sensor : cacheSensorList())
         {
             if (sensor.get() && sensor->id == sensorInfo.first)
             {

--- a/services/vios/src/adaptors/rtsp_streams/rtsp_streams.cpp
+++ b/services/vios/src/adaptors/rtsp_streams/rtsp_streams.cpp
@@ -446,13 +446,13 @@ int RtspStreams::connect()
     int result = -1;
     string url;
     int online_sensors = 0;
-    if (m_adaptorInfo.m_type == TYPE_VST)
+    if (adaptorInfo().m_type == TYPE_VST)
     {
-        addRtspStreams(m_cacheSensorList);
+        addRtspStreams(cacheSensorList());
 
         int max_sensors = GET_CONFIG().max_sensors_supported;
         std::vector<shared_ptr<SensorInfo>>::iterator it;
-        for (it = m_cacheSensorList.begin(); it != m_cacheSensorList.end();)
+        for (it = cacheSensorList().begin(); it != cacheSensorList().end();)
         {
             auto sensor =  *it;
             bool is_stream_offline = false;
@@ -481,7 +481,7 @@ int RtspStreams::connect()
             if(online_sensors >= max_sensors)
             {
                 LOG(warning) << "Max sensor limit is reached, so deleting extra sensor: " << sensor->name << " id: " << sensor->id << endl;
-                it = m_cacheSensorList.erase(it);
+                it = cacheSensorList().erase(it);
                 continue;
             }
             else

--- a/services/vios/src/adaptors/sensors_discovery/native_sensors/native_sensors_discovery.cpp
+++ b/services/vios/src/adaptors/sensors_discovery/native_sensors/native_sensors_discovery.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,6 +47,30 @@ static string trim(const string& str, const string& whitespace = " \t")
     return str.substr(strBegin, strRange);
 }
 
+// Runs a shell command and collects its output. Blocking, must never be called while holding a lock.
+static bool readCommandOutput(const string& cmd, string& output)
+{
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe)
+    {
+        LOG(error) << "Error executing command '" << cmd << "': " << strerror(errno) << " (errno: " << errno << ")"
+                   << endl;
+        return false;
+    }
+
+    char buffer[128];
+    while (!feof(pipe))
+    {
+        if (fgets(buffer, sizeof(buffer), pipe) != nullptr)
+        {
+            output += buffer; // Collect the command output
+        }
+    }
+
+    pclose(pipe); // Close the pipe
+    return true;
+}
+
 static void parseResolution(const string& resolutionStr, string& width, string& height, string& fps)
 {
     size_t xPos = resolutionStr.find('x');
@@ -74,27 +98,13 @@ std::string NativeSensorsDiscovery::getDeviceName(const std::string& devicePath)
 void NativeSensorsDiscovery::doNativeSensorDiscovery(vector<SensorInfo>& sensors)
 {
     string cmd = "v4l2-ctl --list-devices";
-    FILE* pipe = popen(cmd.c_str(), "r"); // Execute v4l2-ctl command
     unsigned int sensor_count = 0;
 
-    if (!pipe)
+    string output;
+    if (!readCommandOutput(cmd, output))
     {
-        LOG(error) << "Error executing v4l2-ctl command: " << strerror(errno) << " (errno: " << errno << ")" << endl;
         return;
     }
-
-    string output;
-    char buffer[128];
-
-    while (!feof(pipe))
-    {
-        if (fgets(buffer, 128, pipe) != nullptr)
-        {
-            output += buffer; // Collect the command output
-        }
-    }
-
-    pclose(pipe); // Close the pipe
 
     // Extract video capture sensor information
     string delimiter = "\n\n";
@@ -150,27 +160,13 @@ void NativeSensorsDiscovery::doNativeSensorDiscovery(vector<SensorInfo>& sensors
         LOG(verbose) << "Sensor Id: " << sensor.id << endl;
 
         string resolutionCmd = "v4l2-ctl --list-formats-ext -d " + sensor.location;
-        pipe = popen(resolutionCmd.c_str(), "r"); // Execute v4l2-ctl command
-
-        if (!pipe)
-        {
-            LOG(error) << "Error executing v4l2-ctl command: " << strerror(errno) << " (errno: " << errno << ")" << endl;
-            return;
-        }
 
         string resOutput;
-        char resBuffer[128];
-
-        while (!feof(pipe))
+        if (!readCommandOutput(resolutionCmd, resOutput))
         {
-            if (fgets(resBuffer, 128, pipe) != nullptr)
-            {
-                resOutput += resBuffer; // Collect the command output
-            }
+            return;
         }
         LOG(verbose) << resOutput << endl;
-
-        pclose(pipe); // Close the pipe
 
         delimiter2 = "Bayer";
         resPos = resOutput.find(delimiter2);
@@ -292,10 +288,11 @@ void NativeSensorsDiscovery::nativeSensorsDiscoveryTask()
 {
     while (m_exit == false)
     {
+        vector<SensorInfo> sensors;
+        doNativeSensorDiscovery(sensors); // Runs blocking v4l2-ctl commands, keep it out of the critical section
+
         {
             std::lock_guard<std::mutex> sensorsLock(m_monitorMutex);
-            vector<SensorInfo> sensors;
-            doNativeSensorDiscovery(sensors);
             m_freshList.clear();
 
             for (uint32_t ele = 0; ele < sensors.size(); ele++)

--- a/services/vios/src/adaptors/sensors_discovery/native_sensors/native_sensors_discovery.cpp
+++ b/services/vios/src/adaptors/sensors_discovery/native_sensors/native_sensors_discovery.cpp
@@ -269,11 +269,21 @@ void NativeSensorsDiscovery::start()
 }
 void  NativeSensorsDiscovery::stop()
 {
-    std::lock_guard<std::mutex> sensorsLock(m_monitorMutex);
-    m_exit = true;
+    // Release m_monitorMutex BEFORE joining. The worker now runs the blocking
+    // v4l2 scan unlocked and re-acquires this mutex afterwards, so holding it
+    // across join() deadlocks: stop() waits for a worker that is waiting for
+    // the very lock stop() holds. Deterministic, not a race -- any stop()
+    // landing during a scan hangs.
+    {
+        std::lock_guard<std::mutex> sensorsLock(m_monitorMutex);
+        m_exit = true;
+    }
     m_sleeperWait.notify_all();
     LOG(info) << "Stoping Native Sensor discovery task" << endl;
-    m_nativeSensorDiscoveryThread.join();
+    if (m_nativeSensorDiscoveryThread.joinable())
+    {
+        m_nativeSensorDiscoveryThread.join();
+    }
     LOG(info) << "Stopped Native Sensor discovery task" << endl;
 }
 

--- a/services/vios/src/adaptors/sensors_discovery/native_sensors/native_sensors_discovery.h
+++ b/services/vios/src/adaptors/sensors_discovery/native_sensors/native_sensors_discovery.h
@@ -20,6 +20,7 @@
 #include "sensor_discovery_adaptor.h"
 #include <memory>
 #include <thread>
+#include <atomic>
 #include <mutex>
 
 namespace nv_vms {
@@ -41,7 +42,8 @@ private:
     void doNativeSensorDiscovery(vector<SensorInfo>& sensors);
 
     std::thread m_nativeSensorDiscoveryThread;
-    bool m_exit;
+    // Read by the worker loop without holding m_monitorMutex.
+    std::atomic<bool> m_exit;
     std::mutex   m_monitorMutex;
     map<string, SensorInfo> m_freshList;
     std::mutex   m_sleeperLock;

--- a/services/vios/src/adaptors/streamer/data/sensor_data.cpp
+++ b/services/vios/src/adaptors/streamer/data/sensor_data.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,7 +90,8 @@ void SensorDataCollector::start()
 
 void SensorDataCollector::stop()
 {
-
+    // Intentionally empty: discovery is a one-shot scan performed by start(),
+    // so there is no background activity or resource to release here.
 }
 
 int SensorDataCollector::searchSensor(SensorInfo& sensor)

--- a/services/vios/src/adaptors/vms_media/vms_media.cpp
+++ b/services/vios/src/adaptors/vms_media/vms_media.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -302,7 +302,11 @@ public:
         }
     }
 
-    void close() override {}
+    void close() override
+    {
+        // Intentionally blank: no persistent connection is held. The gRPC client
+        // owns its channel and is released by the destructor via its unique_ptr.
+    }
 };
 
 } // anonymous namespace

--- a/services/vios/src/app/vstmodule.h
+++ b/services/vios/src/app/vstmodule.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +40,7 @@ class IVstModule
         nv_vms::IMediaInterface* m_mediaInterface = nullptr;
 
         virtual const std::map<std::string,HttpServerRequestHandler::httpFunction, std::less<>> getHttpApi() { return m_func; };
-        virtual void postInit() {}
+        virtual void postInit() { /* Optional hook: modules that need no post-initialization work keep this no-op. */ }
         virtual ~IVstModule() {}
 };
 

--- a/services/vios/src/framework/database/include/database_manager.h
+++ b/services/vios/src/framework/database/include/database_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,10 +86,10 @@ public:
     virtual std::vector<UserSessionsDBColumns> getUserSessions(const string username) { return {}; };
     virtual int deleteUserSession(const string username, const string sessionId) { return -1; };
     virtual int setUserSession(UserSessionsDBColumns &row) { return -1; };
-    virtual void deleteExpiredUserSessions() {};
+    virtual void deleteExpiredUserSessions() { /* Default no-op: backends without user session support have nothing to expire */ };
     virtual std::vector<UserSessionsDBColumns> getAllSessions() { return {}; };
     virtual int deleteUserDetails(const string username) { return -1; };
-    virtual void extendSession(const string username, const string sessionId) {};
+    virtual void extendSession(const string username, const string sessionId) { /* Default no-op; concrete database backends override this. */ };
     virtual std::string getLocalDeviceId() { return ""; };
     virtual std::string getLocalDeviceName() { return ""; };
     virtual int setLocalDeviceId(const string deviceId) { return -1; };
@@ -118,7 +118,7 @@ public:
     virtual int updateFilesProtectionInDb(bool fileProtection, const std::vector<string>& filePaths) { return -1; };
     virtual int resetProtectedFlagsInDb() { return -1; };
     virtual std::vector<VideoRecordDBColumns> getProtectedFilesFromDB() { return {}; };
-    virtual void createDatabaseTables() {};
+    virtual void createDatabaseTables() { /* No-op default: backends without a fixed schema have no tables to create. */ };
     virtual VmsErrorCode getMainStreamFromDB(shared_ptr<StreamInfo> &mainStream, const SensorDetailsDBColumns &sensorDetails) { return VmsErrorCode::NoError; };
     virtual VmsErrorCode getSubStreamFromDB(shared_ptr<StreamInfo> &subStream, const SensorStreamsDBColumns &streamDetails, const string device_name) { return VmsErrorCode::NoError; };
     virtual VmsErrorCode getSensorInfoFromDB(shared_ptr<SensorInfo> &deviceInfo, const SensorDetailsDBColumns &sensorDetails) { return VmsErrorCode::NoError; };

--- a/services/vios/src/framework/live555/rtsp_client/testRTSP.cpp
+++ b/services/vios/src/framework/live555/rtsp_client/testRTSP.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -125,7 +125,7 @@ int testRtspUrl(const char* url, std::string& codec, std::string& frame_rate, st
         if (rtsp_client->m_describeState == false)
         {
             auto until = std::chrono::system_clock::now() + 2s;
-            rtsp_client->m_sdpMonitorCv.wait_until(sdp_lock, until, [&]() { return rtsp_client->m_describeState; });
+            rtsp_client->m_sdpMonitorCv.wait_until(sdp_lock, until, [rtsp_client]() { return rtsp_client->m_describeState; });
         }
     }
     delete client;

--- a/services/vios/src/framework/media/media_pipelines/decoder_base.h
+++ b/services/vios/src/framework/media/media_pipelines/decoder_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,9 +20,9 @@
 class DecoderBase
 {
     public:
-        virtual void setResolution(int width, int height) { }
+        virtual void setResolution(int width, int height) { /* Default: consumers that do not track resolution changes ignore them. */ }
         /** Pass decoder output strides (Y, U, V) to consumers; 0 means not set / use width. */
-        virtual void setDecoderStride(int stride_y, int stride_u, int stride_v) { }
+        virtual void setDecoderStride(int stride_y, int stride_u, int stride_v) { /* Default: consumers that do not care about strides ignore them. */ }
         /** B-frame presence flag for low-latency mode optimization */
         virtual bool hasBframes() const { return false; }
 };

--- a/services/vios/src/framework/media/media_pipelines/gstnvaudioudpclient.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvaudioudpclient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -158,7 +158,7 @@ on_new_sample_from_sink (GstElement * appsink, GstUDPAudioClient* nvAudioUDPClie
 
 int GstUDPAudioClient::create_internal ()
 {
-    LOG (info) << "Creating Gstreamer UDP Audio Client Pipeline on port: " << m_id << endl;
+    LOG (info) << "Creating Gstreamer UDP Audio Client Pipeline on port: " << getId() << endl;
     if (gst_is_initialized() == false)
     {
         gst_init (nullptr, nullptr);
@@ -223,15 +223,15 @@ int GstUDPAudioClient::create_internal ()
         return -1;
     }
 
-    LOG (info) << "Created Gstreamer UDP Audio Client Pipeline on port: " << m_id << endl;
+    LOG (info) << "Created Gstreamer UDP Audio Client Pipeline on port: " << getId() << endl;
     return 0;
 }
 
 void GstUDPAudioClient::play_internal ()
 {
-    LOG (info) << "Transitioning to PLAY Gstreamer UDP Audio Client Pipeline on port: " << m_id << endl;
+    LOG (info) << "Transitioning to PLAY Gstreamer UDP Audio Client Pipeline on port: " << getId() << endl;
     gst_element_set_state (m_pipeline, GST_STATE_PLAYING);
-    LOG (info) << "Setting Completed to PLAY Gstreamer UDP Audio Client Pipeline on port: " << m_id << endl;
+    LOG (info) << "Setting Completed to PLAY Gstreamer UDP Audio Client Pipeline on port: " << getId() << endl;
 }
 
 bool GstUDPAudioClient::pause_internal()
@@ -239,17 +239,17 @@ bool GstUDPAudioClient::pause_internal()
     bool ret = true;
     if (m_pipeline)
     {
-        LOG (info) << "Pausing the pipeline, port:" << m_id << endl;
+        LOG (info) << "Pausing the pipeline, port:" << getId() << endl;
         GstStateChangeReturn gstStateChangeRet = gst_element_set_state (m_pipeline, GST_STATE_PAUSED);
         if (gstStateChangeRet == GST_STATE_CHANGE_FAILURE)
         {
-            LOG (error) << "gst_element_set_state failed UDP Audio Client Pipeline on port: " << m_id << endl;
+            LOG (error) << "gst_element_set_state failed UDP Audio Client Pipeline on port: " << getId() << endl;
             ret = false;
         }
         else
         {
             gst_element_get_state (m_pipeline, nullptr, nullptr, GST_SECOND);
-            LOG (info) << "State change success UDP Audio Client Pipeline on port: " << m_id << endl;
+            LOG (info) << "State change success UDP Audio Client Pipeline on port: " << getId() << endl;
         }
     }
     return ret;
@@ -257,7 +257,7 @@ bool GstUDPAudioClient::pause_internal()
 
 void GstUDPAudioClient::resume_internal ()
 {
-    LOG (info) << "Resume the pipeline, port:" << m_id << endl;
+    LOG (info) << "Resume the pipeline, port:" << getId() << endl;
     if (m_pipeline)
     {
         gst_element_set_state (m_pipeline, GST_STATE_PLAYING);
@@ -266,7 +266,7 @@ void GstUDPAudioClient::resume_internal ()
 
 void GstUDPAudioClient::destroy_internal ()
 {
-    LOG(info) << "Terminating gstreamer UDP Audio Client Pipeline on port: " << m_id << endl;
+    LOG(info) << "Terminating gstreamer UDP Audio Client Pipeline on port: " << getId() << endl;
     if (m_pipeline == nullptr)
     {
         return;
@@ -288,7 +288,7 @@ void GstUDPAudioClient::destroy_internal ()
         gst_object_unref (m_bus);
         m_bus = nullptr;
     }
-    LOG(info) << "Terminated gstreamer UDP Audio Client Pipeline on port: " << m_id << endl;
+    LOG(info) << "Terminated gstreamer UDP Audio Client Pipeline on port: " << getId() << endl;
 }
 
 int GstUDPAudioClient::create(int freq)

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoudpclient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -155,7 +155,7 @@ GstUDPVideoClient::GstUDPVideoClient (const string&  id, UdpStream& stream)
 
 GstUDPVideoClient::~GstUDPVideoClient ()
 {
-    LOG(info) << "~GstUDPVideoClient port:" << m_id << endl;
+    LOG(info) << "~GstUDPVideoClient port:" << getId() << endl;
     if (GET_CONFIG().enable_udp_input_dump)
     {
         fclose(m_dumpFile);
@@ -936,7 +936,7 @@ static bool link_decoder(GstElement* decoder, GstElement* element)
 
 int GstUDPVideoClient::create_internal ()
 {
-    LOG (info) << "Creating Gstreamer udp-video on port: " << m_id << endl;
+    LOG (info) << "Creating Gstreamer udp-video on port: " << getId() << endl;
     if (gst_is_initialized() == false)
     {
         gst_init (nullptr, nullptr);
@@ -1243,7 +1243,7 @@ void GstUDPVideoClient::play_internal ()
     LOG (info) << "Exit - play Gstreamer GstUDPVideoClient pipeline" << endl;   
 
     m_videoDataWatchDog = make_unique<Bosma::Scheduler>(1);
-    m_videoDataWatchDog->interval(VIDEO_DATA_WATCH_DOG_SCHEDULER_INTERVAL, [=]() {
+    m_videoDataWatchDog->interval(VIDEO_DATA_WATCH_DOG_SCHEDULER_INTERVAL, [this]() {
         checkVideoDataFlowStatus();
     });
 }
@@ -1253,7 +1253,7 @@ bool GstUDPVideoClient::pause_internal()
     bool ret = true;
     if (m_pipeline)
     {
-        LOG (info) << "Pausing the pipeline, port:" << m_id << endl;
+        LOG (info) << "Pausing the pipeline, port:" << getId() << endl;
         GstStateChangeReturn gstStateChangeRet = gst_element_set_state (m_pipeline, GST_STATE_PAUSED);
         if (gstStateChangeRet == GST_STATE_CHANGE_FAILURE)
         {
@@ -1296,7 +1296,7 @@ void GstUDPVideoClient::reset_pipeline_internal ()
 void GstUDPVideoClient::destroy_internal ()
 {
     GstStateChangeReturn state_change;
-    LOG(info) << "Terminating gstreamer udp-video pipeline port:" << m_id << endl;
+    LOG(info) << "Terminating gstreamer udp-video pipeline port:" << getId() << endl;
     m_videoDataWatchDog.reset();
     if (m_pipeline == nullptr)
     {
@@ -1340,7 +1340,7 @@ void GstUDPVideoClient::destroy_internal ()
         m_bus = nullptr;
     }
     m_videoDataReceived = false;
-    LOG(info) << "Terminated gstreamer udp-video pipeline port:" << m_id << endl;
+    LOG(info) << "Terminated gstreamer udp-video pipeline port:" << getId() << endl;
 }
 
 int GstUDPVideoClient::create()

--- a/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1090,7 +1090,7 @@ bool ClipReaderProducer::buildPipeline()
         if (appsink_sink)
         {
             gst_pad_add_probe(appsink_sink, GST_PAD_PROBE_TYPE_BUFFER,
-                              appsink_collect_probe_cb, this, NULL);
+                              appsink_collect_probe_cb, this, nullptr);
             gst_object_unref(appsink_sink);
         }
     }

--- a/services/vios/src/framework/media/media_pipelines/media_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/media_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -210,8 +210,11 @@ class IMediaDataConsumer : public std::enable_shared_from_this<IMediaDataConsume
                 m_transcodeStats.clearQueue();
             }
 
-        virtual void onFrame(FrameParams& frame_params) {}
-        virtual void onFrame(std::shared_ptr<RawFrameParams> frame_data) {};
+        virtual void onFrame(FrameParams& frame_params) { /* No-op by default: consumers that do not handle encoded frames ignore them. */ }
+        virtual void onFrame(std::shared_ptr<RawFrameParams> frame_data)
+        {
+            /* Default no-op: only consumers that handle raw frames override this. */
+        };
 
         virtual eMediaType getConsumerMediaType() { return m_mediaType; }
         virtual void setConsumerMediaType(eMediaType media_type) { m_mediaType = media_type; }
@@ -221,16 +224,16 @@ class IMediaDataConsumer : public std::enable_shared_from_this<IMediaDataConsume
         bool isPpsAvailable();
         bool isSpsPpsAvailable();
 
-        virtual void setWebrtcBroadcaster(void* broadcaster) { };
-        virtual void onLastFrame() { }
-        virtual void reset() { }
+        virtual void setWebrtcBroadcaster(void* broadcaster) { /* Default no-op: only WebRTC consumers hold a broadcaster reference. */ };
+        virtual void onLastFrame() { /* No-op by default: only consumers that finalize output on end-of-stream override this. */ }
+        virtual void reset() { /* Default no-op: only consumers holding restartable state (encoders, overlays, transforms) override this. */ }
         /* Update start time for overlay */
-        virtual void updateStartTime(string start_time) { }
+        virtual void updateStartTime(string start_time) { /* No-op by default: only consumers rendering a timestamp overlay use the start time. */ }
         /* Set decoder frame size provides original resolution decoded */
-        virtual void setOriginalFrameSize(int w, int h) { }
-        virtual void setOriginalFrameSize() { }
-        virtual void setIPCMeta() { };
-        virtual void getwebRTCFeedback(int* qp, int* bitrate, double* frame_rate) {}
+        virtual void setOriginalFrameSize(int w, int h) { /* No-op by default: only consumers that need the decoded resolution override this. */ }
+        virtual void setOriginalFrameSize() { /* No-op by default: only elements that cache a source resolution re-propagate it downstream. */ }
+        virtual void setIPCMeta() { /* Default no-op: only consumers in an IPC path need to propagate IPC metadata. */ };
+        virtual void getwebRTCFeedback(int* qp, int* bitrate, double* frame_rate) { /* Default no-op: only WebRTC consumers report encoder feedback, others leave the outputs untouched. */ }
         void startStatsProcessing()
         {
             m_transcodeStats.startProcessing();
@@ -254,8 +257,8 @@ class IMediaDataConsumer : public std::enable_shared_from_this<IMediaDataConsume
         // Writer lifecycle methods - default no-op implementations
         // ─────────────────────────────────────────────────────────────
         virtual bool start() { return true; }
-        virtual void stop() { }
-        virtual void sendEOS() { }
+        virtual void stop() { /* No-op by default: consumers without a writer lifecycle have nothing to stop. */ }
+        virtual void sendEOS() { /* Consumers that do not own a pipeline have no EOS to signal. */ }
         virtual bool waitForCompletion(int64_t /*timeout_secs*/) { return true; }
         virtual bool hasError() const { return false; }
         virtual std::shared_ptr<IMediaDataConsumer> getAudioConsumer() { return nullptr; }

--- a/services/vios/src/framework/media/media_utils/libav_wrapper.h
+++ b/services/vios/src/framework/media/media_utils/libav_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 
 #include <dlfcn.h>
 #include <iostream>
+#include <iterator>
 #include <stdexcept>
 // Include for platform-specific macros (same as vstmodule.cpp)
 #include <string>
@@ -102,7 +103,7 @@ private:
         "/lib64/",
         "/usr/lib64/"
     };
-    static constexpr size_t TRUSTED_SYSTEM_DIRS_COUNT = sizeof(TRUSTED_SYSTEM_DIRS) / sizeof(TRUSTED_SYSTEM_DIRS[0]);
+    static constexpr size_t TRUSTED_SYSTEM_DIRS_COUNT = std::size(TRUSTED_SYSTEM_DIRS);
 
     // Secure library loading function with path validation
     void* tryLoadLibrary(const char* lib_path)

--- a/services/vios/src/framework/media/metadata/ElasticMetadataStore.cpp
+++ b/services/vios/src/framework/media/metadata/ElasticMetadataStore.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,7 @@ namespace
 }
 
 ElasticMetadataStore::ElasticMetadataStore(MetadataParams& params, bool use_frameid)
-    : m_bboxMetadata(m_metadataQueue, m_metadataQueueMutex)
+    : m_bboxMetadata(metadataQueue(), metadataQueueMutex())
 {
     SearchParams inData(params.m_startTime, params.m_endTime, params.m_sensorName);
     if (use_frameid)
@@ -93,21 +93,21 @@ ElasticMetadataStore::~ElasticMetadataStore()
 
 // Pops queue entries older than frameTS and returns the first entry whose
 // timestamp is >= frameTS (the "ceiling" match), or nullValue if the queue
-// drained. Caller must NOT hold m_metadataQueueMutex.
+// drained. Caller must NOT hold metadataQueueMutex().
 Json::Value ElasticMetadataStore::matchQueueFront(const int64_t frameTS)
 {
-    std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
+    std::lock_guard<std::mutex> guard(metadataQueueMutex());
     Json::Value metadata = Json::nullValue;
-    if (!m_metadataQueue.empty())
+    if (!metadataQueue().empty())
     {
-        metadata = m_metadataQueue.front();
+        metadata = metadataQueue().front();
         int64_t elasticTS = metadata["epocTime"].asUInt64() * 1000;
-        while(elasticTS < frameTS && !m_metadataQueue.empty())
+        while(elasticTS < frameTS && !metadataQueue().empty())
         {
-            m_metadataQueue.pop();
-            if (!m_metadataQueue.empty())
+            metadataQueue().pop();
+            if (!metadataQueue().empty())
             {
-                metadata = m_metadataQueue.front();
+                metadata = metadataQueue().front();
                 elasticTS = metadata["epocTime"].asUInt64() * 1000;
             }
             else
@@ -386,10 +386,10 @@ void ElasticMetadataStore::prefetchRange()
                       });
 
             {
-                std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
+                std::lock_guard<std::mutex> guard(metadataQueueMutex());
                 for (auto& h : all)
                 {
-                    m_metadataQueue.push(h);
+                    metadataQueue().push(h);
                 }
             }
 

--- a/services/vios/src/framework/media/metadata/LiveMetadataStore.cpp
+++ b/services/vios/src/framework/media/metadata/LiveMetadataStore.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,8 +112,8 @@ void LiveMetadataStore::addMetadata(const Json::Value& metadata)
         return;
     }
 
-    std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
-    m_metadataQueue.push(metadata);
+    std::lock_guard<std::mutex> guard(metadataQueueMutex());
+    metadataQueue().push(metadata);
     m_metaWait.signal();
 }
 
@@ -127,10 +127,10 @@ Json::Value LiveMetadataStore::getMetadata(const int64_t frameTS)
 
     Json::Value metadata = Json::nullValue;
     {
-        std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
-        if (!m_metadataQueue.empty())
+        std::lock_guard<std::mutex> guard(metadataQueueMutex());
+        if (!metadataQueue().empty())
         {
-            metadata = m_metadataQueue.front();
+            metadata = metadataQueue().front();
         }
     }
     if (metadata == Json::nullValue)
@@ -142,10 +142,10 @@ Json::Value LiveMetadataStore::getMetadata(const int64_t frameTS)
     {
         if (metadataTS == frameTS)
         {
-            std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
-            if (!m_metadataQueue.empty())
+            std::lock_guard<std::mutex> guard(metadataQueueMutex());
+            if (!metadataQueue().empty())
             {
-                m_metadataQueue.pop();
+                metadataQueue().pop();
             }
         }
         return metadata;
@@ -154,10 +154,10 @@ Json::Value LiveMetadataStore::getMetadata(const int64_t frameTS)
     while(metadataTS < frameTS && !isMetadataQueueEmpty())
     {
         {
-            std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
-            if (!m_metadataQueue.empty())
+            std::lock_guard<std::mutex> guard(metadataQueueMutex());
+            if (!metadataQueue().empty())
             {
-                metadata = m_metadataQueue.front();
+                metadata = metadataQueue().front();
                 metadataTS = metadata["epocTime"].asUInt64() * 1000;
                 if (metadataTS >= frameTS)
                 {
@@ -165,7 +165,7 @@ Json::Value LiveMetadataStore::getMetadata(const int64_t frameTS)
                 }
                 else
                 {
-                    m_metadataQueue.pop();
+                    metadataQueue().pop();
                 }
             }
         }
@@ -174,10 +174,10 @@ Json::Value LiveMetadataStore::getMetadata(const int64_t frameTS)
 
     if (metadataTS == frameTS)
     {
-        std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
-        if (!m_metadataQueue.empty())
+        std::lock_guard<std::mutex> guard(metadataQueueMutex());
+        if (!metadataQueue().empty())
         {
-            m_metadataQueue.pop();
+            metadataQueue().pop();
         }
     }
     return metadata;
@@ -189,10 +189,10 @@ void LiveMetadataStore::reFillMetadata(std::queue<Json::Value>& qToFill, std::mu
 
     std::queue<Json::Value> tempQueue;
     {
-        std::lock_guard<std::mutex> guard(m_metadataQueueMutex);
-        if (!m_metadataQueue.empty())
+        std::lock_guard<std::mutex> guard(metadataQueueMutex());
+        if (!metadataQueue().empty())
         {
-            tempQueue.swap(m_metadataQueue);
+            tempQueue.swap(metadataQueue());
         }
     }
     {

--- a/services/vios/src/framework/media/metadata/MetadataStore.h
+++ b/services/vios/src/framework/media/metadata/MetadataStore.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,6 +53,10 @@ public:
     }
 
 protected:
+    std::queue<Json::Value>& metadataQueue() { return m_metadataQueue; }
+    std::mutex& metadataQueueMutex() { return m_metadataQueueMutex; }
+
+private:
     std::queue<Json::Value> m_metadataQueue;
     std::mutex              m_metadataQueueMutex;
 };

--- a/services/vios/src/framework/media/metadata/ReplayMetadataStore.h
+++ b/services/vios/src/framework/media/metadata/ReplayMetadataStore.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,9 +24,20 @@ class ReplayMetadataStore : public IMetadataStore
 public:
     virtual ~ReplayMetadataStore() = default;
 
-    virtual void addMetadata(const Json::Value& metadata) override {};
+    virtual void addMetadata(const Json::Value& metadata) override
+    {
+        // No-op: replay stores pull metadata from the backend themselves
+        // (fetchMetadata/checkAndRefillMetadata); nothing is ever pushed in.
+        (void)metadata;
+    };
     virtual Json::Value getMetadata(const int64_t frameTS) override = 0;
-    virtual void reFillMetadata(std::queue<Json::Value>& qToFill, std::mutex& qToFillMutex) override {};
+    virtual void reFillMetadata(std::queue<Json::Value>& qToFill, std::mutex& qToFillMutex) override
+    {
+        // No-op: the replay queue is refilled from the backend by
+        // checkAndRefillMetadata(), not from a caller-supplied queue.
+        (void)qToFill;
+        (void)qToFillMutex;
+    };
 
     virtual void checkAndRefillMetadata(const int64_t searchAfterTS) =0;
     virtual void waitForMetadata() =0;
@@ -38,5 +49,9 @@ public:
     // metadata queue before/while the pipeline starts, so faster-than-real-time
     // transcoding never outruns the async fetch (bbox flicker). Default no-op
     // preserves existing behavior for stores that do not implement it.
-    virtual void startPrefetch() {}
+    virtual void startPrefetch()
+    {
+        // Intentionally blank: prefetch is an opt-in optimization, so stores
+        // that do not implement it keep their existing lazy-fetch behavior.
+    }
 };

--- a/services/vios/src/framework/media/overlays/ll_overlay.cpp
+++ b/services/vios/src/framework/media/overlays/ll_overlay.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -722,11 +722,11 @@ void NvLLOverlay::doDrawTask()
                     NvBufWrapper::getInstance()->NvBufSurfaceFromFd (sink_frame->m_fd, (void **)&ip_surf);
                     if (isJetsonPlatform() && m_isIPCMeta)
                     {
-                        meta_union.ipcMeta = (GstNvIpcMeta*)sink_frame->meta;
+                        meta_union.setIpcMeta((GstNvIpcMeta*)sink_frame->meta);
                     }
                     else
                     {
-                        meta_union.vstMeta = (GstNvVstMeta*)sink_frame->meta;
+                        meta_union.setVstMeta((GstNvVstMeta*)sink_frame->meta);
                     }
                     pts = sink_frame->pts;
                 }
@@ -815,13 +815,13 @@ void NvLLOverlay::doDrawTask()
 #ifdef AARCH64_PLATFORM
                     if (isJetsonPlatform() && GET_CONFIG().enable_ipc_path == true && m_isIPCMeta)
                     {
-                        meta_union.ipcMeta = GST_NV_IPC_META_GET(sink_frame->m_gstBuffer);
+                        meta_union.setIpcMeta(GST_NV_IPC_META_GET(sink_frame->m_gstBuffer));
                         pts = GST_BUFFER_PTS (sink_frame->m_gstBuffer);
                     }
                     else
 #endif
                     {
-                        meta_union.vstMeta = GST_NV_VST_META_GET (sink_frame->m_gstBuffer);
+                        meta_union.setVstMeta(GST_NV_VST_META_GET (sink_frame->m_gstBuffer));
                         pts = GST_BUFFER_PTS (sink_frame->m_gstBuffer);
                     }
                 }
@@ -1141,10 +1141,10 @@ bool NvLLOverlay::streamSettings(const std::unordered_map<std::string, std::stri
     it = opts.find("overlayOpacity");
     if (it != opts.end() && !it->second.empty())
     {
-        uint8_t opacity = stoi(it->second);
+        int opacity = stoi(it->second);
         if (opacity >= 0 && opacity <= 255)
         {
-            m_overlayParams.m_bboxOpacity = stoi(it->second);
+            m_overlayParams.m_bboxOpacity = static_cast<uint8_t>(opacity);
             m_overlay->setBboxOpacity(m_overlayParams.m_bboxOpacity);
         }
         else

--- a/services/vios/src/framework/media/overlays/overlay_internal.cpp
+++ b/services/vios/src/framework/media/overlays/overlay_internal.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,7 @@
 #include "vst_common.h"
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <opencv2/opencv.hpp>
 #include <fstream>
 #include <sstream>
@@ -2143,7 +2144,7 @@ bool NvLLOverlayInternal::doDraw (void* data, GstMetaUnion *meta, int64_t pts)
     bool ret = false;
     if (m_useId)
     {
-        ret = processOsdSinkPadBufferProbeStreamer(data, meta->vstMeta);
+        ret = processOsdSinkPadBufferProbeStreamer(data, meta->vstMeta());
     }
     ret = processOsdSinkPadBufferProbe(data, meta, pts);
     return ret;
@@ -3425,11 +3426,11 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
     void* meta = nullptr;
     if (GET_CONFIG().enable_ipc_path && m_enableBbox)
     {
-        meta = ipc_meta = union_meta->ipcMeta;
+        meta = ipc_meta = union_meta->ipcMeta();
     }
     else
     {
-        meta = vst_meta = union_meta->vstMeta;
+        meta = vst_meta = union_meta->vstMeta();
     }
 
 #ifdef USE_CUOSD
@@ -4530,7 +4531,8 @@ GstPadProbeReturn osd_sink_pad_buffer_probe (GstPad* pad, GstPadProbeInfo* info,
         }
         /* Get vst metadata of the buffer */
         GstNvVstMeta *meta;
-        meta = meta_union.vstMeta = GST_NV_VST_META_GET (buffer);
+        meta = GST_NV_VST_META_GET (buffer);
+        meta_union.setVstMeta(meta);
         if (meta)
         {
             /* ms for live playback from onFrame */
@@ -5141,10 +5143,10 @@ void NvLLOverlayInternal::draw_pose_cuosd(const std::vector<float>& keypoints,
                             OSD_COLOR_GREEN
                             };
 
-    const size_t bone_colors_count = sizeof(bone_colors) / sizeof(bone_colors[0]);
+    const size_t bone_colors_count = std::size(bone_colors);
 
     // Validate idx_bones array - ensure all indices are within bounds
-    const int num_bones = sizeof(idx_bones) / (2 * sizeof(idx_bones[0]));
+    const int num_bones = static_cast<int>(std::size(idx_bones) / 2);
     for (int i = 0; i < num_bones * 2; i++)
     {
         if (idx_bones[i] >= numKeyPoints)

--- a/services/vios/src/framework/media/overlays/overlay_internal.h
+++ b/services/vios/src/framework/media/overlays/overlay_internal.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@
 #include <queue>
 #include <condition_variable>
 #include <atomic>
+#include <variant>
 #include <dlfcn.h>
 #include <jsoncpp/json/json.h>
 
@@ -69,10 +70,26 @@ typedef void (*osd_draw_t) (OsdContext_t, void *);
 typedef void (*osd_global_init_t) ();
 typedef void (*osd_global_destroy_t) ();
 
-union GstMetaUnion
+class GstMetaUnion
 {
-    GstNvVstMeta* vstMeta;
-    GstNvIpcMeta* ipcMeta;
+    public:
+        void setVstMeta (GstNvVstMeta* meta) { m_meta = meta; }
+        void setIpcMeta (GstNvIpcMeta* meta) { m_meta = meta; }
+
+        GstNvVstMeta* vstMeta () const
+        {
+            auto* meta = std::get_if<GstNvVstMeta*>(&m_meta);
+            return meta ? *meta : nullptr;
+        }
+
+        GstNvIpcMeta* ipcMeta () const
+        {
+            auto* meta = std::get_if<GstNvIpcMeta*>(&m_meta);
+            return meta ? *meta : nullptr;
+        }
+
+    private:
+        std::variant<std::monostate, GstNvVstMeta*, GstNvIpcMeta*> m_meta;
 };
 
 struct Point2D

--- a/services/vios/src/framework/media/video_source/builders/CompositePipelineBuilder.cpp
+++ b/services/vios/src/framework/media/video_source/builders/CompositePipelineBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -232,14 +232,14 @@ void CompositePipelineBuilder::buildCompositorPipeline(const PipelineConfigurati
               << " with " << gridLayout.tiles.size() << " tiles" << endl;
     
     if (NvHwDetection::getInstance()->m_useNvV4l2Enc == true) {
-        m_compositor->setConsumer(m_transform);
-        m_transform->setConsumer(m_encoder);
-        m_encoder->setConsumer(m_webrtcConsumer);
+        m_compositor->setConsumer(getTransform());
+        getTransform()->setConsumer(getEncoder());
+        getEncoder()->setConsumer(getWebrtcConsumer());
         LOG(info) << "   🔗 [Compositor] → [Transform] → [HW Encoder] → [WebRTC Consumer]" << endl;
         LOG(info) << "✅ Compositor Pipeline: Using Hardware Encoding" << endl;
     } else {
-        m_compositor->setConsumer(m_transformSink);
-        m_transformSink->setConsumer(m_webrtcConsumer);
+        m_compositor->setConsumer(getTransformSink());
+        getTransformSink()->setConsumer(getWebrtcConsumer());
         LOG(info) << "   🔗 [Compositor] → [TransformSink] → [WebRTC Consumer]" << endl;
         LOG(info) << "✅ Compositor Pipeline: Using Software Encoding" << endl;
     }
@@ -265,7 +265,7 @@ void CompositePipelineBuilder::setupCompositorConsumers(const PipelineConfigurat
         LOG(info) << "==========================================" << endl;
         
         // Validate that we have the required components for image capture
-        if (!m_imageEncoder) {
+        if (!getImageEncoder()) {
             LOG(error) << "❌ Image encoder not initialized for composite image capture" << endl;
             return;
         }
@@ -281,14 +281,14 @@ void CompositePipelineBuilder::setupCompositorConsumers(const PipelineConfigurat
         }
 
         // For composite image capture, we'll use the first decoder and connect it to image encoder
-        if (m_transform) {
-            m_decoders[0]->setConsumer(config.getPeerId(), m_transform);
-            m_transform->setConsumer(m_imageEncoder);
+        if (getTransform()) {
+            m_decoders[0]->setConsumer(config.getPeerId(), getTransform());
+            getTransform()->setConsumer(getImageEncoder());
             LOG(info) << "✅ Pipeline: [First Decoder] → [Transform] → [ImageEncoder] → [JPEG Output]" << endl;
             LOG(info) << "   📸 Composite image will be captured from first stream and returned as JPEG buffer" << endl;
         } else {
             // Fallback: First Decoder -> ImageEncoder (direct connection)
-            m_decoders[0]->setConsumer(config.getPeerId(), m_imageEncoder);
+            m_decoders[0]->setConsumer(config.getPeerId(), getImageEncoder());
             LOG(info) << "✅ Pipeline: [First Decoder] → [ImageEncoder] → [JPEG Output]" << endl;
             LOG(info) << "   📸 Composite image will be captured from first stream and returned as JPEG buffer" << endl;
         }
@@ -301,7 +301,7 @@ void CompositePipelineBuilder::setupCompositorConsumers(const PipelineConfigurat
             resizeHeight = stringToInt(opts.at("resize_height"), 0);
         }
         // Set target resolution in decoder if transform is present and resize dimensions provided
-        if (m_transform && resizeWidth > 0 && resizeHeight > 0)
+        if (getTransform() && resizeWidth > 0 && resizeHeight > 0)
         {
             m_decoders[0]->setQuality(config.getPeerId(), "custom", resizeWidth, resizeHeight);
             LOG(info) << "   ⚙️  Quality set to: custom, " << resizeWidth << "x" << resizeHeight << endl;

--- a/services/vios/src/framework/media/video_source/builders/CompositePipelineBuilder.h
+++ b/services/vios/src/framework/media/video_source/builders/CompositePipelineBuilder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,12 +32,7 @@ public:
     void stopPipeline() override;
     
     std::shared_ptr<GstNvVideoDecoder> getDecoder() const override { return nullptr; }
-    std::shared_ptr<NvEncoderVideoConsumer> getEncoder() const override { return m_encoder; }
-    std::shared_ptr<WebrtcSinkConsumer> getWebrtcConsumer() const override { return m_webrtcConsumer; }
     std::shared_ptr<NvLLOverlay> getOverlay() const override { return nullptr; }
-    std::shared_ptr<NvLLTransform> getTransform() const override { return m_transform; }
-    std::shared_ptr<NvLLTransform> getTransformSink() const override { return m_transformSink; }
-    std::shared_ptr<ImageEnc> getImageEncoder() const override { return m_imageEncoder; }
     std::shared_ptr<NvCompositor> getCompositor() const override { return m_compositor; }
     std::shared_ptr<VideoWebRTCSender> getVideoSender() const override { return nullptr; }
     std::shared_ptr<NativeStreamProducer> getNativeStreamProducer() const override { return nullptr; }

--- a/services/vios/src/framework/media/video_source/builders/PipelineBuilder.h
+++ b/services/vios/src/framework/media/video_source/builders/PipelineBuilder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,12 +54,12 @@ public:
     
     // Common getters for pipeline components
     virtual std::shared_ptr<GstNvVideoDecoder> getDecoder() const = 0;
-    virtual std::shared_ptr<NvEncoderVideoConsumer> getEncoder() const = 0;
-    virtual std::shared_ptr<WebrtcSinkConsumer> getWebrtcConsumer() const = 0;
-    virtual std::shared_ptr<NvLLOverlay> getOverlay() const = 0;
-    virtual std::shared_ptr<NvLLTransform> getTransform() const = 0;
-    virtual std::shared_ptr<NvLLTransform> getTransformSink() const = 0;
-    virtual std::shared_ptr<ImageEnc> getImageEncoder() const = 0;
+    virtual std::shared_ptr<NvEncoderVideoConsumer> getEncoder() const { return m_encoder; }
+    virtual std::shared_ptr<WebrtcSinkConsumer> getWebrtcConsumer() const { return m_webrtcConsumer; }
+    virtual std::shared_ptr<NvLLOverlay> getOverlay() const { return m_overlay; }
+    virtual std::shared_ptr<NvLLTransform> getTransform() const { return m_transform; }
+    virtual std::shared_ptr<NvLLTransform> getTransformSink() const { return m_transformSink; }
+    virtual std::shared_ptr<ImageEnc> getImageEncoder() const { return m_imageEncoder; }
     virtual std::shared_ptr<NvCompositor> getCompositor() const = 0;
     virtual std::shared_ptr<VideoWebRTCSender> getVideoSender() const = 0;
     virtual std::shared_ptr<NativeStreamProducer> getNativeStreamProducer() const = 0;
@@ -84,6 +84,7 @@ protected:
     void setupDecoderWithProducer(std::shared_ptr<GstNvVideoDecoder> decoder, const std::string& url, const PipelineConfiguration& config);
     void clearDecoderProducer(std::shared_ptr<GstNvVideoDecoder> decoder, const PipelineConfiguration& config);
 
+private:
     // Common pipeline components
     std::shared_ptr<NvEncoderVideoConsumer> m_encoder = nullptr;
     std::shared_ptr<NvLLOverlay> m_overlay = nullptr;

--- a/services/vios/src/framework/media/video_source/builders/SingleStreamPipelineBuilder.cpp
+++ b/services/vios/src/framework/media/video_source/builders/SingleStreamPipelineBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -340,18 +340,18 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
     
     // Log overlay component status
     LOG(info) << "OVERLAY COMPONENT STATUS:" << endl;
-    LOG(info) << "  m_overlay created: " << (m_overlay ? "YES" : "NO") << endl;
-    if (m_overlay) {
-        LOG(info) << "  m_overlay->isOverlayEnabled(): " << (m_overlay->isOverlayEnabled() ? "YES" : "NO") << endl;
-        LOG(info) << "  m_overlay->isBboxEnabled(): " << (m_overlay->isBboxEnabled() ? "YES" : "NO") << endl;
+    LOG(info) << "  m_overlay created: " << (getOverlay() ? "YES" : "NO") << endl;
+    if (getOverlay()) {
+        LOG(info) << "  m_overlay->isOverlayEnabled(): " << (getOverlay()->isOverlayEnabled() ? "YES" : "NO") << endl;
+        LOG(info) << "  m_overlay->isBboxEnabled(): " << (getOverlay()->isBboxEnabled() ? "YES" : "NO") << endl;
     }
     LOG(info) << "  GET_OSD_INSTANCE()->isError(): " << (GET_OSD_INSTANCE()->isError() ? "YES" : "NO") << endl;
     
     // Log transform component status
     LOG(info) << "TRANSFORM COMPONENT STATUS:" << endl;
-    LOG(info) << "  m_transform created: " << (m_transform ? "YES" : "NO") << endl;
-    LOG(info) << "  m_transformSink created: " << (m_transformSink ? "YES" : "NO") << endl;
-    LOG(info) << "  m_imageEncoder created: " << (m_imageEncoder ? "YES" : "NO") << endl;
+    LOG(info) << "  m_transform created: " << (getTransform() ? "YES" : "NO") << endl;
+    LOG(info) << "  m_transformSink created: " << (getTransformSink() ? "YES" : "NO") << endl;
+    LOG(info) << "  m_imageEncoder created: " << (getImageEncoder() ? "YES" : "NO") << endl;
     LOG(info) << "==========================================" << endl;
     
     // Handle image capture pipeline
@@ -360,35 +360,35 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
         LOG(info) << "==========================================" << endl;
         
         // Validate that we have the required components for image capture
-        if (!m_imageEncoder) {
+        if (!getImageEncoder()) {
             LOG(error) << "❌ Image encoder not initialized for image capture" << endl;
             return;
         }
 
         if (m_decoder) {
             // Check if overlay is enabled for image capture
-            if (m_overlay && !GET_OSD_INSTANCE()->isError() && m_overlay->isOverlayEnabled()) {
+            if (getOverlay() && !GET_OSD_INSTANCE()->isError() && getOverlay()->isOverlayEnabled()) {
                 LOG(info) << "🎨 IMAGE CAPTURE WITH OVERLAY PIPELINE" << endl;
                 
-                if (m_transform && m_transformSink) {
+                if (getTransform() && getTransformSink()) {
                     // CORRECT: Decoder -> Transform -> Overlay -> TransformSink -> ImageEncoder
-                    m_decoder->setConsumer(config.getPeerId(), m_transform);
-                    m_transform->setConsumer(m_overlay);
-                    m_overlay->setConsumer(m_transformSink);
-                    m_transformSink->setConsumer(m_imageEncoder);
+                    m_decoder->setConsumer(config.getPeerId(), getTransform());
+                    getTransform()->setConsumer(getOverlay());
+                    getOverlay()->setConsumer(getTransformSink());
+                    getTransformSink()->setConsumer(getImageEncoder());
                     LOG(info) << "✅ Pipeline: [Decoder] → [Transform] → [Overlay] → [TransformSink] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   📸 Image with overlay will be captured and returned as JPEG buffer" << endl;
-                } else if (m_transform) {
+                } else if (getTransform()) {
                     // Fallback without transformSink: Decoder -> Transform -> Overlay -> ImageEncoder
-                    m_decoder->setConsumer(config.getPeerId(), m_transform);
-                    m_transform->setConsumer(m_overlay);
-                    m_overlay->setConsumer(m_imageEncoder);
+                    m_decoder->setConsumer(config.getPeerId(), getTransform());
+                    getTransform()->setConsumer(getOverlay());
+                    getOverlay()->setConsumer(getImageEncoder());
                     LOG(info) << "✅ Pipeline: [Decoder] → [Transform] → [Overlay] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   ⚠️  Missing TransformSink - may affect image quality" << endl;
                 } else {
                     // Fallback: Decoder -> Overlay -> ImageEncoder (direct connection)
-                    m_decoder->setConsumer(config.getPeerId(), m_overlay);
-                    m_overlay->setConsumer(m_imageEncoder);
+                    m_decoder->setConsumer(config.getPeerId(), getOverlay());
+                    getOverlay()->setConsumer(getImageEncoder());
                     LOG(info) << "✅ Pipeline: [Decoder] → [Overlay] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   ⚠️  Missing Transform components - may affect image quality" << endl;
                 }
@@ -396,42 +396,42 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
                 LOG(info) << "📸 IMAGE CAPTURE WITHOUT OVERLAY PIPELINE" << endl;
                 
                 // For image capture without overlay: Decoder -> Transform -> ImageEncoder
-                if (m_transform) {
-                    m_decoder->setConsumer(config.getPeerId(), m_transform);
-                    m_transform->setConsumer(m_imageEncoder);
+                if (getTransform()) {
+                    m_decoder->setConsumer(config.getPeerId(), getTransform());
+                    getTransform()->setConsumer(getImageEncoder());
                     LOG(info) << "✅ Pipeline: [Decoder] → [Transform] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   📸 Image will be captured and returned as JPEG buffer" << endl;
                 } else {
                     // Fallback: Decoder -> ImageEncoder (direct connection)
-                    m_decoder->setConsumer(config.getPeerId(), m_imageEncoder);
+                    m_decoder->setConsumer(config.getPeerId(), getImageEncoder());
                     LOG(info) << "✅ Pipeline: [Decoder] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   📸 Image will be captured and returned as JPEG buffer" << endl;
                 }
             }
         } else if (m_nativeStreamProducer) {
             // Check if overlay is enabled for native stream image capture
-            if (m_overlay && !GET_OSD_INSTANCE()->isError() && m_overlay->isOverlayEnabled()) {
+            if (getOverlay() && !GET_OSD_INSTANCE()->isError() && getOverlay()->isOverlayEnabled()) {
                 LOG(info) << "🎨 NATIVE STREAM IMAGE CAPTURE WITH OVERLAY PIPELINE" << endl;
                 
-                if (m_transform && m_transformSink) {
+                if (getTransform() && getTransformSink()) {
                     // CORRECT: NativeStream -> Transform -> Overlay -> TransformSink -> ImageEncoder
-                    m_nativeStreamProducer->setConsumer(config.getPeerId(), m_transform);
-                    m_transform->setConsumer(m_overlay);
-                    m_overlay->setConsumer(m_transformSink);
-                    m_transformSink->setConsumer(m_imageEncoder);
+                    m_nativeStreamProducer->setConsumer(config.getPeerId(), getTransform());
+                    getTransform()->setConsumer(getOverlay());
+                    getOverlay()->setConsumer(getTransformSink());
+                    getTransformSink()->setConsumer(getImageEncoder());
                     LOG(info) << "✅ Pipeline: [NativeStreamProducer] → [Transform] → [Overlay] → [TransformSink] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   📸 Native stream image with overlay will be captured and returned as JPEG buffer" << endl;
-                } else if (m_transform) {
+                } else if (getTransform()) {
                     // Fallback without transformSink: NativeStream -> Transform -> Overlay -> ImageEncoder
-                    m_nativeStreamProducer->setConsumer(config.getPeerId(), m_transform);
-                    m_transform->setConsumer(m_overlay);
-                    m_overlay->setConsumer(m_imageEncoder);
+                    m_nativeStreamProducer->setConsumer(config.getPeerId(), getTransform());
+                    getTransform()->setConsumer(getOverlay());
+                    getOverlay()->setConsumer(getImageEncoder());
                     LOG(info) << "✅ Pipeline: [NativeStreamProducer] → [Transform] → [Overlay] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   ⚠️  Missing TransformSink - may affect image quality" << endl;
                 } else {
                     // Fallback: NativeStream -> Overlay -> ImageEncoder (direct connection)
-                    m_nativeStreamProducer->setConsumer(config.getPeerId(), m_overlay);
-                    m_overlay->setConsumer(m_imageEncoder);
+                    m_nativeStreamProducer->setConsumer(config.getPeerId(), getOverlay());
+                    getOverlay()->setConsumer(getImageEncoder());
                     LOG(info) << "✅ Pipeline: [NativeStreamProducer] → [Overlay] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   ⚠️  Missing Transform components - may affect image quality" << endl;
                 }
@@ -439,14 +439,14 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
                 LOG(info) << "📸 NATIVE STREAM IMAGE CAPTURE WITHOUT OVERLAY PIPELINE" << endl;
                 
                 // For native stream image capture without overlay: NativeStream -> Transform -> ImageEncoder
-                if (m_transform) {
-                    m_nativeStreamProducer->setConsumer(config.getPeerId(), m_transform);
-                    m_transform->setConsumer(m_imageEncoder);
+                if (getTransform()) {
+                    m_nativeStreamProducer->setConsumer(config.getPeerId(), getTransform());
+                    getTransform()->setConsumer(getImageEncoder());
                     LOG(info) << "✅ Pipeline: [NativeStreamProducer] → [Transform] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   📸 Native stream image will be captured and returned as JPEG buffer" << endl;
                 } else {
                     // Fallback: NativeStream -> ImageEncoder (direct connection)
-                    m_nativeStreamProducer->setConsumer(config.getPeerId(), m_imageEncoder);
+                    m_nativeStreamProducer->setConsumer(config.getPeerId(), getImageEncoder());
                     LOG(info) << "✅ Pipeline: [NativeStreamProducer] → [ImageEncoder] → [JPEG Output]" << endl;
                     LOG(info) << "   📸 Native stream image will be captured and returned as JPEG buffer" << endl;
                 }
@@ -465,7 +465,7 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
                 resizeHeight = stringToInt(opts.at("resize_height"), 0);
             }
             // Set target resolution in decoder if transform is present and resize dimensions provided
-            if (m_transform && resizeWidth > 0 && resizeHeight > 0)
+            if (getTransform() && resizeWidth > 0 && resizeHeight > 0)
             {
                 m_decoder->setQuality(config.getPeerId(), "custom", resizeWidth, resizeHeight);
                 LOG(info) << "   ⚙️  Quality set to: custom, " << resizeWidth << "x" << resizeHeight << endl;
@@ -488,30 +488,30 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
     if (m_decoder) {
         LOG(info) << "📹 Using GstNvVideoDecoder as source" << endl;
         
-        if (m_overlay && !GET_OSD_INSTANCE()->isError() && m_overlay->isOverlayEnabled()) {
+        if (getOverlay() && !GET_OSD_INSTANCE()->isError() && getOverlay()->isOverlayEnabled()) {
             LOG(info) << "🎨 OVERLAY PIPELINE (with OSD enabled)" << endl;
             
             // Decoder -> Transform -> Overlay -> Encoder -> WebRTC
-            if (m_transform) {
-                m_decoder->setConsumer(config.getPeerId(), m_transform);
-                m_transform->setConsumer(m_overlay);
+            if (getTransform()) {
+                m_decoder->setConsumer(config.getPeerId(), getTransform());
+                getTransform()->setConsumer(getOverlay());
                 LOG(info) << "   🔗 [Decoder] → [Transform] → [Overlay]" << endl;
             } else {
-                m_decoder->setConsumer(config.getPeerId(), m_overlay);
+                m_decoder->setConsumer(config.getPeerId(), getOverlay());
                 LOG(info) << "   🔗 [Decoder] → [Overlay]" << endl;
             }
             
             if (NvHwDetection::getInstance()->m_useNvV4l2Enc == true) {
-                if (m_encoder && m_webrtcConsumer) {
-                    m_overlay->setConsumer(m_encoder);
-                    m_encoder->setConsumer(m_webrtcConsumer);
+                if (getEncoder() && getWebrtcConsumer()) {
+                    getOverlay()->setConsumer(getEncoder());
+                    getEncoder()->setConsumer(getWebrtcConsumer());
                     LOG(info) << "   🔗 [Overlay] → [HW Encoder] → [WebRTC Consumer]" << endl;
                     LOG(info) << "✅ Complete Pipeline: [Decoder] → [Transform] → [Overlay] → [HW Encoder] → [WebRTC]" << endl;
                 }
             } else {
-                if (m_transformSink && m_webrtcConsumer) {
-                    m_overlay->setConsumer(m_transformSink);
-                    m_transformSink->setConsumer(m_webrtcConsumer);
+                if (getTransformSink() && getWebrtcConsumer()) {
+                    getOverlay()->setConsumer(getTransformSink());
+                    getTransformSink()->setConsumer(getWebrtcConsumer());
                     LOG(info) << "   🔗 [Overlay] → [TransformSink] → [WebRTC Consumer]" << endl;
                     LOG(info) << "✅ Complete Pipeline: [Decoder] → [Transform] → [Overlay] → [TransformSink] → [WebRTC]" << endl;
                 }
@@ -521,16 +521,16 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
             
             // Decoder -> Transform -> Encoder -> WebRTC (no overlay)
             if (NvHwDetection::getInstance()->m_useNvV4l2Enc == true) {
-                if (m_transform && m_encoder && m_webrtcConsumer) {
-                    m_decoder->setConsumer(config.getPeerId(), m_transform);
-                    m_transform->setConsumer(m_encoder);
-                    m_encoder->setConsumer(m_webrtcConsumer);
+                if (getTransform() && getEncoder() && getWebrtcConsumer()) {
+                    m_decoder->setConsumer(config.getPeerId(), getTransform());
+                    getTransform()->setConsumer(getEncoder());
+                    getEncoder()->setConsumer(getWebrtcConsumer());
                     LOG(info) << "✅ Complete Pipeline: [Decoder] → [Transform] → [HW Encoder] → [WebRTC]" << endl;
                 }
             } else {
-                if (m_transformSink && m_webrtcConsumer) {
-                    m_decoder->setConsumer(config.getPeerId(), m_transformSink);
-                    m_transformSink->setConsumer(m_webrtcConsumer);
+                if (getTransformSink() && getWebrtcConsumer()) {
+                    m_decoder->setConsumer(config.getPeerId(), getTransformSink());
+                    getTransformSink()->setConsumer(getWebrtcConsumer());
                     LOG(info) << "✅ Complete Pipeline: [Decoder] → [TransformSink] → [WebRTC]" << endl;
                 }
             }
@@ -538,24 +538,24 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
     } else if (m_nativeStreamProducer) {
         LOG(info) << "🌐 Using NativeStreamProducer as source" << endl;
         
-        if (m_overlay && !GET_OSD_INSTANCE()->isError() && m_overlay->isOverlayEnabled()) {
+        if (getOverlay() && !GET_OSD_INSTANCE()->isError() && getOverlay()->isOverlayEnabled()) {
             LOG(info) << "🎨 NATIVE STREAM OVERLAY PIPELINE" << endl;
-            if (m_transform) {
-                m_nativeStreamProducer->setConsumer(config.getPeerId(), m_transform);
-                m_transform->setConsumer(m_overlay);
+            if (getTransform()) {
+                m_nativeStreamProducer->setConsumer(config.getPeerId(), getTransform());
+                getTransform()->setConsumer(getOverlay());
                 LOG(info) << "✅ Complete Pipeline: [NativeStream] → [Transform] → [Overlay]" << endl;
             }
         } else {
             LOG(info) << "🎬 NATIVE STREAM STANDARD PIPELINE" << endl;
             if (NvHwDetection::getInstance()->m_useNvV4l2Enc == true) {
-                if (m_transform && m_encoder) {
-                    m_nativeStreamProducer->setConsumer(config.getPeerId(), m_transform);
-                    m_transform->setConsumer(m_encoder);
+                if (getTransform() && getEncoder()) {
+                    m_nativeStreamProducer->setConsumer(config.getPeerId(), getTransform());
+                    getTransform()->setConsumer(getEncoder());
                     LOG(info) << "✅ Complete Pipeline: [NativeStream] → [Transform] → [HW Encoder]" << endl;
                 }
             } else {
-                if (m_transformSink) {
-                    m_nativeStreamProducer->setConsumer(config.getPeerId(), m_transformSink);
+                if (getTransformSink()) {
+                    m_nativeStreamProducer->setConsumer(config.getPeerId(), getTransformSink());
                     LOG(info) << "✅ Complete Pipeline: [NativeStream] → [TransformSink]" << endl;
                 }
             }
@@ -566,10 +566,10 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
         LOG(info) << "🔗 Using IPC Producer as source" << endl;
         LOG(info) << "🎨 IPC OVERLAY PIPELINE (with bbox enabled)" << endl;
 
-        if (m_overlay && !GET_OSD_INSTANCE()->isError() && m_overlay->isBboxEnabled()) {
-            if (m_transform) {
-                m_ipcProducer->setConsumer(config.getPeerId(), m_transform);
-                m_transform->setConsumer(m_overlay);
+        if (getOverlay() && !GET_OSD_INSTANCE()->isError() && getOverlay()->isBboxEnabled()) {
+            if (getTransform()) {
+                m_ipcProducer->setConsumer(config.getPeerId(), getTransform());
+                getTransform()->setConsumer(getOverlay());
                 LOG(info) << "✅ Complete Pipeline: [IPC Producer] → [Transform] → [Overlay]" << endl;
             }
         }
@@ -580,16 +580,16 @@ void SingleStreamPipelineBuilder::setupConsumerPipeline(const PipelineConfigurat
     LOG(info) << "⚙️  CONFIGURING COMPONENT FRAME SIZES" << endl;
     LOG(info) << "==========================================" << endl;
     
-    if (m_overlay) {
-        m_overlay->setOriginalFrameSize();
+    if (getOverlay()) {
+        getOverlay()->setOriginalFrameSize();
         LOG(info) << "   📐 Overlay frame size configured" << endl;
     }
-    if (m_transform) {
-        m_transform->setOriginalFrameSize();
+    if (getTransform()) {
+        getTransform()->setOriginalFrameSize();
         LOG(info) << "   📐 Transform frame size configured" << endl;
     }
-    if (m_transformSink) {
-        m_transformSink->setOriginalFrameSize();
+    if (getTransformSink()) {
+        getTransformSink()->setOriginalFrameSize();
         LOG(info) << "   📐 TransformSink frame size configured" << endl;
     }
     

--- a/services/vios/src/framework/media/video_source/builders/SingleStreamPipelineBuilder.h
+++ b/services/vios/src/framework/media/video_source/builders/SingleStreamPipelineBuilder.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,12 +31,6 @@ public:
     void stopPipeline() override;
     
     std::shared_ptr<GstNvVideoDecoder> getDecoder() const override { return m_decoder; }
-    std::shared_ptr<NvEncoderVideoConsumer> getEncoder() const override { return m_encoder; }
-    std::shared_ptr<WebrtcSinkConsumer> getWebrtcConsumer() const override { return m_webrtcConsumer; }
-    std::shared_ptr<NvLLOverlay> getOverlay() const override { return m_overlay; }
-    std::shared_ptr<NvLLTransform> getTransform() const override { return m_transform; }
-    std::shared_ptr<NvLLTransform> getTransformSink() const override { return m_transformSink; }
-    std::shared_ptr<ImageEnc> getImageEncoder() const override { return m_imageEncoder; }
     std::shared_ptr<NvCompositor> getCompositor() const override { return nullptr; }
     std::shared_ptr<VideoWebRTCSender> getVideoSender() const override { return m_videoSender; }
     std::shared_ptr<NativeStreamProducer> getNativeStreamProducer() const override { return m_nativeStreamProducer; }

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1830,7 +1830,7 @@ GstNvVideoDecoder::GstNvVideoDecoder (const std::string& consumer_name, const st
         m_vodDebugFile.open(file_name, ios::out | ios::app);
     }
     m_playbackWD = make_unique<Bosma::Scheduler>(1);
-    m_playbackWD->interval(SCHEDULER_WD_INTERVAL, [=]()
+    m_playbackWD->interval(SCHEDULER_WD_INTERVAL, [this]()
     {
         /* Reset playstate to not playing, it will be set again in appsink callback*/
         m_playbackState.store(STATE_NOT_PLAYING);

--- a/services/vios/src/framework/media/video_source/encoders/image_encoder.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/image_encoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@
 #include <gst/app/gstappsrc.h>
 #include <gst/app/gstappsink.h>
 #include "nvjpegenc_loader.h"
+#include <limits>
 
 using namespace std;
 using namespace std::chrono_literals;
@@ -321,7 +322,7 @@ void ImageEnc::pushBuffer(std::shared_ptr<RawFrameParams> frameData)
 
 void ImageEnc::hwEncode(uint64_t fd, std::shared_ptr<RawFrameParams> frameData)
 {
-    if (fd < 0)
+    if (fd > static_cast<uint64_t>(std::numeric_limits<int>::max()))
     {
         LOG(error) << "fd error " << fd << endl;
         return;

--- a/services/vios/src/framework/notification/kafka/kafka_consumer.h
+++ b/services/vios/src/framework/notification/kafka/kafka_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,12 @@ public:
     void registerMessageListener(nv_vms::INotificationListener* listener) override;
     void deregisterMessageListener(nv_vms::INotificationListener* listener) override;
     bool deliverMessage (Json::Value& message) override { return true; }
-    void retryConnection () override {}
+    void retryConnection () override
+    {
+        // Intentionally blank: librdkafka reconnects to the brokers on its own,
+        // and the poll thread started in kafkaInit() keeps consuming across
+        // broker outages, so no manual retry is needed here.
+    }
 
     void deliverMessage(void* msg, int len);
 

--- a/services/vios/src/framework/notification/mqtt/mqtt_publisher.cpp
+++ b/services/vios/src/framework/notification/mqtt/mqtt_publisher.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -187,6 +187,9 @@ void MqttPublisher::handleConnectionLost(const std::string& cause)
 
 void MqttPublisher::handleMessageArrived(mqtt::const_message_ptr msg)
 {
+    // This client is publish-only and subscribes to no topic, so any inbound
+    // message is unexpected and intentionally ignored.
+    (void)msg;
 }
 
 void MqttPublisher::handleDeliveryComplete(mqtt::delivery_token_ptr token)

--- a/services/vios/src/framework/notification/mqtt/mqtt_publisher.h
+++ b/services/vios/src/framework/notification/mqtt/mqtt_publisher.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,8 @@ class MqttPublisher : public nv_vms::INotificationInterface
 public:
     static MqttPublisher* getInstance();
 
+    // Intentionally blank: the paho async client is created with
+    // set_automatic_reconnect(true), so reconnection is handled internally.
     void retryConnection() override {}
     bool deliverMessage(Json::Value& message) override;
     bool sendToMqtt(std::string payload);

--- a/services/vios/src/framework/notification/mqtt/mqtt_subscriber.h
+++ b/services/vios/src/framework/notification/mqtt/mqtt_subscriber.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,12 @@ public:
     static void deleteInstance();
     void registerMessageListener(nv_vms::INotificationListener* listener) override;
     void deregisterMessageListener(nv_vms::INotificationListener* listener) override;
-    void retryConnection() override {}
+    void retryConnection() override
+    {
+        // Intentionally blank: the paho async client is configured with
+        // set_automatic_reconnect(true) in clientInit(), so it reconnects on
+        // its own and no manual retry is needed here.
+    }
     bool deliverMessage(Json::Value& message) override { return true; }
 
 private:

--- a/services/vios/src/framework/notification/notification_manager.h
+++ b/services/vios/src/framework/notification/notification_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,8 +52,18 @@ namespace nv_vms
         virtual void retryConnection () = 0;
 
         // Notification Consumer related methods
-        virtual void registerMessageListener(INotificationListener* listener) {}
-        virtual void deregisterMessageListener(INotificationListener* listener) {}
+        virtual void registerMessageListener(INotificationListener* listener)
+        {
+            // Intentionally blank: publisher-only implementations do not consume
+            // messages. Consumer implementations override this to manage m_listeners.
+            (void)listener;
+        }
+        virtual void deregisterMessageListener(INotificationListener* listener)
+        {
+            // Intentionally blank: publisher-only implementations do not consume
+            // messages. Consumer implementations override this to manage m_listeners.
+            (void)listener;
+        }
 
         bool                            m_libError = false;
         std::queue<Json::Value>         m_messages;

--- a/services/vios/src/framework/notification/redis/redis_subscriber.h
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,11 @@ public:
     void deliverMessage(void *msg, int len);
 
     bool deliverMessage (Json::Value& message) override { return true; }
-    void retryConnection () override {}
+    void retryConnection () override
+    {
+        // Intentionally blank: reconnection to the Redis endpoint is handled
+        // internally by the nvds_msgapi subscriber connection.
+    }
 
 private:
     static RedisSubscriber*                         _instance;

--- a/services/vios/src/framework/platform_specific/nvlibs.cpp
+++ b/services/vios/src/framework/platform_specific/nvlibs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,11 +31,11 @@
 #define ABSOLUTE_LIBRARY_PATH_X86_64 "/usr/lib/x86_64-linux-gnu/libv4l2.so.0"
 #define ABSOLUTE_LIBRARY_PATH_ARCH64 "/usr/lib/aarch64-linux-gnu/libv4l2.so.0"
 
-NvLibs* NvLibs::_instance = NULL;
+NvLibs* NvLibs::_instance = nullptr;
 
 NvLibs* NvLibs::getInstance()
 {
-    if(_instance == NULL)
+    if(_instance == nullptr)
     {
         _instance = new NvLibs();
     }

--- a/services/vios/src/framework/platform_specific/nvsurfacepool.cpp
+++ b/services/vios/src/framework/platform_specific/nvsurfacepool.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ bool NvSurfacePool::allocateSurfaces (int num_surfaces, unsigned int target_widt
 {
     std::lock_guard<std::mutex> queueLock(m_fdSurfaceQLock);
     NvBufSurfaceCreateParams buf_params       = {0};
-    NvBufSurface *op_surf                     = NULL;
+    NvBufSurface *op_surf                     = nullptr;
     if (need_allocations)
     {
         buf_params.width       = target_width;

--- a/services/vios/src/framework/protocols/grpc/nvgrpc.cpp
+++ b/services/vios/src/framework/protocols/grpc/nvgrpc.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -531,7 +531,7 @@ Status GrpcWebrtcSignallingService::sdpExchange(ServerContext* context, const Sd
     {
         // Wait for answer from UI
         std::unique_lock<std::mutex> lock(remotePeerAnswer->m_mtx);
-        if (!remotePeerAnswer->m_cv.wait_for(lock, std::chrono::seconds(GET_CONFIG().webrtc_peer_conn_timeout_sec), [&]{ return remotePeerAnswer->m_ready; }))
+        if (!remotePeerAnswer->m_cv.wait_for(lock, std::chrono::seconds(GET_CONFIG().webrtc_peer_conn_timeout_sec), [&remotePeerAnswer]{ return remotePeerAnswer->m_ready; }))
         {
             timeout = true;
         }
@@ -590,7 +590,7 @@ Status GrpcWebrtcSignallingService::iceCandidateExchange(ServerContext* context,
                 remotePeerCandidate = it->second;
             }
             std::unique_lock<std::mutex> lock(remotePeerCandidate->m_mtx);
-            if (!remotePeerCandidate->m_cv.wait_for(lock, std::chrono::seconds(GET_CONFIG().webrtc_peer_conn_timeout_sec), [&]{ return remotePeerCandidate->m_candidateList.size(); }))
+            if (!remotePeerCandidate->m_cv.wait_for(lock, std::chrono::seconds(GET_CONFIG().webrtc_peer_conn_timeout_sec), [&remotePeerCandidate]{ return remotePeerCandidate->m_candidateList.size(); }))
             {
                 string err_msg = "Timeout while waiting for candidate for " + streamId;
                 LOG(error) << err_msg << endl;
@@ -674,7 +674,7 @@ Status GrpcWebrtcSignallingService::iceCandidateExchange(ServerContext* context,
         });
         {
             std::unique_lock<std::mutex> lock(mtx);
-            if (cv.wait_for(lock, std::chrono::seconds(GET_CONFIG().webrtc_peer_conn_timeout_sec), [&]() { return readComplete.load(); }))
+            if (cv.wait_for(lock, std::chrono::seconds(GET_CONFIG().webrtc_peer_conn_timeout_sec), [&readComplete]() { return readComplete.load(); }))
             {
                 if (readerThread.joinable())
                 {

--- a/services/vios/src/framework/protocols/soap/nvsoap.cpp
+++ b/services/vios/src/framework/protocols/soap/nvsoap.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -3866,7 +3866,7 @@ static int composeSetCameraImageSettingsXml(xmlTextWriterPtr& writer, nvsoap_& s
         }
         _xmlTextWriterEndElement_(writer); // BacklightCompensation
     }
-    if(values.Brightness.c_str() != 0)
+    if(values.Brightness.c_str() != nullptr)
     {
         _xmlTextWriterStartElement_(writer, BAD_CAST "Brightness");
         rc = _xmlTextWriterWriteAttribute_(writer, BAD_CAST "xmlns", BAD_CAST "http://www.onvif.org/ver10/schema");

--- a/services/vios/src/framework/stream_monitor/stream_monitor.cpp
+++ b/services/vios/src/framework/stream_monitor/stream_monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -406,11 +406,6 @@ void StreamMonitor::livenessMonitorTask()
 void StreamMonitor::sendStatusEvent(const string &url, StreamStatus status, StreamEncParam& details)
 {
     StreamEventManager::getInstance().sendEvent(url, status, details);
-}
-
-void StreamMonitor::notifyStreamStatus(const StreamStatus& status, const std::string& camera_id)
-{
-
 }
 
 /* =============Implementation of QoS Measurement ====================== */

--- a/services/vios/src/framework/stream_monitor/stream_monitor.h
+++ b/services/vios/src/framework/stream_monitor/stream_monitor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,7 +54,12 @@ class IStreamStatusEvent
 {
 public:
     virtual void onStreamStatusChange(const string &url, const StreamStatus newStatus, StreamEncParam& details) = 0;
-    virtual void onDecoderPlayingStatus(const string &url) {}
+    virtual void onDecoderPlayingStatus(const string &url)
+    {
+        // Optional notification: listeners that do not track decoder playing
+        // state intentionally ignore it, so the default implementation is a no-op.
+        (void)url;
+    }
 };
 
 class StreamMonitor : public IMediaDataProducer
@@ -159,7 +164,6 @@ private:
     bool isCurlResponsePendingForUri(const std::string& url);
     void setCurlResponsePendingStatus(CURL *curl, bool isResponsePending);
     std::string getUriByUsingCurlHandle(const CURL *curl);
-    void notifyStreamStatus(const StreamStatus& status, const std::string& camera_id);
     std::vector<UrlInfo> getQosMonitorStreamList();
     void qosMeasurementTask();
     void cleanupQoSThread();

--- a/services/vios/src/framework/unified_storage/manager/cloud_manager.h
+++ b/services/vios/src/framework/unified_storage/manager/cloud_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -224,7 +224,18 @@ protected:
     std::string formatTimestamp(const std::string& timestamp) const;
     bool validateConfiguration(const CloudManagerConfig& config) const;
     bool validateEndpointUrl(const std::string& endpointUrl) const;
-    
+
+    // Accessors for derived classes
+    const CloudManagerConfig& config() const { return m_config; }
+    void setConfig(const CloudManagerConfig& newConfig) { m_config = newConfig; }
+    CloudManagerStats& stats() { return m_stats; }
+    const CloudManagerStats& stats() const { return m_stats; }
+    const std::string& lastError() const { return m_last_error; }
+    void storeLastError(const std::string& error) { m_last_error = error; }
+    bool isInitialized() const { return m_initialized; }
+    void setInitialized(bool initialized) { m_initialized = initialized; }
+
+private:
     // Member variables
     CloudManagerConfig m_config;
     CloudManagerStats m_stats;

--- a/services/vios/src/framework/unified_storage/manager/minio_cloud_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/minio_cloud_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ MinioCloudManager::~MinioCloudManager()
 
 bool MinioCloudManager::isAvailable() const
 {
-    return m_initialized;
+    return isInitialized();
 }
 
 bool MinioCloudManager::configure(const CloudManagerConfig& config)
@@ -47,7 +47,7 @@ bool MinioCloudManager::configure(const CloudManagerConfig& config)
     LOG(info) << "MinioCloudManager::configure called with endpoint: " << config.endpoint << std::endl;
     
     // Store the configuration for later access
-    m_config = config;
+    setConfig(config);
     
     // Call base class configure method
     if (!CloudManager::configure(config))
@@ -65,17 +65,17 @@ bool MinioCloudManager::configure(const CloudManagerConfig& config)
     m_max_retries = config.maxRetries;
     
     // Initialize the MinIO client
-    m_initialized = initializeMinioClient();
+    setInitialized(initializeMinioClient());
     
-    LOG(info) << "MinioCloudManager::configure - MinIO client initialization result: " << (m_initialized ? "SUCCESS" : "FAILED") << std::endl;
+    LOG(info) << "MinioCloudManager::configure - MinIO client initialization result: " << (isInitialized() ? "SUCCESS" : "FAILED") << std::endl;
     
-    return m_initialized;
+    return isInitialized();
 }
 
 CloudManagerConfig MinioCloudManager::getConfiguration() const
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    return m_config;
+    return config();
 }
 
 CloudResult MinioCloudManager::deleteObject(const std::string& bucket, const std::string& objectKey)
@@ -594,19 +594,19 @@ CloudResult MinioCloudManager::performHealthCheck()
 std::string MinioCloudManager::getLastError() const
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    return m_last_error;
+    return lastError();
 }
 
 CloudManagerStats MinioCloudManager::getStats() const
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    return m_stats;
+    return stats();
 }
 
 void MinioCloudManager::resetStats()
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    m_stats = CloudManagerStats();
+    stats() = CloudManagerStats();
 }
 
 bool MinioCloudManager::validateBucketName(const std::string& bucketName) const
@@ -746,17 +746,17 @@ void MinioCloudManager::shutdownMinioClient()
     std::lock_guard<std::mutex> lock(m_client_mutex);
     m_minio_client.reset();
     m_credentials.reset();
-    m_initialized = false;
+    setInitialized(false);
 }
 
 bool MinioCloudManager::ensureClientInitialized()
 {
-    if (m_minio_client && m_initialized)
+    if (m_minio_client && isInitialized())
     {
         return true;
     }
     
-    if (!m_initialized)
+    if (!isInitialized())
     {
         return initializeMinioClient();
     }
@@ -1238,13 +1238,13 @@ std::string MinioCloudManager::extractRegionFromEndpoint(const std::string& endp
 void MinioCloudManager::setLastError(const std::string& error)
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    m_last_error = error;
+    storeLastError(error);
 }
 
 void MinioCloudManager::updateStats(bool success, std::chrono::milliseconds duration, const std::string& errorCode)
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    m_stats.recordRequest(success, duration, errorCode);
+    stats().recordRequest(success, duration, errorCode);
 }
 
 CloudResult MinioCloudManager::checkObjectExists(const std::string& bucket, const std::string& objectKey)

--- a/services/vios/src/framework/unified_storage/manager/minio_cloud_manager.h
+++ b/services/vios/src/framework/unified_storage/manager/minio_cloud_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -152,6 +152,7 @@ protected:
     void setLastError(const std::string& error) override;
     void updateStats(bool success, std::chrono::milliseconds duration, const std::string& errorCode = "") override;
     
+private:
     // Member variables
     std::unique_ptr<minio::s3::Client> m_minio_client;
     std::unique_ptr<minio::creds::StaticProvider> m_credentials;

--- a/services/vios/src/framework/unified_storage/manager/s3_cloud_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/s3_cloud_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,7 @@ S3CloudManager::~S3CloudManager()
 
 bool S3CloudManager::isAvailable() const
 {
-    return m_initialized;
+    return isInitialized();
 }
 
 bool S3CloudManager::configure(const CloudManagerConfig& config)
@@ -62,24 +62,24 @@ bool S3CloudManager::configure(const CloudManagerConfig& config)
     // Validate required configuration parameters
     if (config.endpoint.empty())
     {
-        m_last_error = "Endpoint is required but not provided";
+        storeLastError("Endpoint is required but not provided");
         return false;
     }
     
     if (config.accessKeyId.empty())
     {
-        m_last_error = "Access key ID is required but not provided";
+        storeLastError("Access key ID is required but not provided");
         return false;
     }
     
     if (config.secretAccessKey.empty())
     {
-        m_last_error = "Secret access key is required but not provided";
+        storeLastError("Secret access key is required but not provided");
         return false;
     }
     
     // Store configuration
-    m_config = config;
+    setConfig(config);
     m_endpoint = config.endpoint;
     m_access_key = config.accessKeyId;
     m_secret_key = config.secretAccessKey;
@@ -91,24 +91,24 @@ bool S3CloudManager::configure(const CloudManagerConfig& config)
     // Attempt to initialize the S3 client
     if (!initializeS3Client())
     {
-        m_last_error = "Failed to initialize S3 client";
-        m_initialized = false;
+        storeLastError("Failed to initialize S3 client");
+        setInitialized(false);
         return false;
     }
     
     // Only set initialized to true if client initialization succeeds
-    m_initialized = true;
+    setInitialized(true);
     return true;
 }
 
 CloudManagerConfig S3CloudManager::getConfiguration() const
 {
-    return m_config;
+    return config();
 }
 
 CloudResult S3CloudManager::deleteObject(const std::string& bucket, const std::string& objectKey)
 {
-    if (!m_initialized)
+    if (!isInitialized())
     {
         CloudResult result(false);
         result.message = "S3 cloud manager not initialized";
@@ -121,7 +121,7 @@ CloudResult S3CloudManager::deleteObject(const std::string& bucket, const std::s
 
 CloudResult S3CloudManager::deleteMultipleObjects(const std::string& bucket, const std::vector<std::string>& objectKeys)
 {
-    if (!m_initialized)
+    if (!isInitialized())
     {
         CloudResult result(false);
         result.message = "S3 cloud manager not initialized";
@@ -215,19 +215,19 @@ CloudResult S3CloudManager::performHealthCheck()
 std::string S3CloudManager::getLastError() const
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    return m_last_error;
+    return lastError();
 }
 
 CloudManagerStats S3CloudManager::getStats() const
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    return m_stats;
+    return stats();
 }
 
 void S3CloudManager::resetStats()
 {
     std::lock_guard<std::mutex> lock(m_client_mutex);
-    m_stats.reset();
+    stats().reset();
 }
 
 bool S3CloudManager::validateBucketName(const std::string& bucketName) const
@@ -264,8 +264,8 @@ bool S3CloudManager::initializeS3Client()
         
         if (!sdkManager.initializeAwsSDK())
         {
-            m_last_error = "Failed to initialize AWS SDK";
-            LOG(error) << m_last_error;
+            storeLastError("Failed to initialize AWS SDK");
+            LOG(error) << lastError();
             return false;
         }
         m_awsSdkInitialized = true;
@@ -274,8 +274,8 @@ bool S3CloudManager::initializeS3Client()
         m_credentialsProvider = sdkManager.createCredentialsProvider(m_access_key, m_secret_key);
         if (!m_credentialsProvider)
         {
-            m_last_error = "Failed to create AWS credentials provider";
-            LOG(error) << m_last_error;
+            storeLastError("Failed to create AWS credentials provider");
+            LOG(error) << lastError();
             return false;
         }
         
@@ -287,8 +287,8 @@ bool S3CloudManager::initializeS3Client()
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent);
         if (!m_signer)
         {
-            m_last_error = "Failed to create AWS V4 signer";
-            LOG(error) << m_last_error;
+            storeLastError("Failed to create AWS V4 signer");
+            LOG(error) << lastError();
             return false;
         }
         
@@ -297,8 +297,8 @@ bool S3CloudManager::initializeS3Client()
         m_clientConfig = sdkManager.createClientConfiguration(m_region, m_use_ssl, m_timeout_seconds, m_endpoint);
         if (!m_clientConfig)
         {
-            m_last_error = "Failed to create AWS client configuration";
-            LOG(error) << m_last_error;
+            storeLastError("Failed to create AWS client configuration");
+            LOG(error) << lastError();
             return false;
         }
         
@@ -306,8 +306,8 @@ bool S3CloudManager::initializeS3Client()
         m_httpClient = sdkManager.createHttpClient(m_clientConfig);
         if (!m_httpClient)
         {
-            m_last_error = "Failed to create AWS HTTP client";
-            LOG(error) << m_last_error;
+            storeLastError("Failed to create AWS HTTP client");
+            LOG(error) << lastError();
             return false;
         }
         
@@ -317,8 +317,8 @@ bool S3CloudManager::initializeS3Client()
     }
     catch (const std::exception& e)
     {
-        m_last_error = "Exception during S3 client initialization: " + std::string(e.what());
-        LOG(error) << m_last_error;
+        storeLastError("Exception during S3 client initialization: " + std::string(e.what()));
+        LOG(error) << lastError();
         return false;
     }
 }
@@ -352,7 +352,7 @@ bool S3CloudManager::ensureClientInitialized()
     
     if (!m_httpClient || !m_signer || !m_credentialsProvider)
     {
-        m_last_error = "S3 client not initialized";
+        storeLastError("S3 client not initialized");
         return false;
     }
     
@@ -365,7 +365,7 @@ CloudResult S3CloudManager::deleteObjectWithS3Client(const std::string& bucket, 
     
     if (!ensureClientInitialized())
     {
-        result.message = m_last_error;
+        result.message = lastError();
         result.errorCode = "CLIENT_NOT_INITIALIZED";
         return result;
     }
@@ -384,10 +384,10 @@ CloudResult S3CloudManager::deleteObjectWithS3Client(const std::string& bucket, 
         // Update stats
         {
             std::lock_guard<std::mutex> lock(m_client_mutex);
-            m_stats.recordRequest(result.success, latency, result.errorCode);
+            stats().recordRequest(result.success, latency, result.errorCode);
             if (result.success)
             {
-                m_stats.objectsDeleted++;
+                stats().objectsDeleted++;
             }
         }
         
@@ -408,7 +408,7 @@ CloudResult S3CloudManager::deleteMultipleObjectsWithS3Client(const std::string&
     
     if (!ensureClientInitialized())
     {
-        result.message = m_last_error;
+        result.message = lastError();
         result.errorCode = "CLIENT_NOT_INITIALIZED";
         return result;
     }
@@ -434,10 +434,10 @@ CloudResult S3CloudManager::deleteMultipleObjectsWithS3Client(const std::string&
         // Update stats
         {
             std::lock_guard<std::mutex> lock(m_client_mutex);
-            m_stats.recordRequest(result.success, latency, result.errorCode);
+            stats().recordRequest(result.success, latency, result.errorCode);
             if (result.success)
             {
-                m_stats.objectsDeleted += objectKeys.size();
+                stats().objectsDeleted += objectKeys.size();
             }
         }
         

--- a/services/vios/src/framework/unified_storage/manager/unified_cloud_storage_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/unified_cloud_storage_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -543,7 +543,7 @@ bool UnifiedCloudStorageManager::performHealthCheck()
 {
     if (!isAvailable())
     {
-        m_last_error = "Cloud storage manager not initialized";
+        setLastError("Cloud storage manager not initialized");
         return false;
     }
     
@@ -557,14 +557,14 @@ bool UnifiedCloudStorageManager::performHealthCheck()
                 std::lock_guard<std::mutex> lock(m_cloud_manager_mutex);
                 if (!m_cloud_manager)
                 {
-                    m_last_error = "Cloud manager not initialized";
+                    setLastError("Cloud manager not initialized");
                     return false;
                 }
                 result = m_cloud_manager->checkBucketExists(m_bucket_name);
             }
             if (!result.success)
             {
-                m_last_error = "Cannot access bucket: " + m_bucket_name;
+                setLastError("Cannot access bucket: " + m_bucket_name);
                 return false;
             }
         }
@@ -573,7 +573,7 @@ bool UnifiedCloudStorageManager::performHealthCheck()
     }
     catch (const std::exception& e)
     {
-        m_last_error = "Health check failed: " + std::string(e.what());
+        setLastError("Health check failed: " + std::string(e.what()));
         return false;
     }
 }
@@ -588,15 +588,16 @@ bool UnifiedCloudStorageManager::initializeStorage()
     try
     {
         // Get configuration parameters
-        std::string cloud_type = m_config.getParameter(StorageConstants::CLOUD_TYPE_KEY, StorageConstants::MINIO_TYPE);
-        m_bucket_name = m_config.getParameter(StorageConstants::BUCKET_NAME_KEY, "");
-        m_endpoint = m_config.getParameter(StorageConstants::ENDPOINT_KEY, "");
-        m_access_key = m_config.getParameter(StorageConstants::ACCESS_KEY_KEY, "");
-        m_secret_key = m_config.getParameter(StorageConstants::SECRET_KEY_KEY, "");
-        m_region = m_config.getParameter(StorageConstants::REGION_KEY, "");
-        m_use_ssl = m_config.getParameter(StorageConstants::USE_SSL_KEY, "true") == "true";
-        m_timeout_seconds = std::stoul(m_config.getParameter(StorageConstants::TIMEOUT_SECONDS_KEY, "30"));
-        m_max_retries = std::stoul(m_config.getParameter(StorageConstants::MAX_RETRIES_KEY, "3"));
+        const StorageConfig config = getConfig();
+        std::string cloud_type = config.getParameter(StorageConstants::CLOUD_TYPE_KEY, StorageConstants::MINIO_TYPE);
+        m_bucket_name = config.getParameter(StorageConstants::BUCKET_NAME_KEY, "");
+        m_endpoint = config.getParameter(StorageConstants::ENDPOINT_KEY, "");
+        m_access_key = config.getParameter(StorageConstants::ACCESS_KEY_KEY, "");
+        m_secret_key = config.getParameter(StorageConstants::SECRET_KEY_KEY, "");
+        m_region = config.getParameter(StorageConstants::REGION_KEY, "");
+        m_use_ssl = config.getParameter(StorageConstants::USE_SSL_KEY, "true") == "true";
+        m_timeout_seconds = std::stoul(config.getParameter(StorageConstants::TIMEOUT_SECONDS_KEY, "30"));
+        m_max_retries = std::stoul(config.getParameter(StorageConstants::MAX_RETRIES_KEY, "3"));
         
         // Create cloud manager configuration
         CloudManagerConfig cloud_config;
@@ -616,7 +617,7 @@ bool UnifiedCloudStorageManager::initializeStorage()
         }
         if (!m_cloud_manager)
         {
-            m_last_error = "Failed to create cloud manager for type: " + cloud_type;
+            setLastError("Failed to create cloud manager for type: " + cloud_type);
             return false;
         }
         
@@ -624,7 +625,7 @@ bool UnifiedCloudStorageManager::initializeStorage()
     }
     catch (const std::exception& e)
     {
-        m_last_error = "Failed to initialize cloud storage: " + std::string(e.what());
+        setLastError("Failed to initialize cloud storage: " + std::string(e.what()));
         return false;
     }
 }

--- a/services/vios/src/framework/unified_storage/manager/unified_cloud_storage_manager.h
+++ b/services/vios/src/framework/unified_storage/manager/unified_cloud_storage_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,6 +93,7 @@ protected:
     bool isLocalFilePath(const std::string& path) const;
     DeleteResult deleteLocalFile(const std::string& path);
 
+private:
     // Member variables
     // Mutex to protect m_cloud_manager from concurrent access and use-after-free issues
     // All methods accessing m_cloud_manager must acquire this lock before dereferencing

--- a/services/vios/src/framework/unified_storage/manager/unified_local_storage_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/unified_local_storage_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -313,7 +313,7 @@ bool UnifiedLocalStorageManager::createDirectory(const std::string& path, bool c
 {
     if (!isAvailable())
     {
-        m_last_error = "Local storage manager not initialized";
+        setLastError("Local storage manager not initialized");
         return false;
     }
     
@@ -336,12 +336,12 @@ bool UnifiedLocalStorageManager::createDirectory(const std::string& path, bool c
     }
     catch (const std::filesystem::filesystem_error& e)
     {
-        m_last_error = "Filesystem error: " + std::string(e.what());
+        setLastError("Filesystem error: " + std::string(e.what()));
         return false;
     }
     catch (const std::exception& e)
     {
-        m_last_error = "Exception: " + std::string(e.what());
+        setLastError("Exception: " + std::string(e.what()));
         return false;
     }
 }
@@ -379,7 +379,7 @@ bool UnifiedLocalStorageManager::performHealthCheck()
 {
     if (!isAvailable())
     {
-        m_last_error = "Local storage manager not initialized";
+        setLastError("Local storage manager not initialized");
         return false;
     }
     
@@ -389,13 +389,13 @@ bool UnifiedLocalStorageManager::performHealthCheck()
         std::filesystem::path base_path(m_base_path);
         if (!std::filesystem::exists(base_path))
         {
-            m_last_error = "Base directory does not exist: " + m_base_path;
+            setLastError("Base directory does not exist: " + m_base_path);
             return false;
         }
         
         if (!std::filesystem::is_directory(base_path))
         {
-            m_last_error = "Base path is not a directory: " + m_base_path;
+            setLastError("Base path is not a directory: " + m_base_path);
             return false;
         }
         
@@ -404,7 +404,7 @@ bool UnifiedLocalStorageManager::performHealthCheck()
         std::ofstream test_stream(test_file);
         if (!test_stream.is_open())
         {
-            m_last_error = "Cannot write to base directory: " + m_base_path;
+            setLastError("Cannot write to base directory: " + m_base_path);
             return false;
         }
         test_stream.close();
@@ -414,7 +414,7 @@ bool UnifiedLocalStorageManager::performHealthCheck()
     }
     catch (const std::exception& e)
     {
-        m_last_error = "Health check failed: " + std::string(e.what());
+        setLastError("Health check failed: " + std::string(e.what()));
         return false;
     }
 }
@@ -429,11 +429,12 @@ bool UnifiedLocalStorageManager::initializeStorage()
     try
     {
         // Get configuration parameters
-        m_base_path = m_config.getParameter(StorageConstants::BASE_PATH_KEY, "/tmp/vms_storage");
-        m_create_directories = m_config.getParameter(StorageConstants::CREATE_DIRECTORIES_KEY, "true") == "true";
-        m_recursive_listing = m_config.getParameter(StorageConstants::RECURSIVE_LISTING_KEY, "false") == "true";
-        m_max_depth = std::stoul(m_config.getParameter(StorageConstants::MAX_DEPTH_KEY, "10"));
-        m_include_hidden = m_config.getParameter(StorageConstants::INCLUDE_HIDDEN_KEY, "false") == "true";
+        const StorageConfig config = getConfig();
+        m_base_path = config.getParameter(StorageConstants::BASE_PATH_KEY, "/tmp/vms_storage");
+        m_create_directories = config.getParameter(StorageConstants::CREATE_DIRECTORIES_KEY, "true") == "true";
+        m_recursive_listing = config.getParameter(StorageConstants::RECURSIVE_LISTING_KEY, "false") == "true";
+        m_max_depth = std::stoul(config.getParameter(StorageConstants::MAX_DEPTH_KEY, "10"));
+        m_include_hidden = config.getParameter(StorageConstants::INCLUDE_HIDDEN_KEY, "false") == "true";
         
         // Create base directory if it doesn't exist and create_directories is enabled
         if (m_create_directories)
@@ -449,7 +450,7 @@ bool UnifiedLocalStorageManager::initializeStorage()
     }
     catch (const std::exception& e)
     {
-        m_last_error = "Failed to initialize local storage: " + std::string(e.what());
+        setLastError("Failed to initialize local storage: " + std::string(e.what()));
         return false;
     }
 }

--- a/services/vios/src/framework/unified_storage/manager/unified_local_storage_manager.h
+++ b/services/vios/src/framework/unified_storage/manager/unified_local_storage_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,6 +80,7 @@ protected:
     uint64_t calculateDirectorySize(const std::string& path) const;
     size_t countFilesInDirectory(const std::string& path, bool recursive = false) const;
 
+private:
     // Member variables
     std::string m_base_path;
     bool m_create_directories;

--- a/services/vios/src/framework/unified_storage/manager/unified_storage_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/unified_storage_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -348,6 +348,18 @@ void UnifiedStorageManager::recordOperation(bool success, std::chrono::milliseco
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_stats.recordRequest(success, duration, errorCode);
+}
+
+StorageConfig UnifiedStorageManager::getConfig() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_config;
+}
+
+void UnifiedStorageManager::setLastError(const std::string& error)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_last_error = error;
 }
 
 std::string UnifiedStorageManager::formatPath(const std::string& path) const

--- a/services/vios/src/framework/unified_storage/manager/unified_storage_manager.h
+++ b/services/vios/src/framework/unified_storage/manager/unified_storage_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -180,6 +180,21 @@ protected:
      */
     bool validatePath(const std::string& path) const;
 
+    /**
+     * @brief Returns a copy of the current storage configuration
+     * @return The configuration set by configureStorage()
+     * @note This function is thread-safe and handles its own mutex locking
+     */
+    StorageConfig getConfig() const;
+
+    /**
+     * @brief Records the last error message
+     * @param error The error message to store
+     * @note This function is thread-safe and handles its own mutex locking
+     */
+    void setLastError(const std::string& error);
+
+private:
     // Member variables
     StorageType m_storage_type;
     StorageConfig m_config;

--- a/services/vios/src/framework/unified_storage/reader/cloud_reader.h
+++ b/services/vios/src/framework/unified_storage/reader/cloud_reader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -329,11 +329,14 @@ public:
                                   const std::string& errorMessage = "") const;
     
 protected:
-    mutable std::mutex m_stats_mutex;
-    CloudReaderStats m_stats;
-    std::string m_lastError;
-    CloudReaderConfig m_config;
-    
+    // Internal state access for derived implementations
+    std::mutex& getStatsMutexInternal() const { return m_stats_mutex; }
+    CloudReaderStats& getStatsInternal() { return m_stats; }
+    const CloudReaderStats& getStatsInternal() const { return m_stats; }
+    const std::string& getLastErrorInternal() const { return m_lastError; }
+    CloudReaderConfig& getConfigInternal() { return m_config; }
+    const CloudReaderConfig& getConfigInternal() const { return m_config; }
+
     // Helper methods for implementations
     void updateStats(bool success, std::chrono::milliseconds latency, 
                     const std::string& errorCode = "");
@@ -349,7 +352,19 @@ protected:
     void shutdownDownloadWorkers();
     void downloadWorkerThread();
     bool processDownloadTask(const DownloadTask& task, FileDownloadResult& result);
-    
+
+    // Helper methods for async downloads
+    std::string generateSessionId();
+    void processAsyncDownloadSession(const std::string& sessionId);
+    void completeAsyncDownloadSession(const std::string& sessionId);
+    void cleanupCompletedSessions();
+
+private:
+    mutable std::mutex m_stats_mutex;
+    CloudReaderStats m_stats;
+    std::string m_lastError;
+    CloudReaderConfig m_config;
+
     // Download worker thread members
     mutable std::mutex m_download_mutex;
     std::vector<std::thread> m_worker_threads;
@@ -364,12 +379,6 @@ protected:
     std::map<std::string, std::shared_ptr<AsyncDownloadSession>, std::less<>> m_async_sessions;
     std::atomic<uint64_t> m_session_counter{0};
     std::condition_variable m_session_completion_cv;
-    
-    // Helper methods for async downloads
-    std::string generateSessionId();
-    void processAsyncDownloadSession(const std::string& sessionId);
-    void completeAsyncDownloadSession(const std::string& sessionId);
-    void cleanupCompletedSessions();
 };
 
 } // namespace nv_vms 

--- a/services/vios/src/framework/unified_storage/reader/minio_cloud_reader.cpp
+++ b/services/vios/src/framework/unified_storage/reader/minio_cloud_reader.cpp
@@ -82,7 +82,7 @@ bool MinioCloudReader::configure(const CloudReaderConfig& config)
     try
     {
         // Store configuration
-        m_config = config;
+        getConfigInternal() = config;
 
         LOG(info) << "MinioCloudReader::configure called with:" << std::endl;
         LOG(info) << "  endpoint: '" << config.endpoint << "'" << std::endl;
@@ -152,7 +152,7 @@ bool MinioCloudReader::configure(const CloudReaderConfig& config)
 
 CloudReaderConfig MinioCloudReader::getConfiguration() const
 {
-    return m_config;
+    return getConfigInternal();
 }
 
 CloudListResult MinioCloudReader::listObjects(const std::string& bucket, const std::string& prefix, uint32_t maxKeys)
@@ -736,14 +736,14 @@ CloudResult MinioCloudReader::deleteObject(const std::string& bucket, const std:
 
 CloudReaderStats MinioCloudReader::getStats() const
 {
-    std::lock_guard<std::mutex> lock(m_stats_mutex);
-    return m_stats;
+    std::lock_guard<std::mutex> lock(getStatsMutexInternal());
+    return getStatsInternal();
 }
 
 void MinioCloudReader::resetStats()
 {
-    std::lock_guard<std::mutex> lock(m_stats_mutex);
-    m_stats = CloudReaderStats();
+    std::lock_guard<std::mutex> lock(getStatsMutexInternal());
+    getStatsInternal() = CloudReaderStats();
 }
 
 CloudResult MinioCloudReader::performHealthCheck()
@@ -801,7 +801,7 @@ CloudResult MinioCloudReader::performHealthCheck()
 
 std::string MinioCloudReader::getLastError() const
 {
-    return m_lastError;
+    return getLastErrorInternal();
 }
 
 // Private implementation methods

--- a/services/vios/src/framework/unified_storage/reader/s3_cloud_reader.cpp
+++ b/services/vios/src/framework/unified_storage/reader/s3_cloud_reader.cpp
@@ -89,40 +89,40 @@ void S3CloudReader::shutdownAwsSDK()
 bool S3CloudReader::isAvailable() const
 {
     std::lock_guard<std::mutex> lock(m_config_mutex);
-    return m_initialized && m_awsSdkInitialized && !m_config.accessKeyId.empty() && !m_config.secretAccessKey.empty();
+    return m_initialized && m_awsSdkInitialized && !getConfigInternal().accessKeyId.empty() && !getConfigInternal().secretAccessKey.empty();
 }
 
 bool S3CloudReader::configure(const CloudReaderConfig& config)
 {
     std::lock_guard<std::mutex> lock(m_config_mutex);
 
-    m_config = config;
-    m_config.storageType = CloudStorageType::AWS_S3;
+    getConfigInternal() = config;
+    getConfigInternal().storageType = CloudStorageType::AWS_S3;
 
     // Set default region if not specified
-    if (m_config.region.empty())
+    if (getConfigInternal().region.empty())
     {
-        m_config.region = "us-west-1";
+        getConfigInternal().region = "us-west-1";
     }
 
     // Set endpoint based on configuration
     // Priority: 1) Explicit config.endpoint (for MinIO/custom S3)
     //           2) Default AWS endpoints by region
-    if (!m_config.endpoint.empty())
+    if (!getConfigInternal().endpoint.empty())
     {
-        m_endpoint = m_config.endpoint;
+        m_endpoint = getConfigInternal().endpoint;
     }
     else
     {
-        auto it = DEFAULT_ENDPOINTS.find(m_config.region);
+        auto it = DEFAULT_ENDPOINTS.find(getConfigInternal().region);
         if (it != DEFAULT_ENDPOINTS.end())
         {
-            m_endpoint = std::string(m_config.useSSL ? "https://" : "http://") + it->second;
+            m_endpoint = std::string(getConfigInternal().useSSL ? "https://" : "http://") + it->second;
         }
         else
         {
             m_endpoint =
-                std::string(m_config.useSSL ? "https://" : "http://") + "s3." + m_config.region + ".amazonaws.com";
+                std::string(getConfigInternal().useSSL ? "https://" : "http://") + "s3." + getConfigInternal().region + ".amazonaws.com";
         }
     }
 
@@ -134,7 +134,7 @@ bool S3CloudReader::configure(const CloudReaderConfig& config)
 
     // Create credentials provider using thread-safe method
     m_credentialsProvider =
-        AwsSdkManager::getInstance().createCredentialsProvider(m_config.accessKeyId, m_config.secretAccessKey);
+        AwsSdkManager::getInstance().createCredentialsProvider(getConfigInternal().accessKeyId, getConfigInternal().secretAccessKey);
     if (!m_credentialsProvider)
     {
         setLastError("Failed to create AWS credentials provider");
@@ -145,7 +145,7 @@ bool S3CloudReader::configure(const CloudReaderConfig& config)
     m_signer = AwsSdkManager::getInstance().createV4Signer(
         m_credentialsProvider,
         "s3",
-        m_config.region,
+        getConfigInternal().region,
         Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent);
     if (!m_signer)
     {
@@ -155,8 +155,8 @@ bool S3CloudReader::configure(const CloudReaderConfig& config)
 
     // Create client configuration using thread-safe method
     // Pass endpoint for MinIO/custom S3 compatibility
-    m_clientConfig = AwsSdkManager::getInstance().createClientConfiguration(m_config.region, m_config.useSSL,
-                                                                            m_config.timeoutSeconds, m_endpoint);
+    m_clientConfig = AwsSdkManager::getInstance().createClientConfiguration(getConfigInternal().region, getConfigInternal().useSSL,
+                                                                            getConfigInternal().timeoutSeconds, m_endpoint);
     if (!m_clientConfig)
     {
         setLastError("Failed to create client configuration");
@@ -184,7 +184,7 @@ bool S3CloudReader::configure(const CloudReaderConfig& config)
 CloudReaderConfig S3CloudReader::getConfiguration() const
 {
     std::lock_guard<std::mutex> lock(m_config_mutex);
-    return m_config;
+    return getConfigInternal();
 }
 
 CloudListResult S3CloudReader::listObjects(const std::string& bucket, const std::string& prefix, uint32_t maxKeys)
@@ -334,8 +334,8 @@ CloudListResult S3CloudReader::listObjectsPaginated(const std::string& bucket, c
 
         // Update stats with objects listed
         {
-            std::lock_guard<std::mutex> lock(m_stats_mutex);
-            m_stats.objectsListed += result.count;
+            std::lock_guard<std::mutex> lock(getStatsMutexInternal());
+            getStatsInternal().objectsListed += result.count;
         }
     }
     catch (const std::exception& e)
@@ -426,9 +426,9 @@ CloudResult S3CloudReader::makeS3RequestWithParams(const std::string& method, co
         else
         {
             // Default to AWS S3 endpoint
-            host = "s3." + m_config.region + ".amazonaws.com";
+            host = "s3." + getConfigInternal().region + ".amazonaws.com";
         }
-        Aws::Http::Scheme awsScheme = m_config.useSSL ? Aws::Http::Scheme::HTTPS : Aws::Http::Scheme::HTTP;
+        Aws::Http::Scheme awsScheme = getConfigInternal().useSSL ? Aws::Http::Scheme::HTTPS : Aws::Http::Scheme::HTTP;
 
         // Build path
         std::string path = "/" + bucket;
@@ -527,9 +527,9 @@ CloudResult S3CloudReader::makeS3Request(const std::string& method, const std::s
         else
         {
             // Default to AWS S3 endpoint
-            host = "s3." + m_config.region + ".amazonaws.com";
+            host = "s3." + getConfigInternal().region + ".amazonaws.com";
         }
-        Aws::Http::Scheme awsScheme = m_config.useSSL ? Aws::Http::Scheme::HTTPS : Aws::Http::Scheme::HTTP;
+        Aws::Http::Scheme awsScheme = getConfigInternal().useSSL ? Aws::Http::Scheme::HTTPS : Aws::Http::Scheme::HTTP;
 
         // Build path
         std::string path = "/" + bucket;
@@ -765,7 +765,7 @@ std::string S3CloudReader::buildS3Endpoint(const std::string& bucket) const
         return bucket + "." + host;
     }
     // Default to AWS S3 endpoint
-    return bucket + ".s3." + m_config.region + ".amazonaws.com";
+    return bucket + ".s3." + getConfigInternal().region + ".amazonaws.com";
 }
 
 Aws::String S3CloudReader::convertToAwsString(const std::string& str) const
@@ -876,10 +876,10 @@ CloudResult S3CloudReader::generatePresignedUrl(const std::string& bucket, const
         else
         {
             // Default to AWS S3 endpoint
-            host = "s3." + m_config.region + ".amazonaws.com";
+            host = "s3." + getConfigInternal().region + ".amazonaws.com";
         }
         std::string uri = "/" + bucket + "/" + objectKey;
-        std::string fullUrl = (m_config.useSSL ? "https://" : "http://") + host + uri;
+        std::string fullUrl = (getConfigInternal().useSSL ? "https://" : "http://") + host + uri;
 
         // Create HTTP request for pre-signing
         auto request = Aws::Http::CreateHttpRequest(convertToAwsString(fullUrl), Aws::Http::HttpMethod::HTTP_GET,
@@ -916,14 +916,14 @@ CloudResult S3CloudReader::generatePresignedUrl(const std::string& bucket, const
 
 CloudReaderStats S3CloudReader::getStats() const
 {
-    std::lock_guard<std::mutex> lock(m_stats_mutex);
-    return m_stats;
+    std::lock_guard<std::mutex> lock(getStatsMutexInternal());
+    return getStatsInternal();
 }
 
 void S3CloudReader::resetStats()
 {
-    std::lock_guard<std::mutex> lock(m_stats_mutex);
-    m_stats = CloudReaderStats{};
+    std::lock_guard<std::mutex> lock(getStatsMutexInternal());
+    getStatsInternal() = CloudReaderStats{};
 }
 
 CloudResult S3CloudReader::performHealthCheck()
@@ -934,27 +934,27 @@ CloudResult S3CloudReader::performHealthCheck()
 
 std::string S3CloudReader::getLastError() const
 {
-    std::lock_guard<std::mutex> lock(m_stats_mutex);
-    return m_lastError;
+    std::lock_guard<std::mutex> lock(getStatsMutexInternal());
+    return getLastErrorInternal();
 }
 
 // Helper method implementations
 
 bool S3CloudReader::validateConfig() const
 {
-    return !m_config.accessKeyId.empty() && !m_config.secretAccessKey.empty() && !m_config.region.empty();
+    return !getConfigInternal().accessKeyId.empty() && !getConfigInternal().secretAccessKey.empty() && !getConfigInternal().region.empty();
 }
 
 std::string S3CloudReader::getRequiredConfigParameter(const std::string& key) const
 {
     if (key == "accessKeyId")
-        return m_config.accessKeyId;
+        return getConfigInternal().accessKeyId;
     if (key == "secretAccessKey")
-        return m_config.secretAccessKey;
+        return getConfigInternal().secretAccessKey;
     if (key == "region")
-        return m_config.region;
+        return getConfigInternal().region;
     if (key == "endpoint")
-        return m_config.endpoint;
+        return getConfigInternal().endpoint;
     return "";
 }
 

--- a/services/vios/src/framework/unified_storage/reader/unified_cloud_storage_reader.cpp
+++ b/services/vios/src/framework/unified_storage/reader/unified_cloud_storage_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,13 +38,13 @@ UnifiedCloudStorageReader::~UnifiedCloudStorageReader()
         LOG(info) << "UnifiedCloudStorageReader destructor called - cleaning up cloud reader" << std::endl;
 
         // Cancel all async downloads in the cloud reader
-        if (m_cloudReader)
+        if (getCloudReaderInternal())
         {
-            m_cloudReader->cancelAllAsyncDownloads();
+            getCloudReaderInternal()->cancelAllAsyncDownloads();
         }
 
         // Reset the cloud reader (this will trigger its destructor)
-        m_cloudReader.reset();
+        setCloudReaderInternal(nullptr);
 
         LOG(info) << "UnifiedCloudStorageReader destructor completed" << std::endl;
     }
@@ -60,7 +60,7 @@ UnifiedCloudStorageReader::~UnifiedCloudStorageReader()
 
 bool UnifiedCloudStorageReader::isAvailable() const
 {
-    return m_cloudReader != nullptr && m_cloudReader->isAvailable();
+    return getCloudReaderInternal() != nullptr && getCloudReaderInternal()->isAvailable();
 }
 
 std::string UnifiedCloudStorageReader::getStorageMode() const
@@ -85,7 +85,7 @@ bool UnifiedCloudStorageReader::configureStorage(const StorageConfig& config)
     LOG(info) << "configureStorage succeeded, cloud reader should already be initialized" << std::endl;
 
     // Verify that cloud reader was actually created
-    if (!m_cloudReader)
+    if (!getCloudReaderInternal())
     {
         LOG(error) << "Cloud reader was not created during initialization" << std::endl;
         return false;
@@ -123,7 +123,7 @@ FileResult UnifiedCloudStorageReader::downloadFile(const std::string& remote_pat
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -136,7 +136,7 @@ FileResult UnifiedCloudStorageReader::downloadFile(const std::string& remote_pat
             LOG(info) << "Downloading file from cloud: " << remote_path << " to " << local_path
                       << " from bucket: " << bucket << std::endl;
 
-            CloudResult cloudResult = m_cloudReader->downloadObject(bucket, objectKey, local_path);
+            CloudResult cloudResult = getCloudReaderInternal()->downloadObject(bucket, objectKey, local_path);
             result = convertCloudResultToFileResult(cloudResult);
 
             if (result.success)
@@ -173,7 +173,7 @@ FileResult UnifiedCloudStorageReader::getFileInfo(const std::string& path, FileI
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -185,7 +185,7 @@ FileResult UnifiedCloudStorageReader::getFileInfo(const std::string& path, FileI
             std::string objectKey = extractObjectKeyFromPath(path);
 
             CloudObject cloudObject;
-            CloudResult cloudResult = m_cloudReader->getObjectInfo(bucket, objectKey, cloudObject);
+            CloudResult cloudResult = getCloudReaderInternal()->getObjectInfo(bucket, objectKey, cloudObject);
 
             if (cloudResult.success)
             {
@@ -223,7 +223,7 @@ FileResult UnifiedCloudStorageReader::checkFileExists(const std::string& path)
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -236,7 +236,7 @@ FileResult UnifiedCloudStorageReader::checkFileExists(const std::string& path)
 
             LOG(info) << "Extracted bucket: '" << bucket << "' and objectKey: '" << objectKey << "'" << std::endl;
 
-            CloudResult cloudResult = m_cloudReader->checkObjectExists(bucket, objectKey);
+            CloudResult cloudResult = getCloudReaderInternal()->checkObjectExists(bucket, objectKey);
             result = convertCloudResultToFileResult(cloudResult);
         }
     }
@@ -262,7 +262,7 @@ FileListResult UnifiedCloudStorageReader::listFiles(const std::string& path, con
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -283,7 +283,7 @@ FileListResult UnifiedCloudStorageReader::listFiles(const std::string& path, con
                 objectPrefix = prefix;
             }
 
-            CloudListResult cloudResult = m_cloudReader->listObjects(bucket, objectPrefix);
+            CloudListResult cloudResult = getCloudReaderInternal()->listObjects(bucket, objectPrefix);
             result = convertCloudListResultToFileListResult(cloudResult);
             result.path = path;
         }
@@ -311,7 +311,7 @@ FileListResult UnifiedCloudStorageReader::listFilesPaginated(const std::string& 
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -332,7 +332,7 @@ FileListResult UnifiedCloudStorageReader::listFilesPaginated(const std::string& 
                 objectPrefix = prefix;
             }
 
-            CloudListResult cloudResult = m_cloudReader->listObjectsPaginated(bucket, objectPrefix, marker, maxKeys);
+            CloudListResult cloudResult = getCloudReaderInternal()->listObjectsPaginated(bucket, objectPrefix, marker, maxKeys);
             result = convertCloudListResultToFileListResult(cloudResult);
             result.path = path;
         }
@@ -360,7 +360,7 @@ FileResult UnifiedCloudStorageReader::generatePresignedUrl(const std::string& pa
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -371,7 +371,7 @@ FileResult UnifiedCloudStorageReader::generatePresignedUrl(const std::string& pa
             std::string bucket = extractBucketFromPath(path);
             std::string objectKey = extractObjectKeyFromPath(path);
 
-            CloudResult cloudResult = m_cloudReader->generatePresignedUrl(bucket, objectKey, expirationSeconds, url);
+            CloudResult cloudResult = getCloudReaderInternal()->generatePresignedUrl(bucket, objectKey, expirationSeconds, url);
             result = convertCloudResultToFileResult(cloudResult);
         }
     }
@@ -466,7 +466,7 @@ FileResult UnifiedCloudStorageReader::getPresignedUrl(const std::string& path, s
         // Generate new presigned URL (NO LOCK - S3 API call can take time)
         const uint32_t REQUESTED_EXPIRATION_SECONDS = 12 * 60 * 60;  // Request 12 hours
 
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -477,7 +477,7 @@ FileResult UnifiedCloudStorageReader::getPresignedUrl(const std::string& path, s
             std::string bucket = extractBucketFromPath(path);
             std::string objectKey = extractObjectKeyFromPath(path);
 
-            CloudResult cloudResult = m_cloudReader->generatePresignedUrl(bucket, objectKey, REQUESTED_EXPIRATION_SECONDS, url);
+            CloudResult cloudResult = getCloudReaderInternal()->generatePresignedUrl(bucket, objectKey, REQUESTED_EXPIRATION_SECONDS, url);
             result = convertCloudResultToFileResult(cloudResult);
 
             if (result.success)
@@ -519,7 +519,7 @@ FileResult UnifiedCloudStorageReader::listBuckets(std::vector<std::string>& buck
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -527,7 +527,7 @@ FileResult UnifiedCloudStorageReader::listBuckets(std::vector<std::string>& buck
         }
         else
         {
-            CloudResult cloudResult = m_cloudReader->listBuckets(buckets);
+            CloudResult cloudResult = getCloudReaderInternal()->listBuckets(buckets);
             result = convertCloudResultToFileResult(cloudResult);
         }
     }
@@ -553,7 +553,7 @@ FileResult UnifiedCloudStorageReader::checkBucketExists(const std::string& bucke
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -561,7 +561,7 @@ FileResult UnifiedCloudStorageReader::checkBucketExists(const std::string& bucke
         }
         else
         {
-            CloudResult cloudResult = m_cloudReader->checkBucketExists(bucket);
+            CloudResult cloudResult = getCloudReaderInternal()->checkBucketExists(bucket);
             result = convertCloudResultToFileResult(cloudResult);
         }
     }
@@ -591,14 +591,14 @@ CloudListResult UnifiedCloudStorageReader::listCloudObjects(const std::string& b
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
             result.errorCode = "NOT_INITIALIZED";
             LOG(error) << "Cloud reader not initialized for listCloudObjects" << std::endl;
         }
-        else if (!m_cloudReader->isAvailable())
+        else if (!getCloudReaderInternal()->isAvailable())
         {
             result.success = false;
             result.message = "Cloud reader is not available";
@@ -608,7 +608,7 @@ CloudListResult UnifiedCloudStorageReader::listCloudObjects(const std::string& b
         else
         {
             // Use the cloud reader to list objects
-            result = m_cloudReader->listObjects(bucketName, prefix, maxKeys);
+            result = getCloudReaderInternal()->listObjects(bucketName, prefix, maxKeys);
 
             if (result.success)
             {
@@ -648,14 +648,14 @@ CloudListResult UnifiedCloudStorageReader::listAllCloudObjects(const std::string
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
             result.errorCode = "NOT_INITIALIZED";
             LOG(error) << "Cloud reader not initialized for listAllCloudObjects" << std::endl;
         }
-        else if (!m_cloudReader->isAvailable())
+        else if (!getCloudReaderInternal()->isAvailable())
         {
             result.success = false;
             result.message = "Cloud reader is not available";
@@ -666,7 +666,7 @@ CloudListResult UnifiedCloudStorageReader::listAllCloudObjects(const std::string
         {
             // Use the cloud reader's listAllObjects method (works for S3, MinIO, and other compatible storages)
             LOG(info) << "Using CloudReader::listAllObjects for complete listing" << std::endl;
-            result = m_cloudReader->listAllObjects(bucketName, prefix);
+            result = getCloudReaderInternal()->listAllObjects(bucketName, prefix);
 
             if (result.success)
             {
@@ -718,7 +718,7 @@ FileResult UnifiedCloudStorageReader::performHealthCheck()
 
     try
     {
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             result.success = false;
             result.message = "Cloud reader not initialized";
@@ -726,7 +726,7 @@ FileResult UnifiedCloudStorageReader::performHealthCheck()
         }
         else
         {
-            CloudResult cloudResult = m_cloudReader->performHealthCheck();
+            CloudResult cloudResult = getCloudReaderInternal()->performHealthCheck();
             result = convertCloudResultToFileResult(cloudResult);
         }
     }
@@ -746,7 +746,7 @@ FileResult UnifiedCloudStorageReader::performHealthCheck()
 
 std::shared_ptr<CloudReader> UnifiedCloudStorageReader::getCloudReader() const
 {
-    return m_cloudReader;
+    return getCloudReaderInternal();
 }
 
 // Async download operations implementation
@@ -754,7 +754,7 @@ std::string UnifiedCloudStorageReader::downloadFilesWithPathsAsync(const std::ve
                                                                   DownloadCompletionCallback completionCallback,
                                                                   DownloadProgressCallback progressCallback)
 {
-    if (!m_cloudReader)
+    if (!getCloudReaderInternal())
     {
         setLastError("Cloud reader not initialized");
         return "";
@@ -775,7 +775,7 @@ std::string UnifiedCloudStorageReader::downloadFilesWithPathsAsync(const std::ve
         objectKeyPathPairs.emplace_back(objectKey, pair.second);
     }
 
-    return m_cloudReader->downloadObjectsWithPathsAsync(bucket, objectKeyPathPairs, completionCallback, progressCallback);
+    return getCloudReaderInternal()->downloadObjectsWithPathsAsync(bucket, objectKeyPathPairs, completionCallback, progressCallback);
 }
 
 std::string UnifiedCloudStorageReader::downloadMultipleFilesAsync(const std::string& remote_directory,
@@ -784,7 +784,7 @@ std::string UnifiedCloudStorageReader::downloadMultipleFilesAsync(const std::str
                                                                  DownloadCompletionCallback completionCallback,
                                                                  DownloadProgressCallback progressCallback)
 {
-    if (!m_cloudReader)
+    if (!getCloudReaderInternal())
     {
         setLastError("Cloud reader not initialized");
         return "";
@@ -798,52 +798,52 @@ std::string UnifiedCloudStorageReader::downloadMultipleFilesAsync(const std::str
         objectKeys.push_back(objectKey);
     }
 
-    return m_cloudReader->downloadMultipleObjectsAsync(getBucketName(), objectKeys, local_directory, completionCallback, progressCallback);
+    return getCloudReaderInternal()->downloadMultipleObjectsAsync(getBucketName(), objectKeys, local_directory, completionCallback, progressCallback);
 }
 
 bool UnifiedCloudStorageReader::cancelAsyncDownload(const std::string& sessionId)
 {
-    if (!m_cloudReader)
+    if (!getCloudReaderInternal())
     {
         setLastError("Cloud reader not initialized");
         return false;
     }
-    return m_cloudReader->cancelAsyncDownload(sessionId);
+    return getCloudReaderInternal()->cancelAsyncDownload(sessionId);
 }
 
 bool UnifiedCloudStorageReader::cancelAllAsyncDownloads()
 {
-    if (!m_cloudReader)
+    if (!getCloudReaderInternal())
     {
         setLastError("Cloud reader not initialized");
         return false;
     }
-    return m_cloudReader->cancelAllAsyncDownloads();
+    return getCloudReaderInternal()->cancelAllAsyncDownloads();
 }
 
 std::vector<std::string> UnifiedCloudStorageReader::getActiveAsyncDownloads() const
 {
-    if (!m_cloudReader)
+    if (!getCloudReaderInternal())
     {
         return {};
     }
-    return m_cloudReader->getActiveAsyncDownloads();
+    return getCloudReaderInternal()->getActiveAsyncDownloads();
 }
 
 bool UnifiedCloudStorageReader::isAsyncDownloadCompleted(const std::string& sessionId) const
 {
-    if (!m_cloudReader)
+    if (!getCloudReaderInternal())
     {
         return false;
     }
-    return m_cloudReader->isAsyncDownloadCompleted(sessionId);
+    return getCloudReaderInternal()->isAsyncDownloadCompleted(sessionId);
 }
 
 DownloadResult UnifiedCloudStorageReader::getAsyncDownloadResult(const std::string& sessionId) const
 {
     DownloadResult result;
 
-    if (!m_cloudReader)
+    if (!getCloudReaderInternal())
     {
         result.overall_success = false;
         result.error_message = "Cloud reader not initialized";
@@ -851,7 +851,7 @@ DownloadResult UnifiedCloudStorageReader::getAsyncDownloadResult(const std::stri
     }
 
     // Get result from cloud reader and convert
-    MultiDownloadResult cloudResult = m_cloudReader->getAsyncDownloadResult(sessionId);
+    MultiDownloadResult cloudResult = getCloudReaderInternal()->getAsyncDownloadResult(sessionId);
 
     result.overall_success = cloudResult.overall_success;
     result.error_message = cloudResult.error_message;
@@ -923,16 +923,16 @@ bool UnifiedCloudStorageReader::initializeCloudReader()
                   << "' (enum: " << static_cast<int>(m_cloudConfig.storageType) << ")" << std::endl;
 
         // Use the factory's createReader function directly with the CloudStorageType enum
-        m_cloudReader = CloudReaderFactory::createReader(m_cloudConfig.storageType, m_cloudConfig);
+        setCloudReaderInternal(CloudReaderFactory::createReader(m_cloudConfig.storageType, m_cloudConfig));
 
-        if (!m_cloudReader)
+        if (!getCloudReaderInternal())
         {
             LOG(error) << "Failed to create cloud reader for type: " + cloudTypeStr << std::endl;
             setLastError("Failed to create cloud reader for type: " + cloudTypeStr);
             return false;
         }
 
-        if (!m_cloudReader->isAvailable())
+        if (!getCloudReaderInternal()->isAvailable())
         {
             setLastError("Cloud reader is not available for type: " + cloudTypeStr);
             return false;
@@ -1041,7 +1041,7 @@ FileResult UnifiedCloudStorageReader::convertCloudResultToFileResult(const Cloud
 std::string UnifiedCloudStorageReader::extractBucketFromPath(const std::string& path) const
 {
     // Always use the configured bucket from storage config
-    std::string bucket = m_config.getParameter(StorageConstants::BUCKET_NAME_KEY);
+    std::string bucket = getBucketName();
     if (bucket.empty())
     {
         LOG(error) << "No bucket configured in storage config" << std::endl;

--- a/services/vios/src/framework/unified_storage/reader/unified_storage_reader.cpp
+++ b/services/vios/src/framework/unified_storage/reader/unified_storage_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <mutex>
 #include <sstream>
+#include <utility>
 
 namespace nv_vms
 {
@@ -491,6 +492,16 @@ FileResult UnifiedStorageReader::performHealthCheck()
 
     updateStats(result.success, result.duration, result.errorCode);
     return result;
+}
+
+const std::shared_ptr<CloudReader>& UnifiedStorageReader::getCloudReaderInternal() const
+{
+    return m_cloudReader;
+}
+
+void UnifiedStorageReader::setCloudReaderInternal(std::shared_ptr<CloudReader> cloudReader)
+{
+    m_cloudReader = std::move(cloudReader);
 }
 
 void UnifiedStorageReader::setLastError(const std::string& error)

--- a/services/vios/src/framework/unified_storage/reader/unified_storage_reader.h
+++ b/services/vios/src/framework/unified_storage/reader/unified_storage_reader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -140,6 +140,21 @@ public:
     virtual FileResult performHealthCheck();
 
 protected:
+    // Storage reader access for derived implementations
+    const std::shared_ptr<CloudReader>& getCloudReaderInternal() const;
+    void setCloudReaderInternal(std::shared_ptr<CloudReader> cloudReader);
+
+    // Helper methods
+    void setLastError(const std::string& error);
+    void clearLastError();
+    void updateStats(bool success, std::chrono::milliseconds latency,
+                    const std::string& errorCode = "");
+
+    // Abstract methods for specific storage implementations
+    virtual bool initializeStorage() = 0;
+    virtual bool validateConfiguration(const StorageConfig& config) = 0;
+
+private:
     // Storage mode
     StorageType m_storageMode;
 
@@ -157,16 +172,6 @@ protected:
 
     // Storage readers
     std::shared_ptr<CloudReader> m_cloudReader = nullptr;
-
-    // Helper methods
-    void setLastError(const std::string& error);
-    void clearLastError();
-    void updateStats(bool success, std::chrono::milliseconds latency,
-                    const std::string& errorCode = "");
-
-    // Abstract methods for specific storage implementations
-    virtual bool initializeStorage() = 0;
-    virtual bool validateConfiguration(const StorageConfig& config) = 0;
 };
 
 } // namespace nv_vms

--- a/services/vios/src/framework/unified_storage/writer/unified_cloud_storage_writer.h
+++ b/services/vios/src/framework/unified_storage/writer/unified_cloud_storage_writer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,6 +61,7 @@ protected:
     // Session management helper
     void cleanupSessionTracking(const std::string& session_id);
 
+private:
     // Cloud writer integration
     std::shared_ptr<StorageWriter> m_cloud_writer;
     mutable std::mutex m_cloud_writer_mutex;

--- a/services/vios/src/framework/unified_storage/writer/unified_storage_writer.cpp
+++ b/services/vios/src/framework/unified_storage/writer/unified_storage_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -375,7 +375,7 @@ bool UnifiedStorageWriter::createPipelineInternal(const std::string& video_codec
         std::string vcodec_lc = video_codec;
         std::transform(vcodec_lc.begin(), vcodec_lc.end(), vcodec_lc.begin(), ::tolower);
         std::string filter_caps_str = "video/x-" + vcodec_lc + ", alignment=(string)au";
-        m_capsfilterVideo = gst_element_factory_make("capsfilter", NULL);
+        m_capsfilterVideo = gst_element_factory_make("capsfilter", nullptr);
         if (m_capsfilterVideo)
         {
             GstCaps* filter_caps = gst_caps_from_string(filter_caps_str.c_str());
@@ -428,10 +428,9 @@ bool UnifiedStorageWriter::createPipelineInternal(const std::string& video_codec
         else if (iequals(audio_codec, "mpeg4-generic"))
         {
             m_parserAudio = gst_element_factory_make("aacparse", nullptr);
-            std::string caps_string = string(
-                                          "audio/mpeg, mpegversion=(int)4, \
-                                    stream-format=(string)raw, \
-                                    codec_data=(buffer)") +
+            std::string caps_string = string("audio/mpeg, mpegversion=(int)4, "
+                                             "stream-format=(string)raw, "
+                                             "codec_data=(buffer)") +
                                       to_string(codec_data);
             GstCaps* caps_before_dec = gst_caps_from_string(caps_string.c_str());
             if (caps_before_dec)

--- a/services/vios/src/framework/utilities/cmdline_parser.cpp
+++ b/services/vios/src/framework/utilities/cmdline_parser.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,11 +27,11 @@ using namespace std;
 using namespace nv_vms;
 
 /* Null, because instance will be initialized on demand. */
-CmdLineParser* CmdLineParser::m_instance = 0;
+CmdLineParser* CmdLineParser::m_instance = nullptr;
 
 CmdLineParser* CmdLineParser::getInstance()
 {
-    if (m_instance == 0)
+    if (m_instance == nullptr)
     {
         m_instance = new CmdLineParser();
     }

--- a/services/vios/src/framework/utilities/event_loop.cpp
+++ b/services/vios/src/framework/utilities/event_loop.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,7 +98,7 @@ std::thread::id EventLoop::GetCurrentThreadId()
 void EventLoop::processFunctionWrapper(std::shared_ptr<EventLoopData> userData, void *parent)
 {
     m_isProcessFuncDone = false;
-    std::thread t([&]()
+    std::thread t([this, userData]()
     {
         if (m_processMsg)
         {
@@ -245,7 +245,7 @@ void EventLoop::ExitThread()
         return;
 
     // Create a new EventLoopMsg
-    std::shared_ptr<EventLoopMsg> eventLoopMsg(new EventLoopMsg(MSG_EXIT_EVENT_LOOP, 0));
+    std::shared_ptr<EventLoopMsg> eventLoopMsg(new EventLoopMsg(MSG_EXIT_EVENT_LOOP, nullptr));
 
     // Put exit thread message into the queue
     {

--- a/services/vios/src/framework/utilities/signal_handler.h
+++ b/services/vios/src/framework/utilities/signal_handler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,7 +72,7 @@ private:
         void* addrlist[max_frames+1];
 
         // retrieve current stack addresses
-        int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
+        int addrlen = backtrace(addrlist, static_cast<int>(max_frames + 1));
         if (addrlen == 0)
         {
             LOG(error) << " <empty, possibly corrupt>" << endl;

--- a/services/vios/src/framework/web/websocket_client/WebsocketClient.cpp
+++ b/services/vios/src/framework/web/websocket_client/WebsocketClient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,7 +110,7 @@ WebsocketClient::WebsocketClient() : m_connection(nullptr),
     int keepAliveMs = max(5000, GET_CONFIG().websocket_keep_alive_ms);
     auto chronoMs = std::chrono::milliseconds(keepAliveMs);
     m_watchdog = make_unique<Bosma::Scheduler>(1);
-    m_watchdog->interval(chronoMs, [=]()
+    m_watchdog->interval(chronoMs, [this]()
                          { websocketClientMonitorTask(); });
 }
 

--- a/services/vios/src/framework/web/websocket_server/Websocket.cpp
+++ b/services/vios/src/framework/web/websocket_server/Websocket.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -156,8 +156,8 @@ bool Websocket::sendMessage(std::string peerId, std::string data, int op_code)
 
     std::lock_guard<std::mutex> lock(ws->connectionMutex);
     LOG(verbose2) << "Writing " << data.size() << " bytes on websocket with ID: " << peerId << std::endl;
-    size_t ret = mg_websocket_write(ws->connection, op_code, data.c_str(), data.size());
-    if (ret != data.size())
+    int ret = mg_websocket_write(ws->connection, op_code, data.c_str(), data.size());
+    if (ret < 0 || static_cast<size_t>(ret) != data.size())
     {
         std::string msg = (ret == 0) ? "Connection Closed" : (ret < 0) ? "Send Error: " + std::string(std::strerror(errno)) : "Partial data sent";
         LOG(warning) << "Failed to send data via websocket connection. Reason: " << msg;

--- a/services/vios/src/framework/webrtc_streamer/WebrtcCallbacks.cpp
+++ b/services/vios/src/framework/webrtc_streamer/WebrtcCallbacks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -480,7 +480,7 @@ void PeerConnectionObserver::OnAddStream(webrtc::scoped_refptr<webrtc::MediaStre
     m_bitrateThresold *= STANDARD_BITRATE_720P_KBPS;
     m_webrtcInputDataWatchDog = make_unique<Bosma::Scheduler>(1);
     m_webrtcInputDataWatchDog->every(
-                WEBRTC_INPUT_DATA_WATCH_DOG_SCHEDULER_INTERVAL, [=, this]() {
+                WEBRTC_INPUT_DATA_WATCH_DOG_SCHEDULER_INTERVAL, [this]() {
                 checkInputDataFlowStatus();
                 Json::Value inboundVideoStats = getInboundVideoStats();
                 uint64_t currentBitrate = calculateCurrentBitrate(inboundVideoStats);
@@ -525,7 +525,7 @@ void PeerConnectionObserver::OnSignalingChange(webrtc::PeerConnectionInterface::
         const uint64_t frequency = GET_CONFIG().webrtc_peer_conn_timeout_sec;
         std::chrono::seconds seconds (frequency);
         m_peerConnectionTimeout = make_unique<Bosma::Scheduler>(PEER_CONNECTION_TIMEOUT_THREAD_COUNT);
-        m_peerConnectionTimeout->in(seconds, [=, this]() {
+        m_peerConnectionTimeout->in(seconds, [this]() {
             m_peerConnection->isIceCandidateAdded();
         });
 

--- a/services/vios/src/framework/webrtc_streamer/inc/PeerConnectionManager.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/PeerConnectionManager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -170,7 +170,7 @@ class PeerConnectionManager : public IStreamStatusEvent, public IVstModule
         void generateRpCandidate(const string& streamId, Json::Value iceCandidate);
     public:
         std::string                                                     m_pcType {""};
-    protected:
+    private:
         std::unique_ptr<webrtc::TaskQueueFactory>                       m_taskQueueFactory;
         webrtc::scoped_refptr<webrtc::AudioDeviceModule>                   m_audioDeviceModule;
 #ifndef ASYNC_API
@@ -189,7 +189,6 @@ class PeerConnectionManager : public IStreamStatusEvent, public IVstModule
         static std::string                                              m_rpStunServer;
         static std::mutex                                               m_rpStunServerLock;
         Json::Value                                                     m_externalPeerInfo;
-    private:
         std::shared_ptr<nv_vms::DeviceManager>                          m_deviceManager;
         std::thread                                                     m_peerConnMonitoringThread;
         std::atomic<bool>                                               m_exitPeerConnThread;

--- a/services/vios/src/framework/webrtc_streamer/inc/V4l2AlsaMap.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/V4l2AlsaMap.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,8 +55,8 @@ std::map<std::string,std::string>  getV4l2AlsaMap() {
 	std::map<std::string,std::string> videodevices;
 	std::string video4linuxPath("/sys/class/video4linux");
 	DIR *dp = opendir(video4linuxPath.c_str());
-	if (dp != NULL) {
-		struct dirent *entry = NULL;
+	if (dp != nullptr) {
+		struct dirent *entry = nullptr;
 		while((entry = readdir(dp))) {
 			std::string devicename;
 			std::string deviceid;
@@ -84,7 +84,7 @@ std::map<std::string,std::string>  getV4l2AlsaMap() {
 	std::map<std::string,std::string> audiodevices;
 	int rcard = -1;
 	while ( (snd_card_next(&rcard) == 0) && (rcard>=0) ) {
-		void **hints = NULL;
+		void **hints = nullptr;
 		if (snd_device_name_hint(rcard, "pcm", &hints) >= 0) {
 			void **str = hints;
 			while (*str) {

--- a/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +46,7 @@ public:
 
     std::atomic<bool>   m_webrtcVideoInDataFlow{false};
     std::string         m_fpsValues;
-protected:
+private:
     webrtc::scoped_refptr<webrtc::VideoTrackInterface> m_track;
     std::shared_ptr<WebrtcStream>                   m_producer;
     bool                                            m_notify {true};
@@ -73,7 +73,7 @@ public:
         size_t number_of_frames);
 
     std::atomic<bool>   m_webrtcAudioInDataFlow{false};
-protected:
+private:
     webrtc::scoped_refptr<webrtc::AudioTrackInterface> m_track;
     std::shared_ptr<WebrtcStream>                   m_producer;
     bool                                            m_notify {true};
@@ -128,6 +128,7 @@ class PeerConnectionStatsCollectorCallback : public webrtc::RTCStatsCollectorCal
     protected:
         virtual void OnStatsDelivered(const webrtc::scoped_refptr<const webrtc::RTCStatsReport>& report);
 
+    private:
         Json::Value m_report;
         std::string m_transportId;
 };
@@ -163,6 +164,8 @@ public:
     virtual void OnConnectionChange(webrtc::PeerConnectionInterface::PeerConnectionState new_state);
     virtual void OnIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState state);
     virtual void OnIceGatheringChange(webrtc::PeerConnectionInterface::IceGatheringState) {
+        // Intentionally blank: ICE candidates are handled as they arrive in
+        // OnIceCandidate(), so gathering state transitions need no action.
     }
 
     void setDeviceId(std::string deviceId)

--- a/services/vios/src/framework/webrtc_streamer/inc/liveaudiosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/liveaudiosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -135,7 +135,7 @@ public:
             LOG(verbose2) << "LiveAudioSource::onData decode ts:" << ts
                               << " source ts:" << sourcets;
 
-            if (m_decoder.get() != NULL)
+            if (m_decoder.get() != nullptr)
             {
 
                 // waiting

--- a/services/vios/src/framework/webrtc_streamer/inc/livevideosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/livevideosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -372,14 +372,13 @@ public:
     }
 
     uint64_t m_resume_time_in_epoch;
+protected:
+    T& getLiveClient() { return m_liveclient; }
+
 private:
     EventLoopWatchVariable m_stop{0};
     Environment m_env;
-
-protected:
     T m_liveclient;
-
-private:
     std::thread                        m_capturethread;
     std::vector<uint8_t>               m_cfg;
     std::map<std::string, std::string, std::less<>> m_media;

--- a/services/vios/src/framework/webrtc_streamer/inc/mkvclient.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/mkvclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +47,7 @@ class MKVClient
 		class Callback : public SessionCallback
 		{
 			public:
-				virtual void    onError(MKVClient&, const char*)  {}
+				virtual void    onError(MKVClient&, const char*)  { /* errors are ignored by default; subclasses override to report them */ }
 				virtual void    onEndOfFile(MKVClient& client)  { client.stop(); }
 		};
 			
@@ -69,7 +69,7 @@ class MKVClient
 			((MKVClient*)(clientData))->onEndOfFile();
 		}
 		
-	protected:
+	private:
 		Environment&             m_env;
 		Callback*                m_callback; 	
 		MatroskaFile*            m_mkvfile; 

--- a/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -254,7 +254,7 @@ class NvBufWrapper
                 sw_surf->surfaceList->planeParams.bytesPerPix[2] = 1;
 
                 // convert from I420 sw memory to I420 hw memory
-                NvBufSurface *hw_surf = 0;
+                NvBufSurface *hw_surf = nullptr;
                 NvBufSurfaceAllocateParams input_params = {0};
                 input_params.params.width       = sourceWidth;
                 input_params.params.height      = sourceHeight;
@@ -293,7 +293,7 @@ class NvBufWrapper
                 }
 
                 // Color conversion from I420 to NV12 and Resolution change
-                NvBufSurface *op_surf = 0;
+                NvBufSurface *op_surf = nullptr;
                 // On Jetson/Orin a fresh output surface is always allocated; on
                 // Thor/SBSA/x86 it is derived from an existing fd when one is provided.
                 if (isJetsonPlatform() || (fd && *fd == -1))
@@ -403,7 +403,7 @@ class NvBufWrapper
                     int dmabuf_fd = fd != nullptr ? *fd : -1;
                     for (int plane = 0; plane < 2; ++plane)
                     {
-                        NvBufSurface *nvbuf_surf = 0;
+                        NvBufSurface *nvbuf_surf = nullptr;
                         ret = NvBufSurfaceFromFd(dmabuf_fd, (void**)(&nvbuf_surf));
                         if (ret != 0)
                         {
@@ -597,7 +597,7 @@ class NvBufWrapper
                 LOG(error) << "NvBufSurface functions not loaded" << endl;
                 return;
             }
-            NvBufSurface *nvbuf_surf = 0;
+            NvBufSurface *nvbuf_surf = nullptr;
             int status = -1;
             status = NvBufSurfaceFromFd (fd, (void**)(&nvbuf_surf));
             if (status < 0)
@@ -703,7 +703,7 @@ class NvBufWrapper
                 LOG(error) << "NvBufSurfaceFromFd not loaded" << endl;
                 return nullptr;
             }
-            NvBufSurface *nvbuf_surf = 0;
+            NvBufSurface *nvbuf_surf = nullptr;
             int status = -1;
             status = NvBufSurfaceFromFd (fd, (void**)(&nvbuf_surf));
             if (status < 0)
@@ -1237,7 +1237,7 @@ class NvBufWrapper
                     int dmabuf_fd = op_surf->surfaceList->bufferDesc;
                     for (int plane = 0; plane < 2; ++plane)
                     {
-                        NvBufSurface *nvbuf_surf = 0;
+                        NvBufSurface *nvbuf_surf = nullptr;
                         ret = NvBufSurfaceFromFd(dmabuf_fd, (void**)(&nvbuf_surf));
                         ret = NvBufSurfaceMap(nvbuf_surf, 0, plane, NVBUF_MAP_READ_WRITE);
                         if (ret < 0)

--- a/services/vios/src/framework/webrtc_streamer/inc/nvgstudpvideosource.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvgstudpvideosource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -289,7 +289,9 @@ class NvGstUDPVideoSource : public webrtc::VideoSourceInterface<webrtc::VideoFra
 public:
     void getDecodeStats(LatencyStats& stats)
     {
-
+        // The UDP source receives already-decoded frames, so it owns no decoder
+        // and has no latency statistics to report. Leave the caller's stats untouched.
+        (void)stats;
     }
     NvGstUDPVideoSource(const std::string &uri, const std::map<std::string, std::string, std::less<>> &opts)
     : m_udpVideoClient(nullptr)
@@ -398,7 +400,10 @@ public:
 
     void controlStreamFileVideoSource(const std::string& action, const std::string& seek_value)
     {
-
+        // Intentionally empty: a UDP source is a live stream with no file playback
+        // to pause, resume or seek, so playback control requests are a no-op here.
+        (void)action;
+        (void)seek_value;
     }
 
     void setupClient (const std::map<std::string, std::string, std::less<>> &opts)

--- a/services/vios/src/framework/webrtc_streamer/inc/screencapturer.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/screencapturer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,6 +77,10 @@ class DesktopCapturer : public webrtc::VideoSourceInterface<webrtc::VideoFrame>,
 		}
 	
 	protected:
+		void SetCapturer(std::unique_ptr<webrtc::DesktopCapturer> capturer) { m_capturer = std::move(capturer); }
+		webrtc::DesktopCapturer* GetCapturer() const { return m_capturer.get(); }
+
+	private:
 		std::thread                              m_capturethread;
 		std::unique_ptr<webrtc::DesktopCapturer> m_capturer;
 		int                                      m_width;		
@@ -90,10 +94,11 @@ class ScreenCapturer : public DesktopCapturer {
 	public:
 		ScreenCapturer(const std::string & url, const std::map<std::string,std::string> & opts) : DesktopCapturer(opts) {
 			const std::string prefix("screen://");
-			m_capturer = webrtc::DesktopCapturer::CreateScreenCapturer(webrtc::DesktopCaptureOptions::CreateDefault());
-			if (m_capturer) {
+			SetCapturer(webrtc::DesktopCapturer::CreateScreenCapturer(webrtc::DesktopCaptureOptions::CreateDefault()));
+			webrtc::DesktopCapturer* capturer = GetCapturer();
+			if (capturer) {
 				webrtc::DesktopCapturer::SourceList sourceList;
-				if (m_capturer->GetSourceList(&sourceList)) {
+				if (capturer->GetSourceList(&sourceList)) {
 					const std::string screen(url.substr(prefix.length()));
 					if (screen.empty() == false) {
 						for (auto source : sourceList) {
@@ -101,7 +106,7 @@ class ScreenCapturer : public DesktopCapturer {
 							try {
 								if (std::stoi(screen) == source.id)
 								{
-									m_capturer->SelectSource(source.id);
+									capturer->SelectSource(source.id);
 									break;
 								}
 							} catch (const std::invalid_argument& e) {
@@ -131,16 +136,17 @@ class WindowCapturer : public DesktopCapturer {
 		WindowCapturer(const std::string & url, const std::map<std::string,std::string> & opts) : DesktopCapturer(opts) {
 			const std::string windowprefix("window://");
 			if (url.find(windowprefix) == 0) {	
-				m_capturer = webrtc::DesktopCapturer::CreateWindowCapturer(webrtc::DesktopCaptureOptions::CreateDefault());
-			
-				if (m_capturer) {
+				SetCapturer(webrtc::DesktopCapturer::CreateWindowCapturer(webrtc::DesktopCaptureOptions::CreateDefault()));
+
+				webrtc::DesktopCapturer* capturer = GetCapturer();
+				if (capturer) {
 					webrtc::DesktopCapturer::SourceList sourceList;
-					if (m_capturer->GetSourceList(&sourceList)) {
+					if (capturer->GetSourceList(&sourceList)) {
 						const std::string windowtitle(url.substr(windowprefix.length()));
 						for (auto source : sourceList) {
 							LOG(error) << "WindowCapturer source:" << source.id << " title:"<< source.title;
 							if (windowtitle == source.title) {
-								m_capturer->SelectSource(source.id);
+								capturer->SelectSource(source.id);
 								break;
 							}
 						}

--- a/services/vios/src/framework/webrtc_streamer/inc/udpclient.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/udpclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,7 +86,7 @@ namespace nv_vms
             unsigned int getAudioPort() { return m_udpStream.m_audioPort; }
             int getAudioFreq() { return m_udpStream.m_audioFreq; }
             string getVideoCodec() { return m_udpStream.m_videoCodec; }
-        protected:
+        private:
             string m_id;
             UdpStream m_udpStream;
             mediaConsumerMap m_consumerMap;

--- a/services/vios/src/framework/webrtc_streamer/inc/webrtcDataChannel.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/webrtcDataChannel.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,7 +105,7 @@ public:
 		m_listeners.erase(listener);
 	}
 
-protected:
+private:
 	webrtc::scoped_refptr<webrtc::DataChannelInterface> m_dataChannel;
 
 	std::mutex m_listenerMutex;

--- a/services/vios/src/framework/webrtc_streamer/rtspvideocapturer.cpp
+++ b/services/vios/src/framework/webrtc_streamer/rtspvideocapturer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,7 +95,7 @@ void RTSPVideoCapturer::setEOS()
 }
 
 void RTSPVideoCapturer::onError(RTSPConnection& connection, const char* error) {
-	LOG(error) << "RTSPVideoCapturer:onError url:" << secureUrlForLogging(m_liveclient.getUrl()) <<  " error:" << error;
+	LOG(error) << "RTSPVideoCapturer:onError url:" << secureUrlForLogging(getLiveClient().getUrl()) <<  " error:" << error;
 	connection.start(1);
 }
 

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -591,7 +591,9 @@ std::pair<uint64_t, uint64_t> NvFileServerMediaSubsession::getRangeFromUrlParams
 
 void NvFileServerMediaSubsession::testScaleFactor(float& scale)
 {
-
+    /* Intentionally blank: unlike the base class, which clamps "scale" back
+     * to 1.0, the file source honours any client-requested scale factor via
+     * setStreamSourceScale(), so the requested value is left untouched. */
 }
 void NvFileServerMediaSubsession::setStreamSourceScale(FramedSource* inputSource, float scale)
 {

--- a/services/vios/src/modules/rtsp_server/rtspserver.cpp
+++ b/services/vios/src/modules/rtsp_server/rtspserver.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,10 +133,7 @@ RtspServer::RtspServer(u_int16_t port)
     {
         live555Config.setBoolean("enable_packet_pacing", True);
         live555Config.setInt("packet_pace_time_us", config.rtp_packet_pace_time_us);
-        if (config.rtp_packet_batch_size >= 0)
-        {
-            live555Config.setInt("packet_batch_size", config.rtp_packet_batch_size);
-        }
+        live555Config.setInt("packet_batch_size", config.rtp_packet_batch_size);
     }
 
     m_env.mPreferredIface = nullptr;

--- a/services/vios/src/modules/storage_management/storage_management.cpp
+++ b/services/vios/src/modules/storage_management/storage_management.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,7 +109,7 @@ StorageManagement::StorageManagement(const string deviceType, const string devic
         const uint64_t frequency = config.storage_monitoring_frequency_secs;
         std::chrono::seconds seconds (frequency);
         m_storage = make_unique<Bosma::Scheduler>(AGING_POLICY_THREAD_COUNT);
-        m_storage->interval(seconds, [=]() {
+        m_storage->interval(seconds, [this]() {
             StorageMonitorTask();
         });
         LOG(info) << "Aging policy enabled (enable_aging_policy=" << config.enable_aging_policy << ")" << endl;
@@ -134,7 +134,7 @@ StorageManagement::StorageManagement(const string deviceType, const string devic
 
     std::chrono::seconds prometheus_interval (5);
     m_monitoring = make_unique<Bosma::Scheduler>(1);
-    m_monitoring->interval(prometheus_interval, [=]() {
+    m_monitoring->interval(prometheus_interval, [this]() {
         sendCurrentUsedStorageSizeToPrometheus();
     });
 

--- a/services/vios/src/modules/storage_management/storage_management_utils.cpp
+++ b/services/vios/src/modules/storage_management/storage_management_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1875,7 +1875,7 @@ VmsErrorCode handleFileUpload(std::shared_ptr<DeviceManager> deviceMngr,
             ", deviceType:" << deviceMngr->getDeviceType() << endl;
 
         // Add B-frame presence flag to stream data for database storage
-        if (enable_transcode != NULL && strcmp(enable_transcode, "true") == 0)
+        if (enable_transcode != nullptr && strcmp(enable_transcode, "true") == 0)
         {
             is_bframesPresent = false;
             LOG(info) << "B-frames presence flag disabled due to transcoding" << endl;

--- a/services/vios/src/modules/storage_management/video_download.cpp
+++ b/services/vios/src/modules/storage_management/video_download.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -569,13 +569,13 @@ nv_vms::VmsErrorCode downloadVideoFile(
     std::atomic<bool> finished{false};
     std::atomic<bool> readerError{false};
 
-    readerProducer->onFinished([&]() {
+    readerProducer->onFinished([&finished, &log_prefix, &videoConsumer]() {
         finished = true;
         LOG(info) << log_prefix << "Reader producer: EOS reached" << endl;
         videoConsumer->sendEOS();
     });
 
-    readerProducer->onError([&](const std::string& errorMsg, int errorCode) {
+    readerProducer->onError([&finished, &readerError, &log_prefix, &videoConsumer](const std::string& errorMsg, int errorCode) {
         finished = true;
         readerError = true;
         LOG(error) << log_prefix << "Reader producer error: " << errorMsg << " (code: " << errorCode << ")" << endl;

--- a/services/vios/src/modules/stream_recorder/streamrecorder.cpp
+++ b/services/vios/src/modules/stream_recorder/streamrecorder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1095,7 +1095,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
     // Schedule start of recording
     try
     {
-        start_tp = current_schedule->m_scheduler->cron(start_time, [=]()
+        start_tp = current_schedule->m_scheduler->cron(start_time, [this, current_schedule, recorder, streamId]()
                                                        {
             std::lock_guard<std::mutex> mlock(m_recorderMutex);
             current_schedule->m_isRunning = recorder->startRecord(streamId, Schedule); });
@@ -1106,7 +1106,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
     {
         try
         {
-            start_tp = current_schedule->m_scheduler->at(start_time, [=]()
+            start_tp = current_schedule->m_scheduler->at(start_time, [this, current_schedule, recorder, streamId]()
                                                          {
                 std::lock_guard<std::mutex> mlock(m_recorderMutex);
                 current_schedule->m_isRunning = recorder->startRecord(streamId, Schedule); });
@@ -1126,7 +1126,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
     {
         if (start_schedule_type == at)
         {
-            end_tp = current_schedule->m_scheduler->cron(end_time, [=]()
+            end_tp = current_schedule->m_scheduler->cron(end_time, [this, current_schedule, recorder, streamId, unique_id, start_time_utc, end_time_utc]()
                                                          {
                 std::lock_guard<std::mutex> mlock(m_recorderMutex);
                 if (current_schedule->m_isRunning == RecordScheduleStarted)
@@ -1134,14 +1134,14 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
                     stopRecordIfScheduled(recorder, streamId);
                     current_schedule->m_isRunning = RecordScheduleOFF;
                 }
-                m_schedule_eraser->in(5s, [=]() {
+                m_schedule_eraser->in(5s, [this, recorder, streamId, unique_id, start_time_utc, end_time_utc]() {
                     LOG(info) << "Erasing schedule: " << unique_id <<endl;
                     deleteStreamSchedule(recorder, streamId, start_time_utc, end_time_utc);
                 }); });
         }
         else
         {
-            end_tp = current_schedule->m_scheduler->cron(end_time, [=]()
+            end_tp = current_schedule->m_scheduler->cron(end_time, [this, current_schedule, recorder, streamId]()
                                                          {
                 std::lock_guard<std::mutex> mlock(m_recorderMutex);
                 if (current_schedule->m_isRunning == RecordScheduleStarted)
@@ -1157,7 +1157,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
     {
         try
         {
-            end_tp = current_schedule->m_scheduler->at(end_time, [=]()
+            end_tp = current_schedule->m_scheduler->at(end_time, [this, current_schedule, recorder, streamId, unique_id, start_time_utc, end_time_utc]()
                                                        {
                 std::lock_guard<std::mutex> mlock(m_recorderMutex);
                 if (current_schedule->m_isRunning == RecordScheduleStarted)
@@ -1165,7 +1165,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
                     stopRecordIfScheduled(recorder, streamId);
                     current_schedule->m_isRunning = RecordScheduleOFF;
                 }
-                m_schedule_eraser->in(5s, [=]() {
+                m_schedule_eraser->in(5s, [this, recorder, streamId, unique_id, start_time_utc, end_time_utc]() {
                     LOG(info) << "Erasing schedule: " << unique_id <<endl;
                     deleteStreamSchedule(recorder, streamId, start_time_utc, end_time_utc);
                 }); });


### PR DESCRIPTION
## Description
Fixes 105 HIGH-severity SonarQube issues in `services/vios`: misc c++ cleanups.

Empty methods, redundant constructs and small correctness nits.

Rules addressed: `cpp:S1186`, `cpp:S1768`, `cpp:S2479`, `cpp:S3608`, `cpp:S3656`, `cpp:S4962`, `cpp:S5314`, `cpp:S6147`, `cpp:S7127`

**How these were produced.** Each issue was fixed independently in its own git
worktree; the results were merged into a single tree and **that combined tree
was compiled before anything was committed**. A fix that failed to build was
rebuilt in isolation and dropped on its own evidence rather than dragging the
rest of the batch with it. The branch was then rebuilt from clean, so no result
here depends on a stale object file.

Each fix updates the file SonarQube flagged **and** its header and every use
site together. A partial conversion does not compile, so the build is what
guarantees the change is complete rather than half-applied.

**Verification.** `./build.sh clean` followed by
`./build.sh package module=sensor,streamprocessing` — no errors.

**Not included.** `cpp:S134` (Structural refactor (nesting depth / cognitive complexity))
`cpp:S4423` (TLS/crypto behaviour change)


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
