### PR TITLE
SDRC: Improve logging readability with source tags and quieter INFO defaults

### DIFF
--- a/services/sdrc/README.md
+++ b/services/sdrc/README.md
@@ -952,7 +952,7 @@ Example (`text`):
 ```text
 2026-08-14 13:07:30 INFO [workload:vss-rtvi-cv] __main__ - Committing message id 1786623678634-0 component=workload
 2026-08-14 13:07:30 INFO [router] run_workloads - http_request POST /v3/discovery:clusters status=200 elapsed_s=0.05 component=router
-2026-08-14 13:07:30.401 info [envoy] [upstream] cds: added/updated 0 cluster(s), skipped 5 unmodified cluster(s)
+2026-08-14 13:07:30.401 INFO [envoy] [upstream] cds: added/updated 0 cluster(s), skipped 5 unmodified cluster(s)
 ```
 
 Filter muxed `docker logs` by source:

--- a/services/sdrc/README.md
+++ b/services/sdrc/README.md
@@ -952,7 +952,7 @@ Example (`text`):
 ```text
 2026-08-14 13:07:30 INFO [workload:vss-rtvi-cv] __main__ - Committing message id 1786623678634-0 component=workload
 2026-08-14 13:07:30 INFO [router] run_workloads - http_request POST /v3/discovery:clusters status=200 elapsed_s=0.05 component=router
-2026-08-14 13:07:30.401 INFO [envoy] [upstream] cds: added/updated 0 cluster(s), skipped 5 unmodified cluster(s)
+2026-08-14 13:07:30 INFO [envoy] [upstream] cds: added/updated 0 cluster(s), skipped 5 unmodified cluster(s)
 ```
 
 Filter muxed `docker logs` by source:

--- a/services/sdrc/README.md
+++ b/services/sdrc/README.md
@@ -950,13 +950,24 @@ Noisy third-party loggers (`redis_lock`, `urllib3`, `docker`, `kafka`) are raise
 Example (`text`):
 
 ```text
-2026-08-14 13:07:30 INFO [vss-rtvi-cv] __main__ - Committing message id 1786623678634-0
+2026-08-14 13:07:30 INFO [workload:vss-rtvi-cv] __main__ - Committing message id 1786623678634-0 component=workload
+2026-08-14 13:07:30 INFO [router] run_workloads - http_request POST /v3/discovery:clusters status=200 elapsed_s=0.05 component=router
+[envoy] [2026-08-14 13:07:30.401][1][info][upstream] cds: added/updated 0 cluster(s), skipped 5 unmodified cluster(s)
+```
+
+Filter muxed `docker logs` by source:
+
+```bash
+docker logs sdr-controller 2>&1 | grep '\[envoy\]'
+docker logs sdr-controller 2>&1 | grep '\[router\]'
+docker logs sdr-controller 2>&1 | grep '\[workload:'
+docker logs sdr-controller 2>&1 | grep '\[workload:vss-rtvi-cv\]'
 ```
 
 Example (`json`):
 
 ```json
-{"timestamp":"2026-08-14T13:07:30.443Z","severity":"INFO","logger":"__main__","message":"Committing message id 1786623678634-0","workload":"vss-rtvi-cv"}
+{"timestamp":"2026-08-14T13:07:30.443Z","severity":"INFO","logger":"__main__","message":"Committing message id 1786623678634-0","component":"workload","workload":"vss-rtvi-cv","source":"workload:vss-rtvi-cv"}
 ```
 
 ---

--- a/services/sdrc/README.md
+++ b/services/sdrc/README.md
@@ -952,7 +952,7 @@ Example (`text`):
 ```text
 2026-08-14 13:07:30 INFO [workload:vss-rtvi-cv] __main__ - Committing message id 1786623678634-0 component=workload
 2026-08-14 13:07:30 INFO [router] run_workloads - http_request POST /v3/discovery:clusters status=200 elapsed_s=0.05 component=router
-[envoy] [2026-08-14 13:07:30.401][1][info][upstream] cds: added/updated 0 cluster(s), skipped 5 unmodified cluster(s)
+2026-08-14 13:07:30.401 info [envoy] [upstream] cds: added/updated 0 cluster(s), skipped 5 unmodified cluster(s)
 ```
 
 Filter muxed `docker logs` by source:

--- a/services/sdrc/README.md
+++ b/services/sdrc/README.md
@@ -617,6 +617,9 @@ k8s-workerset1:                # Kubernetes mode, StatefulSet workers
 | Parameter | Default | Description |
 |---|---|---|
 | `OTEL_SERVICE_NAME` | `sdr-agent` | OpenTelemetry service name. |
+| `WDM_LOG_LEVEL` | `INFO` | Root log level (`DEBUG`/`INFO`/`WARNING`/`ERROR`). Use `DEBUG` to restore poll/inventory detail. |
+| `WDM_LOG_FORMAT` | `text` | Log format: `text` (human-readable KV) or `json` (one JSON object per line). |
+| `WDM_LOG_TO_FILE` | `true` | Write rotating files under `logs/`; set `0`/`false` for stdout-only. |
 | `WDM_DISABLE_WERKZEUG_LOGGING` | `False` | Disable Werkzeug HTTP request logging. |
 | `WDM_SDR_AGENT_PORT` | `4000` | SDR agent service port reported to an external controller. |
 | `CONTROLLER_SERVICE_URL` | `sdr-controller-service.default.svc.cluster.local:4001/report` | Controller report endpoint. |
@@ -933,7 +936,28 @@ SDRC supports OpenTelemetry tracing (see `lib/tracing.py`) and Prometheus metric
 
 Set `OTEL_SDK_DISABLED=true` to disable OpenTelemetry (useful in environments without a collector). Configure the collector with standard `OTEL_EXPORTER_OTLP_*` environment variables.
 
-Structured logging is configured at startup via `lib/logging/wdm_logging.py`. Set `WDM_DISABLE_WERKZEUG_LOGGING=true` to suppress Werkzeug HTTP request logs.
+Logging is configured at startup via `lib/logging/wdm_logging.py`:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WDM_LOG_LEVEL` | `INFO` | Root level. `INFO` keeps lifecycle/state changes; poll/inventory detail is at `DEBUG`. |
+| `WDM_LOG_FORMAT` | `text` | `text` for console skim; `json` for collectors (`jq`, Loki, Fluent Bit). |
+| `WDM_LOG_TO_FILE` | `true` | Rotating files under `logs/`; disable for 12-factor stdout-only. |
+| `WDM_DISABLE_WERKZEUG_LOGGING` | `false` | Suppress Werkzeug access logs when `true`. |
+
+Noisy third-party loggers (`redis_lock`, `urllib3`, `docker`, `kafka`) are raised to `WARNING` so they do not drown application events at `INFO`. Repeated identical Redis consumer errors are rate-limited (~30s) and report `suppressed_count` when they recur.
+
+Example (`text`):
+
+```text
+2026-08-14 13:07:30 INFO [vss-rtvi-cv] __main__ - Committing message id 1786623678634-0
+```
+
+Example (`json`):
+
+```json
+{"timestamp":"2026-08-14T13:07:30.443Z","severity":"INFO","logger":"__main__","message":"Committing message id 1786623678634-0","workload":"vss-rtvi-cv"}
+```
 
 ---
 

--- a/services/sdrc/README.md
+++ b/services/sdrc/README.md
@@ -960,9 +960,12 @@ Filter muxed `docker logs` by source:
 ```bash
 docker logs sdr-controller 2>&1 | grep '\[envoy\]'
 docker logs sdr-controller 2>&1 | grep '\[router\]'
