### PR TITLE
refactor(ci): drop the GHCR candidates comment and the gate's release-set read

### DIFF
--- a/.github/scripts/github_build_run.py
+++ b/.github/scripts/github_build_run.py
@@ -1,29 +1,24 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Publish immutable GHCR candidate coordinates after downstream CI passes."""
+"""Locate and await the Build Dev Images run that publishes a commit's GHCR set.
+
+Shared by the downstream gate. Polls the workflow-run API for the run matching an
+exact commit and ref, and reports success only on a terminal successful conclusion.
+"""
 from __future__ import annotations
 
-import argparse
-import io
 import json
 import os
 import re
-import sys
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
-import zipfile
-from pathlib import Path
 from typing import Any
 
-MARKER = "<!-- vss-ghcr-candidates -->"
 API_ROOT = "https://api.github.com"
-COMMENT_PAGE_SIZE = 100
-MAX_COMMENT_PAGES = 100
 MAX_API_RESPONSE_BYTES = 64 * 1024 * 1024
-MAX_RELEASE_SET_BYTES = 8 * 1024 * 1024
 
 
 class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -80,68 +75,6 @@ def enforce_memory_ceiling() -> None:
     if hard != resource.RLIM_INFINITY:
         requested = min(requested, hard)
     resource.setrlimit(resource.RLIMIT_AS, (requested, requested))
-
-
-def pr_number(ref_name: str) -> int | None:
-    match = re.fullmatch(r"pull-request/(\d+)", ref_name)
-    return int(match.group(1)) if match else None
-
-
-def candidate_entries(release_set: dict[str, Any]) -> list[dict[str, Any]]:
-    return sorted(
-        (
-            entry
-            for entry in release_set.get("images", [])
-            if entry.get("strategy") == "build"
-            and str(entry.get("image", "")).startswith("ghcr.io/")
-        ),
-        key=lambda entry: str(entry.get("name", "")),
-    )
-
-
-def moving_alias(tag: str) -> str:
-    suffix_pattern = r"(?P<suffix>-[A-Za-z0-9_.-]+)?"
-    match = re.fullmatch(rf"develop-[0-9a-f]{{7,40}}{suffix_pattern}", tag)
-    if match:
-        return f"develop-latest{match.group('suffix') or ''}"
-    match = re.fullmatch(
-        rf"pr-(?P<number>\d+)-[0-9a-f]{{7,40}}{suffix_pattern}",
-        tag,
-    )
-    if not match:
-        return ""
-    return f"pr-{match.group('number')}-latest{match.group('suffix') or ''}"
-
-
-def render_comment(release_set: dict[str, Any], sha: str) -> str:
-    entries = candidate_entries(release_set)
-    lines = [
-        MARKER,
-        "## GHCR candidates validated downstream",
-        "",
-        f"Downstream validation passed for commit `{sha}`.",
-        f"Release set: `{release_set.get('release_set_id', 'unknown')}`",
-        "",
-    ]
-    if not entries:
-        lines.append("No GHCR image was rebuilt for this commit.")
-    else:
-        lines.append("Immutable candidates:")
-        for entry in entries:
-            lines.append(
-                f"- `{entry['name']}`: "
-                f"`{entry['image']}:{entry['tag']}@{entry['digest']}`"
-            )
-            alias = moving_alias(str(entry["tag"]))
-            if alias:
-                lines.append(f"  - developer alias: `{entry['image']}:{alias}`")
-    lines.extend(
-        [
-            "",
-            "These tags are immutable. Promotion copies the same manifest digests to NGC; it does not rebuild them.",
-        ]
-    )
-    return "\n".join(lines)
 
 
 class GitHubApi:
@@ -227,7 +160,7 @@ def select_release_set_run(
     )
 
 
-def download_release_set(
+def await_build_run(
     api: GitHubApi,
     repository: str,
     sha: str,
@@ -235,6 +168,12 @@ def download_release_set(
     attempts: int,
     interval_seconds: int,
 ) -> dict[str, Any]:
+    """Block until Build Dev Images succeeds for this exact commit and ref.
+
+    Returns the run. Raises on a terminal failure conclusion, or once the
+    polling budget is exhausted. The run's success is the completion signal:
+    the release set it publishes is consumed inside that workflow, not here.
+    """
     query = urllib.parse.urlencode(
         {"head_sha": sha, "branch": ref_name, "per_page": 100}
     )
@@ -260,7 +199,7 @@ def download_release_set(
                 # has finished and will never publish a release set.
                 raise RuntimeError(
                     f"GHCR build run {run.get('id')} for {sha[:12]} on {ref_name} "
-                    f"concluded {conclusion!r}; it will not produce a release set. "
+                    f"concluded {conclusion!r}; its GHCR images were not published. "
                     f"See {run.get('html_url') or 'the Build Dev Images run'}."
                 )
             # Present but not finished: keep waiting.
@@ -280,138 +219,6 @@ def download_release_set(
             f"{interval_seconds}s intervals"
         )
 
-    return download_release_set_artifact(api, repository, int(run["id"]))
+    return run
 
 
-def download_release_set_artifact(
-    api: GitHubApi, repository: str, run_id: int
-) -> dict[str, Any]:
-    artifacts = api.request(
-        "GET",
-        f"/repos/{repository}/actions/runs/{run_id}/artifacts?per_page=100",
-    ).get("artifacts", [])
-    artifact = next(
-        (
-            item
-            for item in artifacts
-            if item.get("name") == "release-set" and not item.get("expired")
-        ),
-        None,
-    )
-    if artifact is None:
-        raise RuntimeError(f"release-set artifact missing from workflow run {run_id}")
-
-    archive = api.request("GET", artifact["archive_download_url"])
-    with zipfile.ZipFile(io.BytesIO(archive)) as bundle:
-        matches = [name for name in bundle.namelist() if name.endswith("release-set.json")]
-        if len(matches) != 1:
-            raise RuntimeError("release-set artifact has an unexpected shape")
-        if bundle.getinfo(matches[0]).file_size > MAX_RELEASE_SET_BYTES:
-            raise RuntimeError("release-set artifact is too large")
-        return json.loads(bundle.read(matches[0]))
-
-
-def upsert_comment(
-    api: GitHubApi, repository: str, number: int, body: str
-) -> None:
-    existing: dict[str, Any] | None = None
-    seen_comment_ids: set[Any] = set()
-    for page in range(1, MAX_COMMENT_PAGES + 1):
-        comments = api.request(
-            "GET",
-            f"/repos/{repository}/issues/{number}/comments"
-            f"?per_page={COMMENT_PAGE_SIZE}&page={page}",
-        )
-        if not isinstance(comments, list):
-            raise RuntimeError("GitHub comments response was not a list")
-        page_ids = {
-            comment.get("id")
-            for comment in comments
-            if isinstance(comment, dict) and comment.get("id") is not None
-        }
-        if page_ids and page_ids.issubset(seen_comment_ids):
-            raise RuntimeError("GitHub comment pagination repeated a page")
-        seen_comment_ids.update(page_ids)
-        existing = next(
-            (
-                comment
-                for comment in comments
-                if MARKER in str(comment.get("body", ""))
-            ),
-            None,
-        )
-        if existing is not None or len(comments) < COMMENT_PAGE_SIZE:
-            break
-    else:
-        raise RuntimeError(
-            f"GitHub comment pagination exceeded {MAX_COMMENT_PAGES} pages"
-        )
-    if existing:
-        api.request(
-            "PATCH",
-            f"/repos/{repository}/issues/comments/{existing['id']}",
-            {"body": body},
-        )
-        print(f"Updated GHCR candidate comment on PR #{number}.")
-    else:
-        api.request(
-            "POST",
-            f"/repos/{repository}/issues/{number}/comments",
-            {"body": body},
-        )
-        print(f"Created GHCR candidate comment on PR #{number}.")
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
-    parser.add_argument("--sha", default=os.environ.get("GITHUB_SHA", ""))
-    parser.add_argument("--ref-name", default=os.environ.get("GITHUB_REF_NAME", ""))
-    parser.add_argument("--attempts", type=int, default=20)
-    parser.add_argument("--interval-seconds", type=int, default=15)
-    parser.add_argument("--release-set", type=Path)
-    parser.add_argument("--dry-run", action="store_true")
-    args = parser.parse_args()
-
-    number = pr_number(args.ref_name)
-    if number is None:
-        print(f"{args.ref_name!r} is not a synthetic PR ref; nothing to update.")
-        return 0
-    token = os.environ.get("GITHUB_TOKEN", "").strip()
-    api = GitHubApi(token) if token else None
-    if args.release_set:
-        release_set = json.loads(args.release_set.read_text())
-    else:
-        if api is None or not args.repository or not args.sha:
-            raise SystemExit("GITHUB_TOKEN, repository, and SHA are required")
-        release_set = download_release_set(
-            api,
-            args.repository,
-            args.sha,
-            args.ref_name,
-            args.attempts,
-            args.interval_seconds,
-        )
-    if release_set.get("source", {}).get("commit") != args.sha:
-        raise RuntimeError("release-set source commit does not match downstream SHA")
-    body = render_comment(release_set, args.sha)
-    if args.dry_run:
-        print("[ghcr-candidate-reporter] DRY RUN comment body:")
-        print(body)
-        return 0
-    if api is None:
-        raise SystemExit("GITHUB_TOKEN is required unless --dry-run is used")
-    upsert_comment(api, args.repository, number, body)
-    return 0
-
-
-if __name__ == "__main__":
-    try:
-        enforce_memory_ceiling()
-        raise SystemExit(main())
-    except Exception as exc:
-        print(
-            f"[ghcr-candidate-reporter] ERROR {type(exc).__name__}: {exc}",
-            file=sys.stderr,
-        )
-        raise

--- a/.github/scripts/prepare_downstream_release_set.py
+++ b/.github/scripts/prepare_downstream_release_set.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Wait for this commit's GHCR release set and pass it to downstream CI."""
+"""Gate and parameterise the downstream acceptance run for this commit.
+
+Waits for Build Dev Images to succeed, decides whether downstream is
+warranted from what changed, and emits the variables the GitLab pipeline
+reads. The release set itself is consumed inside the build workflow (it
+drives the candidate alias publication); nothing is fetched here.
+"""
 from __future__ import annotations
 
 import argparse
