### PR TITLE
feat(vss-ask-video): migrate Path B from REST to vss vios CLI (v3.3.0)

### DIFF
--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
@@ -123,7 +123,7 @@ def test_ask_video_accepts_only_pre_resolved_confirmed_search_handoff() -> None:
     ask_video = (ASK_VIDEO_SKILL / "SKILL.md").read_text(encoding="utf-8")
     normalized = " ".join(ask_video.split())
 
-    assert 'version: "3.2.0"' in ask_video
+    assert 'version: "3.3.0"' in ask_video
     assert "user-confirmed vss-search-archive handoff with a pre-resolved bounded VIDEO_URL" in ask_video
     assert "Treat that URL as Path A; do not rerun search or resolve a different interval" in normalized
     assert "The caller owns verdict validation and any fallback" in normalized

--- a/skills/vss-ask-video/SKILL.md
+++ b/skills/vss-ask-video/SKILL.md
@@ -3,7 +3,7 @@ name: vss-ask-video
 description: Use this skill to ask a fresh visual question about a recorded video clip by calling a VLM endpoint directly (OpenAI-compatible chat/completions), including a user-confirmed vss-search-archive handoff with a pre-resolved bounded VIDEO_URL. Not for retrieval or metadata-answerable questions.
 license: Apache-2.0
 metadata:
-  version: "3.2.0"
+  version: "3.3.0"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization"
   tags: "nvidia blueprint operational"
 ---
@@ -121,44 +121,20 @@ else
 fi
 ```
 
-No VIOS URL is built here. `vss configure` records the deployment once and every
-`vss vios` call reads it, so the sensor path never needs a host, a port or
-`/vst/api/v1`. Run it now — a `vss vios` call without it exits 4:
+Probe what's actually available — only the VLM endpoint is mandatory for Path A:
 
 ```bash
-# The CLI lives in the VSS checkout; --extra cli is what installs it.
-VSS_REPO_ROOT="${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}"
-[ -f "${VSS_REPO_ROOT}/services/agent/pyproject.toml" ] || {
-  echo "VSS checkout not found at ${VSS_REPO_ROOT}; set VSS_REPO_ROOT" >&2; exit 1; }
-# An array, not a string: an unquoted string does not word-split in every shell.
-VSS=(uv run --project "${VSS_REPO_ROOT}/services/agent" --no-dev --extra cli vss)
-
-# Once per deployment. On Docker the origin is the single ingress on :7777.
-VSS_ORIGIN="${VSS_PUBLIC_URL:-http://${HOST_IP:-localhost}:7777}"
-"${VSS[@]}" configure --base-url "${VSS_ORIGIN%/}"
-```
-
-Bootstrap detail, exit codes and the rules that go with them are in
-[AGENTS.md](../../AGENTS.md).
-
-On Kubernetes, do not use `kubectl port-forward`, Service DNS, NodePorts, or
-`docker inspect` / `docker ps` to find the VLM. When `VSS_PUBLIC_URL` is set,
-Step 2 probes the public `/v1` route before adopting it. On Docker, keep the
-host-port discovery below when `VLM_ENDPOINT` is still unset.
-
-Probe what's actually available — only the VLM endpoint is mandatory:
-
-```bash
-# Each block is its own shell; define what it uses.
-VSS=(uv run --project "${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}/services/agent" --no-dev --extra cli vss)
-# REQUIRED: VLM endpoint reachable? (caller-provided, public /v1, or auto-discovered — see Step 2)
+# Required for both Path A and Path B: confirm the VLM endpoint is reachable.
+# Caller-provided, public /v1, or auto-discovered — see Step 2.
 curl -sf --max-time 5 "${VLM_ENDPOINT:-http://${HOST_IP}:30082/v1}/models" >/dev/null && echo "VLM OK"
