### PR TITLE
fix(skills): read vss-agent VLM env via docker inspect

### DIFF
--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -3,7 +3,7 @@ name: vss-generate-video-report
 description: Use this skill when producing a VSS analysis report — Mode A per-clip VLM, Mode B incident-range via video-analytics, Mode C SOP compliance via the SOP tools. Not for standalone video summarization, real-time alerts or ad-hoc Q&A.
 license: Apache-2.0
 metadata:
-  version: "3.3.3"
+  version: "3.3.0"
   author: "NVIDIA Video Search and Summarization team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -103,8 +103,8 @@ fi
 ```
 
 On Kubernetes, do not use `kubectl port-forward`, Service DNS, NodePorts, or
-`docker exec` / `docker inspect` to discover VIOS, the VLM, or VA-MCP. Mode A
-uses `${VST_API_BASE}` and `${VLM_ENDPOINT}` only; Mode B uses `${VA_MCP_URL}`.
+host-side container discovery for VIOS, the VLM, or VA-MCP. Mode A uses
+`${VST_API_BASE}` and `${VLM_ENDPOINT}` only; Mode B uses `${VA_MCP_URL}`.
 
 ### Mode-by-mode checklist (required)
 
@@ -149,8 +149,8 @@ If VLM/deployment choice is unclear and no default selection has been made, ask 
 1. **Provide an endpoint** — user supplies `VLM_ENDPOINT` and model id.
 2. **Use the public Ingress VLM** — when `VSS_PUBLIC_URL` is set, probe
    `${VSS_PUBLIC_URL%/}/v1/models` (base Helm RT-VLM route). Do **not** use `/vlm/v1`.
-3. **Suggest options based on auto-discover** — on Docker, inspect running `vss-agent`
-   env and probe default local ports.
+3. **Suggest options based on auto-discover** — on Docker, probe the standard
+   local VLM ports. For shared VLM-selection guidance, follow `/vss-ask-video`.
 4. **Deploy a local VLM** — hand off to `/vss-deploy-profile` (with user confirmation) and then continue.
 
 Auto-discover hints:
@@ -161,21 +161,10 @@ if [ -n "${VSS_PUBLIC_URL:-}" ]; then
   curl -sf --max-time 5 "${VSS_PUBLIC_URL%/}/v1/models" | jq -r '.data[].id'
 fi
 
-# Docker only — from running vss-agent env (when present).
-# Use docker inspect, not docker exec: the vss-agent image is distroless
-if [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ] && docker ps --format '{{.Names}}' | grep -qx vss-agent; then
-  while IFS='=' read -r _k _v; do
-    case "$_k" in
-      HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL|RTVI_VLM_MODEL_TO_USE)
-        printf -v "$_k" '%s' "$_v"; export "$_k"
-        printf '%s=%s\n' "$_k" "$_v"
-        ;;
-    esac
-  done < <(docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}')
-
-  # Probe common local endpoints
-  curl -sf --max-time 5 "http://${HOST_IP}:30082/v1/models" | jq -r '.data[].id'   # base RT-VLM default
-  curl -sf --max-time 5 "http://${HOST_IP}:8018/v1/models" | jq -r '.data[].id'    # alerts RT-VLM default
+# Docker only — probe common local endpoints without inspecting any container.
+if [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ]; then
+  curl -sf --max-time 5 "http://${HOST_IP}:30082/v1/models" | jq -r '.data[].id'   # local NIM / base default
+  curl -sf --max-time 5 "http://${HOST_IP}:8018/v1/models" | jq -r '.data[].id'    # RT-VLM / alerts default
 fi
 ```
 
@@ -360,11 +349,11 @@ Do not continue direct VLM Mode A on videos that are 120 seconds or longer.
 
 The deploy may serve the VLM through either of two stacks. Both expose an OpenAI-compatible `chat/completions` API — pick whichever is live:
 
-| Backend | Env vars | Typical host endpoint | Picked when |
+| Backend | Discovery input | Typical host endpoint | Picked when |
 |---|---|---|---|
 | **Public Ingress RT-VLM** | `VSS_PUBLIC_URL` / `VLM_ENDPOINT` | `${VSS_PUBLIC_URL}/v1` | Kubernetes / Helm base when `VSS_PUBLIC_URL` is set (preferred) |
