### PR TITLE
feat(helm): DGX Spark (GB10) support — values overlays and standalone NIM manifests

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-search/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-search/README.md
@@ -80,6 +80,15 @@ When time-slicing is enabled, each time-sliced partition appears as a separate `
 --set nims.nemotron.resources.requests."nvidia.com/gpu"="2"
 ```
 
+### DGX Spark 3-Node Cluster (Experimental)
+
+For deploying on a 3-node NVIDIA DGX Spark (GB10 Grace Blackwell) Kubernetes
+cluster with a single shared model pool, use the `values-dgx-spark.yaml`
+overlay in this directory and the deploy tooling under
+`deploy/helm/scripts/dgx-spark/`. See the
+[DGX Spark deployment guide](../../scripts/dgx-spark/README.md) for the full
+procedure, architecture, and known limitations.
+
 ## Prerequisites
 
 - **Kubernetes cluster**

--- a/deploy/helm/developer-profiles/dev-profile-search/values-dgx-spark-3node.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values-dgx-spark-3node.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# values-dgx-spark-3node.yaml
+# Optional node placement for a 3-node DGX Spark cluster. Stacks on top of
+# values-dgx-spark.yaml; a single-node Spark does not need this file.
+#
+# Assumes these node labels:
+#   kubectl label node <spark-1> vss-role=llm
+#   kubectl label node <spark-2> vss-role=vlm vss-infra=infra2
+#   kubectl label node <spark-3> vss-role=vss
+#
+# spark-1 and spark-2 host the LLM and VLM NIMs (see
+# scripts/dgx-spark/manifests/). Everything below lands on spark-3, except the
+# RAM-heavy infra moved to spark-2 to keep spark-3 free for GPU workloads.
+#
+# Usage:
+#   helm upgrade --install vss-search ./dev-profile-search \
+#     -f dev-profile-search/values-dgx-spark.yaml \
+#     -f dev-profile-search/values-dgx-spark-3node.yaml \
+#     -n vss --create-namespace
+
+infra:
+  phoenix:
+    nodeSelector:
+      vss-role: vss
+  sdrc:
+    nodeSelector:
+      vss-role: vss
+  kibana:
+    nodeSelector:
+      vss-role: vss
+    # No ingress controller on the Spark cluster.
+    service:
+      type: NodePort
+      nodePort: 30784
+  # RAM-heavy infra moved off the VSS core node.
+  redis:
+    nodeSelector:
+      vss-infra: infra2
+  elasticsearch:
+    nodeSelector:
+      vss-infra: infra2
+  kafka:
+    nodeSelector:
+      vss-infra: infra2
+  logstash:
+    nodeSelector:
+      vss-infra: infra2
+
+vios:
+  vss-vios-postgres:
+    nodeSelector:
+      vss-role: vss
+  vss-vios-sensor:
+    nodeSelector:
+      vss-role: vss
+  vss-vios-streamprocessing:
+    nodeSelector:
+      vss-role: vss
+  vss-vios-ingress:
+    nodeSelector:
+      vss-role: vss
+
+agent:
+  vss-agent:
+    nodeSelector:
+      vss-role: vss
+
+vss-agent-ui:
+  nodeSelector:
+    vss-role: vss
+
+rtvi:
+  vss-rtvi-cv:
+    nodeSelector:
+      vss-role: vss
+
+analytics:
+  vss-video-analytics-api:
+    nodeSelector:
+      vss-role: vss
+  vss-behavior-analytics:
+    nodeSelector:
+      vss-role: vss

--- a/deploy/helm/developer-profiles/dev-profile-search/values-dgx-spark.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values-dgx-spark.yaml
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# values-dgx-spark.yaml
+# Override file for NVIDIA DGX Spark (GB10 Grace Blackwell, arm64).
+#
+# Covers platform compatibility only: arm64 image variants, the GPU runtime
+# class, and remote model serving. The LLM and VLM run as standalone
+# Deployments rather than in-cluster NIMs, so nims.enabled=false and the
+# agent is pointed at global.llmBaseUrl / global.vlmBaseUrl
+# (see deploy/helm/scripts/dgx-spark/manifests/).
+#
+# Node placement, NodePort exposure, and multi-node layout are deliberately
+# not set here — see deploy/helm/scripts/dgx-spark/README.md for a reference
+# 3-node layout expressed as --set flags.
+#
+# Usage:
+#   helm upgrade --install vss-search ./dev-profile-search \
+#     -f dev-profile-search/values-dgx-spark.yaml \
+#     -n vss --create-namespace
+
+global:
+  # Shared remote model endpoints (bare origins; chart appends /v1).
+  llmBaseUrl: "http://llm-nim.vss.svc:8000"
+  vlmBaseUrl: "http://vlm-nim.vss.svc:8000"
+  llmName: "nvidia/nemotron-nano-9b-v2"
+  vlmName: "nvidia/cosmos3-nano-reasoner"
+  ingress:
+    enabled: false
+
+ingress:
+  enabled: false
+
+# LLM and VLM are served by standalone Deployments, not in-cluster NIMs.
+nims:
+  enabled: false
+
+infra:
+  elasticsearch:
+    init:
+      env:
+        BP_PROFILE: "bp_developer_search"
+
+vios:
+  # SBSA (arm64) builds for the GB10. 3.1.0-sbsa is the newest public arm64
+  # tag; the default multi-arch tag has no arm64 variant.
+  vss-vios-sensor:
+    image:
+      repository: nvcr.io/nvidia/vss-core/vss-vios-sensor
+      tag: "3.1.0-sbsa"
+  vss-vios-streamprocessing:
+    image:
+      repository: nvcr.io/nvidia/vss-core/vss-vios-streamprocessing
+      tag: "3.1.0-sbsa"
+  vss-vios-nvstreamer:
+    enabled: false
+
+agent:
+  vss-agent:
+    # Point the agent at the standalone NIM Deployments and the single shared
+    # embedding release (fullnameOverride vss-rt-embed).
+    llmName: "nvidia/nemotron-nano-9b-v2"
+    vlmName: "nvidia/cosmos3-nano-reasoner"
+    llmBaseUrl: "http://llm-nim.vss.svc:8000"
+    vlmBaseUrl: "http://vlm-nim.vss.svc:8000"
+    cosmosEmbedEndpoint: "http://vss-rt-embed:8000"
+    rtviEmbedBaseUrl: "http://vss-rt-embed:8000"
+    elasticsearchUrl: "http://elasticsearch:9200"
+    elasticsearchIndex: "video_embeddings"
+
+vss-agent-ui:
+  # extraEnv is appended last and overrides by name. Setting envOverrides here
+  # would replace the profile's full list rather than merge into it.
+  extraEnv:
+    - name: NEXT_PUBLIC_ENABLE_CHAT_TAB
+      value: "true"
+    - name: NEXT_PUBLIC_ENABLE_ALERTS_TAB
+      value: "true"
+
+# RTVI-Embed and RTVI-VLM are installed as separate releases from the rtvi
+# service chart, so the profile's copies stay off.
+rtvi:
+  vss-rtvi-embed:
+    enabled: false
+  vss-rtvi-vlm:
+    enabled: false
+  vss-rtvi-cv:
+    image:
+      repository: nvcr.io/nvidia/vss-core/vss-rt-cv
+      # 3.2.1-sbsa is the newest public arm64 tag; 3.3.0-sbsa-26.07.2 exists
+      # only in nvstaging and has not been promoted yet.
+      tag: "3.2.1-sbsa"
+    runtimeClassName: nvidia
+    # The upstream model-download Job installs the amd64 NGC CLI, which fails
+    # on arm64. Pre-stage models on the PVC using the arm64 NGC CLI instead.
+    downloadModelsFromNgc: false
+
+analytics:
+  video-analytics-ui:
+    enabled: false

