### PR TITLE
test(lvs): init aggregation empty retries on mock stream handler

### DIFF
--- a/services/video-summarization/tests/unit/test_via_stream_handler.py
+++ b/services/video-summarization/tests/unit/test_via_stream_handler.py
@@ -263,6 +263,8 @@ def _make_mock_stream_handler():
         handler.num_ctx_mgr = 0
         handler.MAX_STREAMS = 4
         handler._start_time = time.time()
+        # Bypass real __init__; empty-guard needs this (0 => single attempt).
+        handler._aggregation_empty_retries = 0
         return handler
 
 


### PR DESCRIPTION
Bypass of ViaStreamHandler.__init__ left _aggregation_empty_retries unset, so the empty-guard path crashed the Kafka DB flush-wait unit test.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
