### PR TITLE
fix(helm): fall back to global.storageClass for persistent volumes

### DIFF
--- a/deploy/helm/services/infra/charts/elasticsearch/templates/statefulset.yaml
+++ b/deploy/helm/services/infra/charts/elasticsearch/templates/statefulset.yaml
@@ -128,8 +128,10 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-        {{- if .Values.persistence.storageClass }}
-        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- $global := .Values.global | default dict }}
+        {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+        {{- with $sc }}
+        storageClassName: {{ . | quote }}
         {{- end }}
         resources:
           requests:
@@ -141,8 +143,10 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-        {{- if .Values.persistence.storageClass }}
-        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- $global := .Values.global | default dict }}
+        {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+        {{- with $sc }}
+        storageClassName: {{ . | quote }}
         {{- end }}
         resources:
           requests:

--- a/deploy/helm/services/infra/charts/kafka/templates/statefulset.yaml
+++ b/deploy/helm/services/infra/charts/kafka/templates/statefulset.yaml
@@ -144,8 +144,10 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-        {{- if .Values.persistence.storageClass }}
-        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- $global := .Values.global | default dict }}
+        {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+        {{- with $sc }}
+        storageClassName: {{ . | quote }}
         {{- end }}
         resources:
           requests:

--- a/deploy/helm/services/infra/charts/logstash/templates/deployment.yaml
+++ b/deploy/helm/services/infra/charts/logstash/templates/deployment.yaml
@@ -140,8 +140,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.persistence.storageClass }}
-  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- $global := .Values.global | default dict }}
+  {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+  {{- with $sc }}
+  storageClassName: {{ . | quote }}
   {{- end }}
   resources:
     requests:

--- a/deploy/helm/services/infra/charts/phoenix/templates/pvc.yaml
+++ b/deploy/helm/services/infra/charts/phoenix/templates/pvc.yaml
@@ -23,8 +23,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.persistence.storageClass }}
-  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- $global := .Values.global | default dict }}
+  {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+  {{- with $sc }}
+  storageClassName: {{ . | quote }}
   {{- end }}
   resources:
     requests:

--- a/deploy/helm/services/infra/charts/redis/templates/statefulset.yaml
+++ b/deploy/helm/services/infra/charts/redis/templates/statefulset.yaml
@@ -109,8 +109,10 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-        {{- if .Values.persistence.storageClass }}
-        storageClassName: {{ .Values.persistence.storageClass }}
+        {{- $global := .Values.global | default dict }}
+        {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+        {{- with $sc }}
+        storageClassName: {{ . | quote }}
         {{- end }}
         resources:
           requests:

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/pvc.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/pvc.yaml
@@ -43,8 +43,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.persistence.storageClass }}
-  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- $global := .Values.global | default dict }}
+  {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+  {{- with $sc }}
+  storageClassName: {{ . | quote }}
   {{- end }}
   resources:
     requests:
@@ -62,8 +64,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.persistence.storageClass }}
-  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- $global := .Values.global | default dict }}
+  {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+  {{- with $sc }}
+  storageClassName: {{ . | quote }}
   {{- end }}
   resources:
     requests:

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
@@ -345,8 +345,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.persistence.storageClass }}
-  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- $global := .Values.global | default dict }}
+  {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+  {{- with $sc }}
+  storageClassName: {{ . | quote }}
   {{- end }}
   resources:
     requests:
@@ -362,8 +364,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.persistence.storageClass }}
-  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- $global := .Values.global | default dict }}
+  {{- $sc := .Values.persistence.storageClass | default (index $global "storageClass") }}
+  {{- with $sc }}
+  storageClassName: {{ . | quote }}
   {{- end }}
   resources:
     requests:


### PR DESCRIPTION
## Summary
- Align Elasticsearch, Kafka, Logstash, Phoenix, Redis, RTVI-CV, and RTVI-Embed PVC templates to resolve `storageClassName` from chart `persistence.storageClass`, falling back to `global.storageClass`.
- Avoid leaving PVCs on the cluster default when only the profile-level `global.storageClass` is set.

## Test plan
- [ ] `helm template` an alerts/base profile with `global.storageClass` set and chart-level `persistence.storageClass` empty — PVC `storageClassName` matches global
- [ ] Override a chart `persistence.storageClass` — that value wins over global
- [ ] Leave both empty — `storageClassName` is omitted (cluster default)