### PR TITLE
ci: add shruthiraghu23 to the copy-pr-bot vetter list

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -47,6 +47,7 @@ additional_vetters:
   - rahul3349
   - romalakar
   - sarathm-nvidia
+  - shruthiraghu23
   - shubham050300
   - simings-nv
   - soumilinandi


### PR DESCRIPTION
## Summary
Add `shruthiraghu23` to the copy-pr-bot `additional_vetters` list so this GitHub account can vet PRs.

## Plan
Insert the username in alphabetical order in `.github/copy-pr-bot.yaml` and open this PR.

## Related Issue
N/A

## Changes
- Add `shruthiraghu23` under `additional_vetters` in `.github/copy-pr-bot.yaml`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.

## Test plan
- [ ] Confirm `shruthiraghu23` appears under `additional_vetters` in `.github/copy-pr-bot.yaml`.
- [ ] Confirm the list remains alphabetically ordered.