### PR TITLE
Feat/update search llm nemo 3.5

### DIFF
--- a/deploy/docker/developer-profiles/dev-profile-search/overrides.env
+++ b/deploy/docker/developer-profiles/dev-profile-search/overrides.env
@@ -50,9 +50,9 @@ VLM_MODE=local_shared
 # - nvidia/llama-3.3-nemotron-super-49b-v1.5 -> llama-3.3-nemotron-super-49b-v1.5
 # - openai/gpt-oss-20b -> gpt-oss-20b
 # Select the local LLM model name, or the model id exposed by a remote /v1/models endpoint.
-LLM_NAME=nvidia/nvidia-nemotron-nano-9b-v2
+LLM_NAME=nvidia/nemotron-3.5-lightning-30b-a3b
 # Enables the local LLM compose profile; set to none for remote LLM.
-LLM_NAME_SLUG=nvidia-nemotron-nano-9b-v2
+LLM_NAME_SLUG=nemotron-3.5-lightning-30b-a3b
 # Extra env file for local LLM container settings.
 LLM_ENV_FILE=''
 # LLM endpoint base URL. Local deployments use the Compose service; remote deployments use the external endpoint.

--- a/deploy/docker/services/nim/nemotron-3.5-lightning-30b-a3b/hw-H100-shared.env
+++ b/deploy/docker/services/nim/nemotron-3.5-lightning-30b-a3b/hw-H100-shared.env
@@ -7,3 +7,10 @@ NIM_MAX_MODEL_LEN=32000
 MAX_JOBS=4
 # Parse reasoning separately and support OpenAI-compatible automatic tool calls.
 NIM_PASSTHROUGH_ARGS="--reasoning-parser nemotron_v3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --max-num-seqs 2"
+# Pin the INT4 single-GPU profile (vllm-int4-tp1-pp1-32.0, requires >=32 GB) rather
+# than relying on auto-resolution. At NIM_GPU_MEM_FRACTION=0.5 the LLM gets ~40 GB on
+# an 80 GB H100 (~47 GB on a 94 GB H100 NVL), and INT4 is the only tp1 profile in this
+# image that fits: bf16-tp1 needs 66 GB, and nvfp4 is Blackwell-only (incompatible on
+# Hopper). Shared-GPU profiles pin one device, so tp2/tp4 variants are not candidates.
+# Re-derive via `list-model-profiles` if the image tag changes.
+NIM_MODEL_PROFILE=2ef85c7286907e706eb0d6c4750a1aefa719447097d151ab34c7837fc02bdac4

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1530,6 +1530,12 @@ run_dry_run_up_and_check_generated_env "generated.env LVS defaults to Nemotron 3
   "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
   "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b"
 
+run_dry_run_up_and_check_generated_env "generated.env Search defaults to Nemotron 3.5 Lightning on H100" "search" \
+ -i 127.0.0.1 -H H100 -d -- \
+  "HARDWARE_PROFILE" "H100" \
+  "LLM_NAME" "nvidia/nemotron-3.5-lightning-30b-a3b" \
+  "LLM_NAME_SLUG" "nemotron-3.5-lightning-30b-a3b"
+
 run_dry_run_up_and_check_generated_env "generated.env Base GB300 overlay selects ARM64 LLM and SBSA RT-VLM" "base" \
  -i 127.0.0.1 -H GB300 --llm-device-id 1 --vlm-device-id 1 -d -- \
   "HARDWARE_PROFILE" "GB300" \

--- a/deploy/docker/test-scripts/test-dev-profile.sh
+++ b/deploy/docker/test-scripts/test-dev-profile.sh
@@ -1561,6 +1561,18 @@ for _nemotron_3_5_env in \
   fi
 done
 
