### PR TITLE
chore(ci): drop the retired has_ghcr_build_entries gate signal

### DIFF
--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -57,8 +57,7 @@ def downstream_relevant(changed: list[str] | None, inventory: dict) -> tuple[boo
         OR deploy/ changed
 
     Scoped on what *changed*, not on what got built. The previous gate keyed off
-    has_ghcr_build_entries -- "did any GHCR image get rebuilt" -- which is a poor
-    proxy twice over: build avoidance means a real source change can rebuild
+    "did any GHCR image get rebuilt", which is a poor proxy twice over: build avoidance means a real source change can rebuild
     nothing, and deploy-only changes never rebuild anything yet are exactly what
     acceptance exists to catch. Config and deploy edits were getting no
     downstream coverage at all.
@@ -93,15 +92,6 @@ def downstream_relevant(changed: list[str] | None, inventory: dict) -> tuple[boo
     if reasons:
         return True, "; ".join(reasons)
     return False, "no watched source or deploy/ change"
-
-
-def has_ghcr_build_entries(release_set: dict) -> bool:
-    """Whether downstream has newly built GHCR images to accept/promote."""
-    return any(
-        image.get("strategy") == "build"
-        and str(image.get("image", "")).startswith("ghcr.io/")
-        for image in release_set.get("images", [])
-    )
 
 
 def candidate_container_tag(release_set: dict) -> str:
@@ -188,8 +178,6 @@ def main() -> int:
             json.dumps(release_set, indent=2, sort_keys=True) + "\n"
         )
 
-    has_builds = has_ghcr_build_entries(release_set)
-
     if PR_REF_PATTERN.fullmatch(args.ref_name):
         try:
             base = pr_merge_base_sha(GitHubApi(token), args.repository, args.ref_name)
@@ -217,14 +205,10 @@ def main() -> int:
 
     if github_output:
         with Path(github_output).open("a") as output:
-            output.write(
-                f"has_ghcr_build_entries={'true' if has_builds else 'false'}\n"
-            )
             output.write(f"run_downstream={'true' if run_downstream else 'false'}\n")
     print(
         f"Prepared release set {release_set['release_set_id']} "
-        f"for downstream acceptance ({len(release_set['images'])} images, "
-        f"GHCR builds: {'yes' if has_builds else 'no'}).\n"
+        f"for downstream acceptance ({len(release_set['images'])} images).\n"
         f"Downstream gate: {'run' if run_downstream else 'skip'} "
         f"-- {gate_reason} (base: {base_reason})."
     )

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -23,46 +23,6 @@ from prepare_downstream_release_set import (  # noqa: E402
 )
 
 
-class GhcrBuildEntriesTest(unittest.TestCase):
-    def test_requires_new_ghcr_build(self):
-        self.assertTrue(
-            module.has_ghcr_build_entries(
-                {
-                    "images": [
-                        {
-                            "strategy": "build",
-                            "image": "ghcr.io/nvidia/vss-agent",
-                        }
-                    ]
-                }
-            )
-        )
-        self.assertFalse(
-            module.has_ghcr_build_entries(
-                {
-                    "images": [
-                        {
-                            "strategy": "reuse-pinned",
-                            "image": "ghcr.io/nvidia/vss-agent",
-                        }
-                    ]
-                }
-            )
-        )
-        self.assertFalse(
-            module.has_ghcr_build_entries(
-                {
-                    "images": [
-                        {
-                            "strategy": "build",
-                            "image": "nvcr.io/nvidia/vss-agent",
-                        }
-                    ]
-                }
-            )
-        )
-
-
 class PrMergeBaseShaTest(unittest.TestCase):
     def test_uses_compare_merge_base_not_target_tip(self):
         target = "b" * 40
@@ -175,7 +135,6 @@ class DownstreamVariablesTest(unittest.TestCase):
             )
             self.assertEqual(
                 output_path.read_text(),
-                "has_ghcr_build_entries=false\n"
                 "run_downstream=false\n",
             )
             self.assertEqual(json.loads(release_output_path.read_text()), release_set)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,8 @@ jobs:
           )
 
           # Folders that warrant a downstream acceptance run on their own.
-          # Image sources are absent by design: a container source change
-          # surfaces as trigger-from-new-image once the image is built, and
+          # Image sources are absent by design: a container source change is
+          # already picked up by the per-image source_path check, and
           # containers this repo does not build cannot invalidate a deployed
           # artifact from a source edit alone.
           DOWNSTREAM_TRIGGER_PATHS = ["deploy"]
@@ -1496,8 +1496,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 140
     outputs:
-      trigger-from-new-image: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
-      has-ghcr-build-entries: ${{ steps.release-set.outputs.has_ghcr_build_entries }}
       run-downstream: ${{ steps.release-set.outputs.run_downstream }}
     permissions:
       actions: read


### PR DESCRIPTION
## Description

`has_ghcr_build_entries` was the **previous** downstream acceptance gate. It was replaced by `run_downstream`, and the replacement's own docstring records why:

> Scoped on what *changed*, not on what got built. The previous gate keyed off "did any GHCR image get rebuilt", which is a poor proxy twice over: build avoidance means a real source change can rebuild nothing, and deploy-only changes never rebuild anything yet are exactly what acceptance exists to catch.

The signal survived the replacement. `ci.yml` still exports it as **two** job outputs — `trigger-from-new-image` and `has-ghcr-build-entries` — and **nothing reads either one**, in this repo or in `ci-vss-oss`. The only remaining mentions were the exports, one comment, the function, and its tests.

Removed: both job outputs, `has_ghcr_build_entries()`, its call, its `GITHUB_OUTPUT` line, and its tests. `run_downstream` — the live gate consumed at `ci.yml:1585` — is untouched.

Also corrected the comment that described a container source change as "surfacing as `trigger-from-new-image` once the image is built", since that path no longer exists; the per-image `source_path` check is what covers it now.

## Plan

**Tracking:** none — CI maintenance, `no-tracking-ref`.

**Goal:** the downstream gate has one signal instead of one live signal plus a retired one that two job outputs still advertise.

**Decisions**

| # | Question | I recommended | Decided |
|---|----------|---------------|---------|
| Q1 | Is it safe to remove? | Yes — no consumer in either repo | Remove |
| Q2 | Keep the docstring rationale that names the retired signal? | Keep the reasoning, drop the stale identifier, so the *why* survives without referring to code that no longer exists | Keep reworded |

**Steps**

1. Prove nothing consumes it → verify: `git grep` across the VSS repo and `ci-vss-oss` returns only the exports, a comment, the function and its tests.
2. Remove the outputs, function, call, output line and tests → verify: no residual references anywhere under `.github/`.
3. Prove nothing regressed → verify: `ci.yml` parses; `prepare_downstream_release_set`, `release_set`, `update_pr_ghcr_candidates` and `trigger_downstream_pipeline` suites all pass.

**Out of scope**

- `run_downstream` and `downstream_relevant()` — the live gate, unchanged.
- The release-set assemble/validate/upload path. It is still exercised on every build, and now that #1727 removed the last-green controller its only consumers are this gate and the PR candidates comment. Whether the schema-validated manifest still earns its keep is a design question, not a drive-by removal.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes. — obsolete tests removed with the function; four neighbouring suites pass.
- [ ] The documentation is up to date with these changes. — n/a beyond the comment fix included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
