### PR TITLE
Fix 353 HIGH SonarQube issues: Memory & ownership

### DIFF
--- a/services/vios/include/sensor_discovery_adaptor.h
+++ b/services/vios/include/sensor_discovery_adaptor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,8 +29,8 @@ namespace nv_vms {
 class ISensorDiscoveryEvent
 {
     public:
-        ISensorDiscoveryEvent() {}
-        virtual ~ISensorDiscoveryEvent() {}
+        ISensorDiscoveryEvent() = default;
+        virtual ~ISensorDiscoveryEvent() = default;
 
         virtual int onSensorFound(SensorInfo& sensorInfo) = 0;
         virtual int onSensorChanged(SensorInfo& sensorInfo) = 0;

--- a/services/vios/include/sensor_info.h
+++ b/services/vios/include/sensor_info.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -143,6 +143,11 @@ class ClientSession
     public:
         virtual ~ClientSession();
         ClientSession();
+
+        ClientSession(const ClientSession&) = delete;
+        ClientSession& operator=(const ClientSession&) = delete;
+        ClientSession(ClientSession&&) = delete;
+        ClientSession& operator=(ClientSession&&) = delete;
 
         CURL* getCurlClient();
         std::shared_ptr<NvSoap> getNvSoap();
@@ -327,7 +332,6 @@ struct SensorPosition
     string fieldOfView;
     string depth;
     SensorPosition();
-    void operator=(const SensorPosition& pos);
     void printInfo();
 };
 

--- a/services/vios/src/adaptors/native_sensors/native_sensors_control.cpp
+++ b/services/vios/src/adaptors/native_sensors/native_sensors_control.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,23 +16,22 @@
  */
 
 #include <stdio.h>
+#include <memory>
 
 #include "native_sensors_control.h"
 #include "sensor_info.h"
 
 extern "C" ISensorControlInterface* createObject()
 {
-    return new NativeSensorControlInterface;
+    return std::make_unique<NativeSensorControlInterface>().release();
 }
 
 extern "C" void destroyObject( NativeSensorControlInterface* object )
 {
-    delete object;
+    std::unique_ptr<NativeSensorControlInterface> owner(object);
 }
 
-NativeSensorControlInterface::NativeSensorControlInterface()
-{
-}
+NativeSensorControlInterface::NativeSensorControlInterface() = default;
 
 int NativeSensorControlInterface::connect()
 {

--- a/services/vios/src/adaptors/native_sensors/native_sensors_control.h
+++ b/services/vios/src/adaptors/native_sensors/native_sensors_control.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ class NativeSensorControlInterface : public ISensorControlInterface
 {
     public:
     NativeSensorControlInterface();
-    virtual ~NativeSensorControlInterface() {}
+    virtual ~NativeSensorControlInterface() = default;
 
     int connect();
     int getSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sensors);

--- a/services/vios/src/adaptors/onvif/onvif_client.cpp
+++ b/services/vios/src/adaptors/onvif/onvif_client.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,12 +43,12 @@ constexpr long long DEFAULT_RECORDING_DURATION_MS = 157680000000LL;
 
 extern "C" ISensorControlInterface* createObject()
 {
-    return new OnvifClient;
+    return std::make_unique<OnvifClient>().release();
 }
 
 extern "C" void destroyObject( OnvifClient* object )
 {
-    delete object;
+    std::unique_ptr<OnvifClient> owner{ object };
 }
 
 static bool isDuplicateUrl(vector<shared_ptr<StreamInfo>>streams, string url)
@@ -64,9 +64,7 @@ static bool isDuplicateUrl(vector<shared_ptr<StreamInfo>>streams, string url)
     return false;
 }
 
-OnvifClient::OnvifClient()
-{
-}
+OnvifClient::OnvifClient() = default;
 
 OnvifClient::~OnvifClient()
 {

--- a/services/vios/src/adaptors/onvif/onvif_client.h
+++ b/services/vios/src/adaptors/onvif/onvif_client.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,11 @@ class OnvifClient : public ISensorControlInterface
 public:
     OnvifClient();
     virtual  ~OnvifClient();
+
+    OnvifClient(const OnvifClient&) = delete;
+    OnvifClient& operator=(const OnvifClient&) = delete;
+    OnvifClient(OnvifClient&&) = delete;
+    OnvifClient& operator=(OnvifClient&&) = delete;
 
     int connect();
     int getSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sensors);

--- a/services/vios/src/adaptors/remote_device/remote_device.cpp
+++ b/services/vios/src/adaptors/remote_device/remote_device.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,12 +40,12 @@
 
 extern "C" ISensorControlInterface *createObject()
 {
-    return new RemoteDevice;
+    return std::make_unique<RemoteDevice>().release();
 }
 
 extern "C" void destroyObject(RemoteDevice *object)
 {
-    delete object;
+    std::unique_ptr<RemoteDevice> deleter(object);
 }
 
 static void fillEncoderSettingsOptions(const Json::Value &jsettings, VideoEncoderConfigurationsOptions& settings);

--- a/services/vios/src/adaptors/sensors_discovery/native_sensors/native_sensors_discovery.cpp
+++ b/services/vios/src/adaptors/sensors_discovery/native_sensors/native_sensors_discovery.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,12 +26,12 @@ using namespace nv_vms;
 
 extern "C" ISensorDiscoveryInterface* createObject()
 {
-    return new NativeSensorsDiscovery;
+    return std::make_unique<NativeSensorsDiscovery>().release();
 }
 
 extern "C" void destroyObject(NativeSensorsDiscovery* object)
 {
-    delete object;
+    std::unique_ptr<NativeSensorsDiscovery> deleter(object);
 }
 
 //function to remove the spaces from string
@@ -248,15 +248,13 @@ void NativeSensorsDiscovery::doNativeSensorDiscovery(vector<SensorInfo>& sensors
     LOG(verbose) << "Total Number of Video Capture Devices: " << sensor_count << endl;
 }
 
-NativeSensorsDiscovery::NativeSensorsDiscovery()
-{
-}
+NativeSensorsDiscovery::NativeSensorsDiscovery() = default;
 
 NativeSensorsDiscovery::~NativeSensorsDiscovery()
 {
     try {
         LOG(info) << "Destroying NativeSensorsDiscovery" << endl;
-        stop();
+        NativeSensorsDiscovery::stop();
     } catch (const std::exception& e) {
         try { LOG(error) << "Exception in ~NativeSensorsDiscovery: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
     } catch (...) {

--- a/services/vios/src/adaptors/sensors_discovery/onvif/onvif_discovery.cpp
+++ b/services/vios/src/adaptors/sensors_discovery/onvif/onvif_discovery.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,6 +46,11 @@ struct SensorCurlData {
 
     SensorCurlData() : curl(nullptr), headers(nullptr) {}
 
+    SensorCurlData(const SensorCurlData&) = delete;
+    SensorCurlData& operator=(const SensorCurlData&) = delete;
+    SensorCurlData(SensorCurlData&&) = delete;
+    SensorCurlData& operator=(SensorCurlData&&) = delete;
+
     ~SensorCurlData()
     {
         if (headers)
@@ -61,12 +66,12 @@ struct SensorCurlData {
 
 extern "C" ISensorDiscoveryInterface* createObject()
 {
-    return new OnvifDiscovery;
+    return std::make_unique<OnvifDiscovery>().release();
 }
 
 extern "C" void destroyObject( OnvifDiscovery* object )
 {
-    delete object;
+    std::unique_ptr<OnvifDiscovery> deleter(object);
 }
 
 OnvifDiscovery::OnvifDiscovery()
@@ -82,7 +87,7 @@ OnvifDiscovery::OnvifDiscovery()
 OnvifDiscovery::~OnvifDiscovery()
 {
     LOG(info) << "Destroying onvif disclovery" << endl;
-    stop();
+    OnvifDiscovery::stop();
 
     // Cleanup CURL multi handle
     if (m_sensorSyncMultiHandle)

--- a/services/vios/src/adaptors/streamer/data/sensor_data.cpp
+++ b/services/vios/src/adaptors/streamer/data/sensor_data.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,14 +22,16 @@
 #include "gst_utils.h"
 #include "logger.h"
 
+#include <memory>
+
 extern "C" ISensorDiscoveryInterface* createObject()
 {
-    return new SensorDataCollector;
+    return std::make_unique<SensorDataCollector>().release();
 }
 
 extern "C" void destroyObject(SensorDataCollector* object)
 {
-    delete object;
+    std::unique_ptr<SensorDataCollector> owner(object);
 }
 
 void SensorDataCollector::addSensor()

--- a/services/vios/src/adaptors/streamer/streams/local_streams.cpp
+++ b/services/vios/src/adaptors/streamer/streams/local_streams.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,10 +31,6 @@ extern "C" ISensorControlInterface* createObject()
 extern "C" void destroyObject( LocalStreams* object )
 {
     delete object;
-}
-
-LocalStreams::LocalStreams()
-{
 }
 
 bool LocalStreams::isSensorExist(vector<shared_ptr<SensorInfo>>& sensors, const string &filepath)

--- a/services/vios/src/adaptors/streamer/streams/local_streams.h
+++ b/services/vios/src/adaptors/streamer/streams/local_streams.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,8 +29,8 @@ using namespace std;
 class LocalStreams : public ISensorControlInterface
 {
     public:
-        LocalStreams();
-        virtual ~LocalStreams() {}
+        LocalStreams() = default;
+        virtual ~LocalStreams() = default;
 
         int connect();
         int getSensorStreamInfo(vector<shared_ptr<SensorInfo>>& sensors);

--- a/services/vios/src/adaptors/vms_media/vms_media.cpp
+++ b/services/vios/src/adaptors/vms_media/vms_media.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -309,12 +309,12 @@ public:
 
 extern "C" nv_vms::IMediaInterface* createMediaObject()
 {
-    return new VmsMedia();
+    return std::make_unique<VmsMedia>().release();
 }
 
 extern "C" void destroyMediaObject(nv_vms::IMediaInterface* object)
 {
-    delete object;
+    std::unique_ptr<nv_vms::IMediaInterface> owner(object);
 }
 
 

--- a/services/vios/src/app/vstmodule.h
+++ b/services/vios/src/app/vstmodule.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +41,7 @@ class IVstModule
 
         virtual const std::map<std::string,HttpServerRequestHandler::httpFunction, std::less<>> getHttpApi() { return m_func; };
         virtual void postInit() {}
-        virtual ~IVstModule() {}
+        virtual ~IVstModule() = default;
 };
 
 class ModuleLoader
@@ -54,6 +54,11 @@ class ModuleLoader
         }
         ModuleLoader();
         ~ModuleLoader();
+
+        ModuleLoader(const ModuleLoader&) = delete;
+        ModuleLoader& operator=(const ModuleLoader&) = delete;
+        ModuleLoader(ModuleLoader&&) = delete;
+        ModuleLoader& operator=(ModuleLoader&&) = delete;
 
         int initialize(ModuleId module_id = ModuleAll);
         void deInitialize();

--- a/services/vios/src/framework/apis/common/device_manager.cpp
+++ b/services/vios/src/framework/apis/common/device_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1882,16 +1882,6 @@ SensorPosition::SensorPosition():origin(std::make_pair("",""))
                      , fieldOfView("")
                      , depth("")
 {
-}
-
-void SensorPosition::operator=(const SensorPosition& pos)
-{
-    origin = pos.origin;
-    geoLocation = pos.geoLocation;
-    coordinates = pos.coordinates;
-    direction = pos.direction;
-    fieldOfView = pos.fieldOfView;
-    depth = pos.depth;
 }
 
 void SensorPosition::printInfo()

--- a/services/vios/src/framework/database/include/database_manager.h
+++ b/services/vios/src/framework/database/include/database_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +40,7 @@ public:
     virtual bool executeQuery(const std::string &queryTemplate, const std::vector<std::string> &params) = 0;
     virtual bool executeQuery(const std::string &queryTemplate, const std::vector<std::string> &params, queryResult &result) = 0;
     
-    virtual ~IDatabaseInterface() {}
+    virtual ~IDatabaseInterface() = default;
 
     // Database type identification
     virtual DatabaseType getDatabaseType() const = 0;

--- a/services/vios/src/framework/database/sqlite/sqlite_helper.cpp
+++ b/services/vios/src/framework/database/sqlite/sqlite_helper.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,8 +34,6 @@ constexpr const char* DB_FILE_NAME = "nvvst.db";
 #define CHECK_DB_IF_NULL_RETURN(ret) \
     if (m_db == nullptr)             \
         return ret;
-
-Sqlite *Sqlite::m_instance = nullptr;
 
 // Callback function to fill up query result
 static int fillResultCallback(void *userData, int argc, char **argv, char **azColName)

--- a/services/vios/src/framework/database/sqlite/sqlite_helper.h
+++ b/services/vios/src/framework/database/sqlite/sqlite_helper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,20 +41,14 @@ namespace nv_vms
     public:
         static Sqlite *getInstance()
         {
-            if (m_instance == nullptr)
+            static Sqlite instance;
+            static bool initialized = false;
+            if (!initialized)
             {
-                m_instance = new Sqlite;
-                assert(m_instance->connect() == 0);
+                assert(instance.connect() == 0);
+                initialized = true;
             }
-            return m_instance;
-        }
-        static void destroy()
-        {
-            if (m_instance)
-            {
-                delete m_instance;
-                m_instance = nullptr;
-            }
+            return &instance;
         }
 
         // IDatabaseInterface mandatory
@@ -183,7 +177,6 @@ namespace nv_vms
 
     private:
         sqlite3 *m_db;
-        static Sqlite *m_instance;
         bool m_connected;
     };
 

--- a/services/vios/src/framework/live555/inc/live555helper/rtspconnectionclient.h
+++ b/services/vios/src/framework/live555/inc/live555helper/rtspconnectionclient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -190,7 +190,7 @@ class RTSPConnection
 				bool                     m_isQoSMode;
 				MediaSession*            m_session;                   
 				MediaSubsession*         m_subSession;
-				MediaSubsessionIterator* m_subSessionIter;
+				std::unique_ptr<MediaSubsessionIterator> m_subSessionIter;
 				Callback*                m_callback; 	
 				unsigned int             m_nbPacket;
 				std::string              m_startTime;
@@ -199,7 +199,7 @@ class RTSPConnection
 				std::string              m_action;
 				uint64_t*                m_resumeTimeEpoch;
 				int64_t                  m_playback_speed;
-				Authenticator* 		     m_authenticator;
+				std::unique_ptr<Authenticator> m_authenticator;
 			private:
                 std::string              m_playbackState;
 #ifdef QuickTimeFileSink
@@ -219,11 +219,7 @@ class RTSPConnection
 		int         getRtpTransport() { return m_rtptransport; }
 		void closeRTSPClient()
 		{
-			if (m_rtspClient)
-			{
-				Medium::close(m_rtspClient);
-				m_rtspClient = nullptr;
-			}
+			m_rtspClient.reset();
 		}
 
 	protected:
@@ -238,6 +234,10 @@ class RTSPConnection
 		double                   m_framerate;
 		int                      m_verbosity;
 		bool m_isFileSink;
-		RTSPClientConnection*    m_rtspClient;
+		struct RTSPClientConnectionDeleter
+		{
+			void operator()(RTSPClientConnection* client) const { Medium::close(client); }
+		};
+		std::unique_ptr<RTSPClientConnection, RTSPClientConnectionDeleter> m_rtspClient;
 		bool                     m_isQoSMode;
 };

--- a/services/vios/src/framework/live555/rtsp_client/rtspconnectionclient.cpp
+++ b/services/vios/src/framework/live555/rtsp_client/rtspconnectionclient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,20 +120,14 @@ void RTSPConnection::start(unsigned int delay)
 
 void RTSPConnection::TaskstartCallback() 
 {
-	if (m_rtspClient)
-	{
-		
-		Medium::close(m_rtspClient);
-		m_rtspClient = nullptr;
-	}
-	m_rtspClient = new RTSPClientConnection(*this, m_env, m_callback, m_url.c_str(), m_timeout, m_rtptransport, m_framerate, m_isQoSMode, m_verbosity);
+	m_rtspClient.reset(new RTSPClientConnection(*this, m_env, m_callback, m_url.c_str(), m_timeout, m_rtptransport, m_framerate, m_isQoSMode, m_verbosity));
 }
 
 RTSPConnection::~RTSPConnection()
 {
 	LOG(info) << __func__ << endl;
 	m_env.taskScheduler().unscheduleDelayedTask(m_startCallbackTask);
-	Medium::close(m_rtspClient);
+	m_rtspClient.reset();
 	LOG(info) << "RTSPConnection destroyed: " << m_url << endl;
 }
 
@@ -180,7 +174,7 @@ RTSPConnection::RTSPClientConnection::RTSPClientConnection(RTSPConnection& conne
 	if(GET_CONFIG().use_rtsp_authentication)
 	{
 		std::string passwordHash = getPasswordHash(DEFAULT_USERNAME);
-		m_authenticator = new Authenticator(DEFAULT_USERNAME, passwordHash.c_str(), true);
+		m_authenticator = std::make_unique<Authenticator>(DEFAULT_USERNAME, passwordHash.c_str(), true);
 	}
 	MultiFramedRTPSource::maxReceiveBufferSize = 2 * 1024 * 1024; // 2MB of buffer in MultiFramedRTPSource Class
 	// start tasks
@@ -236,11 +230,6 @@ RTSPConnection::RTSPClientConnection::~RTSPClientConnection()
 		envir().taskScheduler().unscheduleDelayedTask(m_periodicFileOutputTask);
 	}
 #endif
-	delete m_subSessionIter;
-	if(m_authenticator) 
-	{
-		delete m_authenticator;
-	}
 	// free subsession
 	if (m_session != nullptr) 
 	{
@@ -303,7 +292,7 @@ void RTSPConnection::RTSPClientConnection::sendNextCommand()
 	{
 		// no SDP, send DESCRIBE
 		LOG(info) << "[CLIENT] Sending Describe command" << endl;
-		this->sendDescribeCommand(continueAfterDESCRIBE, m_authenticator); 
+		this->sendDescribeCommand(continueAfterDESCRIBE, m_authenticator.get()); 
 	}
 	else
 	{
@@ -330,7 +319,7 @@ void RTSPConnection::RTSPClientConnection::sendNextCommand()
 					envir() << "Initiated " << m_subSession->mediumName() << "/" << m_subSession->codecName() << " subsession" << "\n";
 				}
 				LOG(info) << "[CLIENT] Sending Setup command" << endl;
-				this->sendSetupCommand(*m_subSession, continueAfterSETUP, false, (m_rtptransport == RTPOVERTCP), (m_rtptransport == RTPUDPMULTICAST), m_authenticator);
+				this->sendSetupCommand(*m_subSession, continueAfterSETUP, false, (m_rtptransport == RTPOVERTCP), (m_rtptransport == RTPUDPMULTICAST), m_authenticator.get());
 			}
 		}
 		else
@@ -350,7 +339,7 @@ void RTSPConnection::RTSPClientConnection::sendNextCommand()
 				if (!m_startTime.empty())
 				{
 					LOG(info) << "sendPlayCommand: m_startTime: " << m_startTime << ", m_endTime: " << m_endTime << endl;
-					this->sendPlayCommand(*m_session, continueAfterPLAY, m_startTime.c_str(), absEndTime, 1.0, m_authenticator);
+					this->sendPlayCommand(*m_session, continueAfterPLAY, m_startTime.c_str(), absEndTime, 1.0, m_authenticator.get());
 				}
 				else
 				{
@@ -378,13 +367,13 @@ void RTSPConnection::RTSPClientConnection::doPauseResume(uint64_t* resume_time_i
 	{
 		if (m_playback_speed != 1)
 		{
-			this->sendPauseCommand(*m_session, continueAfterPAUSE, m_authenticator);
+			this->sendPauseCommand(*m_session, continueAfterPAUSE, m_authenticator.get());
 			m_resumeTimeEpoch = resume_time_in_epoch;
 			m_playback_speed = 1;
 		}
 		else
 		{
-			this->sendPlayCommand(*m_session, continueAfterPLAY, -1, -1, 1.0, m_authenticator);
+			this->sendPlayCommand(*m_session, continueAfterPLAY, -1, -1, 1.0, m_authenticator.get());
 		}
 	}
 	else if (action == "seek_forward")
@@ -393,7 +382,7 @@ void RTSPConnection::RTSPClientConnection::doPauseResume(uint64_t* resume_time_i
 		m_resumeTimeEpoch = resume_time_in_epoch;
 		m_resumeTime = convertEpocToISO8601(*m_resumeTimeEpoch + 10000000);
 		LOG(info) << "Seek 10 secs forward to time: " << m_resumeTime << endl;
-		this->sendPlayCommand(*m_session, continueAfterPLAY, m_resumeTime.c_str(), m_endTime.c_str(), m_playback_speed, m_authenticator);
+		this->sendPlayCommand(*m_session, continueAfterPLAY, m_resumeTime.c_str(), m_endTime.c_str(), m_playback_speed, m_authenticator.get());
 	}
 	else if (action == "seek_backward")
 	{
@@ -401,13 +390,13 @@ void RTSPConnection::RTSPClientConnection::doPauseResume(uint64_t* resume_time_i
 		m_resumeTimeEpoch = resume_time_in_epoch;
 		m_resumeTime = convertEpocToISO8601(*m_resumeTimeEpoch - 10000000);
 		LOG(info) << "Seek 10 secs backward to time: " << m_resumeTime << endl;
-		this->sendPlayCommand(*m_session, continueAfterPLAY, m_resumeTime.c_str(), m_endTime.c_str(), m_playback_speed, m_authenticator);
+		this->sendPlayCommand(*m_session, continueAfterPLAY, m_resumeTime.c_str(), m_endTime.c_str(), m_playback_speed, m_authenticator.get());
 	}
 	else if (action == "rewind" || action == "fast_forward")
 	{
 		m_playback_speed = stringToInt(seek_value, 1);
 		m_playback_speed = (action=="rewind") ? (-m_playback_speed) : m_playback_speed;
-		this->sendPauseCommand(*m_session, continueAfterPAUSE, m_authenticator);
+		this->sendPauseCommand(*m_session, continueAfterPAUSE, m_authenticator.get());
 		m_resumeTimeEpoch = resume_time_in_epoch;
 	}
 	else
@@ -433,7 +422,7 @@ void RTSPConnection::RTSPClientConnection::continueAfterDESCRIBE(int resultCode,
 		m_session = MediaSession::createNew(envir(), resultString);
 		if (m_session)
 		{
-			m_subSessionIter = new MediaSubsessionIterator(*m_session);
+			m_subSessionIter = std::make_unique<MediaSubsessionIterator>(*m_session);
 			this->sendNextCommand();
 		}
 		else
@@ -573,11 +562,11 @@ void RTSPConnection::RTSPClientConnection::continueAfterPAUSE(int resultCode, ch
 		if (m_action == "rewind" || m_action == "fast_forward")
 		{
 			LOG(info) << m_action << " at speed " << m_playback_speed << endl;
-			this->sendPlayCommand(*m_session, continueAfterPLAY, m_resumeTime.c_str(), m_endTime.c_str(), m_playback_speed, m_authenticator);
+			this->sendPlayCommand(*m_session, continueAfterPLAY, m_resumeTime.c_str(), m_endTime.c_str(), m_playback_speed, m_authenticator.get());
 		}
 		else if (m_action == "resume")
 		{
-			this->sendPlayCommand(*m_session, continueAfterPLAY, -1, -1, 1.0, m_authenticator);
+			this->sendPlayCommand(*m_session, continueAfterPLAY, -1, -1, 1.0, m_authenticator.get());
 		}
 		else
 		{

--- a/services/vios/src/framework/media/media_pipelines/cloud_stream/s3stream_producer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/cloud_stream/s3stream_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -300,17 +300,10 @@ CloudStreamProducer::CloudStreamProducer(const std::string& streamId,
 CloudStreamProducer::~CloudStreamProducer()
 {
     try {
-        stop();
+        CloudStreamProducer::stop();
 
-        if (m_streamInfo) {
-            delete m_streamInfo;
-            m_streamInfo = nullptr;
-        }
-
-        if (m_seekData) {
-            delete m_seekData;
-            m_seekData = nullptr;
-        }
+        m_streamInfo.reset();
+        m_seekData.reset();
 
         LOG(info) << "CloudStreamProducer destroyed for stream: " << m_streamId << endl;
     } catch (const std::exception& e) {
@@ -388,7 +381,7 @@ bool CloudStreamProducer::start()
     }
 
     // Initialize seek data
-    m_seekData = new SeekData{m_pipeline, m_startTime, m_endTime, false, false};
+    m_seekData = std::make_unique<SeekData>(SeekData{m_pipeline, m_startTime, m_endTime, false, false});
 
     // Set pipeline to PAUSED first (for preroll and seeking and then play in asyncDone callback)
     GstStateChangeReturn ret = gst_element_set_state(m_pipeline, GST_STATE_PAUSED);
@@ -659,10 +652,10 @@ bool CloudStreamProducer::createSingleSegmentPipeline()
     }
 
     // Setup stream info for pad-added callback
-    m_streamInfo = new StreamInfo{0, 0, 0.0, this};
+    m_streamInfo = std::make_unique<StreamInfo>(StreamInfo{0, 0, 0.0, this});
 
     // Connect demux pad-added signal for dynamic linking
-    g_signal_connect(m_demux, "pad-added", G_CALLBACK(onPadAdded), m_streamInfo);
+    g_signal_connect(m_demux, "pad-added", G_CALLBACK(onPadAdded), m_streamInfo.get());
 
     // Connect appsink new-sample signal
     g_signal_connect(m_appsink, "new-sample", G_CALLBACK(onNewSample), this);
@@ -877,7 +870,7 @@ bool CloudStreamProducer::createMultiSegmentPipeline()
     }
 
     // Setup stream info for first demuxer (to extract framerate/resolution)
-    m_streamInfo = new StreamInfo{0, 0, 0.0, this};
+    m_streamInfo = std::make_unique<StreamInfo>(StreamInfo{0, 0, 0.0, this});
     if (!m_demuxers.empty()) {
         g_signal_connect(m_demuxers[0], "notify::n-video-streams",
             G_CALLBACK(+[](GObject* /*object*/, GParamSpec* /*pspec*/, gpointer userData) {
@@ -885,7 +878,7 @@ bool CloudStreamProducer::createMultiSegmentPipeline()
                 if (info && info->producer) {
                     LOG(info) << "Demuxer detected video streams" << endl;
                 }
-            }), m_streamInfo);
+            }), m_streamInfo.get());
     }
 
     // Connect appsink new-sample signal
@@ -1204,7 +1197,7 @@ bool CloudStreamProducer::createLocalFilePipeline()
                 GstPad* concatSinkPad;  // Pre-requested pad
             };
 
-            SegmentLinkData* linkData = new SegmentLinkData{this, i, concatSinkPads[i]};
+            auto linkData = std::make_unique<SegmentLinkData>(SegmentLinkData{this, i, concatSinkPads[i]});
 
             g_signal_connect_data(demuxer, "pad-added",
                 G_CALLBACK(+[](GstElement* src, GstPad* newPad, gpointer userData) {
@@ -1238,8 +1231,8 @@ bool CloudStreamProducer::createLocalFilePipeline()
 
                     g_free(padName);
                 }),
-                linkData,
-                +[](gpointer data, GClosure* /*closure*/) { delete static_cast<SegmentLinkData*>(data); },
+                linkData.release(),
+                +[](gpointer data, GClosure* /*closure*/) { std::unique_ptr<SegmentLinkData>(static_cast<SegmentLinkData*>(data)); },
                 (GConnectFlags)0);
         } else {
             // Single file: connect directly to parser
@@ -1309,7 +1302,7 @@ bool CloudStreamProducer::createLocalFilePipeline()
     }
 
     // Setup stream info
-    m_streamInfo = new StreamInfo{0, 0, 0.0, this};
+    m_streamInfo = std::make_unique<StreamInfo>(StreamInfo{0, 0, 0.0, this});
 
     // Monitor concat's active-pad to track which file is currently playing
     if (m_concat) {
@@ -2033,7 +2026,7 @@ gboolean CloudStreamProducer::busWatch(GstBus* bus, GstMessage* msg, gpointer us
 
         case GST_MESSAGE_ASYNC_DONE: {
             // Pipeline is prerolled and ready for seeking
-            SeekData* seekData = producer->m_seekData;
+            SeekData* seekData = producer->m_seekData.get();
             if (!seekData->seekDone && seekData->pausedStateReached) {
                 LOG(info) << "Pipeline ready for seeking" << endl;
 

--- a/services/vios/src/framework/media/media_pipelines/cloud_stream/s3stream_producer.h
+++ b/services/vios/src/framework/media/media_pipelines/cloud_stream/s3stream_producer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -407,8 +407,8 @@ private:
         bool pausedStateReached;
     };
 
-    StreamInfo* m_streamInfo;
-    SeekData* m_seekData;
+    std::unique_ptr<StreamInfo> m_streamInfo;
+    std::unique_ptr<SeekData> m_seekData;
     
     // Completion and error callbacks
     std::function<void()> m_finishedCallback;

--- a/services/vios/src/framework/media/media_pipelines/gstmux.h
+++ b/services/vios/src/framework/media/media_pipelines/gstmux.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,12 +88,10 @@ class GstMux : public IMediaDataConsumer
         m_recordingStopped = false;
         m_fpsDisplay.reset(new FPSDisplay());
         m_checkStatusScheduler = make_unique<Bosma::Scheduler>(1);
-        setConsumerMediaType(MediaTypeAudioVideo);
+        IMediaDataConsumer::setConsumerMediaType(MediaTypeAudioVideo);
         m_videoQueue.setRecordingState(m_recordingState);
     }
-    ~GstMux()
-    {
-    }
+    ~GstMux() = default;
 
     int create(shared_ptr<StreamInfo> stream, GAsyncQueue* qErrorDeviceID, bool recreate_muxer = false);
     void destroy();

--- a/services/vios/src/framework/media/media_pipelines/gstnvvideoencoder.cpp
+++ b/services/vios/src/framework/media/media_pipelines/gstnvvideoencoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -453,13 +453,13 @@ static void gst_buffer_object_free_cb(gpointer data, GstMiniObject *obj)
     if (!encoder)
     {
         LOG(error) << "gst_buffer_object_free_cb: consumer is null" << endl;
-        free(buffer_data);
+        delete buffer_data;
         return;
     }
 
     encoder->freeVideoFrameData(buffer_data->m_decoderFd);
 
-    free (buffer_data);
+    delete buffer_data;
 }
 
 void GstNvVideoEncoder::freeVideoFrameData(int fd)
@@ -601,7 +601,7 @@ int GstNvVideoEncoder::onFrame(FrameParams& frame_params, const string& codec, i
     if (is_zero_copy)
     {
         mem = gst_buffer_peek_memory (gstbuffer, 0);
-        struct WebrtcVideoDecoderBufferData* buffer_data = (WebrtcVideoDecoderBufferData*) malloc(sizeof (WebrtcVideoDecoderBufferData));
+        WebrtcVideoDecoderBufferData* buffer_data = new WebrtcVideoDecoderBufferData();
         buffer_data->m_videoEncInstance = this;
         buffer_data->m_decoderFd = buf_surf->surfaceList[0].bufferDesc;
         gst_mini_object_weak_ref(GST_MINI_OBJECT(mem), (GstMiniObjectNotify)gst_buffer_object_free_cb, (void*)buffer_data);

--- a/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/local_stream/clip_reader_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -508,7 +508,7 @@ ClipReaderProducer::ClipReaderProducer(const ClipReaderConfig& cfg)
 ClipReaderProducer::~ClipReaderProducer()
 {
     try {
-        stop();
+        ClipReaderProducer::stop();
         teardown();
         LOG(info) << mLogPrefix << "~ClipReaderProducer destructor" << endl;
     } catch (const std::exception& e) {

--- a/services/vios/src/framework/media/media_pipelines/media_consumer.h
+++ b/services/vios/src/framework/media/media_pipelines/media_consumer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,11 +104,6 @@ struct _RawFrameParams
             gst_caps_unref (m_caps);
             m_caps = nullptr;
         }
-        if (m_fdWrapperObj)
-        {
-            delete (m_fdWrapperObj);
-            m_fdWrapperObj = nullptr;
-        }
     }
 
     string     m_streamId;
@@ -137,7 +132,7 @@ struct _RawFrameParams
     void *meta = nullptr;
     int64_t pts = 0;
 
-    std::shared_ptr<fdWrapper>*       m_fdWrapperObj = nullptr;
+    std::unique_ptr<std::shared_ptr<fdWrapper>> m_fdWrapperObj;
     EncoderMsgType m_encoderMsgType = Buffer;
     std::atomic<bool> m_eos;
 } typedef RawFrameParams;

--- a/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/remux_writer_consumer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,7 +60,7 @@ RemuxWriterConsumer::RemuxWriterConsumer(const RemuxWriterConfig& cfg)
 RemuxWriterConsumer::~RemuxWriterConsumer()
 {
     try {
-        stop();
+        RemuxWriterConsumer::stop();
         teardown();
     } catch (const std::exception& e) {
         try { LOG(error) << "Exception in ~RemuxWriterConsumer: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
@@ -368,7 +368,7 @@ void RemuxWriterConsumer::attachProbes()
     // Attach EOS enforcement probe on mux sink (for end_time_ms)
     if (mMux && mCfg.end_time_ms != std::numeric_limits<int64_t>::max())
     {
-        MuxProbeCtx* mctx = new MuxProbeCtx();
+        auto mctx = std::make_unique<MuxProbeCtx>();
         mctx->end_ms = mCfg.end_time_ms;
         mctx->mux = mMux;
         mctx->videoSrc = mVideoAppsrc ? GST_APP_SRC(mVideoAppsrc) : nullptr;
@@ -410,7 +410,7 @@ void RemuxWriterConsumer::attachProbes()
                                         }
                                     }
                                     return GST_PAD_PROBE_OK;
-                                }, mctx, (GDestroyNotify)+[](gpointer data) { delete static_cast<MuxProbeCtx*>(data); });
+                                }, mctx.release(), (GDestroyNotify)+[](gpointer data) { delete static_cast<MuxProbeCtx*>(data); });
 
                             g_value_reset(&item);
                             done = TRUE;  // First video pad is enough

--- a/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.cpp
+++ b/services/vios/src/framework/media/media_pipelines/transcode_writer_consumer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -280,7 +280,7 @@ TranscodeWriterConsumer::TranscodeWriterConsumer(const TranscodeWriterConfig& cf
 TranscodeWriterConsumer::~TranscodeWriterConsumer()
 {
     try {
-        stop();
+        TranscodeWriterConsumer::stop();
         teardown();
     } catch (const std::exception& e) {
         try { LOG(error) << "Exception in ~TranscodeWriterConsumer: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }

--- a/services/vios/src/framework/media/media_utils/OverlayDataTypes.h
+++ b/services/vios/src/framework/media/media_utils/OverlayDataTypes.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,38 +104,6 @@ struct OverlayBBoxParams
                         , m_enableHalos(false)
                         , m_overlayClassTypeList()
     { }
-
-    OverlayBBoxParams(const OverlayBBoxParams& params)
-    {
-        this->m_bboxColor = params.m_bboxColor;
-        this->m_bboxDebug = params.m_bboxDebug;
-        this->m_bboxDebugFontSize = params.m_bboxDebugFontSize;
-        this->m_bboxOpacity = params.m_bboxOpacity;
-        this->m_bboxThickness = params.m_bboxThickness;
-        this->m_enableTripwire = params.m_enableTripwire;
-        this->m_enableROI = params.m_enableROI;
-        this->m_enableBbox = params.m_enableBbox;
-        this->m_enableSensorNameText = params.m_enableSensorNameText;
-        this->m_sensorNameTextPosX = params.m_sensorNameTextPosX;
-        this->m_sensorNameTextPosY = params.m_sensorNameTextPosY;
-        this->m_proximityClass = params.m_proximityClass;
-        this->m_entrantClass = params.m_entrantClass;
-        this->m_proximityAreaFactor = params.m_proximityAreaFactor;
-        this->m_proximityAnimation = params.m_proximityAnimation;
-        this->m_colorCode = params.m_colorCode;
-        this->m_enableGodsEyeView = params.m_enableGodsEyeView;
-        this->m_enablePose = params.m_enablePose;
-        this->m_enableBboxId = params.m_enableBboxId;
-        this->m_bboxIdPosition = params.m_bboxIdPosition;
-        this->m_bboxIdColor = params.m_bboxIdColor;
-        this->m_bboxIdBgColor = params.m_bboxIdBgColor;
-        this->m_enableHalos = params.m_enableHalos;
-        this->m_overlayClassTypeList = params.m_overlayClassTypeList;
-        for (uint32_t i = 0; i < OVERLAYCOUNT; ++i)
-        {
-            this->m_overlayIdList[i] = params.m_overlayIdList[i];
-        }
-    }
 };
 
 typedef struct _searchParams
@@ -145,7 +113,7 @@ typedef struct _searchParams
                                             , m_end_time(endTime)
                                             , m_sensor_id(sensor_id)
                 {}
-    _searchParams() {}
+    _searchParams() = default;
     std::string     m_start_time;
     std::string     m_end_time;
     std::string     m_sensor_id;

--- a/services/vios/src/framework/media/media_utils/gst_utils.cpp
+++ b/services/vios/src/framework/media/media_utils/gst_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1827,20 +1827,19 @@ error:
     return (ret == 0) ? result : Json::nullValue;
 }
 
-GstDummyUdpPipeline* GstDummyUdpPipeline::m_instance = nullptr;
+std::unique_ptr<GstDummyUdpPipeline> GstDummyUdpPipeline::m_instance = nullptr;
 GstDummyUdpPipeline* GstDummyUdpPipeline::getInstance()
 {
     if (m_instance == nullptr)
     {
-        m_instance = new GstDummyUdpPipeline();
+        m_instance = std::make_unique<GstDummyUdpPipeline>();
     }
-    return m_instance;
+    return m_instance.get();
 }
 
 void GstDummyUdpPipeline::deleteInstance()
 {
-    delete m_instance;
-    m_instance = nullptr;
+    m_instance.reset();
 }
 
 GstDummyUdpPipeline::~GstDummyUdpPipeline()

--- a/services/vios/src/framework/media/media_utils/gst_utils.h
+++ b/services/vios/src/framework/media/media_utils/gst_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -228,14 +228,17 @@ class GstTranscode : public GstNvElements
         string m_inAudioCaps;
     } TranscodeParam;
 
-    GstTranscode()
-    {
-    }
+    GstTranscode() = default;
 
     ~GstTranscode()
     {
         LOG(info) << "Destroying GstTranscode" << endl;
     }
+
+    GstTranscode(const GstTranscode&) = delete;
+    GstTranscode& operator=(const GstTranscode&) = delete;
+    GstTranscode(GstTranscode&&) = default;
+    GstTranscode& operator=(GstTranscode&&) = default;
 
     bool transcode (TranscodeParam params);
 
@@ -314,7 +317,7 @@ bool muxElementaryStream(const std::string& elementaryFilePath, const std::strin
 class GstDummyUdpPipeline
 {
 public:
-    GstDummyUdpPipeline() {}
+    GstDummyUdpPipeline() = default;
     ~GstDummyUdpPipeline();
     static GstDummyUdpPipeline* getInstance();
     static void deleteInstance();
@@ -323,7 +326,7 @@ public:
     void stopAllUdpPipelines();
 
 private:
-    static GstDummyUdpPipeline*                                          m_instance;
+    static std::unique_ptr<GstDummyUdpPipeline>                          m_instance;
     std::mutex                                                      m_pipelineMapMutex;
     std::unordered_map<std::string, std::shared_ptr<gstElements> >  m_udpPipelines;
 

--- a/services/vios/src/framework/media/media_utils/libav_wrapper.h
+++ b/services/vios/src/framework/media/media_utils/libav_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -353,6 +353,11 @@ public:
         if (handle_libavcodec) dlclose(handle_libavcodec);
         if (handle_libavutil) dlclose(handle_libavutil);
     }
+
+    LibavWrapper(const LibavWrapper&) = delete;
+    LibavWrapper& operator=(const LibavWrapper&) = delete;
+    LibavWrapper(LibavWrapper&&) = delete;
+    LibavWrapper& operator=(LibavWrapper&&) = delete;
 
     LibavMode getLibavMode() const
     {

--- a/services/vios/src/framework/media/media_utils/mm_utils.h
+++ b/services/vios/src/framework/media/media_utils/mm_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,11 +168,6 @@ struct FrameSize
     {}
     FrameSize (uint32_t w, uint32_t h) : m_width(w), m_height(h)
     {}
-    void operator=(const FrameSize& size)
-    {
-        this->m_width = size.m_width;
-        this->m_height = size.m_height;
-    }
     int getPixels() { return m_width * m_height; }
     FrameSize minimum(FrameSize size)
     {

--- a/services/vios/src/framework/media/metadata/LiveMetadataStore.cpp
+++ b/services/vios/src/framework/media/metadata/LiveMetadataStore.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,9 +49,8 @@ LiveMetadataStore::LiveMetadataStore(const std::string& sensorName, bool startLi
             m_notificationConsumer = nv_vms::NotificationFactory::CreateNotificationConsumer();
             if (m_notificationConsumer)
             {
-                auto tmp = std::make_unique<NotificationListener>(this);
-                m_notificationConsumer->registerMessageListener(tmp.get());
-                m_notificationListener = tmp.release();
+                m_notificationListener = std::make_unique<NotificationListener>(this);
+                m_notificationConsumer->registerMessageListener(m_notificationListener.get());
             }
         }
         catch(const std::exception& e)
@@ -65,13 +64,9 @@ LiveMetadataStore::~LiveMetadataStore()
 {
     if (m_notificationConsumer && m_notificationListener)
     {
-        m_notificationConsumer->deregisterMessageListener(m_notificationListener);
+        m_notificationConsumer->deregisterMessageListener(m_notificationListener.get());
     }
-    if (m_notificationListener)
-    {
-        delete m_notificationListener;
-        m_notificationListener = nullptr;
-    }
+    m_notificationListener.reset();
     m_metaWait.signal();
 }
 

--- a/services/vios/src/framework/media/metadata/LiveMetadataStore.h
+++ b/services/vios/src/framework/media/metadata/LiveMetadataStore.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,8 @@
  */
 
 #pragma once
+
+#include <memory>
 
 #include "MetadataStore.h"
 #include "syncobject.h"
@@ -46,7 +48,7 @@ private:
 
     SyncObject                      m_metaWait = {};
     nv_vms::INotificationInterface* m_notificationConsumer = nullptr;
-    NotificationListener*           m_notificationListener = nullptr;
+    std::unique_ptr<NotificationListener> m_notificationListener;
     std::string                     m_sensorName = "";
     std::string                     m_sensorName3d = "";
     std::string                     m_cachedSensorId = "";

--- a/services/vios/src/framework/media/overlays/halo_safety.cpp
+++ b/services/vios/src/framework/media/overlays/halo_safety.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
+#include <memory>
 
 constexpr int MAX_HALO_SAFETY_DATA_SIZE = 16;
 constexpr int DEFAULT_HALO_SAFETY_PORT = 12345;
@@ -370,13 +371,9 @@ void HaloSafetyCommandListener::listenerThread()
 // HaloSafetyManager Implementation
 // =============================================================================
 
-HaloSafetyManager::HaloSafetyManager()
-{
-}
+HaloSafetyManager::HaloSafetyManager() = default;
 
-HaloSafetyManager::~HaloSafetyManager()
-{
-}
+HaloSafetyManager::~HaloSafetyManager() = default;
 
 bool HaloSafetyManager::checkHalosData(const std::string& obj_type, const std::string& proximity_class,
                                        bool& draw_halo_text, const std::string& metadata_object_id)
@@ -555,21 +552,16 @@ static OSD_ColorParams getHaloTextColor(const std::string& color)
 void HaloSafetyManager::drawHaloText(const Point& left_top, const Point& right_bottom,
                                      const std::string& text, OsdContext_t context, GstBuffer* buffer)
 {
-    OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+    auto text_params_owner = std::make_unique<OSD_TextParams>();
+    OSD_TextParams* text_params = text_params_owner.get();
     if (text_params != nullptr)
     {
-        char* cstr = (char*)calloc(text.size() + 1, sizeof(char));
-        if (cstr != nullptr)
-        {
-            strncpy(cstr, text.c_str(), text.size());
-            cstr[text.size()] = '\0';
-            text_params->text = cstr;
-        }
-        else
+        char* cstr = strdup(text.c_str());
+        if (cstr == nullptr)
         {
             LOG(error) << "Failed to allocate memory for halo text" << endl;
-            text_params->text = nullptr;
         }
+        text_params->text = cstr;
 
         if (GET_CONFIG().halo_safety_text_size > 0)
         {
@@ -622,13 +614,13 @@ void HaloSafetyManager::drawHaloText(const Point& left_top, const Point& right_b
 
         if (buffer)
         {
-            GET_OSD_INSTANCE()->gst_buffer_add_cu_osd_meta(buffer, OSD_TEXT, text_params);
+            GET_OSD_INSTANCE()->gst_buffer_add_cu_osd_meta(buffer, OSD_TEXT, text_params_owner.release());
         }
         else
         {
             OsdMeta meta;
             meta.meta_type = OSD_TEXT;
-            meta.params = (void *)text_params;
+            meta.params = (void *)text_params_owner.release();
             GET_OSD_INSTANCE()->osd_add_metadata(context, &meta);
         }
     }

--- a/services/vios/src/framework/media/overlays/ll_overlay.cpp
+++ b/services/vios/src/framework/media/overlays/ll_overlay.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,10 +91,6 @@ NvLLOverlay::NvLLOverlay (const std::string& consumer_name, const std::string& u
                 m_height = stringToInt(resolution.height, HEIGHT_480p);
             }
         }
-    }
-    for (int i = 0; i < OUTPUT_PLANE_NUM_BUFFERS; i++)
-    {
-        m_cpuPtr[i] = nullptr;
     }
 
     NvLLOverlayInternal::OverlayParams params;
@@ -561,14 +557,6 @@ NvLLOverlay::~NvLLOverlay ()
         m_surfacePool->freeSurfacesAndDataStructure(false);
     }
     m_surfacePool.reset();
-    for (int i = 0; i < OUTPUT_PLANE_NUM_BUFFERS; i++)
-    {
-        if (m_cpuPtr[i])
-        {
-            free (m_cpuPtr[i]);
-            m_cpuPtr[i] = nullptr;
-        }
-    }
     LOG(info) << "Exit " << __METHOD_NAME__ <<  endl;
 }
 
@@ -762,11 +750,8 @@ void NvLLOverlay::doDrawTask()
                     m_surfacePool->m_surfacesAllocated = false;
                     for (int i = 0; i < OUTPUT_PLANE_NUM_BUFFERS; i++)
                     {
-                        if (m_cpuPtr[i])
-                        {
-                            free (m_cpuPtr[i]);
-                            m_cpuPtr[i] = nullptr;
-                        }
+                        m_cpuPtr[i].clear();
+                        m_cpuPtr[i].shrink_to_fit();
                     }
                 }
                 LOG(info) << "Allocating surfaces of resolution = " << m_width << " x " << m_height << endl;
@@ -796,11 +781,11 @@ void NvLLOverlay::doDrawTask()
                         LOG(error) << "No free FD available, continue" << endl;
                         continue;
                     }
-                    if (!m_cpuPtr[index])
+                    if (m_cpuPtr[index].empty())
                     {
-                        m_cpuPtr[index] = (uint8_t *) malloc (m_width * m_height * 3 / 2);
+                        m_cpuPtr[index].resize (m_width * m_height * 3 / 2);
                     }
-                    memcpy((void *)m_cpuPtr[index], sink_frame->m_map.data, sink_frame->m_map.size);
+                    memcpy(m_cpuPtr[index].data(), sink_frame->m_map.data, sink_frame->m_map.size);
                 }
                 else
                 {
@@ -829,7 +814,7 @@ void NvLLOverlay::doDrawTask()
                 // Perform overlay using GPU/CPU based on config
                 if (!isJetsonPlatform() && is_sw_mode)
                 {
-                    data_ptr = (void *)m_cpuPtr[index];
+                    data_ptr = (void *)m_cpuPtr[index].data();
                     ret = m_overlay->doDraw(data_ptr, &meta_union, pts);
                 }
                 else
@@ -859,10 +844,10 @@ void NvLLOverlay::doDrawTask()
                         {
                             frame_data->m_fd        = (fd_index_pair.first * -1) + 1;
                         }
-                        frame_data->m_map.data  = m_cpuPtr[index];
+                        frame_data->m_map.data  = m_cpuPtr[index].data();
                         frame_data->m_map.size  = m_width * m_height * 3 / 2;
                     }
-                    frame_data->m_fdWrapperObj  = new std::shared_ptr<fdWrapper>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, index));
+                    frame_data->m_fdWrapperObj = std::make_unique<std::shared_ptr<fdWrapper>>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, index));
                     frame_data->m_sourceWidth   = m_overlay->m_width;
                     frame_data->m_sourceHeight  = m_overlay->m_height;
                     frame_data->m_targetWidth   = m_overlay->m_width;

--- a/services/vios/src/framework/media/overlays/ll_overlay.h
+++ b/services/vios/src/framework/media/overlays/ll_overlay.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,7 +110,7 @@ private:
     std::string                                    m_isoStartTime;
     std::string                                    m_isoEndTime;
     void*                                          m_broadcaster = nullptr;
-    uint8_t*                                       m_cpuPtr[OUTPUT_PLANE_NUM_BUFFERS];
+    std::vector<uint8_t>                           m_cpuPtr[OUTPUT_PLANE_NUM_BUFFERS];
     bool                                           m_imageCapture = false;
     bool                                           m_isIPCMeta = false;
     std::shared_ptr<IMetadataStore>                m_metadataStore = nullptr;

--- a/services/vios/src/framework/media/overlays/overlay_internal.cpp
+++ b/services/vios/src/framework/media/overlays/overlay_internal.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -753,7 +753,7 @@ void NvLLOverlayInternal::draw_bbox_id_cuosd(const Point& left_top, const Point&
     const int bottom = right_bottom.y;
     const int right = right_bottom.x;
 
-    OSD_TextParams* text_params = static_cast<OSD_TextParams*>(malloc(sizeof(OSD_TextParams)));
+    OSD_TextParams* text_params = g_new0(OSD_TextParams, 1);
     if (!text_params)
     {
         LOG(error) << "Failed to allocate OSD_TextParams for bbox id" << endl;
@@ -761,17 +761,15 @@ void NvLLOverlayInternal::draw_bbox_id_cuosd(const Point& left_top, const Point&
     }
 
     const string text = object_id;
-    char* cstr = static_cast<char*>(calloc(text.size() + 1, sizeof(char)));
+    char* cstr = strdup(text.c_str());
     if (cstr)
     {
-        strncpy(cstr, text.c_str(), text.size());
-        cstr[text.size()] = '\0';
         text_params->text = cstr;
     }
     else
     {
         LOG(error) << "Failed to allocate memory for overlay object id text" << endl;
-        free(text_params);
+        g_free(text_params);
         return;
     }
 
@@ -955,32 +953,28 @@ int NvLLOverlayInternal::draw_3d_bbox(const vector<Point2D>& corners2d, const st
         clamp_point(x1, y1, m_sourceWidth, m_sourceHeight);
         clamp_point(x2, y2, m_sourceWidth, m_sourceHeight);
 
-        OSD_LineParams* line_params = (OSD_LineParams*)malloc(sizeof(OSD_LineParams));
-        if (line_params)
+        OSD_LineParams line_params{};
+        Point start = interpolateCoordinate(x1, y1, m_sourceWidth, m_sourceHeight, m_width, m_height);
+        Point end = interpolateCoordinate(x2, y2, m_sourceWidth, m_sourceHeight, m_width, m_height);
+        line_params.pos_x0 = start.x;
+        line_params.pos_y0 = start.y;
+        line_params.pos_x1 = end.x;
+        line_params.pos_y1 = end.y;
+
+        OSD_ColorParams output_color = {0,0,0,0};
+        if (override_color.alpha != 0)
         {
-            Point start = interpolateCoordinate(x1, y1, m_sourceWidth, m_sourceHeight, m_width, m_height);
-            Point end = interpolateCoordinate(x2, y2, m_sourceWidth, m_sourceHeight, m_width, m_height);
-            line_params->pos_x0 = start.x;
-            line_params->pos_y0 = start.y;
-            line_params->pos_x1 = end.x;
-            line_params->pos_y1 = end.y;
-
-            OSD_ColorParams output_color = {0,0,0,0};
-            if (override_color.alpha != 0)
-            {
-                output_color = override_color;
-            }
-            else
-            {
-                if (!get_color_from_label(obj_type.c_str(), box_params->m_overlay.m_colorCode, &output_color))
-                {
-                    output_color = {0,0,0,0};
-                }
-            }
-
-            draw_line_cuosd(line_params, box_params, context, buffer, output_color);
-            free(line_params);
+            output_color = override_color;
         }
+        else
+        {
+            if (!get_color_from_label(obj_type.c_str(), box_params->m_overlay.m_colorCode, &output_color))
+            {
+                output_color = {0,0,0,0};
+            }
+        }
+
+        draw_line_cuosd(&line_params, box_params, context, buffer, output_color);
     }
 
     if (box_params->m_overlay.m_enableBboxId && !object_id.empty())
@@ -1019,12 +1013,9 @@ int NvLLOverlayInternal::draw_3d_bbox(const vector<Point2D>& corners2d, const st
         OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
         if (text_params != nullptr)
         {
-            // Use safe strncpy with explicit bounds checking
-            char* cstr = (char*)calloc(label_text.size() + 1, sizeof(char));
+            char* cstr = strdup(label_text.c_str());
             if (cstr != nullptr)
             {
-                strncpy(cstr, label_text.c_str(), label_text.size());
-                cstr[label_text.size()] = '\0';  // Guarantee null termination
                 text_params->text = cstr;
             }
             else
@@ -1252,7 +1243,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
         }
 
         /* Assign bounding box coordinates */
-        OSD_RectParams* rect_params = (OSD_RectParams*)malloc(sizeof(OSD_RectParams));
+        OSD_RectParams* rect_params = g_new0(OSD_RectParams, 1);
         Point left_top = {}, right_bottom = {};
         if (rect_params)
         {
@@ -1311,16 +1302,13 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
             int bottom = right_bottom.y;
 
             // Display coordinates above each bbox.
-            OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+            OSD_TextParams* text_params = g_new0(OSD_TextParams, 1);
             if (text_params)
             {
                 string text = to_string(left) + "    " + to_string(top);
-                // Use safe strncpy with explicit bounds checking
-                char* cstr = (char*)calloc(text.size() + 1, sizeof(char));
+                char* cstr = strdup(text.c_str());
                 if (cstr)
                 {
-                    strncpy(cstr, text.c_str(), text.size());
-                    cstr[text.size()] = '\0';  // Guarantee null termination
                     text_params->text = cstr;
                 }
                 else
@@ -1352,16 +1340,13 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
 
             // Display retail name & confidence under bbox.
             {
-                OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+                OSD_TextParams* text_params = g_new0(OSD_TextParams, 1);
                 if (text_params)
                 {
                     string text = obj_type + "    " + to_string(confidence);
-                    // Use safe strncpy with explicit bounds checking
-                    char* cstr = (char*)calloc(text.size() + 1, sizeof(char));
+                    char* cstr = strdup(text.c_str());
                     if (cstr)
                     {
-                        strncpy(cstr, text.c_str(), text.size());
-                        cstr[text.size()] = '\0';  // Guarantee null termination
                         text_params->text = cstr;
                     }
 
@@ -1522,7 +1507,8 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
         if (box_params->m_overlay.m_proximityAnimation == "circleOnly" ||
             box_params->m_overlay.m_proximityAnimation == "circleAndLine")
         {
-            OSD_CircleParams* circle_params = (OSD_CircleParams*)malloc(sizeof(OSD_CircleParams));
+            auto circle_params_owner = std::make_unique<OSD_CircleParams>();
+            OSD_CircleParams* circle_params = circle_params_owner.get();
             if (circle_params)
             {
                 // Use the bottom face center for the circle
@@ -1576,19 +1562,15 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                 {
                     if (buffer)
                     {
-                        GET_OSD_INSTANCE()->gst_buffer_add_cu_osd_meta(buffer, OSD_CIRCLE, circle_params);
+                        GET_OSD_INSTANCE()->gst_buffer_add_cu_osd_meta(buffer, OSD_CIRCLE, circle_params_owner.release());
                     }
                     else
                     {
                         OsdMeta meta;
                         meta.meta_type = OSD_CIRCLE;
-                        meta.params = (void*)circle_params;
+                        meta.params = (void*)circle_params_owner.release();
                         GET_OSD_INSTANCE()->osd_add_metadata(context, &meta);
                     }
-                }
-                else
-                {
-                    free(circle_params);
                 }
             }
         }
@@ -1597,7 +1579,8 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
         if (box_params->m_overlay.m_proximityAnimation == "ellipseOnly" ||
             box_params->m_overlay.m_proximityAnimation == "ellipseAndLine")
         {
-            OSD_EllipseParams* ellipse_params = (OSD_EllipseParams*)malloc(sizeof(OSD_EllipseParams));
+            auto ellipse_params_owner = std::make_unique<OSD_EllipseParams>();
+            OSD_EllipseParams* ellipse_params = ellipse_params_owner.get();
             if (ellipse_params)
             {
                 // Check if we have bbox3d coordinates in the original JSON
@@ -1841,19 +1824,15 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                         }
                         if (buffer)
                         {
-                            GET_OSD_INSTANCE()->gst_buffer_add_cu_osd_meta(buffer, OSD_ELLIPSE, ellipse_params);
+                            GET_OSD_INSTANCE()->gst_buffer_add_cu_osd_meta(buffer, OSD_ELLIPSE, ellipse_params_owner.release());
                         }
                         else
                         {
                             OsdMeta meta;
                             meta.meta_type = OSD_ELLIPSE;
-                            meta.params = (void*)ellipse_params;
+                            meta.params = (void*)ellipse_params_owner.release();
                             GET_OSD_INSTANCE()->osd_add_metadata(context, &meta);
                         }
-                    }
-                    else
-                    {
-                        free(ellipse_params);
                     }
                 }
             }
@@ -1914,8 +1893,7 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                 if (entrantStates.find(entrantId) != entrantStates.end())
                 {
                     // Draw line between bottom face centers
-                    OSD_LineParams* line_params = (OSD_LineParams*)malloc(sizeof(OSD_LineParams));
-                    if (line_params)
+                    OSD_LineParams line_params{};
                     {
                         // Use the bottom face centers for both proximity and entrant objects
                         Point start = interpolateCoordinate(state.second.centerX, state.second.centerY,
@@ -1923,10 +1901,10 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                         Point end = interpolateCoordinate(entrantStates[entrantId].centerX, entrantStates[entrantId].centerY,
                                                         m_sourceWidth, m_sourceHeight, m_width, m_height);
 
-                        line_params->pos_x0 = start.x;
-                        line_params->pos_y0 = start.y;
-                        line_params->pos_x1 = end.x;
-                        line_params->pos_y1 = end.y;
+                        line_params.pos_x0 = start.x;
+                        line_params.pos_y0 = start.y;
+                        line_params.pos_x1 = end.x;
+                        line_params.pos_y1 = end.y;
 
                         // Use white color for the line
                         OSD_ColorParams lineColor = OSD_COLOR_WHITE;
@@ -1937,11 +1915,10 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                         }
                         else
                         {
-                            free(line_params);
                             continue;
                         }
 
-                        draw_line_cuosd(line_params, box_params, context, buffer, lineColor, 1);
+                        draw_line_cuosd(&line_params, box_params, context, buffer, lineColor, 1);
 
                         // Calculate the distance between objects in 2D space
                         float dx = state.second.centerX - entrantStates[entrantId].centerX;
@@ -1961,12 +1938,9 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                         OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
                         if (text_params != nullptr)
                         {
-                            // Use safe strncpy with explicit bounds checking
-                            char* cstr = (char*)calloc(distance_text.size() + 1, sizeof(char));
+                            char* cstr = strdup(distance_text.c_str());
                             if (cstr != nullptr)
                             {
-                                strncpy(cstr, distance_text.c_str(), distance_text.size());
-                                cstr[distance_text.size()] = '\0';  // Guarantee null termination
                                 text_params->text = cstr;
                             }
                             else
@@ -1996,8 +1970,6 @@ void NvLLOverlayInternal::draw_bbox_cuosd(Json::Value & objects, BBoxDrawingData
                                 GET_OSD_INSTANCE()->osd_add_metadata(context, &meta);
                             }
                         }
-                        free (line_params);
-                        line_params = nullptr;
                     }
                 }
             }
@@ -2205,7 +2177,7 @@ void NvLLOverlayInternal::readTripwire()
                 {
                     if (tripwire.wires[j])
                     {
-                        free(tripwire.wires[j]);
+                        delete tripwire.wires[j];
                         tripwire.wires[j] = nullptr;
                     }
                 }
@@ -2213,7 +2185,7 @@ void NvLLOverlayInternal::readTripwire()
                 {
                     if (tripwire.endpoints[j])
                     {
-                        free(tripwire.endpoints[j]);
+                        delete tripwire.endpoints[j];
                         tripwire.endpoints[j] = nullptr;
                     }
                 }
@@ -2221,7 +2193,7 @@ void NvLLOverlayInternal::readTripwire()
                 {
                     if (tripwire.direction[j])
                     {
-                        free(tripwire.direction[j]);
+                        delete tripwire.direction[j];
                         tripwire.direction[j] = nullptr;
                     }
                 }
@@ -2247,15 +2219,15 @@ void NvLLOverlayInternal::readTripwire()
                     tripwire.direction_count = tripwire.endpoints_count = tripwire.wires_count = 0;
                     for (uint32_t j = 0; j < MAX_LINES; j++)
                     {
-                        tripwire.wires[j] = (OSD_LineParams *)malloc(sizeof(OSD_LineParams));
+                        tripwire.wires[j] = new OSD_LineParams();
                     }
                     for (uint32_t j = 0; j < MAX_POINTS; j++)
                     {
-                        tripwire.endpoints[j] = (OSD_PointParams *)malloc(sizeof(OSD_PointParams));
+                        tripwire.endpoints[j] = new OSD_PointParams();
                     }
                     for (uint32_t j = 0; j < MAX_ARROWS; j++)
                     {
-                        tripwire.direction[j] = (OSD_ArrowParams *)malloc(sizeof(OSD_ArrowParams));
+                        tripwire.direction[j] = new OSD_ArrowParams();
                     }
 
                     Json::Value wire = tripwire_details[i].get("wire", Json::Value::null);
@@ -2408,13 +2380,12 @@ void NvLLOverlayInternal::drawTripwire(GstBuffer* buffer)
         }
         if (tripwire.stats.size())
         {
-            OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+            OSD_TextParams* text_params = g_new0(OSD_TextParams, 1);
             if (text_params != nullptr)
             {
-                char* cstr = (char*)malloc(tripwire.stats.size() + 1);
+                char* cstr = strdup(tripwire.stats.c_str());
                 if (cstr != nullptr)
                 {
-                    strcpy(cstr, tripwire.stats.c_str());
                     text_params->text = cstr;
                 }
 
@@ -2501,7 +2472,7 @@ void NvLLOverlayInternal::readRoi()
                 {
                     if (roi.lines[j])
                     {
-                        free(roi.lines[j]);
+                        delete roi.lines[j];
                         roi.lines[j] = nullptr;
                     }
                 }
@@ -2509,7 +2480,7 @@ void NvLLOverlayInternal::readRoi()
                 {
                     if (roi.endpoints[j])
                     {
-                        free(roi.endpoints[j]);
+                        delete roi.endpoints[j];
                         roi.endpoints[j] = nullptr;
                     }
                 }
@@ -2535,11 +2506,11 @@ void NvLLOverlayInternal::readRoi()
                     roi.lines_count = roi.endpoints_count = 0;
                     for (uint32_t j = 0; j < MAX_LINES; j++)
                     {
-                        roi.lines[j] = (OSD_LineParams *)malloc(sizeof(OSD_LineParams));
+                        roi.lines[j] = new OSD_LineParams();
                     }
                     for (uint32_t j = 0; j < MAX_POINTS; j++)
                     {
-                        roi.endpoints[j] = (OSD_PointParams *)malloc(sizeof(OSD_PointParams));
+                        roi.endpoints[j] = new OSD_PointParams();
                     }
                     Json::Value roi_coord = roi_details[i].get("coordinates", Json::Value::null);
                     if (roi_details[i].get("id", Json::Value::null) != Json::Value::null)
@@ -2687,13 +2658,12 @@ void NvLLOverlayInternal::drawRoi(GstBuffer* buffer)
         }
         if (roi.stats.size())
         {
-            OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+            OSD_TextParams* text_params = g_new0(OSD_TextParams, 1);
             if (text_params != nullptr)
             {
-                char* cstr = (char*)malloc(roi.stats.size() + 1);
+                char* cstr = strdup(roi.stats.c_str());
                 if (cstr != nullptr)
                 {
-                    strcpy(cstr, roi.stats.c_str());
                     text_params->text = cstr;
                 }
 
@@ -3445,13 +3415,13 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
     {
         if (!m_cpuCtx)
         {
-            m_cpuCtx = new OsdCpuDataContext();
+            m_cpuCtx = std::make_unique<OsdCpuDataContext>();
         }
         m_cpuCtx->width = m_width;
         m_cpuCtx->height = m_height;
         m_cpuCtx->data = &buffer;
         m_cpuCtx->size = (m_width * m_height * 3) / 2;
-        ip_buffer = (OsdCpuDataContext *)m_cpuCtx;
+        ip_buffer = m_cpuCtx.get();
     }
 #endif
     string frameTimestamp;
@@ -3516,7 +3486,7 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
                 Point left_top = {}, right_bottom = {};
 
                 /* Assign bounding box coordinates */
-                OSD_RectParams* rect_params = (OSD_RectParams*)malloc(sizeof(OSD_RectParams));
+                OSD_RectParams* rect_params = g_new0(OSD_RectParams, 1);
 
                 if (rect_params)
                 {
@@ -3560,7 +3530,7 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbe (void* buffer, GstMetaUni
 
     if (m_enableSensorNameText)
     {
-        OSD_TextParams* text_params=(OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+        OSD_TextParams* text_params = g_new0(OSD_TextParams, 1);
         if (text_params != nullptr)
         {
             char* cstr = (char*)malloc(m_sensorName.size() + 1);
@@ -3881,13 +3851,13 @@ bool NvLLOverlayInternal::processOsdSinkPadBufferProbeStreamer (void* buffer, Gs
     {
         if (!m_cpuCtx)
         {
-            m_cpuCtx = new OsdCpuDataContext();
+            m_cpuCtx = std::make_unique<OsdCpuDataContext>();
         }
         m_cpuCtx->width = m_width;
         m_cpuCtx->height = m_height;
         m_cpuCtx->data = &buffer;
         m_cpuCtx->size = (m_width * m_height * 3) / 2;
-        ip_buffer = (OsdCpuDataContext *)m_cpuCtx;
+        ip_buffer = m_cpuCtx.get();
     }
 #endif
 
@@ -4211,9 +4181,7 @@ void NvLLOverlayInternal::updateIPCStreamResolution(int width, int height)
     m_ipcSourceHeight = height;
 }
 
-NvLLOverlayInternal::NvLLOverlayInternal()
-{
-}
+NvLLOverlayInternal::NvLLOverlayInternal() = default;
 
 void NvLLOverlayInternal::enableOverlay(OverlayParams& params, bool use_frameid, bool wait_for_es_query)
 {
@@ -4421,7 +4389,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (tripwire.wires[j])
                 {
-                    free(tripwire.wires[j]);
+                    delete tripwire.wires[j];
                     tripwire.wires[j] = nullptr;
                 }
             }
@@ -4429,7 +4397,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (tripwire.endpoints[j])
                 {
-                    free(tripwire.endpoints[j]);
+                    delete tripwire.endpoints[j];
                     tripwire.endpoints[j] = nullptr;
                 }
             }
@@ -4437,7 +4405,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (tripwire.direction[j])
                 {
-                    free(tripwire.direction[j]);
+                    delete tripwire.direction[j];
                     tripwire.direction[j] = nullptr;
                 }
             }
@@ -4450,7 +4418,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (roi.lines[j])
                 {
-                    free(roi.lines[j]);
+                    delete roi.lines[j];
                     roi.lines[j] = nullptr;
                 }
             }
@@ -4458,7 +4426,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
             {
                 if (roi.endpoints[j])
                 {
-                    free(roi.endpoints[j]);
+                    delete roi.endpoints[j];
                     roi.endpoints[j] = nullptr;
                 }
             }
@@ -4488,11 +4456,7 @@ NvLLOverlayInternal::~NvLLOverlayInternal()
         osd_ctx = nullptr;
     }
 #if !defined(AARCH64_PLATFORM)
-    if (m_cpuCtx)
-    {
-        delete m_cpuCtx;
-        m_cpuCtx = nullptr;
-    }
+    m_cpuCtx.reset();
 #endif
     m_calibrationData.clear();
     activeObjectCorners.clear();
@@ -5296,15 +5260,12 @@ void NvLLOverlayInternal::draw_pose_cuosd(const std::vector<float>& keypoints,
     {
         Point text_pos = interpolateCoordinate(x, y, m_sourceWidth, m_sourceHeight, m_width, m_height);
 
-        OSD_TextParams* text_params = (OSD_TextParams*)malloc(sizeof(OSD_TextParams));
+        OSD_TextParams* text_params = g_new0(OSD_TextParams, 1);
         if (text_params)
         {
-            // Use safe strncpy with explicit bounds checking
-            char* cstr = (char*)calloc(action_label.size() + 1, sizeof(char));
+            char* cstr = strdup(action_label.c_str());
             if (cstr)
             {
-                strncpy(cstr, action_label.c_str(), action_label.size());
-                cstr[action_label.size()] = '\0';  // Guarantee null termination
                 text_params->text = cstr;
             }
             else
@@ -5319,7 +5280,7 @@ void NvLLOverlayInternal::draw_pose_cuosd(const std::vector<float>& keypoints,
 
             // Add error checking for strdup
             const char* font_type_str = GET_CONFIG().overlay_text_font_type.c_str();
-            text_params->font_type = strdup(font_type_str);
+            text_params->font_type = g_strdup(font_type_str);
             if (!text_params->font_type)
             {
                 LOG(error) << "Failed to duplicate font type string" << endl;
@@ -5349,9 +5310,9 @@ void NvLLOverlayInternal::draw_pose_cuosd(const std::vector<float>& keypoints,
                 // Clean up if we failed to allocate text
                 if (text_params->font_type)
                 {
-                    free(text_params->font_type);
+                    g_free(text_params->font_type);
                 }
-                free(text_params);
+                g_free(text_params);
             }
         }
         else
@@ -5369,7 +5330,7 @@ void NvLLOverlayInternal::draw_ellipse_around_2d_bbox(const Point& left_top, con
     right   = right_bottom.x;
     bottom  = right_bottom.y;
 
-    OSD_EllipseParams* ellipse_params = (OSD_EllipseParams*)malloc(sizeof(OSD_EllipseParams));
+    OSD_EllipseParams* ellipse_params = g_new0(OSD_EllipseParams, 1);
     if (ellipse_params)
     {
         // Calculate the midpoint of the bottom line of the 2D box

--- a/services/vios/src/framework/media/overlays/overlay_internal.h
+++ b/services/vios/src/framework/media/overlays/overlay_internal.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -367,7 +367,7 @@ class NvLLOverlayInternal
         std::mutex                  m_calibrationLock;
         SyncObject                  m_metaWait = {};
 #if !defined(AARCH64_PLATFORM)
-        OsdCpuDataContext*          m_cpuCtx = nullptr;
+        std::unique_ptr<OsdCpuDataContext> m_cpuCtx;
 #endif
         std::unique_ptr<HaloSafetyManager> m_haloSafetyManager;
 };

--- a/services/vios/src/framework/media/video_segment_extractor/VideoSegmentExtractor.cpp
+++ b/services/vios/src/framework/media/video_segment_extractor/VideoSegmentExtractor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@
  #include <filesystem>
  #include <iomanip>
  #include <chrono>
+ #include <memory>
  
  // Enable detailed logging
  #define LOG_INFO(msg) std::cout << "[INFO] " << msg << std::endl
@@ -542,7 +543,7 @@ extern "C" {
     // Create VideoSegmentExtractor instance
     nv_vms::VideoSegmentExtractor* createVideoSegmentExtractor() {
         try {
-            return new nv_vms::VideoSegmentExtractor();
+            return std::make_unique<nv_vms::VideoSegmentExtractor>().release();
         } catch (const std::exception& e) {
             LOG_ERROR("Failed to create VideoSegmentExtractor: " << e.what());
             return nullptr;
@@ -551,9 +552,7 @@ extern "C" {
     
     // Destroy VideoSegmentExtractor instance
     void destroyVideoSegmentExtractor(nv_vms::VideoSegmentExtractor* extractor) {
-        if (extractor) {
-            delete extractor;
-        }
+        std::unique_ptr<nv_vms::VideoSegmentExtractor>{extractor};
     }
     
     // Extract video segment using stream copy

--- a/services/vios/src/framework/media/video_source/core/CommonVideoSource.h
+++ b/services/vios/src/framework/media/video_source/core/CommonVideoSource.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,6 +93,11 @@ public:
 
     CommonVideoSource(const std::string &uri, const std::map<std::string, std::string, std::less<>> &opts);
     virtual ~CommonVideoSource(); // Custom destructor for pimpl-like pattern
+
+    CommonVideoSource(const CommonVideoSource &) = delete;
+    CommonVideoSource &operator=(const CommonVideoSource &) = delete;
+    CommonVideoSource(CommonVideoSource &&) = delete;
+    CommonVideoSource &operator=(CommonVideoSource &&) = delete;
 
     // Public interface methods
     VmsErrorCode controlStreamFileVideoSource(const std::string& action, const std::string& seek_value);

--- a/services/vios/src/framework/media/video_source/decoders/decoderpool.h
+++ b/services/vios/src/framework/media/video_source/decoders/decoderpool.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,7 @@ class DecoderPool
             static DecoderPool instance;
             return &instance;
         }
-        ~DecoderPool() {}
+        ~DecoderPool() = default;
 
         dec_map getDecoderPool()
         {

--- a/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
+++ b/services/vios/src/framework/media/video_source/decoders/gstnvvideodecoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1830,12 +1830,12 @@ GstNvVideoDecoder::GstNvVideoDecoder (const std::string& consumer_name, const st
         m_vodDebugFile.open(file_name, ios::out | ios::app);
     }
     m_playbackWD = make_unique<Bosma::Scheduler>(1);
-    m_playbackWD->interval(SCHEDULER_WD_INTERVAL, [=]()
+    m_playbackWD->interval(SCHEDULER_WD_INTERVAL, [this]()
     {
         /* Reset playstate to not playing, it will be set again in appsink callback*/
         m_playbackState.store(STATE_NOT_PLAYING);
     });
-    setConsumerMediaType(MediaTypeAudioVideo);
+    IMediaDataConsumer::setConsumerMediaType(MediaTypeAudioVideo);
 
     if (m_perfLogging)
     {

--- a/services/vios/src/framework/media/video_source/encoders/image_encoder.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/image_encoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -328,35 +328,30 @@ void ImageEnc::hwEncode(uint64_t fd, std::shared_ptr<RawFrameParams> frameData)
     }
 
     unsigned long out_buf_size = 0;
-    unsigned char *out_buf = nullptr;
 
     // Extra 512 Kbytes are required for some case encoded bitstream exceeds input buffer size
     out_buf_size = (frameData->m_targetWidth * frameData->m_targetHeight * 3/2) + (512 << 10) ;
-    out_buf = (unsigned char *)malloc(out_buf_size);
-    if (NvJpegEncLoader::getInstance()->nvjpegEncodeFromFd(fd, &out_buf, out_buf_size) == 0)
+    std::vector<unsigned char> out_buf(out_buf_size);
+    unsigned char *out_buf_ptr = out_buf.data();
+    if (NvJpegEncLoader::getInstance()->nvjpegEncodeFromFd(fd, &out_buf_ptr, out_buf_size) == 0)
     {
         LOG(info) << "HW jpeg conversion success" << endl;
     }
     else
     {
         LOG(error) << "HW jpeg conversion failed" << endl;
-        free(out_buf);
-        out_buf = nullptr;
         m_stop = true;
         return;
     }
 
     std::string image_buf(out_buf_size, 1);
-    memmove (&image_buf[0], out_buf, out_buf_size);
+    memmove (&image_buf[0], out_buf_ptr, out_buf_size);
 
     std::lock_guard<std::mutex> lock(m_imgBufferLock);
     m_imgBuffer = image_buf;
     std::string().swap(image_buf);
     m_stop = true;
     m_imgBufferWait.notify_all();
-
-    free(out_buf);
-    out_buf = nullptr;
 }
 
 int ImageEnc::create(string sourceWidth, string sourceHeight, string resizeWidth, string resizeHeight)

--- a/services/vios/src/framework/media/video_source/encoders/libnv_encoder.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/libnv_encoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,21 +89,19 @@ std::unordered_map<std::string, uint32_t> stringToPresetIDMap =
         {"slow"       , 7 }
 };
 
-NvVideoEncoder::NvVideoEncoder()
-{
-}
+NvVideoEncoder::NvVideoEncoder() = default;
 
 NvVideoEncoder::~NvVideoEncoder()
 {
     // Ensure cleanup of allocated resources
     if (capturePlane != nullptr)
     {
-        free(capturePlane);
+        delete capturePlane;
         capturePlane = nullptr;
     }
     if (outputPlane != nullptr)
     {
-        free(outputPlane);
+        delete outputPlane;
         outputPlane = nullptr;
     }
 }
@@ -113,13 +111,13 @@ void NvVideoEncoder::Init()
     int ret = 0;
     if (capturePlane == nullptr)
     {
-        capturePlane = (v4l2Planes_ *)(malloc(sizeof(v4l2Planes_)));
+        capturePlane = new v4l2Planes_();
         capturePlane->plane_name = "Capture Plane";
         InitPlane(capturePlane);
     }
     if (outputPlane == nullptr)
     {
-        outputPlane = (v4l2Planes_ *)(malloc(sizeof(v4l2Planes_)));
+        outputPlane = new v4l2Planes_();
         outputPlane->plane_name = "Output Plane";
         InitPlane(outputPlane);
     }
@@ -181,13 +179,13 @@ void NvVideoEncoder::Deinit()
 
     if (capturePlane != nullptr)
     {
-        free(capturePlane);
+        delete capturePlane;
         capturePlane = nullptr;
     }
 
     if (outputPlane != nullptr)
     {
-        free(outputPlane);
+        delete outputPlane;
         outputPlane = nullptr;
     }
 
@@ -588,11 +586,11 @@ int NvVideoEncoder::reqbufs(struct v4l2Planes_ * currentPlane, uint32_t num)
         if (reqbuf.count)
         {
             currentPlane->buffer_count = reqbuf.count;
-            currentPlane->buffers  = (NvBuffer ** )malloc(reqbuf.count*sizeof(NvBuffer *));
+            currentPlane->buffers  = new NvBuffer *[reqbuf.count]();
 
             for (uint32_t i = 0; i < reqbuf.count; i++)
             {
-                currentPlane->buffers[i] = (NvBuffer *)malloc(sizeof(NvBuffer));
+                currentPlane->buffers[i] = new NvBuffer();
                 InitNvBuffer(currentPlane->buffers[i], currentPlane->buf_type,
                         currentPlane->memory_type, currentPlane->n_planes,
                         currentPlane->planefmts, i);
@@ -602,9 +600,9 @@ int NvVideoEncoder::reqbufs(struct v4l2Planes_ * currentPlane, uint32_t num)
         {
             for (uint32_t i = 0; i < currentPlane->num_buffers; i++)
             {
-                free(currentPlane->buffers[i]);
+                delete currentPlane->buffers[i];
             }
-            free(currentPlane->buffers);
+            delete[] currentPlane->buffers;
             currentPlane->buffers = nullptr;
         }
         currentPlane->num_buffers = reqbuf.count;
@@ -1446,7 +1444,7 @@ int NvVideoEncoder::GetEncodedPartitions(unsigned char** data, ssize_t *size, bo
         LOG(error) << "capplane_buffer is NULL" << endl;
         return -1;
     }
-    *data = (uint8_t* )malloc(capplane_buffer->planes[0].bytesused);
+    *data = new uint8_t[capplane_buffer->planes[0].bytesused];
     *size =  capplane_buffer->planes[0].bytesused;
     if (isJetsonPlatform())
     {

--- a/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,23 +30,20 @@ constexpr int JPEG_DEFAULT_QUALITY = 75;
 #endif
 #define ROUND_UP_4(num)  (((num) + 3) & ~3)
 
-NvJpegEncLoader* NvJpegEncLoader::m_instance = nullptr;
+std::unique_ptr<NvJpegEncLoader> NvJpegEncLoader::m_instance = nullptr;
 
 NvJpegEncLoader* NvJpegEncLoader::getInstance()
 {
     if (m_instance == nullptr)
     {
-        m_instance = new NvJpegEncLoader();
+        m_instance.reset(new NvJpegEncLoader());
     }
-    return m_instance;
+    return m_instance.get();
 }
 
 void NvJpegEncLoader::deleteInstance()
 {
-    if (m_instance)
-    {
-        delete m_instance;
-    }
+    m_instance.reset();
 }
 
 NvJpegEncLoader::NvJpegEncLoader()

--- a/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.h
+++ b/services/vios/src/framework/media/video_source/encoders/nvjpegenc_loader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <memory>
 #include "libjpeg-8b/jpeglib.h"
 
 typedef struct jpeg_error_mgr* (*jpeg_std_error_t) (struct jpeg_error_mgr*);
@@ -60,7 +61,9 @@ public:
     int nvjpegEncodeFromFd(int fd, unsigned char **out_buf, unsigned long &out_buf_size);
     int nvjpegEncodeFromBuffer(unsigned char* buffer, uint32_t width, uint32_t height, unsigned char **out_buf, unsigned long &out_buf_size);
 private:
-    static NvJpegEncLoader* m_instance;
+    friend struct std::default_delete<NvJpegEncLoader>;
+
+    static std::unique_ptr<NvJpegEncLoader> m_instance;
     bool m_error;
     void* m_handleNvJpeg;
 

--- a/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.cpp
+++ b/services/vios/src/framework/media/video_source/encoders/nvvideoencoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ NvEncoderVideoConsumer::NvEncoderVideoConsumer(const std::string& consumer_name,
     m_encoderProcessThread = std::thread(&NvEncoderVideoConsumer::encoderProcessThread, this);
     m_transcodeStats.clear();
     // Performance tracking element name is now set in base constructor
-    setConsumerType (encoder);
+    IMediaDataConsumer::setConsumerType (encoder);
 
     /* Initialize encoder with default resolution */
     if (NvHwDetection::getInstance()->m_useNvV4l2Enc == true)
@@ -375,7 +375,7 @@ void NvEncoderVideoConsumer::encoderProcessThread()
                 }
                 if (output_buffer)
                 {
-                    free (output_buffer);
+                    delete[] output_buffer;
                     output_buffer = nullptr;
                 }
             }
@@ -578,7 +578,7 @@ void NvEncoderVideoConsumer::encoderProcessThread()
         }
         if (output_buffer)
         {
-            free (output_buffer);
+            delete[] output_buffer;
             output_buffer = nullptr;
         }
         {

--- a/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.cpp
+++ b/services/vios/src/framework/media/video_source/processors/compositors/nvcompositor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -220,22 +220,19 @@ void NvCompositor::doCompositeTask()
             {
                 // Create layout rectangles array for custom layout
                 size_t buffer_count = nv_buffer_list.size();
-                NvBufSurfTransformRect* dstCompRect = nullptr;
-                
+
                 // Check if we should use custom layout
                 if (m_gridLayout.isCustom && !m_gridLayout.tiles.empty()) {
-                    dstCompRect = new NvBufSurfTransformRect[buffer_count];
-                    calculateCustomLayout(dstCompRect, buffer_count, target_width, target_height);
-                    
+                    std::vector<NvBufSurfTransformRect> dstCompRect(buffer_count);
+                    calculateCustomLayout(dstCompRect.data(), buffer_count, target_width, target_height);
+
                     NvBufWrapper::getInstance()->doComposition(
-                        &fd_index_pair.first, 
-                        nv_buffer_list, 
-                        m_sourceFrameSize.m_width, 
-                        m_sourceFrameSize.m_height, 
-                        dstCompRect, 
+                        &fd_index_pair.first,
+                        nv_buffer_list,
+                        m_sourceFrameSize.m_width,
+                        m_sourceFrameSize.m_height,
+                        dstCompRect.data(),
                         buffer_count);
-                        
-                    delete[] dstCompRect;
                 } else {
                     // Use default layout
                     NvBufWrapper::getInstance()->doComposition(
@@ -254,7 +251,7 @@ void NvCompositor::doCompositeTask()
                     frame_data->m_targetWidth = target_width;
                     frame_data->m_targetHeight = target_height;
                     frame_data->m_isTransformed = false;
-                    frame_data->m_fdWrapperObj = new std::shared_ptr<fdWrapper>(
+                    frame_data->m_fdWrapperObj = std::make_unique<std::shared_ptr<fdWrapper>>(
                         std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, -1));
                     
                     m_consumer->onFrame(frame_data);

--- a/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.cpp
+++ b/services/vios/src/framework/media/video_source/processors/transforms/ll_transform.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <new>
 
 #include "ll_transform.h"
 #include "logger.h"
@@ -98,10 +100,10 @@ NvLLTransform::~NvLLTransform ()
     {
         if (m_swSurf->surfaceList != nullptr)
         {
-            free(m_swSurf->surfaceList);
+            delete m_swSurf->surfaceList;
             m_swSurf->surfaceList = nullptr;
         }
-        free(m_swSurf);
+        delete m_swSurf;
         m_swSurf = nullptr;
     }
     LOG(info) << "Exit " << __METHOD_NAME__ <<  endl;
@@ -391,10 +393,10 @@ void NvLLTransform::doTransformTask()
                     config_params.cuda_stream  = nullptr;
                     NvBufWrapper::getInstance()->NvBufSurfTransformSetSessionParams (&config_params);
 
-                    NvBufSurfTransformRect *src_rect = nullptr, *dst_rect = nullptr;
+                    NvBufSurfTransformRect src_rect_storage = {};
+                    NvBufSurfTransformRect dst_rect_storage = {};
+                    NvBufSurfTransformRect *src_rect = &src_rect_storage, *dst_rect = &dst_rect_storage;
                     NvBufSurfTransformParams transform_params = {0};
-                    src_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-                    dst_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
                     src_rect->top                       = 0;
                     src_rect->left                      = 0;
                     src_rect->width                     = sink_frame->m_sourceWidth;
@@ -413,13 +415,9 @@ void NvLLTransform::doTransformTask()
                     if (transform_error != NvBufSurfTransformError_Success)
                     {
                         LOG(error) << "Transform failure" << endl;
-                        free (dst_rect);
-                        free (src_rect);
                         is_error = true;
                         goto error;
                     }
-                    free (dst_rect);
-                    free (src_rect);
                 }
 
                 if (NvHwDetection::getInstance()->m_useNvV4l2Enc == true || (m_consumer && m_consumer->getConsumerType() != ConsumerType::webrtcConsumer))
@@ -440,7 +438,7 @@ void NvLLTransform::doTransformTask()
                         {
                             // case 1.2 hw mode full
                             frame_data->m_fd            = fd_index_pair.first;
-                            frame_data->m_fdWrapperObj  = new std::shared_ptr<fdWrapper>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, fd_index_pair.second));
+                            frame_data->m_fdWrapperObj = std::make_unique<std::shared_ptr<fdWrapper>>(std::make_shared<fdWrapper>(m_surfacePool, frame_data->m_fd, fd_index_pair.second));
                             frame_data->m_sourceWidth   = sink_frame->m_targetWidth;
                             frame_data->m_sourceHeight  = sink_frame->m_targetHeight;
                         }
@@ -583,14 +581,14 @@ void NvLLTransform::doTransformTask()
                         // Create the NvBufSurface for webrtc SW buffer storage
                         if (!m_swSurf)
                         {
-                            m_swSurf = (NvBufSurface *) calloc (1, sizeof(NvBufSurface));
+                            m_swSurf = new (std::nothrow) NvBufSurface{};
                             if (!m_swSurf)
                             {
                                 LOG(error) << "Allocate SW surface failed" << endl;
                                 is_error = true;
                                 goto error;
                             }
-                            m_swSurf->surfaceList = (NvBufSurfaceParams *) calloc (1, sizeof(NvBufSurfaceParams));
+                            m_swSurf->surfaceList = new (std::nothrow) NvBufSurfaceParams{};
                             if (!m_swSurf->surfaceList)
                             {
                                 LOG(error) << "Allocate SW surfaceList failed" << endl;

--- a/services/vios/src/framework/media/video_source/producers/ipcproducerpool.h
+++ b/services/vios/src/framework/media/video_source/producers/ipcproducerpool.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ class IPCProducerPool
             static IPCProducerPool instance;
             return &instance;
         }
-        ~IPCProducerPool() {}
+        ~IPCProducerPool() = default;
 
         ipc_producer_map getVideoSenderPool()
         {

--- a/services/vios/src/framework/media/video_source/producers/native_stream_monitor.cpp
+++ b/services/vios/src/framework/media/video_source/producers/native_stream_monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@
 #include "sensor_info.h"
 #include "utils.h"
 
-NativeStreamMonitor*  NativeStreamMonitor::m_pInstance = nullptr;
+std::unique_ptr<NativeStreamMonitor>  NativeStreamMonitor::m_pInstance;
 
 bool NativeStreamMonitor::addNativeStream(std::shared_ptr<StreamInfo> stream, const string location)
 {

--- a/services/vios/src/framework/media/video_source/producers/native_stream_monitor.h
+++ b/services/vios/src/framework/media/video_source/producers/native_stream_monitor.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,31 +18,32 @@
 #pragma once
 
 #include<iostream>
+#include<memory>
 #include "logger.h"
 #include "nativestreamproducer.h"
 
 class NativeStreamMonitor
 {
 private:
-    static NativeStreamMonitor* m_pInstance;
+    static std::unique_ptr<NativeStreamMonitor> m_pInstance;
     NativeStreamMonitor() { }
+    friend std::unique_ptr<NativeStreamMonitor> std::make_unique<NativeStreamMonitor>();
 
 public:
     static NativeStreamMonitor* getInstance()
     {
         if(m_pInstance == nullptr)
         {
-            m_pInstance  = new NativeStreamMonitor();
+            m_pInstance = std::make_unique<NativeStreamMonitor>();
         }
-        return m_pInstance;
+        return m_pInstance.get();
     }
 
     static void deleteInstance()
     {
         if(m_pInstance != nullptr)
         {
-            delete m_pInstance;
-            m_pInstance = nullptr;
+            m_pInstance.reset();
         }
     }
     ~NativeStreamMonitor();

--- a/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
+++ b/services/vios/src/framework/media/video_source/producers/webrtcstreamproducer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -221,10 +221,10 @@ class WebrtcStream
 class WebrtcStreamProducer : public IMediaDataProducer
 {
     private:
-        WebrtcStreamProducer () {}
+        WebrtcStreamProducer () = default;
 
     public:
-        ~WebrtcStreamProducer ()  {}
+        ~WebrtcStreamProducer () = default;
 
         static WebrtcStreamProducer* getInstance()
         {

--- a/services/vios/src/framework/media/video_source/senders/videosenderpool.h
+++ b/services/vios/src/framework/media/video_source/senders/videosenderpool.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ class VideoSenderPool
             static VideoSenderPool instance;
             return &instance;
         }
-        ~VideoSenderPool() {}
+        ~VideoSenderPool() = default;
 
         video_sender_map getVideoSenderPool()
         {

--- a/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.cpp
+++ b/services/vios/src/framework/media/video_source/senders/webrtc_sink_consumer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@
 WebrtcSinkConsumer::WebrtcSinkConsumer(const std::string& consumer_name) : IMediaDataConsumer(consumer_name)
 {
     m_videowebRTCSender = std::make_shared<VideoWebRTCSender>("VideoWebRTCSender");
-    setConsumerType (ConsumerType::webrtcConsumer);
+    IMediaDataConsumer::setConsumerType (ConsumerType::webrtcConsumer);
 }
 
 WebrtcSinkConsumer::WebrtcSinkConsumer(const std::string& consumer_name, string peer_id, double frame_rate,
@@ -33,7 +33,7 @@ WebrtcSinkConsumer::WebrtcSinkConsumer(const std::string& consumer_name, string 
         : IMediaDataConsumer(consumer_name), m_peerIdStreamId (peer_id)
 {
     m_videowebRTCSender = std::make_shared<VideoWebRTCSender>("VideoWebRTCSender", frame_rate, enable_frame_sync);
-    setConsumerType (ConsumerType::webrtcConsumer);
+    IMediaDataConsumer::setConsumerType (ConsumerType::webrtcConsumer);
 }
 
 WebrtcSinkConsumer::~WebrtcSinkConsumer()

--- a/services/vios/src/framework/notification/composite_notifier.cpp
+++ b/services/vios/src/framework/notification/composite_notifier.cpp
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-CompositeNotifier* CompositeNotifier::_instance = nullptr;
+std::unique_ptr<CompositeNotifier> CompositeNotifier::_instance;
 std::mutex CompositeNotifier::_instanceMutex;
 
 CompositeNotifier* CompositeNotifier::getInstance()
@@ -27,16 +27,15 @@ CompositeNotifier* CompositeNotifier::getInstance()
     std::lock_guard<std::mutex> lock(_instanceMutex);
     if (_instance == nullptr)
     {
-        _instance = new CompositeNotifier();
+        _instance = std::make_unique<CompositeNotifier>();
     }
-    return _instance;
+    return _instance.get();
 }
 
 void CompositeNotifier::deleteInstance()
 {
     std::lock_guard<std::mutex> lock(_instanceMutex);
-    delete _instance;
-    _instance = nullptr;
+    _instance.reset();
 }
 
 CompositeNotifier::CompositeNotifier()

--- a/services/vios/src/framework/notification/composite_notifier.h
+++ b/services/vios/src/framework/notification/composite_notifier.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -49,9 +50,11 @@ public:
 private:
     CompositeNotifier();
 
+    friend std::unique_ptr<CompositeNotifier> std::make_unique<CompositeNotifier>();
+
     mutable std::mutex m_notifiersMutex;
     std::vector<nv_vms::INotificationInterface*> m_notifiers;
 
-    static CompositeNotifier* _instance;
+    static std::unique_ptr<CompositeNotifier> _instance;
     static std::mutex _instanceMutex;
 };

--- a/services/vios/src/framework/notification/ds_proto_parser.cpp
+++ b/services/vios/src/framework/notification/ds_proto_parser.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,8 @@
 #include "logger.h"
 #include "utils.h"
 #include <dlfcn.h>
+#include <cstdlib>
+#include <memory>
 #include <vector>
 
 constexpr const char* ABSOLUTE_LIBRARY_PATH_2D_X86_64 = "/home/vst/vst_release/prebuilts/x86_64/libnvds_schema_2d.so";
@@ -198,9 +200,8 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
         }
 
         // SensorId
-        char* sensorid = m_frame_get_sensorid(frame);
-        payload["sensorId"] = sensorid ? sensorid : "";
-        free(sensorid);
+        std::unique_ptr<char, decltype(&std::free)> sensorid(m_frame_get_sensorid(frame), std::free);
+        payload["sensorId"] = sensorid ? sensorid.get() : "";
 
         // Timestamp
         frameTimeMs = 0;
@@ -215,13 +216,12 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
             void* obj = m_frame_get_object(frame, i);
             Json::Value objJson;
             // id, type, confidence
-            char* id = m_object_get_id(obj);
-            char* type = m_object_get_type(obj);
-            objJson["id"] = id ? id : "";
-            objJson["type"] = type ? type : "";
+            auto cFree = [](char* ptr) { std::free(ptr); };
+            std::unique_ptr<char, decltype(cFree)> id(m_object_get_id(obj), cFree);
+            std::unique_ptr<char, decltype(cFree)> type(m_object_get_type(obj), cFree);
+            objJson["id"] = id ? id.get() : "";
+            objJson["type"] = type ? type.get() : "";
             objJson["confidence"] = m_object_get_confidence(obj);
-            if (id) free(id);
-            if (type) free(type);
             // 3D or 2D bbox
             if (m_data2d)
             {
@@ -311,22 +311,22 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
                     if (actionsCount > 0)
                     {
                         // For compatibility with overlay_internal.cpp, use the first action as primary
-                        char* primaryActionType = m_object_get_pose_action_type(obj, 0);
+                        std::unique_ptr<char, decltype(&std::free)> primaryActionType(
+                            m_object_get_pose_action_type(obj, 0), &std::free);
                         float primaryActionConfidence = m_object_get_pose_action_confidence(obj, 0);
-                        poseJson["action"] = primaryActionType ? primaryActionType : "";
+                        poseJson["action"] = primaryActionType ? primaryActionType.get() : "";
                         poseJson["action_confidence"] = primaryActionConfidence;
-                        if (primaryActionType) free(primaryActionType);
 
                         // Also add all actions as an array for completeness
                         Json::Value actionsArray = Json::arrayValue;
                         for (int i = 0; i < actionsCount; i++)
                         {
-                            char* actionType = m_object_get_pose_action_type(obj, i);
+                            std::unique_ptr<char, decltype(&std::free)> actionType(
+                                m_object_get_pose_action_type(obj, i), &std::free);
                             float actionConfidence = m_object_get_pose_action_confidence(obj, i);
                             Json::Value actionJson;
-                            actionJson["type"] = actionType ? actionType : "";
+                            actionJson["type"] = actionType ? actionType.get() : "";
                             actionJson["confidence"] = actionConfidence;
-                            if (actionType) free(actionType);
                             actionsArray.append(actionJson);
                         }
                         poseJson["actions"] = actionsArray;
@@ -351,29 +351,27 @@ Json::Value DsProtoParser::parseMessage(const void* msg, int len, int64_t& frame
             std::vector<char*> values(infoSize, nullptr);
             int infoCount = m_frame_get_info(frame, keys.data(), values.data(), infoSize);
 
+            auto cFree = [](char* ptr) { std::free(ptr); };
+            using CStrPtr = std::unique_ptr<char, decltype(cFree)>;
+
             Json::Value perCameraPayloads = Json::arrayValue;
             for (int i = 0; i < infoCount; i++)
             {
-                if (!keys[i] || !values[i])
+                CStrPtr key(keys[i], cFree);
+                CStrPtr value(values[i], cFree);
+                if (!key || !value)
                 {
-                    free(keys[i]);
-                    free(values[i]);
                     continue;
                 }
-                std::time_t epochMs = isoToEpoch(std::string(values[i]));
+                std::time_t epochMs = isoToEpoch(std::string(value.get()));
                 if (epochMs == 0)
                 {
-                    free(keys[i]);
-                    free(values[i]);
                     continue;
                 }
                 Json::Value cameraPayload = payload;
-                cameraPayload["sensorId"] = std::string(keys[i]);
+                cameraPayload["sensorId"] = std::string(key.get());
                 cameraPayload["epocTime"] = static_cast<int64_t>(epochMs);
                 perCameraPayloads.append(cameraPayload);
-
-                free(keys[i]);
-                free(values[i]);
             }
 
             if (perCameraPayloads.size() > 0)

--- a/services/vios/src/framework/notification/ds_schema_2d_c_api.cpp
+++ b/services/vios/src/framework/notification/ds_schema_2d_c_api.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <memory>
 #include <google/protobuf/timestamp.pb.h>
 
 extern "C" {
@@ -34,18 +35,11 @@ bool nv_frame_parse(void* frame, const void* data, size_t len) {
 
 char* nv_frame_get_sensorid(void* frame) {
     std::string id = static_cast<nv::Frame*>(frame)->sensorid();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(id.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, id.c_str(), id.size());
-        cstr[id.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    return strdup(id.c_str());  // Will be nullptr if allocation failed
 }
 
 void nv_frame_destroy(void* frame) {
-    delete static_cast<nv::Frame*>(frame);
+    std::unique_ptr<nv::Frame>(static_cast<nv::Frame*>(frame));
 }
 
 // Get timestamp in epoch ms, returns 0 if not present
@@ -71,25 +65,12 @@ void* nv_frame_get_object(void* frame, int idx) {
 // Object-level getters
 const char* nv_object_get_id(void* obj) {
     std::string id = static_cast<nv::Object*>(obj)->id();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(id.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, id.c_str(), id.size());
-        cstr[id.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    return strdup(id.c_str());  // Caller releases with free()
 }
 const char* nv_object_get_type(void* obj) {
     std::string type = static_cast<nv::Object*>(obj)->type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller frees with free(); strdup keeps that contract without C-style calloc
+    return strdup(type.c_str());  // Will be nullptr if allocation failed
 }
 float nv_object_get_confidence(void* obj) {
     return static_cast<nv::Object*>(obj)->confidence();
@@ -112,14 +93,7 @@ bool nv_object_has_pose(void* obj) {
 }
 char* nv_object_get_pose_type(void* obj) {
     std::string type = static_cast<nv::Object*>(obj)->pose().type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    return strdup(type.c_str());  // Caller frees with free(); nullptr if allocation failed
 }
 int nv_object_get_pose_keypoints_count(void* obj) {
     return static_cast<nv::Object*>(obj)->pose().keypoints_size();
@@ -141,14 +115,7 @@ int nv_object_get_pose_actions_count(void* obj) {
 }
 char* nv_object_get_pose_action_type(void* obj, int idx) {
     std::string type = static_cast<nv::Object*>(obj)->pose().actions(idx).type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    return strdup(type.c_str());  // Caller frees with free(); nullptr if allocation failed
 }
 float nv_object_get_pose_action_confidence(void* obj, int idx) {
     return static_cast<nv::Object*>(obj)->pose().actions(idx).confidence();

--- a/services/vios/src/framework/notification/ds_schema_3d_c_api.cpp
+++ b/services/vios/src/framework/notification/ds_schema_3d_c_api.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <memory>
 #include <google/protobuf/timestamp.pb.h>
 
 extern "C" {
@@ -34,18 +35,11 @@ bool nv_frame_parse(void* frame, const void* data, size_t len) {
 
 char* nv_frame_get_sensorid(void* frame) {
     std::string id = static_cast<nv::Frame*>(frame)->sensorid();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(id.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, id.c_str(), id.size());
-        cstr[id.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    return strdup(id.c_str());  // Will be nullptr if allocation failed
 }
 
 void nv_frame_destroy(void* frame) {
-    delete static_cast<nv::Frame*>(frame);
+    std::unique_ptr<nv::Frame>(static_cast<nv::Frame*>(frame));
 }
 
 // Get timestamp in epoch ms, returns 0 if not present
@@ -71,25 +65,13 @@ void* nv_frame_get_object(void* frame, int idx) {
 // Object-level getters
 const char* nv_object_get_id(void* obj) {
     std::string id = static_cast<nv::Object*>(obj)->id();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(id.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, id.c_str(), id.size());
-        cstr[id.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller frees with free(); strdup keeps that contract without C-style calloc
+    return strdup(id.c_str());  // Will be nullptr if allocation failed
 }
 const char* nv_object_get_type(void* obj) {
     std::string type = static_cast<nv::Object*>(obj)->type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    // Caller frees with free(); strdup keeps that contract without C-style calloc
+    return strdup(type.c_str());  // Will be nullptr if allocation failed
 }
 float nv_object_get_confidence(void* obj) {
     return static_cast<nv::Object*>(obj)->confidence();
@@ -115,14 +97,7 @@ bool nv_object_has_pose(void* obj) {
 }
 char* nv_object_get_pose_type(void* obj) {
     std::string type = static_cast<nv::Object*>(obj)->pose().type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    return strdup(type.c_str());  // Caller frees with free(); nullptr on allocation failure
 }
 int nv_object_get_pose_keypoints_count(void* obj) {
     return static_cast<nv::Object*>(obj)->pose().keypoints_size();
@@ -144,14 +119,7 @@ int nv_object_get_pose_actions_count(void* obj) {
 }
 char* nv_object_get_pose_action_type(void* obj, int idx) {
     std::string type = static_cast<nv::Object*>(obj)->pose().actions(idx).type();
-    // Use safe strncpy with explicit bounds checking
-    char* cstr = (char*)calloc(type.size() + 1, sizeof(char));
-    if (cstr)
-    {
-        strncpy(cstr, type.c_str(), type.size());
-        cstr[type.size()] = '\0';  // Guarantee null termination
-    }
-    return cstr;  // Will be nullptr if allocation failed
+    return strdup(type.c_str());  // Caller frees with free(); nullptr on allocation failure
 }
 float nv_object_get_pose_action_confidence(void* obj, int idx) {
     return static_cast<nv::Object*>(obj)->pose().actions(idx).confidence();

--- a/services/vios/src/framework/notification/kafka/kafka_producer.cpp
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,24 +41,20 @@ DeliveryCallback(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *opaq
 }
 #endif
 
-NvKafka* NvKafka::_instance = nullptr;
+std::unique_ptr<NvKafka> NvKafka::_instance = nullptr;
 
 NvKafka* NvKafka::getInstance()
 {
     if (_instance == nullptr)
     {
-        _instance = new NvKafka();
+        _instance = std::unique_ptr<NvKafka>(new NvKafka());
     }
-    return _instance;
+    return _instance.get();
 }
 
 void NvKafka::deleteInstance()
 {
-    if (_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    _instance.reset();
 }
 
 NvKafka::NvKafka()

--- a/services/vios/src/framework/notification/kafka/kafka_producer.h
+++ b/services/vios/src/framework/notification/kafka/kafka_producer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "notification_manager.h"
+#include <memory>
 #include <string>
 #include <mutex>
 #if !defined(AARCH64_PLATFORM)
@@ -49,7 +50,7 @@ public:
     virtual ~NvKafka();
 
 private:
-    static NvKafka* _instance;
+    static std::unique_ptr<NvKafka> _instance;
     bool m_error;
     std::string m_topic_vms_event;
     std::string m_kafkaServerEndpoint;

--- a/services/vios/src/framework/notification/mqtt/mqtt_subscriber.cpp
+++ b/services/vios/src/framework/notification/mqtt/mqtt_subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@
 using namespace std;
 #define MQTT_WAIT_TIMEOUT (10 * 1000)   // 10 seconds
 
-MqttSubscriber* MqttSubscriber::_instance = nullptr;
+std::unique_ptr<MqttSubscriber> MqttSubscriber::_instance = nullptr;
 std::mutex MqttSubscriber::m_instanceMutex;
 
 MqttSubscriber* MqttSubscriber::getInstance()
@@ -34,19 +34,15 @@ MqttSubscriber* MqttSubscriber::getInstance()
     std::lock_guard<std::mutex> lock(m_instanceMutex);
     if (_instance == nullptr)
     {
-        _instance = new MqttSubscriber();
+        _instance.reset(new MqttSubscriber());
     }
-    return _instance;
+    return _instance.get();
 }
 
 void MqttSubscriber::deleteInstance()
 {
     std::lock_guard<std::mutex> lock(m_instanceMutex);
-    if (_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    _instance.reset();
 }
 
 MqttSubscriber::MqttSubscriber()

--- a/services/vios/src/framework/notification/mqtt/mqtt_subscriber.h
+++ b/services/vios/src/framework/notification/mqtt/mqtt_subscriber.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,7 @@ public:
 private:
     MqttSubscriber();
     virtual ~MqttSubscriber();
+    friend struct std::default_delete<MqttSubscriber>;
     void clientInit();
 
     class MqttCallback : public virtual mqtt::callback
@@ -53,7 +54,7 @@ private:
         void delivery_complete(mqtt::delivery_token_ptr token) override;
     };
 
-    static MqttSubscriber*              _instance;
+    static std::unique_ptr<MqttSubscriber> _instance;
     static std::mutex                   m_instanceMutex;
     std::unique_ptr<mqtt::async_client> m_client = nullptr;
     std::unique_ptr<MqttCallback>       m_callback = nullptr;

--- a/services/vios/src/framework/notification/redis/redis_publisher.cpp
+++ b/services/vios/src/framework/notification/redis/redis_publisher.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,24 +28,20 @@
 
 using namespace std;
 
-NvRedis* NvRedis::_instance = nullptr;
+std::unique_ptr<NvRedis> NvRedis::_instance = nullptr;
 
 NvRedis* NvRedis::getInstance()
 {
     if (_instance == nullptr)
     {
-        _instance = new NvRedis();
+        _instance.reset(new NvRedis());
     }
-    return _instance;
+    return _instance.get();
 }
 
 void NvRedis::deleteInstance()
 {
-    if (_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    _instance.reset();
 }
 
 NvRedis::NvRedis()

--- a/services/vios/src/framework/notification/redis/redis_publisher.h
+++ b/services/vios/src/framework/notification/redis/redis_publisher.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 #include <string>
 #include <mutex>
 #include <fstream>
+#include <memory>
 
 using namespace nv_vms;
 
@@ -46,7 +47,7 @@ public:
     void reconnectToRedisServer();
 
 private:
-    static NvRedis* _instance;
+    static std::unique_ptr<NvRedis> _instance;
     bool m_error;
     void* m_redisHandle;
     void* m_handle_redis_proto;

--- a/services/vios/src/framework/notification/redis/redis_subscriber.cpp
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,24 +63,20 @@ static void subscribe_cb(NvDsMsgApiErrorType flag, void *msg, int len, char *top
     }
 }
 
-RedisSubscriber* RedisSubscriber::_instance = nullptr;
+std::unique_ptr<RedisSubscriber> RedisSubscriber::_instance = nullptr;
 
 RedisSubscriber* RedisSubscriber::getInstance()
 {
     if (_instance == nullptr)
     {
-        _instance = new RedisSubscriber();
+        _instance.reset(new RedisSubscriber());
     }
-    return _instance;
+    return _instance.get();
 }
 
 void RedisSubscriber::deleteInstance()
 {
-    if (_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    _instance.reset();
 }
 
 RedisSubscriber::RedisSubscriber()

--- a/services/vios/src/framework/notification/redis/redis_subscriber.h
+++ b/services/vios/src/framework/notification/redis/redis_subscriber.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +41,8 @@ public:
     void retryConnection () override {}
 
 private:
-    static RedisSubscriber*                         _instance;
+    friend struct std::default_delete<RedisSubscriber>;
+    static std::unique_ptr<RedisSubscriber>         _instance;
     msgapi_connect_ptr                              nvds_msgapi_connect;
     msgapi_subscribe_ptr                            nvds_msgapi_subscribe;
     msgapi_disconnect_ptr                           nvds_msgapi_disconnect;

--- a/services/vios/src/framework/notification/webhook/webhook_notifier.cpp
+++ b/services/vios/src/framework/notification/webhook/webhook_notifier.cpp
@@ -149,7 +149,7 @@ bool anyEnabledWebhook(const Json::Value& config)
 }
 }  // unnamed namespace
 
-WebhookNotifier* WebhookNotifier::_instance = nullptr;
+std::unique_ptr<WebhookNotifier> WebhookNotifier::_instance;
 std::mutex WebhookNotifier::_instanceMutex;
 
 WebhookNotifier* WebhookNotifier::getInstance()
@@ -160,17 +160,16 @@ WebhookNotifier* WebhookNotifier::getInstance()
         const Json::Value config = loadNotificationConfig(NOTIFICATION_CONFIG_FILE);
         if (anyEnabledWebhook(config))
         {
-            _instance = new WebhookNotifier(config);
+            _instance = std::unique_ptr<WebhookNotifier>(new WebhookNotifier(config));
         }
     }
-    return _instance;
+    return _instance.get();
 }
 
 void WebhookNotifier::deleteInstance()
 {
     std::lock_guard<std::mutex> lock(_instanceMutex);
-    delete _instance;
-    _instance = nullptr;
+    _instance.reset();
 }
 
 WebhookNotifier::WebhookNotifier(const Json::Value& config)

--- a/services/vios/src/framework/notification/webhook/webhook_notifier.h
+++ b/services/vios/src/framework/notification/webhook/webhook_notifier.h
@@ -132,6 +132,6 @@ private:
     std::vector<WebhookConfig> m_webhooks;  // immutable after construction
     std::unique_ptr<AsyncHttpClient> m_httpClient;
 
-    static WebhookNotifier* _instance;
+    static std::unique_ptr<WebhookNotifier> _instance;
     static std::mutex _instanceMutex;
 };

--- a/services/vios/src/framework/platform_specific/cudaLoader.cpp
+++ b/services/vios/src/framework/platform_specific/cudaLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,23 +19,10 @@
 #include <dlfcn.h>
 #include "logger.h"
 
-CudaLoader* CudaLoader::m_instance = nullptr;
-
 CudaLoader* CudaLoader::getInstance()
 {
-    if (m_instance == nullptr)
-    {
-        m_instance = new CudaLoader();
-    }
-    return m_instance;
-}
-
-void CudaLoader::deleteInstance()
-{
-    if (m_instance)
-    {
-        delete m_instance;
-    }
+    static CudaLoader instance;
+    return &instance;
 }
 
 CudaLoader::CudaLoader()

--- a/services/vios/src/framework/platform_specific/cudaLoader.h
+++ b/services/vios/src/framework/platform_specific/cudaLoader.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,6 @@ class CudaLoader
 {
 public:
     static CudaLoader* getInstance();
-    static void deleteInstance();
 
     cuInit_t cuInit;
     cuDeviceGet_t cuDeviceGet;
@@ -41,7 +40,6 @@ public:
     bool isError()  { return m_error; }
 
 private:
-    static CudaLoader* m_instance;
     bool m_error;
     void* m_handleCuda;
     void* m_handleCudart;

--- a/services/vios/src/framework/platform_specific/nvlibs.cpp
+++ b/services/vios/src/framework/platform_specific/nvlibs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,15 +31,10 @@
 #define ABSOLUTE_LIBRARY_PATH_X86_64 "/usr/lib/x86_64-linux-gnu/libv4l2.so.0"
 #define ABSOLUTE_LIBRARY_PATH_ARCH64 "/usr/lib/aarch64-linux-gnu/libv4l2.so.0"
 
-NvLibs* NvLibs::_instance = NULL;
-
 NvLibs* NvLibs::getInstance()
 {
-    if(_instance == NULL)
-    {
-        _instance = new NvLibs();
-    }
-    return _instance;
+    static NvLibs instance;
+    return &instance;
 }
 
 NvLibs::NvLibs()

--- a/services/vios/src/framework/platform_specific/nvlibs.h
+++ b/services/vios/src/framework/platform_specific/nvlibs.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,6 @@ public:
   bool isV4l2DecPresent();
 
 private:
-  static NvLibs* _instance;
   bool error;
   void* handle_v4l2;
 

--- a/services/vios/src/framework/platform_specific/nvsurfacepool.h
+++ b/services/vios/src/framework/platform_specific/nvsurfacepool.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,8 +30,8 @@ struct _FdIndexInfo
 class NvSurfacePool
 {
 public:
-    NvSurfacePool() {};
-    ~NvSurfacePool() {};
+    NvSurfacePool() = default;
+    ~NvSurfacePool() = default;
     FD_Index_Pair getFreeFd(bool is_drc, unsigned int target_width, unsigned int target_height, bool need_allocations);
 
     bool allocateSurfaces    (int num_surfaces, unsigned int target_width, unsigned int target_height, bool need_allocations,
@@ -63,6 +63,10 @@ public:
     { 
         m_fd = fd; m_index = index;
     }
+    fdWrapper (const fdWrapper&) = delete;
+    fdWrapper& operator= (const fdWrapper&) = delete;
+    fdWrapper (fdWrapper&&) = delete;
+    fdWrapper& operator= (fdWrapper&&) = delete;
     ~fdWrapper ()
     {
         try {

--- a/services/vios/src/framework/protocols/grpc/nvgrpc.h
+++ b/services/vios/src/framework/protocols/grpc/nvgrpc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,8 +54,7 @@ public:
     GrpcUdpService(std::shared_ptr<nv_vms::DeviceManager> deviceMngr): m_deviceManager(deviceMngr)
     {}
 
-    ~GrpcUdpService()
-    {}
+    ~GrpcUdpService() = default;
 
     grpc::Status CreateUDPConnection(ServerContext* context, const CreateUDPConnectionRequest* request,
                             CreateUDPConnectionReply* reply) override;

--- a/services/vios/src/framework/stream_monitor/stream_monitor.cpp
+++ b/services/vios/src/framework/stream_monitor/stream_monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -435,7 +435,7 @@ void printQoSData();
 void printBackendQoSData();
 
 std::map<string, shared_ptr<QosMeasurementRecord>, std::less<>> g_records;
-std::map<string, QosRtspClient *, std::less<>> g_rtspSources;
+std::map<string, std::unique_ptr<QosRtspClient>, std::less<>> g_rtspSources;
 std::map<string, struct timeval, std::less<>> g_blackList;
 std::multimap<string, pair<string, string>, std::less<>> g_streamFailureCount;
 std::mutex g_streamFailureMapMutex, g_qosDumpMutex, g_rtspSourceMutex;
@@ -625,9 +625,9 @@ public:
         struct timeval m_latencyStartTime;
     };
 
-    static QosRtspClient *Create(const std::string &url, const std::string& name, const std::map<std::string, std::string, std::less<>> &opts)
+    static std::unique_ptr<QosRtspClient> Create(const std::string &url, const std::string& name, const std::map<std::string, std::string, std::less<>> &opts)
     {
-        return new QosRtspClient(url, name, opts);
+        return std::make_unique<QosRtspClient>(url, name, opts);
     }
 
     void restartConnection(bool no_delay = false)
@@ -1368,26 +1368,24 @@ QosRtspClient *startRtspClient(string uri, string devName = "")
 
     std::lock_guard<std::mutex> devicesLock(g_rtspSourceMutex);
     // Check if rtsp client for given url is present, remove it.
-    std::map<string, QosRtspClient *, std::less<>>::iterator it = g_rtspSources.find(uri);
+    auto it = g_rtspSources.find(uri);
     if (it != g_rtspSources.end())
     {
-        QosRtspClient *oldRtspSrc = it->second;
-        if (oldRtspSrc)
+        if (it->second)
         {
-            old_retryCount = oldRtspSrc->m_retryCount;
-            tryTcpTransport = oldRtspSrc->m_tryTcpStreaming;
+            old_retryCount = it->second->m_retryCount;
+            tryTcpTransport = it->second->m_tryTcpStreaming;
             removeRecord(uri);
-            delete oldRtspSrc;
             g_rtspSources.erase(uri);
         }
     }
 
-    rtspSrc = QosRtspClient::Create(uri, devName, opts);
+    rtspSrc = QosRtspClient::Create(uri, devName, opts).release();
     if (rtspSrc)
     {
         rtspSrc->m_retryCount = old_retryCount;
         rtspSrc->m_tryTcpStreaming = tryTcpTransport;
-        g_rtspSources[uri] = rtspSrc;
+        g_rtspSources[uri] = std::unique_ptr<QosRtspClient>(rtspSrc);
     }
     LOG(verbose) << "[streamMonitor] Created rtspClient for " << devName << ", uri:" << uri << endl;
     return rtspSrc;
@@ -1395,21 +1393,17 @@ QosRtspClient *startRtspClient(string uri, string devName = "")
 
 void removeRtspClient(string uri)
 {
-    QosRtspClient *rtspSrc = nullptr;
+    std::unique_ptr<QosRtspClient> rtspSrc;
     {
         std::lock_guard<std::mutex> devicesLock(g_rtspSourceMutex);
-        std::map<string, QosRtspClient *, std::less<>>::iterator it = g_rtspSources.find(uri);
+        auto it = g_rtspSources.find(uri);
         if (it != g_rtspSources.end())
         {
             LOG(verbose) << "[streamMonitor] Removing rtspClient for "
                     << it->second->getDevName() << ", uri:" << uri << endl;
-            rtspSrc = it->second;
+            rtspSrc = std::move(it->second);
             g_rtspSources.erase(uri);
         }
-    }
-    if (rtspSrc)
-    {
-        delete rtspSrc;
     }
 }
 
@@ -1417,10 +1411,10 @@ QosRtspClient *getRtspClient(string uri)
 {
     QosRtspClient *rtspSrc = nullptr;
     std::lock_guard<std::mutex> devicesLock(g_rtspSourceMutex);
-    std::map<string, QosRtspClient *, std::less<>>::iterator it = g_rtspSources.find(uri);
+    auto it = g_rtspSources.find(uri);
     if (it != g_rtspSources.end())
     {
-        rtspSrc = it->second;
+        rtspSrc = it->second.get();
     }
     return rtspSrc;
 }
@@ -1943,7 +1937,7 @@ void StreamMonitor::qosMeasurementTask()
                 -> 3. If stream is not blacklisted due to multiple failures.
                 */
                 bool createRecord = false;
-                std::map<std::string, QosRtspClient*, std::less<>>::iterator it = g_rtspSources.find(stream.m_url);
+                auto it = g_rtspSources.find(stream.m_url);
                 if (it == g_rtspSources.end() && stream.m_isMainStream)
                 {
                     QosRtspClient *rtspSource = startRtspClient(stream.m_url, stream.m_devName);
@@ -2033,7 +2027,7 @@ void StreamMonitor::qosMeasurementTask()
             }
 
             // Check if any url to be removed from monitoring.
-            std::map<std::string, QosRtspClient *, std::less<>>::iterator it_record = g_rtspSources.begin();
+            auto it_record = g_rtspSources.begin();
             while (it_record != g_rtspSources.end())
             {
                 bool found = false;
@@ -2049,7 +2043,6 @@ void StreamMonitor::qosMeasurementTask()
                 {
                     LOG(info) << "Proxy url not present in streamList, removing " << it_record->second->getDevName() << endl;
                     removeRecord(it_record->first);
-                    delete it_record->second;
                     it_record = g_rtspSources.erase(it_record);
                     if (g_blackList.size() > 0)
                     {
@@ -2102,10 +2095,6 @@ void StreamMonitor::cleanupQoSThread()
     g_streamFailureCount.clear();
 
     // Delete the rtsp sources
-    for (const auto& source : g_rtspSources)
-    {
-        delete source.second;
-    }
     g_rtspSources.clear();
 }
 
@@ -2410,7 +2399,7 @@ void StreamMonitor::waitForCompleteRemoval(const string& url)
 bool StreamMonitor::isRtspSourceDestroyed(const string& url)
 {
     std::lock_guard<std::mutex> devicesLock(g_rtspSourceMutex);
-    std::map<string, QosRtspClient *, std::less<>>::iterator it = g_rtspSources.find(url);
+    auto it = g_rtspSources.find(url);
     if (it == g_rtspSources.end())
     {
        return true;

--- a/services/vios/src/framework/stream_monitor/stream_monitor.cpp
+++ b/services/vios/src/framework/stream_monitor/stream_monitor.cpp
@@ -2042,11 +2042,17 @@ void StreamMonitor::qosMeasurementTask()
                 if (found == false)
                 {
                     LOG(info) << "Proxy url not present in streamList, removing " << it_record->second->getDevName() << endl;
-                    removeRecord(it_record->first);
+                    // Capture the key BEFORE erasing. erase() returns the
+                    // NEXT iterator -- or end() when the erased entry was last
+                    // -- so using it_record->first afterwards either
+                    // dereferences end() or removes the following camera's
+                    // blacklist entry instead of this one's.
+                    const std::string removedUri = it_record->first;
+                    removeRecord(removedUri);
                     it_record = g_rtspSources.erase(it_record);
                     if (g_blackList.size() > 0)
                     {
-                        std::map<string, struct timeval, std::less<>>::iterator it = g_blackList.find(it_record->first);
+                        std::map<string, struct timeval, std::less<>>::iterator it = g_blackList.find(removedUri);
                         if (it != g_blackList.end())
                         {
                             it = g_blackList.erase(it);

--- a/services/vios/src/framework/unified_storage/manager/cloud_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/cloud_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,9 +32,7 @@ CloudManager::CloudManager()
 {
 }
 
-CloudManager::~CloudManager()
-{
-}
+CloudManager::~CloudManager() = default;
 
 bool CloudManager::configure(const CloudManagerConfig& config)
 {

--- a/services/vios/src/framework/unified_storage/manager/minio_cloud_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/minio_cloud_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,9 +33,7 @@ MinioCloudManager::MinioCloudManager()
 {
 }
 
-MinioCloudManager::~MinioCloudManager()
-{
-}
+MinioCloudManager::~MinioCloudManager() = default;
 
 bool MinioCloudManager::isAvailable() const
 {

--- a/services/vios/src/framework/unified_storage/manager/unified_cloud_storage_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/unified_cloud_storage_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,9 +36,7 @@ UnifiedCloudStorageManager::UnifiedCloudStorageManager()
 {
 }
 
-UnifiedCloudStorageManager::~UnifiedCloudStorageManager()
-{
-}
+UnifiedCloudStorageManager::~UnifiedCloudStorageManager() = default;
 
 bool UnifiedCloudStorageManager::isAvailable() const
 {

--- a/services/vios/src/framework/unified_storage/manager/unified_local_storage_manager.cpp
+++ b/services/vios/src/framework/unified_storage/manager/unified_local_storage_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,10 +34,6 @@ UnifiedLocalStorageManager::UnifiedLocalStorageManager()
     , m_recursive_listing(false)
     , m_max_depth(10)
     , m_include_hidden(false)
-{
-}
-
-UnifiedLocalStorageManager::~UnifiedLocalStorageManager()
 {
 }
 

--- a/services/vios/src/framework/unified_storage/manager/unified_local_storage_manager.h
+++ b/services/vios/src/framework/unified_storage/manager/unified_local_storage_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +32,7 @@ class UnifiedLocalStorageManager : public UnifiedStorageManager
 {
 public:
     UnifiedLocalStorageManager();
-    virtual ~UnifiedLocalStorageManager();
+    virtual ~UnifiedLocalStorageManager() = default;
 
     // Core interface
     bool isAvailable() const override;

--- a/services/vios/src/framework/unified_storage/reader/cloud_reader.cpp
+++ b/services/vios/src/framework/unified_storage/reader/cloud_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,10 +36,10 @@ CloudReader::~CloudReader()
         LOG(info) << "CloudReader destructor called - cleaning up ongoing sessions" << std::endl;
         
         // Cancel all async download sessions
-        cancelAllAsyncDownloads();
+        CloudReader::cancelAllAsyncDownloads();
         
         // Cancel all active downloads
-        cancelAllDownloads();
+        CloudReader::cancelAllDownloads();
         
         // Shutdown worker threads
         shutdownDownloadWorkers();

--- a/services/vios/src/framework/unified_storage/reader/unified_local_storage_reader.cpp
+++ b/services/vios/src/framework/unified_storage/reader/unified_local_storage_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,7 +65,7 @@ UnifiedLocalStorageReader::UnifiedLocalStorageReader()
 {
 }
 
-UnifiedLocalStorageReader::~UnifiedLocalStorageReader() {}
+UnifiedLocalStorageReader::~UnifiedLocalStorageReader() = default;
 
 bool UnifiedLocalStorageReader::isAvailable() const
 {

--- a/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.h
+++ b/services/vios/src/framework/unified_storage/writer/cloud_storage_buffer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,6 +110,8 @@ struct BufferedFrame
     // Delete copy constructor and copy assignment operator to prevent expensive copies
     BufferedFrame(const BufferedFrame&) = delete;
     BufferedFrame& operator=(const BufferedFrame&) = delete;
+
+    ~BufferedFrame() = default;
 
     // Clear method for buffer reuse
     void clear()

--- a/services/vios/src/framework/unified_storage/writer/unified_storage_writer.cpp
+++ b/services/vios/src/framework/unified_storage/writer/unified_storage_writer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,11 +66,6 @@ UnifiedStorageWriter::UnifiedStorageWriter(StorageType type) : m_storageMode(typ
 UnifiedStorageWriter::~UnifiedStorageWriter()
 {
     try {
-        if (m_format)
-        {
-            free(m_format);
-            m_format = nullptr;
-        }
         destroyPipeline();
     } catch (const std::exception& e) {
         try { LOG(error) << "Exception in ~UnifiedStorageWriter: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
@@ -669,7 +664,7 @@ bool UnifiedStorageWriter::destroyPipeline()
     return destroyPipelineInternal();
 }
 
-bool UnifiedStorageWriter::destroyPipelineInternal()
+bool UnifiedStorageWriter::destroyPipelineInternal(bool call_cleanup_session)
 {
     // Store stream ID before clearing it for logging purposes
     std::string stream_id = m_streamId;
@@ -687,7 +682,10 @@ bool UnifiedStorageWriter::destroyPipelineInternal()
     // Clean up session state without calling stopWrite (which could cause recursion)
     if (!m_current_session_id.empty())
     {
-        cleanupSession(m_current_session_id);
+        if (call_cleanup_session)
+        {
+            cleanupSession(m_current_session_id);
+        }
         m_current_session_id.clear();
         m_current_remote_path.clear();
     }
@@ -886,11 +884,7 @@ bool UnifiedStorageWriter::destroyPipelineInternal()
     m_height = 0;
     m_numerator = 0;
     m_denominator = 0;
-    if (m_format)
-    {
-        free(m_format);
-        m_format = nullptr;
-    }
+    m_format.clear();
 
     // Reset session state
     m_session_active = false;
@@ -1342,11 +1336,7 @@ void UnifiedStorageWriter::setVideoMetadata(int width, int height, int numerator
     m_height = height;
     m_numerator = numerator;
     m_denominator = denominator;
-    if (m_format)
-    {
-        free(m_format);
-    }
-    m_format = format ? strdup(format) : nullptr;
+    m_format = format ? format : "";
 }
 
 void UnifiedStorageWriter::setResolution(const std::string& resolution)
@@ -1572,7 +1562,7 @@ GstPadProbeReturn event_probe(GstPad* pad, GstPadProbeInfo* info, gpointer user_
         format = gst_structure_get_string(gstStruct, "stream-format");
 
         // Store video metadata
-        if (writer->getWidth() == 0 && writer->getHeight() == 0 && writer->getFormat() == nullptr)
+        if (writer->getWidth() == 0 && writer->getHeight() == 0 && writer->getFormat().empty())
         {
             writer->setVideoMetadata(width, height, numerator, denominator, format);
 
@@ -1592,8 +1582,8 @@ GstPadProbeReturn event_probe(GstPad* pad, GstPadProbeInfo* info, gpointer user_
         }
 
         // Drop caps events if only framerate changed
-        if (writer->getWidth() == width && writer->getHeight() == height && writer->getFormat() && format &&
-            !strcmp(writer->getFormat(), format) &&
+        if (writer->getWidth() == width && writer->getHeight() == height && !writer->getFormat().empty() && format &&
+            writer->getFormat() == format &&
             (writer->getNumerator() != numerator || writer->getDenominator() != denominator))
         {
             LOG(verbose) << "Dropping framerate-only caps change for stream ID: "

--- a/services/vios/src/framework/unified_storage/writer/unified_storage_writer.h
+++ b/services/vios/src/framework/unified_storage/writer/unified_storage_writer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,8 +106,10 @@ protected:
     // Pipeline management
     bool setPipelineState(GstState state);
     bool isPipelineReady() const;
-    // Internal pipeline destruction (no locking - for internal use)
-    bool destroyPipelineInternal();
+    // Internal pipeline destruction (no locking - for internal use).
+    // call_cleanup_session must be false when invoked from the destructor, since
+    // cleanupSession() is virtual and calling it during destruction is undefined.
+    bool destroyPipelineInternal(bool call_cleanup_session = true);
 
 public:
     bool resetPipeline();
@@ -195,7 +197,7 @@ public:
     int m_height = 0;
     int m_numerator = 0;
     int m_denominator = 0;
-    char* m_format = nullptr;
+    std::string m_format;
     std::string m_resolution;
     int m_maxAllowedFrameDiff = 0;
     std::string m_parserVideoName; // Store parser element name
@@ -234,7 +236,7 @@ public:
     {
         return m_height;
     }
-    char* getFormat() const
+    std::string getFormat() const
     {
         return m_format;
     }

--- a/services/vios/src/framework/utilities/async_http_client.h
+++ b/services/vios/src/framework/utilities/async_http_client.h
@@ -101,6 +101,10 @@ private:
         std::string m_responseBody;
         char m_errorBuffer[CURL_ERROR_SIZE]{};
 
+        RequestContext() = default;
+        RequestContext(const RequestContext&) = delete;
+        RequestContext& operator=(const RequestContext&) = delete;
+
         ~RequestContext()
         {
             if (m_headerList != nullptr)

--- a/services/vios/src/framework/utilities/fps_display.h
+++ b/services/vios/src/framework/utilities/fps_display.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,7 @@ class FPSDisplay
             m_fpsCaptureIntervalSecs = DEFAULT_FPS_CAPTURE_INTERVAL_SEC * 1000 * 1000;
             m_fpsPublishIntervalSecs = DEFAULT_FPS_PUBLISH_INTERVAL_SEC * 1000 * 1000;
         }
-        ~FPSDisplay(){ }
+        ~FPSDisplay() = default;
 
         void       displayFPS           (unsigned long pts_in_ms, string peerId_streamId);
         double     getAvgFPS            () { return m_avgFPS; }

--- a/services/vios/src/framework/utilities/gmainloop_manager.h
+++ b/services/vios/src/framework/utilities/gmainloop_manager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,29 @@ public:
         {
             g_main_loop_unref(m_loop);
         }
+    }
+
+    GMainLoopManager(const GMainLoopManager&) = delete;
+    GMainLoopManager& operator=(const GMainLoopManager&) = delete;
+
+    GMainLoopManager(GMainLoopManager&& other) noexcept
+        : m_loop(other.m_loop)
+    {
+        other.m_loop = nullptr;
+    }
+
+    GMainLoopManager& operator=(GMainLoopManager&& other) noexcept
+    {
+        if (this != &other)
+        {
+            if (m_loop)
+            {
+                g_main_loop_unref(m_loop);
+            }
+            m_loop = other.m_loop;
+            other.m_loop = nullptr;
+        }
+        return *this;
     }
 
     void run()

--- a/services/vios/src/framework/utilities/logger.cpp
+++ b/services/vios/src/framework/utilities/logger.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,15 +45,11 @@ void Logger::setRedirect(bool flag)
     std::lock_guard<std::mutex> lock(m_LogLock);
     if (flag)
     {
-        m_redirect = new CoutToString(m_stringBuffer.rdbuf());
+        m_redirect = std::make_unique<CoutToString>(m_stringBuffer.rdbuf());
     }
     else
     {
-        if (m_redirect)
-        {
-            delete m_redirect;
-            m_redirect = nullptr;
-        }
+        m_redirect.reset();
     }
 }
 

--- a/services/vios/src/framework/utilities/logger.h
+++ b/services/vios/src/framework/utilities/logger.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <streambuf>
 #include <atomic>
+#include <memory>
 #include <string.h>
 
 #include "utils.h"
@@ -92,11 +93,7 @@ class Logger {
 
         ~Logger ()
         {
-            if (m_redirect)
-            {
-                delete m_redirect;
-                m_redirect = nullptr;
-            }
+            m_redirect.reset();
             m_stringBuffer.clear();
             m_fileStream.close ();
             m_qosStream.close();
@@ -114,7 +111,7 @@ class Logger {
         /* here user's file logging preference will be stored */
         bool m_enableFileLog;
 
-        CoutToString *m_redirect;
+        std::unique_ptr<CoutToString> m_redirect;
         std::stringstream m_stringBuffer;
         std::mutex m_LogLock;
 

--- a/services/vios/src/framework/utilities/network_utils.cpp
+++ b/services/vios/src/framework/utilities/network_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,6 +73,10 @@ class AutoDestroyXml
 public:
     AutoDestroyXml(xmlBufferPtr xml) :m_xml(xml) {}
     ~AutoDestroyXml() { xmlBufferFree(m_xml); }
+    AutoDestroyXml(const AutoDestroyXml&) = delete;
+    AutoDestroyXml& operator=(const AutoDestroyXml&) = delete;
+    AutoDestroyXml(AutoDestroyXml&&) = delete;
+    AutoDestroyXml& operator=(AutoDestroyXml&&) = delete;
 private:
     xmlBufferPtr m_xml;
 };

--- a/services/vios/src/framework/utilities/signal_handler.h
+++ b/services/vios/src/framework/utilities/signal_handler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <cstdlib>
 #include <cxxabi.h>
+#include <memory>
 #include "logger.h"
 
 // Initialize the static member variable
@@ -29,7 +30,7 @@ struct sigaction sigact;
 class SignalHandler
 {
 public:
-    SignalHandler() {}
+    SignalHandler() = default;
     SignalHandler(void (*handler)(int))
     {
         signal(SIGINT, handler);
@@ -80,12 +81,9 @@ private:
         }
 
         // resolve addresses into strings containing "filename(function+address)",
-        // this array must be free()-ed
-        char** symbollist = backtrace_symbols(addrlist, addrlen);
-
-        // allocate string which will be filled with the demangled function name
-        size_t funcnamesize = 256;
-        char* funcname = (char*)malloc(funcnamesize);
+        // this array is heap-allocated and owned by the unique_ptr below
+        std::unique_ptr<char*, decltype(&std::free)> symbollist(
+            backtrace_symbols(addrlist, addrlen), &std::free);
 
         // iterate over the returned symbol lines. skip the first, it is the
         // address of this function.
@@ -94,7 +92,7 @@ private:
             char *begin_name = nullptr, *begin_offset = nullptr, *end_offset = nullptr;
             // find parentheses and +address offset surrounding the mangled name:
             // ./module(function+0x15c) [0x8048a6d]
-            for (char *p = symbollist[i]; *p; ++p)
+            for (char *p = symbollist.get()[i]; *p; ++p)
             {
                 if (*p == '(')
                     begin_name = p;
@@ -116,28 +114,27 @@ private:
 
                 // mangled name is now in [begin_name, begin_offset) and caller
                 // offset in [begin_offset, end_offset). now apply
-                // __cxa_demangle():
+                // __cxa_demangle(). Passing a null buffer makes it allocate one
+                // with malloc, which the unique_ptr releases with free.
                 int status;
-                char* ret = abi::__cxa_demangle(begin_name, funcname, &funcnamesize, &status);
+                std::unique_ptr<char, decltype(&std::free)> funcname(
+                    abi::__cxa_demangle(begin_name, nullptr, nullptr, &status), &std::free);
                 if (status == 0)
                 {
-                    funcname = ret;
-                    LOG(error) << symbollist[i] << " : " << funcname << "+" << begin_offset << endl;
+                    LOG(error) << symbollist.get()[i] << " : " << funcname.get() << "+" << begin_offset << endl;
                 }
                 else
                 {
                     // demangling failed. Output function name as a C function with no arguments.
-                    LOG(error) << symbollist[i] << " : " << begin_name << "+" << begin_offset << endl;
+                    LOG(error) << symbollist.get()[i] << " : " << begin_name << "+" << begin_offset << endl;
                 }
             }
             else
             {
                 // couldn't parse the line? print the whole line.
-                LOG(error) << " " << symbollist[i] << endl;
+                LOG(error) << " " << symbollist.get()[i] << endl;
             }
         }
-        free(funcname);
-        free(symbollist);
         return;
     }
 

--- a/services/vios/src/framework/utilities/stats.h
+++ b/services/vios/src/framework/utilities/stats.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,10 +33,7 @@ struct LatencyStats
                     , m_maxLatency(0)
     {
     }
-    ~LatencyStats()
-    {
-
-    }
+    ~LatencyStats() = default;
     void clear()
     {
         m_totalFrames = 0;
@@ -53,8 +50,8 @@ struct LatencyStats
 class CodecStats : public LatencyStats
 {
     public:
-        CodecStats() {}
-        ~CodecStats() {}
+        CodecStats() = default;
+        ~CodecStats() = default;
         void startProcessing();
         void finishProcessing();
         void clearQueue();

--- a/services/vios/src/framework/utilities/utils.cpp
+++ b/services/vios/src/framework/utilities/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1724,14 +1724,13 @@ Json::Value stringToJson(string in)
 {
     Json::Value out;
     Json::CharReaderBuilder builder;
-    Json::CharReader* reader = builder.newCharReader();
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
     std::string errors;
 
     reader->parse(in.c_str(),
                 in.c_str() + in.size(),
                 &out,
                 &errors);
-    delete reader;
     return out;
 }
 

--- a/services/vios/src/framework/web/websocket_client/WebsocketClient.cpp
+++ b/services/vios/src/framework/web/websocket_client/WebsocketClient.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,8 +23,6 @@ using namespace std;
 
 constexpr const char* WEBSOCKET_SERVER_PATH = "/vms/ws?connectionId=";
 constexpr const char* HTTPS_PROTOCOL = "https://";
-
-WebsocketClient *WebsocketClient::m_instance = nullptr;
 
 // WebSocket data handler implementation
 bool WebsocketClient::processReceivedMessage(struct mg_connection *conn, int flags, char *data, size_t data_len)
@@ -110,7 +108,7 @@ WebsocketClient::WebsocketClient() : m_connection(nullptr),
     int keepAliveMs = max(5000, GET_CONFIG().websocket_keep_alive_ms);
     auto chronoMs = std::chrono::milliseconds(keepAliveMs);
     m_watchdog = make_unique<Bosma::Scheduler>(1);
-    m_watchdog->interval(chronoMs, [=]()
+    m_watchdog->interval(chronoMs, [this]()
                          { websocketClientMonitorTask(); });
 }
 

--- a/services/vios/src/framework/web/websocket_client/WebsocketClient.h
+++ b/services/vios/src/framework/web/websocket_client/WebsocketClient.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,19 +35,8 @@ class WebsocketClient
 public:
     static WebsocketClient *getInstance()
     {
-        if (m_instance == nullptr)
-        {
-            m_instance = new WebsocketClient;
-        }
-        return m_instance;
-    }
-    static void destroy()
-    {
-        if (m_instance)
-        {
-            delete m_instance;
-            m_instance = nullptr;
-        }
+        static WebsocketClient instance;
+        return &instance;
     }
     typedef std::function<void(const Json::Value &, Json::Value &, struct mg_connection *conn)> httpFunction;
     void addRequestHandler(std::map<std::string, httpFunction, std::less<>> &func);
@@ -71,7 +60,6 @@ private:
 
     WebsocketClient(const WebsocketClient &) = delete;
     WebsocketClient &operator=(const WebsocketClient &) = delete;
-    static WebsocketClient *m_instance;
     // Websocket connection and its mutex
     struct mg_connection *m_connection;
     std::mutex m_connectionMutex;

--- a/services/vios/src/framework/web/websocket_server/WebsocketServerRequestHandler.h
+++ b/services/vios/src/framework/web/websocket_server/WebsocketServerRequestHandler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,9 +35,7 @@ using namespace nv_vms;
 class WebsocketServerRequestHandler : public CivetWebSocketHandler
 {
 public:
-    WebsocketServerRequestHandler()
-    {
-    }
+    WebsocketServerRequestHandler() = default;
     ~WebsocketServerRequestHandler()
     {
         LOG(info) << "Exiting from websocket server request handler" << endl;

--- a/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
+++ b/services/vios/src/framework/webrtc_streamer/PeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -516,9 +516,9 @@ PeerConnection::~PeerConnection()
     m_pc = nullptr;
     m_peer_connection_factory = nullptr;
     m_workerThread->BlockingCall([this] {
-        auto* fakeAdm = static_cast<webrtc::FakeAudioDeviceModule*>(m_audioDeviceModule.get());
+        std::unique_ptr<webrtc::FakeAudioDeviceModule> fakeAdm(
+            static_cast<webrtc::FakeAudioDeviceModule*>(m_audioDeviceModule.get()));
         m_audioDeviceModule = nullptr;
-        delete fakeAdm;
     });
 }
 
@@ -787,7 +787,7 @@ VmsErrorCode PeerConnection::setAnswer(const Json::Value &jmessage, Json::Value&
                 std::promise<const webrtc::SessionDescriptionInterface *> remotepromise;
                 std::string out_sdp;
                 webrtc::scoped_refptr<webrtc::SetSessionDescriptionObserver> remoteSessionObserver(
-                    SetSessionDescriptionObserver::Create(m_pc.get(), remotepromise, out_sdp));
+                    SetSessionDescriptionObserver::Create(m_pc.get(), remotepromise, out_sdp).get());
                 m_pc->SetRemoteDescription(std::move(session_description),
                     RemoteSetObserverAdapter::Create(remoteSessionObserver));
                 // waiting for remote description
@@ -1278,7 +1278,7 @@ PeerConnection::call(const Json::Value& req_info, const Json::Value &in, Json::V
             std::promise<const webrtc::SessionDescriptionInterface *> remotepromise;
             std::string out_sdp;
             webrtc::scoped_refptr<webrtc::SetSessionDescriptionObserver> remoteSessionObserver(
-                SetSessionDescriptionObserver::Create(m_pc.get(), remotepromise, out_sdp));
+                SetSessionDescriptionObserver::Create(m_pc.get(), remotepromise, out_sdp).get());
             m_pc->SetRemoteDescription(std::move(session_description),
                 RemoteSetObserverAdapter::Create(remoteSessionObserver));
             // waiting for remote description
@@ -1332,7 +1332,7 @@ PeerConnection::call(const Json::Value& req_info, const Json::Value &in, Json::V
         rtcoptions.offer_to_receive_audio = 1;
         std::promise<const webrtc::SessionDescriptionInterface *> localpromise;
         std::string sdp;
-        m_pc->CreateAnswer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp), rtcoptions);
+        m_pc->CreateAnswer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp).get(), rtcoptions);
 
         // waiting for answer
         std::future<const webrtc::SessionDescriptionInterface *> localfuture = localpromise.get_future();
@@ -2486,7 +2486,7 @@ VmsErrorCode PeerConnection::createOffer(const Json::Value& in, Json::Value &off
     std::promise<const webrtc::SessionDescriptionInterface *> localpromise;
     std::string sdp;
 
-    m_pc->CreateOffer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp), rtcoptions);
+    m_pc->CreateOffer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp).get(), rtcoptions);
 
     std::future<const webrtc::SessionDescriptionInterface *> localfuture = localpromise.get_future();
     if (localfuture.wait_for(std::chrono::milliseconds(5000)) == std::future_status::ready)
@@ -2925,7 +2925,7 @@ VmsErrorCode PeerConnection::setOffer(const Json::Value& in, Json::Value& answer
             std::promise<const webrtc::SessionDescriptionInterface *> remotepromise;
             std::string out_sdp;
             webrtc::scoped_refptr<webrtc::SetSessionDescriptionObserver> remoteSessionObserver(
-                SetSessionDescriptionObserver::Create(m_pc.get(), remotepromise, out_sdp));
+                SetSessionDescriptionObserver::Create(m_pc.get(), remotepromise, out_sdp).get());
             m_pc->SetRemoteDescription(std::move(session_description),
                 RemoteSetObserverAdapter::Create(remoteSessionObserver));
             // waiting for remote description
@@ -2955,7 +2955,7 @@ VmsErrorCode PeerConnection::getAnswer(const Json::Value& in, Json::Value& answe
     rtcoptions.offer_to_receive_audio = 1;
     std::promise<const webrtc::SessionDescriptionInterface *> localpromise;
     std::string sdp;
-    m_pc->CreateAnswer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp), rtcoptions);
+    m_pc->CreateAnswer(CreateSessionDescriptionObserver::Create(m_pc.get(), localpromise, sdp).get(), rtcoptions);
 
     // waiting for answer
     std::future<const webrtc::SessionDescriptionInterface *> localfuture = localpromise.get_future();

--- a/services/vios/src/framework/webrtc_streamer/PeerConnectionManager.cpp
+++ b/services/vios/src/framework/webrtc_streamer/PeerConnectionManager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <utility>
 #include <functional>
 #include <math.h>
@@ -132,14 +133,14 @@ extern "C" void* createPeerConnectionManagerObject()
 {
     std::string publishFilter(".*");
     webrtc::AudioDeviceModule::AudioLayer audioLayer = webrtc::AudioDeviceModule::kPlatformDefaultAudio;
-    return static_cast<void*>(static_cast<IVstModule*>(
-        new PeerConnectionManager("", audioLayer, publishFilter, ModuleLoader::getInstance()->getDeviceManagerObject())));
+    auto pcm = std::make_unique<PeerConnectionManager>(
+        "", audioLayer, publishFilter, ModuleLoader::getInstance()->getDeviceManagerObject());
+    return static_cast<void*>(static_cast<IVstModule*>(pcm.release()));
 }
 
 extern "C" void deletePeerConnectionManagerObject(IVstModule* object)
 {
-    PeerConnectionManager* pcm = static_cast<PeerConnectionManager*>(object);
-    delete pcm;
+    std::unique_ptr<PeerConnectionManager>(static_cast<PeerConnectionManager*>(object));
 }
 
 // character to remove from url to make webrtc label
@@ -664,7 +665,8 @@ PeerConnectionManager::PeerConnectionManager(std::string pcType,
 #ifdef HAVE_SOUND
       m_audioDeviceModule(webrtc::AudioDeviceModule::Create(audioLayer, m_taskQueueFactory.get())),
 #else
-      m_audioDeviceModule(new webrtc::FakeAudioDeviceModule()),
+      m_fakeAudioDeviceModule(std::make_unique<webrtc::FakeAudioDeviceModule>()),
+      m_audioDeviceModule(m_fakeAudioDeviceModule.get()),
 #endif
       m_publishFilter(publishFilter), m_deviceManager(deviceManager)
 #ifdef ASYNC_API
@@ -708,9 +710,8 @@ PeerConnectionManager::~PeerConnectionManager()
 #ifdef HAVE_SOUND
     m_audioDeviceModule = nullptr;
 #else
-    auto* fakeAdm = static_cast<webrtc::FakeAudioDeviceModule*>(m_audioDeviceModule.get());
     m_audioDeviceModule = nullptr;
-    delete fakeAdm;
+    m_fakeAudioDeviceModule.reset();
 #endif
     webrtc::CleanupSSL();
 }
@@ -929,7 +930,7 @@ VmsErrorCode PeerConnectionManager::createOffer(unordered_map<string, string> ur
         rtcoptions.offer_to_receive_audio = 0;
         std::promise<const webrtc::SessionDescriptionInterface *> promise;
         std::string sdp;
-        rtcPeerConnection->CreateOffer(vst_webrtc::CreateSessionDescriptionObserver::Create(rtcPeerConnection.get(), promise, sdp), rtcoptions);
+        rtcPeerConnection->CreateOffer(vst_webrtc::CreateSessionDescriptionObserver::Create(rtcPeerConnection.get(), promise, sdp).get(), rtcoptions);
 
         // waiting for offer
         std::future<const webrtc::SessionDescriptionInterface *> future = promise.get_future();

--- a/services/vios/src/framework/webrtc_streamer/WebrtcCallbacks.cpp
+++ b/services/vios/src/framework/webrtc_streamer/WebrtcCallbacks.cpp
@@ -409,7 +409,7 @@ void CreateSessionDescriptionObserver::OnSuccess(webrtc::SessionDescriptionInter
 {
     if (desc)
     {
-        m_pc->SetLocalDescription(SetSessionDescriptionObserver::Create(m_pc, m_promise, m_sdp), desc);
+        m_pc->SetLocalDescription(SetSessionDescriptionObserver::Create(m_pc, m_promise, m_sdp).get(), desc);
     }
 }
 

--- a/services/vios/src/framework/webrtc_streamer/inc/IWebrtcConnection.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/IWebrtcConnection.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,8 +24,8 @@
 class IWebrtcConnection
 {
 public:
-    IWebrtcConnection() {}
-    virtual ~IWebrtcConnection() {}
+    IWebrtcConnection() = default;
+    virtual ~IWebrtcConnection() = default;
 
     virtual nv_vms::VmsErrorCode post(const std::string& task_name, const std::string& peerid,
                             Json::Value in, Json::Value req_info, Json::Value& response,

--- a/services/vios/src/framework/webrtc_streamer/inc/PeerConnectionManager.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/PeerConnectionManager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,9 @@
 #include "api/peer_connection_interface.h"
 
 #include "modules/audio_device/include/audio_device.h"
+#ifndef HAVE_SOUND
+#include "modules/audio_device/include/fake_audio_device.h"
+#endif
 
 #include "rtc_base/logging.h"
 #include "rtc_base/strings/json.h"
@@ -172,6 +175,9 @@ class PeerConnectionManager : public IStreamStatusEvent, public IVstModule
         std::string                                                     m_pcType {""};
     protected:
         std::unique_ptr<webrtc::TaskQueueFactory>                       m_taskQueueFactory;
+#ifndef HAVE_SOUND
+        std::unique_ptr<webrtc::FakeAudioDeviceModule>                  m_fakeAudioDeviceModule;
+#endif
         webrtc::scoped_refptr<webrtc::AudioDeviceModule>                   m_audioDeviceModule;
 #ifndef ASYNC_API
         std::mutex                                                      m_peerMapMutex;

--- a/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/WebrtcCallbacks.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "api/peer_connection_interface.h"
+#include "api/make_ref_counted.h"
 #include "Scheduler.h"
 #include "webrtcstreamproducer.h"
 #include "fps_display.h"
@@ -84,9 +85,9 @@ protected:
 class SetSessionDescriptionObserver : public webrtc::SetSessionDescriptionObserver
 {
     public:
-        static SetSessionDescriptionObserver* Create(webrtc::PeerConnectionInterface* pc, std::promise<const webrtc::SessionDescriptionInterface*> & promise, std::string &sdp)
+        static webrtc::scoped_refptr<SetSessionDescriptionObserver> Create(webrtc::PeerConnectionInterface* pc, std::promise<const webrtc::SessionDescriptionInterface*> & promise, std::string &sdp)
         {
-            return new webrtc::RefCountedObject<SetSessionDescriptionObserver>(pc, promise, sdp);
+            return webrtc::make_ref_counted<SetSessionDescriptionObserver>(pc, promise, sdp);
         }
         virtual void OnSuccess();
         virtual void OnFailure(webrtc::RTCError error);
@@ -102,9 +103,9 @@ class SetSessionDescriptionObserver : public webrtc::SetSessionDescriptionObserv
 class CreateSessionDescriptionObserver : public webrtc::CreateSessionDescriptionObserver
 {
     public:
-        static CreateSessionDescriptionObserver* Create(webrtc::PeerConnectionInterface* pc, std::promise<const webrtc::SessionDescriptionInterface*> & promise, std::string &sdp)
+        static webrtc::scoped_refptr<CreateSessionDescriptionObserver> Create(webrtc::PeerConnectionInterface* pc, std::promise<const webrtc::SessionDescriptionInterface*> & promise, std::string &sdp)
         {
-            return new webrtc::RefCountedObject<CreateSessionDescriptionObserver>(pc,promise, sdp);
+            return webrtc::make_ref_counted<CreateSessionDescriptionObserver>(pc, promise, sdp);
         }
         virtual void OnSuccess(webrtc::SessionDescriptionInterface* desc);
         virtual void OnFailure(webrtc::RTCError error);

--- a/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
+++ b/services/vios/src/framework/webrtc_streamer/inc/nvbufwrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 #include <dlfcn.h>
 #include "logger.h"
 #include "nvbuf_utils.h"
@@ -213,8 +214,10 @@ class NvBufWrapper
             if (m_nvBufferMode == NvBufferModeSoftware || software_mode)
             {
                 is_transformed_needed = true;
-                NvBufSurface *sw_surf   = (NvBufSurface *) calloc (1, sizeof(NvBufSurface));
-                sw_surf->surfaceList    = (NvBufSurfaceParams *) calloc (1, sizeof(NvBufSurfaceParams));
+                auto sw_surf_holder      = std::make_unique<NvBufSurface>();
+                auto sw_surf_list_holder = std::make_unique<NvBufSurfaceParams>();
+                NvBufSurface *sw_surf    = sw_surf_holder.get();
+                sw_surf->surfaceList     = sw_surf_list_holder.get();
 
                 sw_surf->gpuId                                   = g_gpuIndex;
                 sw_surf->batchSize                               = 1;
@@ -274,8 +277,6 @@ class NvBufWrapper
                 int ret = NvBufSurfaceAllocate(&hw_surf, 1, &input_params);
                 if (ret != 0)
                 {
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
                     LOG(error) << "NvBufSurfaceAllocate failed" << endl;
                     ret = -1;
                     return ret;
@@ -284,8 +285,6 @@ class NvBufWrapper
                 ret = NvBufSurfaceCopy (sw_surf, hw_surf);
                 if (ret != 0)
                 {
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
                     NvBufSurfaceDestroy(hw_surf);
                     LOG(error) << "NvBufSurfaceCopy failed" << endl;
                     ret = -1;
@@ -317,8 +316,6 @@ class NvBufWrapper
                     ret = NvBufSurfaceAllocate(&op_surf, 1, &input_params);
                     if (ret != 0)
                     {
-                        free(sw_surf->surfaceList);
-                        free (sw_surf);
                         NvBufSurfaceDestroy(hw_surf);
                         LOG(error) << "NvBufSurfaceAllocate1 failed" << endl;
                         ret = -1;
@@ -335,8 +332,6 @@ class NvBufWrapper
                         if (status < 0)
                         {
                             LOG(error) << "Failed to get surface from fd =" << *fd << endl;
-                            free(sw_surf->surfaceList);
-                            free (sw_surf);
                             NvBufSurfaceDestroy(hw_surf);
                             NvBufSurfaceDestroy(op_surf);
                             ret = -1;
@@ -350,10 +345,9 @@ class NvBufWrapper
                 config_params.cuda_stream  = nullptr;
                 NvBufSurfTransformSetSessionParams (&config_params);
 
-                NvBufSurfTransformRect *src_rect = nullptr, *dst_rect = nullptr;
+                NvBufSurfTransformRect src_rect_storage = {0}, dst_rect_storage = {0};
+                NvBufSurfTransformRect *src_rect = &src_rect_storage, *dst_rect = &dst_rect_storage;
                 NvBufSurfTransformParams transform_params = {0};
-                src_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-                dst_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
                 src_rect->top                       = 0;
                 src_rect->left                      = 0;
                 src_rect->width                     = sourceWidth;
@@ -372,10 +366,6 @@ class NvBufWrapper
                 if (transform_error != NvBufSurfTransformError_Success)
                 {
                     LOG(error) << "Failed to Transform" << endl;
-                    free(sw_surf->surfaceList);
-                    free (sw_surf);
-                    free (dst_rect);
-                    free (src_rect);
                     NvBufSurfaceDestroy(hw_surf);
                     NvBufSurfaceDestroy(op_surf);
                     ret = -1;
@@ -386,10 +376,6 @@ class NvBufWrapper
                     *fd = op_surf->surfaceList->bufferDesc;
                     *ret_transform = is_transformed_needed;
                 }
-                free (src_rect);
-                free (dst_rect);
-                free (sw_surf->surfaceList);
-                free (sw_surf);
                 NvBufSurfaceDestroy(hw_surf);
 #ifdef DUMP_YUV
                 {
@@ -449,8 +435,10 @@ class NvBufWrapper
                 }
                 if (is_transformed_needed)
                 {
-                    NvBufSurfTransformRect *src_rect          = nullptr;
-                    NvBufSurfTransformRect *dst_rect          = nullptr;
+                    NvBufSurfTransformRect src_rect_storage   = {0};
+                    NvBufSurfTransformRect dst_rect_storage   = {0};
+                    NvBufSurfTransformRect *src_rect          = &src_rect_storage;
+                    NvBufSurfTransformRect *dst_rect          = &dst_rect_storage;
                     NvBufSurfaceCreateParams buf_params       = {0};
                     NvBufSurfTransformParams transform_params = {0};
                     NvBufSurface *op_surf                     = nullptr;
@@ -516,9 +504,6 @@ class NvBufWrapper
                         }
                         ip_surf = (NvBufSurface*)buffer_type.m_inputBuffer;
                     }
-                    src_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-                    dst_rect = (NvBufSurfTransformRect*)calloc (1, sizeof(NvBufSurfTransformRect));
-
                     src_rect->top    = 0;
                     src_rect->left   = 0;
                     src_rect->width  = sourceWidth;
@@ -544,8 +529,6 @@ class NvBufWrapper
                         {
                             LOG(error) << "Failed to destroy surface" << endl;
                         }
-                        free (src_rect);
-                        free (dst_rect);
                         ret = -1;
                         return ret;
                     }
@@ -557,8 +540,6 @@ class NvBufWrapper
                     {
                         *ret_transform = is_transformed_needed;
                     }
-                    free (src_rect);
-                    free (dst_rect);
                 }
                 else
                 {
@@ -1163,17 +1144,17 @@ class NvBufWrapper
             compositeParam.params.composite_blend_filter = NvBufSurfTransformInter_Algo3;
 
             size_t alloc_size = (sizeof(NvBufSurfTransformRect) * list_size);
-            compositeParam.dst_comp_rect = static_cast<NvBufSurfTransformRect*> (malloc(alloc_size));
-            compositeParam.src_comp_rect = static_cast<NvBufSurfTransformRect*> (malloc(alloc_size));
+            std::vector<NvBufSurfTransformRect> dst_comp_rect(list_size);
+            std::vector<NvBufSurfTransformRect> src_comp_rect(list_size);
+            compositeParam.dst_comp_rect = dst_comp_rect.data();
+            compositeParam.src_comp_rect = src_comp_rect.data();
 
             // Use safe memory copy with bounds validation
             size_t src_size = sizeof(dstCompRect);
             if (alloc_size > src_size)
             {
-                LOG(error) << "Buffer overflow prevented: alloc_size(" << alloc_size 
+                LOG(error) << "Buffer overflow prevented: alloc_size(" << alloc_size
                           << ") > src_size(" << src_size << ")" << endl;
-                free(compositeParam.dst_comp_rect);
-                free(compositeParam.src_comp_rect);
                 return;  // Early return from void function
             }
             memmove(compositeParam.dst_comp_rect, &dstCompRect[0], alloc_size);
@@ -1261,14 +1242,6 @@ class NvBufWrapper
                 }
 #endif
             NvBufWrapper::getInstance()->destroyFd(blk_surface_fd);
-            if (compositeParam.src_comp_rect)
-            {
-                free(compositeParam.src_comp_rect);
-            }
-            if (compositeParam.dst_comp_rect)
-            {
-                free(compositeParam.dst_comp_rect);
-            }
         }
 
         int getSwNvBufSurface(webrtc::scoped_refptr<webrtc::I420Buffer> buffer, NvBufSurface* sw_surf)

--- a/services/vios/src/framework/webrtc_streamer/sensordatamanager.cpp
+++ b/services/vios/src/framework/webrtc_streamer/sensordatamanager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -364,9 +364,7 @@ SensorDataManager::SensorDataManager(shared_ptr<SensorManagement> sensorMgmt) : 
 {
 }
 
-SensorDataManager::~SensorDataManager()
-{
-}
+SensorDataManager::~SensorDataManager() = default;
 
 VmsErrorCode SensorDataManager::startStream(std::map<std::string, std::string, std::less<>> opts, Json::Value &response)
 {

--- a/services/vios/src/modules/rtsp_server/DynamicRTSPServer.cpp
+++ b/services/vios/src/modules/rtsp_server/DynamicRTSPServer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,15 +65,14 @@ void DynamicRTSPServer::cleanup()
 
     std::vector<std::string> streamNames;
     {
-        GenericMediaServer::ServerMediaSessionIterator *iter =
-                new GenericMediaServer::ServerMediaSessionIterator(*this);
+        auto iter =
+                std::make_unique<GenericMediaServer::ServerMediaSessionIterator>(*this);
         ServerMediaSession *sms = nullptr;
         while((sms = (ServerMediaSession *)iter->next()) != nullptr)
         {
             LOG(info) << "scheduling removal of sms:" << sms << ", stream:" << sms->streamName() << endl;
             streamNames.push_back(sms->streamName());
         }
-        delete iter;
     }
 
     for (const auto& name : streamNames)
@@ -85,14 +84,14 @@ void DynamicRTSPServer::cleanup()
         removeServerMediaSession(name.c_str());
     }
     LOG(info) << "DynamicRTSPServer::cleanup() - deleted streams" << endl;
-    delete this;
+    Medium::close(this);
 }
 
 vector<string> DynamicRTSPServer::getActiveStreams()
 {
     vector<string> active_streams;
-    GenericMediaServer::ServerMediaSessionIterator *iter =
-            new GenericMediaServer::ServerMediaSessionIterator(*this);
+    auto iter =
+            std::make_unique<GenericMediaServer::ServerMediaSessionIterator>(*this);
     ServerMediaSession *sms = nullptr;
     while((sms = (ServerMediaSession *)iter->next()) != nullptr)
     {
@@ -101,7 +100,6 @@ vector<string> DynamicRTSPServer::getActiveStreams()
             active_streams.push_back(sms->streamName());
         }
     }
-    delete iter;  // Add cleanup of iterator
     return active_streams;
 }
 

--- a/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
+++ b/services/vios/src/modules/rtsp_server/H264ByteStreamSource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -243,11 +243,11 @@ H264ByteStreamSource* H264ByteStreamSource
       string url_params, string sourceState, string sessionId,
 	    unsigned preferredFrameSize, unsigned playTimePerFrame)
 {
-    H264ByteStreamSource* newSource
-      = new H264ByteStreamSource(env, streamName, mediasource, url_params, sourceState, sessionId,
+    auto newSource
+      = std::make_unique<H264ByteStreamSource>(env, streamName, mediasource, url_params, sourceState, sessionId,
               preferredFrameSize, playTimePerFrame);
 
-    return newSource;
+    return newSource.release();
 }
 
 void H264ByteStreamSource::doGetNextFrame()

--- a/services/vios/src/modules/rtsp_server/H264ByteStreamSource.hh
+++ b/services/vios/src/modules/rtsp_server/H264ByteStreamSource.hh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,6 @@ public:
     int64_t getSeekOffset() { return m_seekOffset; }
     string getUrlParams() { return m_url_params; }
 
-protected:
     H264ByteStreamSource(UsageEnvironment& env, std::string streamName, shared_ptr<NvMediaSource> mediasource,
             string url_params, string sourceState, string sessionId,
             unsigned preferredFrameSize, unsigned playTimePerFrame);

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,10 +87,7 @@ NvFileServerMediaSubsession::~NvFileServerMediaSubsession()
         }
         m_stream_state = DestroyState;
         setDoneFlag();
-        if (fAuxSDPLine != nullptr)
-        {
-            delete[] fAuxSDPLine;
-        }
+        fAuxSDPLine.reset();
     } catch (const std::exception& e) {
         try { LOG(error) << "Exception in ~NvFileServerMediaSubsession: " << e.what() << endl; } catch (...) { (void)std::current_exception(); }
     } catch (...) {
@@ -470,7 +467,7 @@ void NvFileServerMediaSubsession::checkForAuxSDPLine1()
         dasl = fDummyRTPSink ? fDummyRTPSink->auxSDPLine() : nullptr;
         if (fDummyRTPSink != nullptr && dasl != nullptr)
         {
-            fAuxSDPLine = strDup(dasl);
+            fAuxSDPLine.reset(strDup(dasl));
             fDummyRTPSink = nullptr;
 
             // Signal the event loop that we're done:
@@ -495,7 +492,7 @@ char const* NvFileServerMediaSubsession::getAuxSDPLine(RTPSink* rtpSink, FramedS
 {
     if (fAuxSDPLine != nullptr)
     {
-        return fAuxSDPLine; // it's already been set up (for a previous client)
+        return fAuxSDPLine.get(); // it's already been set up (for a previous client)
     }
 
     if (m_mediaSource && m_mediaSource->isError())
@@ -529,7 +526,7 @@ char const* NvFileServerMediaSubsession::getAuxSDPLine(RTPSink* rtpSink, FramedS
         m_PlayModeCheckTask = envir().taskScheduler().scheduleDelayedTask(_delay,
                 (TaskFunc*)checkIfSourceInPlayMode, this);
     }
-    return fAuxSDPLine;
+    return fAuxSDPLine.get();
 }
 
 std::pair<uint64_t, uint64_t> NvFileServerMediaSubsession::getRangeFromUrlParams(const string& url_params)
@@ -621,6 +618,11 @@ void NvFileServerMediaSubsession::seekStreamSource(FramedSource* inputSource,
 void NvFileServerMediaSubsession::seekStreamSource(FramedSource* inputSource,
         char*& absStart, char*& absEnd)
 {
+    std::unique_ptr<char[]> absStartOwner(absStart);
+    std::unique_ptr<char[]> absEndOwner(absEnd);
+    absStart = nullptr;
+    absEnd = nullptr;
+
     if (inputSource == nullptr)
     {
         LOG(error) << "input source is null" << endl;
@@ -630,22 +632,20 @@ void NvFileServerMediaSubsession::seekStreamSource(FramedSource* inputSource,
     /* Ignore this seek in case of sync_playback, It will be handled while createNewStreamSource */
     if (GET_CONFIG().nv_streamer_sync_playback == true || m_vodEnableOverlay)
     {
-        delete[] absStart; absStart = nullptr;
-        delete[] absEnd; absEnd = nullptr;
         return;
     }
 
     FramedFilter* fSource = static_cast<FramedFilter*>(inputSource);
     H264ByteStreamSource* source = static_cast<H264ByteStreamSource *> (fSource->inputSource());
     uint64_t start = 0;
-    if (absStart != nullptr)
+    if (absStartOwner != nullptr)
     {
-        start = getEpocTimeInMS(absStart, false);
+        start = getEpocTimeInMS(absStartOwner.get(), false);
     }
     uint64_t end = 0;
-    if (absEnd != nullptr)
+    if (absEndOwner != nullptr)
     {
-        end = getEpocTimeInMS(absEnd, false);
+        end = getEpocTimeInMS(absEndOwner.get(), false);
     }
 
     start = m_startTime;
@@ -669,8 +669,6 @@ void NvFileServerMediaSubsession::seekStreamSource(FramedSource* inputSource,
             m_isSeekStreamDone = true;
         }
     }
-    delete[] absStart; absStart = nullptr;
-    delete[] absEnd; absEnd = nullptr;
 }
 
 static void checkAndSeekToGlobalFrameId(void* clientData)

--- a/services/vios/src/modules/rtsp_server/NvMediaServer.h
+++ b/services/vios/src/modules/rtsp_server/NvMediaServer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,7 +101,7 @@ protected: // redefined virtual functions
   std::string getSessionId() { return m_sessionId; }
 private:
   void setDoneFlagAndResetSource();
-  char* fAuxSDPLine;
+  std::unique_ptr<char[]> fAuxSDPLine;
   EventLoopWatchVariable fDoneFlag{0}; // used when setting up "fAuxSDPLine"
   RTPSink* fDummyRTPSink; // ditto
   std::string m_streamName;

--- a/services/vios/src/modules/rtsp_server/RtspLoadBalancer.h
+++ b/services/vios/src/modules/rtsp_server/RtspLoadBalancer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 #include "rtspserver.h"
 #include "network_utils.h"
 #include "logger.h"
+#include <memory>
 #include <regex>
 
 inline constexpr int MAX_RTSP_SERVER_COUNT = 512;
@@ -28,8 +29,8 @@ namespace nv_vms
 class RtspLoadBalancer
 {
 public:
-    RtspLoadBalancer() {}
-    ~RtspLoadBalancer() {}
+    RtspLoadBalancer() = default;
+    ~RtspLoadBalancer() = default;
 
     int start(uint16_t serversCount, uint16_t startPort)
     {
@@ -45,10 +46,10 @@ public:
         {
             if (serversCount == 1)
             {
-                RtspServer *rtspserver = new RtspServer(startPort);
+                auto rtspserver = std::make_unique<RtspServer>(startPort);
                 if (rtspserver && !rtspserver->isError())
                 {
-                    m_servers.push_back(rtspserver);
+                    m_servers.push_back(std::move(rtspserver));
                     portArray[0] = startPort;
                     break;
                 }
@@ -72,10 +73,10 @@ public:
             /* Launch the rtsp-server instances */
             for (int i = 0; i < m_serversCount; i++)
             {
-                RtspServer *rtspserver = new RtspServer(portArray[i]);
+                auto rtspserver = std::make_unique<RtspServer>(portArray[i]);
                 if (rtspserver && !rtspserver->isError())
                 {
-                    m_servers.push_back(rtspserver);
+                    m_servers.push_back(std::move(rtspserver));
                 }
             }
         } while (0);
@@ -118,14 +119,8 @@ public:
     void stop()
     {
         /* Stop all the rtsp-server instances */
-        for (int i = 0; i < m_serversCount; i++)
-        {
-            delete m_servers[i];
-        }
-        if (m_vodServer)
-        {
-            delete m_vodServer;
-        }
+        m_servers.clear();
+        m_vodServer.reset();
     }
 
     int startVodServer(uint16_t startPort)
@@ -141,16 +136,16 @@ public:
             }
         }
 
-        RtspServer *rtspserver = new RtspServer(server_port);
+        auto rtspserver = std::make_unique<RtspServer>(server_port);
         if (rtspserver == nullptr)
         {
             LOG(error) << "Failed to create VoD server on port:" << server_port << endl;
             return -1;
         }
         LOG(info) << "Created Vod rtsp-server on port:" << server_port << endl;
-        m_vodServer = rtspserver;
         m_vodServerPort = server_port;
         rtspserver->setVodServer(true);
+        m_vodServer = std::move(rtspserver);
         return 0;
     }
 
@@ -224,7 +219,7 @@ public:
         auto it = m_serverIndexMap.find(streamId);
         if (it != m_serverIndexMap.end())
         {
-            RtspServer *rtspserver = m_servers[it->second];
+            RtspServer *rtspserver = m_servers[it->second].get();
             if (rtspserver)
             {
                 try
@@ -250,13 +245,13 @@ public:
     {
         std::lock_guard<std::mutex> guard(m_serverMapLock);
         if (m_servers[m_currentServerIndex])
-            return m_servers[m_currentServerIndex];
+            return m_servers[m_currentServerIndex].get();
         else
-            return m_servers[0];
+            return m_servers[0].get();
     }
     RtspServer* rtspServer(uint16_t index)
     {
-        return m_servers[index];
+        return m_servers[index].get();
     }
 
     RtspServer* rtspServer(const string& id)
@@ -268,7 +263,7 @@ public:
         {
             serverIndex = it->second;
         }
-        return m_servers[serverIndex];
+        return m_servers[serverIndex].get();
     }
 
     RtspServer* getRtspServerFromDbList(const std::string& streamId)
@@ -284,7 +279,7 @@ public:
                 if (server->getPort() == port)
                 {
                     m_currentServerIndex = portIndex;
-                    return server;
+                    return server.get();
                 }
                 portIndex++;
             }
@@ -294,7 +289,7 @@ public:
 
     RtspServer* getVodServer()
     {
-        return m_vodServer;
+        return m_vodServer.get();
     }
 
     string getVodUrl(const string& url)
@@ -315,12 +310,12 @@ public:
     }
 
 private:
-    std::vector<RtspServer*> m_servers;
+    std::vector<std::unique_ptr<RtspServer>> m_servers;
     uint16_t m_serversCount = 0;
     std::atomic<unsigned int> m_currentServerIndex{0};
     std::map<std::string, int, std::less<>> m_serverIndexMap;
     std::mutex m_serverMapLock;
-    RtspServer* m_vodServer = nullptr;
+    std::unique_ptr<RtspServer> m_vodServer;
     int32_t m_vodServerPort = 0;
     std::map<std::string, int, std::less<>> m_streamListDb;
     std::mutex m_streamListDbLock;

--- a/services/vios/src/modules/rtsp_server/rtspserver.cpp
+++ b/services/vios/src/modules/rtsp_server/rtspserver.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,7 +95,7 @@ RtspServer::RtspServer(u_int16_t port)
     // To implement client access control to the RTSP server, do the following:
     if(config.use_rtsp_authentication)
     {
-        m_authDB = new UserAuthenticationDatabase(AUTHENTICATION_DOMAIN, true);
+        m_authDB = std::make_unique<UserAuthenticationDatabase>(AUTHENTICATION_DOMAIN, true);
         updateUser(DEFAULT_USERNAME);
     }
     // Repeat the above with each <username>, <password> that you wish to allow
@@ -116,7 +116,7 @@ RtspServer::RtspServer(u_int16_t port)
     }
 
     m_rtspServer = DynamicRTSPServer::createNew(m_env, m_rtspServerPortNum,
-                    m_authDB, rtsp_server_reclamation_test_sec);
+                    m_authDB.get(), rtsp_server_reclamation_test_sec);
     if (m_rtspServer == nullptr)
     {
         LOG(error) << "Failed to create RTSP server: " << m_env.getResultMsg() << "\n";
@@ -142,10 +142,8 @@ RtspServer::RtspServer(u_int16_t port)
     m_env.mPreferredIface = nullptr;
     if (!config.rtsp_preferred_network_iface.empty())
     {
-        int iface_len = config.rtsp_preferred_network_iface.length();
-        m_env.mPreferredIface = new char[iface_len + 1];
-        strncpy(m_env.mPreferredIface, config.rtsp_preferred_network_iface.c_str(), iface_len);
-        m_env.mPreferredIface[iface_len] = '\0';
+        m_preferredIface = config.rtsp_preferred_network_iface;
+        m_env.mPreferredIface = m_preferredIface.data();
     }
 
     if (config.rtsp_in_base_udp_port_num != -1)
@@ -168,11 +166,7 @@ RtspServer::~RtspServer()
   {
     LOG(info) << "Deleting Rtspserver port:" << m_rtspServerPortNum << endl;
     stopAsyncWorker();
-    if (m_env.mPreferredIface)
-    {
-        delete[] m_env.mPreferredIface;
-        m_env.mPreferredIface = nullptr;
-    }
+    m_env.mPreferredIface = nullptr;
     if (m_eventAddStream)
     {
         m_env.taskScheduler().unscheduleDelayedTask(m_eventAddStream);
@@ -183,10 +177,7 @@ RtspServer::~RtspServer()
         m_env.taskScheduler().unscheduleDelayedTask(m_eventRemoveStream);
         m_eventRemoveStream = nullptr;
     }
-    if(m_authDB)
-    {
-        delete m_authDB;
-    }
+    m_authDB.reset();
     m_env.stop();
     m_thread->join();
 
@@ -262,9 +253,8 @@ int RtspServer::start()
     string threadName = "RtspSvrTh_" + to_string(m_rtspServerPortNum);
     prctl(PR_SET_NAME, threadName.c_str(), 0, 0, 0);
 
-    char *urlPrefix = m_rtspServer->rtspURLPrefix();
-    m_urlPrefix = urlPrefix;
-    delete[] urlPrefix;
+    std::unique_ptr<char[]> urlPrefix(m_rtspServer->rtspURLPrefix());
+    m_urlPrefix = urlPrefix.get();
 
     if (config.server_domain_name.empty())
     {
@@ -315,7 +305,7 @@ int RtspServer::start()
 
 static void addProxyTaskFunc(void* clientData)
 {
-    auto* task = static_cast<AddProxyTask*>(clientData);
+    std::unique_ptr<AddProxyTask> task(static_cast<AddProxyTask*>(clientData));
     try
     {
         std::string mutableUrl = task->url;
@@ -326,7 +316,6 @@ static void addProxyTaskFunc(void* clientData)
     {
         task->promise.set_exception(std::current_exception());
     }
-    delete task;
 }
 
 std::string RtspServer::createProxy(const string& id, const string& name, const string& url)
@@ -334,10 +323,10 @@ std::string RtspServer::createProxy(const string& id, const string& name, const 
     std::promise<std::string> promise;
     std::future<std::string> future = promise.get_future();
 
-    auto* task = new AddProxyTask(this, id, name, url, std::move(promise));
+    auto task = std::make_unique<AddProxyTask>(this, id, name, url, std::move(promise));
     m_env.taskScheduler().scheduleDelayedTask(0,
         (TaskFunc*)addProxyTaskFunc,
-        task
+        task.release()
     );
 
     // Wait for the result with a 1-second timeout
@@ -356,7 +345,7 @@ int RtspServer::addProxy(const string& id, const string& name, string& url)
 {
     std::lock_guard<std::mutex> lock(m_streamLock);
     int ret = 0;
-    char* proxyStreamURL = nullptr;
+    std::unique_ptr<char[]> proxyStreamURL;
     m_sms = nullptr;
     string streamName = "";
     string proxiedStreamURL = "";
@@ -473,7 +462,7 @@ int RtspServer::addProxy(const string& id, const string& name, string& url)
         ((ProxyServerMediaSession *)m_sms)->setTxSocketBufSize(GET_CONFIG().tx_socket_buffer_size);
     }
 set_proxy:
-    proxyStreamURL = m_rtspServer->rtspURL(m_sms);
+    proxyStreamURL.reset(m_rtspServer->rtspURL(m_sms));
     if(proxyStreamURL == nullptr)
     {
          LOG(error) << "Received null proxy url from ServerMediaSession" << endl;
@@ -485,12 +474,11 @@ set_proxy:
     stream.name = streamName;
     stream.sensorUrl = url;
     stream.sensorName = name;
-    stream.proxyUrl = proxyStreamURL;
+    stream.proxyUrl = proxyStreamURL.get();
     m_streamsList.insert ({ id, stream});
-    url = proxyStreamURL;
+    url = proxyStreamURL.get();
 
-    LOG(info) << "\tPlay this stream using the URL: " << proxyStreamURL << "\n";
-    delete[] proxyStreamURL;
+    LOG(info) << "\tPlay this stream using the URL: " << proxyStreamURL.get() << "\n";
 notify_exit:
     return ret;
 }
@@ -540,7 +528,7 @@ int RtspServer::removeProxy(const string& id)
 
 static void removeProxyTaskFunc(void* clientData)
 {
-    auto* task = static_cast<RemoveProxyTask*>(clientData);
+    std::unique_ptr<RemoveProxyTask> task(static_cast<RemoveProxyTask*>(clientData));
     try
     {
         int result = task->server->removeProxy(task->id);
@@ -550,7 +538,6 @@ static void removeProxyTaskFunc(void* clientData)
     {
         task->promise.set_exception(std::current_exception());
     }
-    delete task;
 }
 
 bool RtspServer::deleteProxy(const string& id)
@@ -558,10 +545,10 @@ bool RtspServer::deleteProxy(const string& id)
     std::promise<bool> promise;
     std::future<bool> future = promise.get_future();
 
-    auto* task = new RemoveProxyTask(this, id, std::move(promise));
+    auto task = std::make_unique<RemoveProxyTask>(this, id, std::move(promise));
     m_env.taskScheduler().scheduleDelayedTask(0,
         (TaskFunc*)removeProxyTaskFunc,
-        task
+        task.release()
     );
 
     std::future_status status = future.wait_for(std::chrono::seconds(1));
@@ -597,11 +584,10 @@ vector<string> RtspServer::getActiveStreams()
 string RtspServer::originalPrefix()
 {
     string rtspServerPrefix;
-    char *rtsp_prefix = m_rtspServer->rtspURLPrefix();
+    std::unique_ptr<char[]> rtsp_prefix(m_rtspServer->rtspURLPrefix());
     if (rtsp_prefix)
     {
-        rtspServerPrefix = rtsp_prefix;
-        delete[] rtsp_prefix;
+        rtspServerPrefix = rtsp_prefix.get();
     }
     return rtspServerPrefix;
 }

--- a/services/vios/src/modules/rtsp_server/rtspserver.h
+++ b/services/vios/src/modules/rtsp_server/rtspserver.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -135,8 +135,9 @@ class RtspServer
         TaskToken m_eventAddStream;
         TaskToken m_eventRemoveStream;
         std::string m_urlPrefix;
+        std::string m_preferredIface;
         ServerMediaSession* m_sms = nullptr;
-        UserAuthenticationDatabase* m_authDB = nullptr;
+        std::unique_ptr<UserAuthenticationDatabase> m_authDB;
         SyncObject m_sync;
         map<string, StreamDetails, std::less<>> m_streamsList;
         std::string m_rtspServerDomainPrefix;
@@ -165,11 +166,12 @@ class RtspServer
                                                     int socketNumToServer = -1,
                                                     MediaTranscodingTable* transcodingTable = nullptr)
         {
-            return new AppProxyServerMediaSession(rtspServer, env, ourMediaServer, inputStreamURL,
+            return std::make_unique<AppProxyServerMediaSession>(
+                                                rtspServer, env, ourMediaServer, inputStreamURL,
                                                 streamName, username, password,
                                                 tunnelOverHTTPPortNum, verbosityLevel,
                                                 initialPortNum, multiplexRTCPWithRTP,
-                                                socketNumToServer, transcodingTable);
+                                                socketNumToServer, transcodingTable).release();
         }
 
         AppProxyServerMediaSession(RtspServer *rtspServer,
@@ -214,10 +216,10 @@ class RtspServer
             Json::Value detectedAudioInfo;
             Json::Value videoParameterSets(Json::arrayValue);
             detectedAudioInfo["present"] = false;
-            char* sdpDesc = generateSDPDescription(AF_INET);
+            std::unique_ptr<char[]> sdpDesc(generateSDPDescription(AF_INET));
             if (sdpDesc)
             {
-                Json::Value videoInfo = parseVideoInfoFromSDP(sdpDesc);
+                Json::Value videoInfo = parseVideoInfoFromSDP(sdpDesc.get());
                 detectedVideoCodecs = videoInfo["codecs"];
                 videoParameterSets  = videoInfo["parameterSets"];
                 for (const auto& codec : detectedVideoCodecs)
@@ -228,7 +230,7 @@ class RtspServer
                  * earliest hook we have for audio detection -- it runs at
                  * proxy DESCRIBE-response time, before any RTSP client
                  * connects and well before the recorder is started. */
-                detectedAudioInfo = parseAudioInfoFromSDP(sdpDesc);
+                detectedAudioInfo = parseAudioInfoFromSDP(sdpDesc.get());
                 if (detectedAudioInfo.get("present", false).asBool())
                 {
                     LOG(warning) << "Detected audio from SDP: codec="
@@ -252,7 +254,6 @@ class RtspServer
                     }
                     detectedAudioInfo["encoding"] = normalizedCodec;
                 }
-                delete[] sdpDesc; // Important: free the memory as per Live555 documentation
             }
 
 

--- a/services/vios/src/modules/rtsp_server/rtspservermanager.cpp
+++ b/services/vios/src/modules/rtsp_server/rtspservermanager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <set>
 #include <limits>
+#include <memory>
 
 using namespace nv_vms;
 
@@ -954,10 +955,10 @@ VmsErrorCode RtspServerManager::handleStreamAPIrequest(const Json::Value &req_in
 
 extern "C" void* createRtspServerManagerObject()
 {
-    return new RtspServerManager;
+    return std::make_unique<RtspServerManager>().release();
 }
 
 extern "C" void deleteRtspServerManagerObject(RtspServerManager* object)
 {
-    delete object;
+    std::unique_ptr<RtspServerManager> owner(object);
 }

--- a/services/vios/src/modules/sensor_management/remote_sensor_control_apis.h
+++ b/services/vios/src/modules/sensor_management/remote_sensor_control_apis.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,10 @@ class RemoteSensorControlApis
         {
             LOG(info) << __PRETTY_FUNCTION__ << endl;
         }
+        RemoteSensorControlApis(const RemoteSensorControlApis&) = default;
+        RemoteSensorControlApis& operator=(const RemoteSensorControlApis&) = default;
+        RemoteSensorControlApis(RemoteSensorControlApis&&) = default;
+        RemoteSensorControlApis& operator=(RemoteSensorControlApis&&) = default;
         typedef std::function<void(const Json::Value& receivedData, Json::Value& response)> remoteSensorFunc;
         const std::map<std::string, remoteSensorFunc, std::less<>> getRemoteSensorControlApis() { return m_func; };
         void handleSensorCredentials(const Json::Value &data, Json::Value &response);

--- a/services/vios/src/modules/sensor_management/sensor_control.h
+++ b/services/vios/src/modules/sensor_management/sensor_control.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,6 +39,11 @@ class SensorControl
     public:
         SensorControl(DeviceManager* deviceMngr);
         ~SensorControl();
+
+        SensorControl(const SensorControl&) = delete;
+        SensorControl& operator=(const SensorControl&) = delete;
+        SensorControl(SensorControl&&) = delete;
+        SensorControl& operator=(SensorControl&&) = delete;
 
         int connect();
         int getSensorsStreamInfo();

--- a/services/vios/src/modules/sensor_management/sensor_management.cpp
+++ b/services/vios/src/modules/sensor_management/sensor_management.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,13 +45,13 @@ using namespace std;
 extern "C" void* createSensorManagementObject()
 {
     std::shared_ptr<DeviceManager> deviceManager = ModuleLoader::getInstance()->getDeviceManagerObject();
-    return static_cast<void*>(static_cast<IVstModule*>(new SensorManagement(deviceManager)));
+    auto sensorManagement = std::make_unique<SensorManagement>(deviceManager);
+    return static_cast<void*>(static_cast<IVstModule*>(sensorManagement.release()));
 }
 
 extern "C" void deleteSensorManagementObject(IVstModule* object)
 {
-    SensorManagement* sensorManagement = static_cast<SensorManagement*>(object);
-    delete sensorManagement;
+    std::unique_ptr<SensorManagement> sensorManagement(static_cast<SensorManagement*>(object));
 }
 
 void SensorManagement::onDecoderPlayingStatus(const string &url)

--- a/services/vios/src/modules/storage_management/VideoGeneratorTaskManager.cpp
+++ b/services/vios/src/modules/storage_management/VideoGeneratorTaskManager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,9 +27,7 @@
 #include <cctype>
 #include <chrono>
 
-VideoGeneratorTaskManager::VideoGeneratorTaskManager()
-{
-}
+VideoGeneratorTaskManager::VideoGeneratorTaskManager() = default;
 
 VideoGeneratorTaskManager::~VideoGeneratorTaskManager() noexcept
 {

--- a/services/vios/src/modules/storage_management/storage_management.cpp
+++ b/services/vios/src/modules/storage_management/storage_management.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,12 +81,12 @@ bool StorageManagement::m_isStorageCapacityInitialized = false;
 extern "C" void* createStorageManagementObject()
 {
     std::shared_ptr<DeviceManager> deviceManager = ModuleLoader::getInstance()->getDeviceManagerObject();
-    return new StorageManagement(ModuleLoader::getInstance()->getDeviceType(), ModuleLoader::getInstance()->getDeviceId(), deviceManager);
+    return std::make_unique<StorageManagement>(ModuleLoader::getInstance()->getDeviceType(), ModuleLoader::getInstance()->getDeviceId(), deviceManager).release();
 }
 
 extern "C" void deleteStorageManagementObject(StorageManagement* object)
 {
-    delete object;
+    std::unique_ptr<StorageManagement> owner(object);
 }
 
 StorageManagement::StorageManagement(const string deviceType, const string deviceId, std::shared_ptr<DeviceManager> deviceMngr)
@@ -109,7 +109,7 @@ StorageManagement::StorageManagement(const string deviceType, const string devic
         const uint64_t frequency = config.storage_monitoring_frequency_secs;
         std::chrono::seconds seconds (frequency);
         m_storage = make_unique<Bosma::Scheduler>(AGING_POLICY_THREAD_COUNT);
-        m_storage->interval(seconds, [=]() {
+        m_storage->interval(seconds, [this]() {
             StorageMonitorTask();
         });
         LOG(info) << "Aging policy enabled (enable_aging_policy=" << config.enable_aging_policy << ")" << endl;
@@ -134,7 +134,7 @@ StorageManagement::StorageManagement(const string deviceType, const string devic
 
     std::chrono::seconds prometheus_interval (5);
     m_monitoring = make_unique<Bosma::Scheduler>(1);
-    m_monitoring->interval(prometheus_interval, [=]() {
+    m_monitoring->interval(prometheus_interval, [this]() {
         sendCurrentUsedStorageSizeToPrometheus();
     });
 
@@ -1620,7 +1620,7 @@ VmsErrorCode StorageManagement::getFileListSensorIdBased(const string &sensorId,
                 try
                 {
                     Json::CharReaderBuilder builder;
-                    Json::CharReader* reader = builder.newCharReader();
+                    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
                     Json::Value metadata;
                     string errors;
 
@@ -1630,7 +1630,6 @@ VmsErrorCode StorageManagement::getFileListSensorIdBased(const string &sensorId,
                         &metadata,
                         &errors
                     );
-                    delete reader;
 
                     if (parsingSuccessful && !metadata.isNull())
                     {
@@ -3725,7 +3724,7 @@ VmsErrorCode StorageManagement::listLocalFiles(const Json::Value& req_info, cons
                 try
                 {
                     Json::CharReaderBuilder builder;
-                    Json::CharReader* reader = builder.newCharReader();
+                    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
                     Json::Value metadata;
                     string errors;
 
@@ -3735,7 +3734,6 @@ VmsErrorCode StorageManagement::listLocalFiles(const Json::Value& req_info, cons
                         &metadata,
                         &errors
                     );
-                    delete reader;
 
                     if (parsingSuccessful && !metadata.isNull())
                     {

--- a/services/vios/src/modules/storage_management/storage_management_utils.cpp
+++ b/services/vios/src/modules/storage_management/storage_management_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -155,6 +155,11 @@ public:
     ~DynamicVideoSegmentExtractor() {
         cleanup();
     }
+
+    DynamicVideoSegmentExtractor(const DynamicVideoSegmentExtractor&) = delete;
+    DynamicVideoSegmentExtractor& operator=(const DynamicVideoSegmentExtractor&) = delete;
+    DynamicVideoSegmentExtractor(DynamicVideoSegmentExtractor&&) = delete;
+    DynamicVideoSegmentExtractor& operator=(DynamicVideoSegmentExtractor&&) = delete;
 
     bool initialize() {
         // Try to load the VideoSegmentExtractor library following vstmodule.cpp pattern

--- a/services/vios/src/modules/stream_recorder/streamrecorder.cpp
+++ b/services/vios/src/modules/stream_recorder/streamrecorder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -324,12 +324,12 @@ void StreamRecorder::performCrashRecovery()
 
 extern "C" void *createStreamRecorderObject()
 {
-    return new StreamRecorder(GET_CONFIG().recorded_video_root, ModuleLoader::getInstance()->getDeviceId());
+    return std::make_unique<StreamRecorder>(GET_CONFIG().recorded_video_root, ModuleLoader::getInstance()->getDeviceId()).release();
 }
 
 extern "C" void deleteStreamRecorderObject(StreamRecorder *object)
 {
-    delete object;
+    std::unique_ptr<StreamRecorder> owner(object);
 }
 
 string StreamRecorder::recordStatus(const string streamId)
@@ -1095,7 +1095,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
     // Schedule start of recording
     try
     {
-        start_tp = current_schedule->m_scheduler->cron(start_time, [=]()
+        start_tp = current_schedule->m_scheduler->cron(start_time, [this, current_schedule, recorder, streamId]()
                                                        {
             std::lock_guard<std::mutex> mlock(m_recorderMutex);
             current_schedule->m_isRunning = recorder->startRecord(streamId, Schedule); });
@@ -1106,7 +1106,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
     {
         try
         {
-            start_tp = current_schedule->m_scheduler->at(start_time, [=]()
+            start_tp = current_schedule->m_scheduler->at(start_time, [this, current_schedule, recorder, streamId]()
                                                          {
                 std::lock_guard<std::mutex> mlock(m_recorderMutex);
                 current_schedule->m_isRunning = recorder->startRecord(streamId, Schedule); });
@@ -1126,7 +1126,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
     {
         if (start_schedule_type == at)
         {
-            end_tp = current_schedule->m_scheduler->cron(end_time, [=]()
+            end_tp = current_schedule->m_scheduler->cron(end_time, [this, current_schedule, recorder, streamId, unique_id, start_time_utc, end_time_utc]()
                                                          {
                 std::lock_guard<std::mutex> mlock(m_recorderMutex);
                 if (current_schedule->m_isRunning == RecordScheduleStarted)
@@ -1134,14 +1134,14 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
                     stopRecordIfScheduled(recorder, streamId);
                     current_schedule->m_isRunning = RecordScheduleOFF;
                 }
-                m_schedule_eraser->in(5s, [=]() {
+                m_schedule_eraser->in(5s, [this, recorder, streamId, unique_id, start_time_utc, end_time_utc]() {
                     LOG(info) << "Erasing schedule: " << unique_id <<endl;
                     deleteStreamSchedule(recorder, streamId, start_time_utc, end_time_utc);
                 }); });
         }
         else
         {
-            end_tp = current_schedule->m_scheduler->cron(end_time, [=]()
+            end_tp = current_schedule->m_scheduler->cron(end_time, [this, current_schedule, recorder, streamId]()
                                                          {
                 std::lock_guard<std::mutex> mlock(m_recorderMutex);
                 if (current_schedule->m_isRunning == RecordScheduleStarted)
@@ -1157,7 +1157,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
     {
         try
         {
-            end_tp = current_schedule->m_scheduler->at(end_time, [=]()
+            end_tp = current_schedule->m_scheduler->at(end_time, [this, current_schedule, recorder, streamId, unique_id, start_time_utc, end_time_utc]()
                                                        {
                 std::lock_guard<std::mutex> mlock(m_recorderMutex);
                 if (current_schedule->m_isRunning == RecordScheduleStarted)
@@ -1165,7 +1165,7 @@ bool RecordScheduler::createNewSchedule(StreamRecorder *recorder,
                     stopRecordIfScheduled(recorder, streamId);
                     current_schedule->m_isRunning = RecordScheduleOFF;
                 }
-                m_schedule_eraser->in(5s, [=]() {
+                m_schedule_eraser->in(5s, [this, recorder, streamId, unique_id, start_time_utc, end_time_utc]() {
                     LOG(info) << "Erasing schedule: " << unique_id <<endl;
                     deleteStreamSchedule(recorder, streamId, start_time_utc, end_time_utc);
                 }); });

--- a/services/vios/src/modules/webrtc_live/LivePeerConnection.cpp
+++ b/services/vios/src/modules/webrtc_live/LivePeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,13 +33,12 @@ extern "C" void* createPeerConnectionLiveManagerObject()
     std::shared_ptr<DeviceManager> deviceManager = ModuleLoader::getInstance()->getDeviceManagerObject();
     std::shared_ptr<PeerConnectionManager> pcm = std::make_shared<PeerConnectionManager>("live", audioLayer, publishFilter, deviceManager);
 
-    return static_cast<void*>(static_cast<IVstModule*>(new LivePeerConnection(pcm, deviceManager)));
+    return static_cast<void*>(static_cast<IVstModule*>(std::make_unique<LivePeerConnection>(pcm, deviceManager).release()));
 }
 
 extern "C" void deletePeerConnectionLiveManagerObject(IVstModule* object)
 {
-    LivePeerConnection* pcm_live = static_cast<LivePeerConnection*>(object);
-    delete pcm_live;
+    std::unique_ptr<LivePeerConnection>(static_cast<LivePeerConnection*>(object));
 }
 
 LivePeerConnection::LivePeerConnection(std::shared_ptr<PeerConnectionManager> peerConnectionManager,

--- a/services/vios/src/modules/webrtc_replay/ReplayPeerConnection.cpp
+++ b/services/vios/src/modules/webrtc_replay/ReplayPeerConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,13 +32,13 @@ extern "C" void* createPeerConnectionReplayManagerObject()
     std::shared_ptr<DeviceManager> deviceManager = ModuleLoader::getInstance()->getDeviceManagerObject();
     std::shared_ptr<PeerConnectionManager> pcm = std::make_shared<PeerConnectionManager>("replay", audioLayer, publishFilter, deviceManager);
 
-    return static_cast<void*>(static_cast<IVstModule*>(new ReplayPeerConnection(pcm, deviceManager)));
+    auto replayPeerConnection = std::make_unique<ReplayPeerConnection>(pcm, deviceManager);
+    return static_cast<void*>(static_cast<IVstModule*>(replayPeerConnection.release()));
 }
 
 extern "C" void deletePeerConnectionReplayManagerObject(IVstModule* object)
 {
-    ReplayPeerConnection* pcm_live = static_cast<ReplayPeerConnection*>(object);
-    delete pcm_live;
+    std::unique_ptr<ReplayPeerConnection> pcm_live(static_cast<ReplayPeerConnection*>(object));
 }
 
 ReplayPeerConnection::ReplayPeerConnection(std::shared_ptr<PeerConnectionManager> peerConnectionManager,

--- a/services/vios/src/modules/webrtc_stream_bridge/StreamBridgeService.cpp
+++ b/services/vios/src/modules/webrtc_stream_bridge/StreamBridgeService.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,13 +46,12 @@ extern "C" void* createStreamBridgeObject()
     std::shared_ptr<DeviceManager> deviceManager = ModuleLoader::getInstance()->getDeviceManagerObject();
     std::shared_ptr<PeerConnectionManager> pcm = std::make_shared<PeerConnectionManager>("streambridge", audioLayer, publishFilter, deviceManager, true);
 
-    return static_cast<void*>(static_cast<IVstModule*>(new StreamBridgeService(pcm, deviceManager)));
+    return static_cast<void*>(static_cast<IVstModule*>(std::make_unique<StreamBridgeService>(pcm, deviceManager).release()));
 }
 
 extern "C" void deleteStreamBridgeObject(IVstModule* object)
 {
-    StreamBridgeService* stream_bridge = static_cast<StreamBridgeService*>(object);
-    delete stream_bridge;
+    std::unique_ptr<StreamBridgeService>(static_cast<StreamBridgeService*>(object));
 }
 
 StreamBridgeService::StreamBridgeService(std::shared_ptr<PeerConnectionManager> peerConnectionManager,


### PR DESCRIPTION
## Description
  Fixes 353 HIGH-severity SonarQube issues in `services/vios`: memory & ownership.

  Manual memory management, C-style allocation, and special member functions were modernized using RAII, smart pointers, and rule-of-zero patterns.

  Rules addressed:

  - `cpp:S5025`
  - `cpp:S1231`
  - `cpp:S3490`
  - `cpp:S3624`
  - `cpp:S5019`
  - `cpp:S1699`
  - `cpp:S5506`

  **How these were produced.** Each issue was fixed independently in its own worktree; the results were merged into a single tree and the combined result compiled before anything was committed. Same-wave
  conflicts were retried in later waves. The final branch was clean-rebuilt and squashed to one commit.

  **Verification.**

  - `./build.sh clean`
  - `./build.sh package module=sensor,streamprocessing`
  - Containers built and deployed from the locally built image references.
  - BDD results were compared against the `develop + PR #1537` baseline: no newly regressed tests were identified.

  **Not included.** 126 issues were left as terminal no-change/manual-review items where no safe minimal automated edit was available.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
