### PR TITLE
Streamline image tag handling including SBSA variants across docker

### DIFF
--- a/deploy/docker/containers.env
+++ b/deploy/docker/containers.env
@@ -64,6 +64,10 @@ VSS_CONTAINER_RELEASE_REGISTRY="${VSS_CONTAINER_RELEASE_REGISTRY:-nvcr.io/nvidia
 # build (agent, UI, alert) rather than a released tag.
 VSS_CONTAINER_STAGING_REGISTRY="${VSS_CONTAINER_STAGING_REGISTRY:-nvcr.io/nvstaging/vss-core}"
 
+# Image tag suffix for VSS_RT_EMBED_TAG, VSS_RT_CV_TAG, VSS_RT_VLM_TAG and VSS_VIDEO_SUMMARIZATION_TAG on sbsa platforms
+# Set to -sbsa on SPARK, GB300 etc
+VSS_CONTAINER_TAG_SUFFIX="${VSS_CONTAINER_TAG_SUFFIX:-}"
+
 # -----------------------------------------------------------------------------
 # Source-gated images (check-*-container-source verifies these against the
 # current source content; migrated defaults use the shared managed tag)
@@ -73,59 +77,45 @@ VSS_CONTAINER_STAGING_REGISTRY="${VSS_CONTAINER_STAGING_REGISTRY:-nvcr.io/nvstag
 VSS_AGENT_IMAGE="${VSS_AGENT_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-agent}"
 
 VSS_AGENT_UI_IMAGE="${VSS_AGENT_UI_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-agent-ui}"
-VSS_AGENT_UI_TAG="${VSS_AGENT_UI_TAG:-${VSS_CONTAINER_TAG:-3.2.1-26.07.1-dd945777eef9}}"
+VSS_AGENT_UI_TAG="${VSS_AGENT_UI_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
 VSS_ALERT_IMAGE="${VSS_ALERT_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-alert-ms}"
-VSS_ALERT_TAG="${VSS_ALERT_TAG:-${VSS_CONTAINER_TAG:-3.3.0-26.07.10-e4c886ba00e5}}"
+VSS_ALERT_TAG="${VSS_ALERT_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
 # Analytics images joined the managed set when #1356 gave them GitHub-native
 # GHCR builds. They follow VSS_CONTAINER_REGISTRY/VSS_CONTAINER_TAG exactly like
 # the agent/UI/alert set; the inner fallback preserves the previous NGC
 # coordinate for anyone who unsets the shared pair.
 VSS_VIDEO_ANALYTICS_API_IMAGE="${VSS_VIDEO_ANALYTICS_API_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-video-analytics-api}"
-VSS_VIDEO_ANALYTICS_API_TAG="${VSS_VIDEO_ANALYTICS_API_TAG:-${VSS_CONTAINER_TAG:-3.2.0}}"
+VSS_VIDEO_ANALYTICS_API_TAG="${VSS_VIDEO_ANALYTICS_API_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
 VSS_BEHAVIOR_ANALYTICS_IMAGE="${VSS_BEHAVIOR_ANALYTICS_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-behavior-analytics}"
-VSS_BEHAVIOR_ANALYTICS_TAG="${VSS_BEHAVIOR_ANALYTICS_TAG:-${VSS_CONTAINER_TAG:-3.3.0-26.07.4}}"
+VSS_BEHAVIOR_ANALYTICS_TAG="${VSS_BEHAVIOR_ANALYTICS_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
-# RT-CV joined the managed set the same way. These two replace the old
-# PERCEPTION_IMAGE / PERCEPTION_TAG pair, which was unnamespaced (a bare
-# PERCEPTION_IMAGE exported for any unrelated reason silently redirected the
-# image) and split across containers.env and services/rtvi/rtvi.env.
-#
-# The inner fallback keeps the previous nvstaging coordinate for anyone who
-# unsets the shared pair.
-#
-# SBSA cannot ride this multiarch manifest -- it is a different base image on
-# the same linux/arm64 platform -- so it is built as a separate image. It does
-# share this GHCR repository though, distinguished only by an -sbsa tag suffix
-# (see the vss-rt-cv-sbsa entry in container-inventory.json). DGX-SPARK deploys
-# therefore override only the TAG; the image default already resolves:
-#   VSS_RT_CV_TAG="develop-latest-sbsa"
 VSS_RT_CV_IMAGE="${VSS_RT_CV_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-rt-cv}"
