### PR TITLE
docs(behavior-analytics): correct FOV threshold semantics, document n…

### DIFF
--- a/services/analytics/behavior-analytics/docs/incident-detection.md
+++ b/services/analytics/behavior-analytics/docs/incident-detection.md
@@ -13,7 +13,7 @@ The `frame_state_management.py` module processes **enhanced frames** to detect v
 ## Key Concepts
 
 **Enhanced Frame** → Frame with pre-calculated violation data (proximity, ROI violations, FOV metrics, etc.)  
-**Violation** → Detected event from enhanced frame (e.g., people too close, unauthorized area access, objects in FOV more than a threshold)
+**Violation** → Detected event from enhanced frame (e.g., people too close, unauthorized area access, object count in FOV reaching a threshold)
 **Violation State** → Internal tracking of violation duration  
 **Incident** → Violation that exceeds time threshold and needs reporting  
 

--- a/services/analytics/behavior-analytics/docs/incident-detection.md
+++ b/services/analytics/behavior-analytics/docs/incident-detection.md
@@ -13,7 +13,7 @@ The `frame_state_management.py` module processes **enhanced frames** to detect v
 ## Key Concepts
 
 **Enhanced Frame** → Frame with pre-calculated violation data (proximity, ROI violations, FOV metrics, etc.)  
-**Violation** → Detected event from enhanced frame (e.g., people too close, unauthorized area access, object count in FOV reaching a threshold)
+**Violation** → Detected event from enhanced frame (e.g., people too close, unauthorized area access, object count in FOV reaching a threshold)  
 **Violation State** → Internal tracking of violation duration  
 **Incident** → Violation that exceeds time threshold and needs reporting  
 

--- a/skills/deployment/vss-setup-behavior-analytics/SKILL.md
+++ b/skills/deployment/vss-setup-behavior-analytics/SKILL.md
@@ -4,7 +4,7 @@ description: Use this skill to deploy the vss-behavior-analytics service standal
 license: Apache-2.0
 metadata:
   author: "NVIDIA Video Search and Summarization team"
-  version: "3.2.0"
+  version: "3.3.0"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational deployment behavior-analytics"
 ---
@@ -112,7 +112,7 @@ If any required prerequisite fails, surface the gap before going further.
 
 Hand the user [`references/deploy-behavior-analytics-service.md`](references/deploy-behavior-analytics-service.md) and walk them through its steps in order:
 
-1. Pick an entrypoint (analytics 2D / 3D / mv3dt, search_and_alerts).
+1. Pick an entrypoint (analytics 2D / 3D, search_and_alerts, public_safety, smart_city, composite).
 2. Choose a config — profile-shipped or custom.
 3. Choose a calibration — optional; profile-shipped or custom; otherwise the app waits for a dynamic-calibration notification.
 4. Decide whether a broker is reachable; if yes, point them at the dynamic-update flows.

--- a/skills/deployment/vss-setup-behavior-analytics/references/configuration.md
+++ b/skills/deployment/vss-setup-behavior-analytics/references/configuration.md
@@ -2,7 +2,7 @@
 # Configuration Guide
 
 ## Overview
-Configurations are JSON files consumed by `AppConfig` (`video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/schema/config.py`).
+Configurations are JSON files consumed by `AppConfig` (`services/analytics/behavior-analytics/src/mdx/analytics/core/schema/config.py`).
 
 ## Structure
 ```json
@@ -30,7 +30,7 @@ Configurations are JSON files consumed by `AppConfig` (`video-search-and-summari
 - `sourceType` / `sinkType`: typically "kafka" (also supports `redisStream`, `mqtt`)
 - `spaceAnalyticsIntervalSec`: "5.0"
 - Playback: `playbackLoop`, `playbackSensors`, `playbackInSimulationMode`, etc.
-- Trajectory/space: `traj*`, `spaceAnalytics*`, see `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/schema/config.py` for full list.
+- Trajectory/space: `traj*`, `spaceAnalytics*`, see `services/analytics/behavior-analytics/src/mdx/analytics/core/schema/config.py` for full list.
 
 ## Common sensor keys (examples)
 - `tripwireMinPoints`: "5"
