### PR TITLE
Always pull the rt-cv images so a moving tag is not served stale

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -256,7 +256,7 @@ rtvi:
     # -sbsa tag suffix, so it needs a tag override only:
     #   tag: develop-latest-sbsa
     image:
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
     httpPort: 9000
     streamType: kafka
     env:

--- a/deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/values.yaml
+++ b/deploy/helm/industry-profiles/warehouse-operations/warehouse-2d-app/values.yaml
@@ -370,7 +370,7 @@ rtvi:
     # pinned in profile values. Override globally with
     # global.container_prefix / global.container_tag instead.
     image:
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
     httpPort: 9000
     streamType: kafka
     downloadNgcAppData: true

--- a/deploy/helm/industry-profiles/warehouse-operations/warehouse-3d-app/values.yaml
+++ b/deploy/helm/industry-profiles/warehouse-operations/warehouse-3d-app/values.yaml
@@ -394,7 +394,7 @@ rtvi:
     # pinned in profile values. Override globally with
     # global.container_prefix / global.container_tag instead.
     image:
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
     httpPort: 9000
     streamType: kafka
     downloadNgcAppData: true

--- a/deploy/helm/industry-profiles/warehouse-operations/warehouse-mv3dt-app/values.yaml
+++ b/deploy/helm/industry-profiles/warehouse-operations/warehouse-mv3dt-app/values.yaml
@@ -388,7 +388,7 @@ rtvi:
     # pinned in profile values. Override globally with
     # global.container_prefix / global.container_tag instead.
     image:
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
     httpPort: 9000
     streamType: kafka
     deepstreamEnableSensorIdExtraction: "0"
@@ -425,14 +425,14 @@ rtvi:
               # repository/tag intentionally unset: inherit the managed GHCR
               # channel from the rtvi-cv subchart so Helm and Compose ship the
               # same image. Override with global.container_prefix/container_tag.
-              pullPolicy: IfNotPresent
+              pullPolicy: Always
         fusion:
           enabled: true
           image:
             # repository/tag intentionally unset: inherit the managed GHCR
             # channel from the rtvi-cv subchart so Helm and Compose ship the
             # same image. Override with global.container_prefix/container_tag.
-            pullPolicy: IfNotPresent
+            pullPolicy: Always
           rawTopic: mdx-raw
           fusedTopic: mdx-bev
           sensorTimeoutMs: "100"

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/deployment-standalone-mv3dt-fusion.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/deployment-standalone-mv3dt-fusion.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: mv3dt-fusion
           image: {{ include "vss-rtvi-cv.fusionImage" . }}
-          imagePullPolicy: {{ $fusion.image.pullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ $fusion.image.pullPolicy | default "Always" }}
           env:
             - name: BROKER_TYPE
               value: {{ $sw.streamType | default "kafka" | quote }}

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset-standalone-mv3dt.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset-standalone-mv3dt.yaml
@@ -137,7 +137,7 @@ spec:
         {{- if ($mv3dt.dynamicCameraConfig | default dict).enabled }}
         - name: mv3dt-config-init
           image: {{ include "vss-rtvi-cv.configInitImage" . }}
-          imagePullPolicy: {{ $mv3dt.dynamicCameraConfig.configInit.image.pullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ $mv3dt.dynamicCameraConfig.configInit.image.pullPolicy | default "Always" }}
           env:
             - name: CALIBRATION_API_URL
               value: {{ $mv3dt.dynamicCameraConfig.calibrationApiUrl | quote }}

--- a/deploy/helm/services/rtvi/charts/rtvi-cv/values.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/values.yaml
@@ -42,7 +42,7 @@ scripts:
 image:
   repository: ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv
   tag: "develop-latest"
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 replicas: 1
 statefulSetName: "vss-rtvi-cv"
@@ -168,7 +168,7 @@ standaloneWarehouse:
       image:
         repository: ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv-mv3dt-bev-fusion
         tag: develop-latest
-        pullPolicy: IfNotPresent
+        pullPolicy: Always
       rawTopic: mdx-raw
       fusedTopic: mdx-bev
       sensorTimeoutMs: "100"
@@ -191,7 +191,7 @@ standaloneWarehouse:
         image:
           repository: ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv-mv3dt-config-init
           tag: develop-latest
-          pullPolicy: IfNotPresent
+          pullPolicy: Always
 
 modelsPvc:
   create: false


### PR DESCRIPTION
The rt-cv Helm images resolve to develop-latest, which is overwritten on every build, but were set to pullPolicy: IfNotPresent. A node that had already pulled develop-latest kept serving its cached copy, so redeploying silently reran whatever that node happened to pull first.

That is how the recent text_embedder failure surfaced. develop-latest had been rebuilt on the stock DeepStream base, which does not ship the gst-nvdstextembedder plugin, and IfNotPresent pinned that image on the node even after a corrected image was published:

  ERROR: <create_common_elements:1853>: Failed to create 'text_embedder'

GST_PLUGIN_PATH was set correctly throughout -- it pointed at a directory the cached image did not contain.

Six settings move to Always. The subchart defaults alone were not enough: the profile values override them, so a fix confined to the chart would have been silently undone by every profile.

  services/rtvi/charts/rtvi-cv/values.yaml      vss-rt-cv, mv3dt fusion,
                                                mv3dt config-init
  developer-profiles/dev-profile-search         vss-rtvi-cv
  industry-profiles/.../warehouse-2d-app        vss-rtvi-cv
  industry-profiles/.../warehouse-3d-app        vss-rtvi-cv
  industry-profiles/.../warehouse-mv3dt-app     vss-rtvi-cv, fusion,
                                                config-init

The two template fallbacks for the fusion and config-init images default to Always as well, so partially overridden values cannot reintroduce the stale pull.

Deliberately left on IfNotPresent: rt-cv's ngcDownload and vios-nvstreamer's ngcVideoSeed both run docker.io/library/ubuntu:22.04, an immutable tag where caching is correct.

Verified by enumerating every pullPolicy in deploy/helm and by rendering all four rt-cv workload modes -- alerts, standalone-2d, standalone-3d and standalone-mv3dt -- confirming each emits imagePullPolicy: Always, with mv3dt emitting it for both of its containers.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
