### PR TITLE
ci: add default-off SBSA self-hosted builder path

### DIFF
--- a/.github/docker-builder/admit-job-sbsa.sh
+++ b/.github/docker-builder/admit-job-sbsa.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Job-started hook for the *new* SBSA builder cohort (horde-sbsa-NN).
+# Do not install this on horde-docker-0[1-4]: that pool keeps its own hook
+# and continues to serve the amd64 vss-rt-vlm canary.
+set -euo pipefail
+
+deny() {
+  echo "::error::SBSA builder rejected this job: $1"
+  exit 1
+}
+
+readonly expected_repo="NVIDIA-AI-Blueprints/video-search-and-summarization"
+readonly build_workflow="Build Dev Images (GHCR)"
+readonly canary_workflow="SBSA builder canary"
+readonly build_job="build-native-platforms"
+
+[[ "${GITHUB_REPOSITORY:-}" == "$expected_repo" ]] ||
+  deny "repository is not approved"
+[[ "${RUNNER_NAME:-}" =~ ^horde-sbsa-[0-9]{2}$ ]] ||
+  deny "runner is not an approved SBSA builder"
+
+workflow="${GITHUB_WORKFLOW:-}"
+job="${GITHUB_JOB:-}"
+
+if [[ "$workflow" == "$canary_workflow" ]]; then
+  [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]] ||
+    deny "canary is workflow_dispatch only"
+  [[ "$job" == "preflight" ]] || deny "canary job is not approved"
+  exit 0
+fi
+
+[[ "$workflow" == "$build_workflow" ]] || deny "workflow is not approved"
+[[ "${GITHUB_EVENT_NAME:-}" == "push" ]] ||
+  deny "only copied push events are approved"
+[[ "$job" == "$build_job" ]] || deny "job is not approved"
+[[ "${GITHUB_ACTOR:-}" == "copy-pr-bot[bot]" ]] ||
+  deny "actor is not approved"
+[[ "${GITHUB_REF:-}" =~ ^refs/heads/pull-request/[0-9]+$ ]] ||
+  deny "ref is not an approved copied PR branch"
+[[ "${GITHUB_WORKFLOW_REF:-}" == \
+  "$expected_repo/.github/workflows/build-dev-images.yml@${GITHUB_REF}" ]] ||
+  deny "workflow source does not match the copied PR ref"
+
+job_name="${GITHUB_JOB_DISPLAY_NAME:-${GITHUB_JOB_NAME:-}}"
+[[ -n "$job_name" ]] || deny "job display name is unavailable"
+[[ "$job_name" =~ ^Build[[:space:]].+-sbsa[[:space:]]\(arm64,[[:space:]]native\)$ ]] ||
+  deny "job display name is not an SBSA native cell"
+
+event_path="${GITHUB_EVENT_PATH:-}"
+[[ -n "$event_path" && -r "$event_path" ]] ||
+  deny "event payload is unavailable"
+
+python3 - "$event_path" "$expected_repo" <<'PY'
+import json
+import re
+import sys
+
+path, expected_repo = sys.argv[1:]
+with open(path, encoding="utf-8") as event_file:
+    event = json.load(event_file)
+
+sender = (event.get("sender") or {}).get("login")
+repo = (event.get("repository") or {}).get("full_name")
+ref = str(event.get("ref") or "")
+allowed = (
+    sender == "copy-pr-bot[bot]"
+    and repo == expected_repo
+    and re.fullmatch(r"refs/heads/pull-request/[0-9]+", ref)
+)
+sys.exit(0 if allowed else 1)
+PY

