### PR TITLE
feat(vios): share one APT package cache across standalone and e2e deployments

### DIFF
--- a/deploy/docker/services/nvstreamer/base.yml
+++ b/deploy/docker/services/nvstreamer/base.yml
@@ -33,6 +33,11 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
+      # Install from the shared APT cache (populated by vios-apt-cache-init in
+      # the streamprocessing compose) instead of downloading. The ro mount and
+      # the dependency below are inherited by every nvstreamer variant via
+      # `extends`; the volume and init service share this project via `include`.
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - ADAPTOR=streamer
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT}
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
@@ -46,6 +51,10 @@ services:
       - ${VSS_APPS_DIR}/services/nvstreamer/configs/notification-config.json:/home/vst/vst_release/configs/notification_config.json
       - ${VSS_APPS_DIR}/services/nvstreamer/configs/vst-storage.json:/home/vst/vst_release/configs/vst_storage.json
       - ${VSS_APPS_DIR}/services/vios/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+      - vios_apt_cache:/opt/apt-cache:ro
+    depends_on:
+      vios-apt-cache-init:
+        condition: service_completed_successfully
     deploy:
       restart_policy:
         condition: on-failure

--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -182,6 +182,36 @@ if [[ -n "${VST_APT_PIPELINE_DEPTH:-}" ]]; then
   APT_OPTS+=(-o "Acquire::http::Pipeline-Depth=${VST_APT_PIPELINE_DEPTH}")
 fi
 