+# H100 shared-GPU: the LLM gets NIM_GPU_MEM_FRACTION=0.5 while co-located with RT-Embed
+# (search) or RT-VLM (base/LVS), so the INT4 tp1 profile must stay pinned — bf16-tp1
+# needs 66 GB and nvfp4 is Blackwell-only.
+_nemotron_3_5_h100_shared="${REPO_ROOT}/deploy/docker/services/nim/nemotron-3.5-lightning-30b-a3b/hw-H100-shared.env"
+if grep -Fq "NIM_MODEL_PROFILE=2ef85c7286907e706eb0d6c4750a1aefa719447097d151ab34c7837fc02bdac4" "${_nemotron_3_5_h100_shared}"; then
+  echo "PASS: hw-H100-shared.env pins the Nemotron 3.5 INT4 tp1 profile"
+  ((TESTS_PASSED++)) || true
+else
+  echo "FAIL: hw-H100-shared.env does not pin the Nemotron 3.5 INT4 tp1 profile"
+  ((TESTS_FAILED++)) || true
+fi
+
 # DGX-SPARK: for each profile, run dry-run with -H DGX-SPARK and assert sbsa variants (keys from profile overrides.env).
 # DGX-SPARK (and IGX-THOR) are only valid for base and alerts
 for _profile in base alerts; do

--- a/deploy/helm/developer-profiles/dev-profile-search/Chart.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/Chart.yaml
@@ -25,7 +25,7 @@ description: |
     - analytics             : VSS analytics umbrella (vss-behavior-analytics search_and_alerts for Search + vss-video-analytics-api)
     - agent                 : VSS agent umbrella (vss-agent; vss-va-mcp off by default)
     - vss-agent-ui          : VSS UI frontend
-    - nims                  : NVIDIA NIM models (Nemotron Nano 9B v2 LLM; Cosmos3 VLM NIM off by default — VLM served by rtvi.vss-rtvi-vlm)
+    - nims                  : NVIDIA NIM models (Nemotron 3.5 Lightning 30B A3B LLM; Cosmos3 VLM NIM off by default — VLM served by rtvi.vss-rtvi-vlm)
 
   Installation – from deploy/helm/developer-profiles, vendor subcharts (required):
     helm dependency build ./dev-profile-search