--- a/.github/docker-builder/register-horde-sbsa.sh
+++ b/.github/docker-builder/register-horde-sbsa.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Register a *new* SBSA builder (horde-sbsa-NN). Does not modify
+# horde-docker-0[1-4]. Cohort label only — no canary/active labels — so the
+# listener can be online without receiving production or canary jobs.
+#
+# Required env:
+#   RUNNER_TOKEN  short-lived GitHub Actions registration token
+#   RUNNER_NAME   e.g. horde-sbsa-01
+# Optional:
+#   RUNNER_DIR    default /srv/github-actions/$RUNNER_NAME
+set -euo pipefail
+
+repo="NVIDIA-AI-Blueprints/video-search-and-summarization"
+name="${RUNNER_NAME:?set RUNNER_NAME to horde-sbsa-NN}"
+token="${RUNNER_TOKEN:?set RUNNER_TOKEN from the repo registration-token API}"
+dir="${RUNNER_DIR:-/srv/github-actions/${name}}"
+
+[[ "$name" =~ ^horde-sbsa-[0-9]{2}$ ]] || {
+  echo "RUNNER_NAME must match horde-sbsa-NN" >&2
+  exit 2
+}
+
+cd "$dir"
+./config.sh --unattended \
+  --url "https://github.com/${repo}" \
+  --token "$token" \
+  --name "$name" \
+  --labels "vss-sbsa-builder" \
+  --work _work \
+  --replace

--- a/.github/scripts/detect_changed_images.py
+++ b/.github/scripts/detect_changed_images.py
@@ -70,12 +70,71 @@ KERNEL_ARCH_BY_PLATFORM = {
     "linux/arm64": "aarch64",
 }
 
+# Dedicated SBSA builder cohort. These labels must not overlap the existing
+# horde-docker-0[1-4] amd64 canary pool (vss-docker-builder-*). Register new
+# runners with the cohort label only. Add the canary or active label later;
+# GitHub will not send production jobs until the workflow asks for `active`
+# and SBSA_SELF_HOSTED_IMAGES names that image.
+SBSA_BUILDER_COHORT_LABEL = "vss-sbsa-builder"
+SBSA_BUILDER_CANARY_LABEL = "vss-sbsa-builder-canary"
+SBSA_BUILDER_ACTIVE_LABEL = "vss-sbsa-builder-active"
+SBSA_SELF_HOSTED_RUNS_ON: tuple[str, ...] = (
+    "self-hosted",
+    "Linux",
+    "X64",
+    SBSA_BUILDER_COHORT_LABEL,
+    SBSA_BUILDER_ACTIVE_LABEL,
+)
+# Empty: every SBSA native cell stays on ubuntu-24.04-arm. Add one image
+# name at a time after the Windows/WSL runner canary passes.
+SBSA_SELF_HOSTED_IMAGES: frozenset[str] = frozenset()
+
 
 def is_native_platform_build(entry: dict) -> bool:
     return (
         entry["name"] in NATIVE_PLATFORM_IMAGE_NAMES
         or entry.get("native_platform_build") is True
     )
+
+
+def is_sbsa_image(entry: dict) -> bool:
+    suffix = str(entry.get("tag_suffix") or "")
+    return suffix == "-sbsa" or str(entry.get("name") or "").endswith("-sbsa")
+
+
+def native_platform_runner(entry: dict, platform: str) -> dict:
+    """Pick the GitHub runner and architecture checks for one native cell."""
+    try:
+        runner = RUNNER_BY_PLATFORM[platform]
+        runner_arch = RUNNER_ARCH_BY_PLATFORM[platform]
+        kernel_arch = KERNEL_ARCH_BY_PLATFORM[platform]
+    except KeyError as exc:
+        raise ValueError(
+            f"{entry['name']}: no native runner configured for {platform}"
+        ) from exc
+
+    emulated = False
+    runs_on: list[str] = [runner]
+    if (
+        platform == "linux/arm64"
+        and is_sbsa_image(entry)
+        and entry["name"] in SBSA_SELF_HOSTED_IMAGES
+    ):
+        # x86_64 self-hosted builder runs linux/arm64 through QEMU. The
+        # kernel/runner arch checks must match the host, not the image.
+        runs_on = list(SBSA_SELF_HOSTED_RUNS_ON)
+        runner = "self-hosted"
+        runner_arch = "X64"
+        kernel_arch = "x86_64"
+        emulated = True
+
+    return {
+        "runner": runner,
+        "runs_on": runs_on,
+        "runner_arch": runner_arch,
+        "kernel_arch": kernel_arch,
+        "emulated": "true" if emulated else "false",
+    }
 
 
 def run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -300,20 +359,12 @@ def split_build_matrices(entries: list[dict]) -> dict[str, dict]:
     for entry in native:
         base = matrix_entry(entry)
         for platform in entry["platforms"]:
