### PR TITLE
fix(ci): grant statuses:read on main so /nvskills-ci stops failing at startup

### DIFF
--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -14,9 +14,14 @@ jobs:
       (github.event_name == 'push' &&
         github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
         startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    # Must cover every permission the called workflow declares, otherwise the
+    # run dies with startup_failure before any job executes. NVIDIA/skills
+    # added `statuses: read` in bc8b450a (it reads the commit status list to
+    # find the NVSkills CI verdict), so the caller has to grant it too.
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Description

`/nvskills-ci` has been dead on arrival for every PR. This grants the one missing permission on
`main` that makes it run.

### Why the fix on `develop` never took effect

`/nvskills-ci` is an `issue_comment` trigger. **GitHub always resolves `issue_comment` handlers
from the default branch** — `main` — regardless of which branch the PR changes or which branch it
targets. So `main`'s copy of `.github/workflows/team-request.yml` is the one that actually executes
for every `/nvskills-ci` comment in the repo.

That copy grants only `contents: read` and `pull-requests: read`. The callee,
`NVIDIA/skills/.github/workflows/team-request.yml@main`, declares three:

```yaml
permissions:
  contents: read
  pull-requests: read
  statuses: read     # reads the commit status list to find the NVSkills CI verdict
```

A caller must grant **every** permission the callee declares, or the run dies with
`startup_failure` before any job executes — no logs, no job, just a red X.

#1422 (`1af3d3334`, *"fix(ci): grant statuses:read so NVSkills CI stops failing at startup"*) already
made exactly this change — but it landed on `develop`. That repaired the `push` path, which resolves
from the PR branch, and **not the comment path the fix was named for**. The bug has been live ever
since.

### Evidence

Four `/nvskills-ci` runs failed at startup on #1746 today, all attributed to `main`:

| Run | Branch | Event | Conclusion |
|---|---|---|---|
| [32172453691](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/32172453691) | `main` | `issue_comment` | `startup_failure` |
| [32172451895](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/32172451895) | `main` | `issue_comment` | `startup_failure` |
| [32172431266](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/32172431266) | `main` | `issue_comment` | `startup_failure` |
| [32172396204](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/32172396204) | `main` | `issue_comment` | `startup_failure` |

This is easy to miss: `gh run list --branch <your-branch>` shows a `skipped` run, which is the
unrelated `push` trigger correctly not firing for a non-bot actor. The failing run is on `main`.

### Scope

`main` is the **only** branch that needs a change. Verified:

- `.github/workflows/team-request.yml` is the only workflow on `main` that calls an external
  reusable workflow, so this is the only caller that can hit the permission mismatch.
- `develop` already grants all three permissions and needs no PR.
- Upstream declares exactly those three and nothing further, so `statuses: read` is sufficient
  and `develop` is not missing anything newer.

After this change the file is **byte-identical to `develop`'s copy**, explanatory comment included,
so the two branches can't silently drift apart again.

## Plan

| Question | Recommendation | Decision |
|---|---|---|
| Port to `main` only, or also raise a `develop` PR? | `main` only — `develop` already has `statuses: read` from #1422, so a `develop` PR would be an empty diff. | `main` only |
| Cherry-pick just the permission line, or match `develop` exactly? | Match exactly, comment and all — leaving the file identical is what stops this from re-diverging on the next promotion. | Match exactly |

## Verification

- `team-request.yml` parses as valid YAML; `jobs.request.permissions` resolves to exactly
  `{contents: read, pull-requests: read, statuses: read}`.
- `diff` against `origin/develop`'s copy of the file is empty.
- End-to-end confirmation requires merging: because `issue_comment` resolves from the default
  branch, `/nvskills-ci` cannot be exercised from a PR branch. Once this lands, re-comment
  `/nvskills-ci` on #1746 and the run should reach its jobs instead of `startup_failure`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes. — n/a, CI permission grant; verified by YAML parse and diff-vs-`develop`.
- [x] The documentation is up to date with these changes. — the inline comment ported from `develop` documents the constraint at the point of use.