### PR TITLE
feat(ci): build video summarization SBSA image

### DIFF
--- a/.github/scripts/test_detect_changed_images.py
+++ b/.github/scripts/test_detect_changed_images.py
@@ -241,9 +241,7 @@ class SelectImagesTest(unittest.TestCase):
             self.assertEqual(entry["source_path"], expected_fields["source_path"])
             if "native_platform_build" in expected_fields:
                 self.assertIs(entry["native_platform_build"], True)
-            self.assertEqual(
-                entry["platforms"], ["linux/amd64", "linux/arm64"]
-            )
+            self.assertEqual(entry["platforms"], ["linux/amd64", "linux/arm64"])
 
         va_entries, _ = dci.select_images(
             inventory, ["services/analytics/video-analytics-api/src/app.ts"]
@@ -536,6 +534,7 @@ class SelectImagesTest(unittest.TestCase):
                 "vss-vios-ingress",
                 "vss-rt-embed",
                 "vss-rt-embed-sbsa",
+                "vss-video-summarization-sbsa",
             },
         )
         self.assertNotIn(

--- a/deploy/docker/container-inventory.json
+++ b/deploy/docker/container-inventory.json
@@ -105,6 +105,20 @@
       "tag_variables": ["CONTAINER_IMAGE"]
     },
     {
+      "name": "vss-video-summarization-sbsa",
+      "strategy": "build",
+      "ghcr_build": true,
+      "source_path": "services/video-summarization",
+      "context": "services/video-summarization",
+      "dockerfile": "services/video-summarization/docker/Dockerfile",
+      "platforms": ["linux/arm64"],
+      "compose_image_names": [],
+      "repository": "vss-video-summarization",
+      "tag_suffix": "-sbsa",
+      "native_platform_build": true,
+      "notes": "Native ARM64 SBSA variant published in the shared GHCR package under -sbsa tags"
+    },
+    {
       "name": "vss-rt-vlm",
       "strategy": "build",
       "ghcr_build": true,

--- a/deploy/docker/container-inventory.json
+++ b/deploy/docker/container-inventory.json
@@ -113,6 +113,7 @@
       "dockerfile": "services/video-summarization/docker/Dockerfile",
       "platforms": ["linux/arm64"],
       "compose_image_names": [],
+      "tag_variables": [],
       "repository": "vss-video-summarization",
       "tag_suffix": "-sbsa",
       "native_platform_build": true,


### PR DESCRIPTION
Add a native linux/arm64 variant with dedicated -sbsa GHCR tags. Keep it separate from the generic multiarch manifest.

## Summary
- Add a native `linux/arm64` SBSA build variant for video summarization.
- Publish the variant in the existing `vss-video-summarization` GHCR package.
- Apply the `-sbsa` suffix to candidate, content, and moving tags.
- Keep the SBSA image separate from the generic multiarch manifest.

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
