### PR TITLE
(fix)(search-agent): fold looped-playback hits back onto the recorded pass

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/tools/attribute_search.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/attribute_search.py
@@ -40,6 +40,8 @@ from vss_agents.tools.vst.snapshot import build_screenshot_url
 from vss_agents.utils.es_client import VSSESClient
 from vss_agents.utils.time_measure import TimeMeasure
 from vss_agents.utils.uuid_string import is_standard_uuid_string
+from vss_core.vst import fold_looped_file_window
+from vss_core.vst import get_timelines_map
 
 logger = logging.getLogger(__name__)
 
@@ -554,12 +556,19 @@ async def enrich_attribute_results(
     results: list["AttributeSearchResult"],
     vst_internal_url: str | None,
     vst_external_url: str | None = None,
+    source_type: str = "video_file",
 ) -> None:
     """Enrich attribute search results with screenshot URLs and resolved stream IDs.
 
-    Mutates results in-place: resolves sensor_id → stream_id (UUID) and builds
-    screenshot URLs via VST. Stream resolution prefers the internal VST URL;
+    Mutates results in-place: resolves sensor_id → stream_id (UUID), folds
+    looped ``video_file`` windows onto the stream's epoch-anchored VST pass,
+    and builds screenshot URLs. Stream resolution prefers the internal VST URL;
     returned screenshot URLs prefer the external VST URL.
+
+    Looped nvstreamer playback stamps later passes past the single recorded
+    file; folding those bounds is what makes clip/picture requests succeed
+    (NVBug 6538344). Live ``rtsp`` and wall-clock-anchored recordings stay
+    literal so metadata remains on the ES clock.
     """
     resolution_base_url = vst_internal_url or vst_external_url
     screenshot_base_url = vst_external_url or vst_internal_url
@@ -567,19 +576,46 @@ async def enrich_attribute_results(
         return
     from vss_agents.tools.vst.utils import get_stream_id
 
+    needs_enrichment = any(r.metadata and r.metadata.sensor_id and not r.screenshot_url for r in results)
+    timelines = await _get_timelines_best_effort(resolution_base_url) if needs_enrichment else {}
+
     async def _enrich_result(r: AttributeSearchResult) -> None:
         if r.metadata and r.metadata.sensor_id and not r.screenshot_url:
             try:
-                ts = r.metadata.start_time or r.metadata.frame_timestamp
                 stream_id = await get_stream_id(r.metadata.sensor_id, resolution_base_url)
                 if stream_id:
-                    if ts:
+                    timeline = timelines.get(stream_id)
+                    if source_type == "video_file" and timeline:
+                        mapped_start, mapped_end, mapped_frame = fold_looped_file_window(
+                            r.metadata.start_time,
+                            r.metadata.end_time,
+                            r.metadata.frame_timestamp,
+                            timeline[0],
+                            timeline[1],
+                        )
+                        r.metadata.start_time = mapped_start
+                        r.metadata.end_time = mapped_end
+                        if mapped_frame is not None:
+                            r.metadata.frame_timestamp = mapped_frame
+                    ts = r.metadata.start_time or r.metadata.frame_timestamp
+                    if timelines and not timeline:
+                        logger.warning(f"Stream {stream_id} not in VST timelines; returning hit without screenshot")
+                    elif ts:
                         r.screenshot_url = build_screenshot_url(screenshot_base_url, stream_id, ts)
                     r.metadata.sensor_id = stream_id
             except Exception as e:
                 logger.warning(f"Failed to enrich result for sensor {r.metadata.sensor_id}: {e}")
 
     await asyncio.gather(*(_enrich_result(r) for r in results))
+
+
+async def _get_timelines_best_effort(vst_base_url: str) -> dict[str, tuple[str, str]]:
+    """Fetch every VST replay timeline, or {} when VST cannot be reached."""
+    try:
+        return await get_timelines_map(vst_base_url, timeout_seconds=5, retries=1)
+    except Exception as e:
+        logger.warning(f"Could not fetch VST timelines; result timestamps left unmapped: {e}")
+        return {}
 
 
 async def _search_behavior(

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/search.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/search.py
@@ -1034,7 +1034,9 @@ async def execute_core_search(
 
         vst_internal_url = getattr(config, "vst_internal_url", None)
         vst_external_url = getattr(config, "vst_external_url", None)
-        await enrich_attribute_results(attr_results, vst_internal_url, vst_external_url)
+        await enrich_attribute_results(
+            attr_results, vst_internal_url, vst_external_url, source_type=search_input.source_type
+        )
 
         search_results = [attribute_result_to_search_result(r) for r in attr_results]
         result_count = len(search_results)

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_attribute_search_inner.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_attribute_search_inner.py
@@ -30,6 +30,8 @@ def _make_result(
     sensor_id: str = "camera-1",
     screenshot_url: str | None = None,
     start_time: str | None = None,
+    end_time: str | None = None,
+    frame_timestamp: str = "2025-01-01T00:00:01Z",
 ) -> AttributeSearchResult:
     return AttributeSearchResult(
         screenshot_url=screenshot_url,
@@ -37,14 +39,21 @@ def _make_result(
             sensor_id=sensor_id,
             object_id="42",
             object_type="person",
-            frame_timestamp="2025-01-01T00:00:01Z",
+            frame_timestamp=frame_timestamp,
             start_time=start_time,
-            end_time=None,
+            end_time=end_time,
             bbox=None,
             behavior_score=0.95,
             frame_score=None,
             video_name=None,
         ),
+    )
+
+
+def _patch_timelines(timelines: dict | None = None):
+    return patch(
+        "vss_agents.tools.attribute_search._get_timelines_best_effort",
+        AsyncMock(return_value={} if timelines is None else timelines),
     )
 
 
@@ -60,7 +69,7 @@ class TestEnrichAttributeResults:
 
         mock_get_stream_id = AsyncMock(side_effect=["stream-1", "stream-2"])
 
-        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id):
+        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id), _patch_timelines():
             await enrich_attribute_results(results, "http://vst-internal:30888")
 
         assert [r.metadata.sensor_id for r in results] == ["stream-1", "stream-2"]
@@ -83,7 +92,7 @@ class TestEnrichAttributeResults:
                 raise RuntimeError("boom")
             return "stream-2"
 
-        with patch("vss_agents.tools.vst.utils.get_stream_id", side_effect=_get_stream_id):
+        with patch("vss_agents.tools.vst.utils.get_stream_id", side_effect=_get_stream_id), _patch_timelines():
             await enrich_attribute_results(results, "http://vst-internal:30888")
 
         assert results[0].metadata.sensor_id == "camera-1"
@@ -102,7 +111,7 @@ class TestEnrichAttributeResults:
 
         mock_get_stream_id = AsyncMock(return_value="stream-2")
 
-        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id):
+        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id), _patch_timelines():
             await enrich_attribute_results(results, "http://vst-internal:30888")
 
         assert results[0].screenshot_url == "http://existing"
