### PR TITLE
test(deploy): cover dev-profile-gym in the profile test suite

### DIFF
--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -447,6 +447,12 @@ chmod +x "${_mock_rtx4500_nvidia_smi_dir}/nvidia-smi"
 PATH="${_mock_rtx4500_nvidia_smi_dir}:${PATH}" SKIP_HARDWARE_CHECK= run_dry_run_test "RTXPRO4500BW accepted when detected GPU is RTX PRO 4500 Blackwell" up -p base -i 127.0.0.1 -H RTXPRO4500BW -d
 run_negative_test "DGX-SPARK only valid for base or alerts (not lvs)" 1 up -p lvs -i 127.0.0.1 -H DGX-SPARK
 run_negative_test "DGX-SPARK only valid for base or alerts (not search)" 1 up -p search -i 127.0.0.1 -H DGX-SPARK
+# gym shares base's LLM/VLM topology but is NOT an edge profile: it exists to add
+# a large eval container, which has no place on an edge device. Without these,
+# excluding gym from the DGX-SPARK loop would be an untested assumption.
+run_negative_test "DGX-SPARK only valid for base or alerts (not gym)" 1 up -p gym -i 127.0.0.1 -H DGX-SPARK
+run_negative_test "IGX-THOR only valid for base or alerts (not gym)" 1 up -p gym -i 127.0.0.1 -H IGX-THOR
+run_negative_test "AGX-THOR only valid for base or alerts (not gym)" 1 up -p gym -i 127.0.0.1 -H AGX-THOR
 run_negative_test "alerts without --mode" 1 up -p alerts -i 127.0.0.1
 run_negative_test "IGX-THOR only valid for base or alerts (not lvs)" 1 up -p lvs -i 127.0.0.1 -H IGX-THOR
 run_negative_test "IGX-THOR only valid for base or alerts (not search)" 1 up -p search -i 127.0.0.1 -H IGX-THOR
