### PR TITLE
feat(deploy): placement-neutral gateway contract for Docker service-to-service HTTP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,19 @@ vss configure show                              # what was recorded
 vss configure check                             # re-probe + what each group can serve
 ```
 
-`configure` probes the origin's ingress routes and writes `~/.vss/config.json`
-(0600, no credentials). Re-run it after any deployment change.
+`configure` probes the origin's ingress routes — `/api`, `/vst`,
+`/elasticsearch`, `/rtvi-embed`, `/rtvi-cv`, `/rtvi-vlm`, `/lvs`, `/va-mcp` —
+and writes `~/.vss/config.json` (0600, no credentials). Re-run it after any
+deployment change.
+
+**Use the origin the host can reach, never the in-network gateway name.**
+`VSS_PUBLIC_URL` is it: `http://<host>:7777` locally, or the platform's
+`https://…` URL where TLS terminates in front of the deployment (a Brev secure
+link forwards plain HTTP inward). Services *inside* the deployment address the
+same HAProxy front door as `http://vss.local:7777` — that is `VSS_GATEWAY_ORIGIN`,
+and it is correct for them and useless here: it is a container-network alias, so
+configuring it fails every probe with a connection error and makes a healthy
+deployment look broken. One front door, one path contract, two origins.
 
 **Never construct an endpoint.** No `kubectl port-forward`, no Service DNS, no
 NodePort, no reading `HOST_IP` or `VST_INTERNAL_URL` out of a container. The CLI

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -154,6 +154,146 @@ If you choose to pass `overrides.env` directly instead of `generated.env`, first
 replace its placeholder values for `VSS_APPS_DIR`, `VSS_DATA_DIR`, `HOST_IP`,
 credentials, ports, and model settings.
 
+### Gateway identity
+
+HAProxy is the HTTP front door. Service-to-service HTTP inside the deployment
+uses one logical origin plus the stable path contract below — not Compose DNS
+nicknames like `http://vss-va-mcp:9901`. Placement lives in DNS and in HAProxy;
+no caller branches on whether a service is colocated.
+
+Profiles expose three variables:
+
+| Variable | Default | What it is |
+|---|---|---|
+| `VSS_GATEWAY_HOST` | `vss.local` | The gateway's name. HAProxy publishes `vss.local` as a bridge network alias unconditionally. |
+| `VSS_GATEWAY_PORT` | `${HAPROXY_PORT:-7777}` | The listener HAProxy binds. |
+| `VSS_GATEWAY_ORIGIN` | `http://vss.local:7777` | What callers prefix a mount with. |
+
+**The gateway origin is pinned to HAProxy's listener and is deliberately not
+derived from `VSS_PUBLIC_*`.** The two describe different callers. `VSS_PUBLIC_*`
+is the browser's origin; where a platform terminates TLS outside the stack — a
+Brev secure link is `https` on `443`, forwarding plain HTTP to `7777` — reusing
+it here would hand every container `https://vss.local:443`, a listener that does
+not exist. `VSS_PUBLIC_*` keeps browsers, report links, and
+`vss configure --base-url` on the host; the gateway keeps the containers. Never
+point a container at the platform's secure-link hostname.
+
+The end state is one front door, one path contract, two origins: internal
+callers use `http://vss.local:7777`, external callers use the platform's HTTPS
+URL.
+
+None of these may render empty. An empty origin produces URLs like
+`/elasticsearch`, which fail inside an HTTP client as a malformed request rather
+than here as a configuration error, so `services/agent/compose.yml` spells out
+an inline default on every gateway-derived variable.
+
+Agent Compose derives the agent's HTTP backends from the origin —
+`VIDEO_ANALYSIS_MCP_URL`, `VST_INTERNAL_URL`, `ELASTIC_SEARCH_ENDPOINT`,
+`COSMOS_EMBED_ENDPOINT`, `RTVI_CV_ENDPOINT`, `RTVI_VLM_BASE_URL`,
+`ALERT_BRIDGE_URL`, `LVS_BACKEND_URL`, `PHOENIX_ENDPOINT`. Browser-facing
+`VST_EXTERNAL_URL` stays on `VSS_PUBLIC_*`. Non-HTTP data planes — Kafka, Redis,
+RTSP, raw media — are out of scope and keep their own addressing.
+
+Same-bridge check (native Compose; no helper script):
+
+```bash
+cd deploy/docker
+docker compose -f compose.yml \
+  --env-file containers.env \
+  --env-file developer-profiles/dev-profile-alerts/.env \
+  --env-file developer-profiles/dev-profile-alerts/overrides.env \
+  config vss-agent vss-va-mcp vss-haproxy-ingress
+```
+
+After `up -d`, from a container on the bridge:
+
+```bash
+docker exec vss-agent getent hosts vss.local
+docker exec vss-agent curl -fsS http://vss.local:7777/va-mcp/health
+docker exec vss-agent curl -fsS http://vss.local:7777/elasticsearch/
+```
+
+The last two prove the rewrite, not just the route: `/va-mcp/health` must return
+the MCP server's own health body and `/elasticsearch/` the cluster banner. A 404
+means HAProxy matched the path but rewrote it into something the backend does
+not serve.
+
+From the host, the same front door on the published port:
+
+```bash
+curl -fsS "${VSS_PUBLIC_URL}/va-mcp/health"
+vss configure --base-url "${VSS_PUBLIC_URL}"   # never http://vss.local:7777
+vss configure check
+```
+
+Off-bridge: set `VSS_GATEWAY_HOST` and `VSS_GATEWAY_ORIGIN` to the externally
+resolvable name (and TLS scheme/port), then pass `-f compose.gateway-alias.yml`
+only when you also want that hostname aliased on the Compose network.
+
+```bash
+docker compose -f compose.yml -f compose.gateway-alias.yml \
+  --env-file containers.env \
+  --env-file developer-profiles/dev-profile-alerts/.env \
+  --env-file developer-profiles/dev-profile-alerts/overrides.env \
+  config vss-haproxy-ingress
+```
+
+Gateway path contract (HAProxy). Callers use `${VSS_GATEWAY_ORIGIN}<mount>` then
+the service's own path. Prefix is stripped only where the backend does not
+serve that prefix natively.
+
+| Mount | Prefix | Caller base when gateway-routed | Example public path | Backend path |
+|---|---|---|---|---|
+| `/va-mcp` | strip | `${VSS_GATEWAY_ORIGIN}/va-mcp` | `/va-mcp/mcp`, `/va-mcp/health` | `/mcp`, `/health` |
+| `/alert-bridge` | strip | `${VSS_GATEWAY_ORIGIN}/alert-bridge` | `/alert-bridge/health` | `/health` |
+| `/video-analytics-api` | strip | origin + `/video-analytics-api` | `/video-analytics-api/...` | `/...` |
+| `/elasticsearch` | strip (method/path restricted) | `${VSS_GATEWAY_ORIGIN}/elasticsearch` | `/elasticsearch/_cat/indices` | `/_cat/indices` |
+| `/rtvi-vlm` | strip | `${VSS_GATEWAY_ORIGIN}/rtvi-vlm` | `/rtvi-vlm/v1/models` | `/v1/models` |
+| `/rtvi-cv` | strip | `${VSS_GATEWAY_ORIGIN}/rtvi-cv` | `/rtvi-cv/api/v1/stream/add` | `/api/v1/stream/add` |
+| `/rtvi-embed` | strip | `${VSS_GATEWAY_ORIGIN}/rtvi-embed` | `/rtvi-embed/v1/models` | `/v1/models` |
+| `/lvs` | strip | `${VSS_GATEWAY_ORIGIN}/lvs` | `/lvs/v1/live` | `/v1/live` |
+| `/phoenix` | strip | `${VSS_GATEWAY_ORIGIN}/phoenix` | `/phoenix` | `/` (keep `PHOENIX_HOST_ROOT_PATH=/phoenix`) |
+| `/vst` | preserve | `${VSS_GATEWAY_ORIGIN}` (not `/vst`) | `/vst/api/...` | `/vst/api/...` |
+| `/storage` | rewrite to `/vst/storage` | origin | `/storage/...` | `/vst/storage/...` |
+| `/kibana` | preserve | origin + `/kibana` | `/kibana/...` | `/kibana/...` |
+| `/api`, `/chat`, `/websocket`, `/static` | preserve | origin | `/api/v1/...` | `/api/v1/...` |
+| `/behavior-analytics`, `/perception-sdr` | preserve | origin + prefix | prefix paths | same (often 503 if backend has no HTTP) |
+
+The proposed renames to `/vios`, `/alerts` and `/video-summarization` are not
+applied: those prefixes exist in neither Helm nor the CLI today, and Docker
+matches the current Helm and CLI mounts. Renaming them is a separate change that
+has to move all three at once.
+
+### Elasticsearch through the gateway
+
+`/elasticsearch` is a **narrow** mount, not a general-purpose ES proxy. The
+frontend allows `GET`/`HEAD`/`POST`/`OPTIONS`, answers `403` on
+`_cluster`/`_nodes`/`_snapshot`/`_security`/`_settings`/`_shutdown`/`_license`
+and on `<index>/_bulk`, `_update`, `_delete_by_query`, `_forcemerge`, `_close`
+and `_open`, and permits exactly one `PUT` — `vss-memory[-suffix]/_doc/<id>`,
+for unified memory. That is the query surface the agent and the `vss` CLI need,
+and widening it would turn an ingress-exposed route into unauthenticated cluster
+administration.
+
+So which ES clients ride the gateway is decided by that ACL, not by preference:
+
+| ES client | Routing | Why |
+|---|---|---|
+| `vss-agent` (search, embed, critic, memory, `es_caption`) | gateway `/elasticsearch` | Query paths plus the one permitted memory `PUT`. |
+| `vss-va-mcp` (`video_analytics.es_url`) | gateway `/elasticsearch` | `_search` only. |
+| `vss` CLI | gateway `/elasticsearch` | Same query surface, from outside. |
+| Kibana | direct `elasticsearch:9200` | It does honor a path in `elasticsearch.hosts`, but its startup node/version probe is `GET _nodes/_all/_none`, which the mount answers `403`: measured against this route, Kibana logs "Unable to retrieve version information from Elasticsearch nodes" and retries forever without becoming ready. It also needs `_cluster`, `_security` and `PUT`/`DELETE` on its own `.kibana*` indices. `kibana.yml` is mounted verbatim with no variable substitution besides. |
+| `vss-video-analytics-api` | direct `elasticsearch:9200` | A read-write client: `indices.putIndexTemplate`, `index()` with an id (`PUT`), and `bulk()` on `<index>/_bulk` are 405/403 through the mount. Its JSON config is mounted verbatim, so it has no substitution hook either. |
+| `alert-bridge` / `vlm-as-verifier` | direct `elasticsearch:9200` | Writes `mdx-vlm-incidents` / `mdx-vlm-alerts` and creates its own `ab-*` indices. `source_elasticsearch.py` also takes host and port separately and cannot express a path prefix. |
+| Logstash pipelines | direct `elasticsearch:9200` | Ingest data plane: ILM and index-template `PUT`s, plus bulk indexing. Not something to put behind an HTTP edge proxy. |
+| `elasticsearch-init-container`, `kibana-import-dashboard.sh` | direct `elasticsearch:9200` | Bootstrap: they create the ILM policies, templates and pipelines with `PUT`, and they run before and independently of HAProxy. |
+| LVS (`lvs-server`) | direct `ES_HOST` / `ES_PORT` | Takes host and port as separate settings, so it cannot express `origin + /elasticsearch` without a code change. |
+| VST / nvstreamer `video_metadata_server` | direct `elasticsearch:9200/mdx-*` | Not a base URL — the setting embeds an index pattern in the host string. |
+
+Every entry left direct is either denied by the ACL above, unable to express a
+path prefix, or part of the bootstrap that has to run before the proxy. Moving
+any of them means changing the client, not the route.
+
 Create writable host directories for the bind-mounted infrastructure volumes
 before starting a direct Compose stack:
 

