### PR TITLE
feat(skill-eval): add --remote-vss for disaggregated runs

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -614,6 +614,15 @@ Notes that have burned prior runs:
   trial dispatches.
 - `-i` / `--include` is a different flag and will silently match
   nothing or everything.
+- `--remote-vss <base-url>` is a **developer path, not a CI path** — do not
+  use it in a matrix leg. It evaluates an already-deployed VSS from Harbor's
+  default sandbox, so it skips pool selection, the box lock and every `brev`
+  call, and it drops `BREV_INSTANCE` from the Harbor env. Nothing about the
+  fleet-selection contract in § 5a changes for the runs you dispatch; the flag
+  exists so a workstation or non-pool GPU box can run runtime specs without
+  being registered. Runtime skills only — `REMOTE_VSS_SUPPORTED_SKILLS` in
+  `run_leg.py` gates it and deploy-centric specs raise. See README
+  § "Disaggregated run against an already-deployed VSS".
 - **Multi-step specs MUST be dispatched one step at a time, in
   order, with skip-on-prior-fail.** Harbor's default scheduler treats every
   `step-*/` subdir as an independent task and runs them unordered

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -197,6 +197,52 @@ python3 .github/skill-eval/run_leg.py \
 
 `CLAUDE_CODE_DISABLE_THINKING=1` is required when routing through the NVIDIA Anthropic proxy — claude-code ≥ 2.1.x otherwise emits a `context_management` field the proxy rejects with HTTP 400.
 
