### PR TITLE
(auto-calibration): bump container tags to 3.3.0-3

### DIFF
--- a/deploy/docker/containers.env
+++ b/deploy/docker/containers.env
@@ -122,10 +122,10 @@ CONTAINER_IMAGE="${CONTAINER_IMAGE:-${VSS_CONTAINER_REGISTRY}/vss-video-summariz
 # services on different images. These tags therefore have no helm counterpart
 # to keep in sync, and helm parity is not expected for this service.
 VSS_AUTO_CALIBRATION_IMAGE="${VSS_AUTO_CALIBRATION_IMAGE:-${VSS_CONTAINER_STAGING_REGISTRY}/vss-auto-calibration}"
-VSS_AUTO_CALIBRATION_TAG="${VSS_AUTO_CALIBRATION_TAG:-3.3.0-2}"
+VSS_AUTO_CALIBRATION_TAG="${VSS_AUTO_CALIBRATION_TAG:-3.3.0-3}"
 
 VSS_AUTO_CALIBRATION_UI_IMAGE="${VSS_AUTO_CALIBRATION_UI_IMAGE:-${VSS_CONTAINER_STAGING_REGISTRY}/vss-auto-calibration-ui}"
-VSS_AUTO_CALIBRATION_UI_TAG="${VSS_AUTO_CALIBRATION_UI_TAG:-3.3.0-2}"
+VSS_AUTO_CALIBRATION_UI_TAG="${VSS_AUTO_CALIBRATION_UI_TAG:-3.3.0-3}"
 
 # -----------------------------------------------------------------------------
 # First-party images whose TAG variable already exists in service/profile .env files.

--- a/deploy/docker/services/auto-calibration/ms/compose.yml
+++ b/deploy/docker/services/auto-calibration/ms/compose.yml
@@ -15,7 +15,7 @@
 
 services:
   vss-auto-calibration:
-    image: ${VSS_AUTO_CALIBRATION_IMAGE:-nvcr.io/nvstaging/vss-core/vss-auto-calibration}:${VSS_AUTO_CALIBRATION_TAG:-3.3.0-2}
+    image: ${VSS_AUTO_CALIBRATION_IMAGE:-nvcr.io/nvstaging/vss-core/vss-auto-calibration}:${VSS_AUTO_CALIBRATION_TAG:-3.3.0-3}
 
     container_name: vss-auto-calibration
     profiles: ["vss-auto-calibration"]

--- a/deploy/docker/services/auto-calibration/ui/compose.yml
+++ b/deploy/docker/services/auto-calibration/ui/compose.yml
@@ -15,7 +15,7 @@
 
 services:
   vss-auto-calibration-ui:
-    image: ${VSS_AUTO_CALIBRATION_UI_IMAGE:-nvcr.io/nvstaging/vss-core/vss-auto-calibration-ui}:${VSS_AUTO_CALIBRATION_UI_TAG:-3.3.0-2}
+    image: ${VSS_AUTO_CALIBRATION_UI_IMAGE:-nvcr.io/nvstaging/vss-core/vss-auto-calibration-ui}:${VSS_AUTO_CALIBRATION_UI_TAG:-3.3.0-3}
     container_name: vss-auto-calibration-ui
     profiles: ["vss-auto-calibration-ui"]
 

--- a/deploy/docker/test-scripts/compose-images.golden
+++ b/deploy/docker/test-scripts/compose-images.golden
@@ -11,8 +11,8 @@ deploy/docker/services/agent/compose.yml ghcr.io/nvidia-ai-blueprints/vss/vss-ag
 deploy/docker/services/alert/compose.yml ghcr.io/nvidia-ai-blueprints/vss/vss-alert-ms:develop-latest
 deploy/docker/services/analytics/behavior-analytics/compose.yml ghcr.io/nvidia-ai-blueprints/vss/vss-behavior-analytics:develop-latest
 deploy/docker/services/analytics/video-analytics-api/compose.yml ghcr.io/nvidia-ai-blueprints/vss/vss-video-analytics-api:develop-latest
-deploy/docker/services/auto-calibration/ms/compose.yml nvcr.io/nvstaging/vss-core/vss-auto-calibration:3.3.0-2
-deploy/docker/services/auto-calibration/ui/compose.yml nvcr.io/nvstaging/vss-core/vss-auto-calibration-ui:3.3.0-2
+deploy/docker/services/auto-calibration/ms/compose.yml nvcr.io/nvstaging/vss-core/vss-auto-calibration:3.3.0-3
+deploy/docker/services/auto-calibration/ui/compose.yml nvcr.io/nvstaging/vss-core/vss-auto-calibration-ui:3.3.0-3
 deploy/docker/services/configurators/vss-configurator/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-configurator:develop-latest
 deploy/docker/services/infra/compose.yml alpine:3.24.1
 deploy/docker/services/infra/compose.yml arizephoenix/phoenix:19.8.0


### PR DESCRIPTION
## Summary
Container tag update to latest Auto Calib MS v3.3.0 for 26.08.3

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
