### PR TITLE
feat(lvs): expose GPU hardware metrics with DCGM

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -92,6 +92,26 @@ export NGC_CLI_API_KEY="<your-key>"
 ./deploy/docker/scripts/dev-profile.sh --help
 ```
 
+### LVS GPU hardware metrics
+
+The LVS developer profile starts NVIDIA DCGM Exporter alongside the application.
+It uses NVIDIA Data Center GPU Manager to expose host GPU telemetry in Prometheus
+format at `http://localhost:9400/metrics`, including GPU and decoder utilization,
+frame-buffer usage, power draw, and temperature when supported by the GPU and
+driver.
+
+```bash
+# Verify the exporter is ready and inspect its GPU metrics.
+curl --fail http://localhost:9400/metrics |
+  grep -E 'DCGM_FI_DEV_(GPU_UTIL|DEC_UTIL|FB_USED|POWER_USAGE|GPU_TEMP)'
+```
+
+Set `DCGM_EXPORTER_HOST_PORT` in
+`developer-profiles/dev-profile-lvs/overrides.env` if port 9400 is already in
+use. The exporter requires the NVIDIA driver, NVIDIA Container Toolkit, and a
+GPU supported by DCGM. Its `/metrics` endpoint can be scraped directly by
+Prometheus, Dynatrace, or another Prometheus-compatible monitoring system.
+
 Each developer profile ships a stable **`.env`** and a mutable
 **`overrides.env`** under **`developer-profiles/dev-profile-<profile>/`**. On
 `up`, the helper reads both, copies `overrides.env` to **`generated.env`**, adds

--- a/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
@@ -118,6 +118,7 @@ ELASTICSEARCH_HOST_PORT=9200
 KAFKA_HOST_PORT=9092
 REDIS_HOST_PORT=6379
 KIBANA_HOST_PORT=5601
+DCGM_EXPORTER_HOST_PORT=9400
 VST_INGRESS_HOST_PORT=30888
 SENSOR_HTTP_HOST_PORT=30000
 STREAM_PROCESSOR_HTTP_HOST_PORT=30001
@@ -187,4 +188,5 @@ RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final
 # COMPOSE PROFILE SELECTION
 # =============================================================================
 # Services for LVS profile. rtvi-vlm is explicit; no separate VLM NIM token is required.
-COMPOSE_PROFILES=kibana-init-container-lvs,nvstreamer-lvs,vss-agent,phoenix,elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,kibana,logstash,broker-health-check,vss-haproxy-ingress,init-dirs,render-config,wdm-env-from-config,wait-for-redis,wait-for-docker-workloads,sdr-controller,rtvi-vlm,vss-ui,lvs-server,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,llm_${LLM_MODE}_${LLM_NAME_SLUG}
+# dcgm-exporter publishes GPU hardware telemetry in Prometheus format on port 9400.
+COMPOSE_PROFILES=kibana-init-container-lvs,nvstreamer-lvs,vss-agent,phoenix,elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,kibana,logstash,broker-health-check,vss-haproxy-ingress,init-dirs,render-config,wdm-env-from-config,wait-for-redis,wait-for-docker-workloads,sdr-controller,rtvi-vlm,vss-ui,lvs-server,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,dcgm-exporter,llm_${LLM_MODE}_${LLM_NAME_SLUG}

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1219,7 +1219,7 @@ for _profile in base lvs search alerts; do
       ;;
     lvs)
       _expected_override_keys+=(RT_VLM_DEVICE_ID VLM_PORT RTVI_VLM_PORT EVAL_LLM_JUDGE_NAME EVAL_LLM_JUDGE_BASE_URL SDR_CONTROLLER_CONFIG_PATH RTVI_VLM_ENDPOINT RTVI_VLM_MODEL_TO_USE RTVI_VLLM_GPU_MEMORY_UTILIZATION RTVI_VLM_MAX_MODEL_LEN RTVI_VLM_MODEL_PATH)
