### PR TITLE
Use credentials from host env in docker compose overrides.env

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
@@ -147,16 +147,16 @@ VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PU
 # =============================================================================
 # Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
-NGC_CLI_API_KEY=''
+NGC_CLI_API_KEY=${NGC_CLI_API_KEY:-}
 # Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
-NVIDIA_API_KEY=''
+NVIDIA_API_KEY=${NVIDIA_API_KEY:-}
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
-OPENAI_API_KEY=''
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
 # Optional for authenticated Hugging Face model downloads (higher rate limits).
 # Obtain from: https://huggingface.co/settings/tokens
-HF_TOKEN=''
+HF_TOKEN=${HF_TOKEN:-}
 
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES

--- a/deploy/docker/developer-profiles/dev-profile-base/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/overrides.env
@@ -133,16 +133,16 @@ VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PU
 # =============================================================================
 # Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
-NGC_CLI_API_KEY=''
+NGC_CLI_API_KEY=${NGC_CLI_API_KEY:-}
 # Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
-NVIDIA_API_KEY=''
+NVIDIA_API_KEY=${NVIDIA_API_KEY:-}
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
-OPENAI_API_KEY=''
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
 # Optional for authenticated Hugging Face model downloads (higher rate limits).
 # Obtain from: https://huggingface.co/settings/tokens
-HF_TOKEN=''
+HF_TOKEN=${HF_TOKEN:-}
 
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES

--- a/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
@@ -143,16 +143,16 @@ VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PU
 # =============================================================================
 # Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
-NGC_CLI_API_KEY=''
+NGC_CLI_API_KEY=${NGC_CLI_API_KEY:-}
 # Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
-NVIDIA_API_KEY=''
+NVIDIA_API_KEY=${NVIDIA_API_KEY:-}
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
-OPENAI_API_KEY=''
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
 # Optional for authenticated Hugging Face model downloads (higher rate limits).
 # Obtain from: https://huggingface.co/settings/tokens
-HF_TOKEN=''
+HF_TOKEN=${HF_TOKEN:-}
 
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES

--- a/deploy/docker/developer-profiles/dev-profile-search/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/overrides.env
@@ -143,16 +143,16 @@ VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PU
 # =============================================================================
 # Required for local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
-NGC_CLI_API_KEY=''
+NGC_CLI_API_KEY=${NGC_CLI_API_KEY:-}
 # Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
-NVIDIA_API_KEY=''
+NVIDIA_API_KEY=${NVIDIA_API_KEY:-}
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
-OPENAI_API_KEY=''
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
 # Optional for authenticated Hugging Face model downloads (higher rate limits).
 # Obtain from: https://huggingface.co/settings/tokens
-HF_TOKEN=''
+HF_TOKEN=${HF_TOKEN:-}
 
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES

--- a/deploy/docker/industry-profiles/smartcities/overrides.env
+++ b/deploy/docker/industry-profiles/smartcities/overrides.env
@@ -36,7 +36,7 @@ EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
 # SMARTCITIES RUNTIME INPUTS
 # =============================================================================
 # Google Maps API key for smartcities map rendering.
-GOOGLE_MAPS_API_KEY=''
+GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY:-}
 
 # Video directory for nvstreamer sample input.
 NVSTREAMER_VIDEO_DIR='vss-nvstreamer-video-dir'

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -200,16 +200,16 @@ VSS_AUTO_CALIBRATION_MS_API_URL=
 # =============================================================================
 # Required for warehouse RT-CV model downloads and local NIM image/model pulls.
 # Obtain from: https://ngc.nvidia.com/
-NGC_CLI_API_KEY=''
+NGC_CLI_API_KEY=${NGC_CLI_API_KEY:-}
 # Required for build.nvidia.com remote endpoints.
 # Obtain from: https://build.nvidia.com/
-NVIDIA_API_KEY=''
+NVIDIA_API_KEY=${NVIDIA_API_KEY:-}
 # Required for OpenAI remote endpoints.
 # Obtain from: https://platform.openai.com/
-OPENAI_API_KEY=''
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
 # Optional for authenticated Hugging Face model downloads (higher rate limits).
 # Obtain from: https://huggingface.co/settings/tokens
-HF_TOKEN=''
+HF_TOKEN=${HF_TOKEN:-}
 
 # =============================================================================
 # CONFIGURATOR AND PROFILE PATHS


### PR DESCRIPTION
## Description
- Use credentials from host env in docker compose overrides.env

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