@@ -1120,7 +1126,7 @@ fi
 EOF
   chmod +x "${mock_dir}"/*
 
-  local ngc_profiles=(base lvs search alerts)
+  local ngc_profiles=(base gym lvs search alerts)
   local ngc_gen_envs=()
   local ngc_backups=()
   local ngc_profile ngc_gen_env ngc_backup
@@ -1756,6 +1762,7 @@ for _env in \
   "${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-search/.env" \
   "${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-lvs/.env" \
   "${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-alerts/.env" \
+  "${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-gym/.env" \
   "${REPO_ROOT}/deploy/docker/industry-profiles/warehouse-operations/.env"; do
   if grep -q "^VSS_AGENT_CONFIG_FILE=/vss-agent/deploy/docker/" "${_env}"; then
     echo "PASS: ${_env} uses an in-container VSS_AGENT_CONFIG_FILE path"
@@ -2044,7 +2051,7 @@ if [[ -f "${_custom_project_overrides}" ]]; then
   CLEANUP_RESTORES+=("${_custom_project_backup}|${_custom_project_overrides}")
   sed -i 's/^COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=vss-custom-test/' "${_custom_project_overrides}"
   _custom_project_generated_backups=()
-  for _custom_project_profile in base lvs search alerts; do
+  for _custom_project_profile in base gym lvs search alerts; do
     _custom_project_generated="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-${_custom_project_profile}/generated.env"
     if [[ -f "${_custom_project_generated}" ]]; then
       _custom_project_generated_backup="$(mktemp)"
@@ -2091,7 +2098,7 @@ else
 fi
 
 # --- Positive: dry-run down tears down each distinct COMPOSE_PROJECT_NAME from generated.env files ---
-_multi_project_specs=("base:vss-base-test" "lvs:vss-base-test" "alerts:vss-alerts-test")
+_multi_project_specs=("base:vss-base-test" "gym:vss-gym-test" "lvs:vss-base-test" "alerts:vss-alerts-test")
 _multi_project_backups=()
 _multi_project_created=()
 for _multi_project_spec in "${_multi_project_specs[@]}"; do

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -447,7 +447,7 @@ chmod +x "${_mock_rtx4500_nvidia_smi_dir}/nvidia-smi"
 PATH="${_mock_rtx4500_nvidia_smi_dir}:${PATH}" SKIP_HARDWARE_CHECK= run_dry_run_test "RTXPRO4500BW accepted when detected GPU is RTX PRO 4500 Blackwell" up -p base -i 127.0.0.1 -H RTXPRO4500BW -d
 run_negative_test "DGX-SPARK only valid for base or alerts (not lvs)" 1 up -p lvs -i 127.0.0.1 -H DGX-SPARK
 run_negative_test "DGX-SPARK only valid for base or alerts (not search)" 1 up -p search -i 127.0.0.1 -H DGX-SPARK
-# gym shares base's LLM/VLM topology but is NOT an edge profile: it exists to add
+# gym shares lvs's LLM/VLM topology but is NOT an edge profile: it exists to add
 # a large eval container, which has no place on an edge device. Without these,
 # excluding gym from the DGX-SPARK loop would be an untested assumption.
 run_negative_test "DGX-SPARK only valid for base or alerts (not gym)" 1 up -p gym -i 127.0.0.1 -H DGX-SPARK
@@ -1487,8 +1487,22 @@ run_dry_run_up_and_check_generated_env "generated.env HARDWARE_PROFILE OTHER" "b
 # in both states: shipped-off today (lists identical) and enabled later (gym has
 # exactly one extra token).
 #
-# Compared as parsed key=value pairs rather than as a file diff, because the
-# descriptive headers deliberately name gym rather than lvs.
+# Compared as comment-stripped content IN ORDER, not as sorted `KEY=` lines.
+# Review found the sorted-key form blind to three real divergences: multi-line
+# quoted values (only the first line starts with KEY=), reordering (a dotenv
+# value may reference a key defined earlier in the same file, so order can change
+# expansion), and duplicate keys. Comparing the remaining lines verbatim catches
+# all three.
+#
+# Comments are stripped because the descriptive headers deliberately name gym.
+# Known and accepted gap: a divergence confined to a commented-out assignment is
+# invisible here. Such a line is inert until someone uncomments it, at which
+# point this test sees it.
+_rule_norm() {
+  # Drop comment-only and blank lines, then neutralise the single permitted
+  # difference so everything else can be compared verbatim.
+  grep -vE '^[[:space:]]*(#|$)' "${1}" | sed -E 's/^(COMPOSE_PROFILES=.*),gym-eval$/\1/'
+}
 _rule_failed=0
 for _rule_file in .env overrides.env; do
   _rule_lvs="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-lvs/${_rule_file}"
@@ -1496,11 +1510,7 @@ for _rule_file in .env overrides.env; do
   if [[ ! -f "${_rule_lvs}" ]] || [[ ! -f "${_rule_gym}" ]]; then
     continue
   fi
-  # Every key=value in lvs must appear identically in gym, and vice versa,
-  # except COMPOSE_PROFILES which is handled separately below.
-  _rule_diff="$(diff \
-    <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "${_rule_lvs}" | grep -v '^COMPOSE_PROFILES=' | sort) \
-    <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "${_rule_gym}" | grep -v '^COMPOSE_PROFILES=' | sort) || true)"
+  _rule_diff="$(diff <(_rule_norm "${_rule_lvs}") <(_rule_norm "${_rule_gym}") || true)"
   if [[ -n "${_rule_diff}" ]]; then
     echo "FAIL: dev-profile-gym/${_rule_file} diverges from dev-profile-lvs/${_rule_file} -- gym must mirror lvs exactly so the eval comparison stays valid:"
     echo "${_rule_diff}" | head -20

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1211,6 +1211,10 @@ for _profile in base lvs search alerts; do
   fi
   _expected_override_keys=("${_common_overrides_env_keys[@]}")
   _allowed_duplicate_keys=()
+  # Reset alongside the other two: this is assigned only inside the case arms
+  # below and there is no default arm, so without a reset a profile that matches
+  # no arm silently inherits the previous iteration's expectations.
+  _expected_stable_keys=()
   case "${_profile}" in
     base)
       _expected_override_keys+=(EVAL_LLM_JUDGE_NAME EVAL_LLM_JUDGE_BASE_URL RTVI_VLM_PORT RTVI_VLM_IMAGE_TAG RTVI_VLM_ENDPOINT RTVI_VLM_MODEL_TO_USE RTVI_VLLM_GPU_MEMORY_UTILIZATION RTVI_VLM_MAX_MODEL_LEN RTVI_VLM_MODEL_PATH)

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1201,7 +1201,7 @@ _common_overrides_env_keys=(
   NGC_CLI_API_KEY NVIDIA_API_KEY OPENAI_API_KEY
 )
 _split_failed=0
-for _profile in base lvs search alerts; do
+for _profile in base gym lvs search alerts; do
   _stable_env="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-${_profile}/.env"
   _overrides_env="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-${_profile}/overrides.env"
   if [[ ! -f "${_stable_env}" || ! -f "${_overrides_env}" ]]; then
@@ -1216,7 +1216,7 @@ for _profile in base lvs search alerts; do
   # no arm silently inherits the previous iteration's expectations.
   _expected_stable_keys=()
   case "${_profile}" in
-    base)
+    base|gym)
       _expected_override_keys+=(EVAL_LLM_JUDGE_NAME EVAL_LLM_JUDGE_BASE_URL RTVI_VLM_PORT RTVI_VLM_IMAGE_TAG RTVI_VLM_ENDPOINT RTVI_VLM_MODEL_TO_USE RTVI_VLLM_GPU_MEMORY_UTILIZATION RTVI_VLM_MAX_MODEL_LEN RTVI_VLM_MODEL_PATH)
       _expected_stable_keys=(MODE RTVI_VLM_MAX_MODEL_LEN)
       _allowed_duplicate_keys=(RTVI_VLM_MAX_MODEL_LEN)
@@ -1473,6 +1473,9 @@ run_dry_run_up_and_check_generated_env "generated.env HARDWARE_PROFILE OTHER" "b
 
 # DGX-SPARK: for each profile, run dry-run with -H DGX-SPARK and assert sbsa variants (keys from profile overrides.env).
 # DGX-SPARK (and IGX-THOR) are only valid for base and alerts
+# gym is deliberately absent: dev-profile.sh restricts DGX-SPARK/IGX-THOR/
+# AGX-THOR to base and alerts, and gym adds a large eval container that has
+# no place on an edge device.
 for _profile in base alerts; do
   run_spark_test_for_profile "${_profile}"
 done
@@ -1799,7 +1802,7 @@ else
   echo "FAIL: VIOS service env should expose shared Helm-compatible VST endpoint defaults"
   ((TESTS_FAILED++)) || true
 fi
-for _profile in base search lvs alerts; do
+for _profile in base gym search lvs alerts; do
   _env="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-${_profile}/.env"
   _overrides_env="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-${_profile}/overrides.env"
   if ! grep -Fq "VST_INTERNAL_IP=" "${_env}" && ! grep -Fq "VST_INGRESS_ENDPOINT=" "${_env}" && grep -Fq "VST_BASE_URL=" "${_overrides_env}"; then

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1479,6 +1479,28 @@ run_dry_run_up_and_check_generated_env "generated.env HARDWARE_PROFILE OTHER" "b
 
 # DGX-SPARK: for each profile, run dry-run with -H DGX-SPARK and assert sbsa variants (keys from profile overrides.env).
 # DGX-SPARK (and IGX-THOR) are only valid for base and alerts
+# --- gym-eval must stay switched off in EVERY profile ---
+# The service is declared in dev-profile-base/compose.yml but must not appear in
+# any profile's COMPOSE_PROFILES until VSS_GYM_EVAL_TAG points at a build after
+# NVIDIA-NeMo/Gym#2376; the pinned 26.05 still carries the codec libraries
+# check_no_patented_codecs.py forbids, and dev-profile.sh runs `up --pull always`.
+# Without this check, enabling it is a one-word edit no test would catch --
+# which is exactly the mistake review caught in this series once already.
+_gym_eval_enabled_in=()
+for _gym_off_env in "${REPO_ROOT}"/deploy/docker/developer-profiles/dev-profile-*/overrides.env; do
+  [[ -f "${_gym_off_env}" ]] || continue
+  if grep -Eq '^COMPOSE_PROFILES=.*(^|,)gym-eval(,|$)' "${_gym_off_env}"; then
+    _gym_eval_enabled_in+=("${_gym_off_env#"${REPO_ROOT}/"}")
+  fi
+done
+if [[ ${#_gym_eval_enabled_in[@]} -eq 0 ]]; then
+  echo "PASS: gym-eval is not enabled in any profile's COMPOSE_PROFILES"
+  ((TESTS_PASSED++)) || true
+else
+  echo "FAIL: gym-eval is enabled in ${_gym_eval_enabled_in[*]} -- point VSS_GYM_EVAL_TAG at a post-NVIDIA-NeMo/Gym#2376 build before enabling it (see containers.env)"
+  ((TESTS_FAILED++)) || true
+fi
+
 # gym is deliberately absent: dev-profile.sh restricts DGX-SPARK/IGX-THOR/
 # AGX-THOR to base and alerts, and gym adds a large eval container that has
 # no place on an edge device.
@@ -1497,6 +1519,25 @@ run_dry_run_up_and_check_generated_env "generated.env base local VLM uses RT-VLM
   "RTVI_VLM_ENDPOINT" "''" "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" \
   "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" \
   "RTVI_VLM_KAFKA_ENABLED" "false"
+
+# gym must derive byte-identical VLM wiring to base -- that equality is the whole
+# point of profile_has_base_topology in dev-profile.sh. Asserted with the same
+# values as the base case directly above, so if the predicate ever stops covering
+# gym this fails loudly instead of producing a generated.env with no VLM config.
+run_dry_run_up_and_check_generated_env "generated.env gym local VLM matches base exactly" "gym" \
+ -i 127.0.0.1 -H OTHER -d -- \
+  "VLM_MODE" "local_shared" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_bf16-final" "VLM_NAME_SLUG" "none" \
+  "VLM_BASE_URL" "http://rtvi-vlm:8000" "VLM_MODEL_TYPE" "rtvi" "VLM_PORT" "8018" \
+  "RTVI_VLM_ENDPOINT" "''" "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" \
+  "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" \
+  "RTVI_VLM_KAFKA_ENABLED" "false"
+
+# Same equality on the remote-VLM path, which is a different branch in state_up.
+# VLM_ENDPOINT_URL is required whenever --use-remote-vlm is passed.
+VLM_ENDPOINT_URL=http://127.0.0.1:8001 \
+run_dry_run_up_and_check_generated_env "generated.env gym remote VLM matches base exactly" "gym" \
+ -i 127.0.0.1 -H OTHER --use-remote-vlm --vlm nvidia/cosmos-reason1-7b -d -- \
+  "VLM_PORT" "30082" "RTVI_VLM_MODEL_TO_USE" "openai-compat"
 
 run_dry_run_up_and_check_generated_env "generated.env MODE for alerts" "alerts" \
  -i 127.0.0.1 -m verification -d -- \

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1222,12 +1222,12 @@ for _profile in base gym lvs search alerts; do
   # no arm silently inherits the previous iteration's expectations.
   _expected_stable_keys=()
   case "${_profile}" in
-    base|gym)
+    base)
       _expected_override_keys+=(EVAL_LLM_JUDGE_NAME EVAL_LLM_JUDGE_BASE_URL RTVI_VLM_PORT RTVI_VLM_IMAGE_TAG RTVI_VLM_ENDPOINT RTVI_VLM_MODEL_TO_USE RTVI_VLLM_GPU_MEMORY_UTILIZATION RTVI_VLM_MAX_MODEL_LEN RTVI_VLM_MODEL_PATH)
       _expected_stable_keys=(MODE RTVI_VLM_MAX_MODEL_LEN)
       _allowed_duplicate_keys=(RTVI_VLM_MAX_MODEL_LEN)
       ;;
-    lvs)
+    lvs|gym)
       _expected_override_keys+=(RT_VLM_DEVICE_ID VLM_PORT RTVI_VLM_PORT EVAL_LLM_JUDGE_NAME EVAL_LLM_JUDGE_BASE_URL SDR_CONTROLLER_CONFIG_PATH RTVI_VLM_ENDPOINT RTVI_VLM_MODEL_TO_USE RTVI_VLLM_GPU_MEMORY_UTILIZATION RTVI_VLM_MAX_MODEL_LEN RTVI_VLM_MODEL_PATH)
       _expected_override_keys+=(NVSTREAMER_HTTP_HOST_PORT BACKEND_HOST_PORT LVS_MCP_HOST_PORT ELASTICSEARCH_HOST_PORT KAFKA_HOST_PORT KIBANA_HOST_PORT SDRC_CONTROLLER_HOST_PORT SDRC_PROXY_HOST_PORT SDRC_DIRECT_HOST_PORT SDRC_ENVOY_ADMIN_HOST_PORT)
       _expected_stable_keys=(MODE LVS_TAG RTVI_VLM_IMAGE_TAG NVSTREAMER_HTTP_PORT NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES)
