### PR TITLE
Add per-receiver user_defined_metadata to webhook notifications

### DIFF
--- a/services/vios/configs/notification_config.json
+++ b/services/vios/configs/notification_config.json
@@ -30,7 +30,8 @@
 						"query_params": {"change": "{{event.change}}"},
 						"camera_type": ["rtsp", "file"],
 						"timeout_ms": 5000,
-						"retry": {"max_attempts": 3, "backoff_ms": [1000, 5000, 15000], "retry_on_status": [408, 429, 500, 502, 503, 504]}
+						"retry": {"max_attempts": 3, "backoff_ms": [1000, 5000, 15000], "retry_on_status": [408, 429, 500, 502, 503, 504]},
+						"user_defined_metadata": {"model": "some_model_name", "chunk": 123}
 					}
 				],
 				"auth": {"type": "hmac-sha256", "secret": "{{secrets.signing_key}}", "header_name": "X-VIOS-Signature"}

--- a/services/vios/src/framework/notification/webhook/webhook_notifier.cpp
+++ b/services/vios/src/framework/notification/webhook/webhook_notifier.cpp
@@ -126,6 +126,30 @@ std::string makeEventLabel(const Json::Value& message)
     return label + "]";
 }
 
+// Copies the tagged event body and merges the receiver's user_defined_metadata
+// members into event.metadata, creating the object when the event carries
+// none. User-defined keys overwrite same-named event-generated keys.
+Json::Value mergeUserMetadata(const Json::Value& taggedEvent, const Json::Value& userMetadata)
+{
+    Json::Value merged = taggedEvent;
+    Json::Value& event = merged["event"];
+    if (!event.isNull() && !event.isObject())
+    {
+        // A scalar event cannot hold metadata; operator[] on it would throw.
+        event = Json::Value(Json::objectValue);
+    }
+    Json::Value& metadata = event["metadata"];
+    if (!metadata.isNull() && !metadata.isObject())
+    {
+        metadata = Json::Value(Json::objectValue);
+    }
+    for (const std::string& key : userMetadata.getMemberNames())
+    {
+        metadata[key] = userMetadata[key];
+    }
+    return merged;
+}
+
 bool anyEnabledWebhook(const Json::Value& config)
 {
     const Json::Value webhooks = config.get("webhooks", Json::nullValue);
@@ -349,6 +373,17 @@ void WebhookNotifier::loadConfig(const Json::Value& config)
                            << (webhook.m_requests.size() + 1)
                            << " camera_type must be an array, filter ignored" << endl;
             }
+            const Json::Value userMetadata = requestJson.get("user_defined_metadata", Json::nullValue);
+            if (userMetadata.isObject())
+            {
+                requestConfig.m_userDefinedMetadata = userMetadata;
+            }
+            else if (!userMetadata.isNull())
+            {
+                LOG(error) << "Webhook " << webhook.m_id << ": receiver "
+                           << (webhook.m_requests.size() + 1)
+                           << " user_defined_metadata must be a JSON object, ignored" << endl;
+            }
             const Json::Value timeoutMs = requestJson.get("timeout_ms", Json::nullValue);
             if (timeoutMs.isNumeric())
             {
@@ -541,12 +576,18 @@ bool WebhookNotifier::deliverMessage(Json::Value& message)
             LOG(info) << "Webhook " << webhook.m_id << ": delivering " << loggingLabel << " to receiver "
                       << (r + 1) << "/" << webhook.m_requests.size() << " (attempt 1/"
                       << requestConfig.m_maxAttempts << ")" << endl;
+            // A receiver with user_defined_metadata gets its own body with the
+            // extra keys merged into event.metadata; others share the plain body.
+            const std::string receiverBody =
+                requestConfig.m_userDefinedMetadata.isNull()
+                    ? body
+                    : jsonToString(mergeUserMetadata(taggedEvent, requestConfig.m_userDefinedMetadata));
             DeliveryState state;
             state.m_webhookIndex = i;
             state.m_requestIndex = r;
             state.m_attempt = 0;
             state.m_eventLabel = loggingLabel;
-            state.m_request = buildRequest(requestConfig, event, body, webhook.m_id);
+            state.m_request = buildRequest(requestConfig, event, receiverBody, webhook.m_id);
             submitDelivery(std::move(state), 0);
         }
     }

