### PR TITLE
ci: disable BuildKit attestations on GHCR publishes

### DIFF
--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -221,6 +221,11 @@ jobs:
           platforms: ${{ matrix.platforms }}
           build-args: ${{ matrix.build_args }}
           push: true
+          # BuildKit's default SLSA/SBOM attestations show up in GHCR as
+          # unknown/unknown OS/Arch rows and break some docker/containerd pulls.
+          # Image provenance here is the com.nvidia.vss.* labels, not these.
+          provenance: false
+          sbom: false
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           # Publish the content-addressed alias too so a later build of the same
@@ -426,6 +431,10 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: ${{ matrix.build_args }}
           push: true
+          # See the standard multiarch build-push step: skip index-attached
+          # attestations so GHCR does not list unknown/unknown platforms.
+          provenance: false
+          sbom: false
           cache-from: type=gha,scope=${{ matrix.name }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}-${{ matrix.arch }}
           tags: ${{ steps.meta.outputs.image }}:${{ steps.platform-meta.outputs.tag }}


### PR DESCRIPTION
## Summary
- Turn off default BuildKit SLSA provenance and SBOM attestations on both `docker/build-push-action` steps in `Build Dev Images (GHCR)`.
- Those attestations are unused here (provenance is the `com.nvidia.vss.*` labels) and show up in GHCR as `unknown/unknown` OS/Arch, which also breaks some Docker/containerd pulls.
- Existing tags keep their attached attestations until the next rebuild; this only affects new publishes.

## Test plan
- [ ] Confirm the workflow YAML parses (`provenance: false` / `sbom: false` on both build-push steps).
- [ ] After merge, trigger (or wait for) a candidate image build and check the GHCR package OS/Arch list: only `linux/amd64` and/or `linux/arm64`, no `unknown/unknown`.
- [ ] Confirm `ghcr_image_guard.py verify` still passes (labels unchanged).