-VSS_RT_CV_TAG="${VSS_RT_CV_TAG:-${VSS_CONTAINER_TAG:-3.3.0-26.07.2}}"
+VSS_RT_CV_TAG="${VSS_RT_CV_TAG:-${VSS_CONTAINER_TAG:-develop-latest}${VSS_CONTAINER_TAG_SUFFIX:-}}"
 
 VSS_CONFIGURATOR_IMAGE="${VSS_CONFIGURATOR_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-configurator}"
-VSS_CONFIGURATOR_TAG="${VSS_CONFIGURATOR_TAG:-${VSS_CONTAINER_TAG:-3.3.0-2026.08.2-1}}"
+VSS_CONFIGURATOR_TAG="${VSS_CONFIGURATOR_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
 VSS_RT_CONFIG_ADAPTOR_IMAGE="${VSS_RT_CONFIG_ADAPTOR_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-rt-config-adaptor}"
-VSS_RT_CONFIG_ADAPTOR_TAG="${VSS_RT_CONFIG_ADAPTOR_TAG:-${VSS_CONTAINER_TAG:-3.2.0}}"
+VSS_RT_CONFIG_ADAPTOR_TAG="${VSS_RT_CONFIG_ADAPTOR_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
 VSS_RT_CV_MV3DT_BEV_FUSION_IMAGE="${VSS_RT_CV_MV3DT_BEV_FUSION_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-rt-cv-mv3dt-bev-fusion}"
-VSS_RT_CV_MV3DT_BEV_FUSION_TAG="${VSS_RT_CV_MV3DT_BEV_FUSION_TAG:-${VSS_CONTAINER_TAG:-3.2.0}}"
+VSS_RT_CV_MV3DT_BEV_FUSION_TAG="${VSS_RT_CV_MV3DT_BEV_FUSION_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
 # MV3DT config-init runs once at pod/stack start to generate camInfo and the
 # pub/sub topology from calibration, then exits. Compose keeps it behind the
 # `dynamic-config` profile; Helm behind standaloneWarehouse.mv3dt.dynamicCameraConfig.
 VSS_RT_CV_MV3DT_CONFIG_INIT_IMAGE="${VSS_RT_CV_MV3DT_CONFIG_INIT_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-rt-cv-mv3dt-config-init}"
-VSS_RT_CV_MV3DT_CONFIG_INIT_TAG="${VSS_RT_CV_MV3DT_CONFIG_INIT_TAG:-${VSS_CONTAINER_TAG:-3.3.0-26.08.1}}"
+VSS_RT_CV_MV3DT_CONFIG_INIT_TAG="${VSS_RT_CV_MV3DT_CONFIG_INIT_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
 VSS_RT_EMBED_IMAGE="${VSS_RT_EMBED_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-rt-embed}"
-VSS_RT_EMBED_TAG="${VSS_RT_EMBED_TAG:-${VSS_CONTAINER_TAG:-3.3.0-26.08.1}}"
+VSS_RT_EMBED_TAG="${VSS_RT_EMBED_TAG:-${VSS_CONTAINER_TAG:-develop-latest}${VSS_CONTAINER_TAG_SUFFIX:-}}"
 
 # SDRC keeps the full image override for compatibility with existing profile
 # env files and scripts that set SDR_MW_L_IMAGE directly.
-SDR_MW_L_IMAGE="${SDR_MW_L_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/sdr-mw-l:${VSS_CONTAINER_TAG:-3.3.0-2026.08.2-2}}"
+SDR_MW_L_IMAGE="${SDR_MW_L_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/sdr-mw-l:${VSS_CONTAINER_TAG:-develop-latest}}"
 
 # -----------------------------------------------------------------------------
 # Released first-party images (fixed release tags today)
