### PR TITLE
fix(rtvi-vlm): add RTVI_VLLM_MM_PROCESSOR_CACHE_GB variable to overri…

### DIFF
--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -144,6 +144,7 @@ SENSOR_INFO_SOURCE=nvstreamer
 # RTVI CONFIGURATION
 # =============================================================================
 RTVI_VLLM_GPU_MEMORY_UTILIZATION='0.8'
+RTVI_VLLM_MM_PROCESSOR_CACHE_GB=0
 # Uncomment RTVI_VLM_MAX_MODEL_LEN=18000 when using RTXPRO4500BW (32 GB) for COMPOSE_PROFILES=${COMPOSE_PROFILES_WH_2D} which deploys vss-rtvi-vlm:
 # cap RT-VLM context so the KV cache can be allocated.
 # RTVI_VLM_MAX_MODEL_LEN=18000


### PR DESCRIPTION
…des.env

This change introduces the RTVI_VLLM_MM_PROCESSOR_CACHE_GB variable, setting it to 0, to enhance the configuration for the RTVI VLM model. This addition aims to improve memory management during processing.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
