### PR TITLE
DEBUG: probe the downstream gate expression inputs (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1417,6 +1417,20 @@ jobs:
               "${{ needs.spatialai-data-utils-test.outputs.package-version-suffix }}" \
             --release-set-output downstream-release-set.json
 
+      # TEMPORARY probe -- do not merge. Shows the literal bytes the script wrote,
+      # which is what the gate comparison actually reads.
+      - name: Probe release-set step outputs
+        if: always()
+        env:
+          STEP_RUN_DOWNSTREAM: ${{ steps.release-set.outputs.run_downstream }}
+          STEP_HAS_BUILDS: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
+        run: |
+          printf 'steps.release-set.outputs.run_downstream ......: [%s]\n' "$STEP_RUN_DOWNSTREAM"
+          printf 'steps.release-set.outputs.has_ghcr_build_entries: [%s]\n' "$STEP_HAS_BUILDS"
+          printf '\n-- raw $GITHUB_OUTPUT --\n'
+          cat "$GITHUB_OUTPUT"
+          printf -- '-- end --\n'
+
       - name: Upload downstream release-set handoff
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
@@ -1450,22 +1464,33 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Values go through env, never interpolated into script text: toJSON is
+      # multi-line and would otherwise break out of the surrounding command.
       - name: Dump gate inputs
+        env:
+          RUN_DOWNSTREAM: ${{ needs.wait-for-build-dev-images.outputs.run-downstream }}
+          HAS_BUILDS: ${{ needs.wait-for-build-dev-images.outputs.has-ghcr-build-entries }}
+          WAIT_RESULT: ${{ needs.wait-for-build-dev-images.result }}
+          EQUALS_TRUE: ${{ needs.wait-for-build-dev-images.outputs.run-downstream == 'true' }}
+          WAIT_OUTPUTS: ${{ toJSON(needs.wait-for-build-dev-images.outputs) }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "run-downstream raw ......: '${{ needs.wait-for-build-dev-images.outputs.run-downstream }}'"
-          echo "has-ghcr-build-entries ..: '${{ needs.wait-for-build-dev-images.outputs.has-ghcr-build-entries }}'"
-          echo "== equality test =="
-          echo "== '${{ needs.wait-for-build-dev-images.outputs.run-downstream }}' == 'true' ? ${{ needs.wait-for-build-dev-images.outputs.run-downstream == 'true' }}"
-          echo "== success() ? ${{ success() }}"
-          echo "== wait result ? ${{ needs.wait-for-build-dev-images.result }}"
-          echo "== all outputs of wait job =="
-          cat <<'JSON'
-          ${{ toJSON(needs.wait-for-build-dev-images.outputs) }}
-          JSON
-          echo "== all needs results =="
-          cat <<'JSON'
-          ${{ toJSON(needs) }}
-          JSON
+          printf 'run-downstream ..........: [%s]\n' "$RUN_DOWNSTREAM"
+          printf 'has-ghcr-build-entries ..: [%s]\n' "$HAS_BUILDS"
+          printf 'wait job result .........: [%s]\n' "$WAIT_RESULT"
+          printf "== 'true' ? ............: [%s]\n" "$EQUALS_TRUE"
+          printf '\n-- wait job outputs --\n%s\n' "$WAIT_OUTPUTS"
+          printf '\n-- all needs --\n%s\n' "$NEEDS_JSON"
+
+      # success() is only legal in an `if:`, never inside `run:` -- that is what
+      # made GitHub reject this file outright on the first attempt.
+      - name: success() was true
+        if: success()
+        run: echo "success() == true"
+
+      - name: success() was false
+        if: '!success()'
+        run: echo "success() == false"
 
   trigger-downstream-pipeline:
     name: Trigger Downstream Pipeline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1428,6 +1428,45 @@ jobs:
   # ---------------------------------------------------------------------------
   # Job 13: Trigger downstream pipeline and poll it to completion
   # ---------------------------------------------------------------------------
+  # TEMPORARY probe -- do not merge. Prints exactly what the expression engine
+  # sees for the gate, to settle why trigger-downstream-pipeline skips while the
+  # release-set step reports "Downstream gate: run".
+  downstream-gate-probe:
+    name: Downstream Gate Probe
+    needs:
+      - prepare-source
+      - lint
+      - codec-installer-test
+      - typecheck
+      - security
+      - frontend-lint
+      - copyright-headers
+      - dco
+      - license-check-python
+      - license-check-ui
+      - folder-structure
+      - wait-for-build-dev-images
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dump gate inputs
+        run: |
+          echo "run-downstream raw ......: '${{ needs.wait-for-build-dev-images.outputs.run-downstream }}'"
+          echo "has-ghcr-build-entries ..: '${{ needs.wait-for-build-dev-images.outputs.has-ghcr-build-entries }}'"
+          echo "== equality test =="
+          echo "== '${{ needs.wait-for-build-dev-images.outputs.run-downstream }}' == 'true' ? ${{ needs.wait-for-build-dev-images.outputs.run-downstream == 'true' }}"
+          echo "== success() ? ${{ success() }}"
+          echo "== wait result ? ${{ needs.wait-for-build-dev-images.result }}"
+          echo "== all outputs of wait job =="
+          cat <<'JSON'
+          ${{ toJSON(needs.wait-for-build-dev-images.outputs) }}
+          JSON
+          echo "== all needs results =="
+          cat <<'JSON'
+          ${{ toJSON(needs) }}
+          JSON
+
   trigger-downstream-pipeline:
     name: Trigger Downstream Pipeline
     # Intentionally NOT depending on `test` (pytest) or `frontend-build`

--- a/deploy/docker/containers.env
+++ b/deploy/docker/containers.env
@@ -122,3 +122,5 @@ RTVI_EMBED_IMAGE="${RTVI_EMBED_IMAGE:-${VSS_CONTAINER_STAGING_REGISTRY}/vss-rt-e
 
 # NOTE: external-pin images (rtvi-cv, mv3dt bev-fusion, and sdr-mw-l) remain
 # independently controlled because they are outside the VSS release set.
+
+# probe: force the downstream gate to evaluate as run


### PR DESCRIPTION
**Temporary diagnostic — do not merge.**

`trigger-downstream-pipeline` has skipped on every PR since #1567 (2026-08-05), including runs where the release-set step prints `Downstream gate: run`. 8/8 such runs skipped; before #1567 the job ran.

Ruled out so far:
- **Not the dependency graph.** `wait-for-build-dev-images` never skips — 10/10 `success`. Its `always()` rescue works.
- **Not a failed sibling.** All 12 direct needs of the trigger job are `success`.
- **Not an empty output.** GitHub logs `Set output 'run-downstream'`.

Since `success()` should therefore be true, the remaining suspect is the value comparison `needs.wait-for-build-dev-images.outputs.run-downstream == 'true'`.

This job mirrors the trigger job's `needs` exactly but runs under `always()`, and prints the literal strings the expression engine sees — the raw value, the equality result, `success()`, and `toJSON` of the wait job outputs and the full `needs` context. `containers.env` is touched so the gate resolves to `run`.

Fix PR: #1614 (works regardless of mechanism, but its description asserts a cause I could not defend and needs correcting once this lands).