### PR TITLE
fix(rt-embed): remediate form parser CVEs

### DIFF
--- a/services/rtvi/rt-embed/docker/py_deps/pdm.lock
+++ b/services/rtvi/rt-embed/docker/py_deps/pdm.lock
@@ -4,8 +4,8 @@
 [metadata]
 groups = ["default", "amd64"]
 strategy = ["inherit_metadata"]
-lock_version = "4.5.0"
-content_hash = "sha256:70425f344f4720b6af71ed479f9e2b3e546697bd916237005d4125669b174e7d"
+lock_version = "4.5.1"
+content_hash = "sha256:1b76d3abdd1a6d859405f27a6eb3a68acb5113c74bffe4520cb556e3157d5f68"
 
 [[metadata.targets]]
 requires_python = "==3.12.*"
@@ -480,19 +480,20 @@ files = [
 
 [[package]]
 name = "fastapi"
-version = "0.121.3"
-requires_python = ">=3.8"
+version = "0.136.3"
+requires_python = ">=3.10"
 summary = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 groups = ["default"]
 dependencies = [
     "annotated-doc>=0.0.2",
-    "pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4",
-    "starlette<0.51.0,>=0.40.0",
+    "pydantic>=2.9.0",
+    "starlette>=0.46.0",
     "typing-extensions>=4.8.0",
+    "typing-inspection>=0.4.2",
 ]
 files = [
-    {file = "fastapi-0.121.3-py3-none-any.whl", hash = "sha256:0c78fc87587fcd910ca1bbf5bc8ba37b80e119b388a7206b39f0ecc95ebf53e9"},
-    {file = "fastapi-0.121.3.tar.gz", hash = "sha256:0055bc24fe53e56a40e9e0ad1ae2baa81622c406e548e501e717634e2dfbc40b"},
+    {file = "fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620"},
+    {file = "fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab"},
 ]
 
 [[package]]
@@ -1675,13 +1676,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 requires_python = ">=3.8"
 summary = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 groups = ["default"]
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]
@@ -1795,13 +1796,13 @@ files = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.27"
+version = "0.0.30"
 requires_python = ">=3.10"
 summary = "A streaming multipart parser for Python"
 groups = ["default"]
 files = [
-    {file = "python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"},
-    {file = "python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602"},
+    {file = "python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b"},
+    {file = "python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118"},
 ]
 
 [[package]]
@@ -2089,7 +2090,7 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.3.1"
 requires_python = ">=3.10"
 summary = "The little ASGI library that shines."
 groups = ["default"]
