### PR TITLE
ci: port OSRB Review to develop, keeping License Diff as the gate

### DIFF
--- a/.github/OSRB_REVIEW.md
+++ b/.github/OSRB_REVIEW.md
@@ -1,0 +1,95 @@
+# License Diff and OSRB Review
+
+Dependency-related pull requests receive two related GitHub checks:
+
+1. **License Diff** creates the public package-change overview and complete CSV.
+2. **OSRB Review** evaluates changes that may require approval and publishes the
+   final result.
+
+Both checks run automatically. Do not manually edit the generated PR comment.
+
+> **Transitional on `develop`.** License Diff still **fails** when the diff is
+> non-empty, and that failure is still a real signal — get OSRB approval for the
+> touched lockfile/manifest paths from
+> `@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers`, as before. OSRB Review runs
+> alongside it and posts its verdict, but it does not yet replace License Diff as
+> the gate. Expect both signals until that changes. On `main`, License Diff has
+> already been downgraded to a notice and OSRB Review is the gate.
+
+## What developers should do
+
+### License Diff reports no reviewable changes
+
+No OSRB action is required. Continue with the normal code and CODEOWNERS review.
+Same-license version updates and dependency removals remain in the complete CSV
+for traceability, but do not require OSRB re-engagement.
+
+### OSRB Review is running
+
+Wait for it to finish. The protected reviewer is checking the public diff
+against existing approval evidence. Do not merge while this check is running.
+
+### OSRB Review passes
+
+No further OSRB action is required for the reported dependency changes.
+Normal required checks, CODEOWNERS approval, and maintainer review still apply.
+
+### OSRB Review passes with notes
+
+The check is green and you can merge. A note means something worth recording
+was found that does not affect approval, most often a package listed in an
+attribution file that no code imports, or a changed container base image whose
+own OSRB record should be confirmed. Fix the attribution gap in this PR if it
+is yours to fix; otherwise raise it with the OSRB owner separately.
+
+### The review says its verdict is provisional
+
+The reviewer ran a pre-release build of itself, which happens during rollout. Do
+not treat the verdict as final and do not merge on the strength of it. Tell a
+repository maintainer, who will confirm what the check ran against.
+
+### OSRB Review fails or is inconclusive
+
+1. Read the automated review on the PR.
+2. Open the linked **License Diff** Actions run.
+3. Inspect the short overview. Download `license-diff.csv` only when more detail
+   is needed.
+4. Address the reported issue:
+   - correct or remove an unintended dependency;
+   - provide a resolvable public license or component URL;
+   - preserve or add the required third-party notice and license text;
+   - work with the OSRB owner when a new component, license change, or changed
+     use needs approval;
+   - ask a repository maintainer to retry an infrastructure failure.
+5. Push the correction. If no source change was needed, a maintainer can rerun
+   the License Diff workflow.
+
+Do not paste private ticket comments, approval sheets, credentials, or internal
+links into the public PR. The protected reviewer reads that evidence privately
+and publishes only the decision.
+
+## What triggers review
+
+The overview requests attention for:
+
+- a new dependency;
+- a confirmed license change;
+- an old or new license that cannot be resolved.
+
+The complete CSV also retains same-license version updates and removals, but
+those rows do not require OSRB re-engagement by themselves.
+
+Container images that add dependencies without editing a manifest are covered
+too. If your PR changes a Dockerfile base image or installs packages in it, the
+review evaluates those lines even when the CSV is empty.
+
+Changes in how an approved component is used can still require review even when
+its package version and license are unchanged. Examples include static instead
+of dynamic linking, vendoring source, or moving a build-only dependency into a
+distributed runtime.
+
+## Release-target pull requests
+
+Pull requests targeting `dev/*` or `release/*` are marked not applicable because
+OSRB review is performed on the earlier pull request into the development
+branch.