--- a/deploy/helm/scripts/dgx-spark/README.md
+++ b/deploy/helm/scripts/dgx-spark/README.md
@@ -1,0 +1,420 @@
+# DGX Spark Deployment (Experimental)
+
+Helm values overlays for running the NVIDIA VSS search profile on NVIDIA DGX
+Spark (GB10 Grace Blackwell, arm64) hardware.
+
+> **Experimental:** Validated on real DGX Spark hardware but not part of
+> upstream VSS CI. Maintained as a feature branch for partners who need VSS
+> on edge GPU hardware.
+
+## What the overlays do
+
+The `values-dgx-spark*.yaml` files cover **platform compatibility only**:
+
+- arm64 (`-sbsa`) image variants where the default tag has no arm64 build
+- `runtimeClassName: nvidia` for CDI-based GPU driver injection
+- `podSecurityContext.fsGroup` so the non-root DeepStream process can read
+  models from a PVC
+- `downloadModelsFromNgc: false`, because the upstream model-download Job
+  installs the amd64 NGC CLI
+- remote model serving (`nims.enabled=false` plus shared `global.llmBaseUrl` /
+  `global.vlmBaseUrl`), since the LLM and VLM run as standalone Deployments
+
+They deliberately set **no node placement, no resource limits, and no service
+exposure**. A single-node Spark needs none of that. If you are running a
+multi-node cluster, see [Reference 3-node layout](#reference-3-node-layout-optional)
+below for the tested arrangement, shipped as a separate overlay you stack with
+`-f` (the same pattern as `values-nodeport.yaml`).
+
+### GB10 NIM parameters
+
+The DGX Spark has 128 GiB of unified LPDDR5x shared between CPU and GPU.
+NIM parameters are sourced from upstream's official Docker Compose profiles
+to stay aligned with the VSS team's validated values:
+
+- **VLM (Cosmos3):** `deploy/docker/services/nim/cosmos3-reasoner/hw-DGX-SPARK.env` — pins the BF16 model profile, sets `NIM_GPU_MEMORY_UTILIZATION=0.7`, `NIM_MAX_MODEL_LEN=32768`, disables CUDA graph and the MM preprocessor cache.
+- **LLM (Nemotron):** uses the DGX Spark NIM image (`nvidia-nemotron-nano-9b-v2-dgx-spark:1.0.0-variant`), which has built-in GB10 optimizations and needs no extra env vars. Per `skills/vss-deploy-profile/references/edge.md`, do **not** use the standard `nvidia-nemotron-nano-9b-v2:1` image on DGX Spark.
+- **GB10 gpuProfile** in `deploy/helm/services/nims/values.yaml` mirrors the same env vars for future NIM Operator integration.
+
+## Prerequisites
+
+1. **DGX Spark system(s)** with the NVIDIA driver and CUDA toolkit installed.
+2. **k3s cluster** (single node, or one server plus agents).
+3. **GPU operator** with `driver.enabled=false`, `toolkit.enabled=false`,
+   `cdi.enabled=true`.
+4. **NGC secrets** in namespace `vss`, using the chart's default secret names:
+   ```sh
+   kubectl create namespace vss
+   kubectl create secret docker-registry ngc-docker-reg-secret -n vss \
+     --docker-server=nvcr.io --docker-username='$oauthtoken' \
+     --docker-password='<NGC_API_KEY>'
+   kubectl create secret generic ngc-api-key-secret -n vss \
+     --from-literal=NGC_API_KEY='<NGC_API_KEY>'
+   ```
+5. **GPU time-slicing**, if several GPU pods share one GPU:
+   ```sh
+   kubectl apply -f deploy/helm/scripts/dgx-spark/manifests/gpu-time-slicing.yaml
+   kubectl label node <node> nvidia.com/device-plugin.config=vss-shared
+   ```
+
+## Deployment
+
+All commands run from the repo root. Replace `<SC>` with your StorageClass
+(e.g. `local-path`) and `<IP>` with the externally reachable Spark IP.
+
+### 1. Deploy the LLM and VLM NIMs
+
+```sh
+kubectl apply -f deploy/helm/scripts/dgx-spark/manifests/llm-nim.yaml
+kubectl apply -f deploy/helm/scripts/dgx-spark/manifests/vlm-nim.yaml
+
+kubectl wait -n vss pod/llm-nim-0 --for=condition=ready --timeout=20m
+kubectl wait -n vss pod/vlm-nim-0 --for=condition=ready --timeout=20m
+```
+
+### 2. Helm install the VSS stack (5 releases)
+
+```sh
+helm dep up deploy/helm/developer-profiles/dev-profile-search
+helm upgrade --install vss-search deploy/helm/developer-profiles/dev-profile-search \
+  -f deploy/helm/developer-profiles/dev-profile-search/values-dgx-spark.yaml \
+  --set global.storageClass=<SC> \
+  -n vss --create-namespace --timeout 30m
+
+helm dep up deploy/helm/services/rtvi
+helm upgrade --install vss-rtvi-embed deploy/helm/services/rtvi \
+  -f deploy/helm/services/rtvi/values-dgx-spark-embed.yaml \
+  --set global.storageClass=<SC> \
+  -n vss --timeout 30m
+
+helm upgrade --install vss-rtvi-vlm deploy/helm/services/rtvi \
+  -f deploy/helm/services/rtvi/values-dgx-spark-vlm.yaml \
+  --set global.storageClass=<SC> \
+  -n vss --timeout 30m
+
+helm dep up deploy/helm/services/alert
+helm upgrade --install vss-alert deploy/helm/services/alert \
+  -f deploy/helm/services/alert/values-dgx-spark.yaml \
+  -n vss --timeout 10m
+
+helm dep up deploy/helm/services/video-summarization
+helm upgrade --install vss-summarization deploy/helm/services/video-summarization \
+  -f deploy/helm/services/video-summarization/values-dgx-spark.yaml \
+  -n vss --timeout 10m
+```
+
+### 3. Post-install steps
+
+**RTVI-CV model staging** — the upstream model-download Job uses the amd64
+NGC CLI, which fails on arm64. Pre-stage models on the PVC with the arm64
+NGC CLI:
+```sh
+kubectl -n vss exec vss-rtvi-cv-0 -- /opt/nvidia/nvidia_ngc/arm64/ngc \
+  config set API_KEY <NGC_API_KEY>
+kubectl -n vss exec vss-rtvi-cv-0 -- /opt/nvidia/nvidia_ngc/arm64/ngc \
+  model download <model-path> --dest <pvc-mount>
+```
+
+**Local-path PVC permissions** — the k3s local-path provisioner creates PV
+directories as `root:root`; the non-root DeepStream process needs read access:
+```sh
+kubectl -n vss exec vss-rtvi-cv-0 -- chown -R 1000:1000 /opt/storage
+kubectl -n vss exec vss-rtvi-vlm-0 -- chown -R 1000:1000 /opt/storage
+```
+
+**Tokenizer file permissions** — the model staging process leaves SigLIP
+tokenizer files at chmod 600. The non-root text-embedder process cannot
+read them, breaking the `attribute_search` endpoint. Fix after staging:
+```sh
+kubectl -n vss exec vss-rtvi-cv-0 -- sh -c \
+  'chmod 644 /opt/storage/*.onnx /opt/storage/*.bin && chmod 755 /opt/storage/*_tokenizer/ && chmod 644 /opt/storage/*_tokenizer/*'
+```
+
+**SigLIP `.plan` timestamp** — if you re-stage the `.onnx` after the encoder
+has first built the `.plan`, `kubectl cp` resets the `.onnx` mtime ahead of
+the `.plan`, triggering a rebuild that fails on arm64 FP16. After staging:
+```sh
+kubectl -n vss exec vss-rtvi-cv-0 -- touch \
+  /opt/storage/siglip_v2_v1.1.onnx_batch16.plan \
+  /opt/storage/siglip_v2_v1.1.onnx_batch16.plan.meta
+```
+
+**video_embeddings ES alias** — the upstream ES init Job creates the
+`video_embeddings` alias for the current day's index only. Uploaded videos
+use a fixed `2025-01-01` timestamp, so their embeddings land in a different
+index that is NOT in the alias. Without this fix, `embed_search` returns 0
+results for uploaded videos. Add all `mdx-embed-filtered-*` indices to the
+alias:
+```sh
+# Create an index template so future daily indices auto-join the alias:
+curl -s -X POST "http://elasticsearch:9200/_index_template/video_embeddings_alias" \
+  -H "Content-Type: application/json" \
+  -d '{"index_patterns":["mdx-embed-filtered-*"],"template":{"aliases":{"video_embeddings":{}}}}'
+
+# Add any existing indices to the alias:
+curl -s -X POST "http://elasticsearch:9200/_aliases" \
+  -H "Content-Type: application/json" \
+  -d '{"actions":[{"add":{"index":"mdx-embed-filtered-*","alias":"video_embeddings"}}]}'
+```
+Run these from a pod in the `vss` namespace (e.g. `kubectl exec` into the
+agent pod) or via `kubectl port-forward svc/elasticsearch 9200:9200 -n vss`.
+
+**SSE embed keepalive** — the search profile's continuous embedding path
+uses a long-lived SSE connection to the RTVI-Embed service. A keepalive pod
+holds this connection open so embeddings are not dropped between queries.
+Deploy a simple keepalive Deployment:
+```sh
+cat <<'EOF' | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embed-gen-keepalive
+  namespace: vss
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: embed-gen-keepalive
+  template:
+    metadata:
+      labels:
+        app: embed-gen-keepalive
+    spec:
+      containers:
+        - name: keepalive
+          image: curlimages/curl:8.10.1
+          command: ["sh", "-c"]
+          args:
+            - |
+              while true; do
+                curl -s -N http://vss-rt-embed:8000/v1/generate_embeddings \
+                  -H "Content-Type: application/json" \
+                  -d '{"model":"cosmos-embed1-448p-anomaly-detection","input":"keepalive"}' \
+                  > /dev/null 2>&1
+                sleep 60
+              done
+      restartPolicy: Always
+EOF
+```
+
+### 4. Expose the UI and backend APIs
+
+No ingress controller is assumed. Expose the UI, backend APIs, and Kibana
+with NodePorts. Replace `<IP>` with the externally reachable Spark IP.
+
+> **Security note:** NodePorts expose the agent, video-analytics,
+> alert-bridge, VST, and Kibana APIs without authentication or TLS. This
+> matches the existing `values-nodeport.yaml` overlay pattern and is
+> appropriate for a DGX Spark on a trusted LAN. If the Spark is reachable
+> from an untrusted network, add a firewall rule or an auth proxy (e.g.
+> oauth2-proxy + nginx ingress) before exposing the NodePorts.
+
+**Patch existing services to NodePort:**
+```sh
+kubectl -n vss patch svc vss-agent-ui \
+  -p '{"spec":{"type":"NodePort","ports":[{"port":3000,"nodePort":30777}]}}'
+kubectl -n vss patch svc vss-vios-ingress \
+  -p '{"spec":{"type":"NodePort","ports":[{"port":30888,"nodePort":30888}]}}'
+```
+
+**Create NodePort services for backend APIs** (the chart exposes these as
+ClusterIP by default; the UI needs to reach them from the browser):
+```sh
+cat <<'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: vss-agent-nodeport
+  namespace: vss
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: vss-agent
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      nodePort: 30780
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vss-video-analytics-api-nodeport
+  namespace: vss
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: vss-video-analytics-api
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081
+      nodePort: 30781
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vss-alert-bridge-nodeport
+  namespace: vss
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: vss-alert-bridge
+  ports:
+    - name: http
+      port: 9080
+      targetPort: 9080
+      nodePort: 30783
+EOF
+```
+
+Kibana is already exposed as NodePort 30784 by `values-dgx-spark-3node.yaml`.
+
+**Set UI environment variables** — the Next.js UI reads `NEXT_PUBLIC_*` env
+vars (not `EXTERNAL_HOST`) to locate its backend APIs. Set all of them so
+the Chat, Search, Alerts, and Dashboard tabs can reach their backends:
+```sh
+IP=<IP>
+kubectl set env deployment/vss-agent-ui -n vss \
+  NEXT_PUBLIC_ENABLE_CHAT_TAB=true \
+  NEXT_PUBLIC_ENABLE_SEARCH_TAB=true \
+  NEXT_PUBLIC_ENABLE_ALERTS_TAB=true \
+  NEXT_PUBLIC_ENABLE_DASHBOARD_TAB=true \
+  NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE=true \
+  NEXT_PUBLIC_AGENT_API_URL_BASE="http://${IP}:30780/api/v1" \
+  NEXT_PUBLIC_SIDEBAR_CHAT_AGENT_API_URL_BASE="http://${IP}:30780/api/v1" \
+  NEXT_PUBLIC_VST_API_URL="http://${IP}:30888/vst/api" \
+  NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL="http://${IP}:30780/chat/stream" \
+  NEXT_PUBLIC_SIDEBAR_CHAT_HTTP_CHAT_COMPLETION_URL="http://${IP}:30780/chat/stream" \
+  NEXT_PUBLIC_WEBSOCKET_CHAT_COMPLETION_URL="ws://${IP}:30780/websocket" \
+  NEXT_PUBLIC_SIDEBAR_CHAT_WEBSOCKET_CHAT_COMPLETION_URL="ws://${IP}:30780/websocket" \
+  NEXT_PUBLIC_ALERTS_API_URL="http://${IP}:30783/api/v1" \
+  NEXT_PUBLIC_DASHBOARD_TAB_KIBANA_BASE_URL="http://${IP}:30784" \
+  NEXT_PUBLIC_MDX_WEB_API_URL="http://${IP}:30781" \
+  NEXT_PUBLIC_SEARCH_TAB_CHAT_AGENT_API_URL_BASE="http://${IP}:30780/api/v1" \
+  NEXT_PUBLIC_SEARCH_TAB_CHAT_HTTP_CHAT_COMPLETION_URL="http://${IP}:30780/generate" \
+  NEXT_PUBLIC_SEARCH_TAB_CHAT_WEBSOCKET_CHAT_COMPLETION_URL="ws://${IP}:30780/websocket"
+```
+
+**Set agent environment variables** — the agent needs the external VST URL
+for file upload URL rewriting:
+```sh
+kubectl set env deployment/vss-agent -n vss \
+  VST_EXTERNAL_URL="http://${IP}:30888" \
+  VSS_AGENT_EXTERNAL_URL="http://${IP}:30780" \
+  VSS_AGENT_REPORTS_BASE_URL="http://${IP}:30780/static/" \
+  LVS_BACKEND_URL="http://vss-summarization:38111" \
+  RTVI_VLM_BASE_URL="http://vss-rtvi-vlm:8000"
+kubectl rollout restart deployment/vss-agent-ui deployment/vss-agent -n vss
+```
+
+**Fix VST CORS** — the VST ingress nginx ConfigMap ships with
+`__EXTERNAL_IP__` / `__INTERNAL_IP__` placeholders. Replace them with your
+Spark IP so browser cross-origin requests to the VST API succeed:
+```sh
+kubectl get cm vss-vios-ingress-nginx -n vss -o json | python3 -c "
+import json, sys
+cm = json.load(sys.stdin)
+cfg = cm['data']['nginx.conf']
+cfg = cfg.replace('__EXTERNAL_IP__', '${IP}')
+cfg = cfg.replace('__INTERNAL_IP__', '${IP}')
+cm['data']['nginx.conf'] = cfg
+json.dump(cm, sys.stdout)
+" | kubectl apply -f -
+kubectl rollout restart deploy vss-vios-ingress -n vss
+```
+
+The UI is then reachable at `http://<IP>:30777`.
+
+| Service | URL | NodePort |
+|---------|-----|----------|
+| VSS UI | `http://<IP>:30777` | 30777 |
+| Agent API (Chat/Search) | `http://<IP>:30780` | 30780 |
+| Video Analytics API | `http://<IP>:30781` | 30781 |
+| Alert-Bridge API | `http://<IP>:30783` | 30783 |
+| Kibana (Dashboard) | `http://<IP>:30784` | 30784 |
+| VST API | `http://<IP>:30888` | 30888 |
+
+> **Re-patch invariant:** `helm upgrade` resets the env vars and CORS config
+> above. Re-run steps 3 and 4 after any `helm upgrade` of `vss-search`. The
+> NodePort Services survive `helm upgrade` (they are standalone, not
+> helm-managed).
+
+## Reference 3-node layout (optional)
+
+This is the arrangement the overlays were validated against. Nothing below is
+required: a single-node Spark works without any of it. Apply it only if you
+are spreading VSS across three Sparks.
+
+Exactly one LLM, one VLM, and one embedding instance exist cluster-wide.
+
+| Node    | Role | Model tier                                     | Infra                                     |
+|---------|------|------------------------------------------------|-------------------------------------------|
+| spark-1 | LLM  | nemotron-nano-9b-v2-dgx-spark (arm64)          | —                                         |
+| spark-2 | VLM  | cosmos3-reasoner (arm64 native)                | Kafka, Elasticsearch, Redis, Logstash     |
+| spark-3 | VSS  | vss-rt-embed + vss-rt-vlm + vss-rt-cv (sbsa)   | Phoenix, Postgres, VST, agent, UI, Kibana |
+
+Label the nodes:
+```sh
+kubectl label node <spark-1> vss-role=llm
+kubectl label node <spark-2> vss-role=vlm vss-infra=infra2
+kubectl label node <spark-3> vss-role=vss
+```
+
+Uncomment the `nodeSelector` block in `manifests/llm-nim.yaml` and
+`manifests/vlm-nim.yaml` so each NIM lands on its own node.
+
+Then stack `values-dgx-spark-3node.yaml` on the `vss-search` install in step 2.
+It carries the placement for every component in the profile, plus a Kibana
+NodePort since the cluster has no ingress controller:
+```sh
+helm upgrade --install vss-search deploy/helm/developer-profiles/dev-profile-search \
+  -f deploy/helm/developer-profiles/dev-profile-search/values-dgx-spark.yaml \
+  -f deploy/helm/developer-profiles/dev-profile-search/values-dgx-spark-3node.yaml \
+  --set global.storageClass=<SC> \
+  -n vss --create-namespace --timeout 30m
+```
+
+The four service releases each take a single flag:
+```sh
+helm upgrade --install vss-rtvi-embed ... --set vss-rtvi-embed.nodeSelector.vss-role=vss
+helm upgrade --install vss-rtvi-vlm   ... --set vss-rtvi-vlm.nodeSelector.vss-role=vss
+helm upgrade --install vss-alert      ... --set nodeSelector.vss-role=vss
+helm upgrade --install vss-summarization ... --set nodeSelector.vss-role=vss
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `developer-profiles/dev-profile-search/values-dgx-spark.yaml` | Search profile platform overlay |
+| `developer-profiles/dev-profile-search/values-dgx-spark-3node.yaml` | Optional 3-node placement, stacked with `-f` |
+| `services/rtvi/values-dgx-spark-embed.yaml` | Embedding microservice overlay |
+| `services/rtvi/values-dgx-spark-vlm.yaml` | RTVI-VLM proxy overlay |
+| `services/alert/values-dgx-spark.yaml` | Alert-bridge overlay |
+| `services/video-summarization/values-dgx-spark.yaml` | Summarization overlay |
+| `services/nims/override-values-GB10.yaml` | GB10 GPU selector for NIM Operator |
+| `scripts/dgx-spark/manifests/llm-nim.yaml` | LLM NIM standalone Deployment |
+| `scripts/dgx-spark/manifests/vlm-nim.yaml` | VLM NIM standalone Deployment |
+| `scripts/dgx-spark/manifests/gpu-time-slicing.yaml` | GPU time-slicing ConfigMap |
+
+## Known limitations
+
+| Limitation | Impact | Workaround |
+|------------|--------|------------|
+| `vss-rt-cv` has no arm64 tag on the default channel | Model-download Job and SigLIP engine build fail on arm64 | Pre-stage models with the arm64 NGC CLI; overlay pins `3.2.1-sbsa`, the newest public arm64 tag |
+| `vss-vios-sensor` / `vss-vios-streamprocessing` arm64 tags lag the multi-arch ones | Overlay pins `3.1.0-sbsa` rather than the current release | Promote newer `-sbsa` builds to the public catalog |
+| File-based streams carry epoch-0 timestamps | behavior-analytics creates 0 behaviors from file input | Use live RTSP streams via `/api/v1/stream/add` |
+| LLM/VLM NIMs use plain Deployments | Bypasses the NIM Operator convention | Switch to the NIM Operator once GB10 support is validated |
+
+While `develop` is mid-cycle, several charts default to `nvcr.io/nvstaging/...`
+images that external users cannot pull. That affects every architecture
+equally and is resolved by upstream's release sweep to the public catalog, so
+these overlays deliberately do not pin around it.
+
+## Open upstream ask
+
+**Add `linux/arm64` to `vss-rt-cv` in `deploy/docker/container-inventory.json`,
+and promote the 3.3.0 `-sbsa` builds to the public NGC catalog.** With an
+arm64 `vss-rt-cv` build, the `downloadModelsFromNgc: false` override, the
+image pins, and the manual post-install permission fixes can all be dropped.

--- a/deploy/helm/scripts/dgx-spark/manifests/gpu-time-slicing.yaml
+++ b/deploy/helm/scripts/dgx-spark/manifests/gpu-time-slicing.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GPU time-slicing ConfigMap for the NVIDIA GPU operator.
+#
+# Enables 8-replica time-slicing on a single GPU so multiple pods can
+# co-reside (e.g. embedding + VST streamprocessing + RTVI-VLM on the
+# same node).  Time-slicing SHARES (does not partition) GPU memory.
+#
+# Usage:
+#   kubectl apply -f deploy/manifests/gpu-time-slicing.yaml
+#   CLUSTERPOLICY=$(kubectl get clusterpolicy -o jsonpath='{.items[0].metadata.name}')
+#   kubectl patch clusterpolicy "$CLUSTERPOLICY" --type merge \
+#     -p '{"spec":{"devicePlugin":{"config":{"name":"time-slicing-config","default":"default"}}}}'
+#   kubectl label node <hostname> nvidia.com/device-plugin.config=vss-shared --overwrite
+#
+# Nodes WITHOUT the label keep nvidia.com/gpu=1 (no time-slicing).
+# The labeled node will show nvidia.com/gpu=8 (allocatable).
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: time-slicing-config
+  namespace: gpu-operator
+data:
+  # "default" = no time-slicing (replicas: 1 is invalid for time-slicing;
+  # omit the sharing section entirely to disable it).
+  default: |-
+    version: v1
+    flags:
+      migStrategy: none
+  # "vss-shared" = 8-replica time-slicing for the shared GPU node.
+  vss-shared: |-
+    version: v1
+    flags:
+      migStrategy: none
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        failRequestsGreaterThanOne: false
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 8

--- a/deploy/helm/scripts/dgx-spark/manifests/llm-nim.yaml
+++ b/deploy/helm/scripts/dgx-spark/manifests/llm-nim.yaml
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# LLM NIM — shared model endpoint
+#
+# Standalone, OpenAI-compatible Nemotron-Nano-9B-v2 service using the
+# DGX-Spark-optimized NIM build. One of the three cluster-wide model
+# instances (exactly one LLM, one VLM, one embedding). Deployed as a plain
+# Deployment + ClusterIP Service (no NIM Operator dependency) into the `vss`
+# namespace.
+#
+# Wiring: reachable cluster-wide at http://llm-nim.vss.svc:8000/v1
+# Served model id: nvidia/nemotron-nano-9b-v2 (probe /v1/models after
+# rollout to confirm the exact id).
+#
+# Image: nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark:1.0.0-variant
+# This is the DGX Spark-specific NIM (per skills/vss-deploy-profile/references/
+# edge.md). Do NOT use the standard nvidia-nemotron-nano-9b-v2:1 image on DGX
+# Spark — it has an arm64 manifest problem in this blueprint context.
+#
+# The DGX Spark NIM has built-in GB10 optimizations (unified-memory aware,
+# pre-tuned for the 128 GiB LPDDR5x pool). No additional NIM_* env vars are
+# needed — the image's defaults are designed for the GB10. The upstream's
+# Docker Compose graph does not yet include a hw-DGX-SPARK.env for this NIM
+# (the directory deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2-dgx-spark/
+# does not exist yet); when it does, any env vars it defines should be
+# mirrored here.
+#
+# Note: This is the NIM image, not the vLLM FP8 path
+# (NVIDIA-Nemotron-Nano-9B-v2-FP8 + vllm:25.12) that the edge deployment doc
+# references for single-device deployments. The NIM image is preferred for
+# Kubernetes because it provides health endpoints (/v1/health/ready) and
+# NGC-native model weight management.
+#
+# Prerequisites:
+#   - NVIDIA GPU operator / device plugin installed
+#   - ngc-docker-reg-secret (image pull) and ngc-api-key-secret (model weights) k8s Secrets
+#     pre-created in namespace vss (see README.md)
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llm-nim-cache
+  namespace: vss
+  labels:
+    app: nvidia-nemotron-nano-9b-v2
+spec:
+  accessModes: ["ReadWriteOnce"]
+  # Uses the cluster default StorageClass. Override with:
+  #   kubectl apply -f <(sed 's/# storageClassName:/storageClassName: local-path/' llm-nim.yaml)
+  # storageClassName: local-path
+  resources:
+    requests:
+      storage: 60Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-nim
+  namespace: vss
+  labels:
+    app: nvidia-nemotron-nano-9b-v2
+    component: llm-nim
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nvidia-nemotron-nano-9b-v2
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: nvidia-nemotron-nano-9b-v2
+        component: llm-nim
+    spec:
+      # Uncomment to pin the LLM to a dedicated node in a multi-node cluster.
+      # nodeSelector:
+      #   vss-role: llm
+      runtimeClassName: nvidia
+      imagePullSecrets:
+        - name: ngc-docker-reg-secret
+      # fsGroup ensures PVC files are group-readable. runAsUser/runAsGroup
+      # are deliberately omitted: the DGX Spark NIM variant does not support
+      # running as a non-default user (per edge.md). The image runs as its
+      # built-in default user.
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: nim
+          image: nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark:1.0.0-variant
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            - name: NGC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ngc-api-key-secret
+                  key: NGC_API_KEY
+            # The DGX Spark NIM has built-in GB10 optimizations.
+            # No NIM_GPU_MEMORY_CAP_MIB / NIM_LOW_MEMORY_MODE / NIM_MAX_MODEL_LEN
+            # overrides — the image defaults are pre-tuned for the GB10's
+            # 128 GiB unified memory. When the upstream adds a
+            # hw-DGX-SPARK.env for this NIM, mirror any env vars here.
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - name: nim-cache
+              mountPath: /opt/nim/.cache
+            - name: dshm
+              mountPath: /dev/shm
+          startupProbe:
+            httpGet:
+              path: /v1/health/ready
+              port: http
+            # NIM weight download + engine build can take tens of minutes.
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 240
+          readinessProbe:
+            httpGet:
+              path: /v1/health/ready
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /v1/health/live
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+      volumes:
+        - name: nim-cache
+          persistentVolumeClaim:
+            claimName: llm-nim-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-nim
+  namespace: vss
+  labels:
+    app: nvidia-nemotron-nano-9b-v2
+    component: llm-nim
+spec:
+  type: ClusterIP
+  selector:
+    app: nvidia-nemotron-nano-9b-v2
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/scripts/dgx-spark/manifests/vlm-nim.yaml
+++ b/deploy/helm/scripts/dgx-spark/manifests/vlm-nim.yaml
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# VLM NIM — shared model endpoint
+#
+# Standalone, memory-capped, OpenAI-compatible Cosmos Reason 3 service.
+# One of the three cluster-wide model instances (exactly one LLM, one VLM,
+# one embedding). Deployed as a plain Deployment + ClusterIP Service (no NIM
+# Operator dependency) into the `vss` namespace.
+#
+# Wiring: reachable cluster-wide at http://vlm-nim.vss.svc:8000/v1
+# Served model id: nvidia/cosmos3-nano-reasoner (probe /v1/models after
+# rollout to confirm the exact id).
+#
+# The cosmos3-reasoner:1.7 tag is multi-arch (arm64 + amd64) so the same tag
+# pulls natively on the GB10 Spark. Uses the NANO variant (~8B, fits one GPU).
+# Do NOT use the super-reasoner 32B variant (requires 2 GPUs, would break the
+# single-instance-per-node design).
+#
+# GB10 parameters are sourced from the upstream's official Docker Compose
+# profile: deploy/docker/services/nim/cosmos3-reasoner/hw-DGX-SPARK.env.
+# This pins the BF16 model profile and sets the memory/utilization knobs
+# validated by the VSS team for the GB10 unified-memory architecture.
+#
+# Prerequisites:
+#   - NVIDIA GPU operator / device plugin installed
+#   - ngc-docker-reg-secret (image pull) and ngc-api-key-secret (model weights) k8s Secrets
+#     pre-created in namespace vss (see README.md)
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vlm-nim-cache
+  namespace: vss
+  labels:
+    app: cosmos3-nano-reasoner
+spec:
+  accessModes: ["ReadWriteOnce"]
+  # Uses the cluster default StorageClass. Override with:
+  #   kubectl apply -f <(sed 's/# storageClassName:/storageClassName: local-path/' vlm-nim.yaml)
+  # storageClassName: local-path
+  resources:
+    requests:
+      storage: 60Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vlm-nim
+  namespace: vss
+  labels:
+    app: cosmos3-nano-reasoner
+    component: vlm-nim
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cosmos3-nano-reasoner
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: cosmos3-nano-reasoner
+        component: vlm-nim
+    spec:
+      # Uncomment to pin the VLM to a dedicated node in a multi-node cluster.
+      # nodeSelector:
+      #   vss-role: vlm
+      runtimeClassName: nvidia
+      imagePullSecrets:
+        - name: ngc-docker-reg-secret
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: nim
+          image: nvcr.io/nim/nvidia/cosmos3-reasoner:1.7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            - name: NGC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ngc-api-key-secret
+                  key: NGC_API_KEY
+            # GB10 DGX Spark parameters — sourced from the upstream's
+            # deploy/docker/services/nim/cosmos3-reasoner/hw-DGX-SPARK.env
+            # to stay aligned with the official Docker Compose profile.
+            # NIM_GPU_MEMORY_UTILIZATION: unified-memory fraction (0.7 =
+            #   70% of the GB10's 128 GiB shared CPU/GPU pool).
+            # NIM_MODEL_PROFILE: pins the BF16 profile so it isn't
+            #   auto-resolved to a GPU-tuned nvfp4/fp8 profile that may
+            #   not exist on the GB10.
+            # NIM_MAX_NUM_SEQS: limits concurrent requests on one GPU.
+            # NIM_DISABLE_CUDA_GRAPH: avoids CUDA graph capture issues
+            #   on the GB10's unified memory architecture.
+            # NIM_DISABLE_MM_PREPROCESSOR_CACHE: saves memory by
+            #   disabling the multimodal preprocessor cache.
+            # NIM_DELETE_LAST_FRAMES: Cosmos3-specific optimization that
+            #   drops the last frame batch to avoid padding artifacts.
+            - name: NIM_GPU_MEMORY_UTILIZATION
+              value: "0.7"
+            - name: NIM_MAX_MODEL_LEN
+              value: "32768"
+            - name: NIM_MAX_NUM_SEQS
+              value: "4"
+            - name: NIM_DISABLE_CUDA_GRAPH
+              value: "1"
+            - name: NIM_DISABLE_MM_PREPROCESSOR_CACHE
+              value: "1"
+            - name: NIM_DELETE_LAST_FRAMES
+              value: "1"
+            - name: NIM_MODEL_PROFILE
+              value: "e55fdb44f41441032f546360d0dcf61caa8b39fa2852d31124c03953d01e1cb3"
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - name: nim-cache
+              mountPath: /opt/nim/.cache
+            - name: dshm
+              mountPath: /dev/shm
+          startupProbe:
+            httpGet:
+              path: /v1/health/ready
+              port: http
+            # NIM weight download + engine build can take tens of minutes.
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 240
+          readinessProbe:
+            httpGet:
+              path: /v1/health/ready
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /v1/health/live
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+      volumes:
+        - name: nim-cache
+          persistentVolumeClaim:
+            claimName: vlm-nim-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vlm-nim
+  namespace: vss
+  labels:
+    app: cosmos3-nano-reasoner
+    component: vlm-nim
+spec:
+  type: ClusterIP
+  selector:
+    app: cosmos3-nano-reasoner
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/services/alert/values-dgx-spark.yaml
+++ b/deploy/helm/services/alert/values-dgx-spark.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DGX Spark overlay for the alert-bridge chart.
+# Points the VLM at the shared cluster-wide VLM NIM instead of a local model,
+# and tunes the VLM request timeout for remote inference.
+#
+# Usage (standalone release):
+#   helm upgrade --install vss-alert ./alert \
+#     -f alert/values-dgx-spark.yaml \
+#     -n vss --create-namespace
+
+enabled: true
+
+global:
+  imagePullSecrets:
+    - name: ngc-docker-reg-secret
+  ngcApiSecret:
+    name: ngc-api-key-secret
+    key: NGC_API_KEY
+  # Shared remote VLM.
+  vlmBaseUrl: "http://vlm-nim.vss.svc:8000"
+  vlmName: "nvidia/cosmos3-nano-reasoner"
+
+# Subchart-level VLM wiring (wins over global; keeps VLM_* identical to agent).
+vlmBaseUrl: "http://vlm-nim.vss.svc:8000"
+vlmName: "nvidia/cosmos3-nano-reasoner"
+# In-cluster VST for media fetch (no external ingress on this cluster).
+vstBaseUrl: "http://vss-vios-ingress:30888"
+
+# Point at the shared infra services (release-independent names).
+kafkaBootstrapServers: "kafka-kafka:9092"
+redisHost: "redis"
+redisPort: "6379"
+elasticHosts: "http://elasticsearch:9200"
+
+waitForDependencies:
+  enabled: true
+  kafkaHost: "kafka-kafka"
+  kafkaPort: "9092"
+  redisHost: "redis"
+  redisPort: "6379"
+  elasticsearchHost: "elasticsearch"
+  elasticsearchPort: "9200"

--- a/deploy/helm/services/nims/override-values-GB10.yaml
+++ b/deploy/helm/services/nims/override-values-GB10.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GPU override for NVIDIA DGX Spark (GB10 Grace Blackwell).
+# Usage: helm install nims ./nims -f override-values-GB10.yaml
+#    or: helm install nims ./nims --set gpuType=GB10
+#
+# The GB10 has 128 GiB of unified LPDDR5x shared between CPU and GPU.
+# The gpuProfiles.GB10 entry in values.yaml mirrors the upstream's
+# Docker Compose hw-DGX-SPARK.env files for validated parameters.
+#
+# When using the DGX-Spark-optimized Nemotron build, also override the image:
+#   --set nemotron.image.repository=nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark
+#   --set nemotron.image.tag=1.0.0-variant
+
+gpuType: "GB10"

--- a/deploy/helm/services/nims/values.yaml
+++ b/deploy/helm/services/nims/values.yaml
@@ -105,6 +105,33 @@ gpuProfiles:
       NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
       NIM_DELETE_LAST_FRAMES: "1"
 
+  # NVIDIA DGX Spark (GB10 Grace Blackwell). 128 GiB unified LPDDR5x shared
+  # between CPU and GPU. Env vars are sourced from the upstream's official
+  # Docker Compose hw-DGX-SPARK.env files to stay aligned with the VSS team's
+  # validated parameters:
+  #   cosmos3:    deploy/docker/services/nim/cosmos3-reasoner/hw-DGX-SPARK.env
+  #   cosmos:     deploy/docker/services/nim/cosmos-reason2-8b/hw-DGX-SPARK.env
+  #   nemotron:   no hw-DGX-SPARK.env exists yet — the DGX Spark NIM
+  #               (nvidia-nemotron-nano-9b-v2-dgx-spark) has built-in GB10
+  #               optimizations and is not yet wired into the compose graph.
+  GB10:
+    nemotron: {}
+    cosmos:
+      NIM_KVCACHE_PERCENT: "0.8"
+      NIM_PASSTHROUGH_ARGS: "--gpu-memory-utilization 0.8"
+      NIM_MAX_MODEL_LEN: "32768"
+      NIM_MAX_NUM_SEQS: "4"
+      NIM_DISABLE_CUDA_GRAPH: "1"
+      NIM_MODEL_PROFILE: "3266ed3ec2297386d2e4a94e6c84a5b0ba92244f787c538f33577c4c78c5aef2"
+    cosmos3:
+      NIM_GPU_MEMORY_UTILIZATION: "0.7"
+      NIM_MAX_MODEL_LEN: "32768"
+      NIM_MAX_NUM_SEQS: "4"
+      NIM_DISABLE_CUDA_GRAPH: "1"
+      NIM_DISABLE_MM_PREPROCESSOR_CACHE: "1"
+      NIM_DELETE_LAST_FRAMES: "1"
+      NIM_MODEL_PROFILE: "e55fdb44f41441032f546360d0dcf61caa8b39fa2852d31124c03953d01e1cb3"
+
   # Generic fallback for GPUs outside the validated list. Mirrors the Docker
   # hw-OTHER.env profiles exactly: no GPU tuning at all — the NIM applies its own
   # defaults, since we have no validated numbers for unknown GPUs. The rendered

--- a/deploy/helm/services/rtvi/values-dgx-spark-embed.yaml
+++ b/deploy/helm/services/rtvi/values-dgx-spark-embed.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DGX Spark overlay for the rtvi chart — embedding subchart only.
+# Deploys a single Cosmos-Embed1 instance shared by every VSS workflow
+# (one-LLM / one-VLM / one-embedding invariant). The CV and VLM subcharts stay
+# off — they belong to other releases.
+#
+# Usage (standalone release):
+#   helm upgrade --install vss-rtvi-embed ./rtvi \
+#     -f rtvi/values-dgx-spark-embed.yaml \
+#     -n vss --create-namespace
+
+global:
+  useReleaseNamePrefix: false
+
+# CV + VLM belong to other releases — off here.
+vss-rtvi-cv:
+  enabled: false
+vss-rtvi-vlm:
+  enabled: false
+
+vss-rtvi-embed:
+  enabled: true
+  # Name the Deployment/Service vss-rt-embed (matches the cross-release
+  # endpoint the base agent is wired to: http://vss-rt-embed:8000).
+  fullnameOverride: vss-rt-embed
+  replicas: 1
+  image:
+    repository: nvcr.io/nvidia/vss-core/vss-rt-embed
+    # SBSA (arm64) build for the GB10 DGX Spark.
+    # 3.2.1-sbsa is the latest public NGC tag; 3.3.0-26.07.4-sbsa exists
+    # only in nvstaging and has not been promoted yet.
+    tag: "3.2.1-sbsa"
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      nvidia.com/gpu: 1
+  # Cosmos-Embed1 (448p, anomaly-detection) served via the bundled Triton
+  # model repo. The anomaly-detection HF repo makes the NIM serve
+  # cosmos-embed1-448p-anomaly-detection — the id the agent's /complete
+  # embedding step requests.
+  modelPath: "git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection"
+  kafkaEnabled: true
+  kafkaTopic: "mdx-embed"
+  waitForKafka:
+    enabled: true
+  persistence:
+    storageClass: ""
+    ngcModelCache:
+      size: 50Gi
+    hfCache:
+      size: 50Gi

--- a/deploy/helm/services/rtvi/values-dgx-spark-vlm.yaml
+++ b/deploy/helm/services/rtvi/values-dgx-spark-vlm.yaml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DGX Spark overlay for the rtvi chart — VLM subchart only.
+# Deploys a VLM proxy that forwards to the shared cluster-wide VLM NIM instead
+# of loading a local model. This is the summarization leg of the VLM pipeline;
+# the CV perception leg is in the search release.
+#
+# Usage (standalone release):
+#   helm upgrade --install vss-rtvi-vlm ./rtvi \
+#     -f rtvi/values-dgx-spark-vlm.yaml \
+#     -n vss --create-namespace
+
+global:
+  useReleaseNamePrefix: false
+  imagePullSecrets:
+    - name: ngc-docker-reg-secret
+  ngcApiSecret:
+    name: ngc-api-key-secret
+    key: NGC_API_KEY
+  # Shared remote VLM — bare origin, the template appends /v1.
+  vlmBaseUrl: "http://vlm-nim.vss.svc:8000"
+  vlmName: "nvidia/cosmos3-nano-reasoner"
+
+# CV + embedding belong to other releases — off here.
+vss-rtvi-cv:
+  enabled: false
+vss-rtvi-embed:
+  enabled: false
+
+vss-rtvi-vlm:
+  enabled: true
+  image:
+    repository: nvcr.io/nvidia/vss-core/vss-rt-vlm
+    # SBSA (arm64) build for the GB10 DGX Spark.
+    # 3.2.1-sbsa is the latest public NGC tag; 3.3.0-26.07.4-sbsa exists
+    # only in nvstaging and has not been promoted yet.
+    tag: "3.2.1-sbsa"
+    pullPolicy: IfNotPresent
+  # NVIDIA runtime class for GPU driver-library injection (CDI-based GPU
+  # operator). Without it the pod CrashLoopBackOffs with
+  # NVJPEG_STATUS_ALLOCATOR_FAILURE.
+  runtimeClassName: nvidia
+  # Proxy to the shared VLM NIM instead of loading a model in this pod.
+  useSharedNim: true
+  # Subchart-local nims toggle must be set explicitly (root --set does not
+  # reach it).
+  nims:
+    enabled: false
+  vlmBaseUrl: "http://vlm-nim.vss.svc:8000"
+  vlmName: "nvidia/cosmos3-nano-reasoner"
+  ngcApiSecret:
+    name: ngc-api-key-secret
+    key: NGC_API_KEY
+  # Base Kafka has no pre-created RTVI topics; skip the topic-existence gate.
+  waitForKafka:
+    enabled: false
+  tolerations:
+    - key: "nvidia.com/gpu"
+      operator: "Exists"
+      effect: "NoSchedule"
+  resources:
+    limits:
+      nvidia.com/gpu: 1
+    requests:
+      nvidia.com/gpu: 1

--- a/deploy/helm/services/video-summarization/values-dgx-spark.yaml
+++ b/deploy/helm/services/video-summarization/values-dgx-spark.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DGX Spark overlay for the video-summarization chart.
+# Points the LLM/VLM at the shared cluster-wide NIMs and configures SSE-mode
+# caption ingestion (dev-profile-base does not ship Logstash, so DB-mode
+# aggregation finds 0 events without this).
+#
+# Usage (standalone release):
+#   helm upgrade --install vss-summarization ./video-summarization \
+#     -f video-summarization/values-dgx-spark.yaml \
+#     -n vss --create-namespace
+
+global:
+  imagePullSecrets:
+    - name: ngc-docker-reg-secret
+  ngcApiSecret:
+    name: ngc-api-key-secret
+    key: NGC_API_KEY
+  # Shared remote endpoints — bare origins, the lvs template appends /v1.
+  llmBaseUrl: "http://llm-nim.vss.svc:8000"
+  vlmBaseUrl: "http://vlm-nim.vss.svc:8000"
+  llmName: "nvidia/nemotron-nano-9b-v2"
+  vlmName: "nvidia/cosmos3-nano-reasoner"
+
+enabled: true
+
+# Shared infra services (release-independent names).
+elasticsearchHost: "elasticsearch"
+elasticsearchPort: "9200"
+kafkaBootstrapServers: "kafka-kafka:9092"
+# In-cluster VST so LVS rewrites media download URLs to a reachable endpoint.
+vstInternalUrl: "http://vss-vios-ingress:30888"
+
+extraEnv:
+  - name: RTVI_VLM_URL
+    value: "http://vss-rtvi-vlm:8000"
+  - name: RTVI_VLM_URL_PASSTHROUGH
+    value: "true"
+  # SSE-mode caption ingestion: dev-profile-base does not ship Logstash, so
+  # DB-mode aggregation (LVS_CAPTION_SOURCE=db) finds 0 events. SSE mode
+  # reads captions in-process instead of querying ES.
+  - name: LVS_CAPTION_SOURCE
+    value: "sse"
+  - name: LVS_ENABLE_LLM_MERGING
+    value: "true"
+
+modelCache:
+  enabled: true
+
+tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
+resources:
+  requests:
+    nvidia.com/gpu: "1"
+  limits:
+    nvidia.com/gpu: "1"


### PR DESCRIPTION
## Description
Add experimental Helm values overlays and standalone NIM manifests for running the VSS search profile on NVIDIA DGX Spark (GB10 Grace Blackwell, arm64). Includes arm64 `-sbsa` image variants, remote LLM/VLM endpoints, optional 3-node placement overlay, and a deployment guide.

## Test plan
- [ ] `helm lint` passes on all 5 charts with DGX Spark overlays
- [ ] `helm template` with `values-dgx-spark.yaml` renders arm64 images and remote model endpoints
- [ ] Deployed on 3-node cluster (1 DGX Spark + 2 Brev H100): 26/26 pods Ready, all model endpoints serving correct model IDs

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
