### PR TITLE
Update versioning in workflows and tests to align with GHCR conventions

### DIFF
--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -239,7 +239,7 @@ class WorkflowSeparationTest(unittest.TestCase):
         self.assertNotIn("SPATIALAI_PACKAGE_VERSION_SUFFIX", main)
         self.assertIn("name: Spatial AI Data Utils", sdu)
         self.assertIn("name: Gate", sdu)
-        self.assertIn("GITHUB_RUN_ID", sdu)
+        self.assertIn("commit[:12]", sdu)
         self.assertIn("DOWNSTREAM_REF: main", sdu)
         self.assertIn('"SPATIALAI_PIPELINE": "true"', sdu)
 

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -239,7 +239,7 @@ class WorkflowSeparationTest(unittest.TestCase):
         self.assertNotIn("SPATIALAI_PACKAGE_VERSION_SUFFIX", main)
         self.assertIn("name: Spatial AI Data Utils", sdu)
         self.assertIn("name: Gate", sdu)
-        self.assertIn("commit[:12]", sdu)
+        self.assertIn('suffix = f".dev0+g{commit[:12]}"', sdu)
         self.assertIn("DOWNSTREAM_REF: main", sdu)
         self.assertIn('"SPATIALAI_PIPELINE": "true"', sdu)
 

--- a/.github/workflows/spatialai-data-utils.yml
+++ b/.github/workflows/spatialai-data-utils.yml
@@ -96,13 +96,10 @@ jobs:
           if not re.fullmatch(r"[0-9a-f]{40}", tree_sha):
               raise RuntimeError(f"invalid Spatial AI source tree SHA: {tree_sha!r}")
 
-          # GITHUB_RUN_ID is repository-global. A separate workflow must not use
-          # GITHUB_RUN_NUMBER because that counter has a different namespace
-          # from the legacy monolithic CI workflow.
-          suffix = (
-              f".dev{os.environ['GITHUB_RUN_ID']}+t{tree_sha}."
-              f"g{commit[:12]}.gh.r{os.environ['GITHUB_RUN_ATTEMPT']}"
-          )
+          # Match the established GHCR convention: package identity is the
+          # first 12 characters of the VSS source commit, with no CI counter
+          # embedded in the public package version.
+          suffix = f".dev0+g{commit[:12]}"
           publish = changed and ref_name == "develop" and not recovery
           reconcile = recovery or publish
 

--- a/libs/analytics/spatialai-data-utils/README.md
+++ b/libs/analytics/spatialai-data-utils/README.md
@@ -295,3 +295,4 @@ Copyright (c) 2020 Jonathon Luiten, licensed under the MIT License. Each
 file in that subtree is dual-licensed `MIT AND Apache-2.0`: the MIT terms
 cover the upstream TrackEval portions; the NVIDIA modifications are
 released under Apache-2.0.
+


### PR DESCRIPTION
- Changed the version suffix in the spatialai-data-utils workflow to follow the established convention, removing the GITHUB_RUN_ID and using only the first 12 characters of the commit hash.
- Updated the corresponding test to reflect this change in the expected output.

Additionally, added a blank line to the README for consistency.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
