### PR TITLE
fix(mv3dt): MV3DT config update for Bug 6304863

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/blueprint-configurator/blueprint_config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/blueprint-configurator/blueprint_config.yml
@@ -539,6 +539,13 @@ commons:
           msg-broker-proto-lib: "${msg-broker-proto-lib}"
           latency: "${ds_config_latency}"
 
+      # Update DeepStream YAML config to avoid rebuilding the engine when the batch size changes
+      - operation_type: "yaml_update"
+        target_file: "${DS_CONFIG_DIR}/ds-pgie-config.yml"
+        backup: true
+        updates:
+          property.model-engine-file: /opt/storage/rtdetr_warehouse_v1.0.2.fp16.onnx_b${final_stream_count}_gpu0_fp16.engine
+
       # Update NVStreamer configs
       - operation_type: "json_update"
         target_file: ${VSS_APPS_DIR}/industry-profiles/warehouse-operations/warehouse-mv3dt-app/nvstreamer/configs/vst-config.json

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/configs/ds-mv3dt-tracker-config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/configs/ds-mv3dt-tracker-config.yml
@@ -1,4 +1,17 @@
-%YAML:1.0
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 BaseConfig:
   minDetectorConfidence: 0.266
@@ -9,32 +22,52 @@ TargetManagement:
   enableBboxUnClipping: 1
   preserveStreamUpdateOrder: 0
   maxTargetsPerStream: 200
-  minIouDiff4NewTarget: 0.33485659954800495
-  minTrackerConfidence: 0.6019478047482886
+  minIouDiff4NewTarget: 0.3
+  minTrackerConfidence: 0.6
   probationAge: 17
-  maxShadowTrackingAge: 131
+  maxShadowTrackingAge: 150
   earlyTerminationAge: 7
   maxTrajectoryBufferLength: -1
+
+TrajectoryManagement:
+  useUniqueID: 0
+  enableReAssoc: 1
+  minMatchingScore4Overall: 0.95
+  minTrackletMatchingScore: 0.3
+  minMatchingScore4ReidSimilarity: 0
+  matchingScoreWeight4TrackletSimilarity: 0.8
+  matchingScoreWeight4ReidSimilarity: 0
+  minTrajectoryLength4Projection: 34
+  prepLength4TrajectoryProjection: 58
+  trajectoryProjectionLength: 33
+  maxAngle4TrackletMatching: 67
+  minSpeedSimilarity4TrackletMatching: 0.06
+  minBboxSizeSimilarity4TrackletMatching: 0.1
+  maxTrackletMatchingTimeSearchRange: 27
+  trajectoryProjectionProcessNoiseScale: 0.01
+  trajectoryProjectionMeasurementNoiseScale: 100
+  trackletSpacialSearchRegionScale: 0.01
+  reidExtractionInterval: 0
 
 DataAssociator:
   dataAssociatorType: 0
   associationMatcherType: 1
-  minMatchingScore4Overall: 0.5082953005836124
-  minMatchingScore4SizeSimilarity: 0.009643993655030297
-  minMatchingScore4Iou: 0.11557371329518315
-  matchingScoreWeight4SizeSimilarity: 0.5084913673983223
-  matchingScoreWeight4Iou: 0.3494256836722713
-  tentativeDetectorConfidence: 0.7745249596202076
-  minMatchingScore4TentativeIou: 0.42388480686796887
-  minMatchingScore4PeerAssocIou: 0.6955557941537551
+  minMatchingScore4Overall: 0.5
+  minMatchingScore4SizeSimilarity: 0.1
+  minMatchingScore4Iou: 0.25
+  matchingScoreWeight4SizeSimilarity: 0.2
+  matchingScoreWeight4Iou: 0.6
+  tentativeDetectorConfidence: 0.8
+  minMatchingScore4TentativeIou: 0.25
+  minMatchingScore4PeerAssocIou: 0.25
 
 StateEstimator:
   stateEstimatorType: 4
-  processNoiseVar4Loc: 56.29654177092754
-  processNoiseVar4Size: 96.07257407264093
-  processNoiseVar4Vel: 84.56030088053706
-  measurementNoiseVar4Detector: 78.43805173471176
-  measurementNoiseVar4Tracker: 82.2705749896136
+  processNoiseVar4Loc: 56.3
+  processNoiseVar4Size: 96.1
+  processNoiseVar4Vel: 84.6
+  measurementNoiseVar4Detector: 78.4
+  measurementNoiseVar4Tracker: 82.3
 
 PoseEstimator:
   poseEstimatorType: 1
@@ -70,7 +103,7 @@ MultiViewAssociator:
   maxPeerTrackletSize: 30
   recentlyActiveAge: 150
   minCommonFrames4MatchScore: 15
