### PR TITLE
skill-eval: coordinate shared workers across runners

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -316,8 +316,9 @@ The canonical harbor command is in § Harbor invocation.
       requirements from the dataset's `task.toml` `[metadata]`
       (`gpu_type`, `gpu_count`), snapshots `brev ls --json`, filters to
       RUNNING `vss-eval-*` boxes whose GPU matches, and walks the
-      candidates best-first with **non-blocking** `flock` attempts —
-      claiming the first box it can actually lock. Selection and
+      candidates best-first with **non-blocking** runner-local `flock`
+      attempts, then atomically acquires a lease on the candidate worker —
+      claiming the first box it can lock at both layers. Selection and
       reservation are one atomic step inside the wrapper, so two
       concurrent legs fan out to different boxes instead of both
       "choosing" the same lock-free-looking one and serialising
@@ -333,8 +334,8 @@ The canonical harbor command is in § Harbor invocation.
       `gpu_count = 0` specs (remote-all / GPU-independent) accept any
       RUNNING pool box.
 
-      When every candidate is held — or none is eligible — the wrapper
-      re-snapshots the fleet and retries every 60s up to its 21000s
+      When every candidate is held at either lock layer — or none is eligible —
+      the wrapper re-snapshots the fleet and retries every 60s up to its 21000s
       budget (the pool is operator-managed; a box may come online
       mid-run), then exits 75 with `BLOCKED: lock timeout`. You do not
       implement any of this; you just invoke the wrapper and read its
@@ -347,10 +348,14 @@ The canonical harbor command is in § Harbor invocation.
 
    b. **Run the structural leg wrapper**. Do not acquire or release
       `flock` manually in a separate Bash call, and do not pass
