### PR TITLE
fix(lvs): keep bundled DCGM exporter opt-in

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-lvs/Chart.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/Chart.yaml
@@ -48,11 +48,9 @@ dependencies:
     version: 3.3.0
     repository: "file://../../services/rtvi"
     condition: rtvi.enabled
-  # Mirrors the LVS compose profile's dcgm-exporter opt-in (see
-  # deploy/docker/developer-profiles/dev-profile-lvs/overrides.env,
-  # COMPOSE_PROFILES=...,dcgm-exporter,...). Chart-level toggle;
-  # sub-services (prometheus/grafana/node-exporter/dcgm) are gated by
-  # monitoring.*.enabled in values-lvs.yaml.
+  # Optional monitoring stack. The chart-level toggle and individual
+  # monitoring.*.enabled values are disabled by default so clusters that
+  # already use the GPU Operator do not get a duplicate dcgm-exporter.
   - name: monitoring
     version: 3.3.0
     repository: "file://../../services/monitoring"

--- a/deploy/helm/developer-profiles/dev-profile-lvs/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/README.md
@@ -76,6 +76,20 @@ With default **`values.yaml`** and typical LVS install (LLM NIM enabled, **`vss-
 
 To run the RTVI-VLM against a shared/remote VLM endpoint instead of the integrated checkpoint, set `rtvi.vss-rtvi-vlm.useSharedNim=true` and configure the target VLM endpoint/model values.
 
+### Optional GPU monitoring
+
+The chart's DCGM exporter is disabled by default because the NVIDIA GPU
+Operator commonly installs one cluster-wide. On clusters without an existing
+exporter, enable the bundled component explicitly:
+
+```bash
+helm upgrade --install <RELEASE NAME> ./dev-profile-lvs \
+  -f dev-profile-lvs/values-lvs.yaml \
+  --set monitoring.enabled=true \
+  --set monitoring.dcgmExporter.enabled=true \
+  -n <NAMESPACE> --create-namespace
+```
+
 ### NIM GPU profile guidance
 
 The chart requests **one GPU per enabled NIM**, but the repo does **not** encode an exact minimum GPU memory size for each profile. Treat the **`nims.gpuType`** values as tuning profiles, not a certified capacity statement. Use only a profile that matches the GPU class you have validated on the cluster.

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values-lvs.yaml
@@ -70,13 +70,11 @@ rtvi:
     enabled: true
     useSharedNim: false
 
-# Mirrors dev-profile-lvs/overrides.env → COMPOSE_PROFILES=...,dcgm-exporter,...
-# Compose activates only dcgm-exporter (GPU hardware telemetry on port 9400);
-# prometheus / grafana / node-exporter stay off. If your cluster already runs
-# the NVIDIA GPU Operator (which bundles its own dcgm-exporter), leave
-# monitoring.dcgmExporter.enabled=false to avoid duplicate DaemonSets.
+# Monitoring is opt-in because clusters using the NVIDIA GPU Operator commonly
+# already run dcgm-exporter. To deploy this chart's exporter, set both
+# monitoring.enabled=true and monitoring.dcgmExporter.enabled=true.
 monitoring:
-  enabled: true
+  enabled: false
   prometheus:
     enabled: false
   grafana:
@@ -84,7 +82,7 @@ monitoring:
   nodeExporter:
     enabled: false
   dcgmExporter:
-    enabled: true
+    enabled: false
 
 # Helm-managed Ingress (uses existing IngressClass). Set ingressClassName to match your controller (default haproxy).
 vssIngress:

--- a/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-lvs/values.yaml
@@ -631,9 +631,8 @@ nims:
         nvidia.com/gpu: "1"
 
 # Optional monitoring subchart (Kubernetes port of services/monitoring compose).
-# Off by default here so bare `helm install` (no -f values-lvs.yaml) doesn't add
-# a monitoring DaemonSet. values-lvs.yaml turns dcgm-exporter on to match the
-# LVS compose profile's dcgm-exporter opt-in.
+# Keep it off by default because the NVIDIA GPU Operator commonly provides
+# dcgm-exporter. Enable both monitoring.enabled and the desired component.
 monitoring:
   enabled: false
   prometheus:


### PR DESCRIPTION
## Summary
- disable the LVS Helm monitoring subchart and bundled DCGM exporter by default
- avoid duplicate DCGM DaemonSets on clusters where the NVIDIA GPU Operator already provides one
- document the explicit Helm flags for clusters that need the bundled exporter

## Test plan
- [x] Parse `values.yaml` and `values-lvs.yaml` and verify both monitoring defaults are disabled
- [x] Render the LVS chart and verify the default omits DCGM exporter resources
- [x] Render with `monitoring.enabled=true` and `monitoring.dcgmExporter.enabled=true` and verify DCGM resources are present
- [x] `git diff --check`