### PR TITLE
fix(ci): clean up PR tags carrying variant and platform suffixes

### DIFF
--- a/.github/scripts/cleanup_pr_tags.py
+++ b/.github/scripts/cleanup_pr_tags.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Delete a merged/closed PR's ``pr-<N>-*`` candidate images from GHCR.
 
-Candidate tags are build scaffolding: ``pr-<N>-<sha12>`` immutable candidates and
-the ``pr-<N>-latest`` alias. Once the PR closes they can never be rebuilt or
+Candidate tags are build scaffolding: ``pr-<N>-<sha12>`` immutable candidates,
+the ``pr-<N>-latest`` alias, and the two optional suffixes those carry — the
+inventory's ``tag_suffix`` variant marker (``pr-<N>-latest-sbsa``) and the
+per-architecture staging tag the native build publishes before merging the
+multiarch manifest (``pr-<N>-<sha12>-amd64``, ``…-sbsa-arm64``). Once the PR closes they can never be rebuilt or
 referenced, so retaining them only grows the package indefinitely. ``develop-*``
 tags are the opposite — they are the derivable coordinate set and are kept
 forever.
@@ -54,6 +57,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Callable
 
@@ -61,9 +65,65 @@ API_ROOT = "https://api.github.com"
 Requester = Callable[[str, str], object]
 
 
-def pr_tag_pattern(pr_number: int) -> re.Pattern[str]:
-    """Tags owned by this PR: ``pr-<N>-<sha12>`` and ``pr-<N>-latest``."""
-    return re.compile(rf"^pr-{pr_number}-(?:[0-9a-f]{{12}}|latest)$")
+def tag_variants(inventory: dict) -> tuple[list[str], list[str]]:
+    """``(tag_suffixes, platform_suffixes)`` a candidate tag may legitimately carry.
+
+    Both are read from the inventory rather than written as a literal list, so
+    a new variant or platform is covered the day it is added instead of leaking
+    until somebody notices.
+    """
+    images = inventory.get("images") or []
+    suffixes = sorted(
+        {
+            (item.get("tag_suffix") or "").lstrip("-")
+            for item in images
+            if item.get("ghcr_build")
+        }
+        - {""}
+    )
+    platforms = sorted(
+        {
+            platform.rsplit("/", 1)[-1]
+            for item in images
+            if item.get("ghcr_build")
+            for platform in (item.get("platforms") or [])
+        }
+    )
+    return suffixes, platforms
+
+
+def pr_tag_pattern(
+    pr_number: int,
+    tag_suffixes: Sequence[str] = (),
+    platform_suffixes: Sequence[str] = (),
+) -> re.Pattern[str]:
+    """Tags owned by this PR.
+
+    The base shapes are ``pr-<N>-<sha12>`` and ``pr-<N>-latest``. Two optional
+    suffixes ride on top, and neither was matched here — which is why 929 of
+    1886 ``pr-*`` tags in GHCR were unreachable by this cleanup:
+
+    * ``tag_suffix`` from the inventory, e.g. ``pr-1885-latest-sbsa``.
+      ``container_build_plan`` appends it to candidate, content AND alias tags,
+      so it can follow ``latest`` as well as a SHA. This is the large class:
+      879 of the 929.
+    * the platform suffix the native build appends while staging one
+      architecture at a time, e.g. ``pr-1885-fc5a4cbe98bf-amd64`` — and both
+      together, ``…-sbsa-arm64``.
+
+    Both are ENUMERATED from the inventory, never a wildcard. This pattern
+    decides tag ownership and ownership decides deletion: a version is
+    deletable only when every tag on it is ours. A loose pattern would let a
+    foreign tag read as owned and take a live image with it, which is
+    unrecoverable without a rebuild. A missed shape only leaks storage. Those
+    costs are not symmetric, so the pattern stays narrow.
+    """
+    optional = ""
+    if tag_suffixes:
+        optional += "(?:-(?:" + "|".join(re.escape(s) for s in tag_suffixes) + "))?"
+    if platform_suffixes:
+        optional += "(?:-(?:" + "|".join(re.escape(p) for p in platform_suffixes) + "))?"
+    return re.compile(rf"^pr-{pr_number}-(?:[0-9a-f]{{12}}|latest){optional}$")
 
 
 def is_deletable(tags: list[str], pattern: re.Pattern[str]) -> tuple[bool, str]:
