### PR TITLE
fix(lvs): do not auto-open caption HITL on summarize

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/agents/top_agent.py
@@ -74,6 +74,9 @@ from vss_agents.agents.data_models import AgentRequestOptions
 from vss_agents.agents.postprocessing import POSTPROCESSING_FEEDBACK_MARKER
 from vss_agents.agents.postprocessing import PostprocessingConfig
 from vss_agents.agents.postprocessing import PostprocessingNode
+from vss_agents.tools.lvs_config_media import LVS_CONFIG_MEDIA_BLOCKED_MESSAGE
+from vss_agents.tools.lvs_config_media import LVS_CONFIG_MEDIA_TOOL_NAME
+from vss_agents.tools.lvs_config_media import user_requested_caption_generation
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import get_name_to_stream_id_map
 from vss_agents.utils.asyncmixin import AsyncMixin
@@ -966,12 +969,32 @@ class TopAgent(AsyncMixin):
                             content=f"Tool '{tool_call['name']}' not found",
                         )
 
-                    logger.info(f"Executing tool/sub-agent: {tool_call['name']}")
                     tool_response: Any = None
 
                     # Check if this is a sub-agent that we should call natively for streaming
                     tool_name = tool_call["name"]
                     is_subagent = tool_name in self.subagent_names
+
+                    # Caption HITL (lvs_config_media) is allowed only on an explicit user
+                    # request. Summarize/report not_configured must stop in chat instead.
+                    if tool_name == LVS_CONFIG_MEDIA_TOOL_NAME:
+                        user_text = (
+                            _get_content_text(state.current_message) if state.current_message is not None else ""
+                        )
+                        if not user_requested_caption_generation(user_text):
+                            logger.warning(
+                                "Blocked %s: current user message is not an explicit caption-generation request",
+                                tool_name,
+                            )
+                            if not state.final_answer:
+                                state.final_answer = LVS_CONFIG_MEDIA_BLOCKED_MESSAGE
+                            return ToolMessage(
+                                name=tool_name,
+                                tool_call_id=tool_call["id"],
+                                content=LVS_CONFIG_MEDIA_BLOCKED_MESSAGE,
+                            )
+
+                    logger.info(f"Executing tool/sub-agent: {tool_name}")
 
                     # Build tool args once, filtering None values and injecting request options when supported.
                     tool_args = {k: v for k, v in tool_call["args"].items() if v is not None}

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -19,6 +19,7 @@ from collections.abc import AsyncGenerator
 from enum import StrEnum
 import json
 import logging
+import re
 from typing import Any
 from typing import Literal
 
@@ -46,6 +47,24 @@ logger = logging.getLogger(__name__)
 
 GENERATE_CAPTIONS_ENDPOINT = "/v1/generate_captions"
 CAPTION_GENERATION_STARTED_MESSAGE = "Caption generation started. Please try again later."
+LVS_CONFIG_MEDIA_TOOL_NAME = "lvs_config_media"
+LVS_CONFIG_MEDIA_BLOCKED_MESSAGE = (
+    "lvs_config_media was not executed. Caption generation starts only after the user "
+    'explicitly replies with "start captioning <stream_name>" (or "set up stream" / '
+    '"configure stream"). Surface any not_configured caption prompt and stop; do not '
+    "open HITL on this turn."
+)
+# Phrases that count as an explicit user request to start LVS caption generation.
+_CAPTION_GENERATION_REQUEST_RE = re.compile(
+    r"(?i)\b(?:start\s+captioning|set\s+up\s+stream|configure\s+stream)\b",
+)
+
+
+def user_requested_caption_generation(user_text: str | None) -> bool:
+    """Return True when the current user turn explicitly asks to start captions."""
+    if not user_text or not user_text.strip():
+        return False
+    return _CAPTION_GENERATION_REQUEST_RE.search(user_text) is not None
 
 
 class LVSMediaStatus(StrEnum):

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -56,7 +56,12 @@ LVS_CONFIG_MEDIA_BLOCKED_MESSAGE = (
 )
 # Phrases that count as an explicit user request to start LVS caption generation.
 _CAPTION_GENERATION_REQUEST_RE = re.compile(
-    r"(?i)\b(?:start\s+captioning|set\s+up\s+stream|configure\s+stream)\b",
+    r"(?i)\b(?P<trigger>start\s+captioning|set\s+up\s+stream|configure\s+stream)\b",
+)
+# Reject "do not start captioning …" / "never configure stream …" even though the
+# trigger phrase is present.
+_CAPTION_GENERATION_NEGATION_RE = re.compile(
+    r"(?i)(?:\b(?:do\s+not|don't|dont|never)\b(?:\s+\w+){0,4}|\bnot)\s+$",
 )
 
 
