### PR TITLE
docs: add Fern staging instance and Stage Fern Docs workflow

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -69,7 +69,7 @@ jobs:
              [ -n "$BEFORE" ] && \
              [ "$BEFORE" != "0000000000000000000000000000000000000000" ] && \
              git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
-            if git diff --name-only "$BEFORE" HEAD | grep -qE '^(docs/|fern/|\.github/workflows/fern-docs-ci\.yml)'; then
+            if git diff --name-only "$BEFORE" HEAD | grep -qE '^(docs/|fern/|\.github/workflows/(fern-docs-ci|stage-fern-docs|publish-fern-docs)\.yml)'; then
               DOCS=true
             else
               DOCS=false
@@ -181,7 +181,7 @@ jobs:
           URL=""
           for i in $(seq 1 "$ATTEMPTS"); do
             echo "::group::fern generate attempt $i/$ATTEMPTS"
-            if fern generate --docs --preview --id "$PREVIEW_ID" 2>&1 | tee /tmp/fern-output.log; then
+            if fern generate --docs --instance nvidia-vss.docs.buildwithfern.com/vss --preview --id "$PREVIEW_ID" 2>&1 | tee /tmp/fern-output.log; then
               URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)
             fi
             echo "::endgroup::"

--- a/.github/workflows/stage-fern-docs.yml
+++ b/.github/workflows/stage-fern-docs.yml
@@ -31,7 +31,9 @@ permissions:
 
 concurrency:
   group: fern-stage
-  cancel-in-progress: true
+  # Do not cancel an in-flight Fern upload. Killing the ledger mid-register
+  # can leave the shared staging site incomplete until a later run succeeds.
+  cancel-in-progress: false
 
 jobs:
   stage:

--- a/.github/workflows/stage-fern-docs.yml
+++ b/.github/workflows/stage-fern-docs.yml
@@ -16,8 +16,12 @@
 # Publishes the current ref to the persistent Fern staging instance:
 #   https://nvidia-vss-staging.docs.buildwithfern.com/vss
 #
-# Manual only (Actions → Stage Fern Docs → Run workflow). Does not update
-# docs.nvidia.com. Production publish remains publish-fern-docs.yml.
+# Triggers:
+#   - workflow_dispatch (Actions → Stage Fern Docs → Run workflow)
+#   - pull_request closed, only when the PR was merged into develop
+#
+# Does not update docs.nvidia.com. Production publish remains
+# publish-fern-docs.yml.
 #
 # Requires the DOCS_FERN_TOKEN repo secret.
 
@@ -25,6 +29,12 @@ name: Stage Fern Docs
 
 on:
   workflow_dispatch: {}
+  pull_request:
+    types: [closed]
+    paths:
+      - 'docs/**'
+      - 'fern/**'
+      - '.github/workflows/stage-fern-docs.yml'
 
 permissions:
   contents: read
@@ -38,12 +48,14 @@ concurrency:
 jobs:
   stage:
     name: Stage
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.github/workflows/stage-fern-docs.yml
+++ b/.github/workflows/stage-fern-docs.yml
@@ -13,41 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Publishes the Fern documentation site to production
-# (nvidia-vss.docs.buildwithfern.com/vss and docs.nvidia.com/vss).
+# Publishes the current ref to the persistent Fern staging instance:
+#   https://nvidia-vss-staging.docs.buildwithfern.com/vss
 #
-# Staging is a separate workflow: stage-fern-docs.yml.
-# After docs.yml lists more than one instance, this job must pass --instance
-# so it cannot publish to nvidia-vss-staging by accident.
-#
-# Runs on a published GitHub Release, or manually. On a release event GitHub
-# already points the checkout at refs/tags/<tag>, so this publishes exactly the
-# tagged content without naming a branch.
-#
-# Docs versioning (a version picker on the site, serving frozen content per
-# release) is deliberately not here. It needs a release tag cut *after* the docs
-# landed, plus a fern/docs.yml restructured around `products:`. Neither exists
-# yet. See the follow-up issue.
+# Manual only (Actions → Stage Fern Docs → Run workflow). Does not update
+# docs.nvidia.com. Production publish remains publish-fern-docs.yml.
 #
 # Requires the DOCS_FERN_TOKEN repo secret.
 
-name: Publish Fern Docs
+name: Stage Fern Docs
 
 on:
-  release:
-    types: [published]
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
 concurrency:
-  group: fern-publish
-  cancel-in-progress: false
+  group: fern-stage
+  cancel-in-progress: true
 
 jobs:
-  publish:
-    name: Publish
+  stage:
+    name: Stage
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -71,29 +59,30 @@ jobs:
           fi
           npm install -g "fern-api@${VERSION}"
 
