### PR TITLE
fix(vss-configurator): wait for the NVStreamer stream list to stop growing before registering cameras

### DIFF
--- a/services/configurators/vss-configurator/README.md
+++ b/services/configurators/vss-configurator/README.md
@@ -133,6 +133,7 @@ The Sensor Configuration Manager manages sensor/camera configurations for video 
   - Generates mappings between sensor IDs, names, URLs, and metadata
   - Persists mappings to disk for reliability
   - Supports sensor sources: Metropolis Sensor Bridge (`msb`), NVStreamer (`nvstreamer`), or local JSON (`file`)
+  - For the `nvstreamer` source, waits for the advertised stream count to stop changing before registering cameras. NVStreamer registers video files serially, so its streams endpoint serves a partial list for a short window after startup; accepting that would drop the cameras still registering. This costs a couple of seconds of startup and needs no configuration
   
 - **VMS Integration**
   - Automatically registers sensors with Video Management Systems

--- a/services/configurators/vss-configurator/README.md
+++ b/services/configurators/vss-configurator/README.md
@@ -133,7 +133,7 @@ The Sensor Configuration Manager manages sensor/camera configurations for video 
   - Generates mappings between sensor IDs, names, URLs, and metadata
   - Persists mappings to disk for reliability
   - Supports sensor sources: Metropolis Sensor Bridge (`msb`), NVStreamer (`nvstreamer`), or local JSON (`file`)
-  - For the `nvstreamer` source, waits for the advertised stream count to stop changing before registering cameras. NVStreamer registers video files serially, so its streams endpoint serves a partial list for a short window after startup; accepting that would drop the cameras still registering. This costs a couple of seconds of startup and needs no configuration
+  - For the `nvstreamer` source, waits for the advertised stream count to stop changing before registering cameras. NVStreamer registers video files serially, so its streams endpoint serves a partial list for a short window after startup; accepting that would drop the cameras still registering. This costs one poll interval of startup and needs no configuration. Note that it is a heuristic — a registration stall longer than the poll interval would still settle early — so cameras that appear after startup are not picked up until the list is reconciled
   
 - **VMS Integration**
   - Automatically registers sensors with Video Management Systems

--- a/services/configurators/vss-configurator/app/sensor_config_manager.py
+++ b/services/configurators/vss-configurator/app/sensor_config_manager.py
@@ -38,12 +38,14 @@ logger = get_logger(__name__)
 app = Flask(__name__)
 sensor_mapping = None
 
-# Back-off while the Nvstreamer streams endpoint is not answering usefully yet.
+# Delay between reads of the Nvstreamer streams endpoint, used both while it is
+# not answering usefully yet and between the two reads that have to agree before
+# the advertised stream list is treated as complete. Nvstreamer registers streams
+# roughly 100ms apart, so 5s is a wide margin, but it is still a heuristic: a
+# registration stall longer than this would settle early. Reconciling the list
+# after startup is the durable answer to that, and would also pick up cameras
+# added later.
 NVSTREAMER_STREAMS_RETRY_DELAY = 5
-# Gap between the two reads that have to agree before the advertised stream list
-# is treated as complete. Nvstreamer registers streams a little over 100ms apart,
-# so this is a wide margin, and it is the only startup cost the check adds.
-NVSTREAMER_STREAMS_SETTLE_DELAY = 2
 
 # Video upload status tracking (for NVStreamer video upload feature)
 # Status can be: "not_started", "in_progress", "completed", "failed", "disabled"
@@ -770,8 +772,8 @@ def fetch_all_streams_from_nvstreamer():
             break
         previous_count = len(streams)
         logger.info(f"Nvstreamer advertised {previous_count} streams - re-checking in "
-                    f"{NVSTREAMER_STREAMS_SETTLE_DELAY}s before registering cameras")
-        time.sleep(NVSTREAMER_STREAMS_SETTLE_DELAY)
+                    f"{NVSTREAMER_STREAMS_RETRY_DELAY}s before registering cameras")
+        time.sleep(NVSTREAMER_STREAMS_RETRY_DELAY)
 
     logger.info(f"Successfully parsed Nvstreamer streams endpoint response: {json_vals}")
 

--- a/services/configurators/vss-configurator/app/sensor_config_manager.py
+++ b/services/configurators/vss-configurator/app/sensor_config_manager.py
@@ -38,6 +38,13 @@ logger = get_logger(__name__)
 app = Flask(__name__)
 sensor_mapping = None
 