+### Disaggregated run against an already-deployed VSS (`--remote-vss`)
+
+`--remote-vss <base-url>` separates the system under test from the trial
+sandbox: VSS stays deployed on whatever box you already have, and the trial
+runs in **Harbor's own default sandbox** on the machine you invoke
+`run_leg.py` from, reaching that deployment over HTTP.
+
+This needs no Brev at all — no `brev register`, no `BREV_REGISTERED_POOL`
+entry, no `vss-eval-*` naming, no pool selection and no box lock. It is the
+path to use on a workstation or any GPU box that is not a pool member.
+
+```bash
+# VSS already running elsewhere; nothing here deploys or resets it.
+python3 .github/skill-eval/adapters/vss-ask-video/generate.py \
+  --output-dir /tmp/skill-eval/datasets/vss-ask-video \
+  --skill-dir skills/vss-ask-video \
+  --platform RTXPRO6000BW
+
+export PYTHONPATH="$(pwd)/.github/skill-eval:${PYTHONPATH:-}"
+
+python3 .github/skill-eval/run_leg.py \
+  --dataset-root /tmp/skill-eval/datasets/vss-ask-video \
+  --results-root /tmp/skill-eval/results/remote-$(date +%Y%m%d-%H%M%S) \
+  --scratch /tmp/skill-eval/manual \
+  --spec-stem base_profile_video_understanding \
+  --platform RTXPRO6000BW \
+  --remote-vss http://10.0.0.5:8000
+```
+
+The endpoint is forwarded into the trial as `VSS_BASE_URL`, `HOST_IP` and
+`VSS_AGENT_PORT` (via Harbor `--ae`); the runtime skills' existing port
+conventions resolve from `HOST_IP`, which defaults to `localhost` otherwise.
+`REMOTE_VSS_BASE_URL` works as an env-var default for the flag.
+
+Because the box is never touched, the warning above about wiping the docker
+runtime does **not** apply — a disaggregated leg only makes HTTP calls, so it
+is safe to point at a deployment you care about.
+
+**Runtime skills only.** Deploy-centric specs are rejected with a clear error
+rather than run against a stack they did not build: a disaggregated leg has no
+box to deploy onto, so `/vss-deploy-profile` in a first turn would either fail
+deep inside the trial or quietly score something other than what the spec name
+says. Supported today: `vss-ask-video`, `vss-generate-video-report`,
+`vss-query-analytics`, `vss-search-archive`, `vss-summarize-video`
+(`REMOTE_VSS_SUPPORTED_SKILLS` in `run_leg.py`).
+
 ### Inspect a result
 
 ```

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -54,6 +54,24 @@ HARBOR_REQUIREMENT = "harbor==0.20.0"
 STEP_COUNT_RE = re.compile(r"^\s*step_count\s*=\s*(\d+)\s*$", re.MULTILINE)
 SAFE_PART_RE = re.compile(r"[^A-Za-z0-9_-]+")
 RTX4090_PREFIX = "vss-eval-geforce-rtx4090-"
+
+# Harbor's own default environment. `--remote-vss` runs the trial in this
+# sandbox instead of `envs.brev_env:BrevEnvironment`, because a disaggregated
+# leg drives an already-deployed VSS over HTTP and so needs no GPU, no Brev
+# box, and no pool lock.
+BREV_ENVIRONMENT_IMPORT_PATH = "envs.brev_env:BrevEnvironment"
+
+# Skills whose trials exercise an already-running VSS over its APIs, and so
+# can run disaggregated. Deploy-centric skills (vss-deploy-profile,
+# vss-build-vision-agent, ...) build or bring up a stack on the box itself and
+# are rejected rather than silently measuring something else.
+REMOTE_VSS_SUPPORTED_SKILLS = frozenset({
+    "vss-ask-video",
+    "vss-generate-video-report",
+    "vss-query-analytics",
+    "vss-search-archive",
+    "vss-summarize-video",
+})
 # RTX 4090 capability-routing is opt-in at the spec level via gpu_type.
 # These tables are intentionally empty: a test runs on RTX 4090 only when
 # its spec metadata declares gpu_type that matches GEFORCE RTX 4090.
@@ -299,6 +317,8 @@ def build_harbor_command(
     model: str,
     anthropic_base_url: str,
     agent: str = "claude-code",
+    environment_import_path: str | None = BREV_ENVIRONMENT_IMPORT_PATH,
+    agent_env: dict[str, str] | None = None,
 ) -> list[str]:
     if agent == "codex":
         # Custom NvCodex subclass (agents/nv_codex.py) keeps the full
@@ -320,6 +340,16 @@ def build_harbor_command(
         ]
     else:
         raise ValueError(f"unsupported agent {agent!r} (expected claude-code | codex)")
+    for key, value in sorted((agent_env or {}).items()):
+        agent_flags += ["--ae", f"{key}={value}"]
+    # Omitting the flag leaves Harbor on its own default environment (docker).
+    # That is what a disaggregated leg wants: a sandbox that only needs to
+    # reach the remote VSS over HTTP.
+    environment_flags = (
+        ["--environment-import-path", environment_import_path]
+        if environment_import_path
+        else []
+    )
     return [
         "uvx",
         "--python",
@@ -328,8 +358,7 @@ def build_harbor_command(
         HARBOR_REQUIREMENT,
         "harbor",
         "run",
-        "--environment-import-path",
-        "envs.brev_env:BrevEnvironment",
+        *environment_flags,
         "-p",
         str(invocation.harbor_root),
         "--include-task-name",
@@ -351,7 +380,46 @@ def build_harbor_command(
     ]
 
 
-def harbor_env(instance: str) -> dict[str, str]:
+def remote_vss_env(remote_vss: str) -> dict[str, str]:
+    """Endpoint vars a disaggregated trial needs to reach the remote VSS.
+
+    ``HOST_IP`` is included because the runtime skills' gold solutions and
+    checks already resolve endpoints from it (with a ``localhost`` default),
+    so pointing that one variable at the remote box redirects the existing
+    port conventions without teaching every check a new URL.
+    """
+    parsed = urllib.parse.urlparse(remote_vss)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise ValueError(
+            f"--remote-vss must be an http(s) URL with a host, got {remote_vss!r}"
+        )
+    env = {
+        "VSS_BASE_URL": remote_vss.rstrip("/"),
+        "HOST_IP": parsed.hostname,
+    }
+    if parsed.port:
+        env["VSS_AGENT_PORT"] = str(parsed.port)
+    return env
+
+
+def validate_remote_vss_skill(skill: str | None) -> None:
+    """Reject deploy-centric skills instead of silently mis-measuring them.
+
+    A disaggregated leg has no box to deploy onto, so a spec whose first turn
+    runs ``/vss-deploy-profile`` would either fail deep inside the trial or
+    quietly score something other than what its name says.
+    """
+    if skill in REMOTE_VSS_SUPPORTED_SKILLS:
+        return
+    supported = ", ".join(sorted(REMOTE_VSS_SUPPORTED_SKILLS))
+    raise ValueError(
+        f"--remote-vss does not support skill {skill!r}: a disaggregated leg "
+        f"drives an already-deployed VSS and cannot run deploy-centric specs. "
+        f"Supported skills: {supported}"
+    )
+
+
+def harbor_env(instance: str, remote_vss: str | None = None) -> dict[str, str]:
     env = os.environ.copy()
     workspace = env.get("GITHUB_WORKSPACE") or str(REPO_ROOT)
     skill_eval_path = str(Path(workspace) / ".github" / "skill-eval")
@@ -360,8 +428,20 @@ def harbor_env(instance: str) -> dict[str, str]:
         pythonpath = f"{skill_eval_path}:{pythonpath}" if pythonpath else skill_eval_path
     env["PYTHONPATH"] = pythonpath
     env["PATH"] = f"{Path.home() / '.local' / 'bin'}:{env.get('PATH', '')}"
-    env["BREV_INSTANCE"] = instance
     env["CLAUDE_CODE_DISABLE_THINKING"] = "1"
+    if remote_vss:
+        # No Brev box is involved, so leaving BREV_INSTANCE set (it defaults
+        # from the environment) would point BrevEnvironment at a machine this
+        # leg never locked. Drop the whole Brev transport surface instead.
+        for key in (
+            "BREV_INSTANCE",
+            "BREV_EXEC_TIMEOUT",
+            "BREV_TRANSFER_TOTAL_TIMEOUT_SEC",
+        ):
+            env.pop(key, None)
+        env.update(remote_vss_env(remote_vss))
+        return env
+    env["BREV_INSTANCE"] = instance
     try:
         configured_brev_timeout = int(env.get("BREV_EXEC_TIMEOUT", "0"))
     except ValueError as exc:
@@ -1253,8 +1333,9 @@ def run_invocations(
     platform: str,
     harbor_timeout_sec: int,
     work_deadline: float | None = None,
+    remote_vss: str | None = None,
 ) -> int:
-    env = harbor_env(instance)
+    env = harbor_env(instance, remote_vss)
     agent = os.environ.get("EVAL_AGENT", "claude-code")
     # Reject unknown agents loudly — otherwise a typo (e.g. "Codex") would
     # silently fall through to the claude-code path and be indistinguishable
@@ -1330,7 +1411,17 @@ def run_invocations(
                     )
                 return 124
 
-        cmd = build_harbor_command(invocation, results_root, model, base_url, agent)
+        cmd = build_harbor_command(
+            invocation,
+            results_root,
+            model,
+            base_url,
+            agent,
+            environment_import_path=(
+                None if remote_vss else BREV_ENVIRONMENT_IMPORT_PATH
+            ),
+            agent_env=remote_vss_env(remote_vss) if remote_vss else None,
+        )
         started_at = time.time() - 1.0
         with phase(f"harbor:{invocation.include_task_name}"):
             rc = run_command(cmd, env, harbor_timeout_sec)
@@ -1383,6 +1474,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=os.environ.get("BREV_INSTANCE") or None,
         help="Operator override: pin the leg to this Brev instance instead "
              "of pool selection (still lock-guarded; waits if held)",
+    )
+    parser.add_argument(
+        "--remote-vss",
+        default=os.environ.get("REMOTE_VSS_BASE_URL") or None,
+        metavar="BASE_URL",
+        help="Disaggregated run: evaluate an already-deployed VSS reachable at "
+             "BASE_URL (e.g. http://10.0.0.5:8000). Runs the trial in Harbor's "
+             "default sandbox instead of BrevEnvironment, and skips pool "
+             "selection, the box lock, and every brev call. Runtime skills "
+             "only -- deploy-centric specs are rejected.",
     )
     parser.add_argument("--dataset-root", required=True, type=Path, help="Per-leg generated dataset root")
     parser.add_argument("--results-root", required=True, type=Path, help="Per-leg Harbor results root")
@@ -1466,6 +1567,30 @@ def main(argv: list[str] | None = None) -> int:
                 "whole-leg deadline cannot fit one complete Harbor invocation"
             )
         effective_lock_timeout = min(args.lock_timeout_sec, max_lock_wait)
+        if args.remote_vss:
+            # Nothing to select and nothing to lock: the system under test is
+            # already deployed elsewhere and the sandbox is local to this
+            # process, so two disaggregated legs never contend for a box.
+            validate_remote_vss_skill(
+                metadata.get("skill") or os.environ.get("EVAL_SKILL") or None
+            )
+            print(
+                f"[run-leg] disaggregated run against {args.remote_vss} "
+                "(harbor default sandbox; no pool selection, no box lock, "
+                "no brev)",
+                flush=True,
+            )
+            return run_invocations(
+                invocations,
+                "remote-vss",
+                args.results_root,
+                args.scratch,
+                args.spec_stem,
+                args.platform,
+                args.harbor_timeout_sec,
+                work_deadline,
+                remote_vss=args.remote_vss,
+            )
         # Pin precedence: CLI/--instance (incl. BREV_INSTANCE env default)
         # > task.toml brev_instance > pool selection.
         pinned = args.instance or metadata.get("brev_instance") or None

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -1443,5 +1443,99 @@ run_leg.main(sys.argv[2:])
         )
 
 
+class RemoteVssModeTest(unittest.TestCase):
+    """`--remote-vss` evaluates an already-deployed VSS from Harbor's sandbox."""
+
+    def _invocation(self):
+        return run_leg.HarborInvocation(
+            harbor_root=Path("/tmp/datasets/ask_video"),
+            include_task_name="rtxpro6000bw",
+            chain_key="ask_video_rtxpro6000bw",
+        )
+
+    def test_remote_env_derives_host_and_rejects_non_http(self):
+        env = run_leg.remote_vss_env("http://10.0.0.5:8000/")
+        self.assertEqual(env["VSS_BASE_URL"], "http://10.0.0.5:8000")
+        # HOST_IP is what the runtime skills' existing port conventions key on.
+        self.assertEqual(env["HOST_IP"], "10.0.0.5")
+        self.assertEqual(env["VSS_AGENT_PORT"], "8000")
+        for bad in ("not-a-url", "ftp://box/path", "http://"):
+            with self.assertRaises(ValueError):
+                run_leg.remote_vss_env(bad)
+
+    def test_deploy_centric_skills_are_rejected(self):
+        for skill in ("vss-deploy-profile", "vss-build-vision-agent", None):
+            with self.assertRaises(ValueError) as ctx:
+                run_leg.validate_remote_vss_skill(skill)
+            self.assertIn("--remote-vss", str(ctx.exception))
+        for skill in sorted(run_leg.REMOTE_VSS_SUPPORTED_SKILLS):
+            run_leg.validate_remote_vss_skill(skill)
+
+    def test_remote_command_uses_default_sandbox_and_forwards_endpoint(self):
+        cmd = run_leg.build_harbor_command(
+            self._invocation(),
+            Path("/tmp/results"),
+            "aws/anthropic/bedrock-claude-opus-4-6",
+            "https://inference-api.nvidia.com/v1",
+            "claude-code",
+            environment_import_path=None,
+            agent_env=run_leg.remote_vss_env("http://10.0.0.5:8000"),
+        )
+        # No BrevEnvironment: Harbor falls back to its own default sandbox.
+        self.assertNotIn("--environment-import-path", cmd)
+        forwarded = {cmd[i + 1] for i, flag in enumerate(cmd) if flag == "--ae"}
+        self.assertIn("VSS_BASE_URL=http://10.0.0.5:8000", forwarded)
+        self.assertIn("HOST_IP=10.0.0.5", forwarded)
+        self.assertIn("CLAUDE_CODE_DISABLE_THINKING=1", forwarded)
+
+    def test_default_path_still_pins_brev_environment(self):
+        """The Brev path is the CI default and must be untouched by this flag."""
+        cmd = run_leg.build_harbor_command(
+            self._invocation(),
+            Path("/tmp/results"),
+            "model",
+            "https://inference-api.nvidia.com/v1",
+        )
+        self.assertEqual(
+            cmd[cmd.index("--environment-import-path") + 1],
+            run_leg.BREV_ENVIRONMENT_IMPORT_PATH,
+        )
+        forwarded = [cmd[i + 1] for i, flag in enumerate(cmd) if flag == "--ae"]
+        self.assertEqual(forwarded, ["CLAUDE_CODE_DISABLE_THINKING=1"])
+
+    def test_remote_env_drops_brev_transport_and_keeps_default_intact(self):
+        with mock.patch.dict(
+            os.environ,
+            {"BREV_INSTANCE": "vss-eval-rtx-2g-x", "BREV_EXEC_TIMEOUT": "0"},
+            clear=False,
+        ):
+            remote = run_leg.harbor_env("unused", "http://10.0.0.5:8000")
+            # An inherited BREV_INSTANCE would aim BrevEnvironment at a box
+            # this leg never locked.
+            self.assertNotIn("BREV_INSTANCE", remote)
+            self.assertNotIn("BREV_EXEC_TIMEOUT", remote)
+            self.assertEqual(remote["VSS_BASE_URL"], "http://10.0.0.5:8000")
+
+            default = run_leg.harbor_env("vss-eval-rtx-2g-x")
+            self.assertEqual(default["BREV_INSTANCE"], "vss-eval-rtx-2g-x")
+            self.assertIn("BREV_EXEC_TIMEOUT", default)
+            self.assertNotIn("VSS_BASE_URL", default)
+
+    def test_parse_args_exposes_flag_and_env_default(self):
+        base = [
+            "--dataset-root", "/tmp/ds",
+            "--results-root", "/tmp/res",
+        ]
+        self.assertIsNone(run_leg.parse_args(base).remote_vss)
+        parsed = run_leg.parse_args([*base, "--remote-vss", "http://10.0.0.5:8000"])
+        self.assertEqual(parsed.remote_vss, "http://10.0.0.5:8000")
+        with mock.patch.dict(
+            os.environ, {"REMOTE_VSS_BASE_URL": "http://10.0.0.6:8000"}, clear=False
+        ):
+            self.assertEqual(
+                run_leg.parse_args(base).remote_vss, "http://10.0.0.6:8000"
+            )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Adds `--remote-vss <base-url>` to `run_leg.py`: a **disaggregated** skill-eval run that
evaluates an already-deployed VSS from Harbor's own default sandbox, instead of requiring a
Brev pool member.

Today a leg can only run on an operator-managed `vss-eval-*` box. That is enforced at two
points, and both fail closed for anyone else:

- `pool_candidates()` drops any name not starting with `vss-eval-`.
- `_registered_gpu_hint()` maps only the documented prefixes (`vss-eval-rtx-`,
  `vss-eval-l40s`, `vss-eval-h100`, `vss-eval-geforce-rtx4090-`) to a GPU family and returns
  `""` otherwise, so GPU-requiring legs are filtered out.

So a developer with a perfectly capable GPU workstation cannot run a leg without
`brev register`-ing the box under a conforming name and getting it added to
`BREV_REGISTERED_POOL`.

`--remote-vss` removes the need for any of that by separating the **system under test** from
the **trial sandbox**:

- Skips pool selection, the per-box `flock`, and every `brev` call.
- Omits `--environment-import-path`, leaving Harbor on its own default (docker) sandbox — a
  disaggregated leg only makes HTTP calls, so it needs no GPU and no `BrevEnvironment`.
- Forwards `VSS_BASE_URL`, `HOST_IP` and `VSS_AGENT_PORT` into the trial via Harbor `--ae`.
  `HOST_IP` is the important one: the runtime skills' gold solutions and checks already
  resolve endpoints from it (defaulting to `localhost`), so redirecting that single variable
  reuses the existing port conventions rather than teaching every check a new URL.
- Drops `BREV_INSTANCE` and the Brev transport timeouts from the Harbor env, so an inherited
  value can't aim `BrevEnvironment` at a box this leg never locked.

**Runtime skills only.** `REMOTE_VSS_SUPPORTED_SKILLS` gates it to `vss-ask-video`,
`vss-generate-video-report`, `vss-query-analytics`, `vss-search-archive` and
`vss-summarize-video`. Deploy-centric specs raise a clear error rather than run against a
stack they did not build — a disaggregated leg has no box to deploy onto, so a first turn
calling `/vss-deploy-profile` would either fail deep in the trial or quietly score something
other than what the spec name says.

```bash
python3 .github/skill-eval/run_leg.py \
  --dataset-root /tmp/skill-eval/datasets/vss-ask-video \
  --results-root /tmp/skill-eval/results/remote-$(date +%Y%m%d-%H%M%S) \
  --scratch /tmp/skill-eval/manual \
  --spec-stem direct_vlm_video_understanding \
  --platform RTXPRO6000BW \
  --remote-vss http://10.0.0.5:8000
