### PR TITLE
docs(ci): add the two post-build onboarding steps to github-first

### DIFF
--- a/.github/github-first.md
+++ b/.github/github-first.md
@@ -25,7 +25,7 @@ GitLab side.** Onboarding is entirely a change in this repo.
 
 ---
 
-## The five steps
+## The seven steps
 
 ### 1. Flip `ghcr_build` in the inventory
 
@@ -131,10 +131,46 @@ The golden diff is the point of review: it shows the resolved coordinate moving
 from NGC to GHCR in one line, which is exactly the change a reviewer should be
 asked to approve.
 
-### 5. Land it, then check the first build
+### 5. Make the GHCR package public
 
-Nothing else is required. On merge, `build-dev-images.yml` picks the image up
-from the inventory and publishes:
+A newly published GHCR package is **private by default**. The nightly deploys the
+mirrored images from `nvstaging`, and the mirror cannot read a private package —
+so a private image fails the nightly, not your PR.
+
+Check before merging:
+
+```bash
+IMG=nvidia-ai-blueprints/vss/<image-name>
+TOK=$(curl -s "https://ghcr.io/token?scope=repository:$IMG:pull" | jq -r .token)
+curl -s -H "Authorization: Bearer $TOK" "https://ghcr.io/v2/$IMG/tags/list?n=1"
+```
+
+A JSON body with `"tags"` means public. `{"errors":[{"code":"DENIED"}]}` means it
+is still private — ask **Sarath** to flip it. Visibility is per package
+name and sticky, so this is a one-time action per image.
+
+### 6. Register the image for mirror + promotion
+
+`deploy/docker/container-inventory.json` says *how the image is built*. It does
+**not** say where it is mirrored or promoted. That is a second inventory, in the
+devops repo:
+
+[`ci/vss-ghcr-images.yml`](https://gitlab-master.nvidia.com/metromind/ci-vss-oss/-/blob/main/ci/vss-ghcr-images.yml)
+
+Copy an existing `images:` block and edit it. Ask the agent what the entry should
+contain if you are unsure — the fields route the mirror and pick the
+artifacts-promotion config, and a wrong `promotion_config` promotes into the
+wrong team.
+
+Nothing fails if you skip this. The image builds and publishes to GHCR
+perfectly; it is simply invisible to the mirror, so `nvstaging` never receives
+it and the nightly deploy of that profile fails looking for an image that was
+never promoted. **An absent entry is not an error — it is silence.**
+
+### 7. Land it, then check the first build
+
+With steps 5 and 6 done, merging is all that remains. On merge,
+`build-dev-images.yml` picks the image up from the inventory and publishes:
 
 - `develop-<sha12>` — immutable per-commit candidate
 - `tree-<tree_sha>` — content-addressed, drives reuse and the post-merge retag
@@ -249,7 +285,8 @@ coordinate breaks the invariant for everyone.
 
 | | |
 |---|---|
-| Inventory | `deploy/docker/container-inventory.json` |
+| Build inventory | `deploy/docker/container-inventory.json` — how the image is built |
+| Mirror inventory | `ci-vss-oss` → `ci/vss-ghcr-images.yml` — where it is mirrored and promoted |
 | Shared coordinate | `deploy/docker/containers.env` |
 | Golden | `deploy/docker/test-scripts/compose-images.golden` |
 | Build | `.github/workflows/build-dev-images.yml` |


### PR DESCRIPTION
## Why

`.github/github-first.md` ended at *"Land it, then check the first build"* and said **"Nothing else is required."** Two things are required, and both fail on someone else rather than in the onboarding PR:

1. **A new GHCR package is private by default.** The nightly deploys the mirrored images from `nvstaging`, and the mirror cannot read a private package.
2. **`container-inventory.json` says how an image is *built*, not where it is *mirrored or promoted*.** That is a second inventory — `ci/vss-ghcr-images.yml` in `ci-vss-oss` — and an absent entry is silence, not an error.

## #1643 is the worked example, and both halves are still true today

```
ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv-mv3dt-bev-fusion
  → {"errors":[{"code":"DENIED"}]}        still private

container-inventory.json ghcr_build: true   11 images
ci/vss-ghcr-images.yml registered            9 images
missing: vss-rt-cv-mv3dt-bev-fusion, vss-rt-cv-mv3dt-config-init
```

That PR's GitHub checks were **green throughout** — no CI in this repo verifies either step. The warehouse mv3dt profile broke in the nightly instead. That gap is precisely why these belong in the guide.

## Changes

- **Step 5 — Make the GHCR package public.** With a copy-pasteable anonymous-pull check, so it can be verified before merging rather than discovered after. Names @Sarath Maddala for the flip; notes visibility is per package name and sticky, so it is one-time per image.
- **Step 6 — Register the image for mirror + promotion.** Links `ci/vss-ghcr-images.yml`, says to copy an existing block, and warns that a wrong `promotion_config` promotes into the wrong team.
- **"Nothing else is required" corrected**, and *Land it* renumbered to step 7 (heading now "The seven steps").
- **New pitfall** naming #1643, in the section that already says *"Each of these has actually happened."*
- **Reference table** split its single `Inventory` row into **build inventory** and **mirror inventory**, since conflating the two is the root of this whole class of failure.

## Not included

The actual `ci/vss-ghcr-images.yml` entries for the two mv3dt images. That file lives in `ci-vss-oss` and routing is non-obvious — the promotion configs already exist (`vss-core-rt-mv3dt-bev.yml`, `vss-core-rt-mv3dt-init.yml`) but they mirror from **different NGC teams** (`auto-calib` and `vss-warehouse` respectively, both targeting `nvstaging/vss-core`). Happy to raise that MR separately; it needs whoever owns those images to confirm the source teams.

The two packages also still need making public — that is an action, not a PR.