### PR TITLE
adding pre-commit hook to check file size under services/ libs/ tools…

### DIFF
--- a/.github/scripts/check_large_files_lfs.sh
+++ b/.github/scripts/check_large_files_lfs.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fail if any git blob under services/, libs/, or tools/ is larger than 5 MiB
+# (GitLab Master regular-file limit for mirror-sync).
+#
+# Git LFS files are stored in git as ~130-byte pointers, so they pass.
+# Working-tree size is ignored (smudged LFS files are large on disk).
+# Paths outside those prefixes are ignored.
+#
+# Usage:
+#   bash .github/scripts/check_large_files_lfs.sh            # staged files in scope
+#   bash .github/scripts/check_large_files_lfs.sh --all      # all tracked files in scope
+#   bash .github/scripts/check_large_files_lfs.sh path ...   # those paths (in-scope only)
+
+set -euo pipefail
+
+MAX_BYTES=$((5 * 1024 * 1024))
+SCOPE_PREFIXES=(services/ libs/ tools/)
+
+in_scope() {
+  local path="$1"
+  local prefix
+  for prefix in "${SCOPE_PREFIXES[@]}"; do
+    if [[ "$path" == "$prefix"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+ALL=0
+PATHS=()
+for arg in "$@"; do
+  if [[ "$arg" == "--all" ]]; then
+    ALL=1
+  else
+    PATHS+=("$arg")
+  fi
+done
+
+if [[ "$ALL" -eq 0 && ${#PATHS[@]} -eq 0 ]]; then
+  staged=()
+  while IFS= read -r -d '' path; do
+    if in_scope "$path"; then
+      staged+=("$path")
+    fi
+  done < <(git diff --cached --name-only --diff-filter=ACMR -z || true)
+  if [[ ${#staged[@]} -eq 0 ]]; then
+    exit 0
+  fi
+  PATHS=("${staged[@]}")
+fi
+
+if [[ "$ALL" -eq 0 && ${#PATHS[@]} -gt 0 ]]; then
+  scoped=()
+  for path in "${PATHS[@]}"; do
+    if in_scope "$path"; then
+      scoped+=("$path")
+    fi
+  done
+  if [[ ${#scoped[@]} -eq 0 ]]; then
+    exit 0
+  fi
+  PATHS=("${scoped[@]}")
+fi
+
+raw_tmp="$(mktemp)"
+sha_path_tmp="$(mktemp)"
+size_map_tmp="$(mktemp)"
+offenders_tmp="$(mktemp)"
+trap 'rm -f "$raw_tmp" "$sha_path_tmp" "$size_map_tmp" "$offenders_tmp"' EXIT
+
+if [[ "$ALL" -eq 1 ]]; then
+  git ls-files -z -s -- "${SCOPE_PREFIXES[@]}" > "$raw_tmp"
+else
+  git ls-files -z -s -- "${PATHS[@]}" > "$raw_tmp"
+fi
+
+: > "$sha_path_tmp"
+while IFS= read -r -d '' record; do
+  meta="${record%%$'\t'*}"
+  path="${record#*$'\t'}"
+  mode="${meta%% *}"
+  rest="${meta#* }"
+  sha="${rest%% *}"
+  # Skip gitlinks (submodules) and symlinks — GitLab size check is for blobs.
+  case "$mode" in
+    16*|12*) continue ;;
+  esac
+  in_scope "$path" || continue
+  printf '%s\t%s\n' "$sha" "$path" >> "$sha_path_tmp"
+done < "$raw_tmp"
+
+if [[ ! -s "$sha_path_tmp" ]]; then
+  exit 0
+fi
+
+cut -f1 "$sha_path_tmp" | sort -u | git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize)' \
+  | awk '$2 == "blob" { print $1 "\t" $3 }' > "$size_map_tmp"
+
+awk -F '\t' -v max="$MAX_BYTES" '
+  NR == FNR { size[$1] = $2; next }
+  ($1 in size) && size[$1] > max { print $2 "\t" size[$1] }
+' "$size_map_tmp" "$sha_path_tmp" | sort -u > "$offenders_tmp"
+
+if [[ ! -s "$offenders_tmp" ]]; then
+  exit 0
+fi
+
+awk -F '\t' '
+  BEGIN {
+    print "ERROR: These files under services/, libs/, or tools/ are regular git blobs larger than 5 MiB." > "/dev/stderr"
+    print "Track them with Git LFS." > "/dev/stderr"
+    print "" > "/dev/stderr"
+  }
+  {
+    mib = $2 / (1024 * 1024)
+    printf "  %s: %.2f MiB (%s bytes)\n", $1, mib, $2 > "/dev/stderr"
+  }
+  END {
+    print "" > "/dev/stderr"
+    print "Fix (example):" > "/dev/stderr"
+    print "  git lfs install" > "/dev/stderr"
+    print "  git lfs track \"<path>\"" > "/dev/stderr"
+    print "  git add .gitattributes \"<path>\"" > "/dev/stderr"
+    print "Then commit. Do not use git lfs migrate unless you intend to rewrite history." > "/dev/stderr"
+  }
+' "$offenders_tmp"
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # GitLab Master rejects regular blobs > 5 MiB. Scoped to services/,
+      # libs/, tools/ (mirror-sync). LFS pointers are small in git and pass.
+      - name: Files >5 MiB under services/ libs/ tools/ must be Git LFS
+        run: bash .github/scripts/check_large_files_lfs.sh --all
+
       # One diff resolution answering several path questions. A second step
       # would have to re-resolve the same base, which is how the two gates
       # drifted apart last time.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,16 @@ repos:
     language: system
     stages: [commit-msg]
 
+  # GitLab Master rejects regular git blobs > 5 MiB. Scoped to services/,
+  # libs/, tools/ (mirror-sync folders). LFS pointers pass; checks git blob size.
+  - id: large-files-must-be-lfs
+    name: Files >5 MiB under services/ libs/ tools/ must be Git LFS
+    entry: bash .github/scripts/check_large_files_lfs.sh
+    language: system
+    files: ^(services|libs|tools)/
+    pass_filenames: true
+    stages: [pre-commit]
+
   # Mirrors CI Job 7 — SPDX copyright headers on source files
   - id: copyright-headers
     name: SPDX copyright headers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,7 @@ The repository ships with a `.pre-commit-config.yaml` at the root that runs the 
 - `ruff format --check` — mirrors the CI `Lint (Python)` job
 - `mypy src/agent/` — mirrors the CI `Type Check (mypy)` job
 - TruffleHog secret scan
+- Files >5 MiB under `services/`, `libs/`, or `tools/` must be Git LFS 
 
 Install the hooks once after cloning the repo:
 


### PR DESCRIPTION
…/ folder

## Summary
adding pre-commit hook to check file size under services/ libs/ tools…

## Related Issue
- We hit a GitLab file size limit while mirroring VSS Microservices from services/* subfolder to individual GitLab repo, regular git files/blobs over 5 MiB are rejected on push. GitHub allows them; GitLab does not, so mirror-sync failed (e.g. LICENSE.3rdparty file of 6MB in services/vios folder).

## Changes
a local pre-commit hook plus a CI check that fails if any file under services/* is stored as a regular git blob > 5 MiB.
this will be defined in existing .pre-commit-config.yaml

