### PR TITLE
vss-configurator: Upgrade NVIDIA distroless Python tag to v4.1.1

### DIFF
--- a/services/configurators/vss-configurator/README.md
+++ b/services/configurators/vss-configurator/README.md
@@ -310,7 +310,7 @@ docker build \
   -t vss-configurator .
 ```
 
-The image uses a multi-stage build: **Python 3.13** dependencies, including the in-repo SDU package, via `uv sync --frozen --no-dev`, runtime on **`nvcr.io/nvidian/distroless/python:3.13-v4.0.5`**.
+The image uses a multi-stage build: **Python 3.13** dependencies, including the in-repo SDU package, via `uv sync --frozen --no-dev`, runtime on **`nvcr.io/nvidia/distroless/python:3.13-v4.1.1`**. Python and distroless versions are `ARG`s at the top of `docker/Dockerfile` (`PYTHON_VERSION`, `DISTROLESS_IMG`, `DISTROLESS_TAG`).
 
 **Legal requirements (container distribution):**
 
@@ -634,7 +634,7 @@ Status for NVStreamer/VMS video upload (for init-container polling).
 |------|--------|
 | Build context | monorepo root (`.`) |
 | Builder | `python:3.13-trixie` + `uv sync --frozen --no-dev` |
-| Runtime base | `nvcr.io/nvidian/distroless/python:3.13-v4.0.5` |
+| Runtime base | `nvcr.io/nvidia/distroless/python:3.13-v4.1.1` (`DISTROLESS_IMG`:`DISTROLESS_TAG`) |
 | Entrypoint | `python entrypoint.py` (no shell in image) |
 | Working directory | `/usr/src/app` |
 | Python deps | `PYTHONPATH=/usr/src/app/site-packages` |

--- a/services/configurators/vss-configurator/docker/Dockerfile
+++ b/services/configurators/vss-configurator/docker/Dockerfile
@@ -15,7 +15,7 @@
 
 ARG PYTHON_VERSION=3.13
 ARG DISTROLESS_IMG=nvcr.io/nvidia/distroless/python
-ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.0.9
+ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.1.1
 
 # -----------------------------------------------------------------------------
 # Stage 1: Builder — install Python deps (with build tools for any C extensions)

--- a/services/configurators/vss-configurator/docker/Dockerfile
+++ b/services/configurators/vss-configurator/docker/Dockerfile
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG PYTHON_VERSION=3.13
+ARG DISTROLESS_IMG=nvcr.io/nvidia/distroless/python
+ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.0.9
+
 # -----------------------------------------------------------------------------
 # Stage 1: Builder — install Python deps (with build tools for any C extensions)
 # -----------------------------------------------------------------------------
-FROM python:3.13-trixie AS builder
+FROM python:${PYTHON_VERSION}-trixie AS builder
 
 WORKDIR /usr/src/app
 
@@ -41,14 +45,16 @@ RUN uv sync --frozen --no-dev
 # Chainguard Python 3.13 is distroless: ~23MB base, no shell, non-root by default.
 # Google distroless does not ship Python 3.13; Chainguard does.
 # Runtime is distroless, so startup must use a Python entrypoint instead of a shell script.
-# FROM cgr.dev/chainguard/python:3.13 AS runtime
-FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.5 AS runtime
+# FROM cgr.dev/chainguard/python:${PYTHON_VERSION} AS runtime
+FROM ${DISTROLESS_IMG}:${DISTROLESS_TAG} AS runtime
+
+ARG PYTHON_VERSION
 
 WORKDIR /usr/src/app
 
 # Bring in deps from builder; distroless has its own Python, so we use PYTHONPATH
 # instead of copying into system paths (avoids mixing builder and runtime layouts).
-COPY --from=builder /usr/src/app/.venv/lib/python3.13/site-packages /usr/src/app/site-packages
+COPY --from=builder /usr/src/app/.venv/lib/python${PYTHON_VERSION}/site-packages /usr/src/app/site-packages
 ENV PYTHONPATH=/usr/src/app/site-packages
 
 # Application code (entrypoint.py is used because distroless has no shell).


### PR DESCRIPTION
## Summary
- Upgrade the vss-configurator runtime from `nvcr.io/nvidia/distroless/python:3.13-v4.0.5` to `3.13-v4.1.1`.
- Add `PYTHON_VERSION`, `DISTROLESS_IMG`, and `DISTROLESS_TAG` at the top of the Dockerfile so the builder image, runtime image, and venv `site-packages` path stay in sync.
- Later Python or distroless bumps are a single ARG change (overridable with `--build-arg`).

## Test plan
- [x] `docker build -f services/configurators/vss-configurator/docker/Dockerfile -t vss_cfgtr:test .` from the monorepo root succeeds.
- [x] Build uses `python:3.13-trixie`, `nvcr.io/nvidia/distroless/python:3.13-v4.1.1`, and `.venv/lib/python3.13/site-packages`.
- [x] Warehouse deploy runs this image with profile + sensor configurator enabled (`bp-configurator-3d`).
- [x] `GET /healthz` returns 200 `{"status":"healthy"}`.
- [x] `GET /readyz` returns 200 after profile configuration completes.
- [x] Container healthcheck is healthy; no startup traceback.
- [x] `uv sync --python 3.13 --frozen && uv run --python 3.13 pytest tests/ -v` — 158 passed.