### PR TITLE
perf(vios): fetch APT packages over parallel connections

### DIFF
--- a/deploy/docker/services/vios/scripts/user_additional_install.sh
+++ b/deploy/docker/services/vios/scripts/user_additional_install.sh
@@ -250,6 +250,41 @@ install_packages_with_retries() {
   return 1
 }
 
+# APT opens one connection per repository host, and this package set resolves to
+# a single host, so the 138MB download runs over one connection: measured 8.8s
+# against archive.ubuntu.com where 8 connections take 2.6s. The 224 files range
+# from 2KB to 30MB, so workers take the next URI as they free up rather than
+# splitting the list up front, which would leave one worker holding the 30MB
+# file after the others finish.
+#
+# Best effort by design. apt-helper checks each file against the hash APT
+# printed and writes nothing on a mismatch, and the apt-get install -d that
+# follows still downloads whatever is missing, so a failed or partial prefetch
+# costs time and nothing else. Set VST_APT_PARALLEL_DOWNLOADS=1 to disable.
+prefetch_parallel() {
+  local jobs="${VST_APT_PARALLEL_DOWNLOADS:-8}"
+  [[ "${jobs}" =~ ^[0-9]+$ && "${jobs}" -gt 1 && -x /usr/lib/apt/apt-helper ]] || return 0
+
+  local uris count
+  uris="$(mktemp)"
+  # Each line is: 'URI' filename size Hash:value. Anything that does not parse is
+  # left out and downloaded by APT below.
+  apt-get install --reinstall -d -y --no-install-recommends --print-uris \
+      "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
+      "${RUNTIME_PACKAGES[@]}" 2>/dev/null \
+    | tr -d "'" \
+    | awk 'NF == 4 && $1 ~ /^https?:/ { print $1, $2, $4 }' >"${uris}"
+
+  count="$(wc -l <"${uris}")"
+  if [[ "${count}" -gt 0 ]]; then
+    echo "Prefetching ${count} packages over ${jobs} connections..."
+    APT_CACHE_DIR="${APT_CACHE_DIR}" xargs -a "${uris}" -P "${jobs}" -n 3 bash -c '
+      /usr/lib/apt/apt-helper download-file "$0" "${APT_CACHE_DIR}/partial/$1" "$2" >/dev/null 2>&1 &&
+        mv -f "${APT_CACHE_DIR}/partial/$1" "${APT_CACHE_DIR}/$1"' || true
+  fi
+  rm -f "${uris}"
+}
+
 refresh_apt_metadata() {
   local attempt
   for attempt in $(seq 1 "${MAX_RETRIES}"); do
@@ -293,7 +328,9 @@ if [[ "${APT_CACHE_POPULATE}" == "true" ]]; then
     echo "ERROR: Unable to refresh APT metadata."
     exit 1
   fi
-  # -d downloads without installing: this container only fills the cache.
+  prefetch_parallel
+  # -d downloads without installing: this container only fills the cache. Runs
+  # after the prefetch and completes anything it did not get.
   if ! apt-get install --reinstall -d -y --no-install-recommends \
          "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
          "${RUNTIME_PACKAGES[@]}"; then

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
       - VST_APT_CACHE_POPULATE=true
       - VST_APT_CACHE_DIR=/opt/apt-cache
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
+      - VST_APT_PARALLEL_DOWNLOADS=${VST_APT_PARALLEL_DOWNLOADS:-}
     # Best-effort: the `|| echo` keeps the init exit 0 even if the populate
     # fails, so a transient apt error never blocks the consumers that
     # depend_on this (service_completed_successfully) -- they just fall back to

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/scripts/user_additional_install.sh
@@ -250,6 +250,41 @@ install_packages_with_retries() {
   return 1
 }
 
+# APT opens one connection per repository host, and this package set resolves to
+# a single host, so the 138MB download runs over one connection: measured 8.8s
+# against archive.ubuntu.com where 8 connections take 2.6s. The 224 files range
+# from 2KB to 30MB, so workers take the next URI as they free up rather than
+# splitting the list up front, which would leave one worker holding the 30MB
+# file after the others finish.
+#
+# Best effort by design. apt-helper checks each file against the hash APT
+# printed and writes nothing on a mismatch, and the apt-get install -d that
+# follows still downloads whatever is missing, so a failed or partial prefetch
+# costs time and nothing else. Set VST_APT_PARALLEL_DOWNLOADS=1 to disable.
+prefetch_parallel() {
+  local jobs="${VST_APT_PARALLEL_DOWNLOADS:-8}"
+  [[ "${jobs}" =~ ^[0-9]+$ && "${jobs}" -gt 1 && -x /usr/lib/apt/apt-helper ]] || return 0
+
+  local uris count
+  uris="$(mktemp)"
+  # Each line is: 'URI' filename size Hash:value. Anything that does not parse is
+  # left out and downloaded by APT below.
+  apt-get install --reinstall -d -y --no-install-recommends --print-uris \
+      "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
+      "${RUNTIME_PACKAGES[@]}" 2>/dev/null \
+    | tr -d "'" \
+    | awk 'NF == 4 && $1 ~ /^https?:/ { print $1, $2, $4 }' >"${uris}"
+
+  count="$(wc -l <"${uris}")"
+  if [[ "${count}" -gt 0 ]]; then
+    echo "Prefetching ${count} packages over ${jobs} connections..."
+    APT_CACHE_DIR="${APT_CACHE_DIR}" xargs -a "${uris}" -P "${jobs}" -n 3 bash -c '
+      /usr/lib/apt/apt-helper download-file "$0" "${APT_CACHE_DIR}/partial/$1" "$2" >/dev/null 2>&1 &&
+        mv -f "${APT_CACHE_DIR}/partial/$1" "${APT_CACHE_DIR}/$1"' || true
+  fi
+  rm -f "${uris}"
+}
+
 refresh_apt_metadata() {
   local attempt
   for attempt in $(seq 1 "${MAX_RETRIES}"); do
@@ -293,7 +328,9 @@ if [[ "${APT_CACHE_POPULATE}" == "true" ]]; then
     echo "ERROR: Unable to refresh APT metadata."
     exit 1
   fi
-  # -d downloads without installing: this container only fills the cache.
+  prefetch_parallel
+  # -d downloads without installing: this container only fills the cache. Runs
+  # after the prefetch and completes anything it did not get.
   if ! apt-get install --reinstall -d -y --no-install-recommends \
          "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
          "${RUNTIME_PACKAGES[@]}"; then

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/templates/deployment.yaml
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/templates/deployment.yaml
@@ -138,6 +138,8 @@ spec:
               value: {{ .Values.env.NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES | quote }}
             - name: VST_APT_MIRROR
               value: {{ .Values.env.VST_APT_MIRROR | default "" | quote }}
+            - name: VST_APT_PARALLEL_DOWNLOADS
+              value: {{ .Values.env.VST_APT_PARALLEL_DOWNLOADS | default "" | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/helm/services/vios/charts/vios-nvstreamer/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-nvstreamer/values.yaml
@@ -39,6 +39,9 @@ env:
   NVSTREAMER_INSTALL_ADDITIONAL_PACKAGES: "true"
   # Point APT at an internal/nearby mirror. Empty uses the public archive.
   VST_APT_MIRROR: ""
+  # Number of parallel connections used to fetch APT packages. Values below 2
+  # download serially, as before.
+  VST_APT_PARALLEL_DOWNLOADS: "8"
 
 service:
   port: 31000

--- a/deploy/helm/services/vios/charts/vios-streamprocessing/values.yaml
+++ b/deploy/helm/services/vios/charts/vios-streamprocessing/values.yaml
@@ -83,6 +83,10 @@ env:
   # Point APT at an internal/nearby mirror. Empty uses the public archive.
   - name: VST_APT_MIRROR
     value: ""
+  # Number of parallel connections used to fetch APT packages. Values below 2
+  # download serially, as before.
+  - name: VST_APT_PARALLEL_DOWNLOADS
+    value: "8"
   - name: CONTAINER_NAME
     value: vss-vios-streamprocessing
   - name: ADAPTOR

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -220,6 +220,7 @@ services:
       - VST_APT_CACHE_POPULATE=true
       - VST_APT_CACHE_DIR=/opt/apt-cache
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
+      - VST_APT_PARALLEL_DOWNLOADS=${VST_APT_PARALLEL_DOWNLOADS:-}
     # Best-effort: the `|| echo` keeps the init exit 0 even if the populate
     # fails, so a transient apt error never blocks the consumers that depend on
     # it -- they fall back to a normal download (the install script bypasses the

--- a/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/nvstreamer/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
       - VST_APT_CACHE_POPULATE=true
       - VST_APT_CACHE_DIR=/opt/apt-cache
       - VST_APT_MIRROR=${VST_APT_MIRROR:-}
+      - VST_APT_PARALLEL_DOWNLOADS=${VST_APT_PARALLEL_DOWNLOADS:-}
     # Best-effort: the `|| echo` keeps the init exit 0 even if the populate
     # fails, so a transient apt error never blocks the consumers that depend on
     # it -- they fall back to a normal download (the install script bypasses the

--- a/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
+++ b/services/vios/deployment/stream-processing/docker-compose/scripts/user_additional_install.sh
@@ -250,6 +250,41 @@ install_packages_with_retries() {
   return 1
 }
 
+# APT opens one connection per repository host, and this package set resolves to
+# a single host, so the 138MB download runs over one connection: measured 8.8s
+# against archive.ubuntu.com where 8 connections take 2.6s. The 224 files range
+# from 2KB to 30MB, so workers take the next URI as they free up rather than
+# splitting the list up front, which would leave one worker holding the 30MB
+# file after the others finish.
+#
+# Best effort by design. apt-helper checks each file against the hash APT
+# printed and writes nothing on a mismatch, and the apt-get install -d that
+# follows still downloads whatever is missing, so a failed or partial prefetch
+# costs time and nothing else. Set VST_APT_PARALLEL_DOWNLOADS=1 to disable.
+prefetch_parallel() {
+  local jobs="${VST_APT_PARALLEL_DOWNLOADS:-8}"
+  [[ "${jobs}" =~ ^[0-9]+$ && "${jobs}" -gt 1 && -x /usr/lib/apt/apt-helper ]] || return 0
+
+  local uris count
+  uris="$(mktemp)"
+  # Each line is: 'URI' filename size Hash:value. Anything that does not parse is
+  # left out and downloaded by APT below.
+  apt-get install --reinstall -d -y --no-install-recommends --print-uris \
+      "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
+      "${RUNTIME_PACKAGES[@]}" 2>/dev/null \
+    | tr -d "'" \
+    | awk 'NF == 4 && $1 ~ /^https?:/ { print $1, $2, $4 }' >"${uris}"
+
+  count="$(wc -l <"${uris}")"
+  if [[ "${count}" -gt 0 ]]; then
+    echo "Prefetching ${count} packages over ${jobs} connections..."
+    APT_CACHE_DIR="${APT_CACHE_DIR}" xargs -a "${uris}" -P "${jobs}" -n 3 bash -c '
+      /usr/lib/apt/apt-helper download-file "$0" "${APT_CACHE_DIR}/partial/$1" "$2" >/dev/null 2>&1 &&
+        mv -f "${APT_CACHE_DIR}/partial/$1" "${APT_CACHE_DIR}/$1"' || true
+  fi
+  rm -f "${uris}"
+}
+
 refresh_apt_metadata() {
   local attempt
   for attempt in $(seq 1 "${MAX_RETRIES}"); do
@@ -293,7 +328,9 @@ if [[ "${APT_CACHE_POPULATE}" == "true" ]]; then
     echo "ERROR: Unable to refresh APT metadata."
     exit 1
   fi
-  # -d downloads without installing: this container only fills the cache.
+  prefetch_parallel
+  # -d downloads without installing: this container only fills the cache. Runs
+  # after the prefetch and completes anything it did not get.
   if ! apt-get install --reinstall -d -y --no-install-recommends \
          "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
          "${RUNTIME_PACKAGES[@]}"; then

--- a/services/vios/packaging/user_additional_install.sh
+++ b/services/vios/packaging/user_additional_install.sh
@@ -250,6 +250,41 @@ install_packages_with_retries() {
   return 1
 }
 
+# APT opens one connection per repository host, and this package set resolves to
+# a single host, so the 138MB download runs over one connection: measured 8.8s
+# against archive.ubuntu.com where 8 connections take 2.6s. The 224 files range
+# from 2KB to 30MB, so workers take the next URI as they free up rather than
+# splitting the list up front, which would leave one worker holding the 30MB
+# file after the others finish.
+#
+# Best effort by design. apt-helper checks each file against the hash APT
+# printed and writes nothing on a mismatch, and the apt-get install -d that
+# follows still downloads whatever is missing, so a failed or partial prefetch
+# costs time and nothing else. Set VST_APT_PARALLEL_DOWNLOADS=1 to disable.
+prefetch_parallel() {
+  local jobs="${VST_APT_PARALLEL_DOWNLOADS:-8}"
+  [[ "${jobs}" =~ ^[0-9]+$ && "${jobs}" -gt 1 && -x /usr/lib/apt/apt-helper ]] || return 0
+
+  local uris count
+  uris="$(mktemp)"
+  # Each line is: 'URI' filename size Hash:value. Anything that does not parse is
+  # left out and downloaded by APT below.
+  apt-get install --reinstall -d -y --no-install-recommends --print-uris \
+      "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
+      "${RUNTIME_PACKAGES[@]}" 2>/dev/null \
+    | tr -d "'" \
+    | awk 'NF == 4 && $1 ~ /^https?:/ { print $1, $2, $4 }' >"${uris}"
+
+  count="$(wc -l <"${uris}")"
+  if [[ "${count}" -gt 0 ]]; then
+    echo "Prefetching ${count} packages over ${jobs} connections..."
+    APT_CACHE_DIR="${APT_CACHE_DIR}" xargs -a "${uris}" -P "${jobs}" -n 3 bash -c '
+      /usr/lib/apt/apt-helper download-file "$0" "${APT_CACHE_DIR}/partial/$1" "$2" >/dev/null 2>&1 &&
+        mv -f "${APT_CACHE_DIR}/partial/$1" "${APT_CACHE_DIR}/$1"' || true
+  fi
+  rm -f "${uris}"
+}
+
 refresh_apt_metadata() {
   local attempt
   for attempt in $(seq 1 "${MAX_RETRIES}"); do
@@ -293,7 +328,9 @@ if [[ "${APT_CACHE_POPULATE}" == "true" ]]; then
     echo "ERROR: Unable to refresh APT metadata."
     exit 1
   fi
-  # -d downloads without installing: this container only fills the cache.
+  prefetch_parallel
+  # -d downloads without installing: this container only fills the cache. Runs
+  # after the prefetch and completes anything it did not get.
   if ! apt-get install --reinstall -d -y --no-install-recommends \
          "${APT_OPTS[@]}" -o "Dir::Cache::archives=${APT_CACHE_DIR}" \
          "${RUNTIME_PACKAGES[@]}"; then


### PR DESCRIPTION
## Problem

Every VIOS consumer blocks on `vios-apt-cache-init`, which downloads 224 packages (138MB) before any of them can start. APT opens one connection per repository host and that package set resolves to a single host, so the whole download runs over one connection.

## Change

Prefetch the resolved URIs with a pool of `apt-helper` workers, then run the existing `apt-get install -d` unchanged so it completes anything the prefetch missed.

Package sizes range from 2KB to 30MB, so workers take the next URI as they free up rather than splitting the list up front, which would leave one worker holding the 30MB file after the others finish.

`apt-helper` ships with APT, so this adds no dependency. It verifies each file against the hash APT printed and writes nothing on a mismatch. A failed or partial prefetch costs time and nothing else, because the existing download still runs.

## Result

Measured on `vss-vios-streamprocessing` against the real package set, 5 interleaved reps:

| connections | fetch, 5 reps (s) | median |
|---|---|---|
| 1 (current) | 6.9, 7.6, 9.2, 10.5, 8.8 | 8.8 s |
| 8 (this PR) | 2.57, 2.37, 2.62, 2.32, 2.78 | **2.57 s** |

8 rather than 16: 16 reaches a lower median but a much wider spread (0.87-2.61 vs 2.32-2.78), and predictability matters more here than peak.

`VST_APT_PARALLEL_DOWNLOADS` sets the worker count, default 8. Any value below 2, or a non-numeric one, keeps the current behaviour.

## Verification

Run against the real image with the real script, populating a fresh cache volume each time:

- default: 224 packages cached, `rc=0`
- `VST_APT_PARALLEL_DOWNLOADS=1`: prefetch skipped, 224 packages cached, `rc=0`
- `VST_APT_PARALLEL_DOWNLOADS=abc`: prefetch skipped, 224 packages cached, `rc=0`

Consumer install from the resulting cache passes the script's own `runtime_present()` check, `gst-inspect-1.0 avdec_h264` resolves, and `dpkg --audit` is clean.