-            try:
-                runner = RUNNER_BY_PLATFORM[platform]
-            except KeyError as exc:
-                raise ValueError(
-                    f"{entry['name']}: no native runner configured for {platform}"
-                ) from exc
             native_platforms.append(
                 {
                     **base,
                     "platform": platform,
                     "arch": platform.rsplit("/", 1)[-1],
-                    "runner": runner,
-                    "runner_arch": RUNNER_ARCH_BY_PLATFORM[platform],
-                    "kernel_arch": KERNEL_ARCH_BY_PLATFORM[platform],
+                    **native_platform_runner(entry, platform),
                 }
             )
     return {

--- a/.github/scripts/test_detect_changed_images.py
+++ b/.github/scripts/test_detect_changed_images.py
@@ -348,8 +348,10 @@ class SelectImagesTest(unittest.TestCase):
                 "platform": "linux/arm64",
                 "arch": "arm64",
                 "runner": "ubuntu-24.04-arm",
+                "runs_on": ["ubuntu-24.04-arm"],
                 "runner_arch": "ARM64",
                 "kernel_arch": "aarch64",
+                "emulated": "false",
             },
             matrices["native_platform_matrix"]["include"],
         )
@@ -394,6 +396,20 @@ class SelectImagesTest(unittest.TestCase):
             '"${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}-${platform##*/}"',
             workflow,
         )
+        self.assertIn("runs-on: ${{ matrix.runs_on }}", workflow)
+        self.assertIn("matrix.emulated == 'true'", workflow)
+
+    def test_sbsa_canary_workflow_does_not_share_production_labels(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        canary = (
+            repo_root / ".github/workflows/sbsa-builder-canary.yml"
+        ).read_text()
+        self.assertIn("vss-sbsa-builder-canary", canary)
+        self.assertNotIn("vss-sbsa-builder-active", canary)
+        self.assertNotIn("vss-docker-builder", canary)
+        self.assertIn("workflow_dispatch", canary)
+        self.assertNotIn("\n  push:", canary)
+        self.assertNotIn("schedule:", canary)
 
     def test_matrix_shape(self):
         inventory = INVENTORY
@@ -556,6 +572,88 @@ class SelectImagesTest(unittest.TestCase):
         ]
         with self.assertRaisesRegex(ValueError, "no native runner configured"):
             dci.split_build_matrices(entries)