--- a/deploy/helm/developer-profiles/dev-profile-search/README.md
+++ b/deploy/helm/developer-profiles/dev-profile-search/README.md
@@ -47,7 +47,7 @@ The critic agent is available by default and controlled per request with `use_cr
 | `vss-rtvi-cv` | 1 | |
 | `vss-rtvi-embed` (Cosmos Embed) | 1 | |
 | `vss-vios-streamprocessing` | 1 | |
-| `nvidia-nemotron-nano-9b-v2` (NIM) | 1 | |
+| `nemotron-3.5-lightning-30b-a3b` (NIM) | 1 | |
 | `vss-rtvi-vlm` (Cosmos3 checkpoint) | 1 | VLM used by the critic and `video_understanding` — enabled by default |
 | **Total** | **5** | **4** if the VLM is disabled (`rtvi.vss-rtvi-vlm.enabled=false`) |
 

--- a/deploy/helm/developer-profiles/dev-profile-search/override-values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/override-values.yaml
@@ -30,11 +30,11 @@ global:
 
 # ── Agent config: search profile wired to in-cluster services ───────────────
 vss-agent:
-  llmBaseUrl: "http://nvidia-nemotron-nano-9b-v2:8000"
+  llmBaseUrl: "http://nemotron-3.5-lightning-30b-a3b:8000"
   # VLM is local (rtvi.vss-rtvi-vlm); leave empty so VLM_MODE stays `local` and the agent
   # uses RTVI_VLM_BASE_URL. Set only for a remote VLM (also flip VLM_MODEL_TYPE to `nim`).
   vlmBaseUrl: ""
-  evalLlmJudgeBaseUrl: "http://nvidia-nemotron-nano-9b-v2:8000"
+  evalLlmJudgeBaseUrl: "http://nemotron-3.5-lightning-30b-a3b:8000"
   rtviEmbedBaseUrl: "http://vss-search-vss-rtvi-embed:8000"
   cosmosEmbedEndpoint: "http://vss-search-vss-rtvi-embed:8000"
   elasticsearchUrl: "http://vss-search-elasticsearch:9200"

--- a/deploy/helm/developer-profiles/dev-profile-search/templates/NOTES.txt
+++ b/deploy/helm/developer-profiles/dev-profile-search/templates/NOTES.txt
@@ -28,7 +28,7 @@ Chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   When nims is enabled, the NIM Operator exposes ClusterIP services matching the
   NIMService metadata.name (same slugs as dev-profile-base nims charts):
 
-  1. Nemotron Nano 9B v2 (LLM):  nvidia-nemotron-nano-9b-v2:8000
+  1. Nemotron 3.5 Lightning 30B A3B (LLM):  nemotron-3.5-lightning-30b-a3b:8000
   2. VLM (critic + video_understanding): vss-rtvi-vlm:8000  (rtvi.vss-rtvi-vlm, in-pod
                                   Cosmos3 checkpoint; set nims.cosmos3.enabled=true to use
                                   the standalone NIM instead)

--- a/deploy/helm/developer-profiles/dev-profile-search/values-build-endpoint.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values-build-endpoint.yaml
@@ -61,6 +61,8 @@ nims:
   enabled: false
   nemotron:
     enabled: false
+  nemotron35:
+    enabled: false
   cosmos3:
     enabled: false
 

--- a/deploy/helm/developer-profiles/dev-profile-search/values.yaml
+++ b/deploy/helm/developer-profiles/dev-profile-search/values.yaml
@@ -665,7 +665,10 @@ agent:
     profile: search
     replicas: 1
     rtviEmbedModelName: cosmos-embed1-448p-anomaly-detection
-    llmName: nvidia/nvidia-nemotron-nano-9b-v2
+    llmName: nvidia/nemotron-3.5-lightning-30b-a3b
+    # In-cluster LLM NIM Service name; feeds LLM_BASE_URL / EVAL_LLM_JUDGE_BASE_URL below.
+    # Keep in sync with the enabled nims.* model (nims.nemotron35).
+    llmServiceName: "nemotron-3.5-lightning-30b-a3b"
     # The VLM is served by rtvi-vlm (see rtvi.vss-rtvi-vlm) for both the critic and
     # video_understanding. Model id must match the rtvi-vlm /v1/models advertisement,
     # not the cosmos3-reasoner NIM id.
@@ -678,7 +681,7 @@ agent:
     rtviVlmBaseUrl: ''
     llmBaseUrl: ''
     vlmBaseUrl: ''
-    evalLlmJudgeName: nvidia/nvidia-nemotron-nano-9b-v2
+    evalLlmJudgeName: nvidia/nemotron-3.5-lightning-30b-a3b
     evalLlmJudgeBaseUrl: ''
     phoenixEndpoint: ''
     vstExternalUrl: ''
@@ -779,7 +782,7 @@ agent:
       - name: PHOENIX_ENDPOINT
         value: '{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{ ternary (printf "http://%s-phoenix:6006" .Release.Name) "http://phoenix:6006" $pfx }}'
       - name: LLM_BASE_URL
-        value: '{{- $g := .Values.global | default dict }}{{- $llm := default "" (coalesce (.Values.llmBaseUrl | default "") ((index $g "llmBaseUrl") | default "")) | toString | trim }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $def := ternary (printf "http://%s-nvidia-nemotron-nano-9b-v2:8000" .Release.Name) "http://nvidia-nemotron-nano-9b-v2:8000" $pfx }}{{- if $llm }}{{ $llm }}{{- else }}{{ $def }}{{- end }}'
+        value: '{{- $g := .Values.global | default dict }}{{- $llm := default "" (coalesce (.Values.llmBaseUrl | default "") ((index $g "llmBaseUrl") | default "")) | toString | trim }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $svc := trim (.Values.llmServiceName | default "nemotron-3.5-lightning-30b-a3b") }}{{- $def := ternary (printf "http://%s-%s:8000" .Release.Name $svc) (printf "http://%s:8000" $svc) $pfx }}{{- if $llm }}{{ $llm }}{{- else }}{{ $def }}{{- end }}'
       # VLM endpoint (vss-rtvi-vlm) for the critic and video_understanding. Consumed by the rtvi_vlm agent profile.
       - name: RTVI_VLM_BASE_URL
         value: '{{- if (trim (.Values.rtviVlmBaseUrl | default "")) }}{{ trim .Values.rtviVlmBaseUrl }}{{- else }}{{- $g := .Values.global | default dict }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $svc := trim (.Values.rtviVlmServiceName | default "vss-rtvi-vlm") }}{{- printf "http://%s:8000" (ternary (printf "%s-%s" .Release.Name $svc) $svc $pfx) -}}{{- end }}'
@@ -790,13 +793,13 @@ agent:
       - name: VST_INTERNAL_URL
         value: '{{- if (trim (.Values.vstInternalUrl | default "")) }}{{ trim .Values.vstInternalUrl }}{{- else }}http://vss-vios-ingress:30888{{- end }}'
       - name: LLM_NAME
-        value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.llmName ((index $g "llmName") | default "") "nvidia/nvidia-nemotron-nano-9b-v2") }}'
+        value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.llmName ((index $g "llmName") | default "") "nvidia/nemotron-3.5-lightning-30b-a3b") }}'
       - name: VLM_NAME
         value: '{{- $g := .Values.global | default dict }}{{ trim (coalesce .Values.vlmName ((index $g "vlmName") | default "") "nim_nvidia_cosmos3-nano-reasoner_modelopt-fp8-final_format_fix") }}'
       - name: EVAL_LLM_JUDGE_NAME
-        value: '{{- $g := .Values.global | default dict }}{{- $ln := trim (coalesce .Values.llmName ((index $g "llmName") | default "") "nvidia/nvidia-nemotron-nano-9b-v2") }}{{ coalesce .Values.evalLlmJudgeName $ln }}'
+        value: '{{- $g := .Values.global | default dict }}{{- $ln := trim (coalesce .Values.llmName ((index $g "llmName") | default "") "nvidia/nemotron-3.5-lightning-30b-a3b") }}{{ coalesce .Values.evalLlmJudgeName $ln }}'
       - name: EVAL_LLM_JUDGE_BASE_URL
-        value: '{{- $g := .Values.global | default dict }}{{- $llm := default "" (coalesce (.Values.llmBaseUrl | default "") ((index $g "llmBaseUrl") | default "")) | toString | trim }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $def := ternary (printf "http://%s-nvidia-nemotron-nano-9b-v2:8000" .Release.Name) "http://nvidia-nemotron-nano-9b-v2:8000" $pfx }}{{ coalesce .Values.evalLlmJudgeBaseUrl $llm $def }}'
+        value: '{{- $g := .Values.global | default dict }}{{- $llm := default "" (coalesce (.Values.llmBaseUrl | default "") ((index $g "llmBaseUrl") | default "")) | toString | trim }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $svc := trim (.Values.llmServiceName | default "nemotron-3.5-lightning-30b-a3b") }}{{- $def := ternary (printf "http://%s-%s:8000" .Release.Name $svc) (printf "http://%s:8000" $svc) $pfx }}{{ coalesce .Values.evalLlmJudgeBaseUrl $llm $def }}'
       - name: VSS_AGENT_REPORTS_BASE_URL
         value: '{{- $g := .Values.global | default dict }}{{- $eh := index $g "externalHost" | default "" | trim }}{{- $ipRaw := index $g "externalHost" | default "127.0.0.1" | trim }}{{- $ip := $ipRaw }}{{- if and (hasPrefix "vss-search." $ipRaw) (hasSuffix "nip.io" $ipRaw) }}{{- $ip = $ipRaw | trimPrefix "vss-search." | trimSuffix ".nip.io" }}{{- end }}{{- $mainHostDef := printf "vss-search.%s.nip.io" $ip }}{{- $mainHost := .Values.vstPublicIngressHost | default $mainHostDef | trim }}{{- $useNip := default true .Values.vstPublicBaseUseNipIo }}{{- $nipBase := ternary (printf "http://%s" $mainHost) "" (and $useNip (ne $mainHost "")) }}{{- $es := index $g "externalScheme" | default "http" }}{{- $ep := index $g "externalPort" | default "" | trim }}{{- $globalBase := ternary (ternary (printf "%s://%s:%s" $es $eh $ep) (printf "%s://%s" $es $eh) (ne $ep "")) "" (ne $eh "") }}{{- $pfx := default false (coalesce .Values.useReleaseNamePrefix ((index $g "useReleaseNamePrefix") | default false)) }}{{- $vssAgentHttp := ternary (printf "http://%s-vss-agent:8000" .Release.Name) "http://vss-agent:8000" $pfx }}{{ if .Values.reportsBaseUrl }}{{ printf "%s" .Values.reportsBaseUrl }}{{ else if and $useNip (ne $nipBase "") }}{{ printf "%s/static/" $nipBase }}{{ else if ne $globalBase "" }}{{ printf "%s/static/" $globalBase }}{{ else }}{{ printf "%s/static/" $vssAgentHttp }}{{ end }}'
       - name: VSS_AGENT_EXTERNAL_URL
@@ -953,8 +956,10 @@ nims:
     pullSecretName: ngc-nim-docker-reg-secret
     authSecretName: ngc-api
     storageClass: ""
+  # Nemotron Nano 9B v2: superseded by nemotron35 below. Set enabled: true (and
+  # flip nemotron35 off, plus agent.vss-agent.llmName/llmServiceName) to go back.
   nemotron:
-    enabled: true
+    enabled: false
     image:
       repository: nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2
       tag: '1'
@@ -979,6 +984,33 @@ nims:
         effect: NoSchedule
     env:
       CUDA_VISIBLE_DEVICES: '0'
+  # Nemotron 3.5 Lightning 30B A3B — search profile LLM (matches base/LVS).
+  # The subchart takes no env map; NIM runtime env comes from the
+  # nims gpuProfiles.<gpuType>.nemotron35 ConfigMap (see helm/services/nims/values.yaml).
+  nemotron35:
+    enabled: true
+    image:
+      repository: nvcr.io/nim/nvidia/nemotron-3.5-lightning-30b-a3b
+      tag: '2.0.9-variant'
+      pullPolicy: IfNotPresent
+    replicas: 1
+    resources:
+      limits:
+        nvidia.com/gpu: '1'
+      requests:
+        nvidia.com/gpu: '1'
+    storage:
+      pvc:
+        storageClass: ''
+        size: 100Gi
+    service:
+      type: ClusterIP
+      port: 8000
+    nodeSelector: {}
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
   cosmos3:
     # Disabled: the VLM (used by the critic and video_understanding) is served by
     # rtvi.vss-rtvi-vlm (in-pod Cosmos3 checkpoint). Set true only to bypass RTVI and

--- a/docs/agent-workflow-search.mdx
+++ b/docs/agent-workflow-search.mdx
@@ -338,7 +338,7 @@ You can now access the agent UI at `http://<HOST_IP>:7777/`.
 **This deployment uses the following defaults:**
 
 - Host IP: src IP from `ip route get 1.1.1.1`
