### PR TITLE
perf(skill-eval): keep model-weight caches across the per-trial docker reset

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -390,8 +390,9 @@ The canonical harbor command is in § Harbor invocation.
    `vss-eval-*` boxes are a long-running pool managed by the
    operator; instances stay up across runs, and so do the slow caches
    that survive a volume wipe (docker **image** layers, the repo clone, the
-   `data/` sample-data extract — but NOT the model-weight *volumes*, which
-   the per-trial reset drops; see § 7).
+   `data/` sample-data extract, and the NIM / `rtvi-hf-cache` /
+   `rtvi-ngc-model-cache` model-weight volumes, which the per-trial reset now
+   preserves; see § 7).
    `run_leg.py` releases the per-box lock automatically when its process
    exits; there is no shell FD for you to close. You never `brev stop` /
    `brev delete`. Pool lifecycle is strictly an operator concern.
@@ -400,8 +401,8 @@ The canonical harbor command is in § Harbor invocation.
    not on exit.** On a spec's first trial — a single-step spec, or `step-1`
    of a multi-step one — `BrevEnvironment.start()` (the env provider, before
    the agent runs) wipes the docker runtime to a clean slate: it force-removes
-   **all** containers, **all** user-defined networks, and **all** volumes
-   (images are preserved — re-pulling them is slow). So a spec always begins
+   **all** containers, **all** user-defined networks, and every volume except
+   the model-weight caches (images are preserved — re-pulling them is slow). So a spec always begins
    from a deterministic, leak-free runtime regardless of what the previous
    spec left — a leftover container from a *different* compose project used to
    port-conflict the new deploy (observed: a stuck `phoenix` + missing init
@@ -415,12 +416,13 @@ The canonical harbor command is in § Harbor invocation.
    You still do **not** tear anything down on *exit* — no `atexit`, no signal
    handler — and you never `brev stop` / `brev delete`; the *next* spec's
    `start()` is what cleans up, on every exit path (happy, `BLOCKED`, cancel,
-   max-turns, crash, SIGKILL, reboot). One consequence: wiping all volumes
-   drops the `rtvi-hf-cache` / `rtvi-ngc-model-cache` model-weight volumes, so
-   a spec's first deploy is cold (~20 min weight download vs ~55 s warm) under
-   the canonical `-n 1 --max-retries 0` invocation — paid once per spec; an
-   `-n>1` rollout or a harbor retry re-wipes the caches and re-pays it. The
-   per-trial harbor timeout already budgets for a cold deploy. The deploy
+   max-turns, crash, SIGKILL, reboot). The reset wipes every volume EXCEPT
+   the model-weight caches (`MODEL_CACHE_VOLUME_RE` in `envs/brev_env.py`:
+   the nine NIM `<model>_cache` volumes, `rtvi-hf-cache` and
+   `rtvi-ngc-model-cache`), so a spec's first deploy reuses weights another
+   spec already downloaded. Set `SKILL_EVAL_WIPE_MODEL_CACHES=1` to force the
+   old wipe-everything behaviour if a cache is suspected bad. The per-trial
+   harbor timeout still budgets for a cold deploy. The deploy
    runbook may still `docker compose down` defensively, but it no longer has to.
 
    ⚠️ **`start()` is now destructive on a spec's first trial — never run

--- a/.github/skill-eval/envs/brev_env.py
+++ b/.github/skill-eval/envs/brev_env.py
@@ -100,6 +100,35 @@ def _resolve_rtsp_sample_url() -> str:
     return os.environ.get("RTSP_SAMPLE_URL") or DEFAULT_RTSP_SAMPLE_URL
 
 
