### PR TITLE
fix(ci): scan pyproject.toml and pdm.lock in License Diff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@ package-lock.json       @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 yarn.lock               @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 pnpm-lock.yaml          @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 poetry.lock             @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
+pdm.lock                @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 Pipfile.lock            @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 Cargo.lock              @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers
 go.sum                  @NVIDIA-AI-Blueprints/VSS_OSRB_Approvers

--- a/.github/scripts/license_diff_csv.py
+++ b/.github/scripts/license_diff_csv.py
@@ -24,6 +24,10 @@ it is deterministic — unchanged unpinned lines never produce phantom rows.
 It does NOT resolve the transitive closure; a committed lockfile remains the
 way to get full coverage.
 
+Added files whose names look like a lock or manifest (`pyproject.toml`,
+`*.lock`, `requirements*.txt`) but are not in that scan set are logged as a
+WARNING so a new lock format cannot stay invisible PR-by-PR.
+
 CSV columns: language, package, change, old_version, new_version, old_license,
 new_license, repository_url, notes.
 
@@ -82,6 +86,70 @@ def _list_lockfiles(ref: str, filename: str) -> list[str]:
         if p.endswith("/" + filename) or p == filename
         if "node_modules/" not in p
     ]
+
+
+# Basenames this scanner inventories. The tool is filename-recursive (any
+# nesting depth), not a path allow-list — the coverage gap is an unrecognized
+# *name*, which is how pdm.lock on RTVI-VLM slipped past OSRB.
+_SCANNED_BASENAMES = {
+    "uv.lock",
+    "pipfile.lock",
+    "pdm.lock",
+    "package-lock.json",
+    "pyproject.toml",
+}
+
+# Lock-shaped files that are not language package inventories.
+_NON_PACKAGE_LOCK_BASENAMES = {
+    "chart.lock",  # Helm chart dependency pin, not a language lockfile
+}
+
+
+def _basename(path: str) -> str:
+    return path.rsplit("/", 1)[-1]
+
+
+def looks_like_manifest(path: str) -> bool:
+    """True for added-file names that OSRB would expect License Diff to read."""
+    if "node_modules/" in path:
+        return False
+    base = _basename(path).lower()
+    if base in _NON_PACKAGE_LOCK_BASENAMES:
+        return False
+    if base == "pyproject.toml" or base.endswith(".lock"):
+        return True
+    return base.startswith("requirements") and base.endswith(".txt")
+
+
+def is_scanned_manifest(path: str) -> bool:
+    """True when this filename is one the inventory walkers already handle."""
+    base = _basename(path).lower()
+    if base in _SCANNED_BASENAMES:
+        return True
+    # requirements*.txt is handled, including the apt exclusion — that skip
+    # is deliberate, not a coverage gap.
+    return base.startswith("requirements") and base.endswith(".txt")
+
+
+def unscanned_added_manifests(base_paths: list[str], head_paths: list[str]) -> list[str]:
+    """Return added lock/manifest paths that no inventory walker will read."""
+    added = sorted(set(head_paths) - set(base_paths))
+    return [
+        path
+        for path in added
+        if looks_like_manifest(path) and not is_scanned_manifest(path)
+    ]
+
+
+def warn_unscanned_added_manifests(paths: list[str]) -> None:
+    """Log each coverage gap to stderr and as a GitHub Actions warning."""
+    for path in paths:
+        message = f"Skipped path — not in scan set: {path}"
+        _log(f"WARNING: {message}")
+        print(
+            f"::warning title=License Diff coverage gap::{message}",
+            file=sys.stderr,
+        )
 
 
 def parse_uv_lock(data: bytes) -> Inventory:
@@ -641,6 +709,9 @@ def main() -> int:
     args = parser.parse_args()
 
     _log(f"Comparing {args.base_ref} -> {args.head_ref}")
+    warn_unscanned_added_manifests(
+        unscanned_added_manifests(_ls_tree(args.base_ref), _ls_tree(args.head_ref))
+    )
 
     # Each (filename, parser) is scanned recursively across the whole repo tree
     # at the given ref (_list_lockfiles uses `git ls-tree -r`), so lockfiles at

