### PR TITLE
docs(helm): use advertised remote VLM model

### DIFF
--- a/deploy/helm/developer-profiles/dev-profile-base/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-base/README.md
@@ -62,6 +62,7 @@ With default **`values.yaml`** and typical overrides (LLM NIM + RT-VLM + **`vss-
 
 - **Helm** 3.x
 - **Kubectl**
+- **Curl** and **jq** (to discover model IDs from remote endpoints)
 - **GPUs**: see [GPU requirements](#gpu-requirements) (3 with defaults).
 - **NVIDIA NIM** (if using NIM subcharts): NIM Operator on the cluster (see [Prerequisites](#prerequisites) above).
 - **NGC**: API key for NIM, image pull / chart secret creation (see below).
@@ -218,6 +219,10 @@ helm upgrade --install vss-base ./dev-profile-base \
 export LLM_BASE_URL='<REMOTE LLM SERVICE ROOT, no trailing /v1>'
 export VLM_BASE_URL='<REMOTE VLM SERVICE ROOT, no trailing /v1>'
 
+# Query the remote VLM and select the exact model ID it advertises.
+curl -fsS "$VLM_BASE_URL/v1/models" | jq -r '.data[].id'
+export VLM_MODEL_NAME='<MODEL ID returned by the command above>'
+
 helm upgrade --install vss-base ./dev-profile-base \
   -f dev-profile-base/values-base.yaml \
   -n vss-base --create-namespace \
@@ -228,7 +233,7 @@ helm upgrade --install vss-base ./dev-profile-base \
   --set-string global.llmBaseUrl="$LLM_BASE_URL" \
   --set-string global.vlmBaseUrl="$VLM_BASE_URL" \
   --set-string global.llmName="nvidia/nvidia-nemotron-nano-9b-v2" \
-  --set-string global.vlmName="nim_nvidia_cosmos3-nano-reasoner_bf16-final" \
+  --set-string global.vlmName="$VLM_MODEL_NAME" \
   --set rtvi.vss-rtvi-vlm.useSharedNim=true
 ```
 


### PR DESCRIPTION
## Summary
- update the Base Helm remote LLM/VLM example to query the remote VLM's `/v1/models` endpoint
- require the user to select the exact advertised model ID and pass it through `global.vlmName`
- document `curl` and `jq` as prerequisites for remote model discovery

## Problem
The generic remote VLM example hardcoded `nim_nvidia_cosmos3-nano-reasoner_bf16-final`, which is the integrated RT-VLM checkpoint name. Remote endpoints can advertise a different model ID, such as `nvidia/cosmos3-nano-reasoner`. RT-VLM forwards `global.vlmName` as `VIA_VLM_OPENAI_MODEL_DEPLOYMENT_NAME`, so following the example could send every request with a nonexistent model and return HTTP 404 even while all pods were Ready.

## Root cause
The integrated checkpoint identifier introduced during the Base RT-VLM migration was reused in the generic remote-endpoint command. The documentation did not instruct users to discover and supply the model ID exposed by their selected service.

## Fix
The example now:
1. queries `$VLM_BASE_URL/v1/models`
2. has the user select the returned model ID as `VLM_MODEL_NAME`
3. passes `$VLM_MODEL_NAME` to `global.vlmName`

## Validation
- reproduced the documentation failure with a check that required endpoint model discovery and variable-based Helm wiring
- reran the check after the change and confirmed the integrated checkpoint is no longer hardcoded in the remote example
- ran `git diff --check`
- confirmed no IDE lint diagnostics for the modified README

## Scope
Documentation-only change. Chart templates and runtime behavior are unchanged; they already forward `global.vlmName` correctly.

## Rollout / rollback
No deployment rollout is required. Merge to publish the corrected develop-branch instructions. Revert commit `348aa7862` to roll back.

## Tracking
- [NVBug 6677581](https://nvbugspro.nvidia.com/bug/6677581)