-      _expected_override_keys+=(NVSTREAMER_HTTP_HOST_PORT BACKEND_HOST_PORT LVS_MCP_HOST_PORT ELASTICSEARCH_HOST_PORT KAFKA_HOST_PORT KIBANA_HOST_PORT SDRC_CONTROLLER_HOST_PORT SDRC_PROXY_HOST_PORT SDRC_DIRECT_HOST_PORT SDRC_ENVOY_ADMIN_HOST_PORT)
+      _expected_override_keys+=(NVSTREAMER_HTTP_HOST_PORT BACKEND_HOST_PORT LVS_MCP_HOST_PORT ELASTICSEARCH_HOST_PORT KAFKA_HOST_PORT KIBANA_HOST_PORT DCGM_EXPORTER_HOST_PORT SDRC_CONTROLLER_HOST_PORT SDRC_PROXY_HOST_PORT SDRC_DIRECT_HOST_PORT SDRC_ENVOY_ADMIN_HOST_PORT)
       _expected_stable_keys=(MODE LVS_TAG RTVI_VLM_IMAGE_TAG NVSTREAMER_HTTP_PORT NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES)
       ;;
     search)
@@ -1840,7 +1840,7 @@ LLM_ENDPOINT_URL=http://127.0.0.1:9999 VLM_ENDPOINT_URL=http://127.0.0.1:9998 ru
  -i 127.0.0.1 -H OTHER -m real-time --use-remote-llm --llm my-llm --use-remote-vlm --vlm my-vlm -d -- \
   "VLM_MODE" "remote" "VLM_PORT" "30082" "RTVI_VLM_ENDPOINT" "http://127.0.0.1:9998/v1" "RTVI_VLM_MODEL_TO_USE" "openai-compat"
 
-_expected_lvs_compose_profiles='kibana-init-container-lvs,nvstreamer-lvs,vss-agent,phoenix,elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,kibana,logstash,broker-health-check,vss-haproxy-ingress,init-dirs,render-config,wdm-env-from-config,wait-for-redis,wait-for-docker-workloads,sdr-controller,rtvi-vlm,vss-ui,lvs-server,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,llm_${LLM_MODE}_${LLM_NAME_SLUG}'
+_expected_lvs_compose_profiles='kibana-init-container-lvs,nvstreamer-lvs,vss-agent,phoenix,elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,kibana,logstash,broker-health-check,vss-haproxy-ingress,init-dirs,render-config,wdm-env-from-config,wait-for-redis,wait-for-docker-workloads,sdr-controller,rtvi-vlm,vss-ui,lvs-server,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,dcgm-exporter,llm_${LLM_MODE}_${LLM_NAME_SLUG}'
 
 # LVS with local/local_shared VLM: route LVS through RT-VLM and let RT-VLM load the integrated Cosmos checkpoint.
 run_dry_run_up_and_check_generated_env "generated.env lvs local VLM uses RT-VLM integrated checkpoint" "lvs" \

--- a/deploy/helm/developer-profiles/dev-profile-lvs/Chart.lock
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: rtvi
   repository: file://../../services/rtvi
   version: 3.2.1
-digest: sha256:6e9f3505990f678acc88a46049c5beebf39faaa50311fb3e45aa7d0a44b9eebe
-generated: "2026-07-13T20:09:17.924858116+00:00"
+- name: monitoring
+  repository: file://../../services/monitoring
+  version: 3.2.0
+digest: sha256:0b03c6a9585f194b71f7e9ea874f132452b46770ecda05d576f84f66845ea733
+generated: "2026-08-13T15:31:24.499182814Z"

--- a/deploy/helm/developer-profiles/dev-profile-lvs/Chart.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/Chart.yaml
@@ -48,6 +48,15 @@ dependencies:
     version: 3.2.1
     repository: "file://../../services/rtvi"
     condition: rtvi.enabled