-      - name: Publish docs
+      - name: Stage docs
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
         run: |
           set -eo pipefail
           ATTEMPTS=3
           URL=""
+          INSTANCE="nvidia-vss-staging.docs.buildwithfern.com/vss"
           for i in $(seq 1 "$ATTEMPTS"); do
             echo "::group::fern generate attempt $i/$ATTEMPTS"
-            if fern generate --docs --instance nvidia-vss.docs.buildwithfern.com/vss 2>&1 | tee /tmp/fern-output.log; then
+            if fern generate --docs --instance "$INSTANCE" --force 2>&1 | tee /tmp/fern-output.log; then
               URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)
             fi
             echo "::endgroup::"
             if [ -n "$URL" ]; then
               break
             fi
-            echo "Publish failed on attempt $i/$ATTEMPTS"
+            echo "Stage failed on attempt $i/$ATTEMPTS"
             if [ "$i" -lt "$ATTEMPTS" ]; then
               sleep $((i * 20))
             fi
           done
           if [ -z "$URL" ]; then
-            echo "::error::Failed to publish docs after ${ATTEMPTS} attempts. See fern output above."
+            echo "::error::Failed to stage docs after ${ATTEMPTS} attempts. See fern output above."
             exit 1
           fi
-          echo "### Published: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Staged: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,32 @@ fern docs dev
 
 Open `http://localhost:3000/vss`.
 
+## Stage
+
+Staging uploads the checked-out tree to a persistent Fern instance. It does not update `docs.nvidia.com`.
+
+Staging URL: https://nvidia-vss-staging.docs.buildwithfern.com/vss
+
+### From the CLI
+
+```bash
+cd fern
+fern login
+fern generate --docs --instance nvidia-vss-staging.docs.buildwithfern.com/vss --force
+```
+
+### From GitHub Actions
+
+1. Open the repository on GitHub.
+2. Click **Actions**.
+3. Select **Stage Fern Docs**.
+4. Click **Run workflow**.
+5. Choose the branch you want to stage.
+6. Click **Run workflow** again.
+7. After the job succeeds, open https://nvidia-vss-staging.docs.buildwithfern.com/vss
+
+Do not run **Publish Fern Docs** to stage. That workflow publishes production.
+
 ## CI
 
-GitHub Actions under `.github/workflows/` run `fern check`, MDX safety, previews, and publish. Preview comments and live publish need the `DOCS_FERN_TOKEN` repository or organization secret.
+GitHub Actions under `.github/workflows/` run `fern check`, MDX safety, PR previews, staging, and production publish. Preview comments, staging, and live publish need the `DOCS_FERN_TOKEN` repository or organization secret.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,8 @@ fern generate --docs --instance nvidia-vss-staging.docs.buildwithfern.com/vss --
 6. Click **Run workflow** again.
 7. After the job succeeds, open https://nvidia-vss-staging.docs.buildwithfern.com/vss
 
+The same workflow also runs when a pull request that touches `docs/` or `fern/` is merged into `develop`. It does not run when a pull request is closed without merging, and it does not publish production.
+
 Do not run **Publish Fern Docs** to stage. That workflow publishes production.
 
 ## CI

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -6,6 +6,7 @@ instances:
   - url: nvidia-vss.docs.buildwithfern.com/vss
     custom-domain: docs.nvidia.com/vss
     multi-source: true
+  - url: nvidia-vss-staging.docs.buildwithfern.com/vss
 
 title: NVIDIA Blueprint for Video Search and Summarization
 


### PR DESCRIPTION
## Summary
- Adds a persistent Fern staging instance at `https://nvidia-vss-staging.docs.buildwithfern.com/vss` (same pattern as NemoClaw staging).
- Adds a manual **Stage Fern Docs** workflow (`workflow_dispatch`) so you can stage from Actions → Run workflow without publishing `docs.nvidia.com`.
- Pins production `fern generate --docs` to `--instance nvidia-vss.docs.buildwithfern.com/vss` now that `docs.yml` lists two sites.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan
- [ ] `fern check` still passes with two instances in `fern/docs.yml`.
- [ ] Actions → **Stage Fern Docs** → Run workflow on this branch; confirm `Published docs to https://nvidia-vss-staging.docs.buildwithfern.com/vss`.
- [ ] Open https://nvidia-vss-staging.docs.buildwithfern.com/vss and confirm the site loads.
- [ ] Confirm **Publish Fern Docs** is unchanged in intent (production only; `--instance` is the production URL).
- [ ] Confirm a PR docs preview still posts (uses the production instance URL with `--preview`).