### PR TITLE
fix(vss-configurator): handle partial NVStreamer stream list due to cold start

### DIFF
--- a/services/configurators/vss-configurator/README.md
+++ b/services/configurators/vss-configurator/README.md
@@ -462,7 +462,8 @@ services:
 | `RECOMPUTE_BEV_CENTERS_ENABLED` | `false` | Recompute BEV group origins via `spatialai_data_utils` (3D mode only) |
 | `NVSTREAMER_STREAMS_ENDPOINT` | `http://localhost:30000/api/v1/live/streams` | NVStreamer streams endpoint |
 | `NVSTREAMER_SENSOR_STATUS_ENDPOINT` | `http://localhost:30000/api/v1/sensor/status` | NVStreamer status endpoint |
-| `NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT` | `100` | Timeout for NVStreamer endpoint (seconds) |
+| `NUM_STREAMS` | `0` | Expected NVStreamer camera count; wait until the stream list reaches this size before registering with VST (`0` = wait for a stable non-empty list instead) |
+| `NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT` | `120` | Seconds to keep waiting after NVStreamer returns a non-empty list that is still below `NUM_STREAMS` (or not yet stable when `NUM_STREAMS=0`). Then the partial list is used. Unreachable / non-200 / empty responses retry indefinitely |
 | `NVSTREAMER_STREAM_VALIDATION_MAX_RETRIES` | `50` | Max retries for stream validation |
 | `NVSTREAMER_STREAM_VALIDATION_RETRY_DELAY` | `5` | Delay between validation retries (seconds) |
 | **Video upload (NVStreamer / VMS)** | | |

