### PR TITLE
chore(codeowners): require maintainer review for .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,13 @@
 /skills/                @NVIDIA-AI-Blueprints/VSS-Skill-Developers
 /services/agent/        @NVIDIA-AI-Blueprints/VSS-Agent-Developers
 
+# CI, workflows, and repository automation.
+# A workflow edit can silently disable a gate for every PR in the repo
+# without failing anything, so these need maintainer review rather than the
+# default `*` owner. Last-match-wins means this REPLACES VSS-developers for
+# .github rather than adding to it.
+/.github/               @NVIDIA-AI-Blueprints/vss-maintainers
+
 # Lockfiles and 3rd-party license inventory.
 # Resolved-dependency state is the authoritative record of which packages
 # (and which licenses) ship in VSS, so OSRB must approve any change.


### PR DESCRIPTION
## Why

A workflow edit can silently disable a gate for every PR in the repo without failing anything.

#1567 added `needs: spatialai-data-utils-test` to `wait-for-build-dev-images`. That job is skipped on almost every PR, so `trigger-downstream-pipeline`'s bare `success()` inherited the skip. **No PR got a downstream acceptance run for three days, and nothing turned red** — a skipped job reads as green. The same commit also stopped Spatial AI Data Utils publishing to URM. Fix in #1614.

Reviewing that as ordinary code is what let it through. `.github` currently has no specific owner and falls to the catch-all `*` → `VSS-developers`.

## Change

```
/.github/               @NVIDIA-AI-Blueprints/vss-maintainers
```

Placed **before** the OSRB block, matching the existing `/skills/` and `/services/agent/` pattern, so dependency files under `.github` still route to `VSS_OSRB_Approvers`. Resolution check:

| path | owner | matched rule |
|---|---|---|
| `.github/workflows/ci.yml` | `vss-maintainers` | `/.github/` |
| `.github/CODEOWNERS` | `vss-maintainers` | `/.github/` |
| `.github/scripts/requirements.txt` | `VSS_OSRB_Approvers` | `requirements*.txt` |
| `.github/actions/x/Dockerfile` | `VSS_OSRB_Approvers` | `Dockerfile` |
| `services/agent/src/x.py` | `VSS-Agent-Developers` | `/services/agent/` |
| `uv.lock` | `VSS_OSRB_Approvers` | `uv.lock` |

No path outside `.github` changes owner.

## Two things worth knowing

CODEOWNERS is **last-match-wins and not additive** — this *replaces* `VSS-developers` as the owner of `.github` rather than adding to it. That is the intent here, but it is worth stating because two separate lines for the same path would not combine.

CODEOWNERS alone **enforces nothing**. The target branch also needs *Require review from Code Owners* (classic branch protection), or a ruleset with *Require a pull request before merging*. That is repo configuration, not visible in this diff — worth confirming it is on for `develop`.