### PR TITLE
fix(ci): put VIOS third-party notices in the source artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,20 +190,32 @@ jobs:
           git lfs pull \
             --include='services/vios/LICENSE.3rdparty' \
             --exclude=''
+          if head -c 64 services/vios/LICENSE.3rdparty | grep -q '^version https://git-lfs'; then
+            echo "::error::git lfs pull did not materialize services/vios/LICENSE.3rdparty"
+            exit 1
+          fi
 
       - name: Package tracked source
         run: |
           # actions/checkout above runs with lfs:false, but `git archive` applies
           # checkout-side conversion (ident, then smudge/process), so it fetches
           # the repo's entire ~989 MB of LFS payload on every run. 414 MB of that
-          # is services/vios. The required third-party notices are fetched above.
+          # is services/vios. Skip those binaries via lfs.fetchexclude.
           #
-          # lfs.fetchexclude makes git-lfs pass unfetched paths through as pointer
-          # text rather than fetching them. Scoped to this one command with -c,
-          # so nothing under .git is mutated and the services/analytics fixtures
-          # the integration jobs do read are still smudged normally.
+          # fetchexclude is a path filter: matching files stay LFS pointers even
+          # when already pulled. LICENSE.3rdparty lives under services/vios, so
+          # archive would pack the pointer. Pull the notices above, then replace
+          # that one tar member after archive. Scoped to this command with -c,
+          # so analytics fixtures are still smudged normally.
           git -c lfs.fetchexclude='services/vios/**' \
-            archive --format=tar.gz --prefix=repo/ -o source.tar.gz HEAD
+            archive --format=tar --prefix=repo/ -o source.tar HEAD
+          license_member='repo/services/vios/LICENSE.3rdparty'
+          tar --delete -f source.tar "$license_member"
+          mkdir -p .archive-license/repo/services/vios
+          cp services/vios/LICENSE.3rdparty .archive-license/repo/services/vios/LICENSE.3rdparty
+          tar --append -C .archive-license -f source.tar "$license_member"
+          rm -rf .archive-license
+          gzip -n source.tar
           git ls-files > tracked-files.txt
           ls -lh source.tar.gz
 


### PR DESCRIPTION
## Summary
- Source packaging skipped all of `services/vios/**` as LFS pointers, including `LICENSE.3rdparty`.
- CI still pulls that license file, then replaces the pointer in the tar so the source artifact has the real notices. VIOS binaries stay skipped.

## Test plan
- [ ] `Prepare source artifact` passes on this PR
- [ ] Verify step still sees a VIOS binary as an LFS pointer
- [ ] Verify step sees real `LICENSE.3rdparty` text, not a pointer