### PR TITLE
feat(deploy): add dev-profile-gym, the profile that runs the Gym eval

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-gym/.env
+++ b/deploy/docker/developer-profiles/dev-profile-gym/.env
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runtime/profile values modified by dev-profile.sh live in overrides.env.
+# dev-profile.sh generates generated.env from overrides.env and passes it after this file.
+
+# =============================================================================
+# PROFILE STATIC DEFAULTS
+# =============================================================================
+# Values in this section are not rewritten by dev-profile.sh for this profile.
+MODE=2d
+RTVI_VLM_MAX_MODEL_LEN=''
+
+# =============================================================================
+# DEV-PROFILE-BASE ENVIRONMENT CONFIGURATION
+# =============================================================================
+# This file contains environment variables for the developer base profile.
+# Services: Foundational, VST, NIM, Agents
+#
+# Profile variants:
+# 2d:
+#   bp_developer_base
+# =============================================================================
+
+# =============================================================================
+# DEPLOYMENT CONFIGURATION
+# =============================================================================
+# Blueprint profile for the developer base compose services.
+BP_PROFILE=bp_developer_base
+
+# GPU IDs reserved for non-LLM/VLM services in this profile.
+RESERVED_DEVICE_IDS=''
+# GPU IDs treated as shared by dev-profile.sh when deriving LLM/VLM placement.
+FIXED_SHARED_DEVICE_IDS=''
+
+# =============================================================================
+# ELASTICSEARCH CONFIGURATION
+# =============================================================================
+
+# Elasticsearch ILM policy retention period
+ELASTICSEARCH_ILM_MIN_AGE=4h
+
+# =============================================================================
+# MESSAGE BROKER CONFIGURATION
+# =============================================================================
+# Message broker type: kafka or redis
+STREAM_TYPE=kafka
+
+# =============================================================================
+# VSS AGENT CONFIGURATION
+# =============================================================================
+# VSS Agent Core
+VSS_AGENT_CONFIG_FILE=/vss-agent/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
+# Enable audio handling for models and pipelines that require audio-aware clips.
+ENABLE_AUDIO=false
+
+# =============================================================================
+# VST PROFILE CONFIGURATION
+# =============================================================================
+# Used by: VST
+
+# VST deployment mode: Default: Direct mode
+# To switch to SDRC mode, uncomment the lines below:
+#VST_USE_SDRC=true
+#STREAM_PROCESSOR_MODULE_ENDPOINT=http://sdr-controller:10000
+#VST_NGINX_MODE=vst-sdrc
+
+# =============================================================================
+# AGENT UI CONFIGURATION
+# =============================================================================
+NEXT_PUBLIC_APP_SUBTITLE="Vision (Base)"
+NEXT_PUBLIC_SIDEBAR_CHAT_WORKFLOW="VSS Agent"
+NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_API_CUSTOM_AGENT_PARAMS_JSON={"params":[{"name":"llm_reasoning","label":"LLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""},{"name":"vlm_reasoning","label":"VLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""}]}
+NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_UPLOAD_FILE_ENABLE=true
+NEXT_PUBLIC_SIDEBAR_CHAT_WEB_SOCKET_DEFAULT_ON=true
+NEXT_PUBLIC_ENABLE_ALERTS_TAB=false
+NEXT_PUBLIC_ENABLE_SEARCH_TAB=false
+NEXT_PUBLIC_ENABLE_DASHBOARD_TAB=false
+NEXT_PUBLIC_ENABLE_VIDEO_MANAGEMENT_TAB=true
+NEXT_PUBLIC_VIDEO_MANAGEMENT_VIDEO_UPLOAD_ENABLE=true
+NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE=false
+
+# =============================================================================
+# EVAL CONFIGURATION
+# =============================================================================
+
+EVAL_DIR=deploy/docker/developer-profiles/dev-profile-base/eval/
+DATASET_DIR=agent_eval/dataset/vss-devx-base
+DATASET_FILE_NAME=dataset_single_turn.json
+REPORT_REFERENCE_BASE_DIR=/vss-agent/agent_eval/dataset/vss-devx-base/gt
+EVAL_OUTPUT_DIR=agent_eval/results

--- a/deploy/docker/developer-profiles/dev-profile-gym/.env
+++ b/deploy/docker/developer-profiles/dev-profile-gym/.env
@@ -21,29 +21,56 @@
 # =============================================================================
 # Values in this section are not rewritten by dev-profile.sh for this profile.
 MODE=2d
-RTVI_VLM_MAX_MODEL_LEN=''
+LVS_TAG="3.3.0-rc2"
+# LVS_TAG="3.3.0-rc2-sbsa"
+RTVI_VLM_IMAGE_TAG="3.3.0-26.08.2"
+# RTVI_VLM_IMAGE_TAG="3.3.0-26.08.2-sbsa"
 
 # =============================================================================
