### PR TITLE
fix(agent-ui): bump sharp to 0.35.3 for GHSA-f88m-g3jw-g9cj

### DIFF
--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -4224,9 +4224,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -4579,9 +4579,9 @@
             }
         },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+            "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
             "cpu": [
                 "arm64"
             ],
@@ -4591,19 +4591,19 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+                "@img/sharp-libvips-darwin-arm64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+            "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
             "cpu": [
                 "x64"
             ],
@@ -4613,19 +4613,38 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.2.4"
+                "@img/sharp-libvips-darwin-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-freebsd-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+            "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+            "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
             "cpu": [
                 "arm64"
             ],
@@ -4639,9 +4658,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+            "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
             "cpu": [
                 "x64"
             ],
@@ -4655,9 +4674,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+            "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
             "cpu": [
                 "arm"
             ],
@@ -4671,9 +4690,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+            "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
             "cpu": [
                 "arm64"
             ],
@@ -4687,9 +4706,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+            "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
             "cpu": [
                 "ppc64"
             ],
@@ -4703,9 +4722,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-riscv64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+            "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
             "cpu": [
                 "riscv64"
             ],
@@ -4719,9 +4738,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+            "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
             "cpu": [
                 "s390x"
             ],
@@ -4735,9 +4754,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+            "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
             "cpu": [
                 "x64"
             ],
@@ -4751,9 +4770,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+            "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
             "cpu": [
                 "arm64"
             ],
@@ -4767,9 +4786,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+            "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
             "cpu": [
                 "x64"
             ],
@@ -4783,9 +4802,9 @@
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+            "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
             "cpu": [
                 "arm"
             ],
@@ -4795,19 +4814,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.2.4"
+                "@img/sharp-libvips-linux-arm": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+            "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4817,19 +4836,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.2.4"
+                "@img/sharp-libvips-linux-arm64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-ppc64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+            "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
             "cpu": [
                 "ppc64"
             ],
@@ -4839,19 +4858,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+                "@img/sharp-libvips-linux-ppc64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-riscv64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+            "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -4861,19 +4880,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+                "@img/sharp-libvips-linux-riscv64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+            "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
             "cpu": [
                 "s390x"
             ],
@@ -4883,19 +4902,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.2.4"
+                "@img/sharp-libvips-linux-s390x": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+            "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
             "cpu": [
                 "x64"
             ],
@@ -4905,19 +4924,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.2.4"
+                "@img/sharp-libvips-linux-x64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+            "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
             "cpu": [
                 "arm64"
             ],
@@ -4927,19 +4946,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+            "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
             "cpu": [
                 "x64"
             ],
@@ -4949,38 +4968,54 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-            "cpu": [
-                "wasm32"
-            ],
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+            "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.7.0"
+                "@emnapi/runtime": "^1.11.1"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-webcontainers-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+            "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+            "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
             "cpu": [
                 "arm64"
             ],
@@ -4990,16 +5025,16 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+            "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
             "cpu": [
                 "ia32"
             ],
@@ -5009,16 +5044,16 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": "^20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+            "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
             "cpu": [
                 "x64"
             ],
@@ -5028,7 +5063,7 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
@@ -20859,54 +20894,59 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-            "hasInstallScript": true,
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+            "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@img/colour": "^1.0.0",
+                "@img/colour": "^1.1.0",
                 "detect-libc": "^2.1.2",
-                "semver": "^7.7.3"
+                "semver": "^7.8.5"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.34.5",
-                "@img/sharp-darwin-x64": "0.34.5",
-                "@img/sharp-libvips-darwin-arm64": "1.2.4",
-                "@img/sharp-libvips-darwin-x64": "1.2.4",
-                "@img/sharp-libvips-linux-arm": "1.2.4",
-                "@img/sharp-libvips-linux-arm64": "1.2.4",
-                "@img/sharp-libvips-linux-ppc64": "1.2.4",
-                "@img/sharp-libvips-linux-riscv64": "1.2.4",
-                "@img/sharp-libvips-linux-s390x": "1.2.4",
-                "@img/sharp-libvips-linux-x64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-                "@img/sharp-linux-arm": "0.34.5",
-                "@img/sharp-linux-arm64": "0.34.5",
-                "@img/sharp-linux-ppc64": "0.34.5",
-                "@img/sharp-linux-riscv64": "0.34.5",
-                "@img/sharp-linux-s390x": "0.34.5",
-                "@img/sharp-linux-x64": "0.34.5",
-                "@img/sharp-linuxmusl-arm64": "0.34.5",
-                "@img/sharp-linuxmusl-x64": "0.34.5",
-                "@img/sharp-wasm32": "0.34.5",
-                "@img/sharp-win32-arm64": "0.34.5",
-                "@img/sharp-win32-ia32": "0.34.5",
-                "@img/sharp-win32-x64": "0.34.5"
+                "@img/sharp-darwin-arm64": "0.35.3",
+                "@img/sharp-darwin-x64": "0.35.3",
+                "@img/sharp-freebsd-wasm32": "0.35.3",
+                "@img/sharp-libvips-darwin-arm64": "1.3.2",
+                "@img/sharp-libvips-darwin-x64": "1.3.2",
+                "@img/sharp-libvips-linux-arm": "1.3.2",
+                "@img/sharp-libvips-linux-arm64": "1.3.2",
+                "@img/sharp-libvips-linux-ppc64": "1.3.2",
+                "@img/sharp-libvips-linux-riscv64": "1.3.2",
+                "@img/sharp-libvips-linux-s390x": "1.3.2",
+                "@img/sharp-libvips-linux-x64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+                "@img/sharp-linux-arm": "0.35.3",
+                "@img/sharp-linux-arm64": "0.35.3",
+                "@img/sharp-linux-ppc64": "0.35.3",
+                "@img/sharp-linux-riscv64": "0.35.3",
+                "@img/sharp-linux-s390x": "0.35.3",
+                "@img/sharp-linux-x64": "0.35.3",
+                "@img/sharp-linuxmusl-arm64": "0.35.3",
+                "@img/sharp-linuxmusl-x64": "0.35.3",
+                "@img/sharp-webcontainers-wasm32": "0.35.3",
+                "@img/sharp-win32-arm64": "0.35.3",
+                "@img/sharp-win32-ia32": "0.35.3",
+                "@img/sharp-win32-x64": "0.35.3"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/sharp/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "optional": true,
             "bin": {

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -41,7 +41,8 @@
         "i18next-fs-backend": "2.6.7",
         "dompurify": "3.4.13",
         "undici": "7.29.0",
-        "ws": "8.21.3"
+        "ws": "8.21.3",
+        "sharp": "0.35.3"
     },
     "packageManager": "npm@10.9.7"
 }


### PR DESCRIPTION
Override Next.js optional sharp to a patched libvips release so the UI container is not affected by the inherited libvips CVEs.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