--- a/services/vios/src/framework/notification/webhook/webhook_notifier.h
+++ b/services/vios/src/framework/notification/webhook/webhook_notifier.h
@@ -39,7 +39,10 @@
  * matching event is posted to all receivers in that array through
  * AsyncHttpClient. A receiver may narrow further with a camera_type list;
  * it then only gets events whose event.camera_type is listed. An item's "id"
- * is copied into the delivered body under "webhook_id".
+ * is copied into the delivered body under "webhook_id". A receiver may carry
+ * a user_defined_metadata object; its members are merged verbatim into the
+ * delivered body's event.metadata (created when absent), overwriting
+ * same-named event-generated keys.
  *
  * deliverMessage() only enqueues HTTP work and returns true immediately: the
  * event-level 5 s retry loop in INotificationInterface is deliberately opted
@@ -89,6 +92,9 @@ private:
         std::vector<int> m_retryOnStatus;  // empty retries any non-2xx status
         // Camera types this receiver accepts; empty receives every matched event.
         std::vector<std::string> m_cameraTypes;
+        // Operator-supplied key/value pairs merged into event.metadata of the
+        // delivered body; null when the receiver defines none.
+        Json::Value m_userDefinedMetadata;
     };
 
     struct WebhookConfig

--- a/services/vios/test/gtests/webhook_notifier.cpp
+++ b/services/vios/test/gtests/webhook_notifier.cpp
@@ -23,7 +23,8 @@
  * switch over the items array, alert-type trigger keys, receiver fan-out over
  * the request array with a non-blocking deliverMessage, per-receiver
  * camera_type filtering, retry_on_status and backoff handling, header
- * templating, and the deferred HMAC signature header (must be absent).
+ * templating, per-receiver user_defined_metadata merging into event.metadata,
+ * and the deferred HMAC signature header (must be absent).
  */
 
 #include "gtest/gtest.h"
@@ -380,6 +381,108 @@ TEST(WebhookNotifierTest, HeaderValuesAreSanitizedAgainstCrlfInjection)
     EXPECT_EQ(seen[0].m_headers.find("X-Evil"), seen[0].m_headers.end());
     ASSERT_NE(seen[0].m_headers.find("streamId"), seen[0].m_headers.end());
     EXPECT_EQ(seen[0].m_headers.at("streamId"), "cam-1X-Evil: injected");
