### PR TITLE
docs: expand the pull request template to five sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,10 @@
-## Description
-<!-- Provide a standalone description of changes in this PR. -->
-<!-- Reference any issues closed by this PR with "closes #1234". -->
+## Summary
+
+## Plan
+
+## Related Issue
+
+## Changes
 
 ## Checklist
 - [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
@@ -8,3 +12,4 @@
 - [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
 - [ ] New or existing tests cover these changes.
 - [ ] The documentation is up to date with these changes.
+- [ ] No secrets, API keys, or credentials committed.


### PR DESCRIPTION
## Summary

The pull request template asks for a description and a checklist. Everything else a reviewer needs — why the change is shaped the way it is, which issue it lands under, what to read first — has no slot, so it either goes missing or lands under whatever headings the author invents that day.

This adds `Summary`, `Plan`, `Related Issue` and `Changes` around the existing checklist, plus one checklist item for secrets.

Headings only, with no guidance comments. This repository is public, so the template is the wrong place to document how internal tracking and release tooling behave. That guidance lives in the internal agent guidelines file, which is being updated in parallel to point here rather than restate the body. The headings alone give a reviewer a predictable shape to read and give contributors somewhere to put each part.

## Plan

**Goal:** every PR opened against this repository arrives with its intent, its design decisions, its tracking reference and its review entry point in named sections, rather than in whatever structure the author chose.

**Decisions**

| # | Question | Recommended | Decided |
|---|----------|-------------|---------|
| Q1 | Which tracking ticket does this land under? | None — repository maintenance, so apply `no-tracking-ref` | None, `no-tracking-ref` |
| Q2 | Target `main` or `develop`? | `main` — GitHub serves the template from the default branch, so a merge into `develop` would change nothing a contributor sees | `main` |
| Q3 | How demanding should `## Plan` be on a public repo? | Goal and steps required, the decisions table asked for only when an agent helped design the change | Superseded by Q5 |
| Q4 | How much guidance should the internal guidelines file keep, now that it points here? | Refer to this template and work its checklist; drop the deep links for licensing, DCO and pre-commit, which that file already states inline | As recommended, with branch naming also kept inline |
| Q5 | How much guidance belongs in the template itself? | — (raised on review) | **Headings only.** Detail moves to the internal guidelines file, which instructs authors to include the decisions and directions behind a change while stripping anything sensitive from the surrounding discussion |

**Steps**

1. Add the four headings around the existing checklist, and the secrets checklist item → verify: `git diff origin/main` is 8 insertions and 3 deletions, and every heading the internal guidelines file names is present.
2. Independent review before human review → verify: ran the draft through the OpenAI Codex CLI with authorship disclosed. It returned two P1 findings against the earlier, comment-heavy draft — that asking for a design record next to a "do not paste internal discussion" warning creates a trap on a public repo, and that the tracking-workflow prose asserted internal automation behavior with nothing public behind it. Both are resolved by dropping the guidance comments entirely.
3. Run the repository hooks → verify: `pre-commit run --files .github/PULL_REQUEST_TEMPLATE.md` passes TruffleHog and the SPDX header check; the DCO hook passes at commit.

**Out of scope**

- **Enforcement.** Nothing checks that a section is filled in. A section left empty is caught at review, not by CI.
- **`## Changes` overlapping `## Summary`.** They can read similarly on a small PR. Kept separate because they answer different questions — what the change is, versus what to read first — and merging them was not worth a second round.
- **The issue templates** under `.github/ISSUE_TEMPLATE/`, which are unrelated to this and untouched.

## Related Issue

None — repository maintenance. `no-tracking-ref` applied.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` — `## Description` becomes `## Summary`; `## Plan`, `## Related Issue` and `## Changes` are added ahead of the existing `## Checklist`; one checklist item is appended for secrets. The five existing checklist items are unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes. — n/a, a markdown template has nothing to test
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