+# Model-weight caches, preserved across the per-trial reset; every other
+# volume is wiped. `(^|_)` because compose creates these as `<project>_<name>`.
+#
+# Named rather than pattern-matched: test_model_cache_preserved.py re-derives
+# this list from the compose files, so a new NIM missing here fails CI.
+#
+# Excluded: `rtvi-triton-model-repo` (assembled at deploy time, not
+# downloaded), `vios_apt_cache` (APT packages).
+#
+# `rtvi-ngc-model-cache` holds RT-VLM weights, populated only when the VLM runs
+# a local model; the default `openai-compat` mode proxies a remote endpoint and
+# writes nothing here. Its downloader treats directory existence as completion,
+# so a crash mid-copy can leave a partial model that the next deploy reuses;
+# recover with SKILL_EVAL_WIPE_MODEL_CACHES=1.
+MODEL_CACHE_VOLUME_RE = r"(^|_)(cosmos3_reasoner_cache|cosmos_reason1_7b_cache|cosmos_reason2_8b_cache|gpt_oss_20b_cache|llama_3\.3_nemotron_super_49b_v1\.5_cache|nemotron_3_nano_cache|nvidia_nemotron_nano_9b_v2_cache|nvidia_nemotron_nano_9b_v2_fp8_cache|qwen3_vl_8b_instruct_cache|rtvi\-hf\-cache|rtvi\-ngc\-model\-cache)$"
+
+
+def _wipe_model_caches() -> bool:
+    """Escape hatch: force the old behaviour of wiping model caches too.
+
+    A preserved cache is a cache that can go bad. If a corrupt or partial
+    download ever survives a reset it would follow the box across trials, and
+    the operator needs a way to clear it without editing code.
+    """
+    return os.environ.get("SKILL_EVAL_WIPE_MODEL_CACHES", "").strip().lower() in (
+        "1", "true", "yes",
+    )
+
+
 class BrevEnvironmentType(str, Enum):
     BREV = "brev"
 
@@ -417,7 +446,8 @@ class BrevEnvironment(BaseEnvironment):
         # Wipe the warm-pool box's docker runtime to a clean slate so no
         # prior trial's deployment state can contaminate this one. Images are
         # preserved (re-pulling the image set is slow); all containers,
-        # user-defined networks, and volumes are removed. See
+        # all user-defined networks, and every volume except the model-weight
+        # caches are removed. See
         # _reset_docker_runtime for why this is blanket, not VSS-scoped.
         #
         # Gate: ONLY on a spec's first trial — a single-step spec (task dir is
@@ -533,10 +563,11 @@ class BrevEnvironment(BaseEnvironment):
     async def _reset_docker_runtime(self) -> None:
         """Wipe the warm-pool box's docker runtime before the trial.
 
-        Removes **all** containers (running + stopped), **all** volumes
-        (named + anonymous), and **all** user-defined networks, while
+        Removes **all** containers (running + stopped), **all** user-defined
+        networks, and every volume EXCEPT the model-weight caches, while
         **preserving images** — re-pulling the multi-GB VSS/NIM image set on
-        every trial would dominate wall-clock.
+        every trial would dominate wall-clock, and the same argument applies
+        to the weights those images then download.
 
         Why blanket, not VSS-project-scoped: trials reach a deploy through
         heterogeneous paths — direct `docker compose --profile …`, the
@@ -551,16 +582,12 @@ class BrevEnvironment(BaseEnvironment):
         last trial deployed. Safe because `vss-eval-*` boxes are a dedicated,
         flock-serialised eval pool — nothing else runs on them.
 
-        NOTE: wiping all volumes also drops the model-weight caches
-        (`rtvi-hf-cache`, `rtvi-ngc-model-cache`), so the next deploy pays the
-        full cold model-weight download (~20 min vs ~55 s warm). The caller
-        gates this to a spec's first trial only (single-step, or step-1 of a
-        multi-step spec — later steps reuse step-1's deployment), so under the
-        canonical `-n 1 --max-retries 0` invocation (one trial per spec) the
-        cost is paid once per spec, not once per step. An `-n>1` rollout, a
-        harbor retry, or a repeated manual run on the same warm box each
-        re-wipes the caches and re-pays the cold start. The per-trial harbor
-        timeout already budgets for a cold deploy.
+        Model-weight caches (`MODEL_CACHE_VOLUME_RE`) are the exception.
+        Wiping them made every spec's first trial re-download weights another
+        spec had just fetched. Measured on an L40: cosmos-reason1-7b reaches
+        ready in 501 s cold against 319 s warm, a 9.4 GB cache.
+
+        Set `SKILL_EVAL_WIPE_MODEL_CACHES=1` to wipe them too.
 
         Runs as the normal (docker-group) user — the same identity the
         trial's deploy uses; no sudo. `network prune` leaves the built-in
@@ -570,10 +597,17 @@ class BrevEnvironment(BaseEnvironment):
         half-reset box surfaces as a trial error rather than silent cross-trial
         contamination.
         """
