### PR TITLE
fix(skill-eval): schedule on catalog GPU counts and survive a refused box

### DIFF
--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -1106,6 +1106,7 @@ def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
     proc: subprocess.Popen | None = None
     pgid: int | None = None
     pending_signal: int | None = None
+    harbor_rc: int | None = None
     cleanup_started = False
     previous_handlers: dict[signal.Signals, object] = {}
 
@@ -1171,6 +1172,11 @@ def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
                         cleanup_started = True
                         return rc
                     cleanup_started = True
+                    # Harbor finished on its own; only its transports linger.
+                    # Remember the real result: if the bounded cleanup below
+                    # reaps them, the trial stands and this is housekeeping,
+                    # not a timeout.
+                    harbor_rc = rc
                     outcome = 124
                     reason = (
                         "Harbor exited while detached transport groups remained: "
@@ -1201,6 +1207,18 @@ def run_command(cmd: list[str], env: dict[str, str], timeout_sec: int) -> int:
                 "preserving primary outcome",
                 flush=True,
             )
+        elif harbor_rc is not None:
+            # Harbor completed and the strays are now gone. Reporting 124
+            # here discards a finished trial -- and because rc == 124 also
+            # writes skip markers, it takes every later step of a multi-step
+            # spec with it. A step that scored 1.0 was recorded as a timeout
+            # and its successors never ran.
+            print(
+                f"[run-leg] detached transports reaped; keeping Harbor's "
+                f"result rc={harbor_rc}",
+                flush=True,
+            )
+            return harbor_rc
         return outcome
     finally:
         for sig, previous in previous_handlers.items():

--- a/.github/skill-eval/run_leg.py
+++ b/.github/skill-eval/run_leg.py
@@ -619,6 +619,77 @@ def _loose_gpu_match(want: str, have: str) -> bool:
     return want_tokens.issubset(have_tokens) or want in have
 
 
