### PR TITLE
debug(skill-eval): record (machine, run, leg) triple per leg

### DIFF
--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -1205,13 +1205,16 @@ def record_machine(
 
     Never raises: a debug signal must not fail the leg.
     """
-    try:
-        print(
-            f"[run-leg] machine: {instance} leg={leg_slug} run={run_id}",
-            flush=True,
-        )
-    except Exception:  # noqa: BLE001
-        pass
+    def _say(msg: str) -> None:
+        # Even the diagnostics must not raise: a broken or unencodable stdout
+        # (e.g. the outer agent closed the pipe) would otherwise propagate out
+        # of a sink's except block and fail the leg.
+        try:
+            print(msg, flush=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+    _say(f"[run-leg] machine: {instance} leg={leg_slug} run={run_id}")
     # Broad excepts + explicit utf-8: a non-UTF-8 runner locale would otherwise
     # raise UnicodeEncodeError (not an OSError) and fail the leg. Nothing here
     # may propagate.
@@ -1220,7 +1223,7 @@ def record_machine(
             f"{instance}\t{leg_slug}\t{run_id}\n", encoding="utf-8"
         )
     except Exception as exc:  # noqa: BLE001
-        print(f"[run-leg] machine.txt write failed: {exc!r}", flush=True)
+        _say(f"[run-leg] machine.txt write failed: {exc!r}")
     summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary:
         try:
@@ -1229,7 +1232,7 @@ def record_machine(
                     f"- leg `{leg_slug}` -> **{instance}** (run {run_id})\n"
                 )
         except Exception as exc:  # noqa: BLE001
-            print(f"[run-leg] step-summary write failed: {exc!r}", flush=True)
+            _say(f"[run-leg] step-summary write failed: {exc!r}")
 
 
 def run_invocations(

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -1185,6 +1185,53 @@ def write_skip_markers(
         print(f"[run-leg] wrote skip marker: {marker}", flush=True)
 
 
+def record_machine(
+    results_root: Path, instance: str, leg_slug: str, run_id: str
+) -> None:
+    """Persist the (machine, run, leg) triple the moment the box is claimed.
+
+    This is the only point in the pipeline where all three coexist, and
+    ``run_leg.py`` runs as a Bash *tool call* inside the outer agent session —
+    so its stdout is swallowed by the SDK and never reaches the CI job log.
+    Absent this, the box a leg ran on is unrecoverable after the run
+    (``BREV_INSTANCE`` lives only in the Harbor child's env; ``result.json``,
+    the saved trajectory, and the results artifact all omit it).
+
+    Two best-effort writes, independent of stdout capture:
+      * ``results_root/machine.txt`` — tarred into the per-leg results artifact
+        (run/slug-keyed), and dashboard-ingestible.
+      * ``$GITHUB_STEP_SUMMARY`` — surfaces in the Actions run UI + API, with
+        far longer retention than the 7-day artifact.
+
+    Never raises: a debug signal must not fail the leg.
+    """
+    try:
+        print(
+            f"[run-leg] machine: {instance} leg={leg_slug} run={run_id}",
+            flush=True,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+    # Broad excepts + explicit utf-8: a non-UTF-8 runner locale would otherwise
+    # raise UnicodeEncodeError (not an OSError) and fail the leg. Nothing here
+    # may propagate.
+    try:
+        (results_root / "machine.txt").write_text(
+            f"{instance}\t{leg_slug}\t{run_id}\n", encoding="utf-8"
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[run-leg] machine.txt write failed: {exc!r}", flush=True)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        try:
+            with open(summary, "a", encoding="utf-8") as handle:
+                handle.write(
+                    f"- leg `{leg_slug}` -> **{instance}** (run {run_id})\n"
+                )
+        except Exception as exc:  # noqa: BLE001
+            print(f"[run-leg] step-summary write failed: {exc!r}", flush=True)
+
+
 def run_invocations(
     invocations: list[HarborInvocation],
     instance: str,
@@ -1231,6 +1278,10 @@ def run_invocations(
     # the env vars are the authoritative source when the agent exports them.
     leg_slug = os.environ.get("EVAL_SLUG") or results_root.parent.name
     run_id = os.environ.get("GITHUB_RUN_ID") or results_root.name
+    # Record which box this leg locked BEFORE the first Harbor invocation, so a
+    # leg that dies inside BrevEnvironment.start() (e.g. a disk-full box) still
+    # leaves a trail pointing at the machine to inspect.
+    record_machine(results_root, instance, leg_slug, run_id)
     skipped_after: dict[str, int] = {}
     overall_rc = 0
 


### PR DESCRIPTION
## Why

`run_leg.py` runs as a **Bash tool call inside the outer `skills_eval_agent.py` session**, so its stdout is a tool result the SDK summarizes — it never reaches the GitHub job log. As a result, **the brev box a leg locked is unrecoverable after the run**: `BREV_INSTANCE` lives only in the Harbor child's env, and `result.json` / the saved trajectory / the results artifact all omit it. Today, correlating a failed job (e.g. a disk-full box) to the physical machine requires reading `/proc/<pid>/environ` of a *still-running* leg — impossible post-hoc.

## What

New `record_machine(results_root, instance, leg_slug, run_id)` persists the `(machine, run, leg)` triple the moment the box is claimed. Two best-effort, utf-8, **never-raising** sinks:

- `results_root/machine.txt` — rides the run/slug-keyed results artifact (only `agent/` dirs are excluded from the tarball).
- `$GITHUB_STEP_SUMMARY` — surfaces in the Actions run UI + API (longer retention than the 7-day artifact).

Called in `run_invocations` **before the first Harbor invocation**, so a leg that dies inside `BrevEnvironment.start()` (e.g. a disk-full box) still records which box to inspect.

## Impact

Additive/debug-only. No change to fleet selection, locking, Harbor invocation, timing, or return codes. All write paths are caught (explicit `encoding="utf-8"` + broad `except`) so the signal can never fail a leg — verified against a non-writable `$GITHUB_STEP_SUMMARY`.

## Note

For a leg that dies **before any `result.json`** (the disk-full-in-`start()` case), the Collect-results step skips the tarball (it gates on `result.json` existing), so `machine.txt` won't be in the artifact — but the box is still captured via `$GITHUB_STEP_SUMMARY` and the on-disk file. Widening that gate is a separate `skills-eval-daily.yml` change, intentionally not included here.