### PR TITLE
Ensure PR trigger workflow considers the entire PR diff and not just …

### DIFF
--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from detect_changed_images import (
     changed_paths,
+    commit_exists,
     paths_changed_under,
     resolve_diff_base,
 )
@@ -30,6 +31,21 @@ SPATIALAI_DATA_UTILS_PATH = "libs/analytics/spatialai-data-utils"
 SPATIALAI_VERSION_SUFFIX_PATTERN = re.compile(
     r"\.dev[1-9][0-9]*\+g[0-9a-f]{12}\.r[1-9][0-9]*"
 )
+
+
+PR_REF_PATTERN = re.compile(r"pull-request/(\d+)")
+
+
+def pr_base_sha(api: GitHubApi, repository: str, ref_name: str) -> str | None:
+    """Return the PR base commit for a mirrored PR branch."""
+    match = PR_REF_PATTERN.fullmatch(ref_name)
+    if not match:
+        return None
+    payload = api.request("GET", f"/repos/{repository}/pulls/{match.group(1)}")
+    base = str(payload.get("base", {}).get("sha", ""))
+    if not re.fullmatch(r"[0-9a-f]{40}", base):
+        raise RuntimeError("PR metadata did not contain a valid base SHA")
+    return base
 
 
 def downstream_relevant(changed: list[str] | None, inventory: dict) -> tuple[bool, str]:
@@ -211,9 +227,19 @@ def main() -> int:
 
     has_builds = has_ghcr_build_entries(release_set)
 
-    base, base_reason = resolve_diff_base(
-        args.repo_root, "push", args.ref_name, args.before, "develop"
-    )
+    if PR_REF_PATTERN.fullmatch(args.ref_name):
+        try:
+            base = pr_base_sha(GitHubApi(token), args.repository, args.ref_name)
+            if not base or not commit_exists(args.repo_root, base):
+                raise RuntimeError("PR base commit is unavailable in this checkout")
+            base_reason = f"PR base from GitHub metadata: {base[:12]}"
+        except Exception as exc:
+            base = None
+            base_reason = f"PR base unavailable ({exc}); running downstream"
+    else:
+        base, base_reason = resolve_diff_base(
+            args.repo_root, "push", args.ref_name, args.before, "develop"
+        )
     changed = changed_paths(args.repo_root, base) if base else None
     relevant, gate_reason = downstream_relevant(
         changed, load_inventory(args.repo_root)

--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -36,16 +36,26 @@ SPATIALAI_VERSION_SUFFIX_PATTERN = re.compile(
 PR_REF_PATTERN = re.compile(r"pull-request/(\d+)")
 
 
-def pr_base_sha(api: GitHubApi, repository: str, ref_name: str) -> str | None:
-    """Return the PR base commit for a mirrored PR branch."""
+def pr_merge_base_sha(api: GitHubApi, repository: str, ref_name: str) -> str | None:
+    """Return the merge base for a mirrored PR branch.
+
+    A pull request API response exposes the target branch tip as ``base.sha``.
+    The compare API supplies the actual common ancestor, which is the only
+    correct starting point for a complete PR diff.
+    """
     match = PR_REF_PATTERN.fullmatch(ref_name)
     if not match:
         return None
-    payload = api.request("GET", f"/repos/{repository}/pulls/{match.group(1)}")
-    base = str(payload.get("base", {}).get("sha", ""))
-    if not re.fullmatch(r"[0-9a-f]{40}", base):
-        raise RuntimeError("PR metadata did not contain a valid base SHA")
-    return base
+    pull = api.request("GET", f"/repos/{repository}/pulls/{match.group(1)}")
+    target = str(pull.get("base", {}).get("sha", ""))
+    head = str(pull.get("head", {}).get("sha", ""))
+    if not all(re.fullmatch(r"[0-9a-f]{40}", sha) for sha in (target, head)):
+        raise RuntimeError("PR metadata did not contain valid base and head SHAs")
+    compare = api.request("GET", f"/repos/{repository}/compare/{target}...{head}")
+    merge_base = str(compare.get("merge_base_commit", {}).get("sha", ""))
+    if not re.fullmatch(r"[0-9a-f]{40}", merge_base):
+        raise RuntimeError("PR comparison did not contain a valid merge-base SHA")
+    return merge_base
 
 
 def downstream_relevant(changed: list[str] | None, inventory: dict) -> tuple[bool, str]:
@@ -229,10 +239,10 @@ def main() -> int:
 
     if PR_REF_PATTERN.fullmatch(args.ref_name):
         try:
-            base = pr_base_sha(GitHubApi(token), args.repository, args.ref_name)
+            base = pr_merge_base_sha(GitHubApi(token), args.repository, args.ref_name)
             if not base or not commit_exists(args.repo_root, base):
                 raise RuntimeError("PR base commit is unavailable in this checkout")
-            base_reason = f"PR base from GitHub metadata: {base[:12]}"
+            base_reason = f"PR merge base from GitHub metadata: {base[:12]}"
         except Exception as exc:
             base = None
             base_reason = f"PR base unavailable ({exc}); running downstream"

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -19,6 +19,7 @@ from prepare_downstream_release_set import (  # noqa: E402
     candidate_container_tag,
     downstream_relevant,
     downstream_variables,
+    pr_base_sha,
     spatialai_publish_variables,
 )
 
@@ -61,6 +62,25 @@ class GhcrBuildEntriesTest(unittest.TestCase):
                 }
             )
         )
