### PR TITLE
fix(configurator): pull distroless base from the public nvcr.io/nvidia org

### DIFF
--- a/services/configurators/vss-configurator/docker/Dockerfile
+++ b/services/configurators/vss-configurator/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN uv sync --frozen --no-dev
 # Google distroless does not ship Python 3.13; Chainguard does.
 # Runtime is distroless, so startup must use a Python entrypoint instead of a shell script.
 # FROM cgr.dev/chainguard/python:3.13 AS runtime
-FROM nvcr.io/nvidian/distroless/python:3.13-v4.0.5 AS runtime
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.5 AS runtime
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Description

`develop` has been red since 17:23 UTC on 2026-08-13. Every PR branched off it inherits the same three red checks — `Build vss-configurator (amd64/arm64, native)`, `Assemble release set`, and `Wait for Build Dev Images` — including PRs whose own images build cleanly (e.g. #1643, whose `vss-rt-cv-mv3dt-bev-fusion` build succeeds).

The cause is one line. #1623 enabled GHCR builds for `vss-configurator`, `sdr-mw-l` and `vss-rt-config-adaptor`, so CI started actually building them. `vss-configurator`'s runtime stage pulls its base image from **`nvcr.io/nvidian/...`** — the internal NGC org — and the GitHub-hosted runner only authenticates to `ghcr.io`, so the pull is anonymous:

```
#5 ERROR: failed to authorize: failed to fetch anonymous token: unexpected status from
GET https://nvcr.io/proxy_auth?scope=repository%3Anvidian%2Fdistroless%2Fpython%3Apull: 403 Forbidden
```

`vss-rt-config-adaptor`, enabled in the same PR, builds fine because it uses `nvcr.io/nvidia/distroless/python` — the public org — at the *same* tag, `3.13-v4.0.5`. This change makes `vss-configurator` do the same.

### Why three checks go red, not one

Worth flagging separately, because it turns a single-service failure into a repo-wide stoppage:

1. Both `vss-configurator` arch builds fail.
2. `build-native-platforms` is a single matrix job, so its **aggregate** result is `failure` — even though `sdr-mw-l`, `vss-rt-config-adaptor` and `vss-behavior-analytics` all built successfully.
3. `Publish … multiarch manifest` is gated on `needs.build-native-platforms.result == 'success' || == 'skipped'` (`.github/workflows/build-dev-images.yml:406-411`), so it is **skipped for the entire matrix**, including the images that passed.
4. With no `tree-<sha>` manifest pushed, `Assemble release set` fails at the first one it needs: `RuntimeError: ghcr.io/nvidia-ai-blueprints/vss/sdr-mw-l:tree-644b73f2569…: not found` (`advance_ghcr_alias.py:228`).
5. `Wait for Build Dev Images` then fails as pure cascade.

`fail-fast: false` on the build job buys nothing here, because the publish job re-couples the matrix at the aggregate `needs.result`. This PR does **not** change that — it only removes the trigger. Fixing the gating so one bad image cannot suppress manifests for every good one is worth a follow-up.

## Plan

**Goal:** `develop` builds green again, so PRs stop failing on a defect none of them introduced.

**Decisions**

| # | Question | I recommended | Decided |
|---|----------|---------------|---------|
| Q1 | Fix it in place, or ask #1623's author to fix their own commit? | Standalone `fix/` PR against `develop`, crediting #1623 — `develop` is red for everyone right now and waiting costs every open PR | Standalone `fix/` PR |
| Q2 | Swap the org, or add NGC credentials to the build job so the internal base can be pulled? | Swap the org. The identical tag exists in the public org, and its sibling service in the same PR already uses it — the `nvidian` reference reads as a slip | Swap the org |
| Q3 | Also fix the manifest-job gating in this PR? | No — separate defect, separate blast radius; this PR should be revertible in one line | Not in this PR; noted above for follow-up |

**Steps**

1. Point the runtime stage at the public org → verify: `docker pull nvcr.io/nvidia/distroless/python:3.13-v4.0.5` succeeds with **no NGC credentials** — done locally, digest `sha256:fc98699a1eeb724951bf05dd06a5364c7b858420cb153215c047e83c907dea6f`. Anonymous auth probe: public org `200`, `nvidian` `403`.
2. Keep the change minimal → verify: diff is one line, one character; `pre-commit run` passes (TruffleHog, SPDX headers; ruff/mypy/license hooks skip — no matching files).
3. Confirm the tag matches what the working sibling uses → verify: `vss-rt-config-adaptor` resolves `DISTROLESS_TAG=${PYTHON_VERSION}-v4.0.5` = `3.13-v4.0.5`, identical.
4. Green CI → verify: `Build vss-configurator` passes, the manifest job stops being skipped, `Assemble release set` completes. **Not yet verified — this is what this PR's CI run establishes.**

**Out of scope**

- The manifest-job aggregate gating (Q3).
- The commented-out `# FROM cgr.dev/chainguard/python:3.13` on the line above, and the surrounding comments about Chainguard vs Google distroless, which are now slightly stale. Left untouched deliberately — not this PR's business.

**Assumption, stated plainly:** that the `nvidian` reference was a slip rather than a deliberate dependency on an internal-only image. If `vss-configurator` genuinely needs the internal variant, this PR is the wrong fix and the right one is NGC credentials in the build job — which would then raise its own question, since it means publishing a public GHCR image built `FROM` an internal base. @munjalp / #1623 reviewers, please confirm.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [ ] New or existing tests cover these changes. — n/a, container base image reference.
- [ ] The documentation is up to date with these changes. — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