--- a/.github/scripts/license_diff_csv.py
+++ b/.github/scripts/license_diff_csv.py
@@ -4,16 +4,17 @@
 
 """Generate a license-diff CSV between two git refs for OSRB review.
 
-Walks every Python lockfile (`uv.lock`, `Pipfile.lock`, `pdm.lock`) and Node
-lockfile (`package-lock.json`) tracked by the repo at the base and head refs —
+Walks every Python lockfile (`uv.lock`, `Pipfile.lock`, `pdm.lock`,
+`poetry.lock`) and Node lockfile (`package-lock.json`) tracked by the repo at
+the base and head refs —
 at any nesting depth (services/*, tools/*, repo root) — diffs the
 (package, version) sets, and writes one CSV row per change. Python rows are
 enriched with license + repository URL from PyPI; Node rows use the metadata
 embedded in the lockfile.
 
 For Pipfile.lock only the `default` (runtime) section is inventoried — dev-only
-deps never ship, so OSRB does not review them. PDM follows the same rule:
-only packages in the `default` / `main` groups are inventoried.
+deps never ship, so OSRB does not review them. PDM and Poetry follow the same
+rule: only packages in the `default` / `main` groups are inventoried.
 
 Services that ship a plain `requirements.txt` or `pyproject.toml` (no
 recognized lockfile) get a lighter, name-level pass: direct dependencies
@@ -95,6 +96,7 @@ _SCANNED_BASENAMES = {
     "uv.lock",
     "pipfile.lock",
     "pdm.lock",
+    "poetry.lock",
     "package-lock.json",
     "pyproject.toml",
 }
@@ -289,6 +291,30 @@ def parse_pdm_lock(data: bytes) -> Inventory:
     doc = tomllib.loads(data.decode("utf-8"))
     out: Inventory = {}
     for pkg in doc.get("package", []) or []:
+        groups = {str(group).lower() for group in (pkg.get("groups") or [])}
+        if groups and groups.isdisjoint(_RUNTIME_LOCK_GROUPS):
+            continue
+        name = (pkg.get("name") or "").lower()
+        version = str(pkg.get("version") or "")
+        if not name or not version:
+            continue
+        out[(name, version)] = {"repository_url": ""}
+    return out
+
+
+def parse_poetry_lock(data: bytes) -> Inventory:
+    """Return {(name, version): {repository_url}} parsed from poetry.lock.
+
+    Poetry 2 records ``groups``; Poetry 1 used ``category``. Only ``main`` /
+    ``default`` runtime membership is inventoried. A package present in both
+    ``main`` and ``dev`` is kept; a ``dev``-only package is omitted.
+    """
+    doc = tomllib.loads(data.decode("utf-8"))
+    out: Inventory = {}
+    for pkg in doc.get("package", []) or []:
+        category = str(pkg.get("category") or "").lower()
+        if category and category not in _RUNTIME_LOCK_GROUPS:
+            continue
         groups = {str(group).lower() for group in (pkg.get("groups") or [])}
         if groups and groups.isdisjoint(_RUNTIME_LOCK_GROUPS):
             continue
@@ -717,11 +743,12 @@ def main() -> int:
     # at the given ref (_list_lockfiles uses `git ls-tree -r`), so lockfiles at
     # any nesting depth — services/<svc>/..., tools/<tool>/..., or the repo
     # root — are all picked up. Python deps may be locked by uv (uv.lock),
-    # pipenv (Pipfile.lock), or PDM (pdm.lock); merge them into one inventory.
+    # pipenv (Pipfile.lock), PDM (pdm.lock), or Poetry (poetry.lock).
     PYTHON_LOCKS = [
         ("uv.lock", parse_uv_lock),
         ("Pipfile.lock", parse_pipfile_lock),
         ("pdm.lock", parse_pdm_lock),
+        ("poetry.lock", parse_poetry_lock),
     ]
 
     def python_inventory(ref: str) -> Inventory:

--- a/.github/scripts/license_diff_csv.py
+++ b/.github/scripts/license_diff_csv.py
@@ -4,22 +4,25 @@
 
 """Generate a license-diff CSV between two git refs for OSRB review.
 
