### PR TITLE
fix(agent): Support base profile on GB300

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-base/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/overrides.env
@@ -20,7 +20,7 @@ COMPOSE_PROJECT_NAME=vss
 # DEPLOYMENT SELECTION
 # =============================================================================
 # Hardware profile for NIM and RTVI optimization.
-# Valid: H100, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
+# Valid: H100, GB300, L40S, RTXPRO4500BW, RTXPRO6000BW, DGX-SPARK, IGX-THOR, AGX-THOR, OTHER.
 HARDWARE_PROFILE=H100
 
 # =============================================================================
@@ -50,6 +50,7 @@ VLM_MODE=local_shared
 # - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
 # - openai/gpt-oss-20b -> gpt-oss-20b
 # Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
+# GB300 selects Nemotron 3.5 Lightning in generated.env; other hardware keeps this Nano v2 default.
 LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
 # Enables the local LLM compose profile; set to none for remote LLM.
 LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2

--- a/deploy/docker/developer-profiles/dev-profile-base/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/overrides.env
@@ -50,10 +50,9 @@ VLM_MODE=local_shared
 # - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
 # - openai/gpt-oss-20b -> gpt-oss-20b
 # Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
-# GB300 selects Nemotron 3.5 Lightning in generated.env; other hardware keeps this Nano v2 default.
-LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
+LLM_NAME=nvidia/nemotron-3.5-lightning-30b-a3b
 # Enables the local LLM compose profile; set to none for remote LLM.
-LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
+LLM_NAME_SLUG=nemotron-3.5-lightning-30b-a3b
 # Extra env file for local LLM container settings.
 LLM_ENV_FILE=''
 # LLM endpoint base URL. Local deployments use the Compose service; remote deployments use the external endpoint.

--- a/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-base/vss-agent/configs/config.yml
@@ -248,6 +248,19 @@ workflow:
   subagent_names:
   - report_agent
   # yamllint disable rule:line-length
+  # Keep named report requests deterministic for models that over-apply the
+  # top agent's default clarification examples.
+  plan_prompt: |
+    Review the available tools, the conversation history, and the user's question, then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.
+    Put relevant context (for example, sensor IDs or time ranges) from the conversation history directly in the plan steps so the execution agent does not need to re-read the history.
+    A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
+    If the user requests a report and supplies a name, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
+    Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
+    Only use tools from the available tools list. Never invent or assume tools that are not listed.
+
+    Example plan for "Generate a report for warehouse_sample":
+    1. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report for warehouse_sample".
+
   prompt: |
     You are a routing agent for a video surveillance system. Your job is to route requests to the correct tool.
     ## Routing Rules:

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -106,6 +106,7 @@ function host_has_detected_hardware_profile() {
   done < <(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null)
   return 1
 }
