### PR TITLE
ci(skill-eval): render the leg result comment without an LLM

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -373,17 +373,17 @@ The canonical harbor command is in § Harbor invocation.
       wrapper. While a trial is running, do NOT poll the remote box from
       your tool loop — Harbor has its own agent-execution timeout and
       will fail the trial cleanly.
-   d. After each trial, parse
-      `$RES/<date>/<trial>/verifier/reward.txt`
-      and `test-stdout.txt`. Record `(spec, platform, reward,
-      checks_passed/total, duration_s, trace_url)` for the comment. A
-      missing `reward.txt` means the trial errored (e.g. non-zero
-      harbor exit) — record it as a failure, do not skip it silently.
+   d. Do NOT parse `reward.txt`, `test-stdout.txt`, `judge.json` or any
+      trajectory in order to build the comment — `leg_report.py` reads the
+      tree once and owns every column, including the trials that errored
+      (§ Result comment format). Read a trial log only to diagnose a
+      failure you are going to act on, per (c).
 
-6. **Post ONE results comment per `(PR, eval_spec)` batch** when every
-   `(platform)` tuple in that spec's matrix has a result. Format
-   per § Result comment format below. Use `gh pr comment $PR_NUMBER
-   --body-file …`. Do NOT post a planning / "refresh" comment up
+6. **Post ONE results comment for the `(spec, platform)` leg you ran**,
+   rendered by `leg_report.py` per § Result comment format below, with
+   `gh pr comment $PR_NUMBER --body-file …`. Do NOT wait for or aggregate
+   the spec's other platforms: since matrix dispatch those are separate
+   legs this job cannot see. Do NOT post a planning / "refresh" comment up
    front — comments carry results, not intent.
 
 7. **Do not tear down any Brev instance.** The
@@ -785,126 +785,63 @@ viewer; box-side session history is at `$HOME/.claude-archive/<ts>/`
 One comment per `(spec, platform)` leg. Your leg posts **its own** single
 comment for the one platform it ran (`EVAL_PLATFORM`) — it does **not**
 wait for or aggregate the spec's other platforms: those run as separate
-parallel legs this job cannot see. A two-platform spec therefore yields
-two independent comments, one per platform.
+parallel legs this job cannot see.
 
-**Where the comment goes:** on a PR run (`PR_NUMBER` set) post it with
-`gh pr comment`. On a **manual sweep** (`PR_NUMBER` empty —
-`workflow_dispatch`) there is no PR: append the exact same markdown to
-`$GITHUB_STEP_SUMMARY` instead (see § "Manual full-sweep mode").
-
-```markdown
-## Harbor Eval — `skills/<skill>/<eval-dir>/<spec>.json`
-
-Head: `<short-sha>` · platform `<platform>` · spec `<spec-sha>`
-First started: `<utc>` · Last finished: `<utc>` · Total: `<Ahr Bmin>`
-
-| Platform | Result | Reward | Duration | Turns | Prompt tok | Cached tok | Trace |
-|---|---|---|---|---|---|---|---|
-| L40S | ✅ 1.0 (7/7) | 1.0 | 9m 40s | 23 | 8.4k | 156k | [trace](…) |
-
-For multi-step specs, render one row per step and mark
-prior-fail-skips explicitly:
-
-| Platform | Step | Query | Result | Reward | Duration | Turns | Prompt tok | Cached tok | Trace |
-|---|---|---|---|---|---|---|---|---|---|
-| L40S | step-1 | Deploy alerts (VLM real-time) | ✅ 1.0 (6/6) | 1.0 | 11m 12s | 18 | 6.1k | 98k | [trace](…) |
-| L40S | step-2 | Add warehouse_sample via NVStreamer | ❌ 0.2 (1/5) | 0.2 | 3m 04s | 12 | 4.2k | 41k | [trace](…) |
-| L40S | step-3 | Query incidents | ⏭️ skipped (prior-step fail, step-2 reward=0.2) | — | — | — | — | — | — |
-| L40S | step-4 | … | ⏭️ skipped | — | — | — | — | — | — |
-
-A `⏭️ skipped` row means the dispatch loop short-circuited after
-the previous step's reward < 1.0. The step was not run — its
-checks would have asserted state that was never set up. Read the
-prior step's trace to see the actual failure.
-
-### Extracting per-trial metrics
-
-For each completed trial under `$RES/<date>/<trial>/`, populate the new
-columns by reading the trajectory's `final_metrics` block (or falling
-back to the streaming usage blocks if `final_metrics` is missing because
-the trial crashed mid-run):
+**You do not build this comment.** `leg_report.py` owns the format, reads
+the results tree once and writes both the markdown and a machine-readable
+summary. The exact command, with every path already expanded, is handed to
+you in the turn prompt. It has this shape:
 
 ```bash
