### PR TITLE
Honour container_prefix/container_tag in the rt-cv search profile

### DIFF
--- a/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-cv/templates/statefulset.yaml
@@ -230,7 +230,7 @@ spec:
               echo "Kafka is ready!"
       containers:
         - name: vss-rtvi-cv
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "vss-rtvi-cv.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
statefulset.yaml holds two workloads. The alerts one resolves its image through the vss-rtvi-cv.image helper, which applies global.container_prefix and global.container_tag. The search one, added separately, hardcoded the coordinate instead:

    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

so both globals were silently dropped and the pod always ran the values default, ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv:develop-latest, no matter what was passed on the command line.

Rendered with --set global.container_prefix=nvcr.io/nvstaging/vss-core --set global.container_tag=nightly-20260824-2:

    before   search  ghcr.io/nvidia-ai-blueprints/vss/vss-rt-cv:develop-latest
             alerts  nvcr.io/nvstaging/vss-core/vss-rt-cv:nightly-20260824-2
    after    search  nvcr.io/nvstaging/vss-core/vss-rt-cv:nightly-20260824-2

This is what produced the recent search-profile failure:

    ERROR: <create_common_elements:1853>: Failed to create 'text_embedder'

The requested nightly does ship gst-nvdstextembedder; the develop-latest image the pod actually ran, built on the stock DeepStream base, does not. So GST_PLUGIN_PATH was correct all along and pointed into an image that had no such directory.

Verified that search without overrides still resolves the unchanged values default, and that alerts, standalone-2d, standalone-3d and standalone-mv3dt are unaffected.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