+
 # Maps requested hardware_profile (CLI/env) to the same canonical type used by get_detected_hardware_profile.
 # AGX-THOR and IGX-THOR both map to THOR; all other profiles map to themselves.
 function get_canonical_hardware_profile() {
@@ -1375,6 +1376,11 @@ function state_up() {
   elif [[ -n "${llm}" ]]; then
     set_env_var "LLM_NAME" "${llm}"
     set_env_var "LLM_NAME_SLUG" "$(get_llm_slug "${llm}")"
+  elif [[ "${profile}" == "base" ]] && [[ "${hardware_profile}" == "GB300" ]]; then
+    # Nano v2's NIM cannot execute on ARM64. Keep the checked-in Base default
+    # unchanged and select the supported LVS model only for the GB300 overlay.
+    set_env_var "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b"
+    set_env_var "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b"
   fi
   if contains_element "${hardware_profile}" "${edge_hardware_profiles[@]}"; then
     set_env_var "LLM_DEVICE_ID" "0"
@@ -1575,7 +1581,7 @@ function state_up() {
       sed -i -E "/sbsa/! s/^(${_key})=(.*)/# \1=\2/" "${_generated_env}"
       # Uncomment the commented line for this key when value contains sbsa
       sed -i -E "/sbsa/ s/^#[[:space:]]*(${_key})=(.*)/\1=\2/" "${_generated_env}"
-      echo "[INFO] Swapped to SBSA (DGX-SPARK): ${_key}"
+      echo "[INFO] Swapped to SBSA (${hardware_profile}): ${_key}"
     done < <(grep -E '^#[[:space:]]*[A-Za-z0-9_]+=.*sbsa' "${_generated_env}" 2>/dev/null | sed -nE 's/^#[[:space:]]*([A-Za-z0-9_]+)=.*/\1/p' | sort -u)
   fi
   # LVS keeps RTVI_VLM_IMAGE_TAG in its static .env, so write the ARM64
@@ -1584,7 +1590,6 @@ function state_up() {
     set_env_var "RTVI_VLM_IMAGE_TAG" "3.3.0-26.08.2-sbsa"
     echo "[INFO] Selected SBSA RT-VLM image for GB300"
   fi
-
 
   echo "[INFO] Generated environment file: ${_generated_env}"
 

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -1376,11 +1376,6 @@ function state_up() {
   elif [[ -n "${llm}" ]]; then
     set_env_var "LLM_NAME" "${llm}"
     set_env_var "LLM_NAME_SLUG" "$(get_llm_slug "${llm}")"
-  elif [[ "${profile}" == "base" ]] && [[ "${hardware_profile}" == "GB300" ]]; then
-    # Nano v2's NIM cannot execute on ARM64. Keep the checked-in Base default
-    # unchanged and select the supported LVS model only for the GB300 overlay.
-    set_env_var "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b"
-    set_env_var "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b"
   fi
   if contains_element "${hardware_profile}" "${edge_hardware_profiles[@]}"; then
     set_env_var "LLM_DEVICE_ID" "0"

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1530,6 +1530,20 @@ run_dry_run_up_and_check_generated_env "generated.env LVS defaults to Nemotron 3
   "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
   "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b"
 
+run_dry_run_up_and_check_generated_env "generated.env Base GB300 overlay selects ARM64 LLM and SBSA RT-VLM" "base" \
+ -i 127.0.0.1 -H GB300 --llm-device-id 1 --vlm-device-id 1 -d -- \
+  "HARDWARE_PROFILE" "GB300" \
+  "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
+  "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b" \
+  "RTVI_VLM_IMAGE_TAG" "3.3.0-26.08.2-sbsa"
+
+run_dry_run_up_and_check_generated_env "generated.env Base H100 keeps existing defaults" "base" \
+ -i 127.0.0.1 -H H100 -d -- \
+  "HARDWARE_PROFILE" "H100" \
+  "LLM_NAME" "nvidia/nvidia-nemotron-nano-9b-v2" \
+  "LLM_NAME_SLUG" "nvidia-nemotron-nano-9b-v2" \
+  "RTVI_VLM_IMAGE_TAG" '"3.3.0-26.08.2"'
+
 for _nemotron_3_5_env in \
   "${REPO_ROOT}"/deploy/docker/services/nim/nemotron-3.5-lightning-30b-a3b/hw-*.env; do
   if grep -Fq -- "--reasoning-parser nemotron_v3 --enable-auto-tool-choice --tool-call-parser qwen3_coder" "${_nemotron_3_5_env}"; then
@@ -1540,7 +1554,6 @@ for _nemotron_3_5_env in \
     ((TESTS_FAILED++)) || true
   fi
 done
-
 
 # DGX-SPARK: for each profile, run dry-run with -H DGX-SPARK and assert sbsa variants (keys from profile overrides.env).
 # DGX-SPARK (and IGX-THOR) are only valid for base and alerts

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1537,11 +1537,11 @@ run_dry_run_up_and_check_generated_env "generated.env Base GB300 overlay selects
   "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b" \
   "RTVI_VLM_IMAGE_TAG" "3.3.0-26.08.2-sbsa"
 
-run_dry_run_up_and_check_generated_env "generated.env Base H100 keeps existing defaults" "base" \
+run_dry_run_up_and_check_generated_env "generated.env Base defaults to Nemotron 3.5 Lightning on H100" "base" \
  -i 127.0.0.1 -H H100 -d -- \
   "HARDWARE_PROFILE" "H100" \
-  "LLM_NAME" "nvidia/nvidia-nemotron-nano-9b-v2" \
-  "LLM_NAME_SLUG" "nvidia-nemotron-nano-9b-v2" \
+  "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
+  "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b" \
   "RTVI_VLM_IMAGE_TAG" '"3.3.0-26.08.2"'
 
 for _nemotron_3_5_env in \

--- a/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
+++ b/deploy/helm/developer-profiles/dev-profile-base/configs/vss-agent/config.yml
@@ -248,6 +248,19 @@ workflow:
   subagent_names:
   - report_agent
   # yamllint disable rule:line-length
+  # Keep named report requests deterministic for models that over-apply the
+  # top agent's default clarification examples.
+  plan_prompt: |
+    Review the available tools, the conversation history, and the user's question, then produce a concise numbered execution plan. Start each step with a tool name and a brief description of the step.
+    Put relevant context (for example, sensor IDs or time ranges) from the conversation history directly in the plan steps so the execution agent does not need to re-read the history.
+    A non-empty name supplied in the request is the sensor_id. For example, in "Generate a report for warehouse_sample", the sensor_id is "warehouse_sample"; this request is complete and MUST NOT trigger a clarifying question.
+    If the user requests a report and supplies a name, the plan MUST contain exactly one action: call `report_agent` directly with that exact name as sensor_id and the original request as user_query. Do not verify the name or media type first.
+    Ask which video or camera the user means only when the request contains no name and the conversation provides no usable name.
+    Only use tools from the available tools list. Never invent or assume tools that are not listed.
+
+    Example plan for "Generate a report for warehouse_sample":
+    1. Call `report_agent` with sensor_id="warehouse_sample" and user_query="Generate a report for warehouse_sample".
+
   prompt: |
     You are a routing agent for a video surveillance system. Your job is to route requests to the correct tool.
     ## Routing Rules:


### PR DESCRIPTION
## Summary
- Keep H100 Base on Nano v2
- On GB300, generate Nemotron 3.5 Lightning plus the existing SBSA RT-VLM tag so Base can start on ARM64.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