+# ---------------------------------------------------------------------------
+# Shared package cache
+#
+# Every VIOS service on a host installs the same package set, and each cold
+# start otherwise re-downloads ~138MB. An init container populates a shared
+# volume once (VST_APT_CACHE_POPULATE=true); services then install from it with
+# no network.
+#
+# Consumers mount the cache READ-ONLY at VST_APT_CACHE_DIR. Two options make
+# that work and both matter:
+#
+#   Dir::Cache::archives  points apt at the shared copy instead of its own.
+#   Debug::NoLocking      skips the archives lock. apt takes that lock even with
+#                         nothing to download, and a shared volume means a shared
+#                         lock file -- measured: two containers starting together,
+#                         the loser fails outright with
+#                         "Could not get lock ... held by process 0".
+#
+# Skipping the lock is safe HERE ONLY because consumers never write to that
+# directory: the mount is read-only and the init container has finished. If the
+# mount is ever made writable, or a service can start before the init completes,
+# restore locking -- two writers with NoLocking race unprotected.
+APT_CACHE_DIR="${VST_APT_CACHE_DIR:-/opt/apt-cache}"
+APT_CACHE_POPULATE="${VST_APT_CACHE_POPULATE:-false}"
+
+if [[ "${APT_CACHE_POPULATE}" != "true" ]] && compgen -G "${APT_CACHE_DIR}/*.deb" >/dev/null 2>&1; then
+  echo "Using shared package cache at ${APT_CACHE_DIR} ($(ls "${APT_CACHE_DIR}"/*.deb | wc -l) packages)."
+  APT_OPTS+=(-o "Dir::Cache::archives=${APT_CACHE_DIR}" -o Debug::NoLocking=true)
+fi
+
 
 install_packages() {
   apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
@@ -232,6 +262,41 @@ refresh_apt_metadata() {
   done
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# Init-container mode: populate the shared cache and exit.
+#
+# The only writer, so it removes docker-clean -- the base image ships that file
+# and it deletes every .deb after each apt operation, which would leave the cache
+# volume empty and the whole scheme silently doing nothing.
+#
+# flock serialises populators: in the standalone deployment nvstreamer and
+# stream-processing are separate compose projects, so depends_on cannot order
+# them and both run an init against the same volume. The second blocks here, then
+# finds the cache warm and returns in seconds.
+if [[ "${APT_CACHE_POPULATE}" == "true" ]]; then
+  echo "Populating shared package cache in ${APT_CACHE_DIR}..."
+  install -d "${APT_CACHE_DIR}/partial"
+  rm -f /etc/apt/apt.conf.d/docker-clean
+  exec 9>"${APT_CACHE_DIR}/.populate.lock"
+  if ! flock -w "${VST_APT_CACHE_LOCK_WAIT:-600}" 9; then
+    echo "ERROR: timed out waiting for another cache populator."
+    exit 1
+  fi
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata."
+    exit 1
+  fi
+  # -d downloads without installing: this container only fills the cache.
+  if ! apt-get install --reinstall -d -y --no-install-recommends \
+         "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
+         "${RUNTIME_PACKAGES[@]}"; then
+    echo "ERROR: Unable to populate the package cache."
+    exit 1
+  fi
+  echo "Cache ready: $(ls "${APT_CACHE_DIR}"/*.deb 2>/dev/null | wc -l) packages, $(du -sh "${APT_CACHE_DIR}" | cut -f1)."
+  exit 0
+fi
 
 # A mirror override invalidates the metadata the base image ships, which is
 # indexed against the default archive. Measured: with a mirror configured and the

--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -207,9 +207,15 @@ fi
 APT_CACHE_DIR="${VST_APT_CACHE_DIR:-/opt/apt-cache}"
 APT_CACHE_POPULATE="${VST_APT_CACHE_POPULATE:-false}"
 
+# Snapshot the options WITHOUT the cache overrides, so a cache-mode install that
+# fails (stale, partial, or -- being read-only -- unable to fetch a package it
+# lacks) can fall back to a normal networked install instead of blocking startup.
+BASE_APT_OPTS=("${APT_OPTS[@]}")
+CACHE_MODE=false
 if [[ "${APT_CACHE_POPULATE}" != "true" ]] && compgen -G "${APT_CACHE_DIR}/*.deb" >/dev/null 2>&1; then
   echo "Using shared package cache at ${APT_CACHE_DIR} ($(ls "${APT_CACHE_DIR}"/*.deb | wc -l) packages)."
   APT_OPTS+=(-o "Dir::Cache::archives=${APT_CACHE_DIR}" -o Debug::NoLocking=true)
+  CACHE_MODE=true
 fi
 
 
@@ -325,8 +331,27 @@ if ! install_packages; then
     dpkg --configure -a
   fi
   if ! install_packages_with_retries; then
-    echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
-    exit 1
+    if [[ "${CACHE_MODE}" == "true" ]]; then
+      # The shared cache is stale, incomplete, or (being read-only) cannot be
+      # written to for a package it lacks. Never let that block startup: drop
+      # the cache overrides and install normally over the network -- exactly
+      # what a deployment without the cache does. The cache is an optimization,
+      # not a hard dependency.
+      echo "Cache-mode install failed; falling back to a normal networked install (bypassing the shared cache)."
+      APT_OPTS=("${BASE_APT_OPTS[@]}")
+      CACHE_MODE=false
+      if ! refresh_apt_metadata; then
+        echo "ERROR: Unable to refresh APT metadata for the cache-fallback install."
+        exit 1
+      fi
+      if ! install_packages_with_retries; then
+        echo "ERROR: Unable to install runtime media packages after the cache fallback."
+        exit 1
+      fi
+    else
+      echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
+      exit 1
+    fi
   fi
 fi
 

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
@@ -14,6 +14,33 @@
 # limitations under the License.
 
 services:
+  # Populate the shared APT package cache once per bring-up. Every vios
+  # consumer (streamprocessing + all nvstreamer-base profiles) then installs
+  # from it read-only instead of each downloading ~138MB independently. The
+  # streamprocessing and nvstreamer images resolve to the same package set, so
+  # one populator covers both. Gated on VST_INSTALL_ADDITIONAL_PACKAGES and
+  # carries every vios profile so it activates whenever a vios service does
+  # (and never for a non-vios profile). Add new vios profiles here too.
+  vios-apt-cache-init:
+    image: ${VST_STREAM_PROCESSOR_IMAGE}
+    container_name: vios-apt-cache-init
+    profiles: ["streamprocessing-ms", "streamprocessing-ms-2d", "streamprocessing-ms-3d", "streamprocessing-ms-mv3dt", "nvstreamer-alerts", "nvstreamer-lvs", "nvstreamer-2d-fusion", "nvstreamer-2d", "nvstreamer-3d", "nvstreamer-mv3dt"]
+    user: "0:0"
+    environment:
+      - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_POPULATE=true
+      - VST_APT_CACHE_DIR=/opt/apt-cache
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
+    # Best-effort: the `|| echo` keeps the init exit 0 even if the populate
+    # fails, so a transient apt error never blocks the consumers that
+    # depend_on this (service_completed_successfully) -- they just fall back to
+    # downloading. The cache is an optimization, not a hard dependency.
+    entrypoint: ["/bin/bash", "-c", "if [ \"${VST_INSTALL_ADDITIONAL_PACKAGES}\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh || echo 'cache populate failed (best-effort); consumers will download'; else echo 'additional packages disabled; nothing to cache'; fi"]
+    volumes:
+      - vios_apt_cache:/opt/apt-cache
+      - ${VSS_APPS_DIR}/services/vios/scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+    restart: "no"
+
   streamprocessing-ms:
     image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
     profiles: ["streamprocessing-ms"]
@@ -31,6 +58,7 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - CONTAINER_NAME=vss-vios-streamprocessing
       - ADAPTOR=${VST_ADAPTOR:-vst_rtsp}
       - HTTP_PORT=${STREAM_PROCESSOR_HTTP_PORT:-30001}
@@ -44,6 +72,7 @@ services:
       - VST_VIDEO_STORAGE_SIZE_MB=${VST_VIDEO_STORAGE_SIZE_MB}
     volumes:
       - ${VST_CONFIG_PATH:-${VSS_APPS_DIR}/services/vios/configs}:/home/vst/vst_release/configs
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${CLIP_STORAGE_PATH}:/home/vst/vst_release/streamer_videos
@@ -70,6 +99,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      vios-apt-cache-init:
+        condition: service_completed_successfully
 
   streamprocessing-ms-2d:
     image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
@@ -88,6 +119,7 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - CONTAINER_NAME=vss-vios-streamprocessing
       - ADAPTOR=${VST_ADAPTOR:-vst_rtsp}
       - HTTP_PORT=${STREAM_PROCESSOR_HTTP_PORT:-30001}
@@ -110,6 +142,7 @@ services:
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-2d-app/vst/configs/vst_config.json:/home/vst/vst_release/configs/vst_config.json
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-2d-app/vst/configs/notification_config.json:/home/vst/vst_release/configs/notification_config.json
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-2d-app/deepstream/configs/ds-detector-labels.txt:/home/vst/vst_release/configs/labels.txt
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${CLIP_STORAGE_PATH}:/home/vst/vst_release/streamer_videos
@@ -138,6 +171,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      vios-apt-cache-init:
+        condition: service_completed_successfully
 
   streamprocessing-ms-3d:
     image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
@@ -156,6 +191,7 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - CONTAINER_NAME=vss-vios-streamprocessing
       - ADAPTOR=${VST_ADAPTOR:-vst_rtsp}
       - HTTP_PORT=${STREAM_PROCESSOR_HTTP_PORT:-30001}
@@ -180,6 +216,7 @@ services:
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-3d-app/calibration/sample-data/${SAMPLE_VIDEO_DATASET}/calibration.json:/home/vst/vst_release/configs/calibration.json
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-3d-app/calibration/sample-data/${SAMPLE_VIDEO_DATASET}/images/Top.png:/home/vst/vst_release/configs/Top.png
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-3d-app/deepstream/label/labels.txt:/home/vst/vst_release/configs/labels.txt
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${CLIP_STORAGE_PATH}:/home/vst/vst_release/streamer_videos
@@ -208,6 +245,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      vios-apt-cache-init:
+        condition: service_completed_successfully
 
   streamprocessing-ms-mv3dt:
     image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
@@ -226,6 +265,7 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - CONTAINER_NAME=vss-vios-streamprocessing
       - ADAPTOR=${VST_ADAPTOR:-vst_rtsp}
       - HTTP_PORT=${STREAM_PROCESSOR_HTTP_PORT:-30001}
@@ -250,6 +290,7 @@ services:
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-mv3dt-app/calibration/sample-data/${SAMPLE_VIDEO_DATASET}/calibration.json:/home/vst/vst_release/configs/calibration.json
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-mv3dt-app/calibration/sample-data/${SAMPLE_VIDEO_DATASET}/images/Top.png:/home/vst/vst_release/configs/Top.png
       - ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/configs/ds-detector-labels.txt:/home/vst/vst_release/configs/labels.txt
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${CLIP_STORAGE_PATH}:/home/vst/vst_release/streamer_videos
@@ -278,3 +319,9 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      vios-apt-cache-init:
+        condition: service_completed_successfully
+
+volumes:
+  vios_apt_cache:
+    name: vios_apt_cache

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
   # carries every vios profile so it activates whenever a vios service does
   # (and never for a non-vios profile). Add new vios profiles here too.
   vios-apt-cache-init:
-    image: ${VST_STREAM_PROCESSOR_IMAGE}
+    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
     container_name: vios-apt-cache-init
     profiles: ["streamprocessing-ms", "streamprocessing-ms-2d", "streamprocessing-ms-3d", "streamprocessing-ms-mv3dt", "nvstreamer-alerts", "nvstreamer-lvs", "nvstreamer-2d-fusion", "nvstreamer-2d", "nvstreamer-3d", "nvstreamer-mv3dt"]
     user: "0:0"

--- a/deploy/docker/test-scripts/compose-images.golden
+++ b/deploy/docker/test-scripts/compose-images.golden
@@ -77,3 +77,4 @@ deploy/docker/services/vios/streamprocessing/docker-compose.yaml ghcr.io/nvidia-
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-streamprocessing:develop-latest
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-streamprocessing:develop-latest
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-streamprocessing:develop-latest
+deploy/docker/services/vios/streamprocessing/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-streamprocessing:develop-latest

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -182,6 +182,36 @@ if [[ -n "${VST_APT_PIPELINE_DEPTH:-}" ]]; then
   APT_OPTS+=(-o "Acquire::http::Pipeline-Depth=${VST_APT_PIPELINE_DEPTH}")
 fi
 
+# ---------------------------------------------------------------------------
+# Shared package cache
+#
+# Every VIOS service on a host installs the same package set, and each cold
+# start otherwise re-downloads ~138MB. An init container populates a shared
+# volume once (VST_APT_CACHE_POPULATE=true); services then install from it with
+# no network.
+#
+# Consumers mount the cache READ-ONLY at VST_APT_CACHE_DIR. Two options make
+# that work and both matter:
+#
+#   Dir::Cache::archives  points apt at the shared copy instead of its own.
+#   Debug::NoLocking      skips the archives lock. apt takes that lock even with
+#                         nothing to download, and a shared volume means a shared
+#                         lock file -- measured: two containers starting together,
+#                         the loser fails outright with
+#                         "Could not get lock ... held by process 0".
+#
+# Skipping the lock is safe HERE ONLY because consumers never write to that
+# directory: the mount is read-only and the init container has finished. If the
+# mount is ever made writable, or a service can start before the init completes,
+# restore locking -- two writers with NoLocking race unprotected.
+APT_CACHE_DIR="${VST_APT_CACHE_DIR:-/opt/apt-cache}"
+APT_CACHE_POPULATE="${VST_APT_CACHE_POPULATE:-false}"
+
+if [[ "${APT_CACHE_POPULATE}" != "true" ]] && compgen -G "${APT_CACHE_DIR}/*.deb" >/dev/null 2>&1; then
+  echo "Using shared package cache at ${APT_CACHE_DIR} ($(ls "${APT_CACHE_DIR}"/*.deb | wc -l) packages)."
+  APT_OPTS+=(-o "Dir::Cache::archives=${APT_CACHE_DIR}" -o Debug::NoLocking=true)
+fi
+
 
 install_packages() {
   apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
@@ -232,6 +262,41 @@ refresh_apt_metadata() {
   done
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# Init-container mode: populate the shared cache and exit.
+#
+# The only writer, so it removes docker-clean -- the base image ships that file
+# and it deletes every .deb after each apt operation, which would leave the cache
+# volume empty and the whole scheme silently doing nothing.
+#
+# flock serialises populators: in the standalone deployment nvstreamer and
+# stream-processing are separate compose projects, so depends_on cannot order
+# them and both run an init against the same volume. The second blocks here, then
+# finds the cache warm and returns in seconds.
+if [[ "${APT_CACHE_POPULATE}" == "true" ]]; then
+  echo "Populating shared package cache in ${APT_CACHE_DIR}..."
+  install -d "${APT_CACHE_DIR}/partial"
+  rm -f /etc/apt/apt.conf.d/docker-clean
+  exec 9>"${APT_CACHE_DIR}/.populate.lock"
+  if ! flock -w "${VST_APT_CACHE_LOCK_WAIT:-600}" 9; then
+    echo "ERROR: timed out waiting for another cache populator."
+    exit 1
+  fi
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata."
+    exit 1
+  fi
+  # -d downloads without installing: this container only fills the cache.
+  if ! apt-get install --reinstall -d -y --no-install-recommends \
+         "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
+         "${RUNTIME_PACKAGES[@]}"; then
+    echo "ERROR: Unable to populate the package cache."
+    exit 1
+  fi
+  echo "Cache ready: $(ls "${APT_CACHE_DIR}"/*.deb 2>/dev/null | wc -l) packages, $(du -sh "${APT_CACHE_DIR}" | cut -f1)."
+  exit 0
+fi
 
 # A mirror override invalidates the metadata the base image ships, which is
 # indexed against the default archive. Measured: with a mirror configured and the

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -207,9 +207,15 @@ fi
 APT_CACHE_DIR="${VST_APT_CACHE_DIR:-/opt/apt-cache}"
 APT_CACHE_POPULATE="${VST_APT_CACHE_POPULATE:-false}"
 
+# Snapshot the options WITHOUT the cache overrides, so a cache-mode install that
+# fails (stale, partial, or -- being read-only -- unable to fetch a package it
+# lacks) can fall back to a normal networked install instead of blocking startup.
+BASE_APT_OPTS=("${APT_OPTS[@]}")
+CACHE_MODE=false
 if [[ "${APT_CACHE_POPULATE}" != "true" ]] && compgen -G "${APT_CACHE_DIR}/*.deb" >/dev/null 2>&1; then
   echo "Using shared package cache at ${APT_CACHE_DIR} ($(ls "${APT_CACHE_DIR}"/*.deb | wc -l) packages)."
   APT_OPTS+=(-o "Dir::Cache::archives=${APT_CACHE_DIR}" -o Debug::NoLocking=true)
+  CACHE_MODE=true
 fi
 
 
@@ -325,8 +331,27 @@ if ! install_packages; then
     dpkg --configure -a
   fi
   if ! install_packages_with_retries; then
-    echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
-    exit 1
+    if [[ "${CACHE_MODE}" == "true" ]]; then
+      # The shared cache is stale, incomplete, or (being read-only) cannot be
+      # written to for a package it lacks. Never let that block startup: drop
+      # the cache overrides and install normally over the network -- exactly
+      # what a deployment without the cache does. The cache is an optimization,
+      # not a hard dependency.
+      echo "Cache-mode install failed; falling back to a normal networked install (bypassing the shared cache)."
+      APT_OPTS=("${BASE_APT_OPTS[@]}")
+      CACHE_MODE=false
+      if ! refresh_apt_metadata; then
+        echo "ERROR: Unable to refresh APT metadata for the cache-fallback install."
+        exit 1
+      fi
+      if ! install_packages_with_retries; then
+        echo "ERROR: Unable to install runtime media packages after the cache fallback."
+        exit 1
+      fi
+    else
+      echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
+      exit 1
+    fi
   fi
 fi
 

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -224,7 +224,16 @@ services:
     # fails, so a transient apt error never blocks the consumers that depend on
     # it -- they fall back to a normal download (the install script bypasses the
     # cache on failure). The cache is an optimization, not a hard dependency.
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$VST_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh || echo 'cache populate failed (best-effort); consumers will download'; else echo 'additional packages disabled; nothing to cache'; fi"]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        if [ "$$VST_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then
+          /home/vst/vst_release/tools/user_additional_install.sh \
+            || echo 'cache populate failed (best-effort); consumers will download'
+        else
+          echo 'additional packages disabled; nothing to cache'
+        fi
     volumes:
       - vios_apt_cache:/opt/apt-cache
       # This compose file lives in docker-compose/, so the shared populate

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -220,7 +220,11 @@ services:
       - VST_APT_CACHE_POPULATE=true
       - VST_APT_CACHE_DIR=/opt/apt-cache
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$VST_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; else echo 'additional packages disabled; nothing to cache'; fi"]
+    # Best-effort: the `|| echo` keeps the init exit 0 even if the populate
+    # fails, so a transient apt error never blocks the consumers that depend on
+    # it -- they fall back to a normal download (the install script bypasses the
+    # cache on failure). The cache is an optimization, not a hard dependency.
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$VST_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh || echo 'cache populate failed (best-effort); consumers will download'; else echo 'additional packages disabled; nothing to cache'; fi"]
     volumes:
       - vios_apt_cache:/opt/apt-cache
       # This compose file lives in docker-compose/, so the shared populate

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -208,6 +208,11 @@ services:
     user: "0:0"
     network_mode: host
     environment:
+      # Gate the populate step on the same switch the consumers use, and inject
+      # it here: without this line the variable is unset inside the init
+      # container, the entrypoint check below always takes the else branch, and
+      # the cache is never populated (consumers then each download on their own).
+      - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
       - VST_APT_CACHE_POPULATE=true
       - VST_APT_CACHE_DIR=/opt/apt-cache
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -98,6 +98,10 @@ services:
     volumes:
       - ${VST_CONFIG_PATH}:/home/vst/vst_release/configs
       - vios_apt_cache:/opt/apt-cache:ro
+      # Run the cache-aware host script (same as the init container and the
+      # NVStreamer consumers already do) instead of the image's baked-in copy,
+      # so this consumer installs from the shared cache rather than downloading.
+      - ./scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${CLIP_STORAGE_PATH}:/home/vst/vst_release/streamer_videos

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -219,7 +219,11 @@ services:
     entrypoint: ["/bin/bash", "-c", "if [ \"$$VST_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; else echo 'additional packages disabled; nothing to cache'; fi"]
     volumes:
       - vios_apt_cache:/opt/apt-cache
-      - ../scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+      # This compose file lives in docker-compose/, so the shared populate
+      # script is ./scripts/ (NOT ../scripts/ -- that resolves one level too
+      # high to stream-processing/scripts/, which does not exist, and Docker
+      # then bind-mounts an auto-created empty dir onto a file, failing the up).
+      - ./scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
     restart: "no"
 
 volumes:

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -80,6 +80,7 @@ services:
       - VST_INSTALL_ADDITIONAL_PACKAGES=${VST_INSTALL_ADDITIONAL_PACKAGES}
       - VST_VIDEO_STORAGE_SIZE_MB=${VST_VIDEO_STORAGE_SIZE_MB:-}
       - CONTAINER_NAME=streamprocessing-ms-1
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - ADAPTOR=${VST_ADAPTOR}
       - HTTP_PORT=${STREAM_PROCESSOR_HTTP_PORT_1}
       - PROMETHEUS_PORT=${STREAM_PROCESSOR_PROMETHEUS_PORT_1}
@@ -96,6 +97,7 @@ services:
       - DEEPSTREAM_ENABLE_SENSOR_ID_EXTRACTION=1
     volumes:
       - ${VST_CONFIG_PATH}:/home/vst/vst_release/configs
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${VST_DATA_PATH}:/home/vst/vst_release/vst_data
       - ${VST_VIDEO_STORAGE_PATH}:/home/vst/vst_release/vst_video
       - ${CLIP_STORAGE_PATH}:/home/vst/vst_release/streamer_videos
@@ -120,6 +122,8 @@ services:
       retries: 60
       start_period: 20s
     depends_on:
+      vios-apt-cache-init:
+        condition: service_completed_successfully
       centralizedb:
         condition: service_healthy
       redis:
@@ -193,5 +197,27 @@ services:
       retries: 60
       start_period: 2s
 
+  # Downloads the runtime media packages once per host into a shared volume so
+  # every VIOS service installs from disk instead of re-fetching ~138MB. Runs to
+  # completion before the services start and is the only writer; services mount
+  # the cache read-only, which is what makes skipping the apt archives lock safe
+  # (see the note in user_additional_install.sh).
+  vios-apt-cache-init:
+    image: ${VST_STREAM_PROCESSOR_IMAGE}
+    container_name: vios-apt-cache-init
+    user: "0:0"
+    network_mode: host
+    environment:
+      - VST_APT_CACHE_POPULATE=true
+      - VST_APT_CACHE_DIR=/opt/apt-cache
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$VST_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; else echo 'additional packages disabled; nothing to cache'; fi"]
+    volumes:
+      - vios_apt_cache:/opt/apt-cache
+      - ../scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+    restart: "no"
+
 volumes:
   vst_pg_data:
+  vios_apt_cache:
+    name: vios_apt_cache

--- a/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
@@ -40,7 +40,11 @@ services:
       - VST_APT_CACHE_POPULATE=true
       - VST_APT_CACHE_DIR=/opt/apt-cache
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; else echo 'additional packages disabled; nothing to cache'; fi"]
+    # Best-effort: the `|| echo` keeps the init exit 0 even if the populate
+    # fails, so a transient apt error never blocks the consumers that depend on
+    # it -- they fall back to a normal download (the install script bypasses the
+    # cache on failure). The cache is an optimization, not a hard dependency.
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh || echo 'cache populate failed (best-effort); consumers will download'; else echo 'additional packages disabled; nothing to cache'; fi"]
     volumes:
       - vios_apt_cache:/opt/apt-cache
       - ../scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh

--- a/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
@@ -32,6 +32,11 @@ services:
     network_mode: host
     profiles: ["nvstreamer-1", "nvstreamer-2", "nvstreamer-3", "nvstreamer-4", "nvstreamer-5"]
     environment:
+      # Inject the enable switch the entrypoint checks below; without it the
+      # variable is unset inside the init container, the check always takes the
+      # else branch, and the shared cache is never populated (each consumer then
+      # downloads packages on its own).
+      - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
       - VST_APT_CACHE_POPULATE=true
       - VST_APT_CACHE_DIR=/opt/apt-cache
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}

--- a/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
@@ -44,7 +44,16 @@ services:
     # fails, so a transient apt error never blocks the consumers that depend on
     # it -- they fall back to a normal download (the install script bypasses the
     # cache on failure). The cache is an optimization, not a hard dependency.
-    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh || echo 'cache populate failed (best-effort); consumers will download'; else echo 'additional packages disabled; nothing to cache'; fi"]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        if [ "$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES" = "true" ]; then
+          /home/vst/vst_release/tools/user_additional_install.sh \
+            || echo 'cache populate failed (best-effort); consumers will download'
+        else
+          echo 'additional packages disabled; nothing to cache'
+        fi
     volumes:
       - vios_apt_cache:/opt/apt-cache
       - ../scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh

--- a/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
@@ -22,9 +22,31 @@ x-nvstreamer-base: &nvstreamer-base  # Base configuration
       condition: always
 
 services:
+  # Separate compose project from stream-processing, so depends_on cannot order
+  # the two. Both run an init against the SAME pinned volume; flock inside the
+  # script serialises them and the loser finds the cache already warm.
+  nvstreamer-apt-cache-init:
+    image: ${NVSTREAMER_IMAGE}
+    container_name: nvstreamer-apt-cache-init
+    user: "0:0"
+    network_mode: host
+    profiles: ["nvstreamer-1", "nvstreamer-2", "nvstreamer-3", "nvstreamer-4", "nvstreamer-5"]
+    environment:
+      - VST_APT_CACHE_POPULATE=true
+      - VST_APT_CACHE_DIR=/opt/apt-cache
+      - VST_APT_MIRROR=${VST_APT_MIRROR:-}
+    entrypoint: ["/bin/bash", "-c", "if [ \"$$NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES\" = \"true\" ]; then /home/vst/vst_release/tools/user_additional_install.sh; else echo 'additional packages disabled; nothing to cache'; fi"]
+    volumes:
+      - vios_apt_cache:/opt/apt-cache
+      - ../scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+    restart: "no"
+
   nvstreamer-1:
     <<: *nvstreamer-base
     container_name: nvstreamer-1
+    depends_on:
+      nvstreamer-apt-cache-init:
+        condition: service_completed_successfully
     profiles: ["nvstreamer-1"]
     entrypoint:
       - /bin/bash
@@ -37,11 +59,13 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_1}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_1}
     volumes:
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${NVSTREAMER_CONFIG}/vst_config.json:/home/vst/vst_release/configs/vst_config.json
       - ${NVSTREAMER_CONFIG}/vst_storage.json:/home/vst/vst_release/configs/vst_storage.json
       - ${NVSTREAMER_CONFIG}/notification_config.json:/home/vst/vst_release/configs/notification_config.json
@@ -52,6 +76,9 @@ services:
   nvstreamer-2:
     <<: *nvstreamer-base
     container_name: nvstreamer-2
+    depends_on:
+      nvstreamer-apt-cache-init:
+        condition: service_completed_successfully
     profiles: ["nvstreamer-2"]
     entrypoint:
       - /bin/bash
@@ -64,11 +91,13 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_2}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_2}
     volumes:
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${NVSTREAMER_CONFIG}/vst_config.json:/home/vst/vst_release/configs/vst_config.json
       - ${NVSTREAMER_CONFIG}/vst_storage.json:/home/vst/vst_release/configs/vst_storage.json
       - ${NVSTREAMER_CONFIG}/notification_config.json:/home/vst/vst_release/configs/notification_config.json
