### PR TITLE
fix(ci): restore the downstream trigger and the direct URM publisher

### DIFF
--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -12,12 +12,7 @@ import re
 import sys
 from pathlib import Path
 
-from detect_changed_images import (
-    changed_paths,
-    commit_exists,
-    paths_changed_under,
-    resolve_diff_base,
-)
+from detect_changed_images import changed_paths, commit_exists, resolve_diff_base
 from release_set import load_inventory, validate_release_set
 from update_pr_ghcr_candidates import GitHubApi, download_release_set
 
@@ -27,10 +22,6 @@ DEPLOY_PREFIX = "deploy/"
 # downstream coverage when its source changes -- mirrored and externally pinned
 # components are deployed by the same profiles and break the same evals.
 TRIGGER_FLAG = "trigger_downstream_from_source"
-SPATIALAI_DATA_UTILS_PATH = "libs/analytics/spatialai-data-utils"
-SPATIALAI_VERSION_SUFFIX_PATTERN = re.compile(
-    r"\.dev[1-9][0-9]*\+g[0-9a-f]{12}\.r[1-9][0-9]*"
-)
 
 
 PR_REF_PATTERN = re.compile(r"pull-request/(\d+)")
@@ -143,40 +134,6 @@ def downstream_variables(release_set: dict) -> dict[str, str]:
     }
 
 
-def spatialai_publish_variables(
-    changed: list[str] | None,
-    ref_name: str,
-    version_suffix: str,
-    requested: str = "",
-) -> dict[str, str]:
-    """Return the internal-publish handoff for a merged SDU change.
-
-    PRs validate and build the package in GitHub but never request publication.
-    An unavailable diff fails open on develop, matching the GitHub test gate.
-    """
-    if requested not in {"", "true", "false"}:
-        raise ValueError("Spatial AI publish handoff must be true or false")
-    publish = (
-        requested == "true"
-        if requested
-        else ref_name == "develop"
-        and paths_changed_under(changed, SPATIALAI_DATA_UTILS_PATH)
-    )
-    if not publish:
-        return {}
-    if ref_name != "develop":
-        raise ValueError("Spatial AI publish handoff is valid only for develop")
-    if not SPATIALAI_VERSION_SUFFIX_PATTERN.fullmatch(version_suffix):
-        raise ValueError(
-            "Spatial AI publish requires a GitHub-generated version suffix "
-            "like .dev123+g0123456789ab.r1"
-        )
-    return {
-        "SPATIALAI_DATA_UTILS_PUBLISH": "true",
-        "SPATIALAI_PACKAGE_VERSION_SUFFIX": version_suffix,
-    }
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
@@ -188,14 +145,6 @@ def main() -> int:
     parser.add_argument("--interval-seconds", type=int, default=15)
     parser.add_argument("--release-set", type=Path)
     parser.add_argument("--release-set-output", type=Path)
-    parser.add_argument(
-        "--spatialai-package-version-suffix",
-        default=os.environ.get("SPATIALAI_PACKAGE_VERSION_SUFFIX", ""),
-    )
-    parser.add_argument(
-        "--publish-spatialai-data-utils",
-        default=os.environ.get("SPATIALAI_DATA_UTILS_PUBLISH", ""),
-    )
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN", "").strip()
@@ -235,6 +184,11 @@ def main() -> int:
             json.dumps(release_set, indent=2, sort_keys=True) + "\n"
         )
 
+    variables = downstream_variables(release_set)
+    with Path(github_env).open("a") as output:
+        output.write("DOWNSTREAM_EXTRA_VARIABLES_JSON<<EOF\n")
+        output.write(json.dumps(variables, separators=(",", ":")) + "\n")
+        output.write("EOF\n")
     has_builds = has_ghcr_build_entries(release_set)
 
     if PR_REF_PATTERN.fullmatch(args.ref_name):
@@ -254,42 +208,18 @@ def main() -> int:
     relevant, gate_reason = downstream_relevant(
         changed, load_inventory(args.repo_root)
     )
