### PR TITLE
fix(agent-ui): always show upload filename rename in UploadFilesDialog

### DIFF
--- a/docs/vss-ui.mdx
+++ b/docs/vss-ui.mdx
@@ -876,13 +876,15 @@ The upload dialog allows you to select video files and optionally configure them
 
 **File Configuration:**
 
-Each file in the upload list can be expanded (click the chevron icon) to configure optional fields if system-level configuration is enabled.
+Each file in the upload list can be expanded (click the chevron icon) to rename the file and to configure optional fields if system-level configuration is enabled.
 
-**Note:** Configuration fields are optional and only appear if `NEXT_PUBLIC_CHAT_UPLOAD_FILE_CONFIG_TEMPLATE_JSON` is configured. Common field types include boolean toggles, text inputs, number inputs, and select dropdowns. The available fields depend entirely on your system's deployment configuration.
+**Renaming:** The expanded row always shows a required **Filename** field, pre-filled with the selected file's name. Edit it to upload the video under a different name without going back and re-selecting the file. Filenames cannot be empty or contain spaces; spaces in the original name are removed automatically. The collapsed row shows the name the file will be uploaded under, so you can confirm a rename at a glance (hover it to see the original name).
+
+**Note:** Configuration fields are optional and only appear if `NEXT_PUBLIC_CHAT_UPLOAD_FILE_CONFIG_TEMPLATE_JSON` is configured. Common field types include boolean toggles, text inputs, number inputs, and select dropdowns. The available fields depend entirely on your system's deployment configuration. Renaming does not depend on this setting.
 
 **File Management:**
 
-Each file in the list shows the video icon, filename, file size in MB, expand/collapse button (chevron icon) to show/hide configuration fields, and remove button (X icon) to remove file from upload queue.
+Each file in the list shows the video icon, upload filename, file size in MB, expand/collapse button (chevron icon) to show/hide the filename field and configuration fields, and remove button (X icon) to remove file from upload queue.
 
 Click "Upload (N)" button to start uploading all files, or "Cancel" to close the dialog without uploading.
 

--- a/services/ui/packages/common/__tests__/components/UploadFilesDialog.test.tsx
+++ b/services/ui/packages/common/__tests__/components/UploadFilesDialog.test.tsx
@@ -259,6 +259,70 @@ describe('UploadFilesDialog', () => {
     expect(screen.getByTestId('upload-confirm-button')).toBeDisabled();
   });
 