@@ -16,8 +22,8 @@ from detect_changed_images import (
     commit_exists,
     resolve_diff_base,
 )
-from release_set import load_inventory, validate_release_set
-from update_pr_ghcr_candidates import GitHubApi, download_release_set
+from github_build_run import GitHubApi, await_build_run
+from release_set import load_inventory
 
 
 DEPLOY_PREFIX = "deploy/"
@@ -94,26 +100,27 @@ def downstream_relevant(changed: list[str] | None, inventory: dict) -> tuple[boo
     return False, "no watched source or deploy/ change"
 
 
-def candidate_container_tag(release_set: dict) -> str:
-    """Return the shared immutable GHCR tag published for this release set."""
-    source = release_set.get("source") or {}
-    commit = str(source.get("commit") or "")
-    if not re.fullmatch(r"[0-9a-f]{40}", commit):
-        raise ValueError("release-set source commit must be a 40-hex SHA")
+def candidate_container_tag(ref_name: str, sha: str) -> str:
+    """The shared immutable GHCR tag this ref publishes for every image.
 
-    ref = str(source.get("ref") or "")
-    if ref == "develop":
+    Same scheme as container_build_plan.py: the build tags every GHCR image
+    with it, including ones it did not rebuild, so a consumer can derive the
+    coordinate from the ref and commit alone.
+    """
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise ValueError("commit must be a 40-hex SHA")
+    if ref_name == "develop":
         prefix = "develop"
-    elif match := re.fullmatch(r"pull-request/(\d+)", ref):
+    elif match := PR_REF_PATTERN.fullmatch(ref_name):
         prefix = f"pr-{match.group(1)}"
     else:
         raise ValueError(
-            f"release-set source ref {ref!r} does not publish a shared candidate tag"
+            f"ref {ref_name!r} does not publish a shared candidate tag"
         )
-    return f"{prefix}-{commit[:12]}"
+    return f"{prefix}-{sha[:12]}"
 
 
-def downstream_variables(release_set: dict) -> dict[str, str]:
+def downstream_variables(ref_name: str, sha: str) -> dict[str, str]:
     """Variables the downstream GitLab pipeline actually reads.
 
     The release set itself is no longer sent. ci-vss-oss retired every
@@ -124,7 +131,7 @@ def downstream_variables(release_set: dict) -> dict[str, str]:
     """
     return {
         "BUILD_TYPE": "ghcr-acceptance",
-        "VSS_CONTAINER_TAG": candidate_container_tag(release_set),
+        "VSS_CONTAINER_TAG": candidate_container_tag(ref_name, sha),
     }
 
 
@@ -137,8 +144,6 @@ def main() -> int:
     parser.add_argument("--before", default=os.environ.get("GITHUB_EVENT_BEFORE", ""))
     parser.add_argument("--attempts", type=int, default=240)
     parser.add_argument("--interval-seconds", type=int, default=15)
-    parser.add_argument("--release-set", type=Path)
-    parser.add_argument("--release-set-output", type=Path)
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN", "").strip()
@@ -149,34 +154,16 @@ def main() -> int:
             "SHA and GITHUB_ENV are required"
         )
 
