### PR TITLE
Move smartcities services to docker bridge networking

### DIFF
--- a/deploy/docker/industry-profiles/smartcities/compose.yml
+++ b/deploy/docker/industry-profiles/smartcities/compose.yml
@@ -31,8 +31,13 @@ services:
       file: ${VSS_APPS_DIR}/services/vios/nvstreamer/compose.yml
       service: nvstreamer-base
     profiles: ["nvstreamer-alerts"]
-    network_mode: "host"
+    ports:
+      - ${NVSTREAMER_HTTP_HOST_PORT:-31000}:${NVSTREAMER_HTTP_PORT:-31000}
     container_name: vss-vios-nvstreamer
+    networks:
+      default:
+        aliases:
+          - vss-vios-nvstreamer
     volumes:
       - $VSS_APPS_DIR/developer-profiles/dev-profile-alerts/nvstreamer/configs/vst-config.json:/home/vst/vst_release/configs/vst_config.json
       - $VSS_APPS_DIR/developer-profiles/dev-profile-alerts/nvstreamer/configs/notification-config.json:/home/vst/vst_release/configs/notification_config.json
@@ -95,7 +100,6 @@ services:
     build:
       context: $VSS_APPS_DIR/developer-profiles/dev-profile-alerts
       dockerfile: $VSS_APPS_DIR/developer-profiles/dev-profile-alerts/Dockerfiles/kibana-dashboard.Dockerfile
-    network_mode: "host"
     profiles: ["kibana-init-container-alerts"]
     container_name: vss-kibana-init
     command: bash /opt/mdx/init-scripts/kibana-import-dashboard.sh
@@ -109,6 +113,10 @@ services:
       service: vss-video-analytics-api
     profiles: ["vss-video-analytics-api-alerts"]
     container_name: vss-video-analytics-api
+    networks:
+      default:
+        aliases:
+          - vss-video-analytics-api
     volumes:
       - $VSS_APPS_DIR/developer-profiles/dev-profile-alerts/smc-app/vss-video-analytics-api:/opt/mdx/vss-video-analytics-api
       - $VSS_DATA_DIR/data_log/vss_video_analytics_api:/web-api-app/files
@@ -117,9 +125,10 @@ services:
     build:
       context: $VSS_APPS_DIR/developer-profiles/dev-profile-alerts/smc-app
       dockerfile: $VSS_APPS_DIR/developer-profiles/dev-profile-alerts/smc-app/Dockerfiles/import-calibration.Dockerfile
-    network_mode: "host"
     profiles: ["import-calibration-output-container-smartcities"]
     container_name: mdx-import-calibration-output-smc
+    environment:
+      VIDEO_ANALYTICS_API_URL: http://vss-video-analytics-api:8081
     command: bash /opt/mdx/init-scripts/calibration-import.sh
     depends_on:
       - vss-video-analytics-api-alerts
@@ -127,7 +136,8 @@ services:
   calibration-toolkit-smartcities:
     image: ${VSS_CALIBRATION_TOOLKIT_IMAGE:-nvcr.io/nvidia/vss-core/calibration}:${CALIBRATION_TOOLKIT_IMAGE_TAG}
     profiles: ["calibration-toolkit-smartcities"]
-    network_mode: "host"
+    ports:
+      - ${CALIBRATION_TOOLKIT_HOST_PORT:-8003}:8003
     volumes:
       - calibration-toolkit-alerts:/calibration/server/data:rw
     container_name: mdx-calibration-toolkit
@@ -136,7 +146,8 @@ services:
   vss-video-analytics-ui-smartcities:
     image: ${VSS_VIDEO_ANALYTICS_UI_IMAGE:-nvcr.io/nvidia/vss-core/vss-video-analytics-ui}:${VIDEO_ANALYTICS_UI_IMAGE_TAG}
     profiles: ["vss-video-analytics-ui-smartcities"]
-    network_mode: "host"
+    ports:
+      - ${VIDEO_ANALYTICS_UI_HOST_PORT:-3002}:3002
     volumes:
       - $VSS_APPS_DIR/developer-profiles/dev-profile-alerts/smc-app/vss-video-analytics-ui/config/vss-video-analytics-ui-config.json:/config/${VIDEO_ANALYTICS_UI_APP_NAME}/default-ui-config.json
     environment:

--- a/deploy/docker/industry-profiles/smartcities/overrides.env
+++ b/deploy/docker/industry-profiles/smartcities/overrides.env
@@ -19,6 +19,13 @@ COMPOSE_PROFILES_CV=vss-behavior-analytics-alerts,nvstreamer-alerts,perception-a
 COMPOSE_PROFILES=${COMPOSE_PROFILES_CV}
 
 # =============================================================================
