### PR TITLE
Allow HF_TOKEN to be set in all profiles

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
@@ -154,6 +154,9 @@ NVIDIA_API_KEY=''
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
+# Optional for authenticated Hugging Face model downloads (higher rate limits).
+# Obtain from: https://huggingface.co/settings/tokens
+HF_TOKEN=''
 
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES

--- a/deploy/docker/developer-profiles/dev-profile-base/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/overrides.env
@@ -140,6 +140,9 @@ NVIDIA_API_KEY=''
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
+# Optional for authenticated Hugging Face model downloads (higher rate limits).
+# Obtain from: https://huggingface.co/settings/tokens
+HF_TOKEN=''
 
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES

--- a/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
@@ -150,6 +150,9 @@ NVIDIA_API_KEY=''
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
+# Optional for authenticated Hugging Face model downloads (higher rate limits).
+# Obtain from: https://huggingface.co/settings/tokens
+HF_TOKEN=''
 
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES
@@ -178,7 +181,6 @@ RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final
 # VLM_MODEL_SUPPORTS_AUDIO=true
 # VLM_TRUST_REMOTE_CODE=true
 # INSTALL_PROPRIETARY_CODECS=true
-# HF_TOKEN=<your_hf_token>
 # ENABLE_AUDIO=true
 
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -119,11 +119,6 @@ RTVI_EMBED_MODEL=cosmos-embed1-448p-anomaly-detection
 MODEL_PATH=git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection
 RTVI_CV_PORT=9000
 
-# HuggingFace token for rt-embed's MODEL_PATH download. Optional — fill in
-# (https://huggingface.co/settings/tokens) for faster first-run download of
-# the Cosmos-Embed1 model. Anonymous downloads work but are noticeably slower.
-HF_TOKEN=
-
 # =============================================================================
 # VSS-UI SERVICE CONFIGURATION
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-search/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/overrides.env
@@ -150,6 +150,9 @@ NVIDIA_API_KEY=''
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
+# Optional for authenticated Hugging Face model downloads (higher rate limits).
+# Obtain from: https://huggingface.co/settings/tokens
+HF_TOKEN=''
 
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -207,6 +207,9 @@ NVIDIA_API_KEY=''
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
 OPENAI_API_KEY=''
+# Optional for authenticated Hugging Face model downloads (higher rate limits).
+# Obtain from: https://huggingface.co/settings/tokens
+HF_TOKEN=''
 
 # =============================================================================
 # CONFIGURATOR AND PROFILE PATHS


### PR DESCRIPTION
## Description
HF_TOKEN can passed to vss-va-mcp, rt-vlm and rt-embed for authenticated model downloads.
This change makes it something that can be provided across all profiles.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
