### PR TITLE
fix(vios): make the ingress wait for streamprocessing instead of crash-looping

### DIFF
--- a/deploy/docker/services/vios/foundational/docker-compose.yaml
+++ b/deploy/docker/services/vios/foundational/docker-compose.yaml
@@ -73,18 +73,13 @@ services:
         required: false
       # nginx resolves a literal proxy_pass host once, at config load, and this
       # config names vss-vios-streamprocessing with no resolver. Without this
-      # wait nginx starts before that container exists, fails to resolve it,
-      # exits, and restart: always puts it into exponential backoff: measured 6
-      # restarts and 13.0 s to healthy for a 5 s wait, 8 and 32.4 s for 15 s,
-      # 11 and 169.8 s for 128 s. The backoff overshoots by up to one interval,
-      # so it costs more than the wait it is covering.
+      # wait nginx exits before that container exists and `restart: always`
+      # backs it off, which costs more than the wait itself.
       #
-      # service_started, not service_healthy: Compose registers the network
-      # alias when it creates the container, so this is satisfied as soon as
-      # streamprocessing is running and long before it finishes its startup
-      # install. nginx then resolves, starts first try, and 502s until the
-      # backend listens. Waiting for service_healthy would instead hold ingress
-      # down for the whole install and make it come up later than it does today.
+      # service_started, not service_healthy: the network alias exists as soon
+      # as the container runs, so nginx resolves and 502s until the backend
+      # listens. service_healthy would hold ingress down for the whole
+      # streamprocessing install and bring it up later than it does today.
       streamprocessing-ms:
         condition: service_started
         required: false

--- a/deploy/docker/services/vios/foundational/docker-compose.yaml
+++ b/deploy/docker/services/vios/foundational/docker-compose.yaml
@@ -71,6 +71,32 @@ services:
       sensor-ms-3d:
         condition: service_healthy
         required: false
+      # nginx resolves a literal proxy_pass host once, at config load, and this
+      # config names vss-vios-streamprocessing with no resolver. Without this
+      # wait nginx starts before that container exists, fails to resolve it,
+      # exits, and restart: always puts it into exponential backoff: measured 6
+      # restarts and 13.0 s to healthy for a 5 s wait, 8 and 32.4 s for 15 s,
+      # 11 and 169.8 s for 128 s. The backoff overshoots by up to one interval,
+      # so it costs more than the wait it is covering.
+      #
+      # service_started, not service_healthy: Compose registers the network
+      # alias when it creates the container, so this is satisfied as soon as
+      # streamprocessing is running and long before it finishes its startup
+      # install. nginx then resolves, starts first try, and 502s until the
+      # backend listens. Waiting for service_healthy would instead hold ingress
+      # down for the whole install and make it come up later than it does today.
+      streamprocessing-ms:
+        condition: service_started
+        required: false
+      streamprocessing-ms-2d:
+        condition: service_started
+        required: false
+      streamprocessing-ms-3d:
+        condition: service_started
+        required: false
+      streamprocessing-ms-mv3dt:
+        condition: service_started
+        required: false
 
 volumes:
   vios_pg_data:

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -179,6 +179,13 @@ services:
     depends_on:
       sensor-ms:
         condition: service_healthy
+      # See the note in deploy/docker/services/vios/foundational/docker-compose.yaml:
+      # nginx resolves the literal proxy_pass host once at config load, so without
+      # this wait it crash-loops through restart backoff until streamprocessing
+      # exists. service_started is satisfied as soon as the container runs.
+      streamprocessing-ms-1:
+        condition: service_started
+        required: false
 
   # Redis is the message broker SDR consumes from, and the routing-table
   # backing store Envoy's Lua filter reads. It's only used in SDRC mode. Profile-

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -179,10 +179,8 @@ services:
     depends_on:
       sensor-ms:
         condition: service_healthy
-      # See the note in deploy/docker/services/vios/foundational/docker-compose.yaml:
-      # nginx resolves the literal proxy_pass host once at config load, so without
-      # this wait it crash-loops through restart backoff until streamprocessing
-      # exists. service_started is satisfied as soon as the container runs.
+      # nginx resolves the literal proxy_pass host once at config load, so
+      # without this wait it crash-loops until streamprocessing exists.
       streamprocessing-ms-1:
         condition: service_started
         required: false

--- a/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
+++ b/services/vios/deployment/stream-processing/docker-compose/docker-compose.yaml
@@ -179,11 +179,6 @@ services:
     depends_on:
       sensor-ms:
         condition: service_healthy
-      # nginx resolves the literal proxy_pass host once at config load, so
-      # without this wait it crash-loops until streamprocessing exists.
-      streamprocessing-ms-1:
-        condition: service_started
-        required: false
 
   # Redis is the message broker SDR consumes from, and the routing-table
   # backing store Envoy's Lua filter reads. It's only used in SDRC mode. Profile-


### PR DESCRIPTION
## Problem

nginx resolves a literal `proxy_pass` host **once, at config load**. `nginx-vst.conf` names `vss-vios-streamprocessing` with no `resolver`, and `vst-ingress` waits only on the `sensor-ms*` services. So ingress can start before streamprocessing exists, fail to resolve it, exit, and be restarted by `restart: always` with growing backoff.

The backoff overshoots by up to one interval, so it costs more than the wait it is covering. Measured against the real ingress image and the real config, driving it with a stub upstream that appears after a fixed delay:

| upstream appears after | ingress healthy at | restarts |
|---|---|---|
| 0 s | 5.7 s | 1 |
| 5 s | 13.0 s | 6 |
| 15 s | 32.4 s | 8 |
| 128 s | 169.8 s | 11 |

## Change

Add the streamprocessing services to `vst-ingress`'s existing `depends_on`, matching the `required: false` pattern already used there for the sensor variants.

`service_started`, not `service_healthy`: Compose registers the network alias when it creates the container, so the condition is satisfied as soon as streamprocessing is running and well before it finishes its startup package install. nginx then resolves, starts first try, and returns 502 until the backend is listening, which is the intended behaviour.

Waiting for `service_healthy` would be worse than the status quo: ingress would be held down for the entire install and come up **later** than it does today, merely without restarts.

## Result

The wait is not shortened, the amplification is removed. Ingress becomes `wait + ~5.7 s`, and predictable:

| upstream appears after | before | after |
|---|---|---|
| 5 s | 13.0 s, 6 restarts | ~10.7 s, 0 restarts |
| 15 s | 32.4 s, 8 restarts | ~20.7 s, 0 restarts |
| 128 s | 169.8 s, 11 restarts | ~133.7 s, 0 restarts |

The slower the machine, the more it saves, and it never makes anything slower.

## Safety

- **No dependency cycle.** streamprocessing depends on `centralizedb`, `redis` and `vios-apt-cache-init`, not on ingress. Verified by resolving the full compose model and walking the dependency graph.
- **No deadlock.** `VST_INGRESS_ENDPOINT` is a URL streamprocessing calls at runtime, not a startup gate, so streamprocessing does not need ingress to be up.
- `required: false` covers profiles where a given streamprocessing variant is not active.

Scoped to `deploy/docker` only. The standalone VIOS deployment runs `network_mode: host` and its nginx configs proxy to `127.0.0.1`, so its ingress resolves no hostname and cannot hit this.