-  minPeerTrackletMatchScore: 0.5
+  minPeerTrackletMatchScore: 0.25
   minPeerVisibility4Fusion: 0.1
   maxPeerToPredDistance4Fusion: 2.0
   maxTrackletMatchingTimeSearchRange: 5

--- a/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/configs/ds-pgie-config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/warehouse-mv3dt-app/deepstream/configs/ds-pgie-config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
 
 class-attrs-all:
   pre-cluster-threshold: 0.25
-  topk: 15
+#   topk: 15
 # class-attrs-0:
 #   pre-cluster-threshold: 0.5
 #   topk: 20

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/configs/ds-mv3dt-tracker-config.yml
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/configs/ds-mv3dt-tracker-config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,89 +12,63 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 BaseConfig:
-  minDetectorConfidence: 0.027087304322979212
+  minDetectorConfidence: 0.266
+  checkClassMatch: 1
   useBatchNumForFrameId: 1
+
 TargetManagement:
   enableBboxUnClipping: 1
   preserveStreamUpdateOrder: 0
   maxTargetsPerStream: 200
-  minIouDiff4NewTarget: 0.22656630527418112
-  minTrackerConfidence: 0.6957540479571296
-  probationAge: 5
-  maxShadowTrackingAge: 162
-  earlyTerminationAge: 1
+  minIouDiff4NewTarget: 0.3
+  minTrackerConfidence: 0.6
+  probationAge: 17
+  maxShadowTrackingAge: 150
+  earlyTerminationAge: 7
   maxTrajectoryBufferLength: -1
-  outputTerminatedTracks: 0
+
 TrajectoryManagement:
   useUniqueID: 0
   enableReAssoc: 1
-  minMatchingScore4Overall: 0.9349462651721144
-  minTrackletMatchingScore: 0.2940
+  minMatchingScore4Overall: 0.95
+  minTrackletMatchingScore: 0.3
   minMatchingScore4ReidSimilarity: 0
-  matchingScoreWeight4TrackletSimilarity: 0.7981
+  matchingScoreWeight4TrackletSimilarity: 0.8
   matchingScoreWeight4ReidSimilarity: 0
   minTrajectoryLength4Projection: 34
   prepLength4TrajectoryProjection: 58
   trajectoryProjectionLength: 33
   maxAngle4TrackletMatching: 67
-  minSpeedSimilarity4TrackletMatching: 0.0574
-  minBboxSizeSimilarity4TrackletMatching: 0.1013
+  minSpeedSimilarity4TrackletMatching: 0.06
+  minBboxSizeSimilarity4TrackletMatching: 0.1
   maxTrackletMatchingTimeSearchRange: 27
-  trajectoryProjectionProcessNoiseScale: 0.0100
+  trajectoryProjectionProcessNoiseScale: 0.01
   trajectoryProjectionMeasurementNoiseScale: 100
-  trackletSpacialSearchRegionScale: 0.0100
+  trackletSpacialSearchRegionScale: 0.01
   reidExtractionInterval: 0
+
 DataAssociator:
   dataAssociatorType: 0
   associationMatcherType: 1
-  checkClassMatch: 1
-  minMatchingScore4Overall: 0.4
-  minMatchingScore4SizeSimilarity: 0.4
-  minMatchingScore4Iou: 0.1393522182207021
-  minMatchingScore4VisualSimilarity: 0.0520394823204932
-  matchingScoreWeight4SizeSimilarity: 0.104589699500018
-  matchingScoreWeight4Iou: 0.7844652139368062
-  matchingScoreWeight4VisualSimilarity: 0.9294872869302965
-  tentativeDetectorConfidence: 0.70167245554449
-  minMatchingScore4TentativeIou: 0.1768733030811293
-  minMatchingScore4PeerAssocIou: 0.2
+  minMatchingScore4Overall: 0.5
+  minMatchingScore4SizeSimilarity: 0.1
+  minMatchingScore4Iou: 0.25
+  matchingScoreWeight4SizeSimilarity: 0.2
+  matchingScoreWeight4Iou: 0.6
+  tentativeDetectorConfidence: 0.8
+  minMatchingScore4TentativeIou: 0.25
+  minMatchingScore4PeerAssocIou: 0.25
+
 StateEstimator:
-  stateEstimatorType: 3
-  processNoiseVar4Loc: 6497.75224242603
-  processNoiseVar4Vel: 8035.858212054732
-  measurementNoiseVar4Detector: 100.0000
-  measurementNoiseVar4Tracker: 883.5847350922555
-ObjectModelProjection:
-  minPoseConfidence: 0.925
-  outputFootLocation: 1
-  outputVisibility: 1
-  outputConvexHull: 0
-  cameraModelFilepath:
-    Camera: /tmp/camInfo/Camera.yml
-    Camera_01: /tmp/camInfo/Camera_01.yml
-    Camera_02: /tmp/camInfo/Camera_02.yml
-    Camera_03: /tmp/camInfo/Camera_03.yml
-  objectModelType: 0
-VisualTracker:
-  visualTrackerType: 0
-  useColorNames: 1
-  useHog: 1
-  featureImgSizeLevel: 5
-  featureFocusOffsetFactor_y: -0.10525549278780495
-  filterLr: 0.025008995723548734
-  filterChannelWeightsLr: 0.09460260509799209
-  gaussianSigma: 0.44967391866177786
-MultiViewAssociator:
-  multiViewAssociatorType: 1
-  maxPeerToPredDistance4Fusion: 3.0
-  minPeerTrackletMatchScore: 0.3
-  minPeerVisibility4Fusion: 0.15
-  recentlyActiveAge: 178
-Communicator:
-  communicatorType: 2
-  pubSubInfoConfigPath: /tmp/generated/pub_sub_info_config.yml
-  mqttProtoAdaptorConfigPath: /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/configs/config_mqtt.txt
+  stateEstimatorType: 4
+  processNoiseVar4Loc: 56.3
+  processNoiseVar4Size: 96.1
+  processNoiseVar4Vel: 84.6
+  measurementNoiseVar4Detector: 78.4
+  measurementNoiseVar4Tracker: 82.3
+
 PoseEstimator:
   poseEstimatorType: 1
   useVPICropScaler: 1
@@ -110,3 +84,32 @@ PoseEstimator:
   onnxFile: /opt/storage/BodyPose3DNet/bodypose3dnet_accuracy.onnx
   modelEngineFile: /opt/storage/BodyPose3DNet/bodypose3dnet_accuracy.onnx_b1_gpu0_fp16.engine
   poseInferenceInterval: -1
+
+ObjectModelProjection:
+  outputFootLocation: 1
+  minPoseConfidence: 0.95
+  cameraModelFilepath:
+    Camera: /tmp/camInfo/Camera.yml
+    Camera_01: /tmp/camInfo/Camera_01.yml
+    Camera_02: /tmp/camInfo/Camera_02.yml
+    Camera_03: /tmp/camInfo/Camera_03.yml
+  objectModelType: 0
+
+MultiViewAssociator:
+  multiViewAssociatorType: 1
+  enableLatePeerReAssoc: 1
+  enableIDCorrection: 0
+  enableSeeThrough: 1
+  maxPeerTrackletSize: 30
+  recentlyActiveAge: 150
+  minCommonFrames4MatchScore: 15
+  minPeerTrackletMatchScore: 0.25
+  minPeerVisibility4Fusion: 0.1
+  maxPeerToPredDistance4Fusion: 2.0
+  maxTrackletMatchingTimeSearchRange: 5
+  maxPeerFrameDiff4NoDet: 5
+
+Communicator:
+  communicatorType: 2
+  pubSubInfoConfigPath: /tmp/generated/pub_sub_info_config.yml
+  mqttProtoAdaptorConfigPath: /opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/configs/config_mqtt.txt

--- a/services/rtvi/rt-cv-3d/rt-cv-mv3dt/configs/ds-pgie-config.yml
+++ b/services/rtvi/rt-cv-3d/rt-cv-mv3dt/configs/ds-pgie-config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,24 +14,23 @@
 # limitations under the License.
 
 class-attrs-all:
-  pre-cluster-threshold: 0.5
-  topk: 20
-
-class-attrs-0:
-  pre-cluster-threshold: 0.5
-  topk: 20
-class-attrs-1:
-  pre-cluster-threshold: 0.85
-class-attrs-2:
-  pre-cluster-threshold: 0.85
-class-attrs-3:
-  pre-cluster-threshold: 0.85
-class-attrs-4:
-  pre-cluster-threshold: 0.9
-class-attrs-5:
-  pre-cluster-threshold: 0.5
-class-attrs-6:
-  pre-cluster-threshold: 0.5
+  pre-cluster-threshold: 0.25
+#   topk: 15
+# class-attrs-0:
+#   pre-cluster-threshold: 0.5
+#   topk: 20
+# class-attrs-1:
+#   pre-cluster-threshold: 0.85
+# class-attrs-2:
+#   pre-cluster-threshold: 0.85
+# class-attrs-3:
+#   pre-cluster-threshold: 0.85
+# class-attrs-4:
+#   pre-cluster-threshold: 0.9
+# class-attrs-5:
+#   pre-cluster-threshold: 0.5
+# class-attrs-6:
+#   pre-cluster-threshold: 0.5
 
 property:
   # 1=DBSCAN, 2=NMS, 3= DBSCAN+NMS Hybrid, 4 = None(No clustering)


### PR DESCRIPTION
## Summary
Improving default tracker configuration for RTVI-CV-3D (MV3DT). Both, `Blueprint` and `Standalone` deployments are updated.

## Related Issue
Bug 6304863 - ID propagation issues generating multiple bboxes

## Changes

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
