### PR TITLE
feat(deployments): Adding info for additional CR3 models for RTVI VLM via skills depeloyment

### DIFF
--- a/skills/vss-build-vision-agent/references/services/rt-vlm.md
+++ b/skills/vss-build-vision-agent/references/services/rt-vlm.md
@@ -15,6 +15,52 @@
 - Redis is required only when `ENABLE_REDIS_ERROR_MESSAGES=true`.
 - Do not add `vlm_${VLM_MODE}_${VLM_NAME_SLUG}` for an integrated RT-VLM path.
 
+## Available integrated model variants
+
+These are the Cosmos Reason3 checkpoints RT-VLM can load on the integrated path.
+`RTVI_VLM_MODEL_PATH` selects the checkpoint; `VLM_NAME` is the id RT-VLM then
+advertises at `GET /v1/models`, derived from the path by dropping the `ngc:`
+prefix and replacing `/` and `:` with `_`. Take both values from the same row —
+a mismatch makes consumers fail with `400 BadParameters: No such model`.
+
+| Model | `VLM_NAME` | `RTVI_VLM_MODEL_PATH` |
+|---|---|---|
+| CR3 Nano BF16 | `nim_nvidia_cosmos3-nano-reasoner_bf16-final` | `ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final` |
+| CR3 Nano FP8 | `nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix` | `ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix` |
+| CR3 Nano NVFP4 | `nim_nvidia_cosmos3-nano-reasoner_modelopt-nvfp4-full-quantize-final_format_fix` | `ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-nvfp4-full-quantize-final_format_fix` |
+| CR3 Super BF16 | `nim_nvidia_cosmos3-super-reasoner_modelopt-bf16-final` | `ngc:nim/nvidia/cosmos3-super-reasoner:modelopt-bf16-final` |
+| CR3 Super FP8 | `nim_nvidia_cosmos3-super-reasoner_modelopt-fp8-final_format_fix` | `ngc:nim/nvidia/cosmos3-super-reasoner:modelopt-fp8-final_format_fix` |
+| CR3 Super NVFP4 | `nim_nvidia_cosmos3-super-reasoner_modelopt-nvfp4-full-quantize-final_format_fix` | `ngc:nim/nvidia/cosmos3-super-reasoner:modelopt-nvfp4-full-quantize-final_format_fix` |
+
+Notes on choosing a row:
+
+- **Default to the profile, not to this table.** When the user does not name a
+  model or quantization, keep the variant the selected deployment profile already
+  ships and leave `RTVI_VLM_MODEL_PATH` / `VLM_NAME` untouched (`alerts` and
+  `lvs` ship Nano BF16, `search` ships Nano FP8). Consult this table only when
+  the user asks for a specific variant, or when placement forces a change under
+  [Singleton and variant convergence](#singleton-and-variant-convergence).
+- Nano is the default family for every profile in this repo; select Super only on
+  an explicit request.
+- Within a family, quantization is a memory/placement decision, not a capability
+  one: BF16 is heaviest, FP8 fits alongside another GPU service, NVFP4 is the
+  lightest and requires FP4-capable (Blackwell-class) hardware.
+- Super is supported only on H100 and RTX PRO 6000, and needs one GPU dedicated
+  to the VLM — do not co-locate another GPU service on it. Treat both as hard
+  constraints when you are the one choosing the variant.
+- **Surface an unsupported-hardware Super request before acting on it.** If Super
+  is requested and the detected GPUs are neither H100 nor RTX PRO 6000, or no GPU
+  can be dedicated to RT-VLM, stop and tell the user which constraint their system
+  fails and what the detected hardware and placement actually are. Then ask
+  (`AskUserQuestion`) whether to fall back to the equivalent Nano variant or
+  override the constraint anyway. Only proceed with Super after the user overrides
+  it knowingly — never assume the request itself is the override, and never
+  silently downgrade to Nano either.
+- Only the BF16 tag differs in shape between families (`bf16-final` for Nano,
+  `modelopt-bf16-final` for Super). Copy tags verbatim rather than deriving them.
+- `RTVI_VLM_MODEL_TO_USE=cosmos-reason3` for all six rows, and the served
+  endpoint stays `http://rtvi-vlm:8000`; neither changes with the variant.
+
 ## Singleton and variant convergence
 
 RT-VLM is a singleton owner: one instance, one checkpoint, and one
@@ -31,7 +77,9 @@ Resolve the variant/placement knobs as one set:
 name from the profile that ships the resolved variant; resolve maximum model
 length, device ID, and utilization together for the selected hardware and
 placement. Keep `VLM_NAME` aligned with the model id advertised by
-`RTVI_VLM_MODEL_PATH`; do not combine values from different variants.
+`RTVI_VLM_MODEL_PATH` — one row of
+[Available integrated model variants](#available-integrated-model-variants) —
+and do not combine values from different variants.
 
 Consumer wiring is not part of that set.
 `RTVI_VLM_KAFKA_ENABLED`, `RTVI_VLM_MESSAGE_BUS_TOPIC` (generated captions),
@@ -51,7 +99,7 @@ variant profile.
 | Environment variable | Use |
 |---|---|
 | `RTVI_VLM_IMAGE_TAG`, `RTVI_VLM_PORT`, `RT_VLM_DEVICE_ID` | Select image, host port, and GPU. |
-| `RTVI_VLM_MODEL_TO_USE`, `RTVI_VLM_MODEL_PATH`, `VLM_NAME` | Select an integrated model and its advertised id. |
+| `RTVI_VLM_MODEL_TO_USE`, `RTVI_VLM_MODEL_PATH`, `VLM_NAME` | Select an integrated model and its advertised id (see [Available integrated model variants](#available-integrated-model-variants)). |
 | `RTVI_VLM_ENDPOINT`, `RTVI_VLM_API_KEY`, `VLM_BASE_URL` | Configure an OpenAI-compatible backend. |
 | `RTVI_VLLM_GPU_MEMORY_UTILIZATION`, `RTVI_VLM_MAX_MODEL_LEN`, `RTVI_VLLM_MAX_NUM_SEQS`, `RTVI_VLLM_MAX_NUM_BATCHED_TOKENS` | Bound vLLM memory and concurrency. |
 | `RTVI_VLM_DEFAULT_NUM_FRAMES_PER_SECOND_OR_FIXED_FRAMES_CHUNK`, `RTVI_VLM_BATCH_SIZE` | Tune frame sampling and batching. |


### PR DESCRIPTION
## Summary
Add details for CR3 models for the user to choose when deploying via skills

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
