### PR TITLE
Bump Redis to 8.10.0-alpine for infra and related consumers.

### DIFF
--- a/deploy/LICENSE-3rd-party.txt
+++ b/deploy/LICENSE-3rd-party.txt
@@ -255,8 +255,8 @@ running developer profiles via scripts/dev-profile.sh or docker compose).
     See: https://www.apache.org/licenses/LICENSE-2.0
 
 
-21. redis:8.6.2-alpine
-    Image: redis:8.6.2-alpine
+21. redis:8.10.0-alpine
+    Image: redis:8.10.0-alpine
     License: Redis 8 is available under a tri-license: Redis Source Available
              License v2 (RSALv2), SSPL v1, or AGPL v3. See Redis licensing.
     Registry: https://hub.docker.com/_/redis

--- a/deploy/docker/services/infra/compose.yml
+++ b/deploy/docker/services/infra/compose.yml
@@ -235,7 +235,7 @@ services:
     command: "bash /usr/bin/create-kafka-topics.sh"  
 
   redis:
-    image: redis:8.6.2-alpine
+    image: redis:8.10.0-alpine
     profiles: ["redis"]
     restart: always
     command: redis-server /config/redis.conf

--- a/deploy/docker/test-scripts/compose-images.golden
+++ b/deploy/docker/test-scripts/compose-images.golden
@@ -24,7 +24,7 @@ deploy/docker/services/infra/compose.yml docker.elastic.co/kibana/kibana:9.4.4
 deploy/docker/services/infra/compose.yml docker.elastic.co/logstash/logstash:9.4.4
 deploy/docker/services/infra/compose.yml eclipse-mosquitto:2
 deploy/docker/services/infra/compose.yml elasticsearch
-deploy/docker/services/infra/compose.yml redis:8.6.2-alpine
+deploy/docker/services/infra/compose.yml redis:8.10.0-alpine
 deploy/docker/services/infra/compose.yml vss-kafka-topic-init
 deploy/docker/services/infra/haproxy/compose.yml docker.io/library/haproxy:3.4.2-alpine
 deploy/docker/services/infra/sdrc/docker-compose.yaml alpine:3.24.1

--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -60,7 +60,7 @@ global:
 # External access: set global.externalScheme / externalHost / externalPort in your values file (no separate externalAccess.baseUrl).
 
 # Verification stack enabled by default. Image repository/tag/replicas: charts/<name>/values.yaml (override when needed).
-# Redis is the shared StatefulSet from helm/services/infra (vanilla redis:8.2.2-alpine),
+# Redis is the shared StatefulSet from helm/services/infra (vanilla redis:8.10.0-alpine),
 # used by the CV / streamprocessing (sdrc) pipeline. Alert MS no longer uses Redis
 # (dedup/filter state is in-process; verdict protection + alert configs are in Elasticsearch).
 infra:

--- a/deploy/helm/services/infra/charts/redis/Chart.yaml
+++ b/deploy/helm/services/infra/charts/redis/Chart.yaml
@@ -18,4 +18,4 @@ name: redis
 description: Redis message broker for VST event routing
 type: application
 version: 3.2.0
-appVersion: "8.2.2"
+appVersion: "8.10.0"

--- a/deploy/helm/services/infra/charts/redis/values.yaml
+++ b/deploy/helm/services/infra/charts/redis/values.yaml
@@ -18,7 +18,7 @@ global: {}
 replicas: 1
 image:
   repository: docker.io/library/redis
-  tag: 8.6.2-alpine
+  tag: 8.10.0-alpine
   pullPolicy: IfNotPresent
 # Optional container command/args override (used by alerts profile to load Redis modules for JSON.SET support).
 command: []

--- a/deploy/helm/services/infra/values.yaml
+++ b/deploy/helm/services/infra/values.yaml
@@ -47,7 +47,7 @@ redis:
   replicas: 1
   image:
     repository: docker.io/library/redis
-    tag: 8.6.2-alpine
+    tag: 8.10.0-alpine
     pullPolicy: IfNotPresent
   port: 6379
   persistence:

--- a/services/analytics/behavior-analytics/tests/integration/docker_compose/infra/compose.yml
+++ b/services/analytics/behavior-analytics/tests/integration/docker_compose/infra/compose.yml
@@ -114,7 +114,7 @@ services:
     command: "bash /usr/bin/create-kafka-topics.sh"
 
   redis:
-    image: redis:8.6.2-alpine
+    image: redis:8.10.0-alpine
     profiles: ["redis"]
     restart: always
     command: redis-server /config/redis.conf

--- a/services/vios/deployment/stream-processing/docker-compose/compose.env
+++ b/services/vios/deployment/stream-processing/docker-compose/compose.env
@@ -53,7 +53,7 @@ SENSOR_MODULE_ENDPOINT=http://${HOST_IP}:${SENSOR_HTTP_PORT}
 ###################### Base Infrastructure Images ########################
 POSTGRES_IMAGE=postgres:17.10-alpine
 NGINX_IMAGE=nvcr.io/nvstaging/vss-core/vss-vios-ingress:2.1.0-26.07.1
-REDIS_IMAGE=redis:8.6.5-alpine
+REDIS_IMAGE=redis:8.10.0-alpine
 
 # Public-facing ingress URL. Same in both modes.
 VST_INGRESS_ENDPOINT=${HOST_IP}:30888/vst


### PR DESCRIPTION
Update the infra Redis service, helm pins, behavior-analytics test infra, VIOS compose env, LICENSE entry, and compose golden infra line. Leave SDRC wait-for-redis on 8.6.2-alpine.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
