### PR TITLE
feat(skill-eval): report which eval cells can actually accumulate samples

### DIFF
--- a/.github/skill-eval/eval_attainability.py
+++ b/.github/skill-eval/eval_attainability.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Report which eval cells can actually accumulate samples, from nightly results.
+
+Steps chain: a step scoring below 1.0 aborts the rest of its spec, so a later
+cell only produces a result on nights where every preceding step scored exactly
+1.0. A cell behind a reliably imperfect step yields nothing -- not rarely, but
+never. Any plan assuming "N samples per cell" has to be checked against what the
+nightlies produce.
+
+Reads downloaded `skills-eval-daily` artifacts and labels every cell as
+EXECUTED (a judge verdict exists), SKIPPED_BY_CHAIN (an earlier step scored
+< 1.0 that night) or ABSENT (the leg produced nothing at all).
+
+    gh run download <run-id> -D nightly/          # repeat per run
+    eval_attainability.py --artifacts nightly/ --min-samples 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tarfile
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from eval_parity_scope import REPO_ROOT, all_skills, scan_spec  # noqa: E402
+from plan_matrix import specs_for_skill  # noqa: E402
+
+ARTIFACT_PREFIX = "skills-eval-daily-results-"
+
+# Step number comes from judge.json, never the path: multi-step specs use
+# `step-N__<hash>/` but single-step specs use a flat `<platform>__<hash>/`, so
+# keying off the path drops every single-step verdict and misreports it ABSENT.
+JUDGE_SUFFIX = "verifier/judge.json"
+
+EXECUTED, SKIPPED, ABSENT = "EXECUTED", "SKIPPED_BY_CHAIN", "ABSENT"
+
+
+def parse_artifact_name(filename: str) -> tuple[str, str, str] | None:
+    """`...-<skill>__<stem>__<platform>-<run_id>.tar.gz` -> (skill, stem, platform)."""
+    name = filename[:-7] if filename.endswith(".tar.gz") else filename
+    if not name.startswith(ARTIFACT_PREFIX):
+        return None
+    body = name[len(ARTIFACT_PREFIX):].rsplit("-", 1)[0]  # drop the run id
+    parts = body.split("__")
+    if len(parts) != 3:
+        return None
+    return parts[0], parts[1], parts[2]
+
+
+def read_leg(path: Path) -> dict[int, float]:
+    """Step number -> reward, for one leg's artifact tarball."""
+    out: dict[int, float] = {}
+    with tarfile.open(path, "r:gz") as tf:
+        for member in tf.getmembers():
+            if not member.name.endswith(JUDGE_SUFFIX) or not member.isfile():
+                continue
+            fh = tf.extractfile(member)
+            if fh is None:
+                continue
+            try:
+                verdict = json.load(fh)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            step = verdict.get("step")
+            if step is None:
+                continue
+            out[int(step)] = float(verdict.get("reward", 0.0))
+    return out
+
+
+def classify_leg(total_cells: int, rewards: dict[int, float]) -> dict[int, str]:
+    """Label every 1-indexed cell of one spec for one night.
+
+    A cell is SKIPPED_BY_CHAIN rather than ABSENT when some earlier step ran and
+    scored below 1.0 -- that is the chain abort, and it is the interesting case
+    because it recurs every night the earlier step is imperfect.
+    """
+    labels: dict[int, str] = {}
+    aborted = False
+    for cell in range(1, total_cells + 1):
+        if cell in rewards:
+            labels[cell] = EXECUTED
+            if rewards[cell] < 1.0:
+                aborted = True
+        else:
+            labels[cell] = SKIPPED if aborted else ABSENT
+    return labels
+
+
+def spec_cell_counts() -> dict[tuple[str, str], int]:
+    """(skill, stem) -> number of cells, from the committed specs."""
+    counts = {}
+    for skill in all_skills():
+        for rel, _eval_dir, stem in specs_for_skill(skill):
+            counts[(skill, stem)] = scan_spec(rel)["cells"]
+    return counts
+
+
+def analyse(artifact_dir: Path, min_samples: int) -> dict:
+    counts = spec_cell_counts()
+    samples: dict[tuple[str, str, int], int] = defaultdict(int)
+    labels: dict[tuple[str, str, int], dict[str, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
+    runs, unknown = set(), set()
+
+    for tarball in sorted(artifact_dir.rglob("*.tar.gz")):
+        parsed = parse_artifact_name(tarball.name)
+        if not parsed:
+            continue
+        skill, stem, _platform = parsed
+        total = counts.get((skill, stem))
+        if total is None:
+            unknown.add(f"{skill}/{stem}")
+            continue
+        runs.add(tarball.name.rsplit("-", 1)[1])
+        for cell, label in classify_leg(total, read_leg(tarball)).items():
+            key = (skill, stem, cell)
+            labels[key][label] += 1
+            if label == EXECUTED:
+                samples[key] += 1
+
+    cells = []
+    for (skill, stem), total in sorted(counts.items()):
+        for cell in range(1, total + 1):
+            key = (skill, stem, cell)
+            n = samples.get(key, 0)
+            cells.append(
+                {
+                    "spec": f"{skill}/{stem}",
+                    "cell": cell,
+                    "samples": n,
+                    "reachable": n >= min_samples,
+                    "labels": dict(labels.get(key, {})),
+                }
+            )
+
+    return {
+        "runs_seen": len(runs),
+        "min_samples": min_samples,
+        "cells_total": len(cells),
+        "cells_reachable": sum(1 for c in cells if c["reachable"]),
+        "cells_starved": sum(1 for c in cells if c["samples"] == 0),
+        "unknown_specs": sorted(unknown),
+        "cells": cells,
+    }
+
+
+def format_report(result: dict) -> str:
+    pct = 100.0 * result["cells_reachable"] / (result["cells_total"] or 1)
+    lines = [
+        f"nightly runs analysed: {result['runs_seen']}",
+        f"cells: {result['cells_total']}",
+        f"reachable at >={result['min_samples']} samples: {result['cells_reachable']} ({pct:.1f}%)",
+        f"never sampled: {result['cells_starved']}",
+    ]
+    if result["unknown_specs"]:
+        lines.append(f"artifacts with no matching spec: {', '.join(result['unknown_specs'])}")
+    worst = [c for c in result["cells"] if c["samples"] == 0]
+    if worst:
+        lines += ["", "cells that never produced a sample (deterministic gates only):"]
+        lines += [
+            f"  {c['spec']} cell {c['cell']}"
+            f"  ({max(c['labels'], key=c['labels'].get) if c['labels'] else 'no data'})"
+            for c in worst
+        ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Report per-cell sample attainability.")
+    ap.add_argument("--artifacts", required=True, type=Path, help="dir of artifact tarballs")
+    ap.add_argument("--min-samples", type=int, default=10, help="samples to count as reachable")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    if not args.artifacts.is_dir():
+        print(f"FATAL: no such directory: {args.artifacts}", file=sys.stderr)
+        return 2
+
+    result = analyse(args.artifacts, args.min_samples)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(format_report(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/tests/test_eval_attainability.py
+++ b/.github/skill-eval/tests/test_eval_attainability.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for eval_attainability."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import eval_attainability as att  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("skills-eval-daily-results-vss-search-archive__search__RTXPRO6000BW-31770137518.tar.gz",
+         ("vss-search-archive", "search", "RTXPRO6000BW")),
+        ("something-else.tar.gz", None),
+        ("skills-eval-daily-results-malformed-1.tar.gz", None),
+    ],
+)
+def test_parse_artifact_name(name, expected):
+    assert att.parse_artifact_name(name) == expected
+
+
+def test_chain_abort_marks_later_cells_skipped_not_absent():
+    """A cell after a sub-1.0 step is starved every night that step is imperfect,
+    which is a different problem from a leg that simply did not run. Conflating
+    the two hides a permanently unreachable cell."""
+    labels = att.classify_leg(9, {1: 1.0, 2: 0.6})
+    assert labels[1] == labels[2] == att.EXECUTED
+    assert all(labels[c] == att.SKIPPED for c in range(3, 10))
+    assert set(att.classify_leg(3, {}).values()) == {att.ABSENT}
+    assert set(att.classify_leg(3, {1: 1.0, 2: 1.0, 3: 1.0}).values()) == {att.EXECUTED}
+
+
+def _tarball(path: Path, steps: dict[int, float], flat: bool = False) -> None:
+    """`flat` mimics a single-step spec: trial dir `<platform>__<hash>`, no step."""
+    with tarfile.open(path, "w:gz") as tf:
+        for step, reward in steps.items():
+            payload = json.dumps({"step": step, "reward": reward}).encode()
+            trial = "l40s__abc" if flat else f"step-{step}__abc"
+            info = tarfile.TarInfo(f"123/2026-01-01/{trial}/verifier/judge.json")
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+
+
+@pytest.mark.parametrize("flat", [False, True])
+def test_read_leg_takes_the_step_from_judge_json_not_the_path(tmp_path, flat):
+    """Single-step specs produce a flat trial dir. Keying off the path would drop
+    every one of their verdicts and misreport those cells as never sampled."""
+    p = tmp_path / "leg.tar.gz"
+    _tarball(p, {1: 1.0}, flat=flat)
+    assert att.read_leg(p) == {1: 1.0}
+
+
+def test_analyse_counts_samples_across_runs(tmp_path, monkeypatch):
+    monkeypatch.setattr(att, "spec_cell_counts", lambda: {("skl", "spec"): 3})
+    for run in (1, 2):
+        _tarball(tmp_path / f"skills-eval-daily-results-skl__spec__L40S-{run}.tar.gz",
+                 {1: 1.0, 2: 0.5})
+
+    result = att.analyse(tmp_path, min_samples=2)
+    by_cell = {c["cell"]: c for c in result["cells"]}
+    assert result["runs_seen"] == 2
+    # Cells 1 and 2 ran on both nights; cell 3 was starved by the abort both times.
+    assert by_cell[1]["samples"] == 2 and by_cell[1]["reachable"]
+    assert by_cell[2]["samples"] == 2
+    assert by_cell[3]["samples"] == 0 and not by_cell[3]["reachable"]
+    assert by_cell[3]["labels"] == {att.SKIPPED: 2}
+    assert result["cells_starved"] == 1


### PR DESCRIPTION
## Description

Steps chain: a step scoring below 1.0 aborts the rest of its spec, so a later cell only produces a result on nights where **every** preceding step scored exactly 1.0. A cell behind a reliably imperfect step yields nothing — not rarely, but never.

This reads downloaded `skills-eval-daily` artifacts and labels every cell `EXECUTED`, `SKIPPED_BY_CHAIN` or `ABSENT`, then reports how many samples each accumulated.

```
gh run download <run-id> -D nightly/          # repeat per run
.github/skill-eval/eval_attainability.py --artifacts nightly/ --min-samples 10
```

### What it found

Measured over the 7 most recent nightly runs, across 154 cells:

| | cells | share |
|---|---:|---:|
| sampled 7 of 7 nights | 55 | 35.7% |
| sampled ≥ 5 nights | 116 | 75.3% |
| sampled ≥ 1 night | 136 | 88.3% |
| **sampled 0 nights** | **18** | **11.7%** |

**Every one of the 18 starved cells is chain-aborted; none are absent.** So the starvation has a single cause, and one fixable at the source: repairing the earlier step that scores below 1.0 recovers the cells behind it. Those cells are not reachable by waiting longer, which is what a per-cell sample target assumes.

A concrete example: `vss-search-archive/search.json` has 9 cells. On one recent night step 1 scored 1.0 and step 2 scored 3/5 = 0.6, so cells 3 through 9 produced nothing — and will produce nothing on any night step 2 is imperfect.

### Note on the step number

The step is read from `judge.json`, never from the artifact path. Multi-step specs write `step-N__<hash>/`, but single-step specs write a flat `<platform>__<hash>/` with no step in the path. Keying off the path drops every single-step verdict and misreports those cells as never sampled — **121 of 783 verdicts (15%)** on the nights measured. Thanks to @greptile-apps for catching this; the earlier revision of this PR had exactly that bug and reported 36 starved cells instead of 18. Both layouts are covered by a parametrized test.

### Scope

Analysis only. Reads artifacts that already exist, adds no CI job, runs no eval, uses no GPU. Cell counts come from `eval_parity_scope` so the two tools cannot disagree about how many cells a spec has.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.