@@ -79,6 +108,9 @@ services:
   nvstreamer-3:
     <<: *nvstreamer-base
     container_name: nvstreamer-3
+    depends_on:
+      nvstreamer-apt-cache-init:
+        condition: service_completed_successfully
     profiles: ["nvstreamer-3"]
     entrypoint:
       - /bin/bash
@@ -91,11 +123,13 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_3}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_3}
     volumes:
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${NVSTREAMER_CONFIG}/vst_config.json:/home/vst/vst_release/configs/vst_config.json
       - ${NVSTREAMER_CONFIG}/vst_storage.json:/home/vst/vst_release/configs/vst_storage.json
       - ${NVSTREAMER_CONFIG}/notification_config.json:/home/vst/vst_release/configs/notification_config.json
@@ -106,6 +140,9 @@ services:
   nvstreamer-4:
     <<: *nvstreamer-base
     container_name: nvstreamer-4
+    depends_on:
+      nvstreamer-apt-cache-init:
+        condition: service_completed_successfully
     profiles: ["nvstreamer-4"]
     entrypoint:
       - /bin/bash
@@ -118,11 +155,13 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_4}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_4}
     volumes:
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${NVSTREAMER_CONFIG}/vst_config.json:/home/vst/vst_release/configs/vst_config.json
       - ${NVSTREAMER_CONFIG}/vst_storage.json:/home/vst/vst_release/configs/vst_storage.json
       - ${NVSTREAMER_CONFIG}/notification_config.json:/home/vst/vst_release/configs/notification_config.json