-| **NIM Cosmos** | `VLM_BASE_URL`, `VLM_NAME`, `VLM_MODE`, `VLM_MODEL_TYPE` | `${VLM_BASE_URL}/v1` (no trailing `/v1` on the env var; the agent appends it) | Docker: `VLM_MODEL_TYPE != rtvi` **and** `VLM_MODE` ∈ {`local`, `local_shared`, `remote`} **and** `VLM_BASE_URL` is non-empty |
-| **RT-VLM Cosmos** | `RTVI_VLM_BASE_URL`, `RTVI_VLM_MODEL_TO_USE`, `VLM_MODEL_TYPE` | `${RTVI_VLM_BASE_URL}/v1` — if unset, derive from `${HOST_IP}` (`http://${HOST_IP}:8018/v1` for alerts, `http://${HOST_IP}:30082/v1` for base) | Docker: `VLM_MODEL_TYPE = rtvi`, or `VLM_MODE=none`, or `VLM_BASE_URL` empty; also the only path for `warehouse` |
+| **NIM Cosmos** | Explicit `VLM_ENDPOINT`, or successful `/models` probe | `http://${HOST_IP}:30082/v1` | Docker: port 30082 responds with at least one model |
+| **RT-VLM Cosmos** | Explicit `VLM_ENDPOINT`, or successful `/models` probe | `http://${HOST_IP}:8018/v1` | Docker: port 8018 responds with at least one model |
 
 If the user already supplied a `VLM_ENDPOINT` + model id, use those directly.
 
@@ -378,51 +367,42 @@ if [ -z "${VLM_ENDPOINT:-}" ] && [ -n "${VSS_PUBLIC_URL:-}" ]; then
 fi
 ```
 
-Otherwise, on **Docker only**, read the live values off a running `vss-agent`
-container (when present) and do not guess. Use `docker inspect`, **not**
-`docker exec … sh`: the image is distroless (no `sh`/`printenv` on `PATH`).
-
-```bash
-# Assign into a fixed whitelist of vars WITHOUT eval, so a hostile or malformed
-# env value is always treated as data and never executed.
-if [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ] && docker ps --format '{{.Names}}' | grep -qx vss-agent; then
-  while IFS='=' read -r _k _v; do
-    case "$_k" in
-      HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL|RTVI_VLM_MODEL_TO_USE)
-        printf -v "$_k" '%s' "$_v"; export "$_k" ;;
-    esac
-  done < <(docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}')
-fi
-```
-
-Do not require `RTVI_VLM_ENDPOINT` from `vss-agent` env; several profiles do not inject it.
-
-Selection rule (Docker host discovery when `VLM_ENDPOINT` is still unset):
+Otherwise, on **Docker only**, probe the standard host endpoints directly,
+following the same endpoint-selection contract as `/vss-ask-video`.
 
 ```bash
 if [ -z "${VLM_ENDPOINT:-}" ] && [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ]; then
-  if [ "${VLM_MODEL_TYPE:-}" = "rtvi" ]; then
-    VLM_BACKEND="rtvlm"
-    VLM_ENDPOINT="${RTVI_VLM_BASE_URL:+${RTVI_VLM_BASE_URL%/}/v1}"
-    [ -z "${VLM_ENDPOINT}" ] && VLM_ENDPOINT="http://${HOST_IP}:8018/v1"   # alerts default
-    VLM_MODEL="${RTVI_VLM_MODEL_TO_USE}"
-  elif [ -n "${VLM_BASE_URL}" ] && [ "${VLM_MODE}" != "none" ]; then
-    VLM_BACKEND="nim_cosmos"
-    VLM_ENDPOINT="${VLM_BASE_URL%/}/v1"
-    VLM_MODEL="${VLM_NAME}"
-  else
-    VLM_BACKEND="rtvlm"
-    VLM_ENDPOINT="${RTVI_VLM_BASE_URL:+${RTVI_VLM_BASE_URL%/}/v1}"
-    [ -z "${VLM_ENDPOINT}" ] && VLM_ENDPOINT="http://${HOST_IP}:30082/v1"  # base default
-    VLM_MODEL="${RTVI_VLM_MODEL_TO_USE}"
-  fi
+  for _candidate in \
+    "nim_cosmos|http://${HOST_IP}:30082/v1" \
+    "rtvlm|http://${HOST_IP}:8018/v1"; do
+    _backend="${_candidate%%|*}"
+    _endpoint="${_candidate#*|}"
+    if _models="$(curl -sf --max-time 5 "${_endpoint}/models")" &&
+       _model="$(printf '%s' "${_models}" | jq -er '.data[0].id')"; then
+      VLM_BACKEND="${_backend}"
+      VLM_ENDPOINT="${_endpoint}"
+      VLM_MODEL="${VLM_MODEL:-$_model}"
+      break
+    fi
+  done
 fi
