### PR TITLE
feat(ci): support tagged GHCR image variants

### DIFF
--- a/.github/scripts/advance_ghcr_alias.py
+++ b/.github/scripts/advance_ghcr_alias.py
@@ -122,11 +122,14 @@ def alias_plan(
                 "cannot retag without an immutable source"
             )
         source = f"{repository}:{content_tag}"
+        target_tag = f"{alias}{image.get('tag_suffix') or ''}"
+        if not ALIAS_RE.fullmatch(target_tag):
+            raise ValueError(f"{name}: invalid variant alias {target_tag!r}")
         updates.append(
             AliasUpdate(
                 name=name,
                 source=source,
-                target=f"{repository}:{alias}",
+                target=f"{repository}:{target_tag}",
                 digest=digest,
             )
         )
@@ -174,7 +177,8 @@ def tree_sources(
             continue  # mirror entries carry no repo source
         tree_sha = tree_reader(repo_root, commit, str(source_path))
         if tree_sha:
-            sources[str(image.get("name") or "")] = f"tree-{tree_sha}"
+            suffix = str(image.get("tag_suffix") or "")
+            sources[str(image.get("name") or "")] = f"tree-{tree_sha}{suffix}"
     return sources
 
 

--- a/.github/scripts/container_build_plan.py
+++ b/.github/scripts/container_build_plan.py
@@ -41,6 +41,7 @@ def candidate_coordinates(
     owner: str,
     image_name: str,
     tree_sha: str,
+    tag_suffix: str = "",
 ) -> CandidateCoordinates:
     short = commit_sha[:12]
     if not re.fullmatch(r"[0-9a-f]{12}", short):
@@ -61,11 +62,16 @@ def candidate_coordinates(
         raise ValueError(f"invalid GHCR owner {owner!r}")
     if not re.fullmatch(r"[A-Za-z0-9_.-]+", image_name):
         raise ValueError(f"invalid image name {image_name!r}")
+    if tag_suffix and not re.fullmatch(r"-[A-Za-z0-9_.-]+", tag_suffix):
+        raise ValueError(
+            f"tag suffix must be empty or start with '-' and contain only "
+            f"tag-safe characters, got {tag_suffix!r}"
+        )
     return CandidateCoordinates(
         image=f"ghcr.io/{normalized_owner}/vss/{image_name}",
-        tag=tag,
+        tag=f"{tag}{tag_suffix}",
         tree_sha=tree_sha,
-        content_tag=f"tree-{tree_sha}",
+        content_tag=f"tree-{tree_sha}{tag_suffix}",
     )
 
 
@@ -141,6 +147,7 @@ def main() -> int:
     metadata.add_argument("--owner", required=True)
     metadata.add_argument("--image-name", required=True)
     metadata.add_argument("--tree-sha", required=True)
+    metadata.add_argument("--tag-suffix", default="")
     metadata.add_argument("--github-output", type=Path, required=True)
 
     verify = subparsers.add_parser("verify-manifest")
@@ -156,6 +163,7 @@ def main() -> int:
             owner=args.owner,
             image_name=args.image_name,
             tree_sha=args.tree_sha,
+            tag_suffix=args.tag_suffix,
         )
         write_github_outputs(
             args.github_output,

--- a/.github/scripts/detect_changed_images.py
+++ b/.github/scripts/detect_changed_images.py
@@ -255,13 +255,20 @@ def content_tag_missing(
     if result.returncode != 0:
         return True
     tree_sha = result.stdout.strip()
-    reference = f"ghcr.io/{owner.lower()}/vss/{entry['name']}:tree-{tree_sha}"
+    repository = entry.get("repository", entry["name"])
+    tag_suffix = entry.get("tag_suffix", "")
+    reference = (
+        f"ghcr.io/{owner.lower()}/vss/{repository}:"
+        f"tree-{tree_sha}{tag_suffix}"
+    )
     return probe(reference) is not True
 
 
 def matrix_entry(entry: dict) -> dict:
     return {
         "name": entry["name"],
+        "repository": entry.get("repository", entry["name"]),
+        "tag_suffix": entry.get("tag_suffix", ""),
         "context": entry["context"],
         "dockerfile": entry["dockerfile"],
         "lfs_include": entry.get("lfs_include", ""),

--- a/.github/scripts/release_set.py
+++ b/.github/scripts/release_set.py
@@ -200,6 +200,18 @@ def build_fragment(
         problems.append("tag must be non-empty")
 
     if entry is not None:
+        expected_repository = entry.get("repository", name)
+        if image.rsplit("/", 1)[-1] != expected_repository:
+            problems.append(
+                f"{name}: image repository {image!r} does not end in "
+                f"/{expected_repository}"
+            )
+        expected_suffix = entry.get("tag_suffix", "")
+        if expected_suffix and not tag.endswith(expected_suffix):
+            problems.append(
+                f"{name}: tag {tag!r} does not end in inventory suffix "
+                f"{expected_suffix!r}"
+            )
         required = set(entry.get("platforms", []))
         missing = required - set(platforms)
         if missing:
@@ -231,6 +243,7 @@ def build_fragment(
         "strategy": strategy,
         "image": image,
         "tag": tag,
+        "tag_suffix": entry.get("tag_suffix", ""),
         "digest": digest,
         "platforms": sorted(platforms),
         "source_path": entry.get("source_path"),
@@ -304,6 +317,25 @@ def reuse_entries(
         if name in built_names or entry.get("strategy") not in IN_SCOPE_STRATEGIES:
             continue
         coordinates = sorted(pinned.get(name, set()))
+        # A tagged variant can intentionally have no dedicated Compose
+        # reference: it shares the base image repository and is selected by
+        # an environment/profile tag override (for example, ``-sbsa``).
+        # Carry it forward from its own moving alias so a no-change commit
+        # still produces a complete release set.
+        if not coordinates and entry.get("tag_suffix"):
+            ghcr_roots = [
+                root.rstrip("/")
+                for root in inventory.get("first_party_registry_roots", [])
+                if root.startswith("ghcr.io/")
+            ]
+            if len(ghcr_roots) == 1:
+                repository = entry.get("repository", name)
+                coordinates = [
+                    (
+                        f"{ghcr_roots[0]}/{repository}",
+                        f"develop-latest{entry['tag_suffix']}",
+                    )
+                ]
         if not coordinates:
             problems.append(
                 f"{name}: in-scope inventory image has no resolvable compose "
@@ -323,6 +355,7 @@ def reuse_entries(
                 "strategy": "reuse-pinned",
                 "image": image,
                 "tag": tag,
+                "tag_suffix": entry.get("tag_suffix", ""),
                 "digest": None,
                 "platforms": sorted(entry.get("platforms", [])),
                 "source_path": entry.get("source_path"),
@@ -368,9 +401,27 @@ def validate_release_set(release_set: dict, inventory: dict) -> list[str]:
             problems.append(f"{name}: tag is required")
         elif "${" in tag:
             problems.append(f"{name}: tag contains unresolved variable {tag!r}")
+        expected_suffix = names.get(name, {}).get("tag_suffix", "")
+        tag_suffix = item.get("tag_suffix", "")
+        if tag_suffix != expected_suffix:
+            problems.append(
+                f"{name}: tag_suffix {tag_suffix!r} does not match inventory "
+                f"{expected_suffix!r}"
+            )
         image = item.get("image") or ""
         if "${" in image:
             problems.append(f"{name}: image contains unresolved variable {image!r}")
+        expected_repository = names.get(name, {}).get("repository", name)
+        if image and image.rsplit("/", 1)[-1] != expected_repository:
+            problems.append(
+                f"{name}: image repository {image!r} does not end in "
+                f"/{expected_repository}"
+            )
+        if tag_suffix and tag and not tag.endswith(tag_suffix):
+            problems.append(
+                f"{name}: tag {tag!r} does not end in tag_suffix "
+                f"{tag_suffix!r}"
+            )
         digest = item.get("digest")
         if item.get("strategy") in ("build", "mirror"):
             if not DIGEST_RE.match(digest or ""):

--- a/.github/scripts/release_set.py
+++ b/.github/scripts/release_set.py
@@ -38,8 +38,10 @@ import argparse
 import hashlib
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
+from typing import Callable
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -79,6 +81,19 @@ def inventory_by_compose_name(inventory: dict) -> dict[str, dict]:
         for compose_name in entry.get("compose_image_names", [entry["name"]]):
             mapping[compose_name] = entry
     return mapping
+
+
+def git_tree_sha(repo_root: Path, source_path: str) -> str | None:
+    """Return the current commit's tree SHA for ``source_path``."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", f"HEAD:{source_path}"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value if TREE_RE.fullmatch(value) else None
 
 
 def first_party_refs(repo_root: Path, inventory: dict) -> list[tuple[str, str]]:
@@ -297,7 +312,10 @@ def _split_ref(resolved_ref: str) -> tuple[str, str]:
 
 
 def reuse_entries(
-    repo_root: Path, inventory: dict, built_names: set[str]
+    repo_root: Path,
+    inventory: dict,
+    built_names: set[str],
+    tree_reader: Callable[[Path, str], str | None] = git_tree_sha,
 ) -> tuple[list[dict], list[str]]:
     """Explicit ``reuse-pinned`` entries for every in-scope inventory image
     that has no fragment, at its current committed coordinate. Returns
@@ -320,20 +338,22 @@ def reuse_entries(
         # A tagged variant can intentionally have no dedicated Compose
         # reference: it shares the base image repository and is selected by
         # an environment/profile tag override (for example, ``-sbsa``).
-        # Carry it forward from its own moving alias so a no-change commit
-        # still produces a complete release set.
+        # Carry it forward from its immutable content tag so a no-change
+        # commit still produces a complete release set. This is branch-neutral:
+        # a PR must never fall back to develop-latest for unchanged content.
         if not coordinates and entry.get("tag_suffix"):
             ghcr_roots = [
                 root.rstrip("/")
                 for root in inventory.get("first_party_registry_roots", [])
                 if root.startswith("ghcr.io/")
             ]
-            if len(ghcr_roots) == 1:
+            tree_sha = tree_reader(repo_root, str(entry.get("source_path") or ""))
+            if len(ghcr_roots) == 1 and tree_sha:
                 repository = entry.get("repository", name)
                 coordinates = [
                     (
                         f"{ghcr_roots[0]}/{repository}",
-                        f"develop-latest{entry['tag_suffix']}",
+                        f"tree-{tree_sha}{entry['tag_suffix']}",
                     )
                 ]
         if not coordinates:

--- a/.github/scripts/test_advance_ghcr_alias.py
+++ b/.github/scripts/test_advance_ghcr_alias.py
@@ -103,6 +103,38 @@ class AliasPlanTest(unittest.TestCase):
             all(item.target.endswith(":develop-deadbeef1234") for item in plan)
         )
 
+    def test_variant_alias_keeps_shared_repository_and_adds_suffix(self):
+        data = release_set()
+        variant = {
+            **data["images"][0],
+            "name": "vss-agent-sbsa",
+            "image": "ghcr.io/nvidia-ai-blueprints/vss/vss-agent",
+            "tag": "develop-deadbeef1234-sbsa",
+            "tag_suffix": "-sbsa",
+        }
+        data["images"].append(variant)
+        content = {
+            **ALL_CONTENT,
+            "vss-agent-sbsa": "tree-" + "a" * 40 + "-sbsa",
+        }
+        by_name = {
+            item.name: item
+            for item in alias_plan(data, "develop-latest", content)
+        }
+        update = by_name["vss-agent-sbsa"]
+        self.assertEqual(
+            update.source,
+            "ghcr.io/nvidia-ai-blueprints/vss/vss-agent:"
+            + "tree-"
+            + "a" * 40
+            + "-sbsa",
+        )
+        self.assertEqual(
+            update.target,
+            "ghcr.io/nvidia-ai-blueprints/vss/vss-agent:"
+            "develop-latest-sbsa",
+        )
+
     def test_pull_request_ref_is_accepted(self):
         """A PR branch publishes pr-<N>-* and needs the same complete coverage."""
         plan = alias_plan(release_set("pull-request/1190"), "pr-1190-abc123abc123", ALL_CONTENT)
@@ -215,6 +247,17 @@ class TreeSourceTest(unittest.TestCase):
             self._digestless(), Path("/repo"), "abc123", lambda *_: TREE
         )
         self.assertEqual(found.get("vss-agent"), f"tree-{TREE}")
+
+    def test_variant_content_tag_includes_suffix(self):
+        data = self._digestless()
+        variant = {
+            **data["images"][0],
+            "name": "vss-agent-sbsa",
+            "tag_suffix": "-sbsa",
+        }
+        data["images"].append(variant)
+        found = tree_sources(data, Path("/repo"), "abc123", lambda *_: TREE)
+        self.assertEqual(found["vss-agent-sbsa"], f"tree-{TREE}-sbsa")
 
     def test_mirror_entry_without_source_path_has_none(self):
         found = tree_sources(

--- a/.github/scripts/test_container_build_plan.py
+++ b/.github/scripts/test_container_build_plan.py
@@ -47,6 +47,33 @@ class CandidateCoordinatesTest(unittest.TestCase):
         )
         self.assertEqual(result.tag, "develop-" + "a" * 12)
 
+    def test_variant_uses_shared_repository_and_suffixes_all_tags(self):
+        result = candidate_coordinates(
+            ref_name="develop",
+            commit_sha=COMMIT,
+            owner="NVIDIA-AI-Blueprints",
+            image_name="vss-rt-cv",
+            tree_sha=TREE,
+            tag_suffix="-sbsa",
+        )
+        self.assertEqual(
+            result.image,
+            "ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv",
+        )
+        self.assertEqual(result.tag, "develop-" + "a" * 12 + "-sbsa")
+        self.assertEqual(result.content_tag, "tree-" + TREE + "-sbsa")
+
+    def test_variant_suffix_must_be_tag_safe_and_explicit(self):
+        with self.assertRaisesRegex(ValueError, "tag suffix"):
+            candidate_coordinates(
+                ref_name="develop",
+                commit_sha=COMMIT,
+                owner="NVIDIA-AI-Blueprints",
+                image_name="vss-rt-cv",
+                tree_sha=TREE,
+                tag_suffix="sbsa",
+            )
+
 
 class ManifestValidationTest(unittest.TestCase):
     def test_exact_platforms_ignore_attestations(self):

--- a/.github/scripts/test_detect_changed_images.py
+++ b/.github/scripts/test_detect_changed_images.py
@@ -303,6 +303,8 @@ class SelectImagesTest(unittest.TestCase):
                 "include": [
                     {
                         "name": "vss-agent",
+                        "repository": "vss-agent",
+                        "tag_suffix": "",
                         "context": "services",
                         "dockerfile": "services/agent/docker/Dockerfile",
                         "lfs_include": "",
@@ -311,6 +313,8 @@ class SelectImagesTest(unittest.TestCase):
                     },
                     {
                         "name": "vss-agent-ui",
+                        "repository": "vss-agent-ui",
+                        "tag_suffix": "",
                         "context": ".",
                         "dockerfile": "services/ui/Dockerfile",
                         "lfs_include": "",
@@ -318,6 +322,31 @@ class SelectImagesTest(unittest.TestCase):
                         "source_path": "services/ui",
                     },
                 ]
+            },
+        )
+
+    def test_matrix_can_target_shared_repository_with_variant_suffix(self):
+        entry = {
+            "name": "vss-rt-cv-sbsa",
+            "repository": "vss-rt-cv",
+            "tag_suffix": "-sbsa",
+            "context": "services/rtvi/rt-cv",
+            "dockerfile": "services/rtvi/rt-cv/docker/Dockerfile.sbsa",
+            "platforms": ["linux/arm64"],
+            "source_path": "services/rtvi/rt-cv",
+        }
+        matrix = dci.to_matrix([entry])
+        self.assertEqual(
+            matrix["include"][0],
+            {
+                "name": "vss-rt-cv-sbsa",
+                "repository": "vss-rt-cv",
+                "tag_suffix": "-sbsa",
+                "context": "services/rtvi/rt-cv",
+                "dockerfile": "services/rtvi/rt-cv/docker/Dockerfile.sbsa",
+                "lfs_include": "",
+                "platforms": "linux/arm64",
+                "source_path": "services/rtvi/rt-cv",
             },
         )
 
@@ -496,6 +525,28 @@ class ContentTagGapTest(unittest.TestCase):
             lambda ref: seen.append(ref) or True, "Org")
         self.assertEqual(len(seen), 1)
         self.assertTrue(seen[0].startswith("ghcr.io/org/vss/vss-agent:tree-"))
+
+    def test_variant_probe_uses_shared_repository_and_suffixed_content_tag(self):
+        seen: list[str] = []
+        variant = {
+            **BUILDABLE[0],
+            "name": "vss-agent-sbsa",
+            "repository": "vss-agent",
+            "tag_suffix": "-sbsa",
+        }
+        dci.add_missing_content_tags(
+            [variant],
+            [],
+            _content_repo(),
+            "HEAD",
+            lambda ref: seen.append(ref) or True,
+            "Org",
+        )
+        self.assertEqual(len(seen), 1)
+        self.assertRegex(
+            seen[0],
+            r"^ghcr\.io/org/vss/vss-agent:tree-[0-9a-f]{40}-sbsa$",
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_release_set.py
+++ b/.github/scripts/test_release_set.py
@@ -289,7 +289,7 @@ class ReuseEntriesTest(unittest.TestCase):
         self.assertEqual(entry["image"], "nvcr.io/nvidia/vss-core/vss-configurator")
         self.assertEqual(entry["tag"], "3.2.1")
 
-    def test_unbuilt_variant_without_compose_ref_uses_its_moving_alias(self):
+    def test_unbuilt_variant_without_compose_ref_uses_immutable_content_tag(self):
         variant = {
             **AGENT_ENTRY,
             "name": "vss-agent-sbsa",
@@ -309,7 +309,12 @@ class ReuseEntriesTest(unittest.TestCase):
                 ],
             )
             inventory = rs.load_inventory(root)
-            entries, problems = rs.reuse_entries(root, inventory, {"vss-agent"})
+            entries, problems = rs.reuse_entries(
+                root,
+                inventory,
+                {"vss-agent"},
+                tree_reader=lambda _root, _path: TREE_SHA,
+            )
         self.assertEqual(problems, [])
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0]["name"], "vss-agent-sbsa")
@@ -317,7 +322,7 @@ class ReuseEntriesTest(unittest.TestCase):
             entries[0]["image"],
             "ghcr.io/nvidia-ai-blueprints/vss/vss-agent",
         )
-        self.assertEqual(entries[0]["tag"], "develop-latest-sbsa")
+        self.assertEqual(entries[0]["tag"], f"tree-{TREE_SHA}-sbsa")
         self.assertEqual(entries[0]["tag_suffix"], "-sbsa")
 
     def test_profile_env_resolves_required_pinned_tag(self):

--- a/.github/scripts/test_release_set.py
+++ b/.github/scripts/test_release_set.py
@@ -157,6 +157,57 @@ class FragmentTest(unittest.TestCase):
         self.assertEqual(fragment["name"], "vss-agent")
         self.assertEqual(fragment["source_path"], "services/agent")
         self.assertEqual(fragment["platforms"], ["linux/amd64", "linux/arm64"])
+        self.assertEqual(fragment["tag_suffix"], "")
+
+    def test_variant_fragment_uses_shared_repository_and_suffix(self):
+        variant = {
+            **AGENT_ENTRY,
+            "name": "vss-agent-sbsa",
+            "repository": "vss-agent",
+            "tag_suffix": "-sbsa",
+            "platforms": ["linux/arm64"],
+        }
+        inventory = {**self.INVENTORY, "images": [variant]}
+        fragment = rs.build_fragment(
+            inventory,
+            **{
+                **self.good_kwargs(),
+                "name": "vss-agent-sbsa",
+                "tag": "develop-abc123def456-sbsa",
+                "platforms": ["linux/arm64"],
+            },
+        )
+        self.assertEqual(fragment["image"], "ghcr.io/org/vss-agent")
+        self.assertEqual(fragment["tag_suffix"], "-sbsa")
+
+    def test_variant_fragment_rejects_wrong_repository_or_unsuffixed_tag(self):
+        variant = {
+            **AGENT_ENTRY,
+            "name": "vss-agent-sbsa",
+            "repository": "vss-agent",
+            "tag_suffix": "-sbsa",
+            "platforms": ["linux/arm64"],
+        }
+        inventory = {**self.INVENTORY, "images": [variant]}
+        with self.assertRaisesRegex(ValueError, "repository"):
+            rs.build_fragment(
+                inventory,
+                **{
+                    **self.good_kwargs(),
+                    "name": "vss-agent-sbsa",
+                    "image": "ghcr.io/org/vss-agent-sbsa",
+                    "platforms": ["linux/arm64"],
+                },
+            )
+        with self.assertRaisesRegex(ValueError, "tag .*suffix"):
+            rs.build_fragment(
+                inventory,
+                **{
+                    **self.good_kwargs(),
+                    "name": "vss-agent-sbsa",
+                    "platforms": ["linux/arm64"],
+                },
+            )
 
     def test_unknown_name_rejected(self):
         with self.assertRaisesRegex(ValueError, "unknown image name"):
@@ -200,6 +251,7 @@ class FragmentTest(unittest.TestCase):
         kwargs = {
             **self.good_kwargs(),
             "name": "vss-configurator",
+            "image": "ghcr.io/org/vss-configurator",
             "strategy": "mirror",
             "source_tree_sha": None,
             "platforms": ["linux/amd64"],
@@ -236,6 +288,37 @@ class ReuseEntriesTest(unittest.TestCase):
         self.assertEqual(entry["strategy"], "reuse-pinned")
         self.assertEqual(entry["image"], "nvcr.io/nvidia/vss-core/vss-configurator")
         self.assertEqual(entry["tag"], "3.2.1")
+
+    def test_unbuilt_variant_without_compose_ref_uses_its_moving_alias(self):
+        variant = {
+            **AGENT_ENTRY,
+            "name": "vss-agent-sbsa",
+            "repository": "vss-agent",
+            "tag_suffix": "-sbsa",
+            "platforms": ["linux/arm64"],
+            "compose_image_names": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_repo(
+                tmp,
+                {"a/compose.yml": AGENT_COMPOSE},
+                [AGENT_ENTRY, variant],
+                roots=[
+                    "nvcr.io/nvidia/vss-core",
+                    "ghcr.io/nvidia-ai-blueprints/vss",
+                ],
+            )
+            inventory = rs.load_inventory(root)
+            entries, problems = rs.reuse_entries(root, inventory, {"vss-agent"})
+        self.assertEqual(problems, [])
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "vss-agent-sbsa")
+        self.assertEqual(
+            entries[0]["image"],
+            "ghcr.io/nvidia-ai-blueprints/vss/vss-agent",
+        )
+        self.assertEqual(entries[0]["tag"], "develop-latest-sbsa")
+        self.assertEqual(entries[0]["tag_suffix"], "-sbsa")
 
     def test_profile_env_resolves_required_pinned_tag(self):
         compose = """services:

--- a/.github/scripts/test_update_pr_ghcr_candidates.py
+++ b/.github/scripts/test_update_pr_ghcr_candidates.py
@@ -100,6 +100,14 @@ class CandidateCommentTest(unittest.TestCase):
         self.assertEqual(
             module.moving_alias("pr-1190-deadbeef"), "pr-1190-latest"
         )
+        self.assertEqual(
+            module.moving_alias("develop-deadbeef-sbsa"),
+            "develop-latest-sbsa",
+        )
+        self.assertEqual(
+            module.moving_alias("pr-1190-deadbeef-sbsa"),
+            "pr-1190-latest-sbsa",
+        )
         self.assertEqual(module.moving_alias("release-3.2.0"), "")
 
     def test_github_network_adapter_is_injected(self):

--- a/.github/scripts/update_pr_ghcr_candidates.py
+++ b/.github/scripts/update_pr_ghcr_candidates.py
@@ -100,10 +100,17 @@ def candidate_entries(release_set: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def moving_alias(tag: str) -> str:
-    if re.fullmatch(r"develop-[0-9a-f]{7,40}", tag):
-        return "develop-latest"
-    match = re.fullmatch(r"pr-(\d+)-[0-9a-f]{7,40}", tag)
-    return f"pr-{match.group(1)}-latest" if match else ""
+    suffix_pattern = r"(?P<suffix>-[A-Za-z0-9_.-]+)?"
+    match = re.fullmatch(rf"develop-[0-9a-f]{{7,40}}{suffix_pattern}", tag)
+    if match:
+        return f"develop-latest{match.group('suffix') or ''}"
+    match = re.fullmatch(
+        rf"pr-(?P<number>\d+)-[0-9a-f]{{7,40}}{suffix_pattern}",
+        tag,
+    )
+    if not match:
+        return ""
+    return f"pr-{match.group('number')}-latest{match.group('suffix') or ''}"
 
 
 def render_comment(release_set: dict[str, Any], sha: str) -> str:

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -135,8 +135,9 @@ jobs:
             --ref-name "$GITHUB_REF_NAME" \
             --commit-sha "$GITHUB_SHA" \
             --owner "$GITHUB_REPOSITORY_OWNER" \
-            --image-name "${{ matrix.name }}" \
+            --image-name "${{ matrix.repository }}" \
             --tree-sha "$(git rev-parse "HEAD:${{ matrix.source_path }}")" \
+            --tag-suffix "${{ matrix.tag_suffix }}" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
@@ -302,8 +303,9 @@ jobs:
             --ref-name "$GITHUB_REF_NAME" \
             --commit-sha "$GITHUB_SHA" \
             --owner "$GITHUB_REPOSITORY_OWNER" \
-            --image-name "${{ matrix.name }}" \
+            --image-name "${{ matrix.repository }}" \
             --tree-sha "$(git rev-parse "HEAD:${{ matrix.source_path }}")" \
+            --tag-suffix "${{ matrix.tag_suffix }}" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Compute platform staging tag
@@ -426,8 +428,9 @@ jobs:
             --ref-name "$GITHUB_REF_NAME" \
             --commit-sha "$GITHUB_SHA" \
             --owner "$GITHUB_REPOSITORY_OWNER" \
-            --image-name "${{ matrix.name }}" \
+            --image-name "${{ matrix.repository }}" \
             --tree-sha "$(git rev-parse "HEAD:${{ matrix.source_path }}")" \
+            --tag-suffix "${{ matrix.tag_suffix }}" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR

--- a/deploy/docker/container-inventory.json
+++ b/deploy/docker/container-inventory.json
@@ -16,7 +16,15 @@
     "                   mirror program (requires distribution approval).",
     "  external-pin   - first-party ecosystem image pinned via its own",
     "                   override variables; out of GHCR release-set scope,",
-    "                   classified here so it is not silently omitted."
+    "                   classified here so it is not silently omitted.",
+    "",
+    "GHCR variants:",
+    "  repository     - optional GHCR repository basename; defaults to name.",
+    "                   Set the same value on multiple logical inventory entries",
+    "                   when variants share one GHCR package.",
+    "  tag_suffix     - optional tag suffix such as -sbsa. It is applied to",
+    "                   immutable, tree-SHA, and moving alias tags so variants",
+    "                   sharing a source tree and repository never collide."
   ],
   "schema_version": 1,
   "first_party_registry_roots": [

--- a/deploy/docker/release-set.schema.json
+++ b/deploy/docker/release-set.schema.json
@@ -42,6 +42,11 @@
           },
           "image": { "type": "string", "description": "registry/name, no tag" },
           "tag": { "type": "string", "description": "Immutable tag for this set" },
+          "tag_suffix": {
+            "type": "string",
+            "pattern": "^(|-[A-Za-z0-9_.-]+)$",
+            "description": "Variant suffix applied to immutable, content-addressed, and moving tags. Empty for the default image variant."
+          },
           "digest": {
             "type": ["string", "null"],
             "pattern": "^sha256:[0-9a-f]{64}$",


### PR DESCRIPTION
## Summary
- allow multiple logical image builds to share one GHCR repository through inventory `repository` and `tag_suffix` fields
- suffix immutable, tree-SHA, and moving tags so SBSA content cannot collide with the default multi-arch image
- preserve variant coordinates through release sets, content reuse, alias publication, and PR candidate reporting

## Test plan
- [x] Run all `.github/scripts` unit tests (260 tests)
- [x] Validate the modified GitHub Actions workflow
- [x] Run pre-commit secret, SPDX, and DCO checks