--- a/services/configurators/vss-configurator/app/sensor_config_manager.py
+++ b/services/configurators/vss-configurator/app/sensor_config_manager.py
@@ -68,6 +68,25 @@ def set_video_upload_status(status: str, message: str, uploaded_count: int = 0, 
 # Configuration cache to avoid re-reading environment variables
 _config_cache = {}
 
+NVSTREAMER_STREAMS_POLL_INTERVAL_SEC = 5
+
+
+def _parse_non_negative_int_env(env_var, default_value=0):
+    """Parse a non-negative integer from the environment; invalid values fall back to default."""
+    raw = os.environ.get(env_var)
+    if raw is None or str(raw).strip() == "":
+        return default_value
+    try:
+        parsed = int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning(f"Invalid {env_var}={raw!r}; using {default_value}")
+        return default_value
+    if parsed < 0:
+        logger.warning(f"{env_var}={parsed} is negative; using {default_value}")
+        return default_value
+    return parsed
+
+
 def get_config():
     """Get configuration from environment variables with caching."""
     if not _config_cache:
@@ -167,8 +186,11 @@ def get_config():
             # Deployment profile (2d or 3d) configuration
             'MODE': os.environ.get("MODE", "3d").lower(),
 
-            # VST stream validation (online and no Errors) retry configuration
-            'NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT': int(os.environ.get("NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT", "100")),
+            # Expected camera count from NVStreamer (0 = unknown; use list stability instead)
+            'NUM_STREAMS': _parse_non_negative_int_env("NUM_STREAMS", 0),
+
+            # After NVStreamer returns a non-empty but incomplete list, wait this many seconds for more streams
+            'NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT': int(os.environ.get("NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT", "120")),
             'NVSTREAMER_STREAM_VALIDATION_MAX_RETRIES': int(os.environ.get("NVSTREAMER_STREAM_VALIDATION_MAX_RETRIES", "50")),
             'NVSTREAMER_STREAM_VALIDATION_RETRY_DELAY': int(os.environ.get("NVSTREAMER_STREAM_VALIDATION_RETRY_DELAY", "5")),
 
@@ -713,58 +735,107 @@ def nvstreamer_stream_is_valid(stream_name):
     logger.warning(f"Stream '{stream_name}' validation failed after {max_retries} attempts")
     return False
 
+def _nvstreamer_stream_list_is_complete(current_count, last_count, expected_count):
+    """Return True when the NVStreamer stream list is ready to commit.
+
+    NVStreamer registers files serially, so a non-empty list is not complete.
+    Prefer NUM_STREAMS when set; otherwise require the count to stay stable
+    across two consecutive polls.
+    """
+    if current_count <= 0:
+        return False
+    if expected_count > 0:
+        return current_count >= expected_count
+    return last_count is not None and last_count == current_count
+
+
 def fetch_all_streams_from_nvstreamer():
     api_up = False
-    # start_time = time.time()
+    timeout = CONFIG['NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT']
+    expected_count = CONFIG.get('NUM_STREAMS', 0) or 0
+    last_count = None
+    json_vals = []
+    poll_interval = NVSTREAMER_STREAMS_POLL_INTERVAL_SEC
+    partial_wait_started_at = None
+
     while not api_up:
         try:
             logger.info("Checking Nvstreamer streams endpoint to see if it's ready")
             resp = requests.get(CONFIG['NVSTREAMER_STREAMS_ENDPOINT'])
-            # api_up = True
         except Exception as e:
-            logger.warning("Error while checking Nvstreamer streams endpoint, retrying in 5 seconds")
+            logger.warning(f"Error while checking Nvstreamer streams endpoint, retrying in {poll_interval} seconds")
             logger.debug(f"Exception details: {repr(e)}")
-            api_up = False
-            time.sleep(5)
+            time.sleep(poll_interval)
             continue
-
-        # if int(time.time() - start_time)  > CONFIG['NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT']:
-        #     logger.error("VST endpoint took too long to respond - skipping VST preload")
-        #     return []
-
-        # resp = requests.get(CONFIG['NVSTREAMER_STREAMS_ENDPOINT']) # TODO: Check if commenting this works
 
         if not resp.status_code == 200:
-            logger.info(f"Getting status code {resp.status_code} from VST endpoint {CONFIG['NVSTREAMER_STREAMS_ENDPOINT']} - retrying in 5 seconds")
-            api_up = False
-            time.sleep(5)
+            logger.info(
+                f"Getting status code {resp.status_code} from Nvstreamer streams endpoint "
+                f"{CONFIG['NVSTREAMER_STREAMS_ENDPOINT']} - retrying in {poll_interval} seconds"
+            )
+            time.sleep(poll_interval)
             continue
-        else:
-            # Check if response is not empty even with 200 status code
-            try:
-                json_vals = resp.json()
-                if not json_vals or len(json_vals) == 0:
-                    logger.info(f"Nvstreamer streams endpoint returned empty response - retrying in 5 seconds")
-                    api_up = False
-                    time.sleep(5)
-                    continue
-            except Exception as e:
-                logger.info(f"Failed to parse Nvstreamer response as JSON - retrying in 5 seconds. Exception: {repr(e)}")
-                api_up = False
-                time.sleep(5)
+
+        try:
+            json_vals = resp.json()
+            current_count = len(json_vals) if json_vals else 0
+            if current_count == 0:
+                logger.info(
+                    f"Nvstreamer streams endpoint returned empty response - retrying in {poll_interval} seconds"
+                )
+                last_count = None
+                partial_wait_started_at = None
+                time.sleep(poll_interval)
                 continue
-            
-            logger.info(f"Getting status code {resp.status_code} from Nvstreamer streams endpoint {CONFIG['NVSTREAMER_STREAMS_ENDPOINT']} with valid response")
-            logger.info(f"Successfully parsed Nvstreamer streams endpoint response: {json_vals}")
+        except Exception as e:
+            logger.info(
+                f"Failed to parse Nvstreamer response as JSON - retrying in {poll_interval} seconds. "
+                f"Exception: {repr(e)}"
+            )
+            time.sleep(poll_interval)
+            continue
+
+        logger.info(
+            f"Getting status code {resp.status_code} from Nvstreamer streams endpoint "
+            f"{CONFIG['NVSTREAMER_STREAMS_ENDPOINT']} with valid response"
+        )
+        logger.info(f"Successfully parsed Nvstreamer streams endpoint response: {json_vals}")
+
+        if _nvstreamer_stream_list_is_complete(current_count, last_count, expected_count):
             api_up = True
             break
 
-    # try:
-        # json_vals = resp.json()
-    #     logger.info(f"Successfully parsed VST endpoint response: {json_vals}")
-    # except Exception as e:
-    #     logger.info("Couldn't parse VST endpoint response, will retry. Exception was - " + repr(e))
-    #     return None
+        now = time.time()
+        if partial_wait_started_at is None:
+            partial_wait_started_at = now
+        partial_elapsed = now - partial_wait_started_at
+        if partial_elapsed >= timeout:
+            expected_note = f", expected {expected_count}" if expected_count else ""
+            logger.warning(
+                f"Nvstreamer reported {current_count} stream(s) for {partial_elapsed:.1f}s "
+                f"(NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT {timeout}s{expected_note}); "
+                "proceeding with the list collected so far"
+            )
+            break
+        retry_in = min(poll_interval, max(0.0, timeout - partial_elapsed))
+        if expected_count > 0:
+            logger.info(
+                f"Nvstreamer reported {current_count} stream(s), waiting for expected {expected_count} "
+                f"- retrying in {retry_in} seconds (timeout {timeout}s)"
+            )
+        else:
+            logger.info(
+                f"Nvstreamer reported {current_count} stream(s); waiting for the list to stabilize "
+                f"- retrying in {retry_in} seconds (timeout {timeout}s)"
+            )
+        last_count = current_count
+        time.sleep(retry_in)
+
+    if expected_count > 0 and len(json_vals) < expected_count:
+        logger.warning(
+            f"Fetched {len(json_vals)} stream(s) from Nvstreamer but NUM_STREAMS={expected_count}; "
+            "cameras may be missing from VST"
+        )
 
     nvstreamer_streams = []
     for stream in json_vals:
@@ -1044,7 +1115,15 @@ def process_sensor_info_from_nvstreamer():
     if CONFIG['CALL_SENSOR_ADD_API']:
         logger.info("Calling sensor add API for VMS/RTSP Server")
         [add_sensor(sensor_info) for sensor_info in sensor_mapping.sensors.values()]
-        logger.info(f"Successfully called sensor add API for {len(sensor_mapping.sensors)} sensors")
+        added_count = len(sensor_mapping.sensors)
+        expected_count = CONFIG.get('NUM_STREAMS', 0) or 0
+        if expected_count > 0 and added_count < expected_count:
+            logger.warning(
+                f"Called sensor add API for {added_count} sensors but NUM_STREAMS={expected_count}; "
+                "cameras may be missing from VST"
+            )
+        else:
+            logger.info(f"Successfully called sensor add API for {added_count} sensors")
     else:
         logger.info("Skipping sensor add API call as CALL_SENSOR_ADD_API is disabled")
     

--- a/services/configurators/vss-configurator/tests/test_fetch_nvstreamer_streams.py
+++ b/services/configurators/vss-configurator/tests/test_fetch_nvstreamer_streams.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for NVStreamer stream-list readiness (partial list race)."""
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def safe_calibration_dir(monkeypatch, tmp_path):
+    """Use tmp_path for calibration dir so no global dirs are created."""
+    monkeypatch.setenv("CALIBRATION_DIR_MOUNT_PATH", str(tmp_path))
+    yield
+    try:
+        import sensor_config_manager as _mod
+        _mod._config_cache.clear()
+    except Exception:
+        pass
+
+
+def _stream_entry(name):
+    return {
+        f"{name}_0": [{
+            "isMain": True,
+            "name": name,
+            "url": f"rtsp://nvstreamer/{name}",
+            "metadata": {},
+        }]
+    }
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+
+    def time(self):
+        return self.t
+
+    def sleep(self, seconds):
+        self.t += seconds
+
+
+def _ok_response(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    return resp
+
+
+def test_stream_list_complete_requires_expected_count():
+    import sensor_config_manager as mod
+
+    assert mod._nvstreamer_stream_list_is_complete(2, None, 3) is False
+    assert mod._nvstreamer_stream_list_is_complete(3, 2, 3) is True
+    assert mod._nvstreamer_stream_list_is_complete(4, None, 3) is True
+
+
+def test_stream_list_complete_requires_stable_count_when_expected_unknown():
+    import sensor_config_manager as mod
+
+    assert mod._nvstreamer_stream_list_is_complete(2, None, 0) is False
+    assert mod._nvstreamer_stream_list_is_complete(2, 2, 0) is True
+    assert mod._nvstreamer_stream_list_is_complete(3, 2, 0) is False
+    assert mod._nvstreamer_stream_list_is_complete(0, 0, 0) is False
+
+
+def test_parse_num_streams_env(monkeypatch):
+    import sensor_config_manager as mod
+
+    monkeypatch.delenv("NUM_STREAMS", raising=False)
+    assert mod._parse_non_negative_int_env("NUM_STREAMS", 0) == 0
+    monkeypatch.setenv("NUM_STREAMS", "3")
+    assert mod._parse_non_negative_int_env("NUM_STREAMS", 0) == 3
+    monkeypatch.setenv("NUM_STREAMS", "not-a-number")
+    assert mod._parse_non_negative_int_env("NUM_STREAMS", 0) == 0
+    monkeypatch.setenv("NUM_STREAMS", "-1")
+    assert mod._parse_non_negative_int_env("NUM_STREAMS", 0) == 0
+
+
+def test_get_config_reads_num_streams(monkeypatch):
+    import sensor_config_manager as mod
+
+    monkeypatch.setenv("NUM_STREAMS", "3")
+    mod.refresh_config()
+    assert mod.CONFIG["NUM_STREAMS"] == 3
+
+
+def test_fetch_waits_for_num_streams_instead_of_first_non_empty(monkeypatch):
+    """A 2-stream poll must not commit when NUM_STREAMS=3; the next full list should."""
+    import sensor_config_manager as mod
+
+    clock = FakeClock()
+    payloads = [
+        [_stream_entry("Camera_02"), _stream_entry("Camera")],
+        [_stream_entry("Camera_02"), _stream_entry("Camera"), _stream_entry("Camera_01")],
+    ]
+
+    monkeypatch.setitem(mod.CONFIG, "NUM_STREAMS", 3)
+    monkeypatch.setitem(mod.CONFIG, "NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT", 100)
+    monkeypatch.setitem(mod.CONFIG, "NVSTREAMER_STREAMS_ENDPOINT", "http://nvstreamer/streams")
+
+    with patch.object(mod.time, "time", clock.time), \
+         patch.object(mod.time, "sleep", clock.sleep), \
+         patch.object(mod.requests, "get", side_effect=[_ok_response(p) for p in payloads]), \
+         patch.object(mod, "nvstreamer_stream_is_valid", return_value=True):
+        streams = mod.fetch_all_streams_from_nvstreamer()
+
+    names = {s["event"]["camera_name"] for s in streams}
+    assert names == {"Camera_02", "Camera", "Camera_01"}
+    assert clock.t == mod.NVSTREAMER_STREAMS_POLL_INTERVAL_SEC
+
+
+def test_fetch_accepts_stable_count_when_num_streams_unset(monkeypatch):
+    import sensor_config_manager as mod
+
+    clock = FakeClock()
+    two = [_stream_entry("Camera_02"), _stream_entry("Camera")]
+
+    monkeypatch.setitem(mod.CONFIG, "NUM_STREAMS", 0)
+    monkeypatch.setitem(mod.CONFIG, "NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT", 100)
+    monkeypatch.setitem(mod.CONFIG, "NVSTREAMER_STREAMS_ENDPOINT", "http://nvstreamer/streams")
+
+    with patch.object(mod.time, "time", clock.time), \
+         patch.object(mod.time, "sleep", clock.sleep), \
+         patch.object(mod.requests, "get", side_effect=[_ok_response(two), _ok_response(two)]), \
+         patch.object(mod, "nvstreamer_stream_is_valid", return_value=True):
+        streams = mod.fetch_all_streams_from_nvstreamer()
+
+    assert len(streams) == 2
+
+
+def test_fetch_times_out_with_partial_list_and_warns(monkeypatch, caplog):
+    import logging
+    import sensor_config_manager as mod
+
+    clock = FakeClock()
+    partial = [_stream_entry("Camera_02"), _stream_entry("Camera")]
+
+    monkeypatch.setitem(mod.CONFIG, "NUM_STREAMS", 3)
+    monkeypatch.setitem(mod.CONFIG, "NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT", 2)
+    monkeypatch.setitem(mod.CONFIG, "NVSTREAMER_STREAMS_ENDPOINT", "http://nvstreamer/streams")
+
+    def always_partial(*_args, **_kwargs):
+        return _ok_response(partial)
+
+    with caplog.at_level(logging.WARNING), \
+         patch.object(mod.time, "time", clock.time), \
+         patch.object(mod.time, "sleep", clock.sleep), \
+         patch.object(mod.requests, "get", side_effect=always_partial), \
+         patch.object(mod, "nvstreamer_stream_is_valid", return_value=True):
+        streams = mod.fetch_all_streams_from_nvstreamer()
+
+    assert len(streams) == 2
+    assert clock.t == 2
+    assert any("NUM_STREAMS=3" in rec.message for rec in caplog.records)
+    assert any("NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT" in rec.message for rec in caplog.records)
+
+
+def test_fetch_errors_and_empty_retry_until_complete_list(monkeypatch):
+    """Unreachable / empty responses retry indefinitely; timeout applies only to a partial list."""
+    import sensor_config_manager as mod
+
+    clock = FakeClock()
+    empty = MagicMock()
+    empty.status_code = 200
+    empty.json.return_value = []
+    error = MagicMock()
+    error.status_code = 503
+    complete = [
+        _stream_entry("Camera_02"),
+        _stream_entry("Camera"),
+        _stream_entry("Camera_01"),
+    ]
+
+    monkeypatch.setitem(mod.CONFIG, "NUM_STREAMS", 3)
+    monkeypatch.setitem(mod.CONFIG, "NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT", 2)
+    monkeypatch.setitem(mod.CONFIG, "NVSTREAMER_STREAMS_ENDPOINT", "http://nvstreamer/streams")
+
+    with patch.object(mod.time, "time", clock.time), \
+         patch.object(mod.time, "sleep", clock.sleep), \
+         patch.object(
+             mod.requests,
+             "get",
+             side_effect=[error, empty, error, _ok_response(complete)],
+         ), \
+         patch.object(mod, "nvstreamer_stream_is_valid", return_value=True):
+        streams = mod.fetch_all_streams_from_nvstreamer()
+
+    names = {s["event"]["camera_name"] for s in streams}
+    assert names == {"Camera_02", "Camera", "Camera_01"}
+    assert clock.t > 2
+
+
+def test_get_config_reads_endpoint_timeout(monkeypatch):
+    import sensor_config_manager as mod
+
+    monkeypatch.setenv("NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT", "120")
+    mod.refresh_config()
+    assert mod.CONFIG["NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT"] == 120


### PR DESCRIPTION
## Summary
- NVStreamer registers files serially. vss-configurator used to treat the first non-empty `/api/v1/sensor/streams` (or live streams) response as ready, call VST `/sensor/add` once, and never reconcile — so warehouse cold start could register 2 of 3 cameras while pods looked healthy.
- Honor `NUM_STREAMS` (already set in Helm/Compose, previously unread). Wait until the list reaches that count. If `NUM_STREAMS` is `0`/unset, wait for two consecutive equal non-empty counts.
- If NVStreamer is down, returns non-200, or returns 0 streams: retry every 5s with **no timeout** (previous behavior).
- If the list is non-empty but still below `NUM_STREAMS` (or not yet stable): wait up to `NVSTREAMER_STREAMS_ENDPOINT_TIMEOUT` (**default 120s**), then commit what we have and warn.

```mermaid
flowchart TD
  A[GET NVStreamer streams] --> B{Response}
  B -->|error / non-200 / empty| C[Sleep 5s]
  C --> A
  B -->|N >= NUM_STREAMS| D[Commit list to VST]
  B -->|0 < N < NUM_STREAMS| E{Partial wait elapsed?}
  E -->|under 120s| F[Sleep 5s]
  F --> A
  E -->|timeout| G[Warn and commit partial list]
```

## Test plan
- [ ] Unit: `tests/test_fetch_nvstreamer_streams.py` (wait for `NUM_STREAMS`, stable-count fallback, 2 min partial timeout, down/empty retries past 2s then succeeds)
- [ ] Warehouse 2D/3D cold start with `NUM_STREAMS` matching sample videos; VST has all cameras after configurator preload
- [ ] Confirm a late NVStreamer (HTTP not up yet) does not skip preload
- [ ] Confirm a stuck partial list (e.g. `NUM_STREAMS` too high) proceeds after ~2 minutes with a warning