### PR TITLE
docs: add uv fallback for build vision agent

### DIFF
--- a/skills/vss-build-vision-agent/references/composition.md
+++ b/skills/vss-build-vision-agent/references/composition.md
@@ -236,6 +236,18 @@ BUILD_DIR="$REPO/_builds/<name>"
 FOUNDATION="$(sed -n 's/^FOUNDATION=//p' "$BUILD_DIR/override.env")"
 FOUNDATION_DIR="$REPO/deploy/docker/developer-profiles/dev-profile-$FOUNDATION"
 
+if command -v uv >/dev/null 2>&1; then
+  VSS_SKILL_PY=(uv run)
+elif python3 - <<'PY' >/dev/null 2>&1
+import yaml
+PY
+then
+  VSS_SKILL_PY=(python3)
+else
+  echo "Install uv or install PyYAML for python3 before normalizing resolved.yml." >&2
+  exit 1
+fi
+
 env_args=(
   --env-file "$REPO/deploy/docker/containers.env"
   --env-file "$FOUNDATION_DIR/.env"
@@ -247,10 +259,10 @@ docker compose "${env_args[@]}" \
   -f "$BUILD_DIR/compose.yml" \
   config --no-consistency > "$BUILD_DIR/resolved.yml"
 
-uv run "$REPO/skills/vss-build-vision-agent/scripts/normalize_resolved_yml.py" \
+"${VSS_SKILL_PY[@]}" "$REPO/skills/vss-build-vision-agent/scripts/normalize_resolved_yml.py" \
   "$BUILD_DIR/resolved.yml"
 
-uv run "$REPO/skills/vss-build-vision-agent/scripts/validate_resolved_yml.py" \
+"${VSS_SKILL_PY[@]}" "$REPO/skills/vss-build-vision-agent/scripts/validate_resolved_yml.py" \
   "$BUILD_DIR/resolved.yml" --repo-root "$REPO"
 ```
 
@@ -287,7 +299,19 @@ rerun normalization and validation. Escaped container-shell variables such as
 REPO="$(git rev-parse --show-toplevel)"
 BUILD_DIR="$REPO/_builds/<name>"
 
-uv run "$REPO/skills/vss-build-vision-agent/scripts/validate_resolved_yml.py" \
+if command -v uv >/dev/null 2>&1; then
+  VSS_SKILL_PY=(uv run)
+elif python3 - <<'PY' >/dev/null 2>&1
+import yaml
+PY
+then
+  VSS_SKILL_PY=(python3)
+else
+  echo "Install uv or install PyYAML for python3 before validating resolved.yml." >&2
+  exit 1
+fi
+
+"${VSS_SKILL_PY[@]}" "$REPO/skills/vss-build-vision-agent/scripts/validate_resolved_yml.py" \
   "$BUILD_DIR/resolved.yml" --repo-root "$REPO"
 
 docker compose -f "$BUILD_DIR/resolved.yml" config --quiet

--- a/skills/vss-build-vision-agent/references/deployment.md
+++ b/skills/vss-build-vision-agent/references/deployment.md
@@ -21,6 +21,18 @@ BUILD_DIR="$REPO/_builds/<name>"
 FOUNDATION="$(sed -n 's/^FOUNDATION=//p' "$BUILD_DIR/override.env")"
 FOUNDATION_DIR="$REPO/deploy/docker/developer-profiles/dev-profile-$FOUNDATION"
 
+if command -v uv >/dev/null 2>&1; then
+  VSS_SKILL_PY=(uv run)
+elif python3 - <<'PY' >/dev/null 2>&1
+import yaml
+PY
+then
+  VSS_SKILL_PY=(python3)
+else
+  echo "Install uv or install PyYAML for python3 before normalizing resolved.yml." >&2
+  exit 1
+fi
+
 env_args=(
   --env-file "$REPO/deploy/docker/containers.env"
   --env-file "$FOUNDATION_DIR/.env"
@@ -32,10 +44,10 @@ docker compose "${env_args[@]}" \
   -f "$BUILD_DIR/compose.yml" \
   config --no-consistency > "$BUILD_DIR/resolved.yml"
 
-uv run "$REPO/skills/vss-build-vision-agent/scripts/normalize_resolved_yml.py" \
+"${VSS_SKILL_PY[@]}" "$REPO/skills/vss-build-vision-agent/scripts/normalize_resolved_yml.py" \
   "$BUILD_DIR/resolved.yml"
 
-uv run "$REPO/skills/vss-build-vision-agent/scripts/validate_resolved_yml.py" \
+"${VSS_SKILL_PY[@]}" "$REPO/skills/vss-build-vision-agent/scripts/validate_resolved_yml.py" \
   "$BUILD_DIR/resolved.yml" --repo-root "$REPO"
 ```
 

--- a/skills/vss-build-vision-agent/references/prerequisites.md
+++ b/skills/vss-build-vision-agent/references/prerequisites.md
@@ -10,6 +10,37 @@ resolution or deployment. For DGX Spark / IGX Thor / AGX Thor, also run the
 cache-cleaner install and verification block in
 [`edge.md`](edge.md#cache-cleaner-every-edge-deploy).
 
+Also verify the runner for the build helper scripts. `uv` is preferred, but a
+host with `python3` and `PyYAML` is supported. Do this before generating
+`resolved.yml`; otherwise a host can pass every system prerequisite and still
+fail during normalization.
+
+```bash
+if command -v uv >/dev/null 2>&1; then
+  VSS_SKILL_PY=(uv run)
+elif python3 - <<'PY' >/dev/null 2>&1
+import yaml
+PY
+then
+  VSS_SKILL_PY=(python3)
+else
+  cat >&2 <<'EOF'
+Missing Python runner for vss-build-vision-agent helper scripts.
+
+Install uv:
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+
+Or install PyYAML for the active Python 3 environment and use the direct
+Python fallback:
+  python3 -m pip install PyYAML
+EOF
+  exit 1
+fi
+
+printf 'VSS_SKILL_PY=%q' "${VSS_SKILL_PY[@]}"
+printf '\n'
+```
+
 ## Repo detection
 <a id="repo-detect"></a>
 


### PR DESCRIPTION
## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