@@ -152,32 +142,29 @@ VSS_AUTO_CALIBRATION_UI_TAG="${VSS_AUTO_CALIBRATION_UI_TAG:-3.3.0-5}"
 # repo (services/vios/docker/Dockerfile, one Dockerfile + MODULE per image);
 # inventory marks them strategy:build, ghcr_build:true. Onboarded onto the shared
 # VSS_CONTAINER_REGISTRY / VSS_CONTAINER_TAG pair (like the agent set): the
-# per-image override comes first and the shared knob folds in as its fallback,
-# which is what actually resolves: VSS_CONTAINER_REGISTRY and VSS_CONTAINER_TAG
-# are given values above. The inner literals are the public release coordinate,
-# so a caller who clears the shared pair still lands on an image that is there.
-# github-first.md step 2.
-VSS_VIOS_SENSOR_IMAGE="${VSS_VIOS_SENSOR_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-vios-sensor}"
-VSS_VIOS_SENSOR_TAG="${VSS_VIOS_SENSOR_TAG:-${VSS_CONTAINER_TAG:-3.3.0}}"
+# per-image override comes first, the shared knob folds in as its fallback, and
+# the nvstaging release coordinate is the inner default. github-first.md step 2.
+VSS_VIOS_SENSOR_IMAGE="${VSS_VIOS_SENSOR_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-vios-sensor}"
+VSS_VIOS_SENSOR_TAG="${VSS_VIOS_SENSOR_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
-VSS_VIOS_STREAMPROCESSING_IMAGE="${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-vios-streamprocessing}"
-VSS_VIOS_STREAMPROCESSING_TAG="${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-3.3.0}}"
+VSS_VIOS_STREAMPROCESSING_IMAGE="${VSS_VIOS_STREAMPROCESSING_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-vios-streamprocessing}"
+VSS_VIOS_STREAMPROCESSING_TAG="${VSS_VIOS_STREAMPROCESSING_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
 # NVStreamer is centralized under services/nvstreamer (develop #1679); its
 # base.yml consumes VSS_NVSTREAMER_IMAGE / VSS_NVSTREAMER_TAG. Same shared-
 # coordinate onboarding as its three siblings; NVSTREAMER_IMAGE_TAG stays in
 # services/nvstreamer/.env as the standalone pin (test-dev-profile contract).
-VSS_NVSTREAMER_IMAGE="${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-vios-nvstreamer}"
-VSS_NVSTREAMER_TAG="${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-3.3.0}}"
+VSS_NVSTREAMER_IMAGE="${VSS_NVSTREAMER_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-vios-nvstreamer}"
+VSS_NVSTREAMER_TAG="${VSS_NVSTREAMER_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 
-VSS_VIOS_INGRESS_IMAGE="${VSS_VIOS_INGRESS_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-vios-ingress}"
-VSS_VIOS_INGRESS_TAG="${VSS_VIOS_INGRESS_TAG:-${VSS_CONTAINER_TAG:-3.3.0}}"
+VSS_VIOS_INGRESS_IMAGE="${VSS_VIOS_INGRESS_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_STAGING_REGISTRY}}/vss-vios-ingress}"
+VSS_VIOS_INGRESS_TAG="${VSS_VIOS_INGRESS_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
 # RT-VLM is part of the shared GHCR-managed image set.
 VSS_RT_VLM_IMAGE="${VSS_RT_VLM_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-rt-vlm}"
-VSS_RT_VLM_TAG="${VSS_RT_VLM_TAG:-${VSS_CONTAINER_TAG:-3.3.0-26.08.2}}"
+VSS_RT_VLM_TAG="${VSS_RT_VLM_TAG:-${VSS_CONTAINER_TAG:-develop-latest}${VSS_CONTAINER_TAG_SUFFIX:-}}"
 # Video Summarization is part of the shared GHCR-managed image set.
 VSS_VIDEO_SUMMARIZATION_IMAGE="${VSS_VIDEO_SUMMARIZATION_IMAGE:-${VSS_CONTAINER_REGISTRY:-${VSS_CONTAINER_RELEASE_REGISTRY}}/vss-video-summarization}"
