### PR TITLE
fix(agent UI): keep Video Management upload popups above the chat sid…

### DIFF
--- a/services/ui/packages/common/__tests__/components/UploadProgressPopup.test.tsx
+++ b/services/ui/packages/common/__tests__/components/UploadProgressPopup.test.tsx
@@ -28,6 +28,33 @@ describe('UploadProgressPopup', () => {
     expect(screen.getByText('network error')).toBeInTheDocument();
   });
 
+  // Chat wants the full window; Video Management needs the overlay confined to its pane so
+  // the popup is not painted underneath the chat sidebar next to it.
+  it('overlays the full viewport by default', () => {
+    render(
+      <UploadProgressPopup
+        files={[{ id: '1', displayName: 'video-1.mp4', uploadStatus: 'uploading', uploadProgress: 10 }]}
+        onCancelAll={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('upload-progress-panel')).toHaveClass('fixed', 'z-50');
+  });
+
+  it('overlays only the positioned ancestor when overlay is contained', () => {
+    render(
+      <UploadProgressPopup
+        overlay="contained"
+        files={[{ id: '1', displayName: 'video-1.mp4', uploadStatus: 'uploading', uploadProgress: 10 }]}
+        onCancelAll={jest.fn()}
+      />,
+    );
+
+    const overlay = screen.getByTestId('upload-progress-panel');
+    expect(overlay).toHaveClass('absolute', 'z-40');
+    expect(overlay).not.toHaveClass('fixed');
+  });
+
   it('calls onCancelAll when Cancel All is clicked', () => {
     const onCancelAll = jest.fn();
     render(

--- a/services/ui/packages/common/__tests__/components/UploadSuccessPopup.test.tsx
+++ b/services/ui/packages/common/__tests__/components/UploadSuccessPopup.test.tsx
@@ -65,6 +65,31 @@ describe('UploadSuccessPopup', () => {
     });
   });
 
+  // Chat wants the full window; Video Management needs the overlay confined to its pane so
+  // the popup is not painted underneath the chat sidebar next to it.
+  it('overlays the full viewport by default', () => {
+    render(
+      <UploadSuccessPopup results={[{ filename: 'a.mp4', result: { id: 'a' } }]} onClose={jest.fn()} />,
+    );
+
+    const overlay = screen.getByText('Upload Complete!').closest('div')?.parentElement;
+    expect(overlay).toHaveClass('fixed', 'z-50');
+  });
+
+  it('overlays only the positioned ancestor when overlay is contained', () => {
+    render(
+      <UploadSuccessPopup
+        overlay="contained"
+        results={[{ filename: 'a.mp4', result: { id: 'a' } }]}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const overlay = screen.getByText('Upload Complete!').closest('div')?.parentElement;
+    expect(overlay).toHaveClass('absolute', 'z-40');
+    expect(overlay).not.toHaveClass('fixed');
+  });
+
   it('calls onClose when close button is clicked', () => {
     const onClose = jest.fn();
     render(

--- a/services/ui/packages/common/lib-src/components/UploadProgressPopup.tsx
+++ b/services/ui/packages/common/lib-src/components/UploadProgressPopup.tsx
@@ -11,7 +11,9 @@ export interface UploadProgressFileItem {
   uploadError?: string;
 }
 
-const POPUP_OVERLAY_CLASS = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+const POPUP_OVERLAY_VIEWPORT = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+/** Covers only the parent `relative` region (e.g. Video Management main pane), not the whole browser window */
+const POPUP_OVERLAY_CONTAINED = 'absolute inset-0 z-40 flex items-center justify-center bg-black/50';
 const POPUP_CONTAINER_CLASS =
   'mx-4 w-full max-w-xl rounded-lg border border-gray-200 bg-white p-6 shadow-xl dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-2xl';
 
@@ -51,18 +53,23 @@ export interface UploadProgressPopupProps {
   files: UploadProgressFileItem[];
   onCancelAll: () => void;
   onCancelSingle?: (fileId: string) => void;
+  /** `contained` = overlay only the nearest positioned ancestor (e.g. Video Management pane). Default `viewport` = full window. */
+  overlay?: 'viewport' | 'contained';
 }
 
 export function UploadProgressPopup({
   files,
   onCancelAll,
   onCancelSingle,
+  overlay = 'viewport',
 }: Readonly<UploadProgressPopupProps>) {
   const hasActive = files.some(f => f.uploadStatus === 'pending' || f.uploadStatus === 'uploading');
+  const overlayClass =
+    overlay === 'contained' ? POPUP_OVERLAY_CONTAINED : POPUP_OVERLAY_VIEWPORT;
   return (
     <div
       data-testid="upload-progress-panel"
-      className={POPUP_OVERLAY_CLASS}
+      className={overlayClass}
       role="dialog"
       aria-modal="true"
       aria-label="Upload progress"

--- a/services/ui/packages/common/lib-src/components/UploadSuccessPopup.tsx
+++ b/services/ui/packages/common/lib-src/components/UploadSuccessPopup.tsx
@@ -9,7 +9,9 @@ export interface UploadResultItem {
   cancelled?: boolean;
 }
 
-const POPUP_OVERLAY_CLASS = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+const POPUP_OVERLAY_VIEWPORT = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+/** Covers only the parent `relative` region (e.g. Video Management main pane), not the whole browser window */
+const POPUP_OVERLAY_CONTAINED = 'absolute inset-0 z-40 flex items-center justify-center bg-black/50';
 const POPUP_CONTAINER_CLASS =
   'mx-4 w-full max-w-xl rounded-lg border border-gray-200 bg-white p-6 shadow-xl dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-2xl';
 
@@ -54,11 +56,14 @@ function getResultItemStyle(item: UploadResultItem) {
 export interface UploadSuccessPopupProps {
   results: UploadResultItem[];
   onClose: () => void;
+  /** `contained` = overlay only the nearest positioned ancestor (e.g. Video Management pane). Default `viewport` = full window. */
+  overlay?: 'viewport' | 'contained';
 }
 
 export function UploadSuccessPopup({
   results,
   onClose,
+  overlay = 'viewport',
 }: Readonly<UploadSuccessPopupProps>) {
   const [expandedResults, setExpandedResults] = useState<Set<number>>(new Set());
   const [copiedResultIndex, setCopiedResultIndex] = useState<number | null>(null);
@@ -94,8 +99,11 @@ export function UploadSuccessPopup({
     cancelledCount === totalCount,
   );
 
+  const overlayClass =
+    overlay === 'contained' ? POPUP_OVERLAY_CONTAINED : POPUP_OVERLAY_VIEWPORT;
+
   return (
-    <div className={POPUP_OVERLAY_CLASS}>
+    <div className={overlayClass}>
       <div className={POPUP_CONTAINER_CLASS}>
         <div className="mb-4 flex justify-center">
           <div className={`flex h-12 w-12 items-center justify-center rounded-full ${statusConfig.bg}`}>

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/VideoManagementComponent.tsx
@@ -759,6 +759,7 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
 
         {uploadProgress.length > 0 && hasActiveUploads && (
           <UploadProgressPopup
+            overlay="contained"
             files={uploadProgressPopupFiles}
             onCancelAll={handleCancelAllUploads}
             onCancelSingle={handleCancelSingleUpload}
@@ -767,6 +768,7 @@ export const VideoManagementComponent: React.FC<VideoManagementComponentProps> =
 
         {showUploadSuccessPopup && uploadResults.length > 0 && (
           <UploadSuccessPopup
+            overlay="contained"
             results={uploadResults}
             onClose={handleClearUploadProgress}
           />

--- a/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/EmptyState.tsx
+++ b/services/ui/packages/nv-metropolis-bp-vss-ui/video-management/lib-src/components/EmptyState.tsx
@@ -61,7 +61,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({ onFilesSelected, enableV
   }
 
   return (
-    <div className="flex-1 flex items-center justify-center">
+    <div className="flex-1 flex min-w-0 items-center justify-center px-4">
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -78,7 +78,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({ onFilesSelected, enableV
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-        className={`rounded-lg border-2 border-dashed text-center transition-colors cursor-pointer w-[580px] py-[60px] px-12 ${
+        className={`rounded-lg border-2 border-dashed text-center transition-colors cursor-pointer w-full max-w-[580px] py-[60px] px-12 ${
           isDragOver
             ? 'border-green-500 bg-green-50 dark:bg-green-500/10'
             : 'border-gray-400 dark:border-gray-600 bg-transparent hover:border-gray-500'


### PR DESCRIPTION
…ebar

- Confine upload progress/result overlays to the Video Management pane and make the empty-state drop zone fluid so it no longer drifts behind the chat sidebar.
- nvbug 6587877

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
