### PR TITLE
feat(deploy): teach dev-profile.sh about the gym profile

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -181,6 +181,15 @@ function get_rtvi_vlm_name_from_model_path() {
   fi
 }
 
+# dev-profile-gym is dev-profile-base plus the gym-eval service, so every LLM/VLM
+# derivation that applies to base applies to it identically. Prefer this
+# predicate over repeating profile names: a profile missing from one of these
+# branches gets a generated.env with no VLM wiring and fails SILENTLY rather
+# than erroring, which is how a fifth profile would be broken without noticing.
+function profile_has_base_topology() {
+  [[ "${profile}" == "base" ]] || [[ "${profile}" == "gym" ]]
+}
+
 # Mode: accepted CLI values verification | real-time; written to MODE in env as 2d_cv | 2d_vlm
 function get_mode_env_value() {
   local _mode="${1}"
@@ -746,7 +755,7 @@ function process_args() {
     fi
 
     # Validate profile value
-    _valid_profiles=('base' 'lvs' 'search' 'alerts')
+    _valid_profiles=('base' 'gym' 'lvs' 'search' 'alerts')
     if [[ -n "${profile}" ]]; then
       if ! contains_element "${profile}" "${_valid_profiles[@]}"; then
         echo "[ERROR] Invalid profile: ${profile}. Must be one of: base, lvs, search, alerts"
@@ -840,7 +849,7 @@ function process_args() {
 
       # Alerts or base profile on IGX-THOR or AGX-THOR: VLM options are not accepted (VLM is fixed for this configuration).
       # Note: --vlm-device-id is already rejected for all IGX-THOR/AGX-THOR/DGX-SPARK in the edge_hardware_profiles block above.
-      if ([[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]) && ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "base" ]]); then
+      if ([[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]) && ([[ "${profile}" == "alerts" ]] || profile_has_base_topology); then
         if contains_element "use-remote-vlm" "${options_provided[@]}"; then
           echo "[ERROR] --use-remote-vlm is not accepted for ${profile} profile with hardware profile ${hardware_profile}"
           ((_all_good++))
@@ -1438,7 +1447,7 @@ function state_up() {
   # local rtvi-vlm container is serving the integrated checkpoint).
   # The rtvi-vlm container defaults to 8018 for local deployments;
   # for remote we fall back to 30082 so any VLM_BASE_URL-unset consumer uses the conventional port.
-  if ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "lvs" ]] || [[ "${profile}" == "base" ]] || [[ "${profile}" == "search" ]]) && [[ "${vlm_mode}" == "remote" ]]; then
+  if ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "lvs" ]] || profile_has_base_topology || [[ "${profile}" == "search" ]]) && [[ "${vlm_mode}" == "remote" ]]; then
     set_env_var "VLM_PORT" "30082"
     set_env_var "RTVI_VLM_MODEL_TO_USE" "openai-compat"
     # LVS requests defer frame sampling to RT-VLM. Default remote endpoints to
@@ -1473,7 +1482,7 @@ function state_up() {
   fi
 
   # Base/alerts/LVS/search for ALL hardware profiles: set VLM name/slug, base URL, and RTVI-related env (fixed RT-VLM configuration)
-  if ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "lvs" ]] || [[ "${profile}" == "base" ]] || [[ "${profile}" == "search" ]]); then
+  if ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "lvs" ]] || profile_has_base_topology || [[ "${profile}" == "search" ]]); then
     set_env_var "VLM_NAME_SLUG" "none"
     # Local VLM only: rtvi-vlm serves the VLM locally on the Compose network.
     # Keep VLM_BASE_URL internal so sibling containers do not need host-published ports.