--- a/deploy/docker/compose.gateway-alias.yml
+++ b/deploy/docker/compose.gateway-alias.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Optional overlay: publish VSS_GATEWAY_HOST as a Docker bridge DNS name for
+# vss-haproxy-ingress. Off-host callers resolve the same name through normal
+# DNS. Do not include this file unless VSS_GATEWAY_HOST is a hostname (not an
+# empty value and not an IP you do not want as a network alias).
+
+services:
+  vss-haproxy-ingress:
+    networks:
+      default:
+        aliases:
+          - ${VSS_GATEWAY_HOST:?set VSS_GATEWAY_HOST to a hostname before using compose.gateway-alias.yml}

--- a/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env
@@ -105,6 +105,22 @@ VSS_PUBLIC_HOST=${EXTERNAL_IP}
 HAPROXY_HOST_PORT=7777
 # Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
+# Canonical gateway identity for in-Docker HTTP service-to-service calls. One
+# origin for colocated and remote callers alike; DNS and the HAProxy vss.local
+# alias supply placement, so no caller branches on where a service runs.
+#
+# Pinned to HAProxy's own listener, NOT derived from VSS_PUBLIC_*. Where the
+# platform terminates TLS outside the stack (a Brev secure link is https on 443
+# forwarding plain HTTP to 7777) VSS_PUBLIC_* describes the browser's origin,
+# and reusing it here hands containers https://vss.local:443 -- a listener that
+# does not exist. VSS_PUBLIC_* stays for browsers, report links, and
+# `vss configure --base-url` on the host. See deploy/docker/README.md.
+#
+# Never leave these empty: an empty origin renders "/elasticsearch" and fails
+# later as a malformed request instead of here as a configuration error.
+VSS_GATEWAY_HOST=vss.local
+VSS_GATEWAY_PORT=${HAPROXY_PORT:-7777}
+VSS_GATEWAY_ORIGIN=http://${VSS_GATEWAY_HOST}:${VSS_GATEWAY_PORT}
 
 # =============================================================================
 # HOST-PUBLISHED PORTS

--- a/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/va_mcp_server_config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/va_mcp_server_config.yml
@@ -16,12 +16,12 @@
 functions:
   vst_sensor_list:
     _type: vst.sensor_list
-    vst_internal_url: http://vst-ingress:30888
+    vst_internal_url: ${VST_INTERNAL_URL}
 
 function_groups:
   video_analytics:
     _type: video_analytics
-    es_url: "http://elasticsearch:9200"
+    es_url: "${ELASTIC_SEARCH_ENDPOINT}"
     index_prefix: "mdx-"
     vlm_verified: true
     vst_sensor_list_tool: vst_sensor_list

--- a/deploy/docker/developer-profiles/dev-profile-base/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-base/overrides.env
@@ -103,6 +103,22 @@ VSS_PUBLIC_HOST=${EXTERNAL_IP}
 HAPROXY_HOST_PORT=7777
 # Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
+# Canonical gateway identity for in-Docker HTTP service-to-service calls. One
+# origin for colocated and remote callers alike; DNS and the HAProxy vss.local
+# alias supply placement, so no caller branches on where a service runs.
+#
+# Pinned to HAProxy's own listener, NOT derived from VSS_PUBLIC_*. Where the
+# platform terminates TLS outside the stack (a Brev secure link is https on 443
+# forwarding plain HTTP to 7777) VSS_PUBLIC_* describes the browser's origin,
+# and reusing it here hands containers https://vss.local:443 -- a listener that
+# does not exist. VSS_PUBLIC_* stays for browsers, report links, and
+# `vss configure --base-url` on the host. See deploy/docker/README.md.
+#
+# Never leave these empty: an empty origin renders "/elasticsearch" and fails
+# later as a malformed request instead of here as a configuration error.
+VSS_GATEWAY_HOST=vss.local
+VSS_GATEWAY_PORT=${HAPROXY_PORT:-7777}
+VSS_GATEWAY_ORIGIN=http://${VSS_GATEWAY_HOST}:${VSS_GATEWAY_PORT}
 
 # =============================================================================
 # HOST-PUBLISHED PORTS

--- a/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/overrides.env
@@ -103,6 +103,22 @@ VSS_PUBLIC_HOST=${EXTERNAL_IP}
 HAPROXY_HOST_PORT=7777
 # Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
+# Canonical gateway identity for in-Docker HTTP service-to-service calls. One
+# origin for colocated and remote callers alike; DNS and the HAProxy vss.local
+# alias supply placement, so no caller branches on where a service runs.
+#
+# Pinned to HAProxy's own listener, NOT derived from VSS_PUBLIC_*. Where the
+# platform terminates TLS outside the stack (a Brev secure link is https on 443
+# forwarding plain HTTP to 7777) VSS_PUBLIC_* describes the browser's origin,
+# and reusing it here hands containers https://vss.local:443 -- a listener that
+# does not exist. VSS_PUBLIC_* stays for browsers, report links, and
+# `vss configure --base-url` on the host. See deploy/docker/README.md.
+#
+# Never leave these empty: an empty origin renders "/elasticsearch" and fails
+# later as a malformed request instead of here as a configuration error.
+VSS_GATEWAY_HOST=vss.local
+VSS_GATEWAY_PORT=${HAPROXY_PORT:-7777}
+VSS_GATEWAY_ORIGIN=http://${VSS_GATEWAY_HOST}:${VSS_GATEWAY_PORT}
 
 # =============================================================================
 # HOST-PUBLISHED PORTS