+        keep_re = MODEL_CACHE_VOLUME_RE if not _wipe_model_caches() else "$^"
         cmd = r"""set -uo pipefail
+KEEP_RE='__KEEP_RE__'
 docker info >/dev/null 2>&1 || { echo "docker daemon unreachable" >&2; exit 1; }
 cids=$(docker ps -aq); [ -n "$cids" ] && docker rm -f $cids >/dev/null 2>&1 || true
-vols=$(docker volume ls -q); [ -n "$vols" ] && docker volume rm -f $vols >/dev/null 2>&1 || true
+# Model-weight caches survive the wipe. Everything else goes, for the reasons
+# in the docstring. `grep -Ev` exits 1 on no match, hence the `|| true`;
+# without it `set -o pipefail` would abort a box whose only volumes are caches.
+vols=$(docker volume ls -q | grep -Ev "$KEEP_RE" || true)
+[ -n "$vols" ] && docker volume rm -f $vols >/dev/null 2>&1 || true
+kept=$(docker volume ls -q | grep -Ec "$KEEP_RE" || true)
 docker network prune -f >/dev/null 2>&1 || true
 # Re-confirm the daemon survived the reset. Without `set -e`, a daemon that
 # died mid-script would make the count commands below print nothing and the
@@ -581,7 +615,9 @@ docker network prune -f >/dev/null 2>&1 || true
 # this check, so the remaining TOCTOU window is negligible.
 docker info >/dev/null 2>&1 || { echo "docker daemon died during reset" >&2; exit 1; }
 rc=$(docker ps -aq | wc -l | tr -d ' ')
-rv=$(docker volume ls -q | wc -l | tr -d ' ')
+# Count only volumes that should be gone. Counting all of them would make the
+# guard fail on exactly the caches this reset now preserves.
+rv=$(docker volume ls -q | grep -Ev "$KEEP_RE" | wc -l | tr -d ' ')
 # Only user-defined networks should be gone; the built-in bridge/host/none
 # are never removable, so filter to type=custom. A surviving user network
 # would collide ("network already exists" / address-range clash) on the next
@@ -591,10 +627,11 @@ if [ "$rc" != "0" ] || [ "$rv" != "0" ] || [ "$rn" != "0" ]; then
   echo "docker runtime reset incomplete: ${rc} containers, ${rv} volumes, ${rn} user-defined networks remain" >&2
   exit 1
 fi
-echo "docker runtime reset OK; images preserved ($(docker images -q | wc -l | tr -d ' ') layers)"
-"""
+echo "docker runtime reset OK; images preserved ($(docker images -q | wc -l | tr -d ' ') layers), model-weight cache volumes kept (${kept})"
+""".replace("__KEEP_RE__", keep_re)
         logger.info(
-            "Resetting docker runtime (all containers/networks/volumes; images kept) on %s",
+            "Resetting docker runtime on %s (all containers/networks, all "
+            "volumes except model-weight caches; images kept)",
             self._instance_name,
         )
         result = await _run_brev_exec(self._instance_name, cmd, timeout=300)

--- a/.github/skill-eval/envs/tests/test_model_cache_preserved.py
+++ b/.github/skill-eval/envs/tests/test_model_cache_preserved.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The per-trial docker reset must keep model weights and wipe everything else.
+
+Wiping the weight caches made every spec's first trial re-download models it
+had just thrown away: ~20 min against ~55 s warm, 17.8 GB measured on a live
+deployment. These tests pin both halves of the bargain, because getting either
+one wrong is expensive in a different way: keep too little and the cold
+download comes back, keep too much and a stateful volume leaks into the next
+trial, which is the contamination the reset exists to prevent.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import types
+import unittest
+from pathlib import Path
+
+_base = types.ModuleType("harbor.environments.base")
+
+
+class _BaseEnvironment:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class _ExecResult:
+    def __init__(self, stdout=None, stderr=None, return_code=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.return_code = return_code
+
+
+_base.BaseEnvironment = _BaseEnvironment
+_base.ExecResult = _ExecResult
+sys.modules.setdefault("harbor", types.ModuleType("harbor"))
+sys.modules.setdefault("harbor.environments", types.ModuleType("harbor.environments"))
+sys.modules["harbor.environments.base"] = _base
+
+ENVS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ENVS_DIR))
+
+import brev_env  # noqa: E402
+
+KEEP = re.compile(brev_env.MODEL_CACHE_VOLUME_RE)
+
+# Real volume names. The NIM ones come from deploy/docker/services/nim/*,
+# the rtvi ones from services/rtvi/*, and the `mdx_` prefix is what compose
+# actually creates because none of them declare `name:`.
+PRESERVE = [
+    "rtvi-hf-cache",
+    "mdx_rtvi-hf-cache",
+    "rtvi-ngc-model-cache",
+    "mdx_rtvi-ngc-model-cache",
+    "cosmos_reason1_7b_cache",
+    "mdx_cosmos_reason1_7b_cache",
+    "cosmos_reason2_8b_cache",
+    "cosmos3_reasoner_cache",
+    "gpt_oss_20b_cache",
+    "llama_3.3_nemotron_super_49b_v1.5_cache",
+    "nemotron_3_nano_cache",
+    "nvidia_nemotron_nano_9b_v2_cache",
+    "nvidia_nemotron_nano_9b_v2_fp8_cache",
+    "qwen3_vl_8b_instruct_cache",
+]
+
+WIPE = [
+    "mdx_vss-data",                 # stateful; leaking it across trials is the bug
+    "vios_apt_cache",               # APT packages, not weights; the `_cache$` trap
+    "mdx_vios_apt_cache",
+    "rtvi-triton-model-repo",       # assembled at deploy time, not a download cache
+    "mdx_cameraModelFilepath",
+    "rtvi-hf-cache-old",            # trailing junk must not sneak past the anchor
+    "notrtvi-hf-cache",             # must be preceded by start-of-name or `_`
+    "cache",                        # bare word is not a model cache
+    "anonymous0123456789abcdef",
+]
+
+
+class WhichVolumesSurvive(unittest.TestCase):
+    def test_every_model_weight_cache_is_kept(self):
+        for name in PRESERVE:
+            with self.subTest(volume=name):
+                self.assertRegex(name, KEEP)
+
+    def test_everything_else_is_wiped(self):
+        for name in WIPE:
+            with self.subTest(volume=name):
+                self.assertNotRegex(name, KEEP)
+
+
+class TheResetScript(unittest.TestCase):
+    """Exercise the generated shell, not a paraphrase of it."""
+
+    def _script(self) -> str:
+        src = (ENVS_DIR / "brev_env.py").read_text()
+        start = src.index('r"""set -uo pipefail')
+        end = src.index('""".replace("__KEEP_RE__", keep_re)', start)
+        body = src[start + len('r"""'):end]
+        return body.replace("__KEEP_RE__", brev_env.MODEL_CACHE_VOLUME_RE)
+
+    def _run_selection(self, volumes: list[str]) -> tuple[list[str], list[str]]:
+        """Run the script's own keep/delete expressions against a fake list."""
+        script = self._script()
+        keep_line = next(ln for ln in script.splitlines()
+                         if ln.startswith("KEEP_RE="))
+        listing = "\n".join(volumes)
+        prog = (
+            f"{keep_line}\n"
+            f'vols=$(printf "%s\\n" "$LIST" | grep -Ev "$KEEP_RE" || true)\n'
+            f'kept=$(printf "%s\\n" "$LIST" | grep -E "$KEEP_RE" || true)\n'
+            'echo "---DELETE---"; echo "$vols"; echo "---KEEP---"; echo "$kept"'
+        )
+        out = subprocess.run(["bash", "-c", prog], capture_output=True, text=True,
+                             check=False,
+                             env={"LIST": listing, "PATH": "/usr/bin:/bin"}).stdout
+        delete, keep = out.split("---KEEP---")
+        delete = [x for x in delete.replace("---DELETE---", "").split("\n") if x]
+        keep = [x for x in keep.split("\n") if x]
+        return delete, keep
+
+    def test_the_shipped_script_keeps_and_wipes_the_right_volumes(self):
+        delete, keep = self._run_selection(PRESERVE + WIPE)
+        self.assertEqual(sorted(keep), sorted(PRESERVE))
+        self.assertEqual(sorted(delete), sorted(WIPE))
+
+    def test_a_box_holding_only_caches_does_not_abort(self):
+        """`grep -Ev` exits 1 on no match; with pipefail that would kill the reset."""
+        delete, keep = self._run_selection(PRESERVE)
+        self.assertEqual(delete, [])
+        self.assertEqual(sorted(keep), sorted(PRESERVE))
+
+    def test_the_guard_counts_only_volumes_that_should_be_gone(self):
+        """Otherwise the reset fails loud on the caches it just preserved."""
+        script = self._script()
+        guard = next(ln for ln in script.splitlines() if ln.startswith("rv="))
+        self.assertIn("grep -Ev", guard)
+
+    def test_the_escape_hatch_restores_the_old_behaviour(self):
+        from unittest import mock
+        with mock.patch.dict("os.environ", {"SKILL_EVAL_WIPE_MODEL_CACHES": "1"}):
+            self.assertTrue(brev_env._wipe_model_caches())
+        with mock.patch.dict("os.environ", {"SKILL_EVAL_WIPE_MODEL_CACHES": ""}):
+            self.assertFalse(brev_env._wipe_model_caches())
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TheAllowlistStaysInSyncWithCompose(unittest.TestCase):
+    """A NIM added without updating the allowlist must fail CI, not go slow.
+
+    The allowlist is named rather than matched on a name shape, so discovery
+    lives here: an omission fails CI instead of costing every leg that deploys
+    that model a re-download.
+    """
+
+    REPO = Path(__file__).resolve().parents[4]
+
+    def _nim_cache_volumes(self) -> set[str]:
+        found = set()
+        compose = list((self.REPO / "deploy" / "docker").rglob("*.yml"))
+        compose += list((self.REPO / "deploy" / "docker").rglob("*.yaml"))
+        for path in compose:
+            for line in path.read_text(errors="replace").splitlines():
+                line = line.strip().lstrip("- ").strip('"\'')
+                if ":/opt/nim/.cache" in line:
+                    found.add(line.split(":/opt/nim/.cache")[0])
+        return found
+
+    def test_every_nim_weight_cache_is_in_the_allowlist(self):
+        discovered = self._nim_cache_volumes()
+        self.assertTrue(discovered, "found no /opt/nim/.cache mounts; glob broke")
+        missing = sorted(v for v in discovered if not KEEP.search(v))
+        self.assertEqual(
+            missing, [],
+            f"NIM weight caches not covered by MODEL_CACHE_VOLUME_RE: {missing}. "
+            "Add them, or every leg deploying that model re-downloads it.",
+        )
+
+    def test_the_apt_cache_is_not_swept_up(self):
+        """The concrete volume that made a `_cache$` pattern unsafe."""
+        self.assertNotRegex("vios_apt_cache", KEEP)
+        self.assertNotRegex("mdx_vios_apt_cache", KEEP)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,7 @@ jobs:
             .github/skill-eval/tests/test_python_runtime_contract.py \
             .github/skill-eval/tests/test_skills_eval_agent_protocol.py \
             .github/skill-eval/envs/tests/test_cancellation_recovery.py \
