### PR TITLE
Upgrade the VIOS Redis to 8.10.0-alpine

### DIFF
--- a/services/vios/deployment/stream-processing/docker-compose/compose.env
+++ b/services/vios/deployment/stream-processing/docker-compose/compose.env
@@ -53,7 +53,7 @@ SENSOR_MODULE_ENDPOINT=http://${HOST_IP}:${SENSOR_HTTP_PORT}
 ###################### Base Infrastructure Images ########################
 POSTGRES_IMAGE=postgres:17.10-alpine
 NGINX_IMAGE=nvcr.io/nvstaging/vss-core/vss-vios-ingress:2.1.0-26.07.1
-REDIS_IMAGE=redis:8.6.5-alpine
+REDIS_IMAGE=redis:8.10.0-alpine
 
 # Public-facing ingress URL. Same in both modes.
 VST_INGRESS_ENDPOINT=${HOST_IP}:30888/vst


### PR DESCRIPTION
## Description
- Upgrades the VIOS Redis pin from `8.6.5-alpine` to `8.10.0-alpine`.
- VIOS deploys its own `redis-server` (`docker-compose.yaml:184`), so this pin is live. Tag verified to exist on Docker Hub before pinning.
- **Scope is limited to `services/vios`.** Redis is pinned in ten other places owned by other teams — the shared VSS StatefulSet, SDRC, the helm charts, analytics integration tests, `compose-images.golden` and `LICENSE-3rd-party.txt` — all on `8.6.2-alpine`. Changing those from here would touch the Broker/SDRC teams' deployments without sign-off, and `compose-images.golden` asserts the exact image list, so a partial edit fails CI.

### Known divergence
VIOS and the shared infra now differ (`8.10.0` vs `8.6.2`). They already differed before this change (`8.6.5` vs `8.6.2`). Reconciling them needs a decision across the owning teams and belongs in its own PR — happy to raise it, the full edit list is 10 files.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.