### PR TITLE
fix(search): disable RT-CV file looping

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/configs/ds-main-config.txt
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/configs/ds-main-config.txt
@@ -237,4 +237,4 @@ batch-size=8
 config-file=ppl_analytics_sgie_config.txt
 
 [tests]
-file-loop=1
+file-loop=0

--- a/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/configs/ds-main-redis-config.txt
+++ b/deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/deepstream/configs/ds-main-redis-config.txt
@@ -233,4 +233,4 @@ batch-size=8
 config-file=ppl_analytics_sgie_config.txt
 
 [tests]
-file-loop=1
+file-loop=0

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/vss-rtvi-cv-configmap.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/vss-rtvi-cv-configmap.yaml
@@ -308,5 +308,5 @@ data:
     config-file=ppl_analytics_sgie_config.txt
 
     [tests]
-    file-loop=1
+    file-loop=0
 {{- end }}


### PR DESCRIPTION
## Description
Fixes nvbug 6538344
### Root Cause of the bug
After Video Management stores the file in VST, the post-upload workflow passes the VST full-file URL to RT-CV for object analytics. RT-CV downloads the file and loops it because DeepStream file-loop=1 is enabled. Repeated passes are indexed with continuously increasing timestamps, while VST retains only the original finite timeline.
### Fix
Disable the looping for search profile

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