-TRAJ="$RES/<date>/<trial>/agent/trajectory.json"
-
-# Turns = count of assistant messages (one per agent reasoning step)
-jq '[.steps[].message | fromjson | select(.type=="assistant")] | length' "$TRAJ"
-
-# Step 1 — decide which extraction path to use. `final_metrics`
-# is written when the trial completes cleanly; crashed-mid-run
-# trials have it missing or null. Branch explicitly so a missing
-# block doesn't silently render as "0 tokens" (indistinguishable
-# from a clean trial that happened to have zero uncached input,
-# which is technically possible).
-if jq -e 'has("final_metrics") and (.final_metrics.modelUsage != null)' "$TRAJ" >/dev/null; then
-  # Step 2a — canonical path: sum across every model entry.
-  # Some trials exercise more than one model (e.g. a vision model
-  # alongside the main reasoning model); `to_entries[0]` would
-  # silently drop them.
-  PROMPT_TOK=$(jq -r '[.final_metrics.modelUsage | to_entries[].value.inputTokens // 0] | add // 0' "$TRAJ")
-
-  # Cached tokens (cache read + cache creation are both "cached"
-  # for our purposes — they're the warm context the prompt reused).
-  CACHED_TOK=$(jq -r '
-    [.final_metrics.modelUsage | to_entries[].value
-     | (.cacheReadInputTokens // 0) + (.cacheCreationInputTokens // 0)] | add // 0
-  ' "$TRAJ")
-else
-  # Step 2b — fallback: sum per-message `usage` blocks from the
-  # stream. `| add` on an empty array evaluates to null, not 0;
-  # guard each field with `// 0` so a trial that crashed before
-  # any assistant message renders 0s, not nulls.
-  read PROMPT_TOK CACHED_TOK < <(jq -r '
-    [.steps[].message | fromjson | select(.type=="assistant") | .message.usage] as $u
-    | ($u | map(.input_tokens // 0) | add // 0) as $in
-    | ($u | map((.cache_read_input_tokens // 0) + (.cache_creation_input_tokens // 0)) | add // 0) as $cached
-    | "\($in) \($cached)"
-  ' "$TRAJ")
-fi
-
-# Duration: trial start/end times — use Harbor's result.json which has
-# `trial_started_at` / `trial_finished_at` (ISO 8601). Compute the diff
-# in seconds; render as `<m>m <s>s` for under an hour, `<h>h <m>m` for
-# over.
-jq -r '[.trial_started_at, .trial_finished_at] | @tsv' \
-  "$RES/<date>/<trial>/result.json"
+RES=/tmp/skill-eval/results/<EVAL_SLUG>/<GITHUB_RUN_ID>
+python3 <repo>/.github/skill-eval/leg_report.py \
+  --results-root "$RES" --spec-path <spec> \
+  --platform <platform> --head-sha <sha> \
+  --summary-json "$RES/leg-summary.json" \
+  --out /tmp/skill-eval/<GITHUB_RUN_ID>/pr-<EVAL_SLUG>.md
 ```
 
-Render tokens with k/M suffixes — `8400` → `8.4k`, `5_178_086` → `5.2M`.
-Round to 1 decimal. Output tokens are intentionally not shown per
-trial (almost always a small fraction of input + cached; if you need
-the breakdown, look at the trace). The "Prompt tok" column is the
-uncached input — what's actually billed at the full input rate. The
-"Cached tok" column is read + creation combined — what the cache hit
-on, billed at the much lower cache rate.
+Run the command you were given verbatim rather than rebuilding it here.
 
-For a `⏭️ skipped` step, write `—` (em-dash) in all four metric
-columns — there's no trial to extract from.
+The body goes under the run scratch dir, not the results root: the benchmark
+step globs `pr-*.md` there, so writing it anywhere else leaves `benchmark.md`
+empty. It is keyed by `EVAL_SLUG`, never by the spec stem: stems repeat
+across skills (`search` and `standalone_deploy` each belong to more than one
+skill), and every leg of a run shares that directory, so a stem-keyed name lets
+one leg overwrite another's comment.
 
-### Failing checks
+Post that file verbatim (`gh pr comment --body-file`, or append it to
+`$GITHUB_STEP_SUMMARY` on a manual sweep). Exit
+codes: `0` rendered, `2` no trials under the results root, `3` the spec was
+named but unusable. A non-zero exit is a FAILED completed leg, not a
+`BLOCKED` condition: do not inspect the tree by hand, emit `DONE: 0/1 specs
+passed; leg_report.py failed (exit N)` so the coordinator exits non-zero.
+Pass absolute paths; `$RES` and `$SCRATCH` are not set in a fresh Bash call.
 
-- **RTXPRO6000BW** — `grep -E '^HARDWARE_PROFILE=L40S$' $HOME/…/.env` returned Permission denied (see [trace](…))
+This replaced ~126 lines of prose that described the table layout and the
+`jq` needed to pull turns and token counts out of each trajectory. Every leg
+re-read and re-implemented that from scratch, which measured at p50 114 s
+across a median of 11 read-only tool calls. Do not reintroduce it: if the
+format needs to change, change `leg_report.py` and its tests.
 
-### Suggestions
+### Reading the verdict
 
-> (concatenate non-null `suggestion` fields from each failing trial's
-> `$RES/<date>/<trial>/suggestions.json`; omit the
-> section entirely if all are null)
+`leg-summary.json` is versioned (`schema`) and carries one entry per step in
+`steps[]`, each with a `state`:
 
-<sub>Generated by the skills-eval agent. Adapter/verifier changes
-required to make this PR evaluable were raised as bot PRs targeting
-the source PR's branch (linked above where applicable) — the
-skills-eval agent never commits to `skills/` and never runs trials
-against locally-synthesized adapters. Trial datasets/results live in
-this leg's workflow artifact
-`skills-eval-results-pr-<N>-<skill>__<spec>-<run_id>.tar.gz`.</sub>
-```
+| state | meaning |
+|---|---|
+| `recorded-pass` | reward exactly 1.0, no exception, judge absent or unanimous |
+| `recorded-fail` | ran and did not pass |
+| `no-verdict` | ran, no reward recorded |
+| `not-run` | the spec declares this step and no trial exists |
+| `ambiguous` | evidence is contradictory or unreadable — never treat as a pass |
 
-Use `gh pr comment $PR_NUMBER --body-file "$SCRATCH/pr-<spec>.md"`. Never
-post a partial batch. If you posted a blocker earlier in the run
-(`missing_probe`, `env_blocker`), the final results comment is still
-separate; don't conflate the two.
+The leg passed only if **every** entry is `recorded-pass` and
+`collection_errors` is empty. Each entry also carries `reward`, `judge`
+(`absent`/`valid`/`unreadable`), `passed`/`total`, `exception`, `attempts`,
+`attempt_path` and `any_attempt_undated`, so nothing requires parsing the
+rendered markdown.
 
 ## Failure modes
 

--- a/.github/skill-eval/leg_report.py
+++ b/.github/skill-eval/leg_report.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Render a leg's result comment from its Harbor output, deterministically.
+
+`skills_eval_agent.py` currently asks an LLM to do this: read the results
+tree, extract per-trial metrics, and render the table in AGENTS.md
+§ "Result comment format". Measured across real job logs, that costs p50
+114 s over a median of 11 read-only tool calls, and it reruns from scratch
+every leg because the agent has no memory of the schema it parsed last
+time. One sampled coordinator rediscovered the trajectory layout three
+times before it could fill in a single column.
+
+Nothing in that step is a judgement, so none of it needs a model.
+
+THIS MODULE DOES NOT DECIDE WHETHER THE LEG PASSED. It renders what Harbor
+recorded and nothing more. An earlier draft also emitted a verdict and a
+pass/fail exit code, and that one responsibility produced every serious
+defect found in review: it turned two real `AgentTimeoutError` trials green,
+it counted steps while calling them specs, and its step-accounting flipped
+316 real single-step legs falsely red. The caller holds `run_leg.py`'s exit
+status and the spec, so the caller owns the verdict. Removing that
+responsibility here removes the whole class of bug and keeps 94% of the
+saving, because the cost is in the reading, not in the deciding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as _dt
+import json
+import math
+import os
+import re
+import sys
+from pathlib import Path
+
+TRACE_URLS_NAME = "trace-urls.tsv"
+PHASE_TIMINGS_NAME = "phase-timings.json"
+MACHINE_NAME = "machine.txt"
+MISSING = "—"
+
+# Rendered, never returned as a verdict.
+MARK_PASS = "✅"
+MARK_FAIL = "❌"
+MARK_SKIP = "⏭️"
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def _ts(value: str | None) -> _dt.datetime | None:
+    """Parse a Harbor timestamp, always returning an aware UTC datetime.
+
+    Harbor writes most timestamps with a trailing `Z`, but not all of them:
+    mixing the two makes `min()`/`max()` raise "can't compare offset-naive
+    and offset-aware datetimes", which took out 1,174 of 1,177 real legs
+    when this module first ran over the corpus.
+    """
+    if not value:
+        return None
+    with contextlib.suppress(Exception):
+        parsed = _dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+        return parsed
+    return None
+
+
+def _load_json(path: Path) -> dict | list | None:
+    with contextlib.suppress(Exception):
+        return json.loads(path.read_text())
+    return None
+
+
+def _step_index(trial_name: str) -> int | None:
+    """`step-3__aBcD` -> 3. Single-step trials are named after the platform."""
+    match = re.match(r"step-(\d+)__", trial_name or "")
+    return int(match.group(1)) if match else None
+
+
+def _trial_key(trial_name: str) -> str:
+    """Identity of a step across retries.
+
+    `rsplit` rather than `split`: a task base that itself contains `__`
+    would otherwise collapse into a different step's group.
+    """
+    return (trial_name or "").rsplit("__", 1)[0] or trial_name
+
+
+def _failing_checks_section(trials: list[dict], multi_step: bool) -> list[str]:
+    """The named checks that failed, for the first step that failed.
+
+    31 of the 33 failing comments in the posted history carry this section,
+    and it is the only place a reader learns WHICH assertion failed rather
+    than just that the reward was 0.5. Sequential dispatch stops at the first
+    failure, so there is exactly one section, which matches the history.
+    """
+    for trial in trials:
+        checks = trial.get("checks")
+        if not isinstance(checks, list):
+            continue
+        failing = [(i, c) for i, c in enumerate(checks, 1)
+                   if isinstance(c, dict) and c.get("pass") is False]
+        if not failing:
+            continue
+        head = "### Failing checks"
+        if multi_step and trial.get("step"):
+            head += f" (step-{trial['step']})"
+        out = ["", head, ""]
+        for index, check in failing:
+            text = str(check.get("check") or "").strip()
+            why = str(check.get("rationale") or "").strip()
+            item = f'- **Check {index}**: "{text}"'
+            if why:
+                item += f" \u2014 {why}"
+            out.append(item)
+        return out
+    return []
+
+
+def _fmt_reward(value: float) -> str:
+    """Match the reward formatting the harness has always posted.
+
+    Real comments and the documented example use `1.0`, not `1`; `.3g` alone
+    drops the trailing zero and silently changes the format readers know.
+    """
+    text = f"{value:.3g}"
+    return f"{text}.0" if "." not in text and "e" not in text else text
+
+
+def _skip_cell(step: int, by_step: dict) -> str:
+    """Why a declared step has no trial.
+
+    § 5 dispatches steps sequentially and stops at the first failure, so a
+    missing step is usually a skip with a cause, not an unexplained gap. Name
+    the blaming step and its reward, which is the form these comments have
+    always used. Falls back to a bare "not run" when nothing earlier failed.
+    """
+    for prior in range(step - 1, 0, -1):
+        t = by_step.get(prior)
+        if t is None:
+            continue
+        reward = t.get("reward")
+        if reward is not None and float(reward) < 1.0:
+            return (f"{MARK_SKIP} skipped (prior-step fail, "
+                    f"step-{prior} reward={_fmt_reward(float(reward))})")
+        if t.get("exception"):
+            return f"{MARK_SKIP} skipped (prior-step error, step-{prior})"
+    return f"{MARK_SKIP} not run"
+
+
+def _fmt_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return MISSING
+    seconds = round(seconds)
+    if seconds >= 3600:
+        return f"{seconds // 3600}hr {seconds % 3600 // 60}min"
+    return f"{seconds // 60}m {seconds % 60:02d}s"
+
+
+def _fmt_tokens(count: int | None) -> str:
+    if not count:
+        return MISSING
+    if count >= 1_000_000:
+        return f"{count / 1_000_000:.1f}M"
+    if count >= 1_000:
+        return f"{count / 1_000:.1f}k"
+    return str(count)
+
+
+def _clean_reward(value: object) -> float | None:
+    """A reward is a finite real number, or it is not a reward.
+
+    `True` is an int in Python and would otherwise compare equal to 1.0, and
+    `inf`/`nan` would slip through a naive `>= 1.0`. Anything else becomes
+    None and renders as unknown rather than as a pass.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if math.isfinite(value) else None
+
+
+def _trial_metrics(trial_dir: Path) -> dict:
+    """Agent turn count for one trial, from the trajectory when it is there.
+
+    The trajectory is excluded from the uploaded artifact but present on the
+    box. Token counts come from `agent_result` in the caller: Harbor's
+    FinalMetrics forbids extra fields, so the trajectory carries no per-model
+    usage to prefer over it.
+    """
+    out: dict = {"turns": None}
+    traj = _load_json(trial_dir / "agent" / "trajectory.json")
+    if isinstance(traj, dict):
+        steps = traj.get("steps")
+        if isinstance(steps, list):
+            turns = sum(1 for s in steps
+                        if isinstance(s, dict) and s.get("source") == "agent")
+            out["turns"] = turns or None
+    return out
+
+
+class SpecError(Exception):
+    """The spec was named but could not be used."""
+
+
+def spec_steps(spec_path: str | Path | None) -> list[str]:
+    """Queries the spec declares, in order — the authoritative step list.
+
+    Raises SpecError when a spec is NAMED but unusable. Returning [] there
+    silently collapsed a partial chain into a complete-looking comment: six
+    harvested legs would have rendered every observed row green with the
+    later declared steps simply absent, and the CLI still exited 0. A
+    caller path or CWD mistake must fail loudly.
+
+    Returns [] only when no spec was named at all.
+    """
+    if not spec_path:
+        return []
+    path = Path(spec_path)
+    if not path.is_file():
+        raise SpecError(f"spec not found: {path}")
+    data = _load_json(path)
+    if not isinstance(data, dict):
+        raise SpecError(f"spec is not a JSON object: {path}")
+    expects = data.get("expects")
+    if not isinstance(expects, list):
+        raise SpecError(f"spec has no `expects` list: {path}")
+    out = []
+    for entry in expects:
+        query = (entry or {}).get("query") if isinstance(entry, dict) else None
+        out.append(str(query) if isinstance(query, str) else "")
+    return out
+
+
+def collect_leg(results_root: Path) -> dict:
+    """Everything the comment needs, read once from the results tree."""
+    results_root = Path(results_root)
+    trials: list[dict] = []
+    unreadable: list[str] = []
+    for result_path in sorted(results_root.rglob("result.json")):
+        trial_dir = result_path.parent
+        data = _load_json(result_path)
+        if data is None:
+            # Surfaced, never dropped: a corrupt NEWER retry beside a valid
+            # older pass would otherwise leave the leg looking clean.
+            unreadable.append(str(result_path.relative_to(results_root)))
+            continue
+        if not isinstance(data, dict):
+            continue
+        # Harbor writes a run-level result.json beside the per-trial ones. It
+        # carries `n_total_trials` and no `trial_name`, and sits next to a
+        # config.json exactly like a trial does, so config.json cannot tell
+        # them apart. Keying on `trial_name` can. Getting this wrong
+        # duplicated every step in the rendered table.
+        trial_name = data.get("trial_name")
+        if not trial_name:
+            continue
+        started, finished = _ts(data.get("started_at")), _ts(data.get("finished_at"))
+        rewards = ((data.get("verifier_result") or {}).get("rewards")) or {}
+        judge_path = trial_dir / "verifier" / "judge.json"
+        if not judge_path.exists():
+            judge, judge_state = {}, "absent"
+        else:
+            loaded = _load_json(judge_path)
+            if isinstance(loaded, dict):
+                judge, judge_state = loaded, "valid"
+            else:
+                # Present but unreadable. Treated as "absent" this would let a
+                # truncated judge sitting beside reward 1.0 render green.
+                judge, judge_state = {}, "unreadable"
+        agent_result = data.get("agent_result") or {}
+        metrics = _trial_metrics(trial_dir)
+        metrics["cached_tok"] = agent_result.get("n_cache_tokens")
+        # `n_input_tokens` is TOTAL input and already contains the cached
+        # tokens — fleet-wide 97.4% of it is cache reads. Reporting it in a
+        # "Prompt tok" column beside "Cached tok" overstated the uncached
+        # prompt by orders of magnitude.
+        total_in = agent_result.get("n_input_tokens")
+        cached = agent_result.get("n_cache_tokens") or 0
+        metrics["prompt_tok"] = (max(total_in - cached, 0)
+                                 if isinstance(total_in, int) else None)
+        exc = data.get("exception_info")
+        trials.append({
+            "trial_name": trial_name,
+            "key": _trial_key(trial_name),
+            "step": _step_index(trial_name),
+            "task_name": data.get("task_name") or "",
+            "started": started,
+            "finished": finished,
+            "seconds": (finished - started).total_seconds() if started and finished else None,
+            "reward": _clean_reward(rewards.get("reward")),
+            "passed": (judge or {}).get("passed"),
+            "checks": (judge or {}).get("checks"),
+            "total": (judge or {}).get("total"),
+            "judge_state": judge_state,
+            "query": (judge or {}).get("query") or "",
+            "exception": bool(exc),
+            "exception_type": (exc.get("exception_type") if isinstance(exc, dict) else None),
+            "cost_usd": agent_result.get("cost_usd"),
+            "path": str(result_path.relative_to(results_root)),
+            **metrics,
+        })
+
+    # A retry writes a NEW <timestamp>/step-N__xxx under the same results
+    # root, so one step can have several attempts: 15 of 1,177 real legs do.
+    # Report the latest attempt per step. Keeping them all both duplicated
+    # rows and let a failed first attempt outvote a successful retry.
+    # A trial with no timestamp sorts LAST, not first, so a later untimed
+    # failure is never silently overwritten by an older timestamped pass.
+    far_future = _dt.datetime.max.replace(tzinfo=_dt.timezone.utc)
+    ordered = sorted(
+        trials,
+        key=lambda t: (t["step"] if t["step"] is not None else 0,
+                       t["started"] or far_future, t["path"]),
+    )
+    latest: dict[str, dict] = {}
+    for trial in ordered:
+        previous = latest.get(trial["key"])
+        trial["attempts"] = (previous or {}).get("attempts", 0) + 1
+        trial["undated"] = trial["started"] is None
+        # Sorting undated attempts last is a convention, not a chronology:
+        # an older undated pass would still beat a newer dated failure. When
+        # a step has several attempts and any of them lacks a timestamp we
+        # cannot know which ran last, so say so instead of guessing.
+        prior_undated = bool((previous or {}).get("any_undated"))
+        trial["any_undated"] = prior_undated or trial["undated"]
+        if trial["attempts"] > 1 and trial["any_undated"]:
+            trial["ambiguous"] = (
+                f"{trial['attempts']} attempts, at least one with no timestamp"
+            )
+        latest[trial["key"]] = trial
+    trials = sorted(
+        latest.values(),
+        key=lambda t: (t["step"] if t["step"] is not None else 0,
+                       t["started"] or far_future),
+    )
+
+    traces: dict[str, str] = {}
+    trace_file = results_root / TRACE_URLS_NAME
+    if trace_file.exists():
+        with contextlib.suppress(Exception):
+            for line in trace_file.read_text().splitlines():
+                parts = line.split("\t")
+                if len(parts) >= 3:
+                    traces[parts[0].strip()] = parts[2].strip()
+                    traces[parts[1].strip()] = parts[2].strip()
+
+    machine = ""
+    machine_file = results_root / MACHINE_NAME
+    if machine_file.exists():
+        with contextlib.suppress(Exception):
+            machine = machine_file.read_text().split("\t")[0].strip()
+
+    phases = _load_json(results_root / PHASE_TIMINGS_NAME) or {}
+    starts = [t["started"] for t in trials if t["started"]]
+    ends = [t["finished"] for t in trials if t["finished"]]
+    return {
+        "trials": trials,
+        "unreadable": unreadable,
+        "traces": traces,
+        "machine": machine,
+        "phases": phases if isinstance(phases, dict) else {},
+        "first_started": min(starts) if starts else None,
+        "last_finished": max(ends) if ends else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def row_state(trial: dict) -> str:
+    """Machine-readable state for one executed step, fail-closed.
+
+    `recorded-pass` requires ALL of: no exception, a finite non-boolean
+    reward exactly 1.0, and judge evidence that either is absent entirely or
+    is well-formed and unanimous. Anything else is a failure or an explicit
+    ambiguity — never a pass by omission.
+    """
+    if trial.get("ambiguous"):
+        return "ambiguous"
+    if trial.get("exception"):
+        return "recorded-fail"
+    reward = trial.get("reward")
+    if reward is None:
+        return "no-verdict"
+    if reward != 1.0:
+        return "recorded-fail"
+
+    state = trial.get("judge_state")
+    if state == "unreadable":
+        # Something is there and we cannot read it. Reward alone is not
+        # enough to call this a pass.
+        return "ambiguous"
+    if state == "valid":
+        passed, total = trial.get("passed"), trial.get("total")
+        ints = isinstance(passed, int) and not isinstance(passed, bool) \
+            and isinstance(total, int) and not isinstance(total, bool)
+        if not ints:
+            # e.g. string counts "0"/"5". An earlier version ignored these
+            # and rendered green.
+            return "ambiguous"
+        if total <= 0:
+            # `total == 0` short-circuited the old `and total` guard, so
+            # {'passed': 1, 'total': 0} rendered green.
+            return "ambiguous"
+        if passed != total:
+            return "recorded-fail"
+    return "recorded-pass"
+
+
+def _verdict_cell(trial: dict) -> str:
+    """The Result cell. Fail-closed, and never bare.
+
+    A failed row must carry its evidence: 483 replayed failures rendered as
+    a bare red row with the failing-check count or the exception type
+    dropped, which tells a reviewer nothing about what went wrong.
+    """
+    reward, passed, total = trial["reward"], trial.get("passed"), trial.get("total")
+    detail = ""
+    if isinstance(passed, (int, str)) and isinstance(total, (int, str)) \
+            and not isinstance(passed, bool) and str(total) not in ("", "0"):
+        detail = f" ({passed}/{total})"
+    got = f" reward {_fmt_reward(reward)}" if isinstance(reward, float) else ""
+    state = row_state(trial)
+
+    if state == "recorded-pass":
+        return f"{MARK_PASS} {_fmt_reward(reward)}{detail}"
+    if state == "no-verdict":
+        return f"{MARK_SKIP} no verdict recorded"
+    if state == "ambiguous":
+        why = {
+            "unreadable": "judge.json unreadable",
+        }.get(trial.get("judge_state"), "")
+        if trial.get("ambiguous"):
+            why = trial["ambiguous"]
+        elif not why:
+            why = "check counts unusable"
+        return f"{MARK_FAIL} ambiguous ({why}){got}"
+    if trial.get("exception"):
+        kind = trial.get("exception_type") or "error"
+        return f"{MARK_FAIL} {kind}{detail}{',' if got else ''}{got}"
+    if reward == 1.0:
+        # A perfect reward with a non-unanimous judge is confusing on its own
+        # ("1 (0/5)"), so name the contradiction rather than leave the reader
+        # to spot it.
+        return f"{MARK_FAIL} {_fmt_reward(reward)}{detail} (reward/checks disagree)"
+    return f"{MARK_FAIL} {_fmt_reward(reward)}{detail}"
+
+
+def _trace_link(trial: dict, traces: dict) -> str:
+    url = traces.get(trial["trial_name"])
+    if not url and trial.get("step"):
+        url = traces.get(f"step-{trial['step']}")
+    return f"[trace]({url})" if url else MISSING
+
+
+def _fill_declared(text: str, platform: str) -> str:
+    """Substitute what we authoritatively know in a declared query.
+
+    Adapters substitute placeholders before execution, so a spec template is
+    not what Harbor judged. `judge.json.query` is preferred everywhere, but
+    8% of trials record no judge query and every not-run row has none, so the
+    template is the only text available there. `{{platform}}` is 51 of the
+    105 placeholders in the spec corpus and its value is known here, so fill
+    it rather than showing a reader raw mustache.
+    """
+    return text.replace("{{platform}}", platform) if platform else text
+
+
+def _short(text: str, limit: int = 60) -> str:
+    text = (text or "").replace("|", "\\|").replace("\n", " ").strip()
+    return (text[: limit - 3] + "...") if len(text) > limit else (text or MISSING)
+
+
+def render_comment(leg: dict, *, spec_path: str, platform: str, head_sha: str,
+                   spec_sha: str = "", declared: list[str] | None = None) -> str:
+    """Render the leg comment. `declared` is the spec's ordered query list."""
+    trials, traces = leg["trials"], leg["traces"]
+    declared = declared or []
+    numbered = [t for t in trials if t["step"]]
+    multi = bool(numbered) or len(declared) > 1
+
+    lines = [f"## Harbor Eval — `{spec_path}`", ""]
+    meta = [f"Head: `{head_sha[:8]}`", f"platform `{platform}`"]
+    if spec_sha:
+        meta.append(f"spec `{spec_sha[:8]}`")
+    if leg["machine"]:
+        meta.append(f"box `{leg['machine']}`")
+    lines.append(" · ".join(meta))
+
+    first, last = leg["first_started"], leg["last_finished"]
+    total_s = leg.get("phases", {}).get("total_s")
+    if total_s is None and first and last:
+        total_s = (last - first).total_seconds()
+    lines.append(
+        f"First started: `{first.strftime('%Y-%m-%d %H:%M:%SZ') if first else MISSING}` · "
+        f"Last finished: `{last.strftime('%Y-%m-%d %H:%M:%SZ') if last else MISSING}` · "
+        f"Total: `{_fmt_duration(total_s)}`"
+    )
+    lines.append("")
+
+    def row(cells: list[str]) -> str:
+        return "| " + " | ".join(cells) + " |"
+
+    if multi:
+        lines.append(row(["Platform", "Step", "Query", "Result", "Reward",
+                          "Duration", "Turns", "Prompt tok", "Cached tok", "Trace"]))
+        lines.append("|" + "---|" * 10)
+        # An unnumbered single trial IS logical step 1 when the spec declares
+        # steps. Treating it as absent flipped 316 real legs falsely red.
+        by_step = {}
+        for t in trials:
+            by_step[t["step"] or 1] = t
+        span = range(1, max(len(declared), max(by_step, default=1)) + 1)
+        for n in span:
+            t = by_step.get(n)
+            # `judge.json.query` is what Harbor actually evaluated; the spec
+            # holds an unsubstituted template (46 of 50 specs contain
+            # placeholders like {{platform}}). Show the executed text for a
+            # step that ran, and fall back to the declaration only for a step
+            # that never ran, labelled so it cannot be mistaken for executed.
+            executed = (t or {}).get("query") or ""
+            template = declared[n - 1] if n - 1 < len(declared) else ""
+            if executed:
+                query = _short(executed)
+            elif template:
+                query = _short(_fill_declared(template, platform)) + " *(declared)*"
+            else:
+                query = MISSING
+            if t is None:
+                lines.append(row([platform, f"step-{n}", query,
+                                  _skip_cell(n, by_step)] + [MISSING] * 6))
+                continue
+            lines.append(row([
+                platform, f"step-{n}", query, _verdict_cell(t),
+                _fmt_reward(t["reward"]) if t["reward"] is not None else MISSING,
+                _fmt_duration(t["seconds"]), str(t["turns"] or MISSING),
+                _fmt_tokens(t["prompt_tok"]), _fmt_tokens(t["cached_tok"]),
+                _trace_link(t, traces)]))
+    else:
+        lines.append(row(["Platform", "Result", "Reward", "Duration", "Turns",
+                          "Prompt tok", "Cached tok", "Trace"]))
+        lines.append("|" + "---|" * 8)
+        for t in trials:
+            lines.append(row([
+                platform, _verdict_cell(t),
+                _fmt_reward(t["reward"]) if t["reward"] is not None else MISSING,
+                _fmt_duration(t["seconds"]), str(t["turns"] or MISSING),
+                _fmt_tokens(t["prompt_tok"]), _fmt_tokens(t["cached_tok"]),
+                _trace_link(t, traces)]))
+
+    retried = [t for t in trials if t.get("attempts", 1) > 1]
+    if retried:
+        lines.append("")
+        lines.append("Retried (latest attempt shown): "
+                     + ", ".join(f"`{t['trial_name']}` ×{t['attempts']}" for t in retried))
+    lines.extend(_failing_checks_section(
+        trials, multi_step=any(t.get("step") for t in trials)))
+    undated = [t for t in trials if t.get("undated")]
+    if undated:
+        lines.append("")
+        lines.append("No start timestamp recorded for: "
+                     + ", ".join(f"`{t['trial_name']}`" for t in undated))
+    if leg["unreadable"]:
+        lines.append("")
+        lines.append("Unreadable result files (NOT reflected above): "
+                     + ", ".join(f"`{p}`" for p in leg["unreadable"]))
+    lines.append("")
+    return "\n".join(lines)
+
+
+SUMMARY_SCHEMA = 1
+
+
+def leg_summary(leg: dict, *, declared: list[str], spec_path: str = "",
+                platform: str = "") -> dict:
+    """Versioned facts for a deterministic caller.
+
+    The module still emits no overall verdict, but a caller must not have to
+    parse Markdown to build one. Everything needed is here: per-step state,
+    reward validity, judge presence and counts, the attempt actually shown,
+    and any collection-integrity error.
+    """
+    steps = []
+    by_step = {}
+    for t in leg["trials"]:
+        by_step[t["step"] or 1] = t
+    span = range(1, max(len(declared), max(by_step, default=1)) + 1)
+    for n in span:
+        t = by_step.get(n)
+        if t is None:
+            steps.append({"step": n, "state": "not-run",
+                          "declared_query": declared[n - 1] if n - 1 < len(declared) else None})
+            continue
+        steps.append({
+            "step": n,
+            "state": row_state(t),
+            "trial_name": t["trial_name"],
+            "reward": t["reward"],
+            "reward_valid": t["reward"] is not None,
+            "judge": t.get("judge_state"),
+            "passed": t.get("passed"),
+            "total": t.get("total"),
+            "exception": t.get("exception_type") if t.get("exception") else None,
+            "attempts": t.get("attempts", 1),
+            "attempt_path": t.get("path"),
+            "any_attempt_undated": bool(t.get("any_undated")),
+            "seconds": t.get("seconds"),
+            "executed_query": t.get("query") or None,
+        })
+    return {
+        "schema": SUMMARY_SCHEMA,
+        "spec_path": spec_path,
+        "platform": platform,
+        "machine": leg.get("machine") or None,
+        "declared_steps": len(declared),
+        "steps": steps,
+        "collection_errors": list(leg.get("unreadable") or []),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Render the comment to stdout or a file.
+
+    NO VERDICT IS EMITTED and the exit code is about rendering only:
+      0  a comment was produced
+      2  nothing to render (no trials under the results root)
+      3  a spec was named but could not be used
+
+    The caller decides whether the leg passed. It holds `run_leg.py`'s exit
+    status and the spec; this module holds neither, and an earlier draft that
+    tried to decide anyway got it wrong in both directions.
+    """
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--results-root", required=True, type=Path)
+    ap.add_argument("--spec-path", default=os.environ.get("EVAL_SPEC_PATH", ""))
+    ap.add_argument("--spec-file", type=Path, default=None,
+                    help="Spec JSON to read the declared step list from "
+                         "(defaults to --spec-path if it exists on disk)")
+    ap.add_argument("--platform", default=os.environ.get("EVAL_PLATFORM", ""))
+    ap.add_argument("--head-sha", default=os.environ.get("PR_HEAD_SHA", ""))
+    ap.add_argument("--spec-sha", default="")
+    ap.add_argument("--out", type=Path, default=None)
+    ap.add_argument("--summary-json", type=Path, default=None,
+                    help="Write the machine-readable summary a caller should "
+                         "use instead of parsing the rendered Markdown")
+    args = ap.parse_args(argv)
+
+    leg = collect_leg(args.results_root)
+    if not leg["trials"]:
+        print("no trials under results root", file=sys.stderr)
+        return 2
+    spec_file = args.spec_file
+    if spec_file is None and args.spec_path and Path(args.spec_path).is_file():
+        spec_file = Path(args.spec_path)
+    try:
+        declared = spec_steps(spec_file)
+    except SpecError as exc:
+        # Rendering without the spec would drop its declared steps and make a
+        # partial chain look complete, so this is a hard error.
+        print(f"spec error: {exc}", file=sys.stderr)
+        return 3
+    body = render_comment(leg, spec_path=args.spec_path, platform=args.platform,
+                          head_sha=args.head_sha, spec_sha=args.spec_sha,
+                          declared=declared)
+    if args.summary_json:
+        args.summary_json.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_json.write_text(json.dumps(
+            leg_summary(leg, declared=declared, spec_path=args.spec_path,
+                        platform=args.platform), indent=2, default=str))
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(body)
+    else:
+        print(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -359,6 +359,194 @@ async def _block_bash_background(input_data, tool_use_id, context):
     return {}
 
 
+def build_user_prompt(*, eval_kind: str, eval_skill: str, eval_spec_path: str,
+                      eval_platform: str, eval_slug: str, eval_spec_stem: str,
+                      pr_repo: str, pr_number: str, pr_base: str, pr_head: str,
+                      run_id: str, manual: bool, daily_run: bool) -> str:
+    """Build the turn prompt for one leg.
+
+    Module level and free of any SDK dependency so the prompt each branch
+    actually sends can be asserted directly in a test. Nothing constructed a
+    prompt in a test before, which is how a change that wired only the PR
+    branch and left the nightly branch rebuilding the table by hand looked
+    complete.
+    """
+    results_root, summary_path, report_path = leg_paths(
+        eval_slug, eval_spec_stem)
+
+    # Single-sourced so the PR leg and the nightly leg cannot drift apart:
+    # both render through leg_report.py and both must land the body where
+    # build_benchmark_md() globs for it.
+    render_block = f"""→ render the comment with ONE command (§ Result comment format):
+
+    python3 {REPO_ROOT}/.github/skill-eval/leg_report.py \\
+      --results-root "{results_root}" --spec-path "{eval_spec_path}" \\
+      --platform "{eval_platform}" --head-sha "{pr_head}" \\
+      --summary-json "{summary_path}" \\
+      --out "{report_path}"
+
+  Every path above is absolute on purpose. Do NOT substitute $RES or
+  $SCRATCH: shell state does not persist between Bash calls, so they are
+  unset and would silently render an empty results tree.
+  DO NOT read the results tree, trajectories or judge.json yourself and DO
+  NOT rebuild the table by hand — the renderer owns the format, and doing it
+  by hand is what used to cost ~114s of rediscovery per leg.
+  If the renderer exits NON-ZERO the leg FAILED. Do not inspect raw results
+  and do not use `BLOCKED`; end with
+  `DONE: 0/1 specs passed; leg_report.py failed (exit N)`."""
+
+    verdict_block = f"""After a zero renderer exit, read `{summary_path}` for the verdict. The leg
+passed only if every entry in `steps[]` has `state == "recorded-pass"`;
+`recorded-fail`, `no-verdict`, `not-run` and `ambiguous` all mean it did not.
+A non-empty `collection_errors` also means it did not."""
+
+    if eval_kind == "missing_adapter":
+        target = f"PR #{pr_number}" if pr_number else "Manual sweep"
+        user_prompt = f"""
+{target}: skill `{eval_skill}` ships eval specs but has NO adapter at
+`.github/skill-eval/adapters/{eval_skill}/generate.py`. The `plan` job
+collapsed every spec on this skill into this one leg so the adapter is
+committed exactly once.
+
+Context:
+  repo         = {pr_repo}
+  PR number    = {pr_number or "(manual sweep — no PR)"}
+  base branch  = {pr_base}
+  mirror head  = {pr_head}
+  workflow run = {run_id}
+  working dir  = {REPO_ROOT}
+
+Per AGENTS.md § "Single-spec mode" (missing-adapter case) + § 3c: generate
+the adapter and COMMIT it directly to the source PR's `headRefName` (NOT the
+mirror) so the eval re-runs against it on the next sync. Do NOT run any trial
+in this leg (the re-run evaluates the committed adapter), and do NOT post a
+results comment. For an external-fork PR (the bot can't push to a fork),
+comment that the contributor must add the adapter and BLOCK instead. If this
+is a manual sweep (`PR number` above is blank) there is no branch to commit
+to — record the missing adapter in `$GITHUB_STEP_SUMMARY` and BLOCK.
+
+End with `BLOCKED: missing adapter for {eval_skill} auto-committed (<sha>)`
+once pushed, `BLOCKED: fork PR — adapter must be added by the contributor`
+for a fork, `BLOCKED: missing adapter for {eval_skill} (manual sweep)` for a
+manual run, or `BLOCKED: <reason>` if you could not commit.
+"""
+    elif daily_run:
+        user_prompt = f"""
+Develop: evaluate exactly ONE spec on ONE platform —
+`{eval_spec_path}` (skill `{eval_skill}`, platform `{eval_platform or "see spec"}`).
+
+Context:
+  repo         = {pr_repo}
+  base branch  = develop
+  mirror head  = {pr_head}
+  workflow run = {run_id}
+  working dir  = {REPO_ROOT}
+  spec         = {eval_spec_path}
+  platform     = {eval_platform or "(read from spec)"}
+  leg slug     = {os.environ.get("EVAL_SLUG", "")}   (scratch scope; see § Per-leg scratch isolation)
+
+Per AGENTS.md § "Single-spec mode": SKIP step 1's diff — the `plan` job
+already selected this (spec, platform). Run steps 2–7 for it only:
+ensure its adapter exists under `.github/skill-eval/adapters/{eval_skill}/`
+(missing/stale → just skip this spec)
+→ generate the dataset → acquire a per-box flock
+on a `vss-eval-*` member matching `{eval_platform or "the spec's platform"}` →
+run harbor synchronously for this platform (§ Harbor invocation; never
+background it)
+{render_block}
+→ append `{report_path}` to `$GITHUB_STEP_SUMMARY` (no PR to comment on).
+Do NOT touch any other spec or skill.
+
+{verdict_block}
+
+End with `DONE: 1/1 specs passed` when it passed, `DONE: 0/1 specs passed;
+<the failing steps and their states>` when it did not, or
+`BLOCKED: <reason>` (e.g. stale adapter auto-committed, pool exhausted).
+"""
+    else:
+        target = f"PR #{pr_number}" if pr_number else "Manual sweep"
+        post_step = (
+            "append the result table to `$GITHUB_STEP_SUMMARY` (no PR to comment on)"
+            if manual else "post ONE PR comment for this spec"
+        )
+        user_prompt = f"""
+{target}: evaluate exactly ONE spec on ONE platform —
+`{eval_spec_path}` (skill `{eval_skill}`, platform `{eval_platform or "see spec"}`).
+
+Context:
+  repo         = {pr_repo}
+  PR number    = {pr_number or "(manual sweep — no PR)"}
+  base branch  = {pr_base}
+  mirror head  = {pr_head}
+  workflow run = {run_id}
+  working dir  = {REPO_ROOT}
+  spec         = {eval_spec_path}
+  platform     = {eval_platform or "(read from spec)"}
+  leg slug     = {os.environ.get("EVAL_SLUG", "")}   (scratch scope; see § Per-leg scratch isolation)
+
+Per AGENTS.md § "Single-spec mode": SKIP step 1's diff — the `plan` job
+already selected this (spec, platform). Run steps 2–7 for it only:
+ensure/refresh its adapter under `.github/skill-eval/adapters/{eval_skill}/`
+(missing/stale → handle per § 3c, then exit BLOCKED — never run a
+locally-patched adapter in this leg) → generate the dataset → select a
+`vss-eval-*` member matching `{eval_platform or "the spec's platform"}` →
+run `.github/skill-eval/run_leg.py` for this platform (§ Harbor invocation;
+never background it; the wrapper holds the per-box lock while Harbor runs)
+{render_block}
+→ {post_step}, posting `{report_path}` verbatim
+  (`gh pr comment --body-file`).
+Do NOT touch any other spec or skill.
+
+{verdict_block}
+
+End with `DONE: 1/1 specs passed` when it passed, `DONE: 0/1 specs passed;
+<the failing steps and their states>` when it did not, or
+`BLOCKED: <reason>` (e.g. stale adapter auto-committed, pool exhausted).
+"""
+    return user_prompt
+
+
+def leg_paths(eval_slug: str, eval_spec_stem: str = "spec") -> tuple[Path, Path, Path]:
+    """Return (results_root, summary_path, report_path) for one leg.
+
+    Absolute and precomputed: the agent's Bash tool starts a fresh shell per
+    call, so a command written against $RES / $SCRATCH would expand to empty
+    strings and render an empty tree.
+
+    The body is keyed by EVAL_SLUG, never the spec stem. Stems are not unique
+    across skills (`search` and `standalone_deploy` are each shared by more
+    than one skill, covering 5 legs of the current matrix), and every leg of a
+    run shares the scratch dir on a self-hosted runner host, so a stem-keyed
+    name lets one leg overwrite another leg's comment. plan_matrix.py already uniqueness-checks the slug, and the
+    resulting name still matches BENCHMARK_INPUT_GLOB.
+    """
+    results_root = Path(f"/tmp/skill-eval/results/{eval_slug}/{_RUN_ID}")
+    return (results_root,
+            results_root / "leg-summary.json",
+            _SCRATCH / f"pr-{eval_slug or eval_spec_stem}.md")
+
+
+def missing_renderer_outputs(marker: str, results_root: Path,
+                             summary_path: Path,
+                             report_path: Path) -> list[Path]:
+    """Renderer outputs that must exist but do not, given the agent's marker.
+
+    leg_report.py exits 2 (no trials) or 3 (unusable spec) and can crash, and
+    none of that reaches this process, which gates only on the final marker.
+    Without this, `BLOCKED: leg_report.py crashed` is a GREEN check on a leg
+    that really ran. Both prompts forbid rebuilding the table by hand, so
+    there is no correct-but-slow fallback to fall back on either.
+
+    A genuine pre-trial BLOCKED stays green: it has no trials and claims no
+    DONE, so nothing is required of it. Returns [] when nothing is owed.
+    """
+    owes_output = marker.startswith("DONE:") or any(
+        results_root.rglob("result.json"))
+    if not owes_output:
+        return []
+    return [p for p in (summary_path, report_path) if not p.is_file()]
+
+
 def _last_nonempty_line(text_blocks: list[str]) -> str | None:
     """Return the final printed assistant line without accepting leading space."""
     for block in reversed(text_blocks):
@@ -470,6 +658,10 @@ async def run_agent() -> int:
     eval_skill = _require("EVAL_SKILL")
     eval_spec_path = os.environ.get("EVAL_SPEC_PATH", "")
     eval_platform = os.environ.get("EVAL_PLATFORM", "")
+    # The workflow exports this alongside EVAL_SPEC_PATH; the renderer writes
+    # `$SCRATCH/pr-<spec>.md` and the benchmark step globs for exactly that.
+    eval_spec_stem = os.environ.get("EVAL_SPEC_STEM", "") or "spec"
+    eval_slug = os.environ.get("EVAL_SLUG", "")
     manual = not pr_number
 
     if not AGENTS_MD.exists():
@@ -478,100 +670,14 @@ async def run_agent() -> int:
 
     system_prompt = AGENTS_MD.read_text()
 
-    if eval_kind == "missing_adapter":
-        target = f"PR #{pr_number}" if pr_number else "Manual sweep"
-        user_prompt = f"""
-{target}: skill `{eval_skill}` ships eval specs but has NO adapter at
-`.github/skill-eval/adapters/{eval_skill}/generate.py`. The `plan` job
-collapsed every spec on this skill into this one leg so the adapter is
-committed exactly once.
-
-Context:
-  repo         = {pr_repo}
-  PR number    = {pr_number or "(manual sweep — no PR)"}
-  base branch  = {pr_base}
-  mirror head  = {pr_head}
-  workflow run = {run_id}
-  working dir  = {REPO_ROOT}
-
-Per AGENTS.md § "Single-spec mode" (missing-adapter case) + § 3c: generate
-the adapter and COMMIT it directly to the source PR's `headRefName` (NOT the
-mirror) so the eval re-runs against it on the next sync. Do NOT run any trial
-in this leg (the re-run evaluates the committed adapter), and do NOT post a
-results comment. For an external-fork PR (the bot can't push to a fork),
-comment that the contributor must add the adapter and BLOCK instead. If this
-is a manual sweep (`PR number` above is blank) there is no branch to commit
-to — record the missing adapter in `$GITHUB_STEP_SUMMARY` and BLOCK.
-
-End with `BLOCKED: missing adapter for {eval_skill} auto-committed (<sha>)`
-once pushed, `BLOCKED: fork PR — adapter must be added by the contributor`
-for a fork, `BLOCKED: missing adapter for {eval_skill} (manual sweep)` for a
-manual run, or `BLOCKED: <reason>` if you could not commit.
-"""
-    elif daily_run:
-        user_prompt = f"""
-Develop: evaluate exactly ONE spec on ONE platform —
-`{eval_spec_path}` (skill `{eval_skill}`, platform `{eval_platform or "see spec"}`).
-
-Context:
-  repo         = {pr_repo}
-  base branch  = develop
-  mirror head  = {pr_head}
-  workflow run = {run_id}
-  working dir  = {REPO_ROOT}
-  spec         = {eval_spec_path}
-  platform     = {eval_platform or "(read from spec)"}
-  leg slug     = {os.environ.get("EVAL_SLUG", "")}   (scratch scope; see § Per-leg scratch isolation)
-
-Per AGENTS.md § "Single-spec mode": SKIP step 1's diff — the `plan` job
-already selected this (spec, platform). Run steps 2–7 for it only:
-ensure its adapter exists under `.github/skill-eval/adapters/{eval_skill}/`
-(missing/stale → just skip this spec)
-→ generate the dataset → acquire a per-box flock
-on a `vss-eval-*` member matching `{eval_platform or "the spec's platform"}` →
-run harbor synchronously for this platform (§ Harbor invocation; never
-background it) → gather results →
-append the result table to `$GITHUB_STEP_SUMMARY` (no PR to comment on). Do NOT touch
-any other spec or skill.
-
-End with `DONE: N/N specs passed; <optional summary>` after posting the comment, or
-`BLOCKED: <reason>` (e.g. stale adapter auto-committed, pool exhausted).
-"""
-    else:
-        target = f"PR #{pr_number}" if pr_number else "Manual sweep"
-        post_step = (
-            "append the result table to `$GITHUB_STEP_SUMMARY` (no PR to comment on)"
-            if manual else "post ONE PR comment for this spec"
-        )
-        user_prompt = f"""
-{target}: evaluate exactly ONE spec on ONE platform —
-`{eval_spec_path}` (skill `{eval_skill}`, platform `{eval_platform or "see spec"}`).
-
-Context:
-  repo         = {pr_repo}
-  PR number    = {pr_number or "(manual sweep — no PR)"}
-  base branch  = {pr_base}
-  mirror head  = {pr_head}
-  workflow run = {run_id}
-  working dir  = {REPO_ROOT}
-  spec         = {eval_spec_path}
-  platform     = {eval_platform or "(read from spec)"}
-  leg slug     = {os.environ.get("EVAL_SLUG", "")}   (scratch scope; see § Per-leg scratch isolation)
-
-Per AGENTS.md § "Single-spec mode": SKIP step 1's diff — the `plan` job
-already selected this (spec, platform). Run steps 2–7 for it only:
-ensure/refresh its adapter under `.github/skill-eval/adapters/{eval_skill}/`
-(missing/stale → handle per § 3c, then exit BLOCKED — never run a
-locally-patched adapter in this leg) → generate the dataset → select a
-`vss-eval-*` member matching `{eval_platform or "the spec's platform"}` →
-run `.github/skill-eval/run_leg.py` for this platform (§ Harbor invocation;
-never background it; the wrapper holds the per-box lock while Harbor runs)
-→ gather results →
-{post_step} (§ Result comment format). Do NOT touch any other spec or skill.
-
-End with `DONE: N/N specs passed; <optional summary>` after posting the result, or
-`BLOCKED: <reason>` (e.g. stale adapter auto-committed, pool exhausted).
-"""
+    user_prompt = build_user_prompt(
+        eval_kind=eval_kind, eval_skill=eval_skill,
+        eval_spec_path=eval_spec_path, eval_platform=eval_platform,
+        eval_slug=eval_slug, eval_spec_stem=eval_spec_stem,
+        pr_repo=pr_repo, pr_number=pr_number, pr_base=pr_base,
+        pr_head=pr_head, run_id=run_id, manual=manual, daily_run=daily_run)
+    results_root, summary_path, report_path = leg_paths(
+        eval_slug, eval_spec_stem)
 
     model = os.environ.get("ANTHROPIC_MODEL") or "claude-sonnet-4-6"
     print(f"[agent] starting · pr={pr_number} base={pr_base} head={pr_head[:8]} "
@@ -663,6 +769,23 @@ End with `DONE: N/N specs passed; <optional summary>` after posting the result, 
     # result; 0/N and partial N/M outcomes are completed eval failures.
     exit_code, reason = _evaluate_terminal_marker(final_text)
     print(f"[agent] {reason}", file=sys.stderr)
+
+    # Fail closed on a renderer that never produced output. leg_report.py
+    # exits 2 (no trials) or 3 (unusable spec) and can crash; none of that
+    # reaches this process, which gates only on the agent's final marker. So
+    # `BLOCKED: leg_report.py crashed` would otherwise be a GREEN check on a
+    # leg that really ran. Both prompts now forbid rebuilding the table by
+    # hand, so there is no correct-but-slow fallback to rely on either.
+    # A genuine pre-trial BLOCKED stays green: no result.json, no DONE.
+    if eval_kind == "eval" and exit_code == 0:
+        missing = missing_renderer_outputs(
+            _last_nonempty_line(final_text) or "",
+            results_root, summary_path, report_path)
+        if missing:
+            names = ", ".join(str(p) for p in missing)
+            print(f"[agent] mandatory renderer output missing: {names}",
+                  file=sys.stderr)
+            return _EVAL_FAILURE_EXIT_CODE
     return exit_code
 
 

--- a/.github/skill-eval/tests/test_leg_report.py
+++ b/.github/skill-eval/tests/test_leg_report.py
@@ -1,0 +1,492 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the deterministic leg-result renderer.
+
+Most of these guard defects found by replaying the renderer over 1,177 real
+harvested legs and by adversarial review. All of them were silent: none
+raised, and several produced a confidently wrong comment.
+
+The module renders and does not judge, so the tests assert what a reviewer
+would SEE, not a pass/fail the module has no authority to decide.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "leg_report", Path(__file__).resolve().parents[1] / "leg_report.py")
+leg_report = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(leg_report)
+
+
+def _trial(tmp: Path, run: str, name: str, *, reward, start, finish,
+           passed=None, total=None, query="", tokens=True, exception=None,
+           checks=None) -> Path:
+    d = tmp / run / name
+    (d / "verifier").mkdir(parents=True, exist_ok=True)
+    (d / "config.json").write_text("{}")
+    payload = {
+        "trial_name": name,
+        "task_name": f"nvidia-vss/{name}",
+        "started_at": start,
+        "finished_at": finish,
+        "verifier_result": {"rewards": {"reward": reward}} if reward is not None else {},
+        "agent_result": ({"n_input_tokens": 1200, "n_cache_tokens": 1000} if tokens else {}),
+    }
+    if exception:
+        payload["exception_info"] = {"exception_type": exception}
+    (d / "result.json").write_text(json.dumps(payload))
+    if passed is not None:
+        judge = {"passed": passed, "total": total, "query": query}
+        if checks is not None:
+            judge["checks"] = checks
+        (d / "verifier" / "judge.json").write_text(json.dumps(judge))
+    return d
+
+
+def _rows(body: str, platform: str = "L40S") -> list[str]:
+    return [ln for ln in body.splitlines() if ln.startswith(f"| {platform} |")]
+
+
+def _render(tmp: Path, declared=None, platform="L40S") -> str:
+    leg = leg_report.collect_leg(tmp)
+    return leg_report.render_comment(leg, spec_path="s.json", platform=platform,
+                                     head_sha="0862faf3", declared=declared)
+
+
+# --- structure --------------------------------------------------------------
+
+def test_run_level_result_json_is_not_mistaken_for_a_trial(tmp_path: Path) -> None:
+    # REGRESSION: the run-level result.json sits beside a config.json exactly
+    # like a trial does, so filtering on config.json duplicated every row.
+    (tmp_path / "r").mkdir(parents=True)
+    (tmp_path / "r" / "config.json").write_text("{}")
+    (tmp_path / "r" / "result.json").write_text(json.dumps(
+        {"id": "abc", "n_total_trials": 2, "started_at": "2026-08-20T08:00:00Z"}))
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=5, total=5,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:10:00Z")
+
+    leg = leg_report.collect_leg(tmp_path)
+    assert [t["trial_name"] for t in leg["trials"]] == ["step-1__aaa"]
+
+
+def test_naive_and_aware_timestamps_can_coexist(tmp_path: Path) -> None:
+    # REGRESSION: mixing them made min()/max() raise, killing 1,174 of 1,177.
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:10:00Z")
+    _trial(tmp_path, "r", "step-2__bbb", reward=1.0,
+           start="2026-08-20T08:10:00", finish="2026-08-20T08:20:00")
+    body = _render(tmp_path)
+    assert len(_rows(body)) == 2
+
+
+def test_steps_render_once_and_in_order(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "step-2__bbb", reward=0.75, passed=3, total=4,
+           start="2026-08-20T08:20:00Z", finish="2026-08-20T08:24:00Z")
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=5, total=5,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:16:00Z")
+    rows = _rows(_render(tmp_path))
+    assert len(rows) == 2
+    assert "step-1" in rows[0] and "step-2" in rows[1]
+    assert leg_report.MARK_PASS in rows[0]
+    assert leg_report.MARK_FAIL in rows[1] and "(3/4)" in rows[1]
+
+
+# --- the false-red the earlier draft introduced ------------------------------
+
+def test_an_unnumbered_single_step_trial_is_logical_step_one(tmp_path: Path) -> None:
+    # REGRESSION: single-step trials are named after the platform, not
+    # `step-N`. Treating logical step 1 as absent flipped 316 real passing
+    # legs to a "not run" row.
+    _trial(tmp_path, "r", "rtxpro6000bw__aaa", reward=1.0, passed=4, total=4,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    body = _render(tmp_path, declared=["Deploy the base profile"])
+    rows = _rows(body)
+    assert len(rows) == 1
+    assert "not run" not in body
+    assert leg_report.MARK_PASS in rows[0]
+
+
+def test_a_step_the_spec_declares_but_never_ran_is_shown_as_skipped(tmp_path: Path) -> None:
+    """Sequential dispatch stops at the first failure, so name the cause.
+
+    step-1 scored 0.2, so steps 2 and 3 did not run because of it. Reporting
+    a bare "not run" would hide why, and this is the wording these comments
+    have always used.
+    """
+    _trial(tmp_path, "r", "step-1__aaa", reward=0.2, passed=1, total=5,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    body = _render(tmp_path, declared=["deploy", "ingest", "query"])
+    rows = _rows(body)
+    assert len(rows) == 3
+    assert body.count("skipped (prior-step fail, step-1 reward=0.2)") == 2
+    assert "ingest" in rows[1]          # the declared query still shows
+
+
+def test_the_declared_step_list_comes_from_the_spec(tmp_path: Path) -> None:
+    spec = tmp_path / "spec.json"
+    spec.write_text(json.dumps({"expects": [{"query": "deploy it"},
+                                            {"query": "ask a question"}]}))
+    assert leg_report.spec_steps(spec) == ["deploy it", "ask a question"]
+    assert leg_report.spec_steps(None) == []          # none named: fine
+    try:                                              # named but absent: error
+        leg_report.spec_steps(tmp_path / "missing.json")
+    except leg_report.SpecError:
+        pass
+    else:
+        raise AssertionError("a named-but-missing spec must raise")
+
+
+# --- fail-closed rendering ---------------------------------------------------
+
+def test_a_timed_out_trial_is_never_green_even_at_reward_one(tmp_path: Path) -> None:
+    # REGRESSION, real data: two corpus trials carry AgentTimeoutError with
+    # reward 1.0. AGENTS.md says a timeout is a failure regardless of reward.
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=16, total=16,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z",
+           exception="AgentTimeoutError")
+    body = _render(tmp_path)
+    assert leg_report.MARK_PASS not in body
+    assert "AgentTimeoutError" in body          # the detail must survive
+    assert "(16/16)" in body
+    assert "reward 1" in body
+
+
+def test_a_failing_row_always_carries_its_evidence(tmp_path: Path) -> None:
+    # REGRESSION: 483 replayed failures rendered as a bare red row with the
+    # failing-check count or exception type dropped.
+    _trial(tmp_path, "r", "step-1__aaa", reward=0.25, passed=1, total=4,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    row = _rows(_render(tmp_path))[0]
+    assert leg_report.MARK_FAIL in row and "(1/4)" in row and "0.25" in row
+
+
+def test_a_reward_that_contradicts_the_judge_is_not_a_pass(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=0, total=5,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    row = _rows(_render(tmp_path))[0]
+    assert leg_report.MARK_PASS not in row
+    assert "disagree" in row
+
+
+def test_malformed_rewards_are_not_passes(tmp_path: Path) -> None:
+    # True is an int in Python; inf and 1.000001 both survive `>= 1.0`.
+    for bad in (True, float("inf"), float("nan"), 1.000001, "1.0"):
+        d = _trial(tmp_path / str(id(bad)), "r", "step-1__aaa", reward=0.0,
+                   start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+        payload = json.loads((d / "result.json").read_text())
+        payload["verifier_result"] = {"rewards": {"reward": bad}}
+        (d / "result.json").write_text(json.dumps(payload))
+        body = _render(tmp_path / str(id(bad)))
+        assert leg_report.MARK_PASS not in body, f"{bad!r} rendered as a pass"
+
+
+# --- retries -----------------------------------------------------------------
+
+def test_a_retry_supersedes_the_earlier_attempt(tmp_path: Path) -> None:
+    # REGRESSION, real data: 15 of 1,177 legs have several attempts per step.
+    _trial(tmp_path, "2026-08-20__08-00-00", "step-1__first", reward=0.5,
+           passed=3, total=6, start="2026-08-20T08:00:00Z",
+           finish="2026-08-20T08:05:00Z")
+    _trial(tmp_path, "2026-08-20__09-00-00", "step-1__retry", reward=1.0,
+           passed=6, total=6, start="2026-08-20T09:00:00Z",
+           finish="2026-08-20T09:05:00Z")
+    leg = leg_report.collect_leg(tmp_path)
+    assert [t["trial_name"] for t in leg["trials"]] == ["step-1__retry"]
+    assert leg["trials"][0]["attempts"] == 2
+    body = leg_report.render_comment(leg, spec_path="s.json", platform="L40S",
+                                     head_sha="0862faf3")
+    assert "Retried" in body and "×2" in body
+
+
+def test_an_undated_retry_is_not_hidden_by_an_older_pass(tmp_path: Path) -> None:
+    # A later failed retry with no start timestamp must not be overwritten by
+    # an older timestamped pass, so undated attempts sort LAST.
+    _trial(tmp_path, "r1", "step-1__old", reward=1.0, passed=4, total=4,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    d = _trial(tmp_path, "r2", "step-1__undated", reward=0.0, passed=0, total=4,
+               start=None, finish=None)
+    payload = json.loads((d / "result.json").read_text())
+    payload.pop("started_at", None)
+    payload.pop("finished_at", None)
+    (d / "result.json").write_text(json.dumps(payload))
+
+    leg = leg_report.collect_leg(tmp_path)
+    assert [t["trial_name"] for t in leg["trials"]] == ["step-1__undated"]
+    body = leg_report.render_comment(leg, spec_path="s.json", platform="L40S",
+                                     head_sha="0862faf3")
+    assert leg_report.MARK_PASS not in body
+    assert "No start timestamp recorded" in body
+
+
+def test_a_task_base_containing_a_double_underscore_does_not_collapse(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "some__task__aaa", reward=1.0,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    _trial(tmp_path, "r", "other__task__bbb", reward=1.0,
+           start="2026-08-20T08:06:00Z", finish="2026-08-20T08:10:00Z")
+    leg = leg_report.collect_leg(tmp_path)
+    assert len(leg["trials"]) == 2, [t["trial_name"] for t in leg["trials"]]
+
+
+def test_an_unreadable_result_is_surfaced_not_dropped(tmp_path: Path) -> None:
+    # A corrupt NEWER retry beside a valid older pass would otherwise leave
+    # the leg looking clean.
+    _trial(tmp_path, "r1", "step-1__ok", reward=1.0, passed=4, total=4,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    bad = tmp_path / "r2" / "step-1__corrupt"
+    bad.mkdir(parents=True)
+    (bad / "result.json").write_text("{not json")
+
+    leg = leg_report.collect_leg(tmp_path)
+    assert leg["unreadable"], "a corrupt result.json must be reported"
+    body = leg_report.render_comment(leg, spec_path="s.json", platform="L40S",
+                                     head_sha="0862faf3")
+    assert "Unreadable result files" in body
+
+
+# --- misc --------------------------------------------------------------------
+
+def test_prompt_tokens_exclude_the_cached_portion(tmp_path: Path) -> None:
+    d = _trial(tmp_path, "r", "step-1__aaa", reward=1.0,
+               start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    payload = json.loads((d / "result.json").read_text())
+    payload["agent_result"] = {"n_input_tokens": 1_216_083,
+                               "n_cache_tokens": 1_145_395}
+    (d / "result.json").write_text(json.dumps(payload))
+    leg = leg_report.collect_leg(tmp_path)
+    assert leg["trials"][0]["prompt_tok"] == 1_216_083 - 1_145_395
+    assert leg["trials"][0]["cached_tok"] == 1_145_395
+
+
+def test_missing_metrics_degrade_and_never_raise(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z",
+           tokens=False)
+    assert leg_report.MISSING in _render(tmp_path)
+
+
+def test_trace_urls_are_matched_by_step_and_by_trial_name(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    (tmp_path / leg_report.TRACE_URLS_NAME).write_text(
+        "step-1\tstep-1__aaa\thttps://harbor.example/jobs/x\n")
+    assert "[trace](https://harbor.example/jobs/x)" in _render(tmp_path)
+
+
+def test_a_pipe_in_a_query_cannot_break_the_table(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=1, total=1,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    body = _render(tmp_path, declared=["run `docker ps | grep vss-agent`"])
+    row = next(ln for ln in body.splitlines() if ln.startswith("| L40S |"))
+    assert "\\|" in row
+    assert row.replace("\\|", "").count("|") == 11      # 10 columns + trailing
+
+
+def test_no_trials_renders_nothing_and_exits_two(tmp_path: Path) -> None:
+    leg = leg_report.collect_leg(tmp_path)
+    assert leg["trials"] == []
+    assert leg_report.main(["--results-root", str(tmp_path)]) == 2
+
+
+def test_the_module_emits_no_verdict(tmp_path: Path, capsys) -> None:
+    # The caller owns pass/fail. A failed leg still renders and still exits 0,
+    # because the exit code describes rendering, and the module says so
+    # rather than implying a verdict it has no authority to give.
+    _trial(tmp_path, "r", "step-1__aaa", reward=0.0, passed=0, total=5,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    assert leg_report.main(["--results-root", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert "DONE:" not in out
+    assert "specs passed" not in out
+    assert not hasattr(leg_report, "terminal_line")
+    assert not hasattr(leg_report, "leg_passed")
+
+
+# --- round-4 fixes ----------------------------------------------------------
+
+def test_the_query_column_shows_what_harbor_evaluated(tmp_path: Path) -> None:
+    # REGRESSION: 46 of 50 specs carry placeholders like {{platform}}. The
+    # spec holds the template; judge.json holds the substituted text Harbor
+    # actually judged. Showing the template told the operator the wrong thing.
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=3, total=3,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z",
+           query="Deploy the VSS alerts profile on L40S in verification mode")
+    body = _render(tmp_path, declared=["Deploy the VSS alerts profile on {{platform}}"])
+    row = next(ln for ln in body.splitlines() if ln.startswith("| L40S |"))
+    assert "{{platform}}" not in row
+    assert "on L40S" in row
+
+
+def test_a_not_run_step_shows_the_declaration_and_says_so(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=3, total=3,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z", query="ran")
+    body = _render(tmp_path, declared=["ran", "Watch {{sensor}} for PPE"])
+    rows = _rows(body)
+    assert "*(declared)*" in rows[1]     # never mistaken for executed text
+    assert "not run" in rows[1]
+
+
+def test_an_unreadable_judge_is_not_a_pass(tmp_path: Path) -> None:
+    # A truncated judge.json beside reward 1.0 used to render green because
+    # unreadable was treated exactly like absent.
+    d = _trial(tmp_path, "r", "step-1__aaa", reward=1.0,
+               start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    (d / "verifier").mkdir(exist_ok=True)
+    (d / "verifier" / "judge.json").write_text('{"passed": 3, "tot')
+    leg = leg_report.collect_leg(tmp_path)
+    assert leg["trials"][0]["judge_state"] == "unreadable"
+    assert leg_report.row_state(leg["trials"][0]) == "ambiguous"
+    body = leg_report.render_comment(leg, spec_path="s.json", platform="L40S",
+                                     head_sha="0862faf3")
+    assert leg_report.MARK_PASS not in body
+    assert "unreadable" in body
+
+
+def test_absent_judge_with_a_perfect_reward_is_still_a_pass(tmp_path: Path) -> None:
+    # Not every trial writes a judge.json; reward is the authority there.
+    # Failing these closed would invent false reds.
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    leg = leg_report.collect_leg(tmp_path)
+    assert leg["trials"][0]["judge_state"] == "absent"
+    assert leg_report.row_state(leg["trials"][0]) == "recorded-pass"
+
+
+def test_unusable_check_counts_are_ambiguous_not_green(tmp_path: Path) -> None:
+    for judge in ({"passed": 1, "total": 0},          # total==0 short-circuited
+                  {"passed": "0", "total": "5"},      # string counts ignored
+                  {"passed": True, "total": True}):   # bools are ints
+        root = tmp_path / str(abs(hash(str(judge))))
+        d = _trial(root, "r", "step-1__aaa", reward=1.0,
+                   start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+        (d / "verifier").mkdir(exist_ok=True)
+        (d / "verifier" / "judge.json").write_text(json.dumps(judge))
+        leg = leg_report.collect_leg(root)
+        assert leg_report.row_state(leg["trials"][0]) == "ambiguous", judge
+        body = leg_report.render_comment(leg, spec_path="s.json", platform="L40S",
+                                         head_sha="0862faf3")
+        assert leg_report.MARK_PASS not in body, judge
+
+
+def test_a_named_spec_that_cannot_be_used_is_an_error(tmp_path: Path) -> None:
+    # Returning [] here made a partial chain render complete and exit 0.
+    missing = tmp_path / "nope.json"
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    noexp = tmp_path / "noexp.json"
+    noexp.write_text('{"skills": []}')
+    for p in (missing, bad, noexp):
+        try:
+            leg_report.spec_steps(p)
+        except leg_report.SpecError:
+            continue
+        raise AssertionError(f"{p.name} should have raised SpecError")
+    assert leg_report.spec_steps(None) == []      # no spec named at all
+
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z")
+    assert leg_report.main(["--results-root", str(tmp_path),
+                            "--spec-file", str(bad)]) == 3
+
+
+def test_multiple_attempts_with_a_missing_timestamp_are_ambiguous(tmp_path: Path) -> None:
+    # Undated-sorts-last is a convention, not a chronology: an older undated
+    # pass would otherwise beat a newer dated failure.
+    _trial(tmp_path, "r1", "step-1__dated", reward=0.0, passed=0, total=4,
+           start="2026-08-20T09:00:00Z", finish="2026-08-20T09:05:00Z")
+    d = _trial(tmp_path, "r2", "step-1__undated", reward=1.0, passed=4, total=4,
+               start=None, finish=None)
+    payload = json.loads((d / "result.json").read_text())
+    payload.pop("started_at", None)
+    payload.pop("finished_at", None)
+    (d / "result.json").write_text(json.dumps(payload))
+
+    leg = leg_report.collect_leg(tmp_path)
+    assert leg["trials"][0]["attempts"] == 2
+    assert leg_report.row_state(leg["trials"][0]) == "ambiguous"
+    body = leg_report.render_comment(leg, spec_path="s.json", platform="L40S",
+                                     head_sha="0862faf3")
+    assert leg_report.MARK_PASS not in body
+    assert "no timestamp" in body
+
+
+def test_the_summary_gives_a_caller_everything_without_markdown(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=3, total=3,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z", query="ran it")
+    leg = leg_report.collect_leg(tmp_path)
+    summary = leg_report.leg_summary(leg, declared=["ran it", "never ran"],
+                                     spec_path="s.json", platform="L40S")
+    assert summary["schema"] == leg_report.SUMMARY_SCHEMA
+    assert summary["declared_steps"] == 2
+    assert [s["state"] for s in summary["steps"]] == ["recorded-pass", "not-run"]
+    first = summary["steps"][0]
+    assert first["reward"] == 1.0 and first["judge"] == "valid"
+    assert first["passed"] == 3 and first["total"] == 3
+    assert first["attempts"] == 1 and first["executed_query"] == "ran it"
+    assert summary["collection_errors"] == []
+    # a caller can decide the verdict from this alone
+    assert all(s["state"] in {"recorded-pass", "recorded-fail", "no-verdict",
+                              "not-run", "ambiguous"} for s in summary["steps"])
+
+
+# --- the posted format must not drift from what readers already know -------
+
+def test_whole_rewards_keep_one_decimal() -> None:
+    """Real comments and the documented example post `1.0`, never `1`.
+
+    `.3g` alone drops the trailing zero, which silently changes a format
+    every reviewer of this repo already reads.
+    """
+    assert leg_report._fmt_reward(1.0) == "1.0"
+    assert leg_report._fmt_reward(0.0) == "0.0"
+    # fractions keep their real precision
+    assert leg_report._fmt_reward(0.2) == "0.2"
+    assert leg_report._fmt_reward(0.75) == "0.75"
+    assert leg_report._fmt_reward(0.833) == "0.833"
+
+
+def test_a_skipped_step_names_the_step_that_blamed_it() -> None:
+    """Sequential dispatch stops at the first failure; say which one."""
+    by_step = {1: {"reward": 1.0}, 2: {"reward": 0.2}, 3: None}
+    assert leg_report._skip_cell(3, by_step) == (
+        "⏭️ skipped (prior-step fail, step-2 reward=0.2)"
+    )
+
+
+def test_a_skipped_step_after_an_error_says_so() -> None:
+    by_step = {1: {"reward": None, "exception": "AgentTimeoutError"}}
+    assert "prior-step error, step-1" in leg_report._skip_cell(2, by_step)
+
+
+def test_a_gap_with_no_earlier_failure_is_not_blamed_on_anyone() -> None:
+    """Never invent a cause: with nothing failing earlier, say `not run`."""
+    assert leg_report._skip_cell(2, {1: {"reward": 1.0}}).endswith("not run")
+
+
+def test_a_failing_step_lists_which_checks_failed(tmp_path: Path) -> None:
+    """31 of 33 failing comments in the posted history carry this section.
+
+    Without it a reader learns the reward was 0.5 but not which assertion
+    broke, which is the only actionable part of a failure report.
+    """
+    _trial(tmp_path, "r", "step-1__aaa", reward=0.5, passed=1, total=3,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z",
+           checks=[{"pass": True, "check": "it deploys"},
+                   {"pass": False, "check": "it answers", "rationale": "got 500"},
+                   {"pass": False, "check": "it persists"}])
+    body = _render(tmp_path, declared=["deploy"])
+    assert "### Failing checks (step-1)" in body
+    assert '- **Check 2**: "it answers" — got 500' in body
+    assert '- **Check 3**: "it persists"' in body
+    assert "it deploys" not in body.split("### Failing checks")[1]  # passing omitted
+
+
+def test_no_failing_checks_section_when_everything_passed(tmp_path: Path) -> None:
+    _trial(tmp_path, "r", "step-1__aaa", reward=1.0, passed=2, total=2,
+           start="2026-08-20T08:00:00Z", finish="2026-08-20T08:05:00Z",
+           checks=[{"pass": True, "check": "a"}, {"pass": True, "check": "b"}])
+    assert "### Failing checks" not in _render(tmp_path, declared=["deploy"])

--- a/.github/skill-eval/tests/test_skills_eval_agent_protocol.py
+++ b/.github/skill-eval/tests/test_skills_eval_agent_protocol.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 from enum import Enum
+import fnmatch
 import importlib.util
 import os
+import pathlib
 from pathlib import Path
 import subprocess
 import sys
@@ -210,3 +212,108 @@ raise SystemExit("agent session outlived its work deadline")
         text=True,
         timeout=5,
     )
+
+
+# --- every leg must delegate rendering, and a silent renderer must go red --
+#
+# build_user_prompt() and missing_renderer_outputs() are pure, so these call
+# them directly. Nothing constructed a prompt in a test before, which is how
+# a change that wired only the PR branch, leaving the nightly full sweep to
+# rebuild the table by hand, could look complete.
+
+_SLUG = "vss-deploy-profile__search__RTXPRO6000BW"
+_LEG = {
+    "eval_kind": "eval",
+    "eval_skill": "vss-deploy-profile",
+    "eval_spec_path": "skills/vss-deploy-profile/evals/search.json",
+    "eval_platform": "RTXPRO6000BW",
+    "eval_slug": _SLUG,
+    "eval_spec_stem": "search",
+    "pr_repo": "NVIDIA-AI-Blueprints/video-search-and-summarization",
+    "pr_base": "develop",
+    "pr_head": "a" * 40,
+    "run_id": "987654",
+}
+
+
+def _assert_delegates(prompt: str) -> None:
+    _, summary_path, report_path = skills_eval_agent.leg_paths(_SLUG, "search")
+
+    assert "leg_report.py" in prompt, "prompt does not invoke the renderer"
+    assert "DO NOT read the results tree" in prompt, "missing no-raw-read guard"
+    assert str(summary_path) in prompt, "verdict must come from the summary"
+
+    # A fresh shell per Bash call means $RES / $SCRATCH are unset; a command
+    # written against them would render an empty results tree.
+    command = prompt[prompt.index("leg_report.py"):]
+    command = command[:command.index("Every path above")]
+    assert "$RES" not in command and "$SCRATCH" not in command, (
+        f"renderer command relies on unset shell state: {command!r}"
+    )
+
+    # Keyed by slug, never the spec stem: `search` and `standalone_deploy`
+    # each belong to more than one skill, and legs of a run share the scratch
+    # dir on a self-hosted host, so a stem-keyed body lets one leg overwrite
+    # another's comment. It must still match the glob the benchmark step uses.
+    assert str(report_path) in prompt, f"body must be {report_path}"
+    assert "/pr-search.md" not in prompt, "stem-keyed body collides across skills"
+    assert fnmatch.fnmatch(report_path.name, pathlib.Path(
+        skills_eval_agent.BENCHMARK_INPUT_GLOB).name), (
+        "slug-keyed name must still match BENCHMARK_INPUT_GLOB"
+    )
+
+    # A renderer that exits non-zero is a failed leg, not a green BLOCKED.
+    assert "DONE: 0/1 specs passed; leg_report.py failed" in prompt, (
+        "prompt must map a non-zero renderer exit to a failed leg"
+    )
+
+
+def test_pr_leg_prompt_delegates_rendering() -> None:
+    _assert_delegates(skills_eval_agent.build_user_prompt(
+        **_LEG, pr_number="1780", manual=False, daily_run=False))
+
+
+def test_nightly_leg_prompt_delegates_rendering() -> None:
+    """The nightly sweep is the bigger consumer; it must not hand-build."""
+    _assert_delegates(skills_eval_agent.build_user_prompt(
+        **_LEG, pr_number="", manual=True, daily_run=True))
+
+
+def test_leg_body_is_keyed_by_slug_not_stem() -> None:
+    """Two skills sharing a spec stem must not share an output file.
+
+    `search.json` really is shipped by both vss-deploy-profile and
+    vss-search-archive, so these two legs run in the same sweep, on hosts
+    that share the run scratch dir.
+    """
+    a = skills_eval_agent.leg_paths("vss-deploy-profile__search__RTX", "search")
+    b = skills_eval_agent.leg_paths("vss-search-archive__search__RTX", "search")
+    assert a[2] != b[2], "distinct legs resolved to the same body path"
+
+
+def test_renderer_that_wrote_nothing_is_not_green(tmp_path) -> None:
+    """A leg that really ran owes both outputs, whatever marker it ends on."""
+    results_root = tmp_path / "res"
+    results_root.mkdir()
+    (results_root / "result.json").write_text('{"trial_name": "t"}')
+    summary, report = results_root / "s.json", tmp_path / "pr-x.md"
+
+    missing = skills_eval_agent.missing_renderer_outputs(
+        "BLOCKED: leg_report.py crashed", results_root, summary, report)
+    assert missing == [summary, report], (
+        "a crashed renderer on a real leg reported nothing owed"
+    )
+
+    summary.write_text("{}")
+    report.write_text("x")
+    assert not skills_eval_agent.missing_renderer_outputs(
+        "DONE: 1/1 specs passed", results_root, summary, report)
+
+
+def test_pretrial_blocked_owes_nothing(tmp_path) -> None:
+    """No trials and no DONE means a legitimate blocker; it stays green."""
+    results_root = tmp_path / "res"
+    results_root.mkdir()
+    assert not skills_eval_agent.missing_renderer_outputs(
+        "BLOCKED: pool exhausted", results_root,
+        results_root / "s.json", tmp_path / "pr-x.md")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,7 @@ jobs:
           uvx --python 3.12 --from "pytest==9.1.1" pytest \
             .github/skill-eval/tests/test_adapter_agent_timeout.py \
             .github/skill-eval/tests/test_leg_timing.py \
+            .github/skill-eval/tests/test_leg_report.py \
             .github/skill-eval/tests/test_python_runtime_contract.py \
             .github/skill-eval/tests/test_skills_eval_agent_protocol.py \
             .github/skill-eval/envs/tests/test_cancellation_recovery.py \


### PR DESCRIPTION
## Description

After `run_leg.py` returns, the outer coordinator agent read the results tree and rebuilt the result table by hand, following ~125 lines of `AGENTS.md` that described the layout and the `jq` needed to pull turns and token counts out of each trajectory. Across real Actions job logs that is p50 **114 s** over a median of 11 read-only tool calls, redone from scratch on every leg because the agent has no memory of the schema it parsed last time. Composing and posting the comment is another 7 s, so 94% of the phase is rediscovery. None of it is a judgement, so none of it needs a model.

This replaces it end to end:

* **`leg_report.py`** (new) collects the tree once and renders the same comment deterministically at p50 **0.59 ms**, and writes a versioned machine-readable summary (`leg-summary.json`) beside it.
* **`skills_eval_agent.py`** now hands the agent ONE command instead of the algorithm, tells it not to read the results tree, trajectories or `judge.json` itself, and points it at `leg-summary.json` for the verdict. Output goes to `$SCRATCH/pr-<spec>.md`, which is where the existing benchmark step already globs for it. **Both prompt branches are wired**: the PR leg and the nightly `DAILY_RUN` leg. They share one `render_block`/`verdict_block` so they cannot drift apart.
* **`AGENTS.md`** drops 1011 → 933 lines: the algorithm becomes a pointer at the renderer plus a table of the summary states. That block was in the *system prompt of every leg*, so it was both re-read and re-implemented each time.

Measured effect per leg: −114 s of wall-clock and ~958 fewer system-prompt tokens. Over the 1,177 legs in the last 8 days that is **−37.3 h** of runner time.

### How it got this way

**The harness was an LLM before it was CI.** At origin the README read: "The framework is run by a **long-running coordinator agent** (`AGENTS.md` is the playbook). You launch it once with `claude` + `/loop AGENTS.md`", and posting the comment was step 6 of that loop. Nobody decided a model should render this table. CI inherited an interactive agent, and the reporting step came along with it.

| date | PR | `§ Result comment` | what happened |
|---|---|---|---|
| 2026-04-28 | #183 | **37** | the harness lands. No `run_leg.py`, and no deterministic Python anywhere between the results tree and the comment |
| 2026-05-18 | #524 | 55 | |
| **2026-05-19** | **#563** | **119** | "include token usage / agent turns / duration per trial". `Turns` / `Prompt tok` / `Cached tok` exist only inside `trajectory.json`, so the instruction grew the `jq` to mine them |
| 2026-06-01 | #819 | 120 | matrix dispatch: one agent per *leg* instead of per *sweep*, multiplying the reporting cost by the leg count |
| 2026-06-03 | #936 | | `run_leg.py` arrives, the first deterministic wrapper to take work back out of the agent |
| 2026-08-20 | this PR | **51** | |

An agent was the right call in April. The Harbor schema was new enough that the judge probed four candidate trajectory filenames, and the comment was largely prose. #563 is where a template became an algorithm; its commit message argues carefully for *why those columns are worth having* and never asks who should render them. That is the whole story: each increment was individually reasonable and none was big enough to look like a decision.

It was then frozen deliberately. `matrix-dispatch-design.md` lists "result-comment format, per-trial metric extraction" under **"Unchanged on purpose"**, and defers the fix on a trigger that never fired: "if N per-spec comments prove noisy, add a thin `report` job later." Noise, not cost.

### Why this belongs in code

**It drifts.** On PR #819 alone the agent posted **four different table headers**, two of which (`| Platform | Result | Notes |` and `| Platform | Result | Details |`) appear in **no revision of `AGENTS.md`**, plus both `0h 21min` and `0hr 10min` for the same field. Replaying 1,177 legs also turned up the run-level `result.json` being mistaken for a trial, mixed aware/naive timestamps, per-step retries, and 480 rows rendering a raw `{{platform}}`. Those are the failure modes of re-deriving a schema 1,177 times instead of once.

**Part of it was never real.** `### Suggestions` instructed every leg to concatenate non-null `suggestion` fields from `$RES/<date>/<trial>/suggestions.json`. That file occurs **0 times in 1,177 legs**, and nothing in this repo writes it, or any `suggestion` field. It has been carried in the system prompt of every leg since April.

**There is no judgement in it.** `results tree -> markdown` is a pure function. The module deliberately emits no verdict, so the pass/fail decision stays with the coordinator where it belongs.

**The repo already works this way.** `plan_matrix.py` is documented as "Pure-Python, no LLM ... Unit-testable offline". `run_leg.py` took the box lock out of the agent. `AGENTS.md` already says "Trace URLs, read them, never build them". This applies the same rule to the one step that still kept the algorithm in the prompt.

### The module emits no verdict

It renders what Harbor recorded; the coordinator decides pass/fail from the summary. An earlier draft emitted a verdict too, and that one extra responsibility produced every serious defect review found: two real `AgentTimeoutError` trials rendered green, steps were counted while being labelled specs, and step accounting flipped 316 real single-step legs falsely red.

Rendering is fail-closed. `row_state()` returns `recorded-pass` only for a finite non-boolean reward exactly `1.0`, no exception, and judge evidence that is absent or well-formed and unanimous. An unreadable `judge.json` is not "no judge". Check counts must be real ints with `total > 0`, so `{"passed": 1, "total": 0}` and string counts are `ambiguous` rather than green. Multiple attempts where any lacks a timestamp are `ambiguous` rather than ordered, because undated-sorts-last is a convention and not a chronology. A spec that is named but unusable raises `SpecError` and exits 3 instead of silently collapsing a partial chain into a complete-looking comment.

The Query column shows what Harbor actually evaluated. Adapters substitute placeholders before execution, so `judge.json.query` is authoritative and the spec holds only a template; 46 of 50 specs contain placeholders and 480 replayed rows displayed a raw `{{platform}}`. Declared text is used only where no judge query exists, is labelled `(declared)`, and has `{{platform}}` filled in.

### Verification

Replayed over **1,177 real legs** (2026-08-13..20): 1,174 rendered, 0 exceptions. Per profile, against ground truth recomputed from the raw files, **0 mismatches** across alerts (320), detection (137), search (112), base (89), lvs (75), warehouse (42), ask-video (22), calibration (19). Fidelity against the coordinator's own recorded verdicts: 6/6.

The replay is also what found the run-level `result.json` being mistaken for a trial, mixed aware/naive timestamps, and per-step retries.

Two new tests construct each prompt and assert it delegates to the renderer. Nothing had ever built a prompt in a test, which is how a first pass that wired only the PR branch could look complete. Against `develop` both tests fail; against a PR-branch-only wiring the nightly one fails; both pass here.

`ruff` matches the `develop` baseline; copyright headers clean (7,411 files); the exact CI skill-eval command passes 110 tests.

### Run on a real leg, not just replayed

Replay proves the renderer agrees with recorded files. It cannot prove the wiring runs. So a genuine Harbor leg was executed end to end on an L40 dev box: real `BrevEnvironment`, real `claude-code` agent through the NVIDIA gateway, a real standalone deploy of `vss-behavior-analytics`, and a real verifier.

```
## Harbor Eval — `skills/vss-setup-behavior-analytics/evals/standalone_deploy.json`

Head: `66c02bca` · platform `ANY`
First started: `2026-08-21 00:06:53Z` · Last finished: `2026-08-21 00:12:24Z` · Total: `5m 31s`

| Platform | Result | Reward | Duration | Turns | Prompt tok | Cached tok | Trace |
|---|---|---|---|---|---|---|---|
| ANY | ✅ 1.0 (4/4) | 1.0 | 5m 31s | 12 | 54.5k | 482.7k | — |
```

`leg_report.py` exited 0 and rendered that in **0.13 s**, interpreter startup included, and wrote `leg-summary.json` beside it. `Turns` is populated here because a real run has `trajectory.json`; the uploaded artifact excludes it, which is why replayed samples show a dash.

The same leg is also a clean measurement of where leg time goes:

| phase | duration | share |
|---|---|---|
| environment_setup | 37 s | 11% |
| agent_setup | 1 s | 0% |
| **agent_execution** | **221 s** | **67%** |
| verifier | 59 s | 18% |

85% of it is LLM round-trips, and 537k input tokens of which 483k are cache reads. That is the same shape as the fleet-wide split across 1,177 legs (agent 69.1%, verifier 14.8%), and it is why the reporting tail was worth removing from the model.

Separately, the aggregation path was exercised for real: the exact command from the prompt was run verbatim against two result trees, and `build_benchmark_md()` picked up both bodies (`wrote benchmark.md (2 spec comments)`). Those two legs are `vss-deploy-profile` and `vss-search-archive`, which both ship a `search.json` and would previously have written the same `pr-search.md`.

### Scope note

Dataset generation still goes through the agent, because each adapter exposes a different CLI (`--skill-dir`, `--deploy-skill-dir`, `--spec`, `--platform` in varying combinations). Normalising that is separate work.

The new tests are registered in `ci.yml`, whose skill-eval step lists files explicitly; without that they would have existed and never run.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


## Measured after merge

Merged 2026-08-21T00:37:42Z. Window is the GitHub Actions job duration minus `run_leg`'s own `total_s`, i.e. everything after `run_leg` returns, which is where the comment rendering ran. Job duration is matched to each leg's `phase-timings.json` by `run_id` and slug, sampling legs either side of the merge commit.

| | n | p25 | p50 | p75 | max |
|---|---|---|---|---|---|
| before merge | 20 | 183.8 s | **220.3 s** | 322.0 s | 5205.1 s |
| after merge | 22 | 106.7 s | **119.5 s** | 196.3 s | 293.6 s |

**100.8 s per leg at p50.** The tail matters more than the median here: the worst case falls from 5205 s to 294 s.

The window measures more than the rendering (it also contains checkout, runner setup and artifact upload), so the delta is the result and the absolute is not. Measured independently from the phase timings the change itself emits, the rendering step alone goes from 113.6 s to 9.3 s, a 104 s delta, which agrees with the 100.8 s above to within 4 seconds.