+# Back-off while the Nvstreamer streams endpoint is not answering usefully yet.
+NVSTREAMER_STREAMS_RETRY_DELAY = 5
+# Gap between the two reads that have to agree before the advertised stream list
+# is treated as complete. Nvstreamer registers streams a little over 100ms apart,
+# so this is a wide margin, and it is the only startup cost the check adds.
+NVSTREAMER_STREAMS_SETTLE_DELAY = 2
+
 # Video upload status tracking (for NVStreamer video upload feature)
 # Status can be: "not_started", "in_progress", "completed", "failed", "disabled"
 _video_upload_status = {
@@ -713,60 +720,63 @@ def nvstreamer_stream_is_valid(stream_name):
     logger.warning(f"Stream '{stream_name}' validation failed after {max_retries} attempts")
     return False
 
+def read_nvstreamer_streams():
+    """
+    Read the Nvstreamer streams endpoint once.
+
+    Returns the advertised stream list, or None while the endpoint is
+    unreachable, answering non-200, or serving something unusable.
+    """
+    try:
+        logger.info("Checking Nvstreamer streams endpoint to see if it's ready")
+        resp = requests.get(CONFIG['NVSTREAMER_STREAMS_ENDPOINT'])
+    except Exception as e:
+        logger.warning(f"Error while checking Nvstreamer streams endpoint, retrying in {NVSTREAMER_STREAMS_RETRY_DELAY}s")
+        logger.debug(f"Exception details: {repr(e)}")
+        return None
+
+    if not resp.status_code == 200:
+        logger.info(f"Getting status code {resp.status_code} from VST endpoint {CONFIG['NVSTREAMER_STREAMS_ENDPOINT']} - retrying in {NVSTREAMER_STREAMS_RETRY_DELAY}s")
+        return None
+
+    try:
+        json_vals = resp.json()
+    except Exception as e:
+        logger.info(f"Failed to parse Nvstreamer response as JSON - retrying in {NVSTREAMER_STREAMS_RETRY_DELAY}s. Exception: {repr(e)}")
+        return None
+
+    if not json_vals:
+        logger.info(f"Nvstreamer streams endpoint returned empty response - retrying in {NVSTREAMER_STREAMS_RETRY_DELAY}s")
+        return None
+
+    logger.info(f"Getting status code {resp.status_code} from Nvstreamer streams endpoint {CONFIG['NVSTREAMER_STREAMS_ENDPOINT']} with valid response")
+    return json_vals
+
 def fetch_all_streams_from_nvstreamer():
-    api_up = False
-    # start_time = time.time()
-    while not api_up:
-        try:
-            logger.info("Checking Nvstreamer streams endpoint to see if it's ready")
-            resp = requests.get(CONFIG['NVSTREAMER_STREAMS_ENDPOINT'])
-            # api_up = True
-        except Exception as e:
-            logger.warning("Error while checking Nvstreamer streams endpoint, retrying in 5 seconds")
-            logger.debug(f"Exception details: {repr(e)}")
-            api_up = False
-            time.sleep(5)
+    # Nvstreamer registers video files serially, each needing a decode pass to
+    # parse its keyframe interval, so the streams endpoint legitimately
+    # advertises a partial list for a few hundred milliseconds after startup.
+    # Accepting the first non-empty reply registers only the cameras that had
+    # made it and never reconciles, so wait for the count to stop growing.
+    previous_count = None
+    while True:
+        streams = read_nvstreamer_streams()
+        if streams is None:
+            previous_count = None
+            time.sleep(NVSTREAMER_STREAMS_RETRY_DELAY)
             continue
-
-        # if int(time.time() - start_time)  > CONFIG['NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT']:
-        #     logger.error("VST endpoint took too long to respond - skipping VST preload")
-        #     return []
-
-        # resp = requests.get(CONFIG['NVSTREAMER_STREAMS_ENDPOINT']) # TODO: Check if commenting this works
-
-        if not resp.status_code == 200:
-            logger.info(f"Getting status code {resp.status_code} from VST endpoint {CONFIG['NVSTREAMER_STREAMS_ENDPOINT']} - retrying in 5 seconds")
-            api_up = False
-            time.sleep(5)
-            continue
-        else:
-            # Check if response is not empty even with 200 status code
-            try:
-                json_vals = resp.json()
-                if not json_vals or len(json_vals) == 0:
-                    logger.info(f"Nvstreamer streams endpoint returned empty response - retrying in 5 seconds")
-                    api_up = False
-                    time.sleep(5)
-                    continue
-            except Exception as e:
-                logger.info(f"Failed to parse Nvstreamer response as JSON - retrying in 5 seconds. Exception: {repr(e)}")
-                api_up = False
-                time.sleep(5)
-                continue
-            
-            logger.info(f"Getting status code {resp.status_code} from Nvstreamer streams endpoint {CONFIG['NVSTREAMER_STREAMS_ENDPOINT']} with valid response")
-            logger.info(f"Successfully parsed Nvstreamer streams endpoint response: {json_vals}")
-            api_up = True
+        if len(streams) == previous_count:
+            json_vals = streams
             break
+        previous_count = len(streams)
+        logger.info(f"Nvstreamer advertised {previous_count} streams - re-checking in "
+                    f"{NVSTREAMER_STREAMS_SETTLE_DELAY}s before registering cameras")
+        time.sleep(NVSTREAMER_STREAMS_SETTLE_DELAY)
 
-    # try:
-        # json_vals = resp.json()
-    #     logger.info(f"Successfully parsed VST endpoint response: {json_vals}")
-    # except Exception as e:
-    #     logger.info("Couldn't parse VST endpoint response, will retry. Exception was - " + repr(e))
-    #     return None
+    logger.info(f"Successfully parsed Nvstreamer streams endpoint response: {json_vals}")
 
     nvstreamer_streams = []
+    offline_streams = []
     for stream in json_vals:
         for key, value in stream.items():
             if len(value) < 1:
@@ -785,11 +795,17 @@ def fetch_all_streams_from_nvstreamer():
                 
                 if not nvstreamer_stream_is_valid(curr_data["name"]):
                     logger.info(f"Stream {curr_data['name']} is not online - skipping add")
+                    offline_streams.append(curr_data["name"])
                     continue
                 else:
                     logger.info(f"Stream {curr_data['name']} is online - adding")
             
                 nvstreamer_streams.append(curr_dict)
+
+    # These cameras are dropped for the lifetime of the deployment, so name them
+    # instead of leaving the loss to be inferred from a count.
+    if offline_streams:
+        logger.warning(f"Dropping {len(offline_streams)} Nvstreamer stream(s) that never came online: {offline_streams}")
 
     return nvstreamer_streams
 

--- a/services/configurators/vss-configurator/tests/test_nvstreamer_stream_discovery.py
+++ b/services/configurators/vss-configurator/tests/test_nvstreamer_stream_discovery.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for Nvstreamer stream discovery.
+
+Nvstreamer registers video files serially, so its streams endpoint advertises a
+partial list for a short window after startup. Discovery used to accept the first
+non-empty reply, which permanently dropped whichever cameras had not registered
+yet while still logging success.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture(autouse=True)
+def populated_config(monkeypatch, tmp_path):
+    """
+    Point calibration at tmp_path and make sure CONFIG is populated.
+
+    CONFIG is the same dict object as _config_cache, so a sibling test module
+    clearing the cache leaves the endpoint lookups here raising KeyError.
+    """
+    monkeypatch.setenv("CALIBRATION_DIR_MOUNT_PATH", str(tmp_path))
+    import sensor_config_manager as mod
+    mod.refresh_config()
+    yield
+    mod._config_cache.clear()
+
+
+@pytest.fixture
+def no_sleep():
+    """Drop the settle and retry delays so the tests run instantly."""
+    import sensor_config_manager as mod
+    with patch.object(mod.time, "sleep", MagicMock()) as sleep:
+        yield sleep
+
+
+def streams(*names):
+    """Build an Nvstreamer streams-endpoint payload for the given cameras."""
+    return [
+        {
+            f"{name}_0": [
+                {
+                    "isMain": True,
+                    "name": name,
+                    "streamId": f"{name}_0",
+                    "url": f"rtsp://nvstreamer:31554/{name}.mp4",
+                    "metadata": {},
+                }
+            ]
+        }
+        for name in names
+    ]
+
+
+def discover(mod, replies):
+    """Run discovery against a scripted sequence of endpoint reads."""
+    with patch.object(mod, "read_nvstreamer_streams", side_effect=replies) as read:
+        with patch.object(mod, "nvstreamer_stream_is_valid", return_value=True):
+            return mod.fetch_all_streams_from_nvstreamer(), read
+
+
+def names_of(result):
+    return sorted(entry["event"]["camera_name"] for entry in result)
+
+
+def test_partial_list_is_not_registered(no_sleep):
+    """
+    The reported bug: Nvstreamer advertises 2 of 3 streams and discovery used to
+    register those 2 and never reconcile. It has to keep reading until the third
+    camera shows up.
+    """
+    import sensor_config_manager as mod
+    result, read = discover(mod, [
+        streams("Camera_02", "Camera"),
+        streams("Camera_02", "Camera", "Camera_01"),
+        streams("Camera_02", "Camera", "Camera_01"),
+    ])
+    assert names_of(result) == ["Camera", "Camera_01", "Camera_02"]
+    assert read.call_count == 3
+
+
+def test_a_steady_count_is_accepted(no_sleep):
+    """Two reads that agree end the wait, so startup is not delayed further."""
+    import sensor_config_manager as mod
+    result, read = discover(mod, [streams("a", "b"), streams("a", "b")])
+    assert names_of(result) == ["a", "b"]
+    assert read.call_count == 2
+
+
+def test_a_growing_count_keeps_waiting(no_sleep):
+    """Every change restarts the wait, so a list still filling up cannot settle."""
+    import sensor_config_manager as mod
+    result, read = discover(mod, [
+        streams("a"),
+        streams("a", "b"),
+        streams("a", "b", "c"),
+        streams("a", "b", "c"),
+    ])
+    assert names_of(result) == ["a", "b", "c"]
+    assert read.call_count == 4
+
+
+def test_endpoint_failure_does_not_count_as_agreement(no_sleep):
+    """A flapping endpoint must not be mistaken for a settled stream list."""
+    import sensor_config_manager as mod
+    result, read = discover(mod, [
+        streams("a", "b"),
+        None,
+        streams("a", "b"),
+        streams("a", "b"),
+    ])
+    assert names_of(result) == ["a", "b"]
+    assert read.call_count == 4
+
+
+def test_unavailable_endpoint_never_registers_zero_cameras(no_sleep):
+    """
+    Waiting for Nvstreamer to come up stays unbounded, so an endpoint that is not
+    ready yet must not be committed as an empty camera list.
+    """
+    import sensor_config_manager as mod
+    result, read = discover(mod, [None, None, streams("a"), streams("a")])
+    assert names_of(result) == ["a"]
+    assert read.call_count == 4
+
+
+def test_streams_that_never_come_online_are_named(no_sleep):
+    """Cameras dropped by the online check are reported, not silently lost."""
+    import sensor_config_manager as mod
+    with patch.object(mod, "read_nvstreamer_streams", return_value=streams("a", "b")):
+        with patch.object(mod, "nvstreamer_stream_is_valid", side_effect=lambda name: name != "b"):
+            with patch.object(mod, "logger") as log:
+                result = mod.fetch_all_streams_from_nvstreamer()
+    assert names_of(result) == ["a"]
+    assert log.warning.called
+    assert "b" in log.warning.call_args[0][0]
+
+
+def test_empty_reply_is_treated_as_not_ready():
+    """read_nvstreamer_streams() reports an empty 200 as not ready rather than done."""
+    import sensor_config_manager as mod
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = []
+    with patch.object(mod.requests, "get", return_value=resp):
+        assert mod.read_nvstreamer_streams() is None
+
+
+def test_non_200_reply_is_treated_as_not_ready():
+    """A non-200 status is reported as not ready."""
+    import sensor_config_manager as mod
+    resp = MagicMock(status_code=503)
+    with patch.object(mod.requests, "get", return_value=resp):
+        assert mod.read_nvstreamer_streams() is None
+
+
+def test_usable_reply_is_returned():
+    """A 200 carrying streams is passed straight back."""
+    import sensor_config_manager as mod
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = streams("a", "b")
+    with patch.object(mod.requests, "get", return_value=resp):
+        assert len(mod.read_nvstreamer_streams()) == 2


### PR DESCRIPTION
## Summary

On a cold start, `vss-configurator` prefetches the camera list from NVStreamer and registers it with VST in a single one-shot pass. Its readiness check only verified that the stream list was **non-empty**, not that it was **complete**.

NVStreamer registers video files serially — each one needs a decode pass to parse its keyframe interval — so the endpoint legitimately serves a partial list for a few hundred milliseconds during startup. If the configurator's poll landed inside that window, it accepted the truncated list as authoritative, registered only those cameras, and never reconciled.

The result was a silent, permanent shortfall: the deployment ran fewer cameras than configured while every pod reported healthy, all Jobs completed, and the configurator logged `Successfully called sensor add API` as an apparent success. Because it depends on disk and CPU speed during NVStreamer's media probing, it reproduced inconsistently across hosts.

Observed on the `warehouse-2d-app` profile with 3 sample videos: NVStreamer registered all 3, VST received only 2, and `Camera_01` never appeared.

## Root cause

In `fetch_all_streams_from_nvstreamer()`, the completeness check tested only for a non-empty list. Any list of length >= 1 set `api_up = True` and broke the retry loop. Since NVStreamer's registration is incremental, there is no point at which a non-empty response is *guaranteed* complete, so that predicate cannot distinguish "ready" from "partially ready".

The success log compounded it: it reported the count that happened to be fetched, never comparing it against anything, so a shortfall read as success.

## The change

Accept the stream list only once **two consecutive reads agree on its length**.

- Any change in the count restarts the wait, so a list that is still filling up cannot settle.
- An unusable reply (unreachable, non-200, unparseable, or empty) resets the wait, so a flapping endpoint is not mistaken for a settled one.
- Waiting for the endpoint to come up at all stays unbounded, exactly as before.

Two supporting changes:

- Streams that NVStreamer advertised but never brought online are now named in a warning. They were being dropped for the lifetime of the deployment behind an `info` log — a second, separate way for cameras to go missing without saying so.
- The single endpoint read is split out as `read_nvstreamer_streams()` so the waiting and the parsing can be tested independently.

### On the alternative: gating on `NUM_STREAMS`

Gating the retry loop on an expected stream count was considered and deliberately not used, even though `NUM_STREAMS` is already in the container environment and is currently read by no application code.

- It would not hold generally. The `bp-configurator` chart ships `env: []` and does not define `NUM_STREAMS`; only some profiles inject it (`warehouse-2d-app` sets `"3"`, docker-compose defaults to `4`). A gate keyed on it would silently do nothing wherever it is unset, which is precisely where a silent failure is hardest to notice.
- It introduces a failure mode that does not exist today. `NUM_STREAMS` set higher than NVStreamer can ever serve — one stale video file, one miscounted profile — turns every cold start into a wait for a count that never arrives, requiring a timeout and a partial-commit fallback to stay safe.

Waiting for the count to settle needs no configuration, behaves identically across every profile, and its worst case is the current behaviour arriving slightly later. It cannot introduce a new way to fail.

`NUM_STREAMS` remains unread; wiring it up as a cross-check is a reasonable follow-up, but it is not needed to close this race.

## Cost

Adds one settle interval (2s) to cold start on the `nvstreamer` sensor path. NVStreamer registers streams a little over 100ms apart, so a 2s gap between the two agreeing reads is a wide margin.

## Test plan

- [x] New `tests/test_nvstreamer_stream_discovery.py` (9 tests): a partial list is not registered; a steady count is accepted; a growing count keeps waiting; endpoint failure does not count as agreement; an unavailable endpoint never registers zero cameras; offline streams are named; and the three `read_nvstreamer_streams()` reply cases.
- [x] Full `vss-configurator` suite passes: 158 tests, under CI's exact dependency set on Python 3.13.
- [x] Verified stable under test reordering (the new fixture repopulates `CONFIG`, which is the same object as `_config_cache` and is cleared by a sibling module).
- [x] Replayed the reported timeline against pre-change and post-change code:

```
BEFORE (develop @ 4c66567)   committed: 2 -> ['Camera', 'Camera_02']                 Camera_01: absent
AFTER  (this change)         committed: 3 -> ['Camera', 'Camera_01', 'Camera_02']    Camera_01: present
```

- [x] SPDX copyright header check passes.
- [ ] Suggested pre-merge validation: cold-start the `warehouse-2d-app` Helm profile repeatedly on a fast host and confirm all configured cameras reach VST every time.

## Notes for reviewers

- Log wording in `read_nvstreamer_streams()` changed from a hardcoded "retrying in 5 seconds" to the actual delay constant. Worth knowing if anything greps these lines.
- Dead commented-out code in the old retry loop (an unused `NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT` deadline and a duplicate `requests.get`) is removed. `NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT` itself is left in `CONFIG` untouched and remains unused.
- Behaviour for the `msb` and `file` sensor sources is unchanged.