+            .github/skill-eval/envs/tests/test_model_cache_preserved.py \
             .github/skill-eval/tests/test_run_leg.py::HarborCommand \
             .github/skill-eval/tests/test_run_leg.py::PhaseBudgets \
             .github/skill-eval/tests/test_run_leg.py::HarborEnvironment \


### PR DESCRIPTION
## Description

`BrevEnvironment._reset_docker_runtime` runs before a spec's **first** trial on a warm `vss-eval-*` box. It removed all containers, all user-defined networks and **all volumes**, preserving images. That included the model-weight caches, so a box that had just downloaded a model threw it away before the next spec asked for the same one.

This preserves the weight caches and still wipes everything else.

## Measured on an L40, cosmos-reason1-7b

| | time to `/v1/health/ready` |
|---|---|
| cold, cache wiped (today) | **501 s** |
| warm, cache preserved | **319 s** |
| **saved per NIM deploy** | **182 s** |

Cache size 9.4 GB. The image was already local in both runs, so this is weights only. The saving scales with weight bytes, so larger models save more.

This applies to legs that load a model on the box: `llm_mode=local`, and a VLM configured for local inference. A leg whose VLM runs in the default `openai-compat` mode downloads no weights and is unaffected.

## What is preserved

The nine NIM `<model>_cache` volumes, all mounted at `/opt/nim/.cache`, plus `rtvi-hf-cache` and `rtvi-ngc-model-cache`. Both have integrity machinery that makes a resumed cache safe: NIM verifies manifest checksums on download-to-cache, and `huggingface_hub` keeps interrupted blobs as `.incomplete` files outside the committed snapshot.

