### PR TITLE
fix(skills): raise python-dotenv floor to 1.2.2 for CVE-2026-28684

### DIFF
--- a/skills/benchmarking/benchmark-video-summarization/scripts/requirements.txt
+++ b/skills/benchmarking/benchmark-video-summarization/scripts/requirements.txt
@@ -17,7 +17,7 @@
 pandas>=1.5.0
 requests>=2.28.0
 pyyaml>=6.0
-python-dotenv>=0.19.0
+python-dotenv>=1.2.2
 urllib3==2.7.0
 psutil>=5.9.0
 pynvml>=11.5.0

--- a/skills/vss-manage-alerts/scripts/alert-notify/requirements.txt
+++ b/skills/vss-manage-alerts/scripts/alert-notify/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.115.0
 uvicorn>=0.34.0
 slack-sdk>=3.33.0
-python-dotenv>=1.0.0
+python-dotenv>=1.2.2
 httpx>=0.28.0
 websockets>=13.0


### PR DESCRIPTION
## Description

Clears the open nSpect finding against VSS: **BDSA-2026-7726 / CVE-2026-28684** (Medium),
`python-dotenv`, reported at `skills/vss-manage-alerts/scripts/alert-notify/requirements.txt:4`.

The pin was `python-dotenv>=1.0.0`. The floor is unbounded, so a real `pip install` already
pulls the latest release — but the scanner resolves a `>=` specifier to its lowest satisfying
version, which is the vulnerable 1.0.0. python-dotenv fixed the issue in **1.2.2**, so the
floor moves to `>=1.2.2`.

### Actual exposure

The advisory is [GHSA-mf9w-mj56-hr94](https://github.com/advisories/GHSA-mf9w-mj56-hr94) —
symlink following (CWE-59) in `set_key()` / `unset_key()`, which rewrite the `.env` file in
place and can overwrite an arbitrary file through a crafted symlink when the cross-device
rename fallback fires. It needs local access plus user interaction.

Neither skill calls those functions. Both only call `load_dotenv()`, which is read-only:

- `skills/vss-manage-alerts/scripts/alert-notify/server.py:43`
- `skills/benchmarking/benchmark-video-summarization/scripts/vss_perf_benchmark.py:302`

So this is a scanner-clearing / defense-in-depth bump, not a fix for a reachable bug. Worth
recording so the Medium severity isn't read as an exploitable path in VSS.

### Second file, not flagged

`skills/benchmarking/benchmark-video-summarization/scripts/requirements.txt:20` floors at
`python-dotenv>=0.19.0` — lower than the flagged pin, same CVE. nSpect did not report it
because that skill carries no `skill.oms.sig` and therefore sits outside the signed-catalog
scan scope. Bumped here too, so it doesn't surface the moment that skill enters the catalog.

### Compatibility

python-dotenv 1.2.2+ requires Python >=3.10 (1.0.0 allowed 3.8). Both skills already document
Python 3.10+ — `skills/vss-manage-alerts/references/alert-notify.md:114` and
`skills/benchmarking/benchmark-video-summarization/SKILL.md:48` — so the floor raise does not
narrow the supported interpreter range.

Verified both requirement sets still resolve (`pip install --dry-run`); `python-dotenv`
resolves to 1.2.3.

## Plan

| Question | Recommendation | Decision |
|---|---|---|
| Floor at the patched release (1.2.2) or the latest (1.2.3)? | 1.2.2 — it's the version the advisory names as fixed; requiring 1.2.3 adds a constraint the finding doesn't justify. | 1.2.2 |
| Also bump the unflagged `benchmark-video-summarization` pin (`>=0.19.0`)? | Yes — same package below the same patched version, same one-line change, and it's equally compatible at Python 3.10+. Closes the gap before that skill enters the signed catalog. | Both files |

## Follow-up

`/nvskills-ci` needs to run on this PR so the signing service re-signs `vss-manage-alerts`
and the catalog picks up the changed `requirements.txt`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes. — n/a, dependency floor bump; verified by dependency resolution instead.
- [x] The documentation is up to date with these changes. — no doc change needed; both skills already document Python 3.10+.