@@ -64,7 +69,12 @@ def user_requested_caption_generation(user_text: str | None) -> bool:
     """Return True when the current user turn explicitly asks to start captions."""
     if not user_text or not user_text.strip():
         return False
-    return _CAPTION_GENERATION_REQUEST_RE.search(user_text) is not None
+    for match in _CAPTION_GENERATION_REQUEST_RE.finditer(user_text):
+        prefix = user_text[: match.start()]
+        if _CAPTION_GENERATION_NEGATION_RE.search(prefix):
+            continue
+        return True
+    return False
 
 
 class LVSMediaStatus(StrEnum):

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -58,21 +58,27 @@ LVS_CONFIG_MEDIA_BLOCKED_MESSAGE = (
 _CAPTION_GENERATION_REQUEST_RE = re.compile(
     r"(?i)\b(?P<trigger>start\s+captioning|set\s+up\s+stream|configure\s+stream)\b",
 )
-# Any of these in the same sentence as the trigger counts as a refusal, including
-# punctuated / long forms ("Do not, under any circumstances, start captioning").
+# Any of these in the same sentence as the trigger counts as a refusal,
+# including prefix forms and post-trigger retractions
+# ("start captioning CAM_1, but actually don't").
 _CAPTION_GENERATION_NEGATION_RE = re.compile(
     r"(?i)\b(?:do\s+not|don't|dont|does\s+not|doesn't|doesnt|"
     r"never|cannot|can't|cant|won't|wont|not)\b",
 )
 
 
-def _sentence_prefix_before(user_text: str, trigger_start: int) -> str:
-    """Return the current-sentence text immediately before a trigger match."""
+def _sentence_containing(user_text: str, trigger_start: int, trigger_end: int) -> str:
+    """Return the sentence that contains the trigger match."""
     last_break = -1
     for index, char in enumerate(user_text[:trigger_start]):
         if char in ".!?":
             last_break = index
-    return user_text[last_break + 1 : trigger_start]
+    next_break = len(user_text)
+    for index, char in enumerate(user_text[trigger_end:], start=trigger_end):
+        if char in ".!?":
+            next_break = index
+            break
+    return user_text[last_break + 1 : next_break]
 
 
 def user_requested_caption_generation(user_text: str | None) -> bool:
@@ -80,8 +86,8 @@ def user_requested_caption_generation(user_text: str | None) -> bool:
     if not user_text or not user_text.strip():
         return False
     for match in _CAPTION_GENERATION_REQUEST_RE.finditer(user_text):
-        sentence_prefix = _sentence_prefix_before(user_text, match.start())
-        if _CAPTION_GENERATION_NEGATION_RE.search(sentence_prefix):
+        sentence = _sentence_containing(user_text, match.start(), match.end())
+        if _CAPTION_GENERATION_NEGATION_RE.search(sentence):
             continue
         return True
     return False

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_config_media.py
@@ -58,11 +58,21 @@ LVS_CONFIG_MEDIA_BLOCKED_MESSAGE = (
 _CAPTION_GENERATION_REQUEST_RE = re.compile(
     r"(?i)\b(?P<trigger>start\s+captioning|set\s+up\s+stream|configure\s+stream)\b",
 )
-# Reject "do not start captioning …" / "never configure stream …" even though the
-# trigger phrase is present.
+# Any of these in the same sentence as the trigger counts as a refusal, including
+# punctuated / long forms ("Do not, under any circumstances, start captioning").
 _CAPTION_GENERATION_NEGATION_RE = re.compile(
-    r"(?i)(?:\b(?:do\s+not|don't|dont|never)\b(?:\s+\w+){0,4}|\bnot)\s+$",
+    r"(?i)\b(?:do\s+not|don't|dont|does\s+not|doesn't|doesnt|"
+    r"never|cannot|can't|cant|won't|wont|not)\b",
 )
+
+
+def _sentence_prefix_before(user_text: str, trigger_start: int) -> str:
+    """Return the current-sentence text immediately before a trigger match."""
+    last_break = -1
+    for index, char in enumerate(user_text[:trigger_start]):
+        if char in ".!?":
+            last_break = index
+    return user_text[last_break + 1 : trigger_start]
 
 
 def user_requested_caption_generation(user_text: str | None) -> bool:
@@ -70,8 +80,8 @@ def user_requested_caption_generation(user_text: str | None) -> bool:
     if not user_text or not user_text.strip():
         return False
     for match in _CAPTION_GENERATION_REQUEST_RE.finditer(user_text):
-        prefix = user_text[: match.start()]
-        if _CAPTION_GENERATION_NEGATION_RE.search(prefix):
+        sentence_prefix = _sentence_prefix_before(user_text, match.start())
+        if _CAPTION_GENERATION_NEGATION_RE.search(sentence_prefix):
             continue
         return True
     return False

--- a/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_stream_understanding.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/lvs_stream_understanding.py
@@ -115,7 +115,10 @@ class LVSStreamUnderstandingOutput(BaseModel):
     def summary(self) -> str | None:
         """Final-answer hint consumed by the top agent for terminal stream states."""
         if self.status == LVSMediaStatus.NOT_CONFIGURED:
-            return None
+            # Terminal for this turn: the user must confirm captioning. Returning
+            # the prompt as summary stops the top agent from auto-calling
+            # lvs_config_media (HITL) on a summarize/report request.
+            return self.message
         if self.status == LVSMediaStatus.SUCCESS:
             if isinstance(self.content, dict):
                 formatted = self._format_lvs_content(self.content)

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -817,3 +817,28 @@ class TestLvsConfigMediaCaptionGate:
 
         assert config_tool.called is True
         assert state.final_answer != LVS_CONFIG_MEDIA_BLOCKED_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_blocks_config_media_on_negated_caption_request(self, monkeypatch):
+        agent, config_tool = self._agent_with_config_tool(monkeypatch)
+        state = TopAgentState(
+            current_message=HumanMessage(content="do not start captioning CAM_1"),
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling config",
+                    tool_calls=[
+                        {
+                            "name": "lvs_config_media",
+                            "args": {"stream_name": "CAM_1"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        await agent.tool_or_subagent_node(state)
+
+        assert config_tool.called is False
+        assert state.final_answer == LVS_CONFIG_MEDIA_BLOCKED_MESSAGE

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -822,7 +822,9 @@ class TestLvsConfigMediaCaptionGate:
     async def test_blocks_config_media_on_negated_caption_request(self, monkeypatch):
         agent, config_tool = self._agent_with_config_tool(monkeypatch)
         state = TopAgentState(
-            current_message=HumanMessage(content="do not start captioning CAM_1"),
+            current_message=HumanMessage(
+                content="Do not, under any circumstances, start captioning CAM_1",
+            ),
             agent_scratchpad=[
                 AIMessage(
                     content="calling config",

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -823,7 +823,7 @@ class TestLvsConfigMediaCaptionGate:
         agent, config_tool = self._agent_with_config_tool(monkeypatch)
         state = TopAgentState(
             current_message=HumanMessage(
-                content="Do not, under any circumstances, start captioning CAM_1",
+                content="start captioning CAM_1, but actually don't",
             ),
             agent_scratchpad=[
                 AIMessage(

--- a/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/agents/test_top_agent.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
+from langchain_core.messages import ToolMessage
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.prompts import MessagesPlaceholder
 from langchain_core.runnables import RunnableLambda
@@ -39,6 +40,7 @@ from vss_agents.agents.top_agent import TopAgentRequest
 from vss_agents.agents.top_agent import TopAgentState
 from vss_agents.agents.top_agent import _augment_context_clip_offsets
 from vss_agents.agents.top_agent import strip_frontend_tags
+from vss_agents.tools.lvs_config_media import LVS_CONFIG_MEDIA_BLOCKED_MESSAGE
 
 
 class TestTopAgentConstants:
@@ -735,3 +737,83 @@ class TestAugmentContextClipOffsets:
         await _augment_context_clip_offsets(msg)
 
         assert sorted(timeline_calls) == ["stream-cam1", "stream-cam2"]
+
+
+class TestLvsConfigMediaCaptionGate:
+    """lvs_config_media must not run HITL unless the user asked to start captioning."""
+
+    def _agent_with_config_tool(self, monkeypatch):
+        monkeypatch.setattr("vss_agents.agents.top_agent.get_stream_writer", lambda: lambda _chunk: None)
+
+        class ConfigTool:
+            args_schema = None
+
+            def __init__(self):
+                self.called = False
+
+            async def astream(self, input, config=None):
+                self.called = True
+                yield "should not run"
+
+        config_tool = ConfigTool()
+        agent = TopAgent.__new__(TopAgent)
+        agent.tools_dict = {"lvs_config_media": config_tool}
+        agent.subagent_names = set()
+        agent.callbacks = []
+        return agent, config_tool
+
+    @pytest.mark.asyncio
+    async def test_blocks_config_media_on_summarize_query(self, monkeypatch):
+        agent, config_tool = self._agent_with_config_tool(monkeypatch)
+        state = TopAgentState(
+            current_message=HumanMessage(
+                content="Summarize the stream sample_warehouse from 45 seconds until now",
+            ),
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling config",
+                    tool_calls=[
+                        {
+                            "name": "lvs_config_media",
+                            "args": {"stream_name": "sample_warehouse"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        await agent.tool_or_subagent_node(state)
+
+        assert config_tool.called is False
+        assert state.final_answer == LVS_CONFIG_MEDIA_BLOCKED_MESSAGE
+        assert any(
+            isinstance(msg, ToolMessage) and LVS_CONFIG_MEDIA_BLOCKED_MESSAGE in str(msg.content)
+            for msg in state.agent_scratchpad
+        )
+
+    @pytest.mark.asyncio
+    async def test_allows_config_media_on_start_captioning_query(self, monkeypatch):
+        agent, config_tool = self._agent_with_config_tool(monkeypatch)
+        state = TopAgentState(
+            current_message=HumanMessage(content="start captioning the stream sample_warehouse"),
+            agent_scratchpad=[
+                AIMessage(
+                    content="calling config",
+                    tool_calls=[
+                        {
+                            "name": "lvs_config_media",
+                            "args": {"stream_name": "sample_warehouse"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            ],
+            options=AgentRequestOptions(),
+        )
+
+        await agent.tool_or_subagent_node(state)
+
+        assert config_tool.called is True
+        assert state.final_answer != LVS_CONFIG_MEDIA_BLOCKED_MESSAGE

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -107,10 +107,22 @@ class TestUserRequestedCaptionGeneration:
             "never set up stream CAM_1",
             "do not configure stream warehouse_cam",
             "not start captioning CAM_1",
+            "Do not, under any circumstances, start captioning CAM_1",
+            "Please don't, under any circumstances, configure stream warehouse_cam",
+            "I never want you to set up stream CAM_1",
+            "I do not, at this time, start captioning sample_warehouse",
         ],
     )
     def test_summarize_and_empty_turns_are_not_caption_requests(self, text):
         assert user_requested_caption_generation(text) is False
+
+    def test_later_sentence_can_still_request_captioning(self):
+        assert (
+            user_requested_caption_generation(
+                "I have not configured captions yet. start captioning CAM_1",
+            )
+            is True
+        )
 
 
 class TestLVSConfigMediaInner:

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -111,6 +111,10 @@ class TestUserRequestedCaptionGeneration:
             "Please don't, under any circumstances, configure stream warehouse_cam",
             "I never want you to set up stream CAM_1",
             "I do not, at this time, start captioning sample_warehouse",
+            "start captioning CAM_1, but actually don't",
+            "start captioning sample_warehouse, never mind",
+            "configure stream warehouse_cam but do not",
+            "set up stream CAM_1 — don't",
         ],
     )
     def test_summarize_and_empty_turns_are_not_caption_requests(self, text):

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -27,6 +27,7 @@ from vss_agents.tools.lvs_config_media import LVSConfigMediaInput
 from vss_agents.tools.lvs_config_media import LVSConfigMediaOutput
 from vss_agents.tools.lvs_config_media import LVSMediaStatus
 from vss_agents.tools.lvs_config_media import lvs_config_media
+from vss_agents.tools.lvs_config_media import user_requested_caption_generation
 from vss_agents.tools.lvs_media_state import clear_configured_media_state
 from vss_agents.tools.lvs_media_state import configured_media
 
@@ -74,6 +75,36 @@ class TestLVSConfigMediaModels:
         )
 
         assert output.summary == "Caption generation started. Please try again later."
+
+
+class TestUserRequestedCaptionGeneration:
+    """Explicit user phrasing required before lvs_config_media may run."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "start captioning the stream sample_warehouse",
+            "Start captioning sample_warehouse",
+            "please set up stream CAM_1",
+            "configure stream warehouse_cam",
+        ],
+    )
+    def test_explicit_caption_requests_are_detected(self, text):
+        assert user_requested_caption_generation(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            None,
+            "",
+            "   ",
+            "Summarize the stream sample_warehouse from 45 seconds until now",
+            "Do you want me to start generating captions for the stream?",
+            "There are no captions stored for stream 'sample_warehouse'.",
+        ],
+    )
+    def test_summarize_and_empty_turns_are_not_caption_requests(self, text):
+        assert user_requested_caption_generation(text) is False
 
 
 class TestLVSConfigMediaInner:

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_config_media.py
@@ -101,6 +101,12 @@ class TestUserRequestedCaptionGeneration:
             "Summarize the stream sample_warehouse from 45 seconds until now",
             "Do you want me to start generating captions for the stream?",
             "There are no captions stored for stream 'sample_warehouse'.",
+            "do not start captioning CAM_1",
+            "don't start captioning sample_warehouse",
+            "please do not start captioning the stream",
+            "never set up stream CAM_1",
+            "do not configure stream warehouse_cam",
+            "not start captioning CAM_1",
         ],
     )
     def test_summarize_and_empty_turns_are_not_caption_requests(self, text):

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_stream_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_lvs_stream_understanding.py
@@ -82,7 +82,7 @@ class TestLVSStreamUnderstandingModels:
                 response_type="invalid",
             )
 
-    def test_not_configured_output_does_not_finalize_agent(self):
+    def test_not_configured_output_finalizes_with_caption_prompt(self):
         output = LVSStreamUnderstandingOutput(
             status=LVSMediaStatus.NOT_CONFIGURED,
             stream_name="CAM_1",
@@ -90,7 +90,7 @@ class TestLVSStreamUnderstandingModels:
             message="Call lvs_config_media before summarizing this stream.",
         )
 
-        assert output.summary is None
+        assert output.summary == output.message
 
     def test_failed_configured_output_finalizes_agent(self):
         output = LVSStreamUnderstandingOutput(


### PR DESCRIPTION
Block lvs_config_media unless the user explicitly asks to start captioning, and treat stream not_configured as a terminal chat reply so the planner cannot jump into HITL on the same turn.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
