### PR TITLE
Add selectable RT-CV service

### DIFF
--- a/deploy/docker/services/rtvi/compose.yml
+++ b/deploy/docker/services/rtvi/compose.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 include:
+  - path: rtvi-cv/rtvi-cv.yaml
   - path: rtvi-embed/rtvi-embed-docker-compose.yml
   - path: rtvi-vlm/rtvi-vlm-docker-compose.yml
 

--- a/deploy/docker/services/rtvi/rtvi-cv/ds-start.sh
+++ b/deploy/docker/services/rtvi/rtvi-cv/ds-start.sh
@@ -30,6 +30,7 @@ DS_VISION_ENCODER="${DS_VISION_ENCODER:-false}"
 DS_APP_DIR="${DS_APP_DIR:-/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app}"
 DS_CONFIG_DIR="${DS_APP_DIR}/configs"
 DS_MOUNTED_CONFIGS_DIR="${DS_APP_DIR}/mounted-configs"
+DS_REFERENCE_CONFIGS_DIR="${DS_REFERENCE_CONFIGS_DIR:-${DS_APP_DIR}/reference-configs}"
 
 # Prepend core DeepStream plugin dirs so GStreamer can find nvvideoconvert and
 # other elements required by metropolis_perception_app (e.g. alerts rtdetr-gdino).
@@ -285,6 +286,28 @@ exec_as_runtime_user() {
     exit 1
 }
 