-    if args.release_set:
-        release_set = json.loads(args.release_set.read_text())
-    else:
-        if not token or not args.repository:
-            raise SystemExit(
-                "GITHUB_TOKEN and repository are required without --release-set"
-            )
-        release_set = download_release_set(
-            GitHubApi(token),
-            args.repository,
-            args.sha,
-            args.ref_name,
-            args.attempts,
-            args.interval_seconds,
-        )
-    if release_set.get("source", {}).get("commit") != args.sha:
-        raise RuntimeError("release-set source commit does not match downstream SHA")
-    problems = validate_release_set(
-        release_set, load_inventory(Path.cwd())
+    if not token or not args.repository:
+        raise SystemExit("GITHUB_TOKEN and repository are required")
+    await_build_run(
+        GitHubApi(token),
+        args.repository,
+        args.sha,
+        args.ref_name,
+        args.attempts,
+        args.interval_seconds,
     )
-    if problems:
-        raise RuntimeError("invalid release set: " + "; ".join(problems))
-
-    if args.release_set_output:
-        args.release_set_output.parent.mkdir(parents=True, exist_ok=True)
-        args.release_set_output.write_text(
-            json.dumps(release_set, indent=2, sort_keys=True) + "\n"
-        )
 
     if PR_REF_PATTERN.fullmatch(args.ref_name):
         try:
@@ -197,7 +184,7 @@ def main() -> int:
     )
     run_downstream = relevant
 