--- a/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
+++ b/deploy/docker/developer-profiles/dev-profile-lvs/vss-agent/configs/config.yml
@@ -282,7 +282,10 @@ functions:
     backend: es_caption
     top_k: 5
     backend_config:
-      elasticsearch_url: ${ELASTIC_SEARCH_ENDPOINT:-http://elasticsearch:9200}
+      # Compose supplies ELASTIC_SEARCH_ENDPOINT as the gateway's /elasticsearch
+      # mount; the fallback matches it rather than naming a Compose service, so
+      # this config resolves the same way wherever the agent runs.
+      elasticsearch_url: ${ELASTIC_SEARCH_ENDPOINT:-http://vss.local:7777/elasticsearch}
       index: default_*                                  # per-stream `default_<stream_id>` indices
       default_doc_type: raw_events
       api_key: ""

--- a/deploy/docker/developer-profiles/dev-profile-search/.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/.env
@@ -140,13 +140,17 @@ NEXT_PUBLIC_SIDEBAR_CHAT_CHAT_API_CUSTOM_AGENT_PARAMS_JSON='{"params":[{"name":"
 # =============================================================================
 # COSMOS EMBED & ELASTICSEARCH CONFIGURATION
 # =============================================================================
-# Cosmos Embed Port
+# Both endpoints are overridden by the gateway-derived values in
+# services/agent/compose.yml. They are written in the gateway's shape here so
+# this file no longer states a Compose DNS name as the contract; VSS_GATEWAY_*
+# is defined in overrides.env, which Compose reads after this file, hence the
+# inline defaults.
 COSMOS_EMBED_PORT=8017
-COSMOS_EMBED_ENDPOINT=http://rtvi-embed:8000
+COSMOS_EMBED_ENDPOINT=http://${VSS_GATEWAY_HOST:-vss.local}:${HAPROXY_PORT:-7777}/rtvi-embed
 
 # ElasticSearch Configuration
 ELASTIC_SEARCH_PORT=9200
-ELASTIC_SEARCH_ENDPOINT=http://elasticsearch:9200
+ELASTIC_SEARCH_ENDPOINT=http://${VSS_GATEWAY_HOST:-vss.local}:${HAPROXY_PORT:-7777}/elasticsearch
 ELASTIC_SEARCH_INDEX=mdx-embed-filtered-2025-01-01
 
 # =============================================================================

--- a/deploy/docker/developer-profiles/dev-profile-search/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/overrides.env
@@ -103,6 +103,22 @@ VSS_PUBLIC_HOST=${EXTERNAL_IP}
 HAPROXY_HOST_PORT=7777
 # Direct local ingress uses HAPROXY_HOST_PORT; TLS or secure-link ingress usually uses 443.
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
+# Canonical gateway identity for in-Docker HTTP service-to-service calls. One
+# origin for colocated and remote callers alike; DNS and the HAProxy vss.local
+# alias supply placement, so no caller branches on where a service runs.
+#
+# Pinned to HAProxy's own listener, NOT derived from VSS_PUBLIC_*. Where the
+# platform terminates TLS outside the stack (a Brev secure link is https on 443
+# forwarding plain HTTP to 7777) VSS_PUBLIC_* describes the browser's origin,
+# and reusing it here hands containers https://vss.local:443 -- a listener that
+# does not exist. VSS_PUBLIC_* stays for browsers, report links, and
+# `vss configure --base-url` on the host. See deploy/docker/README.md.
+#
+# Never leave these empty: an empty origin renders "/elasticsearch" and fails
+# later as a malformed request instead of here as a configuration error.
+VSS_GATEWAY_HOST=vss.local
+VSS_GATEWAY_PORT=${HAPROXY_PORT:-7777}
+VSS_GATEWAY_ORIGIN=http://${VSS_GATEWAY_HOST}:${VSS_GATEWAY_PORT}
 
 # =============================================================================
 # HOST-PUBLISHED PORTS

--- a/deploy/docker/industry-profiles/smartcities/vss-agent/configs/va_mcp_server_config.yml
+++ b/deploy/docker/industry-profiles/smartcities/vss-agent/configs/va_mcp_server_config.yml
@@ -16,12 +16,12 @@
 functions:
   vst_sensor_list:
     _type: vst.sensor_list
-    vst_internal_url: http://${HOST_IP}:30888
+    vst_internal_url: ${VST_INTERNAL_URL}
 
 function_groups:
   video_analytics:
     _type: video_analytics
-    es_url: "http://${HOST_IP}:${VSS_ES_PORT}"
+    es_url: "${ELASTIC_SEARCH_ENDPOINT}"
     index_prefix: "mdx-"
     vlm_verified: false
     vst_sensor_list_tool: vst_sensor_list

--- a/deploy/docker/industry-profiles/warehouse-operations/overrides.env
+++ b/deploy/docker/industry-profiles/warehouse-operations/overrides.env
@@ -122,6 +122,22 @@ VSS_PUBLIC_HTTP_PROTOCOL=http
 VSS_PUBLIC_WS_PROTOCOL=ws
 VSS_PUBLIC_HOST=${EXTERNAL_IP}
 VSS_PUBLIC_PORT=${HAPROXY_HOST_PORT}
+# Canonical gateway identity for in-Docker HTTP service-to-service calls. One
+# origin for colocated and remote callers alike; DNS and the HAProxy vss.local
+# alias supply placement, so no caller branches on where a service runs.
+#
+# Pinned to HAProxy's own listener, NOT derived from VSS_PUBLIC_*. Where the
+# platform terminates TLS outside the stack (a Brev secure link is https on 443
+# forwarding plain HTTP to 7777) VSS_PUBLIC_* describes the browser's origin,
+# and reusing it here hands containers https://vss.local:443 -- a listener that
+# does not exist. VSS_PUBLIC_* stays for browsers, report links, and
+# `vss configure --base-url` on the host. See deploy/docker/README.md.
+#
+# Never leave these empty: an empty origin renders "/elasticsearch" and fails
+# later as a malformed request instead of here as a configuration error.
+VSS_GATEWAY_HOST=vss.local
+VSS_GATEWAY_PORT=${HAPROXY_PORT:-7777}
+VSS_GATEWAY_ORIGIN=http://${VSS_GATEWAY_HOST}:${VSS_GATEWAY_PORT}
 TURN_PUBLIC_HOST=${VSS_PUBLIC_HOST}
 TURN_EXTERNAL_IP=${EXTERNAL_IP}
 # Computed from the public ingress values above; keep after them for Compose interpolation.

--- a/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/va_mcp_server_config.yml
+++ b/deploy/docker/industry-profiles/warehouse-operations/vss-agent/configs/va_mcp_server_config.yml
@@ -16,12 +16,12 @@
 functions:
   vst_sensor_list:
     _type: vst.sensor_list
-    vst_internal_url: http://vst-ingress:30888
+    vst_internal_url: ${VST_INTERNAL_URL}
 
 function_groups:
   video_analytics:
     _type: video_analytics
-    es_url: "http://elasticsearch:9200"
+    es_url: "${ELASTIC_SEARCH_ENDPOINT}"
     index_prefix: "mdx-"
     vlm_verified: false
     vst_sensor_list_tool: vst_sensor_list

--- a/deploy/docker/services/agent/agent.env
+++ b/deploy/docker/services/agent/agent.env
@@ -2,10 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Shared VSS agent defaults.
+#
+# The live values for the agent's HTTP backends are derived from
+# VSS_GATEWAY_ORIGIN in services/agent/compose.yml, which overrides everything
+# here. The URLs below are kept in the gateway's shape rather than as Compose
+# DNS names so that a tool reading this file on its own still gets the endpoint
+# contract the deployment actually serves, instead of a hostname that only
+# resolves inside one Compose network.
 VSS_AGENT_HOST=0.0.0.0
 VSS_AGENT_PORT=8000
 VSS_AGENT_OBJECT_STORE_TYPE=local_object_store
-PHOENIX_ENDPOINT=http://phoenix:6006
+PHOENIX_ENDPOINT=http://${VSS_GATEWAY_HOST:-vss.local}:${HAPROXY_PORT:-7777}/phoenix
 VSS_ES_PORT=9200
 VSS_VA_MCP_PORT=9901
-VIDEO_ANALYSIS_MCP_URL=http://vss-va-mcp:${VSS_VA_MCP_PORT}
+VIDEO_ANALYSIS_MCP_URL=http://${VSS_GATEWAY_HOST:-vss.local}:${HAPROXY_PORT:-7777}/va-mcp

--- a/deploy/docker/services/agent/compose.yml
+++ b/deploy/docker/services/agent/compose.yml
@@ -27,6 +27,13 @@ services:
     environment:
     - HOST_IP=${HOST_IP}
     - VST_MCP_URL=${VST_MCP_URL}
+    # Gateway-derived, like the agent below. The default is spelled out on every
+    # line because Compose has no way to name it once: a bare
+    # ${VSS_GATEWAY_ORIGIN} renders "/elasticsearch" when the variable is unset,
+    # which fails inside the client as a malformed URL rather than here as a
+    # missing configuration value.
+    - VST_INTERNAL_URL=${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}
+    - ELASTIC_SEARCH_ENDPOINT=${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/elasticsearch
     - VSS_AGENT_HOST=${VSS_AGENT_HOST}
     - VSS_VA_MCP_PORT=${VSS_VA_MCP_PORT}
     - VSS_ES_PORT=${VSS_ES_PORT}
@@ -64,6 +71,16 @@ services:
     profiles: ["vss-agent"]
     ports:
     - ${VSS_AGENT_HOST_PORT:-8000}:${VSS_AGENT_PORT:-8000}
+    # Every HTTP backend the agent calls is ${VSS_GATEWAY_ORIGIN} plus the mount
+    # HAProxy publishes for it (see deploy/docker/README.md for the path
+    # contract). The agent therefore holds no Compose DNS name and no
+    # colocated-vs-remote branch; placement is DNS's job. The long inline
+    # default is repeated rather than named because Compose cannot bind an
+    # expression to a variable, and a bare ${VSS_GATEWAY_ORIGIN} would render
+    # "/elasticsearch" if a profile forgot to set it.
+    #
+    # Non-HTTP planes (Kafka, Redis, RTSP, raw media) are out of scope and stay
+    # on their own addressing.
     environment:
       LLM_MODE: ${LLM_MODE} # remote / local / local_shared
       VLM_MODE: ${VLM_MODE} # remote / local / local_shared
@@ -78,32 +95,33 @@ services:
       VSS_AGENT_CONFIG_FILE: ${VSS_AGENT_CONFIG_FILE}
       VSS_AGENT_HOST: ${VSS_AGENT_HOST}
       VSS_AGENT_PORT: ${VSS_AGENT_PORT}
-      LVS_BACKEND_URL: ${LVS_BACKEND_URL}
+      LVS_BACKEND_URL: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/lvs
       RTVI_EMBED_MODEL: ${RTVI_EMBED_MODEL:-cosmos-embed1-448p}
       RTVI_EMBED_PORT: ${RTVI_EMBED_PORT}
       RTVI_CV_PORT: ${RTVI_CV_PORT}
-      RTVI_CV_ENDPOINT: ${RTVI_CV_ENDPOINT:-http://vss-rtvi-cv:${RTVI_CV_PORT:-9000}}
+      RTVI_CV_ENDPOINT: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/rtvi-cv
       VSS_ES_PORT: ${VSS_ES_PORT}
 
       # Phoenix Telemetry
-      PHOENIX_ENDPOINT: ${PHOENIX_ENDPOINT}
+      PHOENIX_ENDPOINT: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/phoenix
 
-      # VST (Video Storage Tool)
+      # VST (Video Storage Tool). Agent-to-VST uses the gateway origin, not
+      # vst.env's Docker hostname (that file stays docker-local for VST itself).
       VST_BASE_URL: ${VST_BASE_URL:-${VST_EXTERNAL_URL}}
-      VST_INTERNAL_URL: ${VST_INTERNAL_URL}
+      VST_INTERNAL_URL: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}
       VST_EXTERNAL_URL: ${VST_EXTERNAL_URL}
       VST_MCP_URL: ${VST_MCP_URL}
 
       # MCP Server
-      VIDEO_ANALYSIS_MCP_URL: ${VIDEO_ANALYSIS_MCP_URL:-http://vss-va-mcp:${VSS_VA_MCP_PORT:-9901}}
+      VIDEO_ANALYSIS_MCP_URL: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/va-mcp
 
       # LLM Endpoints
       LLM_NAME: ${LLM_NAME}
       LLM_BASE_URL: ${LLM_BASE_URL}
       VLM_NAME: ${VLM_NAME}
       VLM_BASE_URL: ${VLM_BASE_URL}
-      RTVI_VLM_BASE_URL: ${RTVI_VLM_BASE_URL}
-      ALERT_BRIDGE_URL: ${ALERT_BRIDGE_URL:-http://alert-bridge:${ALERT_BRIDGE_PORT:-9080}}
+      RTVI_VLM_BASE_URL: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/rtvi-vlm
+      ALERT_BRIDGE_URL: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/alert-bridge
 
       # Audio Configuration
       ENABLE_AUDIO: ${ENABLE_AUDIO:-false}
@@ -133,8 +151,8 @@ services:
       VSS_AGENT_TEMPLATE_NAME: ${VSS_AGENT_TEMPLATE_NAME}
 
       # Cosmos Embed & ElasticSearch (for search profile)
-      COSMOS_EMBED_ENDPOINT: ${COSMOS_EMBED_ENDPOINT}
-      ELASTIC_SEARCH_ENDPOINT: ${ELASTIC_SEARCH_ENDPOINT}
+      COSMOS_EMBED_ENDPOINT: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/rtvi-embed
+      ELASTIC_SEARCH_ENDPOINT: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/elasticsearch
       ELASTIC_SEARCH_INDEX: ${ELASTIC_SEARCH_INDEX}
       # Evaluation, used with nat eval workflow
       EVAL_LLM_JUDGE_NAME: ${EVAL_LLM_JUDGE_NAME}

--- a/deploy/docker/services/infra/haproxy/compose.yml
+++ b/deploy/docker/services/infra/haproxy/compose.yml
@@ -51,6 +51,15 @@ services:
       EXTERNAL_IP: ${EXTERNAL_IP}
       VSS_PUBLIC_HOST: ${VSS_PUBLIC_HOST}
       VSS_PUBLIC_PORT: ${VSS_PUBLIC_PORT}
+      # Canonical gateway identity, used by the Host ACLs so a caller addressing
+      # the gateway name is admitted like any other known vhost. The port is the
+      # listener HAProxy binds (HAPROXY_PORT), not the host-published or public
+      # one: an in-network caller reaches the container port, and VSS_PUBLIC_PORT
+      # is 443 wherever a platform terminates TLS in front of this proxy.
+      # VSS_GATEWAY_ORIGIN is deliberately absent -- haproxy.cfg.template never
+      # reads it, and a `${VAR:-}` default here is how it ends up empty.
+      VSS_GATEWAY_HOST: ${VSS_GATEWAY_HOST:-vss.local}
+      VSS_GATEWAY_PORT: ${VSS_GATEWAY_PORT:-${HAPROXY_PORT:-7777}}
       VSS_UI_SERVICE_HOST: ${VSS_UI_SERVICE_HOST:-vss-ui}
       VSS_UI_PORT: ${VSS_UI_PORT:-3000}
       VSS_AGENT_SERVICE_HOST: ${VSS_AGENT_SERVICE_HOST:-vss-agent}
@@ -77,3 +86,12 @@ services:
       PHOENIX_PORT: ${PHOENIX_PORT:-6006}
     volumes:
       - ./haproxy.cfg.template:/usr/local/etc/haproxy/haproxy.cfg:ro
+    # vss.local is published unconditionally so the gateway origin resolves on
+    # the bridge with no extra overlay and no per-profile opt-in. A different
+    # VSS_GATEWAY_HOST is aliased by compose.gateway-alias.yml instead of being
+    # interpolated here, which would duplicate this entry in the common case
+    # where the two are the same name.
+    networks:
+      default:
+        aliases:
+          - vss.local

--- a/deploy/docker/services/infra/haproxy/haproxy.cfg.template
+++ b/deploy/docker/services/infra/haproxy/haproxy.cfg.template
@@ -77,9 +77,6 @@ backend bk_behavior_analytics
 backend bk_perception_sdr
     server s1 "${PERCEPTION_SDR_SERVICE_HOST}:${PERCEPTION_SDR_PORT}" check resolvers docker init-addr none
 
-backend bk_va_mcp
-    server s1 "${VSS_VA_MCP_SERVICE_HOST}:${VSS_VA_MCP_PORT}" check resolvers docker init-addr none
-
 backend bk_kibana
     server s1 "${KIBANA_SERVICE_HOST}:${KIBANA_PORT}" check resolvers docker init-addr none
 
@@ -129,12 +126,26 @@ backend bk_phoenix_strip
     http-request replace-path ^/phoenix$ /
     server s1 "${PHOENIX_SERVICE_HOST}:${PHOENIX_PORT}" check resolvers docker init-addr none
 
+# Strip /va-mcp so VIDEO_ANALYSIS_MCP_URL=${VSS_GATEWAY_ORIGIN}/va-mcp plus
+# the agent's /mcp suffix reaches the backend as /mcp, matching Helm
+# haproxy.org/path-rewrite and ${VSS_PUBLIC_URL}/va-mcp/mcp. Direct Docker
+# callers that still use http://vss-va-mcp:9901/mcp are unchanged.
+backend bk_va_mcp_strip
+    http-request replace-path ^/va-mcp/(.*) /\1
+    http-request replace-path ^/va-mcp$ /
+    server s1 "${VSS_VA_MCP_SERVICE_HOST}:${VSS_VA_MCP_PORT}" check resolvers docker init-addr none
+
 frontend fe_http
     bind "${HAPROXY_BIND_ADDR}:${HAPROXY_PORT}"
 
     # Named vhosts (nip.io / DNS) plus common dev cases: bare IP, localhost (Host must match or you get 404).
+    # VSS_GATEWAY_* is the canonical service-to-service hostname. It may equal
+    # VSS_PUBLIC_HOST; when it differs, callers use one origin and DNS/alias
+    # choose the path. Do not add colocated vs remote Host exceptions here.
     acl known_host hdr(host) -i "${VSS_PUBLIC_HOST}"
     acl known_host hdr(host) -i "${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}"
+    acl known_host hdr(host) -i "${VSS_GATEWAY_HOST}"
+    acl known_host hdr(host) -i "${VSS_GATEWAY_HOST}:${VSS_GATEWAY_PORT}"
     acl known_host hdr(host) -i "${EXTERNAL_IP}"
     acl known_host hdr(host) -i "${EXTERNAL_IP}:${HAPROXY_PORT}"
     acl known_host hdr(host) -i "${HOST_IP}"
@@ -147,6 +158,8 @@ frontend fe_http
 
     acl h_main hdr(host) -i "${VSS_PUBLIC_HOST}"
     acl h_main hdr(host) -i "${VSS_PUBLIC_HOST}:${VSS_PUBLIC_PORT}"
+    acl h_main hdr(host) -i "${VSS_GATEWAY_HOST}"
+    acl h_main hdr(host) -i "${VSS_GATEWAY_HOST}:${VSS_GATEWAY_PORT}"
     acl h_main hdr(host) -i "${EXTERNAL_IP}"
     acl h_main hdr(host) -i "${EXTERNAL_IP}:${HAPROXY_PORT}"
     acl h_main hdr(host) -i "${HOST_IP}"
@@ -290,6 +303,6 @@ frontend fe_http
 
     acl p_va_mcp path /va-mcp
     acl p_va_mcp path_beg /va-mcp/
-    use_backend bk_va_mcp if h_main p_va_mcp
+    use_backend bk_va_mcp_strip if h_main p_va_mcp
 
     use_backend bk_vss_ui if h_main

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1907,11 +1907,11 @@ for _env in \
 done
 
 # Search vss-agent config validates RTVI_CV_ENDPOINT at startup; compose must export it.
-if grep -q "RTVI_CV_ENDPOINT: \${RTVI_CV_ENDPOINT:-http://vss-rtvi-cv:\${RTVI_CV_PORT:-9000}}" "${REPO_ROOT}/deploy/docker/services/agent/compose.yml"; then
-  echo "PASS: vss-agent compose exports RTVI_CV_ENDPOINT for search config"
+if grep -Fq 'RTVI_CV_ENDPOINT: ${VSS_GATEWAY_ORIGIN:-http://${VSS_GATEWAY_HOST:-vss.local}:${VSS_GATEWAY_PORT:-7777}}/rtvi-cv' "${REPO_ROOT}/deploy/docker/services/agent/compose.yml"; then
+  echo "PASS: vss-agent compose routes RTVI_CV_ENDPOINT through the gateway"
   ((TESTS_PASSED++)) || true
 else
-  echo "FAIL: vss-agent compose should export RTVI_CV_ENDPOINT for search config"
+  echo "FAIL: vss-agent compose should route RTVI_CV_ENDPOINT through the gateway"
   ((TESTS_FAILED++)) || true
 fi
 

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1915,6 +1915,33 @@ else
   ((TESTS_FAILED++)) || true
 fi
 
+# Render the shared agent service and pin the VST media origin contract used by
+# upload post-processing. A host-only rewrite must never combine the gateway's
+# vss.local alias with VST's direct 30888 port, and the preserved media path
+# must contain exactly one /vst prefix.
+_rendered_vst_internal_url="$(
+  VSS_GATEWAY_HOST=vss.local \
+  VSS_GATEWAY_PORT=7777 \
+  VSS_GATEWAY_ORIGIN=http://vss.local:7777 \
+  VSS_APPS_DIR=/tmp \
+  VSS_DATA_DIR=/tmp \
+  RTVI_EMBED_PORT=8017 \
+    docker compose \
+      --profile vss-agent \
+      -f "${REPO_ROOT}/deploy/docker/services/agent/compose.yml" \
+      config --no-consistency --format json 2>/dev/null \
+    | jq -r '.services["vss-agent"].environment.VST_INTERNAL_URL'
+)"
+if [[ "${_rendered_vst_internal_url}" == "http://vss.local:7777" ]] \
+  && [[ "${_rendered_vst_internal_url}" != *"vss.local:30888"* ]] \
+  && [[ "${_rendered_vst_internal_url}" != *"/vst/vst/"* ]]; then
+  echo "PASS: rendered agent VST media origin uses the gateway without a duplicate prefix"
+  ((TESTS_PASSED++)) || true
+else
+  echo "FAIL: rendered agent VST media origin should be http://vss.local:7777 (got ${_rendered_vst_internal_url})"
+  ((TESTS_FAILED++)) || true
+fi
+
 # Alerts stream registration: VIOS webhooks (not Agent rtvi_cv_base_url).
 _alerts_agent_config="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-alerts/vss-agent/configs/config.yml"
 _alerts_overrides="${REPO_ROOT}/deploy/docker/developer-profiles/dev-profile-alerts/overrides.env"

--- a/services/agent/packages/vss_agents/src/vss_agents/api/video_ingest.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/api/video_ingest.py
@@ -58,7 +58,7 @@ from pydantic import Field
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import VSTError
 from vss_agents.utils.time_measure import TimeMeasure
-from vss_agents.utils.url_translation import rewrite_url_host
+from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
 
 logger = logging.getLogger(__name__)
 
@@ -406,7 +406,7 @@ async def _run_rtvi_embedding(
     parsed_vst = urllib.parse.urlparse(f"http://{vst_url}" if "://" not in vst_url else vst_url)
     if not parsed_vst.hostname:
         raise HTTPException(status_code=500, detail=f"Invalid vst_url format: {vst_url}")
-    translated_video_url = rewrite_url_host(vst_file_path, parsed_vst.hostname)
+    translated_video_url = rewrite_to_internal_vst_url(vst_file_path, vst_url)
     logger.info(f"Using internal VST URL for RTVI: {translated_video_url}")
 
     embed_request = {

--- a/services/agent/packages/vss_agents/tests/unit_test/api/test_video_ingest.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/api/test_video_ingest.py
@@ -37,6 +37,7 @@ from vss_agents.api.video_ingest import _parse_timeout_seconds
 from vss_agents.api.video_ingest import _resolve_timeout_seconds
 from vss_agents.api.video_ingest import _resolve_video_upload_config
 from vss_agents.api.video_ingest import _run_post_upload_processing
+from vss_agents.api.video_ingest import _run_rtvi_embedding
 from vss_agents.api.video_ingest import create_video_upload_complete_router
 from vss_agents.api.video_ingest import create_video_upload_router
 from vss_agents.api.video_ingest import register_video_upload
@@ -246,6 +247,45 @@ class TestVideoUploadCompleteInput:
     def test_custom_params_forwarded(self):
         model = VideoUploadCompleteInput(custom_params={"my_field": 42})
         assert model.custom_params == {"my_field": 42}
+
+
+class TestRunRtviEmbedding:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "vst_url",
+        [
+            "http://vss.local:7777",
+            "http://vss.local:7777/",
+            "http://vss.local:7777/vst",
+        ],
+    )
+    async def test_rewrites_direct_vst_media_url_to_gateway_origin(self, vst_url: str) -> None:
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"usage": {"total_chunks_processed": 3}}
+        response.text = "OK"
+
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.post = AsyncMock(return_value=response)
+
+        with patch("vss_agents.api.video_ingest.httpx.AsyncClient", return_value=client):
+            chunks = await _run_rtvi_embedding(
+                rtvi_embed_base_url="http://vss.local:7777/rtvi-embed",
+                sensor_id="sensor-abc",
+                vst_url=vst_url,
+                vst_file_path=("http://vst-ingress:30888/vst/storage/temp_files/warehouse_sample_video.mp4?token=abc"),
+                rtvi_embed_model="cosmos-embed1-448p",
+                rtvi_embed_chunk_duration=5,
+                start_timestamp="2025-01-01T00:00:00.000Z",
+            )
+
+        assert chunks == 3
+        request = client.post.call_args.kwargs["json"]
+        assert request["url"] == ("http://vss.local:7777/vst/storage/temp_files/warehouse_sample_video.mp4?token=abc")
+        assert "vss.local:30888" not in request["url"]
+        assert "/vst/vst/" not in request["url"]
 
 
 class TestRunPostUploadProcessing:

--- a/services/agent/packages/vss_cli/AGENTS.md
+++ b/services/agent/packages/vss_cli/AGENTS.md
@@ -23,6 +23,27 @@ restate it.
 
 This file covers what is specific to the CLI's own surface.
 
+## The origin is the one you can reach
+
+The CLI runs on the host, so `--base-url` takes the origin **the host** can
+reach: `http://<host>:7777` for a local Compose stack, or the platform's
+`https://…` URL where something in front of the deployment terminates TLS (a
+Brev secure link does; plain HTTP is forwarded inward to HAProxy).
+
+**Never configure `vss.local`.** Services inside the deployment address the same
+HAProxy front door as `http://vss.local:7777` — that is what `VSS_GATEWAY_ORIGIN`
+holds, and it is the right answer for them. It is a container-network alias: it
+does not resolve on the host, so `vss configure --base-url http://vss.local:7777`
+fails every probe with a connection error and reports a deployment that is
+actually fine. One front door and one path contract; two origins, because the
+inside and the outside of the network are not the same place.
+
+`vss configure` probes `/api`, `/vst`, `/elasticsearch`, `/rtvi-embed`,
+`/rtvi-cv`, `/rtvi-vlm`, `/lvs` and `/va-mcp`. `/va-mcp` is recorded but belongs
+to no command group — nothing here calls the MCP server, the agent does — so it
+appears in the per-route block of `vss configure check` and never as a group
+requirement. Check it when the agent's video-analytics tools are missing.
+
 ## The two shapes
 
 **Job groups** — `search`, `summarize`. Work that runs a model and produces

--- a/services/agent/packages/vss_cli/README.md
+++ b/services/agent/packages/vss_cli/README.md
@@ -52,9 +52,34 @@ vss configure show     # what was recorded
 vss configure check    # re-probe; exit 3 if a route disappeared
 ```
 
-`configure` probes the origin's ingress routes (`/api`, `/vst`, `/elasticsearch`,
-`/cosmos-embed`, `/rtvi-cv`, `/rtvi-vlm`) and writes `~/.vss/config.json` (mode
-0600, no credentials). Re-run it after any deployment change.
+`configure` probes the origin's ingress routes — `/api`, `/vst`,
+`/elasticsearch`, `/rtvi-embed`, `/rtvi-cv`, `/rtvi-vlm`, `/lvs`, `/va-mcp` —
+and writes `~/.vss/config.json` (mode 0600, no credentials). Re-run it after any
+deployment change.
+
+`/va-mcp` is recorded but required by no command group: nothing here calls the
+MCP server — the agent is its client. It is probed because it is the one gateway
+mount an operator cannot otherwise check from the host, and it is the first
+thing to check when the agent's video-analytics tools go missing.
+
+### Give it the origin you can reach, not the one containers use
+
+The origin is whatever answers **from this host**. Locally that is
+`http://<host>:7777` (the published HAProxy port); on a platform that fronts the
+deployment with TLS — a Brev secure link, for instance — it is that
+platform's `https://…` URL, because TLS terminates at the platform edge and
+plain HTTP is forwarded inward.
+
+**Never `vss.local`.** Inside the deployment, services address the same HAProxy
+front door as `http://vss.local:7777`, and `VSS_GATEWAY_ORIGIN` is set to
+exactly that. It is a Docker bridge network alias: it does not resolve on the
+host, and configuring the CLI with it produces a `ConnectError` on every route
+and a summary that blames the deployment. Same front door, same paths, two
+origins — one for callers inside the network and one for callers outside it.
+
+```bash
+vss configure --base-url "${VSS_PUBLIC_URL}"    # e.g. http://localhost:7777
+```
 
 ## The surface
 

--- a/services/agent/packages/vss_cli/src/vss_cli/config.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/config.py
@@ -445,5 +445,27 @@ INGRESS_SERVICES.update(
             describe="/lvs/models",
             describes="models",
         ),
+        # The Video Analytics MCP server. Recorded but required by no command
+        # group: nothing in this CLI calls it -- the agent is its client, and
+        # ``search`` reaches Elasticsearch and RT-Embed directly. It is probed
+        # anyway because it is the only gateway mount an operator cannot
+        # otherwise confirm from the host, and "does /va-mcp answer?" is the
+        # first question when the agent's MCP tools are missing. So it shows up
+        # in `configure`'s route list and in `configure check`'s per-route
+        # block, and in no group's requirements, which is the honest answer
+        # rather than attaching it to a group that would then fail for the
+        # wrong reason.
+        #
+        # Probed on /health rather than /mcp: a bare GET on /mcp answers 406
+        # (measured against a live streamable-HTTP server), which is not in
+        # _PRESENT_STATUSES, so probing it would record a routed server as
+        # absent. /health is the same 200 the container healthcheck relies on.
+        # A profile without vss-va-mcp leaves the backend DOWN and the route
+        # answers 503, which is absent -- not present-but-broken.
+        #
+        # No `describe`: listing MCP tools needs an initialized JSON-RPC
+        # session, not a GET, and opening one to write a config file would make
+        # discovery stateful.
+        "va_mcp": ServiceRoute(mount="/va-mcp", probe="/va-mcp/health"),
     }
 )

--- a/services/agent/packages/vss_cli/src/vss_cli/configure.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/configure.py
@@ -15,6 +15,13 @@ only if the origin answers; a route the deployment does not expose is absent
 from the config rather than present-but-broken, so the failure surfaces at
 configure time with a URL attached instead of much later as a connection
 error inside a search.
+
+The origin is the one **this host** can reach. A deployment behind HAProxy is
+addressed from inside its own network as ``http://vss.local:7777`` and from
+outside as the published port or the platform's TLS URL -- one front door and
+one path contract, two origins. ``vss.local`` is a container-network alias, so
+configuring it here fails every probe with a connection error and reads as a
+broken deployment. See the package README.
 """
 
 from __future__ import annotations
@@ -83,7 +90,15 @@ def _describe(base_url: str, route: config_mod.ServiceRoute, timeout: float) -> 
 
 
 @click.group(name="configure", invoke_without_command=True)
-@click.option("--base-url", help="Deployment origin, e.g. http://10.0.0.1:7777")
+@click.option(
+    "--base-url",
+    help=(
+        "Deployment origin as reachable from THIS host, e.g. http://10.0.0.1:7777, "
+        "or the platform's https:// URL where TLS terminates outside the deployment. "
+        "Not the in-network gateway name (vss.local): that is a container-network "
+        "alias and does not resolve here."
+    ),
+)
 @click.option(
     "--timeout",
     type=click.FloatRange(0.1, 120.0),

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_va_mcp.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_va_mcp.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""`/va-mcp` is part of the gateway's path contract, so `configure` probes it.
+
+The Video Analytics MCP server is the one mount an operator cannot check from
+the host any other way -- the agent calls it over the container network -- and
+"is /va-mcp routed?" is the first question when the agent's video-analytics
+tools go missing. It is deliberately required by no command group: nothing in
+this CLI is its client, and attaching it to `search` would make that group
+report unavailable for a service it never calls.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from vss_cli import config as config_mod
+from vss_cli import configure as configure_mod
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_va_mcp_is_mounted_and_probed_on_health() -> None:
+    """A bare GET on /mcp answers 406, which is not a "present" status.
+
+    Measured against a live streamable-HTTP MCP server: probing /mcp would
+    record a routed server as absent. /health is the same 200 the container
+    healthcheck already relies on, so the two agree on what "up" means.
+    """
+    from vss_cli.configure import _PRESENT_STATUSES
+
+    route = config_mod.INGRESS_SERVICES["va_mcp"]
+
+    assert route.mount == "/va-mcp"
+    assert route.probe == "/va-mcp/health"
+    assert 406 not in _PRESENT_STATUSES
+    # Listing MCP tools needs an initialized JSON-RPC session, which discovery
+    # must not open just to write a config file.
+    assert route.describe is None
+
+
+def test_va_mcp_is_recorded_from_the_same_origin(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(config_mod.CONFIG_HOME_ENV, str(tmp_path))
+    monkeypatch.setattr(
+        configure_mod,
+        "_probe",
+        lambda _base, path, _t: (path == "/va-mcp/health", "HTTP 200"),
+    )
+    monkeypatch.setattr(configure_mod, "_describe", lambda *_a, **_k: [])
+
+    result = CliRunner().invoke(configure_mod.configure, ["--base-url", "http://h:7777"])
+    assert result.exit_code == 0, result.output
+
+    recorded = config_mod.load()
+    assert recorded.services.keys() == {"va_mcp"}
+    assert recorded.endpoint("va_mcp") == "http://h:7777/va-mcp"
+
+
+def test_a_profile_without_the_mcp_server_records_no_route(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """HAProxy answers 503 when the backend is down, which is absent.
+
+    Recording it as present would move the failure from `configure`, where the
+    URL is on screen, to the first call that needed it.
+    """
+    monkeypatch.setenv(config_mod.CONFIG_HOME_ENV, str(tmp_path))
+    monkeypatch.setattr(
+        configure_mod,
+        "_probe",
+        lambda _base, path, _t: (path != "/va-mcp/health", "HTTP 200" if path != "/va-mcp/health" else "HTTP 503"),
+    )
+    monkeypatch.setattr(configure_mod, "_describe", lambda *_a, **_k: [])
+
+    result = CliRunner().invoke(configure_mod.configure, ["--base-url", "http://h:7777"])
+    assert result.exit_code == 0, result.output
+    assert "va_mcp" not in config_mod.load().services
+
+
+def test_va_mcp_is_no_group_s_requirement() -> None:
+    """It is recorded for the operator, not consumed by a command.
+
+    A deployment exposing only /va-mcp can serve `configure` and nothing else,
+    and no group's "needs ..." line mentions it.
+    """
+    deployment = config_mod.Deployment(
+        base_url="http://h:7777",
+        services={"va_mcp": config_mod.Service(url="http://h:7777/va-mcp")},
+    )
+
+    rows = {name: (ok, detail) for name, ok, detail in configure_mod._command_availability(deployment)}
+
+    assert rows["configure"][0] is True
+    assert rows["search"][0] is False
+    assert not [detail for _ok, detail in rows.values() if "va_mcp" in detail]
+
+
+def test_configure_check_reports_the_recorded_va_mcp_route(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(config_mod.CONFIG_HOME_ENV, str(tmp_path))
+    config_mod.save(
+        config_mod.Deployment(
+            base_url="http://h:7777",
+            services={"va_mcp": config_mod.Service(url="http://h:7777/va-mcp")},
+            written_at="2026-08-26T00:00:00+00:00",
+        )
+    )
+    probed: list[str] = []
+
+    def fake_probe(_base: str, path: str, _timeout: float) -> tuple[bool, str]:
+        probed.append(path)
+        return True, "HTTP 200"
+
+    monkeypatch.setattr(configure_mod, "_probe", fake_probe)
+
+    result = CliRunner().invoke(configure_mod.check, [])
+    assert result.exit_code == 0, result.output
+    assert probed == ["/va-mcp/health"]
+    assert "va_mcp" in result.output
+    assert "http://h:7777/va-mcp" in result.output

--- a/skills/vss-build-vision-ai/references/services/ingress.md
+++ b/skills/vss-build-vision-ai/references/services/ingress.md
@@ -64,6 +64,13 @@ which is expected and harmless because no read path consumes it. Do not add the
 route to satisfy the probe; that would re-expose RT-VLM's SSE generation endpoints
 through HAProxy.
 
+`/va-mcp` is the same shape: `vss configure` probes it, but no command group
+requires it — the agent is the MCP server's client, not the CLI. Keep the route
+when the build deploys `vss-va-mcp` (the agent reaches it through this origin as
+`${VSS_GATEWAY_ORIGIN}/va-mcp`, so pruning it breaks the agent's video-analytics
+tools even though the CLI is unaffected); drop it, and accept a `va_mcp absent`
+line, when the build has no MCP server.
+
 - **Curated (patch).** Write the trimmed config to `patches/haproxy.cfg`, beside
   the `patches/vss-haproxy-ingress.yml` service-definition patch that overrides the
   config volume, keeping the browse + operate routes above for the build's deployed

--- a/skills/vss-deploy-profile/references/warehouse.md
+++ b/skills/vss-deploy-profile/references/warehouse.md
@@ -179,7 +179,7 @@ RTVI VLM has no equivalent mode setting — it is always deployed locally on `RT
 | `/perception-sdr`, `.../...` | `vss-rtvi-cv-sdr` | **Never** — that container is not deployed by any warehouse list, so this route 503s |
 | `/alert-bridge`, `.../...` | `alert-bridge` (path-stripped) | `BP_PROFILE=bp_wh` only |
 | `/phoenix`, `.../...` | `phoenix` (path-stripped) | `BP_PROFILE=bp_wh` only |
-| `/va-mcp`, `.../...` | `vss-va-mcp` | `BP_PROFILE=bp_wh` only |
+| `/va-mcp`, `.../...` | `vss-va-mcp` (path-stripped) | `BP_PROFILE=bp_wh` only |
 | `/api`, `/api/...` | `vss-agent` | `BP_PROFILE=bp_wh` only |
 | `/api/chat`, `.../...` | `vss-ui` (matched before `/api`) | `BP_PROFILE=bp_wh` only |
 | `/chat`, `/static`, `/websocket` | `vss-agent` | `BP_PROFILE=bp_wh` only |
@@ -202,7 +202,7 @@ RTVI VLM has no equivalent mode setting — it is always deployed locally on `RT
 
 > There is **no VST MCP container** (`vss-vios-mcp` was removed) — nothing listens on `8001`.
 
-`EXTERNAL_IP` defaults to `${HOST_IP}` but should be set to the browser-reachable hostname/IP. On Brev, apply the [Brev secure link overrides](#brev-secure-link-overrides) in Phase 5 — the HAProxy ingress, agent, and UI all need `https`/`wss` on the secure-link domain. HAProxy first denies anything whose `Host` header is not in its `known_host` ACL (`VSS_PUBLIC_HOST[:VSS_PUBLIC_PORT]`, `EXTERNAL_IP`, `HOST_IP`, `localhost`, `127.0.0.1`, each with and without `:HAPROXY_PORT`) with a **404**, then routes matching traffic via the identical `h_main` ACL. A wrong `Host` header therefore looks like "every path 404s".
+`EXTERNAL_IP` defaults to `${HOST_IP}` but should be set to the browser-reachable hostname/IP. On Brev, apply the [Brev secure link overrides](#brev-secure-link-overrides) in Phase 5 — the HAProxy ingress, agent, and UI all need `https`/`wss` on the secure-link domain. HAProxy first denies anything whose `Host` header is not in its `known_host` ACL (`VSS_PUBLIC_HOST[:VSS_PUBLIC_PORT]`, `VSS_GATEWAY_HOST[:VSS_GATEWAY_PORT]`, `EXTERNAL_IP`, `HOST_IP`, `localhost`, `127.0.0.1`, each with and without the matching port) with a **404**, then routes matching traffic via the identical `h_main` ACL. A wrong `Host` header therefore looks like "every path 404s".
 
 ## Compose File Structure
 


### PR DESCRIPTION
## Why

The VSS agent has to be able to run off-host, and today it cannot, because its
endpoint configuration encodes *where* every service runs. `http://vss-va-mcp:9901`
is a Compose DNS nickname: it resolves on the bridge and nowhere else. Any caller
that moves off the host needs a different string, which in practice means
caller-side "if colocated do X else Y" branching in config.

This change replaces those nicknames with one logical origin plus a stable path
contract — HAProxy is the HTTP front door, placement lives in DNS and in HAProxy,
and the caller's URL is the same whether it is colocated or remote. Per the SRD's
FR-03 (single logical origin), FR-11 (stable path contract) and NFR-01 (no
caller-side placement branching).

Colocated single-host Compose keeps working; the gateway is the recommended
default rather than a new requirement. Non-HTTP data planes (Kafka, Redis, RTSP,
raw media) are explicitly untouched.

## The pinned gateway origin, and the bug it prevents

`VSS_GATEWAY_PORT` derived from `VSS_PUBLIC_PORT`, with the scheme taken from
`VSS_PUBLIC_HTTP_PROTOCOL`. That is wrong wherever the platform terminates TLS
outside the stack. On Brev, TLS terminates at the Brev/Cloudflare edge, which
forwards **plain HTTP to HAProxy on 7777** — so `VSS_PUBLIC_*` is `https`/`443`,
and every container would have been handed `https://vss.local:443`: a listener
that does not exist, on a name only the bridge can resolve.

The gateway is now pinned to HAProxy's own listener — `http://vss.local:7777`,
port from `HAPROXY_PORT`, scheme forced to `http` — independently of
`VSS_PUBLIC_*`. `VSS_PUBLIC_*` keeps its real job: browsers, report links, and
`vss configure --base-url` on the host.

## A fixed bug, not a refactor side effect

On the base commit, three variables render **empty**:

- `COSMOS_EMBED_ENDPOINT`
- `ELASTIC_SEARCH_ENDPOINT`
- `LVS_BACKEND_URL`

Empty, not wrong — so `${ORIGIN}/elasticsearch` renders as `/elasticsearch` and
fails much later as a malformed request rather than here as a configuration
error. The inline nested defaults in this PR fix that. Worth calling out
separately because it is a live bug on `develop`, not something this refactor
introduced.

The cause was a typo, **`VSS_GATEWAY_ORIGEN`**, which this PR removes. That is
also the explanation for the empty-variable behaviour seen in the earlier spike
[#1760](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/pull/1760):
a misspelled variable name interpolates to the empty string silently.

## Elasticsearch: three consumers moved, seven left direct

Moved to the gateway origin plus the `/elasticsearch` path: the agent, the
search profile's `ELASTIC_SEARCH_ENDPOINT`, and the LVS caption-retrieval
config.

Seven are deliberately left pointing at `elasticsearch:9200`, and the reason is
measured rather than assumed. `/elasticsearch` is a **narrow** mount: its ACLs
admit the query surface and reject cluster administration and writes. Confirmed
against the live deployment — 200 on `/`, `_cat/indices` and `_search`; **403**
on `_nodes`, `_cluster/health`, `_nodes/_all/_none`, `_snapshot` and
`_security/_authenticate`.

Kibana's startup probe is `GET _nodes/_all/_none`, which is one of those 403s,
so a gateway-routed Kibana never becomes ready. In the live run Kibana reached
healthy with `elasticsearch.hosts: ["http://elasticsearch:9200"]` — direct, not
through the mount — which is the reasoning holding up in practice rather than on
paper.

Widening the ACL was considered and rejected. `/elasticsearch` is reachable from
the ingress, so admitting `_nodes` and `_cluster` would turn it into
unauthenticated cluster administration exposed at the edge — a materially worse
trade than seven consumers keeping a Compose DNS name on a single host. The
remaining consumers are documented in `deploy/docker/README.md` with the reason
each stayed.

## An explicitly accepted deviation from the SRD

The SRD prefers one origin per environment. This deployment cannot have that on
Brev: TLS terminates at Brev's edge and plain HTTP is forwarded inward, so
browsers and the host CLI use the HTTPS secure link while containers use
`http://vss.local:7777`. One front door, one path contract, two origins. See
**OI-02** and **OI-09**.

An opt-in HAProxy TLS listener was scoped — roughly two to four days for an
`ssl crt` frontend, a certificate with a SAN for `vss.local`, and CA trust
distributed to the Python clients — and deferred to its own ticket. It is worth
doing for operators who want end-to-end TLS inside the stack, but it would not
change anything on Brev, where the edge terminates TLS regardless.

## CLI

`vss configure` now probes `/va-mcp` alongside the existing routes and reports it
in `vss configure check`, following the existing `INGRESS_SERVICES` pattern. No
command group *requires* it — it is recorded for operator visibility, since a
missing VA-MCP is worth knowing about before a run rather than during one.

Docs now say plainly that the host cannot resolve `vss.local` (it is a Docker
bridge alias) and that the CLI must be configured with `VSS_PUBLIC_URL`.
Configuring the gateway host fails every probe and makes a healthy deployment
look broken, which is a confusing enough failure to be worth naming.

## Validation

Validated against **real GPU deployments**: full `dev-profile-alerts`
(22 containers) and `dev-profile-lvs` (19 containers) on a remote box.

**The agent works through the gateway.** Its MCP client reported a healthy
`streamable-http` session on `http://vss.local:7777/va-mcp/mcp` with tools
listed. `POST http://vss.local:7777/chat` returned **200 in 35.9 s**, having
planned and invoked an MCP tool over the gateway — so the whole agent → gateway →
VA-MCP path carried a real request, not a probe.

**Tracing lands through the gateway.** Phoenix went from a single `default`
project at `traceCount 0` to a new `DEV-ALERTS-vss-agent-` project at
`traceCount 1`, which is OTLP export through `/phoenix/v1/traces` proven by its
effect rather than by a 200.

**Elasticsearch through the mount:** the ACL results above, measured in
production.

**`vss` CLI against the live deployment** at `http://10.63.177.97:7777`: recorded
6/8 services including `va_mcp routed HTTP 200`, and `vss configure check`
reported `summarize available lvs`, `vios available vst`, `search unavailable
needs rt_embed, rtvi_cv`. Real commands ran against live data — `vios add`,
`vios list`, `vios timeline`, `vios snapshot`, `vios clip` (media URLs minted,
`warmed: true`), and `summarize run` producing genuine VLM output. An empty
listing correctly returned `{"count": 0}` at exit 0, so the "empty result is an
answer" contract holds too.

**Previously unexercised routes now exercised:** `/rtvi-vlm/v1/models` 200 with a
real model, `/rtvi-cv/api/v1/stream/add` 200, `/lvs/v1/live` 200,
`/vst/api/v1/sensor/version` returning `{"type":"vst","version":"1.4.0-26.08.1"}`.

**Still untested, and worth knowing:**

- **`/rtvi-embed`** — 503 in both profiles, because it belongs to
  `dev-profile-search`, which was not one of the two deployed.
- **The `timeout server 3600s` override** — config-verified against the 120 s
  global default, but the longest real summarization was 82 s, so no request
  crossed the line that override exists for.
- **`/behavior-analytics`, `/perception-sdr`, `/video-analytics-api`** — routed
  and rendered, but no real HTTP surface was found to call.
- **Kubernetes and Helm** — verified by rendering only; no cluster was involved.

## Known follow-ups

- **`alert-bridge` still holds Compose DNS names** in its own configuration.
- **Three ES consumers need code changes**, not config: their clients cannot
  express a path prefix at all, so moving them is a source change rather than an
  env edit.
- **The CI `detect-secrets` step is vacuous.** It runs from `services/agent` with
  repo-root-relative paths, so it scans nothing and exits 0. It has presumably
  been passing without inspecting anything for some time; worth its own ticket.

### Investigated and closed, so nobody re-opens it

**`/phoenix` strip versus `PHOENIX_HOST_ROOT_PATH` is correct.** An earlier draft
of this PR listed the pairing as a suspected inconsistency — HAProxy strips the
prefix while Phoenix is told it is mounted under one. That was a false alarm. It
is Phoenix's own documented arrangement and the standard FastAPI `root_path`
idiom: HAProxy strips, Phoenix receives bare paths, and `PHOENIX_HOST_ROOT_PATH`
makes Phoenix *generate* `/phoenix`-prefixed URLs. Upstream pairs Traefik's
`stripPrefix` with the same variable. Measured live: `GET /phoenix` → 200 with
every asset URL prefixed `/phoenix/…`, `/phoenix/v1/traces` → 200,
`/phoenix/healthz` → 200. No change needed.
