### PR TITLE
feat: enhanced SonarQube configuration for spatialai-data-utils

### DIFF
--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -243,15 +244,27 @@ class WorkflowSeparationTest(unittest.TestCase):
         self.assertIn("DOWNSTREAM_REF: main", sdu)
         self.assertIn('"SPATIALAI_PIPELINE": "true"', sdu)
         sonar = (workflows / "sonarqube.yml").read_text()
-        self.assertIn("name: spatialai-data-utils", sonar)
+        match = re.search(
+            r"^          - name: spatialai-data-utils\n(?P<entry>(?:            .*\n)+)",
+            sonar,
+            flags=re.MULTILINE,
+        )
+        self.assertIsNotNone(match, "SDU SonarQube matrix entry is missing")
+        assert match is not None
+        entry = match.group("entry")
         self.assertIn(
             "TEGRASW_METROPOLIS_spatialai-data-utils_video-search-and-summarization",
-            sonar,
+            entry,
         )
         self.assertIn(
             "sources: libs/analytics/spatialai-data-utils/spatialai_data_utils",
-            sonar,
+            entry,
         )
+        self.assertIn(
+            "tests: libs/analytics/spatialai-data-utils/tests",
+            entry,
+        )
+        self.assertIn('python_version: "3.13"', entry)
 
     def test_release_set_preparation_has_no_sdu_transport(self):
         script = Path(module.__file__).read_text()

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -242,6 +242,16 @@ class WorkflowSeparationTest(unittest.TestCase):
         self.assertIn('suffix = f".dev0+g{commit[:12]}"', sdu)
         self.assertIn("DOWNSTREAM_REF: main", sdu)
         self.assertIn('"SPATIALAI_PIPELINE": "true"', sdu)
+        sonar = (workflows / "sonarqube.yml").read_text()
+        self.assertIn("name: spatialai-data-utils", sonar)
+        self.assertIn(
+            "TEGRASW_METROPOLIS_spatialai-data-utils_video-search-and-summarization",
+            sonar,
+        )
+        self.assertIn(
+            "sources: libs/analytics/spatialai-data-utils/release/spatialai_data_utils",
+            sonar,
+        )
 
     def test_release_set_preparation_has_no_sdu_transport(self):
         script = Path(module.__file__).read_text()

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -249,7 +249,7 @@ class WorkflowSeparationTest(unittest.TestCase):
             sonar,
         )
         self.assertIn(
-            "sources: libs/analytics/spatialai-data-utils/release/spatialai_data_utils",
+            "sources: libs/analytics/spatialai-data-utils/spatialai_data_utils",
             sonar,
         )
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -68,7 +68,7 @@ jobs:
           - name: spatialai-data-utils
             project_key: TEGRASW_METROPOLIS_spatialai-data-utils_video-search-and-summarization
             project_name: METROPOLIS-spatialai-data-utils
-            sources: libs/analytics/spatialai-data-utils/release/spatialai_data_utils
+            sources: libs/analytics/spatialai-data-utils/spatialai_data_utils
             tests: libs/analytics/spatialai-data-utils/tests
             python_version: "3.13"
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -65,6 +65,12 @@ jobs:
             sources: services/analytics/video-analytics-api/src,services/analytics/video-analytics-api/docker
             tests: services/analytics/video-analytics-api/test
             node_version: "22.22.3"
+          - name: spatialai-data-utils
+            project_key: TEGRASW_METROPOLIS_spatialai-data-utils_video-search-and-summarization
+            project_name: METROPOLIS-spatialai-data-utils
+            sources: libs/analytics/spatialai-data-utils/release/spatialai_data_utils
+            tests: libs/analytics/spatialai-data-utils/tests
+            python_version: "3.13"
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
- Added a new job for spatialai-data-utils in the SonarQube workflow, specifying project key, name, sources, and tests.
- Updated the test script to verify the presence of the new SonarQube job and its configuration.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