+  # Mirrors the LVS compose profile's dcgm-exporter opt-in (see
+  # deploy/docker/developer-profiles/dev-profile-lvs/overrides.env,
+  # COMPOSE_PROFILES=...,dcgm-exporter,...). Chart-level toggle;
+  # sub-services (prometheus/grafana/node-exporter/dcgm) are gated by
+  # monitoring.*.enabled in values-lvs.yaml.
+  - name: monitoring
+    version: 3.2.0
+    repository: "file://../../services/monitoring"
+    condition: monitoring.enabled
   # Optional HAProxy Kubernetes Ingress controller was previously vendored here; it pulled
   # https://haproxytech.github.io/helm-charts on every `helm dependency build`. Install the
   # controller cluster-wide instead (see README). Re-enable as a dependency if you need it back:

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
@@ -71,6 +71,22 @@ rtvi:
     enabled: true
     useSharedNim: false
 
+# Mirrors dev-profile-lvs/overrides.env → COMPOSE_PROFILES=...,dcgm-exporter,...
+# Compose activates only dcgm-exporter (GPU hardware telemetry on port 9400);
+# prometheus / grafana / node-exporter stay off. If your cluster already runs
+# the NVIDIA GPU Operator (which bundles its own dcgm-exporter), leave
+# monitoring.dcgmExporter.enabled=false to avoid duplicate DaemonSets.
+monitoring:
+  enabled: true
+  prometheus:
+    enabled: false
+  grafana:
+    enabled: false
+  nodeExporter:
+    enabled: false
+  dcgmExporter:
+    enabled: true
+
 # Helm-managed Ingress (uses existing IngressClass). Set ingressClassName to match your controller (default haproxy).
 vssIngress:
   enabled: true

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -619,3 +619,18 @@ nims:
         nvidia.com/gpu: "1"
       requests:
         nvidia.com/gpu: "1"
+
+# Optional monitoring subchart (Kubernetes port of services/monitoring compose).
+# Off by default here so bare `helm install` (no -f values-lvs.yaml) doesn't add
+# a monitoring DaemonSet. values-lvs.yaml turns dcgm-exporter on to match the
+# LVS compose profile's dcgm-exporter opt-in.
+monitoring:
+  enabled: false
+  prometheus:
+    enabled: false
+  grafana:
+    enabled: false
+  nodeExporter:
+    enabled: false
+  dcgmExporter:
+    enabled: false

--- a/skills/vss-deploy-profile/references/lvs-profile.md
+++ b/skills/vss-deploy-profile/references/lvs-profile.md
@@ -32,8 +32,15 @@ Container names below are the actual `container_name:` keys from `deploy/docker/
 | Kafka | `kafka` | 9092 | Message broker (VLM captions topic: `mdx-vlm-captions`) |
 | Redis | `redis` | 6379 | Cache |
 | Phoenix | `phoenix` | 6006 | Observability |
+| NVIDIA DCGM Exporter | `dcgm-exporter` | 9400 | Prometheus-format GPU utilization, memory, power, temperature, and decoder metrics |
 
 Post-deploy readiness probe: `curl -sf http://${HOST_IP}:38111/v1/ready` should return exit 0 once `vss-lvs` is serving. The VSS Agent at `http://${HOST_IP}:8000/health` is the cross-profile readiness signal; this one confirms the LVS-specific microservice.
+
+GPU telemetry is available at `http://${HOST_IP}:${DCGM_EXPORTER_HOST_PORT:-9400}/metrics`.
+Use `DCGM_EXPORTER_HOST_PORT` in `dev-profile-lvs/overrides.env` when the default
+host port conflicts with another exporter. DCGM reports host-level GPU metrics,
+so use the `gpu` or `UUID` labels to select the devices assigned to the LVS
+deployment.
 
 For LVS with `LLM_MODE=local` or `LLM_MODE=local_shared`, also require:
 


### PR DESCRIPTION
## Summary
- start the existing NVIDIA DCGM Exporter with the LVS developer profile
- expose Prometheus-format GPU utilization, decoder, memory, power, and temperature metrics on configurable host port 9400
- document direct Prometheus/Dynatrace scraping and cover the profile wiring in regression tests

## Test plan
- [x] `git diff --check`
- [x] Resolve the LVS Compose configuration and verify `dcgm-exporter` is active
- [x] `bash deploy/docker/test-scripts/test-dev-profile.sh` (203 passed; 2 pre-existing unrelated MV3DT checks failed)
- [ ] On a supported GPU host, deploy LVS and scrape `http://localhost:9400/metrics`