### PR TITLE
fix(rtvi-cv): apply Thor perception tuning to all THOR hardware profiles

### DIFF
--- a/deploy/docker/services/rtvi/rtvi-cv/ds-start.sh
+++ b/deploy/docker/services/rtvi/rtvi-cv/ds-start.sh
@@ -37,6 +37,15 @@ _ARCH="$(uname -m)"
 export GST_PLUGIN_PATH="/opt/nvidia/deepstream/deepstream/lib/gst-plugins:/usr/lib/${_ARCH}-linux-gnu/gstreamer-1.0/deepstream${GST_PLUGIN_PATH:+:${GST_PLUGIN_PATH}}"
 unset _ARCH
 
+# HARDWARE_PROFILE names each Thor board separately (IGX-THOR, AGX-THOR,
+# DGX-THOR, ...) but the DeepStream tuning below is identical across the
+# family. Match on the family the same way dev-profile.sh canonicalizes it
+# (case-insensitive *thor*) so a new board name needs no change here.
+is_thor_profile() {
+    local profile="${HARDWARE_PROFILE:-}"
+    [[ "${profile,,}" == *thor* ]]
+}
+
 # Shared: build extra flags from env vars
 build_extra_flags() {
     local flags=""
@@ -426,7 +435,7 @@ start_rtdetr_gdino()
     sed -i "/^\[streammux\]/,/^\[/{s/^batch-size=.*/batch-size=${NUM_SENSORS}/;}" "$config_file"
     sed -i "/^\[primary-gie\]/,/^\[/{s/^batch-size=.*/batch-size=${NUM_SENSORS}/;}" "$config_file"
 
-    if [[ "${HARDWARE_PROFILE:-}" == "DGX-SPARK" || "${HARDWARE_PROFILE:-}" == "IGX-THOR" ]]; then
+    if [[ "${HARDWARE_PROFILE:-}" == "DGX-SPARK" ]] || is_thor_profile; then
         # Replace or add msg-conv-msg2p-lib property in sink1 group
         echo "##### Setting msg-conv-msg2p-lib to libnvds_msgconv.so for sink1 group... #####"
         # First, remove any existing msg-conv-msg2p-lib line within [sink1] section
@@ -444,7 +453,7 @@ start_rtdetr_gdino()
         sed -i '/^\[sink1\]/a msg-conv-msg2p-lib=/opt/nvidia/deepstream/deepstream/lib/libnvds_msgconv_mega2d.so' "$config_file"
     fi
 
-    if [[ "${HARDWARE_PROFILE:-}" == "IGX-THOR" ]]; then
+    if is_thor_profile; then
         # Set compute-hw=2 under tracker section in config_file
         echo "##### Setting compute-hw=2 in tracker section of $config_file... #####"
         sed -i '/^\[tracker\]/,/^\[/{/^compute-hw=/d;}' "$config_file"

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/files/ds-start.sh
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/files/ds-start.sh
@@ -24,6 +24,15 @@ _ARCH="$(uname -m)"
 export GST_PLUGIN_PATH="/opt/nvidia/deepstream/deepstream/lib/gst-plugins:/usr/lib/${_ARCH}-linux-gnu/gstreamer-1.0/deepstream${GST_PLUGIN_PATH:+:${GST_PLUGIN_PATH}}"
 unset _ARCH
 
+# HARDWARE_PROFILE names each Thor board separately (IGX-THOR, AGX-THOR,
+# DGX-THOR, ...) but the DeepStream tuning below is identical across the
+# family. Match on the family the same way dev-profile.sh canonicalizes it
+# (case-insensitive *thor*) so a new board name needs no change here.
+is_thor_profile() {
+    local profile="${HARDWARE_PROFILE:-}"
+    [[ "${profile,,}" == *thor* ]]
+}
+
 build_extra_flags() {
     local flags=""
     [[ "$DS_TRACKER_REID" == "true" ]] && flags="$flags --tracker-reid"
@@ -402,7 +411,7 @@ start_rtdetr_gdino()
     sed -i "/^\[streammux\]/,/^\[/{s/^batch-size=.*/batch-size=${NUM_SENSORS}/;}" "$config_file"
     sed -i "/^\[primary-gie\]/,/^\[/{s/^batch-size=.*/batch-size=${NUM_SENSORS}/;}" "$config_file"
 
-    if [[ "${HARDWARE_PROFILE:-}" == "DGX-SPARK" || "${HARDWARE_PROFILE:-}" == "IGX-THOR" ]]; then
+    if [[ "${HARDWARE_PROFILE:-}" == "DGX-SPARK" ]] || is_thor_profile; then
         echo "##### Setting msg-conv-msg2p-lib to libnvds_msgconv.so for sink1 group... #####"
         sed -i '/^\[sink1\]/,/^\[/{/^msg-conv-msg2p-lib=/d;}' "$config_file"
         sed -i '/^\[sink1\]/a msg-conv-msg2p-lib=/opt/nvidia/deepstream/deepstream/lib/libnvds_msgconv.so' "$config_file"
@@ -415,7 +424,7 @@ start_rtdetr_gdino()
 
     TRACKER_CONFIG="/opt/nvidia/deepstream/deepstream/samples/configs/deepstream-app/config_tracker_NvDCF_accuracy.yml"
 
-    if [[ "${HARDWARE_PROFILE:-}" == "IGX-THOR" ]]; then
+    if is_thor_profile; then
         echo "##### Setting compute-hw=2 in tracker section of $config_file... #####"
         sed -i '/^\[tracker\]/,/^\[/{/^compute-hw=/d;}' "$config_file"
         sed -i '/^\[tracker\]/a compute-hw=2' "$config_file"


### PR DESCRIPTION
The DeepStream entrypoint gated its Thor-specific tuning on the literal
HARDWARE_PROFILE=IGX-THOR, so AGX-THOR, DGX-THOR and any future Thor board
silently fell through to the discrete-GPU path: libnvds_msgconv_mega2d.so
on [sink1], no [tracker] compute-hw=2, no [source-list] low-latency-mode=0,
and no VPI visual-tracker settings in config_tracker_NvDCF_accuracy.yml.

Add is_thor_profile() — a case-insensitive *thor* match on HARDWARE_PROFILE,
mirroring how dev-profile.sh canonicalizes AGX-THOR/IGX-THOR to THOR — and
use it for both gates in start_rtdetr_gdino(). All Thor boards now take the
exact path IGX-THOR took, and a new board name needs no further change.

DGX-SPARK keeps libnvds_msgconv.so without picking up the Thor tracker block;
non-Thor profiles (H100, L40S, RTXPRO6000BW, OTHER, unset) are unchanged.
Applied identically to the Compose and Helm copies of ds-start.sh.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
