### PR TITLE
fix(skills): raise python-dotenv floor to 1.2.2 for CVE-2026-28684

### DIFF
--- a/skills/vss-manage-alerts/scripts/alert-notify/requirements.txt
+++ b/skills/vss-manage-alerts/scripts/alert-notify/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.115.0
 uvicorn>=0.34.0
 slack-sdk>=3.33.0
-python-dotenv>=1.0.0
+python-dotenv>=1.2.2
 httpx>=0.28.0
 websockets>=13.0


### PR DESCRIPTION
## Description

Ports the CVE-2026-28684 fix to `main`. Companion to #1746, which fixes the same pin on `develop`.

`main` still carries the vulnerable `python-dotenv>=1.0.0` at
`skills/vss-manage-alerts/scripts/alert-notify/requirements.txt:4`. Since the published skill
catalog is cut from `main`, the nSpect finding (**BDSA-2026-7726 / CVE-2026-28684**, Medium) stays
open against the release branch until this lands — fixing `develop` alone does not clear it.

python-dotenv patched the issue in **1.2.2**, so the floor moves there. The pin's floor is
unbounded, so a real `pip install` already pulls the latest release; the scanner resolves a `>=`
specifier to its lowest satisfying version, which is the vulnerable 1.0.0.

### Actual exposure

[GHSA-mf9w-mj56-hr94](https://github.com/advisories/GHSA-mf9w-mj56-hr94) — symlink following
(CWE-59) in `set_key()` / `unset_key()`, which rewrite `.env` in place and can overwrite an
arbitrary file via a crafted symlink when the cross-device rename fallback fires. Requires local
access plus user interaction.

`alert-notify` never calls those functions — only `load_dotenv()` at `server.py:43`, which is
read-only. So this clears the scanner and adds defense in depth; it does not fix a reachable bug.
Worth recording so the Medium isn't read as live exposure in a release branch.

### Scope difference vs #1746

One file here, not two. `skills/benchmarking/benchmark-video-summarization` — whose
`python-dotenv>=0.19.0` pin #1746 also raises — **does not exist on `main`**.

### Compatibility

python-dotenv 1.2.2+ requires Python >=3.10 (1.0.0 allowed 3.8). The skill already documents
Python 3.10+ at `skills/vss-manage-alerts/references/alert-notify.md:114`, so the floor raise does
not narrow the supported interpreter range. Resolution verified: `python-dotenv` resolves to 1.2.3.

## ⚠️ This needs a re-sign before it can merge

Changing a file inside `skills/vss-manage-alerts/` invalidates `skills/vss-manage-alerts/skill.oms.sig`.
Verified locally with the repo's own tooling:

```
$ .github/scripts/sign-agent-skill.sh verify skills/vss-manage-alerts     # unmodified main
Verification succeeded

$ .github/scripts/sign-agent-skill.sh verify <tree with this change>
Verification failed with error: Signature mismatch:
  ["Hash mismatch for 'scripts/alert-notify/requirements.txt': ..."]
```

`Skills Signatures / signature-check` is **blocking for PRs targeting `main`** (it is skipped for
`develop`, which is why #1746 is unaffected). It resolves targets from
`git diff --name-only origin/<base>...HEAD`, so `vss-manage-alerts` will be selected and will fail
until the signing service regenerates the signature.

### Merge order

1. **#1748 first** — `/nvskills-ci` is currently dead. It is an `issue_comment` trigger, which
   GitHub resolves from the default branch (`main`), and `main`'s `team-request.yml` is missing the
   `statuses: read` permission the callee declares, so every invocation dies at `startup_failure`.
   #1748 ports that grant to `main`.
2. **Then `/nvskills-ci` on this PR** to regenerate `skill.oms.sig`.
3. **Then merge**, once `signature-check` is green.

Until step 1 lands there is no way to re-sign, so a red signature check on this PR is expected
rather than a defect in the change.

## Plan

| Question | Recommendation | Decision |
|---|---|---|
| Fix `main` separately, or let the `develop` fix reach it by promotion? | Separately — `main` and `develop` have diverged (209 commits apart under `.github/` alone) and there is no promotion in flight, so waiting leaves the release branch exposed indefinitely. | Separate PR |
| Include the benchmarking-skill bump from #1746? | No — that skill does not exist on `main`. | One file |
| Attempt to regenerate the signature in this PR? | No — signing requires the private key held by the signing service. `/nvskills-ci` is the only sanctioned path. | Re-sign via CI |

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes. — n/a, dependency floor bump; verified by dependency resolution and a local signature check.
- [x] The documentation is up to date with these changes. — no doc change needed; the skill already documents Python 3.10+.