+
+    def test_sbsa_self_hosted_routing_stays_off_by_default(self):
+        self.assertEqual(dci.SBSA_SELF_HOSTED_IMAGES, frozenset())
+        matrices = dci.split_build_matrices(
+            [
+                {
+                    "name": "vss-rt-vlm-sbsa",
+                    "repository": "vss-rt-vlm",
+                    "tag_suffix": "-sbsa",
+                    "native_platform_build": True,
+                    "context": "services/rtvi/rt-vlm",
+                    "dockerfile": "services/rtvi/rt-vlm/docker/Dockerfile",
+                    "platforms": ["linux/arm64"],
+                    "source_path": "services/rtvi/rt-vlm",
+                    "build_args": {"ARM_PLATFORM": "sbsa"},
+                }
+            ]
+        )
+        cell = matrices["native_platform_matrix"]["include"][0]
+        self.assertEqual(cell["runner"], "ubuntu-24.04-arm")
+        self.assertEqual(cell["runs_on"], ["ubuntu-24.04-arm"])
+        self.assertEqual(cell["emulated"], "false")
+        self.assertEqual(cell["kernel_arch"], "aarch64")
+
+    def test_sbsa_can_route_one_image_without_moving_siblings(self):
+        original = dci.SBSA_SELF_HOSTED_IMAGES
+        dci.SBSA_SELF_HOSTED_IMAGES = frozenset({"vss-rt-vlm-sbsa"})
+        try:
+            matrices = dci.split_build_matrices(
+                [
+                    {
+                        "name": "vss-rt-vlm-sbsa",
+                        "repository": "vss-rt-vlm",
+                        "tag_suffix": "-sbsa",
+                        "native_platform_build": True,
+                        "context": "services/rtvi/rt-vlm",
+                        "dockerfile": "services/rtvi/rt-vlm/docker/Dockerfile",
+                        "platforms": ["linux/arm64"],
+                        "source_path": "services/rtvi/rt-vlm",
+                        "build_args": {"ARM_PLATFORM": "sbsa"},
+                    },
+                    {
+                        "name": "vss-rt-embed-sbsa",
+                        "repository": "vss-rt-embed",
+                        "tag_suffix": "-sbsa",
+                        "native_platform_build": True,
+                        "context": "services/rtvi/rt-embed",
+                        "dockerfile": "services/rtvi/rt-embed/docker/Dockerfile",
+                        "platforms": ["linux/arm64"],
+                        "source_path": "services/rtvi/rt-embed",
+                    },
+                    {
+                        "name": "vss-rt-vlm",
+                        "native_platform_build": True,
+                        "context": "services/rtvi/rt-vlm",
+                        "dockerfile": "services/rtvi/rt-vlm/docker/Dockerfile",
+                        "platforms": ["linux/arm64"],
+                        "source_path": "services/rtvi/rt-vlm",
+                    },
+                ]
+            )
+            by_name = {
+                item["name"]: item
+                for item in matrices["native_platform_matrix"]["include"]
+            }
+            moved = by_name["vss-rt-vlm-sbsa"]
+            self.assertEqual(list(moved["runs_on"]), list(dci.SBSA_SELF_HOSTED_RUNS_ON))
+            self.assertIn(dci.SBSA_BUILDER_COHORT_LABEL, moved["runs_on"])
+            self.assertIn(dci.SBSA_BUILDER_ACTIVE_LABEL, moved["runs_on"])
+            self.assertNotIn(dci.SBSA_BUILDER_CANARY_LABEL, moved["runs_on"])
+            self.assertEqual(moved["emulated"], "true")
+            self.assertEqual(moved["kernel_arch"], "x86_64")
+            # Other SBSA images and non-SBSA arm64 stay on GitHub-hosted ARM.
+            self.assertEqual(
+                by_name["vss-rt-embed-sbsa"]["runs_on"], ["ubuntu-24.04-arm"]
+            )
+            self.assertEqual(by_name["vss-rt-embed-sbsa"]["emulated"], "false")
+            self.assertEqual(
+                by_name["vss-rt-vlm"]["runs_on"], ["ubuntu-24.04-arm"]
+            )
+        finally:
+            dci.SBSA_SELF_HOSTED_IMAGES = original
 
 
 class PathsChangedUnderTest(unittest.TestCase):

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -303,7 +303,7 @@ jobs:
     name: Build ${{ matrix.name }} (${{ matrix.arch }}, native)
     needs: changes
     if: fromJSON(needs.changes.outputs.native-count) > 0
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -314,11 +314,21 @@ jobs:
           persist-credentials: false
 
       - name: Verify native runner architecture
+        if: matrix.emulated != 'true'
         run: |
           uname -a
           echo "RUNNER_ARCH=$RUNNER_ARCH"
           test "$(uname -m)" = "${{ matrix.kernel_arch }}"
           test "$RUNNER_ARCH" = "${{ matrix.runner_arch }}"
+
+      - name: Verify emulated SBSA builder host
+        if: matrix.emulated == 'true'
+        run: |
+          uname -a
+          echo "RUNNER_ARCH=$RUNNER_ARCH"
+          test "$(uname -m)" = "${{ matrix.kernel_arch }}"
+          test "$RUNNER_ARCH" = "${{ matrix.runner_arch }}"
+          test -e /proc/sys/fs/binfmt_misc/qemu-aarch64
 
       - name: Fetch required LFS build assets
         if: matrix.lfs_include != ''
@@ -397,6 +407,7 @@ jobs:
         # its content store so the native build has sufficient working space.
       - name: Reclaim disk space for native image build
         if: >-
+          runner.environment == 'github-hosted' &&
           steps.candidate-preflight.outputs.skip != 'true' &&
           steps.reuse.outputs.reuse != 'true' &&
           steps.platform-preflight.outputs.skip != 'true'
@@ -406,6 +417,14 @@ jobs:
           sudo docker system prune --all --force --volumes
           df -h /
           docker system df
