### PR TITLE
fix(deploy): pin RT-VLM centrally and stop the deploy step dying at the tool timeout

### DIFF
--- a/deploy/docker/containers.env
+++ b/deploy/docker/containers.env
@@ -173,9 +173,18 @@ VSS_NVSTREAMER_TAG="${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-1.4.0-26.08.1}}"
 
 VSS_VIOS_INGRESS_IMAGE="${VSS_VIOS_INGRESS_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-vios-ingress}"
 VSS_VIOS_INGRESS_TAG="${VSS_VIOS_INGRESS_TAG:-${VSS_CONTAINER_TAG:-1.4.0-26.08.1}}"
-# RT-VLM is part of the shared GHCR-managed image set.
-VSS_RT_VLM_IMAGE="${VSS_RT_VLM_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-rt-vlm}"
-VSS_RT_VLM_TAG="${VSS_RT_VLM_TAG:-${VSS_CONTAINER_TAG:-3.3.0-26.08.2}}"
+# RT-VLM has NOT migrated to the shared GHCR set: the GHCR repository is private
+# and returns HTTP 403 for a pull token even after a successful `docker login`,
+# so it is pinned to the staging registry explicitly rather than inheriting
+# VSS_CONTAINER_REGISTRY. Move it back to the shared knob once the GHCR
+# repository is published.
+#
+# Note the nested `${VSS_CONTAINER_REGISTRY:-...}` fallback used by the shared
+# entries above is unreachable in practice: VSS_CONTAINER_REGISTRY is always
+# assigned a default earlier in this file, so the inner alternative never
+# applies. Naming the registry directly here avoids relying on it.
+VSS_RT_VLM_IMAGE="${VSS_RT_VLM_IMAGE:-${VSS_CONTAINER_STAGING_REGISTRY}/vss-rt-vlm}"
+VSS_RT_VLM_TAG="${VSS_RT_VLM_TAG:-3.3.0-26.08.2}"
 VSS_CALIBRATION_TOOLKIT_IMAGE="${VSS_CALIBRATION_TOOLKIT_IMAGE:-${VSS_CONTAINER_RELEASE_REGISTRY}/calibration}"
 VSS_VIDEO_ANALYTICS_UI_IMAGE="${VSS_VIDEO_ANALYTICS_UI_IMAGE:-${VSS_CONTAINER_STAGING_REGISTRY}/vss-video-analytics-ui}"
 

--- a/skills/vss-deploy-profile/SKILL.md
+++ b/skills/vss-deploy-profile/SKILL.md
@@ -48,10 +48,16 @@ The deployment flow is always: copy `overrides.env` to `generated.env`, apply ov
 ```bash
 # 1. cp dev-profile-<profile>/overrides.env dev-profile-<profile>/generated.env  (clean copy)
 # 2. Apply env overrides to generated.env  (source .env and overrides.env stay untouched)
-# 3. docker compose --env-file .env --env-file generated.env config > resolved.yml  (dry-run)
+# 3. docker compose --env-file containers.env --env-file .env --env-file generated.env config > resolved.yml
 # 4. Review resolved.yml
-# 5. docker compose --env-file .env --env-file generated.env -f resolved.yml up -d
+# 5. docker compose --env-file containers.env --env-file .env --env-file generated.env -f resolved.yml up -d
 ```
+
+**There are THREE env layers and `containers.env` is the first.** It is the
+single source of truth for every first-party image coordinate, and both
+`dev-profile.sh` and `blueprint-deploy.sh` pass it. Omitting it silently drops
+every curated image default and falls back to the compose-level ones, several
+of which resolve to registries this deployment cannot pull from.
 
 `.env` is the read-only checked-in stable-default layer. `overrides.env` is the read-only checked-in profile override layer for values the deploy scripts may modify per host/profile. `generated.env` is the per-deploy working copy created from `overrides.env`. Step 1c covers this in full.
 
@@ -222,9 +228,10 @@ reference has worked examples for that profile's common scenarios.
 #   sed -i "s|^LLM_MODE=.*|LLM_MODE=remote|" "$ENV_GEN"
 #   sed -i "s|^LLM_BASE_URL=.*|LLM_BASE_URL=http://localhost:30081|" "$ENV_GEN"
 
-# Resolve compose
+# Resolve compose. containers.env FIRST; see "Instructions" above.
 cd $REPO/deploy/docker
