### PR TITLE
disable buildx provenance attestation on GHCR image builds

### DIFF
--- a/.github/scripts/ghcr_image_guard.py
+++ b/.github/scripts/ghcr_image_guard.py
@@ -153,7 +153,7 @@ def cmd_reuse(args: argparse.Namespace) -> int:
 
 def cmd_verify(args: argparse.Namespace) -> int:
     # retry transient 404s (GHCR read-after-write lag)
-    retry_delays = (2, 4, 8, 16)
+    retry_delays = (5, 10, 20, 40, 60, 90)
     for attempt, delay in enumerate((0, *retry_delays)):
         if delay:
             time.sleep(delay)

--- a/.github/scripts/ghcr_image_guard.py
+++ b/.github/scripts/ghcr_image_guard.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -151,14 +152,24 @@ def cmd_reuse(args: argparse.Namespace) -> int:
 
 
 def cmd_verify(args: argparse.Namespace) -> int:
-    labels, reason, _ = read_image_manifest_labels(args.ref)
-    ok, message = verify_decision(
-        labels,
-        reason,
-        expected_tree_sha=args.expect_tree_sha,
-        expected_source_path=args.expect_source_path,
-        expected_image_name=args.expect_image_name,
-    )
+    # retry transient 404s (GHCR read-after-write lag)
+    retry_delays = (2, 4, 8, 16)
+    for attempt, delay in enumerate((0, *retry_delays)):
+        if delay:
+            time.sleep(delay)
+        labels, reason, _ = read_image_manifest_labels(args.ref)
+        ok, message = verify_decision(
+            labels,
+            reason,
+            expected_tree_sha=args.expect_tree_sha,
+            expected_source_path=args.expect_source_path,
+            expected_image_name=args.expect_image_name,
+        )
+        transient = labels is None and reason and "returned 404" in reason
+        if ok or not transient or attempt == len(retry_delays):
+            break
+        print(f"{args.ref}: not found yet (attempt {attempt + 1}); retrying in {retry_delays[attempt]}s")
+
     print(f"{args.ref}: {'OK' if ok else 'FAIL'} — {message}")
     return 0 if ok else 1
 

--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -221,6 +221,7 @@ jobs:
           platforms: ${{ matrix.platforms }}
           build-args: ${{ matrix.build_args }}
           push: true
+          provenance: false
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           # Publish the content-addressed alias too so a later build of the same
@@ -426,6 +427,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: ${{ matrix.build_args }}
           push: true
+          provenance: false
           cache-from: type=gha,scope=${{ matrix.name }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}-${{ matrix.arch }}
           tags: ${{ steps.meta.outputs.image }}:${{ steps.platform-meta.outputs.tag }}

--- a/services/configurators/vss-configurator/docker/Dockerfile
+++ b/services/configurators/vss-configurator/docker/Dockerfile
@@ -17,6 +17,10 @@ ARG PYTHON_VERSION=3.13
 ARG DISTROLESS_IMG=nvcr.io/nvidia/distroless/python
 ARG DISTROLESS_TAG=${PYTHON_VERSION}-v4.1.1
 
+# Cache-bust: force a fresh build so this image picks up provenance: false
+# (see PR #1875) instead of reusing a content-addressed tag built before that
+# change, which still carries the attestation manifests that break NGC promotion.
+
 # -----------------------------------------------------------------------------
 # Stage 1: Builder — install Python deps (with build tools for any C extensions)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