--- a/.github/scripts/osrb_check.py
+++ b/.github/scripts/osrb_check.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Publish the public OSRB check around the private downstream pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+GITHUB_API = "https://api.github.com"
+CHECK_NAME = "OSRB Review"
+EXTERNAL_PREFIX = "gitlab-osrb:"
+
+
+class CheckError(RuntimeError):
+    """A GitHub check operation failed."""
+
+
+def guide_url(repo: str) -> str:
+    return f"https://github.com/{repo}/blob/main/.github/OSRB_REVIEW.md"
+
+
+def summary_with_guide(repo: str, summary: str) -> str:
+    return f"{summary}\n\n[How to respond to this check]({guide_url(repo)})"
+
+
+def token() -> str:
+    value = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not value:
+        raise CheckError("GITHUB_TOKEN is not configured")
+    return value
+
+
+def github(
+    method: str,
+    repo: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(
+        f"{GITHUB_API}/repos/{repo}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token()}",
+            "Content-Type": "application/json",
+            "User-Agent": "vss-osrb-check/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=45) as response:
+            body = response.read()
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read(500).decode("utf-8", errors="replace")
+        raise CheckError(f"{method} GitHub check request returned HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise CheckError(f"{method} GitHub check request failed: {exc.reason}") from exc
+
+
+def find_check(repo: str, sha: str, external_id: str) -> dict[str, Any] | None:
+    name = urllib.parse.quote(CHECK_NAME)
+    checks = github("GET", repo, f"/commits/{sha}/check-runs?check_name={name}")
+    matches = [
+        check
+        for check in checks.get("check_runs", [])
+        if check.get("name") == CHECK_NAME
+        and check.get("external_id") == external_id
+    ]
+    return max(matches, key=lambda check: int(check.get("id", 0)), default=None)
+
+
+def start(repo: str, sha: str, run_url: str, external_id: str) -> None:
+    payload = {
+        "name": CHECK_NAME,
+        "head_sha": sha,
+        "status": "in_progress",
+        "details_url": run_url,
+        "external_id": external_id,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "output": {
+            "title": "Private OSRB review is running",
+            "summary": summary_with_guide(
+                repo,
+                "Wait for this check to finish before merging. "
+                "The protected compliance reviewer is evaluating the public License Diff.",
+            ),
+        },
+    }
+    existing = find_check(repo, sha, external_id)
+    if existing:
+        github("PATCH", repo, f"/check-runs/{existing['id']}", payload)
+    else:
+        github("POST", repo, "/check-runs", payload)
+
+
+def complete(
+    repo: str,
+    sha: str,
+    run_url: str,
+    external_id: str,
+    success: bool,
+    summary: str,
+) -> None:
+    payload = {
+        "name": CHECK_NAME,
+        "status": "completed",
+        "conclusion": "success" if success else "failure",
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "details_url": run_url,
+        "output": {
+            "title": "OSRB review passed" if success else "OSRB review needs attention",
+            "summary": summary_with_guide(repo, summary),
+        },
+    }
+    check = find_check(repo, sha, external_id)
+    if check:
+        github("PATCH", repo, f"/check-runs/{check['id']}", payload)
+        return
+    # `start` runs first and should have created it. If that call was lost to a
+    # transient API failure, publish the conclusion anyway: a pull request with
+    # no check at all is worse than one showing the gate did not complete.
+    github("POST", repo, "/check-runs", {**payload, "head_sha": sha, "external_id": external_id})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("start", "complete", "skip"))
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--external-id", required=True)
+    parser.add_argument("--success", action="store_true")
+    parser.add_argument("--summary", default="")
+    args = parser.parse_args()
+    if not args.external_id.startswith(EXTERNAL_PREFIX):
+        raise CheckError(f"external ID must start with {EXTERNAL_PREFIX!r}")
+    if args.command == "start":
+        start(args.repo, args.sha, args.run_url, args.external_id)
+    elif args.command == "skip":
+        start(args.repo, args.sha, args.run_url, args.external_id)
+        complete(
+            args.repo,
+            args.sha,
+            args.run_url,
+            args.external_id,
+            True,
+            args.summary or "Not applicable for this target branch.",
+        )
+    else:
+        complete(
+            args.repo,
+            args.sha,
+            args.run_url,
+            args.external_id,
+            args.success,
+            args.summary
+            or (
+                "The private OSRB review approved this change."
+                if args.success
+                else "The private OSRB review did not approve this change. See the PR review."
+            ),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for the public-to-private OSRB dispatch boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+DIRECTORY = Path(__file__).parent
+WORKFLOW = DIRECTORY.parent / "workflows" / "osrb-review.yml"
+LICENSE_WORKFLOW = DIRECTORY.parent / "workflows" / "license-diff.yml"
+DEVELOPER_GUIDE = DIRECTORY.parent / "OSRB_REVIEW.md"
+
+
+def load_python(name: str, path: Path):
+    loader = SourceFileLoader(name, str(path))
+    spec = importlib.util.spec_from_loader(name, loader)
+    assert spec
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+trigger = load_python("trigger_downstream", DIRECTORY / "trigger_downstream_pipeline.py")
+check = load_python("osrb_check", DIRECTORY / "osrb_check.py")
+
+
+class DispatchTests(unittest.TestCase):
+    def test_extra_variables_are_string_map(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"DOWNSTREAM_EXTRA_VARIABLES_JSON": '{"OSRB_REVIEW":"true","PR":"42"}'},
+            clear=False,
+        ):
+            self.assertEqual(
+                trigger.extra_pipeline_variables(),
+                {"OSRB_REVIEW": "true", "PR": "42"},
+            )
+
+    def test_extra_variables_reject_non_string_values(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"DOWNSTREAM_EXTRA_VARIABLES_JSON": '{"PR":42}'},
+            clear=False,
+        ), self.assertRaises(SystemExit):
+            trigger.extra_pipeline_variables()
+
+    def test_check_external_id_is_private_pipeline_scoped(self) -> None:
+        self.assertEqual(check.EXTERNAL_PREFIX, "gitlab-osrb:")
+
+    def test_check_links_to_public_developer_instructions(self) -> None:
+        repo = "NVIDIA-AI-Blueprints/video-search-and-summarization"
+        self.assertEqual(
+            check.guide_url(repo),
+            f"https://github.com/{repo}/blob/main/.github/OSRB_REVIEW.md",
+        )
+        self.assertIn(
+            "[How to respond to this check]",
+            check.summary_with_guide(repo, "Review passed."),
+        )
+
+    def test_dispatch_passes_canonical_license_diff_run_url(self) -> None:
+        workflow = WORKFLOW.read_text()
+        self.assertIn(
+            '"GITHUB_LICENSE_RUN_URL":"${{ github.event.workflow_run.html_url }}"',
+            workflow,
+        )
+        self.assertIn('LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}', workflow)
+        self.assertIn('--run-url "$LICENSE_RUN_URL"', workflow)
+
+    def test_check_is_created_before_anything_that_can_fail(self) -> None:
+        """A failure before the check exists would be an invisible fail-open.
+
+        `workflow_run` jobs are not listed in the pull request, so if no check
+        run is created the gate simply does not happen and nothing says so.
+        """
+        workflow = WORKFLOW.read_text()
+        steps = re.findall(r"^      - name: (.+)$", workflow, re.M)
+        self.assertEqual(steps[1], "Start OSRB check", steps)
+
+        start_block = workflow.split("- name: Start OSRB check", 1)[1]
+        start_block = start_block.split("- name:", 1)[0]
+        self.assertNotIn("if:", start_block, "Start OSRB check must be unconditional")
+
+    def test_every_path_resolves_the_check(self) -> None:
+        """No branch may leave the check stuck in_progress with nothing to close it."""
+        workflow = WORKFLOW.read_text()
+        complete_block = workflow.split("- name: Complete OSRB check", 1)[1]
+        self.assertIn("if: always()\n", complete_block)
+        self.assertNotIn("always() && steps.pr.outputs.skip", complete_block)
+
+        mark_block = workflow.split("- name: Mark release-branch review as not applicable", 1)[1]
+        mark_block = mark_block.split("- name:", 1)[0]
+        self.assertIn("continue-on-error: true", mark_block)
+
+    def test_complete_publishes_even_when_the_check_was_never_started(self) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        def fake_github(method: str, repo: str, path: str, payload: dict | None = None):
+            calls.append((method, path, payload))
+            return {"check_runs": []} if method == "GET" else {}
+
+        with mock.patch.object(check, "github", fake_github):
+            check.complete("owner/repo", "deadbeef", "https://run", "gitlab-osrb:1", False, "why")
+
+        self.assertEqual([call[0] for call in calls], ["GET", "POST"])
+        created = calls[1][2] or {}
+        self.assertEqual(created["head_sha"], "deadbeef")
+        self.assertEqual(created["conclusion"], "failure")
+        self.assertEqual(created["external_id"], "gitlab-osrb:1")
+
+    def test_dispatch_job_wiring_is_exercised_in_ci(self) -> None:
+        self.assertIn(
+            "python3 .github/scripts/test_osrb_dispatch.py",
+            (DIRECTORY.parent / "workflows" / "ci.yml").read_text(),
+        )
+
+    def test_workflow_supplies_every_variable_the_helpers_require(self) -> None:
+        """The poller reads DOWNSTREAM_PROJECT_PATH even when given a project id.
+
+        ci.yml supplies the shared downstream variables at job level, so both
+        the trigger and the poll step inherit them. Setting them per step is
+        what left the poller a variable short.
+        """
+        workflow = WORKFLOW.read_text()
+        required: set[str] = set()
+        for helper in ("trigger_downstream_pipeline.py", "poll-downstream-pipeline.py"):
+            required.update(
+                re.findall(r'require_env\(\s*"([A-Z0-9_]+)"', (DIRECTORY / helper).read_text())
+            )
+        missing = sorted(name for name in required if name not in workflow)
+        self.assertEqual(missing, [], f"workflow never sets {missing}")
+
+    def test_dispatch_does_not_choose_the_private_pipeline_code_ref(self) -> None:
+        workflow = WORKFLOW.read_text()
+        for variable in ("OSRB_CODE_REF", "OSRB_ALLOW_UNREVIEWED_CODE"):
+            self.assertNotIn(variable, workflow)
+
+    def test_github_output_explains_developer_actions(self) -> None:
+        guide = DEVELOPER_GUIDE.read_text()
+        license_workflow = LICENSE_WORKFLOW.read_text()
+        self.assertIn("### OSRB Review fails or is inconclusive", guide)
+        self.assertIn("Do not paste private ticket comments", guide)
+        self.assertIn("### What to do", license_workflow)
+        self.assertIn("Developer instructions", license_workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1324,6 +1324,28 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------
+  # Job 12: OSRB dispatch wiring
+  # ---------------------------------------------------------------------------
+  # The OSRB Review workflow itself runs on `workflow_run` from the default
+  # branch, so a pull request never executes its own copy. These tests are the
+  # only pre-merge signal on that wiring: they assert the workflow supplies
+  # every variable the downstream helpers require, keeps the private code-ref
+  # choice out of the public repo, and creates the check before anything that
+  # can fail.
+  osrb-dispatch:
+    name: OSRB Dispatch Wiring
+    needs: prepare-source
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Unit-test the OSRB dispatch boundary
+        run: python3 .github/scripts/test_osrb_dispatch.py
+
+  # ---------------------------------------------------------------------------
   # Job 13: Trigger downstream pipeline and poll it to completion
   # ---------------------------------------------------------------------------
   trigger-downstream-pipeline:

--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -140,6 +140,7 @@ jobs:
           RAW_ROWS: ${{ steps.gen.outputs.rows }}
           BASE: ${{ steps.ctx.outputs.base }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GUIDE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/develop/.github/OSRB_REVIEW.md
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
         run: |
           set -euo pipefail
@@ -158,7 +159,14 @@ jobs:
             echo '```'
             echo "</details>"
             echo
-            echo "_This check is informational. CODEOWNERS still gates merge — get approval from \`@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers\` for the touched lockfile/manifest paths._"
+            echo "### What to do"
+            echo
+            echo "The **OSRB Review** check evaluates these changes against existing approval evidence and posts its verdict on this PR."
+            echo "While that check is being rolled out, a red License Diff is still a real signal:"
+            echo "get approval from \`@NVIDIA-AI-Blueprints/VSS_OSRB_Approvers\` for the touched paths."
+            echo "Do not paste private approval evidence into this public PR."
+            echo
+            echo "[Developer instructions](${GUIDE_URL}) · CODEOWNERS remains the final merge gate."
           } > comment.md
           existing=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
             --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id")

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Trusted follow-up to License Diff. `workflow_run` loads this workflow and its
+# scripts from the default branch, not from the PR mirror. It creates the
+# public check, then triggers and polls the isolated private GitLab pipeline.
+# Internal compliance systems and credentials are used only in that pipeline.
+name: OSRB Review
+
+"on":
+  workflow_run:
+    workflows: ["License Diff"]
+    types: [completed]
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: osrb-review-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  review:
+    name: Trigger private OSRB review
+    if: startsWith(github.event.workflow_run.head_branch, 'pull-request/')
+    runs-on: [self-hosted, downstream-pipeline]
+    timeout-minutes: 45
+    env:
+      REPO: ${{ github.repository }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      LICENSE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+      SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+      EXTERNAL_ID: gitlab-osrb:${{ github.event.workflow_run.id }}
+      # Job level, as in ci.yml: the trigger and the poller both need these.
+      DOWNSTREAM_CI_URL: ${{ secrets.DOWNSTREAM_CI_URL }}
+      DOWNSTREAM_CI_TOKEN: ${{ secrets.DOWNSTREAM_CI_TOKEN }}
+      DOWNSTREAM_PROJECT_PATH: ${{ secrets.DOWNSTREAM_PROJECT_PATH }}
+
+    steps:
+      - name: Checkout trusted dispatch implementation
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      # First, so the check exists before anything that can fail. Otherwise a
+      # failure here leaves no check on the commit at all, and `workflow_run`
+      # jobs are not listed in the pull request, so the gate would silently not
+      # happen. Idempotent, which also lets the release-branch path reuse it.
+      - name: Start OSRB check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/osrb_check.py start \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --run-url "$LICENSE_RUN_URL" \
+            --external-id "$EXTERNAL_ID"
+
+      - name: Resolve source PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          pr="${HEAD_BRANCH##pull-request/}"
+          base="$(gh pr view "$pr" --repo "$REPO" --json baseRefName --jq .baseRefName)"
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          case "$base" in
+            dev/*|release/*) echo "skip=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "skip=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Mark release-branch review as not applicable
+        id: mark
+        if: steps.pr.outputs.skip == 'true'
+        # Failing here must not abort before the completion step, or the check
+        # would stay in_progress with nothing left to resolve it.
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/osrb_check.py skip \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --run-url "$LICENSE_RUN_URL" \
+            --external-id "$EXTERNAL_ID" \
+            --summary "PR targets ${{ steps.pr.outputs.base }}; OSRB was already enforced on the develop-targeted PR."
+
+      - name: Trigger private OSRB pipeline
+        if: steps.pr.outputs.skip != 'true'
+        id: trigger
+        continue-on-error: true
+        env:
+          # A standing ref, because the private project's normal jobs are
+          # opt-out gated and a trigger against its default branch would start
+          # a full build. That ref is maintainer-protected and points at
+          # reviewed code; which code the review runs is decided entirely
+          # there, so this dispatcher must never send a code-ref override.
+          DOWNSTREAM_REF: osrb-review-trigger
+          DOWNSTREAM_SUBMODULE_HASH_VARIABLE: GITHUB_MIRROR_SHA
+          GITHUB_SHA: ${{ github.event.workflow_run.head_sha }}
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
+          GITHUB_TOKEN: ${{ github.token }}
+          DOWNSTREAM_EXTRA_VARIABLES_JSON: >-
+            {"OSRB_REVIEW":"true",
+            "GITHUB_REPOSITORY":"${{ github.repository }}",
+            "GITHUB_PR_NUMBER":"${{ steps.pr.outputs.number }}",
+            "GITHUB_LICENSE_RUN_ID":"${{ github.event.workflow_run.id }}",
+            "GITHUB_LICENSE_RUN_URL":"${{ github.event.workflow_run.html_url }}",
+            "GITHUB_OSRB_RUN_URL":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
+        run: |
+          python3 .github/scripts/trigger_downstream_pipeline.py
+
+      - name: Poll private OSRB pipeline
+        if: steps.pr.outputs.skip != 'true' && steps.trigger.outcome == 'success'
+        id: poll
+        continue-on-error: true
+        env:
+          DOWNSTREAM_PIPELINE_ID: ${{ steps.trigger.outputs.pipeline_id }}
+          DOWNSTREAM_PROJECT_ID: ${{ steps.trigger.outputs.project_id }}
+          POLL_INTERVAL_SECONDS: "30"
+          MAX_POLL_DURATION_SECONDS: "2400"
+        run: python3 .github/scripts/poll-downstream-pipeline.py
+
+      # Unconditional, so every path that created the check also resolves it.
+      - name: Complete OSRB check
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SKIP: ${{ steps.pr.outputs.skip }}
+          MARK_OUTCOME: ${{ steps.mark.outcome }}
+          TRIGGER_OUTCOME: ${{ steps.trigger.outcome }}
+          POLL_OUTCOME: ${{ steps.poll.outcome }}
+        run: |
+          set -euo pipefail
+          # The release-branch path already completed the check itself.
+          if [[ "$SKIP" == "true" && "$MARK_OUTCOME" == "success" ]]; then
+            exit 0
+          fi
+          success=()
+          if [[ "$TRIGGER_OUTCOME" == "success" && "$POLL_OUTCOME" == "success" ]]; then
+            success=(--success)
+            summary="The reported dependency changes passed OSRB review. No further OSRB action is required; normal required checks and CODEOWNERS review still apply."
+          elif [[ "$TRIGGER_OUTCOME" != "success" ]]; then
+            # No verdict was ever produced, so this says nothing about the
+            # dependencies themselves. Do not word it like a finding.
+            summary="The OSRB gate could not run, so these dependency changes were not reviewed. Ask a repository maintainer to rerun License Diff; do not merge on the strength of this check."
+          else
+            summary="This change needs attention. Read the automated PR review and linked License Diff, then correct the dependency or work with the OSRB owner before pushing an update."
+          fi
+          python3 .github/scripts/osrb_check.py complete \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --run-url "$LICENSE_RUN_URL" \
+            --external-id "$EXTERNAL_ID" \
+            --summary "$summary" \
+            "${success[@]}"
+          [[ "$TRIGGER_OUTCOME" == "success" && "$POLL_OUTCOME" == "success" ]]


### PR DESCRIPTION
## Why

#1454 landed the OSRB dispatch on **`main`**. Every PR targets `develop`, and GitHub runs workflows from the PR's base branch — so **no PR has ever run it**. `main` is 715 commits behind `develop`, so waiting for a sync leaves dependency PRs ungated indefinitely.

#1655 (bumps `sharp` in `services/ui/package-lock.json`) is exactly the case that should be gated and isn't.

## What's ported

| file | note |
|---|---|
| `.github/workflows/osrb-review.yml` | new |
| `.github/scripts/osrb_check.py` | new |
| `.github/scripts/test_osrb_dispatch.py` | new |
| `.github/OSRB_REVIEW.md` | new |
| `.github/workflows/ci.yml` | **+22, pure addition** — one `osrb-dispatch` job, touches nothing else |

`trigger_downstream_pipeline.py` needed nothing: develop already has `extra_pipeline_variables()` and already logs variable names rather than values.

## What is deliberately NOT ported

#1454 downgrades License Diff from `exit 1` to a notice, on the basis that OSRB Review takes over as the gate. **That isn't safe yet.**

`ci-vss-oss!316` merged with both P1s from its review unaddressed. Reproduced against the merged pipeline:

```
REPRO 1 — model returns no import classifications at all:
   verdict=CLEAN  passes=True  errors=None

REPRO 2 — IMPORT_UNAPPROVED + CONTAINER_UNAPPROVED + High/Unknown risk, soft verdict:
   verdict=GAP_INFORMATIONAL  passes=True  event=COMMENT  errors=None
```

Every deterministic guard in `validate_result` is nested under `if verdict == "CLEAN"`, and nothing checks that the agent classified any imports at all. Porting the softening now would take dependency PRs from **hard-failing to silently passing** — strictly worse than today.

So both signals run: License Diff keeps failing on `review_rows != 0` (the precise gate from #1528), and OSRB Review posts its verdict alongside. Soften License Diff in a follow-up once the pipeline actually enforces.

## Adapted, not cherry-picked

`main` and `develop` have genuinely diverged here:

- `trigger-downstream-pipeline.sh` → **`trigger_downstream_pipeline.py`** on develop (fixed in the workflow and both test references)
- `configured_extra_variables()` → **`extra_pipeline_variables()`**
- quoted the `on:` key, matching `ci.yml` and yamllint
- the guide and the PR-comment **"What to do"** block state that a red License Diff still needs approver sign-off. #1454's wording says OSRB Review alone decides — shipping that verbatim would tell developers to ignore a check that still blocks them.

## Verification

- `python3 .github/scripts/test_osrb_dispatch.py` — **12 tests, OK**
- all three workflows parse; yamllint clean under CI's ruleset (the one remaining `truthy` warning on `license-diff.yml:6` is pre-existing on develop)
- `workflow_run` wiring confirmed: develop's License Diff is `name: License Diff`, matching what `osrb-review.yml` keys on, and it runs on `pull-request/[0-9]+` refs
- License Diff gate intact — `Fail when OSRB re-engagement is required` / `exit 1` still present
- pre-commit + DCO passed

## Follow-ups

1. Fix the two `!316` P1s (import-completeness check; escalate blocking classifications regardless of the model's verdict).
2. Then soften License Diff here — a one-commit change.
3. Decide whether `main` should also carry the "both signals" posture, or stay as-is.