### PR TITLE
style(vss-core): ruff format test_memory.py to unbreak Lint (Python)

### DIFF
--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_memory.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_memory.py
@@ -773,9 +773,7 @@ def test_upsert_bundle_counts_distinct_storage_ids_on_child_collision() -> None:
     assert parent.output is not None
     assert parent.output.ext is not None
     assert parent.output.ext["event_count"] == 1
-    assert service.get_record(
-        "summarize-collision", "event", "evt-72d73704a0ef2ce7"
-    ).output is not None
+    assert service.get_record("summarize-collision", "event", "evt-72d73704a0ef2ce7").output is not None
 
 
 def test_upsert_bundle_skips_children_when_parent_fails() -> None:


### PR DESCRIPTION
## Description

`Lint (Python)` has been failing on `develop` since #1725, and therefore on every PR opened since. The `ruff format` step reports:

```
unformatted: File would be reformatted
 --> packages/vss_core/tests/unit_test/memory/test_memory.py:1:1
1 file would be reformatted, 422 files already formatted
```

This is the output of `uv run ruff format` on that one file, nothing else. One assertion moves from a three-line wrap onto one line. The assertion itself is unchanged.

```diff
-    assert service.get_record(
-        "summarize-collision", "event", "evt-72d73704a0ef2ce7"
-    ).output is not None
+    assert service.get_record("summarize-collision", "event", "evt-72d73704a0ef2ce7").output is not None
```

Verified locally with the exact CI commands from `.github/workflows/ci.yml` (job `Lint (Python)`, working directory `services/agent`):

| command | before | after |
|---|---|---|
| `uv run ruff format --check .` | 1 file would be reformatted, 422 already formatted | **423 files already formatted** |
| `uv run ruff check .` | All checks passed | All checks passed |
| `pytest test_memory.py -k child_collision` | 1 passed | **1 passed** |

Sent as its own PR so it can be stamped and merged quickly: it unblocks the gate for every open PR, not just one.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