-- LLM model: nvidia/nvidia-nemotron-nano-9b-v2
+- LLM model: nvidia/nemotron-3.5-lightning-30b-a3b
 - VLM model: nvidia/cosmos3-nano-reasoner (critic agent), version `bf16-final` (`ngc:nim/nvidia/cosmos3-nano-reasoner:bf16-final`)
 - Critic agent: enabled
 

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -170,12 +170,19 @@ The upstream perf guide doesn't publish a single GB number — it publishes per-
 
 Default layout, Nemotron 3.5 Lightning 30B A3B LLM + Cosmos-Embed1 on GPU 1.
 
-Note: `hw-H100-shared.env` pins `NIM_MODEL_PROFILE` to the INT4 tp1 profile
-(`vllm-int4-tp1-pp1-32.0`, requires >=32 GB). Raising the LLM's share below only
-buys KV cache — the weights already fit. vLLM also requires
-`free_memory >= NIM_GPU_MEM_FRACTION x total_memory` and does *not* subtract
-memory held by other processes, so the fraction must stay under whatever RT-Embed
-and the rest of the stack leave free.
+Note: `hw-H100-shared.env` pins `NIM_MODEL_PROFILE` to the INT4 single-GPU profile,
+which `list-model-profiles` labels `vllm-int4-tp1-pp1-32.0` (requires >=32 GB). The
+env var takes the profile's **SHA**, not that label:
+
+```bash
+NIM_MODEL_PROFILE=2ef85c7286907e706eb0d6c4750a1aefa719447097d151ab34c7837fc02bdac4
+```
+
+Re-derive it with `docker run --rm --gpus all -e NGC_API_KEY=$NGC_CLI_API_KEY <nim-image>
+list-model-profiles` if the image tag changes. (Some NIMs accept a
+`name-hash` form such as `vllm-fp8-tp1-pp1-<sha>` — see
+`services/nim/nemotron-3-nano/hw-H100-shared.env` — so copy whichever form that
+image's own listing prints.)
 
 **RT-Embed budget rule of thumb: 10 GB.** Cosmos-Embed1 weights are ~2 GB (1 B params at FP16); the rest is per-stream activation buffers, decoder workers, and Triton/ONNX runtime overhead. 10 GB is a comfortable budget for `NUM_STREAMS=16` on any GPU. Reserve those 10 GB and give the LLM the rest, leaving the standard 15% framework headroom.
 
@@ -188,11 +195,25 @@ and the rest of the stack leave free.
 
 Formula: `NIM_KVCACHE_PERCENT = (GPU_VRAM - 10) / GPU_VRAM - 0.15`, rounded to 2 decimals.
 
-Two writes:
+The shipped `hw-H100-shared.env` deliberately uses **0.5**, not the table value: the
+pinned INT4 profile needs only 32 GB, so 0.5 already fits the weights and the table's
+larger numbers buy KV cache, nothing else. Raise them only when you actually want more
+KV cache, and change **both** knobs together — `NIM_GPU_MEM_FRACTION` is what vLLM
+checks, so raising `NIM_KVCACHE_PERCENT` alone has no effect.
+
+Ceiling: vLLM refuses to start unless
+`free_memory >= NIM_GPU_MEM_FRACTION x total_memory`, and it does *not* subtract memory
+already held by other processes. On an 80 GB H100 with RT-Embed resident (~10 GB), the
+fraction must stay below ~0.87; on a GPU shared with more services the ceiling is much
+lower. Exceeding it produces `Engine core initialization failed`, not a fallback.
+
+Two writes (optional tuning — the shipped defaults work as-is):
 
 ```bash
 # 1. In deploy/docker/services/nim/nemotron-3.5-lightning-30b-a3b/hw-H100-shared.env
+#    Shipped: both 0.5. Raise together, and only for extra KV cache.
 NIM_KVCACHE_PERCENT=0.72             # LLM gets ~58 GB; leaves 10 GB for RT-Embed + 12 GB framework
+NIM_GPU_MEM_FRACTION=0.72            # must match; this is the value vLLM enforces
 
 # 2. In deploy/docker/developer-profiles/dev-profile-search/generated.env
 RT_EMBED_DEVICE_ID=1

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -21,7 +21,7 @@ Container names below are the actual `container_name:` keys from `deploy/docker/
 |---|---|---|---|
 | RT-CV (DeepStream perception) | `vss-rtvi-cv` | 9000 | Object detection / tracking on incoming streams; default model family `rtdetr-warehouse` |
 | RT-Embed (Cosmos Embed1) | `vss-rtvi-embed` | 8017 | Video + text embedding generation |
-| LLM NIM (default) | `nvidia-nemotron-nano-9b-v2` | 30081 | Same options as `base` (Nano 9B v2 default). Container name = `${LLM_NAME_SLUG}`. |
+| LLM NIM (default) | `nemotron-3.5-lightning-30b-a3b` | 30081 | Same options as `base` (Nemotron 3.5 Lightning 30B A3B default). Container name = `${LLM_NAME_SLUG}`. |
 | RT-VLM | `vss-rtvi-vlm` | 8018 | Local Cosmos3 inference or an OpenAI-compatible proxy to a remote VLM; serves Critique and `video_understanding` |
 | VSS Agent | `vss-agent` | 8000 | Orchestrates tool calls, embed search, critique |
 | VSS Agent UI | `vss-agent-ui` | 3000 | Search tab |
@@ -34,7 +34,7 @@ Container names below are the actual `container_name:` keys from `deploy/docker/
 
 | Role | Model | Slug | Served by |
 |---|---|---|---|
-| LLM | `nvidia/nvidia-nemotron-nano-9b-v2` | `nvidia-nemotron-nano-9b-v2` | NIM (port 30081) |
+| LLM | `nvidia/nemotron-3.5-lightning-30b-a3b` | `nemotron-3.5-lightning-30b-a3b` | NIM (port 30081) |
 | Embed (RT-Embed) | `nvidia/Cosmos-Embed1-448p-anomaly-detection` | — | RT-Embed (port 8017), `MODEL_PATH=git:https://huggingface.co/nvidia/Cosmos-Embed1-448p-anomaly-detection` |
 | Perception (RT-CV) | siglip2 v1.1 + RTDETR (warehouse) | — | RT-CV (DeepStream pipeline) |
 | VLM (RT-VLM) | `ngc:nim/nvidia/cosmos3-nano-reasoner:modelopt-fp8-final_format_fix` (default local checkpoint; FP8 so it fits alongside RT-CV on GPU 0) | `VLM_NAME_SLUG=none`; activated via the `rtvi-vlm` compose profile | RT-VLM (port 8018) |
@@ -184,7 +184,7 @@ Formula: `NIM_KVCACHE_PERCENT = (GPU_VRAM - 10) / GPU_VRAM - 0.15`, rounded to 2
 Two writes:
 
 ```bash
-# 1. In deploy/docker/services/nim/nvidia-nemotron-nano-9b-v2/hw-H100-shared.env
+# 1. In deploy/docker/services/nim/nemotron-3.5-lightning-30b-a3b/hw-H100-shared.env
 NIM_KVCACHE_PERCENT=0.72             # LLM gets ~58 GB; leaves 10 GB for RT-Embed + 12 GB framework
 
 # 2. In deploy/docker/developer-profiles/dev-profile-search/generated.env

--- a/skills/vss-deploy-profile/references/search.md
+++ b/skills/vss-deploy-profile/references/search.md
@@ -168,7 +168,14 @@ The upstream perf guide doesn't publish a single GB number — it publishes per-
 
 ## Worked example — LLM + RT-Embed on GPU 1
 
-Default layout, Nano 9B v2 LLM + Cosmos-Embed1 on GPU 1.
+Default layout, Nemotron 3.5 Lightning 30B A3B LLM + Cosmos-Embed1 on GPU 1.
+
+Note: `hw-H100-shared.env` pins `NIM_MODEL_PROFILE` to the INT4 tp1 profile
+(`vllm-int4-tp1-pp1-32.0`, requires >=32 GB). Raising the LLM's share below only
+buys KV cache — the weights already fit. vLLM also requires
+`free_memory >= NIM_GPU_MEM_FRACTION x total_memory` and does *not* subtract
+memory held by other processes, so the fraction must stay under whatever RT-Embed
+and the rest of the stack leave free.
 
 **RT-Embed budget rule of thumb: 10 GB.** Cosmos-Embed1 weights are ~2 GB (1 B params at FP16); the rest is per-stream activation buffers, decoder workers, and Triton/ONNX runtime overhead. 10 GB is a comfortable budget for `NUM_STREAMS=16` on any GPU. Reserve those 10 GB and give the LLM the rest, leaving the standard 15% framework headroom.
 


### PR DESCRIPTION
Switches the search profile LLM from Nemotron Nano 9B v2 to Nemotron 3.5 Lightning
30B A3B

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