@@ -115,7 +124,7 @@ class TestEnrichAttributeResults:
         results = [_make_result(sensor_id="camera-1", start_time="2025-01-01T00:00:00Z")]
         mock_get_stream_id = AsyncMock(return_value="stream-1")
 
-        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id):
+        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id), _patch_timelines():
             await enrich_attribute_results(
                 results,
                 vst_internal_url="http://vst-internal:30888",
@@ -133,7 +142,7 @@ class TestEnrichAttributeResults:
         results = [_make_result(sensor_id="camera-1", start_time="2025-01-01T00:00:00Z")]
         mock_get_stream_id = AsyncMock(return_value="stream-1")
 
-        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id):
+        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id), _patch_timelines():
             await enrich_attribute_results(
                 results,
                 vst_internal_url=None,
@@ -144,6 +153,28 @@ class TestEnrichAttributeResults:
         assert results[0].metadata.sensor_id == "stream-1"
         assert results[0].screenshot_url == (
             "https://7777-brev.brevlab.com/vst/api/v1/replay/stream/stream-1/picture?startTime=2025-01-01T00:00:00Z"
+        )
+
+    @pytest.mark.asyncio
+    async def test_folds_looped_file_windows_onto_recorded_pass(self):
+        results = [
+            _make_result(
+                sensor_id="camera-1",
+                start_time="2025-01-01T00:08:20.866Z",
+                end_time="2025-01-01T00:08:28.966Z",
+                frame_timestamp="2025-01-01T00:08:24.000Z",
+            )
+        ]
+        mock_get_stream_id = AsyncMock(return_value="stream-1")
+        loop_timeline = {"stream-1": ("2025-01-01T00:00:00.000Z", "2025-01-01T00:03:29.967Z")}
+
+        with patch("vss_agents.tools.vst.utils.get_stream_id", mock_get_stream_id), _patch_timelines(loop_timeline):
+            await enrich_attribute_results(results, "http://vst-internal:30888", source_type="video_file")
+
+        assert results[0].metadata.start_time == "2025-01-01T00:01:20.932Z"
+        assert results[0].metadata.end_time == "2025-01-01T00:01:29.032Z"
+        assert results[0].screenshot_url == (
+            "http://vst-internal:30888/vst/api/v1/replay/stream/stream-1/picture?startTime=2025-01-01T00:01:20.932Z"
         )
 
 

--- a/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_attribute_helpers.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_attribute_helpers.py
@@ -46,6 +46,7 @@ from vss_core._foundation.time import iso8601_to_datetime
 from vss_core._foundation.time import safe_iso8601_to_datetime
 from vss_core.vst import VSTError
 from vss_core.vst import build_screenshot_url
+from vss_core.vst import fold_looped_file_window
 from vss_core.vst import get_stream_id
 from vss_core.vst import get_timeline
 from vss_core.vst import get_timelines_map
@@ -626,23 +627,48 @@ async def enrich_attribute_results(
     results: list[AttributeSearchResult],
     vst_internal_url: str | None,
     vst_external_url: str | None = None,
+    source_type: str = "video_file",
 ) -> None:
-    """Resolve stream ids and build screenshot URLs in place (best-effort)."""
+    """Resolve stream ids, fold looped-file windows, and build screenshot URLs.
+
+    Uploaded files played on a loop keep one VST recording at the file epoch
+    while analytics stamps later passes with an ever-advancing clock. For those
+    epoch-anchored timelines, ``start_time`` / ``end_time`` / ``frame_timestamp``
+    are folded onto the recorded pass so clip and picture requests address
+    footage VST actually holds. Live ``rtsp`` and wall-clock-anchored recordings
+    are left unchanged so metadata stays on the ES clock.
+
+    Best-effort throughout: when VST cannot be reached the raw timestamps are
+    kept rather than dropping otherwise-usable results.
+    """
     resolution_base_url = vst_internal_url or vst_external_url
     screenshot_base_url = vst_external_url or vst_internal_url
     if not resolution_base_url or not screenshot_base_url:
         return
 
-    needs_screenshots = any(r.metadata and r.metadata.sensor_id and not r.screenshot_url for r in results)
-    timelines = await _get_timelines_best_effort(resolution_base_url) if needs_screenshots else {}
+    needs_enrichment = any(r.metadata and r.metadata.sensor_id and not r.screenshot_url for r in results)
+    timelines = await _get_timelines_best_effort(resolution_base_url) if needs_enrichment else {}
 
     async def _enrich(r: AttributeSearchResult) -> None:
         if not (r.metadata and r.metadata.sensor_id and not r.screenshot_url):
             return
         try:
-            ts = r.metadata.start_time or r.metadata.frame_timestamp
             stream_id = await get_stream_id(r.metadata.sensor_id, resolution_base_url)
             if stream_id:
+                timeline = timelines.get(stream_id)
+                if source_type == "video_file" and timeline:
+                    (
+                        r.metadata.start_time,
+                        r.metadata.end_time,
+                        r.metadata.frame_timestamp,
+                    ) = fold_looped_file_window(
+                        r.metadata.start_time,
+                        r.metadata.end_time,
+                        r.metadata.frame_timestamp,
+                        timeline[0],
+                        timeline[1],
+                    )
+                ts = r.metadata.start_time or r.metadata.frame_timestamp
                 if ts:
                     mapped_ts = _map_to_timeline(ts, stream_id, timelines)
                     if mapped_ts is not None:
@@ -996,7 +1022,12 @@ async def _fuse_multi_attribute(
     # several sensors, so relabeling every result with one sensor's stream id (and
     # sharing one screenshot) would misattribute matches on other sensors.
     if vst_external_url:
-        await enrich_attribute_results(all_results, vst_internal_url, vst_external_url)
+        await enrich_attribute_results(
+            all_results,
+            vst_internal_url,
+            vst_external_url,
+            source_type=search_input.source_type,
+        )
 
     return all_results
 

--- a/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_search_helpers.py
+++ b/services/agent/packages/vss_core/src/vss_core/search_core/primitives/_search_helpers.py
@@ -465,7 +465,12 @@ async def execute_core_search(
             [*seen.values(), *unmergeable], key=lambda r: _coerce_float(r.metadata.behavior_score), reverse=True
         )[:top_k]
 
-        await enrich_attribute_results(attr_results, config.vst_internal_url, config.vst_external_url)
+        await enrich_attribute_results(
+            attr_results,
+            config.vst_internal_url,
+            config.vst_external_url,
+            source_type=search_input.source_type,
+        )
 
         search_results = [attribute_result_to_search_result(r) for r in attr_results]
         result_count = len(search_results)

--- a/services/agent/packages/vss_core/src/vss_core/vst/__init__.py
+++ b/services/agent/packages/vss_core/src/vss_core/vst/__init__.py
@@ -5,6 +5,7 @@
 from .client import VSTClient
 from .client import VSTError
 from .client import build_screenshot_url
+from .client import fold_looped_file_window
 from .client import get_name_to_stream_id_map
 from .client import get_sensor_id_from_stream_id
 from .client import get_stream_id
@@ -21,6 +22,7 @@ __all__ = [
     "VSTError",
     "VSTSnapshot",
     "build_screenshot_url",
+    "fold_looped_file_window",
     "get_name_to_stream_id_map",
     "get_sensor_id_from_stream_id",
     "get_stream_id",

--- a/services/agent/packages/vss_core/src/vss_core/vst/client.py
+++ b/services/agent/packages/vss_core/src/vss_core/vst/client.py
@@ -97,19 +97,25 @@ def map_timestamp_to_timeline(timestamp: str, timeline_start: str, timeline_end:
     """Map an ES hit timestamp onto a stream's VST replay timeline.
 
     File-ingested sources are indexed on a synthetic, midnight-anchored epoch
-    (e.g. ``2025-01-01T00:01:00Z`` = 60s into the file) while VST anchors the
-    replay timeline at ingest wall-clock. A raw ES timestamp therefore points
-    outside the recording and VST rejects the picture request
+    (e.g. ``2025-01-01T00:01:00Z`` = 60s into the file) while VST may anchor
+    the replay timeline at ingest wall-clock. A raw ES timestamp therefore
+    points outside the recording and VST rejects the picture/clip request
     (``VMSInternalError: no valid stream found for given timestamps``). Live
     RTSP sources index real wall-clock, which lands inside the timeline and
     must pass through unchanged.
 
     Rules:
-      - timestamp within [start, end]: returned unchanged (live sources)
-      - otherwise: the elapsed offset from the fixed uploaded-file epoch
-        (2025-01-01T00:00:00Z) is re-based onto ``timeline_start``, clamped to
-        the real timeline. Keeping the date component preserves offsets in
-        files longer than 24 hours.
+      - timestamp within [start, end]: returned unchanged
+      - epoch-anchored recording (``timeline_start`` == the uploaded-file epoch,
+        i.e. a single looped file): the file offset is folded modulo the
+        recording duration. ``nvstreamer`` loops the source with an
+        ever-advancing analytics clock, so ES accumulates hits past the single
+        pass VST keeps; wrapping re-anchors later passes onto the recorded
+        frame (NVBug 6538344).
+      - otherwise (wall-clock-anchored recording): the elapsed offset from the
+        fixed uploaded-file epoch is re-based onto ``timeline_start`` and
+        clamped to the real timeline. A multi-segment envelope is never wrapped
+        because a fold could land in a gap between segments.
 
     Any parse failure returns the original timestamp (best-effort — a raw URL
     that may 404 beats dropping the hit).
@@ -123,12 +129,63 @@ def map_timestamp_to_timeline(timestamp: str, timeline_start: str, timeline_end:
     if start <= ts <= end:
         return timestamp
     offset = ts - _FILE_TIMELINE_EPOCH
-    mapped = start + offset
-    if mapped > end:
-        mapped = end
-    elif mapped < start:
-        mapped = start
+    duration = end - start
+    if start == _FILE_TIMELINE_EPOCH and duration.total_seconds() > 0:
+        # Python's timedelta modulo takes the sign of the (positive) divisor, so
+        # the fold lands in [0, duration) even for a timestamp before the epoch.
+        mapped = start + (offset % duration)
+    else:
+        mapped = start + offset
+        if mapped > end:
+            mapped = end
+        elif mapped < start:
+            mapped = start
     return mapped.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def fold_looped_file_window(
+    start: str | None,
+    end: str | None,
+    frame_timestamp: str | None,
+    timeline_start: str,
+    timeline_end: str,
+) -> tuple[str | None, str | None, str | None]:
+    """Fold a looped-file result window onto the single recorded VST pass.
+
+    Only mutates when ``timeline_start`` is the uploaded-file epoch — that is
+    the looped ``nvstreamer`` case where analytics times run past the one file
+    VST recorded. Wall-clock-anchored timelines are left alone so result
+    metadata stays on the ES clock the MDX ``/frames`` API is keyed on.
+
+    Zero-length windows are mapped as a single timestamp because
+    :func:`map_interval_to_timeline` declines non-positive ranges.
+    """
+    try:
+        if iso8601_to_datetime(timeline_start) != _FILE_TIMELINE_EPOCH:
+            return start, end, frame_timestamp
+    except (TypeError, ValueError):
+        return start, end, frame_timestamp
+
+    mapped_start, mapped_end = start, end
+    if start and end:
+        try:
+            if iso8601_to_datetime(end) != iso8601_to_datetime(start):
+                mapped_start, mapped_end = map_interval_to_timeline(start, end, timeline_start, timeline_end)
+            else:
+                mapped_start = map_timestamp_to_timeline(start, timeline_start, timeline_end)
+                mapped_end = mapped_start
+        except (TypeError, ValueError):
+            mapped_start = map_timestamp_to_timeline(start, timeline_start, timeline_end)
+            mapped_end = mapped_start if end else end
+    elif start:
+        mapped_start = map_timestamp_to_timeline(start, timeline_start, timeline_end)
+        mapped_end = mapped_start if end else end
+    elif end:
+        mapped_end = map_timestamp_to_timeline(end, timeline_start, timeline_end)
+    mapped_frame = (
+        map_timestamp_to_timeline(frame_timestamp, timeline_start, timeline_end) if frame_timestamp else frame_timestamp
+    )
+    return mapped_start, mapped_end, mapped_frame
 
 
 def map_interval_to_timeline(

--- a/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_screenshot_timeline.py
+++ b/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_screenshot_timeline.py
@@ -11,11 +11,22 @@ point outside the recording and VST answers
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
+import pytest
+
+from vss_core.search_core.models.attribute_search import AttributeSearchMetadata
+from vss_core.search_core.models.attribute_search import AttributeSearchResult
+from vss_core.vst import fold_looped_file_window
 from vss_core.vst import map_interval_to_timeline
 from vss_core.vst import map_timestamp_to_timeline
 
 TL_START = "2026-07-18T04:15:21.640Z"
 TL_END = "2026-07-18T04:18:51.640Z"
+
+# Looped nvstreamer file: one recorded pass at the file epoch (sample_warehouse.mp4).
+LOOP_START = "2025-01-01T00:00:00.000Z"
+LOOP_END = "2025-01-01T00:03:29.967Z"
 
 
 def test_synthetic_epoch_timestamp_is_rebased_onto_timeline() -> None:
@@ -86,3 +97,111 @@ def test_unknown_stream_in_populated_timelines_means_no_url() -> None:
     assert _map_to_timeline("2025-01-01T00:01:00Z", "known-stream", timelines) == "2026-07-18T04:16:21.640Z"
     # Empty map = timelines unavailable; best-effort identity applies.
     assert _map_to_timeline("2025-01-01T00:01:00Z", "stale-stream", {}) == "2025-01-01T00:01:00Z"
+
+
+def test_looped_hit_folds_back_onto_the_recorded_pass() -> None:
+    # 00:08:20.866 is 500.866s in; the file is 209.967s, so this is the third
+    # pass. Folding twice (419.934s) lands on the recorded frame at 80.932s.
+    mapped = map_timestamp_to_timeline("2025-01-01T00:08:20.866Z", LOOP_START, LOOP_END)
+    assert mapped == "2025-01-01T00:01:20.932Z"
+
+
+def test_first_pass_hit_on_epoch_timeline_is_unchanged() -> None:
+    ts = "2025-01-01T00:00:03.000Z"
+    assert map_timestamp_to_timeline(ts, LOOP_START, LOOP_END) == ts
+
+
+def test_exact_loop_boundary_folds_one_ms_past_end() -> None:
+    assert map_timestamp_to_timeline(LOOP_END, LOOP_START, LOOP_END) == LOOP_END
+    assert map_timestamp_to_timeline("2025-01-01T00:03:29.968Z", LOOP_START, LOOP_END) == "2025-01-01T00:00:00.001Z"
+
+
+def test_fold_looped_file_window_preserves_duration() -> None:
+    start, end, frame = fold_looped_file_window(
+        "2025-01-01T00:08:20.866Z",
+        "2025-01-01T00:08:28.966Z",
+        "2025-01-01T00:08:24.000Z",
+        LOOP_START,
+        LOOP_END,
+    )
+    assert start == "2025-01-01T00:01:20.932Z"
+    assert end == "2025-01-01T00:01:29.032Z"
+    assert frame == "2025-01-01T00:01:24.066Z"
+
+
+def test_fold_looped_file_window_leaves_wall_clock_timelines_alone() -> None:
+    # Wall-clock-anchored recordings must keep ES times so /frames still resolves.
+    start, end, frame = fold_looped_file_window(
+        "2025-01-01T00:01:00Z",
+        "2025-01-01T00:01:10Z",
+        "2025-01-01T00:01:05Z",
+        TL_START,
+        TL_END,
+    )
+    assert (start, end, frame) == (
+        "2025-01-01T00:01:00Z",
+        "2025-01-01T00:01:10Z",
+        "2025-01-01T00:01:05Z",
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrichment_folds_looped_file_windows(monkeypatch) -> None:
+    from vss_core.search_core.primitives import _attribute_helpers as ah
+
+    monkeypatch.setattr(ah, "get_stream_id", AsyncMock(return_value="stream-1"))
+    monkeypatch.setattr(
+        ah,
+        "_get_timelines_best_effort",
+        AsyncMock(return_value={"stream-1": (LOOP_START, LOOP_END)}),
+    )
+
+    results = [
+        AttributeSearchResult(
+            screenshot_url=None,
+            metadata=AttributeSearchMetadata(
+                sensor_id="camera-1",
+                object_id="42",
+                object_type="person",
+                frame_timestamp="2025-01-01T00:08:24.000Z",
+                start_time="2025-01-01T00:08:20.866Z",
+                end_time="2025-01-01T00:08:28.966Z",
+                bbox=None,
+                behavior_score=0.9,
+            ),
+        )
+    ]
+    await ah.enrich_attribute_results(results, "http://vst-internal:30888", source_type="video_file")
+    assert results[0].metadata.start_time == "2025-01-01T00:01:20.932Z"
+    assert results[0].metadata.end_time == "2025-01-01T00:01:29.032Z"
+    assert "startTime=2025-01-01T00%3A01%3A20.932Z" in (results[0].screenshot_url or "")
+
+
+@pytest.mark.asyncio
+async def test_enrichment_does_not_fold_rtsp(monkeypatch) -> None:
+    from vss_core.search_core.primitives import _attribute_helpers as ah
+
+    monkeypatch.setattr(ah, "get_stream_id", AsyncMock(return_value="stream-1"))
+    monkeypatch.setattr(
+        ah,
+        "_get_timelines_best_effort",
+        AsyncMock(return_value={"stream-1": (LOOP_START, LOOP_END)}),
+    )
+
+    results = [
+        AttributeSearchResult(
+            screenshot_url=None,
+            metadata=AttributeSearchMetadata(
+                sensor_id="camera-1",
+                object_id="42",
+                object_type="person",
+                frame_timestamp="2025-01-01T00:08:24.000Z",
+                start_time="2025-01-01T00:08:20.866Z",
+                end_time="2025-01-01T00:08:28.966Z",
+                bbox=None,
+                behavior_score=0.9,
+            ),
+        )
+    ]
+    await ah.enrich_attribute_results(results, "http://vst-internal:30888", source_type="rtsp")
+    assert results[0].metadata.start_time == "2025-01-01T00:08:20.866Z"


### PR DESCRIPTION
…meline

    nvstreamer replays an uploaded file on repeat with an ever-advancing analytics
    clock, so Elasticsearch accumulates behavior/frame hits past the single first
    pass VIOS records at the file epoch. Later-pass hits address footage VIOS never
    kept, so /storage/file/{id}/url answers VMSNoDataError (error 41). Observed on
    Brev: timeline 00:00:00..00:03:29.967, a hit at 00:08:20.866 fails while an
    in-range 00:00:03 hit plays.
    
    When the replay timeline is anchored at the file epoch, map_timestamp_to_timeline
    folds the file offset modulo the recording duration, and attribute enrichment
    rewrites start/end/frame for video_file results so clip and picture requests
    land on the recorded pass. In-range hits pass through; wall-clock-anchored
    timelines are left alone so MDX /frames metadata stays on the ES clock.
    
    nvbug 6538344

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