```

## Plan

Questions raised before implementing, with the recommendation and the decision taken.

| # | Question | Recommended | Decided |
|---|---|---|---|
| 1 | What does "offline" mean — no Brev, no Anthropic, or fully airgapped? | No Brev dependency | **No Brev dependency.** Airgapped is out of scope: Harbor is fetched from PyPI, the agent needs an Anthropic-compatible endpoint, and trials pull from `nvcr.io`/NGC. |
| 2 | How should the local environment execute commands — new `LocalEnvironment`, SSH-to-localhost, or Harbor's built-in sandbox? | New `LocalEnvironment` subclass | **None of the above — disaggregated.** Assume VSS is already deployed on another box and run the trial from a sandbox pointing at it, so Harbor's default sandbox suffices and no new environment class is needed. |
| 3 | How should the mode be selected and the remote VSS addressed? | `--remote-vss <base-url>` | **`--remote-vss <base-url>`** — one flag carries both intent and target, and stays visible in CI logs. |
| 4 | Which eval specs should the mode support? | Query/runtime skills only | **Query/runtime skills only**, deploy-centric specs rejected with a clear error. |
| 5 | Prove end-to-end before raising the PR? | Yes (safe once disaggregated) | **Yes** — see Verification. |

Decision 2 is the one that shaped the change: the original plan was a `LocalEnvironment` that
execs via subprocess. Treating the deployment as remote instead made that unnecessary and
reduced the diff to a flag plus two small helpers.

Note this partially revisits ground the harness deliberately left: `AGENTS.md` records that
`requires_deployed_vss` / `prerequisite_deploy_mode` were removed and the
`_ensure_prerequisite_deployed` hook deleted, in favour of putting deploy steps inside the
trial trajectory where they are visible in the reward and judge. That reasoning is untouched
here — this does not pre-deploy on the trial's own box; it points the trial at a deployment on
a *different* box, and only for specs that never deployed anything in the first place.

## Verification

Run on a 2× RTX PRO 6000 Blackwell box with a live `base` profile deployment.

**Sandbox reaches the remote VSS** (`docker run curlimages/curl` → the deployment):

```
agent  /health  {"value":{"isAlive":true}}
agent  /docs    HTTP 200
VST    :30888   HTTP 200
NIM    :8100    HTTP 200
```

**A/B on the same dataset and spec** — with the flag, no selection and no lock:

```
[run-leg] disaggregated run against http://10.57.233.199:8000
          (harbor default sandbox; no pool selection, no box lock, no brev)
