### PR TITLE
fix(test): reset _expected_stable_keys between profile iterations

### DIFF
--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1211,6 +1211,10 @@ for _profile in base lvs search alerts; do
   fi
   _expected_override_keys=("${_common_overrides_env_keys[@]}")
   _allowed_duplicate_keys=()
+  # Reset alongside the other two: this is assigned only inside the case arms
+  # below and there is no default arm, so without a reset a profile that matches
+  # no arm silently inherits the previous iteration's expectations.
+  _expected_stable_keys=()
   case "${_profile}" in
     base)
       _expected_override_keys+=(EVAL_LLM_JUDGE_NAME EVAL_LLM_JUDGE_BASE_URL RTVI_VLM_PORT RTVI_VLM_IMAGE_TAG RTVI_VLM_ENDPOINT RTVI_VLM_MODEL_TO_USE RTVI_VLLM_GPU_MEMORY_UTILIZATION RTVI_VLM_MAX_MODEL_LEN RTVI_VLM_MODEL_PATH)


### PR DESCRIPTION
## Description

The env-split check in `test-dev-profile.sh` loops over every developer profile and resets `_expected_override_keys` and `_allowed_duplicate_keys` at the top of each iteration — but not `_expected_stable_keys`.

That variable is assigned **only inside the four `case` arms**, and the `case` has **no default arm**. So a profile matching no arm silently inherits the previous iteration's expectations instead of starting empty.

No profile hits this today, because all four have an arm. It bites the moment a fifth is added: the new profile would be checked against whichever profile the loop last visited, producing failures that point at the wrong file and have nothing to do with the change under test — the kind of failure someone loses an afternoon to.

## Verification

Behaviour-neutral. The suite reports **203 passed / 2 failed both with and without** this change, and the two failures (`warehouse MV3DT skill should not reference legacy app-data model paths`, `warehouse MV3DT Compose and Helm startup semantics or perception fallback diverged`) are pre-existing and unrelated to the env split.

```
bash deploy/docker/test-scripts/test-dev-profile.sh
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.