### PR TITLE
fix(deploy): probe fast during start-up with healthcheck start_interval

### DIFF
--- a/deploy/docker/services/nim/cosmos-reason1-7b/compose.yml
+++ b/deploy/docker/services/nim/cosmos-reason1-7b/compose.yml
@@ -60,6 +60,8 @@ services:
       timeout: 650s
       retries: 2
 
+      start_period: 1200s
+      start_interval: 5s
   cosmos-reason1-7b-shared-gpu:
     image: nvcr.io/nim/nvidia/cosmos-reason1-7b:1.4.1
     container_name: cosmos-reason1-7b
@@ -104,5 +106,7 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
 volumes:
   cosmos_reason1_7b_cache:

--- a/deploy/docker/services/nim/cosmos-reason2-8b/compose.yml
+++ b/deploy/docker/services/nim/cosmos-reason2-8b/compose.yml
@@ -58,6 +58,8 @@ services:
       timeout: 650s
       retries: 2
 
+      start_period: 1200s
+      start_interval: 5s
   cosmos-reason2-8b-shared-gpu:
     image: nvcr.io/nim/nvidia/cosmos-reason2-8b:1.6.0
     container_name: nvidia-cosmos-reason2-8b
@@ -101,5 +103,7 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
 volumes:
   cosmos_reason2_8b_cache:

--- a/deploy/docker/services/nim/cosmos3-reasoner/compose.yml
+++ b/deploy/docker/services/nim/cosmos3-reasoner/compose.yml
@@ -64,6 +64,8 @@ services:
       timeout: 650s
       retries: 2
 
+      start_period: 1200s
+      start_interval: 5s
   cosmos3-reasoner-shared-gpu:
     image: nvcr.io/nim/nvidia/cosmos3-reasoner:1.7
     container_name: nvidia-cosmos3-reasoner
@@ -108,5 +110,7 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
 volumes:
   cosmos3_reasoner_cache:

--- a/deploy/docker/services/nim/gpt-oss-20b/compose.yml
+++ b/deploy/docker/services/nim/gpt-oss-20b/compose.yml
@@ -60,6 +60,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
     depends_on:
       gpt-oss-20b-init:
         condition: service_completed_successfully
@@ -100,6 +102,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
     depends_on:
       gpt-oss-20b-init:
         condition: service_completed_successfully

--- a/deploy/docker/services/nim/llama-3.3-nemotron-super-49b-v1.5/compose.yml
+++ b/deploy/docker/services/nim/llama-3.3-nemotron-super-49b-v1.5/compose.yml
@@ -50,6 +50,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
   llama-3.3-nemotron-super-49b-v1.5-shared-gpu:
     image: nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:1
     container_name: llama-3.3-nemotron-super-49b-v1.5
@@ -86,6 +88,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
     depends_on:
       cosmos-reason2-8b-shared-gpu:
         condition: service_healthy

--- a/deploy/docker/services/nim/nemotron-3-nano/compose.yml
+++ b/deploy/docker/services/nim/nemotron-3-nano/compose.yml
@@ -61,6 +61,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
     depends_on:
       nemotron-3-nano-init:
         condition: service_completed_successfully
@@ -123,5 +125,7 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
 volumes:
   nemotron_3_nano_cache:

--- a/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2-fp8/compose.yml
+++ b/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2-fp8/compose.yml
@@ -87,6 +87,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
     depends_on:
       nvidia-nemotron-nano-9b-v2-fp8-toolcall-init:
         condition: service_completed_successfully
@@ -150,6 +152,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
     depends_on:
       nvidia-nemotron-nano-9b-v2-fp8-toolcall-init:
         condition: service_completed_successfully

--- a/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/compose.yml
+++ b/deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/compose.yml
@@ -51,6 +51,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
   nvidia-nemotron-nano-9b-v2-shared-gpu:
     image: nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2:1
     container_name: nvidia-nemotron-nano-9b-v2
@@ -88,6 +90,8 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
     depends_on:
       cosmos-reason2-8b-shared-gpu:
         condition: service_healthy

--- a/deploy/docker/services/nim/qwen3-vl-8b-instruct/compose.yml
+++ b/deploy/docker/services/nim/qwen3-vl-8b-instruct/compose.yml
@@ -54,6 +54,8 @@ services:
       timeout: 650s
       retries: 2
 
+      start_period: 1200s
+      start_interval: 5s
   qwen3-vl-8b-instruct-shared-gpu:
     image: nvcr.io/nvidia/vllm:25.12.post1-py3
     command: python3 -m vllm.entrypoints.openai.api_server --model
@@ -94,5 +96,7 @@ services:
       interval: 60s
       timeout: 650s
       retries: 2
+      start_period: 1200s
+      start_interval: 5s
 volumes:
   qwen3_vl_8b_instruct_cache:


### PR DESCRIPTION
## Problem

A container that is ready immediately is not marked healthy until its first probe fires, and without `start_interval` the first probe waits a full `interval`. Anything gated on it through `depends_on: service_healthy` waits with it, doing nothing.

Measured on Docker 29.4.3, container ready at t=0, `interval: 60s`:

| | healthy at |
|---|---|
| no `start_interval` | **62 s** |
| `start_interval: 3s` | **3 s** |

Every local NIM under `deploy/docker/services/nim/` declares `interval: 60s` with `start_period: 0s`, so each idles for about a minute after it is already serving.

## Change

Add `start_interval` and a generous `start_period` to the 18 NIM healthchecks, which all declare `interval: 60s` with `start_period: 0s`.

Both are needed: **`start_interval` only applies inside `start_period`**, so a service declaring `start_period: 0s` gets no benefit from `start_interval` alone. That is why this touches `start_period` as well.

Steady-state `interval` is unchanged, so this adds no probe load once a service is up. It only changes how quickly readiness is noticed during start-up.

`rtvi-vlm` and `rtvi-embed` already declare `start_period: 1200s`; this follows that precedent for the rest.

## Scope

18 healthchecks across 9 files, all under `deploy/docker/services/nim/`. The diff is exactly 18 `start_period` and 18 `start_interval` lines and nothing else. No image, dependency or service-topology change.

**Deliberately not extended to the non-NIM services.** Their helm counterparts use a Kubernetes `startupProbe`, whose first probe fires at `initialDelaySeconds` (default 0) rather than after a period, so the k8s path does not have this defect. Mirroring the change there would raise probe rates and widen failure budgets without fixing anything, which is also why the helm-sync bot rated its proposed sync 3/5. The NIM charts render `NIMService` CRs whose probe timings are owned by the NIM operator, so there is no chart-side counterpart to drift from.

## What is not claimed

**The end-to-end deploy saving is not measured here.** A full-stack before/after on the dev box was attempted and could not run: the base profile pulls `nvcr.io/nvstaging/vss-core/vss-rt-vlm`, which returns `Access Denied` with the NGC key available on that box, so both arms failed identically at the compose stage rather than producing a comparison.

What is measured is the mechanism, in isolation and reproducibly: 62 s to 3 s for one service. How much of that reaches the deploy depends on how many gated services sit on the critical path, which should be confirmed on a box that can pull the full image set.