@@ -154,6 +214,8 @@ def plan_deletions(
     package: str,
     pr_number: int,
     requester: Requester = _request,
+    tag_suffixes: Sequence[str] = (),
+    platform_suffixes: Sequence[str] = (),
 ) -> tuple[list[tuple[int, str]], list[tuple[str, str]]]:
     """Return ``(to_delete, skipped)`` for one package.
 
@@ -162,7 +224,7 @@ def plan_deletions(
     versions = iter_versions(org, package, requester)
     if not versions:
         return [], []
-    pattern = pr_tag_pattern(pr_number)
+    pattern = pr_tag_pattern(pr_number, tag_suffixes, platform_suffixes)
     to_delete: list[tuple[int, str]] = []
     skipped: list[tuple[str, str]] = []
     for version in versions:
@@ -184,12 +246,14 @@ def plan_detach(
     package: str,
     pr_number: int,
     requester: Requester = _request,
+    tag_suffixes: Sequence[str] = (),
+    platform_suffixes: Sequence[str] = (),
 ) -> list[str]:
     """Return this PR's tags that sit on versions the delete pass must keep."""
     versions = iter_versions(org, package, requester)
     if not versions:
         return []
-    pattern = pr_tag_pattern(pr_number)
+    pattern = pr_tag_pattern(pr_number, tag_suffixes, platform_suffixes)
     tags: list[str] = []
     for version in versions:
         version_tags = (
@@ -199,12 +263,22 @@ def plan_detach(
     return sorted(set(tags))
 
 
-def emit_detach_plan(org: str, packages: list[str], pr_number: int) -> int:
+def emit_detach_plan(
+    org: str,
+    packages: list[str],
+    pr_number: int,
+    tag_suffixes: Sequence[str] = (),
+    platform_suffixes: Sequence[str] = (),
+) -> int:
     """Print ``<package> <tag>`` pairs for the workflow to retag. Never fails."""
     pairs = 0
     for package in packages:
         try:
-            tags = plan_detach(org, package, pr_number)
+            tags = plan_detach(
+                org, package, pr_number,
+                tag_suffixes=tag_suffixes,
+                platform_suffixes=platform_suffixes,
+            )
         except urllib.error.HTTPError as exc:
             print(f"[pr-tags] {package}: SKIP (HTTP {exc.code})", file=sys.stderr)
             continue
@@ -237,16 +311,26 @@ def main() -> int:
 
     inventory = json.loads(args.inventory.read_text())
     packages = ghcr_packages(inventory)
+    # Variant and platform suffixes come from the same inventory as the package
+    # list, so the shapes this cleanup owns always match the shapes the build
+    # publishes.
+    tag_suffixes, platform_suffixes = tag_variants(inventory)
 
     if args.emit_detach_plan:
-        return emit_detach_plan(args.org, packages, args.pr)
+        return emit_detach_plan(
+            args.org, packages, args.pr, tag_suffixes, platform_suffixes
+        )
 
     print(f"[pr-tags] PR #{args.pr}: scanning {len(packages)} GHCR packages")
 
     deleted = kept = 0
     for package in packages:
         try:
-            to_delete, skipped = plan_deletions(args.org, package, args.pr)
+            to_delete, skipped = plan_deletions(
+                args.org, package, args.pr,
+                tag_suffixes=tag_suffixes,
+                platform_suffixes=platform_suffixes,
+            )
         except urllib.error.HTTPError as exc:
             # Never fail the workflow over cleanup: a retained tag is harmless.
             print(f"[pr-tags] {package}: SKIP (HTTP {exc.code})")

--- a/.github/scripts/cleanup_pr_tags.py
+++ b/.github/scripts/cleanup_pr_tags.py
@@ -118,12 +118,26 @@ def pr_tag_pattern(
     unrecoverable without a rebuild. A missed shape only leaks storage. Those
     costs are not symmetric, so the pattern stays narrow.
     """
-    optional = ""
-    if tag_suffixes:
-        optional += "(?:-(?:" + "|".join(re.escape(s) for s in tag_suffixes) + "))?"
-    if platform_suffixes:
-        optional += "(?:-(?:" + "|".join(re.escape(p) for p in platform_suffixes) + "))?"
-    return re.compile(rf"^pr-{pr_number}-(?:[0-9a-f]{{12}}|latest){optional}$")
+    variant = (
+        "(?:-(?:" + "|".join(re.escape(s) for s in tag_suffixes) + "))?"
+        if tag_suffixes
+        else ""
+    )
+    platform = (
+        "(?:-(?:" + "|".join(re.escape(p) for p in platform_suffixes) + "))?"
+        if platform_suffixes
+        else ""
+    )
+    # The platform suffix follows a SHA candidate only. A moving alias is
+    # advanced onto the MERGED manifest, never onto a per-architecture staging
+    # image, so `pr-<N>-latest-amd64` is not a shape this repository can
+    # produce -- confirmed against GHCR, zero such tags exist. Accepting it
+    # would widen ownership past the build's own grammar for no gain, and the
+    # whole argument for enumerating these suffixes is that ownership must not
+    # outrun what the build actually publishes.
+    return re.compile(
+        rf"^pr-{pr_number}-(?:latest{variant}|[0-9a-f]{{12}}{variant}{platform})$"
+    )
 
 
 def is_deletable(tags: list[str], pattern: re.Pattern[str]) -> tuple[bool, str]:

--- a/.github/scripts/test_cleanup_pr_tags.py
+++ b/.github/scripts/test_cleanup_pr_tags.py
@@ -258,6 +258,26 @@ class TagVariantTest(unittest.TestCase):
         ):
             self.assertIsNone(self.pattern().fullmatch(tag), tag)
 
+    def test_platform_suffix_only_follows_a_sha_candidate(self):
+        """`pr-<N>-latest-amd64` is not a shape this repository can produce.
+
+        A moving alias is advanced onto the MERGED manifest, never onto a
+        per-architecture staging image -- confirmed against GHCR, where zero
+        `latest-<arch>` tags exist. Owning it would widen deletion past the
+        build's own grammar for no gain, and the entire argument for
+        enumerating these suffixes is that ownership must not outrun what the
+        build actually publishes. Raised by review on #1894.
+        """
+        for tag in (
+            "pr-1234-latest-amd64",
+            "pr-1234-latest-arm64",
+            "pr-1234-latest-sbsa-arm64",
+        ):
+            self.assertIsNone(self.pattern().fullmatch(tag), tag)
+
+        # the variant suffix DOES follow latest, and must keep working
+        self.assertRegex("pr-1234-latest-sbsa", self.pattern())
+
     def test_rejects_suffixes_the_inventory_does_not_declare(self):
         # Enumerated, not wildcarded. An unknown platform or a trailing extra
         # segment is somebody else's tag until the inventory says otherwise.

--- a/.github/scripts/test_cleanup_pr_tags.py
+++ b/.github/scripts/test_cleanup_pr_tags.py
@@ -18,6 +18,7 @@ from cleanup_pr_tags import (  # noqa: E402
     plan_deletions,
     plan_detach,
     pr_tag_pattern,
+    tag_variants,
 )
 
 SHA = "abc123abc123"
@@ -210,6 +211,100 @@ class PlanDetachTest(unittest.TestCase):
             plan_detach("NVIDIA-AI-Blueprints", "vss/absent", 1234, lambda *_: None), []
         )
 
+
+
+class TagVariantTest(unittest.TestCase):
+    """Variant and platform suffixes must be owned, and nothing else.
+
+    929 of 1886 ``pr-*`` tags in GHCR were unreachable by this cleanup because
+    the pattern knew about neither. The large class was ``-sbsa`` (879), not
+    the architecture suffixes -- so a fix aimed only at ``-amd64``/``-arm64``
+    would have recovered a twentieth of the leak.
+    """
+
+    SUFFIXES = ("sbsa",)
+    PLATFORMS = ("amd64", "arm64")
+
+    def pattern(self, pr=1234):
+        return pr_tag_pattern(pr, self.SUFFIXES, self.PLATFORMS)
+
+    def test_owns_every_shape_the_build_publishes(self):
+        for tag in (
+            "pr-1234-abc123abc123",
+            "pr-1234-latest",
+            "pr-1234-abc123abc123-amd64",
+            "pr-1234-abc123abc123-arm64",
+            "pr-1234-abc123abc123-sbsa",
+            "pr-1234-latest-sbsa",
+            "pr-1234-abc123abc123-sbsa-arm64",
+        ):
+            self.assertRegex(tag, self.pattern(), tag)
+
+    def test_never_owns_a_foreign_tag(self):
+        # The asymmetry that governs this pattern: claiming a foreign tag can
+        # delete a live develop image, which needs a rebuild to recover. Missing
+        # a shape only leaks storage. So over-claiming must be impossible.
+        for tag in (
+            "pr-9999-abc123abc123",            # another PR
+            "pr-9999-abc123abc123-amd64",
+            "pr-12345-abc123abc123",           # prefix overlap with 1234
+            "develop-abc123abc123",
+            "develop-abc123abc123-amd64",
+            "develop-latest",
+            "tree-" + "a" * 40,
+            "tree-" + "a" * 40 + "-sbsa",
+            "latest",
+            "xpr-1234-abc123abc123",
+        ):
+            self.assertIsNone(self.pattern().fullmatch(tag), tag)
+
+    def test_rejects_suffixes_the_inventory_does_not_declare(self):
+        # Enumerated, not wildcarded. An unknown platform or a trailing extra
+        # segment is somebody else's tag until the inventory says otherwise.
+        for tag in (
+            "pr-1234-abc123abc123-x86",
+            "pr-1234-abc123abc123-riscv64",
+            "pr-1234-abc123abc123-sbsa-amd64-extra",
+            "pr-1234-abc123abc12",             # 11 hex, not 12
+        ):
+            self.assertIsNone(self.pattern().fullmatch(tag), tag)
+
+    def test_default_arguments_keep_the_narrow_behaviour(self):
+        # A caller that passes no variants must not become more aggressive.
+        narrow = pr_tag_pattern(1234)
+        self.assertRegex("pr-1234-abc123abc123", narrow)
+        self.assertIsNone(narrow.fullmatch("pr-1234-abc123abc123-amd64"))
+
+    def test_variants_are_read_from_the_inventory(self):
+        inventory = {
+            "images": [
+                {"name": "a", "ghcr_build": True,
+                 "platforms": ["linux/amd64", "linux/arm64"]},
+                {"name": "b", "ghcr_build": True, "tag_suffix": "-sbsa",
+                 "platforms": ["linux/arm64"]},
+                # not a GHCR build: must not contribute a suffix
+                {"name": "c", "tag_suffix": "-ignored",
+                 "platforms": ["linux/s390x"]},
+            ]
+        }
+        suffixes, platforms = tag_variants(inventory)
+        self.assertEqual(suffixes, ["sbsa"])
+        self.assertEqual(platforms, ["amd64", "arm64"])
+
+    def test_a_staging_tag_alone_makes_its_version_deletable(self):
+        # Before the fix this version was kept forever: its only tag read as
+        # foreign, so is_deletable refused it.
+        deletable, _ = is_deletable(
+            ["pr-1234-abc123abc123-amd64"], self.pattern()
+        )
+        self.assertTrue(deletable)
+
+    def test_a_staging_tag_beside_a_develop_tag_is_still_kept(self):
+        # Widening ownership must not weaken the shared-digest rule.
+        deletable, reason = is_deletable(
+            ["pr-1234-abc123abc123-amd64", "develop-def456def456"], self.pattern()
+        )
+        self.assertFalse(deletable, reason)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`cleanup_pr_tags.py` owned only `pr-<N>-<sha12>` and `pr-<N>-latest`. Every candidate tag
carrying a suffix fell outside that pattern and was never deleted.

Measured across six GHCR packages — **929 of 1886 `pr-*` tags leak**:

| shape | count | example |
|---|---|---|
| owned today | 927 | `pr-1885-fc5a4cbe98bf` |
| `-sbsa` | **879** | `pr-1885-latest-sbsa` |
| `-amd64` | 30 | `pr-1885-fc5a4cbe98bf-amd64` |
| `-arm64` | 30 | |
| `-sbsa-arm64` | 20 | |

Spot-checked against PR state: #1623, #1634, #1643, #1672, #1682, #1696 and #1710 all merged
two weeks ago and their staging tags are still in GHCR.

## The two suffixes, and where they come from

**`tag_suffix`** from `container-inventory.json`. `container_build_plan.metadata()` appends it
to candidate, content **and** alias tags, so it follows `latest` as well as a SHA:

```python
tag=f"{tag}{tag_suffix}"            # pr-1885-latest-sbsa
content_tag=f"tree-{tree_sha}{tag_suffix}"
```

**The per-architecture staging tag.** For the 12 images with `native_platform_build: true`,
each arch builds on its own runner and pushes `<tag>-<arch>`, which `imagetools create` later
merges into the multiarch manifest:

```yaml
- name: Compute platform staging tag
  run: echo "tag=${{ steps.meta.outputs.tag }}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
```

Both together give `pr-1885-<sha12>-sbsa-arm64`.

## Why they were kept rather than merely skipped

A staging tag is usually the **only** tag on its version. Because the pattern did not own it,
`is_deletable` classified it as a *foreign* tag and refused to delete — so the rule that
protects shared digests was the thing keeping these alive forever.

## Approach

Both suffix sets are read from the same inventory that already supplies the package list, so a
new variant or platform is covered the day it is added instead of leaking until someone
notices.

They are **enumerated, never wildcarded**. This pattern decides ownership, and ownership
decides deletion. Over-claiming could delete a live `develop` image — unrecoverable without a
rebuild — while under-claiming only leaks storage. The costs are not symmetric, so the pattern
stays narrow:

```
^pr-1885-(?:[0-9a-f]{12}|latest)(?:-(?:sbsa))?(?:-(?:amd64|arm64))?$
```

Default arguments keep the previous behaviour, so a caller that passes no variants is never
made more aggressive by accident.

## Is deleting these safe?

Yes, for the images. The merged index references each platform manifest **by digest**:

```
sha256:3fe7ec14…   develop-7772b18705f0, tree-ef0350…      ← merged index
  ├── sha256:7b9a6960…   (no tags)                        ← amd64 image
  └── sha256:57f938ba…   (no tags)                        ← arm64 image

sha256:f4d063ee…   develop-7772b18705f0-amd64             ← staging wrapper
  └── sha256:7b9a6960…   (same amd64 image)
```

Removing a staging tag drops only the wrapper. The untagged child manifests stay alive because
the merged index depends on them.

One cosmetic caveat: the SLSA provenance attestation records
`subject.name = …@develop-<sha>-amd64`, frozen at staging time. Deleting the tag makes that
*name* a dangling reference; the digest beside it stays valid, which is what verification
actually uses.

## Verification

Run against the real 1894 `pr-*` tags currently in GHCR:

```
owned BEFORE (narrow)   :  932
owned AFTER  (variants) : 1894   (+962)
still unowned           :    0
```

Foreign shapes remain unowned — other PRs, `develop-*`, `tree-*`, unknown platforms, and prefix
overlaps such as `pr-12345` against `pr-1234`.

## Test plan

- [x] `python3 .github/scripts/test_cleanup_pr_tags.py` — 28 tests pass (21 existing + 7 new)
- [x] Widened pattern validated against the live GHCR tag set, both directions
- [x] `is_deletable` still keeps a version shared with a `develop-*` or `tree-*` tag
- [ ] After merge: close a PR touching a native-built image and confirm its `-amd64` / `-arm64`
      tags disappear alongside the plain candidate tag

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [x] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally.
- [x] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No secrets, API keys, or credentials committed.