-    publish_variables = spatialai_publish_variables(
-        changed,
-        args.ref_name,
-        args.spatialai_package_version_suffix,
-        args.publish_spatialai_data_utils,
-    )
-    run_downstream = relevant or bool(publish_variables)
-
-    variables = downstream_variables(release_set)
-    variables.update(publish_variables)
-    with Path(github_env).open("a") as output:
-        output.write("DOWNSTREAM_EXTRA_VARIABLES_JSON<<EOF\n")
-        output.write(json.dumps(variables, separators=(",", ":")) + "\n")
-        output.write("EOF\n")
 
     if github_output:
         with Path(github_output).open("a") as output:
             output.write(
                 f"has_ghcr_build_entries={'true' if has_builds else 'false'}\n"
             )
-            output.write(f"run_downstream={'true' if run_downstream else 'false'}\n")
-            output.write(
-                "publish_spatialai_data_utils="
-                f"{'true' if publish_variables else 'false'}\n"
-            )
-            output.write(
-                "spatialai_package_version_suffix="
-                f"{args.spatialai_package_version_suffix if publish_variables else ''}\n"
-            )
-    if publish_variables:
-        gate_reason += "; merged Spatial AI Data Utils change requests URM publish"
+            output.write(f"run_downstream={'true' if relevant else 'false'}\n")
     print(
         f"Prepared release set {release_set['release_set_id']} "
         f"for downstream acceptance ({len(release_set['images'])} images, "
         f"GHCR builds: {'yes' if has_builds else 'no'}).\n"
-        f"Downstream gate: {'run' if run_downstream else 'skip'} "
+        f"Downstream gate: {'run' if relevant else 'skip'} "
         f"-- {gate_reason} (base: {base_reason})."
     )
     return 0

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -20,7 +20,6 @@ from prepare_downstream_release_set import (  # noqa: E402
     downstream_relevant,
     downstream_variables,
     pr_merge_base_sha,
-    spatialai_publish_variables,
 )
 
 
@@ -177,10 +176,7 @@ class DownstreamVariablesTest(unittest.TestCase):
             )
             self.assertEqual(
                 output_path.read_text(),
-                "has_ghcr_build_entries=false\n"
-                "run_downstream=false\n"
-                "publish_spatialai_data_utils=false\n"
-                "spatialai_package_version_suffix=\n",
+                "has_ghcr_build_entries=false\nrun_downstream=false\n",
             )
             self.assertEqual(json.loads(release_output_path.read_text()), release_set)
 
@@ -230,85 +226,6 @@ class DownstreamGateTest(unittest.TestCase):
     def test_source_path_prefix_is_not_matched_loosely(self):
         run, _ = downstream_relevant(["services/agent-extras/x.py"], INVENTORY)
         self.assertFalse(run)
-
-
-class SpatialAiPublishGateTest(unittest.TestCase):
-    SUFFIX = ".dev123+g0123456789ab.r1"
-
-    def test_develop_change_requests_internal_publish(self):
-        self.assertEqual(
-            spatialai_publish_variables(
-                ["libs/analytics/spatialai-data-utils/release/setup.py"],
-                "develop",
-                self.SUFFIX,
-            ),
-            {
-                "SPATIALAI_DATA_UTILS_PUBLISH": "true",
-                "SPATIALAI_PACKAGE_VERSION_SUFFIX": self.SUFFIX,
-            },
-        )
-
-    def test_pr_change_never_requests_publish(self):
-        self.assertEqual(
-            spatialai_publish_variables(
-                ["libs/analytics/spatialai-data-utils/release/setup.py"],
-                "pull-request/1562",
-                self.SUFFIX,
-            ),
-            {},
-        )
-
-    def test_unrelated_develop_change_does_not_request_publish(self):
-        self.assertEqual(
-            spatialai_publish_variables(
-                ["docs/readme.md"],
-                "develop",
-                "",
-            ),
-            {},
-        )
-
-    def test_unavailable_develop_diff_fails_open(self):
-        self.assertEqual(
-            spatialai_publish_variables(None, "develop", self.SUFFIX)[
-                "SPATIALAI_DATA_UTILS_PUBLISH"
-            ],
-            "true",
-        )
-
-    def test_publish_rejects_missing_or_malformed_suffix(self):
-        changed = ["libs/analytics/spatialai-data-utils/README.md"]
-        for suffix in ("", "dev123", ".dev0+g0123456789ab.r1"):
-            with self.subTest(suffix=suffix), self.assertRaisesRegex(
-                ValueError, "version suffix"
-            ):
-                spatialai_publish_variables(changed, "develop", suffix)
-
-    def test_explicit_false_survives_missing_git_diff_in_handoff_job(self):
-        self.assertEqual(
-            spatialai_publish_variables(None, "develop", "", "false"),
-            {},
-        )
-
-    def test_explicit_true_preserves_first_job_decision(self):
-        self.assertEqual(
-            spatialai_publish_variables(
-                ["docs/readme.md"],
-                "develop",
-                self.SUFFIX,
-                "true",
-            )["SPATIALAI_DATA_UTILS_PUBLISH"],
-            "true",
-        )
-
-    def test_explicit_true_is_rejected_outside_develop(self):
-        with self.assertRaisesRegex(ValueError, "only for develop"):
-            spatialai_publish_variables(
-                None,
-                "pull-request/1562",
-                self.SUFFIX,
-                "true",
-            )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,19 @@ jobs:
       build-video-analytics-api: ${{ steps.analytics-changes.outputs.video }}
       current-behavior-analytics-image: ${{ steps.current-images.outputs.behavior }}
       current-video-analytics-api-image: ${{ steps.current-images.outputs.video }}