```

without it, the existing path is taken unchanged:

```
[run-leg] selected instance: vss-eval-rtx-2g (lock acquired: /tmp/brev/vss-eval-rtx-2g.lock)
[run-leg] phase summary: lock-wait=3s
```

The disaggregated run was executed with `brev` removed from `PATH` and completed the branch
without invoking it.

**Unit tests** — `python3 .github/skill-eval/tests/test_run_leg.py`

- Before: 59 tests, 3 failures
- After: 65 tests, 3 failures

The 6 new tests pass and no regression is introduced. The 3 failures pre-exist on
`origin/develop` (`test_4090_*`, which read `BREV_RTX4090_POOL`, unset locally) and are
unrelated to this change.

## Known gaps

- **The full trial was not driven to a score.** That needs `ANTHROPIC_BASE_URL` /
  `ANTHROPIC_MODEL` / `ANTHROPIC_API_KEY`, which live in the coordinator `.env` on the CI
  runner and were not available here. Everything up to the Harbor invocation is proven; the
  agent-credential gate is where the local run stops.
- **`vss-ask-video`'s spec checks hardcode `http://localhost:8000`**
  (`skills/vss-ask-video/evals/base_profile_video_understanding.json`). They resolve against
  `HOST_IP` in the gold solution but not in the check strings, so those checks need
  templating before that spec scores correctly in disaggregated mode. Deliberately left out
  of this PR to keep the harness change reviewable on its own.
- Only `run_leg.py` is touched; adapters are unchanged.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
