### PR TITLE
fix(alerts): Adding missing kafka topic for alerts helm chart

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-alerts/values.yaml
@@ -152,6 +152,7 @@ infra:
       - name: mdx-events
       - name: mdx-incidents
       - name: mdx-vlm-incidents
+      - name: mdx-vlm-captions
       - name: mdx-vlm
       - name: mdx-embed
       - name: mdx-embed-filtered


### PR DESCRIPTION
## Description
Add missing mdx-vlm-captions Kafka topic to dev alerts helm chart. Without it the real-time profile does not work

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
