### PR TITLE
fix(helm): sync Chart.lock and add runtimeClassName support for CDI clusters

### DIFF
--- a/deploy/helm/services/rtvi/Chart.lock
+++ b/deploy/helm/services/rtvi/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: vss-rtvi-cv
   repository: file://./charts/rtvi-cv
-  version: 3.2.0
+  version: 3.2.1
 - name: vss-rtvi-vlm
   repository: file://./charts/rtvi-vlm
-  version: 3.2.0
+  version: 3.2.1
 - name: vss-rtvi-embed
   repository: file://./charts/rtvi-embed
   version: 3.2.1
-digest: sha256:37bddfb21dfa7cd5ba2a3b8e1d5bf0c076a5259058ce7d332933d0485d129aa1
-generated: "2026-07-13T21:39:34.223822+05:30"
+digest: sha256:eb1ad3c9a082f3875caa0cf1a9614855401b931a1ea908e11053134d91bf1264
+generated: "2026-08-05T16:57:58.005727-04:00"

--- a/deploy/helm/services/rtvi/Chart.yaml
+++ b/deploy/helm/services/rtvi/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     repository: "file://./charts/rtvi-cv"
     condition: vss-rtvi-cv.enabled
   - name: vss-rtvi-vlm
-    version: 3.2.0
+    version: 3.2.1
     repository: "file://./charts/rtvi-vlm"
     condition: vss-rtvi-vlm.enabled
   - name: vss-rtvi-embed

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset.yaml
@@ -202,6 +202,9 @@ spec:
       annotations:
         scripts-configmap: {{ include "vss-rtvi-cv.scriptsConfigMapName" . | quote }}
     spec:
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
         app.kubernetes.io/name: vss-rtvi-vlm
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/services/rtvi/charts/rtvi-vlm/values.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-vlm/values.yaml
@@ -71,6 +71,10 @@ service:
   port: 8000
   type: ClusterIP
 
+# NVIDIA container runtime class (e.g. "nvidia" for CDI-based GPU operator setups).
+# Empty string omits the field from the pod spec (default behavior unchanged).
+runtimeClassName: ""
+
 # Compose: user 1001:1001, shm 16gb, GPU
 securityContext:
   runAsUser: 1001


### PR DESCRIPTION
## Description
- Sync rtvi Chart.lock with subchart source versions (fixes `helm dep build` failure on fresh clone)
- Add `runtimeClassName` support to rtvi-vlm deployment and rtvi-cv search-profile StatefulSet (needed for CDI-based GPU operator setups where nvidia is not the default runtime)

## Test plan
- [ ] `helm dep build` on rtvi chart succeeds (was failing with "Chart.lock is out of sync")
- [ ] `helm template` with `runtimeClassName: nvidia` renders the field in both rtvi-vlm and rtvi-cv search-profile
- [ ] Defaults preserve existing behavior (empty string → block not rendered)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