@@ -71,17 +71,18 @@ Configurations are JSON files consumed by `AppConfig` (`video-search-and-summari
 - Each type has its own `...Threshold` (duration in sec, default `"1"`, min `0.0`) and `...ExpirationWindow` (gap
   tolerance in sec, default `"0.5"`, min `0.1`). Both accept **fractional** seconds — `"0.5"` is valid. The only
   incident knob that must stay a whole number is `fovCountViolationIncidentObjectThreshold`, which is an object count.
-- FOV count uses two keys: `fovCountViolationIncidentObjectType` — the object **class** to count (e.g. `person`; must match the detector's label casing) — and `fovCountViolationIncidentObjectThreshold` — the **count** above which an incident fires.
-- Details and timing: `video-search-and-summarization/services/analytics/behavior-analytics/docs/incident-detection.md`.
+- FOV count uses two keys: `fovCountViolationIncidentObjectType` — the object **class** to count (e.g. `person`; must match the detector's label casing) — and `fovCountViolationIncidentObjectThreshold` — the **count at which** an incident fires. The comparison is `count >= threshold`, **not** `>` (`frame_state_management.py`: `if fov_metric.count < threshold: return`), so the default of `1` makes a single object a violation. To alert on "more than N", set it to `N + 1`.
+- Details and timing: `services/analytics/behavior-analytics/docs/incident-detection.md`.
 
 ## Examples directory
 
-Under `video-search-and-summarization/services/analytics/behavior-analytics/configs/`:
+Under `services/analytics/behavior-analytics/configs/`:
 
 - `smart_city_config*.json`
 - `warehouse_2d_config.json`
 - `warehouse_3d_config.json`
 - `public_safety_config.json`
+- `composite_config.json` (every `numWorkersFor*` is `0` on purpose — set the ones you want or the app exits 0 at startup)
 - `frame_playback_config.json`
 - `rtls_amr_playback_config.json`
 

--- a/skills/deployment/vss-setup-behavior-analytics/references/deploy-behavior-analytics-service.md
+++ b/skills/deployment/vss-setup-behavior-analytics/references/deploy-behavior-analytics-service.md
@@ -3,7 +3,7 @@
 Deploy **just** `vss-behavior-analytics` (no agent, no perception, no UI) — useful when you want to:
 
 - Run a behavior-analytics pipeline against an existing broker (or no broker at all).
-- Pick a different entrypoint (analytics 2D / 3D, search_and_alerts) without modifying the image.
+- Pick a different entrypoint (analytics 2D / 3D, search_and_alerts, public_safety, smart_city, composite) without modifying the image.
 
 Required host runtime: **Docker Engine 28.3.3** with **Docker Compose plugin v2.39.1+**.
 
@@ -34,8 +34,27 @@ Set the first half of `command:` to one of the following:
 | `apps/analytics/main_analytics_2d_app.py` | `Analytics2DApp` | 2D spatial pipeline — operates on **(X, Y) world-plane coordinates** lifted from the image plane via per-sensor homography. Two parallel processors: **behavior creation** (object tracking → behavior + ROI / tripwire / proximity events, plus map-matching) and **frame enhancement** (calibration transform → per-frame state → FOV-count / restricted-area / confined-area incidents). **The default.** |
 | `apps/analytics/main_analytics_3d_app.py` | `Analytics3DApp` | Operates on **full (X, Y, Z) 3D world coordinates** — fed from upstream multi-view 3D tracking (mv3dt) that produces 3D bounding boxes. Same two processors as 2D (with the 3D calibration class), plus a third **space-analyzer** processor that estimates space utilization per region on a periodic interval. Use this for 3D warehouse / multi-view 3D tracking (mv3dt). |
 | `apps/search_and_alerts/main_search_and_alerts_app.py` | `SearchAndAlertsApp` | Three processors, each registered only if its worker count is non-zero: **incident generation** (`numWorkersForIncidentGeneration`) — calibration transform → per-frame state → FOV-count / restricted-area / confined-area / proximity incidents; **behavior creation** (`numWorkersForBehaviorCreation`) — object tracking from raw frames, including ROI / tripwire events; **embedding downsampling** (`numWorkersForEmbedFiltering`) — reads chunked video embeddings and writes the survivors. The three modes are just which counts you set: all three = search + alerts; `numWorkersForIncidentGeneration=0` = search only (`dev-profile-search`); `numWorkersForBehaviorCreation=0` + `numWorkersForEmbedFiltering=0` = alerts only (`dev-profile-alerts`). |
-| `apps/smart_city/main_smart_city_app.py` | `SmartCityApp` | Geo-oriented pipeline for street/city scenes. **Behavior creation** (`numWorkersForBehaviorCreation`) with anomaly detection built **unconditionally** — unlike every other entrypoint there is no `anomalyDetectionEnable` gate, so speed/stop anomalies and the road-network CRS load are always paid for. Collision detection is opt-in via the sensor `collisionDetection.enable` block and writes collision incidents. A second **behavior clustering** processor (`numWorkersForBehaviorClustering`) registers only when the config's `inference.enable` is `true` — worker count alone is not enough here, which differs from `CompositeApp`. **Constraints:** both worker counts are read with no fallback, so a config omitting either key crashes at startup with `ValueError: invalid literal for int()`; the shipped `smart_city_config.json` / `smart_city_config_image.json` set them (4 and 2) with `inference.enable: false`. |
+| `apps/public_safety/main_public_safety_app.py` | `PublicSafetyApp` | Same two-processor shape as `Analytics2DApp` — **behavior creation** (`numWorkersForBehaviorCreation`) with ROI / tripwire events, and **frame enhancement** (`numWorkersForFrameEnhancement`) producing FOV-count / restricted-area / confined-area / proximity incidents — tuned for public-safety scenes. **Constraints:** no profile ships a config — start from the service's own `configs/public_safety_config.json`. |
+| `apps/smart_city/main_smart_city_app.py` | `SmartCityApp` | Geo-oriented pipeline for street/city scenes. **Behavior creation** (`numWorkersForBehaviorCreation`) with anomaly detection built **unconditionally** — unlike every other entrypoint there is no `anomalyDetectionEnable` gate, so speed/stop anomalies and the road-network CRS load are always paid for. Collision detection is opt-in via the sensor `collisionDetection.enable` block and writes collision incidents. A second **behavior clustering** processor (`numWorkersForBehaviorClustering`) registers only when the config's `inference.enable` is `true` — worker count alone is not enough here, which differs from `CompositeApp`. **Constraints:** the shipped `smart_city_config.json` / `smart_city_config_image.json` set the two worker counts (4 and 2) with `inference.enable: false`. |
 | `apps/composite/main_composite_app.py` | `CompositeApp` | **Last resort — prefer one of the apps above.** It is the heavyweight option: it constructs every capability's state (behavior state, frame state, ROI/tripwire generators, space analyzer, embedding state) at startup regardless of which processors you enabled, and the enabled ones are CPU-hungry per batch. Reproducing a shipped profile through it costs more than running that profile's own entrypoint for identical output. Pick it **only** when the capability set you want does not exist as a single shipped app. Every capability in one app, each registered only if its worker count is non-zero: **behavior creation** (`numWorkersForBehaviorCreation`), **frame enhancement** (`numWorkersForFrameEnhancement`), **space estimation** (`numWorkersForSpaceEstimation`), **embedding downsampling** (`numWorkersForEmbedFiltering`), **behavior clustering** (`numWorkersForBehaviorClustering`). These come from different per-profile apps and can be combined freely, which no other entrypoint allows. Detection stages inside behavior creation are opt-in: `anomalyDetectionEnable`, `actionDetectionEnable`, `collisionDetection.enable`. **Constraints:** space estimation needs cartesian 3D and silently produces nothing otherwise; clustering needs a Triton `inference` block; run only one behavior producer per deployment. |
+
+**Worker counts: which entrypoints tolerate a missing key.** Every processor is registered with
+`int(config.get_app_config("numWorkersFor<X>"))`. `get_app_config` defaults to an **empty string**, so an app that
+reads the key with no fallback dies at startup with `ValueError: invalid literal for int() with base 10: ''` — a
+message that names no key, which makes a hand-written config the hard case to debug.
+
+| Fallback | Entrypoints (worker keys read) | Effect of omitting a key |
+|---|---|---|
+| **none** | `Analytics2DApp` (2), `Analytics3DApp` (3), `PublicSafetyApp` (2), `SmartCityApp` (2) | **startup crash** |
+| `"0"` | `SearchAndAlertsApp` (3), `CompositeApp` (5) | processor silently not registered |
+
+This is why `SearchAndAlertsApp` and `CompositeApp` can be mode-switched by simply omitting counts, while the other
+four cannot. Note `Analytics2DApp` — **the default** — is in the crashing group, as is `Analytics3DApp` with one
+extra key (`numWorkersForSpaceEstimation`) to miss.
+
+Every shipped config in `configs/` and every profile-shipped config sets the keys its entrypoint needs, so this only
+bites a config written from scratch (Option B below). The keys must be **present**, not non-zero: the profile 3D
+configs ship `numWorkersForSpaceEstimation: "0"` while `configs/warehouse_3d_config.json` ships `"1"` — both parse.
 
 **Which topics each processor needs.** A destination the config omits is a *disabled output*, not an error: the
 sink logs `No destination configured for '<key>'` once and drops the rest, so an unconfigured topic looks like an
@@ -77,6 +96,7 @@ Recommended pairings (entrypoint → existing config):
 | `main_search_and_alerts_app.py` (search + alerts) | Use the shipped repository-root `services/analytics/behavior-analytics/configs/search_and_alerts_config.json`. It is outside `VSS_APPS_DIR` (`deploy/docker`), so mount it by absolute host path as in Option B. Copy and edit it only for bespoke topic mappings or worker counts. |
 | `main_search_and_alerts_app.py` (alerts only) | `developer-profiles/dev-profile-alerts/vss-behavior-analytics/configs/vss-behavior-analytics-config.json` (behavior + embed workers set to `0`) |
 | `main_search_and_alerts_app.py` (search only) | `developer-profiles/dev-profile-search/video-analytics-2d-app/vss-search-analytics/configs/vss-search-analytics-<stream>-config.json` (incident-generation workers set to `0`) |
+| `main_public_safety_app.py` | No profile ships one. Start from the service's own `configs/public_safety_config.json` and mount it as a custom config (Option B). |
 | `main_smart_city_app.py` | No profile ships one. Start from the service's own `configs/smart_city_config.json` (geo calibration) or `configs/smart_city_config_image.json` (image calibration) and mount it as a custom config (Option B). |
 | `main_composite_app.py` | No profile ships one. `configs/composite_config.json` is a starter that defines every topic but sets every `numWorkersFor*` to `0` — copy it and set the counts you want, or the app exits immediately (see Troubleshooting). |
 

--- a/skills/deployment/vss-setup-behavior-analytics/references/deploy-behavior-analytics-service.md
+++ b/skills/deployment/vss-setup-behavior-analytics/references/deploy-behavior-analytics-service.md
@@ -45,11 +45,11 @@ message that names no key, which makes a hand-written config the hard case to de
 
 | Fallback | Entrypoints (worker keys read) | Effect of omitting a key |
 |---|---|---|
-| **none** | `Analytics2DApp` (2), `Analytics3DApp` (3), `PublicSafetyApp` (2), `SmartCityApp` (2) | **startup crash** |
+| **none** | `Analytics2DApp` (2), `Analytics3DApp` (3), `PublicSafetyApp` (2), `SmartCityApp` (1, +1 only when `inference.enable`) | **startup crash** |
 | `"0"` | `SearchAndAlertsApp` (3), `CompositeApp` (5) | processor silently not registered |
 
 This is why `SearchAndAlertsApp` and `CompositeApp` can be mode-switched by simply omitting counts, while the other
-four cannot. Note `Analytics2DApp` — **the default** — is in the crashing group, as is `Analytics3DApp` with one
+four cannot. `SmartCityApp`'s second key, `numWorkersForBehaviorClustering`, is read **only inside** the `if config.inference.enable:` branch, so with inference off (the shipped default) omitting it is harmless; `numWorkersForBehaviorCreation` is always required. Note `Analytics2DApp` — **the default** — is in the crashing group, as is `Analytics3DApp` with one
 extra key (`numWorkersForSpaceEstimation`) to miss.
 
 Every shipped config in `configs/` and every profile-shipped config sets the keys its entrypoint needs, so this only

--- a/skills/deployment/vss-setup-behavior-analytics/references/dynamic-calibration.md
+++ b/skills/deployment/vss-setup-behavior-analytics/references/dynamic-calibration.md
@@ -63,7 +63,7 @@ The action prefix is parsed by `reload_data` (`os.path.basename(file_path).split
 
 ## Component map
 
-Under `video-search-and-summarization/services/analytics/behavior-analytics/`:
+Under `services/analytics/behavior-analytics/`:
 
 ```
 src/mdx/analytics/core/transform/calibration/
@@ -79,10 +79,10 @@ src/mdx/analytics/core/transform/calibration/
 │                              # no-file to a typed calibration when the
 │                              # first event lands
 └── schemas/calibration.schema.json  # Vendored from
-                                     # video-search-and-summarization/services/analytics/video-analytics-api/src/web-api-core/schemas/ajv/calibration.json
+                                     # services/analytics/video-analytics-api/src/web-api-core/schemas/ajv/calibration.json
 ```
 
-The split mirrors dynamic config. The **main process** runs a single `CalibrationListener` (wired up in `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_runner.py`): it drains `mdx-notification` and atomic-writes files into `CALIBRATION_DIR`. **Each worker** — spawned, not forked (`mp.get_context("spawn")`), so it starts a fresh interpreter with no inherited parent state — builds its own `CalibrationBase`-derived instance in `BaseApp.__init__` and calls `start_listen()`, which runs a **per-worker** watchdog `Observer` on `CALIBRATION_DIR`. Workers race each other to apply the same file in their own process (`on_moved -> reload_data`), so every worker independently reloads the new sensor map. There is no shared parent calibration object and nothing is pickled across the process boundary.
+The split mirrors dynamic config. The **main process** runs a single `CalibrationListener` (wired up in `services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_runner.py`): it drains `mdx-notification` and atomic-writes files into `CALIBRATION_DIR`. **Each worker** — spawned, not forked (`mp.get_context("spawn")`), so it starts a fresh interpreter with no inherited parent state — builds its own `CalibrationBase`-derived instance in `BaseApp.__init__` and calls `start_listen()`, which runs a **per-worker** watchdog `Observer` on `CALIBRATION_DIR`. Workers race each other to apply the same file in their own process (`on_moved -> reload_data`), so every worker independently reloads the new sensor map. There is no shared parent calibration object and nothing is pickled across the process boundary.
 
 ---
 
@@ -145,7 +145,7 @@ DynamicCalibration(config, calibration_path=None)
 
 After the one-time switch, the inherited `CalibrationBase` watcher continues to drive `reload_data`, which now delegates to the typed `_calibrator`. The switch is guarded by `_switch_lock` so a burst of file events can't double-switch.
 
-See `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/transform/calibration/calibration_dynamic.py` and the unit tests in `video-search-and-summarization/services/analytics/behavior-analytics/tests/unit/mdx/analytics/core/transform/calibration/test_calibration_dynamic.py` for the contract.
+See `services/analytics/behavior-analytics/src/mdx/analytics/core/transform/calibration/calibration_dynamic.py` and the unit tests in `services/analytics/behavior-analytics/tests/unit/mdx/analytics/core/transform/calibration/test_calibration_dynamic.py` for the contract.
 
 ---
 

--- a/skills/deployment/vss-setup-behavior-analytics/references/dynamic-config.md
+++ b/skills/deployment/vss-setup-behavior-analytics/references/dynamic-config.md
@@ -114,7 +114,7 @@ Read-only sections (`kafka`, `redisStream`, `mqtt`, `coordinateReferenceSystem`,
 
 ## Component map
 
-Under `video-search-and-summarization/services/analytics/behavior-analytics/`:
+Under `services/analytics/behavior-analytics/`:
 
 ```
 src/mdx/analytics/core/transform/config/
@@ -126,7 +126,7 @@ src/mdx/analytics/core/transform/config/
 └── config_monitor.py          # Per-worker watchdog: pick up files written by the listener
 ```
 
-Wired up in `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_runner.py` (one `ConfigListener` per main process) and `video-search-and-summarization/services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_base.py` (one `ConfigFileMonitor` per worker). The listener writes a JSON file into `CONFIG_DIR` (default `/tmp/checkpoint/config`) on every successful apply; each worker's `ConfigFileMonitor` picks up the file via watchdog `on_moved` and applies through its own local `ConfigApplier`.
+Wired up in `services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_runner.py` (one `ConfigListener` per main process) and `services/analytics/behavior-analytics/src/mdx/analytics/core/app/app_base.py` (one `ConfigFileMonitor` per worker). The listener writes a JSON file into `CONFIG_DIR` (default `/tmp/checkpoint/config`) on every successful apply; each worker's `ConfigFileMonitor` picks up the file via watchdog `on_moved` and applies through its own local `ConfigApplier`.
 
 ### Why per-worker monitor, not per-process
 

--- a/skills/deployment/vss-setup-behavior-analytics/references/integrate-behavior-analytics-service.md
+++ b/skills/deployment/vss-setup-behavior-analytics/references/integrate-behavior-analytics-service.md
@@ -25,18 +25,22 @@ Source-of-truth definitions: `deploy/docker/services/analytics/behavior-analytic
 **Core data path (required):**
 
 - **Message broker (Kafka / Redis Streams / MQTT)** — required. The `sourceType` / `sinkType` app-config keys pick which backend is live (Kafka is the default; brokers are configured **inside the config JSON**, not via env — e.g. `kafka.brokers: kafka:29092` (a Docker DNS service name on the compose bridge network; for a standalone deploy against an external broker, set this to a reachable `host:port` — see Network Requirements § Standalone caveat). Behavior Analytics consumes candidate frame metadata and produces behaviors/events/incidents. Owned by ELK/infra.
-- **kafka-topic-init-container** — required (Kafka backend). **Every topic a registered processor reads or writes must exist and be mapped in `kafka.topics`, or the sink raises `Could not find a kafka topic with key: <name>` at the first batch** (topic resolution is eager, even for empty writes). Map exactly the topics the enabled processors touch (see Outputs). Owned by ELK/infra.
+- **kafka-topic-init-container** — required (Kafka backend). Reads and writes fail **differently**, and only one of them is loud:
+  - **Reads are fatal.** A source key that isn't mapped in `kafka.topics` raises `ValueError: Could not find a kafka topic with key: <name>` on the first poll (`source_kafka.py`), taking the worker — and the app — down.
+  - **Writes are silently disabled.** An unmapped sink key is *not* an error: `Sink.resolve_destination` logs `No destination configured for '<key>'; output for it is disabled.` **once per key** and drops every message for it. This is deliberate — otherwise every app would require the union of all topics. The failure mode is an output topic that stays permanently empty with one warning buried at startup, so map exactly the topics the enabled processors touch (see Outputs) and grep the logs for that warning after bring-up.
+
+  Owned by ELK/infra.
 - **Calibration source** — required for spatial transforms (`transform_frame`, ROIs, tripwires, homography). Supplied as a mounted calibration JSON (`--calibration <path>`) or delivered at runtime via a dynamic-calibration notification (see Inputs). **Optional at startup**: with no file the app uses `CalibrationI` (image-plane, no perspective) and can switch once a calibration arrives. See `dynamic-calibration.md`.
-- **Upstream detector (for the incident / behavior paths)** — an RTVI CV / perception producer (Grounding DINO / RT-DETR, DeepStream) writing frame metadata to the raw topic. Without it the incident/behavior processors have no input. Owned by RT-CV (`skills/deployment/vss-deploy-detection-tracking-2d/`). In the alerts profile the config-bearing key `perception-alerts` is contributed by the `cv-verification` variant in `vss-build-vision-ai/references/patch-alerts.md`.
+- **Upstream detector (for the incident / behavior paths)** — an RTVI CV / perception producer (Grounding DINO / RT-DETR, DeepStream) writing frame metadata to the raw topic. Without it the incident/behavior processors have no input. Owned by RT-CV (`skills/deployment/vss-deploy-detection-tracking-2d/`). In the alerts profile the config-bearing key `perception-alerts` is contributed by the `cv-verification` variant in `vss-build-vision-ai/references/services/alerts.md`.
 
 **Path-specific / downstream (conditional):**
 
-- **Video-embedding producer** — required only when the embedding-downsampling processor runs (search path): it consumes chunked video embeddings from the embed topic. Owned by the video-embedding microservice (`integrate-vss-deploy-video-embedding.md`).
-- **ELK (Elasticsearch / Logstash / Kibana)** — required for the outputs to be queryable/visualized. **Logstash consumes Behavior Analytics' output topics** (`mdx-incidents`, `mdx-frames`, `mdx-behavior`, `mdx-embed-filtered`) via protobuf codecs and indexes them into ES (`mdx-frames-*`, `mdx-behavior-*`, `mdx-incidents-*`, etc.). Not a hard `depends_on` of Behavior Analytics itself, but required for the pipeline to be observable. Owned by ELK (`integrate-elk.md`).
-- **Alert Microservice (`alert-bridge`)** — downstream consumer of `mdx-incidents` / `mdx-alerts` when Behavior Analytics is the candidate-alert source for VLM verification. The `category` field on emitted incidents is the join key into `alert_type_config.json`. Owned by the Alert Microservice (`integrate-alerts.md`).
+- **Video-embedding producer** — required only when the embedding-downsampling processor runs (search path): it consumes chunked video embeddings from the embed topic. Owned by the video-embedding microservice (`skills/deployment/vss-deploy-video-embedding/references/integrate-vss-deploy-video-embedding.md`).
+- **ELK (Elasticsearch / Logstash / Kibana)** — required for the outputs to be queryable/visualized. **Logstash consumes Behavior Analytics' output topics** (`mdx-incidents`, `mdx-frames`, `mdx-behavior`, `mdx-embed-filtered`) via protobuf codecs and indexes them into ES (`mdx-frames-*`, `mdx-behavior-*`, `mdx-incidents-*`, etc.). Not a hard `depends_on` of Behavior Analytics itself, but required for the pipeline to be observable. Owned by ELK (`vss-build-vision-ai/references/services/elk.md`).
+- **Alert Microservice (`alert-bridge`)** — downstream consumer of `mdx-incidents` / `mdx-alerts` when Behavior Analytics is the candidate-alert source for VLM verification. The `category` field on emitted incidents is the join key into `alert_type_config.json`. Owned by the Alert Microservice (`skills/operations/vss-manage-alerts/references/integrate-alerts.md`).
 - **Video Analytics API** — optional headless query surface over the ES indices; does not depend on Behavior Analytics directly. Owned by `skills/deployment/vss-setup-video-analytics-api/`.
 
-> **Where the `component_services:` block lives (decoupling).** Behavior Analytics is owned by the `vss-setup-behavior-analytics` skill, so — per the decoupling convention used by VIOS / RT-VLM / the Alert Microservice — its structured `component_services:` selection (upstream compose keys + the `ba_path` mode/path variant) is **not** carried here. It lives in the orchestrator's own patch reference `vss-build-vision-ai/references/patch-behavior-analytics.md`, which documents **all three** paths (alerts-incident, search-embedding, analytics-2d). This file is the neutral integration contract only.
+> **Orchestrator-side composition (decoupling).** Behavior Analytics is owned by the `vss-setup-behavior-analytics` skill, so how it is *selected and wired into a composed profile* is not carried here. That lives in the orchestrator's own service reference, `vss-build-vision-ai/references/services/behavior-analytics.md` (with the per-profile compose keys in `references/profiles/`). This file is the neutral integration contract only.
 
 ## Integration Interfaces
 
@@ -109,8 +113,8 @@ The base compose is deliberately thin — broker endpoints, topics, and all tuni
 
 ## Known Integration Constraints
 
-- **`extends`, never `include`.** The base `vss-behavior-analytics-base` block is designed to be composed via compose `extends:` (a profile service overrides `command`, `profiles`, `container_name`, and the config volume at the same container path). A standalone/patched deploy must **copy the base compose into the patched tree** so `extends:` resolves (see `patch-alerts.md` Patch 3).
-- **Topic mapping is mandatory per enabled processor.** A processor whose worker count > 0 writes to its sink topic every batch; if that topic isn't in `kafka.topics` the sink raises `Could not find a kafka topic with key: <name>` at boot/first batch. Conversely, disabling a processor (`numWorkersFor*=0`) means you need not map its topics — this is why the alerts config omits `behavior`/`embed*` topics and the search config omits `incidents`/`frames`.
+- **`extends`, never `include`.** The base `vss-behavior-analytics-base` block is designed to be composed via compose `extends:` (a profile service overrides `command`, `profiles`, `container_name`, and the config volume at the same container path). A standalone/patched deploy must **copy the base compose into the patched tree** so `extends:` resolves (see `vss-build-vision-ai/references/services/alerts.md`).
+- **Topic mapping is mandatory per enabled processor — but only reads say so.** A processor whose worker count > 0 reads its source topic and writes its sink topic every batch. An unmapped **source** key raises `Could not find a kafka topic with key: <name>` and kills the app; an unmapped **sink** key only logs `No destination configured for '<key>'` once and drops the output forever. So a missing output topic presents as "the pipeline runs fine but that index never fills", not as a crash. Conversely, disabling a processor (`numWorkersFor*=0`) means you need not map its topics — this is why the alerts config omits `behavior`/`embed*` topics and the search config omits `incidents`/`frames`.
 - **Mode is chosen by worker counts, not app swap.** `SearchAndAlertsApp` runs incident, behavior, and embed processors; deployments pick a mode by zeroing the others. Omitting a `numWorkersFor*` key defaults to `0` for that app (opt-in), so the config must explicitly enable the paths it wants **and** map their topics.
 - **Calibration determines sensor coverage.** With a typed calibration (`cartesian`/`geo`), frames from sensors not in the calibration are handled by the active calibration class; with `CalibrationI` (no file) all frames pass through with image-plane coordinates. Choose the calibration that matches the deployed sensors, or supply one at runtime via `mdx-notification`.
 - **`category` must match `alert_type_config.json` (alerts path).** When Behavior Analytics feeds the Alert Microservice, an incident whose `category` has no `alert_type` entry is never VLM-verified (no prompt). Keep the emitted categories and the verifier config in sync.
@@ -120,7 +124,7 @@ The base compose is deliberately thin — broker endpoints, topics, and all tuni
 
 ## Example Compose Snippet
 
-The base (`deploy/docker/services/analytics/behavior-analytics/compose.yml`) plus the `extends`-based profile override. A standalone deploy patches a copy (never upstream); the `profiles:` placeholder is where Step 6.5 Patch 1 inserts the invented flag.
+The base (`deploy/docker/services/analytics/behavior-analytics/compose.yml`) plus the `extends`-based profile override. A standalone deploy patches a copy (never upstream); the `profiles:` placeholder is where the orchestrator inserts the composed profile's flag.
 
 ```yaml
 # --- base (copied into the patched tree so `extends:` resolves) ---
@@ -142,7 +146,7 @@ services:
       service: vss-behavior-analytics-base
     container_name: vss-behavior-analytics
     profiles:
-      - <your-profile-flag>            # Step 6.5 Patch 1 inserts the invented flag (additive)
+      - <your-profile-flag>            # orchestrator inserts the composed profile's flag (additive)
     volumes:
       - ${VSS_APPS_DIR}/developer-profiles/dev-profile-alerts/vss-behavior-analytics/configs/vss-behavior-analytics-config.json:/resources/vss-behavior-analytics-config.json
     command: python3 apps/search_and_alerts/main_search_and_alerts_app.py --config /resources/vss-behavior-analytics-config.json
@@ -162,4 +166,5 @@ The frame/behavior/incident protobufs (`nv.Frame` on `mdx-raw`/`mdx-frames`, `nv
   ```
 - **Producing enhanced frames:** `mdx-frames-*` ES index is populated (Logstash indexes the `mdx-frames` topic).
 - **Producing filtered embeddings (search path):** logs show `Video embeddings: received=<a>, final=<b>` and `mdx-embed-filtered` is produced.
-- **No topic-resolution crash:** a clean start with no repeated `Could not find a kafka topic` errors confirms every enabled processor's topics are mapped.
+- **No topic-resolution crash:** a clean start with no `Could not find a kafka topic` error confirms every enabled processor's **source** topics are mapped.
+- **No silently-disabled outputs:** `docker logs <container> | grep 'No destination configured'` must come back empty. Each hit is an output topic the config never mapped, which the app drops without failing — this is the check that catches a sink typo, since nothing else will.

--- a/skills/deployment/vss-setup-behavior-analytics/skill-card.md
+++ b/skills/deployment/vss-setup-behavior-analytics/skill-card.md
@@ -21,6 +21,7 @@ Mitigation: Review and scan skill before deployment. <br>
 ## Reference(s): <br>
 - [Deploy Behavior Analytics Service](references/deploy-behavior-analytics-service.md) <br>
 - [Configuration Guide](references/configuration.md) <br>
+- [Integrate Behavior Analytics Service](references/integrate-behavior-analytics-service.md) <br>
 - [Dynamic Calibration](references/dynamic-calibration.md) <br>
 - [Dynamic Config](references/dynamic-config.md) <br>
 - [NGC API Key & Registry Login](references/ngc-api-key-registry-login.md) <br>
@@ -72,7 +73,7 @@ Underlying evaluation signals used in this run: <br>
 | Efficiency | 1 | 94% (+67%) | 28% (+0%) |
 
 ## Skill Version(s): <br>
-3.2.0 (source: frontmatter) <br>
+3.3.0 (source: frontmatter) <br>
 
 ## Ethical Considerations: <br>
 NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>


### PR DESCRIPTION
…ew entrypoints

Path references are made repo-relative (drop the `video-search-and-summarization/` prefix) and two dead cross-skill links are repointed: `patch-alerts.md` and `patch-behavior-analytics.md` no longer exist, so they now target `vss-build-vision-agent/references/services/{alerts,elk,behavior-analytics}.md`.

Substantive corrections:

- FOV count threshold is `count >= threshold`, not `>` (frame_state_management.py: `if fov_metric.count < threshold: return`), so the default of "1" makes a single object a violation. Previously documented as "the count above which an incident fires", which reads as strictly-greater and would make "alert on more than N" off by one.
- Unmapped Kafka topics fail asymmetrically: an unmapped *source* raises ValueError and kills the app, while an unmapped *sink* logs "No destination configured" once and silently drops output forever. Adds a post-bring-up grep for that warning, since nothing else surfaces it.

New entrypoints documented: public_safety, smart_city, composite.

Worker-count fallback behaviour is lifted out of the per-row text into a shared note under the entrypoint table. It applies to 4 of the 6 documented entrypoints, not just public_safety and smart_city: Analytics2DApp (the default) and Analytics3DApp also read their counts with no fallback and crash on a missing key, while SearchAndAlertsApp and CompositeApp default to "0".

Also: drop mv3dt from the step-1 entrypoint list (it runs on main_analytics_3d_app.py; there is no separate entrypoint), bump the skill to 3.3.0, and add trailing newlines to the two files that lacked them.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
