### PR TITLE
helm(dev-profile-search): README deploy options, local NIMs default a…

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-search/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-search/README.md
@@ -36,18 +36,9 @@ warehouse and MV3DT startup scripts remain separate.
 
 ## GPU Requirements
 
-The stack requests GPUs (`nvidia.com/gpu: 1` each) for the workloads listed below. The exact total depends on whether you deploy with hosted NIMs (NVIDIA Build Endpoint) or local NIMs.
+The stack requests GPUs (`nvidia.com/gpu: 1` each) for the workloads listed below. The exact total depends on whether you serve the LLM and VLM locally (Option A) or from remote endpoints (Option B).
 
-### With NVIDIA Build Endpoint (Option A)
-
-| Workload | GPU |
-|----------|-----|
-| `vss-rtvi-cv` | 1 |
-| `vss-rtvi-embed` (Cosmos Embed) | 1 |
-| `vss-vios-streamprocessing` | 1 |
-| **Total** | **3** |
-
-### With Local NIMs (Option B)
+### With Local NIMs (Option A)
 
 The critic agent is available by default and controlled per request with `use_critic`. Its VLM (`rtvi.vss-rtvi-vlm`) is enabled by default. Setting `rtvi.vss-rtvi-vlm.enabled=false` saves one GPU but also disables `video_understanding`.
 
@@ -65,6 +56,16 @@ The critic agent is available by default and controlled per request with `use_cr
 > default). It requests **1 full GPU** (`nvidia.com/gpu: "1"`), scheduled on any free GPU. To use
 > the standalone NIM instead, set `nims.cosmos3.enabled=true`, `rtvi.vss-rtvi-vlm.enabled=false`,
 > and flip the agent `VLM_MODEL_TYPE` back to `nim`.
+
+### With Remote LLM and VLM Endpoints (Option B)
+
+| Workload | GPU | Notes |
+|----------|-----|-------|
+| `vss-rtvi-cv` | 1 | |
+| `vss-rtvi-embed` (Cosmos Embed) | 1 | |
+| `vss-vios-streamprocessing` | 1 | |
+| `vss-rtvi-vlm` (proxy) | 1 | Forwards VLM calls to the remote endpoint and loads no local model, but still requests `nvidia.com/gpu: 1` from the `rtvi-vlm` subchart defaults |
+| **Total** | **4** | |
 
 ### GPU Time-Slicing (Limited GPU Environments)
 
@@ -92,7 +93,7 @@ When time-slicing is enabled, each time-sliced partition appears as a separate `
     - **580.105.08** (x86 hosts with Ubuntu 24.04)
     - **580.65.06** (x86 hosts with Ubuntu 22.04)
 
