### PR TITLE
Build rt-cv on the RTVI DeepStream base images

### DIFF
--- a/deploy/docker/container-inventory.json
+++ b/deploy/docker/container-inventory.json
@@ -188,7 +188,7 @@
       "platforms": ["linux/arm64"],
       "compose_image_names": [],
       "tag_variables": [],
-      "notes": "SBSA (Grace/DGX-Spark) build of vss-rt-cv. It cannot be a platform of the multiarch entry: SBSA reports the same linux/arm64 TARGETARCH as Jetson, so buildx cannot tell them apart, and it needs a different base image (deepstream:9.1-triton-sbsa-dgx-spark). It therefore shares the vss-rt-cv GHCR repository via `repository` and stays collision-free via the -sbsa tag_suffix. No compose reference by design: compose and Helm select SBSA by overriding only the tag on the shared vss-rt-cv image, so this entry is a tagged variant with no dedicated coordinate."
+      "notes": "SBSA (Grace/DGX-Spark) build of vss-rt-cv. It cannot be a platform of the multiarch entry: SBSA reports the same linux/arm64 TARGETARCH as Jetson, so buildx cannot tell them apart, and it needs a different base image (deepstream:rtvi_ds9.1plus-sbsa). It therefore shares the vss-rt-cv GHCR repository via `repository` and stays collision-free via the -sbsa tag_suffix. No compose reference by design: compose and Helm select SBSA by overriding only the tag on the shared vss-rt-cv image, so this entry is a tagged variant with no dedicated coordinate."
     },
     {
       "name": "vss-vios-sensor",

--- a/services/rtvi/rt-cv/docker/Dockerfile
+++ b/services/rtvi/rt-cv/docker/Dockerfile
@@ -51,7 +51,7 @@
 # the SAME TARGETARCH as Jetson, so it cannot be selected by a branch here — it
 # needs its own image. See deploy/docker/container-inventory.json.
 # -----------------------------------------------------------------------------
-ARG BASE_IMAGE="nvcr.io/nvidia/deepstream:9.1-triton-multiarch"
+ARG BASE_IMAGE="nvcr.io/nvidia/deepstream:rtvi_ds9.1plus-triton"
 ARG DS_VERSION=9.1
 
 # =============================================================================

--- a/services/rtvi/rt-cv/docker/sbsa.Dockerfile
+++ b/services/rtvi/rt-cv/docker/sbsa.Dockerfile
@@ -43,7 +43,7 @@
 # Layers are split for cacheability, which preserves execution order; the
 # sequence itself is untouched.
 # -----------------------------------------------------------------------------
-ARG BASE_IMAGE="nvcr.io/nvidia/deepstream:9.1-triton-sbsa-dgx-spark"
+ARG BASE_IMAGE="nvcr.io/nvidia/deepstream:rtvi_ds9.1plus-sbsa"
 ARG DS_VERSION=9.1
 
 # =============================================================================


### PR DESCRIPTION
Both rt-cv Dockerfiles move off the stock public DeepStream SDK tags and onto the RTVI-specific ones:

  multiarch  nvcr.io/nvidia/deepstream:9.1-triton-multiarch
          -> nvcr.io/nvidia/deepstream:rtvi_ds9.1plus-triton

  sbsa       nvcr.io/nvidia/deepstream:9.1-triton-sbsa-dgx-spark
          -> nvcr.io/nvidia/deepstream:rtvi_ds9.1plus-sbsa

Both new tags are anonymously pullable, which is the property the GHCR build depends on: GitHub Actions has no NGC credentials, so a base that needs them cannot be used. Verified with an empty Docker config -- rtvi_ds9.1plus-triton resolves linux/amd64 + linux/arm64, rtvi_ds9.1plus-sbsa resolves linux/arm64.

Checked the new multiarch base against everything the Dockerfile assumes before switching: /usr/local/cuda-13.2 is present (CUDA_VER=13.2 is load-bearing -- the Makefile builds -I/usr/local/cuda-$(CUDA_VER)/include), as are sparse4d's install_dependencies.sh and config_ocr.yaml, apps-common, deepstream-app, the deepstream-9.1 install root, gcc/make, and uid 1000 (triton-server, which the runtime user is deliberately created against).

Compile-tested by building the ds-devel stage on the new base: the app compiles and installs, and the resulting binary is 1,030,344 bytes -- the exact size of the binary in the NGC reference image nvcr.io/nvstaging/vss-core/vss-rt-cv:3.3.0-26.07.2, where the stock public base produced 1,026,024. That match is the expected outcome if these tags are the base the NGC image is built from.

The vss-rt-cv-sbsa inventory note is updated to name the new SBSA base.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