-    variables = downstream_variables(release_set)
+    variables = downstream_variables(args.ref_name, args.sha)
     with Path(github_env).open("a") as output:
         output.write("DOWNSTREAM_EXTRA_VARIABLES_JSON<<EOF\n")
         output.write(json.dumps(variables, separators=(",", ":")) + "\n")
@@ -207,8 +194,7 @@ def main() -> int:
         with Path(github_output).open("a") as output:
             output.write(f"run_downstream={'true' if run_downstream else 'false'}\n")
     print(
-        f"Prepared release set {release_set['release_set_id']} "
-        f"for downstream acceptance ({len(release_set['images'])} images).\n"
+        f"Downstream acceptance for {args.sha[:12]} on {args.ref_name}.\n"
         f"Downstream gate: {'run' if run_downstream else 'skip'} "
         f"-- {gate_reason} (base: {base_reason})."
     )
@@ -220,7 +206,7 @@ if __name__ == "__main__":
         raise SystemExit(main())
     except Exception as exc:
         print(
-            f"[downstream-release-set] ERROR {type(exc).__name__}: {exc}",
+            f"[downstream-gate] ERROR {type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
         raise

--- a/.github/scripts/test_github_build_run.py
+++ b/.github/scripts/test_github_build_run.py
@@ -11,19 +11,14 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-SCRIPT = Path(__file__).with_name("update_pr_ghcr_candidates.py")
-SPEC = importlib.util.spec_from_file_location("update_pr_ghcr_candidates", SCRIPT)
+SCRIPT = Path(__file__).with_name("github_build_run.py")
+SPEC = importlib.util.spec_from_file_location("github_build_run", SCRIPT)
 assert SPEC and SPEC.loader
 module = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(module)
 
 
-class CandidateCommentTest(unittest.TestCase):
-    def test_pr_number_only_accepts_synthetic_ref(self):
-        self.assertEqual(module.pr_number("pull-request/1190"), 1190)
-        self.assertIsNone(module.pr_number("develop"))
-        self.assertIsNone(module.pr_number("pull-request/not-a-number"))
-
+class GitHubApiTest(unittest.TestCase):
     def test_select_release_set_run_requires_exact_ref_and_sha(self):
         """Exact match only; conclusion is the caller's business, not the selector's."""
         runs = [
@@ -67,48 +62,6 @@ class CandidateCommentTest(unittest.TestCase):
             module.select_release_set_run(runs, "a" * 40, "pull-request/1190")["id"], 2
         )
 
-
-    def test_comment_lists_only_immutable_ghcr_builds(self):
-        release_set = {
-            "release_set_id": "sha256:" + "1" * 64,
-            "images": [
-                {
-                    "name": "vss-agent",
-                    "strategy": "build",
-                    "image": "ghcr.io/nvidia-ai-blueprints/vss/vss-agent",
-                    "tag": "pr-1190-deadbeef",
-                    "digest": "sha256:" + "2" * 64,
-                },
-                {
-                    "name": "vss-configurator",
-                    "strategy": "reuse-pinned",
-                    "image": "nvcr.io/nvidia/vss-core/vss-configurator",
-                    "tag": "3.2.1",
-                    "digest": None,
-                },
-            ],
-        }
-        body = module.render_comment(release_set, "a" * 40)
-        self.assertIn(module.MARKER, body)
-        self.assertIn("ghcr.io/nvidia-ai-blueprints/vss/vss-agent", body)
-        self.assertIn("pr-1190-latest", body)
-        self.assertNotIn("vss-configurator", body)
-        self.assertIn("does not rebuild", body)
-
-    def test_moving_alias_derives_from_immutable_tag(self):
-        self.assertEqual(module.moving_alias("develop-deadbeef"), "develop-latest")
-        self.assertEqual(
-            module.moving_alias("pr-1190-deadbeef"), "pr-1190-latest"
-        )
-        self.assertEqual(
-            module.moving_alias("develop-deadbeef-sbsa"),
-            "develop-latest-sbsa",
-        )
-        self.assertEqual(
-            module.moving_alias("pr-1190-deadbeef-sbsa"),
-            "pr-1190-latest-sbsa",
-        )
-        self.assertEqual(module.moving_alias("release-3.2.0"), "")
 
     def test_github_network_adapter_is_injected(self):
         requests = []
@@ -233,96 +186,6 @@ class CandidateCommentTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "exceeded 4 bytes"):
                 api.request("GET", "/example")
 
