### PR TITLE
fix(agent): secure remaining SonarQube VST paths

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/tools/vst/utils.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/vst/utils.py
@@ -594,7 +594,7 @@ async def get_storage_timeline(
             stream_timeline = timelines.get(sensor_id)
 
             if not stream_timeline or len(stream_timeline) == 0:
-                logger.info(f"No timeline found for {sensor_id}")
+                logger.info("No timeline found for %s", scrub_log(sensor_id))
                 return True, "No timeline", None, None
 
             start_time = stream_timeline[0].get("startTime")

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/vst/utils.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/vst/utils.py
@@ -542,15 +542,17 @@ async def delete_sensor(sensor_id: str | None, vst_internal_url: str | None = No
     """
     if vst_internal_url is None:
         vst_internal_url = os.getenv("VST_INTERNAL_URL", "http://localhost:30888")
-    url = f"{vst_internal_url.rstrip('/')}/vst/api/v1/sensor/{sensor_id}"
+    if sensor_id is None:
+        return False, "sensor_id is required"
+    url = f"{vst_internal_url.rstrip('/')}/vst/api/v1/sensor/{quote_path_segment(sensor_id)}"
 
-    logger.info(f"Deleting VST sensor: DELETE {url}")
+    logger.info("Deleting VST sensor: DELETE %s", scrub_log(url))
 
     async with aiohttp.ClientSession() as session:
         try:
             async with session.delete(url) as response:
                 if response.status in (200, 204):
-                    logger.info(f"VST sensor deleted: {sensor_id}")
+                    logger.info("VST sensor deleted: %s", scrub_log(sensor_id))
                     return True, "OK"
                 # Try to parse VST error response for cleaner message
                 try:
@@ -610,6 +612,8 @@ async def delete_storage(sensor_id: str | None, vst_internal_url: str | None = N
     """
     if vst_internal_url is None:
         vst_internal_url = os.getenv("VST_INTERNAL_URL", "http://localhost:30888")
+    if sensor_id is None:
+        return False, "sensor_id is required"
 
     # Get timeline first
     success, msg, start_time, end_time = await get_storage_timeline(sensor_id, vst_internal_url)
@@ -617,18 +621,18 @@ async def delete_storage(sensor_id: str | None, vst_internal_url: str | None = N
         return False, msg
 
     if start_time is None or end_time is None:
-        logger.info(f"No timeline found for {sensor_id}, nothing to delete")
+        logger.info("No timeline found for %s, nothing to delete", scrub_log(sensor_id))
         return True, "No storage to delete"
 
     # Delete storage
-    url = f"{vst_internal_url.rstrip('/')}/vst/api/v1/storage/file/{sensor_id}"
+    url = f"{vst_internal_url.rstrip('/')}/vst/api/v1/storage/file/{quote_path_segment(sensor_id)}"
     params = {"startTime": start_time, "endTime": end_time}
-    logger.info(f"Deleting VST storage: DELETE {url} params={params}")
+    logger.info("Deleting VST storage: DELETE %s params=%s", scrub_log(url), params)
 
     try:
         async with aiohttp.ClientSession() as session, session.delete(url, params=params) as response:
             if response.status in (200, 204):
-                logger.info(f"VST storage deleted: {sensor_id}")
+                logger.info("VST storage deleted: %s", scrub_log(sensor_id))
                 return True, "OK"
             # Try to parse VST error response for cleaner message
             try:

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_utils.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_utils.py
@@ -15,6 +15,7 @@
 """Unit tests for VST utils module."""
 
 import json
+import logging
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -28,6 +29,7 @@ from vss_agents.tools.vst.utils import delete_storage
 from vss_agents.tools.vst.utils import delete_vst_sensor
 from vss_agents.tools.vst.utils import delete_vst_storage
 from vss_agents.tools.vst.utils import get_name_to_stream_id_map
+from vss_agents.tools.vst.utils import get_storage_timeline
 from vss_agents.tools.vst.utils import validate_video_url
 
 # Sample mock data based on real VST server responses
@@ -451,6 +453,21 @@ class TestLegacyDeleteResources:
 
         assert success is False
         assert message == "sensor_id is required"
+
+    @pytest.mark.asyncio
+    async def test_missing_timeline_scrubs_sensor_id_from_log(self, caplog):
+        caplog.set_level(logging.INFO, logger="vss_agents.tools.vst.utils")
+        sensor_id = "camera\r\nforged log line"
+        mock_response = create_mock_response(200, "{}")
+        mock_response.json = AsyncMock(return_value={})
+        mock_session = create_mock_session(mock_response)
+
+        with patch("vss_agents.tools.vst.utils.aiohttp.ClientSession", return_value=mock_session):
+            success, message, start_time, end_time = await get_storage_timeline(sensor_id, "http://localhost:30888")
+
+        assert (success, message, start_time, end_time) == (True, "No timeline", None, None)
+        assert "No timeline found for camera  forged log line" in caplog.messages
+        assert all("\r" not in message and "\n" not in message for message in caplog.messages)
 
 
 class TestValidateVideoUrl:

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_utils.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/vst/test_utils.py
@@ -23,6 +23,8 @@ import pytest
 
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import VSTError
+from vss_agents.tools.vst.utils import delete_sensor
+from vss_agents.tools.vst.utils import delete_storage
 from vss_agents.tools.vst.utils import delete_vst_sensor
 from vss_agents.tools.vst.utils import delete_vst_storage
 from vss_agents.tools.vst.utils import get_name_to_stream_id_map
@@ -396,6 +398,59 @@ class TestDeleteVSTResources:
         assert success is True
         assert message == "No storage to delete"
         mock_session.delete.assert_not_called()
+
+
+class TestLegacyDeleteResources:
+    """Legacy deletion helpers must encode request-derived path segments."""
+
+    @pytest.mark.asyncio
+    async def test_delete_sensor_quotes_sensor_id(self):
+        mock_delete_response = create_mock_response(204, "")
+        mock_session = MagicMock()
+        mock_session.delete = MagicMock(return_value=mock_delete_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("vss_agents.tools.vst.utils.aiohttp.ClientSession", return_value=mock_session):
+            success, message = await delete_sensor("../../camera 1", "http://localhost:30888/")
+
+        assert success is True
+        assert message == "OK"
+        assert mock_session.delete.call_args.args[0] == (
+            "http://localhost:30888/vst/api/v1/sensor/..%2F..%2Fcamera%201"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_storage_quotes_sensor_id(self):
+        mock_delete_response = create_mock_response(204, "")
+        mock_session = MagicMock()
+        mock_session.delete = MagicMock(return_value=mock_delete_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("vss_agents.tools.vst.utils.aiohttp.ClientSession", return_value=mock_session),
+            patch(
+                "vss_agents.tools.vst.utils.get_storage_timeline",
+                new_callable=AsyncMock,
+                return_value=(True, "OK", "2025-01-01T00:00:00Z", "2025-01-01T00:00:30Z"),
+            ),
+        ):
+            success, message = await delete_storage("../../camera 1", "http://localhost:30888/")
+
+        assert success is True
+        assert message == "OK"
+        assert mock_session.delete.call_args.args[0] == (
+            "http://localhost:30888/vst/api/v1/storage/file/..%2F..%2Fcamera%201"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("delete_fn", [delete_sensor, delete_storage])
+    async def test_missing_sensor_id_is_rejected(self, delete_fn):
+        success, message = await delete_fn(None, "http://localhost:30888")
+
+        assert success is False
+        assert message == "sensor_id is required"
 
 
 class TestValidateVideoUrl:


### PR DESCRIPTION
## Summary
- percent-encode request-derived sensor IDs before using them as VST URL path segments
- sanitize sensor IDs and constructed URLs before logging
- reject missing sensor IDs and add traversal-focused regression tests
- note: the archive reflects older SonarQube revisions; the other reported flows are already resolved on current `develop` or refer to a removed CI script

## Test plan
- [x] `uv run --frozen --extra agent --group dev pytest packages/vss_agents/tests/unit_test/utils/test_sanitize.py packages/vss_agents/tests/unit_test/api/test_video_delete.py packages/vss_agents/tests/unit_test/api/test_video_search_ingest.py packages/vss_agents/tests/unit_test/tools/test_video_report_gen.py packages/vss_agents/tests/unit_test/tools/vst/test_utils.py -q` (89 passed)
- [x] ruff check and format check for changed files
- [ ] GitHub PR checks