+
+[ -n "${VLM_ENDPOINT:-}" ] || {
+  echo "ERROR: no VLM found on ${HOST_IP}:30082 or ${HOST_IP}:8018; provide VLM_ENDPOINT and VLM_MODEL" >&2
+  exit 1
+}
 ```
 
 Probe `/v1/models` before sending a chat request to confirm the chosen endpoint is alive and the model is loaded:
 
 ```bash
-curl -sf --max-time 5 "${VLM_ENDPOINT}/models" | jq -r '.data[].id'
+_models="$(curl -sf --max-time 5 "${VLM_ENDPOINT}/models")" || {
+  echo "ERROR: VLM endpoint is not reachable: ${VLM_ENDPOINT}" >&2
+  exit 1
+}
+printf '%s' "${_models}" | jq -er '.data[].id'
+[ -n "${VLM_MODEL:-}" ] ||
+  VLM_MODEL="$(printf '%s' "${_models}" | jq -er '.data[0].id')"
 ```
 
 If `VLM_MODEL` is empty, adopt the first id the endpoint advertises. If the probe fails or the listed ids don't include `${VLM_MODEL}`, either:
@@ -435,9 +415,9 @@ Never silently pick an unknown model.
 
 Use the OpenAI-compatible `chat/completions` endpoint with a `video_url` content block — the same payload shape **and multimodal settings** `video_understanding` builds in `src/vss_agents/tools/video_understanding.py` (`_build_vlm_messages` + the Cosmos `base_vlm.bind(...)` call).
 
-The frame sampling and visual-token (pixel) budget must mirror the **live** `video_understanding` settings for the active profile when `vss-agent` is running. **Send `mm_processor_kwargs` and `media_io_kwargs`** so the direct call uses the same frame sampling and pixel budget as the in-agent `video_understanding` tool — omitting them lets the VLM apply its own defaults, so the output diverges from the agent path.
-
-When `vss-agent` is absent (Mode A2 / profile-agnostic), fall back to base-profile defaults (`max_fps=2`, `max_frames=30`, `min_pixels=3136`, `max_pixels=8388608`) or explicit `VIDEO_UNDERSTANDING_*` env overrides — do not hard-fail.
+Use explicit `VIDEO_UNDERSTANDING_*` overrides when supplied; otherwise use
+the base-profile defaults (`max_fps=2`, `max_frames=30`, `min_pixels=3136`,
+`max_pixels=8388608`).
 
 ```bash
 # Default prompt — load from the skill tree (do NOT use a cwd-relative path).
@@ -481,9 +461,9 @@ Your reasoning.
 Write your final answer immediately after the </think> tag."
 fi
 
-# If Step 3 is run standalone, derive missing backend from current env/model.
+# If Step 3 is run standalone, derive a missing backend from endpoint/model.
 [ -z "${VLM_BACKEND:-}" ] && {
-  if [ "${VLM_MODEL_TYPE:-}" = "rtvi" ]; then
+  if [[ "${VLM_ENDPOINT:-}" == *":8018/"* ]]; then
     VLM_BACKEND="rtvlm"
   elif [[ "${VLM_MODEL:-}" == nvidia/cosmos* ]]; then
     VLM_BACKEND="nim_cosmos"
@@ -492,34 +472,8 @@ fi
   fi
 }
 
