### PR TITLE
feat(skill-eval): pin ordered check identities in an inventory manifest

### DIFF
--- a/.github/skill-eval/eval_parity_scope.py
+++ b/.github/skill-eval/eval_parity_scope.py
@@ -25,15 +25,17 @@ Treat them as a triage hint for finding checks worth reading, never as a
 measurement of what needs the deploy host -- that needs per-check metadata,
 which this does not attempt.
 
-Counts also cannot detect a check MOVING between cells, and reward is per cell
+``--manifest`` is what makes this a baseline rather than a headcount. Counts
+cannot detect a check MOVING between cells, and reward is per cell
 (``passed / len(checks)``, verifiers/generic_judge.py), so a move changes scores
-with every total unchanged. Pinning ordered identities is the follow-up change;
-until it lands this is scaffolding, not a parity baseline.
+while every total stays identical. The manifest records ordered check identities
+per cell, so that move is a diff.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sys
@@ -133,16 +135,17 @@ def scan_spec(rel_path: str) -> dict:
         if not isinstance(checks, list):
             raise SpecError(f"{rel_path}[{idx}]: 'checks' must be a list")
 
-        n, has_host = 0, False
+        hashes, has_host = [], False
         for cidx, check in enumerate(checks):
             if not isinstance(check, str):
                 raise SpecError(f"{rel_path}[{idx}].checks[{cidx}]: must be a string")
             scope = classify_check(check)
             per_scope[scope] += 1
             has_host = has_host or scope == "HOST"
-            n += 1
+            hashes.append(hashlib.sha256(check.encode("utf-8")).hexdigest()[:16])
 
-        cells.append({"index": idx, "check_count": n, "has_host": has_host})
+        cells.append({"index": idx, "check_count": len(hashes), "checks": hashes,
+                      "has_host": has_host})
 
     return {
         "spec": rel_path,
@@ -178,6 +181,29 @@ def scan() -> dict:
     }
 
 
+def manifest(result: dict) -> dict:
+    """The pinnable record: ordered check identities per cell.
+
+    Deliberately excludes the scope buckets. Scope is a lexical hint that will
+    change as the classifier improves; pinning it here would produce noisy diffs
+    that have nothing to do with the corpus actually changing.
+    """
+    return {
+        "version": 1,
+        "totals": {k: result[k] for k in ("specs", "cells", "checks")},
+        "specs": [
+            {
+                "spec": r["spec"],
+                "cells": [
+                    {k: c[k] for k in ("index", "check_count", "checks")}
+                    for c in r["cell_detail"]
+                ],
+            }
+            for r in result["by_spec"]
+        ],
+    }
+
+
 def format_summary(result: dict) -> str:
     hint = " ".join(f"{s}={result['scopes'][s]}" for s in SCOPES)
     return (
@@ -190,6 +216,8 @@ def format_summary(result: dict) -> str:
 def main() -> int:
     ap = argparse.ArgumentParser(description="Inventory the skill-eval corpus.")
     ap.add_argument("--json", action="store_true", help="aggregate counts as JSON")
+    ap.add_argument("--manifest", action="store_true",
+                    help="ordered per-cell check identities (the pinnable baseline)")
     args = ap.parse_args()
 
     try:
@@ -198,7 +226,9 @@ def main() -> int:
         print(f"FATAL: {exc}", file=sys.stderr)
         return 2
 
-    if args.json:
+    if args.manifest:
+        print(json.dumps(manifest(result), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps({k: v for k, v in result.items() if k != "by_spec"},
                          indent=2, sort_keys=True))
     else:

--- a/.github/skill-eval/tests/test_eval_parity_scope.py
+++ b/.github/skill-eval/tests/test_eval_parity_scope.py
@@ -61,6 +61,46 @@ def test_missing_skills_root_is_loud_not_empty(tmp_path, monkeypatch):
         eps.all_skills()
 
 
+def _write_spec(tmp_path, cells):
+    import json
+
+    (tmp_path / "spec.json").write_text(json.dumps({"expects": cells}), encoding="utf-8")
+
+
+def test_manifest_detects_a_check_moving_between_cells(tmp_path, monkeypatch):
+    """The reason the manifest exists. Reward is per cell (passed / len(checks)),
+    so moving a check between cells changes scores -- while every aggregate the
+    inventory reports stays identical."""
+    monkeypatch.setattr(eps, "REPO_ROOT", tmp_path)
+
+    _write_spec(tmp_path, [{"checks": ["alpha", "beta"]}, {"checks": ["gamma"]}])
+    a = eps.scan_spec("spec.json")
+    _write_spec(tmp_path, [{"checks": ["alpha"]}, {"checks": ["beta", "gamma"]}])
+    b = eps.scan_spec("spec.json")
+
+    # Every aggregate is unchanged...
+    assert (a["cells"], a["checks"], a["scopes"]) == (b["cells"], b["checks"], b["scopes"])
+
+    # ...but the manifest is not.
+    totals = {"specs": 1, "cells": 2, "checks": 3}
+    ma = eps.manifest({**totals, "by_spec": [a]})
+    mb = eps.manifest({**totals, "by_spec": [b]})
+    assert ma != mb
+    assert [c["check_count"] for c in ma["specs"][0]["cells"]] == [2, 1]
+    assert [c["check_count"] for c in mb["specs"][0]["cells"]] == [1, 2]
+
+
+def test_manifest_is_deterministic():
+    assert eps.manifest(eps.scan()) == eps.manifest(eps.scan())
+
+
+def test_manifest_excludes_the_lexical_scope_hint():
+    """Scope is a hint that will change as the classifier improves; pinning it
+    would produce diffs unrelated to the corpus changing."""
+    dumped = str(eps.manifest(eps.scan()))
+    assert "HOST" not in dumped and "PROSE" not in dumped
+
+
 def test_unreadable_spec_raises_spec_error(tmp_path, monkeypatch):
     monkeypatch.setattr(eps, "REPO_ROOT", tmp_path)
     with pytest.raises(eps.SpecError) as exc:


### PR DESCRIPTION
## Description

Stacked on #1669 — review that one first. This PR's diff against it is 84 lines.

The corpus inventory added in #1669 reports aggregate counts, which **cannot detect a check moving between cells**. Reward is computed per cell as `passed / len(checks)`, so relocating a check between two cells changes the scores those cells produce while every aggregate stays identical:

| | before | after |
|---|---|---|
| cell 0 | `["alpha", "beta"]` → reward out of 2 | `["alpha"]` → reward out of 1 |
| cell 1 | `["gamma"]` → reward out of 1 | `["beta", "gamma"]` → reward out of 2 |
| specs / cells / checks | 1 / 2 / 3 | 1 / 2 / 3 — **unchanged** |

Counts alone therefore cannot serve as a baseline.

`--manifest` emits, per spec, the ordered cells with each cell's check count and a hash per check in list order. The move above becomes a manifest diff. A test constructs exactly that case and asserts the aggregates match while the manifest does not.

The manifest **deliberately excludes the lexical scope hint**. Scope is an approximation that will change as the classifier improves, and pinning it would produce diffs unrelated to the corpus actually changing.

Still measurement only: nothing is wired into CI and no existing behavior changes. Asserting the manifest in CI is a separate change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.