-- **NVIDIA NIM Operator** (required only for [Option B: Local NIMs](#option-b-deploy-with-local-nims))
+- **NVIDIA NIM Operator** (required only for [Option A: Local NIMs](#option-a-deploy-with-local-nims))
   - Required when `nims` subcharts are enabled (`NIMCache` / `NIMService`).
   - Install **after** the GPU Operator. See [NIM Operator installation](https://docs.nvidia.com/nim-operator/latest/install.html).
   - Install the NIM Operator:
@@ -199,7 +200,7 @@ The `global.rtviInternalIngress.controllerService` default (`haproxy-kubernetes-
 
 ## Step 3: Deploy the Search Profile
 
-**Note:** The Helm install can take several minutes while dependent services start; wait for workloads to become Ready before using the UI. Use **`global.ngcApiKey`** (and **`nims.global.ngcApiKey`** for [Option B](#option-b-deploy-with-local-nims)) as in the examples below—Helm creates the needed NGC and registry secrets from those values.
+**Note:** The Helm install can take several minutes while dependent services start; wait for workloads to become Ready before using the UI. Use **`global.ngcApiKey`** (and **`nims.global.ngcApiKey`** for [Option A](#option-a-deploy-with-local-nims)) as in the examples below—Helm creates the needed NGC and registry secrets from those values.
 
 ```bash
 # Clone the repository. For a specific branch or tag, add: -b <name-or-tag> (before the URL).
@@ -209,55 +210,12 @@ cd video-search-and-summarization/deploy/helm/developer-profiles
 helm dependency build ./dev-profile-search
 ```
 
-### Option A: Remote NIMs
+### Option A: Deploy with Local NIMs
 
-Deploy with NVIDIA Build Endpoint
+**This is the default and recommended way to deploy the Search profile.** Everything the critic
+and `video_understanding` need runs on the cluster, so no external endpoint is required.
 
-Uses hosted NIMs at `https://integrate.api.nvidia.com` — no local GPU required for LLM/VLM inference.
-vss-rtvi-cv and RTVI Embed still run on local GPUs. See [GPU Requirements](#with-nvidia-build-endpoint-option-a).
-
-```bash
-helm upgrade --install vss-search ./dev-profile-search \
-  -f dev-profile-search/values-build-endpoint.yaml \
-  -n vss-search --create-namespace \
-  --set global.externalHost=vss-search.$NODE_EXTERNAL_IP.nip.io \
-  --set global.ngcApiKey=$NGC_CLI_API_KEY \
-  --set agent.vss-agent.apiKeys.nvidia=$NGC_CLI_API_KEY \
-  --set global.storageClass=$STORAGE_CLASS \
-  --wait=false
-```
-
-> **Option A note:** `values-build-endpoint.yaml` disables local Nemotron and Cosmos3 NIM deployments (`nims.nemotron.enabled=false`, `nims.cosmos3.enabled=false`). Critic verification is enabled per request by default and uses the hosted VLM endpoint through RT-VLM.
-
-**Custom remote NIM (self-hosted or external endpoints)**
-
-If you already run **NIM** (or an OpenAI-compatible LLM/VLM API) outside this cluster—another namespace, a shared service, or a hosted endpoint—use the steps below to point **vss-agent** at those URLs. Set **`nims.enabled=false`** so this chart does not deploy in-cluster NIM workloads; set **`agent.vss-agent.llmBaseUrl`** and **`agent.vss-agent.vlmBaseUrl`** to the HTTP(S) base URLs your agent can reach (include path prefix if your service requires it). Keep **`agent.vss-agent.llmName`** and **`agent.vss-agent.vlmName`** aligned with the models those endpoints serve.
-
-This profile lists the **full** **`agent.vss-agent.env`** block for Search deployments. Search behavior is driven by **`general.front_end.streaming_ingest`** in `configs/vss-agent/config.yml`; the chart wires the agent for remote VLM mode and the default Elasticsearch index **`mdx-embed-filtered-2025-01-01`**. Critic verification is controlled per request with `use_critic`. Override **`agent.vss-agent.elasticsearchUrl`** or **`agent.vss-agent.elasticsearchIndex`** when you need a different Elasticsearch endpoint or index.
-
-```bash
-
-export LLM_BASE_URL='<REMOTE LLM ENDPOINT>'
-export VLM_BASE_URL='<REMOTE VLM ENDPOINT>'
-
-helm upgrade --install vss-search ./dev-profile-search \
-  -f dev-profile-search/values-build-endpoint.yaml \
-  -n vss-search --create-namespace \
-  --set global.externalHost=vss-search.$NODE_EXTERNAL_IP.nip.io \
-  --set global.ngcApiKey=$NGC_CLI_API_KEY \
-  --set agent.vss-agent.apiKeys.nvidia=$NGC_CLI_API_KEY \
-  --set global.storageClass=$STORAGE_CLASS \
-  --set nims.enabled=false \
-  --set agent.vss-agent.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
-  --set agent.vss-agent.vlmName="nvidia/cosmos3-nano-reasoner" \
-  --set agent.vss-agent.llmBaseUrl="$LLM_BASE_URL" \
-  --set agent.vss-agent.vlmBaseUrl="$VLM_BASE_URL" \
-  --wait=false
-```
-
-### Option B: Deploy with Local NIMs
-
-Runs the LLM NIM on-cluster via the NIM Operator, with the VLM served by `rtvi.vss-rtvi-vlm`. Requires additional GPUs for Nemotron and the VLM. See [GPU Requirements](#with-local-nims-option-b).
+Runs the LLM NIM on-cluster via the NIM Operator, with the VLM served by `rtvi.vss-rtvi-vlm`. Requires additional GPUs for Nemotron and the VLM. See [GPU Requirements](#with-local-nims-option-a).
 
 **Prerequisite:** Install the [NVIDIA NIM Operator](#prerequisites) before deploying.
 
@@ -292,6 +250,73 @@ helm upgrade --install vss-search ./dev-profile-search \
 
 See [Access via NodePort](#access-via-nodeport) for endpoint URLs.
 
+### Option B: Remote LLM with a user-provided VLM endpoint
+
+Serves the LLM and the VLM from outside the cluster, so neither needs a local GPU for inference.
+`vss-rtvi-cv` and RTVI Embed still run on local GPUs, and `vss-rtvi-vlm` is still deployed — in this
+mode it is an OpenAI-compatible proxy that forwards VLM calls to the remote endpoint rather than
+loading a local checkpoint. See [GPU Requirements](#with-remote-llm-and-vlm-endpoints-option-b).
+
+The LLM and the evaluation judge can use the hosted `nvidia/nvidia-nemotron-nano-9b-v2` on
+`https://integrate.api.nvidia.com`, whose free endpoint NVIDIA has scheduled for deprecation on
+**2026-08-25** — after that date, pick a current model from the
+[API catalog](https://build.nvidia.com) or point `llmBaseUrl` at your own LLM as well.
+**The VLM must be an endpoint you provide**: the Cosmos3 VLM
+(`nvidia/cosmos3-nano-reasoner`) has no working hosted endpoint on `https://integrate.api.nvidia.com`,
+so critic verification and `video_understanding` fail if you leave the VLM pointed there. Supply your
+own OpenAI-compatible VLM — a self-hosted NIM, a shared service in another namespace, or any other
+OpenAI-compatible API — or use [Option A](#option-a-deploy-with-local-nims) instead.
+
+Set **`nims.enabled=false`** so this chart does not deploy in-cluster NIM workloads. The LLM and the
+VLM are then configured through different keys, because the agent calls the LLM directly but reaches
+the VLM through the RT-VLM proxy:
+
+| Key | Purpose |
+|-----|---------|
+| `agent.vss-agent.llmBaseUrl` / `llmName` | The LLM endpoint the agent calls directly. Omit both to keep this file's hosted Nemotron default. |
+| `agent.vss-agent.evalLlmJudgeBaseUrl` / `evalLlmJudgeName` | The judge used by evaluation runs. This file pins them to NVIDIA Build and they take precedence over `llmBaseUrl`, so override them too when you supply your own LLM. |
+| `global.vlmBaseUrl` / `global.vlmName` | The remote VLM that RT-VLM forwards to (`VIA_VLM_ENDPOINT`). Overriding only `agent.vss-agent.vlmBaseUrl` leaves the proxy pointed at this file's Cosmos3 default and the critic still fails. |
+| `agent.vss-agent.vlmName` | The model id the agent asks RT-VLM for. Must match `global.vlmName`, or RT-VLM rejects the request. |
+
+Include a path prefix in the base URLs if your service requires one, and keep every model id aligned
+with what the endpoints actually advertise on `/v1/models`.
+
+This profile lists the **full** **`agent.vss-agent.env`** block for Search deployments. Search behavior is driven by **`general.front_end.streaming_ingest`** in `configs/vss-agent/config.yml`; the chart wires the agent for remote VLM mode and the default Elasticsearch index **`mdx-embed-filtered-2025-01-01`**. Critic verification is controlled per request with `use_critic`. Override **`agent.vss-agent.elasticsearchUrl`** or **`agent.vss-agent.elasticsearchIndex`** when you need a different Elasticsearch endpoint or index.
+
+```bash
+
+export LLM_BASE_URL='<REMOTE LLM ENDPOINT>'
+export VLM_BASE_URL='<YOUR OPENAI-COMPATIBLE VLM ENDPOINT>'
+export VLM_MODEL_ID='<MODEL ID YOUR VLM ENDPOINT SERVES>'
+
+helm upgrade --install vss-search ./dev-profile-search \
+  -f dev-profile-search/values-build-endpoint.yaml \
+  -n vss-search --create-namespace \
+  --set global.externalHost=vss-search.$NODE_EXTERNAL_IP.nip.io \
+  --set global.ngcApiKey=$NGC_CLI_API_KEY \
+  --set agent.vss-agent.apiKeys.nvidia=$NGC_CLI_API_KEY \
+  --set global.storageClass=$STORAGE_CLASS \
+  --set nims.enabled=false \
+  --set agent.vss-agent.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set agent.vss-agent.llmBaseUrl="$LLM_BASE_URL" \
+  --set global.vlmBaseUrl="$VLM_BASE_URL" \
+  --set global.vlmName="$VLM_MODEL_ID" \
+  --set agent.vss-agent.vlmName="$VLM_MODEL_ID" \
+  --wait=false
+```
+
+> **Option B note:** `values-build-endpoint.yaml` disables local Nemotron and Cosmos3 NIM
+> deployments (`nims.nemotron.enabled=false`, `nims.cosmos3.enabled=false`). Its `global.vlmBaseUrl`
+> and `global.vlmName` defaults still point at Cosmos3 on NVIDIA Build, which does not serve that
+> model — override them as shown above.
+
+> **VLM endpoint credentials:** RT-VLM authenticates to the remote VLM with `VIA_VLM_API_KEY`, which
+> the chart injects from `global.ngcApiSecret` (`ngc-api-key-secret` / `NGC_API_KEY`, populated from
+> `global.ngcApiKey`). If your endpoint expects a different token, point
+> `rtvi.vss-rtvi-vlm.ngcApiSecret.name` and `.key` at your own Secret. The `OPENAI_API_KEY` and
+> `NVIDIA_API_KEY` values of `NOAPIKEYSET` in `values-build-endpoint.yaml` are inert, because
+> `VIA_VLM_API_KEY` takes precedence over both.
+
 ### Deployed Components
 
 This single chart deploys all application components:
@@ -306,7 +331,7 @@ This single chart deploys all application components:
 
 The critic agent performs VLM-based verification of search results and is available by default. Set the request-level `use_critic` option to enable or skip verification for each search; it defaults to `true`.
 
-Its VLM is served in-pod by **`rtvi.vss-rtvi-vlm`** (Cosmos3 checkpoint), or proxied to the hosted endpoint with NVIDIA Build Endpoint. The same service supports `video_understanding`, so it is not exclusive to the critic. Setting `rtvi.vss-rtvi-vlm.enabled=false` removes both capabilities and should only be used when neither is needed.
+Its VLM is served in-pod by **`rtvi.vss-rtvi-vlm`** (Cosmos3 checkpoint) in [Option A](#option-a-deploy-with-local-nims), or proxied by the same service to a user-provided remote endpoint in [Option B](#option-b-remote-llm-with-a-user-provided-vlm-endpoint). The same service supports `video_understanding`, so it is not exclusive to the critic. Setting `rtvi.vss-rtvi-vlm.enabled=false` removes both capabilities and should only be used when neither is needed.
 
 ## Verify Deployment
 

--- a/deploy/helm/developer-profiles/dev-profile-search/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-search/README.md
@@ -274,7 +274,7 @@ the VLM through the RT-VLM proxy:
 | Key | Purpose |
 |-----|---------|
 | `agent.vss-agent.llmBaseUrl` / `llmName` | The LLM endpoint the agent calls directly. Omit both to keep this file's hosted Nemotron default. |
-| `agent.vss-agent.evalLlmJudgeBaseUrl` / `evalLlmJudgeName` | The judge used by evaluation runs. This file pins them to NVIDIA Build and they take precedence over `llmBaseUrl`, so override them too when you supply your own LLM. |
+| `agent.vss-agent.evalLlmJudgeBaseUrl` / `evalLlmJudgeName` | The judge used by evaluation runs. This file pins them to NVIDIA Build and they take precedence over `llmBaseUrl`, so a custom LLM leaves the judge on Build unless you set these as well — the example below does. |
 | `global.vlmBaseUrl` / `global.vlmName` | The remote VLM that RT-VLM forwards to (`VIA_VLM_ENDPOINT`). Overriding only `agent.vss-agent.vlmBaseUrl` leaves the proxy pointed at this file's Cosmos3 default and the critic still fails. |
 | `agent.vss-agent.vlmName` | The model id the agent asks RT-VLM for. Must match `global.vlmName`, or RT-VLM rejects the request. |
 
@@ -286,6 +286,7 @@ This profile lists the **full** **`agent.vss-agent.env`** block for Search deplo
 ```bash
 
 export LLM_BASE_URL='<REMOTE LLM ENDPOINT>'
+export LLM_MODEL_ID='<MODEL ID YOUR LLM ENDPOINT SERVES>'
 export VLM_BASE_URL='<YOUR OPENAI-COMPATIBLE VLM ENDPOINT>'
 export VLM_MODEL_ID='<MODEL ID YOUR VLM ENDPOINT SERVES>'
 
@@ -297,8 +298,10 @@ helm upgrade --install vss-search ./dev-profile-search \
   --set agent.vss-agent.apiKeys.nvidia=$NGC_CLI_API_KEY \
   --set global.storageClass=$STORAGE_CLASS \
   --set nims.enabled=false \
-  --set agent.vss-agent.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
+  --set agent.vss-agent.llmName="$LLM_MODEL_ID" \
   --set agent.vss-agent.llmBaseUrl="$LLM_BASE_URL" \
+  --set agent.vss-agent.evalLlmJudgeName="$LLM_MODEL_ID" \
+  --set agent.vss-agent.evalLlmJudgeBaseUrl="$LLM_BASE_URL" \
   --set global.vlmBaseUrl="$VLM_BASE_URL" \
   --set global.vlmName="$VLM_MODEL_ID" \
   --set agent.vss-agent.vlmName="$VLM_MODEL_ID" \

--- a/deploy/helm/developer-profiles/dev-profile-search/values-build-endpoint.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values-build-endpoint.yaml
@@ -14,10 +14,19 @@
 # limitations under the License.
 
 # values-build-endpoint.yaml
-# Override file for deploying with NVIDIA Build Endpoint (hosted NIMs).
-# LLM inference runs at https://integrate.api.nvidia.com. VLM calls route through
-# vss-rtvi-vlm (openai-compat proxy) which forwards to the same hosted endpoint.
-# Perception and RTVI Embed still run locally.
+# Override file for serving the LLM and VLM from remote endpoints instead of
+# in-cluster NIMs. LLM inference can use https://integrate.api.nvidia.com, but the
+# VLM must be an endpoint you provide: Cosmos3 (nvidia/cosmos3-nano-reasoner) is not
+# served on https://integrate.api.nvidia.com, so override vlmBaseUrl and vlmName
+# below with your own OpenAI-compatible VLM. vss-rtvi-vlm is still deployed here as
+# an openai-compat proxy in front of that endpoint. Perception and RTVI Embed still
+# run locally.
+#
+# RT-VLM authenticates to the remote VLM with VIA_VLM_API_KEY, injected from
+# global.ngcApiSecret (ngc-api-key-secret / NGC_API_KEY). Point
+# rtvi.vss-rtvi-vlm.ngcApiSecret at your own Secret when the endpoint expects a
+# different token. The OPENAI_API_KEY / NVIDIA_API_KEY values of NOAPIKEYSET below
+# are inert, because VIA_VLM_API_KEY takes precedence over both.
 #
 # Usage:
 #   helm upgrade --install vss-search ./dev-profile-search \
@@ -26,6 +35,9 @@
 #     --set global.externalHost=vss-search.$NODE_EXTERNAL_IP.nip.io \
 #     --set global.ngcApiKey=$NGC_CLI_API_KEY \
 #     --set nims.global.ngcApiKey=$NGC_CLI_API_KEY \
+#     --set global.vlmBaseUrl=<YOUR VLM ENDPOINT> \
+#     --set global.vlmName=<MODEL ID THAT ENDPOINT SERVES> \
+#     --set agent.vss-agent.vlmName=<SAME MODEL ID> \
 #     (set NGC key via global.ngcApiKey / nims.global.ngcApiKey as in your environment) \
 #     --wait=false
 
@@ -34,6 +46,13 @@ vios:
   enabled: true
 
 global:
+  # These two are what redirect the rtvi-vlm proxy (VIA_VLM_ENDPOINT /
+  # VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME); agent.vss-agent.vlmBaseUrl does not.
+  # Placeholders: NVIDIA Build does not serve cosmos3-nano-reasoner. Override both
+  # with your own OpenAI-compatible VLM endpoint and the model id it advertises on
+  # /v1/models, and keep agent.vss-agent.vlmName equal to vlmName below.
+  # Left non-empty on purpose — an empty vlmBaseUrl makes rtvi-vlm fall back to the
+  # in-cluster nvidia-cosmos3-reasoner Service that this file disables.
   vlmBaseUrl: "https://integrate.api.nvidia.com"
   vlmName: "nvidia/cosmos3-nano-reasoner"
 
@@ -50,6 +69,8 @@ agent:
   vss-agent:
     llmName: "nvidia/nvidia-nemotron-nano-9b-v2"
     llmBaseUrl: "https://integrate.api.nvidia.com"
+    # Placeholder — override with the model id your own VLM endpoint serves. Must
+    # match global.vlmName, which is what rtvi-vlm forwards to that endpoint.
     vlmName: "nvidia/cosmos3-nano-reasoner"
     evalLlmJudgeName: "nvidia/nvidia-nemotron-nano-9b-v2"
     evalLlmJudgeBaseUrl: "https://integrate.api.nvidia.com"

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -686,7 +686,7 @@ agent:
       limits:
         memory: 8Gi
         cpu: '2'
-    # vss-agent: full explicit container env for Search (Option B). URLs use Helm `tpl` against this chart's values + global.
+    # vss-agent: full explicit container env for Search (Option A, local NIMs). URLs use Helm `tpl` against this chart's values + global.
     env:
       - name: VSS_AGENT_CONFIG_FILE
         value: '{{ .Values.configFilePath | default "/etc/vss-agent/config.yml" }}'


### PR DESCRIPTION
helm(dev-profile-search): README deploy options, local NIMs default and BYO VLM

Cosmos3 is not served on https://integrate.api.nvidia.com, so the remote
option is now documented as a user-provided VLM endpoint and overrides
global.vlmBaseUrl/vlmName, which is what RT-VLM actually reads. Option
letters swapped so local NIMs is Option A. README and comments only.

Ref: nvbug 6598025

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