+# HOST-PUBLISHED PORTS
+# =============================================================================
+# Change these when their default host ports conflict with another local service.
+CALIBRATION_TOOLKIT_HOST_PORT=8003
+VIDEO_ANALYTICS_UI_HOST_PORT=3002
+
+# =============================================================================
 # EVALUATION CONFIGURATION
 # =============================================================================
 # Keep aligned with the selected LLM model and endpoint.

--- a/deploy/docker/industry-profiles/smartcities/smc-app/import-calibration/init-scripts/calibration-import.sh
+++ b/deploy/docker/industry-profiles/smartcities/smc-app/import-calibration/init-scripts/calibration-import.sh
@@ -17,6 +17,8 @@
 
 set -e
 
+video_analytics_api_url="${VIDEO_ANALYTICS_API_URL:-http://vss-video-analytics-api:8081}"
+
 ############################
 ## function: exit_with_msg
 ############################
@@ -30,7 +32,7 @@ exit_with_msg(){
 ##############################
 import_calibration(){
     echo -e "Importing Calibration JSON File"
-    until curl -X POST --fail localhost:8081/config/upload-file/calibration \
+    until curl -X POST --fail "${video_analytics_api_url}/config/upload-file/calibration" \
 	--form configFiles=@"/opt/mdx/calibration/sample-data/calibration.json"; do
         echo "Curl command to import calibration file failed with error code $?. Retrying in 5 seconds..."
         sleep 5
@@ -39,7 +41,7 @@ import_calibration(){
 
 import_road_network(){
     echo -e "Importing Road Network JSON File"
-    until curl -X POST --fail localhost:8081/config/upload-file/road-network \
+    until curl -X POST --fail "${video_analytics_api_url}/config/upload-file/road-network" \
 	--form configFiles=@"/opt/mdx/calibration/sample-data/road-network.json"; do
         echo "Curl command to import road-network file failed with error code $?. Retrying in 5 seconds..."
         sleep 5
@@ -52,7 +54,7 @@ fetchstatus() {
     --silent \
     --head \
     --write-out '%{http_code}' \
-    "http://localhost:8081/livez"
+    "${video_analytics_api_url}/livez"
 
     echo ""
 }


### PR DESCRIPTION
## Summary

Moves the remaining Smart Cities overlay services from Docker host networking to
the default Compose bridge network.

This aligns Smart Cities with the repository-wide service-DNS and bridge-network
migration in [#1084](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/1084),
**“Refactor/use ms service names.”**

## Background

Smart Cities was originally introduced in
[#452](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/452),
**“Feat/scbp docker compose,”** which merged before #1084. As a result, its
overlay retained `network_mode: host` and localhost-based service access while
the rest of the Docker deployment moved to Compose service DNS.

A later Smart Cities bridge-network fix addressed NVStreamer connectivity, but
subsequent Compose centralization/rebasing appears to have restored host
networking for the Smart Cities services. This PR restores the intended
bridge-network topology.

## Changes

- Remove `network_mode: host` from Smart Cities services:
  - `nvstreamer-alerts`
  - `kibana-init-container-alerts`
  - `import-calibration-output-container-smartcities`
  - `calibration-toolkit-smartcities`
  - `vss-video-analytics-ui-smartcities`

- Add the `vss-vios-nvstreamer` alias so internal consumers resolve NVStreamer
  through Compose DNS.

- Publish only required host-facing ports:
  - NVStreamer UI/API: `${NVSTREAMER_HTTP_HOST_PORT:-31000}:31000`
  - Calibration toolkit:
    `${CALIBRATION_TOOLKIT_HOST_PORT:-8003}:8003`
  - Smart Cities map UI:
    `${VIDEO_ANALYTICS_UI_HOST_PORT:-3002}:3002`

- Replace the calibration importer's `localhost:8081` calls with the internal
  Video Analytics API endpoint, `http://vss-video-analytics-api:8081`.

- Add the API's bridge-network alias and Smart Cities-specific configurable
  host-port overrides.

## Validation

- Rendered the Smart Cities Compose overlay and confirmed no Smart Cities
  service retains `network_mode: host`.
- Confirmed NVStreamer publishes only port 31000 and is reachable internally
  through its service alias.
- Confirmed the calibration toolkit and map UI retain configurable host ports.
- Ran `bash -n` on the calibration import script.
- Ran `git diff --check`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