-# DEV-PROFILE-BASE ENVIRONMENT CONFIGURATION
+# DEV-PROFILE-GYM ENVIRONMENT CONFIGURATION
 # =============================================================================
-# This file contains environment variables for the developer base profile.
-# Services: Foundational, VST, NIM, Agents
+# DELIBERATELY A COPY OF dev-profile-lvs. Every value here is lvs's value, and
+# that is the point: the gym profile exists to run a side-by-side eval
+# comparison against a real profile, so the stack under test must be identical
+# to lvs. Any value that diverges becomes a confound in every score reported.
+# The only intended difference is the gym-eval token in COMPOSE_PROFILES
+# (overrides.env), and test-dev-profile.sh asserts exactly that.
+#
+# lvs rather than base because base registers only `video_understanding`, whose
+# fixed 30-frame sample over a 210s clip caps scores near 0.70 for any model.
+# lvs's config.yml registers `lvs_video_understanding`, which gives the
+# comparison headroom to show a difference. Note VSS_AGENT_CONFIG_FILE below
+# still points at dev-profile-lvs's config -- that is what registers the denser
+# path, and it must not be "fixed" to a gym-flavoured path.
+#
+# This file contains environment variables for the developer gym profile.
+# Services: Foundational, VST, NIM, LVS, Agents (+ gym-eval when enabled)
 #
 # Profile variants:
 # 2d:
-#   bp_developer_base
+#   bp_developer_lvs
 # =============================================================================
 
 # =============================================================================
 # DEPLOYMENT CONFIGURATION
 # =============================================================================
-# Blueprint profile for the developer base compose services.
-BP_PROFILE=bp_developer_base
+# Blueprint profile for the developer LVS compose services.
+BP_PROFILE=bp_developer_lvs
 
 # GPU IDs reserved for non-LLM/VLM services in this profile.
 RESERVED_DEVICE_IDS=''
 # GPU IDs treated as shared by dev-profile.sh when deriving LLM/VLM placement.
 FIXED_SHARED_DEVICE_IDS=''
+
+# =============================================================================
+# CORE INFRASTRUCTURE PATHS
+# =============================================================================
+# Optional graph/object-storage passwords. Leave empty for the default
+# Elasticsearch-backed LVS profile; set these only when enabling the
+# corresponding backend or object store integration.
+GRAPH_DB_PASSWORD=''
+ARANGO_DB_PASSWORD=''
+MINIO_PASSWORD=''
 
 # =============================================================================
 # ELASTICSEARCH CONFIGURATION
@@ -52,6 +79,9 @@ FIXED_SHARED_DEVICE_IDS=''
 # Elasticsearch ILM policy retention period
 ELASTICSEARCH_ILM_MIN_AGE=4h
 
+# Elasticsearch dense vector embedding fields (off for LVS profile)
+ELASTICSEARCH_ENABLE_EMBEDDINGS=false
+
 # =============================================================================
 # MESSAGE BROKER CONFIGURATION
 # =============================================================================
@@ -59,45 +89,72 @@ ELASTICSEARCH_ILM_MIN_AGE=4h
 STREAM_TYPE=kafka
 
 # =============================================================================
-# VSS AGENT CONFIGURATION
+# NVSTREAMER CONFIGURATION
 # =============================================================================
-# VSS Agent Core
-VSS_AGENT_CONFIG_FILE=/vss-agent/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
-# Enable audio handling for models and pipelines that require audio-aware clips.
-ENABLE_AUDIO=false
+# Install additional packages for audio, software encoding, file upload.
+NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES=true
+
+# NvStreamer HTTP port inside the Compose network. Host port overrides live in overrides.env.
+NVSTREAMER_HTTP_PORT=31000
 
 # =============================================================================
 # VST PROFILE CONFIGURATION
 # =============================================================================
-# Used by: VST
+# This profile uses SDRC; services/vios/vst.env defaults to direct VST mode.
+VST_USE_SDRC=true
+STREAM_PROCESSOR_MODULE_ENDPOINT=http://sdr-controller:10000
+VST_NGINX_MODE=vst-sdrc
 
-# VST deployment mode: Default: Direct mode
-# To switch to SDRC mode, uncomment the lines below:
-#VST_USE_SDRC=true
-#STREAM_PROCESSOR_MODULE_ENDPOINT=http://sdr-controller:10000
-#VST_NGINX_MODE=vst-sdrc
+# =============================================================================
+# VSS AGENT CONFIGURATION
+# =============================================================================
+# VSS Agent Core
+VSS_AGENT_CONFIG_FILE=/vss-agent/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+# Enable audio handling for VST/LVS clips when the selected model requires audio.
+ENABLE_AUDIO=false
+
+# LVS Backend URL
+LVS_BACKEND_URL=http://lvs-server:38111
+
+# =============================================================================
+# RTVI CONFIGURATION
+# =============================================================================
+# Raw VLM event topic produced by rtvi-vlm and consumed by the shared
+# infra Logstash LVS pipeline.
+RTVI_VLM_MESSAGE_BUS=kafka
+RTVI_VLM_MESSAGE_BUS_TOPIC=mdx-vlm-captions
+RTVI_VLM_ERROR_BUS=kafka
 
 # =============================================================================
 # AGENT UI CONFIGURATION
 # =============================================================================