+# How many refusals a leg absorbs before reporting the last one. The pool is
+# small and `remaining_candidates()` already ends the loop when every eligible
+# box has refused; this only bounds a fleet that refuses indefinitely.
+_MAX_BOX_REJECTIONS = 4
+
+_CATALOG_GPU_COUNTS: dict[str, int] | None = None
+
+
+def _catalog_gpu_counts() -> dict[str, int]:
+    """`{instance_type: gpu_count}` from `brev search gpu --json`, cached.
+
+    `brev ls --json` carries no gpu_count -- only {name, gpu, instance_type,
+    status} -- which is why fleet naming became the stand-in. The catalog is
+    the same source `envs/brev_env.py` consults before it falls back to a live
+    nvidia-smi count, so filtering on it here rejects an undersized box while
+    it is still a candidate rather than after it has been locked.
+
+    Returns `{}` when the catalog is unavailable. Callers MUST treat an absent
+    SKU as "not disqualifying": a catalog outage that filtered everything out
+    would turn a slow schedule into a hard blocker.
+    """
+    global _CATALOG_GPU_COUNTS
+    if _CATALOG_GPU_COUNTS is not None:
+        return _CATALOG_GPU_COUNTS
+    counts: dict[str, int] = {}
+    try:
+        proc = subprocess.run(
+            ["brev", "search", "gpu", "--json"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if proc.returncode == 0:
+            for row in _parse_brev_json(proc.stdout):
+                sku = row.get("type")
+                try:
+                    count = int(row.get("gpu_count", 0) or 0)
+                except (TypeError, ValueError):
+                    continue
+                if sku:
+                    counts[sku] = count
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        print(f"[run-leg] brev search gpu failed: {exc}", flush=True)
+    if not counts:
+        # Do not cache an outage: this process can live for hours, and a
+        # single transient `brev search` failure would otherwise blind
+        # scheduling for the rest of the leg.
+        print("[run-leg] gpu catalog unavailable; managed box sizes unknown "
+              "this round (brev_env still validates the pick)", flush=True)
+        return {}
+    _CATALOG_GPU_COUNTS = counts
+    return counts
+
+
+def _instance_gpu_count(inst: dict) -> int | None:
+    """Best available gpu_count for a pool box, or None when unknown.
+
+    Registered nodes are named by the operator to the fleet convention, so the
+    name is what there is. Managed instances carry a catalog SKU, which is
+    authoritative; their names are only a convention and can go stale when a
+    box is resized.
+    """
+    if inst.get("_registered"):
+        # Operator-controlled names, and the only signal these nodes carry.
+        return _name_gpu_count_hint(inst.get("name") or "")
+    # Managed: the catalog SKU is authoritative and the name is not -- a
+    # resized box keeps its old name. An unlisted SKU stays unknown rather
+    # than falling back to the name, so a catalog gap can never filter the
+    # fleet down to nothing; brev_env validates the pick, and a refusal is
+    # now recoverable.
+    return _catalog_gpu_counts().get(inst.get("instance_type") or "")
+
+
 def _name_gpu_count_hint(name: str) -> int | None:
     """Fleet-naming gpu_count hint: `*-1g*` → 1, `*-2g*` → 2 (AGENTS.md
     pool convention). None when the name encodes nothing."""
@@ -658,9 +729,13 @@ def pool_candidates(
             continue
         if (inst.get("status") or "").upper() != "RUNNING":
             continue
-        if inst.get("_registered") and required_count > 0:
-            count_hint = _name_gpu_count_hint(name)
-            if count_hint is not None and count_hint < required_count:
+        if required_count > 0:
+            # Applies to managed instances too, not just registered nodes.
+            # Skipping them here is what let a `*-1g-*` box be locked for a
+            # 2-GPU spec and then rejected by brev_env, killing the leg
+            # before it ran a trial. An unknown count never disqualifies.
+            known_count = _instance_gpu_count(inst)
+            if known_count is not None and known_count < required_count:
                 continue
         if required_count > 0 and required_type:
             gpu = (inst.get("gpu") or "").upper()
@@ -687,6 +762,74 @@ def pool_candidates(
         return (0 if registered else 1, exact, name.lower())
 
     return [name for name, _ in sorted(candidates, key=sort_key)]
+
+
+def attempt_lock_timeout(
+    base: int, work_deadline: float | None, reserve: int
+) -> int:
+    """Lock budget for one attempt: `base`, capped by what the leg has left.
+
+    Reads the clock itself rather than taking `now`: `work_deadline` is on the
+    monotonic clock, and a caller that passed `time.time()` instead would
+    silently collapse every attempt to the floor -- the first one too, not
+    just retries. `reserve` keeps room for one complete Harbor invocation.
+    """
+    if work_deadline is None:
+        return base
+    remaining = int(work_deadline - time.monotonic() - reserve)
+    return max(1, min(base, remaining))
+
+
+# brev_env refuses a box it considers unsuitable for the task's hardware.
+# Matched against Harbor's structured `exception_info`, never against log or
+# transcript text: eval agents quote these very sentences while diagnosing a
+# failure, and a transcript match would discard a healthy box and hide the
+# real result behind a retry.
+_BOX_REFUSAL_MARKERS = (
+    "GPU(s) (live nvidia-smi); task requires at least",
+    "does not meet task",
+)
+
+
+def box_rejected_for_capacity(results_root: Path, since: float) -> str | None:
+    """The refusal message if this leg's box was refused, else None.
+
+    Three conditions, all required, so an ordinary failed trial can never be
+    mistaken for a refusal:
+
+    * the finding comes from `result.json`'s `exception_info` -- structured
+      output Harbor writes, not something an agent can print;
+    * the trial recorded no `agent_execution`, i.e. nothing ever ran;
+    * the file was written since `since`, so a refusal from an earlier
+      attempt in the same results tree cannot re-trigger a retry.
+    """
+    import json as _json
+
+    try:
+        paths = [
+            q for q in results_root.rglob("result.json")
+            if q.is_file() and q.stat().st_mtime >= since
+        ]
+    except OSError:
+        return None
+    for q in paths:
+        try:
+            payload = _json.loads(q.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        info = payload.get("exception_info")
+        if not info:
+            continue
+        # A trial that reached the agent is a real result, whatever it says.
+        if payload.get("agent_execution") or payload.get("agent_result"):
+            continue
+        text = info if isinstance(info, str) else _json.dumps(info)
+        for marker in _BOX_REFUSAL_MARKERS:
+            if marker in text:
+                return " ".join(text.split())[:240]
+    return None
 
 
 @contextlib.contextmanager
@@ -1511,32 +1654,86 @@ def main(argv: list[str] | None = None) -> int:
         # phase the log most needed to name reported the wrong thing.
         outer_phase = leg_timing.current_phase()
         leg_timing.set_phase("lock-wait")
+        # A box refused by brev_env is not a failed trial -- nothing ran. Drop
+        # it and take the next candidate instead of reporting the leg dead,
+        # which is what turned one mis-sized box into a red leg. Bounded:
+        # each attempt costs a lock wait, and a fleet that refuses every box
+        # is an operator problem the log should name rather than a loop.
+        rejected: set[str] = set()
+        attempt_timeout = effective_lock_timeout
         try:
-            with hold_pool_lock(
-                candidates_fn, args.lock_dir, effective_lock_timeout
-            ) as instance:
-                lock_acquired = True
-                leg_timing.record_phase(
-                    "lock-wait", lock_wait_started, leg_timing.leg_elapsed()
+            for attempt in range(_MAX_BOX_REJECTIONS + 1):
+                def remaining_candidates() -> list[str]:
+                    return [n for n in candidates_fn() if n not in rejected]
+
+                # Nothing left to try: say so now. Handing an empty list to
+                # hold_pool_lock would burn the whole lock timeout waiting for
+                # a box that has already been ruled out -- and with a pinned
+                # instance, one refusal always lands here.
+                if rejected and not remaining_candidates():
+                    raise LegDeadlineError(
+                        "every eligible box refused this task's hardware "
+                        f"requirement: {', '.join(sorted(rejected))}"
+                    )
+                # Each retry costs another lock wait, so spend only what is
+                # left of the leg rather than the full timeout again.
+                attempt_timeout = attempt_lock_timeout(
+                    effective_lock_timeout, work_deadline, required
                 )
-                # The wait is over the moment the lock is held; the Harbor
-                # phases below set their own labels.
-                leg_timing.set_phase(outer_phase)
-                return run_invocations(
-                    invocations,
-                    instance,
-                    args.results_root,
-                    args.scratch,
-                    args.spec_stem,
-                    args.platform,
-                    args.harbor_timeout_sec,
-                    work_deadline,
-                )
+                with hold_pool_lock(
+                    remaining_candidates, args.lock_dir, attempt_timeout
+                ) as instance:
+                    lock_acquired = True
+                    leg_timing.record_phase(
+                        "lock-wait", lock_wait_started, leg_timing.leg_elapsed()
+                    )
+                    # The wait is over the moment the lock is held; the Harbor
+                    # phases below set their own labels.
+                    leg_timing.set_phase(outer_phase)
+                    dispatch_started = time.time()
+                    rc = run_invocations(
+                        invocations,
+                        instance,
+                        args.results_root,
+                        args.scratch,
+                        args.spec_stem,
+                        args.platform,
+                        args.harbor_timeout_sec,
+                        work_deadline,
+                    )
+                    if rc == 0:
+                        return rc
+                    refusal = box_rejected_for_capacity(
+                        args.results_root, dispatch_started
+                    )
+                    if not refusal:
+                        # A real result. Report it.
+                        return rc
+                    rejected.add(instance)
+                    print(
+                        f"[run-leg] {instance} refused this task and ran no "
+                        f"trial ({refusal})",
+                        flush=True,
+                    )
+                    if attempt == _MAX_BOX_REJECTIONS:
+                        # Out of attempts; the refusal is the honest outcome.
+                        return rc
+                    print(
+                        f"[run-leg] trying another box "
+                        f"({attempt + 1}/{_MAX_BOX_REJECTIONS})", flush=True,
+                    )
+                # Re-enter the lock wait for the next candidate.
+                lock_wait_started = leg_timing.leg_elapsed()
+                lock_acquired = False
+                leg_timing.set_phase("lock-wait")
         except LockTimeoutError:
             leg_timing.record_phase(
                 "lock-wait-timeout", lock_wait_started, leg_timing.leg_elapsed()
             )
-            if effective_lock_timeout < args.lock_timeout_sec:
+            # The budget that actually expired, which a retry may have
+            # shortened -- comparing the original would report a trimmed
+            # retry wait as whole-leg deadline exhaustion.
+            if attempt_timeout < args.lock_timeout_sec:
                 raise LegDeadlineError(
                     "whole-leg deadline expired while reserving room for Harbor"
                 )

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -1000,6 +1000,43 @@ class PoolCandidates(unittest.TestCase):
             ],
         )
 
+    def test_managed_box_filtered_by_catalog_gpu_count(self):
+        """A managed SKU the catalog says is 1-GPU is not offered for 2 GPUs.
+
+        This is the failure that killed IN-3: the box passed the gpu_type
+        check, was locked, and only then did brev_env reject it on live
+        nvidia-smi -- after the leg had committed to it.
+        """
+        orig = run_leg._CATALOG_GPU_COUNTS
+        run_leg._CATALOG_GPU_COUNTS = {"g7e.4xlarge": 1, "g7e.12xlarge": 2}
+        try:
+            names = run_leg.pool_candidates(
+                {"gpu_type": "RTX PRO 6000", "gpu_count": 2})
+            self.assertEqual(names, ["vss-eval-rtx-2g-VM1b", "vss-eval-rtx-2g-2"])
+        finally:
+            run_leg._CATALOG_GPU_COUNTS = orig
+
+    def test_unknown_sku_is_never_disqualifying(self):
+        """A catalog miss must not filter a box out.
+
+        An empty or partial catalog that excluded everything would convert a
+        slow schedule into a hard blocker, which is worse than the bug.
+        """
+        orig = run_leg._CATALOG_GPU_COUNTS
+        run_leg._CATALOG_GPU_COUNTS = {}          # catalog says nothing
+        try:
+            names = run_leg.pool_candidates(
+                {"gpu_type": "RTX PRO 6000", "gpu_count": 2})
+            # Every managed box stays eligible -- brev_env validates the pick,
+            # and a refusal is recoverable. Filtering on a stale name here is
+            # what would starve the leg.
+            self.assertIn("vss-eval-rtx-2g-2", names)
+            self.assertIn("vss-eval-rtx-1g-2", names)
+            # The registered node is still filtered: its name is authoritative.
+            self.assertIn("vss-eval-rtx-2g-VM1b", names)
+        finally:
+            run_leg._CATALOG_GPU_COUNTS = orig
+
     def test_exact_count_hint_sorts_first(self):
         names = run_leg.pool_candidates(
             {"gpu_type": "RTX PRO 6000", "gpu_count": 2})
@@ -1474,5 +1511,91 @@ run_leg.main(sys.argv[2:])
         )
 
 
+class AttemptLockTimeout(unittest.TestCase):
+    """Per-attempt lock budget.
+
+    The helper reads the monotonic clock itself. An earlier revision took
+    `now` from the caller, which passed `time.time()` against a monotonic
+    deadline and floored every attempt to 1s -- including the first.
+    """
+
+    def setUp(self):
+        self._orig = run_leg.time.monotonic
+        run_leg.time.monotonic = lambda: 100.0
+
+    def tearDown(self):
+        run_leg.time.monotonic = self._orig
+
+    def test_no_deadline_uses_the_base_budget(self):
+        self.assertEqual(run_leg.attempt_lock_timeout(900, None, 60), 900)
+
+    def test_capped_by_what_the_leg_has_left(self):
+        # 500s left at now=100, 60s reserved for Harbor -> 440s, not 900.
+        self.assertEqual(run_leg.attempt_lock_timeout(900, 600.0, 60), 440)
+
+    def test_base_wins_when_the_leg_has_room(self):
+        self.assertEqual(run_leg.attempt_lock_timeout(300, 100_000.0, 60), 300)
+
+    def test_floor_when_the_deadline_has_passed(self):
+        self.assertEqual(run_leg.attempt_lock_timeout(900, 50.0, 60), 1)
+
+
+class BoxRejectedForCapacity(unittest.TestCase):
+    """A refused box is not a failed trial -- nothing ran."""
+
+    def _trial(self, payload: dict, age_sec: float = 0.0) -> Path:
+        import tempfile, os, time as _t, json as _json
+        root = Path(tempfile.mkdtemp())
+        f = root / "result.json"
+        f.write_text(_json.dumps(payload), encoding="utf-8")
+        if age_sec:
+            old = _t.time() - age_sec
+            os.utime(f, (old, old))
+        return root
+
+    def test_detects_live_nvidia_smi_refusal(self):
+        root = self._trial({"exception_info": {"message":
+            "Brev instance 'vss-eval-rtx-1g-1' has 1 GPU(s) (live "
+            "nvidia-smi); task requires at least 2."}})
+        self.assertIsNotNone(run_leg.box_rejected_for_capacity(root, 0))
+
+    def test_detects_requirement_mismatch_refusal(self):
+        root = self._trial({"exception_info":
+            "Brev instance 'vss-eval-l40s' does not meet task requirements"})
+        self.assertIsNotNone(run_leg.box_rejected_for_capacity(root, 0))
+
+    def test_ignores_an_ordinary_trial_failure(self):
+        root = self._trial({"exception_info": None,
+                            "verifier_result": {"rewards": {"reward": 0.83}}})
+        self.assertIsNone(run_leg.box_rejected_for_capacity(root, 0))
+
+    def test_agent_quoting_the_error_is_not_a_refusal(self):
+        """The false positive that matters.
+
+        Eval agents diagnose this failure in their own trajectories, quoting
+        the message verbatim. A trial that reached the agent produced a real
+        result and must never be retried as a refused box.
+        """
+        root = self._trial({
+            "exception_info": "Brev instance 'x' does not meet task reqs",
+            "agent_execution": {"started_at": "2026-08-27T00:00:00Z",
+                                "transcript": "the box does not meet task "
+                                              "requirements, so I checked ..."},
+        })
+        self.assertIsNone(run_leg.box_rejected_for_capacity(root, 0))
+
+    def test_ignores_a_refusal_from_an_earlier_attempt(self):
+        import time as _t
+        root = self._trial({"exception_info":
+            "Brev instance 'old' has 1 GPU(s) (live nvidia-smi); task "
+            "requires at least 2."}, age_sec=600)
+        self.assertIsNone(run_leg.box_rejected_for_capacity(root, _t.time() - 60))
+
+    def test_unreadable_results_root_is_not_a_refusal(self):
+        self.assertIsNone(
+            run_leg.box_rejected_for_capacity(Path("/nonexistent-xyz"), 0))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+

--- a/.github/skill-eval/tests/test_run_leg.py
+++ b/.github/skill-eval/tests/test_run_leg.py
@@ -500,6 +500,64 @@ class RunCommand(unittest.TestCase):
         self.assertEqual(rc, 128 + run_leg.signal.SIGTERM)
         cancel_tree.assert_called_once_with(proc, 4321, mock.ANY)
 
+    def test_reaped_strays_do_not_turn_a_finished_trial_into_a_timeout(self):
+        """Harbor finished; only its transports lingered, and cleanup won.
+
+        Returning 124 here discarded a completed trial -- and because rc==124
+        also writes skip markers, it took every later step of a multi-step
+        spec with it. IN-1 scored reward 1.0 on step 1 and still reported
+        `0/1 specs passed`, steps 2-4 `not-run`.
+        """
+        proc = mock.Mock(pid=4321)
+        proc.wait.return_value = 0
+        with (
+            mock.patch.object(run_leg.subprocess, "Popen", return_value=proc),
+            mock.patch.object(
+                run_leg, "_registered_transport_groups", return_value=[999]
+            ),
+            mock.patch.object(
+                run_leg, "_cancel_process_tree", return_value=True
+            ) as cancel_tree,
+        ):
+            rc = run_leg.run_command(self.COMMAND, self.ENV, timeout_sec=42)
+
+        self.assertEqual(rc, 0)
+        cancel_tree.assert_called_once_with(proc, 4321, mock.ANY)
+
+    def test_unreaped_strays_still_report_a_timeout(self):
+        """The case the 124 exists for: descendants may still touch the box."""
+        proc = mock.Mock(pid=4321)
+        proc.wait.return_value = 0
+        with (
+            mock.patch.object(run_leg.subprocess, "Popen", return_value=proc),
+            mock.patch.object(
+                run_leg, "_registered_transport_groups", return_value=[999]
+            ),
+            mock.patch.object(
+                run_leg, "_cancel_process_tree", return_value=False
+            ),
+        ):
+            rc = run_leg.run_command(self.COMMAND, self.ENV, timeout_sec=42)
+
+        self.assertEqual(rc, 124)
+
+    def test_a_real_harbor_failure_is_still_reported(self):
+        """A nonzero Harbor rc survives the stray-transport path unchanged."""
+        proc = mock.Mock(pid=4321)
+        proc.wait.return_value = 3
+        with (
+            mock.patch.object(run_leg.subprocess, "Popen", return_value=proc),
+            mock.patch.object(
+                run_leg, "_registered_transport_groups", return_value=[999]
+            ),
+            mock.patch.object(
+                run_leg, "_cancel_process_tree", return_value=True
+            ),
+        ):
+            rc = run_leg.run_command(self.COMMAND, self.ENV, timeout_sec=42)
+
+        self.assertEqual(rc, 3)
+
     def test_signal_during_post_wait_group_scan_still_cleans_child_tree(self):
         proc = mock.Mock(pid=4321)
         proc.wait.return_value = 0
@@ -711,6 +769,54 @@ class RunInvocations(unittest.TestCase):
 
         self.assertEqual(rc, 124)
         run.assert_called_once()
+
+    def test_passing_step_lets_the_chain_continue(self):
+        """reward 1.0 and rc 0 must run step 2 and write no skip markers.
+
+        This is the downstream half of the stray-transport fix: when a
+        finished trial was reported as 124, this path wrote skip markers and
+        returned, so a step that scored 1.0 took the rest of the spec down
+        with it.
+        """
+        invocations = [
+            run_leg.HarborInvocation(
+                harbor_root=Path("/tmp/datasets/spec"),
+                include_task_name=f"step-{index}",
+                chain_key="spec_rtx",
+                step_index=index,
+                step_count=2,
+            )
+            for index in (1, 2)
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            scratch = root / "scratch"
+            with (
+                mock.patch.dict(run_leg.os.environ, self.ENV, clear=True),
+                mock.patch.object(run_leg, "harbor_env", return_value={}),
+                mock.patch.object(
+                    run_leg, "build_harbor_command", return_value=["harbor"]
+                ),
+                mock.patch.object(run_leg, "run_command", return_value=0) as run,
+                mock.patch.object(run_leg, "latest_reward", return_value="1.0"),
+                mock.patch.object(run_leg, "publish_trace", return_value=None),
+                mock.patch.object(
+                    run_leg, "write_skip_markers"
+                ) as skip_markers,
+            ):
+                rc = run_leg.run_invocations(
+                    invocations,
+                    "vss-eval-box",
+                    root / "results",
+                    scratch,
+                    "spec",
+                    "RTXPRO6000BW",
+                    run_leg.DEFAULT_HARBOR_TIMEOUT_SEC,
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(run.call_count, 2)
+        skip_markers.assert_not_called()
 
     def test_chain_timeout_writes_skip_markers_before_stopping(self):
         invocations = [


### PR DESCRIPTION
## Summary

A leg whose spec needs two GPUs could be locked onto a one-GPU box and then killed by the very check that caught the mistake. Two independent causes, both fixed here.

Seen on #1863: `IN-3` died in 14s on `vss-eval-rtx-1g-1`, and again on the next head; `AT-1` and `IN-1` were lost the same way. **Three independent eval agents diagnosed the gate in their own traces** before exiting, e.g.

> *"the wrapper's bug is that it doesn't filter managed (non-registered) instances by name-hint gpu_count"*
> *"line 661 gates the gpu_count hint filter on `inst.get("_registered")` … They match on gpu_type alone and then fail at `brev_env.py`'s stricter validation."*

#1744 describes the same failure and reports it fixed, so this regressed or never landed.

## What was wrong

**1. Selection did not know how big a managed box is.** `pool_candidates()` applied its `gpu_count` filter only to registered nodes:

```python
if inst.get("_registered") and required_count > 0:   # managed boxes skip this
```

so a managed `vss-eval-rtx-1g-*` matched on `gpu_type` alone and stayed a candidate for a `gpu_count: 2` spec. `brev ls --json` carries no `gpu_count` — which is why fleet naming became the stand-in — but the catalog does, and it is the same source `envs/brev_env.py` consults before falling back to live `nvidia-smi`.

**2. A refusal ended the leg.** `brev_env` raises when a box cannot satisfy the task, but selection and reservation are one atomic step, so the refusal arrived *after* the lock was held. The leg exited with a `RuntimeError` having never run a trial — indistinguishable, in the PR comment, from a skill that failed its checks.

## What this does

- Resolve managed boxes through `brev search gpu --json`, keyed on `instance_type`. Registered nodes keep the name hint: the operator controls those names, and it is the only signal they carry.
- **An unlisted SKU stays unknown, and unknown never disqualifies.** Names are not authoritative for managed boxes — a resized box keeps its old name — and a catalog outage that filtered the fleet to nothing would be a worse failure than the one being fixed. A transient `brev search` failure is not cached, so it blinds one round rather than the whole leg.
- Treat a refusal as what it is: this box is unusable, the task untouched. Drop it, take the next candidate, and stop when the pool is exhausted rather than waiting out a lock timeout for a box already ruled out. Each retry spends only what is left of the leg deadline.
- Recognise the refusal from Harbor's structured `exception_info` on a trial that recorded no `agent_execution`/`agent_result` — **never** from log or transcript text. Eval agents quote these very sentences while diagnosing the failure, so matching prose would discard a healthy box and hide a real result behind a retry.

## Review

Reviewed by the OpenAI Codex CLI across three rounds, told up front the diff was AI-generated. It rejected the first two revisions and its findings are why this one looks the way it does:

| Round | Finding | Outcome |
|---|---|---|
| 1 | Promoting the regex name hint to a hard fleet-wide gate contradicts the documented design (`brev_env` validates the pick; #929 made scheduling permissive) | Rewritten to use the catalog |
| 1 | Detector scanning prose would false-positive on agent transcripts | Rewritten to structured `exception_info` |
| 2 | **`work_deadline` is monotonic but the retry used `time.time()`** — collapsing every attempt, including the first, to a 1s floor | Fixed; the helper now reads the clock itself so a caller cannot pass the wrong one |
| 2 | Unreachable terminal raise; pinned-instance refusal waited out the full timeout; `LockTimeoutError` handler judged the wrong budget | All fixed |
| 2 | `agent_execution` falsiness admits `{}`/`[]` | Now also checks `agent_result` |

## Testing

`.github/skill-eval/tests/test_run_leg.py` — **69 pass**. New coverage: catalog-filtered managed box; unknown SKU kept; registered node still name-filtered; the four refusal-detector cases including *an agent quoting the error is not a refusal*; stale-refusal window; and the per-attempt budget including the monotonic-clock contract.

**Pre-existing and unrelated:** three `test_4090_*` failures assert `_rtx4090_supports` for `vss-deploy-profile`. They fail identically on a clean `develop` checkout — verified — and are untouched here.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] Pre-commit hooks run locally.
- [x] Every commit is DCO sign-off'd.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
