### PR TITLE
perf(vios): add --prebake-vios-packages to build runtime media into the image

### DIFF
--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -34,6 +34,9 @@ ngc_cli_api_key="${NGC_CLI_API_KEY:-}"
 nvidia_api_key="${NVIDIA_API_KEY:-}"
 openai_api_key="${OPENAI_API_KEY:-}"
 dry_run="false"
+# Build the VIOS runtime-media packages into a local image instead of installing
+# them on every container start. Env var so CI can set it without a flag.
+prebake_vios_packages="${VSS_VIOS_PREBAKE_PACKAGES:-false}"
 
 # NIM-related defaults
 # LLM configuration
@@ -522,6 +525,9 @@ function usage() {
   echo "  --llm-device-id                  LLM device ID."
   echo "                                   • Not allowed when --use-remote-llm is passed"
   echo "                                   • DGX-SPARK, IGX-THOR, AGX-THOR: not accepted"
+  echo "  --prebake-vios-packages          Build the VIOS runtime-media packages into a local image instead of"
+  echo "                                   installing them on every container start. Cuts the VIOS start from"
+  echo "                                   ~100 s to ~0.1 s. The image is built locally and never pushed."
   echo "  --use-remote-llm                 Use remote LLM; requires LLM_ENDPOINT_URL on the host (both are required together)."
   echo "  --llm-model-type                 LLM backend type when --use-remote-llm is passed: nim or openai."
   echo "  --llm-env-file                   Path to LLM env file. Absolute or relative to CWD."
@@ -657,6 +663,11 @@ function process_args() {
         shift
         vlm_device_id="${1}"
         options_provided+=("vlm-device-id")
+        shift
+        ;;
+      --prebake-vios-packages)
+        prebake_vios_packages="true"
+        options_provided+=("prebake-vios-packages")
         shift
         ;;
       --use-remote-llm)