-NEXT_PUBLIC_APP_SUBTITLE="Vision (Base)"
+NEXT_PUBLIC_APP_SUBTITLE="Vision (LVS)"
 NEXT_PUBLIC_SIDEBAR_CHAT_WORKFLOW="VSS Agent"
 NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_API_CUSTOM_AGENT_PARAMS_JSON={"params":[{"name":"llm_reasoning","label":"LLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""},{"name":"vlm_reasoning","label":"VLM Reasoning","type":"boolean","default-value":false,"changeable":true,"tooltip-info":""}]}
 NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_UPLOAD_FILE_ENABLE=true
 NEXT_PUBLIC_SIDEBAR_CHAT_WEB_SOCKET_DEFAULT_ON=true
 NEXT_PUBLIC_ENABLE_ALERTS_TAB=false
 NEXT_PUBLIC_ENABLE_SEARCH_TAB=false
-NEXT_PUBLIC_ENABLE_DASHBOARD_TAB=false
+NEXT_PUBLIC_ENABLE_DASHBOARD_TAB=true
 NEXT_PUBLIC_ENABLE_VIDEO_MANAGEMENT_TAB=true
 NEXT_PUBLIC_VIDEO_MANAGEMENT_VIDEO_UPLOAD_ENABLE=true
-NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE=false
-
+NEXT_PUBLIC_VIDEO_MANAGEMENT_TAB_ADD_RTSP_ENABLE=true
 # =============================================================================
-# EVAL CONFIGURATION
+# LVS (LONG VIDEO SUMMARIZATION) CONFIGURATION
 # =============================================================================
+# LVS Image name
+LVS_IMAGE="ghcr.io/nvidia-ai-blueprints/vss/vss-video-summarization"
 
-EVAL_DIR=deploy/docker/developer-profiles/dev-profile-base/eval/
-DATASET_DIR=agent_eval/dataset/vss-devx-base
-DATASET_FILE_NAME=dataset_single_turn.json
-REPORT_REFERENCE_BASE_DIR=/vss-agent/agent_eval/dataset/vss-devx-base/gt
-EVAL_OUTPUT_DIR=agent_eval/results
+BACKEND_PORT=38111
+LVS_MCP_PORT=38112
+
+
+# Kafka integration: route LVS structured summaries through Kafka
+KAFKA_ENABLED=true
+KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+KAFKA_STRUCTURED_SUMMARY_TOPIC=mdx-structured-events-summary
+LVS_ENABLE_LLM_MERGING=true
+
+# LVS MCP/SSE endpoint is optional for the developer profile; the agent uses
+# the backend HTTP API. Enable only when an external MCP client needs it.
+LVS_ENABLE_MCP=false

--- a/deploy/docker/developer-profiles/dev-profile-gym/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-gym/compose.yml
@@ -13,21 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include:
-  - path: ./dev-profile-base/compose.yml
-    env_file:
-      - ${VSS_APPS_DIR}/services/vios/vst.env
-  - path: ./dev-profile-gym/compose.yml
-    env_file:
-      - ${VSS_APPS_DIR}/services/vios/vst.env
-  - path: ./dev-profile-lvs/compose.yml
-    env_file:
-      - ${VSS_APPS_DIR}/services/vios/vst.env
-  - path: ./dev-profile-alerts/compose.yml
-    env_file:
-      - ${VSS_APPS_DIR}/services/vios/vst.env
-      - ${VSS_APPS_DIR}/services/rtvi/rtvi.env
-  - path: ./dev-profile-search/compose.yml
-    env_file:
-      - ${VSS_APPS_DIR}/services/vios/vst.env
-      - ${VSS_APPS_DIR}/services/rtvi/rtvi.env
+# Defines no services of its own: every developer-profile compose file is
+# included unconditionally and selection happens through COMPOSE_PROFILES, so
+# gym-eval (defined in dev-profile-base) is activated from overrides.env.

--- a/deploy/docker/developer-profiles/dev-profile-gym/compose.yml
+++ b/deploy/docker/developer-profiles/dev-profile-gym/compose.yml
@@ -16,3 +16,13 @@
 # Defines no services of its own: every developer-profile compose file is
 # included unconditionally and selection happens through COMPOSE_PROFILES, so
 # gym-eval (defined in dev-profile-base) is activated from overrides.env.
+#
+# The empty `services` mapping below is deliberate and must not be deleted. A
+# comments-only compose file parses as YAML null, and Compose requires a
+# top-level mapping; older releases reject that with "Top-level object must be a
+# mapping" (docker/compose#10888). Compose v5.1.4 accepts it -- the full include
+# chain resolves 11 services either way -- but this file is included
+# unconditionally by developer-profiles/compose.yml, so on a version that does
+# reject it EVERY profile would fail to load, not just gym. One line removes the
+# whole class of risk.
+services: {}

--- a/deploy/docker/developer-profiles/dev-profile-gym/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-gym/overrides.env
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # =============================================================================
-# DEV-PROFILE-BASE ENVIRONMENT OVERRIDES
+# DEV-PROFILE-GYM ENVIRONMENT OVERRIDES (a deliberate copy of dev-profile-lvs)
 # =============================================================================
 # Mutable deployment-specific values: hardware, model placement, model
 # endpoints, host paths, public ingress, credentials, and host-published
@@ -19,7 +19,7 @@ COMPOSE_PROJECT_NAME=vss
 # =============================================================================
 # DEPLOYMENT SELECTION
 # =============================================================================
-# Hardware profile for NIM and RTVI optimization.
+# Hardware profile for NIM, RTVI, and LVS optimization.
 # Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
 HARDWARE_PROFILE=H100
 
@@ -30,7 +30,7 @@ HARDWARE_PROFILE=H100
 LLM_DEVICE_ID='0'
 # Local VLM GPU device. Remote VLM and edge hardware may use device 0.
 VLM_DEVICE_ID='0'
-# Base RT-VLM device. local_shared follows the shared VLM device; remote and THOR edge use 0.
+# Alerts/LVS RT-VLM device. local_shared follows the shared VLM device; remote and THOR edge use 0.
 RT_VLM_DEVICE_ID='0'
 # LLM runtime mode: local_shared when LLM and VLM share one GPU, local for
 # a dedicated local LLM GPU, or remote for an external endpoint.
@@ -64,17 +64,17 @@ LLM_MODEL_TYPE=nim
 # =============================================================================
 # Local deployments route VLM traffic through RT-VLM. Keep VLM_NAME aligned
 # with the model id advertised by the RT-VLM /v1/models endpoint.
-# --vlm, fixed RT-VLM model for base/alerts/LVS, or remote /v1/models.
+# Select the RT-VLM advertised model id, THOR edge base model id, or remote /v1/models model id.
 VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_bf16-final
-# Derived from VLM_NAME; set to none for remote VLM, base/alerts/LVS RT-VLM, or disabled search critic.
+# Enables the local VLM compose profile; keep none for alerts/LVS RT-VLM or remote VLM.
 VLM_NAME_SLUG=none
-# --vlm-env-file. Local VLM only.
+# Extra env file for local VLM container settings.
 VLM_ENV_FILE=''
-# VLM_ENDPOINT_URL when --use-remote-vlm is passed; base local VLM uses rtvi-vlm.
+# VLM endpoint base URL. Alerts/LVS local VLM uses rtvi-vlm; remote deployments use the external endpoint.
 VLM_BASE_URL=http://rtvi-vlm:8000
-# --vlm-model-type for remote VLM, or rtvi for fixed RT-VLM profiles/hardware.
+# Model API type for the selected VLM endpoint; use rtvi for fixed RT-VLM profiles/hardware.
 VLM_MODEL_TYPE=rtvi
-# Local RT-VLM uses 8018; remote VLM compatibility uses 30082.
+# Alerts/LVS only. Local RT-VLM uses 8018; remote VLM compatibility uses 30082.
 VLM_PORT=8018
 # Optional local VLM custom weights path. Ignored when VLM_MODE=remote.
 # VLM_CUSTOM_WEIGHTS=""
@@ -110,13 +110,23 @@ VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
 VSS_UI_HOST_PORT=3000
 VSS_AGENT_HOST_PORT=8000
 RTVI_VLM_PORT=8018
+NVSTREAMER_HTTP_HOST_PORT=31000
+BACKEND_HOST_PORT=38111
+LVS_MCP_HOST_PORT=38112
 PHOENIX_HOST_PORT=6006
+ELASTICSEARCH_HOST_PORT=9200
+KAFKA_HOST_PORT=9092
 REDIS_HOST_PORT=6379
+KIBANA_HOST_PORT=5601
 VST_INGRESS_HOST_PORT=30888
 SENSOR_HTTP_HOST_PORT=30000
 STREAM_PROCESSOR_HTTP_HOST_PORT=30001
 RTSP_SERVER_HOST_PORT=30554
 RTSP_SERVER_HOST_PORT_END=30564
+SDRC_CONTROLLER_HOST_PORT=5003
+SDRC_PROXY_HOST_PORT=10000
+SDRC_DIRECT_HOST_PORT=8011
+SDRC_ENVOY_ADMIN_HOST_PORT=9902
 # Absolute host path to services/vios/configs under VSS_APPS_DIR.
 VST_CONFIG_PATH=${VSS_APPS_DIR}/services/vios/configs
 # Computed from the public ingress values above; keep after them for Compose interpolation.
@@ -151,39 +161,40 @@ HF_TOKEN=${HF_TOKEN:-}
 EVAL_LLM_JUDGE_NAME=${LLM_NAME}
 # Keep aligned with the selected LLM endpoint.
 EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
-# Use the regular tag by default; switch to the commented sbsa tag for DGX-SPARK/SBSA images.
-RTVI_VLM_IMAGE_TAG="3.3.0-26.08.2"
-#RTVI_VLM_IMAGE_TAG="3.3.0-26.08.2-sbsa"
-# Remote VLM sets this to ${VLM_BASE_URL}/v1; local integrated RT-VLM leaves empty.
+# Profile path under VSS_APPS_DIR selected by MODE.
+SDR_CONTROLLER_CONFIG_PATH=${VSS_APPS_DIR}/developer-profiles/dev-profile-lvs/sdrc/${MODE}
+# Remote VLM sets this to ${VLM_BASE_URL}/v1.
 RTVI_VLM_ENDPOINT=''
-# Base remote VLM uses openai-compat; local RT-VLM uses cosmos-reason3.
+# Alerts/LVS remote VLM uses openai-compat; local RT-VLM uses cosmos-reason3.
 RTVI_VLM_MODEL_TO_USE=cosmos-reason3
 # Set per hardware/mode for local RT-VLM; THOR edge can pass host env override.
 RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
 # Set to 18000 for RTXPRO4500BW local RT-VLM.
 RTVI_VLM_MAX_MODEL_LEN=''
-# Remote VLM sets none; local RT-VLM uses Cosmos3 Nano BF16 path.
+# Remote VLM uses none; RTXPRO4500BW local alerts/LVS uses the Cosmos3 Nano BF16 path.
 RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final
-# Base has no Kafka broker; disable RT-VLM Kafka publishes.
-RTVI_VLM_KAFKA_ENABLED=false
+# Optional Nemotron Nano Omni RT-VLM override. Uncomment these together,
+# provide a Hugging Face token, and set ENABLE_AUDIO=true for audio clips.
+#RTVI_VLM_MODEL_TO_USE=vllm-compatible
+#RTVI_VLM_MODEL_PATH='git:https://huggingface.co/nvidia/Nemotron-Nano-V3-Omni-GA0420-FP8'
+#VLM_NAME=Nemotron-Nano-V3-Omni-GA0420-FP8
+# VLM_MODEL_SUPPORTS_AUDIO=true
+# VLM_TRUST_REMOTE_CODE=true
+# INSTALL_PROPRIETARY_CODECS=true
+# ENABLE_AUDIO=true
 
 # =============================================================================
 # COMPOSE PROFILE SELECTION
 # =============================================================================
-# Services for the gym profile. The VLM is served by the integrated RT-VLM service.
+# Services for the gym profile: byte-identical to dev-profile-lvs's list.
 #
-# gym-eval is NOT in this list yet, so today this resolves the same service set
-# as base. Turning the eval on is appending ",gym-eval" to the line below, and it
-# is deliberately a separate change for two reasons:
+# THE RULE: gym's COMPOSE_PROFILES is lvs's list plus gym-eval, and nothing else
+# differs between the two profiles. That equality is the experiment, not tidiness
+# -- the comparison is two eval harnesses scoring one identical stack, so any
+# other divergence silently invalidates every number. test-dev-profile.sh
+# asserts it.
 #
-#   1. VSS_GYM_EVAL_TAG still points at a pre-#2376 build carrying the codec
-#      libraries VSS bans, and containers.env says in as many words to update the
-#      tag BEFORE adding this tag to any profile's COMPOSE_PROFILES. Activating
-#      it here would contradict that warning: `docker compose config --images`
-#      would resolve nemo-gym:26.05 and `dev-profile.sh -p gym up`, which runs
-#      `up --pull always`, would pull it.
-#   2. Nothing would run anyway. The service has no command and the image has no
-#      ENTRYPOINT (Cmd: ["/bin/bash"]), so it would start, read EOF and exit 0.
-#
-# Enable by appending ,gym-eval to COMPOSE_PROFILES below.
-COMPOSE_PROFILES=phoenix,redis,vss-haproxy-ingress,vss-ui,vss-agent,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,llm_${LLM_MODE}_${LLM_NAME_SLUG},rtvi-vlm
+# gym-eval is NOT in the list yet: VSS_GYM_EVAL_TAG still points at a pre-#2376
+# build carrying the codecs VSS bans, and dev-profile.sh runs `up --pull always`.
+# Enable by appending ,gym-eval to the line below once the tag moves.
+COMPOSE_PROFILES=kibana-init-container-lvs,nvstreamer-lvs,vss-agent,phoenix,elasticsearch,elasticsearch-init-container,kafka,kafka-topic-init-container,redis,kibana,logstash,broker-health-check,vss-haproxy-ingress,init-dirs,render-config,wdm-env-from-config,wait-for-redis,wait-for-docker-workloads,sdr-controller,rtvi-vlm,vss-ui,lvs-server,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,llm_${LLM_MODE}_${LLM_NAME_SLUG}

--- a/deploy/docker/developer-profiles/dev-profile-gym/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-gym/overrides.env
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# =============================================================================
+# DEV-PROFILE-BASE ENVIRONMENT OVERRIDES
+# =============================================================================
+# Mutable deployment-specific values: hardware, model placement, model
+# endpoints, host paths, public ingress, credentials, and host-published
+# port overrides. Docker Compose should read the profile .env first and
+# this file second so these values win.
+# =============================================================================
+
+# =============================================================================
+# DOCKER COMPOSE CONFIGURATION
+# =============================================================================
+# Project name for volume naming. Change this to run multiple profiles on one host.
+COMPOSE_PROJECT_NAME=vss
+
+# =============================================================================
+# DEPLOYMENT SELECTION
+# =============================================================================
+# Hardware profile for NIM and RTVI optimization.
+# Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
+HARDWARE_PROFILE=H100
+
+# =============================================================================
+# MODEL PLACEMENT AND RUNTIME MODE
+# =============================================================================
+# Local LLM GPU device. Edge hardware may require device 0.
+LLM_DEVICE_ID='0'
+# Local VLM GPU device. Remote VLM and edge hardware may use device 0.
+VLM_DEVICE_ID='0'
+# Base RT-VLM device. local_shared follows the shared VLM device; remote and THOR edge use 0.
+RT_VLM_DEVICE_ID='0'
+# LLM runtime mode: local_shared when LLM and VLM share one GPU, local for
+# a dedicated local LLM GPU, or remote for an external endpoint.
+LLM_MODE=local_shared
+# VLM runtime mode: local_shared when VLM shares a GPU, local for a
+# dedicated local VLM GPU, or remote for an external endpoint.
+VLM_MODE=local_shared
+
+# =============================================================================
+# LLM SELECTION
+# =============================================================================
+# Local LLM choices:
+# - nvidia/nvidia-nemotron-nano-9b-v2 -> nvidia-nemotron-nano-9b-v2
+# - nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8 -> nvidia-nemotron-nano-9b-v2-fp8
+# - nvidia/nemotron-3-nano -> nemotron-3-nano
+# - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
+# - openai/gpt-oss-20b -> gpt-oss-20b
+# Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
+LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
+# Enables the local LLM compose profile; set to none for remote LLM.
+LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
+# Extra env file for local LLM container settings.
+LLM_ENV_FILE=''
+# LLM endpoint base URL. Local deployments use the Compose service; remote deployments use the external endpoint.
+LLM_BASE_URL=http://vss-llm-nim:8000
+# Model API type for the selected LLM endpoint.
+LLM_MODEL_TYPE=nim
+
+# =============================================================================
+# VLM SELECTION
+# =============================================================================
+# Local deployments route VLM traffic through RT-VLM. Keep VLM_NAME aligned
+# with the model id advertised by the RT-VLM /v1/models endpoint.
+# --vlm, fixed RT-VLM model for base/alerts/LVS, or remote /v1/models.
+VLM_NAME=nim_nvidia_cosmos3-nano-reasoner_bf16-final
+# Derived from VLM_NAME; set to none for remote VLM, base/alerts/LVS RT-VLM, or disabled search critic.
+VLM_NAME_SLUG=none
+# --vlm-env-file. Local VLM only.
+VLM_ENV_FILE=''
+# VLM_ENDPOINT_URL when --use-remote-vlm is passed; base local VLM uses rtvi-vlm.
+VLM_BASE_URL=http://rtvi-vlm:8000
+# --vlm-model-type for remote VLM, or rtvi for fixed RT-VLM profiles/hardware.
+VLM_MODEL_TYPE=rtvi
+# Local RT-VLM uses 8018; remote VLM compatibility uses 30082.
+VLM_PORT=8018
+# Optional local VLM custom weights path. Ignored when VLM_MODE=remote.
+# VLM_CUSTOM_WEIGHTS=""
+
+# =============================================================================
+# HOST PATHS AND INGRESS
+# =============================================================================
+# Absolute path to this repository's deploy/docker directory.
+VSS_APPS_DIR="/path/to/deploy/docker"
+# Data directory for downloaded models, videos, and runtime logs.
+VSS_DATA_DIR="/path/to/vss-apps-data"
+# Hostname or IP clients should use when services are reachable directly.
+HOST_IP='<HOST_IP>'
+# Public hostname/IP for generated URLs. On local hosts this usually matches HOST_IP; on cloud VMs use the public address.
+EXTERNAL_IP="${HOST_IP}"
+# For Brev secure links, use ${PROXY_PORT:-7777}.
+HAPROXY_PORT=7777
+# Direct local ingress uses http; TLS or secure-link ingress uses https.
+VSS_PUBLIC_HTTP_PROTOCOL=http
+# Direct local WebSocket ingress uses ws; TLS or secure-link ingress uses wss.
+VSS_PUBLIC_WS_PROTOCOL=ws
+# For Brev secure links, use ${PROXY_PORT:-7777}-${BREV_ENV_ID}.brevlab.com.
+VSS_PUBLIC_HOST=${EXTERNAL_IP}
+# Host-published HAProxy port. Change this if 7777 conflicts locally.
+HAPROXY_HOST_PORT=7777
+# Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
+VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
+
+# =============================================================================
+# HOST-PUBLISHED PORTS
+# =============================================================================
+# Change these when a default host port conflicts with another local service.
+VSS_UI_HOST_PORT=3000
+VSS_AGENT_HOST_PORT=8000
+RTVI_VLM_PORT=8018
+PHOENIX_HOST_PORT=6006
+REDIS_HOST_PORT=6379
+VST_INGRESS_HOST_PORT=30888
+SENSOR_HTTP_HOST_PORT=30000
+STREAM_PROCESSOR_HTTP_HOST_PORT=30001
+RTSP_SERVER_HOST_PORT=30554
+RTSP_SERVER_HOST_PORT_END=30564
+# Absolute host path to services/vios/configs under VSS_APPS_DIR.
+VST_CONFIG_PATH=${VSS_APPS_DIR}/services/vios/configs
+# Computed from the public ingress values above; keep after them for Compose interpolation.
+VST_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
+# Keep aligned with VST_EXTERNAL_URL.
+VST_BASE_URL=${VST_EXTERNAL_URL}
+# Computed from the public ingress values above.
+VSS_AGENT_REPORTS_BASE_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}/static/
+# Computed from the public ingress values above.
+VSS_AGENT_EXTERNAL_URL=${VSS_PUBLIC_HTTP_PROTOCOL}://${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}
+
+# =============================================================================
+# CREDENTIALS
+# =============================================================================
+# Required for local NIM image/model pulls.
+# Obtain from: https://ngc.nvidia.com/
+NGC_CLI_API_KEY=${NGC_CLI_API_KEY:-}
+# Required for build.nvidia.com remote endpoints.
+# Obtain from: https://build.nvidia.com/
+NVIDIA_API_KEY=${NVIDIA_API_KEY:-}
+# Required for OpenAI remote endpoints.
+# Obtain from: https://platform.openai.com/
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
+# Optional for authenticated Hugging Face model downloads (higher rate limits).
+# Obtain from: https://huggingface.co/settings/tokens
+HF_TOKEN=${HF_TOKEN:-}
+
+# =============================================================================
+# PROFILE-SPECIFIC SCENARIO OVERRIDES
+# =============================================================================
+# Keep aligned with the selected LLM model.
+EVAL_LLM_JUDGE_NAME=${LLM_NAME}
+# Keep aligned with the selected LLM endpoint.
+EVAL_LLM_JUDGE_BASE_URL=${LLM_BASE_URL}
+# Use the regular tag by default; switch to the commented sbsa tag for DGX-SPARK/SBSA images.
+RTVI_VLM_IMAGE_TAG="3.3.0-26.08.2"
+#RTVI_VLM_IMAGE_TAG="3.3.0-26.08.2-sbsa"
+# Remote VLM sets this to ${VLM_BASE_URL}/v1; local integrated RT-VLM leaves empty.
+RTVI_VLM_ENDPOINT=''
+# Base remote VLM uses openai-compat; local RT-VLM uses cosmos-reason3.
+RTVI_VLM_MODEL_TO_USE=cosmos-reason3
+# Set per hardware/mode for local RT-VLM; THOR edge can pass host env override.
+RTVI_VLLM_GPU_MEMORY_UTILIZATION=''
+# Set to 18000 for RTXPRO4500BW local RT-VLM.
+RTVI_VLM_MAX_MODEL_LEN=''
+# Remote VLM sets none; local RT-VLM uses Cosmos3 Nano BF16 path.
+RTVI_VLM_MODEL_PATH=ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final
+# Base has no Kafka broker; disable RT-VLM Kafka publishes.
+RTVI_VLM_KAFKA_ENABLED=false
+
+# =============================================================================
+# COMPOSE PROFILE SELECTION
+# =============================================================================
+# Services for base profile. The VLM is served by the integrated RT-VLM service.
+# Base's service set plus gym-eval -- the only difference between the two
+# profiles. `-p gym` is base with the NeMo Gym eval runner switched on.
+COMPOSE_PROFILES=phoenix,redis,vss-haproxy-ingress,vss-ui,vss-agent,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,llm_${LLM_MODE}_${LLM_NAME_SLUG},rtvi-vlm,gym-eval

--- a/deploy/docker/developer-profiles/dev-profile-gym/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-gym/overrides.env
@@ -170,7 +170,20 @@ RTVI_VLM_KAFKA_ENABLED=false
 # =============================================================================
 # COMPOSE PROFILE SELECTION
 # =============================================================================
-# Services for base profile. The VLM is served by the integrated RT-VLM service.
-# Base's service set plus gym-eval -- the only difference between the two
-# profiles. `-p gym` is base with the NeMo Gym eval runner switched on.
-COMPOSE_PROFILES=phoenix,redis,vss-haproxy-ingress,vss-ui,vss-agent,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,llm_${LLM_MODE}_${LLM_NAME_SLUG},rtvi-vlm,gym-eval
+# Services for the gym profile. The VLM is served by the integrated RT-VLM service.
+#
+# gym-eval is NOT in this list yet, so today this resolves the same service set
+# as base. Turning the eval on is appending ",gym-eval" to the line below, and it
+# is deliberately a separate change for two reasons:
+#
+#   1. VSS_GYM_EVAL_TAG still points at a pre-#2376 build carrying the codec
+#      libraries VSS bans, and containers.env says in as many words to update the
+#      tag BEFORE adding this tag to any profile's COMPOSE_PROFILES. Activating
+#      it here would contradict that warning: `docker compose config --images`
+#      would resolve nemo-gym:26.05 and `dev-profile.sh -p gym up`, which runs
+#      `up --pull always`, would pull it.
+#   2. Nothing would run anyway. The service has no command and the image has no
+#      ENTRYPOINT (Cmd: ["/bin/bash"]), so it would start, read EOF and exit 0.
+#
+# Enable by appending ,gym-eval to COMPOSE_PROFILES below.
+COMPOSE_PROFILES=phoenix,redis,vss-haproxy-ingress,vss-ui,vss-agent,centralizedb,vst-ingress,sensor-ms,streamprocessing-ms,llm_${LLM_MODE}_${LLM_NAME_SLUG},rtvi-vlm


### PR DESCRIPTION
## Description

> **Stacked on #1720.** Review that one first; this PR's base is set to its branch, so the diff shown here is only this change.

Adds `dev-profile-gym`: the developer profile where the Gym eval will run. It is **`dev-profile-base` plus, later, the `gym-eval` service**.

- `dev-profile-gym/.env` and `overrides.env` — copied from base.
- `dev-profile-gym/compose.yml` — header only, **defines no services**. Every developer-profile compose file is included unconditionally and selection happens through `COMPOSE_PROFILES`, so the `gym-eval` service stays defined once, in base, and would be activated from here.
- Registered in the `developer-profiles/compose.yml` include chain.

### `gym-eval` is not switched on yet, and that is the point

**Today `-p gym` resolves exactly the same 11 services as `-p base`.** `gym-eval` is absent from this profile's `COMPOSE_PROFILES`; the line that turns it on sits directly above it, commented, so the flip is a single visible edit.

The reason is the tag. `VSS_GYM_EVAL_TAG` still points at `nemo-gym:26.05`, which predates [Gym#2376](https://github.com/NVIDIA-NeMo/Gym/pull/2376) and still carries the codec libraries VSS bans — and `containers.env` says in as many words *"update the tag before adding it to any profile's `COMPOSE_PROFILES`"*. Activating it here would have contradicted that warning: `docker compose config --images` for this profile would resolve `nvcr.io/nvidia/eval-factory/nemo-gym:26.05`, and `-p gym up` would pull it.

Nothing is lost by waiting, because the service has no command or dataset wiring yet — starting it today would run `/bin/bash` and exit. What this PR buys is that the profile, the driver support (next PR) and the test coverage (the one after) are all reviewed and in place, so turning the eval on is one uncommented line rather than a four-part change.

### Why a separate profile rather than enabling it in base

Blast radius. `-p base` behaves exactly as it does today and `-p gym` is the opt-in, so no existing deployment changes shape when the eval eventually turns on. Enabling it inside base is a later, separate flip.

## Verification

`docker compose config` with `VSS_APPS_DIR` set:

- **`-p gym` resolves 11 services and 11 images**, identical to `-p base`, with no `nemo-gym` reference.
- **`-p base` is untouched** — 11 services, 11 images, 73 warnings, byte-identical to develop.

Test coverage for this profile lands in the last PR of the stack, once the driver knows the profile name.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