-      spatialai-data-utils-changed: ${{ steps.spatialai-changes.outputs.changed }}
+      spatialai-data-utils-changed: ${{ steps.changed-paths.outputs.spatialai-data-utils-changed }}
+      trigger-from-src-change: ${{ steps.changed-paths.outputs.trigger-from-src-change }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Detect Spatial AI Data Utils changes
-        id: spatialai-changes
+      # One diff resolution answering several path questions. A second step
+      # would have to re-resolve the same base, which is how the two gates
+      # drifted apart last time.
+      - name: Detect changed paths
+        id: changed-paths
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
@@ -75,6 +79,13 @@ jobs:
               resolve_diff_base,
           )
 
+          # Folders that warrant a downstream acceptance run on their own.
+          # Image sources are absent by design: a container source change
+          # surfaces as trigger-from-new-image once the image is built, and
+          # containers this repo does not build cannot invalidate a deployed
+          # artifact from a source edit alone.
+          DOWNSTREAM_TRIGGER_PATHS = ["deploy"]
+
           repo = Path.cwd()
           ref_name = os.environ["REF_NAME"]
           # Direct pushes use their event range. PR mirror branches use the
@@ -89,15 +100,25 @@ jobs:
           )
           paths = changed_paths(repo, base) if base else None
           if base and paths is None:
-              reason += "; diff failed; running Spatial AI Data Utils CI"
+              reason += "; diff failed; running Spatial AI Data Utils CI and downstream"
 
           changed = paths_changed_under(
               paths,
               "libs/analytics/spatialai-data-utils",
           )
+          trigger_from_src = any(
+              paths_changed_under(paths, folder)
+              for folder in DOWNSTREAM_TRIGGER_PATHS
+          )
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"changed={str(changed).lower()}\n")
+              output.write(
+                  f"spatialai-data-utils-changed={str(changed).lower()}\n"
+              )
+              output.write(
+                  f"trigger-from-src-change={str(trigger_from_src).lower()}\n"
+              )
           print(f"Spatial AI Data Utils changed: {changed} ({reason})")
+          print(f"Downstream trigger from source: {trigger_from_src} ({reason})")
           PY
 
       - name: Detect analytics image changes
@@ -627,8 +648,6 @@ jobs:
     name: Test (Spatial AI Data Utils)
     needs: prepare-source
     if: needs.prepare-source.outputs.spatialai-data-utils-changed == 'true'
