### PR TITLE
Drop orphaned dist-info so numpy metadata resolves deterministically

### DIFF
--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -113,7 +113,7 @@ jobs:
     needs: changes
     if: fromJSON(needs.changes.outputs.standard-count) > 0
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.changes.outputs.standard-matrix) }}

--- a/services/rtvi/rt-cv/docker/Dockerfile
+++ b/services/rtvi/rt-cv/docker/Dockerfile
@@ -208,7 +208,39 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-${TARGETARC
       pip3 install --default-timeout=100 --retries 20 open-clip-torch sentencepiece onnx onnxruntime-gpu pillow==12.2.0; \
     fi; \
     pip3 install --default-timeout=100 --retries 20 huggingface_hub==0.36.2; \
-    pip3 install --default-timeout=100 --retries 20 --ignore-installed wheel==0.46.2
+    pip3 install --default-timeout=100 --retries 20 --ignore-installed wheel==0.46.2; \
+    # Drop metadata directories Python cannot read. A pinned package that a
+    # later resolve upgrades leaves its old <name>-<ver>.dist-info behind
+    # holding only REQUESTED, with no METADATA. numpy is the live case:
+    # numpy==1.26.4 is pinned above, then ml_dtypes (unpinned, pulled in by
+    # onnx) raised its floor to numpy>=2.0.0 in 0.6.0, so pip upgrades numpy
+    # and orphans the 1.26.4 directory.
+    #
+    # importlib.metadata returns the FIRST match it finds while scanning, so
+    # with two numpy-*.dist-info dirs the result depends on os.listdir order --
+    # a property of the node's filesystem, not of the image. Real one first
+    # gives "2.5.2"; husk first gives None, and transformers'
+    # require_version("numpy>=1.17") then raises
+    #     ValueError: Unable to compare versions for numpy>=1.17 ... found=None
+    # which fails gdino_preprocess and takes ensemble_python_gdino with it.
+    # The same image therefore works on one machine and fails on another.
+    #
+    # A healthy install always has METADATA, so this cannot match one. It is a
+    # no-op on amd64 today (90 dist-info dirs, none orphaned) and removes
+    # exactly numpy-1.26.4.dist-info on arm64 and SBSA.
+    _dp=/usr/local/lib/python3.12/dist-packages; \
+    find "$_dp" -maxdepth 1 -name '*.dist-info' \
+         '!' -exec test -f '{}/METADATA' ';' -print -exec rm -rf '{}' + ; \
+    # find does NOT propagate a failing -exec, so a permission error would let
+    # the husk survive silently and the bug would come back with no signal.
+    # Assert instead: anything still orphaned fails the build, loudly.
+    _left=$(find "$_dp" -maxdepth 1 -name '*.dist-info' \
+                 '!' -exec test -f '{}/METADATA' ';' -print); \
+    if [ -n "$_left" ]; then \
+      echo "ERROR: orphaned dist-info survived removal:" >&2; \
+      echo "$_left" >&2; \
+      exit 1; \
+    fi
 
 # -- offline model assets -------------------------------------------------
 # Bake the bert-base-uncased tokenizer in so the container never reaches the

--- a/services/rtvi/rt-cv/docker/sbsa.Dockerfile
+++ b/services/rtvi/rt-cv/docker/sbsa.Dockerfile
@@ -168,7 +168,39 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-sbsa \
     pip3 install --default-timeout=100 --retries 20 kafka-python psutil transformers==4.57.6 setuptools==78.1.1 numpy==1.26.4; \
     pip3 install --default-timeout=100 --retries 20 open-clip-torch sentencepiece onnx onnxruntime pillow==12.2.0; \
     pip3 install --default-timeout=100 --retries 20 huggingface_hub==0.36.2; \
-    pip3 install --default-timeout=100 --retries 20 --ignore-installed wheel==0.46.2
+    pip3 install --default-timeout=100 --retries 20 --ignore-installed wheel==0.46.2; \
+    # Drop metadata directories Python cannot read. A pinned package that a
+    # later resolve upgrades leaves its old <name>-<ver>.dist-info behind
+    # holding only REQUESTED, with no METADATA. numpy is the live case:
+    # numpy==1.26.4 is pinned above, then ml_dtypes (unpinned, pulled in by
+    # onnx) raised its floor to numpy>=2.0.0 in 0.6.0, so pip upgrades numpy
+    # and orphans the 1.26.4 directory.
+    #
+    # importlib.metadata returns the FIRST match it finds while scanning, so
+    # with two numpy-*.dist-info dirs the result depends on os.listdir order --
+    # a property of the node's filesystem, not of the image. Real one first
+    # gives "2.5.2"; husk first gives None, and transformers'
+    # require_version("numpy>=1.17") then raises
+    #     ValueError: Unable to compare versions for numpy>=1.17 ... found=None
+    # which fails gdino_preprocess and takes ensemble_python_gdino with it.
+    # The same image therefore works on one machine and fails on another.
+    #
+    # A healthy install always has METADATA, so this cannot match one. It is a
+    # no-op on amd64 today (90 dist-info dirs, none orphaned) and removes
+    # exactly numpy-1.26.4.dist-info on arm64 and SBSA.
+    _dp=/usr/local/lib/python3.12/dist-packages; \
+    find "$_dp" -maxdepth 1 -name '*.dist-info' \
+         '!' -exec test -f '{}/METADATA' ';' -print -exec rm -rf '{}' + ; \
+    # find does NOT propagate a failing -exec, so a permission error would let
+    # the husk survive silently and the bug would come back with no signal.
+    # Assert instead: anything still orphaned fails the build, loudly.
+    _left=$(find "$_dp" -maxdepth 1 -name '*.dist-info' \
+                 '!' -exec test -f '{}/METADATA' ';' -print); \
+    if [ -n "$_left" ]; then \
+      echo "ERROR: orphaned dist-info survived removal:" >&2; \
+      echo "$_left" >&2; \
+      exit 1; \
+    fi
 
 # -- offline model assets -------------------------------------------------
 # Bake the bert-base-uncased tokenizer in so the container never reaches the


### PR DESCRIPTION
A pinned package that a later resolve upgrades leaves its old <name>-<ver>.dist-info behind holding only REQUESTED, with no METADATA. numpy is the live case: numpy==1.26.4 is pinned, then ml_dtypes -- unpinned, pulled in by onnx -- raised its floor from numpy>=1.26.0 in 0.5.4 to numpy>=2.0.0 in 0.6.0, so pip now upgrades numpy to 2.5.2 and orphans the 1.26.4 directory.

importlib.metadata returns the FIRST match it finds while scanning, so with two numpy-*.dist-info dirs the answer depends on os.listdir order, which is a property of the node's filesystem rather than of the image:

  ['numpy-2.5.2.dist-info', 'numpy-1.26.4.dist-info'] -> "2.5.2"   works
  ['numpy-1.26.4.dist-info', 'numpy-2.5.2.dist-info'] -> None      fails

On the None path transformers' require_version("numpy>=1.17") raises

  ValueError: Unable to compare versions for numpy>=1.17 ... found=None

which fails gdino_preprocess and takes ensemble_python_gdino with it. The same image therefore runs fine on one machine and fails on another, which is why a Spark deployment stayed up for 23 hours on the exact image that fails in CI.

This is not a GHCR regression. The Dockerfiles match few-shot-learning's, and the July NGC drop 3.3.0-26.07.2 has ml_dtypes 0.5.4, numpy 1.26.4, a single dist-info and a working import. ml_dtypes 0.6.0 released between that build and ours; rebuilding the Jenkins job today would produce the same defect.

A healthy install always has METADATA, so the filter cannot match one: it is a no-op on amd64 today (90 dist-info dirs, none orphaned) and removes exactly numpy-1.26.4.dist-info on arm64 and SBSA.

find does not propagate a failing -exec, so a permission error would leave the husk in place silently. The removal is therefore followed by an assertion that fails the build and prints what survived. Verified against the broken develop-latest-sbsa image: as root the husk is removed, numpy metadata resolves to 2.5.2 and transformers imports; forced to run unprivileged, the build fails loudly instead of shipping the defect.

This addresses the crash. It does not stop ml_dtypes overriding the numpy pin -- numpy still resolves to 2.5.2 rather than the pinned 1.26.4. Pinning ml_dtypes<0.6 to restore the July package set is a separate behaviour change and wants its own test cycle.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