@@ -133,6 +172,9 @@ services:
   nvstreamer-5:
     <<: *nvstreamer-base
     container_name: nvstreamer-5
+    depends_on:
+      nvstreamer-apt-cache-init:
+        condition: service_completed_successfully
     profiles: ["nvstreamer-5"]
     entrypoint:
       - /bin/bash
@@ -145,14 +187,20 @@ services:
     environment:
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
       - NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=${NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES}
+      - VST_APT_CACHE_DIR=/opt/apt-cache
       - ADAPTOR=streamer
       - NVSTREAMER_UI_BASE_PATH=${NVSTREAMER_UI_BASE_PATH:-}
       - HTTP_PORT=${NVSTREAMER_HTTP_PORT_5}
       - RTSP_SERVER_PORT=${NVSTREAMER_RTSP_PORT_5}
     volumes:
+      - vios_apt_cache:/opt/apt-cache:ro
       - ${NVSTREAMER_CONFIG}/vst_config.json:/home/vst/vst_release/configs/vst_config.json
       - ${NVSTREAMER_CONFIG}/vst_storage.json:/home/vst/vst_release/configs/vst_storage.json
       - ${NVSTREAMER_CONFIG}/notification_config.json:/home/vst/vst_release/configs/notification_config.json
       - ${NVSTREAMER_VIDEO_5}:/home/vst/vst_release/streamer_videos
       - ${NVSTREAMER_CONFIG}/../vst_data/nvstreamer-5:/home/vst/vst_release/vst_data
       - ../scripts/user_additional_install.sh:/home/vst/vst_release/tools/user_additional_install.sh