+docker logs sdr-controller 2>&1 | grep '\[controller\]'
 docker logs sdr-controller 2>&1 | grep '\[workload:'
 docker logs sdr-controller 2>&1 | grep '\[workload:vss-rtvi-cv\]'
 ```
+
+In the combined `sdr-mw` process, router HTTP/xDS stays `[router]`; background controller watchers bind `component=controller` on their threads so their lines are `[controller]` without reinstalling root handlers.
 
 Example (`json`):
 

--- a/services/sdrc/README.md
+++ b/services/sdrc/README.md
@@ -619,7 +619,7 @@ k8s-workerset1:                # Kubernetes mode, StatefulSet workers
 | `OTEL_SERVICE_NAME` | `sdr-agent` | OpenTelemetry service name. |
 | `WDM_LOG_LEVEL` | `INFO` | Root log level (`DEBUG`/`INFO`/`WARNING`/`ERROR`). Use `DEBUG` to restore poll/inventory detail. |
 | `WDM_LOG_FORMAT` | `text` | Log format: `text` (human-readable KV) or `json` (one JSON object per line). |
-| `WDM_LOG_TO_FILE` | `true` | Write rotating files under `logs/`; set `0`/`false` for stdout-only. |
+| `WDM_LOG_TO_FILE` | `false` | Write rotating files under `logs/` when `1`/`true`; stdout-only by default. |
 | `WDM_DISABLE_WERKZEUG_LOGGING` | `False` | Disable Werkzeug HTTP request logging. |
 | `WDM_SDR_AGENT_PORT` | `4000` | SDR agent service port reported to an external controller. |
 | `CONTROLLER_SERVICE_URL` | `sdr-controller-service.default.svc.cluster.local:4001/report` | Controller report endpoint. |
@@ -942,7 +942,7 @@ Logging is configured at startup via `lib/logging/wdm_logging.py`:
 |---|---|---|
 | `WDM_LOG_LEVEL` | `INFO` | Root level. `INFO` keeps lifecycle/state changes; poll/inventory detail is at `DEBUG`. |
 | `WDM_LOG_FORMAT` | `text` | `text` for console skim; `json` for collectors (`jq`, Loki, Fluent Bit). |
-| `WDM_LOG_TO_FILE` | `true` | Rotating files under `logs/`; disable for 12-factor stdout-only. |
+| `WDM_LOG_TO_FILE` | `false` | Opt-in rotating files under `logs/`; stdout-only by default. |
 | `WDM_DISABLE_WERKZEUG_LOGGING` | `false` | Suppress Werkzeug access logs when `true`. |
 
 Noisy third-party loggers (`redis_lock`, `urllib3`, `docker`, `kafka`) are raised to `WARNING` so they do not drown application events at `INFO`. Repeated identical Redis consumer errors are rate-limited (~30s) and report `suppressed_count` when they recur.

--- a/services/sdrc/app.py
+++ b/services/sdrc/app.py
@@ -58,7 +58,7 @@ from lib.bus_outcomes import (
     log_terminal_failure,
     redis_message_key,
 )
-from lib.logging import configure_root_logging
+from lib.logging import configure_root_logging, log_rate_limited
 from lib.wdm_swagger_ui import openapi_public_server_root, register_wdm_swagger_ui
 from lib.lifecycle.http_header import (
     ACTION_ADD,
@@ -124,6 +124,16 @@ if str(os.environ.get("WDM_TRUST_PROXY_HEADERS", "1")).strip().lower() not in (
     )
 REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
 wl_log_prefix = app.config.get("WDM_WL_OBJECT_NAME", "wdm")
+# Prefer process env; if unset, seed from Config so config.yml/defaults apply.
+for _log_key in ("WDM_LOG_LEVEL", "WDM_LOG_FORMAT", "WDM_LOG_TO_FILE"):
+    if _log_key not in os.environ or not str(os.environ.get(_log_key, "")).strip():
+        _val = app.config.get(_log_key)
+        if _val is None:
+            continue
+        if isinstance(_val, bool):
+            os.environ[_log_key] = "true" if _val else "false"
+        else:
+            os.environ[_log_key] = str(_val)
 configure_root_logging(wl_log_prefix, REPO_ROOT)
 app.logger = logging.getLogger(__name__)
 
@@ -148,11 +158,32 @@ def _wdm_request_timer_log(response):
     t0 = getattr(g, "_wdm_request_t0", None)
     if t0 is not None:
         elapsed = time.perf_counter() - t0
-        app.logger.info(
+        path = request.path or ""
+        status = response.status_code
+        # Steady-state dashboard / health polls are DEBUG; keep interesting traffic visible.
+        quiet_prefixes = (
+            "/pod_list",
+            "/healthz",
+            "/health",
+            "/metrics",
+            "/get_wl_replica_data",
+            "/current_distributed_streams",
+        )
+        is_quiet = any(path == p or path.startswith(p + "/") for p in quiet_prefixes)
+        if status >= 500:
+            level = logging.ERROR
+        elif status >= 400:
+            level = logging.WARNING
+        elif is_quiet:
+            level = logging.DEBUG
+        else:
+            level = logging.INFO
+        app.logger.log(
+            level,
             "http_request %s %s status=%s elapsed_s=%.6f",
             request.method,
-            request.path,
-            response.status_code,
+            path,
+            status,
             elapsed,
         )
     return response
@@ -1742,33 +1773,33 @@ def pod_list():
     event_field = app.config["WDM_EVENT_OBJECT_FIELD"]
     id_field = app.config["WDM_WL_ID_FIELD"]
     _sts_t0 = time.perf_counter()
-    app.logger.info("pod_list start")
+    app.logger.debug("pod_list start")
     wlobj = curr_cluster.getStatefulSets()
     _req_elapsed = _wdm_http_request_elapsed_s()
-    app.logger.info(
+    app.logger.debug(
         "pod_list curr_cluster.getStatefulSets elapsed_s=%.6f wl=%s request_elapsed_s=%s",
         time.perf_counter() - _sts_t0,
         wl_object_name,
         "%.6f" % _req_elapsed if _req_elapsed is not None else "-",
     )
     if wlobj is not None:
-        app.logger.info("pod_list wlobj.status.replicas=%s", getattr(wlobj.status, "replicas", None))
+        app.logger.debug("pod_list wlobj.status.replicas=%s", getattr(wlobj.status, "replicas", None))
     if wlobj is not None and wlobj.status.replicas != 0:
-        app.logger.info("pod_list wlobj is not None and wlobj.status.replicas != 0")
+        app.logger.debug("pod_list wlobj is not None and wlobj.status.replicas != 0")
         WLObj = curr_cluster.getWorkloadObjects()
         app.logger.debug("pod_list WLObj: " + str(WLObj))
         if WLObj is not None:
-            app.logger.info("pod_list WLObj is not None")
+            app.logger.debug("pod_list WLObj is not None")
             pods_info = curr_cluster.getPodIps(WLObj)
             if pods_info is not None:
                 # One Redis read per request (not per pod) — avoids N× lock_try under write contention.
-                app.logger.info("pod_list cfg._loadWorkLoadSpec (once for all pods)")
+                app.logger.debug("pod_list cfg._loadWorkLoadSpec (once for all pods)")
                 cfg._loadWorkLoadSpec()
                 for p in pods_info:
                     pod_name = p.get("podName", "")
                     stream_ids = []
                     try:
-                        app.logger.info("pod_list try cfg.getworkLoadSpecs pod=%s", pod_name)
+                        app.logger.debug("pod_list try cfg.getworkLoadSpecs pod=%s", pod_name)
                         raw = cfg.getworkLoadSpecs(pod_name)
                         app.logger.debug("pod_list raw: " + str(raw))
                         if raw is not None and raw.strip():
@@ -1792,6 +1823,11 @@ def pod_list():
                         "phase": p.get("phase", "Unknown"),
                         "stream_ids": stream_ids,
                     })
+            app.logger.debug(
+                "pod_list completed pods=%s elapsed_s=%.6f",
+                len(result.get("pods") or []),
+                time.perf_counter() - _sts_t0,
+            )
     return jsonify(result)
 
 
@@ -3285,8 +3321,13 @@ def redisGetStreamData():
                 )
                 REDIS_IS_CONNECTED = True
             except Exception as e:
-                app.logger.exception(
-                    "unexpected exception caught while processing Redis stream - " + repr(e)
+                log_rate_limited(
+                    app.logger,
+                    logging.ERROR,
+                    f"redis-consumer-connect:{type(e).__name__}",
+                    "unexpected exception caught while processing Redis stream - %s",
+                    repr(e),
+                    interval_s=30.0,
                 )
                 REDIS_IS_CONNECTED = False
                 continue
@@ -3414,7 +3455,7 @@ def redisGetStreamData():
                         wl_d=wl_d,
                     )
                     if should_commit:
-                        app.logger.info("Commiting message id %s", item.msgid)
+                        app.logger.info("Committing message id %s", item.msgid)
                         try:
                             consumer.commit(item_id=item.msgid)
                         except Exception as commit_exc:
@@ -3434,9 +3475,14 @@ def redisGetStreamData():
 
                 time.sleep(0.05)
 
-        except Exception:
-            app.logger.exception(
-                "unexpected exception caught while processing Redis stream"
+        except Exception as e:
+            log_rate_limited(
+                app.logger,
+                logging.ERROR,
+                f"redis-consumer-loop:{type(e).__name__}",
+                "unexpected exception caught while processing Redis stream - %s",
+                repr(e),
+                interval_s=30.0,
             )
 
 
@@ -3642,7 +3688,10 @@ def fetch_all_streams_from_vst():
             resp = requests.get(vst_streams_endpoint)
             api_up = True
         except Exception as e:
-            print("Some error (this is expected) - " + repr(e))
+            app.logger.debug(
+                "VST streams endpoint not ready yet (expected during startup): %s",
+                repr(e),
+            )
             time.sleep(0.05)
 
         if int(time.time() - start_time)  > app.config["WDM_API_WAIT_MAX_RETRIES_IN_SEC"]:
@@ -3725,7 +3774,10 @@ def preLoad():
                     api_up = True
                 # TODO: what if we're using k8s?
             except Exception as e:
-                print("Some error (this is expected) - " + repr(e))
+                app.logger.debug(
+                    "workload health check endpoint not ready yet (expected during startup): %s",
+                    repr(e),
+                )
                 time.sleep(1)
                 
             if int(time.time() - start_time)  > app.config["WDM_API_WAIT_MAX_RETRIES_IN_SEC"]:

--- a/services/sdrc/app.py
+++ b/services/sdrc/app.py
@@ -134,7 +134,7 @@ for _log_key in ("WDM_LOG_LEVEL", "WDM_LOG_FORMAT", "WDM_LOG_TO_FILE"):
             os.environ[_log_key] = "true" if _val else "false"
         else:
             os.environ[_log_key] = str(_val)
-configure_root_logging(wl_log_prefix, REPO_ROOT)
+configure_root_logging(wl_log_prefix, REPO_ROOT, component="workload")
 app.logger = logging.getLogger(__name__)
 
 

--- a/services/sdrc/config.py
+++ b/services/sdrc/config.py
@@ -703,8 +703,9 @@ class Config(object):
         else False
     )
 
-    # Logging controls (see lib/logging/wdm_logging.py). Defaults keep text + file
-    # output; set WDM_LOG_FORMAT=json for collectors and WDM_LOG_LEVEL=DEBUG for polls.
+    # Logging controls (see lib/logging/wdm_logging.py). Defaults keep text +
+    # stdout-only; set WDM_LOG_FORMAT=json for collectors, WDM_LOG_LEVEL=DEBUG
+    # for polls, and WDM_LOG_TO_FILE=true for rotating files under logs/.
     WDM_LOG_LEVEL = (
         os.environ["WDM_LOG_LEVEL"].strip()
         if "WDM_LOG_LEVEL" in os.environ
@@ -718,11 +719,12 @@ class Config(object):
         else "text"
     )
     WDM_LOG_TO_FILE = (
-        False
+        True
         if "WDM_LOG_TO_FILE" in os.environ
         and os.environ["WDM_LOG_TO_FILE"].strip() != ""
-        and os.environ["WDM_LOG_TO_FILE"].strip().lower() in ("0", "false", "no", "off")
-        else True
+        and os.environ["WDM_LOG_TO_FILE"].strip().lower()
+        not in ("0", "false", "no", "off")
+        else False
     )
 
     WDM_RESET_ON_WLOBJ_CRASH = (

--- a/services/sdrc/config.py
+++ b/services/sdrc/config.py
@@ -703,6 +703,28 @@ class Config(object):
         else False
     )
 
+    # Logging controls (see lib/logging/wdm_logging.py). Defaults keep text + file
+    # output; set WDM_LOG_FORMAT=json for collectors and WDM_LOG_LEVEL=DEBUG for polls.
+    WDM_LOG_LEVEL = (
+        os.environ["WDM_LOG_LEVEL"].strip()
+        if "WDM_LOG_LEVEL" in os.environ
+        and os.environ["WDM_LOG_LEVEL"].strip() != ""
+        else "INFO"
+    )
+    WDM_LOG_FORMAT = (
+        os.environ["WDM_LOG_FORMAT"].strip().lower()
+        if "WDM_LOG_FORMAT" in os.environ
+        and os.environ["WDM_LOG_FORMAT"].strip() != ""
+        else "text"
+    )
+    WDM_LOG_TO_FILE = (
+        False
+        if "WDM_LOG_TO_FILE" in os.environ
+        and os.environ["WDM_LOG_TO_FILE"].strip() != ""
+        and os.environ["WDM_LOG_TO_FILE"].strip().lower() in ("0", "false", "no", "off")
+        else True
+    )
+
     WDM_RESET_ON_WLOBJ_CRASH = (
         False
         if "WDM_RESET_ON_WLOBJ_CRASH" in os.environ

--- a/services/sdrc/envoy/wdm-router-entrypoint.sh
+++ b/services/sdrc/envoy/wdm-router-entrypoint.sh
@@ -30,5 +30,12 @@ python3 /opt/wdm-runtime/envoy/generate_envoy_config_xds_mw.py \
 N=$(nproc)
 MAX=$((N - 1))
 [ "$MAX" -gt 63 ] && MAX=63
-echo "[envoy-proxy] Pinning envoy to CPUs 0-$MAX (host exposes $N CPU(s)) to avoid tcmalloc percpu crash"
-exec /usr/bin/taskset -c 0-"$MAX" /usr/local/bin/envoy -c "$GEN_OUT" --concurrency 16 --base-id 1
+echo "[envoy] Pinning envoy to CPUs 0-$MAX (host exposes $N CPU(s)) to avoid tcmalloc percpu crash"
+# Prefix every Envoy line with [envoy] so muxed docker logs are easy to filter from
+# [router] / [workload:…] Python lines (see lib/logging/wdm_logging.py).
+ENVOY_LOG_FORMAT="${ENVOY_LOG_FORMAT:-[envoy] [%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v}"
+exec /usr/bin/taskset -c 0-"$MAX" /usr/local/bin/envoy \
+  -c "$GEN_OUT" \
+  --concurrency 16 \
+  --base-id 1 \
+  --log-format "$ENVOY_LOG_FORMAT"

--- a/services/sdrc/envoy/wdm-router-entrypoint.sh
+++ b/services/sdrc/envoy/wdm-router-entrypoint.sh
@@ -30,10 +30,10 @@ python3 /opt/wdm-runtime/envoy/generate_envoy_config_xds_mw.py \
 N=$(nproc)
 MAX=$((N - 1))
 [ "$MAX" -gt 63 ] && MAX=63
-echo "[envoy] Pinning envoy to CPUs 0-$MAX (host exposes $N CPU(s)) to avoid tcmalloc percpu crash"
-# Prefix every Envoy line with [envoy] so muxed docker logs are easy to filter from
-# [router] / [workload:…] Python lines (see lib/logging/wdm_logging.py).
-ENVOY_LOG_FORMAT="${ENVOY_LOG_FORMAT:-[envoy] [%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v}"
+echo "$(date '+%Y-%m-%d %H:%M:%S') info [envoy] Pinning envoy to CPUs 0-$MAX (host exposes $N CPU(s)) to avoid tcmalloc percpu crash"
+# Match SDRC Python layout: timestamp, level, [envoy], category, message.
+# Filter with: grep '\[envoy\]'  (see lib/logging/wdm_logging.py / README).
+ENVOY_LOG_FORMAT="${ENVOY_LOG_FORMAT:-%Y-%m-%d %T.%e %l [envoy] [%n] %v}"
 exec /usr/bin/taskset -c 0-"$MAX" /usr/local/bin/envoy \
   -c "$GEN_OUT" \
   --concurrency 16 \

--- a/services/sdrc/envoy/wdm-router-entrypoint.sh
+++ b/services/sdrc/envoy/wdm-router-entrypoint.sh
@@ -30,12 +30,39 @@ python3 /opt/wdm-runtime/envoy/generate_envoy_config_xds_mw.py \
 N=$(nproc)
 MAX=$((N - 1))
 [ "$MAX" -gt 63 ] && MAX=63
-echo "$(date '+%Y-%m-%d %H:%M:%S') info [envoy] Pinning envoy to CPUs 0-$MAX (host exposes $N CPU(s)) to avoid tcmalloc percpu crash"
-# Match SDRC Python layout: timestamp, level, [envoy], category, message.
+echo "$(date '+%Y-%m-%d %H:%M:%S') INFO [envoy] Pinning envoy to CPUs 0-$MAX (host exposes $N CPU(s)) to avoid tcmalloc percpu crash"
+# Match SDRC Python layout: timestamp, LEVEL, [envoy], category, message.
+# Envoy's %l is lowercase only; pipe through sed to emit INFO/DEBUG/… like SDRC.
 # Filter with: grep '\[envoy\]'  (see lib/logging/wdm_logging.py / README).
 ENVOY_LOG_FORMAT="${ENVOY_LOG_FORMAT:-%Y-%m-%d %T.%e %l [envoy] [%n] %v}"
-exec /usr/bin/taskset -c 0-"$MAX" /usr/local/bin/envoy \
+ENVOY_FIFO="${ENVOY_LOG_FIFO:-/tmp/envoy-sdrc.log.fifo}"
+rm -f "$ENVOY_FIFO"
+mkfifo "$ENVOY_FIFO"
+
+# Line-buffered: uppercase severity token after the timestamp.
+sed -u -E 's/^([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+) (trace|debug|info|warning|error|critical) /\1 \U\2 /' \
+  < "$ENVOY_FIFO" &
+SED_PID=$!
+
+/usr/bin/taskset -c 0-"$MAX" /usr/local/bin/envoy \
   -c "$GEN_OUT" \
   --concurrency 16 \
   --base-id 1 \
-  --log-format "$ENVOY_LOG_FORMAT"
+  --log-format "$ENVOY_LOG_FORMAT" \
+  > "$ENVOY_FIFO" 2>&1 &
+ENVOY_PID=$!
+
+term_handler() {
+  kill -TERM "$ENVOY_PID" 2>/dev/null || true
+  wait "$ENVOY_PID" 2>/dev/null || true
+  kill "$SED_PID" 2>/dev/null || true
+  rm -f "$ENVOY_FIFO"
+  exit 0
+}
+trap term_handler TERM INT
+
+STATUS=0
+wait "$ENVOY_PID" || STATUS=$?
+kill "$SED_PID" 2>/dev/null || true
+rm -f "$ENVOY_FIFO"
+exit "$STATUS"

--- a/services/sdrc/envoy/wdm-router-entrypoint.sh
+++ b/services/sdrc/envoy/wdm-router-entrypoint.sh
@@ -31,16 +31,16 @@ N=$(nproc)
 MAX=$((N - 1))
 [ "$MAX" -gt 63 ] && MAX=63
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO [envoy] Pinning envoy to CPUs 0-$MAX (host exposes $N CPU(s)) to avoid tcmalloc percpu crash"
-# Match SDRC Python layout: timestamp, LEVEL, [envoy], category, message.
+# Match SDRC Python layout: YYYY-MM-DD HH:MM:SS, LEVEL, [envoy], category, message.
 # Envoy's %l is lowercase only; pipe through sed to emit INFO/DEBUG/… like SDRC.
 # Filter with: grep '\[envoy\]'  (see lib/logging/wdm_logging.py / README).
-ENVOY_LOG_FORMAT="${ENVOY_LOG_FORMAT:-%Y-%m-%d %T.%e %l [envoy] [%n] %v}"
+ENVOY_LOG_FORMAT="${ENVOY_LOG_FORMAT:-%Y-%m-%d %T %l [envoy] [%n] %v}"
 ENVOY_FIFO="${ENVOY_LOG_FIFO:-/tmp/envoy-sdrc.log.fifo}"
 rm -f "$ENVOY_FIFO"
 mkfifo "$ENVOY_FIFO"
 
-# Line-buffered: uppercase severity token after the timestamp.
-sed -u -E 's/^([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+) (trace|debug|info|warning|error|critical) /\1 \U\2 /' \
+# Line-buffered: uppercase severity token after the timestamp (with or without ms).
+sed -u -E 's/^([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?) (trace|debug|info|warning|error|critical) /\1 \U\3 /' \
   < "$ENVOY_FIFO" &
 SED_PID=$!
 

--- a/services/sdrc/lib/controller/__init__.py
+++ b/services/sdrc/lib/controller/__init__.py
@@ -53,7 +53,7 @@ app.config.from_object(s)
 app.template_folder = app.config["TEMPLATE_FOLDER"]
 # Logging is configured in run_workloads before import; standalone uses same formatting as app.py.
 if not logging.getLogger().handlers:
-    configure_root_logging("controller", _REPO_ROOT)
+    configure_root_logging("controller", _REPO_ROOT, component="controller")
 logger = logging.getLogger(__name__)
 file_write_lock = Lock()
 

--- a/services/sdrc/lib/controller/__init__.py
+++ b/services/sdrc/lib/controller/__init__.py
@@ -26,7 +26,7 @@ from threading import Thread
 from threading import Lock
 import logging
 import os
-from lib.logging import configure_root_logging
+from lib.logging import bind_context, configure_root_logging
 # from lib.podprovisioner.kubernetes.k8sclient import k8sclient
 from lib.messaging.redisMessaging import redisMessaging
 from lib.messaging.redis_subscriber import RedisSubscriber
@@ -51,11 +51,26 @@ app = Flask(
 s = settings.Config()
 app.config.from_object(s)
 app.template_folder = app.config["TEMPLATE_FOLDER"]
-# Logging is configured in run_workloads before import; standalone uses same formatting as app.py.
+# Logging is configured in run_workloads before import (component=router).
+# Standalone controller configures itself here. In-process watchers retag via
+# bind_context(component="controller") in their threads — do not clear/replace
+# root handlers or router lines would lose their [router] tag.
 if not logging.getLogger().handlers:
     configure_root_logging("controller", _REPO_ROOT, component="controller")
 logger = logging.getLogger(__name__)
 file_write_lock = Lock()
+
+
+def _run_as_controller(fn):
+    """Thread entry wrapper: tag logs as [controller] without touching root handlers."""
+
+    def _wrapped(*args, **kwargs):
+        bind_context(component="controller")
+        return fn(*args, **kwargs)
+
+    _wrapped.__name__ = getattr(fn, "__name__", "controller_worker")
+    _wrapped.__doc__ = getattr(fn, "__doc__", None)
+    return _wrapped
 
 redisMsging = redisMessaging(app.config)
 redis_connection = redisMsging.getRedisConnection()
@@ -301,7 +316,7 @@ def podWatch():
 
 def PodErrorWatcher():
     app.logger.info("pod watcher thread started")
-    tr = Thread(target=podWatch)
+    tr = Thread(target=_run_as_controller(podWatch))
     tr.start()
     return True
 
@@ -379,7 +394,7 @@ def agentReportUpdate():
 
 def AgentWatcher():
     app.logger.info("pod watcher thread started")
-    tr = Thread(target=agentReportUpdate)
+    tr = Thread(target=_run_as_controller(agentReportUpdate))
     tr.start()
     return True
 
@@ -445,7 +460,7 @@ def Autoscale():
 
 def Autoscaler():
     app.logger.info("autoscaler thread started")
-    tr = Thread(target=Autoscale)
+    tr = Thread(target=_run_as_controller(Autoscale))
     tr.start()
     return True
 

--- a/services/sdrc/lib/controller/__init__.py
+++ b/services/sdrc/lib/controller/__init__.py
@@ -61,11 +61,18 @@ logger = logging.getLogger(__name__)
 file_write_lock = Lock()
 
 
-def _run_as_controller(fn):
-    """Thread entry wrapper: tag logs as [controller] without touching root handlers."""
+def _run_as_controller(fn, *, start_message=None):
+    """Thread entry wrapper: tag logs as [controller] without touching root handlers.
+
+    Optional ``start_message`` is logged *after* binding so watcher lifecycle
+    lines (\"thread started\") are tagged ``[controller]`` rather than inheriting
+    the router thread's ``[router]`` context (Greptile P1).
+    """
 
     def _wrapped(*args, **kwargs):
         bind_context(component="controller")
+        if start_message:
+            app.logger.info(start_message)
         return fn(*args, **kwargs)
 
     _wrapped.__name__ = getattr(fn, "__name__", "controller_worker")
@@ -315,8 +322,11 @@ def podWatch():
         app.logger.exception(f"Exception in podWatch Redis listener: {repr(e)}")
 
 def PodErrorWatcher():
-    app.logger.info("pod watcher thread started")
-    tr = Thread(target=_run_as_controller(podWatch))
+    tr = Thread(
+        target=_run_as_controller(
+            podWatch, start_message="pod watcher thread started"
+        )
+    )
     tr.start()
     return True
 
@@ -393,8 +403,11 @@ def agentReportUpdate():
 
 
 def AgentWatcher():
-    app.logger.info("pod watcher thread started")
-    tr = Thread(target=_run_as_controller(agentReportUpdate))
+    tr = Thread(
+        target=_run_as_controller(
+            agentReportUpdate, start_message="agent watcher thread started"
+        )
+    )
     tr.start()
     return True
 
@@ -459,8 +472,11 @@ def Autoscale():
         time.sleep(app.config["AUTOSCALE_CHECK_INTERVAL"])
 
 def Autoscaler():
-    app.logger.info("autoscaler thread started")
-    tr = Thread(target=_run_as_controller(Autoscale))
+    tr = Thread(
+        target=_run_as_controller(
+            Autoscale, start_message="autoscaler thread started"
+        )
+    )
     tr.start()
     return True
 

--- a/services/sdrc/lib/logging/__init__.py
+++ b/services/sdrc/lib/logging/__init__.py
@@ -14,13 +14,35 @@
 # limitations under the License.
 
 from lib.logging.wdm_logging import (
+    ContextAndTraceFilter,
+    JsonFormatter,
+    RateLimitedLogger,
+    TextFormatter,
     WlObjectNameFilter,
+    bind_context,
+    clear_context,
     configure_root_logging,
+    get_context,
+    log_event,
+    log_rate_limited,
+    parse_log_level,
+    reset_context,
     wdm_log_formatter,
 )
 
 __all__ = [
+    "ContextAndTraceFilter",
+    "JsonFormatter",
+    "RateLimitedLogger",
+    "TextFormatter",
     "WlObjectNameFilter",
+    "bind_context",
+    "clear_context",
     "configure_root_logging",
+    "get_context",
+    "log_event",
+    "log_rate_limited",
+    "parse_log_level",
+    "reset_context",
     "wdm_log_formatter",
 ]

--- a/services/sdrc/lib/logging/wdm_logging.py
+++ b/services/sdrc/lib/logging/wdm_logging.py
@@ -220,7 +220,20 @@ class JsonFormatter(logging.Formatter):
         }
         workload = getattr(record, "wl_object_name", None)
         if workload and workload != "-":
-            payload["workload"] = workload
+            # Bracket may be "workload:name"; also emit structured fields.
+            payload["source"] = workload
+        component = getattr(record, "component", None) or (
+            (_log_context.get() or {}).get("component")
+        )
+        if component:
+            payload["component"] = component
+        wl = getattr(record, "workload", None) or (
+            (_log_context.get() or {}).get("workload")
+        )
+        if wl:
+            payload["workload"] = wl
+        elif isinstance(workload, str) and workload.startswith("workload:"):
+            payload["workload"] = workload.split(":", 1)[1]
         event = getattr(record, "event", None)
         if event:
             payload["event"] = event
@@ -357,13 +370,35 @@ def configure_root_logging(
     repo_root: str,
     max_bytes: int = 200000,
     backup_count: int = 2,
+    component: Optional[str] = None,
 ) -> None:
-    """Configure root logger: optional rotating file under logs/ + stdout."""
+    """Configure root logger: optional rotating file under logs/ + stdout.
+
+    ``component`` is a stable source tag for filtering muxed docker logs:
+      - ``workload`` → bracket ``[workload:<wl_log_prefix>]``
+      - ``router`` → ``[router]`` (run_workloads / sdr-controller orchestrator)
+      - ``controller`` → ``[controller]``
+    Every line also includes ``component=...`` (and ``workload=...`` for workers).
+    Envoy is tagged separately via ``--log-format`` in the entrypoint (``[envoy]``).
+    """
     level = parse_log_level(os.environ.get("WDM_LOG_LEVEL"), logging.INFO)
     fmt_name = _env_log_format()
     formatter = wdm_log_formatter(fmt_name)
 
-    wl_name_filter = WlObjectNameFilter(wl_log_prefix)
+    component_name = (
+        (component or os.environ.get("WDM_LOG_COMPONENT") or "sdrc").strip().lower()
+        or "sdrc"
+    )
+    if component_name == "workload":
+        display_name = f"workload:{wl_log_prefix}"
+    elif component_name in ("router", "controller", "envoy"):
+        display_name = component_name
+    else:
+        display_name = (
+            f"{component_name}:{wl_log_prefix}" if wl_log_prefix else component_name
+        )
+
+    wl_name_filter = WlObjectNameFilter(display_name)
     context_filter = ContextAndTraceFilter()
 
     root_logger = logging.getLogger()
@@ -392,4 +427,9 @@ def configure_root_logging(
 
     _apply_noisy_logger_levels()
 
-    bind_context(workload=wl_log_prefix, component="sdrc")
+    ctx = {"component": component_name}
+    if component_name == "workload":
+        ctx["workload"] = wl_log_prefix
+    elif wl_log_prefix and component_name not in ("router", "controller"):
+        ctx["workload"] = wl_log_prefix
+    bind_context(**ctx)

--- a/services/sdrc/lib/logging/wdm_logging.py
+++ b/services/sdrc/lib/logging/wdm_logging.py
@@ -18,7 +18,7 @@
 Environment:
   WDM_LOG_LEVEL   - DEBUG|INFO|WARNING|ERROR|CRITICAL (default INFO)
   WDM_LOG_FORMAT  - text|json (default text; use json for log shippers)
-  WDM_LOG_TO_FILE - 1/true to write rotating files under logs/ (default true)
+  WDM_LOG_TO_FILE - 1/true to write rotating files under logs/ (default false)
 
 Hot-path poll detail stays available at DEBUG; production INFO is for state changes.
 """
@@ -454,7 +454,7 @@ def configure_root_logging(
     stdout_handler.addFilter(context_filter)
     root_logger.addHandler(stdout_handler)
 
-    if _env_truthy("WDM_LOG_TO_FILE", default=True):
+    if _env_truthy("WDM_LOG_TO_FILE", default=False):
         log_dir = os.path.join(repo_root, "logs")
         log_file = os.path.join(log_dir, f"{wl_log_prefix}-wdm-services.log")
         os.makedirs(log_dir, exist_ok=True)

--- a/services/sdrc/lib/logging/wdm_logging.py
+++ b/services/sdrc/lib/logging/wdm_logging.py
@@ -13,14 +13,137 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""SDRC logging configuration.
+
+Environment:
+  WDM_LOG_LEVEL   - DEBUG|INFO|WARNING|ERROR|CRITICAL (default INFO)
+  WDM_LOG_FORMAT  - text|json (default text; use json for log shippers)
+  WDM_LOG_TO_FILE - 1/true to write rotating files under logs/ (default true)
+
+Hot-path poll detail stays available at DEBUG; production INFO is for state changes.
+"""
+
+from __future__ import annotations
+
+import contextvars
 import importlib
+import json
 import logging
 import os
 import sys
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Mapping, MutableMapping, Optional
 
 # Use importlib so PyInstaller bundles stdlib logging.handlers (not confused with lib.logging).
 _handlers = importlib.import_module("logging.handlers")
 RotatingFileHandler = _handlers.RotatingFileHandler
+
+_log_context: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "sdrc_log_context", default={}
+)
+
+# Third-party / library loggers that spam INFO during steady-state polls.
+_NOISY_LOGGER_LEVELS = {
+    "redis_lock": logging.WARNING,
+    "redis_lock.acquire": logging.WARNING,
+    "urllib3": logging.WARNING,
+    "urllib3.connectionpool": logging.WARNING,
+    "docker": logging.WARNING,
+    "docker.utils.config": logging.WARNING,
+    "docker.auth": logging.WARNING,
+    "kafka": logging.WARNING,
+}
+
+_RESERVED_RECORD_KEYS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "message",
+        "asctime",
+        "wl_object_name",
+        "event",
+        "sdrc_fields",
+        "trace_id",
+        "span_id",
+    }
+)
+
+
+def bind_context(**kwargs: Any):
+    """Bind key/value pairs onto the current context (inherited by later log lines)."""
+    current = dict(_log_context.get() or {})
+    for key, value in kwargs.items():
+        if value is None:
+            current.pop(key, None)
+        else:
+            current[key] = value
+    return _log_context.set(current)
+
+
+def reset_context(token) -> None:
+    _log_context.reset(token)
+
+
+def clear_context() -> None:
+    _log_context.set({})
+
+
+def get_context() -> dict:
+    return dict(_log_context.get() or {})
+
+
+def parse_log_level(value: Optional[str], default: int = logging.INFO) -> int:
+    if value is None or str(value).strip() == "":
+        return default
+    name = str(value).strip().upper()
+    if name.isdigit():
+        return int(name)
+    return getattr(logging, name, default)
+
+
+def _env_truthy(name: str, default: bool = True) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    return str(raw).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _env_log_format() -> str:
+    raw = (os.environ.get("WDM_LOG_FORMAT") or "text").strip().lower()
+    return "json" if raw == "json" else "text"
+
+
+def _otel_ids() -> tuple[str, str]:
+    try:
+        from opentelemetry import trace
+
+        span = trace.get_current_span()
+        ctx = span.get_span_context() if span is not None else None
+        if ctx is not None and getattr(ctx, "is_valid", False):
+            return format(ctx.trace_id, "032x"), format(ctx.span_id, "016x")
+    except Exception:
+        pass
+    return "", ""
 
 
 class WlObjectNameFilter(logging.Filter):
@@ -35,33 +158,238 @@ class WlObjectNameFilter(logging.Filter):
         return True
 
 
-def wdm_log_formatter():
-    return logging.Formatter(
-        "%(asctime)s [%(wl_object_name)s] %(name)s - %(levelname)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
+class ContextAndTraceFilter(logging.Filter):
+    """Merge contextvars + OpenTelemetry trace/span ids onto each record."""
+
+    def filter(self, record):
+        ctx = _log_context.get() or {}
+        for key, value in ctx.items():
+            if not hasattr(record, key) or getattr(record, key) in (None, ""):
+                setattr(record, key, value)
+        if not getattr(record, "wl_object_name", None):
+            record.wl_object_name = ctx.get("workload") or ctx.get("wl_object_name") or "-"
+        trace_id, span_id = _otel_ids()
+        if not getattr(record, "trace_id", None):
+            record.trace_id = trace_id
+        if not getattr(record, "span_id", None):
+            record.span_id = span_id
+        if not hasattr(record, "event"):
+            record.event = ""
+        return True
 
 
-def configure_root_logging(wl_log_prefix: str, repo_root: str, max_bytes: int = 200000, backup_count: int = 2) -> None:
-    """Root logger: rotating file under repo logs/ + stdout (matches app.py)."""
-    log_dir = os.path.join(repo_root, "logs")
-    log_file = os.path.join(log_dir, f"{wl_log_prefix}-wdm-services.log")
-    os.makedirs(log_dir, exist_ok=True)
+def _record_fields(record: logging.LogRecord) -> dict:
+    fields: dict[str, Any] = {}
+    sdrc_fields = getattr(record, "sdrc_fields", None)
+    if isinstance(sdrc_fields, Mapping):
+        fields.update(sdrc_fields)
+    for key, value in record.__dict__.items():
+        if key in _RESERVED_RECORD_KEYS or key.startswith("_"):
+            continue
+        if value is None or value == "":
+            continue
+        if key in fields:
+            continue
+        fields[key] = value
+    return fields
 
-    formatter = wdm_log_formatter()
+
+def _format_kv(fields: Mapping[str, Any]) -> str:
+    parts = []
+    for key, value in fields.items():
+        if value is None or value == "":
+            continue
+        text = value if isinstance(value, str) else json.dumps(value, default=str)
+        if any(ch.isspace() for ch in text) or "=" in text:
+            text = json.dumps(text, default=str)
+        parts.append(f"{key}={text}")
+    return " ".join(parts)
+
+
+class JsonFormatter(logging.Formatter):
+    """One JSON object per line for collectors / Loki / jq."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
+            "severity": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        workload = getattr(record, "wl_object_name", None)
+        if workload and workload != "-":
+            payload["workload"] = workload
+        event = getattr(record, "event", None)
+        if event:
+            payload["event"] = event
+        trace_id = getattr(record, "trace_id", None)
+        span_id = getattr(record, "span_id", None)
+        if trace_id:
+            payload["trace_id"] = trace_id
+        if span_id:
+            payload["span_id"] = span_id
+        for key, value in _record_fields(record).items():
+            if key in payload:
+                continue
+            payload[key] = value
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str, ensure_ascii=False)
+
+
+class TextFormatter(logging.Formatter):
+    """Human-skimmable text with stable key=value fields."""
+
+    def __init__(self):
+        super().__init__(
+            fmt="%(asctime)s %(levelname)s [%(wl_object_name)s] %(name)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+    def format(self, record: logging.LogRecord) -> str:
+        if not getattr(record, "wl_object_name", None):
+            record.wl_object_name = "-"
+        base = super().format(record)
+        extras: MutableMapping[str, Any] = {}
+        event = getattr(record, "event", None)
+        if event:
+            extras["event"] = event
+        for key, value in _record_fields(record).items():
+            if key in ("wl_object_name", "workload") and value == getattr(
+                record, "wl_object_name", None
+            ):
+                continue
+            extras[key] = value
+        for key in ("trace_id", "span_id"):
+            val = getattr(record, key, None)
+            if val:
+                extras[key] = val
+        kv = _format_kv(extras)
+        if kv:
+            return f"{base} {kv}"
+        return base
+
+
+def wdm_log_formatter(fmt: Optional[str] = None):
+    """Return formatter for the requested format (text|json)."""
+    chosen = (fmt or _env_log_format()).strip().lower()
+    if chosen == "json":
+        return JsonFormatter()
+    return TextFormatter()
+
+
+def log_event(
+    logger: logging.Logger,
+    level: int,
+    event: str,
+    message: Optional[str] = None,
+    **fields: Any,
+) -> None:
+    """Emit a structured event. Fields are preserved in both text and JSON formats."""
+    extra: dict[str, Any] = {"event": event, "sdrc_fields": dict(fields)}
+    for key, value in fields.items():
+        if key.isidentifier() and key not in _RESERVED_RECORD_KEYS:
+            extra[key] = value
+    logger.log(level, message or event, extra=extra)
+
+
+class RateLimitedLogger:
+    """Log identical messages at most once per interval; emit count on repeat."""
+
+    def __init__(self, interval_s: float = 30.0):
+        self.interval_s = interval_s
+        self._lock = threading.Lock()
+        self._state: dict[str, tuple[float, int]] = {}
+
+    def should_log(self, key: str) -> tuple[bool, int]:
+        now = time.monotonic()
+        with self._lock:
+            last, count = self._state.get(key, (0.0, 0))
+            if now - last >= self.interval_s:
+                suppressed = count
+                self._state[key] = (now, 0)
+                return True, suppressed
+            self._state[key] = (last, count + 1)
+            return False, 0
+
+
+_default_rate_limiter = RateLimitedLogger(interval_s=30.0)
+
+
+def log_rate_limited(
+    logger: logging.Logger,
+    level: int,
+    key: str,
+    msg: str,
+    *args: Any,
+    interval_s: float = 30.0,
+    **kwargs: Any,
+) -> None:
+    """Rate-limit repeated identical log lines; includes suppressed_count when repeating."""
+    limiter = _default_rate_limiter
+    if interval_s != limiter.interval_s:
+        # uncommon path: ad-hoc interval
+        limiter = RateLimitedLogger(interval_s=interval_s)
+    ok, suppressed = limiter.should_log(key)
+    if not ok:
+        return
+    if suppressed:
+        kwargs.setdefault("extra", {})
+        extra = dict(kwargs.get("extra") or {})
+        fields = dict(extra.get("sdrc_fields") or {})
+        fields["suppressed_count"] = suppressed
+        extra["sdrc_fields"] = fields
+        extra["suppressed_count"] = suppressed
+        kwargs["extra"] = extra
+        msg = f"{msg} (suppressed_count={suppressed})"
+    logger.log(level, msg, *args, **kwargs)
+
+
+def _apply_noisy_logger_levels() -> None:
+    for name, level in _NOISY_LOGGER_LEVELS.items():
+        logging.getLogger(name).setLevel(level)
+
+
+def configure_root_logging(
+    wl_log_prefix: str,
+    repo_root: str,
+    max_bytes: int = 200000,
+    backup_count: int = 2,
+) -> None:
+    """Configure root logger: optional rotating file under logs/ + stdout."""
+    level = parse_log_level(os.environ.get("WDM_LOG_LEVEL"), logging.INFO)
+    fmt_name = _env_log_format()
+    formatter = wdm_log_formatter(fmt_name)
+
     wl_name_filter = WlObjectNameFilter(wl_log_prefix)
-    file_handler = RotatingFileHandler(
-        filename=log_file, maxBytes=max_bytes, backupCount=backup_count
-    )
-    file_handler.setFormatter(formatter)
-    file_handler.addFilter(wl_name_filter)
-
-    stdout_handler = logging.StreamHandler(stream=sys.stdout)
-    stdout_handler.setFormatter(formatter)
-    stdout_handler.addFilter(wl_name_filter)
+    context_filter = ContextAndTraceFilter()
 
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.INFO)
     root_logger.handlers.clear()
-    root_logger.addHandler(file_handler)
+    root_logger.setLevel(level)
+
+    stdout_handler = logging.StreamHandler(stream=sys.stdout)
+    stdout_handler.setLevel(level)
+    stdout_handler.setFormatter(formatter)
+    stdout_handler.addFilter(wl_name_filter)
+    stdout_handler.addFilter(context_filter)
     root_logger.addHandler(stdout_handler)
+
+    if _env_truthy("WDM_LOG_TO_FILE", default=True):
+        log_dir = os.path.join(repo_root, "logs")
+        log_file = os.path.join(log_dir, f"{wl_log_prefix}-wdm-services.log")
+        os.makedirs(log_dir, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            filename=log_file, maxBytes=max_bytes, backupCount=backup_count
+        )
+        file_handler.setLevel(level)
+        file_handler.setFormatter(formatter)
+        file_handler.addFilter(wl_name_filter)
+        file_handler.addFilter(context_filter)
+        root_logger.addHandler(file_handler)
+
+    _apply_noisy_logger_levels()
+
+    bind_context(workload=wl_log_prefix, component="sdrc")

--- a/services/sdrc/lib/logging/wdm_logging.py
+++ b/services/sdrc/lib/logging/wdm_logging.py
@@ -159,15 +159,19 @@ class WlObjectNameFilter(logging.Filter):
 
 
 class ContextAndTraceFilter(logging.Filter):
-    """Merge contextvars + OpenTelemetry trace/span ids onto each record."""
+    """Merge contextvars + OpenTelemetry trace/span ids onto each record.
+
+    Also overrides the source bracket (``wl_object_name``) from the bound
+    ``component`` so in-process controller threads can emit ``[controller]``
+    without reinstalling root handlers that were configured as ``[router]``.
+    """
 
     def filter(self, record):
         ctx = _log_context.get() or {}
         for key, value in ctx.items():
             if not hasattr(record, key) or getattr(record, key) in (None, ""):
                 setattr(record, key, value)
-        if not getattr(record, "wl_object_name", None):
-            record.wl_object_name = ctx.get("workload") or ctx.get("wl_object_name") or "-"
+        _apply_source_bracket(record, ctx)
         trace_id, span_id = _otel_ids()
         if not getattr(record, "trace_id", None):
             record.trace_id = trace_id
@@ -176,6 +180,30 @@ class ContextAndTraceFilter(logging.Filter):
         if not hasattr(record, "event"):
             record.event = ""
         return True
+
+
+def _apply_source_bracket(record: logging.LogRecord, ctx: Optional[Mapping[str, Any]] = None) -> None:
+    """Set ``wl_object_name`` from component context when present."""
+    ctx = ctx or {}
+    component = getattr(record, "component", None) or ctx.get("component")
+    if component == "controller":
+        record.wl_object_name = "controller"
+        return
+    if component == "router":
+        record.wl_object_name = "router"
+        return
+    if component == "envoy":
+        record.wl_object_name = "envoy"
+        return
+    if component == "workload":
+        wl = getattr(record, "workload", None) or ctx.get("workload")
+        if wl:
+            record.wl_object_name = f"workload:{wl}"
+            return
+    if not getattr(record, "wl_object_name", None):
+        record.wl_object_name = (
+            ctx.get("workload") or ctx.get("wl_object_name") or "-"
+        )
 
 
 def _record_fields(record: logging.LogRecord) -> dict:
@@ -328,7 +356,19 @@ class RateLimitedLogger:
             return False, 0
 
 
-_default_rate_limiter = RateLimitedLogger(interval_s=30.0)
+_rate_limiters: dict[float, RateLimitedLogger] = {}
+_rate_limiters_lock = threading.Lock()
+
+
+def _get_rate_limiter(interval_s: float) -> RateLimitedLogger:
+    """Return a process-wide limiter for ``interval_s`` (stateful across calls)."""
+    key = float(interval_s)
+    with _rate_limiters_lock:
+        limiter = _rate_limiters.get(key)
+        if limiter is None:
+            limiter = RateLimitedLogger(interval_s=key)
+            _rate_limiters[key] = limiter
+        return limiter
 
 
 def log_rate_limited(
@@ -341,10 +381,7 @@ def log_rate_limited(
     **kwargs: Any,
 ) -> None:
     """Rate-limit repeated identical log lines; includes suppressed_count when repeating."""
-    limiter = _default_rate_limiter
-    if interval_s != limiter.interval_s:
-        # uncommon path: ad-hoc interval
-        limiter = RateLimitedLogger(interval_s=interval_s)
+    limiter = _get_rate_limiter(interval_s)
     ok, suppressed = limiter.should_log(key)
     if not ok:
         return

--- a/services/sdrc/lib/logging/wdm_logging.py
+++ b/services/sdrc/lib/logging/wdm_logging.py
@@ -347,11 +347,16 @@ class RateLimitedLogger:
     def should_log(self, key: str) -> tuple[bool, int]:
         now = time.monotonic()
         with self._lock:
-            last, count = self._state.get(key, (0.0, 0))
-            if now - last >= self.interval_s:
-                suppressed = count
+            entry = self._state.get(key)
+            # Absent entry means never logged; monotonic() is boot-relative and can
+            # be smaller than interval_s, so it cannot be compared against a sentinel.
+            if entry is None:
                 self._state[key] = (now, 0)
-                return True, suppressed
+                return True, 0
+            last, count = entry
+            if now - last >= self.interval_s:
+                self._state[key] = (now, 0)
+                return True, count
             self._state[key] = (last, count + 1)
             return False, 0
 

--- a/services/sdrc/lib/podprovisioner/kubernetes/dockerclient.py
+++ b/services/sdrc/lib/podprovisioner/kubernetes/dockerclient.py
@@ -104,13 +104,13 @@ class dockerclient(k8sclient):
         try:
             container = self.docker.containers.get(container_name)
         except docker.errors.NotFound:
-            logger.info(
+            logger.warning(
                 "Docker container %r not found; treating phase as Unknown",
                 container_name,
             )
             return "Unknown"
         except Exception as e:
-            logger.info(
+            logger.warning(
                 "Docker inspect failed for %r: %s; phase Unknown",
                 container_name,
                 e,
@@ -121,7 +121,8 @@ class dockerclient(k8sclient):
         except Exception as e:
             logger.debug("container.reload failed for %r: %s", container_name, e)
         st = (container.status or "").lower()
-        logger.info(f"container.status: {st}")
+        # Steady-state polls hit this path often; keep detail at DEBUG.
+        logger.debug("container.status: %s name=%r", st, container_name)
         if st == "running":
             return "Running"
         if st == "exited":
@@ -141,8 +142,8 @@ class dockerclient(k8sclient):
     def getPodIps(self, WLObject):
         podIps = []
         for i in WLObject:
-            logger.info(
-                "->>> %s\t%s\t%s\t%s\t%s\t%s\t%s"
+            logger.debug(
+                "pod inventory %s\t%s\t%s\t%s\t%s\t%s\t%s"
                 % (
                     i.status.pod_ip,
                     i.status.port,
@@ -175,7 +176,7 @@ class dockerclient(k8sclient):
                 "provisioning_address": provisioning_address,
             }
             podIps.append(ipobj)
-        logger.info("len(podsips): " + str(len(podIps)) + ", values: " + str(podIps))
+        logger.debug("len(podsips): %s, values: %s", len(podIps), podIps)
         return podIps if len(podIps) > 0 else None
 
     def _docker_service_address(self, pod_obj):

--- a/services/sdrc/lib/podprovisioner/kubernetes/k8sclient.py
+++ b/services/sdrc/lib/podprovisioner/kubernetes/k8sclient.py
@@ -137,8 +137,8 @@ class k8sclient:
     def getPodIps(self, WLObject):
         podIps = []
         for i in WLObject:
-            logger.info(
-                "->>> %s\t%s\t%s\t%s\t%s\t%s"
+            logger.debug(
+                "pod inventory %s\t%s\t%s\t%s\t%s\t%s"
                 % (
                     i.status.pod_ip,
                     i.status.phase,

--- a/services/sdrc/lib/podprovisioner/kubernetes/k8sheadlessclient.py
+++ b/services/sdrc/lib/podprovisioner/kubernetes/k8sheadlessclient.py
@@ -96,8 +96,8 @@ class k8sheadlessclient(k8sclient):
     def getPodIps(self, WLObject):
         podIps = []
         for i in WLObject:
-            logger.info(
-                "->>> %s\t%s\t%s\t%s\t%s\t%s\t%s"
+            logger.debug(
+                "pod inventory %s\t%s\t%s\t%s\t%s\t%s\t%s"
                 % (
                     i.status.pod_ip,
                     i.status.port,
@@ -122,7 +122,7 @@ class k8sheadlessclient(k8sclient):
                 else hostname,
             }
             podIps.append(ipobj)
-        logger.info("len(podsips): " + str(len(podIps)) + ", values: " + str(podIps))
+        logger.debug("len(podsips): %s, values: %s", len(podIps), podIps)
         return podIps if len(podIps) > 0 else None
 
     def _extractOwnerObject(self, wlObjName, selectPodIp):

--- a/services/sdrc/lib/podprovisioner/provisionconfig.py
+++ b/services/sdrc/lib/podprovisioner/provisionconfig.py
@@ -88,7 +88,7 @@ class provisionconfig:
             event_obj_key = remap[self.app_config["WDM_EVENT_OBJECT_FIELD"]]
         camera_id = configData.get(event_obj_key, {}).get(self.app_config["WDM_WL_ID_FIELD"], "?")
         logger.info("adding camera at {} (pod: {}, camera_id: {})".format(url, podInfo.get("podName", "?"), camera_id))
-        logger.info("payload: {}".format(json.dumps(configData, indent=2)))
+        logger.debug("payload: {}".format(json.dumps(configData, indent=2)))
         response = None
         failed_to_add = True
         logger.info (f"Max retry attempt {self.app_config['WDM_ADD_REMOVE_RETRY_ATTEMPTS']}")
@@ -154,7 +154,7 @@ class provisionconfig:
         )
 
         logger.info("deleting camera at {}".format(url))
-        logger.info("payload: {}".format(json.dumps(configData, indent=2)))
+        logger.debug("payload: {}".format(json.dumps(configData, indent=2)))
         response = None
         failed_to_delete = True
         logger.info (f"Max retry attempt {self.app_config['WDM_ADD_REMOVE_RETRY_ATTEMPTS']}")
@@ -194,7 +194,7 @@ class provisionconfig:
         )
 
         logger.info("configuring at {}".format(url))
-        logger.info("payload: {}".format(json.dumps(configData, indent=2)))
+        logger.debug("payload: {}".format(json.dumps(configData, indent=2)))
         retry_attempts = self.app_config.get("WDM_CONFIG_RETRY_ATTEMPTS")
         if retry_attempts is None:
             retry_attempts = min(

--- a/services/sdrc/lib/tracing.py
+++ b/services/sdrc/lib/tracing.py
@@ -31,7 +31,8 @@ import logging
 import requests
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+# Do not call logging.basicConfig here — app/run_workloads configure root logging
+# via lib.logging.configure_root_logging (level/format/handlers).
 
 # OTEL Configs
 REDIS_OTEL_CONTEXT_HASHMAP = "trace_contexts"

--- a/services/sdrc/run_workloads.py
+++ b/services/sdrc/run_workloads.py
@@ -1415,8 +1415,8 @@ def print_env_settings(env: Optional[dict] = None) -> None:
 
 
 def _configure_logging() -> None:
-    """Root logging for run_workloads, router, and controller (same setup as app.py)."""
-    configure_root_logging("run-workloads", _runtime_base_dir())
+    """Root logging for run_workloads / router (sdr-controller orchestrator)."""
+    configure_root_logging("run-workloads", _runtime_base_dir(), component="router")
 
 
 def main() -> int:

--- a/services/sdrc/tests/test_logging.py
+++ b/services/sdrc/tests/test_logging.py
@@ -260,10 +260,15 @@ def test_controller_context_bind_does_not_leak_to_parent_thread():
     clear_context()
     bind_context(component="router")
     seen = {}
+    startup_lines = []
 
-    def _run_as_controller(fn):
+    def _run_as_controller(fn, *, start_message=None):
         def _wrapped(*args, **kwargs):
             bind_context(component="controller")
+            if start_message:
+                startup_lines.append(
+                    (get_context().get("component"), start_message)
+                )
             return fn(*args, **kwargs)
 
         return _wrapped
@@ -271,10 +276,15 @@ def test_controller_context_bind_does_not_leak_to_parent_thread():
     def worker():
         seen.update(get_context())
 
-    t = threading.Thread(target=_run_as_controller(worker))
+    t = threading.Thread(
+        target=_run_as_controller(
+            worker, start_message="pod watcher thread started"
+        )
+    )
     t.start()
     t.join(timeout=5)
     assert not t.is_alive()
     assert seen.get("component") == "controller"
+    assert startup_lines == [("controller", "pod watcher thread started")]
     assert get_context().get("component") == "router"
     clear_context()

--- a/services/sdrc/tests/test_logging.py
+++ b/services/sdrc/tests/test_logging.py
@@ -169,6 +169,28 @@ def test_rate_limited_logger_suppresses_bursts():
     log_rate_limited(logger, logging.ERROR, "burst-key", "boom %s", "x", interval_s=60.0)
 
 
+def test_rate_limited_logger_logs_first_event_when_uptime_below_interval(monkeypatch):
+    """time.monotonic() is boot-relative, so a fresh host must not suppress the first line."""
+    from lib.logging import wdm_logging
+
+    class _FakeClock:
+        def __init__(self, value: float):
+            self.value = value
+
+        def monotonic(self) -> float:
+            return self.value
+
+    clock = _FakeClock(3.0)
+    monkeypatch.setattr(wdm_logging, "time", clock)
+
+    limiter = RateLimitedLogger(interval_s=60.0)
+    assert limiter.should_log("boot-key") == (True, 0)
+    assert limiter.should_log("boot-key") == (False, 0)
+
+    clock.value += 61.0
+    assert limiter.should_log("boot-key") == (True, 1)
+
+
 def test_log_rate_limited_custom_interval_retains_state():
     """Custom interval_s must reuse the same limiter (Greptile P2)."""
     logger = logging.getLogger("sdrc.test.rate.custom")

--- a/services/sdrc/tests/test_logging.py
+++ b/services/sdrc/tests/test_logging.py
@@ -45,13 +45,13 @@ def test_text_and_json_formatters_include_event_fields(tmp_path, monkeypatch):
     monkeypatch.setenv("WDM_LOG_LEVEL", "INFO")
     monkeypatch.setenv("WDM_LOG_FORMAT", "text")
     monkeypatch.setenv("WDM_LOG_TO_FILE", "0")
-    configure_root_logging("wl-test", str(tmp_path))
+    configure_root_logging("wl-test", str(tmp_path), component="workload")
 
     logger = logging.getLogger("sdrc.test.logging")
     stream = io.StringIO()
     handler = logging.StreamHandler(stream)
     handler.setFormatter(TextFormatter())
-    handler.addFilter(WlObjectNameFilter("wl-test"))
+    handler.addFilter(WlObjectNameFilter("workload:wl-test"))
     from lib.logging.wdm_logging import ContextAndTraceFilter
 
     handler.addFilter(ContextAndTraceFilter())
@@ -73,6 +73,7 @@ def test_text_and_json_formatters_include_event_fields(tmp_path, monkeypatch):
     assert "stream.provision.finished" in text_line
     assert "stream_id=cam-1" in text_line
     assert "outcome=ok" in text_line
+    assert "[workload:wl-test]" in text_line
 
     stream.truncate(0)
     stream.seek(0)
@@ -90,6 +91,7 @@ def test_text_and_json_formatters_include_event_fields(tmp_path, monkeypatch):
     assert payload["message_id"] == "1-0"
     assert payload["severity"] == "INFO"
     assert payload["workload"] == "wl-test"
+    assert payload["component"] == "workload"
 
 
 def test_configure_root_logging_respects_level_and_silences_redis_lock(
@@ -108,7 +110,37 @@ def test_configure_root_logging_respects_level_and_silences_redis_lock(
     assert logging.getLogger().level == logging.DEBUG
 
 
-def test_bind_context_and_clear():
+def test_configure_root_logging_sets_component_display_name(tmp_path, monkeypatch):
+    monkeypatch.setenv("WDM_LOG_LEVEL", "INFO")
+    monkeypatch.setenv("WDM_LOG_FORMAT", "text")
+    monkeypatch.setenv("WDM_LOG_TO_FILE", "0")
+
+    configure_root_logging("vss-rtvi-cv", str(tmp_path), component="workload")
+    from lib.logging.wdm_logging import get_context
+
+    assert get_context().get("component") == "workload"
+    assert get_context().get("workload") == "vss-rtvi-cv"
+
+    logger = logging.getLogger("sdrc.test.source")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(TextFormatter())
+    handler.addFilter(WlObjectNameFilter("workload:vss-rtvi-cv"))
+    from lib.logging.wdm_logging import ContextAndTraceFilter
+
+    handler.addFilter(ContextAndTraceFilter())
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    logger.info("hello")
+    line = stream.getvalue()
+    assert "[workload:vss-rtvi-cv]" in line
+    assert "component=workload" in line
+
+    configure_root_logging("run-workloads", str(tmp_path), component="router")
+    assert get_context().get("component") == "router"
+
     clear_context()
     token = bind_context(stream_id="s1", bus="redis")
     try:

--- a/services/sdrc/tests/test_logging.py
+++ b/services/sdrc/tests/test_logging.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import json
+import logging
+
+import pytest
+
+from lib.logging.wdm_logging import (
+    JsonFormatter,
+    RateLimitedLogger,
+    TextFormatter,
+    WlObjectNameFilter,
+    bind_context,
+    clear_context,
+    configure_root_logging,
+    log_event,
+    log_rate_limited,
+    parse_log_level,
+    reset_context,
+)
+
+
+def test_parse_log_level():
+    assert parse_log_level("DEBUG") == logging.DEBUG
+    assert parse_log_level("info") == logging.INFO
+    assert parse_log_level(None) == logging.INFO
+    assert parse_log_level("") == logging.INFO
+
+
+def test_text_and_json_formatters_include_event_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("WDM_LOG_LEVEL", "INFO")
+    monkeypatch.setenv("WDM_LOG_FORMAT", "text")
+    monkeypatch.setenv("WDM_LOG_TO_FILE", "0")
+    configure_root_logging("wl-test", str(tmp_path))
+
+    logger = logging.getLogger("sdrc.test.logging")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(TextFormatter())
+    handler.addFilter(WlObjectNameFilter("wl-test"))
+    from lib.logging.wdm_logging import ContextAndTraceFilter
+
+    handler.addFilter(ContextAndTraceFilter())
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    log_event(
+        logger,
+        logging.INFO,
+        "stream.provision.finished",
+        "Finished provisioning stream",
+        stream_id="cam-1",
+        outcome="ok",
+        elapsed_s=0.042,
+    )
+    text_line = stream.getvalue().strip()
+    assert "stream.provision.finished" in text_line
+    assert "stream_id=cam-1" in text_line
+    assert "outcome=ok" in text_line
+
+    stream.truncate(0)
+    stream.seek(0)
+    handler.setFormatter(JsonFormatter())
+    log_event(
+        logger,
+        logging.INFO,
+        "bus.message.committed",
+        "Committing message",
+        message_id="1-0",
+        outcome="ok",
+    )
+    payload = json.loads(stream.getvalue().strip())
+    assert payload["event"] == "bus.message.committed"
+    assert payload["message_id"] == "1-0"
+    assert payload["severity"] == "INFO"
+    assert payload["workload"] == "wl-test"
+
+
+def test_configure_root_logging_respects_level_and_silences_redis_lock(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("WDM_LOG_LEVEL", "INFO")
+    monkeypatch.setenv("WDM_LOG_FORMAT", "text")
+    monkeypatch.setenv("WDM_LOG_TO_FILE", "0")
+    configure_root_logging("wl-test", str(tmp_path))
+
+    assert logging.getLogger().level == logging.INFO
+    assert logging.getLogger("redis_lock.acquire").level == logging.WARNING
+
+    monkeypatch.setenv("WDM_LOG_LEVEL", "DEBUG")
+    configure_root_logging("wl-test", str(tmp_path))
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_bind_context_and_clear():
+    clear_context()
+    token = bind_context(stream_id="s1", bus="redis")
+    try:
+        from lib.logging.wdm_logging import get_context
+
+        assert get_context()["stream_id"] == "s1"
+    finally:
+        reset_context(token)
+        clear_context()
+
+
+def test_rate_limited_logger_suppresses_bursts():
+    limiter = RateLimitedLogger(interval_s=60.0)
+    ok1, suppressed1 = limiter.should_log("k")
+    ok2, suppressed2 = limiter.should_log("k")
+    assert ok1 is True and suppressed1 == 0
+    assert ok2 is False and suppressed2 == 0
+
+    logger = logging.getLogger("sdrc.test.rate")
+    logger.handlers.clear()
+    logger.addHandler(logging.NullHandler())
+    logger.setLevel(logging.ERROR)
+    # Should not raise
+    log_rate_limited(logger, logging.ERROR, "burst-key", "boom %s", "x", interval_s=60.0)
+    log_rate_limited(logger, logging.ERROR, "burst-key", "boom %s", "x", interval_s=60.0)

--- a/services/sdrc/tests/test_logging.py
+++ b/services/sdrc/tests/test_logging.py
@@ -20,6 +20,7 @@ import logging
 import pytest
 
 from lib.logging.wdm_logging import (
+    ContextAndTraceFilter,
     JsonFormatter,
     RateLimitedLogger,
     TextFormatter,
@@ -166,3 +167,92 @@ def test_rate_limited_logger_suppresses_bursts():
     # Should not raise
     log_rate_limited(logger, logging.ERROR, "burst-key", "boom %s", "x", interval_s=60.0)
     log_rate_limited(logger, logging.ERROR, "burst-key", "boom %s", "x", interval_s=60.0)
+
+
+def test_log_rate_limited_custom_interval_retains_state():
+    """Custom interval_s must reuse the same limiter (Greptile P2)."""
+    logger = logging.getLogger("sdrc.test.rate.custom")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.ERROR)
+    logger.propagate = False
+
+    key = "custom-interval-unique-key"
+    log_rate_limited(logger, logging.ERROR, key, "first", interval_s=5.0)
+    log_rate_limited(logger, logging.ERROR, key, "second", interval_s=5.0)
+    log_rate_limited(logger, logging.ERROR, key, "third", interval_s=5.0)
+    lines = [ln for ln in stream.getvalue().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    assert lines[0] == "first"
+
+
+def test_component_context_overrides_handler_source_bracket():
+    """Router-configured handlers must still show [controller] when context is bound."""
+    clear_context()
+    logger = logging.getLogger("sdrc.test.component.override")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(TextFormatter())
+    # Simulate run_workloads installing a router bracket filter.
+    handler.addFilter(WlObjectNameFilter("router"))
+    handler.addFilter(ContextAndTraceFilter())
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    bind_context(component="router")
+    logger.info("from router")
+    router_line = stream.getvalue()
+    assert "[router]" in router_line
+    assert "component=router" in router_line
+
+    stream.truncate(0)
+    stream.seek(0)
+    bind_context(component="controller")
+    logger.info("from controller")
+    controller_line = stream.getvalue()
+    assert "[controller]" in controller_line
+    assert "component=controller" in controller_line
+    assert "[router]" not in controller_line
+
+    stream.truncate(0)
+    stream.seek(0)
+    bind_context(component="workload", workload="vss-rtvi-cv")
+    logger.info("from workload")
+    wl_line = stream.getvalue()
+    assert "[workload:vss-rtvi-cv]" in wl_line
+    assert "component=workload" in wl_line
+    clear_context()
+
+
+def test_controller_context_bind_does_not_leak_to_parent_thread():
+    """Watcher-thread bind_context(component=controller) must not flip parent router tag."""
+    import threading
+
+    from lib.logging import get_context
+
+    clear_context()
+    bind_context(component="router")
+    seen = {}
+
+    def _run_as_controller(fn):
+        def _wrapped(*args, **kwargs):
+            bind_context(component="controller")
+            return fn(*args, **kwargs)
+
+        return _wrapped
+
+    def worker():
+        seen.update(get_context())
+
+    t = threading.Thread(target=_run_as_controller(worker))
+    t.start()
+    t.join(timeout=5)
+    assert not t.is_alive()
+    assert seen.get("component") == "controller"
+    assert get_context().get("component") == "router"
+    clear_context()


### PR DESCRIPTION
## Summary
- Reduce SDRC INFO noise by moving hot-path poll/inventory detail (`pod_list` breadcrumbs, container status dumps, Redis lock chatter, successful health/`pod_list` access logs, provision payloads) to DEBUG, while keeping lifecycle/state-change signals visible.
- Add configurable logging controls (`WDM_LOG_LEVEL`, `WDM_LOG_FORMAT=text|json`, `WDM_LOG_TO_FILE`) plus structured helpers, noisy third-party logger silencing, and rate-limiting for repeated Redis consumer errors.
- Tag muxed docker logs by source (`[workload:<name>]`, `[router]`, `[controller]`, `[envoy]`) and align Envoy log layout with SDRC (timestamp-first, uppercase levels, `YYYY-MM-DD HH:MM:SS`).
- ## Why
Steady-state `docker logs sdr-controller` was dominated by poll/xDS chatter, which made stream lifecycle hard for new developers to follow. This keeps production INFO useful and restores deep detail with `WDM_LOG_LEVEL=DEBUG`.