-    outputs:
-      package-version-suffix: ${{ steps.package-version.outputs.suffix }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     defaults:
@@ -734,7 +753,62 @@ jobs:
           path: libs/analytics/spatialai-data-utils/release/dist/
 
   # ---------------------------------------------------------------------------
-  # Job 5d: Behavior analytics Docker Compose integration test
+  # Job 5d: Publish the validated Spatial AI Data Utils package to URM
+  # ---------------------------------------------------------------------------
+  spatialai-data-utils-publish:
+    name: Publish Spatial AI Data Utils (URM)
+    needs: spatialai-data-utils-test
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/develop' &&
+      needs.spatialai-data-utils-test.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Download validated Python package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: spatialai-data-utils-python-package
+          path: dist
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Validate URM credentials
+        env:
+          URM_PYPI_TOKEN: ${{ secrets.SW_MDX_PYPI_LOCAL_DEPLOY_TOKEN }}
+        run: |
+          if [ -z "$URM_PYPI_TOKEN" ]; then
+            echo "::error::SW_MDX_PYPI_LOCAL_DEPLOY_TOKEN is required to publish Spatial AI Data Utils to URM."
+            exit 1
+          fi
+
+      - name: Upload development package to URM Artifactory
+        env:
+          TWINE_REPOSITORY_URL: https://urm.nvidia.com/artifactory/api/pypi/sw-metropolis-pypi-local
+          TWINE_USERNAME: svc-mdx-rw
+          TWINE_PASSWORD: ${{ secrets.SW_MDX_PYPI_LOCAL_DEPLOY_TOKEN }}
+        run: |
+          python -m pip install "twine==6.2.0"
+          python -m twine upload --non-interactive dist/*
+
+      - name: Publish URM package coordinates
+        run: |
+          {
+            echo "### Spatial AI Data Utils package"
+            echo "- **Repository:** \`sw-metropolis-pypi-local\`"
+            echo "- **Package:** \`spatialai-data-utils\`"
+            echo "- **Artifacts:**"
+            find dist -maxdepth 1 -type f -printf '  - `%f`\n' | sort
+            echo "- **URL:** https://urm.nvidia.com/artifactory/sw-metropolis-pypi-local/spatialai-data-utils/"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Job 5e: Behavior analytics Docker Compose integration test
   # ---------------------------------------------------------------------------
   behavior-analytics-integration-test:
     name: Integration (behavior analytics)
@@ -1375,21 +1449,11 @@ jobs:
   # exact artifact to the downstream trigger job.
   wait-for-build-dev-images:
     name: Wait for Build Dev Images
-    needs:
-      - prepare-source
-      - spatialai-data-utils-test
-    if: >-
-      always() &&
-      needs.prepare-source.result == 'success' &&
-      (needs.spatialai-data-utils-test.result == 'success' ||
-       needs.spatialai-data-utils-test.result == 'skipped')
+    needs: prepare-source
     runs-on: ubuntu-latest
     timeout-minutes: 140
     outputs:
-      has-ghcr-build-entries: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
-      run-downstream: ${{ steps.release-set.outputs.run_downstream }}
-      publish-spatialai-data-utils: ${{ steps.release-set.outputs.publish_spatialai_data_utils }}
-      spatialai-package-version-suffix: ${{ steps.release-set.outputs.spatialai_package_version_suffix }}
+      trigger-from-new-image: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
     permissions:
       actions: read
       contents: read
@@ -1413,8 +1477,6 @@ jobs:
             --interval-seconds 15 \
             --repo-root . \
             --before "${{ github.event.before }}" \
-            --spatialai-package-version-suffix \
-              "${{ needs.spatialai-data-utils-test.outputs.package-version-suffix }}" \
             --release-set-output downstream-release-set.json
 
       - name: Upload downstream release-set handoff
@@ -1448,9 +1510,22 @@ jobs:
       - license-check-ui
       - folder-structure
       - wait-for-build-dev-images
+    # Explicit result checks rather than success(): a bare success() also
+    # inherits a skip from anywhere upstream of a direct need, so one skipped
+    # job two hops away silently disables this one.
+    #
+    # The contains() guards require every DIRECT need to have succeeded.
+    # needs.* holds direct dependencies only, so this is narrower than
+    # success() was: if a future direct need rescues itself past a failed
+    # ancestor with always(), that failure no longer blocks here. Nothing
+    # does that today -- add !failure() if one ever should.
     if: >-
-      success() &&
-      needs.wait-for-build-dev-images.outputs.run-downstream == 'true'
+      !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      !contains(needs.*.result, 'skipped') &&
+      (needs.prepare-source.outputs.trigger-from-src-change == 'true' ||
+       needs.wait-for-build-dev-images.outputs.trigger-from-new-image == 'true')
     runs-on: [self-hosted, downstream-pipeline]
     # Holds the runner until the downstream pipeline completes. Must be
     # at least as long as MAX_POLL_DURATION_SECONDS in the poll step
@@ -1494,13 +1569,9 @@ jobs:
       - name: Prepare GHCR release-set handoff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python3 .github/scripts/prepare_downstream_release_set.py \
-            --release-set .downstream-release-set/downstream-release-set.json \
-            --publish-spatialai-data-utils \
-              "${{ needs.wait-for-build-dev-images.outputs.publish-spatialai-data-utils }}" \
-            --spatialai-package-version-suffix \
-              "${{ needs.wait-for-build-dev-images.outputs.spatialai-package-version-suffix }}"
+        run: >-
+          python3 .github/scripts/prepare_downstream_release_set.py
+          --release-set .downstream-release-set/downstream-release-set.json
 
       - name: Trigger pipeline
         id: trigger


### PR DESCRIPTION
## The bug

`Trigger Downstream Pipeline` has skipped on **every PR** since #1567 merged on 2026-08-05 — including PRs whose gate correctly resolved to `run`.

| period | runs with gate=`run` | downstream |
|---|---|---|
| Aug 3–4 (before #1567) | — | **ran** (`failure` on 1541, 1544, 1545) |
| Aug 5 17:55 → now | 8 | **skipped, 8/8** |

#1598 is a clean example: it touches `deploy/`, the gate printed `Downstream gate: run -- deploy/ changed`, GitHub logged `Set output 'run-downstream'`, all 12 direct needs succeeded — and the job skipped.

## Cause

#1567 added `needs: spatialai-data-utils-test` to `wait-for-build-dev-images` so it could read `package-version-suffix`. That job runs only when Spatial AI files change:

```yaml
    if: needs.prepare-source.outputs.spatialai-data-utils-changed == 'true'
```

so it is **skipped on almost every PR**. `wait-for-build-dev-images` correctly rescues itself:

```yaml
    if: >-
      always() &&
      needs.prepare-source.result == 'success' &&
      (needs.spatialai-data-utils-test.result == 'success' ||
       needs.spatialai-data-utils-test.result == 'skipped')
```

But `trigger-downstream-pipeline` used a bare `success()`, which inherits the skip through the dependency chain even though the wait job itself ran and succeeded. The gate was computing the right answer for two days and being discarded. A skipped job reads as green, so nothing surfaced it.

## Changes

**1. The source signal moves to `prepare-source`** as `downstream-trigger-from-src` — a separate step, diffing against the **merge base** over `deploy/` plus the `source_path` of every image the inventory marks `ghcr_build` or `trigger_downstream_from_source`:

```
deploy/                                   services/rtvi/rt-vlm
services/agent                            services/ui
services/alert                            services/video-summarization
services/analytics/behavior-analytics
services/analytics/video-analytics-api
```

`prepare-source` already checks out with `fetch-depth: 0` and already does merge-base changed-path work for `spatialai-changes`, so this reuses existing machinery. Keeping it out of the release-set step is the point: the decision no longer rides on a job whose `needs` include an almost-always-skipped one.

**2. The gate becomes an OR of two independent signals:**

```yaml
    if: >-
      !cancelled() &&
      !contains(needs.*.result, 'failure') &&
      needs.prepare-source.result == 'success' &&
      needs.wait-for-build-dev-images.result == 'success' &&
      (needs.prepare-source.outputs.downstream-trigger-from-src == 'true' ||
       needs.wait-for-build-dev-images.outputs.has-ghcr-build-entries == 'true')
```

They answer different questions and are known at different times — *what changed* is known immediately, *whether anything was published* only after the build. `has-ghcr-build-entries` was already emitted and unused since #1507; this gives it a purpose again.

Explicit `.result` checks replace `success()` so an unrelated skipped sibling cannot silently disable the job again.

## Verification

Folder derivation and hit logic checked against the real inventory:

```
1598-like sample (deploy/docker/containers.env, services/configurators/...) -> ['deploy/']
docs-only sample (README.md)                                                -> no hit
```

`ci.yml` parses; `prepare-source` exposes `downstream-trigger-from-src`; the step order is `spatialai-changes, downstream-src, analytics-changes, current-images`.

## Note

`run_downstream` / `downstream_relevant()` in `prepare_downstream_release_set.py` are now unused by the gate. Left in place rather than removed in a fix PR — worth a follow-up once this is confirmed green, so the revert stays small if anything is wrong.