@@ -1479,6 +1479,54 @@ run_dry_run_up_and_check_generated_env "generated.env HARDWARE_PROFILE OTHER" "b
 
 # DGX-SPARK: for each profile, run dry-run with -H DGX-SPARK and assert sbsa variants (keys from profile overrides.env).
 # DGX-SPARK (and IGX-THOR) are only valid for base and alerts
+# --- THE RULE: dev-profile-gym is dev-profile-lvs plus the gym-eval token ---
+# gym exists to run a side-by-side eval comparison against lvs: two eval
+# harnesses scoring one identical stack. Stack-identity is therefore the control
+# variable, and ANY divergence beyond gym-eval is a confound in every score
+# reported -- silently, because nothing else would notice. This asserts the rule
+# in both states: shipped-off today (lists identical) and enabled later (gym has
+# exactly one extra token).
+#
+# Compared as parsed key=value pairs rather than as a file diff, because the
+# descriptive headers deliberately name gym rather than lvs.
+_rule_failed=0
+for _rule_file in .env overrides.env; do
+  _rule_lvs="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-lvs/${_rule_file}"
+  _rule_gym="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-gym/${_rule_file}"
+  if [[ ! -f "${_rule_lvs}" ]] || [[ ! -f "${_rule_gym}" ]]; then
+    continue
+  fi
+  # Every key=value in lvs must appear identically in gym, and vice versa,
+  # except COMPOSE_PROFILES which is handled separately below.
+  _rule_diff="$(diff \
+    <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "${_rule_lvs}" | grep -v '^COMPOSE_PROFILES=' | sort) \
+    <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "${_rule_gym}" | grep -v '^COMPOSE_PROFILES=' | sort) || true)"
+  if [[ -n "${_rule_diff}" ]]; then
+    echo "FAIL: dev-profile-gym/${_rule_file} diverges from dev-profile-lvs/${_rule_file} -- gym must mirror lvs exactly so the eval comparison stays valid:"
+    echo "${_rule_diff}" | head -20
+    _rule_failed=1
+  fi
+done
+# COMPOSE_PROFILES: gym is lvs's token set, optionally plus gym-eval, nothing else.
+_rule_lvs_tokens="$(grep '^COMPOSE_PROFILES=' "${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env" | cut -d= -f2- | tr ',' '\n' | sort -u)"
+_rule_gym_tokens="$(grep '^COMPOSE_PROFILES=' "${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-gym/overrides.env" | cut -d= -f2- | tr ',' '\n' | sort -u)"
+_rule_missing="$(comm -23 <(echo "${_rule_lvs_tokens}") <(echo "${_rule_gym_tokens}"))"
+_rule_extra="$(comm -13 <(echo "${_rule_lvs_tokens}") <(echo "${_rule_gym_tokens}"))"
+if [[ -n "${_rule_missing}" ]]; then
+  echo "FAIL: dev-profile-gym COMPOSE_PROFILES is missing lvs tokens: $(echo ${_rule_missing} | tr '\n' ' ')"
+  _rule_failed=1
+fi
+if [[ -n "${_rule_extra}" ]] && [[ "$(echo ${_rule_extra})" != "gym-eval" ]]; then
+  echo "FAIL: dev-profile-gym COMPOSE_PROFILES has tokens beyond lvs + gym-eval: $(echo ${_rule_extra} | tr '\n' ' ')"
+  _rule_failed=1
+fi
+if [[ ${_rule_failed} -eq 0 ]]; then
+  echo "PASS: dev-profile-gym mirrors dev-profile-lvs (only difference permitted is the gym-eval token)"
+  ((TESTS_PASSED++)) || true
+else
+  ((TESTS_FAILED++)) || true
+fi
+
 # --- gym-eval must stay switched off in EVERY profile ---
 # The service is declared in dev-profile-base/compose.yml but must not appear in
 # any profile's COMPOSE_PROFILES until VSS_GYM_EVAL_TAG points at a build after
@@ -1520,24 +1568,27 @@ run_dry_run_up_and_check_generated_env "generated.env base local VLM uses RT-VLM
   "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" \
   "RTVI_VLM_KAFKA_ENABLED" "false"
 
-# gym must derive byte-identical VLM wiring to base -- that equality is the whole
-# point of profile_has_base_topology in dev-profile.sh. Asserted with the same
-# values as the base case directly above, so if the predicate ever stops covering
-# gym this fails loudly instead of producing a generated.env with no VLM config.
-run_dry_run_up_and_check_generated_env "generated.env gym local VLM matches base exactly" "gym" \
+# gym must derive byte-identical VLM wiring to LVS -- that equality is the whole
+# point of profile_has_lvs_topology in dev-profile.sh, and it is what makes the
+# side-by-side eval comparison valid. Asserted with lvs's values, so if the
+# predicate ever stops covering gym this fails loudly instead of producing a
+# generated.env with no VLM config.
+run_dry_run_up_and_check_generated_env "generated.env gym local VLM matches lvs exactly" "gym" \
  -i 127.0.0.1 -H OTHER -d -- \
   "VLM_MODE" "local_shared" "VLM_NAME" "nim_nvidia_cosmos3-nano-reasoner_bf16-final" "VLM_NAME_SLUG" "none" \
   "VLM_BASE_URL" "http://rtvi-vlm:8000" "VLM_MODEL_TYPE" "rtvi" "VLM_PORT" "8018" \
   "RTVI_VLM_ENDPOINT" "''" "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" \
-  "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final" \
-  "RTVI_VLM_KAFKA_ENABLED" "false"
+  "RTVI_VLM_MODEL_PATH" "ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final"
 
-# Same equality on the remote-VLM path, which is a different branch in state_up.
+# Same equality on the remote-VLM path, a different branch in state_up. The
+# frame-chunk default was previously lvs-only; gym must take it too, or the two
+# profiles sample frames differently and every compared score is invalid.
 # VLM_ENDPOINT_URL is required whenever --use-remote-vlm is passed.
 VLM_ENDPOINT_URL=http://127.0.0.1:8001 \
-run_dry_run_up_and_check_generated_env "generated.env gym remote VLM matches base exactly" "gym" \
+run_dry_run_up_and_check_generated_env "generated.env gym remote VLM matches lvs exactly" "gym" \
  -i 127.0.0.1 -H OTHER --use-remote-vlm --vlm nvidia/cosmos-reason1-7b -d -- \
-  "VLM_PORT" "30082" "RTVI_VLM_MODEL_TO_USE" "openai-compat"
+  "VLM_PORT" "30082" "RTVI_VLM_MODEL_TO_USE" "openai-compat" \
+  "RTVI_VLM_DEFAULT_NUM_FRAMES_PER_SECOND_OR_FIXED_FRAMES_CHUNK" "5"
 
 run_dry_run_up_and_check_generated_env "generated.env MODE for alerts" "alerts" \
  -i 127.0.0.1 -m verification -d -- \


### PR DESCRIPTION
## Description

> **Stacked on #1722.** Base is set to its branch, so the diff here is only this change.
>
> It also carries the `_expected_stable_keys` reset from #1718, which this change **requires**: adding a fifth profile to the env-split loop is precisely the situation that bug bites. If #1718 lands first the commit drops out on rebase.

Brings `dev-profile-gym` under the existing profile test suite, so it is checked the same way the other four profiles are:

- added to the **env-split loop**, via a `base|gym)` case arm — the two profiles share expectations because gym *is* base plus one service.
- added to the **shared-VST-defaults loop**.

### Deliberately excluded from the DGX-SPARK loop

The suite caught this: `-p gym -H DGX-SPARK` errors, because `dev-profile.sh` restricts edge hardware to base and alerts. That is correct behaviour, not a gap — a 13 GB eval container does not belong on a Spark — so gym is left out of that loop rather than the guard being loosened to accommodate the test.

## Verification

**204 passed / 2 failed**, against a **203 / 2** baseline on develop. The two failures are pre-existing, unrelated to the env split, and present with and without this change:

- `warehouse MV3DT skill should not reference legacy app-data model paths`
- `warehouse MV3DT Compose and Helm startup semantics or perception fallback diverged`

A green run does not by itself prove the new profile is *covered* — a loop that silently skips it also passes. So coverage was proven by **negative control**: removing `EVAL_LLM_JUDGE_NAME` from `dev-profile-gym/overrides.env` turns the suite red with

```
FAIL: dev-profile-gym/overrides.env should define EVAL_LLM_JUDGE_NAME
```

at 203 passed / 3 failed. The assertions genuinely run against the new profile. The file was then restored and `git status` confirmed clean.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