@@ -1630,12 +1641,22 @@ function state_up() {
   # shellcheck disable=SC1091
   source "${deployment_directory}/containers.env"
   set +a
+  # Passing -f disables Compose's default file discovery, so the base file has to
+  # be named explicitly alongside any overlay. Paths inside an overlay resolve
+  # against the project directory, not against the overlay file.
+  local compose_files=(-f compose.yml)
+  if [[ "${prebake_vios_packages}" == "true" ]]; then
+    compose_files+=(-f services/vios/streamprocessing/docker-compose.prebaked.yaml)
+    echo "[INFO] Prebaking VIOS runtime-media packages into a local image."
+  fi
+
   echo "[INFO] Managed container registry: ${VSS_CONTAINER_REGISTRY}"
   echo "[INFO] Managed container tag:      ${VSS_CONTAINER_TAG}"
   echo "[INFO] Resolved compose images:"
   (
     cd "${deployment_directory}"
     docker compose \
+      "${compose_files[@]}" \
       --env-file containers.env \
       --env-file "developer-profiles/dev-profile-${profile}/.env" \
       --env-file "developer-profiles/dev-profile-${profile}/generated.env" \
@@ -1656,10 +1677,11 @@ function state_up() {
   # Docker compose up
   echo "[INFO] Starting docker compose..."
   if [[ "${dry_run}" == "true" ]]; then
-    echo "[DRY-RUN] cd ${deployment_directory} && docker compose --env-file containers.env --env-file developer-profiles/dev-profile-${profile}/.env --env-file developer-profiles/dev-profile-${profile}/generated.env up --detach --pull always --force-recreate --build"
+    echo "[DRY-RUN] cd ${deployment_directory} && docker compose ${compose_files[*]} --env-file containers.env --env-file developer-profiles/dev-profile-${profile}/.env --env-file developer-profiles/dev-profile-${profile}/generated.env up --detach --pull always --force-recreate --build"
   else
     if ! (
       cd "${deployment_directory}" && docker compose \
+        "${compose_files[@]}" \
         --env-file containers.env \
         --env-file "developer-profiles/dev-profile-${profile}/.env" \
         --env-file "developer-profiles/dev-profile-${profile}/generated.env" \

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1641,9 +1641,8 @@ function state_up() {
   # shellcheck disable=SC1091
   source "${deployment_directory}/containers.env"
   set +a
-  # Passing -f disables Compose's default file discovery, so the base file has to
-  # be named explicitly alongside any overlay. Paths inside an overlay resolve
-  # against the project directory, not against the overlay file.
+  # -f disables Compose's default file discovery, so the base file must be named
+  # explicitly alongside any overlay.
   local compose_files=(-f compose.yml)
   if [[ "${prebake_vios_packages}" == "true" ]]; then
     compose_files+=(-f services/vios/streamprocessing/docker-compose.prebaked.yaml)

--- a/deploy/docker/services/vios/streamprocessing/Dockerfile.prebaked
+++ b/deploy/docker/services/vios/streamprocessing/Dockerfile.prebaked
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run the runtime-media install once at build time instead of on every container
+# start. The install is unchanged: same script, same package list. It writes its
+# own marker, so the entrypoint's invocation takes the existing skip path.
+#
+# For locally built images only. The packages are not redistributable, which is
+# why the published image ships without them and installs them at start.
+
+ARG VSS_VIOS_STREAMPROCESSING_BASE
+FROM ${VSS_VIOS_STREAMPROCESSING_BASE}
+
+USER 0:0
+COPY scripts/user_additional_install.sh /home/vst/vst_release/tools/user_additional_install.sh
+RUN VST_INSTALL_ADDITIONAL_PACKAGES=true \
+      /home/vst/vst_release/tools/user_additional_install.sh \
+ && rm -rf /var/lib/apt/lists/*
+USER 1000:1000

--- a/deploy/docker/services/vios/streamprocessing/Dockerfile.prebaked
+++ b/deploy/docker/services/vios/streamprocessing/Dockerfile.prebaked
@@ -13,12 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Run the runtime-media install once at build time instead of on every container
-# start. The install is unchanged: same script, same package list. It writes its
-# own marker, so the entrypoint's invocation takes the existing skip path.
+# Runs the runtime-media install at build time instead of on every container
+# start. Same script, same package list; it writes its own marker, so the
+# entrypoint takes the existing skip path.
 #
-# For locally built images only. The packages are not redistributable, which is
-# why the published image ships without them and installs them at start.
+# Locally built images only. Never pushed.
 
 ARG VSS_VIOS_STREAMPROCESSING_BASE
 FROM ${VSS_VIOS_STREAMPROCESSING_BASE}

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
@@ -28,6 +28,14 @@
 # locally. A service with `build:` is built instead of pulled, and Docker's layer
 # cache makes every deploy after the first a no-op.
 #
+# `vios-apt-cache-init` is deliberately NOT disabled here. It looks redundant
+# once streamprocessing carries the packages, but the same shared cache feeds the
+# NVStreamer services (services/nvstreamer/base.yml mounts vios_apt_cache and
+# depends on the init), and this overlay does not prebake those. Turning the init
+# into a no-op left every NVStreamer on an empty cache doing a full network
+# install, which is worse than the status quo for the lvs, alerts, 2d, 3d and
+# mv3dt profiles.
+#
 # The derived image is never pushed. These packages are not redistributable,
 # which is why the published image ships without them.
 #
@@ -38,10 +46,6 @@
 # it is never released.
 
 services:
-  # Nothing left to cache: the consumers below already carry the packages.
-  vios-apt-cache-init:
-    entrypoint: ["/bin/true"]
-
   streamprocessing-ms:
     image: vss-vios-streamprocessing-prebaked:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
     build:

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
@@ -30,6 +30,12 @@
 #
 # The derived image is never pushed. These packages are not redistributable,
 # which is why the published image ships without them.
+#
+# Its name is deliberately NOT a first-party registry coordinate. Release-set
+# assembly requires one tag per image name across deploy/docker, so reusing the
+# published name with a second tag makes the release set ambiguous. A local-only
+# name keeps this overlay out of the release set entirely, which is correct:
+# it is never released.
 
 services:
   # Nothing left to cache: the consumers below already carry the packages.
@@ -37,7 +43,7 @@ services:
     entrypoint: ["/bin/true"]
 
   streamprocessing-ms:
-    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}-prebaked
+    image: vss-vios-streamprocessing-prebaked:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
     build:
       context: ./services/vios
       dockerfile: streamprocessing/Dockerfile.prebaked
@@ -45,7 +51,7 @@ services:
         VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
 
   streamprocessing-ms-2d:
-    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}-prebaked
+    image: vss-vios-streamprocessing-prebaked:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
     build:
       context: ./services/vios
       dockerfile: streamprocessing/Dockerfile.prebaked
@@ -53,7 +59,7 @@ services:
         VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
 
   streamprocessing-ms-3d:
-    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}-prebaked
+    image: vss-vios-streamprocessing-prebaked:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
     build:
       context: ./services/vios
       dockerfile: streamprocessing/Dockerfile.prebaked
@@ -61,7 +67,7 @@ services:
         VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
 
   streamprocessing-ms-mv3dt:
-    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}-prebaked
+    image: vss-vios-streamprocessing-prebaked:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
     build:
       context: ./services/vios
       dockerfile: streamprocessing/Dockerfile.prebaked

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
@@ -13,37 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Paths here are relative to the project directory (deploy/docker), not to this
-# file: Compose resolves a `-f` overlay against the project, not the overlay.
+# Moves the runtime-media apt install from container start to image build.
+# Opt in with `dev-profile.sh up --prebake-vios-packages`.
 #
-# Overlay that moves the runtime-media apt install from container start to image
-# build. Opt in with `dev-profile.sh up --prebake-vios-packages`.
+# Four things here are load-bearing:
+#   - paths resolve against the project dir (deploy/docker), not this file
+#   - `build:`, not a prebuilt tag: the deploy runs `--pull always`, which fails
+#     on an image that exists only locally
+#   - the image name must stay off the first-party registry, or release-set
+#     assembly sees two tags for one image name and fails
+#   - `vios-apt-cache-init` stays enabled: NVStreamer shares that cache and is
+#     not prebaked here
 #
-# The install runs on every start today and is on the critical path of the whole
-# deploy, because every consumer waits for it. Building it into a local image
-# instead makes that start cost a marker-file check.
-#
-# `build:` rather than a pre-built tag on purpose: the deploy runs
-# `docker compose up --pull always`, which fails on an image that exists only
-# locally. A service with `build:` is built instead of pulled, and Docker's layer
-# cache makes every deploy after the first a no-op.
-#
-# `vios-apt-cache-init` is deliberately NOT disabled here. It looks redundant
-# once streamprocessing carries the packages, but the same shared cache feeds the
-# NVStreamer services (services/nvstreamer/base.yml mounts vios_apt_cache and
-# depends on the init), and this overlay does not prebake those. Turning the init
-# into a no-op left every NVStreamer on an empty cache doing a full network
-# install, which is worse than the status quo for the lvs, alerts, 2d, 3d and
-# mv3dt profiles.
-#
-# The derived image is never pushed. These packages are not redistributable,
-# which is why the published image ships without them.
-#
-# Its name is deliberately NOT a first-party registry coordinate. Release-set
-# assembly requires one tag per image name across deploy/docker, so reusing the
-# published name with a second tag makes the release set ambiguous. A local-only
-# name keeps this overlay out of the release set entirely, which is correct:
-# it is never released.
+# The derived image is local only and never pushed.
 
 services:
   streamprocessing-ms:

--- a/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
+++ b/deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Paths here are relative to the project directory (deploy/docker), not to this
+# file: Compose resolves a `-f` overlay against the project, not the overlay.
+#
+# Overlay that moves the runtime-media apt install from container start to image
+# build. Opt in with `dev-profile.sh up --prebake-vios-packages`.
+#
+# The install runs on every start today and is on the critical path of the whole
+# deploy, because every consumer waits for it. Building it into a local image
+# instead makes that start cost a marker-file check.
+#
+# `build:` rather than a pre-built tag on purpose: the deploy runs
+# `docker compose up --pull always`, which fails on an image that exists only
+# locally. A service with `build:` is built instead of pulled, and Docker's layer
+# cache makes every deploy after the first a no-op.
+#
+# The derived image is never pushed. These packages are not redistributable,
+# which is why the published image ships without them.
+
+services:
+  # Nothing left to cache: the consumers below already carry the packages.
+  vios-apt-cache-init:
+    entrypoint: ["/bin/true"]
+
+  streamprocessing-ms:
+    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}-prebaked
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  streamprocessing-ms-2d:
+    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}-prebaked
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  streamprocessing-ms-3d:
+    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}-prebaked
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}
+
+  streamprocessing-ms-mv3dt:
+    image: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}-prebaked
+    build:
+      context: ./services/vios
+      dockerfile: streamprocessing/Dockerfile.prebaked
+      args:
+        VSS_VIOS_STREAMPROCESSING_BASE: ${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-ghcr.io/nvidia-ai-blueprints/vss}/vss-vios-streamprocessing}:${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}

--- a/deploy/docker/test-scripts/compose-images.golden
+++ b/deploy/docker/test-scripts/compose-images.golden
@@ -73,6 +73,10 @@ deploy/docker/services/vios/initiator/docker-compose.yaml ghcr.io/nvidia-ai-blue
 deploy/docker/services/vios/initiator/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-sensor:develop-latest
 deploy/docker/services/vios/initiator/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-sensor:develop-latest
 deploy/docker/services/vios/initiator/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-sensor:develop-latest
+deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml vss-vios-streamprocessing-prebaked:develop-latest
+deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml vss-vios-streamprocessing-prebaked:develop-latest
+deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml vss-vios-streamprocessing-prebaked:develop-latest
+deploy/docker/services/vios/streamprocessing/docker-compose.prebaked.yaml vss-vios-streamprocessing-prebaked:develop-latest
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-streamprocessing:develop-latest
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-streamprocessing:develop-latest
 deploy/docker/services/vios/streamprocessing/docker-compose.yaml ghcr.io/nvidia-ai-blueprints/vss/vss-vios-streamprocessing:develop-latest


### PR DESCRIPTION
## Problem

The VIOS runtime media packages are installed on every container start, and every other service waits on it.

The cost has two parts. The install itself, and the fact that `vss-vios-ingress` cannot start while it runs: `nginx-vst.conf` has a literal `proxy_pass http://vss-vios-streamprocessing:30001` with no `resolver`, so nginx exits at config load until that name resolves, and Docker restarts it with growing backoff. The wait is therefore amplified, and the backoff overshoots by up to one interval.

## Change

Opt in with `dev-profile.sh up --prebake-vios-packages`, or `VSS_VIOS_PREBAKE_PACKAGES=true` so CI can set it without a flag. Default behaviour is unchanged.

The flag adds a `-f` overlay that gives the streamprocessing services a `build:` section running the same install once at build time. The install script is not modified: it writes its own marker, so the entrypoint takes the skip path that already exists. `vios-apt-cache-init` becomes a no-op, since a prebaked consumer has nothing to download.

The derived image is built locally and never pushed, and carries a local-only name rather than a registry coordinate so it stays out of the release set. These packages are not redistributable, which is why the published image ships without them.

## Result

The saving scales with how long the install takes, which is disk-bound, so it differs by machine. Measured on two:

| | RTX PRO 6000 eval box | L40 dev box |
|---|---|---|
| apt step at container start | **15.42 s → 0.033 s** | **127.7 s → 0.0 s** |
| cold build | 18.2 s | 131 s |
| layer-cache hit (every later deploy) | 0.114 s | 2.9 s |
| image size | 2.857 → 3.352 GB | same |

On the eval box that is about **15 s per deploy**.

On the slower dev box, two runs of the same A/B put `vss-vios-streamprocessing` healthy at 186 s and 161 s before the change and 15 s both times after. The `vss-agent` figure is deliberately not quoted: it moved 205 s → 63 s in one run and was unchanged at ~40 s in the other, and in that second run the agent went healthy before streamprocessing did, so it was not gated on VIOS at all. Only the streamprocessing and ingress numbers reproduce.

### What this PR does not do

An earlier revision also turned `vios-apt-cache-init` into a no-op, on the grounds that a prebaked streamprocessing has nothing to download. That was wrong: the same shared cache feeds the NVStreamer services, which this overlay does not prebake, so it left them doing a full network install each. The init is left alone.

That also means this PR does not shorten the window in which `vss-vios-ingress` crash-loops waiting for streamprocessing to exist. That is a separate problem with its own fix in #1799.

## Rebuild cost

The layer cache has two inputs, the base image and `user_additional_install.sh`. It rebuilds when either changes, not per deploy and not per trial. The eval harness preserves images across trials, so a box builds once.

A rebuild is break-even rather than a regression, because it runs the same install the container would have run anyway: 18.2 s at build time against 15.42 s at container start on the eval box.

## Why `build:` and not a prebuilt tag

The deploy runs `docker compose up --pull always`, which fails on an image that exists only locally, and a service-level `pull_policy: never` does not override the CLI flag. A service with `build:` is built rather than pulled, so it works under the existing flags.

Note for future edits: paths inside a `-f` overlay resolve against the project directory, not against the overlay file.

## Verification

Checked on the eval box against this PR's own Dockerfile and build context, with the repo's `user_additional_install.sh` confirmed byte-identical to the image's:

- entrypoint takes the existing skip path (`Additional packages already installed; skipping APT.`)
- marker written at `/var/lib/vios/additional-packages-installed-<hash>`
- `gst-inspect-1.0 avdec_h264` resolves, and `x264enc`
- `dpkg --audit` clean
- `/var/lib/apt/lists/*` removed

## Scope

This changes only the package install at streamprocessing container start. It is independent of #1799, which removes the ingress crash-loop, and the two compose cleanly.
