### PR TITLE
fix(skills): use RT-CV readiness endpoint for alerts

### DIFF
--- a/skills/vss-build-vision-agent/eval/profile_at_1_alert_verification.json
+++ b/skills/vss-build-vision-agent/eval/profile_at_1_alert_verification.json
@@ -24,6 +24,7 @@
         "No file under `{{repo_root}}/deploy/docker/` is modified by the build.",
         "The deployment is launched directly from `_builds/at-1/resolved.yml` without Foundation env files, profile flags, or a copied Compose project.",
         "All long-running selected containers are running or healthy, and all selected one-shot initialization containers exit 0.",
+        "`curl -sf http://localhost:${RTVI_CV_HOST_PORT:-9010}/api/v1/ready` returns HTTP 200 with `ready-info.ds-ready=YES`.",
         "RT-CV and Behavior Analytics publish candidate alerts, `alert-bridge` can retrieve the corresponding VIOS clip, and the verifier records a verdict of `confirmed`, `rejected`, or `unverified` in Elasticsearch and Kafka.",
         "The VSS Agent, video-analytics MCP, alert API, VIOS playback API, and Elasticsearch health endpoints respond successfully.",
         "The final response identifies `alerts` as the Foundation, reports the effective service delta and changed environment knobs, and includes evidence for the alert-verification round trip."

--- a/skills/vss-build-vision-agent/references/profiles/alerts.md
+++ b/skills/vss-build-vision-agent/references/profiles/alerts.md
@@ -61,7 +61,9 @@ curl -sf "http://${HOST_IP}:3000/"
 ```
 
 For `2d_cv`, also require `vss-rtvi-cv` and `vss-behavior-analytics` to
-resolve and probe `http://${HOST_IP}:${RTVI_CV_HOST_PORT:-9010}/v1/health`.
+resolve and probe
+`http://${HOST_IP}:${RTVI_CV_HOST_PORT:-9010}/api/v1/ready`, requiring
+HTTP 200 and `ready-info.ds-ready=YES`.
 For `2d_vlm`, require those two services to be absent and probe
 `http://${HOST_IP}:8018/v1/health/ready`.
 


### PR DESCRIPTION
## Description
Bug Fix: https://nvbugspro.nvidia.com/bug/6598797

## Summary

Updates the Alerts `2d_cv` readiness check to use the canonical RT-CV endpoint:

- Replaces `/v1/health` with `/api/v1/ready`
- Adds an Alerts profile eval assertion for HTTP 200 and `ready-info.ds-ready=YES`

## Root cause

The Alerts profile reference used an unsupported RT-CV endpoint. On a ready RT-CV instance:

- `/v1/health` returns HTTP 404
- `/api/v1/ready` returns HTTP 200 with `ds-ready: YES`

This could cause a healthy Alerts deployment to fail the documented readiness gate.

## Validation

- Reproduced using the repository’s RT-CV test deployment and image `vss-rt-cv:3.3.0-26.07.2`
- Official RT-CV health test passed
- Alerts readiness contract check passed
- Alerts Harbor eval task generated successfully
- Skill-eval matrix tests: 33 passed
- `git diff --check` passed

## Scope

Documentation and eval coverage only. No runtime, container, Compose, or API implementation changes.

NVBug: [6598797](https://nvbugspro.nvidia.com/bug/6598797)