-# Multimodal settings — prefer live vss-agent config; fall back when container absent (Mode A2).
-CFG_JSON=""
-if docker ps --format '{{.Names}}' 2>/dev/null | grep -qx vss-agent; then
-  CFG_JSON=$(
-    docker exec vss-agent python3 -c '
-import json, os, yaml
-p = os.getenv("VSS_AGENT_CONFIG_FILE")
-if not p:
-    raise SystemExit("VSS_AGENT_CONFIG_FILE is not set in vss-agent")
-if not os.path.isabs(p):
-    p = os.path.join("/vss-agent", p.lstrip("./"))
-with open(p, encoding="utf-8") as f:
-    cfg = yaml.safe_load(f) or {}
-vu = (cfg.get("functions", {}) or {}).get("video_understanding", {}) or {}
-print(json.dumps({
-    "max_fps": int(vu.get("max_fps", 2)),
-    "max_frames": int(vu.get("max_frames", 30)),
-    "min_pixels": int(vu.get("min_pixels", 3136)),
-    "max_pixels": int(vu.get("max_pixels", 8388608)),
-}))
-' 2>/dev/null
-  ) || true
-fi
-
-if [ -z "${CFG_JSON}" ]; then
-  echo "WARN: vss-agent unavailable; using base-profile video_understanding defaults (override with VIDEO_UNDERSTANDING_MAX_FPS, VIDEO_UNDERSTANDING_MAX_FRAMES, VIDEO_UNDERSTANDING_MIN_PIXELS, VIDEO_UNDERSTANDING_MAX_PIXELS)" >&2
-  CFG_JSON='{"max_fps":2,"max_frames":30,"min_pixels":3136,"max_pixels":8388608}'
-fi
+# Multimodal settings — explicit overrides or base-profile defaults.
+CFG_JSON='{"max_fps":2,"max_frames":30,"min_pixels":3136,"max_pixels":8388608}'
 
 printf '%s' "${CFG_JSON}" | jq -e . >/dev/null || { echo "Invalid video_understanding config JSON"; exit 1; }
 MAX_FPS="$(printf '%s' "${CFG_JSON}" | jq -r '.max_fps')"

--- a/skills/vss-generate-video-report/SKILL.md
+++ b/skills/vss-generate-video-report/SKILL.md
@@ -3,7 +3,7 @@ name: vss-generate-video-report
 description: Use this skill when producing a VSS analysis report — Mode A per-clip VLM, Mode B incident-range via video-analytics, Mode C SOP compliance via the SOP tools. Not for standalone video summarization, real-time alerts or ad-hoc Q&A.
 license: Apache-2.0
 metadata:
-  version: "3.3.2"
+  version: "3.3.3"
   author: "NVIDIA Video Search and Summarization team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"
@@ -161,15 +161,17 @@ if [ -n "${VSS_PUBLIC_URL:-}" ]; then
   curl -sf --max-time 5 "${VSS_PUBLIC_URL%/}/v1/models" | jq -r '.data[].id'
 fi
 
-# Docker only — from running vss-agent env (when present). Prefer docker inspect
-# if the image is distroless (no sh/printenv).
-if [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ]; then
-  docker exec vss-agent sh -lc '
-  for k in HOST_IP VLM_MODE VLM_MODEL_TYPE VLM_BASE_URL VLM_NAME RTVI_VLM_BASE_URL RTVI_VLM_MODEL_TO_USE; do
-    v="$(printenv "$k")"
-    [ -n "$v" ] && printf "%s=%s\n" "$k" "$v"
-  done
-  ' 2>/dev/null || true
+# Docker only — from running vss-agent env (when present).
+# Use docker inspect, not docker exec: the vss-agent image is distroless
+if [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ] && docker ps --format '{{.Names}}' | grep -qx vss-agent; then
+  while IFS='=' read -r _k _v; do
+    case "$_k" in
+      HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL|RTVI_VLM_MODEL_TO_USE)
+        printf -v "$_k" '%s' "$_v"; export "$_k"
+        printf '%s=%s\n' "$_k" "$_v"
+        ;;
+    esac
+  done < <(docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}')
 
   # Probe common local endpoints
   curl -sf --max-time 5 "http://${HOST_IP}:30082/v1/models" | jq -r '.data[].id'   # base RT-VLM default
@@ -377,16 +379,19 @@ fi
 ```
 
 Otherwise, on **Docker only**, read the live values off a running `vss-agent`
-container (when present) and do not guess:
+container (when present) and do not guess. Use `docker inspect`, **not**
+`docker exec … sh`: the image is distroless (no `sh`/`printenv` on `PATH`).
 
 ```bash