+}
+
+TEST(WebhookNotifierTest, UserDefinedMetadataMergesIntoEventMetadata)
+{
+    TinyHttpServer server;
+    ASSERT_TRUE(server.start());
+
+    // Receiver with user metadata, including a key colliding with the event's
+    // own metadata, plus nested JSON; a second receiver defines none.
+    Json::Value withMetadata = makeRequest(server.url("/with"));
+    withMetadata["user_defined_metadata"]["model"] = "some_model_name";
+    withMetadata["user_defined_metadata"]["chunk"] = 123;
+    withMetadata["user_defined_metadata"]["codec"] = "user-override";
+    withMetadata["user_defined_metadata"]["nested"]["a"] = true;
+    Json::Value without = makeRequest(server.url("/without"));
+
+    WebhookNotifier notifier(
+        makeConfig({makeWebhook("camera_status_change", "camera_add", {withMetadata, without})}));
+
+    Json::Value message = makeCameraEvent("camera_add");
+    message["event"]["metadata"]["codec"] = "h264";
+    message["event"]["metadata"]["framerate"] = 30;
+    EXPECT_TRUE(notifier.deliverMessage(message));
+
+    ASSERT_TRUE(waitForRequestCount(server, 2));
+    std::this_thread::sleep_for(milliseconds(300));
+
+    const auto seen = server.requests();
+    ASSERT_EQ(seen.size(), 2u);
+    for (const auto& request : seen)
+    {
+        Json::Value body;
+        ASSERT_TRUE(Json::Reader().parse(request.m_body, body));
+        const Json::Value& metadata = body["event"]["metadata"];
+        if (request.m_path == "/with")
+        {
+            // User keys are added, collisions favor the user, others survive.
+            EXPECT_EQ(metadata["model"].asString(), "some_model_name");
+            EXPECT_EQ(metadata["chunk"].asInt(), 123);
+            EXPECT_EQ(metadata["codec"].asString(), "user-override");
+            EXPECT_TRUE(metadata["nested"]["a"].asBool());
+            EXPECT_EQ(metadata["framerate"].asInt(), 30);
+        }
+        else
+        {
+            // The receiver without user metadata gets the event verbatim.
+            EXPECT_EQ(metadata["codec"].asString(), "h264");
+            EXPECT_FALSE(metadata.isMember("model"));
+        }
+    }
+}
+
+TEST(WebhookNotifierTest, UserDefinedMetadataCreatesMissingMetadataObject)
+{
+    TinyHttpServer server;
+    ASSERT_TRUE(server.start());
+
+    Json::Value request = makeRequest(server.url("/hook"));
+    request["user_defined_metadata"]["model"] = "some_model_name";
+
+    WebhookNotifier notifier(
+        makeConfig({makeWebhook("camera_status_change", "camera_add", {request})}));
+
+    // makeCameraEvent carries no event.metadata at all.
+    Json::Value message = makeCameraEvent("camera_add");
+    EXPECT_TRUE(notifier.deliverMessage(message));
+
+    ASSERT_TRUE(waitForRequestCount(server, 1));
+    const auto seen = server.requests();
+    ASSERT_EQ(seen.size(), 1u);
+    Json::Value body;
+    ASSERT_TRUE(Json::Reader().parse(seen[0].m_body, body));
+    ASSERT_TRUE(body["event"]["metadata"].isObject());
+    EXPECT_EQ(body["event"]["metadata"]["model"].asString(), "some_model_name");
+    // The rest of the event is untouched.
+    EXPECT_EQ(body["event"]["camera_id"].asString(), "cam-1");
+}
+
+TEST(WebhookNotifierTest, NonObjectUserDefinedMetadataIsIgnored)
+{
+    TinyHttpServer server;
+    ASSERT_TRUE(server.start());
+
+    Json::Value request = makeRequest(server.url("/hook"));
+    request["user_defined_metadata"] = "not-an-object";
+
+    WebhookNotifier notifier(
+        makeConfig({makeWebhook("camera_status_change", "camera_add", {request})}));
+    EXPECT_EQ(notifier.webhookCount(), 1u);
+
+    Json::Value message = makeCameraEvent("camera_add");
+    EXPECT_TRUE(notifier.deliverMessage(message));
+
+    ASSERT_TRUE(waitForRequestCount(server, 1));
+    const auto seen = server.requests();
+    ASSERT_EQ(seen.size(), 1u);
+    Json::Value body;
+    ASSERT_TRUE(Json::Reader().parse(seen[0].m_body, body));
+    // The malformed field must not leak into the body in any form.
+    EXPECT_FALSE(body["event"].isMember("metadata"));
+    body.removeMember("webhook_id");
+    EXPECT_EQ(body, message);
 }
 
 TEST(WebhookNotifierTest, DisabledAndMalformedWebhooksAreSkipped)


### PR DESCRIPTION
* Parse an optional user_defined_metadata object under each webhook request entry and log an error for non-object values.
* Merge the configured key-value pairs into event.metadata of the delivered body, creating the object when the event carries none and overwriting colliding event-generated keys.
* Document the new field in the sample notification_config.json.
* Add unit tests covering the merge, collision override, nested values, metadata creation, and rejection of malformed values.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