+
+
+class PrBaseShaTest(unittest.TestCase):
+    def test_uses_github_pr_base_for_mirrored_pr_ref(self):
+        api = mock.Mock()
+        api.request.return_value = {"base": {"sha": "a" * 40}}
+        self.assertEqual(
+            pr_base_sha(api, "NVIDIA-AI-Blueprints/vss", "pull-request/1601"),
+            "a" * 40,
+        )
+        api.request.assert_called_once_with(
+            "GET", "/repos/NVIDIA-AI-Blueprints/vss/pulls/1601"
+        )
+
+    def test_invalid_pr_base_fails_open_at_the_caller(self):
+        api = mock.Mock()
+        api.request.return_value = {"base": {"sha": "invalid"}}
+        with self.assertRaisesRegex(RuntimeError, "valid base SHA"):
+            pr_base_sha(api, "owner/repo", "pull-request/1")
 
 
 class DownstreamVariablesTest(unittest.TestCase):

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -19,7 +19,7 @@ from prepare_downstream_release_set import (  # noqa: E402
     candidate_container_tag,
     downstream_relevant,
     downstream_variables,
-    pr_base_sha,
+    pr_merge_base_sha,
     spatialai_publish_variables,
 )
 
@@ -64,23 +64,33 @@ class GhcrBuildEntriesTest(unittest.TestCase):
         )
 
 
-class PrBaseShaTest(unittest.TestCase):
-    def test_uses_github_pr_base_for_mirrored_pr_ref(self):
+class PrMergeBaseShaTest(unittest.TestCase):
+    def test_uses_compare_merge_base_not_target_tip(self):
+        target = "b" * 40
+        head = "c" * 40
+        merge_base = "a" * 40
         api = mock.Mock()
-        api.request.return_value = {"base": {"sha": "a" * 40}}
+        api.request.side_effect = [
+            {"base": {"sha": target}, "head": {"sha": head}},
+            {"merge_base_commit": {"sha": merge_base}},
+        ]
         self.assertEqual(
-            pr_base_sha(api, "NVIDIA-AI-Blueprints/vss", "pull-request/1601"),
-            "a" * 40,
+            pr_merge_base_sha(api, "NVIDIA-AI-Blueprints/vss", "pull-request/1601"),
+            merge_base,
         )
-        api.request.assert_called_once_with(
-            "GET", "/repos/NVIDIA-AI-Blueprints/vss/pulls/1601"
+        self.assertEqual(
+            api.request.call_args_list,
+            [
+                mock.call("GET", "/repos/NVIDIA-AI-Blueprints/vss/pulls/1601"),
+                mock.call("GET", f"/repos/NVIDIA-AI-Blueprints/vss/compare/{target}...{head}"),
+            ],
         )
 
-    def test_invalid_pr_base_fails_open_at_the_caller(self):
+    def test_invalid_pr_metadata_fails_open_at_the_caller(self):
         api = mock.Mock()
         api.request.return_value = {"base": {"sha": "invalid"}}
-        with self.assertRaisesRegex(RuntimeError, "valid base SHA"):
-            pr_base_sha(api, "owner/repo", "pull-request/1")
+        with self.assertRaisesRegex(RuntimeError, "valid base and head SHAs"):
+            pr_merge_base_sha(api, "owner/repo", "pull-request/1")
 
 
 class DownstreamVariablesTest(unittest.TestCase):


### PR DESCRIPTION
## Description

Fixes the downstream acceptance gate for mirrored PR branches.

Previously, the gate could evaluate only the latest `pull-request/<N>` mirror update. A final fix-up commit that touched no watched source or `deploy/` paths could therefore skip downstream validation, even when earlier commits in the same PR changed deploy configuration or downstream-relevant sources.

This change resolves the PR base SHA from GitHub metadata and diffs that base against `HEAD`, so the gate evaluates the complete PR delta.

## Behavior

- Mirrored PR refs (`pull-request/<N>`) use the PR base SHA from GitHub.
- If PR metadata or the base commit cannot be resolved, the gate fails open and runs downstream rather than silently skipping it.
- Regular push behavior remains unchanged.

## Validation

- `python3 .github/scripts/test_prepare_downstream_release_set.py`
  - 22 tests passed
- Added regression coverage for PR base SHA lookup and invalid base metadata.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
