### PR TITLE
fix(osrb): pass the reviewed PR head explicitly

### DIFF
--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -143,6 +143,16 @@ class DispatchTests(unittest.TestCase):
         for variable in ("OSRB_CODE_REF", "OSRB_ALLOW_UNREVIEWED_CODE"):
             self.assertNotIn(variable, workflow)
 
+    def test_dispatch_passes_the_reviewed_pr_head_explicitly(self) -> None:
+        workflow = WORKFLOW.read_text()
+        trigger_block = workflow.split("- name: Trigger private OSRB pipeline", 1)[1]
+        trigger_block = trigger_block.split("- name:", 1)[0]
+        self.assertIn(
+            "DOWNSTREAM_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}",
+            trigger_block,
+        )
+        self.assertNotIn("GITHUB_SHA:", trigger_block)
+
     def test_github_output_explains_developer_actions(self) -> None:
         guide = DEVELOPER_GUIDE.read_text()
         license_workflow = LICENSE_WORKFLOW.read_text()

--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -33,6 +33,26 @@ check = load_python("osrb_check", DIRECTORY / "osrb_check.py")
 
 
 class DispatchTests(unittest.TestCase):
+    def test_explicit_downstream_commit_takes_precedence(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {
+                "DOWNSTREAM_COMMIT_SHA": "reviewed-head",
+                "GITHUB_SHA": "workflow-sha",
+            },
+            clear=False,
+        ):
+            self.assertEqual(trigger.downstream_commit_sha(), "reviewed-head")
+
+    def test_downstream_commit_falls_back_to_event_sha(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"GITHUB_SHA": "event-sha"},
+            clear=False,
+        ):
+            os.environ.pop("DOWNSTREAM_COMMIT_SHA", None)
+            self.assertEqual(trigger.downstream_commit_sha(), "event-sha")
+
     def test_extra_variables_are_string_map(self) -> None:
         with mock.patch.dict(
             os.environ,

--- a/.github/scripts/trigger-downstream-pipeline.sh
+++ b/.github/scripts/trigger-downstream-pipeline.sh
@@ -37,6 +37,12 @@ def require_env(name: str) -> str:
     return value
 
 
+def downstream_commit_sha() -> str:
+    """Return an explicit downstream SHA, falling back to the event SHA."""
+    explicit_sha = os.environ.get("DOWNSTREAM_COMMIT_SHA", "").strip()
+    return explicit_sha or require_env("GITHUB_SHA")
+
+
 def configured_extra_variables() -> dict[str, str]:
     """Parse optional generic GitLab variables without logging their values."""
     raw = os.environ.get("DOWNSTREAM_EXTRA_VARIABLES_JSON", "").strip()
@@ -370,7 +376,7 @@ def main() -> int:
         base_url = api_base_url(raw_url)
         token = require_env("DOWNSTREAM_CI_TOKEN")
         project_path = require_env("DOWNSTREAM_PROJECT_PATH")
-        commit_sha = require_env("GITHUB_SHA")
+        commit_sha = downstream_commit_sha()
         ref = os.environ.get("DOWNSTREAM_REF", "main")
         variable_name = os.environ.get("DOWNSTREAM_SUBMODULE_HASH_VARIABLE", "VSS_SUBMODULE_HASH")
 

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -108,7 +108,9 @@ jobs:
           # there, so this dispatcher must never send a code-ref override.
           DOWNSTREAM_REF: osrb-review-trigger
           DOWNSTREAM_SUBMODULE_HASH_VARIABLE: GITHUB_MIRROR_SHA
-          GITHUB_SHA: ${{ github.event.workflow_run.head_sha }}
+          # GITHUB_SHA is runner-owned and cannot be overridden. Pass the
+          # completed License Diff head explicitly to the shared trigger.
+          DOWNSTREAM_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
           GITHUB_TOKEN: ${{ github.token }}
           DOWNSTREAM_EXTRA_VARIABLES_JSON: >-


### PR DESCRIPTION
## Summary
- pass `workflow_run.head_sha` through `DOWNSTREAM_COMMIT_SHA` instead of reserved `GITHUB_SHA`
- prevent the private OSRB reviewer from comparing the PR against the default-branch workflow SHA
- add a regression assertion for the dispatch contract

## Test plan
- [x] `python3 .github/scripts/test_osrb_dispatch.py`
- [x] pre-commit hooks
- [x] `git diff --check`