-    def test_main_dry_run_needs_no_network(self):
-        sha = "a" * 40
-        release_set = {
-            "release_set_id": "sha256:" + "1" * 64,
-            "source": {"commit": sha},
-            "images": [],
-        }
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "release-set.json"
-            path.write_text(json.dumps(release_set))
-            argv = [
-                "update_pr_ghcr_candidates.py",
-                "--repository",
-                "org/repo",
-                "--sha",
-                sha,
-                "--ref-name",
-                "pull-request/1190",
-                "--release-set",
-                str(path),
-                "--dry-run",
-            ]
-            with mock.patch("sys.argv", argv), mock.patch.dict(
-                os.environ, {}, clear=True
-            ):
-                self.assertEqual(module.main(), 0)
-
-    def test_upsert_comment_finds_marker_after_first_page(self):
-        class FakeApi:
-            def __init__(self):
-                self.calls = []
-
-            def request(self, method, path, payload=None):
-                self.calls.append((method, path, payload))
-                if method == "GET" and path.endswith("&page=1"):
-                    return [{"id": index, "body": "other"} for index in range(100)]
-                if method == "GET" and path.endswith("&page=2"):
-                    return [{"id": 999, "body": module.MARKER}]
-                return {}
-
-        api = FakeApi()
-        module.upsert_comment(api, "org/repo", 1190, "updated")
-        self.assertIn(
-            (
-                "PATCH",
-                "/repos/org/repo/issues/comments/999",
-                {"body": "updated"},
-            ),
-            api.calls,
-        )
-        self.assertFalse(any(method == "POST" for method, _, _ in api.calls))
-
-    def test_upsert_comment_stops_repeating_full_pages(self):
-        class FakeApi:
-            def __init__(self):
-                self.calls = []
-
-            def request(self, method, path, payload=None):
-                self.calls.append((method, path, payload))
-                page = int(path.rsplit("page=", 1)[1])
-                return [
-                    {"id": page * 100 + index, "body": "other"}
-                    for index in range(100)
-                ]
-
-        api = FakeApi()
-        with mock.patch.object(module, "MAX_COMMENT_PAGES", 3):
-            with self.assertRaisesRegex(RuntimeError, "exceeded 3 pages"):
-                module.upsert_comment(api, "org/repo", 1190, "updated")
-        self.assertEqual(
-            [path for method, path, _ in api.calls if method == "GET"],
-            [
-                "/repos/org/repo/issues/1190/comments?per_page=100&page=1",
-                "/repos/org/repo/issues/1190/comments?per_page=100&page=2",
-                "/repos/org/repo/issues/1190/comments?per_page=100&page=3",
-            ],
-        )
-        self.assertFalse(
-            any(method in {"POST", "PATCH"} for method, _, _ in api.calls)
-        )
-
-    def test_upsert_comment_rejects_repeated_page(self):
-        class FakeApi:
-            def request(self, method, path, payload=None):
-                return [{"id": index, "body": "other"} for index in range(100)]
-
-        with self.assertRaisesRegex(RuntimeError, "repeated a page"):
-            module.upsert_comment(FakeApi(), "org/repo", 1190, "updated")
-
-
 class BuildWaitTest(unittest.TestCase):
     """The defect: a failed companion build was invisible, so the poller
     retried 520 times over ~130 minutes for a run that would never appear."""
@@ -347,9 +210,7 @@ class BuildWaitTest(unittest.TestCase):
         what made a failed companion build indistinguishable from an absent
         one, so the query must stay unfiltered by status."""
         api = self._api([self._run(status="completed", conclusion="success")])
-        with mock.patch.object(module, "download_release_set_artifact",
-                               return_value={"ok": True}):
-            module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
+        module.await_build_run(api, "o/r", self.SHA, self.REF, 520, 15)
         url = api.request.call_args[0][1]
         self.assertIn("head_sha=", url)
         self.assertNotIn("status=", url)
@@ -359,7 +220,7 @@ class BuildWaitTest(unittest.TestCase):
         api = self._api([self._run(status="completed", conclusion="failure")])
         with mock.patch.object(module.time, "sleep") as slept:
             with self.assertRaises(RuntimeError) as ctx:
-                module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
+                module.await_build_run(api, "o/r", self.SHA, self.REF, 520, 15)
         slept.assert_not_called()
         self.assertIn("failure", str(ctx.exception))
         self.assertIn("7", str(ctx.exception))
@@ -373,7 +234,7 @@ class BuildWaitTest(unittest.TestCase):
                                            conclusion=conclusion)])
                 with mock.patch.object(module.time, "sleep") as slept:
                     with self.assertRaises(RuntimeError) as ctx:
-                        module.download_release_set(
+                        module.await_build_run(
                             api, "o/r", self.SHA, self.REF, 520, 15)
                 slept.assert_not_called()
                 self.assertIn(conclusion, str(ctx.exception))
@@ -384,13 +245,9 @@ class BuildWaitTest(unittest.TestCase):
             [self._run(status="completed", conclusion="action_required")],
             [self._run(status="completed", conclusion="success")],
         )
-        with mock.patch.object(module.time, "sleep"), mock.patch.object(
-            module, "download_release_set_artifact", return_value={"ok": True}
-        ):
-            self.assertEqual(
-                module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15),
-                {"ok": True},
-            )
+        with mock.patch.object(module.time, "sleep"):
+            run = module.await_build_run(api, "o/r", self.SHA, self.REF, 520, 15)
+        self.assertEqual(run["conclusion"], "success")
 
     def test_in_flight_github_rerun_is_not_aborted(self):
         """A GitHub re-run reuses the run id and resets status to in_progress
