### PR TITLE
add SBSA build variant with -sbsa tag suffix

### DIFF
--- a/.github/scripts/test_detect_changed_images.py
+++ b/.github/scripts/test_detect_changed_images.py
@@ -534,6 +534,7 @@ class SelectImagesTest(unittest.TestCase):
                 "vss-vios-ingress",
                 "vss-rt-embed",
                 "vss-rt-embed-sbsa",
+                "vss-rt-vlm-sbsa",
                 "vss-video-summarization-sbsa",
             },
         )

--- a/deploy/docker/container-inventory.json
+++ b/deploy/docker/container-inventory.json
@@ -128,9 +128,27 @@
       "context": "services/rtvi/rt-vlm",
       "dockerfile": "services/rtvi/rt-vlm/docker/Dockerfile",
       "lfs_include": "services/rtvi/rt-vlm/docker/base/binaries/**,services/rtvi/rt-vlm/artifacts/vss-rt-vlm-3.3.0-26.07.4-*-evs-cython/**",
+      "build_args": {"ARM_PLATFORM": "igpu"},
       "platforms": ["linux/amd64", "linux/arm64"],
       "compose_image_names": ["vss-rt-vlm"],
       "tag_variables": ["VSS_RT_VLM_TAG"]
+    },
+    {
+      "name": "vss-rt-vlm-sbsa",
+      "strategy": "build",
+      "ghcr_build": true,
+      "native_platform_build": true,
+      "repository": "vss-rt-vlm",
+      "tag_suffix": "-sbsa",
+      "source_path": "services/rtvi/rt-vlm",
+      "context": "services/rtvi/rt-vlm",
+      "dockerfile": "services/rtvi/rt-vlm/docker/Dockerfile",
+      "lfs_include": "services/rtvi/rt-vlm/docker/base/binaries/**,services/rtvi/rt-vlm/artifacts/vss-rt-vlm-3.3.0-26.07.4-*-evs-cython/**",
+      "build_args": {"ARM_PLATFORM": "sbsa"},
+      "platforms": ["linux/arm64"],
+      "compose_image_names": [],
+      "tag_variables": [],
+      "notes": "SBSA (Grace/DGX-Spark) build of vss-rt-vlm. Shares the vss-rt-vlm GHCR repository and uses the -sbsa tag suffix; Compose and Helm select it by overriding only the tag."
     },
     {
       "name": "vss-rt-embed",


### PR DESCRIPTION
## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
