### PR TITLE
fix(rtvi): sync RT-Embed codec installer

### DIFF
--- a/services/rtvi/rt-embed/src/scripts/install_codecs_nonroot.sh
+++ b/services/rtvi/rt-embed/src/scripts/install_codecs_nonroot.sh
@@ -26,6 +26,10 @@ INSTALL_DIR=${CODEC_INSTALL_DIR:-/opt/nvidia/rtvi/codecs}
 DEBS_DIR=$(mktemp -d /tmp/rtvi_codec_debs_XXXXXX)
 APT_DIR="$DEBS_DIR/apt"
 SOURCES_LIST="$APT_DIR/sources.list"
+PYTHON_CODEC_DIR="$INSTALL_DIR/python"
+PYNVVIDEO_CODEC_VERSION="${PYNVVIDEO_CODEC_VERSION:-2.1.0}"
+PYAV_VERSION="${PYAV_VERSION:-16.0.1}"
+OPENCV_PYTHON_HEADLESS_VERSION="${OPENCV_PYTHON_HEADLESS_VERSION:-4.13.0.92}"
 
 cleanup() {
     rm -rf "$DEBS_DIR"
@@ -74,6 +78,7 @@ PACKAGES=(
     # FFmpeg and GStreamer
     ffmpeg
     libavcodec60
+    libavdevice60
     libavfilter9
     libavformat60
     libavutil58
@@ -219,6 +224,22 @@ for deb in "${DEBS[@]}"; do
     fi
 done
 
+echo "Installing PyNvVideoCodec ${PYNVVIDEO_CODEC_VERSION}, PyAV ${PYAV_VERSION}," \
+    "and OpenCV headless ${OPENCV_PYTHON_HEADLESS_VERSION} into the codec overlay..."
+if ! python3 -m pip install \
+    --disable-pip-version-check \
+    --no-cache-dir \
+    --no-deps \
+    --only-binary=:all: \
+    --upgrade \
+    --target "$PYTHON_CODEC_DIR" \
+    "PyNvVideoCodec==${PYNVVIDEO_CODEC_VERSION}" \
+    "av==${PYAV_VERSION}" \
+    "opencv-python-headless==${OPENCV_PYTHON_HEADLESS_VERSION}"; then
+    echo "ERROR: Failed to install codec Python packages" >&2
+    exit 1
+fi
+
 [ -f "$LIB_DIR/blas/libblas.so.3" ] &&
     ln -sf "$LIB_DIR/blas/libblas.so.3" "$LIB_DIR/libblas.so.3"
 [ -f "$LIB_DIR/lapack/liblapack.so.3" ] &&
@@ -238,7 +259,8 @@ rm -rf ~/.cache/gstreamer-1.0/
 
 cat > "$INSTALL_DIR/codec_env.sh" <<EOF
 export GST_PLUGIN_PATH=${GST_PLUGIN_DIR}\${GST_PLUGIN_PATH:+:\$GST_PLUGIN_PATH}
-export LD_LIBRARY_PATH=${LIB_DIR}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
+export PYTHONPATH=${PYTHON_CODEC_DIR}\${PYTHONPATH:+:\$PYTHONPATH}
+export LD_LIBRARY_PATH=${PYTHON_CODEC_DIR}/PyNvVideoCodec:${LIB_DIR}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
 export PATH=${INSTALL_DIR}/usr/bin\${PATH:+:\$PATH}
 EOF
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
