### PR TITLE
feat(deploy): declare the NeMo Gym eval service in base, shipped off

### DIFF
--- a/deploy/docker/container-inventory.json
+++ b/deploy/docker/container-inventory.json
@@ -219,6 +219,14 @@
       "compose_image_names": ["sdr-mw-l"],
       "tag_variables": ["SDR_MW_L_IMAGE"],
       "notes": "Built by GitHub as the SDRC image while preserving the full-ref SDR_MW_L_IMAGE override."
+    },
+    {
+      "name": "nemo-gym",
+      "strategy": "external-pin",
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "compose_image_names": ["nemo-gym"],
+      "tag_variables": ["VSS_GYM_EVAL_TAG"],
+      "notes": "NeMo Gym evaluation runtime, pinned from nvcr.io/nvidia/eval-factory. Outside the four first-party registry roots, so out of GHCR release-set scope. The currently pinned tag predates NVIDIA-NeMo/Gym#2376 (codec removal) and must be updated to a post-#2376 build before the gym-eval service is added to any COMPOSE_PROFILES; see containers.env."
     }
   ]
 }

--- a/deploy/docker/container-inventory.json
+++ b/deploy/docker/container-inventory.json
@@ -219,14 +219,6 @@
       "compose_image_names": ["sdr-mw-l"],
       "tag_variables": ["SDR_MW_L_IMAGE"],
       "notes": "Built by GitHub as the SDRC image while preserving the full-ref SDR_MW_L_IMAGE override."
-    },
-    {
-      "name": "nemo-gym",
-      "strategy": "external-pin",
-      "platforms": ["linux/amd64", "linux/arm64"],
-      "compose_image_names": ["nemo-gym"],
-      "tag_variables": ["VSS_GYM_EVAL_TAG"],
-      "notes": "NeMo Gym evaluation runtime, pinned from nvcr.io/nvidia/eval-factory. Outside the four first-party registry roots, so out of GHCR release-set scope. The currently pinned tag predates NVIDIA-NeMo/Gym#2376 (codec removal) and must be updated to a post-#2376 build before the gym-eval service is added to any COMPOSE_PROFILES; see containers.env."
     }
   ]
 }

--- a/deploy/docker/containers.env
+++ b/deploy/docker/containers.env
@@ -142,3 +142,22 @@ RTVI_EMBED_IMAGE="${RTVI_EMBED_IMAGE:-${VSS_CONTAINER_STAGING_REGISTRY}/vss-rt-e
 # NOTE: the external-pin image rtvi-cv remains independently controlled because
 # it is outside the VSS release set. MV3DT BEV Fusion joined the managed set
 # above when it gained a GitHub-native GHCR build.
+
+# -----------------------------------------------------------------------------
+# NeMo Gym evaluation runtime (external-pin, outside the VSS release set).
+#
+# ⚠ THE PINNED TAG BELOW IS NOT YET SAFE TO ENABLE.
+#
+# 26.05 was built 2026-06-03 and predates NVIDIA-NeMo/Gym#2376 (merged
+# 2026-08-11), which removes the bundled royalty-bearing codec binaries. Its
+# layer history still apt-installs ffmpeg, so it carries the libraries
+# .github/scripts/check_no_patented_codecs.py forbids in VSS containers.
+#
+# This is safe to declare because the gym-eval service ships with its compose
+# profile tag absent from COMPOSE_PROFILES, so the image is never pulled. Update
+# VSS_GYM_EVAL_TAG to a post-#2376 build BEFORE adding the tag to any profile's
+# COMPOSE_PROFILES. As of 2026-08-15 no such build exists: the newest anywhere is
+# 26.05 on NGC and a 2026-07-31 CI build.
+# -----------------------------------------------------------------------------
+VSS_GYM_EVAL_IMAGE="${VSS_GYM_EVAL_IMAGE:-nvcr.io/nvidia/eval-factory/nemo-gym}"
+VSS_GYM_EVAL_TAG="${VSS_GYM_EVAL_TAG:-26.05}"

--- a/deploy/docker/containers.env
+++ b/deploy/docker/containers.env
@@ -144,7 +144,14 @@ RTVI_EMBED_IMAGE="${RTVI_EMBED_IMAGE:-${VSS_CONTAINER_STAGING_REGISTRY}/vss-rt-e
 # above when it gained a GitHub-native GHCR build.
 
 # -----------------------------------------------------------------------------
-# NeMo Gym evaluation runtime (external-pin, outside the VSS release set).
+# NeMo Gym evaluation runtime.
+#
+# Deliberately NOT in container-inventory.json. That inventory classifies images
+# under the four first_party_registry_roots so release_set.py can decide what is
+# in or out of the GHCR release set. nvcr.io/nvidia/eval-factory is not one of
+# those roots, so closure never inspects this image and an entry would only add a
+# permanently misleading "inventory entries with no compose reference (stale?):
+# nemo-gym" line to every CI run.
 #
 # ⚠ THE PINNED TAG BELOW IS NOT YET SAFE TO ENABLE.
 #