@@ -2098,8 +2099,8 @@ dependencies = [
     "typing-extensions>=4.10.0; python_version < \"3.13\"",
 ]
 files = [
-    {file = "starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca"},
-    {file = "starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca"},
+    {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
+    {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
 ]
 
 [[package]]

--- a/services/rtvi/rt-embed/docker/py_deps/pyproject.toml
+++ b/services/rtvi/rt-embed/docker/py_deps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 dependencies = [
-    "fastapi==0.121.3",
+    "fastapi==0.136.3",
     "sentencepiece==0.2.0",
     "pillow==12.2.0",
     "tabulate==0.9.0",
@@ -16,11 +16,11 @@ dependencies = [
     "nvidia-ml-py==13.610.43",
     "deepspeed==0.15.1",
     "opencv-python==4.10.0.84",
-    "starlette==0.50.0",
+    "starlette==1.3.1",
     "matplotlib==3.9.4",
     "onnx==1.21.0",
     "langchain-openai==0.3.29",
-    "python-multipart==0.0.27",
+    "python-multipart==0.0.30",
     "pymediainfo==6.1.0",
     "hydra-core==1.3.2",
     "s2wrapper @ https://github.com/bfshi/scaling_on_scales/archive/60da2afe5121533947c1dff2d57d9c583516a157.zip",
@@ -47,7 +47,7 @@ dependencies = [
     "langchain-core==0.3.81",
     "aiohttp==3.13.3",
     "cryptography>=46.0.5",
-    "pyasn1==0.6.3"
+    "pyasn1==0.6.4"
 ]
 requires-python = "==3.12.*"
 

--- a/services/rtvi/rt-embed/docker/py_deps/requirements.txt
+++ b/services/rtvi/rt-embed/docker/py_deps/requirements.txt
@@ -29,7 +29,7 @@ deepspeed==0.15.1
 distro==1.9.0
 docker==7.1.0
 einops==0.8.0
-fastapi==0.121.3
+fastapi==0.136.3
 fastrlock==0.8.3
 filelock==3.29.7
 fonttools==4.61.1
@@ -99,7 +99,7 @@ propcache==0.3.2
 protobuf==6.33.6
 psutil==7.0.0
 py-cpuinfo==9.0.0
-pyasn1==0.6.3
+pyasn1==0.6.4
 pycparser==2.22; platform_python_implementation != "PyPy" and implementation_name != "PyPy"
 pydantic==2.13.4
 pydantic-core==2.46.4
@@ -107,7 +107,7 @@ pygments==2.19.2
 pymediainfo==6.1.0
 pyparsing==3.2.3
 python-dateutil==2.8.2
-python-multipart==0.0.27
+python-multipart==0.0.30
 pywin32==311; sys_platform == "win32"
 pyyaml==6.0.3
 redis==7.1.0
@@ -127,7 +127,7 @@ six==1.17.0
 sniffio==1.3.1
 sse-starlette==2.1.0
 sseclient-py==1.8.0
-starlette==0.50.0
+starlette==1.3.1
 sympy==1.14.0
 tabulate==0.9.0
 tbb==2021.13.1; platform_machine == "x86_64"

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_form_parser_security.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_form_parser_security.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for urlencoded form parsing limits."""
+
+from typing import Annotated
+from urllib.parse import urlencode
+
+from fastapi import FastAPI, Form
+from fastapi.testclient import TestClient
+
+
+def _form_client() -> TestClient:
+    app = FastAPI()
+
+    @app.post("/files")
+    async def add_file(
+        purpose: Annotated[str, Form()],
+        media_type: Annotated[str, Form()],
+        filename: Annotated[str, Form()],
+    ) -> dict[str, str]:
+        return {
+            "purpose": purpose,
+            "media_type": media_type,
+            "filename": filename,
+        }
+
+    return TestClient(app)
+
+
+def test_urlencoded_form_is_accepted():
+    client = _form_client()
+
+    response = client.post(
+        "/files",
+        data={
+            "purpose": "vision",
+            "media_type": "video",
+            "filename": "/tmp/input.mp4",
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_urlencoded_form_rejects_too_many_fields():
+    client = _form_client()
+    fields = [
+        ("purpose", "vision"),
+        ("media_type", "video"),
+        ("filename", "/tmp/input.mp4"),
+    ]
+    fields.extend((f"unused_{index}", "x") for index in range(1000))
+
+    response = client.post(
+        "/files",
+        content=urlencode(fields),
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_semicolon_only_urlencoded_body_is_not_split_into_fields():
+    client = _form_client()
+
+    response = client.post(
+        "/files",
+        content="a;" * 5000,
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 422

--- a/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
+++ b/services/rtvi/rt-embed/tests/rtvi_embed/test_rtvi_embed_server.py
@@ -33,6 +33,7 @@ import logging
 import os
 import tempfile
 import uuid
+from urllib.parse import urlencode
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -393,6 +394,42 @@ class TestFileEndpoints:
         response = test_client.post(f"{API_PREFIX}/files", files=files)
         print(f" response is {response.json()}")
         assert response.status_code == 200
+
+    def test_add_file_from_urlencoded_form(self, test_client):
+        """Test adding a file by path from an urlencoded form request."""
+        response = test_client.post(
+            f"{API_PREFIX}/files",
+            data={
+                "filename": self.VIDEO_FILE_PATH,
+                "purpose": "vision",
+                "media_type": "video",
+            },
+        )
+
+        assert response.status_code == 200
+
+    def test_add_file_rejects_urlencoded_form_with_too_many_fields(self, test_client):
+        """Test urlencoded forms use Starlette's max_fields protection."""
+        fields = [("purpose", "vision"), ("media_type", "video")]
+        fields.extend((f"unused_{index}", "x") for index in range(1000))
+
+        response = test_client.post(
+            f"{API_PREFIX}/files",
+            content=urlencode(fields),
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+
+        assert response.status_code == 400
+
+    def test_add_file_rejects_semicolon_only_urlencoded_form(self, test_client):
+        """Test semicolons are not treated as urlencoded field separators."""
+        response = test_client.post(
+            f"{API_PREFIX}/files",
+            content="a;" * 5000,
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+
+        assert response.status_code == 422
 
     def test_add_file_missing_params(self, test_client):
         """Test adding file with missing parameters"""


### PR DESCRIPTION
## Summary

      Remediates rt-embed form-parser CVEs by upgrading FastAPI, Starlette, python-multipart, and pyasn1. Regenerates locked/scanner requirements and adds regression coverage for multipart and URL-encoded /v1/files requests, including parser field-limit and semicolon-heavy payload handling.

## Plan

## Related Issue

## Changes

## Checklist
- [✅ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ✅] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [✅ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ✅] New or existing tests cover these changes.
- [ ✅] The documentation is up to date with these changes.
- [✅ ] No secrets, API keys, or credentials committed.
