### PR TITLE
Fix/rtvi embed image pull secret

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -339,6 +339,10 @@ rtvi:
   vss-rtvi-embed:
     enabled: true
     replicas: 1
+    # rtvi-embed accepts a per-chart pull-secret list; retain the profile-wide
+    # NGC secret here as an explicit safeguard for private managed images.
+    imagePullSecrets:
+      - name: ngc-docker-reg-secret
     # Shared managed-image channel. Global container_prefix/container_tag values
     # select a promoted image without changing this profile.
     # SBSA/DGX-Spark shares the GHCR repository but needs its separate build

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
@@ -69,7 +69,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- $ips := .Values.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- with $ips }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
+++ b/deploy/helm/services/rtvi/charts/rtvi-embed/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $ips := .Values.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- $ips := .Values.imagePullSecrets | default (index (.Values.global | default dict) "imagePullSecrets") }}
       {{- with $ips }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