+
+      - name: Set up QEMU (emulated arm64 on x86_64)
+        if: >-
+          matrix.emulated == 'true' &&
+          steps.candidate-preflight.outputs.skip != 'true' &&
+          steps.reuse.outputs.reuse != 'true' &&
+          steps.platform-preflight.outputs.skip != 'true'
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
 
       - name: Set up Buildx
         if: >-
@@ -442,7 +461,11 @@ jobs:
           steps.platform-preflight.outputs.skip != 'true'
         run: |
           docker buildx prune --all --force || true
-          sudo docker system prune --all --force --volumes || true
+          if [ "${RUNNER_ENVIRONMENT:-}" = github-hosted ]; then
+            sudo docker system prune --all --force --volumes || true
+          else
+            docker system prune --all --force --volumes || true
+          fi
           df -h /
 
       - name: Verify platform staging labels

--- a/.github/workflows/sbsa-builder-canary.yml
+++ b/.github/workflows/sbsa-builder-canary.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Manual preflight for the new SBSA builder cohort. It does not run on push
+# or schedule, so current GHCR and amd64 horde-docker CIs are unchanged.
+# Register horde-sbsa-NN with vss-sbsa-builder only; add
+# vss-sbsa-builder-canary on one runner before dispatching this workflow.
+
+name: SBSA builder canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbsa-builder-canary
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  preflight:
+    name: Preflight emulated SBSA builder
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - vss-sbsa-builder
+      - vss-sbsa-builder-canary
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Verify host can emulate linux/arm64
+        run: |
+          set -euo pipefail
+          uname -a
+          test "$(uname -m)" = x86_64
+          test "$RUNNER_ARCH" = X64
+          test -e /proc/sys/fs/binfmt_misc/qemu-aarch64
+          docker info
+          docker buildx version
+          df -hP /


### PR DESCRIPTION
## Summary

Immediate merge does **not** change production routing. `SBSA_SELF_HOSTED_IMAGES` stays empty, so every SBSA native cell continues to build on GitHub-hosted `ubuntu-24.04-arm`. Existing GHCR CIs keep their current runners.

`horde-docker-01`–`04` are unchanged: they keep their labels, admit hook, and amd64 `vss-rt-vlm` canary work. This PR only adds a **new** dormant cohort (`vss-sbsa-builder`) plus compatibility code and a manual canary workflow. Registering `horde-sbsa-NN` is an external step; runners are not given `vss-sbsa-builder-canary` or `vss-sbsa-builder-active` here.

Windows host `10.63.177.70` is ICMP-reachable after the WSL reboot, but TCP/22 still times out, so `horde-sbsa-01` was **not** registered in this change. That does not block merge: without the active label and with routing empty, GitHub cannot send production jobs to this cohort.

## Remaining activation steps (after merge)

1. Restore OpenSSH on the Windows CPU box, finish WSL2 Ubuntu + rootless Docker + `qemu-user-static`/`qemu-aarch64` binfmt, and register **new** runner `horde-sbsa-01` with labels **only** `vss-sbsa-builder` (do not copy `vss-docker-builder-*`; do not add canary or active).
2. Add the `vss-sbsa-builder-canary` label on that one runner, then dispatch **SBSA builder canary**.
3. After a green canary, add `vss-sbsa-builder-active` on the runner and put **one** image name into `SBSA_SELF_HOSTED_IMAGES` (separate follow-up).

Rollback: leave `SBSA_SELF_HOSTED_IMAGES` empty (current default). Remove the canary/active labels before draining any later-activated runner. Owner: CI / docker-builder hosts.

## Test plan

- [x] `python3 .github/scripts/test_detect_changed_images.py` (31 tests, including default-off routing and one-image opt-in)
- [x] Confirm `SBSA_SELF_HOSTED_IMAGES` is `frozenset()` and production `runs_on` remains `ubuntu-24.04-arm`
- [x] Confirm canary workflow is `workflow_dispatch` only and does not request `vss-sbsa-builder-active`
- [ ] After SSH is restored: register `horde-sbsa-01` with cohort label only; install `admit-job-sbsa.sh` on that host only
- [ ] Add canary label and dispatch SBSA builder canary
- [ ] Do not add image names to `SBSA_SELF_HOSTED_IMAGES` until the canary is green