-VSS_VIDEO_SUMMARIZATION_TAG="${VSS_VIDEO_SUMMARIZATION_TAG:-${VSS_CONTAINER_TAG:-develop-latest}}"
+VSS_VIDEO_SUMMARIZATION_TAG="${VSS_VIDEO_SUMMARIZATION_TAG:-${VSS_CONTAINER_TAG:-develop-latest}${VSS_CONTAINER_TAG_SUFFIX:-}}"
 
 VSS_CALIBRATION_TOOLKIT_IMAGE="${VSS_CALIBRATION_TOOLKIT_IMAGE:-${VSS_CONTAINER_RELEASE_REGISTRY}/calibration}"
 VSS_VIDEO_ANALYTICS_UI_IMAGE="${VSS_VIDEO_ANALYTICS_UI_IMAGE:-${VSS_CONTAINER_STAGING_REGISTRY}/vss-video-analytics-ui}"

--- a/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
@@ -192,16 +192,6 @@ VLM_AS_VERIFIER_ALERT_TYPE_CONFIG_FILE=${VSS_APPS_DIR}/developer-profiles/dev-pr
 ALERT_AGENT_ALWAYS_ON=false
 # Alerts subtitle. Use "Vision (Alerts - CV)" with MODE=2d_cv and "Vision (Alerts - VLM)" with MODE=2d_vlm.
 NEXT_PUBLIC_APP_SUBTITLE="Vision (Alerts - CV)"
-# rt-cv is a managed image: it inherits VSS_CONTAINER_REGISTRY/VSS_CONTAINER_TAG
-# from containers.env, so no tag is pinned here. Pinning an NGC-style tag would
-# combine with the GHCR image default and resolve to a nonexistent coordinate.
-#
-# DGX-SPARK/SBSA: the SBSA image shares this GHCR repository under an -sbsa tag
-# suffix, so only the TAG needs overriding -- the image default resolves.
-#VSS_RT_CV_TAG="develop-latest-sbsa"
-# RT-VLM shares the managed GHCR release channel. DGX-SPARK activates the
-# commented SBSA tag with the standard profile environment switch.
-#VSS_RT_VLM_TAG="develop-latest-sbsa"
 # Use ${VLM_BASE_URL}/v1 for remote VLM endpoints.
 RTVI_VLM_ENDPOINT=http://rtvi-vlm:8000/v1
 # Alerts/LVS remote VLM uses openai-compat; local RT-VLM uses cosmos-reason3.

--- a/deploy/docker/developer-profiles/dev-profile-lvs/.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/.env
@@ -21,9 +21,6 @@
 # =============================================================================
 # Values in this section are not rewritten by dev-profile.sh for this profile.
 MODE=2d
-LVS_TAG="3.3.0-rc2"
-# LVS_TAG="3.3.0-rc2-sbsa"
-# RT-VLM follows the shared VSS_CONTAINER_TAG release channel.
 
 # =============================================================================
 # DEV-PROFILE-LVS ENVIRONMENT CONFIGURATION

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -22,15 +22,6 @@
 # Values in this section are not rewritten by dev-profile.sh for this profile.
 MODE=2d
 VLM_PORT=30082
-# rt-cv and rt-embed are managed images: they inherit
-# VSS_CONTAINER_REGISTRY/VSS_CONTAINER_TAG from containers.env, so no tag is
-# pinned here. Pinning an NGC-style tag would combine with the GHCR image default
-# and resolve to a nonexistent coordinate. (PERCEPTION_TAG was rt-cv's pin before
-# the rename; it is gone tree-wide.)
-#
-# SBSA image tags (rt-cv, rt-embed, rt-vlm) live in overrides.env, not here:
-# dev-profile.sh only scans generated.env, which it copies from overrides.env.
-# This applies to every SBSA host — GB300 and DGX-SPARK alike.
 
 # =============================================================================
 # DEV-PROFILE-SEARCH ENVIRONMENT CONFIGURATION

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -268,17 +268,6 @@ NVSTREAMER_CONFIG_DIR=${VSS_APPS_DIR}/services/nvstreamer/configs
 # =============================================================================
 # PROFILE-SPECIFIC SCENARIO OVERRIDES
 # =============================================================================
