### PR TITLE
chore(rtvi): upgrade Redis image to 8.10.0

### DIFF
--- a/services/rtvi/rt-embed/README.md
+++ b/services/rtvi/rt-embed/README.md
@@ -262,7 +262,7 @@ To enable password authentication for Redis in the Docker Compose deployment, mo
 
 ```yaml
 redis:
-  image: redis:7-alpine
+  image: redis:8.10.0-alpine
   ports:
     - "6379:6379"
   volumes:

--- a/services/rtvi/rt-embed/docker/compose.yaml
+++ b/services/rtvi/rt-embed/docker/compose.yaml
@@ -147,7 +147,7 @@ services:
       start_period: 30s
 
   redis:
-    image: redis:7-alpine
+    image: redis:8.10.0-alpine
     ports:
       - "${REDIS_HOST_PORT:-6379}:6379"
     volumes:

--- a/services/rtvi/rt-embed/tests/redis/test_redis_consumer.py
+++ b/services/rtvi/rt-embed/tests/redis/test_redis_consumer.py
@@ -99,7 +99,7 @@ def main():
         print(f"Error connecting to Redis: {e}")
         print("\nMake sure Redis is running and accessible.")
         print("You can start Redis with:")
-        print("  docker run -d -p 6379:6379 redis:latest")
+        print("  docker run -d -p 6379:6379 redis:8.10.0-alpine")
         print("Or install locally:")
         print("  sudo apt-get install redis-server")
         sys.exit(1)

--- a/services/rtvi/rt-vlm/README.md
+++ b/services/rtvi/rt-vlm/README.md
@@ -366,7 +366,7 @@ To enable password authentication for Redis in the Docker Compose deployment, mo
 
 ```yaml
 redis:
-  image: redis:7-alpine
+  image: redis:8.10.0-alpine
   ports:
     - "6379:6379"
   volumes:

--- a/services/rtvi/rt-vlm/docker/compose.yaml
+++ b/services/rtvi/rt-vlm/docker/compose.yaml
@@ -199,7 +199,7 @@ services:
       start_period: 30s
 
   redis:
-    image: redis:7-alpine
+    image: redis:8.10.0-alpine
     ports:
       - "${REDIS_HOST_PORT:-6379}:6379"
     volumes:

--- a/services/rtvi/rt-vlm/tests/redis/test_redis_consumer.py
+++ b/services/rtvi/rt-vlm/tests/redis/test_redis_consumer.py
@@ -99,7 +99,7 @@ def main():
         print(f"Error connecting to Redis: {e}")
         print("\nMake sure Redis is running and accessible.")
         print("You can start Redis with:")
-        print("  docker run -d -p 6379:6379 redis:latest")
+        print("  docker run -d -p 6379:6379 redis:8.10.0-alpine")
         print("Or install locally:")
         print("  sudo apt-get install redis-server")
         sys.exit(1)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
