### PR TITLE
fix: make MV3DT routing scope discoverable

### DIFF
--- a/.github/skill-eval/tests/test_vss_deploy_detection_tracking_3d_guidance.py
+++ b/.github/skill-eval/tests/test_vss_deploy_detection_tracking_3d_guidance.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the MV3DT routing summary contract."""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILL = REPO_ROOT / "skills/vss-deploy-detection-tracking-3d/SKILL.md"
+EVAL_SPEC = REPO_ROOT / "skills/vss-deploy-detection-tracking-3d/evals/routing.json"
+COMPOSE_PATH = "services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/compose.yml"
+
+
+def test_routing_summary_is_available_in_skill_metadata() -> None:
+    """The routing model must see the deployment summary before skill loading."""
+    frontmatter = SKILL.read_text().split("---", 2)[1]
+
+    assert COMPOSE_PATH in frontmatter
+    for component in (
+        "perception",
+        "BEV Fusion",
+        "bundled Mosquitto",
+        "bundled Kafka",
+        "kafka-topic-init",
+    ):
+        assert component in frontmatter
+
+
+def test_routing_guidance_matches_the_behavioral_spec() -> None:
+    """The skill and valid verifier should retain the same concrete contract."""
+    skill = SKILL.read_text()
+    first_case = json.loads(EVAL_SPEC.read_text())["expects"][0]
+    contract = "\n".join(first_case["checks"])
+
+    assert COMPOSE_PATH in skill
+    assert COMPOSE_PATH in contract
+    for component in (
+        "perception",
+        "BEV Fusion",
+        "Mosquitto",
+        "Kafka",
+        "kafka-topic-init",
+    ):
+        assert component in skill
+        assert component in contract

--- a/skills/vss-deploy-detection-tracking-3d/SKILL.md
+++ b/skills/vss-deploy-detection-tracking-3d/SKILL.md
@@ -12,6 +12,10 @@ description: >
   2D tracking routes to the 2D tracking or DeepStream skills. Not for full
   warehouse blueprint deployment, single-camera 2D tracking, camera calibration
   itself, or VSS summarization, Q&A, and RAG workflows.
+  The standalone Compose file is
+  services/rtvi/rt-cv-3d/rt-cv-mv3dt/docker/compose.yml; its core services are
+  perception, BEV Fusion, bundled Mosquitto, bundled Kafka, and
+  kafka-topic-init.
 license: Apache-2.0
 metadata:
   author: NVIDIA
@@ -26,6 +30,9 @@ metadata:
 
 Deploy the standalone RT-CV-3D MV3DT stack from `services/rtvi/rt-cv-3d/rt-cv-mv3dt`.
 This is the default path for MV3DT / RTVI-CV-3D / multi-camera tracking requests.
+For concise routing or architecture answers, summarize the standalone Compose
+path and core service roles under **What This Deploys** without adding runtime
+image versions or deployment steps the user did not request.
 
 Do not derive MV3DT services from the warehouse blueprint for this skill. Use
 `vss-deploy-profile` only when the user explicitly asks for warehouse MV3DT,


### PR DESCRIPTION
## Summary
- surface the standalone MV3DT Compose path and core service roles in routing-visible skill metadata
- keep the existing routing verifier and broader deployment semantics unchanged
- add focused regression coverage tying the metadata summary to the behavioral contract

## Evidence
The Opus 4.7 path omitted the exact Compose path and service set in 10/10 sampled PR 1751 routing attempts across H200 and RTX PRO 6000, including [job 97541487947](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/actions/runs/32761064031/job/97541487947). Three sampled Opus 4.6 daily baselines passed the same routing step 3/3. The verifier is valid; the recurring defect is that concise routing answers can rely on frontmatter metadata without loading the detailed skill body.

This is intentionally independent from PR 1751: that PR owns OpenShell runner routing, while this change improves reusable `vss-deploy-detection-tracking-3d` guidance.

## Test plan
- [x] `python3 -m pytest -q .github/skill-eval/tests/test_vss_deploy_detection_tracking_3d_guidance.py` (2 passed)
- [x] `uvx ruff check .github/skill-eval/tests/test_vss_deploy_detection_tracking_3d_guidance.py`
- [x] `uvx ruff format --check .github/skill-eval/tests/test_vss_deploy_detection_tracking_3d_guidance.py`
- [x] `python3 .github/vss-playbook-compliance/skill_compliance_check.py --skills-dir skills/ --skill vss-deploy-detection-tracking-3d --no-color` (0 errors; 2 pre-existing name-length warnings)
- [x] `python3 .github/scripts/check_copyright_headers.py`
- [x] `git diff --check`
- [ ] Run the SHA-qualified Skills Eval after matching fleet capacity is available

The broader `.github/skill-eval/tests` suite reached 211 passes and the same three unrelated RTX 4090 capability-table failures reproduced on the unmodified `develop` baseline.

## Ownership
`/skills/` is owned by @NVIDIA-AI-Blueprints/VSS-Skill-Developers through CODEOWNERS; no additional reviewer ping is needed.