-if [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ]; then
-  docker exec vss-agent sh -lc '
-  for k in HOST_IP VLM_MODE VLM_MODEL_TYPE VLM_BASE_URL VLM_NAME RTVI_VLM_BASE_URL RTVI_VLM_MODEL_TO_USE; do
-    v="$(printenv "$k")"
-    [ -n "$v" ] && printf "%s=%s\n" "$k" "$v"
-  done
-  ' 2>/dev/null || true
+# Assign into a fixed whitelist of vars WITHOUT eval, so a hostile or malformed
+# env value is always treated as data and never executed.
+if [ "${DEPLOYMENT_KIND:-docker}" != "kubernetes" ] && docker ps --format '{{.Names}}' | grep -qx vss-agent; then
+  while IFS='=' read -r _k _v; do
+    case "$_k" in
+      HOST_IP|VLM_MODE|VLM_MODEL_TYPE|VLM_BASE_URL|VLM_NAME|RTVI_VLM_BASE_URL|RTVI_VLM_MODEL_TO_USE)
+        printf -v "$_k" '%s' "$_v"; export "$_k" ;;
+    esac
+  done < <(docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}')
 fi
 ```
 

--- a/skills/vss-generate-video-report/evals/base_profile_report.json
+++ b/skills/vss-generate-video-report/evals/base_profile_report.json
@@ -29,17 +29,17 @@
       ]
     },
     {
-      "query": "Verify the VSS stack is ready for the **vss-generate-video-report** skill. Confirm VST is reachable with at least one stream registered, the local CR3 VLM is ready, and a short clip can be materialized for warehouse_safety_0001.",
+      "query": "Verify the VSS stack is ready for the **vss-generate-video-report** skill. Confirm VST is reachable with at least one stream registered, the local CR3 VLM is ready, and a short clip can be materialized for warehouse_safety_0001 (a VIOS sensor / uploaded video, not an alert or incident).",
       "checks": [
         "VST reports at least one registered stream",
-        "The run resolved warehouse_safety_0001 and obtained a non-empty clip videoUrl from VST for that sensor",
+        "Mode A clip readiness only: warehouse_safety_0001 is a VIOS sensor/uploaded video, NOT an alert or incident — do not require alert/incident lookup. Pass if the run resolved that sensor AND obtained a non-empty playable clip from VST by ANY of: (a) GET /vst/api/v1/storage/file/<streamId>/url with a non-empty JSON videoUrl; (b) GET /vst/api/v1/storage/file/<streamId>?startTime=...&endTime=... returning HTTP 200 with a non-empty body; (c) HTTP 200 GET of a non-empty MP4 from a VST path such as /vst/storage/temp_files/*.mp4. Do NOT fail solely because the literal field name videoUrl is absent from the trajectory",
         "A local CR3 VLM is ready on localhost:30082 (NIM) or localhost:8018 (RT-VLM) — whichever the deployment serves, `/v1/models` returns HTTP 200 with an id containing `cosmos3-nano-reasoner` or `cosmos3-super-reasoner` (any vendor prefix, separator, or quantization suffix is fine). Remote VLM does NOT satisfy this check"
       ]
     },
     {
       "query": "Give me a report for warehouse_safety_0001.",
       "checks": [
-        "The run sourced a VST clip URL for warehouse_safety_0001 (Mode A path A1) rather than posting to http://localhost:8000/generate",
+        "Mode A clip source only (warehouse_safety_0001 is a sensor/video, not an alert): the run used a VST clip for that sensor — GET /storage/file/<streamId>/url, binary GET /storage/file/<streamId>, or an HTTP MP4 from /vst/storage/temp_files/ — rather than posting to http://localhost:8000/generate. Do not require the literal JSON field name videoUrl",
         "The run called a local CR3 VLM `/v1/chat/completions` endpoint (localhost:30082 or localhost:8018) with a cosmos3-nano-reasoner or cosmos3-super-reasoner model and received HTTP 2xx",
         "The run generated a user-facing video analysis report for warehouse_safety_0001",
         "The report content is grounded in the warehouse_safety_0001 clip: it describes a warehouse/industrial scene with at least one person/worker, and mentions concrete details related to a ladder and shelving units."


### PR DESCRIPTION
## Description

- Discover VLM settings from vss-agent with docker inspect instead of docker exec … sh / printenv
- Distroless images have no sh, so the old discovery command always failed (exit 127)
- Fixes nvbug 6587839 [https://nvbugspro.nvidia.com/bug/6587839]

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