`MODEL_CACHE_VOLUME_RE` is an exact allowlist. A test re-derives it from the compose files, so a NIM added without updating the list fails CI rather than silently costing every leg that deploys it three minutes.

`rtvi-ngc-model-cache`'s downloader treats directory existence as completion, so a crash mid-copy can leave a partial model that the next deploy reuses. `SKILL_EVAL_WIPE_MODEL_CACHES=1` clears it.

## What is not preserved

- **`rtvi-triton-model-repo`** — assembled at deploy time rather than downloaded; a stale copy changes what a trial exercises.
- **`vios_apt_cache`** — APT packages, not weights.

Everything else is still wiped blanket, because trials reach a deploy through heterogeneous compose project names and a scoped teardown cannot reach a predecessor's stack. The post-reset guard, which asserted that zero volumes remain, now counts only volumes that should be gone.

`SKILL_EVAL_WIPE_MODEL_CACHES=1` restores the full wipe.

## Cache lifetime

The volume name is not version-keyed (`cosmos_reason1_7b_cache` while the image is `:1.4.1`), so a tag bump downloads the new weights into the same volume. Tags are pinned and bump rarely, so a box stays warm until it is recreated. The fleet dashboard tracks `vss_fleet_disk_used_pct`.

## Verification

Keep/delete selection and the guard are tested against real volume names under `bash`, including a box whose only volumes are caches, a non-cache volume surviving, and the escape hatch. 54 skill-eval env tests pass; copyright headers clean; `ruff` on `brev_env.py` matches `develop`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