-Walks every Python lockfile (`uv.lock`, `Pipfile.lock`) and Node lockfile
-(`package-lock.json`) tracked by the repo at the base and head refs — at any
-nesting depth (services/*, tools/*, repo root) — diffs the (package, version)
-sets, and writes one CSV row per change. Python rows are enriched with license
-+ repository URL from PyPI; Node rows use the metadata embedded in the lockfile.
+Walks every Python lockfile (`uv.lock`, `Pipfile.lock`, `pdm.lock`) and Node
+lockfile (`package-lock.json`) tracked by the repo at the base and head refs —
+at any nesting depth (services/*, tools/*, repo root) — diffs the
+(package, version) sets, and writes one CSV row per change. Python rows are
+enriched with license + repository URL from PyPI; Node rows use the metadata
+embedded in the lockfile.
 
 For Pipfile.lock only the `default` (runtime) section is inventoried — dev-only
-deps never ship, so OSRB does not review them.
+deps never ship, so OSRB does not review them. PDM follows the same rule:
+only packages in the `default` / `main` groups are inventoried.
 
-Services that ship a plain `requirements.txt` (no lockfile) get a lighter,
-name-level pass: direct dependencies ADDED to / REMOVED from a requirements.txt
-are reported (with the license of the pinned version, or of the latest release
-when the line is unpinned), and `==`-pinned bumps are flagged. This is driven
-by the committed file diff, so it is deterministic — unchanged unpinned lines
-never produce phantom rows. It does NOT resolve the transitive closure; a
-committed lockfile remains the way to get full coverage.
+Services that ship a plain `requirements.txt` or `pyproject.toml` (no
+recognized lockfile) get a lighter, name-level pass: direct dependencies
+ADDED to / REMOVED from those manifests are reported (with the license of the
+pinned version, or of the latest release when the line is unpinned), and
+`==`-pinned bumps are flagged. This is driven by the committed file diff, so
+it is deterministic — unchanged unpinned lines never produce phantom rows.
+It does NOT resolve the transitive closure; a committed lockfile remains the
+way to get full coverage.
 
 CSV columns: language, package, change, old_version, new_version, old_license,
 new_license, repository_url, notes.
@@ -202,7 +205,35 @@ def parse_pipfile_lock(data: bytes) -> Inventory:
     return out
 
 
+_RUNTIME_LOCK_GROUPS = {"default", "main"}
+
+
+def parse_pdm_lock(data: bytes) -> Inventory:
+    """Return {(name, version): {repository_url}} parsed from pdm.lock.
+
+    PDM records every resolved package under ``[[package]]`` with a ``groups``
+    list. Only ``default`` / ``main`` groups ship in a release artifact, so
+    ``dev`` and other extra groups are omitted — the same policy as
+    Pipfile.lock ``default`` and uv.lock's skip of ``dev-dependencies``.
+    Packages that omit ``groups`` are kept so an unexpected lock format cannot
+    silently drop a runtime dependency from OSRB review.
+    """
+    doc = tomllib.loads(data.decode("utf-8"))
+    out: Inventory = {}
+    for pkg in doc.get("package", []) or []:
+        groups = {str(group).lower() for group in (pkg.get("groups") or [])}
+        if groups and groups.isdisjoint(_RUNTIME_LOCK_GROUPS):
+            continue
+        name = (pkg.get("name") or "").lower()
+        version = str(pkg.get("version") or "")
+        if not name or not version:
+            continue
+        out[(name, version)] = {"repository_url": ""}
+    return out
+
+
 _REQ_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
+_EXACT_VERSION_RE = re.compile(r"^\d+(?:\.\d+)*(?:[a-zA-Z0-9._+-]*)?$")
 
 
 def parse_requirements(data: bytes) -> dict[str, str]:
@@ -270,12 +301,73 @@ def requirements_inventory(ref: str) -> dict[str, str]:
     return merged
 
 
-def diff_requirements(
-    base: dict[str, str], head: dict[str, str], covered_names: set[str]
-) -> list[dict[str, str]]:
-    """Diff direct-dependency NAME sets across requirements.txt files.
+def _direct_pin(spec: str) -> str:
+    """Return an exact pin from a PEP 440 / Poetry version string, else ''."""
+    spec = spec.strip().strip("'\"")
+    if spec.startswith("=="):
+        return spec[2:].strip().split(",", 1)[0].strip()
+    if _EXACT_VERSION_RE.match(spec):
+        return spec
+    return ""
 
-    Reports packages added to / removed from requirements.txt, and `==`-pinned
+
+def parse_pyproject(data: bytes) -> dict[str, str]:
+    """Return {canonical_name: pinned_version_or_''} from a pyproject.toml.
+
+    Reads PEP 621 ``[project].dependencies`` and Poetry
+    ``[tool.poetry.dependencies]``. Optional extras, PEP 735 dependency
+    groups, and Poetry ``group.*.dependencies`` are omitted — those are
+    typically dev/test and do not ship. Same name-level contract as
+    ``parse_requirements``: only ``==`` pins (or Poetry exact versions) are
+    recorded; ranges stay unpinned so PyPI drift cannot fabricate rows.
+    """
+    doc = tomllib.loads(data.decode("utf-8"))
+    project = doc.get("project") or {}
+    specs = [str(spec) for spec in (project.get("dependencies") or [])]
+    out = parse_requirements("\n".join(specs).encode())
+
+    poetry = ((doc.get("tool") or {}).get("poetry") or {}).get("dependencies") or {}
+    for name, spec in poetry.items():
+        if not name or name.lower() == "python":
+            continue
+        if isinstance(spec, dict) and (spec.get("git") or spec.get("url") or spec.get("path")):
+            continue
+        version_spec = spec.get("version") if isinstance(spec, dict) else spec
+        version = _direct_pin(str(version_spec or ""))
+        lname = name.lower()
+        if lname not in out or (version and not out[lname]):
+            out[lname] = version
+    return out
+
+
+def pyproject_inventory(ref: str) -> dict[str, str]:
+    """Merge every pyproject.toml at `ref` into {name: pinned_version_or_''}."""
+    merged: dict[str, str] = {}
+    for path in _list_lockfiles(ref, "pyproject.toml"):
+        data = _git_show(ref, path)
+        if data is None:
+            continue
+        try:
+            parsed = parse_pyproject(data)
+        except tomllib.TOMLDecodeError as exc:
+            _log(f"skip {path}@{ref}: {exc}")
+            continue
+        for name, version in parsed.items():
+            if name not in merged or (version and not merged[name]):
+                merged[name] = version
+    return merged
+
+
+def diff_requirements(
+    base: dict[str, str],
+    head: dict[str, str],
+    covered_names: set[str],
+    *,
+    source: str = "requirements.txt",
+) -> list[dict[str, str]]:
+    """Diff direct-dependency NAME sets across requirements.txt / pyproject.toml.
+
+    Reports packages added to / removed from the manifest, and `==`-pinned
     version bumps. Packages already inventoried by a lockfile (`covered_names`)
     are skipped — the lockfile diff covers them more accurately. Driven purely
     by the committed file contents, so it is deterministic: unchanged unpinned
@@ -291,7 +383,7 @@ def diff_requirements(
         if not in_base and in_head:  # newly added direct dependency
             meta = pypi_metadata(name, hv)
             resolved = meta.get("version") or hv
-            note = "new requirements.txt dependency"
+            note = f"new {source} dependency"
             if not hv:
                 note += "; unpinned (license shown for latest)"
             rows.append({
@@ -305,14 +397,14 @@ def diff_requirements(
                 "language": "python", "package": name, "change": "removed",
                 "old_version": bv or "(unpinned)", "new_version": "",
                 "old_license": "", "new_license": "",
-                "repository_url": "", "notes": "removed from requirements.txt",
+                "repository_url": "", "notes": f"removed from {source}",
             })
         elif bv != hv and bv and hv:  # pinned == bump on both sides
             old_meta = pypi_metadata(name, bv)
             new_meta = pypi_metadata(name, hv)
             old_license = old_meta.get("license", "")
             new_license = new_meta.get("license", "")
-            notes = "requirements.txt version pin changed"
+            notes = f"{source} version pin changed"
             if old_license and new_license and old_license != new_license:
                 notes += "; license changed"
             rows.append({
@@ -553,9 +645,13 @@ def main() -> int:
     # Each (filename, parser) is scanned recursively across the whole repo tree
     # at the given ref (_list_lockfiles uses `git ls-tree -r`), so lockfiles at
     # any nesting depth — services/<svc>/..., tools/<tool>/..., or the repo
-    # root — are all picked up. Python deps may be locked by uv (uv.lock) or
-    # pipenv (Pipfile.lock); merge both into one Python inventory.
-    PYTHON_LOCKS = [("uv.lock", parse_uv_lock), ("Pipfile.lock", parse_pipfile_lock)]
+    # root — are all picked up. Python deps may be locked by uv (uv.lock),
+    # pipenv (Pipfile.lock), or PDM (pdm.lock); merge them into one inventory.
+    PYTHON_LOCKS = [
+        ("uv.lock", parse_uv_lock),
+        ("Pipfile.lock", parse_pipfile_lock),
+        ("pdm.lock", parse_pdm_lock),
+    ]
 
     def python_inventory(ref: str) -> Inventory:
         merged: Inventory = {}
@@ -573,14 +669,22 @@ def main() -> int:
     rows.extend(diff_language("python", py_base, py_head))
     rows.extend(diff_language("node", nd_base, nd_head))
 
-    # Minimal requirements.txt coverage: catch direct deps added to (or removed
-    # from) plain requirements.txt files that have no lockfile. Deduped against
-    # names already in the lockfile inventory, which the diff above covers more
-    # accurately (resolved version + transitive closure).
+    # Minimal manifest coverage: catch direct deps added to (or removed from)
+    # plain requirements.txt / pyproject.toml files that have no recognized
+    # lockfile. Deduped against names already in the lockfile inventory, which
+    # the diff above covers more accurately (resolved version + transitive
+    # closure). pyproject.toml is also deduped against requirements.txt so a
+    # package declared in both does not produce two rows.
     lock_names = {name for name, _ in py_base} | {name for name, _ in py_head}
     req_base = requirements_inventory(args.base_ref)
     req_head = requirements_inventory(args.head_ref)
     rows.extend(diff_requirements(req_base, req_head, lock_names))
+    direct_covered = lock_names | set(req_base) | set(req_head)
+    pj_base = pyproject_inventory(args.base_ref)
+    pj_head = pyproject_inventory(args.head_ref)
+    rows.extend(
+        diff_requirements(pj_base, pj_head, direct_covered, source="pyproject.toml")
+    )
 
     with open(args.output, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=HEADERS)

--- a/.github/scripts/test_license_diff_csv.py
+++ b/.github/scripts/test_license_diff_csv.py
@@ -307,5 +307,60 @@ class DiffPyprojectTest(unittest.TestCase):
         self.assertIn("pyproject.toml", rows[0]["notes"])
 
 
+class UnscannedAddedManifestsTest(unittest.TestCase):
+    def test_warns_on_added_lockfile_the_scanner_does_not_parse(self) -> None:
+        skipped = license_diff_csv.unscanned_added_manifests(
+            ["services/keep/uv.lock"],
+            [
+                "services/keep/uv.lock",
+                "services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/poetry.lock",
+            ],
+        )
+
+        self.assertEqual(
+            ["services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/poetry.lock"],
+            skipped,
+        )
+
+    def test_does_not_warn_for_filenames_already_in_the_scan_set(self) -> None:
+        skipped = license_diff_csv.unscanned_added_manifests(
+            [],
+            [
+                "services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml",
+                "services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock",
+                "services/agent/uv.lock",
+                "libs/analytics/spatialai-data-utils/Pipfile.lock",
+                "services/foo/requirements.txt",
+                "services/foo/requirements-dev.txt",
+                "services/ui/package-lock.json",
+            ],
+        )
+
+        self.assertEqual([], skipped)
+
+    def test_does_not_warn_for_known_non_package_or_filtered_paths(self) -> None:
+        skipped = license_diff_csv.unscanned_added_manifests(
+            [],
+            [
+                "deploy/helm/services/rtvi/Chart.lock",
+                "services/video-summarization/docker/base/requirements_apt.txt",
+                "ui/node_modules/leftpad/package.lock",
+                "docs/overview.md",
+            ],
+        )
+
+        self.assertEqual([], skipped)
+
+    def test_warning_message_names_the_skipped_path(self) -> None:
+        with mock.patch.object(license_diff_csv, "_log") as log:
+            license_diff_csv.warn_unscanned_added_manifests(
+                ["services/new/poetry.lock"]
+            )
+
+        log.assert_called_once_with(
+            "WARNING: Skipped path — not in scan set: services/new/poetry.lock"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_license_diff_csv.py
+++ b/.github/scripts/test_license_diff_csv.py
@@ -285,6 +285,55 @@ version = "1.0.0"
         )
 
 
+class ParsePoetryLockTest(unittest.TestCase):
+    def test_includes_main_group_and_excludes_dev_only(self) -> None:
+        lock = b'''
+[[package]]
+name = "requests"
+version = "2.32.0"
+groups = ["main"]
+
+[[package]]
+name = "black"
+version = "25.1.0"
+groups = ["dev"]
+
+[[package]]
+name = "shared"
+version = "1.0.0"
+groups = ["main", "dev"]
+
+[[package]]
+name = "legacy-dev"
+version = "0.1.0"
+category = "dev"
+'''
+
+        inventory = license_diff_csv.parse_poetry_lock(lock)
+
+        self.assertEqual(
+            {("requests", "2.32.0"), ("shared", "1.0.0")},
+            set(inventory),
+        )
+
+    def test_vios_bdd_lock_excludes_development_only_packages(self) -> None:
+        lock_path = (
+            Path(__file__).parents[2]
+            / "services"
+            / "vios"
+            / "test"
+            / "bdd_tests"
+            / "poetry.lock"
+        )
+
+        inventory = license_diff_csv.parse_poetry_lock(lock_path.read_bytes())
+        names = {name for name, _version in inventory}
+
+        self.assertTrue(lock_path.is_file())
+        self.assertIn("requests", names)
+        self.assertTrue(names.isdisjoint({"black", "flake8", "mypy"}))
+
+
 class DiffPyprojectTest(unittest.TestCase):
     @mock.patch.object(license_diff_csv, "pypi_metadata")
     def test_new_pyproject_dependency_uses_source_note(self, metadata: mock.Mock) -> None:
@@ -313,14 +362,11 @@ class UnscannedAddedManifestsTest(unittest.TestCase):
             ["services/keep/uv.lock"],
             [
                 "services/keep/uv.lock",
-                "services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/poetry.lock",
+                "services/new/Cargo.lock",
             ],
         )
 
-        self.assertEqual(
-            ["services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/poetry.lock"],
-            skipped,
-        )
+        self.assertEqual(["services/new/Cargo.lock"], skipped)
 
     def test_does_not_warn_for_filenames_already_in_the_scan_set(self) -> None:
         skipped = license_diff_csv.unscanned_added_manifests(
@@ -328,6 +374,7 @@ class UnscannedAddedManifestsTest(unittest.TestCase):
             [
                 "services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pyproject.toml",
                 "services/rtvi/rt-vlm/docker/rtvi_vlm/py_deps/pdm.lock",
+                "services/vios/test/bdd_tests/poetry.lock",
                 "services/agent/uv.lock",
                 "libs/analytics/spatialai-data-utils/Pipfile.lock",
                 "services/foo/requirements.txt",
@@ -354,11 +401,11 @@ class UnscannedAddedManifestsTest(unittest.TestCase):
     def test_warning_message_names_the_skipped_path(self) -> None:
         with mock.patch.object(license_diff_csv, "_log") as log:
             license_diff_csv.warn_unscanned_added_manifests(
-                ["services/new/poetry.lock"]
+                ["services/new/Cargo.lock"]
             )
 
         log.assert_called_once_with(
-            "WARNING: Skipped path — not in scan set: services/new/poetry.lock"
+            "WARNING: Skipped path — not in scan set: services/new/Cargo.lock"
         )
 
 

--- a/.github/scripts/test_license_diff_csv.py
+++ b/.github/scripts/test_license_diff_csv.py
@@ -198,5 +198,114 @@ class DiffRequirementsTest(unittest.TestCase):
         self.assertIn("license changed", rows[0]["notes"])
 
 
+class ParsePyprojectTest(unittest.TestCase):
+    def test_reads_pep621_pins_and_skips_dev_extras(self) -> None:
+        manifest = b'''
+[project]
+name = "sample"
+dependencies = [
+    "pillow==12.2.0",
+    "requests>=2.32",
+    "ray[default]==2.54.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest==8.1.1",
+]
+'''
+
+        inventory = license_diff_csv.parse_pyproject(manifest)
+
+        self.assertEqual(inventory["pillow"], "12.2.0")
+        self.assertEqual(inventory["ray"], "2.54.0")
+        self.assertEqual(inventory["requests"], "")
+        self.assertNotIn("pytest", inventory)
+
+    def test_reads_poetry_runtime_dependencies(self) -> None:
+        manifest = b'''
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0.0"
+requests = "^2.31.0"
+mcp = "1.23.0"
+local-tool = {path = "."}
+remote-tool = {git = "https://example.com/tool.git"}
+'''
+
+        inventory = license_diff_csv.parse_pyproject(manifest)
+
+        self.assertEqual(inventory["mcp"], "1.23.0")
+        self.assertEqual(inventory["requests"], "")
+        self.assertNotIn("python", inventory)
+        self.assertNotIn("local-tool", inventory)
+        self.assertNotIn("remote-tool", inventory)
+
+    def test_lvs_py_deps_manifest_is_inventoried(self) -> None:
+        path = (
+            Path(__file__).parents[2]
+            / "services"
+            / "video-summarization"
+            / "docker"
+            / "base"
+            / "py_deps"
+            / "pyproject.toml"
+        )
+
+        inventory = license_diff_csv.parse_pyproject(path.read_bytes())
+
+        self.assertTrue(path.is_file())
+        self.assertTrue(inventory["pillow"])
+        self.assertTrue(inventory["urllib3"])
+        self.assertIn("requests", inventory)
+
+
+class ParsePdmLockTest(unittest.TestCase):
+    def test_includes_default_group_and_excludes_dev(self) -> None:
+        lock = b'''
+[[package]]
+name = "aiohttp"
+version = "3.13.3"
+groups = ["default"]
+
+[[package]]
+name = "pytest"
+version = "8.1.1"
+groups = ["dev"]
+
+[[package]]
+name = "ungrouped"
+version = "1.0.0"
+'''
+
+        inventory = license_diff_csv.parse_pdm_lock(lock)
+
+        self.assertEqual(
+            {("aiohttp", "3.13.3"), ("ungrouped", "1.0.0")},
+            set(inventory),
+        )
+
+
+class DiffPyprojectTest(unittest.TestCase):
+    @mock.patch.object(license_diff_csv, "pypi_metadata")
+    def test_new_pyproject_dependency_uses_source_note(self, metadata: mock.Mock) -> None:
+        metadata.return_value = {
+            "license": "MIT",
+            "repository_url": "https://example.com/demo",
+            "version": "1.0.0",
+        }
+
+        rows = license_diff_csv.diff_requirements(
+            {},
+            {"demo": "1.0.0"},
+            set(),
+            source="pyproject.toml",
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["change"], "added")
+        self.assertEqual(rows[0]["package"], "demo")
+        self.assertIn("pyproject.toml", rows[0]["notes"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- License Diff only inventoried `uv.lock`, `Pipfile.lock`, and `requirements.txt`, so PDM-managed trees such as `**/py_deps/pyproject.toml` never appeared in the OSRB CSV.
- The scanner now reads every `pyproject.toml` (PEP 621 and Poetry runtime deps) and every `pdm.lock` (default/main groups only), then diffs them the same way as the existing lockfile / requirements pass.
- `pdm.lock` is added to CODEOWNERS so OSRB approvers are requested on those lockfile changes.

This is the gap Mugdha flagged on #1730: new RTVI-VLM packages in `py_deps/pyproject.toml` were invisible to the diff tool.

## Test plan
- [x] `python3 .github/scripts/test_license_diff_csv.py`
- [ ] After merge, rerun License Diff on #1730 (or rebase it) and confirm the new `py_deps` packages appear in the OSRB CSV
- [ ] Confirm License Diff on this PR itself stays empty (no dependency inventory change)