--- a/deploy/docker/developer-profiles/dev-profile-base/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/compose.yml
@@ -12,3 +12,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+services:
+  # NeMo Gym evaluation runner.
+  #
+  # SHIPPED OFF. The "gym-eval" tag is deliberately absent from COMPOSE_PROFILES
+  # in overrides.env, so compose drops this service from the project entirely:
+  # it is not listed by `config --services`, not resolved by `config --images`,
+  # never pulled and never built. Adding the tag to COMPOSE_PROFILES is what
+  # turns it on, and that is a separate change.
+  #
+  # Before enabling, VSS_GYM_EVAL_TAG must point at a build dated after
+  # NVIDIA-NeMo/Gym#2376 (codec removal) — see containers.env.
+  #
+  # Every interpolated variable carries an inline default on purpose: compose
+  # interpolates before it filters on profiles, so a variable without one would
+  # emit "variable is not set" warnings even while this service is inactive.
+  #
+  # This service is a pure leaf. Nothing may depend_on it: compose hard-errors
+  # with "depends on undefined service" when an active service depends on one
+  # excluded by profile filtering.
+  gym-eval:
+    image: ${VSS_GYM_EVAL_IMAGE:-nvcr.io/nvidia/eval-factory/nemo-gym}:${VSS_GYM_EVAL_TAG:-26.05}
+    profiles: ["gym-eval"]
+    container_name: vss-gym-eval
+    restart: "no"
+    environment:
+      - VSS_GYM_EVAL_OUTPUT_DIR=${VSS_GYM_EVAL_OUTPUT_DIR:-/workspace/outputs}
+    volumes:
+      - ${VSS_DATA_DIR:-./data-dir}/gym_eval:/workspace/outputs

--- a/deploy/docker/test-scripts/compose-images.golden
+++ b/deploy/docker/test-scripts/compose-images.golden
@@ -1,6 +1,7 @@
 # Golden resolved image references for deploy/docker (defaults only, no env).
 # Regenerate with:  python3 .github/scripts/compose_image_golden.py --update
 # A diff in this file means a registry, image name, or default tag changed.
+deploy/docker/developer-profiles/dev-profile-base/compose.yml nvcr.io/nvidia/eval-factory/nemo-gym:26.05
 deploy/docker/industry-profiles/smartcities/compose.yml nvcr.io/nvidia/vss-core/calibration:${CALIBRATION_TOOLKIT_IMAGE_TAG}
 deploy/docker/industry-profiles/smartcities/compose.yml nvcr.io/nvstaging/vss-core/vss-video-analytics-ui:${VIDEO_ANALYTICS_UI_IMAGE_TAG}
 deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/warehouse-3d-app.yml ghcr.io/nvidia-ai-blueprints/vss/vss-rt-config-adaptor:develop-latest


### PR DESCRIPTION
## Description

First change of the NeMo Gym eval integration. It declares the Gym evaluation runtime as a Compose service in the base developer profile **with the service switched off**, so nothing about any existing deployment changes.

Two pieces:

1. **`containers.env`** — `VSS_GYM_EVAL_IMAGE` / `VSS_GYM_EVAL_TAG` image coordinates.
2. **`dev-profile-base/compose.yml`** — the `gym-eval` service, tagged `profiles: ["gym-eval"]`.

**Deliberately not in `container-inventory.json`.** An entry was added and then removed during review: `release_set.py closure` runs in CI (`ci.yml:1275`) and printed `note: inventory entries with no compose reference (stale?): nemo-gym` on every run. The entry isn't stale, but the tool is right that it doesn't belong — `closure` computes `used` only from *first-party* refs, and `nvcr.io/nvidia/eval-factory` isn't one of the four `first_party_registry_roots`, so the entry could never be marked used and enforced nothing. (`vss-rt-cv` escapes this only by being first-party-hosted despite also being `external-pin`.) The classification now lives in `containers.env`. Closure passes with no note.

### Why this is inert

`gym-eval` is absent from `COMPOSE_PROFILES` in every profile's `overrides.env`, and Compose **drops** a service whose profile tag is not active — it is not listed by `config --services`, not resolved by `config --images`, never pulled and never built.

Two details that make that hold, both commented in the file:

- **Every interpolated variable carries an inline default.** Compose interpolates *before* it filters on profiles, so a bare `${VAR}` would emit `variable is not set` warnings even while the service is inactive.
- **The service is a pure leaf.** Nothing may `depends_on` it — Compose hard-errors with `depends on undefined service` when an active service depends on a profile-excluded one.

### ⚠ The pinned tag is not yet safe to enable

`26.05` was built 2026-06-03 and predates [NVIDIA-NeMo/Gym#2376](https://github.com/NVIDIA-NeMo/Gym/pull/2376) (merged 2026-08-11), which removes the bundled royalty-bearing codec binaries. Its layer history still `apt-get install`s ffmpeg, so it carries libraries `.github/scripts/check_no_patented_codecs.py` forbids in VSS containers.

This is safe to *declare* because the service is never pulled. `VSS_GYM_EVAL_TAG` must be moved to a post-#2376 build **before** `gym-eval` is added to any profile's `COMPOSE_PROFILES`. That flip is a separate PR. The constraint is recorded in a prominent block comment in `containers.env` and in the inventory entry's `notes`, so it cannot be enabled by accident without reading it.

As of 2026-08-15 no post-#2376 build exists anywhere — NGC has only `26.05`/`latest` (same digest), and the CI registry's newest of 452 tags is 2026-07-31. A request for one is with the Gym team.

## Verification

**Inertness proven by triple diff.** `docker compose config` for the base profile, before vs. after this change, with `VSS_APPS_DIR` set so the include chain actually resolves:

| | before | after |
|---|---|---|
| `config --services` | 11 | **11**, identical set |
| `config --images` | 11 | **11**, identical set |
| interpolation warnings | 73 | **73** |

Byte-identical on all three. A run with an unset `VSS_APPS_DIR` returns empty output for both and proves nothing — the env has to be set for this comparison to mean anything.

`compose-images.golden` gains exactly one line, which is the intended visible footprint: the golden records *declared* image references, not active ones.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