@@ -400,11 +257,9 @@ class BuildWaitTest(unittest.TestCase):
             [self._run(run_attempt=2, status="in_progress", conclusion="failure")],
             [self._run(run_attempt=2, status="completed", conclusion="success")],
         )
-        with mock.patch.object(module.time, "sleep") as slept, mock.patch.object(
-            module, "download_release_set_artifact", return_value={"ok": True}
-        ):
-            out = module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
-        self.assertEqual(out, {"ok": True})
+        with mock.patch.object(module.time, "sleep") as slept:
+            out = module.await_build_run(api, "o/r", self.SHA, self.REF, 520, 15)
+        self.assertEqual(out["conclusion"], "success")
         self.assertEqual(slept.call_count, 1)
 
     def test_in_progress_keeps_waiting_then_succeeds(self):
@@ -412,13 +267,10 @@ class BuildWaitTest(unittest.TestCase):
             [self._run(status="in_progress", conclusion=None)],
             [self._run(status="completed", conclusion="success")],
         )
-        with mock.patch.object(module.time, "sleep") as slept, mock.patch.object(
-            module, "download_release_set_artifact", return_value={"ok": True}
-        ) as dl:
-            out = module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
-        self.assertEqual(out, {"ok": True})
+        with mock.patch.object(module.time, "sleep") as slept:
+            out = module.await_build_run(api, "o/r", self.SHA, self.REF, 520, 15)
+        self.assertEqual(out["conclusion"], "success")
         self.assertEqual(slept.call_count, 1)
