### PR TITLE
Add nspect scan exclusion list in VIOS

### DIFF
--- a/services/vios/.nspect-allowlist.toml
+++ b/services/vios/.nspect-allowlist.toml
@@ -1,0 +1,18 @@
+version = "1.0.0"
+
+[oss]
+
+# if you are not adding excluded directories then remove [oss.excluded] and [[oss.excluded.directories]] both tag from file.
+[oss.excluded]
+
+# paths also accepts file paths, so a single lockfile can be excluded without
+# excluding the directories that contain it.
+[[oss.excluded.directories]]
+paths = ['test/bdd_tests/poetry.lock']
+comment = 'BDD automation test dependencies, not shipped'
+
+[[pulse-trufflehog.files]]
+file = "src/framework/database/include/database_schema.h"
+  [[pulse-trufflehog.files.secrets]]
+  type = "Password"
+  values = [ "pas**************ORD\"" ]


### PR DESCRIPTION
## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