+  // Every shipped profile (base, lvs, search, alerts) deploys an empty config template with
+  // metadata disabled. The rename row used to be gated behind those, so QA saw no way to rename.
+  describe.each([
+    ['null config template', null],
+    ['config template with no fields', { fields: [] } as UploadFileConfigTemplate],
+  ])('with %s and metadata disabled', (_label, configTemplate) => {
+    it('still lets the user rename the file', () => {
+      const onConfirm = jest.fn();
+      const file = createMockFile('recording.mp4');
+      render(
+        <UploadFilesDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          configTemplate={configTemplate}
+          open={true}
+          initialFiles={[file]}
+        />
+      );
+      fireEvent.click(screen.getByText('recording.mp4'));
+      const filenameInput = screen.getByPlaceholderText('e.g. my-video');
+      fireEvent.change(filenameInput, { target: { value: 'renamed.mp4' } });
+      fireEvent.click(screen.getByTestId('upload-confirm-button'));
+      expect(onConfirm).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ file, uploadFilename: 'renamed.mp4' }),
+        ])
+      );
+    });
+
+    it('does not render config fields or metadata in the expanded row', () => {
+      render(
+        <UploadFilesDialog
+          {...defaultProps}
+          configTemplate={configTemplate}
+          open={true}
+          initialFiles={[createMockFile()]}
+        />
+      );
+      fireEvent.click(screen.getByText('test.mp4'));
+      expect(screen.getByPlaceholderText('e.g. my-video')).toBeInTheDocument();
+      expect(screen.queryByText('Metadata (JSON)')).not.toBeInTheDocument();
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows the renamed filename in the collapsed row', () => {
+    render(
+      <UploadFilesDialog
+        {...defaultProps}
+        configTemplate={null}
+        open={true}
+        initialFiles={[createMockFile('original.mp4')]}
+      />
+    );
+    const row = screen.getByText('original.mp4');
+    fireEvent.click(row);
+    fireEvent.change(screen.getByPlaceholderText('e.g. my-video'), {
+      target: { value: 'renamed.mp4' },
+    });
+    fireEvent.click(row);
+    expect(screen.getByText('renamed.mp4')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('e.g. my-video')).not.toBeInTheDocument();
+  });
+
   it('expands file row and shows config fields when config has fields', () => {
     render(
       <UploadFilesDialog

--- a/services/ui/packages/common/lib-src/components/UploadFilesDialog.tsx
+++ b/services/ui/packages/common/lib-src/components/UploadFilesDialog.tsx
@@ -321,7 +321,6 @@ export const UploadFilesDialog = forwardRef<UploadFilesDialogHandle, UploadFiles
     () => Boolean(configTemplate && Array.isArray(configTemplate.fields) && configTemplate.fields.length > 0),
     [configTemplate]
   );
-  const hasExpandableContent = metadataEnabled || hasConfigFields;
 
   const createFileItem = useCallback(
     (file: File): UploadFilesDialogFileItem => ({
@@ -575,24 +574,25 @@ export const UploadFilesDialog = forwardRef<UploadFilesDialogHandle, UploadFiles
                     <div className="flex items-center justify-between bg-white p-3 dark:bg-neutral-900">
                       <button
                         type="button"
-                        className={`flex flex-1 items-center gap-2 overflow-hidden text-left ${hasExpandableContent ? 'cursor-pointer' : ''}`}
-                        onClick={() => hasExpandableContent && handleToggleExpand(fileItem.id)}
-                        aria-expanded={hasExpandableContent ? fileItem.isExpanded : undefined}
+                        className="flex flex-1 cursor-pointer items-center gap-2 overflow-hidden text-left"
+                        onClick={() => handleToggleExpand(fileItem.id)}
+                        aria-expanded={fileItem.isExpanded}
                       >
-                        {hasExpandableContent && (
-                          <IconChevronDown
-                            size={16}
-                            className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${fileItem.isExpanded ? 'rotate-180' : ''}`}
-                          />
-                        )}
+                        <IconChevronDown
+                          size={16}
+                          className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${fileItem.isExpanded ? 'rotate-180' : ''}`}
+                        />
                         <IconVideo size={18} className="flex-shrink-0 text-[#76b900]" />
-                        <span className="truncate text-sm text-gray-700 dark:text-gray-300">
-                          {fileItem.file.name}
+                        <span
+                          className="truncate text-sm text-gray-700 dark:text-gray-300"
+                          title={fileItem.file.name}
+                        >
+                          {(fileItem.uploadFilename ?? '').trim() || fileItem.file.name}
                         </span>
                         <span className="flex-shrink-0 text-xs text-gray-400">
                           ({(fileItem.file.size / 1024 / 1024).toFixed(2)} MB)
                         </span>
-                        {((fileItem.uploadFilename ?? '').trim().length === 0 || /\s/.test(fileItem.uploadFilename ?? '')) && (
+                        {isUploadFilenameInvalid(fileItem.uploadFilename) && (
                           <IconAlertTriangle size={18} className="flex-shrink-0 text-amber-500 dark:text-amber-400" />
                         )}
                       </button>
@@ -605,7 +605,7 @@ export const UploadFilesDialog = forwardRef<UploadFilesDialogHandle, UploadFiles
                       </button>
                     </div>
 
-                    {hasExpandableContent && fileItem.isExpanded && (
+                    {fileItem.isExpanded && (
                       <div className="border-t border-gray-200 bg-gray-50 p-3 dark:border-neutral-700 dark:bg-black">
                         <div className="mb-3 space-y-1">
                           {(() => {


### PR DESCRIPTION
The Filename field was gated behind config-template fields or metadata, so shipped profiles with an empty template had no way to rename a selected file before upload.

nvbug 5953344

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