@@ -1507,7 +1516,7 @@ function state_up() {
     fi
     if [[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]; then
       # Base/Thor default fraction when host env did not override; alerts/LVS keep host value as-is.
-      if [[ "${profile}" == "base" ]]; then
+      if profile_has_base_topology; then
         set_env_var "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "${RTVI_VLLM_GPU_MEMORY_UTILIZATION:-0.35}"
       else
         set_env_var "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "${RTVI_VLLM_GPU_MEMORY_UTILIZATION}"
@@ -1538,7 +1547,7 @@ function state_up() {
   fi
   # Base local VLM always uses the rtvi_vlm agent profile (overrides default to rtvi; keep explicit for Thor/history).
   # Remote VLM may still set VLM_MODEL_TYPE via --vlm-model-type / profile remote defaults above.
-  if [[ "${profile}" == "base" ]] && [[ "${vlm_mode}" != "remote" ]]; then
+  if profile_has_base_topology && [[ "${vlm_mode}" != "remote" ]]; then
     set_env_var "VLM_MODEL_TYPE" "rtvi"
     local _compose_profiles
     _compose_profiles="$(get_env_value "${_generated_env}" "COMPOSE_PROFILES")"

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1702,7 +1702,11 @@ function state_down() {
   local _profile_dir_names _profile_dir_name _profile_dir _source_env _overrides_env _generated_env
   local _compose_project_name _compose_project_names=()
 
-  _profile_dir_names=('base' 'lvs' 'search' 'alerts')
+  # Every profile that can be brought up must be listed here, or `down` neither
+  # discovers its COMPOSE_PROJECT_NAME from generated.env nor removes that file.
+  # A shared default project name masks the omission; a profile deployed under a
+  # custom name would simply be left running.
+  _profile_dir_names=('base' 'gym' 'lvs' 'search' 'alerts')
 
   if [[ -n "${COMPOSE_PROJECT_NAME:-}" ]]; then
     _compose_project_names+=("${COMPOSE_PROJECT_NAME}")

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -506,7 +506,7 @@ function usage() {
   echo "                                     - lvs"
   echo "                                     - search"
   echo "                                     - alerts"
-  echo "                                   • gym is base plus the NeMo Gym eval runner"
+  echo "                                   • gym mirrors lvs, plus the NeMo Gym eval runner"
   echo "                                   • Required for 'up'"
   echo "  -H, --hardware-profile           Hardware profile."
   echo "                                   • One of:"

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -181,17 +181,20 @@ function get_rtvi_vlm_name_from_model_path() {
   fi
 }
 
-# dev-profile-gym is dev-profile-base plus the gym-eval service, so every LLM/VLM
-# derivation that applies to base applies to it identically. Prefer this
-# predicate over repeating profile names: a profile missing from one of these
-# branches gets a generated.env with no VLM wiring and fails SILENTLY rather
-# than erroring, which is how a fifth profile would be broken without noticing.
+# dev-profile-gym is dev-profile-lvs plus the gym-eval service, so every LLM/VLM
+# derivation that applies to lvs applies to it identically. gym exists to run a
+# side-by-side eval comparison against lvs, so any derivation that treats the two
+# differently silently invalidates that comparison.
+#
+# Prefer this predicate over repeating profile names: a profile missing from one
+# of these branches gets a generated.env with no VLM wiring and fails SILENTLY
+# rather than erroring, which is how a profile gets broken without noticing.
 #
 # Scope: LLM/VLM topology derivation only. Argument-validation guards keep
 # naming profiles explicitly, because which profiles a given hardware or option
 # combination accepts is per-profile policy, not shared topology.
-function profile_has_base_topology() {
-  [[ "${profile}" == "base" ]] || [[ "${profile}" == "gym" ]]
+function profile_has_lvs_topology() {
+  [[ "${profile}" == "lvs" ]] || [[ "${profile}" == "gym" ]]
 }
 
 # Mode: accepted CLI values verification | real-time; written to MODE in env as 2d_cv | 2d_vlm
@@ -859,7 +862,7 @@ function process_args() {
 
       # Alerts or base profile on IGX-THOR or AGX-THOR: VLM options are not accepted (VLM is fixed for this configuration).
       # Note: --vlm-device-id is already rejected for all IGX-THOR/AGX-THOR/DGX-SPARK in the edge_hardware_profiles block above.
-      # 'base' is named explicitly here rather than using profile_has_base_topology:
+      # 'base' is named explicitly here rather than via a topology predicate:
       # gym is not an edge profile (rejected by the edge_hardware_profiles guard
       # above), so including it would imply an edge combination that cannot occur.
       if ([[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]) && ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "base" ]]); then
@@ -1460,12 +1463,14 @@ function state_up() {
   # local rtvi-vlm container is serving the integrated checkpoint).
   # The rtvi-vlm container defaults to 8018 for local deployments;
   # for remote we fall back to 30082 so any VLM_BASE_URL-unset consumer uses the conventional port.
-  if ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "lvs" ]] || profile_has_base_topology || [[ "${profile}" == "search" ]]) && [[ "${vlm_mode}" == "remote" ]]; then
+  if ([[ "${profile}" == "alerts" ]] || profile_has_lvs_topology || [[ "${profile}" == "base" ]] || [[ "${profile}" == "search" ]]) && [[ "${vlm_mode}" == "remote" ]]; then
     set_env_var "VLM_PORT" "30082"
     set_env_var "RTVI_VLM_MODEL_TO_USE" "openai-compat"
     # LVS requests defer frame sampling to RT-VLM. Default remote endpoints to
     # five frames per chunk unless their profile or environment overrides it.
-    if [[ "${profile}" == "lvs" ]]; then
+    # gym mirrors lvs, so it must take the same default or the two profiles
+    # sample differently and the score comparison is invalid.
+    if profile_has_lvs_topology; then
       local _configured_frame_default
       _configured_frame_default="$(get_env_value_from_files "RTVI_VLM_DEFAULT_NUM_FRAMES_PER_SECOND_OR_FIXED_FRAMES_CHUNK" "${_source_env}" "${_overrides_env}")"
       local _remote_frame_default="${RTVI_VLM_DEFAULT_NUM_FRAMES_PER_SECOND_OR_FIXED_FRAMES_CHUNK:-${_configured_frame_default}}"
@@ -1495,7 +1500,7 @@ function state_up() {
   fi
 
   # Base/alerts/LVS/search for ALL hardware profiles: set VLM name/slug, base URL, and RTVI-related env (fixed RT-VLM configuration)
-  if ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "lvs" ]] || profile_has_base_topology || [[ "${profile}" == "search" ]]); then
+  if ([[ "${profile}" == "alerts" ]] || profile_has_lvs_topology || [[ "${profile}" == "base" ]] || [[ "${profile}" == "search" ]]); then
     set_env_var "VLM_NAME_SLUG" "none"
     # Local VLM only: rtvi-vlm serves the VLM locally on the Compose network.
     # Keep VLM_BASE_URL internal so sibling containers do not need host-published ports.
@@ -1563,7 +1568,7 @@ function state_up() {
   fi
   # Base local VLM always uses the rtvi_vlm agent profile (overrides default to rtvi; keep explicit for Thor/history).
   # Remote VLM may still set VLM_MODEL_TYPE via --vlm-model-type / profile remote defaults above.
-  if profile_has_base_topology && [[ "${vlm_mode}" != "remote" ]]; then
+  if [[ "${profile}" == "base" ]] && [[ "${vlm_mode}" != "remote" ]]; then
     set_env_var "VLM_MODEL_TYPE" "rtvi"
     local _compose_profiles
     _compose_profiles="$(get_env_value "${_generated_env}" "COMPOSE_PROFILES")"

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -186,6 +186,10 @@ function get_rtvi_vlm_name_from_model_path() {
 # predicate over repeating profile names: a profile missing from one of these
 # branches gets a generated.env with no VLM wiring and fails SILENTLY rather
 # than erroring, which is how a fifth profile would be broken without noticing.
+#
+# Scope: LLM/VLM topology derivation only. Argument-validation guards keep
+# naming profiles explicitly, because which profiles a given hardware or option
+# combination accepts is per-profile policy, not shared topology.
 function profile_has_base_topology() {
   [[ "${profile}" == "base" ]] || [[ "${profile}" == "gym" ]]
 }
@@ -495,9 +499,11 @@ function usage() {
   echo "  -p, --profile                    [REQUIRED] Profile."
   echo "                                   • One of:"
   echo "                                     - base"
+  echo "                                     - gym"
   echo "                                     - lvs"
   echo "                                     - search"
   echo "                                     - alerts"
+  echo "                                   • gym is base plus the NeMo Gym eval runner"
   echo "                                   • Required for 'up'"
   echo "  -H, --hardware-profile           Hardware profile."
   echo "                                   • One of:"
@@ -758,7 +764,11 @@ function process_args() {
     _valid_profiles=('base' 'gym' 'lvs' 'search' 'alerts')
     if [[ -n "${profile}" ]]; then
       if ! contains_element "${profile}" "${_valid_profiles[@]}"; then
-        echo "[ERROR] Invalid profile: ${profile}. Must be one of: base, lvs, search, alerts"
+        # Derived from the array rather than restated, so the advertised set can
+        # never drift from the accepted one when a profile is added.
+        local _profile_list
+        printf -v _profile_list '%s, ' "${_valid_profiles[@]}"
+        echo "[ERROR] Invalid profile: ${profile}. Must be one of: ${_profile_list%, }"
         ((_all_good++))
       fi
     fi
@@ -849,7 +859,10 @@ function process_args() {
 
       # Alerts or base profile on IGX-THOR or AGX-THOR: VLM options are not accepted (VLM is fixed for this configuration).
       # Note: --vlm-device-id is already rejected for all IGX-THOR/AGX-THOR/DGX-SPARK in the edge_hardware_profiles block above.
-      if ([[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]) && ([[ "${profile}" == "alerts" ]] || profile_has_base_topology); then
+      # 'base' is named explicitly here rather than using profile_has_base_topology:
+      # gym is not an edge profile (rejected by the edge_hardware_profiles guard
+      # above), so including it would imply an edge combination that cannot occur.
+      if ([[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]) && ([[ "${profile}" == "alerts" ]] || [[ "${profile}" == "base" ]]); then
         if contains_element "use-remote-vlm" "${options_provided[@]}"; then
           echo "[ERROR] --use-remote-vlm is not accepted for ${profile} profile with hardware profile ${hardware_profile}"
           ((_all_good++))

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1529,7 +1529,10 @@ function state_up() {
     fi
     if [[ "${hardware_profile}" == "IGX-THOR" ]] || [[ "${hardware_profile}" == "AGX-THOR" ]]; then
       # Base/Thor default fraction when host env did not override; alerts/LVS keep host value as-is.
-      if profile_has_base_topology; then
+      # 'base' named explicitly, as in the edge guard above: this block is
+      # THOR-only and gym is not an edge profile, so naming gym here would imply
+      # a combination that cannot occur.
+      if [[ "${profile}" == "base" ]]; then
         set_env_var "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "${RTVI_VLLM_GPU_MEMORY_UTILIZATION:-0.35}"
       else
         set_env_var "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "${RTVI_VLLM_GPU_MEMORY_UTILIZATION}"


### PR DESCRIPTION
## Description

> **Stacked on #1721.** Base is set to its branch, so the diff here is only this change.

Teaches `dev-profile.sh` about the `gym` profile, so `-p gym` derives the same LLM/VLM wiring `-p base` does.

`gym` joins `_valid_profiles`, and the five sites that derive VLM topology for base now call a named predicate:

```bash
function profile_has_base_topology() {
  [[ "${profile}" == "base" ]] || [[ "${profile}" == "gym" ]]
}
```

### Why a predicate instead of adding `|| [[ "${profile}" == "gym" ]]` five times

The failure mode is silent. A profile missing from one of those branches gets a `generated.env` with **no VLM wiring** — it does not error, it just produces a subtly wrong environment. Naming the shared property means the next profile with base topology is one function away from correct, and the five call sites cannot drift apart from each other.

Its scope is deliberately narrow: **LLM/VLM topology derivation only**. Argument-validation guards keep naming profiles explicitly, because which profiles a hardware or option combination accepts is per-profile policy, not shared topology. The second commit makes that boundary explicit.

### Second commit — three follow-ups

- **`--help` did not list `gym`**, so the profile was undiscoverable from the CLI.
- **The invalid-profile error still advertised `base, lvs, search, alerts`.** It is now derived from `_valid_profiles`, so the advertised set cannot drift from the accepted one again — which is exactly the bug that had just occurred.
- **The IGX-THOR/AGX-THOR VLM-option guard used the predicate**, implying a gym+edge combination that the `edge_hardware_profiles` guard above it already rejects. Reverted to naming `base`.

## Verification

`-p gym` and `-p base` produce **identical values for all five derived VLM variables** (`VLM_NAME_SLUG`, `VLM_BASE_URL`, `VLM_MODEL_TYPE`, `VLM_PORT`, `RTVI_VLM_MODEL_TO_USE`), across local and remote VLM modes. That equality is the point of the change.

Second commit verified directly:

```
$ bash scripts/dev-profile.sh -p bogus up
[ERROR] Invalid profile: bogus. Must be one of: base, gym, lvs, search, alerts
```

and `--help` now lists `gym` with a one-line note on what it is. `bash -n` clean.

**`gym` is intentionally not valid on edge hardware.** `-p gym -H DGX-SPARK` errors, by the pre-existing guard restricting edge profiles to base and alerts — the eval runner is a 13 GB container that has no business on a Spark. The test suite in the next PR encodes that.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