-      `--instance` in CI. `run_leg.py` opens `/tmp/brev/<chosen>.lock`,
-      holds that file descriptor for the entire Harbor run (including
-      all step-1..N invocations), and releases it only when the wrapper
-      exits or dies:
+      `--instance` in CI. `run_leg.py` first opens
+      `/tmp/brev/<chosen>.lock`, then acquires the exact-owner lease under
+      `/tmp/skill-eval/locks/` on that worker. It heartbeats the remote lease
+      without a fixed stale-age expiry, holds both reservations for the entire
+      Harbor run (including all step-1..N invocations), and releases the
+      remote lease only when its owner still matches. If heartbeat ownership
+      is lost or cannot be confirmed within the bounded safety window, the
+      wrapper cancels Harbor and exits 125 instead of continuing unsafely:
       ```bash
       "$SKILL_EVAL_PYTHON" .github/skill-eval/run_leg.py \
         --dataset-root "$DS" \
@@ -392,9 +397,12 @@ The canonical harbor command is in § Harbor invocation.
    that survive a volume wipe (docker **image** layers, the repo clone, the
    `data/` sample-data extract — but NOT the model-weight *volumes*, which
    the per-trial reset drops; see § 7).
-   `run_leg.py` releases the per-box lock automatically when its process
-   exits; there is no shell FD for you to close. You never `brev stop` /
-   `brev delete`. Pool lifecycle is strictly an operator concern.
+   On normal shutdown `run_leg.py` releases both per-box locks automatically;
+   there is no shell FD or worker lease for you to close. If the coordinator
+   is hard-killed, the kernel drops its local `flock`, while a later allocator
+   removes the remote lease only after GitHub proves that exact owner job is
+   terminal. You never `brev stop` / `brev delete`. Pool lifecycle is strictly
+   an operator concern.
 
    **The box's docker runtime is reset for you at the *start* of each spec,
    not on exit.** On a spec's first trial — a single-step spec, or `step-1`

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -7,7 +7,7 @@ Evaluation is **fully CI-driven**. [`.github/workflows/skills-eval.yml`](../work
 1. Diffs the PR against its base branch and picks out changed skills with an eval spec at `skills/<skill>/evals/<name>.json` (legacy `skills/<skill>/eval/<name>.json` still accepted).
 2. Generates Harbor datasets per `(skill, profile, platform, mode)` via the adapter at [`adapters/<skill>/generate.py`](adapters/).
 3. Selects an operator-managed `vss-eval-*` pool member matching the target platform, per the fleet-selection algorithm in [`AGENTS.md`](AGENTS.md) § 5a. The harness does **not** auto-provision — if no pool member matches, the run blocks until one appears (or times out).
-4. Calls [`run_leg.py`](run_leg.py), which acquires the per-instance `flock`, holds it while every Harbor subprocess for this `(spec, platform)` runs, and invokes Harbor 0.20.0 through Python 3.12 with the canonical flags from [`AGENTS.md § Harbor invocation`](AGENTS.md).
+4. Calls [`run_leg.py`](run_leg.py), which acquires both the runner-local per-instance `flock` and an atomic lease on the worker itself, holds both while every Harbor subprocess for this `(spec, platform)` runs, and invokes Harbor 0.20.0 through Python 3.12 with the canonical flags from [`AGENTS.md § Harbor invocation`](AGENTS.md).
 5. Verifies each trial (containers running, endpoints healthy, trajectory / response / rubric checks — see `verifiers/generic_judge.py`) and scores 0.0–1.0.
 6. Posts one Markdown results summary per `(PR, eval-spec)` batch as a PR comment, with trace URLs served by `harbor view`.
 
@@ -47,7 +47,7 @@ Per-CI-run hygiene is the trial's own responsibility: each spec's first agent tu
 | `LLM_REMOTE_URL` / `LLM_REMOTE_MODEL` | Remote-LLM endpoint used by `remote-*` deploy modes |
 | `VLM_REMOTE_URL` / `VLM_REMOTE_MODEL` | Remote-VLM endpoint used by `remote-*` deploy modes |
 | `HF_TOKEN` | Required by the Edge 4B vLLM on SPARK / Thor `shared` mode |
-| `GITHUB_TOKEN` | Issued to `gh pr comment` when the agent posts results |
+| `GITHUB_TOKEN` / `GH_TOKEN` | Issued to PR reporting and authenticated Actions job/run liveness checks for abandoned worker leases; the eval workflows require `actions: read` |
 | `BREV_REGISTERED_POOL` | Comma/space-separated registered-node names approved for automatic pool selection |
 | `BREV_RTX4090_POOL` | Registered RTX 4090 workers; routed only to the proven tests in `run_leg.py::RTX4090_TESTS` / `RTX4090_ALL_TESTS` |
 
@@ -58,7 +58,8 @@ Per-CI-run hygiene is the trial's own responsibility: each spec's first agent tu
 ├── README.md              ← you are here
 ├── AGENTS.md              ← skills-eval agent's system prompt
 ├── skills_eval_agent.py   ← the CI entrypoint (spawns the agent)
-├── run_leg.py             ← structural per-box lock + Harbor launcher
+├── run_leg.py             ← two-layer per-box allocator + Harbor launcher
+├── remote_worker_lock.py  ← cross-runner worker lease + heartbeat/liveness
 ├── adapters/              ← per-skill dataset generators
 │   ├── vss-deploy-profile/            ← profile × platform × mode matrix
 │   │   └── generate.py
@@ -183,7 +184,8 @@ python3 .github/skill-eval/adapters/vss-manage-video-io-storage/generate.py \
 INSTANCE_NAME=vss-eval-l40s
 
 # 3. Run one trial. run_leg.py discovers single-step vs multi-step task
-#    layouts, holds /tmp/brev/$INSTANCE_NAME.lock, and invokes Harbor.
+#    layouts, holds the local /tmp/brev/$INSTANCE_NAME.lock plus the matching
+#    worker-side lease, and invokes Harbor.
 export PYTHONPATH="$(pwd)/.github/skill-eval:${PYTHONPATH:-}"
 
 python3 .github/skill-eval/run_leg.py \

--- a/.github/skill-eval/remote_worker_lock.py
+++ b/.github/skill-eval/remote_worker_lock.py
@@ -1,0 +1,783 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-runner lease for a shared skill-eval worker.
+
+The lock itself lives on the worker so coordinators on different self-hosted
+runner machines observe the same reservation.  Transport is deliberately
+injected: callers can use ``brev exec`` for managed workers or direct SSH for
+registered external nodes without duplicating the lock protocol.
+
+Keep ``REMOTE_LOCK_DIR`` stable. Existing jobs already coordinate through
+that worker-side path, so changing it would split one shared-worker mutex into
+two independent locks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import NamedTuple, Protocol
+
+# This legacy basename is now the shared skill-eval worker lease namespace.
+# It remains unchanged so jobs deployed before the generic allocator landed
+# continue to coordinate with current jobs.
+REMOTE_LOCK_DIR = "/tmp/skill-eval/locks/nemoclaw-worker.lockdir"
+REMOTE_LOCK_GUARD = "/tmp/skill-eval/locks/worker-lock.guard"
+REMOTE_LOCK_COMMAND_TIMEOUT_SEC = 60
+REMOTE_LOCK_HEARTBEAT_STOP_TIMEOUT_SEC = 32
+REMOTE_LEASE_RELEASE_BUDGET_SEC = (
+    REMOTE_LOCK_HEARTBEAT_STOP_TIMEOUT_SEC + REMOTE_LOCK_COMMAND_TIMEOUT_SEC
+)
+_MARKER_PREFIX = "SKILL_EVAL_REMOTE_LOCK_"
+
+
+class CommandResultLike(Protocol):
+    """Minimal result contract returned by a remote command executor."""
+
+    returncode: int
+    stdout: str | None
+    stderr: str | None
+
+
+RemoteExecutor = Callable[[str, float], CommandResultLike]
+OwnerInactiveChecker = Callable[[str], bool]
+
+
+class RemoteLockHeartbeat(NamedTuple):
+    stop_event: threading.Event
+    lost_event: threading.Event
+    thread: threading.Thread
+
+
+@dataclass
+class RemoteWorkerLease:
+    """One exact-owner remote lock plus its coordinator-side heartbeat."""
+
+    label: str
+    owner: str
+    run_remote: RemoteExecutor = field(repr=False)
+    heartbeat: RemoteLockHeartbeat = field(repr=False)
+    _release_guard: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        repr=False,
+    )
+    _released: bool = field(default=False, init=False, repr=False)
+    _release_result: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def lost_event(self) -> threading.Event:
+        """Set when ownership is lost or cannot be confirmed safely."""
+        return self.heartbeat.lost_event
+
+    def release(self) -> bool:
+        """Stop the heartbeat, then remove only this lease's exact owner."""
+        with self._release_guard:
+            if self._released:
+                return self._release_result
+            if not _stop_remote_worker_lock_heartbeat(self.heartbeat):
+                print(
+                    "[skill-eval-lock] WARN: leaving remote lock in place "
+                    f"because the heartbeat did not stop on {self.label}",
+                    flush=True,
+                )
+                return False
+            cleared = clear_remote_worker_lock(
+                self.run_remote,
+                self.label,
+                self.owner,
+            )
+            if cleared:
+                self._release_result = True
+                self._released = True
+            return cleared
+
+
+def _safe_slug(value: str) -> str:
+    return (
+        "".join(ch if ch.isalnum() else "-" for ch in value.lower()).strip("-")
+        or "scenario"
+    )
+
+
+def _workflow_job_context() -> str | None:
+    """Reconstruct the matrix job name from already-exported eval metadata."""
+    skill = os.environ.get("EVAL_SKILL", "").strip()
+    spec = os.environ.get("EVAL_SPEC_STEM", "").strip()
+    if skill and spec:
+        platform = os.environ.get("EVAL_PLATFORM", "").strip() or "no-platform"
+        return f"{skill} · {spec} · {platform}"
+    return None
+
+
+def build_remote_lock_owner(owner_context: str | None = None) -> str:
+    """Build an exact owner identity with GitHub run/job liveness fields."""
+    context = (
+        owner_context
+        or os.environ.get("SKILL_EVAL_LOCK_OWNER_CONTEXT")
+        # Compatibility for jobs that adopted the lease before it moved into
+        # the shared allocator.
+        or os.environ.get("NEMOCLAW_LOCK_OWNER_CONTEXT")
+        or _workflow_job_context()
+        or os.environ.get("GITHUB_JOB")
+        or "skill-eval"
+    )
+    return "__".join(
+        _safe_slug(part)
+        for part in (
+            "v2",
+            os.environ.get("GITHUB_RUN_ID", "local"),
+            os.environ.get("GITHUB_RUN_ATTEMPT", "0"),
+            context,
+            str(os.getpid()),
+            str(int(time.time())),
+            uuid.uuid4().hex,
+        )
+    )
+
+
+def _command_output(result: CommandResultLike) -> str:
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def _command_tail(result: CommandResultLike, limit: int = 500) -> str:
+    return _command_output(result)[-limit:].strip()
+
+
+def _owner_marker(action: str, owner: str) -> str:
+    """Return an exact, owner-bound remote protocol marker."""
+    return f"{_MARKER_PREFIX}{action}:{owner}"
+
+
+def _has_exact_stdout_line(result: CommandResultLike, expected: str) -> bool:
+    """Accept a protocol marker only when the remote stdout emitted it alone."""
+    return expected in (result.stdout or "").splitlines()
+
+
+def _deadline_timeout(timeout: float, deadline: float | None) -> float:
+    if deadline is None:
+        return timeout
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise subprocess.TimeoutExpired("remote worker lease deadline", 0)
+    return min(timeout, remaining)
+
+
+def _deadline_remote_executor(
+    run_remote: RemoteExecutor,
+    deadline: float | None,
+) -> RemoteExecutor:
+    """Cap acquisition-side transport calls to one monotonic deadline."""
+    if deadline is None:
+        return run_remote
+
+    def execute(command: str, timeout: float) -> CommandResultLike:
+        return run_remote(command, _deadline_timeout(timeout, deadline))
+
+    return execute
+
+
+def _acquire_command(owner: str) -> str:
+    return f"""set -eu
+lock_dir={shlex.quote(REMOTE_LOCK_DIR)}
+guard={shlex.quote(REMOTE_LOCK_GUARD)}
+lock_root=${{lock_dir%/*}}
+owner={shlex.quote(owner)}
+now=$(date +%s)
+mkdir -p "$lock_root"
+exec 9>"$guard"
+flock -x 9
+finish_new_lock() {{
+  cleanup_incomplete_lock() {{
+    if [ ! -s "$lock_dir/owner" ] || [ ! -s "$lock_dir/created" ]; then
+      rm -rf "$lock_dir"
+    fi
+  }}
+  trap cleanup_incomplete_lock EXIT HUP INT TERM
+  printf '%s\\n' "$owner" > "$lock_dir/owner"
+  printf '%s\\n' "$now" > "$lock_dir/created"
+  trap - EXIT HUP INT TERM
+  printf 'SKILL_EVAL_REMOTE_LOCK_ACQUIRED:%s\\n' "$owner"
+  exit 0
+}}
+if mkdir "$lock_dir" 2>/dev/null; then
+  finish_new_lock
+fi
+locked_owner=$(cat "$lock_dir/owner" 2>/dev/null || true)
+created=$(cat "$lock_dir/created" 2>/dev/null || true)
+if [ -z "$locked_owner" ] || [ -z "$created" ]; then
+  rm -rf "$lock_dir"
+  if mkdir "$lock_dir" 2>/dev/null; then
+    finish_new_lock
+  fi
+  locked_owner=$(cat "$lock_dir/owner" 2>/dev/null || true)
+  created=$(cat "$lock_dir/created" 2>/dev/null || true)
+fi
+case "$created" in
+  ''|*[!0-9]*) created=$now ;;
+esac
+age=$((now - created))
+locked_owner=${{locked_owner:-unknown}}
+printf 'SKILL_EVAL_REMOTE_LOCK_BUSY:%s\\n' "$locked_owner"
+echo "skill-eval worker is leased by $locked_owner age=${{age}}s"
+exit 1
+"""
+
+
+def remote_lock_owner_from_output(output: str) -> str | None:
+    """Parse an exact standalone busy marker produced by the remote command."""
+    prefix = f"{_MARKER_PREFIX}BUSY:"
+    for line in output.splitlines():
+        if not line.startswith(prefix):
+            continue
+        owner = line.removeprefix(prefix)
+        if owner and not re.search(r"\s", owner):
+            return owner
+    return None
+
+
+def _run_acquire_attempt(
+    run_remote: RemoteExecutor,
+    label: str,
+    owner: str,
+) -> tuple[bool, str | None, str]:
+    """Attempt once, retrying only an uncertain response-loss outcome."""
+
+    def invoke() -> tuple[CommandResultLike | None, str]:
+        try:
+            result = run_remote(
+                _acquire_command(owner),
+                REMOTE_LOCK_COMMAND_TIMEOUT_SEC,
+            )
+        except Exception as exc:  # noqa: BLE001 - transport adapters vary.
+            print(
+                f"[skill-eval-lock] remote lock check failed on {label}: {exc!r}",
+                flush=True,
+            )
+            return None, ""
+        tail = _command_tail(result)
+        return result, tail
+
+    result, tail = invoke()
+    acquired_marker = _owner_marker("ACQUIRED", owner)
+    if (
+        result is not None
+        and result.returncode == 0
+        and _has_exact_stdout_line(result, acquired_marker)
+    ):
+        return True, None, tail
+    # Protocol markers are emitted on remote stdout.  Keep parsing them from
+    # the complete stdout stream: Brev can append enough SSH/spinner stderr
+    # that the bounded diagnostic tail no longer contains the BUSY line.
+    locked_owner = remote_lock_owner_from_output(
+        (result.stdout or "") if result is not None else ""
+    )
+    if locked_owner == owner:
+        print(
+            f"[skill-eval-lock] reconciled remote lock acquisition on {label}",
+            flush=True,
+        )
+        return True, owner, tail
+    if locked_owner:
+        return False, locked_owner, tail
+
+    # The first command may have created the directory before its transport
+    # response was lost.  Repeating the same mkdir protocol is safe: it either
+    # acquires a still-free lock or reports the exact UUID owner just written.
+    result, retry_tail = invoke()
+    tail = retry_tail or tail
+    if (
+        result is not None
+        and result.returncode == 0
+        and _has_exact_stdout_line(result, acquired_marker)
+    ):
+        return True, None, tail
+    locked_owner = remote_lock_owner_from_output(
+        (result.stdout or "") if result is not None else ""
+    )
+    if locked_owner == owner:
+        print(
+            f"[skill-eval-lock] reconciled remote lock acquisition on {label}",
+            flush=True,
+        )
+        return True, owner, tail
+    if not locked_owner:
+        print(
+            "[skill-eval-lock] cleaning up an unconfirmed exact-owner "
+            f"acquisition on {label}",
+            flush=True,
+        )
+        clear_remote_worker_lock(run_remote, label, owner)
+    return False, locked_owner, tail
+
+
+def try_acquire_remote_worker_lock(
+    run_remote: RemoteExecutor,
+    label: str,
+    *,
+    owner_context: str | None = None,
+    owner_inactive: OwnerInactiveChecker | None = None,
+    deadline: float | None = None,
+) -> RemoteWorkerLease | None:
+    """Try to acquire and heartbeat the shared worker lock.
+
+    ``run_remote`` receives ``(shell_command, timeout_seconds)``.  It must
+    return an object with ``returncode``, ``stdout``, and ``stderr`` fields.
+    Remote transport failures fail closed and return ``None``.
+    """
+    owner = build_remote_lock_owner(owner_context)
+    acquire_remote = _deadline_remote_executor(run_remote, deadline)
+    acquired, locked_owner, tail = _run_acquire_attempt(
+        acquire_remote,
+        label,
+        owner,
+    )
+    checker = owner_inactive or (
+        lambda candidate: remote_lock_owner_is_inactive(
+            candidate,
+            deadline=deadline,
+        )
+    )
+    if not acquired and locked_owner and locked_owner != owner:
+        try:
+            inactive = checker(locked_owner)
+        except Exception as exc:  # noqa: BLE001 - inability to prove is active.
+            print(
+                "[skill-eval-lock] could not verify remote lock owner "
+                f"{locked_owner} on {label}: {exc!r}",
+                flush=True,
+            )
+            inactive = False
+        if inactive:
+            print(
+                "[skill-eval-lock] removing remote lock from inactive run: "
+                f"{locked_owner}",
+                flush=True,
+            )
+            if clear_remote_worker_lock(acquire_remote, label, locked_owner):
+                acquired, locked_owner, tail = _run_acquire_attempt(
+                    acquire_remote,
+                    label,
+                    owner,
+                )
+
+    if not acquired:
+        if tail:
+            print(
+                f"[skill-eval-lock] {label} remote lock unavailable: {tail}",
+                flush=True,
+            )
+        return None
+
+    try:
+        heartbeat = _start_remote_worker_lock_heartbeat(
+            run_remote,
+            label,
+            owner,
+        )
+    except Exception:
+        clear_remote_worker_lock(acquire_remote, label, owner)
+        raise
+    return RemoteWorkerLease(label, owner, run_remote, heartbeat)
+
+
+def clear_remote_worker_lock(
+    run_remote: RemoteExecutor,
+    label: str,
+    owner: str,
+) -> bool:
+    """Remove the lock only when its current owner is exactly ``owner``."""
+    command = f"""set -eu
+lock_dir={shlex.quote(REMOTE_LOCK_DIR)}
+guard={shlex.quote(REMOTE_LOCK_GUARD)}
+lock_root=${{lock_dir%/*}}
+expected={shlex.quote(owner)}
+mkdir -p "$lock_root"
+exec 9>"$guard"
+flock -x 9
+actual=$(cat "$lock_dir/owner" 2>/dev/null || true)
+if [ -d "$lock_dir" ] && [ "$actual" = "$expected" ]; then
+  rm -rf "$lock_dir"
+  printf 'SKILL_EVAL_REMOTE_LOCK_CLEARED:%s\\n' "$expected"
+  echo "removed skill-eval worker lease owned by $expected"
+  exit 0
+fi
+echo "skill-eval worker lease owner changed to ${{actual:-none}}; not removing"
+exit 1
+"""
+    try:
+        result = run_remote(command, REMOTE_LOCK_COMMAND_TIMEOUT_SEC)
+    except Exception as exc:  # noqa: BLE001 - transport adapters vary.
+        print(
+            f"[skill-eval-lock] remote lock cleanup failed on {label}: {exc!r}",
+            flush=True,
+        )
+        return False
+    tail = _command_tail(result)
+    cleared_marker = _owner_marker("CLEARED", owner)
+    if result.returncode != 0 or not _has_exact_stdout_line(result, cleared_marker):
+        if tail:
+            print(
+                f"[skill-eval-lock] remote lock cleanup skipped on {label}: {tail}",
+                flush=True,
+            )
+        return False
+    if tail:
+        print(f"[skill-eval-lock] {label}: {tail}", flush=True)
+    return True
+
+
+def refresh_remote_worker_lock(
+    run_remote: RemoteExecutor,
+    label: str,
+    owner: str,
+) -> str:
+    """Atomically refresh an exact-owner lease without creating/removing it."""
+    command = f"""set -eu
+lock_dir={shlex.quote(REMOTE_LOCK_DIR)}
+guard={shlex.quote(REMOTE_LOCK_GUARD)}
+lock_root=${{lock_dir%/*}}
+expected={shlex.quote(owner)}
+not_owner() {{
+  printf 'SKILL_EVAL_REMOTE_LOCK_NOT_OWNER:%s\\n' "$expected"
+  echo "skill-eval worker lease is not owned by $expected"
+  exit 3
+}}
+mkdir -p "$lock_root"
+exec 9>"$guard"
+flock -x 9
+[ -d "$lock_dir" ] || not_owner
+actual=$(cat "$lock_dir/owner" 2>/dev/null || true)
+[ "$actual" = "$expected" ] || not_owner
+before=$(stat -Lc '%d:%i' "$lock_dir" 2>/dev/null) || not_owner
+tmp=$(mktemp "$lock_dir/.created.XXXXXX") || exit 4
+trap 'rm -f "$tmp"' EXIT HUP INT TERM
+printf '%s\\n' "$(date +%s)" > "$tmp"
+after=$(stat -Lc '%d:%i' "$lock_dir" 2>/dev/null) || not_owner
+actual=$(cat "$lock_dir/owner" 2>/dev/null || true)
+[ "$before" = "$after" ] && [ "$actual" = "$expected" ] || not_owner
+mv -f "$tmp" "$lock_dir/created"
+trap - EXIT HUP INT TERM
+printf 'SKILL_EVAL_REMOTE_LOCK_REFRESHED:%s\\n' "$expected"
+echo "refreshed skill-eval worker lease owned by $expected"
+"""
+    try:
+        result = run_remote(command, _heartbeat_command_timeout())
+    except Exception:  # noqa: BLE001 - heartbeat converts failures to unknown.
+        return "unknown"
+    if result.returncode == 0 and _has_exact_stdout_line(
+        result,
+        _owner_marker("REFRESHED", owner),
+    ):
+        return "refreshed"
+    if result.returncode == 3 and _has_exact_stdout_line(
+        result,
+        _owner_marker("NOT_OWNER", owner),
+    ):
+        return "not_owner"
+    return "unknown"
+
+
+def _first_env_int(names: tuple[str, ...], default: int) -> int:
+    for name in names:
+        raw = os.environ.get(name)
+        if raw is None:
+            continue
+        try:
+            return int(raw)
+        except ValueError:
+            return default
+    return default
+
+
+def _heartbeat_settings() -> tuple[float, float]:
+    configured_interval = _first_env_int(
+        (
+            "SKILL_EVAL_REMOTE_LOCK_HEARTBEAT_SEC",
+            "NEMOCLAW_REMOTE_LOCK_HEARTBEAT_SEC",
+        ),
+        180,
+    )
+    interval_s = min(240, max(30, configured_interval))
+    configured_max_silence = _first_env_int(
+        (
+            "SKILL_EVAL_REMOTE_LOCK_HEARTBEAT_MAX_SILENCE_SEC",
+            "NEMOCLAW_REMOTE_LOCK_HEARTBEAT_MAX_SILENCE_SEC",
+        ),
+        660,
+    )
+    max_silence_s = min(
+        660,
+        max(interval_s * 2, configured_max_silence),
+    )
+    return float(interval_s), float(max_silence_s)
+
+
+def _heartbeat_command_timeout() -> int:
+    configured = _first_env_int(
+        (
+            "SKILL_EVAL_REMOTE_LOCK_HEARTBEAT_TIMEOUT_SEC",
+            "NEMOCLAW_REMOTE_LOCK_HEARTBEAT_TIMEOUT_SEC",
+        ),
+        30,
+    )
+    return min(30, max(5, configured))
+
+
+def _start_remote_worker_lock_heartbeat(
+    run_remote: RemoteExecutor,
+    label: str,
+    owner: str,
+) -> RemoteLockHeartbeat:
+    stop_event = threading.Event()
+    lost_event = threading.Event()
+    interval_s, max_silence_s = _heartbeat_settings()
+
+    def heartbeat_loop() -> None:
+        last_success = time.monotonic()
+        while True:
+            silence = time.monotonic() - last_success
+            if silence >= max_silence_s:
+                print(
+                    "[skill-eval-lock] ERROR: remote worker lock heartbeat "
+                    f"exceeded the {int(max_silence_s)}s safety window on "
+                    f"{label}",
+                    flush=True,
+                )
+                lost_event.set()
+                return
+            # Wake at the safety deadline even when it falls before the next
+            # normal heartbeat. A remote call is itself capped separately.
+            wait_s = min(interval_s, max_silence_s - silence)
+            if stop_event.wait(wait_s):
+                return
+            try:
+                status = refresh_remote_worker_lock(
+                    run_remote,
+                    label,
+                    owner,
+                )
+            except Exception as exc:  # noqa: BLE001 - fail closed.
+                print(
+                    "[skill-eval-lock] WARN: remote worker lock heartbeat "
+                    f"raised on {label}: {exc!r}",
+                    flush=True,
+                )
+                status = "unknown"
+            if stop_event.is_set():
+                return
+            if status == "refreshed":
+                last_success = time.monotonic()
+                continue
+            if status == "not_owner":
+                print(
+                    f"[skill-eval-lock] ERROR: lost remote worker lock on {label}",
+                    flush=True,
+                )
+                lost_event.set()
+                return
+            silence = time.monotonic() - last_success
+            print(
+                "[skill-eval-lock] WARN: remote worker lock heartbeat "
+                f"unconfirmed on {label} ({int(silence)}s since success)",
+                flush=True,
+            )
+            if silence >= max_silence_s:
+                print(
+                    "[skill-eval-lock] ERROR: remote worker lock heartbeat "
+                    f"exceeded the {int(max_silence_s)}s safety window on "
+                    f"{label}",
+                    flush=True,
+                )
+                lost_event.set()
+                return
+
+    thread = threading.Thread(
+        target=heartbeat_loop,
+        name=f"skill-eval-lock-heartbeat-{_safe_slug(label)}",
+        daemon=True,
+    )
+    thread.start()
+    return RemoteLockHeartbeat(stop_event, lost_event, thread)
+
+
+def _stop_remote_worker_lock_heartbeat(
+    heartbeat: RemoteLockHeartbeat,
+) -> bool:
+    heartbeat.stop_event.set()
+    heartbeat.thread.join(timeout=REMOTE_LOCK_HEARTBEAT_STOP_TIMEOUT_SEC)
+    if heartbeat.thread.is_alive():
+        print(
+            "[skill-eval-lock] WARN: remote worker lock heartbeat did not stop",
+            flush=True,
+        )
+        return False
+    return True
+
+
+def github_run_id_from_lock_owner(owner: str) -> str | None:
+    match = re.match(r"^(?:v2__)?(\d+)__", owner)
+    return match.group(1) if match else None
+
+
+def github_job_identity_from_lock_owner(
+    owner: str,
+) -> tuple[str, str, str] | None:
+    parts = owner.split("__")
+    if (
+        len(parts) != 7
+        or parts[0] != "v2"
+        or not parts[1].isdigit()
+        or not parts[2].isdigit()
+        or not parts[3]
+    ):
+        return None
+    return parts[1], parts[2], parts[3]
+
+
+def _run_local(
+    cmd: list[str],
+    *,
+    timeout: float,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+        check=False,
+    )
+
+
+def _github_job_status(
+    run_id: str,
+    run_attempt: str,
+    job_context: str,
+    deadline: float | None = None,
+) -> str | None:
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not repo or not token:
+        return None
+    try:
+        result = _run_local(
+            [
+                "gh",
+                "api",
+                (
+                    f"repos/{repo}/actions/runs/{run_id}/attempts/"
+                    f"{run_attempt}/jobs?per_page=100"
+                ),
+            ],
+            timeout=_deadline_timeout(30, deadline),
+            env={**os.environ, "GH_TOKEN": token},
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        tail = _command_tail(result, 300)
+        if tail:
+            print(
+                f"[skill-eval-lock] could not query GitHub jobs for run "
+                f"{run_id} attempt {run_attempt}: {tail}",
+                flush=True,
+            )
+        return None
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    jobs = payload.get("jobs") if isinstance(payload, dict) else None
+    if not isinstance(jobs, list):
+        return None
+    matches = [
+        job
+        for job in jobs
+        if isinstance(job, dict)
+        and _safe_slug(str(job.get("name") or "")) == job_context
+    ]
+    total_count = payload.get("total_count")
+    if not isinstance(total_count, int) or total_count > len(jobs):
+        return None
+    if len(matches) != 1:
+        return None
+    status = str(matches[0].get("status") or "").strip()
+    return status or None
+
+
+def _github_run_status(
+    run_id: str,
+    deadline: float | None = None,
+) -> str | None:
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not repo or not token:
+        return None
+    try:
+        result = _run_local(
+            [
+                "gh",
+                "run",
+                "view",
+                run_id,
+                "--repo",
+                repo,
+                "--json",
+                "status",
+                "--jq",
+                ".status",
+            ],
+            timeout=_deadline_timeout(30, deadline),
+            env={**os.environ, "GH_TOKEN": token},
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        tail = _command_tail(result, 300)
+        if tail:
+            print(
+                f"[skill-eval-lock] could not query GitHub run {run_id}: {tail}",
+                flush=True,
+            )
+        return None
+    status = (result.stdout or "").strip()
+    return status or None
+
+
+def remote_lock_owner_is_inactive(
+    owner: str,
+    *,
+    deadline: float | None = None,
+) -> bool:
+    """Return true only when GitHub proves the exact owner is terminal."""
+    run_id = github_run_id_from_lock_owner(owner)
+    if not run_id:
+        return False
+    job_identity = github_job_identity_from_lock_owner(owner)
+    if job_identity:
+        run_id, run_attempt, job_context = job_identity
+        status = _github_job_status(
+            run_id,
+            run_attempt,
+            job_context,
+            deadline=deadline,
+        )
+        if status is not None:
+            return status == "completed"
+    current_run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if run_id == current_run_id:
+        return False
+    status = _github_run_status(run_id, deadline=deadline)
+    if status is None:
+        return False
+    return status == "completed"

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Run one skills-eval leg under a process-held Brev box lock.
+"""Run one skills-eval leg under local and worker-side Brev box locks.
 
-This wrapper owns BOTH fleet selection and the per-instance flock: it
+This wrapper owns fleet selection, the runner-local flock, and a shared
+worker-side lease. It
 reads the task's hardware requirements from the dataset's task.toml,
 snapshots `brev ls --json`, and walks the eligible `vss-eval-*`
-candidates with NON-BLOCKING lock attempts — claiming the first box it
-can actually lock. The lock file descriptor stays open while Harbor
-runs, so the mutex is a real kernel lock instead of a shell-FD
-convention spread across multiple agent tool calls.
+candidates with NON-BLOCKING local lock attempts, then atomically claims
+the same lease on the candidate itself. Both reservations stay held while
+Harbor runs, coordinating jobs across different self-hosted runners.
 
 Why selection lives here and not in the agent: two legs that snapshot
 the fleet at the same moment both see the same "best" lock-free box
@@ -37,8 +37,14 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.parse
+
+SKILL_EVAL_MODULE_ROOT = str(Path(__file__).resolve().parent)
+if SKILL_EVAL_MODULE_ROOT not in sys.path:
+    sys.path.insert(0, SKILL_EVAL_MODULE_ROOT)
+import remote_worker_lock  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_EVAL_PYTHON_VERSION = (3, 12)
@@ -51,6 +57,9 @@ RTX4090_PREFIX = "vss-eval-geforce-rtx4090-"
 # its spec metadata declares gpu_type that matches GEFORCE RTX 4090.
 RTX4090_ALL_TESTS: frozenset[str] = frozenset()
 RTX4090_TESTS: dict[str, frozenset[str]] = {}
+# Transport choices discovered while snapshotting the pool. Managed Brev
+# workspaces use ``brev exec``; registered external nodes use their SSH alias.
+_WORKER_TRANSPORTS: dict[str, str] = {}
 # Shared root served by the coordinator's persistent `harbor-view.service`
 # (AGENTS.md § Harbor viewer). Fixed path — the viewer is started once for
 # the host, not per leg, so every leg publishes its trials in here.
@@ -118,6 +127,10 @@ HARBOR_SIGINT_GRACE_SEC = (
 )
 HARBOR_SIGTERM_GRACE_SEC = 30
 HARBOR_SIGKILL_GRACE_SEC = 10
+# Once the worker lease is lost, another coordinator may already own the box.
+# Skip Harbor's artifact-recovery SIGINT window and bound old-tree overlap.
+LEASE_LOSS_SIGTERM_GRACE_SEC = 5
+LEASE_LOSS_SIGKILL_GRACE_SEC = 5
 PROCESS_GROUP_POLL_INTERVAL_SEC = 0.1
 HARBOR_SHUTDOWN_GRACE_SEC = (
     HARBOR_SIGINT_GRACE_SEC
@@ -141,6 +154,14 @@ class HarborInvocation:
     chain_key: str
     step_index: int | None = None
     step_count: int | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class LockedWorker:
+    """A worker held by both the runner-local mutex and remote lease."""
+
+    instance: str
+    lost_event: threading.Event
 
 
 class LockTimeoutError(RuntimeError):
@@ -281,6 +302,7 @@ def invocation_reserve_sec(harbor_timeout_sec: int) -> int:
         harbor_timeout_sec
         + HARBOR_SHUTDOWN_GRACE_SEC
         + HARBOR_POSTPROCESS_HEADROOM_SEC
+        + remote_worker_lock.REMOTE_LEASE_RELEASE_BUDGET_SEC
     )
 
 
@@ -430,18 +452,42 @@ def _parse_brev_json(raw: str | None) -> list[dict]:
     return []
 
 
-def _list_brev_instances() -> list[dict]:
+def _bounded_call_timeout(default: float, deadline: float | None) -> float:
+    if deadline is None:
+        return default
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise subprocess.TimeoutExpired("skill-eval lock deadline", 0)
+    return min(default, remaining)
+
+
+def _bounded_retry_sleep(seconds: float, deadline: float | None) -> bool:
+    """Sleep within *deadline*; return false once no retry time remains."""
+    if deadline is None:
+        time.sleep(seconds)
+        return True
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return False
+    time.sleep(min(seconds, remaining))
+    return time.monotonic() < deadline
+
+
+def _list_brev_instances(deadline: float | None = None) -> list[dict]:
     """Snapshot `brev ls --json` with retries for transient RPC flakes.
     An org with zero managed instances prints `null` — authoritative-empty."""
     for attempt in range(4):
         try:
             proc = subprocess.run(
                 ["brev", "ls", "--json"],
-                capture_output=True, text=True, timeout=60,
+                capture_output=True,
+                text=True,
+                timeout=_bounded_call_timeout(60, deadline),
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
             print(f"[run-leg] brev ls failed (attempt {attempt + 1}): {exc}", flush=True)
-            time.sleep(5)
+            if not _bounded_retry_sleep(5, deadline):
+                break
             continue
         raw = (proc.stdout or "").strip()
         if raw.startswith("null"):
@@ -449,11 +495,12 @@ def _list_brev_instances() -> list[dict]:
         if raw and raw.rfind("]") >= 0:
             return _parse_brev_json(raw)
         print(f"[run-leg] brev ls returned empty stdout (attempt {attempt + 1})", flush=True)
-        time.sleep(5)
+        if not _bounded_retry_sleep(5, deadline):
+            break
     return []
 
 
-def _list_registered_nodes() -> list[dict]:
+def _list_registered_nodes(deadline: float | None = None) -> list[dict]:
     """Snapshot registered external nodes from ``brev ls nodes --json``.
 
     The CLI intentionally keeps registered nodes out of ``brev ls --json``.
@@ -465,14 +512,17 @@ def _list_registered_nodes() -> list[dict]:
         try:
             proc = subprocess.run(
                 ["brev", "ls", "nodes", "--json"],
-                capture_output=True, text=True, timeout=60,
+                capture_output=True,
+                text=True,
+                timeout=_bounded_call_timeout(60, deadline),
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
             print(
                 f"[run-leg] brev ls nodes failed (attempt {attempt + 1}): {exc}",
                 flush=True,
             )
-            time.sleep(5)
+            if not _bounded_retry_sleep(5, deadline):
+                break
             continue
         raw = (proc.stdout or "").strip()
         if raw.startswith("null"):
@@ -484,7 +534,8 @@ def _list_registered_nodes() -> list[dict]:
             f"(attempt {attempt + 1})",
             flush=True,
         )
-        time.sleep(5)
+        if not _bounded_retry_sleep(5, deadline):
+            break
     return []
 
 
@@ -546,9 +597,17 @@ def _registered_pool_allowlist(
 def _list_pool_instances(
     skill: str | None = None,
     spec_stem: str | None = None,
+    deadline: float | None = None,
 ) -> list[dict]:
     """Return managed instances plus connected registered pool nodes."""
-    instances = list(_list_brev_instances())
+    if deadline is None:
+        instances = list(_list_brev_instances())
+    else:
+        instances = list(_list_brev_instances(deadline=deadline))
+    for instance in instances:
+        name = (instance.get("name") or "").strip().lower()
+        if name:
+            _WORKER_TRANSPORTS[name] = "brev"
     seen = {(inst.get("name") or "").lower() for inst in instances}
     registered_allowlist = _registered_pool_allowlist(skill, spec_stem)
     rtx4090_allowlist = _parse_pool_names(
@@ -556,7 +615,12 @@ def _list_pool_instances(
     )
     if not registered_allowlist:
         return instances
-    for node in _list_registered_nodes():
+    nodes = (
+        _list_registered_nodes()
+        if deadline is None
+        else _list_registered_nodes(deadline=deadline)
+    )
+    for node in nodes:
         name = (node.get("name") or "").strip()
         if (
             not name
@@ -578,6 +642,7 @@ def _list_pool_instances(
                 and name.lower().startswith(RTX4090_PREFIX)
             ),
         })
+        _WORKER_TRANSPORTS[name.lower()] = "ssh"
         seen.add(name.lower())
     return instances
 
@@ -603,6 +668,7 @@ def _name_gpu_count_hint(name: str) -> int | None:
 def pool_candidates(
     metadata: dict,
     spec_stem: str | None = None,
+    deadline: float | None = None,
 ) -> list[str]:
     """Eligible `vss-eval-*` boxes for this leg, best-first.
 
@@ -624,7 +690,12 @@ def pool_candidates(
     )
 
     candidates: list[tuple[str, bool]] = []
-    for inst in _list_pool_instances(skill, spec_stem):
+    instances = (
+        _list_pool_instances(skill, spec_stem)
+        if deadline is None
+        else _list_pool_instances(skill, spec_stem, deadline=deadline)
+    )
+    for inst in instances:
         name = inst.get("name") or ""
         if not name.startswith("vss-eval-"):
             continue
@@ -661,26 +732,138 @@ def pool_candidates(
     return [name for name, _ in sorted(candidates, key=sort_key)]
 
 
+def _worker_uses_ssh(
+    instance: str,
+    deadline: float | None = None,
+) -> bool:
+    """Resolve the lease transport for managed vs registered workers."""
+    key = instance.lower()
+    cached = _WORKER_TRANSPORTS.get(key)
+    if cached is not None:
+        return cached == "ssh"
+
+    # Registered nodes are operator allowlisted before pool admission. Check
+    # both registered pools here so a pinned registered node gets the same
+    # direct-SSH transport even when pool discovery was skipped.
+    registered = _parse_pool_names(os.environ.get("BREV_REGISTERED_POOL", ""))
+    registered.update(_parse_pool_names(os.environ.get("BREV_RTX4090_POOL", "")))
+    if key in registered:
+        _WORKER_TRANSPORTS[key] = "ssh"
+        return True
+
+    # Pool-selected workers were cached by _list_pool_instances. Reaching this
+    # branch means an operator pinned an otherwise unknown worker. Resolve it
+    # explicitly instead of silently sending a registered node to unsupported
+    # ``brev exec``.
+    for managed in _list_brev_instances(deadline=deadline):
+        name = (managed.get("name") or "").strip().lower()
+        if name:
+            _WORKER_TRANSPORTS[name] = "brev"
+    if key in _WORKER_TRANSPORTS:
+        return False
+    for node in _list_registered_nodes(deadline=deadline):
+        name = (node.get("name") or "").strip().lower()
+        if name:
+            _WORKER_TRANSPORTS[name] = "ssh"
+    if key in _WORKER_TRANSPORTS:
+        return True
+    if deadline is not None and time.monotonic() >= deadline:
+        raise LockTimeoutError(
+            f"lock deadline expired while resolving {instance!r} transport"
+        )
+    raise RuntimeError(
+        f"could not resolve pinned worker transport for {instance!r}; "
+        "verify Brev discovery or add the registered node to "
+        "BREV_REGISTERED_POOL"
+    )
+
+
+def _remote_lock_executor(
+    instance: str,
+    deadline: float | None = None,
+) -> remote_worker_lock.RemoteExecutor:
+    """Bind the shared lease protocol to this worker's transport."""
+    use_ssh = _worker_uses_ssh(instance, deadline=deadline)
+
+    def execute(
+        command: str,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        if use_ssh:
+            cmd = [
+                "ssh",
+                "-T",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=15",
+                "-o",
+                "ServerAliveInterval=30",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "ForwardAgent=no",
+                "-o",
+                "ClearAllForwardings=yes",
+                "-o",
+                "PermitLocalCommand=no",
+                "-o",
+                "ControlMaster=no",
+                "-o",
+                "ControlPath=none",
+                instance.lower(),
+                command,
+            ]
+            stdin = ""
+        else:
+            cmd = ["brev", "exec", instance, command]
+            # Brev may ask for an interactive confirmation before executing.
+            stdin = "\n"
+        return subprocess.run(
+            cmd,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    return execute
+
+
+def _try_acquire_remote_worker_lease(
+    instance: str,
+    deadline: float | None = None,
+) -> remote_worker_lock.RemoteWorkerLease | None:
+    return remote_worker_lock.try_acquire_remote_worker_lock(
+        _remote_lock_executor(instance, deadline=deadline),
+        instance,
+        deadline=deadline,
+    )
+
+
 @contextlib.contextmanager
 def hold_pool_lock(candidates_fn, lock_dir: Path, timeout_sec: int):
-    """Claim the first candidate whose flock succeeds NON-BLOCKINGLY.
+    """Claim the first candidate whose local and remote locks both succeed.
 
-    Selection and reservation are one atomic step: a busy box fails the
-    try-lock and we move to the next candidate, so concurrent legs fan
-    out across the pool instead of herding onto one "best" box. When
-    every candidate is held (or none is eligible), re-snapshot the fleet
-    and retry every 60s until `timeout_sec` — the pool is operator-managed
-    and a box may come online mid-run.
+    The non-blocking flock coordinates jobs on one runner host. The atomic
+    worker-side lease coordinates different runner hosts. A candidate is
+    selected only after both layers succeed; a remotely busy candidate gives
+    up its local flock immediately so another local job may use it later.
 
-    Yields the claimed instance name; the lock FD stays open until exit.
+    Yields the claimed instance and lease-loss event. Both locks stay held
+    until exit.
     """
     lock_dir.mkdir(parents=True, exist_ok=True)
     deadline = time.monotonic() + timeout_sec
     chosen: str | None = None
     fp = None
+    remote_lease: remote_worker_lock.RemoteWorkerLease | None = None
     while True:
-        names = candidates_fn()
+        names = candidates_fn(deadline)
         for name in names:
+            if time.monotonic() >= deadline:
+                break
             if "/" in name or name in {"", ".", ".."}:
                 raise ValueError(f"invalid Brev instance name for lock file: {name!r}")
             lock_path = lock_dir / f"{name}.lock"
@@ -692,9 +875,25 @@ def hold_pool_lock(candidates_fn, lock_dir: Path, timeout_sec: int):
                 if exc.errno not in (errno.EACCES, errno.EAGAIN):
                     raise
                 continue
-            chosen, fp = name, candidate_fp
-            print(f"[run-leg] selected instance: {name} (lock acquired: {lock_path})",
-                  flush=True)
+            try:
+                candidate_remote_lease = _try_acquire_remote_worker_lease(
+                    name,
+                    deadline=deadline,
+                )
+            except Exception:
+                fcntl.flock(candidate_fp.fileno(), fcntl.LOCK_UN)
+                candidate_fp.close()
+                raise
+            if candidate_remote_lease is None:
+                fcntl.flock(candidate_fp.fileno(), fcntl.LOCK_UN)
+                candidate_fp.close()
+                continue
+            chosen, fp, remote_lease = name, candidate_fp, candidate_remote_lease
+            print(
+                f"[run-leg] selected instance: {name} "
+                f"(local + remote locks acquired: {lock_path})",
+                flush=True,
+            )
             break
         if chosen:
             break
@@ -712,11 +911,29 @@ def hold_pool_lock(candidates_fn, lock_dir: Path, timeout_sec: int):
         )
         time.sleep(min(60, remaining))
     try:
-        yield chosen
+        assert remote_lease is not None
+        yield LockedWorker(chosen, remote_lease.lost_event)
     finally:
-        fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
-        fp.close()
-        print(f"[run-leg] lock released: {chosen}", flush=True)
+        assert remote_lease is not None
+        remote_released = False
+        try:
+            remote_released = remote_lease.release()
+        finally:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+            fp.close()
+            if remote_released:
+                message = f"[run-leg] local + remote locks released: {chosen}"
+            else:
+                # A failed exact-owner release can be transport uncertainty or
+                # a last-moment owner change. Invalidate the leg result either
+                # way; preserving a possibly useful result is less important
+                # than never reporting a run that may have overlapped.
+                remote_lease.lost_event.set()
+                message = (
+                    "[run-leg] local lock released; exact remote lease retained "
+                    f"for safe reconciliation: {chosen}"
+                )
+            print(message, flush=True)
 
 
 def _process_group_exists(pgid: int) -> bool:
@@ -923,7 +1140,41 @@ def _cancel_process_tree(
     return exited
 
 
-def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
+def _cancel_process_tree_after_lease_loss(
+    proc: subprocess.Popen,
+    pgid: int,
+    registry_path: Path,
+) -> bool:
+    """Terminate promptly when this coordinator no longer owns the worker."""
+    exited = _signal_process_group_and_wait(
+        proc,
+        pgid,
+        signal.SIGTERM,
+        LEASE_LOSS_SIGTERM_GRACE_SEC,
+        registry_path,
+    )
+    if not exited:
+        print(
+            "[run-leg] Harbor tree survived lease-loss SIGTERM; "
+            "escalating to SIGKILL",
+            flush=True,
+        )
+        exited = _signal_process_group_and_wait(
+            proc,
+            pgid,
+            signal.SIGKILL,
+            LEASE_LOSS_SIGKILL_GRACE_SEC,
+            registry_path,
+        )
+    return exited
+
+
+def run_command(
+    cmd: list[str],
+    env: dict[str, str],
+    timeout_sec: int,
+    abort_event: threading.Event | None = None,
+) -> int:
     print(f"[run-leg] exec: {' '.join(cmd)}", flush=True)
     registry_fd, registry_name = tempfile.mkstemp(
         prefix="skill-eval-transport-pgids-",
@@ -979,13 +1230,40 @@ def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
                 cleanup_started = True
                 raise _RunCommandInterrupted(pending_signal)
 
-            try:
-                rc = proc.wait(timeout=timeout_sec)
-            except subprocess.TimeoutExpired:
-                cleanup_started = True
-                outcome = 124
-                reason = f"outer timeout after {timeout_sec}s"
-            else:
+            deadline = time.monotonic() + timeout_sec
+            while True:
+                if abort_event is not None and abort_event.is_set():
+                    cleanup_started = True
+                    outcome = 125
+                    reason = "remote worker lease lost"
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    cleanup_started = True
+                    outcome = 124
+                    reason = f"outer timeout after {timeout_sec}s"
+                    break
+                try:
+                    wait_timeout = (
+                        timeout_sec
+                        if abort_event is None
+                        else min(1.0, remaining)
+                    )
+                    rc = proc.wait(timeout=wait_timeout)
+                except subprocess.TimeoutExpired:
+                    if abort_event is None:
+                        cleanup_started = True
+                        outcome = 124
+                        reason = f"outer timeout after {timeout_sec}s"
+                        break
+                    continue
+                # If ownership was lost while the child exited, fail closed:
+                # the result may have been produced during unsafe overlap.
+                if abort_event is not None and abort_event.is_set():
+                    cleanup_started = True
+                    outcome = 125
+                    reason = "remote worker lease lost"
+                    break
                 if rc < 0:
                     cleanup_started = True
                     outcome = 128 + abs(rc)
@@ -1005,6 +1283,7 @@ def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
                         "Harbor exited while detached transport groups remained: "
                         + ", ".join(map(str, detached))
                     )
+                break
         except _RunCommandInterrupted as exc:
             cleanup_started = True
             outcome = 128 + exc.signum
@@ -1014,16 +1293,27 @@ def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
             return outcome
 
         cleanup_started = True
-        print(
-            f"[run-leg] {reason}; "
-            "requesting graceful Harbor cancellation with SIGINT",
-            flush=True,
-        )
         # Ignore repeated workflow signals while bounded cleanup owns the
         # process tree. A later SIGKILL remains the unavoidable hard ceiling.
         for sig in previous_handlers:
             signal.signal(sig, signal.SIG_IGN)
-        exited = _cancel_process_tree(proc, pgid, registry_path)
+        if outcome == 125:
+            print(
+                f"[run-leg] {reason}; terminating the old Harbor tree now",
+                flush=True,
+            )
+            exited = _cancel_process_tree_after_lease_loss(
+                proc,
+                pgid,
+                registry_path,
+            )
+        else:
+            print(
+                f"[run-leg] {reason}; "
+                "requesting graceful Harbor cancellation with SIGINT",
+                flush=True,
+            )
+            exited = _cancel_process_tree(proc, pgid, registry_path)
         if not exited:
             print(
                 "[run-leg] Harbor tree could not be reaped after SIGKILL; "
@@ -1244,6 +1534,7 @@ def run_invocations(
     platform: str,
     harbor_timeout_sec: int,
     work_deadline: float | None = None,
+    abort_event: threading.Event | None = None,
 ) -> int:
     env = harbor_env(instance)
     agent = os.environ.get("EVAL_AGENT", "claude-code")
@@ -1289,6 +1580,8 @@ def run_invocations(
     overall_rc = 0
 
     for invocation in invocations:
+        if abort_event is not None and abort_event.is_set():
+            return 125
         if (
             invocation.step_index is not None
             and invocation.chain_key in skipped_after
@@ -1323,7 +1616,12 @@ def run_invocations(
 
         cmd = build_harbor_command(invocation, results_root, model, base_url, agent)
         started_at = time.time() - 1.0
-        rc = run_command(cmd, env, harbor_timeout_sec)
+        rc = run_command(
+            cmd,
+            env,
+            harbor_timeout_sec,
+            abort_event=abort_event,
+        )
         # Publish before the rc checks below: a timed-out (rc=124) trial
         # returns early, and its partial trace is exactly what needs reading.
         try:
@@ -1332,6 +1630,8 @@ def run_invocations(
             # A trace link is reporting convenience; the verdict comes from
             # reward.txt. Never let a viewer-publish error fail the leg.
             print(f"[run-leg] trace publish failed: {exc!r}", flush=True)
+        if abort_event is not None and abort_event.is_set():
+            return 125
         if rc != 0 and overall_rc == 0:
             overall_rc = rc
 
@@ -1434,25 +1734,36 @@ def main(argv: list[str] | None = None) -> int:
         if pinned:
             print(f"[run-leg] pinned instance: {pinned} (pool selection skipped)",
                   flush=True)
-            candidates_fn = lambda: [pinned]  # noqa: E731
+            candidates_fn = lambda _deadline: [pinned]  # noqa: E731
         else:
             candidates_fn = (  # noqa: E731
-                lambda: pool_candidates(metadata, args.spec_stem)
+                lambda deadline: pool_candidates(
+                    metadata,
+                    args.spec_stem,
+                    deadline=deadline,
+                )
             )
         try:
             with hold_pool_lock(
                 candidates_fn, args.lock_dir, effective_lock_timeout
-            ) as instance:
-                return run_invocations(
+            ) as worker:
+                result = run_invocations(
                     invocations,
-                    instance,
+                    worker.instance,
                     args.results_root,
                     args.scratch,
                     args.spec_stem,
                     args.platform,
                     args.harbor_timeout_sec,
-                    work_deadline,
+                    work_deadline=work_deadline,
+                    abort_event=worker.lost_event,
                 )
+            # The context exit stops the heartbeat before this final check,
+            # closing the race where ownership could be lost after Harbor's
+            # last process exits but before the lease is released.
+            if worker.lost_event.is_set():
+                return 125
+            return result
         except LockTimeoutError:
             if effective_lock_timeout < args.lock_timeout_sec:
                 raise LegDeadlineError(

--- a/.github/skill-eval/tests/test_remote_worker_lock.py
+++ b/.github/skill-eval/tests/test_remote_worker_lock.py
@@ -1,0 +1,833 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the transport-neutral remote worker lease."""
+
+from __future__ import annotations
+
+import importlib.util
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "remote_worker_lock",
+    Path(__file__).resolve().parents[1] / "remote_worker_lock.py",
+)
+remote_lock = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = remote_lock
+_SPEC.loader.exec_module(remote_lock)
+
+
+class Result:
+    def __init__(
+        self,
+        returncode: int,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _owner_from_acquire_command(command: str) -> str:
+    line = next(line for line in command.splitlines() if line.startswith("owner="))
+    return shlex.split(line.removeprefix("owner="))[0]
+
+
+def _owner_from_clear_command(command: str) -> str:
+    line = next(line for line in command.splitlines() if line.startswith("expected="))
+    return shlex.split(line.removeprefix("expected="))[0]
+
+
+def _marker(action: str, owner: str) -> str:
+    return remote_lock._owner_marker(action, owner)
+
+
+class OwnerIdentityTests(unittest.TestCase):
+    def test_v2_owner_prefers_shared_matrix_context(self):
+        env = {
+            "GITHUB_RUN_ID": "30277029589",
+            "GITHUB_RUN_ATTEMPT": "3",
+            "GITHUB_JOB": "eval",
+            "NEMOCLAW_LOCK_OWNER_CONTEXT": "nemoclaw-row",
+            "SKILL_EVAL_LOCK_OWNER_CONTEXT": "Ask Video · RTXPRO6000BW",
+        }
+        with mock.patch.dict(remote_lock.os.environ, env, clear=True):
+            owner = remote_lock.build_remote_lock_owner()
+
+        parts = owner.split("__")
+        self.assertEqual(len(parts), 7)
+        self.assertEqual(
+            parts[:4],
+            [
+                "v2",
+                "30277029589",
+                "3",
+                "ask-video---rtxpro6000bw",
+            ],
+        )
+        self.assertTrue(parts[4].isdigit())
+        self.assertTrue(parts[5].isdigit())
+        self.assertRegex(parts[6], r"^[0-9a-f]{32}$")
+
+    def test_owner_parsers_reject_non_v2_job_identity(self):
+        self.assertEqual(
+            remote_lock.github_run_id_from_lock_owner("12345__legacy"),
+            "12345",
+        )
+        self.assertIsNone(
+            remote_lock.github_job_identity_from_lock_owner("12345__legacy")
+        )
+        self.assertIsNone(
+            remote_lock.github_job_identity_from_lock_owner(
+                "v2__123__1__job__pid__time"
+            )
+        )
+
+    def test_owner_reconstructs_exact_matrix_job_context_without_extra_env_wiring(self):
+        env = {
+            "GITHUB_RUN_ID": "123",
+            "GITHUB_RUN_ATTEMPT": "2",
+            "EVAL_SKILL": "vss-ask-video",
+            "EVAL_SPEC_STEM": "base_profile_video_understanding",
+            "EVAL_PLATFORM": "RTXPRO6000BW",
+        }
+        with mock.patch.dict(remote_lock.os.environ, env, clear=True):
+            owner = remote_lock.build_remote_lock_owner()
+
+        self.assertEqual(
+            owner.split("__")[3],
+            "vss-ask-video---base-profile-video-understanding---rtxpro6000bw",
+        )
+
+    def test_workflows_grant_actions_read_for_owner_liveness(self):
+        workflows = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+        for name in ("skills-eval.yml", "skills-eval-daily.yml"):
+            with self.subTest(workflow=name):
+                source = (workflows / name).read_text()
+                self.assertIn("\npermissions:\n  actions: read\n", source)
+
+
+class AcquireReleaseTests(unittest.TestCase):
+    def test_real_shell_protocol_serializes_and_releases(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lock_root = Path(tmp) / "locks"
+
+            def execute(command: str, timeout: int) -> subprocess.CompletedProcess[str]:
+                return subprocess.run(
+                    ["bash", "-c", command],
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                )
+
+            with (
+                mock.patch.object(
+                    remote_lock,
+                    "REMOTE_LOCK_DIR",
+                    str(lock_root / "worker.lockdir"),
+                ),
+                mock.patch.object(
+                    remote_lock,
+                    "REMOTE_LOCK_GUARD",
+                    str(lock_root / "worker.guard"),
+                ),
+            ):
+                # Simulate a coordinator dying after mkdir but before writing
+                # a complete owner record. The guard holder may safely repair
+                # this state without evicting any valid lease.
+                (lock_root / "worker.lockdir").mkdir(parents=True)
+                first = remote_lock.try_acquire_remote_worker_lock(
+                    execute,
+                    "worker",
+                    owner_inactive=lambda _owner: False,
+                )
+                self.assertIsNotNone(first)
+                second = remote_lock.try_acquire_remote_worker_lock(
+                    execute,
+                    "worker",
+                    owner_inactive=lambda _owner: False,
+                )
+                self.assertIsNone(second)
+                assert first is not None
+                self.assertTrue(first.release())
+                third = remote_lock.try_acquire_remote_worker_lock(
+                    execute,
+                    "worker",
+                    owner_inactive=lambda _owner: False,
+                )
+                self.assertIsNotNone(third)
+                assert third is not None
+                self.assertTrue(third.release())
+
+    def test_acquire_never_reclaims_a_live_owner_by_fixed_age(self):
+        command = remote_lock._acquire_command("exact-owner")
+
+        self.assertIn("age=$((now - created))", command)
+        self.assertNotIn("900", command)
+        self.assertNotIn('if [ "$age"', command)
+
+    def test_acquire_transport_is_capped_to_remaining_deadline(self):
+        calls: list[float] = []
+        other = "v2__111__1__other-job__1__2__abc"
+
+        def execute(_command: str, timeout: float) -> Result:
+            calls.append(timeout)
+            return Result(1, f"{_marker('BUSY', other)}\n")
+
+        with mock.patch.object(remote_lock.time, "monotonic", return_value=100.0):
+            lease = remote_lock.try_acquire_remote_worker_lock(
+                execute,
+                "worker",
+                owner_inactive=lambda _owner: False,
+                deadline=105.0,
+            )
+
+        self.assertIsNone(lease)
+        self.assertEqual(calls, [5.0])
+
+    def test_busy_active_owner_fails_closed(self):
+        other = "v2__111__1__other-job__1__2__abc"
+        calls: list[int] = []
+
+        def execute(_command: str, timeout: int) -> Result:
+            calls.append(timeout)
+            return Result(
+                1,
+                f"{_marker('BUSY', other)}\n"
+                f"skill-eval worker is leased by {other} age=10s\n",
+            )
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-a",
+            owner_inactive=lambda owner: False,
+        )
+
+        self.assertIsNone(lease)
+        self.assertEqual(calls, [60])
+
+    def test_response_loss_reconciles_only_the_exact_generated_owner(self):
+        attempts = 0
+        release_calls = 0
+        commands: list[str] = []
+
+        def execute(command: str, timeout: int) -> Result:
+            nonlocal attempts, release_calls
+            commands.append(command)
+            if "if mkdir" in command:
+                attempts += 1
+                owner = _owner_from_acquire_command(command)
+                if attempts == 1:
+                    raise subprocess.TimeoutExpired("remote", timeout)
+                return Result(
+                    1,
+                    f"{_marker('BUSY', owner)}\n"
+                    f"skill-eval worker is leased by {owner} age=0s\n",
+                )
+            release_calls += 1
+            owner = _owner_from_clear_command(command)
+            return Result(0, f"{_marker('CLEARED', owner)}\n")
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-a",
+            owner_context="matrix-row",
+        )
+        self.assertIsNotNone(lease)
+        assert lease is not None
+
+        self.assertEqual(attempts, 2)
+        self.assertIn('exec 9>"$guard"', commands[0])
+        self.assertIn("flock -x 9", commands[0])
+        self.assertTrue(lease.release())
+        self.assertEqual(release_calls, 1)
+
+    def test_inactive_owner_is_cleared_then_acquisition_retried(self):
+        old_owner = "v2__111__1__old-job__1__2__abc"
+        acquisitions = 0
+        clears: list[str] = []
+        checked: list[str] = []
+
+        def execute(command: str, _timeout: int) -> Result:
+            nonlocal acquisitions
+            if "if mkdir" in command:
+                acquisitions += 1
+                if acquisitions == 1:
+                    return Result(
+                        1,
+                        f"{_marker('BUSY', old_owner)}\n"
+                        f"skill-eval worker is leased by {old_owner} age=20s\n",
+                    )
+                owner = _owner_from_acquire_command(command)
+                return Result(0, f"{_marker('ACQUIRED', owner)}\n")
+            owner = _owner_from_clear_command(command)
+            clears.append(owner)
+            return Result(0, f"{_marker('CLEARED', owner)}\n")
+
+        def inactive(owner: str) -> bool:
+            checked.append(owner)
+            return True
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-b",
+            owner_inactive=inactive,
+        )
+        self.assertIsNotNone(lease)
+        assert lease is not None
+        lease.release()
+
+        self.assertEqual(checked, [old_owner])
+        self.assertEqual(acquisitions, 2)
+        self.assertEqual(clears[0], old_owner)
+        self.assertEqual(clears[1], lease.owner)
+
+    def test_busy_owner_survives_long_transport_stderr(self):
+        old_owner = "v2__111__1__old-job__1__2__abc"
+        old_owner_cleared = False
+        acquisitions = 0
+        clears: list[str] = []
+        checked: list[str] = []
+        busy_result = Result(
+            1,
+            f"{_marker('BUSY', old_owner)}\n"
+            f"skill-eval worker is leased by {old_owner} age=20s\n",
+            "ssh transport diagnostics\n" * 100,
+        )
+        self.assertIsNone(
+            remote_lock.remote_lock_owner_from_output(
+                remote_lock._command_tail(busy_result)
+            )
+        )
+
+        def execute(command: str, _timeout: int) -> Result:
+            nonlocal acquisitions, old_owner_cleared
+            if "if mkdir" in command:
+                acquisitions += 1
+                if not old_owner_cleared:
+                    return busy_result
+                owner = _owner_from_acquire_command(command)
+                return Result(0, f"{_marker('ACQUIRED', owner)}\n")
+            owner = _owner_from_clear_command(command)
+            clears.append(owner)
+            if owner == old_owner:
+                old_owner_cleared = True
+            return Result(0, f"{_marker('CLEARED', owner)}\n")
+
+        def inactive(owner: str) -> bool:
+            checked.append(owner)
+            return True
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-b",
+            owner_inactive=inactive,
+        )
+        self.assertIsNotNone(lease)
+        assert lease is not None
+        lease.release()
+
+        self.assertEqual(checked, [old_owner])
+        self.assertEqual(acquisitions, 2)
+        self.assertEqual(clears, [old_owner, lease.owner])
+
+    def test_changed_owner_is_never_deleted(self):
+        seen: list[tuple[str, int]] = []
+
+        def execute(command: str, timeout: int) -> Result:
+            seen.append((command, timeout))
+            return Result(
+                1,
+                "skill-eval worker lease owner changed to another; not removing\n",
+            )
+
+        cleared = remote_lock.clear_remote_worker_lock(
+            execute,
+            "worker-c",
+            "expected-owner",
+        )
+
+        self.assertFalse(cleared)
+        self.assertEqual(seen[0][1], 60)
+        self.assertIn(
+            f"lock_dir={remote_lock.REMOTE_LOCK_DIR}",
+            seen[0][0],
+        )
+        self.assertIn('exec 9>"$guard"', seen[0][0])
+        self.assertIn("flock -x 9", seen[0][0])
+        self.assertIn('actual=$(cat "$lock_dir/owner"', seen[0][0])
+        self.assertIn('[ "$actual" = "$expected" ]', seen[0][0])
+
+    def test_rc_zero_with_echoed_command_and_dns_failure_never_acquires(self):
+        commands: list[str] = []
+
+        def execute(command: str, _timeout: int) -> Result:
+            commands.append(command)
+            return Result(
+                0,
+                f"{command}\nw71vmgk8z\nssh: Could not resolve hostname w71vmgk8z\n",
+            )
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-c",
+            owner_context="matrix-row",
+        )
+
+        self.assertIsNone(lease)
+        self.assertEqual(len(commands), 3)
+        self.assertEqual(
+            remote_lock.remote_lock_owner_from_output(commands[0]),
+            None,
+        )
+
+    def test_rc_zero_dns_failure_without_exact_marker_never_clears(self):
+        seen: list[str] = []
+
+        def execute(command: str, _timeout: int) -> Result:
+            seen.append(command)
+            return Result(
+                0,
+                f"{command}\nssh: Could not resolve hostname worker-c\n",
+            )
+
+        self.assertFalse(
+            remote_lock.clear_remote_worker_lock(
+                execute,
+                "worker-c",
+                "expected-owner",
+            )
+        )
+        self.assertEqual(len(seen), 1)
+
+    def test_double_response_loss_attempts_exact_owner_cleanup(self):
+        commands: list[str] = []
+
+        def execute(command: str, timeout: int) -> Result:
+            commands.append(command)
+            if "if mkdir" in command:
+                raise subprocess.TimeoutExpired("remote", timeout)
+            return Result(
+                1,
+                "skill-eval worker lease owner changed to none; not removing\n",
+            )
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-c",
+            owner_context="matrix-row",
+        )
+
+        self.assertIsNone(lease)
+        self.assertEqual(len(commands), 3)
+        owner = _owner_from_acquire_command(commands[0])
+        self.assertIn(f"expected={shlex.quote(owner)}", commands[2])
+
+    def test_timeout_then_transport_error_cleans_unconfirmed_owner(self):
+        commands: list[str] = []
+        attempts = 0
+
+        def execute(command: str, timeout: int) -> Result:
+            nonlocal attempts
+            commands.append(command)
+            if "if mkdir" in command:
+                attempts += 1
+                if attempts == 1:
+                    raise subprocess.TimeoutExpired("remote", timeout)
+                return Result(255, "", "ssh: connection reset\n")
+            return Result(
+                1,
+                "skill-eval worker lease owner changed to none; not removing\n",
+            )
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-c",
+            owner_context="matrix-row",
+        )
+
+        self.assertIsNone(lease)
+        self.assertEqual(len(commands), 3)
+        owner = _owner_from_acquire_command(commands[0])
+        self.assertIn(f"expected={shlex.quote(owner)}", commands[2])
+        acquire = commands[0]
+        self.assertIn('exec 9>"$guard"', acquire)
+        self.assertIn("flock -x 9", acquire)
+        self.assertLess(acquire.index("flock -x 9"), acquire.index('mkdir "$lock_dir"'))
+
+    def test_heartbeat_start_failure_clears_acquired_exact_owner(self):
+        commands: list[str] = []
+
+        def execute(command: str, _timeout: int) -> Result:
+            commands.append(command)
+            if "if mkdir" in command:
+                owner = _owner_from_acquire_command(command)
+                return Result(0, f"{_marker('ACQUIRED', owner)}\n")
+            owner = _owner_from_clear_command(command)
+            return Result(0, f"{_marker('CLEARED', owner)}\n")
+
+        with (
+            mock.patch.object(
+                remote_lock,
+                "_start_remote_worker_lock_heartbeat",
+                side_effect=RuntimeError("thread unavailable"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "thread unavailable"),
+        ):
+            remote_lock.try_acquire_remote_worker_lock(
+                execute,
+                "worker-d",
+            )
+
+        self.assertEqual(len(commands), 2)
+        owner = _owner_from_acquire_command(commands[0])
+        self.assertIn(f"expected={shlex.quote(owner)}", commands[1])
+
+    def test_release_stops_heartbeat_before_exact_delete(self):
+        holder: dict[str, remote_lock.RemoteWorkerLease] = {}
+        heartbeat_alive_at_delete: list[bool] = []
+
+        def execute(command: str, _timeout: int) -> Result:
+            if "if mkdir" in command:
+                owner = _owner_from_acquire_command(command)
+                return Result(0, f"{_marker('ACQUIRED', owner)}\n")
+            heartbeat_alive_at_delete.append(
+                holder["lease"].heartbeat.thread.is_alive()
+            )
+            owner = _owner_from_clear_command(command)
+            return Result(0, f"{_marker('CLEARED', owner)}\n")
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-e",
+        )
+        self.assertIsNotNone(lease)
+        assert lease is not None
+        holder["lease"] = lease
+
+        self.assertTrue(lease.release())
+        self.assertEqual(heartbeat_alive_at_delete, [False])
+        # Release is idempotent and never issues a second delete.
+        self.assertTrue(lease.release())
+        self.assertEqual(heartbeat_alive_at_delete, [False])
+
+    def test_release_can_retry_after_transient_cleanup_failure(self):
+        deletes = 0
+
+        def execute(command: str, _timeout: int) -> Result:
+            nonlocal deletes
+            if "if mkdir" in command:
+                owner = _owner_from_acquire_command(command)
+                return Result(0, f"{_marker('ACQUIRED', owner)}\n")
+            deletes += 1
+            if deletes == 1:
+                raise OSError("temporary transport failure")
+            owner = _owner_from_clear_command(command)
+            return Result(0, f"{_marker('CLEARED', owner)}\n")
+
+        lease = remote_lock.try_acquire_remote_worker_lock(
+            execute,
+            "worker-e",
+        )
+        self.assertIsNotNone(lease)
+        assert lease is not None
+
+        self.assertFalse(lease.release())
+        self.assertTrue(lease.release())
+        self.assertEqual(deletes, 2)
+
+
+class RefreshHeartbeatTests(unittest.TestCase):
+    def test_refresh_is_atomic_and_exact_owner_only(self):
+        commands: list[str] = []
+
+        def execute(command: str, timeout: int) -> Result:
+            commands.append(command)
+            self.assertEqual(timeout, 30)
+            return Result(
+                0,
+                f"{_marker('REFRESHED', 'exact-owner')}\n",
+            )
+
+        status = remote_lock.refresh_remote_worker_lock(
+            execute,
+            "worker-f",
+            "exact-owner",
+        )
+
+        self.assertEqual(status, "refreshed")
+        command = commands[0]
+        self.assertIn("stat -Lc '%d:%i'", command)
+        self.assertIn('exec 9>"$guard"', command)
+        self.assertIn("flock -x 9", command)
+        self.assertIn('mktemp "$lock_dir/.created.', command)
+        self.assertIn('mv -f "$tmp" "$lock_dir/created"', command)
+        self.assertNotIn('mkdir "$lock_dir"', command)
+        self.assertNotIn('rm -rf "$lock_dir"', command)
+
+    def test_refresh_distinguishes_owner_loss_from_transport_unknown(self):
+        not_owner = remote_lock.refresh_remote_worker_lock(
+            lambda _command, _timeout: Result(
+                3,
+                f"{_marker('NOT_OWNER', 'expected')}\n",
+            ),
+            "worker-g",
+            "expected",
+        )
+        unknown = remote_lock.refresh_remote_worker_lock(
+            lambda _command, _timeout: (_ for _ in ()).throw(OSError("network")),
+            "worker-g",
+            "expected",
+        )
+
+        self.assertEqual(not_owner, "not_owner")
+        self.assertEqual(unknown, "unknown")
+
+    def test_rc_zero_echoed_refresh_command_and_dns_failure_is_unknown(self):
+        def execute(command: str, _timeout: int) -> Result:
+            return Result(
+                0,
+                f"{command}\n"
+                "refreshed skill-eval worker lease owned by exact-owner\n"
+                "ssh: Could not resolve hostname worker-f\n",
+            )
+
+        self.assertEqual(
+            remote_lock.refresh_remote_worker_lock(
+                execute,
+                "worker-f",
+                "exact-owner",
+            ),
+            "unknown",
+        )
+
+    def test_owner_loss_sets_lost_event(self):
+        with (
+            mock.patch.object(
+                remote_lock,
+                "_heartbeat_settings",
+                return_value=(0.01, 0.03),
+            ),
+            mock.patch.object(
+                remote_lock,
+                "refresh_remote_worker_lock",
+                return_value="not_owner",
+            ),
+        ):
+            heartbeat = remote_lock._start_remote_worker_lock_heartbeat(
+                lambda _command, _timeout: Result(0),
+                "worker-h",
+                "owner",
+            )
+            self.assertTrue(heartbeat.lost_event.wait(0.5))
+            self.assertTrue(remote_lock._stop_remote_worker_lock_heartbeat(heartbeat))
+
+    def test_unconfirmed_heartbeat_fails_closed_after_bounded_silence(self):
+        refreshes = 0
+
+        def unknown(*_args) -> str:
+            nonlocal refreshes
+            refreshes += 1
+            return "unknown"
+
+        with (
+            mock.patch.object(
+                remote_lock,
+                "_heartbeat_settings",
+                return_value=(0.01, 0.025),
+            ),
+            mock.patch.object(
+                remote_lock,
+                "refresh_remote_worker_lock",
+                side_effect=unknown,
+            ),
+        ):
+            heartbeat = remote_lock._start_remote_worker_lock_heartbeat(
+                lambda _command, _timeout: Result(0),
+                "worker-i",
+                "owner",
+            )
+            self.assertTrue(heartbeat.lost_event.wait(0.5))
+            self.assertTrue(remote_lock._stop_remote_worker_lock_heartbeat(heartbeat))
+
+        self.assertGreaterEqual(refreshes, 3)
+
+    def test_heartbeat_configuration_is_bounded_and_has_compatibility_fallbacks(self):
+        with mock.patch.dict(
+            remote_lock.os.environ,
+            {
+                "SKILL_EVAL_REMOTE_LOCK_HEARTBEAT_SEC": "9999",
+                "SKILL_EVAL_REMOTE_LOCK_HEARTBEAT_MAX_SILENCE_SEC": "9999",
+            },
+            clear=True,
+        ):
+            self.assertEqual(remote_lock._heartbeat_settings(), (240.0, 660.0))
+
+        with mock.patch.dict(
+            remote_lock.os.environ,
+            {
+                "NEMOCLAW_REMOTE_LOCK_HEARTBEAT_SEC": "bad",
+                "NEMOCLAW_REMOTE_LOCK_HEARTBEAT_MAX_SILENCE_SEC": "bad",
+            },
+            clear=True,
+        ):
+            self.assertEqual(remote_lock._heartbeat_settings(), (180.0, 660.0))
+
+        with mock.patch.dict(
+            remote_lock.os.environ,
+            {
+                "SKILL_EVAL_REMOTE_LOCK_HEARTBEAT_SEC": "-1",
+                "SKILL_EVAL_REMOTE_LOCK_HEARTBEAT_MAX_SILENCE_SEC": "-1",
+            },
+            clear=True,
+        ):
+            self.assertEqual(remote_lock._heartbeat_settings(), (30.0, 60.0))
+
+
+class GitHubOwnerStatusTests(unittest.TestCase):
+    def test_same_run_completed_matrix_job_is_inactive(self):
+        owner = "v2__123__2__ask-video__44__55__abc"
+        with (
+            mock.patch.dict(
+                remote_lock.os.environ,
+                {"GITHUB_RUN_ID": "123"},
+                clear=True,
+            ),
+            mock.patch.object(
+                remote_lock,
+                "_github_job_status",
+                return_value="completed",
+            ) as job_status,
+        ):
+            self.assertTrue(remote_lock.remote_lock_owner_is_inactive(owner))
+
+        job_status.assert_called_once_with(
+            "123",
+            "2",
+            "ask-video",
+            deadline=None,
+        )
+
+    def test_same_run_unknown_job_is_never_evicted(self):
+        owner = "v2__123__2__ask-video__44__55__abc"
+        with (
+            mock.patch.dict(
+                remote_lock.os.environ,
+                {"GITHUB_RUN_ID": "123"},
+                clear=True,
+            ),
+            mock.patch.object(
+                remote_lock,
+                "_github_job_status",
+                return_value=None,
+            ),
+            mock.patch.object(remote_lock, "_github_run_status") as run_status,
+        ):
+            self.assertFalse(remote_lock.remote_lock_owner_is_inactive(owner))
+
+        run_status.assert_not_called()
+
+    def test_other_run_requires_a_proven_terminal_status(self):
+        owner = "v2__456__1__job__44__55__abc"
+        with (
+            mock.patch.dict(
+                remote_lock.os.environ,
+                {"GITHUB_RUN_ID": "123"},
+                clear=True,
+            ),
+            mock.patch.object(
+                remote_lock,
+                "_github_job_status",
+                return_value=None,
+            ),
+            mock.patch.object(
+                remote_lock,
+                "_github_run_status",
+                side_effect=["in_progress", "completed", None],
+            ),
+        ):
+            self.assertFalse(remote_lock.remote_lock_owner_is_inactive(owner))
+            self.assertTrue(remote_lock.remote_lock_owner_is_inactive(owner))
+            self.assertFalse(remote_lock.remote_lock_owner_is_inactive(owner))
+
+    def test_unknown_github_status_is_never_treated_as_terminal(self):
+        owner = "v2__456__1__job__44__55__abc"
+        with (
+            mock.patch.dict(
+                remote_lock.os.environ,
+                {"GITHUB_RUN_ID": "123"},
+                clear=True,
+            ),
+            mock.patch.object(
+                remote_lock,
+                "_github_job_status",
+                return_value="mystery-state",
+            ),
+        ):
+            self.assertFalse(remote_lock.remote_lock_owner_is_inactive(owner))
+
+    def test_github_job_match_is_exact_unique_and_unpaginated(self):
+        payload = {
+            "total_count": 2,
+            "jobs": [
+                {"name": "Skill Eval / Ask Video", "status": "completed"},
+                {"name": "Other", "status": "in_progress"},
+            ],
+        }
+        with (
+            mock.patch.dict(
+                remote_lock.os.environ,
+                {
+                    "GITHUB_REPOSITORY": "org/repo",
+                    "GH_TOKEN": "token",
+                },
+                clear=True,
+            ),
+            mock.patch.object(
+                remote_lock,
+                "_run_local",
+                return_value=Result(0, remote_lock.json.dumps(payload)),
+            ),
+        ):
+            self.assertEqual(
+                remote_lock._github_job_status(
+                    "123",
+                    "1",
+                    "skill-eval---ask-video",
+                ),
+                "completed",
+            )
+            self.assertIsNone(
+                remote_lock._github_job_status("123", "1", "ask-video"),
+            )
+
+        payload["total_count"] = 101
+        with (
+            mock.patch.dict(
+                remote_lock.os.environ,
+                {
+                    "GITHUB_REPOSITORY": "org/repo",
+                    "GH_TOKEN": "token",
+                },
+                clear=True,
+            ),
+            mock.patch.object(
+                remote_lock,
+                "_run_local",
+                return_value=Result(0, remote_lock.json.dumps(payload)),
+            ),
+        ):
+            self.assertIsNone(
+                remote_lock._github_job_status("123", "1", "missing"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -13,8 +13,10 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 from unittest import mock
@@ -187,8 +189,12 @@ class PhaseBudgets(unittest.TestCase):
         self.assertEqual(run_leg.HARBOR_SIGINT_GRACE_SEC, 1380)
         self.assertEqual(run_leg.HARBOR_SHUTDOWN_GRACE_SEC, 1420)
         self.assertEqual(
+            run_leg.remote_worker_lock.REMOTE_LEASE_RELEASE_BUDGET_SEC,
+            92,
+        )
+        self.assertEqual(
             run_leg.invocation_reserve_sec(run_leg.DEFAULT_HARBOR_TIMEOUT_SEC),
-            13480,
+            13572,
         )
         self.assertGreater(
             run_leg.DEFAULT_HARBOR_TIMEOUT_SEC,
@@ -498,6 +504,52 @@ class RunCommand(unittest.TestCase):
 
         self.assertEqual(rc, 124)
 
+    def test_lease_loss_skips_sigint_and_uses_bounded_term_kill(self):
+        proc = mock.Mock(pid=4321)
+        lost_event = threading.Event()
+        lost_event.set()
+        with (
+            mock.patch.object(run_leg.subprocess, "Popen", return_value=proc),
+            mock.patch.object(run_leg.os, "killpg") as killpg,
+            mock.patch.object(
+                run_leg,
+                "_wait_for_process_group_exit",
+                side_effect=[False, True],
+            ) as wait_group,
+        ):
+            rc = run_leg.run_command(
+                self.COMMAND,
+                self.ENV,
+                timeout_sec=42,
+                abort_event=lost_event,
+            )
+
+        self.assertEqual(rc, 125)
+        self.assertEqual(
+            killpg.call_args_list,
+            [
+                mock.call(4321, run_leg.signal.SIGTERM),
+                mock.call(4321, run_leg.signal.SIGKILL),
+            ],
+        )
+        self.assertEqual(
+            wait_group.call_args_list,
+            [
+                mock.call(
+                    proc,
+                    4321,
+                    run_leg.LEASE_LOSS_SIGTERM_GRACE_SEC,
+                    mock.ANY,
+                ),
+                mock.call(
+                    proc,
+                    4321,
+                    run_leg.LEASE_LOSS_SIGKILL_GRACE_SEC,
+                    mock.ANY,
+                ),
+            ],
+        )
+
 
 class ProcessGroupShutdown(unittest.TestCase):
     def test_leader_exit_is_not_enough_when_group_still_exists(self):
@@ -671,6 +723,41 @@ class RunInvocations(unittest.TestCase):
 
         self.assertEqual(rc, 124)
         run.assert_called_once()
+
+    def test_child_rc125_without_lease_loss_keeps_existing_semantics(self):
+        invocations = [
+            run_leg.HarborInvocation(
+                harbor_root=Path("/tmp/datasets/spec"),
+                include_task_name=f"task-{index}",
+                chain_key=f"task-{index}",
+            )
+            for index in (1, 2)
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with (
+                mock.patch.dict(run_leg.os.environ, self.ENV, clear=True),
+                mock.patch.object(run_leg, "harbor_env", return_value={}),
+                mock.patch.object(
+                    run_leg, "build_harbor_command", return_value=["harbor"]
+                ),
+                mock.patch.object(
+                    run_leg, "run_command", return_value=125
+                ) as run,
+                mock.patch.object(run_leg, "publish_trace", return_value=None),
+            ):
+                rc = run_leg.run_invocations(
+                    invocations,
+                    "vss-eval-box",
+                    root / "results",
+                    root / "scratch",
+                    "spec",
+                    "RTXPRO6000BW",
+                    run_leg.DEFAULT_HARBOR_TIMEOUT_SEC,
+                )
+
+        self.assertEqual(rc, 125)
+        self.assertEqual(run.call_count, 2)
 
     def test_chain_timeout_writes_skip_markers_before_stopping(self):
         invocations = [
@@ -1144,13 +1231,24 @@ class HoldPoolLock(unittest.TestCase):
             # Hold the preferred box's lock as if another leg owns it.
             held = (lock_dir / "box-a.lock").open("a+")
             fcntl.flock(held.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            remote_lease = mock.Mock(lost_event=threading.Event())
             try:
-                with run_leg.hold_pool_lock(
-                    lambda: ["box-a", "box-b"], lock_dir, timeout_sec=5
-                ) as chosen:
-                    self.assertEqual(chosen, "box-b")
+                with (
+                    mock.patch.object(
+                        run_leg,
+                        "_try_acquire_remote_worker_lease",
+                        return_value=remote_lease,
+                    ),
+                    run_leg.hold_pool_lock(
+                        lambda _deadline: ["box-a", "box-b"],
+                        lock_dir,
+                        timeout_sec=5,
+                    ) as worker,
+                ):
+                    self.assertEqual(worker.instance, "box-b")
             finally:
                 held.close()
+            remote_lease.release.assert_called_once()
 
     def test_times_out_when_all_held(self):
         import fcntl
@@ -1163,7 +1261,9 @@ class HoldPoolLock(unittest.TestCase):
                 start = time.monotonic()
                 with self.assertRaises(run_leg.LockTimeoutError):
                     with run_leg.hold_pool_lock(
-                        lambda: ["box-a"], lock_dir, timeout_sec=0
+                        lambda _deadline: ["box-a"],
+                        lock_dir,
+                        timeout_sec=0,
                     ):
                         pass
                 self.assertLess(time.monotonic() - start, 5)
@@ -1175,13 +1275,233 @@ class HoldPoolLock(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             lock_dir = Path(tmp)
-            with run_leg.hold_pool_lock(lambda: ["box-a"], lock_dir, 5) as chosen:
-                self.assertEqual(chosen, "box-a")
+            remote_lease = mock.Mock(lost_event=threading.Event())
+            with (
+                mock.patch.object(
+                    run_leg,
+                    "_try_acquire_remote_worker_lease",
+                    return_value=remote_lease,
+                ),
+                run_leg.hold_pool_lock(
+                    lambda _deadline: ["box-a"], lock_dir, 5
+                ) as worker,
+            ):
+                self.assertEqual(worker.instance, "box-a")
             probe = (lock_dir / "box-a.lock").open("a+")
             try:
                 fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             finally:
                 probe.close()
+            remote_lease.release.assert_called_once()
+
+    def test_remote_busy_candidate_releases_local_lock_and_uses_next(self):
+        import fcntl
+
+        with tempfile.TemporaryDirectory() as tmp:
+            lock_dir = Path(tmp)
+            remote_lease = mock.Mock(lost_event=threading.Event())
+            attempts: list[str] = []
+
+            def acquire(instance: str, *, deadline: float | None = None):
+                self.assertIsNotNone(deadline)
+                attempts.append(instance)
+                return None if instance == "box-a" else remote_lease
+
+            with (
+                mock.patch.object(
+                    run_leg,
+                    "_try_acquire_remote_worker_lease",
+                    side_effect=acquire,
+                ),
+                run_leg.hold_pool_lock(
+                    lambda _deadline: ["box-a", "box-b"], lock_dir, 5
+                ) as worker,
+            ):
+                self.assertEqual(worker.instance, "box-b")
+                probe = (lock_dir / "box-a.lock").open("a+")
+                try:
+                    fcntl.flock(
+                        probe.fileno(),
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
+                    )
+                finally:
+                    probe.close()
+
+        self.assertEqual(attempts, ["box-a", "box-b"])
+        remote_lease.release.assert_called_once()
+
+    def test_remote_release_failure_invalidates_the_locked_worker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lost_event = threading.Event()
+            remote_lease = mock.Mock(lost_event=lost_event)
+            remote_lease.release.return_value = False
+            with (
+                mock.patch.object(
+                    run_leg,
+                    "_try_acquire_remote_worker_lease",
+                    return_value=remote_lease,
+                ),
+                run_leg.hold_pool_lock(
+                    lambda _deadline: ["box-a"], Path(tmp), 5
+                ) as worker,
+            ):
+                self.assertFalse(worker.lost_event.is_set())
+
+            self.assertTrue(worker.lost_event.is_set())
+
+
+class RemoteWorkerLeaseIntegration(unittest.TestCase):
+    def tearDown(self):
+        run_leg._WORKER_TRANSPORTS.clear()
+
+    def test_remote_executor_routes_managed_and_registered_workers(self):
+        result = subprocess.CompletedProcess([], 0, "", "")
+        with mock.patch.object(
+            run_leg.subprocess,
+            "run",
+            return_value=result,
+        ) as run:
+            run_leg._WORKER_TRANSPORTS["managed-box"] = "brev"
+            run_leg._remote_lock_executor("managed-box")("echo managed", 17)
+
+            run_leg._WORKER_TRANSPORTS["registered-box"] = "ssh"
+            run_leg._remote_lock_executor("Registered-Box")(
+                "echo registered", 19
+            )
+
+        managed_cmd = run.call_args_list[0].args[0]
+        registered_cmd = run.call_args_list[1].args[0]
+        self.assertEqual(managed_cmd[:3], ["brev", "exec", "managed-box"])
+        self.assertEqual(registered_cmd[0], "ssh")
+        self.assertIn("registered-box", registered_cmd)
+        self.assertEqual(run.call_args_list[0].kwargs["timeout"], 17)
+        self.assertEqual(run.call_args_list[1].kwargs["timeout"], 19)
+
+    def test_pinned_registered_worker_is_discovered_without_allowlist(self):
+        with (
+            mock.patch.dict(run_leg.os.environ, {}, clear=True),
+            mock.patch.object(run_leg, "_list_brev_instances", return_value=[]),
+            mock.patch.object(
+                run_leg,
+                "_list_registered_nodes",
+                return_value=[
+                    {"name": "Pinned-Registered", "status": "Connected"}
+                ],
+            ),
+        ):
+            self.assertTrue(run_leg._worker_uses_ssh("pinned-registered"))
+
+    def test_unknown_pinned_worker_transport_fails_explicitly(self):
+        with (
+            mock.patch.dict(run_leg.os.environ, {}, clear=True),
+            mock.patch.object(run_leg, "_list_brev_instances", return_value=[]),
+            mock.patch.object(run_leg, "_list_registered_nodes", return_value=[]),
+            self.assertRaisesRegex(RuntimeError, "could not resolve pinned worker"),
+        ):
+            run_leg._worker_uses_ssh("missing-worker")
+
+    def test_run_command_lease_loss_aborts_harbor(self):
+        lost_event = threading.Event()
+        lost_event.set()
+
+        rc = run_leg.run_command(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            os.environ.copy(),
+            timeout_sec=10,
+            abort_event=lost_event,
+        )
+
+        self.assertEqual(rc, 125)
+
+    def test_multistep_chain_stops_immediately_after_lease_loss(self):
+        invocations = [
+            run_leg.HarborInvocation(
+                harbor_root=Path("/tmp/profile"),
+                include_task_name=f"step-{index}",
+                chain_key="chain",
+                step_index=index,
+                step_count=2,
+            )
+            for index in (1, 2)
+        ]
+        lost_event = threading.Event()
+        lost_event.set()
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            mock.patch.dict(
+                run_leg.os.environ,
+                {
+                    "ANTHROPIC_MODEL": "model",
+                    "ANTHROPIC_BASE_URL": "https://example.test",
+                },
+                clear=True,
+            ),
+            mock.patch.object(run_leg, "harbor_env", return_value={}),
+            mock.patch.object(run_leg, "run_command") as run,
+        ):
+            root = Path(tmp)
+            rc = run_leg.run_invocations(
+                invocations,
+                "worker",
+                root / "results",
+                root / "scratch",
+                "spec",
+                "platform",
+                run_leg.DEFAULT_HARBOR_TIMEOUT_SEC,
+                abort_event=lost_event,
+            )
+
+        self.assertEqual(rc, 125)
+        run.assert_not_called()
+
+    def test_lease_loss_racing_with_last_child_exit_invalidates_result(self):
+        invocation = run_leg.HarborInvocation(
+            harbor_root=Path("/tmp/profile"),
+            include_task_name="task",
+            chain_key="chain",
+        )
+        lost_event = threading.Event()
+
+        def finish_as_lease_is_lost(*_args, **_kwargs):
+            lost_event.set()
+            return 0
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            mock.patch.dict(
+                run_leg.os.environ,
+                {
+                    "ANTHROPIC_MODEL": "model",
+                    "ANTHROPIC_BASE_URL": "https://example.test",
+                },
+                clear=True,
+            ),
+            mock.patch.object(run_leg, "harbor_env", return_value={}),
+            mock.patch.object(
+                run_leg,
+                "build_harbor_command",
+                return_value=["harbor"],
+            ),
+            mock.patch.object(
+                run_leg,
+                "run_command",
+                side_effect=finish_as_lease_is_lost,
+            ),
+            mock.patch.object(run_leg, "publish_trace", return_value=None),
+        ):
+            root = Path(tmp)
+            rc = run_leg.run_invocations(
+                [invocation],
+                "worker",
+                root / "results",
+                root / "scratch",
+                "spec",
+                "platform",
+                run_leg.DEFAULT_HARBOR_TIMEOUT_SEC,
+                abort_event=lost_event,
+            )
+
+        self.assertEqual(rc, 125)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,9 +428,12 @@ jobs:
             .github/skill-eval/tests/test_python_runtime_contract.py \
             .github/skill-eval/tests/test_skills_eval_agent_protocol.py \
             .github/skill-eval/envs/tests/test_cancellation_recovery.py \
+            .github/skill-eval/tests/test_remote_worker_lock.py \
             .github/skill-eval/tests/test_run_leg.py::HarborCommand \
             .github/skill-eval/tests/test_run_leg.py::PhaseBudgets \
             .github/skill-eval/tests/test_run_leg.py::HarborEnvironment \
+            .github/skill-eval/tests/test_run_leg.py::HoldPoolLock \
+            .github/skill-eval/tests/test_run_leg.py::RemoteWorkerLeaseIntegration \
             .github/skill-eval/tests/test_run_leg.py::RunCommand \
             .github/skill-eval/tests/test_run_leg.py::ProcessGroupShutdown \
             .github/skill-eval/tests/test_run_leg.py::RunInvocations \

--- a/.github/workflows/skills-eval-daily.yml
+++ b/.github/workflows/skills-eval-daily.yml
@@ -39,16 +39,18 @@ on:
 # helm-sync.yml does it — no PAT, no rotation, no personal-account
 # binding. The skill-eval bot PRs hit the source PR's headRefName branch
 # in this same repo, so contents:write is enough; pull-requests:write
-# covers gh pr comment + gh pr create.
+# covers gh pr comment + gh pr create; actions:read lets the shared-worker
+# lease prove an abandoned owner job is terminal.
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 
 # Only one sweep runs at a time per ref. A fresh run cancels the in-flight
-# one; the per-box flocks (/tmp/brev/<INSTANCE_NAME>.lock)
-# release automatically when the agent process dies (POSIX flock(2) semantics —
-# no userspace trap needed). Any stale containers / volumes / marker that the
-# cancelled run left on a box are reconciled by the NEXT run's
+# one. The kernel releases each runner-local flock when its wrapper dies; the
+# next allocator removes the matching worker-side lease only after Actions
+# proves its owner job terminal. Any stale containers / volumes / marker that
+# the cancelled run left on a box are reconciled by the NEXT run's
 # `BrevEnvironment._ensure_prerequisite_deployed`: the active-deploy marker
 # carries `<profile_tag>|<run_id>`, so a marker from this run never matches
 # the next run's desired marker and the next run always tears down + redeploys.

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -43,16 +43,19 @@ on:
 # Authenticate as github-actions[bot] for all GitHub operations (gh pr
 # comment + git push of the adapter commit to the contributor's branch).
 # Mirrors helm-sync.yml — no PAT, no rotation. contents:write covers the
-# adapter push; pull-requests:write covers the PR comment.
+# adapter push; pull-requests:write covers the PR comment; actions:read lets
+# the shared-worker lease prove an abandoned owner job is terminal.
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 
 # One eval generation per PR (or manual sweep) at a time. A fresh push
-# cancels every in-flight matrix leg of the prior push for this ref;
-# run_leg.py holds /tmp/brev/<INSTANCE_NAME>.lock while Harbor runs, and
-# the kernel releases it automatically when the wrapper process dies
-# (POSIX flock(2) — no userspace trap).
+# cancels every in-flight matrix leg of the prior push for this ref.
+# run_leg.py holds a runner-local flock plus a lease on the worker while
+# Harbor runs. The kernel releases the flock when the wrapper dies; the next
+# allocator removes the remote lease only after Actions proves its owner job
+# terminal.
 # Stale containers/volumes a cancelled leg left on a box are reconciled by
 # the next trial's own deploy step (the harness no longer pre-deploys or
 # tracks an active-deploy marker). Same path handles SIGKILL (the


### PR DESCRIPTION
## Scope

Adds a generic worker-side lease to the existing skill-eval allocator so jobs running on different self-hosted GitHub runner hosts cannot select the same Brev worker concurrently.

- Keeps the existing runner-local `flock`.
- Atomically acquires an exact-owner lease on the selected worker.
- Heartbeats the lease and aborts Harbor if ownership is lost.
- Removes an abandoned lease only after GitHub proves the owning job or prior run is terminal.
- Supports managed Brev instances and registered SSH nodes.
- Applies to both PR/manual and daily skill-eval workflows.

This is independent of the NemoClaw harness in #1645 and does not change skills, notebooks, compose files, or product code.

## Validation

- `69 passed, 2 subtests passed` — focused lease and `run_leg` integration suite
- Full `test_run_leg.py`: only the same three pre-existing RTX4090 capability assertions fail on clean `develop`
- Rebased on current `develop` without conflicts
- Workflow YAML parsed successfully
- `git diff --check` passed

## Known limitation

Registered external nodes retain the existing Brev SSH/SCP host-key policy from `develop`. Host-key pinning requires trusted-key provisioning and a coordinated update across lease, execution, and artifact-copy transports; changing only the new lease connection would be ineffective or would break currently unprovisioned workers.