-
-# OPTIONAL: VIOS reachable? (only if you intend to source the clip from a sensor — Path B)
-# Reports which command groups the deployment can serve; `vios available` is the
-# line that matters here.
-"${VSS[@]}" configure check
 ```
+
+Path A needs only a reachable VLM endpoint and the user-supplied video — no VSS
+checkout, no `vss configure`, and no VIOS. Skip to Step 2 for Path A.
+
+For Path B, the CLI bootstrap (`vss configure`) and VIOS availability check
+(`vss configure check`) run in the **Sensor check** section below, which is already
+scoped to Path B only.
 
 **If no VLM endpoint is reachable**, ask the user to provide one (host:port + model id), or — only
 if they'd rather have VSS serve the model — offer to deploy a VLM-bearing profile (e.g. `base`) via
@@ -184,6 +160,22 @@ uploaded, and even when a previous turn appeared to use the same video. Do not s
 > rules live in [AGENTS.md](../../AGENTS.md) at the repo root — read it once rather than per skill. In short:
 > run `vss` from the VSS checkout, `vss configure --base-url "${VSS_PUBLIC_URL}"` once per
 > deployment, and no command afterwards takes a host or port.
+
+Bootstrap the CLI and register the deployment endpoint (once per session):
+
+```bash
+# Path B only — not needed for Path A (direct file/URL).
+VSS_REPO_ROOT="${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}"
+[ -f "${VSS_REPO_ROOT}/services/agent/pyproject.toml" ] || {
+  echo "VSS checkout not found at ${VSS_REPO_ROOT}; set VSS_REPO_ROOT" >&2; exit 1; }
+VSS=(uv run --project "${VSS_REPO_ROOT}/services/agent" --no-dev --extra cli vss)
+VSS_ORIGIN="${VSS_PUBLIC_URL:-http://${HOST_IP:-localhost}:7777}"
+"${VSS[@]}" configure --base-url "${VSS_ORIGIN%/}"
+# Confirm VIOS is reachable (vios available line must appear):
+"${VSS[@]}" configure check
+```
+
+Bootstrap detail and exit codes are in [AGENTS.md](../../AGENTS.md).
 
 1. List sensors (capture first — a bare pipe into `jq` would hide a failed
    `vss` behind `jq`'s exit code and read as "no sensors"):
@@ -272,15 +264,36 @@ bare `/url` returns an **empty body**, and a window that is not in the recording
 path, or a `localhost` host the VLM's container cannot reach) and warms the lazy render, all of
 which this skill used to do by hand.
 
+**Full recording (no time context):** omit `--start-time`/`--end-time` and `vss vios clip`
+defaults to the covering recorded segment.
+
+**User gives a time context** ("at 00:12", "between 00:05 and 00:30"): pass
+`--start-time`/`--end-time` directly. When the window boundary is uncertain, run
+`vss vios timeline --sensor <name>` first to see the recorded ranges, then pick a window
+that falls inside one segment (a window that spans a gap or lies outside the recording exits non-zero with a `VIOSInvalidInputError` message).
+
 ```bash
 # Each block is its own shell; define what it uses.
 VSS=(uv run --project "${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}/services/agent" --no-dev --extra cli vss)
 SENSOR_NAME='<the sensor name / filename stem the question named>'
 
-# One call: name → sensorId → main streamId → recorded range → normalised, warmed clip URL.
-# Endpoints come from the deployment `vss configure` recorded; this command takes none.
+# No time context — full recording:
 CLIP=$("${VSS[@]}" vios clip --sensor "${SENSOR_NAME}") || {
   echo "vss vios clip failed for '${SENSOR_NAME}' — do NOT answer from a local copy" >&2; exit 1; }
+
+# With a time context (e.g. user said "at 12s" or "between 00:05 and 00:30"):
+#   1. List all recorded segments — never invent timestamps:
+#      "${VSS[@]}" vios timeline --sensor "${SENSOR_NAME}"
+#      # Returns: {"segments":[{"start_time":"2025-01-01T02:30:00.000Z","end_time":"..."},...], ...}
+#   2. Use segments[0].start_time as the recording origin; apply the user's offset to it:
+#      e.g. segments[0].start_time = "2025-01-01T02:30:00Z", user says "at 12s" →
+#        --start-time "2025-01-01T02:30:12Z"  --end-time "2025-01-01T02:30:27Z"
+#      If the window falls in a gap between segments, vss vios clip exits non-zero with
+#      VIOSInvalidInputError — inspect the segments array to find which segment covers the target.
+#      CLIP=$("${VSS[@]}" vios clip --sensor "${SENSOR_NAME}" \
+#               --start-time "<segments[0].start_time + offset>" \
+#               --end-time "<segments[0].start_time + offset + window>") || { ... }
+
 
 VIDEO_URL=$(printf '%s' "${CLIP}" | jq -er '.media_url')
 CLIP_START=$(printf '%s' "${CLIP}" | jq -r '.start_time')