+
+volumes:
+  vios_apt_cache:
+    name: vios_apt_cache

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -182,6 +182,36 @@ if [[ -n "${VST_APT_PIPELINE_DEPTH:-}" ]]; then
   APT_OPTS+=(-o "Acquire::http::Pipeline-Depth=${VST_APT_PIPELINE_DEPTH}")
 fi
 
+# ---------------------------------------------------------------------------
+# Shared package cache
+#
+# Every VIOS service on a host installs the same package set, and each cold
+# start otherwise re-downloads ~138MB. An init container populates a shared
+# volume once (VST_APT_CACHE_POPULATE=true); services then install from it with
+# no network.
+#
+# Consumers mount the cache READ-ONLY at VST_APT_CACHE_DIR. Two options make
+# that work and both matter:
+#
+#   Dir::Cache::archives  points apt at the shared copy instead of its own.
+#   Debug::NoLocking      skips the archives lock. apt takes that lock even with
+#                         nothing to download, and a shared volume means a shared
+#                         lock file -- measured: two containers starting together,
+#                         the loser fails outright with
+#                         "Could not get lock ... held by process 0".
+#
+# Skipping the lock is safe HERE ONLY because consumers never write to that
+# directory: the mount is read-only and the init container has finished. If the
+# mount is ever made writable, or a service can start before the init completes,
+# restore locking -- two writers with NoLocking race unprotected.
+APT_CACHE_DIR="${VST_APT_CACHE_DIR:-/opt/apt-cache}"
+APT_CACHE_POPULATE="${VST_APT_CACHE_POPULATE:-false}"
+
+if [[ "${APT_CACHE_POPULATE}" != "true" ]] && compgen -G "${APT_CACHE_DIR}/*.deb" >/dev/null 2>&1; then
+  echo "Using shared package cache at ${APT_CACHE_DIR} ($(ls "${APT_CACHE_DIR}"/*.deb | wc -l) packages)."
+  APT_OPTS+=(-o "Dir::Cache::archives=${APT_CACHE_DIR}" -o Debug::NoLocking=true)
+fi
+
 
 install_packages() {
   apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
@@ -232,6 +262,41 @@ refresh_apt_metadata() {
   done
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# Init-container mode: populate the shared cache and exit.
+#
+# The only writer, so it removes docker-clean -- the base image ships that file
+# and it deletes every .deb after each apt operation, which would leave the cache
+# volume empty and the whole scheme silently doing nothing.
+#
+# flock serialises populators: in the standalone deployment nvstreamer and
+# stream-processing are separate compose projects, so depends_on cannot order
+# them and both run an init against the same volume. The second blocks here, then
+# finds the cache warm and returns in seconds.
+if [[ "${APT_CACHE_POPULATE}" == "true" ]]; then
+  echo "Populating shared package cache in ${APT_CACHE_DIR}..."
+  install -d "${APT_CACHE_DIR}/partial"
+  rm -f /etc/apt/apt.conf.d/docker-clean
+  exec 9>"${APT_CACHE_DIR}/.populate.lock"
+  if ! flock -w "${VST_APT_CACHE_LOCK_WAIT:-600}" 9; then
+    echo "ERROR: timed out waiting for another cache populator."
+    exit 1
+  fi
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata."
+    exit 1
+  fi
+  # -d downloads without installing: this container only fills the cache.
+  if ! apt-get install --reinstall -d -y --no-install-recommends \
+         "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
+         "${RUNTIME_PACKAGES[@]}"; then
+    echo "ERROR: Unable to populate the package cache."
+    exit 1
+  fi
+  echo "Cache ready: $(ls "${APT_CACHE_DIR}"/*.deb 2>/dev/null | wc -l) packages, $(du -sh "${APT_CACHE_DIR}" | cut -f1)."
+  exit 0
+fi
 
 # A mirror override invalidates the metadata the base image ships, which is
 # indexed against the default archive. Measured: with a mirror configured and the

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -207,9 +207,15 @@ fi
 APT_CACHE_DIR="${VST_APT_CACHE_DIR:-/opt/apt-cache}"
 APT_CACHE_POPULATE="${VST_APT_CACHE_POPULATE:-false}"
 
+# Snapshot the options WITHOUT the cache overrides, so a cache-mode install that
+# fails (stale, partial, or -- being read-only -- unable to fetch a package it
+# lacks) can fall back to a normal networked install instead of blocking startup.
+BASE_APT_OPTS=("${APT_OPTS[@]}")
+CACHE_MODE=false
 if [[ "${APT_CACHE_POPULATE}" != "true" ]] && compgen -G "${APT_CACHE_DIR}/*.deb" >/dev/null 2>&1; then
   echo "Using shared package cache at ${APT_CACHE_DIR} ($(ls "${APT_CACHE_DIR}"/*.deb | wc -l) packages)."
   APT_OPTS+=(-o "Dir::Cache::archives=${APT_CACHE_DIR}" -o Debug::NoLocking=true)
+  CACHE_MODE=true
 fi
 
 
@@ -325,8 +331,27 @@ if ! install_packages; then
     dpkg --configure -a
   fi
   if ! install_packages_with_retries; then
-    echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
-    exit 1
+    if [[ "${CACHE_MODE}" == "true" ]]; then
+      # The shared cache is stale, incomplete, or (being read-only) cannot be
+      # written to for a package it lacks. Never let that block startup: drop
+      # the cache overrides and install normally over the network -- exactly
+      # what a deployment without the cache does. The cache is an optimization,
+      # not a hard dependency.
+      echo "Cache-mode install failed; falling back to a normal networked install (bypassing the shared cache)."
+      APT_OPTS=("${BASE_APT_OPTS[@]}")
+      CACHE_MODE=false
+      if ! refresh_apt_metadata; then
+        echo "ERROR: Unable to refresh APT metadata for the cache-fallback install."
+        exit 1
+      fi
+      if ! install_packages_with_retries; then
+        echo "ERROR: Unable to install runtime media packages after the cache fallback."
+        exit 1
+      fi
+    else
+      echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
+      exit 1
+    fi
   fi
 fi
 

--- a/services/vios/deployment/stream-processing/oneclick_dc_deployment.py
+++ b/services/vios/deployment/stream-processing/oneclick_dc_deployment.py
@@ -2370,41 +2370,86 @@ class DeploymentManager:
         return val or str(self.config.default_vst_volume)
 
     def _remove_postgres_named_volume(self) -> None:
-        """Remove the postgres named volume (pg_data) used by the
-        centralizedb service.
+        """Remove the postgres named volume (vst_pg_data) used by the
+        centralizedb service, while preserving the shared APT cache.
 
         PGDATA was switched from a host bind mount
         (``${VST_VOLUME}/postgres/db``) to a Docker-managed named
-        volume (``pg_data``) so the postgres entrypoint's chown to
+        volume (``vst_pg_data``) so the postgres entrypoint's chown to
         uid 70 works under rootless Docker. The host bind-mount
-        cleanup in ``remove_vst_volume`` no longer wipes PGDATA, so
-        we run ``docker compose down -v`` against the same compose
-        file to let compose remove the project-prefixed named volume
-        (e.g. ``docker-compose_pg_data``). Idempotent: succeeds even
-        if the volume doesn't exist yet.
+        cleanup in ``remove_vst_volume`` no longer wipes PGDATA.
+
+        We deliberately do NOT use ``docker compose down -v`` here: that
+        also destroys the pinned ``vios_apt_cache`` volume (~138MB of
+        cached .deb packages that keep the next deploy fast). ``--clean``
+        should reset VST data, not the rebuildable package cache. Callers
+        who really want the cache gone opt in explicitly via
+        ``--delete-apt-cache`` (handled by ``remove_apt_cache_volume``).
+        Instead we bring the project down without ``-v`` (named volumes
+        survive) and remove only the postgres volume by name. The compose
+        default project name prefixes pg_data (e.g.
+        ``docker-compose_vst_pg_data``), whereas ``vios_apt_cache`` is
+        pinned and unprefixed, so a ``vst_pg_data`` name filter can never
+        match the cache volume. Idempotent: succeeds even if the volume
+        doesn't exist yet.
         """
-        Logger.info("Removing postgres named volume (pg_data)...")
-        cmd = (
-            "docker compose -f docker-compose.yaml --env-file ./compose.env "
-            "down -v --remove-orphans"
-        )
+        Logger.info("Removing postgres named volume (vst_pg_data), preserving APT cache...")
         try:
+            SystemUtils.run_command(
+                "docker compose -f docker-compose.yaml --env-file ./compose.env "
+                "down --remove-orphans",
+                cwd=str(self.config.vst_compose_dir), check=False,
+            )
             result = SystemUtils.run_command(
-                cmd, cwd=str(self.config.vst_compose_dir), check=False,
+                "docker volume ls -q -f name=vst_pg_data",
+                capture_output=True, check=False,
             )
         except Exception as e:
             # check=False suppresses CalledProcessError, so anything that
             # surfaces here is structural (docker binary missing, cwd
             # inaccessible, etc.). Keep this best-effort — don't abort
             # the broader cleanup flow on a volume-removal hiccup.
-            Logger.warning(f"Failed to invoke docker compose for postgres volume cleanup: {e}")
+            Logger.warning(f"Failed to invoke docker for postgres volume cleanup: {e}")
             return
-        if result.returncode == 0:
+        volumes = [v for v in (result.stdout or "").split() if v]
+        if not volumes:
             Logger.success("Postgres named volume removed (or was not present)")
+            return
+        failed = []
+        for vol in volumes:
+            rm = SystemUtils.run_command(f"docker volume rm -f {vol}", check=False)
+            if rm.returncode != 0:
+                failed.append(vol)
+        if failed:
+            Logger.warning(
+                f"Could not remove postgres volume(s) {', '.join(failed)}; "
+                "they may still be in use (see stderr above)"
+            )
+        else:
+            Logger.success(f"Postgres named volume(s) removed: {', '.join(volumes)}")
+
+    def remove_apt_cache_volume(self) -> None:
+        """Remove the shared APT package cache volume (``vios_apt_cache``).
+
+        Explicit opt-in via ``--delete-apt-cache``. ``--clean`` preserves
+        the cache so redeploys stay fast; this wipes it when the user
+        really wants a cold package fetch. The cache is shared by the VST
+        and NVStreamer compose projects, so both must be stopped first — a
+        volume held by a running container cannot be removed. ``-f`` makes
+        removal of a missing volume a no-op.
+        """
+        Logger.info("Removing shared APT package cache volume (vios_apt_cache)...")
+        result = SystemUtils.run_command(
+            "docker volume rm -f vios_apt_cache",
+            capture_output=True, check=False,
+        )
+        if result.returncode == 0:
+            Logger.success("APT package cache volume removed (or was not present)")
         else:
             Logger.warning(
-                f"docker compose down -v exited {result.returncode} while removing "
-                "postgres named volume; volume may still exist (see stderr above)"
+                "Could not remove vios_apt_cache — it may still be in use by a "
+                "running container. Stop all VST/NVStreamer services first, then "
+                "retry with --delete-apt-cache."
             )
 
     def remove_vst_volume(self, *, auto_confirm: bool = False):
@@ -2647,9 +2692,14 @@ class DeploymentManager:
             self.stop_existing_deployments()
         else:
             Logger.info("No running deployments found, attempting cleanup anyway...")
+            # Best-effort teardown: no `-v`, so named volumes (postgres
+            # vst_pg_data and the shared vios_apt_cache) survive a plain stop.
+            # Persistent-data removal is the job of --clean (postgres, via
+            # remove_vst_volume) and --delete-apt-cache (the shared cache), not
+            # of stop.
             stop_commands = [
                 "docker compose -f docker-compose.yaml --env-file ./compose.env "
-                "down --remove-orphans -v",
+                "down --remove-orphans",
             ]
             for cmd in stop_commands:
                 SystemUtils.run_command(
@@ -2657,7 +2707,7 @@ class DeploymentManager:
                 )
             SystemUtils.run_command(
                 "docker compose -f docker-compose.yaml --env-file ./compose.env "
-                "down --remove-orphans -v",
+                "down --remove-orphans",
                 cwd=str(self.config.nvstreamer_compose_dir),
                 check=False,
             )
@@ -2814,6 +2864,11 @@ DEPLOYMENT OPTIONS:
                         - stop vst --clean         -> remove VST volume directory
                         - stop nvstreamer --clean  -> remove NVStreamer videos directory
                         - stop --clean             -> remove both
+                        Preserves the shared APT package cache (vios_apt_cache);
+                        use --delete-apt-cache to wipe that too.
+    --delete-apt-cache  When used with `stop`, also remove the shared APT package
+                        cache volume (vios_apt_cache). Kept out of --clean so
+                        redeploys stay fast; pass this for a cold package fetch.
     --pull-always       Pull latest Docker images before deployment
     --skip-sysctl       Skip host sysctl network-buffer tuning entirely
                         (avoids sudo prompt; throughput may be lower under load).
@@ -2885,9 +2940,10 @@ EXAMPLES:
     python3 oneclick_dc_deployment.py stop nvstreamer       # stops NVStreamer only
 
     # Stop + clean persistent data (--clean)
-    python3 oneclick_dc_deployment.py stop --clean              # stop + wipe both
+    python3 oneclick_dc_deployment.py stop --clean              # stop + wipe both (APT cache kept)
     python3 oneclick_dc_deployment.py stop vst --clean          # stop VST + wipe vst_volume/
     python3 oneclick_dc_deployment.py stop nvstreamer --clean   # stop NVS + wipe videos/
+    python3 oneclick_dc_deployment.py stop --clean --delete-apt-cache  # wipe data AND the APT cache
 
     # Update configuration only (compose.env files), without deploying
     python3 oneclick_dc_deployment.py config-only
@@ -3136,7 +3192,13 @@ def main():
                         help='When used with `stop`, also delete persistent data: '
                              'VST volume directory (target=vst) and/or NVStreamer '
                              'videos directory (target=nvstreamer). Bare `stop --clean` '
-                             'cleans both.')
+                             'cleans both. Preserves the shared APT package cache '
+                             '(use --delete-apt-cache to wipe that too).')
+    parser.add_argument('--delete-apt-cache', action='store_true',
+                        help='When used with `stop`, also remove the shared APT '
+                             'package cache volume (vios_apt_cache). Not removed by '
+                             '--clean so redeploys stay fast; pass this for a cold '
+                             'package fetch. Stop all VST/NVStreamer services first.')
     parser.add_argument('--pull-always', action='store_true',
                         help='Pull latest Docker images before deployment')
     parser.add_argument('--skip-sysctl', action='store_true',
@@ -3291,6 +3353,14 @@ def main():
             if effective_stop_target in ('all', 'nvstreamer'):
                 deployment_manager.remove_nvstreamer_videos(auto_confirm=True)
             Logger.success("Clean completed")
+
+        # --delete-apt-cache: opt-in removal of the shared APT package cache
+        # volume. Kept separate from --clean so a normal clean stays fast on the
+        # next deploy; combine the two to wipe everything. Requires both VST and
+        # NVStreamer to be stopped (done above) since the volume is shared.
+        if args.delete_apt_cache:
+            print()
+            deployment_manager.remove_apt_cache_volume()
     elif action == 'config-only':
         config_manager = ConfigurationManager(config)
         interactive_config = InteractiveConfiguration(config)

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -182,6 +182,36 @@ if [[ -n "${VST_APT_PIPELINE_DEPTH:-}" ]]; then
   APT_OPTS+=(-o "Acquire::http::Pipeline-Depth=${VST_APT_PIPELINE_DEPTH}")
 fi
 
+# ---------------------------------------------------------------------------
+# Shared package cache
+#
+# Every VIOS service on a host installs the same package set, and each cold
+# start otherwise re-downloads ~138MB. An init container populates a shared
+# volume once (VST_APT_CACHE_POPULATE=true); services then install from it with
+# no network.
+#
+# Consumers mount the cache READ-ONLY at VST_APT_CACHE_DIR. Two options make
+# that work and both matter:
+#
+#   Dir::Cache::archives  points apt at the shared copy instead of its own.
+#   Debug::NoLocking      skips the archives lock. apt takes that lock even with
+#                         nothing to download, and a shared volume means a shared
+#                         lock file -- measured: two containers starting together,
+#                         the loser fails outright with
+#                         "Could not get lock ... held by process 0".
+#
+# Skipping the lock is safe HERE ONLY because consumers never write to that
+# directory: the mount is read-only and the init container has finished. If the
+# mount is ever made writable, or a service can start before the init completes,
+# restore locking -- two writers with NoLocking race unprotected.
+APT_CACHE_DIR="${VST_APT_CACHE_DIR:-/opt/apt-cache}"
+APT_CACHE_POPULATE="${VST_APT_CACHE_POPULATE:-false}"
+
+if [[ "${APT_CACHE_POPULATE}" != "true" ]] && compgen -G "${APT_CACHE_DIR}/*.deb" >/dev/null 2>&1; then
+  echo "Using shared package cache at ${APT_CACHE_DIR} ($(ls "${APT_CACHE_DIR}"/*.deb | wc -l) packages)."
+  APT_OPTS+=(-o "Dir::Cache::archives=${APT_CACHE_DIR}" -o Debug::NoLocking=true)
+fi
+
 
 install_packages() {
   apt-get install --reinstall -y --no-install-recommends "${APT_OPTS[@]}" "${RUNTIME_PACKAGES[@]}"
@@ -232,6 +262,41 @@ refresh_apt_metadata() {
   done
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# Init-container mode: populate the shared cache and exit.
+#
+# The only writer, so it removes docker-clean -- the base image ships that file
+# and it deletes every .deb after each apt operation, which would leave the cache
+# volume empty and the whole scheme silently doing nothing.
+#
+# flock serialises populators: in the standalone deployment nvstreamer and
+# stream-processing are separate compose projects, so depends_on cannot order
+# them and both run an init against the same volume. The second blocks here, then
+# finds the cache warm and returns in seconds.
+if [[ "${APT_CACHE_POPULATE}" == "true" ]]; then
+  echo "Populating shared package cache in ${APT_CACHE_DIR}..."
+  install -d "${APT_CACHE_DIR}/partial"
+  rm -f /etc/apt/apt.conf.d/docker-clean
+  exec 9>"${APT_CACHE_DIR}/.populate.lock"
+  if ! flock -w "${VST_APT_CACHE_LOCK_WAIT:-600}" 9; then
+    echo "ERROR: timed out waiting for another cache populator."
+    exit 1
+  fi
+  if ! refresh_apt_metadata; then
+    echo "ERROR: Unable to refresh APT metadata."
+    exit 1
+  fi
+  # -d downloads without installing: this container only fills the cache.
+  if ! apt-get install --reinstall -d -y --no-install-recommends \
+         "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
+         "${RUNTIME_PACKAGES[@]}"; then
+    echo "ERROR: Unable to populate the package cache."
+    exit 1
+  fi
+  echo "Cache ready: $(ls "${APT_CACHE_DIR}"/*.deb 2>/dev/null | wc -l) packages, $(du -sh "${APT_CACHE_DIR}" | cut -f1)."
+  exit 0
+fi
 
 # A mirror override invalidates the metadata the base image ships, which is
 # indexed against the default archive. Measured: with a mirror configured and the

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -207,9 +207,15 @@ fi
 APT_CACHE_DIR="${VST_APT_CACHE_DIR:-/opt/apt-cache}"
 APT_CACHE_POPULATE="${VST_APT_CACHE_POPULATE:-false}"
 
+# Snapshot the options WITHOUT the cache overrides, so a cache-mode install that
+# fails (stale, partial, or -- being read-only -- unable to fetch a package it
+# lacks) can fall back to a normal networked install instead of blocking startup.
+BASE_APT_OPTS=("${APT_OPTS[@]}")
+CACHE_MODE=false
 if [[ "${APT_CACHE_POPULATE}" != "true" ]] && compgen -G "${APT_CACHE_DIR}/*.deb" >/dev/null 2>&1; then
   echo "Using shared package cache at ${APT_CACHE_DIR} ($(ls "${APT_CACHE_DIR}"/*.deb | wc -l) packages)."
   APT_OPTS+=(-o "Dir::Cache::archives=${APT_CACHE_DIR}" -o Debug::NoLocking=true)
+  CACHE_MODE=true
 fi
 
 
@@ -325,8 +331,27 @@ if ! install_packages; then
     dpkg --configure -a
   fi
   if ! install_packages_with_retries; then
-    echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
-    exit 1
+    if [[ "${CACHE_MODE}" == "true" ]]; then
+      # The shared cache is stale, incomplete, or (being read-only) cannot be
+      # written to for a package it lacks. Never let that block startup: drop
+      # the cache overrides and install normally over the network -- exactly
+      # what a deployment without the cache does. The cache is an optimization,
+      # not a hard dependency.
+      echo "Cache-mode install failed; falling back to a normal networked install (bypassing the shared cache)."
+      APT_OPTS=("${BASE_APT_OPTS[@]}")
+      CACHE_MODE=false
+      if ! refresh_apt_metadata; then
+        echo "ERROR: Unable to refresh APT metadata for the cache-fallback install."
+        exit 1
+      fi
+      if ! install_packages_with_retries; then
+        echo "ERROR: Unable to install runtime media packages after the cache fallback."
+        exit 1
+      fi
+    else
+      echo "ERROR: Unable to install runtime media packages after ${MAX_RETRIES} attempts."
+      exit 1
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Description

Adds a shared APT package cache so the runtime media packages are downloaded **once per host** instead of on every container start — wired into **both** the standalone stream-processing deployment and the `deploy/docker` e2e compose profiles.

### Why

VIOS deliberately ships without the GPL/patent-encumbered media packages (OSRB), so `user_additional_install.sh` re-downloads them at every start. On `vst-base:...-runtime` that is **224 packages / ~138 MB**, measured between **72s and 258s** depending only on which archive mirror answered. Every profile brings up a stream-processing **and** an nvstreamer container that each paid this cost independently.

| | |
|---|---|
| init container, cold | ~186s, 224 packages, ~139 MB cached |
| consumer, warm cache | **~62s, `fetched=0`** — no network |
| two consumers concurrently | both `rc=0`, **zero lock errors** |
| two init containers racing | both succeed, flock serialises |

Correctness after a cache-only install: all four of the script's own sentinels resolve and `avdec_h264` loads.

### Three things this needed, all found by running containers

**1. `docker-clean` would have silently emptied the cache.** The base image ships `/etc/apt/apt.conf.d/docker-clean`, which deletes every `.deb` after each apt operation. Mounting a volume without removing it leaves **28 KB instead of 138 MB**. `Binary::apt::APT::Keep-Downloaded-Packages "true"` does **not** fix it — that is an apt option, `docker-clean` is a `DPkg::Post-Invoke` hook. The init container removes the file; it is the only writer.

**2. A shared read-write cache collides even when warm.** apt takes the archives lock unconditionally, and the volume makes the lock file shared:

```
container A: rc=100  1s  E: Could not get lock /var/cache/apt/archives/lock.
                         It is held by process 0
container B: rc=0   130s
```

`DPkg::Lock::Timeout` does not help — it governs the dpkg frontend lock. Consumers therefore mount the cache **read-only** and pass `Dir::Cache::archives` + `Debug::NoLocking`. That is safe **only** because consumers never write there and the init has completed; the script says so at the point it matters.

**3. The volume name has to be pinned.** nvstreamer and stream-processing are separate compose projects (standalone) / co-tenant services (e2e), so Compose would otherwise prefix the volume per project and each would silently get its own. `name: vios_apt_cache` pins it — verified: `vios_apt_cache` resolves identically in both while `vst_pg_data` still resolves to `<project>_vst_pg_data`.

## Standalone deployment (`services/vios/deployment/stream-processing`)

- An `vios-apt-cache-init` populates the shared volume once; the stream-processing and nvstreamer consumers install from it read-only.
- Because `depends_on` cannot span the two standalone compose projects, both run an init; `flock` in the populate path serialises them and the second finds the cache warm.
- `oneclick_dc_deployment.py` was hardened so lifecycle matches the cache's intent:
  - `stop` / `stop --clean` **preserve** the cache (all `-v` removed from stop paths; `--clean` removes only the `vst_pg_data` volume by name).
  - new **`--delete-apt-cache`** flag explicitly removes the cache for a cold fetch; combine with `--clean` to wipe everything.

## e2e deployment (`deploy/docker`)

Brought the same optimisation to the compose profiles, scoped minimally to the `include:`-merged project:

- **`services/vios/streamprocessing/docker-compose.yaml`**: adds a best-effort `vios-apt-cache-init` populator (carries all 10 vios profiles so it activates iff a vios service does), the pinned non-external `vios_apt_cache` volume, and the ro mount + `VST_APT_CACHE_DIR` + `depends_on` on all four stream-processing consumers.
- **`services/nvstreamer/base.yml`**: wires the same ro mount + env + dependency **once** into the centralized base; all six nvstreamer variants inherit it via `extends`, and their own volumes/`depends_on` still merge.

The init is **best-effort** (exits 0 even if the populate fails), so a transient apt error never blocks the consumers that depend on it — they fall back to downloading. A single populator (stream-processing image) covers the nvstreamer consumers too, because both images resolve to the same package set.

> The earlier blocker (adding `depends_on` to `nvstreamer-base` broke six profiles with *"depends on undefined service"*) is resolved: the init lives in the stream-processing compose, which shares the project via `include`, and develop's NVStreamer-centralization refactor now defines every variant from one shared base.

**Dry-run validated** (no deployment): rendering the full merged project with `docker compose config` for both a developer profile (`dev-profile-search`) and an industry profile (`warehouse-2d`) succeeds with **zero errors**, and confirms — on the real `include`/`extends`/profile machinery — that the init activates, the consumers get the ro mount + env + `depends_on: vios-apt-cache-init`, each variant's own dependencies still merge, and the shared volume is declared.

## Lifecycle

A named volume, deliberately **not** under `VST_VOLUME` because dev/QA clear that on teardown.

| action | cache |
|---|---|
| `rm -rf $VST_VOLUME` | survives |
| `stop` / `start` / `down` (no `-v`) | survives |
| `stop --clean` (standalone) | **survives** (only VST data removed) |
| `stop --delete-apt-cache` (standalone) | removed |
| `docker compose down -v` | removed |
| `docker volume rm vios_apt_cache` | explicit clear |

The cache only grows as versions churn, so it wants a periodic reset. Adding a package needs no invalidation — the marker is keyed on `md5sum` of `RUNTIME_PACKAGES` and apt fetches only what is missing (verified: adding 2 packages to a warm 224-package cache fetched 1).

## OSRB

No new exposure: the `.deb`s are fetched by the customer's apt onto the customer's host, and the shipped image still contains none of them. **A populated cache must never end up in an image layer** — that becomes distribution. Runtime volume only.

## Known limitation

The cache removes the **download**, not the install: the dpkg phase (~26s) still runs per service.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
