### PR TITLE
Update RT-Embed source to 26.08.1

### DIFF
--- a/services/rtvi/rt-embed/src/api_models/live_stream.py
+++ b/services/rtvi/rt-embed/src/api_models/live_stream.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from typing import Annotated, Any, Optional, Union
 from uuid import UUID
 
-from pydantic import Field, field_validator
+from pydantic import ConfigDict, Field, field_validator
 
 from .captions import (
     ABSOLUTE_PROMPT_MAX_LENGTH,
@@ -755,6 +755,10 @@ def _vios_creation_time_from_metadata(
 class ViosStreamEventBase(CommonBaseModel):
     """Common VIOS camera event fields."""
 
+    # VIOS may add fields independently of RTVI. Keep its compatibility
+    # envelope extensible without relaxing the strict CV request schemas.
+    model_config = ConfigDict(extra="ignore", json_schema_extra={"additionalProperties": True})
+
     camera_id: str = Field(
         description="User-provided unique camera identifier.",
         max_length=256,
@@ -841,6 +845,8 @@ class ViosStreamRemoveEvent(ViosStreamEventBase):
 
 class ViosStreamRequestBase(CommonBaseModel):
     """Common VIOS message-bus stream request envelope."""
+
+    model_config = ConfigDict(extra="ignore", json_schema_extra={"additionalProperties": True})
 
     alert_type: str = Field(
         description="VIOS alert type.",

--- a/services/rtvi/rt-embed/src/models/custom/samples/cosmos-embed1/create_triton_model_repo.py
+++ b/services/rtvi/rt-embed/src/models/custom/samples/cosmos-embed1/create_triton_model_repo.py
@@ -230,7 +230,7 @@ def export_onnx_text(
 
 
 def get_gpu_name():
-    """Return a sanitized GPU name suitable for filenames (single GPU, no spaces/newlines)."""
+    """Return a sanitized GPU name suitable for filenames (single GPU, no spaces/parentheses)."""
     try:
         # Query only the first GPU to avoid multi-line output on multi-GPU systems
         command = [
@@ -241,8 +241,8 @@ def get_gpu_name():
             "0",
         ]
         raw_output = subprocess.check_output(command, text=True).strip()
-        # Take the first line and replace spaces with underscores for filename safety
-        gpu_name = raw_output.splitlines()[0].replace(" ", "_")
+        # Take the first line and sanitize for filename safety (no spaces/parentheses)
+        gpu_name = raw_output.splitlines()[0].replace(" ", "_").replace("(", "").replace(")", "")
         return gpu_name
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
         logger.error(f"Error getting GPU name: {e}")

--- a/services/rtvi/rt-embed/src/models/custom/samples/cosmos-embed1/inference.py
+++ b/services/rtvi/rt-embed/src/models/custom/samples/cosmos-embed1/inference.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,9 @@ class CosmosEmbedModel(BaseVlmModel):
         import tritonserver
 
         server_options = tritonserver.Options(
-            model_repository=self._triton_repo_path, exit_timeout=30
+            model_repository=self._triton_repo_path,
+            exit_timeout=30,
+            metrics=False,  # metrics collection is not supported on Orin, needs NVML/DCGM
         )
         self._triton_server = tritonserver.Server(server_options)
         self._triton_server.start(wait_until_ready=True)

--- a/services/rtvi/rt-embed/src/models/vllm_compatible/vllm_compatible_model.py
+++ b/services/rtvi/rt-embed/src/models/vllm_compatible/vllm_compatible_model.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import concurrent.futures
+import copy
 import json
 import math
 import os
@@ -34,6 +35,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 from common.chunk_info import ChunkInfo
 from common.logger import TimeMeasure, logger
+from common.service_exception import ServiceException
 from models.base_vlm_model import (
     BaseVlmModel,
     InputConfig,
@@ -60,6 +62,7 @@ _RTVI_VLLM_ENV_ALIASES = {
     "VLLM_MAX_NUM_SEQS": "RTVI_VLLM_MAX_NUM_SEQS",
     "VLLM_NUM_SCHEDULER_STEPS": "RTVI_VLLM_NUM_SCHEDULER_STEPS",
     "VLLM_NUM_PREPROCESS_WORKERS": "RTVI_VLLM_NUM_PREPROCESS_WORKERS",
+    "VLLM_EVS_SIMILARITY_THRESHOLD": "RTVI_VLLM_EVS_SIMILARITY_THRESHOLD",
     "VLLM_ROOT": "RTVI_VLLM_ROOT",
 }
 
@@ -201,6 +204,27 @@ def _parse_float_env(name: str, default: float) -> float:
     return parsed
 
 
+def _get_evs_token_budget() -> int:
+    """Visual-token budget an EVS session accumulates before forcing generation.
+
+    Defaults to 1: generate on every clip rather than packing tokens across
+    clips, which keeps caption counts aligned with the non-EVS path.
+    """
+    value = (os.environ.get("VIA_EVS_TOKEN_BUDGET") or "").strip()
+    return int(value or "1")
+
+
+def _get_evs_similarity_threshold() -> float:
+    """Server default for EVS session-mode cosine-dissimilarity pruning.
+
+    Read through the alias: _sanitize_rtvi_vllm_env() renames the variable out
+    of the VLLM_ namespace before vLLM is imported, so a raw os.environ lookup
+    here would silently fall back to the default.
+    """
+    value = (_get_rtvi_vllm_env("VLLM_EVS_SIMILARITY_THRESHOLD", "") or "").strip()
+    return float(value or "0.4")
+
+
 def _get_mm_processor_cache_gb() -> float:
     if (_get_rtvi_vllm_env("VLLM_MM_PROCESSOR_CACHE_GB", "") or "").strip():
         return _parse_float_env("VLLM_MM_PROCESSOR_CACHE_GB", 1.0)
@@ -208,6 +232,109 @@ def _get_mm_processor_cache_gb() -> float:
 
 
 CPU_COPY_OTHER_THREAD = True
+
+# Fallback edges for a request that supplies only one half of `size`, per the
+# NIM docs. Used when the calling path has no `size` default of its own.
+_NIM_DEFAULT_LONGEST_EDGE = 12845056
+_NIM_DEFAULT_SHORTEST_EDGE = 3136
+
+# Preprocessing defaults for the EVS session path.
+#
+# No `size` here, matching the regular path: the model's own
+# video_preprocessor_config.json min/max pixels govern. EVS previously pinned
+# {longest_edge: 180000000, shortest_edge: 4096}, which was inert — RTVI resizes
+# frames at decode time (608x320 for CR2/CR3, or VLM_INPUT_WIDTH/HEIGHT), so
+# neither that bound nor the model's own (25165824 for CR3) is ever reached, and
+# max_pixels only ever downscales, never upscales.
+#
+# `do_sample_frames` must stay False: EVS hands vLLM a frame list paired with
+# explicit per-frame timestamps, and processor-side resampling would
+# desynchronise the two.
+_EVS_MM_PROCESSOR_DEFAULTS = {
+    "do_sample_frames": False,
+}
+
+# Qwen3-VL's video processor rejects a clip shorter than its temporal factor
+# ("t:1 must be larger than temporal_factor:2" from smart_resize), so an EVS
+# clip is padded up to this many frames before it is handed to the session.
+_EVS_MIN_CLIP_FRAMES = 2
+
+
+_DEFAULT_MAX_VIDEO_FRAMES = "256"
+
+
+def _get_max_video_frames() -> int:
+    """Per-chunk frame cap from ``VLLM_MM_PROCESSOR_VIDEO_NUM_FRAMES``."""
+    value = _get_rtvi_vllm_env(
+        "VLLM_MM_PROCESSOR_VIDEO_NUM_FRAMES",
+        _DEFAULT_MAX_VIDEO_FRAMES,
+    )
+    return int(value or _DEFAULT_MAX_VIDEO_FRAMES)
+
+
+def _cap_video_frames(images, video_frames_times, max_frames: int):
+    """Uniformly subsample *images* down to *max_frames*, timestamps in step.
+
+    fps-based chunking can produce far more frames than the vLLM processor
+    accepts (10 fps x 60 s = 600). Returns the inputs untouched when the clip
+    is already within the cap. ``video_frames_times`` is subsampled with the
+    same indices so each kept frame keeps its own timestamp; passing ``None``
+    is allowed for callers that have no timestamps.
+    """
+    if len(images) <= 1 or len(images) <= max_frames:
+        return images, video_frames_times
+
+    indices = torch.linspace(0, len(images) - 1, max_frames).long()
+    capped_images = images[indices]
+    if video_frames_times is not None:
+        video_frames_times = [video_frames_times[i] for i in indices.tolist()]
+    return capped_images, video_frames_times
+
+
+def _merge_mm_processor_kwargs(base: dict, requested: dict | None) -> dict:
+    """Merge a request's ``mm_processor_kwargs`` over a path's defaults.
+
+    The HF processor needs both edges of ``size``, so a request that names only
+    one gets the other filled in — from *base*'s own ``size`` when it has one,
+    otherwise from the NIM defaults. Neither input is mutated: the request dict
+    belongs to the caller and ``base`` may be a shared module-level default.
+    """
+    merged = copy.deepcopy(base)
+    if not requested:
+        return merged
+
+    requested = copy.deepcopy(requested)
+    size = requested.get("size")
+    if isinstance(size, dict):
+        base_size = base.get("size") if isinstance(base.get("size"), dict) else {}
+        if "shortest_edge" in size and "longest_edge" not in size:
+            size["longest_edge"] = base_size.get("longest_edge", _NIM_DEFAULT_LONGEST_EDGE)
+        elif "longest_edge" in size and "shortest_edge" not in size:
+            size["shortest_edge"] = base_size.get("shortest_edge", _NIM_DEFAULT_SHORTEST_EDGE)
+
+    merged.update(requested)
+    return merged
+
+
+def _freeze_evs_session_config(value):
+    """Return a hashable, stable representation of EVS session config."""
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (key, _freeze_evs_session_config(nested_value))
+                for key, nested_value in value.items()
+            )
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_evs_session_config(item) for item in value)
+    return value
+
+
+def _evs_session_cache_stream_id(cache_key):
+    """Extract the stream id from new composite or old string cache keys."""
+    if isinstance(cache_key, tuple) and len(cache_key) == 2:
+        return cache_key[0]
+    return cache_key
 
 
 # Both the EA checkpoint (NemotronH_Nano_VL_V2) and the GA checkpoint
@@ -277,6 +404,23 @@ def _build_evs_sampling_kwargs(max_tokens, generation_config):
     if min_tokens is not None:
         kwargs["min_tokens"] = int(min_tokens)
 
+    return kwargs
+
+
+def _build_vllm_sampling_kwargs(config: VlmGenerationConfig) -> dict:
+    """Build regular vLLM sampling kwargs without dropping greedy decoding."""
+    kwargs = {
+        "temperature": config.temperature,
+        "top_p": config.top_p,
+        "top_k": int(config.top_k),
+        "max_tokens": config.max_new_tokens,
+        "repetition_penalty": config.repetition_penalty,
+    }
+    if config.min_tokens is not None:
+        kwargs["min_tokens"] = config.min_tokens
+    env_ignore_eos = _get_rtvi_vllm_env("VLLM_IGNORE_EOS", "false").lower() == "true"
+    if env_ignore_eos or config.ignore_eos is not None:
+        kwargs["ignore_eos"] = env_ignore_eos or bool(config.ignore_eos)
     return kwargs
 
 
@@ -852,10 +996,13 @@ class VllmCompatible(BaseVlmModel):
                 # Similarity-based (content-dependent) pruning only applies on
                 # the EVS session/encode path, so gate it on VIA_EVS_SESSION.
                 # When session mode is on: use VLLM_EVS_SIMILARITY_THRESHOLD if
-                # provided, else default 0.2. When session mode is off: leave
+                # provided, else default 0.4. When session mode is off: leave
                 # evs_similarity_threshold=None so the engine uses deterministic
                 # fixed-rate pruning (video_pruning_rate) instead.
-                _evs_session_on = os.environ.get("VIA_EVS_SESSION", "").lower() in ("true", "1")
+                _evs_session_on = os.environ.get("VIA_EVS_SESSION", "").lower() in (
+                    "true",
+                    "1",
+                )
                 if self._model_architecture in _NEMOTRON_OMNI_ARCHS and _evs_session_on:
                     logger.error(
                         "EVS session mode is not supported for NemotronH_Nano_Omni_Reasoning_V3"
@@ -864,9 +1011,7 @@ class VllmCompatible(BaseVlmModel):
                         "EVS session mode is not supported for NemotronH_Nano_Omni_Reasoning_V3"
                     )
                 if "evs_similarity_threshold" in _engine_supported_params and _evs_session_on:
-                    engine_args_kwargs["evs_similarity_threshold"] = float(
-                        os.environ.get("VLLM_EVS_SIMILARITY_THRESHOLD") or "0.2"
-                    )
+                    engine_args_kwargs["evs_similarity_threshold"] = _get_evs_similarity_threshold()
                 if "enable_mm_embeds" in _engine_supported_params:
                     engine_args_kwargs["enable_mm_embeds"] = True
                 if "num_preprocess_workers" in _engine_supported_params:
@@ -896,8 +1041,8 @@ class VllmCompatible(BaseVlmModel):
 
             # EVS session handler — uses vLLM's serving layer directly (no HTTP)
             self._evs_handler = None  # OpenAIServingVideoSessions, created lazily
-            # Per-stream EVS sessions: streamId → session_id
-            self._evs_sessions: dict[str, str] = {}
+            # Per-stream/config EVS sessions: (streamId, session_config) → session_id
+            self._evs_sessions: dict[tuple, str] = {}
             self._evs_sessions_lock = threading.Lock()
             self._output_tpool = concurrent.futures.ThreadPoolExecutor(
                 max_workers=self._max_batch_size
@@ -919,6 +1064,7 @@ class VllmCompatible(BaseVlmModel):
         if (
             self._model_architecture in _NEMOTRON_OMNI_ARCHS
             or self._model_architecture in _QWEN35_ARCHS
+            or self._model_architecture in _QWEN3VL_ARCHS
         ):
             return {"enable_thinking": bool(config.enable_reasoning)}
         return {}
@@ -969,7 +1115,9 @@ class VllmCompatible(BaseVlmModel):
                 logger.warning("No output generated from model")
                 return [
                     VlmModelOutput(
-                        output="Error: No response generated", input_tokens=0, output_tokens=0
+                        output="Error: No response generated",
+                        input_tokens=0,
+                        output_tokens=0,
                     )
                 ]
 
@@ -1047,9 +1195,9 @@ class VllmCompatible(BaseVlmModel):
     def _update_video_frames_times(self, text, chunk, video_frames_times):
         updated_text = re.sub(
             r"<([0-9]+(?:\.[0-9]+)?)>",
-            lambda m: "<"
-            + chunk.get_timestamp(float(video_frames_times[0]) + float(m.group(1)))
-            + ">",
+            lambda m: (
+                "<" + chunk.get_timestamp(float(video_frames_times[0]) + float(m.group(1))) + ">"
+            ),
             text,
         )
         return updated_text
@@ -1102,7 +1250,9 @@ class VllmCompatible(BaseVlmModel):
         with TimeMeasure("vLLM generate"):
             try:
                 async for output_item in self._llm.generate(
-                    llm_inputs, sampling_params=vllm_sampling_params, request_id=request_id
+                    llm_inputs,
+                    sampling_params=vllm_sampling_params,
+                    request_id=request_id,
                 ):
                     final_output = output_item
             except ValueError as e:
@@ -1127,8 +1277,6 @@ class VllmCompatible(BaseVlmModel):
                         "cover the prompt length.",
                         err_msg,
                     )
-                    from common.service_exception import ServiceException
-
                     raise ServiceException(
                         f"Input exceeds model limits: {err_msg} Reduce frames "
                         f"per chunk or raise VLM_MAX_MODEL_LEN.",
@@ -1147,7 +1295,9 @@ class VllmCompatible(BaseVlmModel):
             self._inflight_req_ids.remove(request_id)
             return [
                 VlmModelOutput(
-                    output="Error: No response generated", input_tokens=0, output_tokens=0
+                    output="Error: No response generated",
+                    input_tokens=0,
+                    output_tokens=0,
                 )
             ]
         self._inflight_req_ids.remove(request_id)
@@ -1231,9 +1381,7 @@ class VllmCompatible(BaseVlmModel):
                 engine_client=self._llm,
                 max_sessions=int(os.environ.get("VIA_EVS_MAX_SESSIONS") or "100"),
                 pruning_rate=float(os.environ.get("VLM_VIDEO_PRUNING_RATE") or "0.5"),
-                similarity_threshold=float(
-                    os.environ.get("VLLM_EVS_SIMILARITY_THRESHOLD") or "0.2"
-                ),
+                similarity_threshold=_get_evs_similarity_threshold(),
                 pd_server_url=os.environ.get("VIA_PD_SERVER_URL") or None,
                 pd_server_timeout_s=float(os.environ.get("VIA_PD_SERVER_TIMEOUT_S") or "120.0"),
             )
@@ -1249,23 +1397,18 @@ class VllmCompatible(BaseVlmModel):
         chunk_size_s=0,
         timestamp_prompt_template=None,
         generation_config=None,
+        system_prompt=None,
     ):
         """Return (or create) the EVS session for *stream_id*."""
         handler = self._ensure_evs_handler()
-        with self._evs_sessions_lock:
-            if stream_id in self._evs_sessions:
-                return self._evs_sessions[stream_id]
 
-        from vllm.entrypoints.openai.engine.protocol import (
-            EvsAdvancedConfig,
-            VideoSessionCreateRequest,
-            VideoSessionSamplingParams,
-        )
-
-        token_budget = int(os.environ.get("VIA_EVS_TOKEN_BUDGET") or "20000")
+        token_budget = _get_evs_token_budget()
         model_name = self._vlm_model_type or self.model_dir_name
 
-        event_only = os.environ.get("VIA_EVS_EVENT_ONLY", "true").lower() in ("true", "1")
+        event_only = os.environ.get("VIA_EVS_EVENT_ONLY", "false").lower() in (
+            "true",
+            "1",
+        )
 
         event_chunk_duration_s = float(chunk_size_s) if chunk_size_s > 0 else 0.0
         event_ema_memory_s = float(os.environ.get("VIA_EVS_EMA_MEMORY_S") or "0")
@@ -1284,6 +1427,10 @@ class VllmCompatible(BaseVlmModel):
         event_downward_baseline_min = float(
             os.environ.get("VIA_EVS_DOWNWARD_BASELINE_MIN") or "0.10"
         )
+        event_chunk_duration_s_config = (
+            event_chunk_duration_s if event_chunk_duration_s > 0 else None
+        )
+        event_ema_memory_s_config = event_ema_memory_s if event_ema_memory_s > 0 else None
 
         # Default sampling policy for this session's event-gated generations.
         # The detector triggers generation server-side with no per-call request
@@ -1298,19 +1445,59 @@ class VllmCompatible(BaseVlmModel):
         #     affected by the process-global RNG reseed the non-EVS path does.
         #   - ignore_eos / min_tokens are forwarded (see _build_evs_sampling_kwargs)
         #     so VLLM_IGNORE_EOS reaches event-gated generations for OSL/perf runs.
-        session_sampling_params = VideoSessionSamplingParams(
-            **_build_evs_sampling_kwargs(max_tokens, generation_config)
+        session_sampling_kwargs = _build_evs_sampling_kwargs(max_tokens, generation_config)
+        # The key holds only what can actually differ between two requests on the
+        # same stream. A session bakes these in at creation and keeps them for
+        # its life, so reusing a session across a change here would answer with
+        # the wrong prompt or sampling policy.
+        #
+        # Everything else in the create request below is deliberately excluded:
+        #   - The event_* tunables, token_budget and event_only are read from
+        #     os.environ on every call, so they are process constants.
+        #   - timestamp_prompt_template derives from those env vars plus whether
+        #     the source is RTSP, which is a property of the stream.
+        #   - event_chunk_duration_s is measured per chunk as
+        #     (end_pts - start_pts) / 1e9, and live chunks are finalized with
+        #     end_pts rewritten to the real last-frame PTS (see
+        #     video_file_frame_getter.py), so it lands on a different float every
+        #     chunk. Keying on it minted a new session per chunk until the engine
+        #     hit its max-sessions cap. It cannot discriminate anyway: a live
+        #     stream rejects a subscriber whose decode signature (chunk_duration
+        #     included) differs, and each file request gets its own stream id.
+        #
+        # Adding a request-overridable knob to the create request means adding it
+        # here too; adding a process- or stream-scoped one does not.
+        session_config_key = _freeze_evs_session_config(
+            {
+                "model": model_name,
+                "prompt": prompt,
+                "system_prompt": system_prompt or None,
+                "sampling_params": session_sampling_kwargs,
+            }
         )
+        session_cache_key = (stream_id, session_config_key)
+        with self._evs_sessions_lock:
+            if session_cache_key in self._evs_sessions:
+                return self._evs_sessions[session_cache_key]
+
+        from vllm.entrypoints.openai.engine.protocol import (
+            EvsAdvancedConfig,
+            VideoSessionCreateRequest,
+            VideoSessionSamplingParams,
+        )
+
+        session_sampling_params = VideoSessionSamplingParams(**session_sampling_kwargs)
 
         request = VideoSessionCreateRequest(
             model=model_name,
             token_budget=token_budget,
             event_only=event_only,
             prompt=prompt,
+            system_prompt=system_prompt or None,
             timestamp_prompt_template=timestamp_prompt_template,
             sampling_params=session_sampling_params,
-            event_chunk_duration_s=(event_chunk_duration_s if event_chunk_duration_s > 0 else None),
-            event_ema_memory_s=(event_ema_memory_s if event_ema_memory_s > 0 else None),
+            event_chunk_duration_s=event_chunk_duration_s_config,
+            event_ema_memory_s=event_ema_memory_s_config,
             event_advanced=EvsAdvancedConfig(
                 spike_std_k=event_spike_std_k,
                 settling_std_k=event_settling_std_k,
@@ -1324,18 +1511,69 @@ class VllmCompatible(BaseVlmModel):
         async def _create():
             return await handler.create_session(request)
 
-        resp = asyncio.run_coroutine_threadsafe(_create(), self._event_loop).result()
+        try:
+            resp = asyncio.run_coroutine_threadsafe(_create(), self._event_loop).result()
+        except ServiceException:
+            # Already classified (code + status_code) by the layer that raised
+            # it; re-wrapping would flatten a 400 into a 500.
+            logger.error(
+                "EVS session creation failed for stream %s:\n%s",
+                stream_id,
+                traceback.format_exc(),
+            )
+            raise
+        except Exception as e:
+            # The session manager raises bare RuntimeErrors, so without this the
+            # caller only sees "An unknown error occurred" -- ProcessBase's
+            # _handle_result forwards a message and status code only for a
+            # ServiceException. The most common one is operator-fixable:
+            # "Cannot create session: max sessions (N) reached", which is a
+            # capacity condition (503) rather than an internal fault (500).
+            is_at_capacity = "max sessions" in str(e).lower()
+            logger.error(
+                "EVS session creation failed for stream %s: %r\n%s",
+                stream_id,
+                e,
+                traceback.format_exc(),
+            )
+            hint = " Raise VIA_EVS_MAX_SESSIONS, Default value is 100." if is_at_capacity else ""
+            raise ServiceException(
+                f"EVS session creation failed for stream {stream_id}: {e}.{hint}",
+                "EVSSessionCreateError",
+                503 if is_at_capacity else 500,
+            ) from e
+        duplicate_session_id = None
         with self._evs_sessions_lock:
-            self._evs_sessions[stream_id] = resp.session_id
+            existing_session_id = self._evs_sessions.get(session_cache_key)
+            if existing_session_id is not None:
+                duplicate_session_id = resp.session_id
+                session_id = existing_session_id
+            else:
+                self._evs_sessions[session_cache_key] = resp.session_id
+                session_id = resp.session_id
+        if duplicate_session_id is not None:
+            logger.info(
+                "Closing duplicate EVS session %s for stream %s after concurrent creation",
+                duplicate_session_id,
+                stream_id,
+            )
+
+            async def _delete_duplicate():
+                await handler.delete_session(duplicate_session_id)
+
+            asyncio.run_coroutine_threadsafe(_delete_duplicate(), self._event_loop).result()
+            return session_id
         logger.info(
             "EVS session created: %s for stream %s (budget=%d, "
-            "event_only=%s, chunk_dur=%.2fs, ema_memory=%.2fs, "
-            "spike_k=%.2f, settling_k=%.2f, std_floor_ratio=%.4f, "
-            "min_clips=%d, downward_baseline_min=%.4f, decision_lag=%d)",
-            resp.session_id,
+            "event_only=%s, similarity_threshold=%.2f, chunk_dur=%.2fs, "
+            "ema_memory=%.2fs, spike_k=%.2f, settling_k=%.2f, "
+            "std_floor_ratio=%.4f, min_clips=%d, "
+            "downward_baseline_min=%.4f, decision_lag=%d)",
+            session_id,
             stream_id,
             token_budget,
             event_only,
+            _get_evs_similarity_threshold(),
             event_chunk_duration_s,
             event_ema_memory_s,
             event_spike_std_k,
@@ -1347,33 +1585,48 @@ class VllmCompatible(BaseVlmModel):
         )
         logger.info(
             "EVS session %s sampling: temp=%.2f top_p=%.2f top_k=%d " "rep_pen=%.2f seed=%s",
-            resp.session_id,
+            session_id,
             session_sampling_params.temperature,
             session_sampling_params.top_p,
             session_sampling_params.top_k,
             session_sampling_params.repetition_penalty,
             session_sampling_params.seed,
         )
-        return resp.session_id
+        return session_id
 
     def _close_evs_session(self, stream_id):
         """Delete the EVS session for a single stream."""
         with self._evs_sessions_lock:
-            session_id = self._evs_sessions.pop(stream_id, None)
-        if session_id is not None and self._evs_handler is not None:
+            session_ids = [
+                self._evs_sessions.pop(cache_key)
+                for cache_key in list(self._evs_sessions.keys())
+                if _evs_session_cache_stream_id(cache_key) == stream_id
+            ]
+        if session_ids and self._evs_handler is not None:
 
-            async def _delete():
-                await self._evs_handler.delete_session(session_id)
+            async def _delete_all():
+                for session_id in session_ids:
+                    await self._evs_handler.delete_session(session_id)
 
-            asyncio.run_coroutine_threadsafe(_delete(), self._event_loop).result()
-            logger.info("EVS session closed: %s (stream %s)", session_id, stream_id)
+            asyncio.run_coroutine_threadsafe(_delete_all(), self._event_loop).result()
+            logger.info("EVS sessions closed: %s (stream %s)", session_ids, stream_id)
 
     def close_evs_session(self):
         """Delete all EVS sessions."""
         with self._evs_sessions_lock:
-            stream_ids = list(self._evs_sessions.keys())
-        for sid in stream_ids:
-            self._close_evs_session(sid)
+            session_items = list(self._evs_sessions.items())
+            self._evs_sessions.clear()
+        if session_items and self._evs_handler is not None:
+
+            async def _delete_all():
+                for _cache_key, session_id in session_items:
+                    await self._evs_handler.delete_session(session_id)
+
+            asyncio.run_coroutine_threadsafe(_delete_all(), self._event_loop).result()
+            logger.info(
+                "EVS sessions closed: %s",
+                [session_id for _cache_key, session_id in session_items],
+            )
 
     def _evs_strip_thinking_tags(self, text: str) -> tuple:
         """Extract reasoning from <think>...</think>, return (content, reasoning).
@@ -1406,6 +1659,7 @@ class VllmCompatible(BaseVlmModel):
         video_frames_times,
         chunk,
         timestamp_prompt_template=None,
+        system_prompt=None,
     ):
         """EVS session flow: add clip as tensors, auto-generate when ready.
 
@@ -1422,6 +1676,25 @@ class VllmCompatible(BaseVlmModel):
         # generation_config may be either a dict (via-engine convention) or a
         # VlmGenerationConfig dataclass (rtvi convention). Support both.
         if isinstance(generation_config, dict):
+            requested_mm_kwargs = generation_config.get("mm_processor_kwargs")
+            preserve_reasoning_tags = generation_config.get("preserve_reasoning_tags", False)
+        else:
+            requested_mm_kwargs = getattr(generation_config, "mm_processor_kwargs", None)
+            preserve_reasoning_tags = getattr(generation_config, "preserve_reasoning_tags", False)
+        mm_processor_kwargs = _merge_mm_processor_kwargs(
+            _EVS_MM_PROCESSOR_DEFAULTS, requested_mm_kwargs
+        )
+        if mm_processor_kwargs.get("do_sample_frames"):
+            # EVS pairs each frame with an explicit timestamp; resampling inside
+            # the processor would desynchronise frames from timestamps.
+            logger.warning(
+                "Ignoring mm_processor_kwargs['do_sample_frames']=True for stream %s: "
+                "EVS sessions require processor-side frame sampling to stay off.",
+                stream_id,
+            )
+            mm_processor_kwargs["do_sample_frames"] = False
+
+        if isinstance(generation_config, dict):
             max_tokens = generation_config.get("max_new_tokens", 2048)
         else:
             max_tokens = getattr(generation_config, "max_new_tokens", 2048)
@@ -1435,6 +1708,7 @@ class VllmCompatible(BaseVlmModel):
             chunk_size_s=chunk_size_s,
             timestamp_prompt_template=timestamp_prompt_template,
             generation_config=generation_config,
+            system_prompt=system_prompt,
         )
         handler = self._evs_handler
         placeholder = [
@@ -1456,29 +1730,86 @@ class VllmCompatible(BaseVlmModel):
             # (0 video tokens -> "0 prompt placeholders" crash at startup).
             pass
 
+        # Cap frames the same way the regular path does. EVS prunes frames of
+        # its own, but that happens *after* the encoder has seen the whole clip,
+        # so an uncapped fps-based chunk would still be encoded in full and can
+        # exceed what the vLLM processor accepts. Timestamps are subsampled with
+        # the frames so the per-frame list handed to the session stays aligned.
+        max_frames = _get_max_video_frames()
+        original_frame_count = len(images)
+        images, video_frames_times = _cap_video_frames(images, video_frames_times, max_frames)
+        if len(images) != original_frame_count:
+            logger.debug(
+                "EVS clip: subsampled %d frames to %d (VLLM_MM_PROCESSOR_VIDEO_NUM_FRAMES)",
+                original_frame_count,
+                max_frames,
+            )
+
+        # Pad a clip that falls below the video processor's temporal factor.
+        # Qwen3-VL's smart_resize rejects a lone frame outright ("t:1 must be
+        # larger than temporal_factor:2"). The regular path never gets there --
+        # a one-frame chunk goes down the image branch (is_single_image), which
+        # has no temporal dimension -- but EVS has no image branch, so every
+        # clip travels as a video. This is reachable from ordinary input: fps
+        # chunking computes int(fps * chunk_seconds), so 4 fps over a 0.167s
+        # clip asks for 0 frames and video_file_frame_getter clamps that to 1.
+        # Repeat the last frame (with its timestamp) so the request still gets
+        # an answer; the duplicate is exactly what EVS similarity pruning
+        # collapses.
+        if 0 < len(images) < _EVS_MIN_CLIP_FRAMES:
+            has_aligned_times = bool(video_frames_times) and len(video_frames_times) == len(images)
+            repeat_index = list(range(len(images)))
+            repeat_index += [len(images) - 1] * (_EVS_MIN_CLIP_FRAMES - len(images))
+            logger.debug(
+                "EVS clip: padded %d frame(s) to %d to satisfy the video "
+                "processor's temporal factor",
+                len(images),
+                _EVS_MIN_CLIP_FRAMES,
+            )
+            images = images[repeat_index]
+            if has_aligned_times:
+                video_frames_times = [video_frames_times[i] for i in repeat_index]
+
         # Build video metadata. Qwen3-VL's HF processor expects
         # frames_indices/fps for video inputs; keep absolute timestamps
         # operator-controlled, but still provide relative metadata by default.
-        video_metadata = {}
-        if len(images) > 1 and video_frames_times and len(video_frames_times) > 1:
+        # It is never optional here: EVS has no single-image branch, so a
+        # degenerate clip (one frame, or timestamps the decoder could not
+        # supply) still goes over as a video. Handing the session an empty dict
+        # leaves frames_indices unset, and Qwen3-VL only recomputes it when
+        # do_sample_frames is on -- which EVS pins off -- so the clip dies in
+        # the processor with "'NoneType' object has no attribute 'tolist'".
+        has_frame_times = bool(video_frames_times) and len(video_frames_times) == len(images)
+        duration = 0.0
+        if has_frame_times and len(video_frames_times) > 1:
             duration = video_frames_times[-1] - video_frames_times[0]
-            if self._uses_absolute_timestamp_metadata():
-                video_metadata = self._build_absolute_timestamp_video_metadata(
-                    images, video_frames_times, duration
-                )
-            else:
-                fps = 1
-                if duration > 0:
-                    fps = (len(video_frames_times) - 1) / duration
-                video_metadata = {
-                    "total_num_frames": len(images),
-                    "frames_indices": list(range(len(images))),
-                    "fps": fps,
-                    "duration": duration,
-                }
+
+        if has_frame_times and self._uses_absolute_timestamp_metadata():
+            video_metadata = self._build_absolute_timestamp_video_metadata(
+                images, video_frames_times, duration
+            )
+        else:
+            # Without usable frame times the clip loses its real timestamps,
+            # not its caption: fall back to relative indices at a nominal fps.
+            fps = 1
+            if duration > 0:
+                fps = (len(video_frames_times) - 1) / duration
+            video_metadata = {
+                "total_num_frames": len(images),
+                "frames_indices": list(range(len(images))),
+                "fps": fps,
+                "duration": duration,
+            }
 
         is_last = getattr(chunk, "is_last", False) if chunk else False
-        client_timestamps = [float(t) for t in video_frames_times] if video_frames_times else []
+        # Same decision as the metadata above: a list that does not describe the
+        # frames being sent must not reach the session, which uses it for the
+        # kept-frame timestamps and the {timestamps} prompt placeholder. The
+        # fallback mirrors the relative metadata (indices at fps=1).
+        if has_frame_times:
+            client_timestamps = [float(t) for t in video_frames_times]
+        else:
+            client_timestamps = [float(i) for i in range(len(images))]
 
         ooo_chunk_id = getattr(chunk, "chunkIdx", None) if chunk is not None else None
 
@@ -1494,6 +1825,18 @@ class VllmCompatible(BaseVlmModel):
         # is what the non-EVS video path does so the processor infers channel
         # layout and resizes normally (avoids a collapsed grid -> 0 video
         # tokens).
+        #
+        # CPU_COPY_OTHER_THREAD is deliberately NOT honored here. On the non-EVS
+        # path it defers to asyncio.to_thread from an event loop that is never
+        # blocked, so the copy starts at once. EVS's only other thread is an
+        # _output_tpool worker, and those block for the whole add_clip_tensors
+        # round trip (encode plus, when the detector fires, a full generation).
+        # Since the in-flight slot is released at encode-done, new clips are
+        # admitted while every worker is still blocked, so a deferred copy could
+        # queue behind them and pin this clip's CUDA frames (~49 MB for a
+        # 40-frame 640x640 chunk) for a whole generation cycle — to save ~14 ms
+        # on a dispatcher that is not the bottleneck. Copying now lets the
+        # pipeline free the frames as soon as generate() returns.
         if self._vlm_model_type == "cosmos-reason1":
             images_cpu = images.cpu()
         else:
@@ -1517,10 +1860,7 @@ class VllmCompatible(BaseVlmModel):
                     session_id=session_id,
                     images=images_cpu,
                     metadata=video_metadata,
-                    mm_processor_kwargs={
-                        "size": {"longest_edge": 180000000, "shortest_edge": 4096},
-                        "do_sample_frames": False,
-                    },
+                    mm_processor_kwargs=mm_processor_kwargs,
                     timestamps=client_timestamps,
                     is_last=is_last,
                     chunk_id=ooo_chunk_id,
@@ -1529,9 +1869,38 @@ class VllmCompatible(BaseVlmModel):
 
             try:
                 clip_resp = asyncio.run_coroutine_threadsafe(_add(), self._event_loop).result()
+            except ServiceException:
+                # Already classified (code + status_code) by the layer that
+                # raised it; re-wrapping would flatten a 400 into a 500.
+                logger.error(
+                    "EVS add_clip_tensors failed for stream %s chunk %s:\n%s",
+                    stream_id,
+                    ooo_chunk_id,
+                    traceback.format_exc(),
+                )
+                raise
             except Exception as e:
-                logger.error("EVS add_clip_tensors failed: %r\n%s", e, traceback.format_exc())
-                return placeholder
+                # Surface as a chunk error rather than an empty caption. A
+                # placeholder here made a failed clip indistinguishable from a
+                # successful one with nothing to say, so neither the ERROR_BUS
+                # nor the request's FAILED status ever saw the failure. As a
+                # ServiceException the message survives ProcessBase's
+                # _handle_result verbatim instead of becoming "An unknown error
+                # occurred"; keeping the original text inline also preserves the
+                # CUDA-OOM match that maps the chunk to 503.
+                logger.error(
+                    "EVS add_clip_tensors failed for stream %s chunk %s: %r\n%s",
+                    stream_id,
+                    ooo_chunk_id,
+                    e,
+                    traceback.format_exc(),
+                )
+                raise ServiceException(
+                    f"EVS clip processing failed for stream {stream_id} "
+                    f"(chunk {ooo_chunk_id}): {e}",
+                    "EVSClipProcessingError",
+                    500,
+                ) from e
             finally:
                 _release_inflight()
 
@@ -1546,7 +1915,13 @@ class VllmCompatible(BaseVlmModel):
 
             if clip_resp.generated:
                 content = clip_resp.response_text or ""
-                content, reasoning = self._evs_strip_thinking_tags(content)
+                # Honor preserve_reasoning_tags the way _postprocess_vllm does on
+                # the regular path: leave the raw text alone when the caller asked
+                # to keep <think> blocks in the output.
+                if preserve_reasoning_tags:
+                    content, reasoning = content.strip(), ""
+                else:
+                    content, reasoning = self._evs_strip_thinking_tags(content)
                 usage = clip_resp.response_usage or {}
 
                 # Log which time range the response actually covers
@@ -1667,6 +2042,42 @@ class VllmCompatible(BaseVlmModel):
             "fps": _ABSOLUTE_TIMESTAMP_SOURCE_FPS,
             "duration": duration,
         }
+
+    def _resolve_system_prompt(self, config: VlmGenerationConfig) -> str:
+        """Per-request system prompt, falling back to the model's default."""
+        return config.system_prompt if config.system_prompt else self._system_prompt
+
+    def _apply_reasoning_prompts(self, query_text, system_prompt, config):
+        """Add the model-appropriate ``<think>`` format instruction.
+
+        Shared by the regular generate path and the EVS session path.
+        cosmos-reason1 takes the instruction on the system prompt; cosmos-reason2
+        and cosmos-reason3 take it on the user query. Returns
+        ``(query_text, system_prompt)`` unchanged when reasoning is off or an
+        instruction is already present.
+        """
+        system_prompt = system_prompt or ""
+        if not config.enable_reasoning:
+            return query_text, system_prompt
+
+        if self._vlm_model_type == "cosmos-reason1" and "<think>" not in system_prompt:
+            system_prompt += (
+                " Answer the question in the following format: "
+                "<think>\nyour reasoning\n</think>\n\n<answer>\nyour answer\n</answer>.\n"
+            )
+        elif (
+            self._vlm_model_type in ("cosmos-reason2", "cosmos-reason3")
+            and "<think>" not in query_text
+            and "<think>" not in system_prompt
+        ):
+            query_text += (
+                "Answer the question using the following format:\n\n"
+                "<think>\n"
+                "Your reasoning.\n"
+                "</think>\n\n"
+                "Write your final answer immediately after the </think> tag.\n"
+            )
+        return query_text, system_prompt
 
     def _apply_timestamp_prompt(self, query_text, chunk, video_frames_times):
         """Prepend/append the timestamp prompt to the user query.
@@ -1794,6 +2205,14 @@ class VllmCompatible(BaseVlmModel):
                         if suffix_tpl:
                             template_parts.append(suffix_tpl)
                         ts_template = "\n".join(template_parts)
+            # Resolve the system prompt and the reasoning instruction exactly as
+            # the non-EVS path does. Both are fixed for the life of the session
+            # (see _ensure_evs_session), so they are applied here, at creation
+            # time, rather than per clip.
+            evs_system_prompt = self._resolve_system_prompt(config)
+            query_text, evs_system_prompt = self._apply_reasoning_prompts(
+                query_text, evs_system_prompt, config
+            )
             # Pass the FULL generation config (not just max_new_tokens) so the
             # session can apply the configured sampling params to its
             # event-gated generations; see _ensure_evs_session.
@@ -1804,6 +2223,7 @@ class VllmCompatible(BaseVlmModel):
                 video_frames_times,
                 chunk,
                 timestamp_prompt_template=ts_template,
+                system_prompt=evs_system_prompt,
             )
 
         # Build generation params dict for the model (excluding non-generation params)
@@ -1812,11 +2232,8 @@ class VllmCompatible(BaseVlmModel):
             "top_p": config.top_p,
             "top_k": int(config.top_k),
             "repetition_penalty": config.repetition_penalty,
+            "temperature": config.temperature,
         }
-
-        # Only include temperature if it's not 0
-        if config.temperature != 0:
-            generation_params["temperature"] = config.temperature
 
         # Set the seed
         seed = config.seed
@@ -1826,32 +2243,10 @@ class VllmCompatible(BaseVlmModel):
         torch.cuda.manual_seed_all(seed)
 
         # Handle system prompt
-        system_prompt = config.system_prompt if config.system_prompt else self._system_prompt
+        system_prompt = self._resolve_system_prompt(config)
 
         # Override system prompt in environment variable with reasoning prompt if enable_reasoning is True
-        if (
-            self._vlm_model_type == "cosmos-reason1"
-            and config.enable_reasoning
-            and "<think>" not in system_prompt
-        ):
-            system_prompt += (
-                " Answer the question in the following format: "
-                "<think>\nyour reasoning\n</think>\n\n<answer>\nyour answer\n</answer>.\n"
-            )
-
-        if (
-            self._vlm_model_type in ("cosmos-reason2", "cosmos-reason3")
-            and config.enable_reasoning
-            and "<think>" not in query_text
-            and "<think>" not in system_prompt
-        ):
-            query_text += (
-                "Answer the question using the following format:\n\n"
-                "<think>\n"
-                "Your reasoning.\n"
-                "</think>\n\n"
-                "Write your final answer immediately after the </think> tag.\n"
-            )
+        query_text, system_prompt = self._apply_reasoning_prompts(query_text, system_prompt, config)
 
         if self._vlm_model_type == "cosmos-reason1":
             cr1_frames = video_frames[0]
@@ -1867,18 +2262,13 @@ class VllmCompatible(BaseVlmModel):
         # Cap frames to VLLM_MM_PROCESSOR_VIDEO_NUM_FRAMES to prevent vLLM rejecting
         # >256 images. When fps-based chunking produces many frames (e.g. 10fps × 60s = 600),
         # uniformly subsample to the configured limit before sending to the engine.
-        max_frames_env = _get_rtvi_vllm_env(
-            "VLLM_MM_PROCESSOR_VIDEO_NUM_FRAMES",
-            "256",
-        )
-        max_frames = int(max_frames_env or "256")
-        if len(images) > 1 and len(images) > max_frames:
-            indices = torch.linspace(0, len(images) - 1, max_frames).long()
-            images = images[indices]
-            video_frames_times = [video_frames_times[i] for i in indices.tolist()]
+        max_frames = _get_max_video_frames()
+        original_frame_count = len(images)
+        images, video_frames_times = _cap_video_frames(images, video_frames_times, max_frames)
+        if len(images) != original_frame_count:
             logger.info(
                 "VLM generate: subsampled %d frames to %d (VLLM_MM_PROCESSOR_VIDEO_NUM_FRAMES)",
-                len(video_frames[0]),
+                original_frame_count,
                 max_frames,
             )
 
@@ -2051,22 +2441,15 @@ class VllmCompatible(BaseVlmModel):
                 logger.warning("Audio processing returned None — audio will NOT be sent to model")
 
         # Prepare LLM inputs
-        mm_processor_kwargs = {}
+        base_mm_processor_kwargs = {}
 
         if self._vlm_model_type == "cosmos-reason1":
-            mm_processor_kwargs["chain_of_thought"] = True
+            base_mm_processor_kwargs["chain_of_thought"] = True
 
         # Merge user-provided mm_processor_kwargs from request
-        if config.mm_processor_kwargs:
-            # Validate 'size' requires both shortest_edge and longest_edge
-            if "size" in config.mm_processor_kwargs:
-                size = config.mm_processor_kwargs["size"]
-                if isinstance(size, dict):
-                    if "shortest_edge" in size and "longest_edge" not in size:
-                        size["longest_edge"] = 12845056  # Default from NIM docs
-                    elif "longest_edge" in size and "shortest_edge" not in size:
-                        size["shortest_edge"] = 3136  # Default from NIM docs
-            mm_processor_kwargs.update(config.mm_processor_kwargs)
+        mm_processor_kwargs = _merge_mm_processor_kwargs(
+            base_mm_processor_kwargs, config.mm_processor_kwargs
+        )
 
         # Note: media_io_kwargs (fps/num_frames) controls frame sampling at the
         # RTVI pipeline level (video_file_frame_getter), NOT at the vLLM engine level.
@@ -2112,20 +2495,8 @@ class VllmCompatible(BaseVlmModel):
         # Generate response using generation parameters
         from vllm import SamplingParams
 
-        sp_kwargs = {
-            "top_p": generation_params["top_p"],
-            "top_k": generation_params["top_k"],
-            "max_tokens": generation_params["max_new_tokens"],
-            "repetition_penalty": generation_params["repetition_penalty"],
-        }
-        if config.min_tokens is not None:
-            sp_kwargs["min_tokens"] = config.min_tokens
-        env_ignore_eos = _get_rtvi_vllm_env("VLLM_IGNORE_EOS", "false").lower() == "true"
-        if env_ignore_eos or config.ignore_eos is not None:
-            sp_kwargs["ignore_eos"] = env_ignore_eos or bool(config.ignore_eos)
+        sp_kwargs = _build_vllm_sampling_kwargs(config)
         vllm_sampling_params = SamplingParams(**sp_kwargs)
-        if "temperature" in generation_params:
-            vllm_sampling_params.temperature = generation_params["temperature"]
         if self._vlm_model_type in ("cosmos-reason2", "cosmos-reason3"):
             vllm_sampling_params.no_repeat_ngram_size = 3
 
@@ -2159,15 +2530,6 @@ class VllmCompatible(BaseVlmModel):
         """Text-only generation using the vLLM engine (no multimodal data)."""
         config = generation_config or VlmGenerationConfig()
 
-        generation_params = {
-            "max_new_tokens": config.max_new_tokens,
-            "top_p": config.top_p,
-            "top_k": int(config.top_k),
-            "repetition_penalty": config.repetition_penalty,
-        }
-        if config.temperature != 0:
-            generation_params["temperature"] = config.temperature
-
         prompt = self._processor.apply_chat_template(
             messages,
             tokenize=False,
@@ -2180,20 +2542,8 @@ class VllmCompatible(BaseVlmModel):
 
         from vllm import SamplingParams
 
-        sp_kwargs = {
-            "top_p": generation_params["top_p"],
-            "top_k": generation_params["top_k"],
-            "max_tokens": generation_params["max_new_tokens"],
-            "repetition_penalty": generation_params["repetition_penalty"],
-        }
-        if config.min_tokens is not None:
-            sp_kwargs["min_tokens"] = config.min_tokens
-        env_ignore_eos = _get_rtvi_vllm_env("VLLM_IGNORE_EOS", "false").lower() == "true"
-        if env_ignore_eos or config.ignore_eos is not None:
-            sp_kwargs["ignore_eos"] = env_ignore_eos or bool(config.ignore_eos)
+        sp_kwargs = _build_vllm_sampling_kwargs(config)
         vllm_sampling_params = SamplingParams(**sp_kwargs)
-        if "temperature" in generation_params:
-            vllm_sampling_params.temperature = generation_params["temperature"]
 
         request_id = str(uuid.uuid4())
         self._inflight_req_ids.append(request_id)
@@ -2232,7 +2582,9 @@ class VllmCompatible(BaseVlmModel):
         if not final_output or not final_output.outputs:
             return [
                 VlmModelOutput(
-                    output="Error: No response generated", input_tokens=0, output_tokens=0
+                    output="Error: No response generated",
+                    input_tokens=0,
+                    output_tokens=0,
                 )
             ]
 
@@ -2286,15 +2638,6 @@ class VllmCompatible(BaseVlmModel):
         """Async generator yielding text deltas for token-level streaming."""
         config = generation_config or VlmGenerationConfig()
 
-        generation_params = {
-            "max_new_tokens": config.max_new_tokens,
-            "top_p": config.top_p,
-            "top_k": int(config.top_k),
-            "repetition_penalty": config.repetition_penalty,
-        }
-        if config.temperature != 0:
-            generation_params["temperature"] = config.temperature
-
         prompt = self._processor.apply_chat_template(
             messages,
             tokenize=False,
@@ -2307,20 +2650,8 @@ class VllmCompatible(BaseVlmModel):
 
         from vllm import SamplingParams
 
-        sp_kwargs = {
-            "top_p": generation_params["top_p"],
-            "top_k": generation_params["top_k"],
-            "max_tokens": generation_params["max_new_tokens"],
-            "repetition_penalty": generation_params["repetition_penalty"],
-        }
-        if config.min_tokens is not None:
-            sp_kwargs["min_tokens"] = config.min_tokens
-        env_ignore_eos = _get_rtvi_vllm_env("VLLM_IGNORE_EOS", "false").lower() == "true"
-        if env_ignore_eos or config.ignore_eos is not None:
-            sp_kwargs["ignore_eos"] = env_ignore_eos or bool(config.ignore_eos)
+        sp_kwargs = _build_vllm_sampling_kwargs(config)
         vllm_sampling_params = SamplingParams(**sp_kwargs)
-        if "temperature" in generation_params:
-            vllm_sampling_params.temperature = generation_params["temperature"]
 
         request_id = str(uuid.uuid4())
         self._inflight_req_ids.append(request_id)
@@ -2426,7 +2757,9 @@ class VllmCompatible(BaseVlmModel):
 
         batch_images = images.permute(0, 3, 1, 2).float()
         batch_with_borders = torch.zeros(
-            (num_images, channels, new_height, width), dtype=batch_images.dtype, device="cuda"
+            (num_images, channels, new_height, width),
+            dtype=batch_images.dtype,
+            device="cuda",
         )
 
         # Paste original images at the top (vectorized operation on GPU)
@@ -2437,7 +2770,7 @@ class VllmCompatible(BaseVlmModel):
             text_overlay = Image.new("RGBA", (width, border_height), color=(0, 0, 0, 0))
             draw = ImageDraw.Draw(text_overlay)
 
-            text = f"{float(video_frames_times[i])-float(video_frames_times[0]):.2f}s"
+            text = f"{float(video_frames_times[i]) - float(video_frames_times[0]):.2f}s"
 
             try:
                 bbox = draw.textbbox((0, 0), text, font=font)

--- a/services/rtvi/rt-embed/src/scripts/start_rtvi_embed.sh
+++ b/services/rtvi/rt-embed/src/scripts/start_rtvi_embed.sh
@@ -102,8 +102,12 @@ python3 src/utils.py 2>/dev/null
 
 FREE_GPU_MEM=$(nvidia-smi --query-gpu=memory.free --format=csv,noheader -i 0 | awk '{print $1}')
 echo "Free GPU memory is $FREE_GPU_MEM MiB"
+GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader -i 0)
 
-if [ $FREE_GPU_MEM -lt 40000 ]; then
+if [[ "$GPU_NAME" == *"Orin"* ]]; then
+    # Disable decoder resue on Orin
+    export DISABLE_DECODER_REUSE=true
+elif [[ "$FREE_GPU_MEM" =~ ^[0-9]+$ && "$FREE_GPU_MEM" -lt 40000 ]]; then
     export DISABLE_DECODER_REUSE="${DISABLE_DECODER_REUSE:-true}"
 else
     export DISABLE_DECODER_REUSE="${DISABLE_DECODER_REUSE:-false}"
@@ -138,7 +142,9 @@ fi
 
 
 if [ -z $VLM_BATCH_SIZE ]; then
-    if [[ "$GPU_MEM" == *"N/A"* || $GPU_MEM -gt 80000 ]]; then
+    if [[ "$GPU_MEM" =~ ^[0-9]+$ && "$GPU_MEM" -lt 16000 ]]; then
+        VLM_BATCH_SIZE=2
+    elif [[ "$GPU_MEM" == *"N/A"* || $GPU_MEM -gt 80000 ]]; then
         VLM_BATCH_SIZE=64
     elif [[ $GPU_MEM -gt 46000 ]]; then
         VLM_BATCH_SIZE=16

--- a/services/rtvi/rt-embed/src/vlm_pipeline/vlm_pipeline.py
+++ b/services/rtvi/rt-embed/src/vlm_pipeline/vlm_pipeline.py
@@ -2220,6 +2220,17 @@ class VlmPipeline:
             )
             lsinfo.all_chunks_processed = True
 
+        # Release the stream's EVS sessions before the map pop. The EOS-driven
+        # close (see the end-of-stream branch in the output loop) only fires on a
+        # natural end of stream and bails once the stream is out of
+        # _live_stream_id_map, so an explicitly deleted stream would otherwise
+        # leak its sessions for the life of the process -- eventually failing
+        # session creation with "max sessions reached". Sent after the drain and
+        # while drop-chunks is still active, so no in-flight chunk can recreate a
+        # session behind us. Idempotent: a stream already closed via EOS has no
+        # cache entries left.
+        self.close_evs_sessions(live_stream_id)
+
         if live_stream_lock:
             with live_stream_lock:
                 removed = self._live_stream_id_map.pop(live_stream_id, None)

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_stream_cv_api.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_stream_cv_api.py
@@ -259,6 +259,55 @@ class TestStreamAddRequest:
 class TestViosStreamRequests:
     """Test VIOS common schema parsing used by RTVI Embed."""
 
+    def test_unknown_envelope_and_event_fields_are_ignored(self):
+        req = ViosStreamAddRequest(
+            alert_type="camera_status_change",
+            created_at="2026-08-03T12:23:45Z",
+            event={
+                "camera_id": "Camera",
+                "camera_name": "Camera",
+                "camera_type": "rtsp",
+                "camera_url": "rtsp://10.24.216.43:30554/live/Camera",
+                "camera_vod_url": "rtsp://10.24.216.43:30562/vod/Camera",
+                "change": "camera_streaming",
+                "metadata": {
+                    "codec": "H264",
+                    "framerate": 30,
+                    "resolution": "1920x1080",
+                },
+                "future_event_field": {"enabled": True},
+            },
+            source="vst",
+            webhook_id="dummy-camera-streaming",
+        )
+
+        value, _headers = normalize_stream_add_request(req)
+
+        assert value.camera_id == "Camera"
+        assert value.metadata.codec == "H264"
+        assert req.model_extra is None
+        assert req.event.model_extra is None
+
+    def test_remove_ignores_unknown_envelope_and_event_fields(self):
+        req = ViosStreamRemoveRequest(
+            alert_type="camera_status_change",
+            created_at="2026-08-03T12:23:45Z",
+            event={
+                "camera_id": "Camera",
+                "camera_name": "Camera",
+                "change": "camera_remove",
+                "future_event_field": "ignored",
+            },
+            source="vst",
+            webhook_id="dummy-camera-streaming",
+        )
+
+        value, _headers = normalize_stream_remove_request(req)
+
+        assert value.camera_id == "Camera"
+        assert req.model_extra is None
+        assert req.event.model_extra is None
+
     def test_file_camera_streaming_normalizes_absolute_path_to_file_url(self):
         req = ViosStreamAddRequest(
             alert_type="camera_status_change",


### PR DESCRIPTION
## Summary
- Sync RT-Embed source files from GitLab `rtvi_embed/26.08.1` into the GitHub RT-Embed tree.
- Include the matching startup script, CE1 sample updates, vLLM-compatible source changes, pipeline updates, and stream-CV test coverage.

## Test plan
- Verified copied files match GitLab `rtvi_embed/26.08.1` exactly.
- Verified runtime source files match the `3.3.0-26.08.1` container exactly.