+# The pgie config is only sanity-checked and echoed; the app resolves the real
+# path from [primary-gie] inside ds-main-config.txt. Blueprint config sets name it
+# ds-pgie-config.yml while the in-image reference sets name it
+# ds-ppl-analytics-pgie-config.yml, so accept either rather than asserting one
+# blueprint's filename. Falls back to the canonical name so a genuinely missing
+# config still reports the path operators expect.
+resolve_pgie_config() {
+    local matches=()
+    if [[ -f "${DS_CONFIG_DIR}/ds-pgie-config.yml" ]]; then
+        echo "${DS_CONFIG_DIR}/ds-pgie-config.yml"
+        return 0
+    fi
+    shopt -s nullglob
+    matches=("${DS_CONFIG_DIR}"/*pgie-config.yml)
+    shopt -u nullglob
+    if ((${#matches[@]} > 0)); then
+        echo "${matches[0]}"
+        return 0
+    fi
+    echo "${DS_CONFIG_DIR}/ds-pgie-config.yml"
+}
+
 resolve_config_file() {
     local default_file="$1"
     local configured_file="${DS_CONFIG_FILE:-$default_file}"
@@ -295,22 +318,111 @@ resolve_config_file() {
     fi
 }
 
-stage_mounted_configs_if_present() {
-    local has_files=false
-    if [[ -d "$DS_MOUNTED_CONFIGS_DIR" ]]; then
-        shopt -s nullglob dotglob
-        local mounted_entries=("$DS_MOUNTED_CONFIGS_DIR"/*)
-        shopt -u nullglob dotglob
-        if ((${#mounted_entries[@]} > 0)); then
-            has_files=true
-        fi
-    fi
+dir_has_entries() {
+    local dir="$1"
+    local entries=()
+    [[ -d "$dir" ]] || return 1
+    shopt -s nullglob dotglob
+    entries=("$dir"/*)
+    shopt -u nullglob dotglob
+    ((${#entries[@]} > 0))
+}
 
-    if [[ "$has_files" == "true" ]]; then
+stage_mounted_configs_if_present() {
+    if dir_has_entries "$DS_MOUNTED_CONFIGS_DIR"; then
         mkdir -p "$DS_CONFIG_DIR"
         cp -rL --no-preserve=all "${DS_MOUNTED_CONFIGS_DIR}/." "${DS_CONFIG_DIR}/"
         echo "##### Staged profile configs from ${DS_MOUNTED_CONFIGS_DIR} -> ${DS_CONFIG_DIR} #####"
     fi
+}
+
+# Map the requested model family onto a directory under reference-configs/.
+# RTVI_CV_REFERENCE_CONFIG_SET overrides the mapping for a set that has no
+# family of its own. Echoes nothing when the family has no reference set.
+resolve_reference_config_set() {
+    if [[ -n "${RTVI_CV_REFERENCE_CONFIG_SET:-}" ]]; then
+        echo "${RTVI_CV_REFERENCE_CONFIG_SET}"
+        return 0
+    fi
+    case "$DS_MODEL_FAMILY" in
+        rtdetr-warehouse)   echo "warehouse-2d" ;;
+        sparse4d-warehouse) echo "warehouse-3d" ;;
+        # Mirrors the MODEL_NAME_2D branch in start_rtdetr_gdino.
+        rtdetr-gdino)
+            if [[ "${MODEL_NAME_2D:-}" == "GDINO" ]]; then
+                echo "smartcities/gdino"
+            else
+                echo "smartcities/rt-detr"
+            fi
+            ;;
+        *) echo "" ;;
+    esac
+}
+
+# The shipped reference configs carry <TOKEN> placeholders for deployment paths
+# (model ONNX, engine, labels, anchors). Fill each from RTVI_CV_REF_<TOKEN>, then
+# refuse to start if any remain: an unsubstituted path fails much later inside
+# nvinfer with an error that does not name the config.
+#
+# Only tokens on active lines are required. Reference sets carry commented-out
+# examples (warehouse-2d ships `# model-engine-file: <PATH_TO_ENGINE_FILE>`), and
+# demanding a value for a line DeepStream never reads is pure friction. Detection
+# skips comments; substitution still rewrites them, so a commented example picks
+# up the real path when one is supplied.
+substitute_reference_placeholders() {
+    local -a unresolved=()
+    local token var value
+    : "${RTVI_CV_REF_N:=${NUM_SENSORS:-${NUM_STREAMS:-4}}}"
+
+    while IFS= read -r token; do
+        [[ -n "$token" ]] || continue
+        var="RTVI_CV_REF_${token//[<>]/}"
+        value="${!var:-}"
+        if [[ -z "$value" ]]; then
+            unresolved+=("${token} (set ${var})")
+            continue
+        fi
+        grep -rlZF "$token" "$DS_CONFIG_DIR" 2>/dev/null |
+            xargs -0 -r sed -i "s|${token}|${value//|/\\|}|g"
+    done < <(grep -rhvE '^[[:space:]]*#' "$DS_CONFIG_DIR" 2>/dev/null \
+        | grep -oE '<[A-Z0-9_]+>' | sort -u)
+
+    if ((${#unresolved[@]} > 0)); then
+        echo "ERROR: reference configs seeded from ${DS_REFERENCE_CONFIGS_DIR} still contain placeholders:" >&2
+        printf '  %s\n' "${unresolved[@]}" >&2
+        echo "Hint: set the listed variables, or mount a complete config set via" >&2
+        echo "      mounted-configs/ (RTVI_CV_MOUNTED_CONFIG_DIR) instead." >&2
+        exit 1
+    fi
+}
+
+# Last-resort default so the module is usable without a blueprint's config tree.
+# Deliberately skipped whenever either config source already has files: a
+# deployment that mounts configs owns its configuration, and seeding underneath
+# it would introduce files it never asked for. Every current profile mounts one
+# of the two, so this is inert for them.
+seed_reference_configs_if_empty() {
+    local mode="${RTVI_CV_REFERENCE_CONFIGS:-auto}"
+    [[ "$mode" == "never" ]] && return 0
+
+    if dir_has_entries "$DS_CONFIG_DIR" || dir_has_entries "$DS_MOUNTED_CONFIGS_DIR"; then
+        return 0
+    fi
+
+    local set_name
+    set_name="$(resolve_reference_config_set)"
+    if [[ -z "$set_name" ]] || ! dir_has_entries "${DS_REFERENCE_CONFIGS_DIR}/${set_name}"; then
+        if [[ "$mode" == "require" ]]; then
+            echo "ERROR: no reference config set for DS_MODEL_FAMILY=${DS_MODEL_FAMILY} under ${DS_REFERENCE_CONFIGS_DIR}" >&2
+            exit 1
+        fi
+        return 0
+    fi
+
+    mkdir -p "$DS_CONFIG_DIR"
+    cp -rL --no-preserve=all "${DS_REFERENCE_CONFIGS_DIR}/${set_name}/." "${DS_CONFIG_DIR}/"
+    echo "##### Seeded reference configs from ${DS_REFERENCE_CONFIGS_DIR}/${set_name} -> ${DS_CONFIG_DIR} #####"
+    substitute_reference_placeholders
 }
 
 patch_vision_encoder_configs_if_enabled() {
@@ -346,8 +458,10 @@ patch_vision_encoder_configs_if_enabled() {
 start_rtdetr_warehouse()
 {
     echo "##### RT-DETR Warehouse models will be used. #####"
-    require_file "${DS_CONFIG_DIR}/ds-pgie-config.yml" "Verify model/config mounts for RT-DETR warehouse."
-    cat "${DS_CONFIG_DIR}/ds-pgie-config.yml"
+    local pgie_config
+    pgie_config="$(resolve_pgie_config)"
+    require_file "$pgie_config" "Verify model/config mounts for RT-DETR warehouse."
+    cat "$pgie_config"
 
     local config_file
     config_file="$(resolve_config_file "ds-main-config.txt")"
@@ -562,6 +676,7 @@ echo "DS_MODEL_FAMILY=$DS_MODEL_FAMILY  STREAM_TYPE=$STREAM_TYPE  DS_MODE_FLAG=$
 echo "DS_VISION_ENCODER=$DS_VISION_ENCODER"
 
 ensure_models_from_manifest
+seed_reference_configs_if_empty
 stage_mounted_configs_if_present
 patch_vision_encoder_configs_if_enabled
 

--- a/deploy/docker/services/rtvi/rtvi-cv/rtvi-cv.yaml
+++ b/deploy/docker/services/rtvi/rtvi-cv/rtvi-cv.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Profile-neutral RT-CV service, selectable as COMPOSE_PROFILES=...,rtvi-cv.
+#
+# This is the concrete sibling of the `perception` template in compose.yaml,
+# and it is the only RT-CV unit that joins the compose project by module name.
+# It exists so a blueprint being composed from the catalog can pick RT-CV
+# directly instead of borrowing another blueprint's clone (`perception-2d`,
+# `perception-3d`, `perception-alerts`, `perception-2d-fusion`).
+#
+# It is additive: the template in compose.yaml is unchanged and the four
+# existing clone tokens keep working exactly as before.
+#
+# `vss-rtvi-cv-mv3dt` is deliberately not covered here. It extends a different
+# base (rtvi-cv-mv3dt/compose.yaml), runs a different entrypoint
+# (ds-start-mv3dt.sh) and needs a measurement-fusion companion, so it stays a
+# structural variant rather than a configuration of this service.
+#
+# ---------------------------------------------------------------------------
+# Configuring it
+# ---------------------------------------------------------------------------
+# Every knob below is optional. The rt-cv image ships no `configs/` directory,
+# only `reference-configs/`, so with no config mount ds-start.sh seeds `configs/`
+# from the `reference-configs/<set>` matching DS_MODEL_FAMILY and this service is
+# usable without a blueprint's config tree. Those reference files carry
+# <PATH_TO_*>-style placeholders: supply each one as RTVI_CV_REF_<TOKEN> (for
+# example RTVI_CV_REF_PATH_TO_ONNX_MODEL) and ds-start.sh stops and lists any
+# that are still missing rather than failing later inside nvinfer.
+#
+# Seeding is skipped whenever either config mount below supplies files, so a
+# deployment that brings its own config tree is never seeded underneath.
+#
+# Mounts — set only the ones the deployment needs:
+#   RTVI_CV_MODELS_DIR            host model tree            -> /opt/storage/
+#   RTVI_CV_MODELS_MANIFEST       models-download.json       -> /opt/config/... (ro)
+#   RTVI_CV_MOUNTED_CONFIG_DIR    configs staged by ds-start -> mounted-configs/ (ro)
+#   RTVI_CV_DIRECT_CONFIG_DIR     configs read in place (rw) -> configs/
+#   RTVI_CV_ENGINES_DIR           TensorRT engine cache      -> /opt/engines/
+#   RTVI_CV_EXTRA_MOUNT_1..3      free-form "src:dst[:opts]" entries
+#
+# Reference-config seeding (ds-start.sh, only when neither config dir is set):
+#   RTVI_CV_REF_<TOKEN>           value for a <TOKEN> placeholder in the set
+#   RTVI_CV_REFERENCE_CONFIG_SET  override the DS_MODEL_FAMILY -> set mapping
+#   RTVI_CV_REFERENCE_CONFIGS     auto (default) | never | require
+#
+# Pick MOUNTED_CONFIG_DIR when the configs are static and may be copied once at
+# startup. Pick DIRECT_CONFIG_DIR when a configurator rewrites them while the
+# service runs and the changes must be visible in place — that is why the
+# warehouse 2D/3D clones bind straight onto configs/ rather than staging.
+#
+# Environment:
+#   Keys the template already declares (DS_MODEL_FAMILY, DS_MODE_FLAG,
+#   DS_CONFIG_FILE, DS_TRACKER_REID, STREAM_TYPE, HARDWARE_PROFILE, ...) are
+#   plain `${VAR:-default}` lookups, so set them in the deployment's .env /
+#   overrides.env like any other value.
+#
+#   RTVI_CV_ENV_FILE points at an extra env file for keys the template does NOT
+#   declare — SPARSE4D_*, VISION_ENCODER_*, NUM_SENSORS, MODEL_NAME_2D,
+#   GST_PLUGIN_PATH, and so on. NOTE: Compose gives `environment:` precedence
+#   over `env_file:`, so this file cannot override a key the template already
+#   lists; use the .env layer for those.
+#
+# Dependencies are declared `required: false`, so the service can be selected on
+# its own. When a broker is part of the same deployment it is still waited on.
+
+services:
+  rtvi-cv:
+    extends:
+      file: compose.yaml
+      service: perception
+    profiles: ["rtvi-cv"]
+
+    env_file:
+      - path: ${RTVI_CV_ENV_FILE:-/dev/null}
+        required: false
+
+    # Each entry collapses to a shared anonymous /dummy volume when its variable
+    # is unset; Compose de-duplicates those, so unused slots cost nothing.
+    volumes:
+      - ${RTVI_CV_MODELS_DIR:-/dummy}${RTVI_CV_MODELS_DIR:+:/opt/storage/}
+      - ${RTVI_CV_MODELS_MANIFEST:-/dummy}${RTVI_CV_MODELS_MANIFEST:+:/opt/config/models-download.json:ro}
+      - ${RTVI_CV_MOUNTED_CONFIG_DIR:-/dummy}${RTVI_CV_MOUNTED_CONFIG_DIR:+:/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/mounted-configs/:ro}
+      - ${RTVI_CV_DIRECT_CONFIG_DIR:-/dummy}${RTVI_CV_DIRECT_CONFIG_DIR:+:/opt/nvidia/deepstream/deepstream/sources/apps/sample_apps/metropolis_perception_app/configs/}
+      - ${RTVI_CV_ENGINES_DIR:-/dummy}${RTVI_CV_ENGINES_DIR:+:/opt/engines/}
+      - ${RTVI_CV_EXTRA_MOUNT_1:-/dummy}
+      - ${RTVI_CV_EXTRA_MOUNT_2:-/dummy}
+      - ${RTVI_CV_EXTRA_MOUNT_3:-/dummy}
+
+    # Only module-level infra is referenced here. Per-blueprint units
+    # (sensor-ms-*, sdr-controller, bp-configurator-*) are deliberately absent:
+    # depending on them is what makes the existing clones un-selectable alone.
+    depends_on:
+      broker-health-check:
+        condition: service_completed_successfully
+        required: false
+      kafka-topic-init-container:
+        condition: service_completed_successfully
+        required: false

--- a/skills/vss-build-vision-ai/references/services/rt-cv.md
+++ b/skills/vss-build-vision-ai/references/services/rt-cv.md
@@ -4,20 +4,43 @@
 
 | Capability | Canonical service profile keys | Foundation | Model family |
 |---|---|---|---|
+| Detection and tracking (module) | `rtvi-cv` | none — Foundation-independent | chosen via `DS_MODEL_FAMILY` |
 | Alerts perception | `perception-alerts` | `alerts` | GDINO |
 | Search detection and tracking | `perception-2d-fusion` | `search` | RT-DETR |
 
-Select the Foundation that ships the requested model family. RT-DETR and
-GDINO are not interchangeable — each requires its own configs, mounts, and
-class-label taxonomy. The detector model family and its emitted class-label
-taxonomy are authoritatively defined in
+`rtvi-cv` is the profile-neutral module. It is a real `COMPOSE_PROFILES` key that
+joins the graph on its own, so a build can request detection without adopting the
+`alerts` or `search` Foundation and without inheriting that Foundation's model
+family.
+
+Which one to use follows the minimize-additions rule in `../composition.md`:
+
+- Deriving from a Foundation that already ships RT-CV in the requested model
+  family — keep that Foundation's clone. It is the smaller delta.
+- Composing from modules, or the requested family is not the one the Foundation
+  ships — use `rtvi-cv` and set `DS_MODEL_FAMILY`.
+
+RT-DETR and GDINO are not interchangeable — each requires its own configs,
+mounts, and class-label taxonomy. With `rtvi-cv` the family is selected rather
+than inherited, but the taxonomy consequence is the same. The detector model
+family and its emitted class-label taxonomy are authoritatively defined in
 `skills/vss-deploy-detection-tracking-2d/references/integrate-vss-detection-tracking-2d.md`;
 the mapping above is the composition surface, not a second source of truth.
 
 ## Required peers
 
-- Use the service key defined by the selected developer profile; the shared
-  `perception` service is an `extends` source, not a profile key.
+- When deriving from a Foundation, use the service key that Foundation defines
+  (`perception-alerts`, `perception-2d-fusion`). When composing from modules, use
+  `rtvi-cv`. The shared `perception` service in `compose.yaml` remains an
+  `extends` template that never joins the project, and is still not a profile key.
+- `rtvi-cv` declares every `depends_on` as `required: false`, so it can be
+  selected on its own and pulls nothing in implicitly — its peers must be listed
+  explicitly, including the Kafka set below.
+- `rtvi-cv` needs no blueprint config tree. With neither config mount set,
+  ds-start seeds `configs/` from the in-image `reference-configs/<set>` matching
+  `DS_MODEL_FAMILY`. Those files carry `<TOKEN>` placeholders for deployment
+  model paths: supply each as `RTVI_CV_REF_<TOKEN>` or startup stops and lists
+  the ones still missing.
 - Kafka-backed pipelines require `kafka`, `kafka-topic-init-container`, and
   `broker-health-check`.
 - Search RT-CV requires checked-in model/config mounts; model download is
@@ -33,8 +56,9 @@ the mapping above is the composition surface, not a second source of truth.
   RT-CV container at first boot (ds-start phase 0 when `DS_MODEL_DOWNLOAD=auto`)
   from its mounted `models-download.json` into `${VSS_DATA_DIR}/models/`; no
   host-side staging is required. This changes **no service definition**, so it
-  needs no `patches/` entry: do not patch `perception-2d-fusion` for a model or
-  detector swap.
+  needs no `patches/` entry: do not patch `perception-2d-fusion` or `rtvi-cv` for
+  a model or detector swap. Selecting and configuring `rtvi-cv` is likewise an env
+  delta only — its mounts are interpolated knobs, so it never requires a patch.
 
 ## Configuration knobs
 
@@ -47,6 +71,12 @@ the mapping above is the composition surface, not a second source of truth.
 | `NUM_SENSORS`, `STREAM_TYPE`, `DS_MESSAGE_RATE` | Configure input count and event transport. |
 | `DS_TRACKER_REID`, `DS_SHOW_SENSOR_ID` | Toggle supported tracking metadata. |
 | `HARDWARE_PROFILE`, `PERCEPTION_DOCKERFILE_PREFIX` | Select hardware-specific behavior exposed by the Foundation. |
+| `RTVI_CV_MOUNTED_CONFIG_DIR`, `RTVI_CV_DIRECT_CONFIG_DIR` | (`rtvi-cv` only) Supply a config tree. `MOUNTED_` is staged into `configs/` once at startup; `DIRECT_` binds onto `configs/` in place, for configs a configurator rewrites while the service runs. Setting either disables reference-config seeding. |
+| `RTVI_CV_MODELS_DIR`, `RTVI_CV_MODELS_MANIFEST` | (`rtvi-cv` only) Host model tree mounted at `/opt/storage/`, and the `models-download.json` that ds-start phase 0 reads. |
+| `RTVI_CV_REF_<TOKEN>` | (`rtvi-cv` only) Value for a `<TOKEN>` placeholder in a seeded reference config, e.g. `RTVI_CV_REF_PATH_TO_ONNX_MODEL`. Tokens appearing only on commented-out lines are ignored. |
+| `RTVI_CV_ENV_FILE` | (`rtvi-cv` only) Extra env file for keys the service definition does not declare (`SPARSE4D_*`, `VISION_ENCODER_*`, `NUM_SENSORS`, `MODEL_NAME_2D`, `GST_PLUGIN_PATH`). Compose gives `environment:` precedence over `env_file:`, so it cannot override a key the definition already lists. |
+| `RTVI_CV_REFERENCE_CONFIG_SET`, `RTVI_CV_REFERENCE_CONFIGS` | (`rtvi-cv` only) Override the `DS_MODEL_FAMILY` -> reference-set mapping, and control seeding: `auto` (default), `never`, or `require` (fail when no set matches). |
+| `RTVI_CV_ENGINES_DIR`, `RTVI_CV_EXTRA_MOUNT_1..3` | (`rtvi-cv` only) TensorRT engine cache at `/opt/engines/`, and free-form `src:dst[:opts]` mounts for anything else a build needs. |
 
 Downstream consumers that filter on class labels (Behavior Analytics, for
 instance) key on this detector's emitted taxonomy. In a combined build that
@@ -62,6 +92,7 @@ fits. See `../sizing.md` for placement resolution and starting stream counts.
 
 ## Sources
 
+- `deploy/docker/services/rtvi/rtvi-cv/rtvi-cv.yaml`
 - `deploy/docker/services/rtvi/rtvi-cv/compose.yaml`
 - `deploy/docker/developer-profiles/dev-profile-alerts/compose.yml`
 - `deploy/docker/developer-profiles/dev-profile-search/video-analytics-2d-app/compose.yml`


### PR DESCRIPTION
* Add a profile-neutral rtvi-cv service for newly composed profiles.
* Preserve all existing profile-specific RT-CV services and tokens.
* Drive mounts and extra environment through optional interpolated knobs so activation stays an env delta rather than a Compose-definition patch.
* Keep dependencies optional so the module can be selected on its own.

The perception template in compose.yaml stays template-only and out of the include graph, so the five existing extends sites are untouched: warehouse 2D/3D/MV3DT and dev-profile-alerts/search all render byte-identically.

vss-rtvi-cv-mv3dt is deliberately out of scope. It extends a different base, runs ds-start-mv3dt.sh and needs a measurement-fusion companion, so it stays a structural variant rather than a configuration of this service.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