-docker compose --env-file $ENV_SRC --env-file $ENV_GEN config > resolved.yml
+docker compose --env-file containers.env --env-file $ENV_SRC --env-file $ENV_GEN \
+  config > resolved.yml
 ```
 
 The resolved YAML is saved to `<repo>/deploy/docker/resolved.yml`.
@@ -278,12 +285,42 @@ Ask: **"Looks good — deploy now?"** and wait for confirmation before Step 5.
 
 ### Step 5 — Deploy
 
+`up -d` does NOT return once the containers are created. It blocks until every
+`depends_on` with `condition: service_healthy` is satisfied. The `lvs` profile
+resolves to 29 services with 14 such gates, two of them model servers that take
+10 to 20 minutes on a cold cache. That is longer than an agent Bash tool can
+run, so a foreground call is killed part-way (observed: exit 143 at exactly
+2m00s) and the deploy is left half-built.
+
+Run it as a supervised detached job that records its own exit status:
+
 ```bash
 cd $REPO/deploy/docker
-docker compose --env-file $ENV_SRC --env-file $ENV_GEN -f resolved.yml up -d
+RUN_DIR=$(mktemp -d /tmp/vss-deploy-XXXXXX)          # unique; never a fixed path
+setsid bash -c "
+  docker compose --env-file containers.env --env-file $ENV_SRC --env-file $ENV_GEN \
+    -f resolved.yml up -d
+  printf '%s' \$? > $RUN_DIR/exit-code
+" > "$RUN_DIR/up.log" 2>&1 < /dev/null &
+echo "deploy log: $RUN_DIR/up.log   status: $RUN_DIR/exit-code"
 ```
 
-> **Both `--env-file` arguments are mandatory and ordered.** Without the same `.env` + `generated.env` pair used in Step 3, `COMPOSE_PROFILES` may be unset or incomplete and `up -d` can exit 0 with zero selected services.
+`setsid` puts the job in its own session so it is not signalled when the agent's
+turn ends. Verify it is present in pre-flight; it is not POSIX. Note that
+`setsid` protects against session and terminal signals, **not** against a
+harness that kills descendants by cgroup or ancestry, so this is a mitigation
+rather than a guarantee.
+
+**Use `$RUN_DIR/exit-code`, not `$!`, as the completion signal.** `$!` is the
+pid of the launcher, which may exec or fork depending on whether it is already
+a process-group leader, so it is not a reliable handle on Compose itself. The
+status file is written exactly once and is the only durable record of how the
+job ended.
+
+> **All THREE `--env-file` arguments are mandatory and ordered**, matching
+> Step 3 exactly. Drop `containers.env` and curated image coordinates revert to
+> compose-level defaults; drop the others and `COMPOSE_PROFILES` may be unset,
+> in which case `up -d` exits 0 having selected zero services.
 
 > **Avoid broad `--force-recreate` on ordinary retries** — it destroys warm
 > NIM containers (another 3–5 min torch.compile + CUDA-graph capture each).
@@ -291,7 +328,36 @@ docker compose --env-file $ENV_SRC --env-file $ENV_GEN -f resolved.yml up -d
 > use targeted `--force-recreate --no-deps <service...>` only when a profile
 > reference documents it as the recovery path.
 
-`docker compose up -d` only creates containers; it does not wait for internal services to finish warming. Never declare deploy success until the readiness gates pass.
+### Step 5a — Wait on the job, not on the container count
+
+Poll in bounded chunks and **never end your turn while the job is running**.
+Stop only when one of these is true:
+
+1. `$RUN_DIR/exit-code` exists. Read it. Non-zero means the deploy failed and
+   `$RUN_DIR/up.log` says why.
+2. A concrete terminal error appears in `$RUN_DIR/up.log`.
+3. A documented overall deadline is reached (see the profile reference).
+
+```bash
+# One bounded wait. Repeat across turns until a stop condition holds.
+timeout 540 bash -c 'until [ -s '"$RUN_DIR"'/exit-code ]; do sleep 10; done' \
+  || echo "still running after 9 min, poll again"
+[ -s "$RUN_DIR/exit-code" ] && echo "compose exited: $(cat $RUN_DIR/exit-code)"
+tail -20 "$RUN_DIR/up.log"
+docker compose -f resolved.yml ps --format '{{.Name}}\t{{.State}}' | sort
+```
+
+**Do not treat a stable container count as completion.** A health-gated deploy
+sits at an unchanged count for the entire 10 to 20 minutes a model server takes
+to load: no containers are created, none change state, and nothing is wrong.
+Anything that stops on "the count stopped changing" will declare success or
+failure part-way through a perfectly healthy deploy. Containers in `created`
+state, or with health `starting`, mean the deploy is still in progress
+regardless of how quiet things look.
+
+A zero exit code means Compose finished its own work. It does **not** mean the
+services behind those gates have finished warming internally, which is what
+Step 5b checks.
 
 ### Step 5b — Wait until the stack is actually healthy
 


### PR DESCRIPTION
## What this changes

Three defects in the deploy path, each measured on an RTX PRO 6000 Blackwell
host by running the real Harbor eval instruction through a headless agent under
1 Hz host telemetry.

**1. RT-VLM resolved to a registry the deployment cannot pull from.**
`containers.env` described RT-VLM as part of the shared GHCR set, so it
inherited `VSS_CONTAINER_REGISTRY`. That GHCR repository is private:

| coordinate | manifest |
|---|---|
| `ghcr.io/nvidia-ai-blueprints/vss/vss-rt-vlm:develop-latest` | **HTTP 403** |
| `nvcr.io/nvstaging/vss-core/vss-rt-vlm:3.3.0-26.08.2` | **HTTP 200** |

403 persists after a successful `docker login`. Measured consequence: an
`alerts` deploy leg scored **0 of 7 checks with zero containers** because the
agent correctly refused to start Compose on an unpullable image, exactly as the
skill's own entitlement gate (Step 3c) instructs.

Fixed in `containers.env` rather than per profile. That matters: `dev-profile.sh`
and `blueprint-deploy.sh` both do `set -a; source containers.env`, which
**exports** these names, and Compose gives the environment precedence over every
`--env-file`. A per-profile override is silently inert on the scripted path. An
earlier revision of this change made exactly that mistake and was rejected in
review.

**2. The skill documented two env layers where there are three.** Both scripted
entrypoints pass `containers.env` first. Omitting it drops every curated image
coordinate back to the compose-level fallbacks, which is how defect 1 reaches a
deploy that follows the skill.

**3. `Step 5` ran `up -d` in the foreground.** `up -d` does not return when
containers are created; it blocks until every `depends_on` with
`condition: service_healthy` is satisfied. The `lvs` profile resolves to 29
services with 14 such gates, two of them model servers documented at 10 to 20
minutes cold. Agent Bash tools cap well below that. Observed repeatedly:

```
Exit code 143
Command timed out after 2m 0s
```

leaving a half-built stack. Step 5 is now a supervised detached job that writes
its own exit status to a unique directory, and Step 5a polls that status rather
than the container count.

## Baseline reliability, measured

Nine deploy legs on unmodified `develop` across six profiles: **four passed,
five failed.** Every failure left the application layer missing. Four were the
same sequence: foreground `up -d` killed at the tool timeout, agent retries by
backgrounding it as a tool call, that call dies when the turn ends. One was
defect 1 above.

The baseline is bimodal rather than deterministically broken. Two runs of the
identical unmodified code on `lvs` differed by 26% in wall clock (860s and
682s), and one later run of the same code failed outright. A single pair per
profile shows direction, not precision.

## Measurement status, stated plainly

The evidence above is about `develop` and is unaffected by how the fix is
implemented. **The speedup numbers are not yet re-measured against this exact
commit.** An earlier revision implementing the same three fixes differently
measured 3.0x, 3.5x and 3.8x wall-clock improvements on `base`, `lvs` and
`search`, each against a baseline that also passed. That revision was rejected
in review for fixing defect 1 at the wrong layer, so those numbers describe code
that no longer exists here. A re-measure against `b6228f235` is running and I
will post it before taking this out of draft.

## Not addressed here

Every leg was scored twice, at agent exit and after convergence. They disagree:
six of seven legs scored between 0/7 and 4/6 the moment the agent's turn ended
and were fully green 2 to 13 minutes later. The eval harness verifies at the
first point, so it records failures for deploys that come up fine. That belongs
in the harness, not this skill.

## Test plan

- `docker compose --env-file containers.env ... config --images` resolves
  `nvcr.io/nvstaging/vss-core/vss-rt-vlm:3.3.0-26.08.2` on both the skill path
  and the scripted path (`set -a; source containers.env`), which is where the
  rejected revision was inert.
- Both manifests re-verified today: nvstaging 200, ghcr 403.
- No profile env file is touched, so the profile-layout contract in
  `test-dev-profile.sh` is unchanged.
- LVS image coordinates are deliberately left alone; that is a separate change
  needing its own validation.
