### PR TITLE
feat(skill-eval): add eval corpus inventory

### DIFF
--- a/.github/skill-eval/eval_parity_scope.py
+++ b/.github/skill-eval/eval_parity_scope.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inventory the skill-eval corpus: how many specs, cells and checks exist.
+
+The corpus size is quoted from memory in several places and the numbers
+disagree. This makes it a measurement with one definition.
+
+The spec/cell/check counts are exact. The scope buckets are NOT: they match on
+mentions, not requirements, so "no docker compose is executed" counts as HOST
+while a live container-state assertion with no command in it counts as PROSE.
+Treat them as a triage hint for finding checks worth reading, never as a
+measurement of what needs the deploy host -- that needs per-check metadata,
+which this does not attempt.
+
+Counts also cannot detect a check MOVING between cells, and reward is per cell
+(``passed / len(checks)``, verifiers/generic_judge.py), so a move changes scores
+with every total unchanged. Pinning ordered identities is the follow-up change;
+until it lands this is scaffolding, not a parity baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from plan_matrix import EXCLUDED_SPEC_NAMES, REPO_ROOT, specs_for_skill  # noqa: E402
+
+# Scope taxonomy, most-specific first. First match wins, so ordering is part of
+# the definition. HOST precedes FILE precedes NET: a check that execs into a
+# container to stat a file is bounded by the host requirement, not the file one.
+HOST_PATTERNS = (
+    r"\bdocker\s+(ps|compose|inspect|logs|exec|images|volume|cp|run|pull|stop|kill|rm|container)\b",
+    r"\bnvidia-smi\b",
+    r"\b(systemctl|journalctl)\b",
+    r"\bon\s+the\s+(deploy\s+)?host\b",
+)
+FILE_PATTERNS = (
+    r"\b(cat|ls|stat|find|file)\s+[/~$]",
+    r"\btest\s+-[efd]\s+[/~$]",
+    r"\bfile\s+exists\b",
+    r"\b(under|at)\s+[/~]\S+",
+)
+NET_PATTERNS = (
+    r"\bcurl\b",
+    r"https?://",
+    r"\b(GET|POST|PUT|DELETE|PATCH)\s+/",
+    r"\bHTTP\s+\d{3}\b",
+)
+
+_HOST_RE = re.compile("|".join(HOST_PATTERNS), re.IGNORECASE)
+_FILE_RE = re.compile("|".join(FILE_PATTERNS), re.IGNORECASE)
+_NET_RE = re.compile("|".join(NET_PATTERNS), re.IGNORECASE)
+
+SCOPES = ("HOST", "FILE", "NET", "PROSE")
+
+
+class SpecError(ValueError):
+    """A spec is malformed. Never silently degrade — a bad corpus must be loud,
+    because every downstream gate sources its numbers from this count."""
+
+
+def classify_check(text: str) -> str:
+    """Primary execution scope a single check needs."""
+    if _HOST_RE.search(text):
+        return "HOST"
+    if _FILE_RE.search(text):
+        return "FILE"
+    if _NET_RE.search(text):
+        return "NET"
+    return "PROSE"
+
+
+def all_skills() -> list[str]:
+    """Every skill directory that ships eval specs.
+
+    Enumerated from the filesystem, NOT from SKILL.md: manual `*` dispatch
+    enumerates directories directly, so a spec in a directory without a
+    SKILL.md is dispatchable. Deriving from SKILL.md would let such a spec run
+    while being absent from this baseline.
+    """
+    root = REPO_ROOT / "skills"
+    if not root.is_dir():
+        raise SpecError(f"no skills directory at {root}")
+    return sorted(
+        d.name
+        for d in root.iterdir()
+        if d.is_dir() and any((d / sub).is_dir() for sub in ("evals", "eval"))
+    )
+
+
+def scan_spec(rel_path: str) -> dict:
+    """Inventory one spec: per-cell check counts and scope buckets."""
+    try:
+        data = json.loads((REPO_ROOT / rel_path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SpecError(f"{rel_path}: invalid JSON: {exc}") from exc
+    except (OSError, UnicodeError) as exc:
+        # Same loud path as bad JSON, else "never silently degrade" holds for
+        # exactly one failure mode.
+        raise SpecError(f"{rel_path}: unreadable: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SpecError(f"{rel_path}: top level must be an object")
+
+    expects = data.get("expects")
+    if not isinstance(expects, list):
+        raise SpecError(f"{rel_path}: 'expects' must be a list")
+
+    per_scope = dict.fromkeys(SCOPES, 0)
+    cells: list[dict] = []
+
+    for idx, step in enumerate(expects):
+        if not isinstance(step, dict):
+            raise SpecError(f"{rel_path}[{idx}]: cell must be an object")
+        checks = step.get("checks")
+        if not isinstance(checks, list):
+            raise SpecError(f"{rel_path}[{idx}]: 'checks' must be a list")
+
+        n, has_host = 0, False
+        for cidx, check in enumerate(checks):
+            if not isinstance(check, str):
+                raise SpecError(f"{rel_path}[{idx}].checks[{cidx}]: must be a string")
+            scope = classify_check(check)
+            per_scope[scope] += 1
+            has_host = has_host or scope == "HOST"
+            n += 1
+
+        cells.append({"index": idx, "check_count": n, "has_host": has_host})
+
+    return {
+        "spec": rel_path,
+        "cells": len(cells),
+        "checks": sum(c["check_count"] for c in cells),
+        "scopes": per_scope,
+        "cells_with_host": sum(1 for c in cells if c["has_host"]),
+        "cell_detail": cells,
+    }
+
+
+def scan() -> dict:
+    """Inventory the whole corpus."""
+    rows = [
+        scan_spec(rel)
+        for skill in all_skills()
+        for rel, _eval_dir, _stem in specs_for_skill(skill)
+    ]
+
+    totals = dict.fromkeys(SCOPES, 0)
+    for row in rows:
+        for scope in SCOPES:
+            totals[scope] += row["scopes"][scope]
+
+    return {
+        "excluded_spec_names": sorted(EXCLUDED_SPEC_NAMES),
+        "specs": len(rows),
+        "cells": sum(r["cells"] for r in rows),
+        "checks": sum(r["checks"] for r in rows),
+        "scopes": totals,
+        "cells_with_host": sum(r["cells_with_host"] for r in rows),
+        "by_spec": rows,
+    }
+
+
+def format_summary(result: dict) -> str:
+    hint = " ".join(f"{s}={result['scopes'][s]}" for s in SCOPES)
+    return (
+        f"specs={result['specs']} cells={result['cells']} checks={result['checks']}\n"
+        f"lexical scope hint (mentions, NOT an execution-scope measurement): {hint}"
+        f" / cells mentioning HOST: {result['cells_with_host']}"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Inventory the skill-eval corpus.")
+    ap.add_argument("--json", action="store_true", help="aggregate counts as JSON")
+    args = ap.parse_args()
+
+    try:
+        result = scan()
+    except SpecError as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps({k: v for k, v in result.items() if k != "by_spec"},
+                         indent=2, sort_keys=True))
+    else:
+        print(format_summary(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/tests/test_eval_parity_scope.py
+++ b/.github/skill-eval/tests/test_eval_parity_scope.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for eval_parity_scope."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import eval_parity_scope as eps  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("docker cp the file into the container", "HOST"),
+        # HOST wins over FILE: the host requirement is the binding constraint.
+        ("docker exec vss-x test -f /tmp/model.pt", "HOST"),
+        # FILE wins over NET: this shadowing is what hid every FILE check.
+        ("the stream url is a local file path under /home/vst/data", "FILE"),
+        ("test -f ~/.ngc/config", "FILE"),
+        ("curl -sf http://localhost:8000/health returns 200", "NET"),
+        ("the final reply answers the question without errors", "PROSE"),
+    ],
+)
+def test_classify_check_precedence(text, expected):
+    assert eps.classify_check(text) == expected
+
+
+def test_enumeration_finds_a_spec_dir_with_no_skill_md(tmp_path, monkeypatch):
+    """Enumeration used to derive skills from SKILL.md while manual `*` dispatch
+    walks directories. Every eval-bearing directory today has a SKILL.md, so only
+    a fixture without one can tell the two implementations apart."""
+    (tmp_path / "skills" / "ghost" / "evals").mkdir(parents=True)
+    (tmp_path / "skills" / "ghost" / "evals" / "s.json").write_text("{}", encoding="utf-8")
+    assert not (tmp_path / "skills" / "ghost" / "SKILL.md").exists()
+    monkeypatch.setattr(eps, "REPO_ROOT", tmp_path)
+    assert "ghost" in eps.all_skills()
+
+
+def test_missing_skills_root_is_loud_not_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(eps, "REPO_ROOT", tmp_path)
+    with pytest.raises(eps.SpecError):
+        eps.all_skills()
+
+
+def test_unreadable_spec_raises_spec_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(eps, "REPO_ROOT", tmp_path)
+    with pytest.raises(eps.SpecError) as exc:
+        eps.scan_spec("does-not-exist.json")
+    assert "unreadable" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "payload,fragment",
+    [
+        ("[]", "top level must be an object"),
+        ('{"expects": {}}', "'expects' must be a list"),
+        ('{"expects": ["nope"]}', "cell must be an object"),
+        ('{"expects": [{"checks": "abc"}]}', "'checks' must be a list"),
+        ('{"expects": [{"checks": [1]}]}', "must be a string"),
+        ("{not json", "invalid JSON"),
+    ],
+)
+def test_malformed_specs_fail_loudly(tmp_path, monkeypatch, payload, fragment):
+    """A damaged corpus must never silently undercount — every downstream gate
+    sources its numbers from this scan."""
+    p = tmp_path / "bad.json"
+    p.write_text(payload, encoding="utf-8")
+    monkeypatch.setattr(eps, "REPO_ROOT", tmp_path)
+    with pytest.raises(eps.SpecError) as exc:
+        eps.scan_spec("bad.json")
+    assert fragment in str(exc.value)


### PR DESCRIPTION
## Description

The size of the skill-eval corpus is quoted from memory in several places and the numbers disagree. This adds one tool that measures it, so a coverage claim can be checked rather than recalled.

On `develop` it reports:

```
specs=50 cells=152 checks=841
lexical scope hint (mentions, NOT an execution-scope measurement): HOST=159 FILE=6 NET=270 PROSE=406 / cells mentioning HOST: 63
```

**Measurement only.** Nothing is wired into CI and no existing behavior changes.

### Design notes

**Spec discovery is imported from `plan_matrix`, not reimplemented**, so the inventory and the dispatcher cannot disagree about what a spec is.

**Skill directories are enumerated from the filesystem, not from `SKILL.md`.** Manual `*` dispatch enumerates directories directly, so a spec in a directory without a `SKILL.md` is dispatchable and must not be missing from the inventory. The test for this uses a fixture directory rather than the live corpus: every eval-bearing directory in the repo today happens to have a `SKILL.md`, so asserting against the real tree cannot tell the two implementations apart.

**The scope hint is deliberately labelled as not a measurement.** It matches on mentions rather than requirements — `"no docker compose is executed"` counts as HOST, and a live container-state assertion containing no command counts as PROSE. It is useful for finding checks worth reading. Deciding where a check can actually execute needs per-check scope metadata, which this does not attempt, and the output says so rather than leaving the caveat in a docstring.

**Malformed, unreadable and non-UTF-8 specs fail loudly** rather than degrading to zero, so a damaged corpus cannot silently undercount.

### Known limitation

Counts alone cannot detect a check *moving* between cells, and reward is computed per cell as `passed / len(checks)`. A move therefore changes scores while every total here stays identical. Pinning ordered check identities is a follow-up; until that lands this is scaffolding and should not be consumed as a parity baseline.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.