-        dl.assert_called_once()
 
     def test_still_in_progress_at_the_final_attempt_times_out(self):
         """Guards the reset at the end of the loop: a non-terminal run on the
@@ -427,14 +279,11 @@ class BuildWaitTest(unittest.TestCase):
         api.request.return_value = {
             "workflow_runs": [self._run(status="in_progress", conclusion=None)]
         }
-        with mock.patch.object(module.time, "sleep") as slept, mock.patch.object(
-            module, "download_release_set_artifact"
-        ) as dl:
+        with mock.patch.object(module.time, "sleep") as slept:
             with self.assertRaises(RuntimeError) as ctx:
-                module.download_release_set(api, "o/r", self.SHA, self.REF, 3, 15)
+                module.await_build_run(api, "o/r", self.SHA, self.REF, 3, 15)
         self.assertEqual(api.request.call_count, 3)
         self.assertEqual(slept.call_count, 2)
-        dl.assert_not_called()
         self.assertIn("3 polling attempts", str(ctx.exception))
 
     def test_absent_run_still_exhausts_its_budget(self):
@@ -445,7 +294,7 @@ class BuildWaitTest(unittest.TestCase):
         api.request.return_value = {"workflow_runs": []}
         with mock.patch.object(module.time, "sleep") as slept:
             with self.assertRaises(RuntimeError):
-                module.download_release_set(api, "o/r", self.SHA, self.REF, 3, 15)
+                module.await_build_run(api, "o/r", self.SHA, self.REF, 3, 15)
         self.assertEqual(api.request.call_count, 3)
         self.assertEqual(slept.call_count, 2)
 
@@ -459,11 +308,9 @@ class BuildWaitTest(unittest.TestCase):
             self._run(id=2, run_number=2, status="completed", conclusion="success",
                       created_at="2026-07-02T00:00:00Z"),
         ])
-        with mock.patch.object(module.time, "sleep"), mock.patch.object(
-            module, "download_release_set_artifact", return_value={"ok": True}
-        ):
-            out = module.download_release_set(api, "o/r", self.SHA, self.REF, 520, 15)
-        self.assertEqual(out, {"ok": True})
+        with mock.patch.object(module.time, "sleep"):
+            out = module.await_build_run(api, "o/r", self.SHA, self.REF, 520, 15)
+        self.assertEqual(out["conclusion"], "success")
 
 if __name__ == "__main__":
     module.enforce_memory_ceiling()

--- a/.github/scripts/test_prepare_downstream_release_set.py
+++ b/.github/scripts/test_prepare_downstream_release_set.py
@@ -53,34 +53,25 @@ class PrMergeBaseShaTest(unittest.TestCase):
 
 
 class DownstreamVariablesTest(unittest.TestCase):
-    def test_derives_candidate_tag_from_release_set_source(self):
+    def test_derives_candidate_tag_from_ref_and_sha(self):
         commit = "a" * 40
         for ref, expected in (
             ("develop", "develop-" + "a" * 12),
             ("pull-request/1396", "pr-1396-" + "a" * 12),
         ):
             with self.subTest(ref=ref):
-                self.assertEqual(
-                    candidate_container_tag(
-                        {"source": {"commit": commit, "ref": ref}}
-                    ),
-                    expected,
-                )
+                self.assertEqual(candidate_container_tag(ref, commit), expected)
 
     def test_rejects_ref_without_shared_candidate_set(self):
         with self.assertRaisesRegex(ValueError, "does not publish"):
-            candidate_container_tag(
-                {"source": {"commit": "a" * 40, "ref": "release/3.2"}}
-            )
+            candidate_container_tag("release/3.2", "a" * 40)
 
-    def test_encodes_exact_release_set_for_acceptance(self):
-        release_set = {
-            "schema_version": 1,
-            "release_set_id": "sha256:" + "1" * 64,
-            "source": {"commit": "a" * 40, "ref": "pull-request/1396"},
-            "images": [{"name": "vss-agent"}],
-        }
-        variables = downstream_variables(release_set)
+    def test_rejects_short_sha(self):
+        with self.assertRaisesRegex(ValueError, "40-hex"):
+            candidate_container_tag("develop", "abc123")
+
+    def test_emits_only_what_downstream_reads(self):
+        variables = downstream_variables("pull-request/1396", "a" * 40)
         self.assertEqual(variables["BUILD_TYPE"], "ghcr-acceptance")
         self.assertEqual(
             variables["VSS_CONTAINER_TAG"], "pr-1396-" + "a" * 12
@@ -89,57 +80,6 @@ class DownstreamVariablesTest(unittest.TestCase):
         # consumer for it. Assert its absence so a reintroduction is caught.
         self.assertNotIn("VSS_RELEASE_SET_ID", variables)
         self.assertNotIn("VSS_RELEASE_SET_B64", variables)
-
-    def test_main_with_release_set_file_performs_no_network(self):
-        sha = "a" * 40
-        release_set = {
-            "source": {"commit": sha, "ref": "pull-request/1396"},
-            "release_set_id": "sha256:" + "1" * 64,
-            "images": [],
-        }
-        with tempfile.TemporaryDirectory() as tmp:
-            release_path = Path(tmp) / "release-set.json"
-            release_output_path = Path(tmp) / "handoff/release-set.json"
-            env_path = Path(tmp) / "github.env"
-            output_path = Path(tmp) / "github.output"
-            release_path.write_text(json.dumps(release_set))
-            argv = [
-                "prepare_downstream_release_set.py",
-                "--sha",
-                sha,
-                "--release-set",
-                str(release_path),
-                "--release-set-output",
-                str(release_output_path),
-            ]
-            with mock.patch("sys.argv", argv), mock.patch.dict(
-                os.environ,
-                {
-                    "GITHUB_ENV": str(env_path),
-                    "GITHUB_OUTPUT": str(output_path),
-                },
-                clear=True,
-            ), mock.patch.object(
-                module, "validate_release_set", return_value=[]
-            ), mock.patch.object(
-                # Pin the gate: its real inputs depend on git state, which
-                # differs between a local worktree and a CI checkout.
-                module, "downstream_relevant", return_value=(False, "pinned")
-            ), mock.patch.object(module, "download_release_set") as download:
-                self.assertEqual(module.main(), 0)
-                download.assert_not_called()
-            self.assertIn("DOWNSTREAM_EXTRA_VARIABLES_JSON", env_path.read_text())
-            self.assertIn(
-                '"VSS_CONTAINER_TAG":"pr-1396-' + "a" * 12 + '"',
-                env_path.read_text(),
-            )
-            self.assertEqual(
-                output_path.read_text(),
-                "run_downstream=false\n",
-            )
-            self.assertEqual(json.loads(release_output_path.read_text()), release_set)
-
-
 
 INVENTORY = {
     "images": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1468,7 +1468,7 @@ jobs:
 
       - name: Unit-test the downstream GHCR candidate reporter
         run: |
-          python3 .github/scripts/test_update_pr_ghcr_candidates.py
+          python3 .github/scripts/test_github_build_run.py
           python3 .github/scripts/test_prepare_downstream_release_set.py
           python3 .github/scripts/test_trigger_downstream_pipeline.py
           python3 .github/scripts/test_advance_ghcr_alias.py
@@ -1519,16 +1519,8 @@ jobs:
             --attempts 520 \
             --interval-seconds 15 \
             --repo-root . \
-            --before "${{ github.event.before }}" \
-            --release-set-output downstream-release-set.json
+            --before "${{ github.event.before }}"
 
-      - name: Upload downstream release-set handoff
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
-        with:
-          name: downstream-release-set
-          path: downstream-release-set.json
-          if-no-files-found: error
-          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Job 12: OSRB dispatch wiring
@@ -1615,18 +1607,11 @@ jobs:
           mv .source-artifact/tracked-files.txt .ci/tracked-files.txt
           rm -rf .source-artifact
 
-      - name: Download completed GHCR release set
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
-        with:
-          name: downstream-release-set
-          path: .downstream-release-set
-
       - name: Prepare GHCR release-set handoff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 .github/scripts/prepare_downstream_release_set.py \
-            --release-set .downstream-release-set/downstream-release-set.json
+          python3 .github/scripts/prepare_downstream_release_set.py
 
       - name: Trigger pipeline
         id: trigger
@@ -1642,8 +1627,3 @@ jobs:
           MAX_POLL_DURATION_SECONDS: "14400"  # 4 hours
         run: python3 .github/scripts/poll-downstream-pipeline.py
 
-      - name: Update PR with downstream-validated GHCR candidates
-        if: startsWith(github.ref_name, 'pull-request/')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 .github/scripts/update_pr_ghcr_candidates.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1626,4 +1626,3 @@ jobs:
           POLL_INTERVAL_SECONDS: "120"
           MAX_POLL_DURATION_SECONDS: "14400"  # 4 hours
         run: python3 .github/scripts/poll-downstream-pipeline.py
-


### PR DESCRIPTION
## Description

> **Stacked on #1793.** Base is `chore/drop-has-ghcr-build-entries`, so this diff shows only its own changes. Rebase onto `develop` once #1793 lands.

Two consumers of the release set go away. The one that matters stays.

**1. The PR candidates comment is unread.** Nothing machine-parses its marker `<!-- vss-ghcr-candidates -->` — verified across this repo and `ci-vss-oss` — and it is not read by hand either. The publisher, its `ci.yml` step and the comment machinery go.

**2. The downstream gate never needed the manifest.** It read exactly two fields — `source.commit` and `source.ref` — to derive `{develop|pr-N}-{sha12}`, a tag the workflow already holds as `GITHUB_SHA` and `GITHUB_REF_NAME`, and which `container_build_plan.py` computes identically. So the gate stopped fetching, validating and round-tripping a release set through an artifact. It derives the tag directly and still waits on the build run's conclusion — which was always the real completion signal, independent of the artifact.

### What deliberately survives

`fragment`, `assemble`, `validate`, the `release-set` artifact and `release-set.schema.json`. `advance_ghcr_alias.py` consumes the assembled manifest to publish `develop-latest` and `develop-<sha12>` across **every** GHCR image, including ones this build did not rebuild. That coverage cannot be derived from what changed — `build-dev-images.yml` says so in its own comment:

> Both sets must cover EVERY GHCR image, not just the ones rebuilt on this ref: a consumer that derives a coordinate from the ref would otherwise 404 on the untouched images, which is why PR acceptance still needs a per-image manifest today.

That is the guarantee §4.2 of the design doc sells, so the release set keeps exactly one consumer — an honest one.

`update_pr_ghcr_candidates.py` becomes `github_build_run.py`, retaining only the GitHub API adapter and the build-run polling the gate imports. `download_release_set` becomes `await_build_run` and returns the run rather than an artifact. 417 → 224 lines.

## Plan

**Tracking:** none — CI maintenance, `no-tracking-ref`.

**Goal:** the release set has one consumer that genuinely needs it, instead of three where two were derivable or unread.

**Decisions**

| # | Question | I recommended | Decided |
|---|----------|---------------|---------|
| Q1 | Replace the release set entirely? | Initially offered it — **then withdrew the option**: tracing every consumer showed `advance_ghcr_alias.py` needs the full per-image manifest, and deriving the alias set from the inventory would silently 404 `develop-<sha12>` on untouched images | Keep it for the alias publication |
| Q2 | What about the candidates comment? | Delete — no machine reads the marker | Delete |
| Q3 | Keep the 90-day release-set archive? | Keep it; it rides along with the artifact the alias step already needs | Kept |

**Steps**

1. Prove nothing parses the comment marker → verify: `git grep` in both repos finds only the publisher and its `ci.yml` step.
2. Derive the candidate tag from ref+SHA → verify: tests cover `develop`, `pull-request/N`, an unsupported ref, and a short SHA.
3. Keep the completion signal → verify: `await_build_run` still polls the workflow-run API and raises on terminal failure conclusions; 17 tests cover re-runs, in-flight runs and budget exhaustion.
4. Prove the alias path is untouched → verify: `test_advance_ghcr_alias` passes; `assemble`/`validate` and the `release-set` artifact are unchanged.
5. Prove nothing regressed → verify: `ci.yml` parses, no residual references under `.github/` or `deploy/`, and seven tooling suites pass.

**Out of scope**

- `release_set.py closure`, the inventory-coverage check in `ci.yml` — independent of assembly.
- Whether the alias set could one day be derived from the inventory plus registry lookups. That is a redesign of the `develop-<sha12>` completeness guarantee, not a cleanup.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes. — 32 tests across the two touched suites; seven suites pass in total.
- [ ] The documentation is up to date with these changes. — n/a; no doc describes the removed comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