-# rt-cv is a managed image: it inherits VSS_CONTAINER_REGISTRY/VSS_CONTAINER_TAG
-# from containers.env like every other managed image, so no tag is pinned here.
-# Pinning an NGC-style tag would combine with the GHCR image default and resolve
-# to a coordinate that does not exist.
-#
-# DGX-SPARK/SBSA: the SBSA image shares this GHCR repository under an -sbsa tag
-# suffix, so only the TAG needs overriding -- the image default resolves.
-# VSS_RT_CV_TAG="develop-latest-sbsa"
-# RT-VLM shares the managed GHCR release channel. DGX-SPARK activates the
-# commented SBSA tag with the standard profile environment switch.
-# VSS_RT_VLM_TAG="develop-latest-sbsa"
 
 # =============================================================================
 # COMPOSE PROFILE SELECTION

--- a/deploy/docker/scripts/blueprint-deploy.sh
+++ b/deploy/docker/scripts/blueprint-deploy.sh
@@ -510,18 +510,6 @@ function disable_sdrc_routing_in_env() {
   done
 }
 
-# Swap non-SBSA image tag lines for commented *sbsa* variants in generated.env (DGX-SPARK or --use-sbsa-images).
-function apply_sbsa_image_tags_to_env() {
-  local _generated_env="${1}"
-  local _reason="${2}"
-  local _key
-  while IFS= read -r _key; do
-    [[ -z "${_key}" ]] && continue
-    sed -i -E "/sbsa/! s/^(${_key})=(.*)/# \1=\2/" "${_generated_env}"
-    sed -i -E "/sbsa/ s/^#[[:space:]]*(${_key})=(.*)/\1=\2/" "${_generated_env}"
-    echo "[INFO] Swapped to SBSA (${_reason}): ${_key}"
-  done < <(grep -E '^#[[:space:]]*[A-Za-z0-9_]+=.*sbsa' "${_generated_env}" 2>/dev/null | sed -nE 's/^#[[:space:]]*([A-Za-z0-9_]+)=.*/\1/p' | sort -u)
-}
 
 function validate_args() {
   local _args _valid_args _all_good
@@ -1254,11 +1242,6 @@ function state_up() {
     echo "[INFO] Warehouse COMPOSE_PROFILES=\${${compose_profiles_selector}}"
   fi
 
-  if [[ "${hardware_profile}" == "DGX-SPARK" ]]; then
-    apply_sbsa_image_tags_to_env "${_generated_env}" "DGX-SPARK"
-  elif [[ "${use_sbsa_images}" == "true" ]]; then
-    apply_sbsa_image_tags_to_env "${_generated_env}" "${hardware_profile:-OTHER} (--use-sbsa-images)"
-  fi
 
   echo "[INFO] Generated environment file: ${_generated_env}"
 
@@ -1295,6 +1278,11 @@ function state_up() {
   local _compose_file_args=(-f compose.yml -f services/infra/compose-no-turn-tcp-relay.yml)
   local _compose_file_args_text=" ${_compose_file_args[*]}"
   echo "[INFO] TURN TCP relay host-port publishing disabled for blueprint-deploy.sh"
+
+  if [[ "${hardware_profile}" == "DGX-SPARK" || "${hardware_profile}" == "GB300" || "${use_sbsa_images}" == "true" ]]; then
+    export VSS_CONTAINER_TAG_SUFFIX="-sbsa"
+    echo "[INFO] Managed container tag suffix: ${VSS_CONTAINER_TAG_SUFFIX}"
+  fi
 
   # Resolve and display the managed container channel before deployment.
   set -a

--- a/deploy/docker/scripts/dev-profile.sh
+++ b/deploy/docker/scripts/dev-profile.sh
@@ -34,6 +34,7 @@ ngc_cli_api_key="${NGC_CLI_API_KEY:-}"
 nvidia_api_key="${NVIDIA_API_KEY:-}"
 openai_api_key="${OPENAI_API_KEY:-}"
 dry_run="false"
+use_sbsa_images="false"
 # Build the VIOS runtime-media packages into a local image instead of installing
 # them on every container start. Env var so CI can set it without a flag.
 prebake_vios_packages="${VSS_VIOS_PREBAKE_PACKAGES:-false}"
@@ -645,6 +646,8 @@ function usage() {
   echo "  --vlm-env-file                   Path to VLM env file. Absolute or relative to CWD."
   echo "                                   • Not allowed when --use-remote-vlm is passed"
   echo "                                   • Not accepted for profile=alerts or base on IGX-THOR or AGX-THOR"
+  echo "  --use-sbsa-images                Use SBSA-tagged managed-image variants."
+  echo "                                   • Enabled automatically for -H DGX-SPARK or GB300"
   echo ""
   echo "Options for 'up' and 'down':"
   echo "  -d, --dry-run                    print commands without executing them"
@@ -669,7 +672,7 @@ function validate_args() {
   _args=("${@}")
   _all_good=0
 
-  _valid_args=$(getopt -q -o p:H:i:e:m:dh --long profile:,hardware-profile:,host-ip:,external-ip:,mode:,llm-device-id:,vlm-device-id:,use-remote-llm,use-remote-vlm,llm:,vlm:,llm-model-type:,vlm-model-type:,llm-env-file:,vlm-env-file:,dry-run,help -- "${_args[@]}")
+  _valid_args=$(getopt -q -o p:H:i:e:m:dh --long profile:,hardware-profile:,host-ip:,external-ip:,mode:,llm-device-id:,vlm-device-id:,use-remote-llm,use-remote-vlm,llm:,vlm:,llm-model-type:,vlm-model-type:,llm-env-file:,vlm-env-file:,use-sbsa-images,dry-run,help -- "${_args[@]}")
   if [[ $? -ne 0 ]]; then
     echo "[ERROR] Invalid usage: $(mask_external_ip_args "${_args[@]}")"
     ((_all_good++))
@@ -710,7 +713,7 @@ function process_args() {
   _args=("${@}")
   _all_good=0
 
-  _valid_args=$(getopt -q -o p:H:i:e:m:dh --long profile:,hardware-profile:,host-ip:,external-ip:,mode:,llm-device-id:,vlm-device-id:,use-remote-llm,use-remote-vlm,llm:,vlm:,llm-model-type:,vlm-model-type:,llm-env-file:,vlm-env-file:,dry-run,help -- "${_args[@]}")
+  _valid_args=$(getopt -q -o p:H:i:e:m:dh --long profile:,hardware-profile:,host-ip:,external-ip:,mode:,llm-device-id:,vlm-device-id:,use-remote-llm,use-remote-vlm,llm:,vlm:,llm-model-type:,vlm-model-type:,llm-env-file:,vlm-env-file:,use-sbsa-images,dry-run,help -- "${_args[@]}")
   eval set -- "${_valid_args}"
 
   # Parse options
@@ -807,6 +810,11 @@ function process_args() {
         shift
         vlm_env_file="${1}"
         options_provided+=("vlm-env-file")
+        shift
+        ;;
+      --use-sbsa-images)
+        use_sbsa_images="true"
+        options_provided+=("use-sbsa-images")
         shift
         ;;
       -d | --dry-run)
@@ -1924,29 +1932,6 @@ function state_up() {
     esac
   fi
 
-  # ARM64 GPU systems use explicit SBSA image tags where profiles provide them.
-  # This includes DGX-SPARK and GB300 (Grace Blackwell), whose generic image
-  # manifests do not include the required DeepStream/Tegra runtime libraries.
-  # For any env var with a commented line whose value contains sbsa, comment the
-  # uncommented line (non-sbsa) and uncomment the sbsa line. Discover keys from
-  # the file. Comment format may be "# VAR=..." or "#VAR=..." (optional space).
-  if [[ "${hardware_profile}" == "DGX-SPARK" || "${hardware_profile}" == "GB300" ]]; then
-    local _key
-    while IFS= read -r _key; do
-      [[ -z "${_key}" ]] && continue
-      # Comment the uncommented line for this key when value does not contain sbsa
-      sed -i -E "/sbsa/! s/^(${_key})=(.*)/# \1=\2/" "${_generated_env}"
-      # Uncomment the commented line for this key when value contains sbsa
-      sed -i -E "/sbsa/ s/^#[[:space:]]*(${_key})=(.*)/\1=\2/" "${_generated_env}"
-      echo "[INFO] Swapped to SBSA (${hardware_profile}): ${_key}"
-    done < <(grep -E '^#[[:space:]]*[A-Za-z0-9_]+=.*sbsa' "${_generated_env}" 2>/dev/null | sed -nE 's/^#[[:space:]]*([A-Za-z0-9_]+)=.*/\1/p' | sort -u)
-  fi
-  # Write the ARM64 RT-VLM image selector into generated.env where it wins
-  # during Compose interpolation.
-  if [[ "${hardware_profile}" == "GB300" ]]; then
-    set_env_var "VSS_RT_VLM_TAG" "3.3.0-26.08.2-sbsa"
-    echo "[INFO] Selected SBSA RT-VLM image for GB300"
-  fi
 
   echo "[INFO] Generated environment file: ${_generated_env}"
 
@@ -2007,6 +1992,11 @@ function state_up() {
   if [[ "${dry_run}" != "true" ]]; then
     echo "[INFO] Applying VSS Linux kernel settings..."
     set_vss_linux_kernel_settings
+  fi
+
+  if [[ "${hardware_profile}" == "DGX-SPARK" || "${hardware_profile}" == "GB300" || "${use_sbsa_images}" == "true" ]]; then
+    export VSS_CONTAINER_TAG_SUFFIX="-sbsa"
+    echo "[INFO] Managed container tag suffix: ${VSS_CONTAINER_TAG_SUFFIX}"
   fi
 
   # Resolve and display the managed container channel before deployment.

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -232,9 +232,9 @@ get_commented_sbsa_keys() {
   grep -E '^#[[:space:]]*[A-Za-z0-9_]+=.*sbsa' "${env_file}" 2>/dev/null | sed -nE 's/^#[[:space:]]*([A-Za-z0-9_]+)=.*/\1/p' | sort -u
 }
 
-# Run one DGX-SPARK dry-run test for a profile: discover sbsa keys from profile overrides.env, run up -H DGX-SPARK, assert.
-# Skips if profile overrides.env is missing. Alerts gets -m real-time. Search must
-# name remote LLM/VLM endpoints, which the single-GPU edge policy requires.
+# Run one DGX-SPARK dry-run test for a profile and assert the centralized SBSA tag suffix.
+# Alerts gets -m real-time. Search must name remote LLM/VLM endpoints.
+
 run_spark_test_for_profile() {
   local profile="${1}"
   local env_file="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-${profile}/overrides.env"
@@ -250,12 +250,12 @@ run_spark_test_for_profile() {
   [[ "${profile}" == "alerts" ]] && run_args+=(-m real-time)
   if [[ "${profile}" == "search" ]]; then
     run_args+=(--use-remote-llm --llm x --use-remote-vlm --vlm y)
-    LLM_ENDPOINT_URL=http://127.0.0.1:8000 VLM_ENDPOINT_URL=http://127.0.0.1:8001 \
-      run_dry_run_up_and_check_generated_env "generated.env DGX-SPARK swaps to sbsa tags (${profile})" "${profile}" \
+    LLM_ENDPOINT_URL=http://127.0.0.1:8000 VLM_ENDPOINT_URL=http://127.0.0.1:8001 EXPECTED_STDOUT="Managed container tag suffix: -sbsa" \
+      run_dry_run_up_and_check_generated_env "generated.env DGX-SPARK enables the SBSA tag suffix (${profile})" "${profile}" \
       "${run_args[@]}" -- "${check_args[@]}"
     return 0
   fi
-  run_dry_run_up_and_check_generated_env "generated.env DGX-SPARK swaps to sbsa tags (${profile})" "${profile}" \
+  EXPECTED_STDOUT="Managed container tag suffix: -sbsa" run_dry_run_up_and_check_generated_env "generated.env DGX-SPARK enables the SBSA tag suffix (${profile})" "${profile}" \
     "${run_args[@]}" -- "${check_args[@]}"
 }
 
@@ -319,6 +319,10 @@ run_dry_run_up_and_check_generated_env() {
   fi
 
   local failed=0
+  if [[ -n "${EXPECTED_STDOUT:-}" ]] && ! grep -Fq "${EXPECTED_STDOUT}" "${out_file}"; then
+    echo "FAIL: ${name} (stdout missing: ${EXPECTED_STDOUT})"
+    ((failed++)) || true
+  fi
   local i=0
   while [[ $i -lt ${#checks[@]} ]]; do
     local var="${checks[$i]}"
@@ -958,9 +962,8 @@ run_dry_run_up_and_check_generated_env "generated.env search default wires RT-VL
   "VLM_BASE_URL" "http://rtvi-vlm:8000" "RT_VLM_DEVICE_ID" "0" \
   "RTVI_VLM_MODEL_TO_USE" "cosmos-reason3" \
   "RTVI_VLLM_GPU_MEMORY_UTILIZATION" "0.4"
-run_dry_run_up_and_check_generated_env "generated.env search selects SBSA RT Embed tag" "search" \
+EXPECTED_STDOUT="Managed container tag suffix: -sbsa" run_dry_run_up_and_check_generated_env "search explicit SBSA override enables the tag suffix" "search" \
   -i 127.0.0.1 -H OTHER --use-sbsa-images -d -- \
-  "VSS_RT_EMBED_TAG" "develop-latest-sbsa"
 _mock_brev_one_gpu_dir="$(mktemp -d)"
 CLEANUP_DIRS+=("${_mock_brev_one_gpu_dir}")
 cat > "${_mock_brev_one_gpu_dir}/nvidia-smi" <<'EOF'
@@ -1824,12 +1827,11 @@ run_dry_run_up_and_check_generated_env "generated.env Search keeps Nemotron 3.5 
   "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
   "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b"
 
-run_dry_run_up_and_check_generated_env "generated.env Base GB300 overlay selects ARM64 LLM and SBSA RT-VLM" "base" \
+EXPECTED_STDOUT="Managed container tag suffix: -sbsa" run_dry_run_up_and_check_generated_env "generated.env Base GB300 selects the centralized SBSA suffix" "base" \
  -i 127.0.0.1 -H GB300 --llm-device-id 1 --vlm-device-id 1 -d -- \
   "HARDWARE_PROFILE" "GB300" \
   "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
   "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b" \
-  "VSS_RT_VLM_TAG" "3.3.0-26.08.2-sbsa"
 
 run_dry_run_up_and_check_generated_env "generated.env Base defaults to Nemotron 3.5 Lightning on H100" "base" \
  -i 127.0.0.1 -H H100 -d -- \


### PR DESCRIPTION
## Summary

Centralizes Docker Compose image-tag selection around VSS_CONTAINER_TAG, with SBSA variants selected through a shared VSS_CONTAINER_TAG_SUFFIX rather than profile-specific commented tag overrides.

## Plan

- Use VSS_CONTAINER_TAG as the common managed-image release channel.
- Apply VSS_CONTAINER_TAG_SUFFIX=-sbsa automatically for DGX Spark/GB300, or explicitly with --use-sbsa-images.  
- Keep SBSA selection out of profile overrides.env files.
- Update Dev Profile regression checks for the centralized environment and shared Compose layout.

## Related Issue

## Changes

- Added VSS_CONTAINER_TAG_SUFFIX; it appends to RT-CV, RT-Embed, RT-VLM, and Video Summarization managed tags.
- Standardized managed image fallback tags on develop-latest.
- Removed SBSA-specific commented tag overrides from developer and warehouse profiles.
- Updated dev-profile.sh and blueprint-deploy.sh to export the SBSA suffix before Compose runs; retained --use-sbsa-images as an explicit override.
- Removed generated-env tag-swapping logic.
- Updated test-dev-profile.sh for centralized RTVI/NVStreamer configuration and managed RT-CV coordinates.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