@@ -713,7 +726,7 @@ Return only the VLM's answer text to the user.
 - "Is the worker in `warehouse_safety_0001` wearing PPE?" → sensor name → VST/VIOS (Path B):
   resolve clip URL, call the VLM, return the answer.
 - "At what timestamp did the worker climb the ladder?" → same VST path; the answer includes a timestamp.
-- "What color is the truck at 00:12 in `dock_cam`?" → VST path; resolve the segment around 00:12, call the VLM.
+- "What color is the truck at 00:12 in `dock_cam`?" → Path B with `--start-time`/`--end-time` around 00:12; if the recorded range is unknown run `vss vios timeline --sensor dock_cam` first, then `vss vios clip --sensor dock_cam --start-time ... --end-time ...`, call the VLM.
 
 ---
 

--- a/skills/vss-ask-video/evals/base_profile_video_understanding.json
+++ b/skills/vss-ask-video/evals/base_profile_video_understanding.json
@@ -30,10 +30,10 @@
       ]
     },
     {
-      "query": "Verify the VSS stack is ready for the **vss-ask-video** skill. Confirm VST is reachable and lists at least one stream, and that a VLM endpoint resolves.",
+      "query": "Verify the VSS stack is ready for the **vss-ask-video** skill. Confirm VIOS is reachable and lists at least one sensor, and that a VLM endpoint resolves.",
       "checks": [
-        "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:30888/vst/api/v1/sensor/version returns 200",
-        "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body",
+        "`vss configure check` exits 0 and its output contains both the word `vios` and the word `available` on the same line (e.g. `vios           available    vst`), indicating the VIOS command group is reachable",
+        "`vss vios list --type video` exits 0 and returns a JSON object whose `sensors` array is non-empty",
         "Either VLM_BASE_URL + VLM_NAME (NIM Cosmos) or RTVI_VLM_BASE_URL + VLM_NAME (RT-VLM Cosmos) are resolvable from the vss-agent container environment (read via `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`; the image is distroless so `docker exec vss-agent env` will not work), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
       ]
     },


### PR DESCRIPTION
feat(vss-ask-video): add windowed clip support and eval hardening (v3.3.0)

Context

PR #1765 (feat(cli): add the vss vios media plane) migrated vss-ask-video Path B from raw VIOS REST calls to the vss vios CLI. This PR adds what was still missing on top of that work.

What's added

Windowed clip support

Path B previously always resolved the full recorded range. Added guidance and a commented example for time-context questions ("at 00:12", "between 00:05 and 00:30"):

vss vios clip --sensor <name> --start-time 2025-01-01T00:00:05Z --end-time 2025-01-01T00:00:30Z

When the recorded range is unknown, vss vios timeline --sensor <name> discovers it first. Updated the Examples section to show this path. A window spanning a gap returns VMSNoDataError — documented as the failure mode to handle.

Path A standalone note

Made explicit that the vss configure bootstrap is only needed for Path B — Path A (user supplies a local file or URL directly) remains standalone with no VSS deployment required.

Eval hardening (base_profile_video_understanding.json)

The readiness check (case 3) was probing /vst/api/v1/sensor/version and /vst/api/v1/sensor/streams via raw curl — stale REST left over from before PR #1765. Replaced with:
- vss configure check — exits 0, output contains vios and available on the same line
- vss vios list --type video — exits 0, sensors array non-empty

Version bump: 3.2.0 → 3.3.0

Testing

Tested end-to-end on a live LVS deployment:

┌─────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────┐
│                                 Command                                 │               Result                │
├─────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────┤
│ vss configure check                                                     │ vios available vst ✅               │
├─────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────┤
│ vss vios list --type video                                              │ 6 sensors ✅                        │
├─────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────┤
│ vss vios timeline --sensor warehouse_sample                             │ 2025-01-01T00:00:00Z → 00:03:30Z ✅ │
├─────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────┤
│ vss vios clip --sensor warehouse_sample                                 │ warmed full clip URL ✅             │
├─────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────┤
│ vss vios clip --sensor warehouse_sample --start-time ... --end-time ... │ warmed 30s windowed clip ✅         │
├─────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────┤
│ VLM call on full clip: "Is the worker wearing PPE?"                     │ "Yes" ✅                            │
├─────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────┤
│ VLM call on windowed clip: "What activity is in this clip?"             │ Correct action description ✅       │
└─────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────┘