### PR TITLE
Feat/vss memory introspection

### DIFF
--- a/services/agent/packages/vss_agents/src/vss_agents/tools/video_understanding.py
+++ b/services/agent/packages/vss_agents/src/vss_agents/tools/video_understanding.py
@@ -17,7 +17,6 @@ from collections.abc import AsyncGenerator
 from datetime import datetime
 from datetime import timedelta
 import logging
-import tempfile
 from typing import Any
 from typing import Literal
 
@@ -47,7 +46,6 @@ except ImportError:
 
 from vss_agents.tools.vst.timeline import get_timeline
 from vss_agents.tools.vst.utils import get_stream_id
-from vss_agents.utils.frame_select import frame_select
 from vss_agents.utils.retry import create_retry_strategy
 from vss_agents.utils.url_translation import rewrite_to_internal_vst_url
 
@@ -116,7 +114,7 @@ def _should_use_video_base64(
     enable_audio: bool = False,
     model_name: str = "",
 ) -> bool:
-    """Return whether the video payload should be downloaded locally and sent as base64 JPEG frames.
+    """Return whether the video should be downloaded and sent as one base64 MP4.
 
     Returns ``False`` when the full-MP4 ``video_url`` path should be used instead
     (see ``_should_use_video_file_base64``).  That covers:
@@ -124,18 +122,16 @@ def _should_use_video_base64(
     * Remote Omni + ``enable_audio`` — preserves the audio track.
     * Remote Cosmos models — avoids the per-prompt image count limit.
 
-    Edge case: ``enable_audio=True`` with a non-Omni remote VLM. The model can't process
-    the audio track anyway, and the internal VST URL is unreachable from a remote NIM, so
-    sending ``video_url`` would produce no analysis at all. Fall back to JPEG frame
-    sampling (the normal remote-VLM path) and warn loudly so the misconfiguration is
-    visible in logs.
+    Edge case: ``enable_audio=True`` with a non-Omni remote VLM. The full MP4 is
+    still sent because the internal VST URL is unreachable from a remote NIM,
+    though the model may ignore its audio track.
     """
     if enable_audio:
         if _is_remote_vlm(vlm_mode) and not _is_omni_audio_model(model_name):
             logger.warning(
                 "enable_audio=True with non-Omni remote VLM (model=%r) cannot honor audio "
-                "(remote NIM cannot reach internal VST URL, and the model has no audio "
-                "head). Falling back to JPEG frame sampling; audio is dropped. Set "
+                "(the model has no audio head). Sending the full MP4 inline; the audio "
+                "track may be ignored. Set "
                 "enable_audio=false or use an Omni-capable model to silence this warning.",
                 model_name,
             )
@@ -189,8 +185,8 @@ def _should_use_video_file_base64(
        that rejects >5 individual ``image_url`` entries.  The NIM handles
        frame sampling server-side via ``media_io_kwargs``.
 
-    Non-cosmos remote VLMs (Qwen, GPT-4o, etc.) stay on the ``image_url``
-    frame-sampling path for OpenAI API compatibility.
+    Non-cosmos remote VLMs also use the native MP4 path selected by
+    ``_should_use_video_base64``.
     """
     return _is_remote_vlm(vlm_mode) and (
         _is_cosmos_model(model_name) or (enable_audio and _is_omni_audio_model(model_name))
@@ -279,7 +275,7 @@ class VideoUnderstandingConfig(FunctionBaseConfig, name="video_understanding"):
     enable_audio: bool = Field(
         False,
         description="When True, send the full MP4 via video_url (preserves audio for Omni VLMs). "
-        "When False with VLM_MODE=remote, JPEG frame sampling is used instead. "
+        "When False with VLM_MODE=remote, the MP4 is downloaded and sent as one base64 video input. "
         "Align with vst.video_clip.enable_audio and ENABLE_AUDIO.",
     )
 
@@ -400,12 +396,9 @@ async def _build_vlm_messages(
     *,
     use_base64: bool,
     use_video_file_base64: bool = False,
-    video_length_seconds: float,
-    num_frames: int,
-    max_fps: int,
 ) -> list[HumanMessage]:
     """Download/transform video and build VLM messages for the appropriate backend."""
-    if use_video_file_base64:
+    if use_video_file_base64 or use_base64:
         timeout = aiohttp.ClientTimeout(total=300)
         async with aiohttp.ClientSession(timeout=timeout) as session, session.get(video_url) as resp:
             resp.raise_for_status()
@@ -416,33 +409,6 @@ async def _build_vlm_messages(
                 content=[
                     {"type": "text", "text": user_prompt},
                     {"type": "video_url", "video_url": {"url": f"data:video/mp4;base64,{video_b64}"}},
-                ]
-            )
-        ]
-
-    if use_base64:
-        timeout = aiohttp.ClientTimeout(total=300)
-        async with aiohttp.ClientSession(timeout=timeout) as session, session.get(video_url) as resp:
-            resp.raise_for_status()
-            video_data = await resp.read()
-
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=True) as tmp:
-            tmp.write(video_data)
-            tmp.flush()
-            step_size = max(video_length_seconds / num_frames, 1.0 / max_fps)
-            base64_frames = frame_select(tmp.name, 0.0, video_length_seconds, step_size)
-
-        return [
-            HumanMessage(
-                content=[
-                    {
-                        "type": "text",
-                        "text": f"The following images are a sequence of frames from a video. Answer the user's question based on the video: {user_prompt}",
-                    },
-                    *[
-                        {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{frame}"}}
-                        for frame in base64_frames
-                    ],
                 ]
             )
         ]
@@ -703,9 +669,6 @@ async def video_understanding(config: VideoUnderstandingConfig, builder: Builder
             user_prompt,
             use_base64=use_video_base64,
             use_video_file_base64=use_video_file_base64,
-            video_length_seconds=video_length_seconds,
-            num_frames=num_frames,
-            max_fps=config.max_fps,
         )
 
         # Suppress NAT's profiler for the VLM call — it deep-copies the full

--- a/services/agent/packages/vss_agents/tests/unit_test/tools/test_video_understanding.py
+++ b/services/agent/packages/vss_agents/tests/unit_test/tools/test_video_understanding.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Unit tests for video_understanding module."""
 
+import base64
+
 import pytest
 
 from vss_agents.tools.video_understanding import VideoUnderstandingConfig
@@ -186,7 +188,7 @@ class TestShouldUseVideoBase64:
             model_name="nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
         )
 
-    def test_enable_audio_non_omni_remote_falls_back_to_jpeg(self, caplog):
+    def test_enable_audio_non_omni_remote_inlines_mp4_with_warning(self, caplog):
         with caplog.at_level("WARNING"):
             assert _should_use_video_base64(
                 use_base64=False,
@@ -195,7 +197,7 @@ class TestShouldUseVideoBase64:
                 model_name="Qwen/Qwen3-VL-8B-Instruct",
             )
         assert "non-Omni remote VLM" in caplog.text
-        assert "Falling back to JPEG" in caplog.text
+        assert "Sending the full MP4 inline" in caplog.text
 
     def test_enable_audio_warns_when_use_base64_explicit(self, caplog):
         # Local VLM (URL reachable), Omni model: enable_audio takes precedence over
@@ -278,10 +280,10 @@ class TestBuildVlmMessages:
     """Test VLM media message construction."""
 
     @pytest.mark.asyncio
-    async def test_base64_uses_sampled_image_frames(self, monkeypatch):
-        class FakeResponse:
-            # aiohttp response: _build_vlm_messages reads Content-Type and validates body bytes.
+    async def test_base64_inlines_one_native_mp4(self, monkeypatch):
+        video_bytes = b"\x00\x00\x00\x20ftypisom\x00\x00\x02\x00" + b"\x00" * 200
 
+        class FakeResponse:
             async def __aenter__(self):
                 self.headers = {"Content-Type": "video/mp4"}
                 return self
@@ -293,7 +295,7 @@ class TestBuildVlmMessages:
                 return None
 
             async def read(self):
-                return b"\x00\x00\x00\x20ftypisom\x00\x00\x02\x00" + b"\x00" * 200
+                return video_bytes
 
         class FakeSession:
             def __init__(self, timeout):
@@ -309,32 +311,22 @@ class TestBuildVlmMessages:
                 assert url == "http://10.0.0.1:30888/vst/storage/video.mp4"
                 return FakeResponse()
 
-        def fake_frame_select(path, start, end, step_size):
-            assert path.endswith(".mp4")
-            assert start == 0.0
-            assert end == 4.0
-            assert step_size == 2.0
-            return ["frame-a", "frame-b"]
-
         monkeypatch.setattr("vss_agents.tools.video_understanding.aiohttp.ClientSession", FakeSession)
-        monkeypatch.setattr("vss_agents.tools.video_understanding.frame_select", fake_frame_select)
 
         messages = await _build_vlm_messages(
             "http://10.0.0.1:30888/vst/storage/video.mp4",
             "What is happening?",
             use_base64=True,
-            video_length_seconds=4.0,
-            num_frames=2,
-            max_fps=1,
         )
 
         content = messages[0].content
-        assert content[0]["type"] == "text"
-        assert "sequence of frames" in content[0]["text"]
-        assert content[1:] == [
-            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,frame-a"}},
-            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,frame-b"}},
-        ]
+        assert content[0] == {"type": "text", "text": "What is happening?"}
+        assert len(content) == 2
+        video_part = content[1]
+        assert video_part["type"] == "video_url"
+        data_uri = video_part["video_url"]["url"]
+        assert data_uri.startswith("data:video/mp4;base64,")
+        assert base64.b64decode(data_uri.partition(",")[2]) == video_bytes
 
     @pytest.mark.asyncio
     async def test_video_file_base64_inlines_full_mp4(self, monkeypatch):
@@ -371,9 +363,6 @@ class TestBuildVlmMessages:
             "What is said?",
             use_base64=False,
             use_video_file_base64=True,
-            video_length_seconds=4.0,
-            num_frames=2,
-            max_fps=1,
         )
 
         content = messages[0].content

--- a/services/agent/packages/vss_cli/AGENTS.md
+++ b/services/agent/packages/vss_cli/AGENTS.md
@@ -25,7 +25,7 @@ This file covers what is specific to the CLI's own surface.
 
 ## The two shapes
 
-**Job groups** — `search`, `summarize`. Work that runs a model and produces
+**Job groups** — `search`, `summarize`, `vlm`. Work that runs a model and produces
 evidence. Every `run` mints a `job_id` and persists a record, so the result is
 retrievable afterwards by that id:
 
@@ -85,7 +85,7 @@ vss vios add --type video /path/to/clip.mp4         # if absent; the filename be
 Uploaded filenames must have no whitespace — the filename *is* the sensor name.
 The CLI rejects a bad one locally rather than spending the upload first.
 
-## `vss search` and `vss summarize`
+## `vss search`, `vss summarize`, and `vss vlm`
 
 ```bash
 vss search run "forklift near the loading dock" [--limit N]
@@ -93,6 +93,9 @@ vss search get --job-id <id>
 
 vss summarize run --video-uri <uri> --prompt "..." --timeout <seconds>
 vss summarize get --job-id <id>
+
+vss vlm run --sensor NAME --start-time <ISO-UTC> --end-time <ISO-UTC> --prompt "..."
+vss vlm get --job-id <id>
 ```
 
 If a preflight fails, report its error and stop. Do not fall back to calling

--- a/services/agent/packages/vss_cli/MEMORY.md
+++ b/services/agent/packages/vss_cli/MEMORY.md
@@ -61,8 +61,10 @@ relevance before recency, while queries without text remain newest-first.
 
 `memory introspect` performs bounded, memory-first question answering and emits
 exactly one JSON object to stdout (compact by default, indented with `--pretty`).
-The query must be scoped by `--sensor`, `--job-id`, `--record-id`, or a complete
-`--start-time`/`--end-time` range. Time bounds accept ISO-8601 UTC instants only.
+The query must be scoped by `--sensor`, `--job-id`, or a complete
+`--start-time`/`--end-time` range. A child lookup requires its full public
+identity: `--job-id`, `--record-type`, and `--record-id`. Time bounds accept
+ISO-8601 UTC instants only.
 `--record-type event|search_hit|incident` and `--group summary|search|alert`
 refine a useful scope but do not establish one by themselves.
 

--- a/services/agent/packages/vss_cli/MEMORY.md
+++ b/services/agent/packages/vss_cli/MEMORY.md
@@ -45,6 +45,7 @@ vss memory upsert
 vss memory get --job-id <job-id>
 vss memory query --job-id <job-id>
 vss memory events --asset-id <sensor-or-video-id>
+vss memory introspect --query "What happened?" --sensor <sensor-name>
 ```
 
 Use `get` for an exact parent or child identity, `query` for filtered or text
@@ -57,6 +58,20 @@ Memory records use the human-readable VIOS sensor name in
 under `input.sensors[].info`. Sensor filters also match older records that
 stored the readable name as `input.sensors[].info.name`. Text queries rank by
 relevance before recency, while queries without text remain newest-first.
+
+`memory introspect` performs bounded, memory-first question answering and emits
+exactly one JSON object to stdout (compact by default, indented with `--pretty`).
+The query must be scoped by `--sensor`, `--job-id`, `--record-id`, or a complete
+`--start-time`/`--end-time` range. Time bounds accept ISO-8601 UTC instants only.
+`--record-type event|search_hit|incident` and `--group summary|search|alert`
+refine a useful scope but do not establish one by themselves.
+
+One workflow retrieves at most 10 records, requests at most 3 VLM follow-ups,
+limits each clip to 60 seconds, and has a 180-second overall timeout. The
+introspection request/result is never stored and never creates a Markdown note.
+Any internal VLM follow-up is a normal `vlm` job: it follows the configured
+static persistence policy and remains independently visible through VLM job
+reads when persistence is enabled.
 
 Accepted job groups are `summary`, `search`, `alert`, and `vlm`. `media` is
 not a job group because VIOS does not mint job IDs or memory completion
@@ -100,9 +115,9 @@ Elasticsearch persistence. Markdown status is reported separately as
 
 ## Scope
 
-This surface preserves parent/child persistence and recall. It does not
-implement introspection, gap or sufficiency analysis, VLM follow-up
-orchestration, introspection traces, semantic/vector recall, or graph memory.
+This surface preserves parent/child persistence and recall. Introspection adds
+bounded sufficiency analysis and VLM follow-ups without storing an
+introspection trace. Semantic/vector recall and graph memory are not included.
 
 Trusted persistence callbacks are not supported. No active code or tests
 require them, and arbitrary callback execution is not exposed to agents.

--- a/services/agent/packages/vss_cli/MEMORY.md
+++ b/services/agent/packages/vss_cli/MEMORY.md
@@ -31,6 +31,50 @@ vss configure memory show
 vss configure memory check
 ```
 
+Configure introspection separately. This is explicit static configuration: VSS
+does not discover a judge endpoint, model, or credential automatically.
+
+For an OpenClaw Gateway:
+
+```console
+openclaw config set gateway.http.endpoints.chatCompletions.enabled true
+# Restart the gateway after changing its HTTP endpoint configuration.
+export OPENCLAW_GATEWAY_TOKEN='<gateway-token>'
+
+vss configure memory introspection \
+  --judge-endpoint http://127.0.0.1:18789/v1 \
+  --judge-model openclaw/default \
+  --judge-api-key-env OPENCLAW_GATEWAY_TOKEN
+```
+
+`--judge-api-key-env` stores only the environment-variable name. The variable
+must contain the Bearer token whenever `vss memory introspect` runs. The token
+is never written to `~/.vss/config.json` or displayed by `memory show`.
+
+`openclaw/default` delegates model selection to OpenClaw. To request one
+specific OpenClaw backend, add `--judge-backend-model <provider/model>`; VSS
+sends that value as `x-openclaw-model`. For any other OpenAI-compatible Chat
+Completions service, set its base `/v1` URL and API-facing model explicitly:
+
+```console
+vss configure memory introspection \
+  --judge-endpoint https://llm.example.com/v1 \
+  --judge-model llama-3.3-70b-instruct \
+  --judge-api-key-env CUSTOM_LLM_API_KEY
+```
+
+Set sufficiency criteria inline or from a UTF-8 file:
+
+```console
+vss configure memory introspection --judge-criteria "Require direct evidence for every material claim."
+vss configure memory introspection --judge-criteria-file ./introspection-criteria.txt
+```
+
+Updates preserve unspecified values. Use `--clear-judge-api-key-env` or
+`--clear-judge-backend-model` to remove those optional settings.
+`vss configure memory show` and `check` never run introspection or call the
+judge (`check` still validates the configured memory backend).
+
 Backend and index selection are not normal per-request flags. Search,
 summarize, status, get, list, and `vss memory` do not expose
 `--memory-index`. Job-producing commands do not expose a positive `--persist`
@@ -71,9 +115,13 @@ refine a useful scope but do not establish one by themselves.
 One workflow retrieves at most 10 records, requests at most 3 VLM follow-ups,
 limits each clip to 60 seconds, and has a 180-second overall timeout. The
 introspection request/result is never stored and never creates a Markdown note.
-Any internal VLM follow-up is a normal `vlm` job: it follows the configured
-static persistence policy and remains independently visible through VLM job
-reads when persistence is enabled.
+The configured OpenAI-compatible text LLM performs both memory-sufficiency
+judgment and final answer synthesis. RT-VLM is not used as a judge or
+synthesizer. It is used only for grounded visual follow-ups when the text judge
+identifies a missing sensor/time window. Each follow-up uses the normal
+`vss vlm run` execution path, follows the configured static persistence policy,
+and remains independently visible through VLM job reads when persistence is
+enabled.
 
 Accepted job groups are `summary`, `search`, `alert`, and `vlm`. `media` is
 not a job group because VIOS does not mint job IDs or memory completion

--- a/services/agent/packages/vss_cli/MEMORY.md
+++ b/services/agent/packages/vss_cli/MEMORY.md
@@ -52,6 +52,12 @@ recall, `events` for temporal child-record recall, and `upsert` for explicit
 record writes. Identity, status, sensor, time-window, text, and result-limit
 flags remain dynamic.
 
+Memory records use the human-readable VIOS sensor name in
+`input.sensors[].id`; internal sensor UUIDs, stream IDs, and video IDs remain
+under `input.sensors[].info`. Sensor filters also match older records that
+stored the readable name as `input.sensors[].info.name`. Text queries rank by
+relevance before recency, while queries without text remain newest-first.
+
 Accepted job groups are `summary`, `search`, `alert`, and `vlm`. `media` is
 not a job group because VIOS does not mint job IDs or memory completion
 records.

--- a/services/agent/packages/vss_cli/README.md
+++ b/services/agent/packages/vss_cli/README.md
@@ -63,12 +63,18 @@ vss configure check    # re-probe; exit 3 if a route disappeared
 | `vss search` | Fused archive search over ES + the embedding NIM | `run`, `status`, `get`, `list` |
 | `vss summarize` | VLM summarization of stored video | `run`, `status`, `get`, `list` |
 | `vss vlm` | One VLM answer from a recorded sensor window | `run`, `status`, `get`, `list` |
+| `vss memory` | Unified-memory access and bounded introspection | `upsert`, `get`, `query`, `events`, `introspect` |
 | `vss vios` | Media plane: sensors, timelines, clip and snapshot URLs | `list`, `timeline`, `clip`, `snapshot`, `add`, `delete` |
 | `vss configure` | Resolve and record a deployment | `show`, `check` |
 
 `search`, `summarize`, and `vlm` are **job groups**: every run mints a `job_id`, and the
 result stays retrievable by that id. `vios` is **not** — it resolves handles and
 mints URLs, so it has no job verbs. See [AGENTS.md](AGENTS.md#the-two-shapes).
+
+Memory introspection requires an explicitly configured OpenAI-compatible text
+LLM for sufficiency judgment and answer synthesis. RT-VLM is reserved for
+grounded visual follow-ups. See [the memory policy and configuration
+guide](MEMORY.md).
 
 ## Extending it
 

--- a/services/agent/packages/vss_cli/README.md
+++ b/services/agent/packages/vss_cli/README.md
@@ -62,10 +62,11 @@ vss configure check    # re-probe; exit 3 if a route disappeared
 |-------|-----------|-------|
 | `vss search` | Fused archive search over ES + the embedding NIM | `run`, `status`, `get`, `list` |
 | `vss summarize` | VLM summarization of stored video | `run`, `status`, `get`, `list` |
+| `vss vlm` | One VLM answer from a recorded sensor window | `run`, `status`, `get`, `list` |
 | `vss vios` | Media plane: sensors, timelines, clip and snapshot URLs | `list`, `timeline`, `clip`, `snapshot`, `add`, `delete` |
 | `vss configure` | Resolve and record a deployment | `show`, `check` |
 
-`search` and `summarize` are **job groups**: every run mints a `job_id`, and the
+`search`, `summarize`, and `vlm` are **job groups**: every run mints a `job_id`, and the
 result stays retrievable by that id. `vios` is **not** — it resolves handles and
 mints URLs, so it has no job verbs. See [AGENTS.md](AGENTS.md#the-two-shapes).
 

--- a/services/agent/packages/vss_cli/src/vss_cli/config.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/config.py
@@ -61,6 +61,14 @@ class ConfigError(Exception):
 
 
 _ELASTICSEARCH_INDEX_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_ENVIRONMENT_VARIABLE_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+DEFAULT_INTROSPECTION_CRITERIA_PROMPT = """Memory is sufficient only when:
+1. The supplied records directly answer every material part of the user's question.
+2. The evidence applies to the requested sensor and time range.
+3. Each factual conclusion is supported by one or more supplied record IDs.
+4. No critical fact required to answer the question is missing.
+If any required condition fails, mark the evidence insufficient and produce grounded gaps for the missing information."""
 
 
 def validate_memory_index(value: str) -> str:
@@ -184,6 +192,101 @@ class MarkdownMemoryConfig:
 
 
 @dataclass(frozen=True)
+class IntrospectionJudgeConfig:
+    """OpenAI-compatible text judge and answer-synthesis endpoint."""
+
+    endpoint: str
+    model: str = "openclaw/default"
+    backend_model: str | None = None
+    api_key_env: str | None = None
+    criteria_prompt: str = DEFAULT_INTROSPECTION_CRITERIA_PROMPT
+
+    def validate(self) -> IntrospectionJudgeConfig:
+        if not self.endpoint.strip():
+            raise ConfigError("introspection judge endpoint must be non-empty")
+        if not self.model.strip():
+            raise ConfigError("introspection judge model must be non-empty")
+        if self.backend_model is not None and not self.backend_model.strip():
+            raise ConfigError("introspection judge backend model must be non-empty when configured")
+        if self.api_key_env is not None and not _ENVIRONMENT_VARIABLE_PATTERN.fullmatch(self.api_key_env):
+            raise ConfigError(
+                "introspection judge API-key environment variable must start with a letter or '_' "
+                "and contain only letters, digits, or '_'"
+            )
+        if not self.criteria_prompt.strip():
+            raise ConfigError("introspection judge criteria must be non-empty")
+        return self
+
+    def to_json(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "endpoint": self.endpoint,
+            "model": self.model,
+            "backend_model": self.backend_model,
+            "api_key_env": self.api_key_env,
+            "criteria_prompt": self.criteria_prompt,
+        }
+
+    @classmethod
+    def from_json(cls, raw: object) -> IntrospectionJudgeConfig:
+        if not isinstance(raw, dict):
+            raise ConfigError("config 'memory.introspection.judge' must be a JSON object")
+        expected = {"endpoint", "model", "backend_model", "api_key_env", "criteria_prompt"}
+        unknown = sorted(set(raw) - expected)
+        if unknown:
+            raise ConfigError(f"config 'memory.introspection.judge' contains unknown fields: {', '.join(unknown)}")
+        endpoint = raw.get("endpoint")
+        model = raw.get("model", "openclaw/default")
+        backend_model = raw.get("backend_model")
+        api_key_env = raw.get("api_key_env")
+        criteria_prompt = raw.get("criteria_prompt", DEFAULT_INTROSPECTION_CRITERIA_PROMPT)
+        if not isinstance(endpoint, str):
+            raise ConfigError("config 'memory.introspection.judge.endpoint' must be a string")
+        if not isinstance(model, str):
+            raise ConfigError("config 'memory.introspection.judge.model' must be a string")
+        if backend_model is not None and not isinstance(backend_model, str):
+            raise ConfigError("config 'memory.introspection.judge.backend_model' must be a string or null")
+        if api_key_env is not None and not isinstance(api_key_env, str):
+            raise ConfigError("config 'memory.introspection.judge.api_key_env' must be a string or null")
+        if not isinstance(criteria_prompt, str):
+            raise ConfigError("config 'memory.introspection.judge.criteria_prompt' must be a string")
+        return cls(
+            endpoint=endpoint,
+            model=model,
+            backend_model=backend_model,
+            api_key_env=api_key_env,
+            criteria_prompt=criteria_prompt,
+        ).validate()
+
+
+@dataclass(frozen=True)
+class IntrospectionMemoryConfig:
+    """Static configuration for bounded memory introspection."""
+
+    judge: IntrospectionJudgeConfig
+
+    def validate(self) -> IntrospectionMemoryConfig:
+        self.judge.validate()
+        return self
+
+    def to_json(self) -> dict[str, Any]:
+        self.validate()
+        return {"judge": self.judge.to_json()}
+
+    @classmethod
+    def from_json(cls, raw: object) -> IntrospectionMemoryConfig:
+        if not isinstance(raw, dict):
+            raise ConfigError("config 'memory.introspection' must be a JSON object")
+        expected = {"judge"}
+        unknown = sorted(set(raw) - expected)
+        if unknown:
+            raise ConfigError(f"config 'memory.introspection' contains unknown fields: {', '.join(unknown)}")
+        if "judge" not in raw:
+            raise ConfigError("config 'memory.introspection.judge' is required")
+        return cls(judge=IntrospectionJudgeConfig.from_json(raw["judge"])).validate()
+
+
+@dataclass(frozen=True)
 class MemoryConfig:
     """Static policy and infrastructure for authoritative VSS memory."""
 
@@ -192,6 +295,7 @@ class MemoryConfig:
     index: str = "vss-memory"
     persist_by_default: bool = True
     markdown: MarkdownMemoryConfig = field(default_factory=MarkdownMemoryConfig)
+    introspection: IntrospectionMemoryConfig | None = None
 
     def validate(self) -> MemoryConfig:
         if self.backend != "elasticsearch":
@@ -203,6 +307,8 @@ class MemoryConfig:
                 "use `vss configure memory --disable --no-persist-by-default`"
             )
         self.markdown.validate()
+        if self.introspection is not None:
+            self.introspection.validate()
         if self.markdown.enabled and not self.enabled:
             raise ConfigError("Markdown memory cannot be enabled while authoritative memory is disabled")
         if self.markdown.write_by_default and not self.persist_by_default:
@@ -220,13 +326,14 @@ class MemoryConfig:
             "index": self.index,
             "persist_by_default": self.persist_by_default,
             "markdown": self.markdown.to_json(),
+            "introspection": self.introspection.to_json() if self.introspection is not None else None,
         }
 
     @classmethod
     def from_json(cls, raw: object) -> MemoryConfig:
         if not isinstance(raw, dict):
             raise ConfigError("config 'memory' must be a JSON object")
-        expected = {"enabled", "backend", "index", "persist_by_default", "markdown"}
+        expected = {"enabled", "backend", "index", "persist_by_default", "markdown", "introspection"}
         unknown = sorted(set(raw) - expected)
         if unknown:
             raise ConfigError(f"config 'memory' contains unknown fields: {', '.join(unknown)}")
@@ -248,6 +355,11 @@ class MemoryConfig:
             index=index,
             persist_by_default=persist_by_default,
             markdown=MarkdownMemoryConfig.from_json(raw["markdown"]) if "markdown" in raw else MarkdownMemoryConfig(),
+            introspection=(
+                IntrospectionMemoryConfig.from_json(raw["introspection"])
+                if raw.get("introspection") is not None
+                else None
+            ),
         ).validate()
 
 

--- a/services/agent/packages/vss_cli/src/vss_cli/configure.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/configure.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from datetime import UTC
 from datetime import datetime
 import json
+from pathlib import Path
 from typing import Any
 from typing import NoReturn
 
@@ -271,6 +272,7 @@ def configure_memory(
             if write_notes_by_default is None
             else write_notes_by_default,
         ),
+        introspection=current.introspection,
     )
     try:
         candidate.validate()
@@ -285,6 +287,109 @@ def configure_memory(
     except config_mod.ConfigError as error:
         _memory_config_error(str(error))
     click.echo(f"wrote memory configuration to {path}", err=True)
+
+
+@configure_memory.command(name="introspection")
+@click.option("--judge-endpoint", help="OpenAI-compatible text-judge base URL.")
+@click.option("--judge-model", help="API-facing text-judge model (default: openclaw/default on first setup).")
+@click.option("--judge-backend-model", help="Optional OpenClaw backend model sent as x-openclaw-model.")
+@click.option("--clear-judge-backend-model", is_flag=True, help="Remove the OpenClaw backend-model override.")
+@click.option("--judge-api-key-env", help="Environment variable containing the text-judge Bearer token.")
+@click.option("--clear-judge-api-key-env", is_flag=True, help="Remove the text-judge credential environment name.")
+@click.option("--judge-criteria", help="Inline memory-sufficiency criteria.")
+@click.option(
+    "--judge-criteria-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False, readable=True),
+    help="UTF-8 file whose contents become the memory-sufficiency criteria.",
+)
+def configure_memory_introspection(
+    judge_endpoint: str | None,
+    judge_model: str | None,
+    judge_backend_model: str | None,
+    clear_judge_backend_model: bool,
+    judge_api_key_env: str | None,
+    clear_judge_api_key_env: bool,
+    judge_criteria: str | None,
+    judge_criteria_file: Path | None,
+) -> None:
+    """Configure the text LLM used to judge and synthesize introspection."""
+    if judge_backend_model is not None and clear_judge_backend_model:
+        raise click.UsageError("cannot combine --judge-backend-model with --clear-judge-backend-model")
+    if judge_api_key_env is not None and clear_judge_api_key_env:
+        raise click.UsageError("cannot combine --judge-api-key-env with --clear-judge-api-key-env")
+    if judge_criteria is not None and judge_criteria_file is not None:
+        raise click.UsageError("cannot combine --judge-criteria with --judge-criteria-file")
+
+    deployment = _load_memory_deployment()
+    current_memory = deployment.memory or config_mod.MemoryConfig()
+    current_introspection = current_memory.introspection
+    current_judge = current_introspection.judge if current_introspection is not None else None
+    if current_judge is None and judge_endpoint is None:
+        raise click.UsageError("--judge-endpoint is required on first introspection configuration")
+
+    criteria = judge_criteria
+    if judge_criteria_file is not None:
+        try:
+            criteria = judge_criteria_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            _memory_config_error(f"cannot read introspection judge criteria file {judge_criteria_file}: {error}")
+
+    candidate_judge = config_mod.IntrospectionJudgeConfig(
+        endpoint=judge_endpoint if judge_endpoint is not None else current_judge.endpoint,  # type: ignore[union-attr]
+        model=(
+            judge_model
+            if judge_model is not None
+            else current_judge.model
+            if current_judge is not None
+            else "openclaw/default"
+        ),
+        backend_model=(
+            None
+            if clear_judge_backend_model
+            else judge_backend_model
+            if judge_backend_model is not None
+            else current_judge.backend_model
+            if current_judge is not None
+            else None
+        ),
+        api_key_env=(
+            None
+            if clear_judge_api_key_env
+            else judge_api_key_env
+            if judge_api_key_env is not None
+            else current_judge.api_key_env
+            if current_judge is not None
+            else None
+        ),
+        criteria_prompt=(
+            criteria
+            if criteria is not None
+            else current_judge.criteria_prompt
+            if current_judge is not None
+            else config_mod.DEFAULT_INTROSPECTION_CRITERIA_PROMPT
+        ),
+    )
+    candidate = config_mod.MemoryConfig(
+        enabled=current_memory.enabled,
+        backend=current_memory.backend,
+        index=current_memory.index,
+        persist_by_default=current_memory.persist_by_default,
+        markdown=current_memory.markdown,
+        introspection=config_mod.IntrospectionMemoryConfig(judge=candidate_judge),
+    )
+    try:
+        candidate.validate()
+        path = config_mod.save(
+            config_mod.Deployment(
+                base_url=deployment.base_url,
+                services=deployment.services,
+                memory=candidate,
+                written_at=deployment.written_at,
+            )
+        )
+    except config_mod.ConfigError as error:
+        _memory_config_error(str(error))
+    click.echo(f"wrote introspection judge configuration to {path}", err=True)
 
 
 @configure_memory.command(name="show")

--- a/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
@@ -323,7 +323,7 @@ def introspect_memory(
     group: str | None,
     pretty: bool,
 ) -> None:
-    """Answer one scoped question using memory and bounded VLM follow-ups."""
+    """Answer via the configured text judge and bounded RT-VLM follow-ups."""
     try:
         from vss_core.introspection import IntrospectionRequest
 

--- a/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 from typing import TYPE_CHECKING
 from typing import Any
@@ -133,17 +134,30 @@ async def _execute_introspection(request: IntrospectionRequest) -> tuple[Introsp
     from vss_core.introspection import introspect
 
     deployment = config_mod.load()
+    memory_config = deployment.memory
+    if memory_config is None or memory_config.introspection is None:
+        raise config_mod.ConfigError(
+            "memory introspection judge is not configured; run `vss configure memory introspection`"
+        )
+    judge_config = memory_config.introspection.judge
+    api_key: str | None = None
+    if judge_config.api_key_env is not None:
+        api_key = os.environ.get(judge_config.api_key_env, "")
+        if not api_key.strip():
+            raise config_mod.ConfigError(
+                f"introspection judge credential environment variable {judge_config.api_key_env!r} is missing or empty"
+            )
     memory = _memory(deployment)
     owns_memory = _TEST_MEMORY is None
     client: OpenAIIntrospectionClient | None = None
     try:
-        rt_vlm = deployment.services.get("rt_vlm")
-        if rt_vlm is None or not rt_vlm.url or not rt_vlm.models:
-            raise config_mod.ConfigError("the configured RT-VLM service reports no model")
         settings = IntrospectionSettings()
         client = OpenAIIntrospectionClient(
-            base_url=rt_vlm.url,
-            model=rt_vlm.models[0],
+            base_url=judge_config.endpoint,
+            model=judge_config.model,
+            backend_model=judge_config.backend_model,
+            api_key=api_key,
+            criteria_prompt=judge_config.criteria_prompt,
             settings=settings,
         )
         runner = IntrospectionVLMJobRunner(

--- a/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
@@ -9,10 +9,12 @@ the underlying parent/child store across groups.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import cast
 
 import click
 from pydantic import ValidationError
@@ -22,9 +24,17 @@ from . import memory as memory_mod
 from .exits import Exit
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from collections.abc import Callable
+
     from vss_cli.memory import Memory
+    from vss_core.introspection import IntrospectionRequest
+    from vss_core.introspection import IntrospectionResult
+    from vss_core.memory.models import MemoryGroup
+    from vss_core.memory.models import RecordType
 
 _TEST_MEMORY: Memory | None = None
+_TEST_INTROSPECT: Callable[[IntrospectionRequest], Awaitable[IntrospectionResult]] | None = None
 
 
 def set_test_memory(memory: Memory | None) -> None:
@@ -33,14 +43,29 @@ def set_test_memory(memory: Memory | None) -> None:
     _TEST_MEMORY = memory
 
 
-def _memory() -> Memory:
+def set_test_introspect(
+    function: Callable[[IntrospectionRequest], Awaitable[IntrospectionResult]] | None,
+) -> None:
+    """Inject the complete workflow boundary for hermetic CLI tests."""
+    global _TEST_INTROSPECT
+    _TEST_INTROSPECT = function
+
+
+def _memory(deployment: config_mod.Deployment | None = None) -> Memory:
     if _TEST_MEMORY is not None:
         return _TEST_MEMORY
-    return memory_mod.build(config_mod.load())
+    return memory_mod.build(deployment or config_mod.load())
 
 
 def _emit(value: Any, *, pretty: bool) -> None:
-    click.echo(json.dumps(value, indent=2 if pretty else None, default=str))
+    click.echo(
+        json.dumps(
+            value,
+            indent=2 if pretty else None,
+            separators=None if pretty else (",", ":"),
+            default=str,
+        )
+    )
 
 
 def _fail(prefix: str, error: BaseException, exit_code: Exit) -> None:
@@ -67,6 +92,88 @@ def _read_failure(error: BaseException) -> None:
 def _output_options(function: Any) -> Any:
     function = click.option("--pretty", is_flag=True, help="Indent JSON output.")(function)
     return function
+
+
+def _exception_exit(error: BaseException) -> Exit:
+    if isinstance(error, (config_mod.ConfigError, memory_mod.MemoryUnavailable)):
+        return Exit.CONFIGURATION
+    names = {klass.__name__ for klass in type(error).__mro__}
+    if "ConfigurationError" in names:
+        return Exit.CONFIGURATION
+    if names & {
+        "BackendUnreachableError",
+        "ConnectError",
+        "ConnectTimeout",
+        "HTTPStatusError",
+        "ReadTimeout",
+        "VSTError",
+        "VIOSTimeoutError",
+    }:
+        return Exit.BACKEND_UNREACHABLE
+    if isinstance(error, (ValidationError, ValueError)):
+        return Exit.INVALID_INPUT
+    if isinstance(error, TimeoutError):
+        return Exit.TIMEOUT
+    return Exit.ERROR
+
+
+async def _execute_introspection(request: IntrospectionRequest) -> tuple[IntrospectionResult, Exit]:
+    if _TEST_INTROSPECT is not None:
+        result = await _TEST_INTROSPECT(request)
+        if result.failure_kind == "timeout":
+            return result, Exit.TIMEOUT
+        if result.failure_kind == "backend_unreachable":
+            return result, Exit.BACKEND_UNREACHABLE
+        return result, Exit.NOT_FOUND if result.status == "no_memory" else Exit.SUCCESS
+
+    from vss_cli.memory_policy import effective_persist
+    from vss_cli.vlm.runner import IntrospectionVLMJobRunner
+    from vss_core.introspection import IntrospectionSettings
+    from vss_core.introspection import OpenAIIntrospectionClient
+    from vss_core.introspection import introspect
+
+    deployment = config_mod.load()
+    memory = _memory(deployment)
+    owns_memory = _TEST_MEMORY is None
+    client: OpenAIIntrospectionClient | None = None
+    try:
+        rt_vlm = deployment.services.get("rt_vlm")
+        if rt_vlm is None or not rt_vlm.url or not rt_vlm.models:
+            raise config_mod.ConfigError("the configured RT-VLM service reports no model")
+        settings = IntrospectionSettings()
+        client = OpenAIIntrospectionClient(
+            base_url=rt_vlm.url,
+            model=rt_vlm.models[0],
+            settings=settings,
+        )
+        runner = IntrospectionVLMJobRunner(
+            deployment,
+            memory=memory if effective_persist(deployment, no_persist=False) else None,
+            timeout_seconds=settings.timeout_seconds,
+        )
+        result = await introspect(
+            request,
+            memory=memory.service,
+            judge=client,
+            synthesizer=client,
+            vlm_runner=runner,
+            settings=settings,
+        )
+    finally:
+        if client is not None:
+            await client.aclose()
+        if owns_memory:
+            close_memory = getattr(memory.service.store, "close", None)
+            if close_memory is not None:
+                close_memory()
+
+    if runner.persistence_errors:
+        return result, Exit.PARTIAL
+    if result.failure_kind == "timeout" or runner.timed_out:
+        return result, Exit.TIMEOUT
+    if result.failure_kind == "backend_unreachable" or runner.backend_errors:
+        return result, Exit.BACKEND_UNREACHABLE
+    return result, Exit.NOT_FOUND if result.status == "no_memory" else Exit.SUCCESS
 
 
 @click.group(name="memory")
@@ -181,6 +288,56 @@ def query_records(
     _emit({"records": [record.model_dump_memory() for record in records]}, pretty=pretty)
 
 
+@memory.command("introspect")
+@click.option("--query", required=True, help="Question to answer from stored memory.")
+@click.option("--sensor", help="Limit recall to one VIOS sensor name.")
+@click.option("--start-time", help="Inclusive ISO-8601 UTC window start.")
+@click.option("--end-time", help="Inclusive ISO-8601 UTC window end.")
+@click.option("--job-id")
+@click.option("--record-id")
+@click.option("--record-type", type=click.Choice(("event", "search_hit", "incident")))
+@click.option("--group", type=click.Choice(("summary", "search", "alert")))
+@_output_options
+def introspect_memory(
+    query: str,
+    sensor: str | None,
+    start_time: str | None,
+    end_time: str | None,
+    job_id: str | None,
+    record_id: str | None,
+    record_type: str | None,
+    group: str | None,
+    pretty: bool,
+) -> None:
+    """Answer one scoped question using memory and bounded VLM follow-ups."""
+    try:
+        from vss_core.introspection import IntrospectionRequest
+
+        request = IntrospectionRequest(
+            query=query,
+            sensor=sensor,
+            start_time=start_time,
+            end_time=end_time,
+            job_id=job_id,
+            record_id=record_id,
+            record_type=cast("RecordType | None", record_type),
+            group=cast("MemoryGroup | None", group),
+        )
+        has_time_range = request.start_time is not None and request.end_time is not None
+        if not (request.sensor or request.job_id or request.record_id or has_time_range):
+            raise ValueError(
+                "provide useful scope with --sensor, --job-id, --record-id, or both --start-time and --end-time"
+            )
+        result, exit_code = asyncio.run(_execute_introspection(request))
+    except Exception as error:
+        _fail("introspection failed", error, _exception_exit(error))
+        raise AssertionError("unreachable") from error
+
+    _emit(result.model_dump(mode="json"), pretty=pretty)
+    if exit_code != Exit.SUCCESS:
+        raise SystemExit(int(exit_code))
+
+
 @memory.command("events")
 @click.option("--asset-id", required=True)
 @click.option("--start-time")
@@ -230,4 +387,4 @@ class _MemoryGroup:
 
 MEMORY = _MemoryGroup()
 
-__all__ = ["MEMORY", "memory", "set_test_memory"]
+__all__ = ["MEMORY", "memory", "set_test_introspect", "set_test_memory"]

--- a/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/memory_cmd.py
@@ -167,12 +167,12 @@ async def _execute_introspection(request: IntrospectionRequest) -> tuple[Introsp
             if close_memory is not None:
                 close_memory()
 
-    if runner.persistence_errors:
-        return result, Exit.PARTIAL
     if result.failure_kind == "timeout" or runner.timed_out:
         return result, Exit.TIMEOUT
     if result.failure_kind == "backend_unreachable" or runner.backend_errors:
         return result, Exit.BACKEND_UNREACHABLE
+    if runner.persistence_errors:
+        return result, Exit.PARTIAL
     return result, Exit.NOT_FOUND if result.status == "no_memory" else Exit.SUCCESS
 
 
@@ -324,9 +324,10 @@ def introspect_memory(
             group=cast("MemoryGroup | None", group),
         )
         has_time_range = request.start_time is not None and request.end_time is not None
-        if not (request.sensor or request.job_id or request.record_id or has_time_range):
+        if not (request.sensor or request.job_id or has_time_range):
             raise ValueError(
-                "provide useful scope with --sensor, --job-id, --record-id, or both --start-time and --end-time"
+                "provide useful scope with --sensor, --job-id, or both --start-time and --end-time; "
+                "child identity requires --job-id, --record-type, and --record-id together"
             )
         result, exit_code = asyncio.run(_execute_introspection(request))
     except Exception as error:

--- a/services/agent/packages/vss_cli/src/vss_cli/search/memory_adapter.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/search/memory_adapter.py
@@ -53,14 +53,16 @@ class SearchAdapter(LifecycleAdapter):
             if isinstance(item, SensorInfo):
                 sensor_models.append(item)
             else:
-                sensor_id = str(item.get("id") or item.get("sensor_id") or "").strip()
-                if not sensor_id:
-                    raise ValueError("search sensors require a non-empty id")
+                sensor_name = str(
+                    item.get("name") or item.get("sensor_name") or item.get("id") or item.get("sensor_id") or ""
+                ).strip()
+                if not sensor_name:
+                    raise ValueError("search sensors require a non-empty name or id")
                 sensor_models.append(
                     SensorInfo(
-                        id=sensor_id,
+                        id=sensor_name,
                         type=str(item.get("type") or "video") or None,
-                        info={k: v for k, v in item.items() if k not in {"id", "sensor_id", "type"}} or None,
+                        info={k: v for k, v in item.items() if k not in {"name", "sensor_name", "type"}} or None,
                     )
                 )
         window_model: TimeWindow | None = None
@@ -180,11 +182,14 @@ class SearchAdapter(LifecycleAdapter):
             prefix="hit",
             digest_payload=_search_digest_payload(row),
         )
-        sensor_id = (
-            str(row.get("sensor_id") or row.get("camera_id") or row.get("stream_id") or "").strip() or default_sensor_id
+        sensor_name = (
+            str(row.get("name") or row.get("sensor_name") or row.get("video_name") or "").strip() or default_sensor_id
         )
+        sensor_info = {
+            key: row[key] for key in ("sensor_id", "camera_id", "stream_id", "video_id") if row.get(key) is not None
+        }
         child_input = MemoryInput(
-            sensors=[SensorInfo(id=sensor_id)] if sensor_id else None,
+            sensors=[SensorInfo(id=sensor_name, info=sensor_info or None)] if sensor_name else None,
             window=window_from_row(row),
         )
         answer = row.get("description") or row.get("caption") or row.get("answer") or row.get("text")

--- a/services/agent/packages/vss_cli/src/vss_cli/summarize/group.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/summarize/group.py
@@ -43,6 +43,7 @@ to run it again -- not that an in-flight VLM call can be rejoined.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
@@ -371,7 +372,25 @@ def _adapter() -> SummaryAdapter:
     return SummaryAdapter()
 
 
-def _memory_input(inputs: SummarizeInput, options: SummarizeOptions, request: dict[str, Any]) -> MemoryInput:
+def _resolve_memory_sensor(
+    deployment: config_mod.Deployment,
+    inputs: SummarizeInput,
+    options: SummarizeOptions,
+) -> Any | None:
+    """Resolve a raw ``--id`` to VIOS identity when memory needs a name."""
+    if options.media_name or not inputs.id or not deployment.has("vst"):
+        return None
+    from vss_core import vios
+
+    return asyncio.run(vios.resolve_sensor(str(deployment.base_url).rstrip("/"), inputs.id))
+
+
+def _memory_input(
+    inputs: SummarizeInput,
+    options: SummarizeOptions,
+    request: dict[str, Any],
+    resolved_sensor: Any | None = None,
+) -> MemoryInput:
     """The record's request side: what was asked, of which asset, with what.
 
     ``params`` carries the LVS request verbatim, so a persisted job describes
@@ -382,8 +401,12 @@ def _memory_input(inputs: SummarizeInput, options: SummarizeOptions, request: di
         media_ref["stream_id"] = inputs.id
     if inputs.url:
         media_ref["url"] = inputs.url
-    if options.media_name:
-        media_ref["name"] = options.media_name
+    media_name = options.media_name or getattr(resolved_sensor, "name", None)
+    if media_name:
+        media_ref["name"] = media_name
+    if resolved_sensor is not None:
+        media_ref["sensor_id"] = resolved_sensor.sensor_id
+        media_ref["stream_id"] = resolved_sensor.stream_id
     return _adapter().build_input(
         prompt=inputs.prompt,
         video_id=options.video_id or inputs.id,
@@ -523,7 +546,8 @@ class SummarizeGroup(CommandGroup):
 
         job_id = _mint_job_id()
         created_at = utc_now_iso()
-        input_data = _memory_input(inputs, options, request)
+        resolved_sensor = _resolve_memory_sensor(deployment, inputs, options) if want_persist else None
+        input_data = _memory_input(inputs, options, request, resolved_sensor)
         persist_error: str | None = None
 
         def outcome(

--- a/services/agent/packages/vss_cli/src/vss_cli/summarize/memory_adapter.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/summarize/memory_adapter.py
@@ -56,7 +56,11 @@ class SummaryAdapter(LifecycleAdapter):
         sensors: list[SensorInfo] | None = None
         if video_id:
             info = dict(media_ref or {})
-            sensors = [SensorInfo(id=str(video_id), type=str(info.get("source") or "video"), info=info or None)]
+            # Sensor ids are recall handles, so persist the readable VIOS name
+            # there and keep backend video/stream/sensor identifiers as details.
+            sensor_name = str(info.get("name") or video_id).strip()
+            info.setdefault("video_id", str(video_id))
+            sensors = [SensorInfo(id=sensor_name, type=str(info.get("source") or "video"), info=info or None)]
         return MemoryInput(
             query=prompt,
             intent=intent,
@@ -154,12 +158,15 @@ class SummaryAdapter(LifecycleAdapter):
             prefix="evt",
             digest_payload=_event_digest_payload(event),
         )
-        sensor_id = (
-            str(event.get("sensor_id") or event.get("camera_id") or event.get("video_id") or "").strip()
+        sensor_name = (
+            str(event.get("name") or event.get("sensor_name") or event.get("video_name") or "").strip()
             or default_sensor_id
         )
+        sensor_info = {
+            key: event[key] for key in ("sensor_id", "camera_id", "stream_id", "video_id") if event.get(key) is not None
+        }
         child_input = MemoryInput(
-            sensors=[SensorInfo(id=sensor_id)] if sensor_id else None,
+            sensors=[SensorInfo(id=sensor_name, info=sensor_info or None)] if sensor_name else None,
             window=window_from_row(event),
         )
         answer = event.get("description") or event.get("summary") or event.get("answer") or event.get("text")

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/__init__.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/__init__.py
@@ -1,3 +1,23 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """``vss vlm`` — point-call visual question-answering over video."""
+
+from .group import VLM
+from .group import VlmGroup
+from .group import VlmInput
+from .group import VlmOptions
+from .runner import VLMJobError
+from .runner import VLMJobRequest
+from .runner import VLMJobResult
+from .runner import run_vlm_job
+
+__all__ = [
+    "VLM",
+    "VLMJobError",
+    "VLMJobRequest",
+    "VLMJobResult",
+    "VlmGroup",
+    "VlmInput",
+    "VlmOptions",
+    "run_vlm_job",
+]

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/memory_adapter.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/memory_adapter.py
@@ -8,10 +8,14 @@ helpers) and the command group owns the translation from its backend's shapes.
 ``vss vlm run`` is a **point call** — one bounded synchronous inference. The
 lifecycle is simpler than ``vss summarize``: no submitted/running intermediate
 states are needed. Exactly one record is written, with a terminal status.
+
+``VLMAdapter`` is the runner/introspection shape: a fully resolved sensor window
+with stream identity. The CLI point-call uses ``VlmAdapter``.
 """
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from vss_core.memory.adapters import LifecycleAdapter
@@ -28,10 +32,10 @@ def _time_window(start_time: str | None, end_time: str | None) -> TimeWindow | N
     if not start_time:
         return None
     from datetime import UTC
-    from datetime import datetime
+    from datetime import datetime as datetime_cls
 
     def _parse(value: str) -> TimestampPoint:
-        dt = datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+        dt = datetime_cls.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
         return TimestampPoint(timestamp=dt)
 
     return TimeWindow(
@@ -91,4 +95,55 @@ class VlmAdapter(LifecycleAdapter):
         return MemoryOutput(answer=answer, handles=handles, ext=ext)
 
 
-__all__ = ["VlmAdapter"]
+class VLMAdapter(LifecycleAdapter):
+    """Parent adapter for the shared ``run_vlm_job`` runner (group ``vlm``)."""
+
+    group: MemoryGroup = "vlm"
+
+    @staticmethod
+    def build_input(
+        *,
+        prompt: str,
+        intent: str,
+        sensor_name: str,
+        sensor_type: str,
+        sensor_id: str,
+        stream_id: str,
+        start_time: str,
+        end_time: str,
+        params: dict[str, Any],
+    ) -> MemoryInput:
+        return MemoryInput(
+            query=prompt,
+            intent=intent,
+            sensors=[
+                SensorInfo(
+                    id=sensor_name,
+                    type=sensor_type,
+                    info={"sensor_id": sensor_id, "stream_id": stream_id},
+                )
+            ],
+            window=TimeWindow(
+                start=TimestampPoint(timestamp=datetime.fromisoformat(start_time.replace("Z", "+00:00"))),
+                end=TimestampPoint(timestamp=datetime.fromisoformat(end_time.replace("Z", "+00:00"))),
+            ),
+            params=params,
+        )
+
+    @staticmethod
+    def build_output(
+        *,
+        answer: str,
+        model: str,
+        media_urls: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> MemoryOutput:
+        ext = {"model": model, **(metadata or {})}
+        return MemoryOutput(
+            answer=answer,
+            handles=OutputHandles(media_urls=media_urls) if media_urls else None,
+            ext=ext,
+        )
+
+
+__all__ = ["VLMAdapter", "VlmAdapter"]

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -278,6 +278,34 @@ async def run_vlm_job(
     model = analyzer_model or (type(analyzer).__name__ if analyzer is not None else "")
     adapter = VLMAdapter()
     persistence_error: str | None = None
+    persistence_lock = threading.Lock()
+
+    async def persist_record(record: Any) -> None:
+        """Run a synchronous store write without blocking deadline cancellation."""
+        if memory is None:
+            return
+        target_memory = memory
+        write_finished: asyncio.Future[Exception | None] = loop.create_future()
+
+        def write() -> None:
+            outcome: Exception | None = None
+            try:
+                with persistence_lock:
+                    target_memory.service.upsert(record)
+            except Exception as error:
+                outcome = error
+
+            def report(result: Exception | None = outcome) -> None:
+                if not write_finished.done():
+                    write_finished.set_result(result)
+
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(report)
+
+        threading.Thread(target=write, name="vss-vlm-persistence-write", daemon=True).start()
+        outcome = await asyncio.shield(write_finished)
+        if outcome is not None:
+            raise outcome
 
     async def close(
         status: Literal["failed", "partial", "timeout"],
@@ -285,20 +313,22 @@ async def run_vlm_job(
     ) -> Literal["absent", "closed", "stale"]:
         if memory is None or job_id is None or created_at is None or input_data is None:
             return "absent"
+        target_memory = memory
         write_finished: asyncio.Future[bool] = loop.create_future()
 
         def write() -> None:
-            closed = mark_terminal(
-                memory,
-                adapter,
-                job_id=job_id,
-                created_at=created_at,
-                input_data=input_data,
-                status=status,
-                message=detail,
-                attempts=1,
-                backoff_seconds=0,
-            )
+            with persistence_lock:
+                closed = mark_terminal(
+                    target_memory,
+                    adapter,
+                    job_id=job_id,
+                    created_at=created_at,
+                    input_data=input_data,
+                    status=status,
+                    message=detail,
+                    attempts=1,
+                    backoff_seconds=0,
+                )
 
             def report() -> None:
                 if not write_finished.done():
@@ -372,7 +402,7 @@ async def run_vlm_job(
                 )
                 if memory is not None:
                     try:
-                        memory.service.upsert(
+                        await persist_record(
                             adapter.submitted_record(job_id=job_id, created_at=created_at, input_data=input_data)
                         )
                     except Exception as error:
@@ -391,7 +421,7 @@ async def run_vlm_job(
                 persisted = False
                 if memory is not None:
                     try:
-                        memory.service.upsert(
+                        await persist_record(
                             adapter.terminal_record(
                                 job_id=job_id,
                                 created_at=created_at,

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -219,7 +219,10 @@ def _production_analyzer(deployment: config_mod.Deployment, timeout_seconds: int
             vst=vst,
             timeout_seconds=timeout_seconds,
             media_mode="video_url",
-            video_url_scope="external",
+            # RT-VLM fetches the clip itself. Use VST's in-cluster videoUrl
+            # (for example http://vst-ingress:30888/...) so SSRF policy does
+            # not reject the host-side localhost origin.
+            video_url_scope="internal",
             cosmos_nim_runtime_options=False,
         ),
         model,

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -57,7 +57,7 @@ class VLMJobRequest(BaseModel):
     start_time: str = Field(min_length=1)
     end_time: str = Field(min_length=1)
     prompt: str = Field(min_length=1, max_length=512_000)
-    intent: Literal["video-qa", "introspection/internal"] = "video-qa"
+    intent: Literal["video-qa", "introspection"] = "video-qa"
 
     @field_validator("sensor", "prompt")
     @classmethod

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -279,80 +279,122 @@ async def run_vlm_job(
     adapter = VLMAdapter()
     persistence_error: str | None = None
     persistence_lock = threading.Lock()
+    persistence_abandoned = threading.Event()
+    in_flight_write: asyncio.Future[object] | None = None
 
-    async def persist_record(record: Any) -> None:
-        """Run a synchronous store write without blocking deadline cancellation."""
-        if memory is None:
-            return
-        target_memory = memory
-        write_finished: asyncio.Future[Exception | None] = loop.create_future()
+    def abandon_persistence() -> None:
+        persistence_abandoned.set()
+
+    def spawn_persistence_write(action: Callable[[], object], *, name: str) -> asyncio.Future[object]:
+        write_finished: asyncio.Future[object] = loop.create_future()
 
         def write() -> None:
-            outcome: Exception | None = None
+            outcome: object = None
             try:
-                with persistence_lock:
-                    target_memory.service.upsert(record)
+                if not persistence_abandoned.is_set():
+                    with persistence_lock:
+                        if not persistence_abandoned.is_set():
+                            outcome = action()
             except Exception as error:
-                outcome = error
+                if not persistence_abandoned.is_set():
+                    outcome = error
 
-            def report(result: Exception | None = outcome) -> None:
+            def report(result: object = outcome) -> None:
                 if not write_finished.done():
                     write_finished.set_result(result)
 
             with contextlib.suppress(RuntimeError):
                 loop.call_soon_threadsafe(report)
 
-        threading.Thread(target=write, name="vss-vlm-persistence-write", daemon=True).start()
-        outcome = await asyncio.shield(write_finished)
-        if outcome is not None:
+        threading.Thread(target=write, name=name, daemon=True).start()
+        return write_finished
+
+    async def await_in_flight_write() -> bool:
+        """Wait for an unfinished persist, or abandon it so no later write starts."""
+        pending = in_flight_write
+        if pending is None or pending.done():
+            return not persistence_abandoned.is_set()
+        write_timeout = min(terminal_write_reserve, max(0.0, deadline - loop.time()))
+        if write_timeout <= 0:
+            abandon_persistence()
+            return False
+        try:
+            async with asyncio.timeout(write_timeout):
+                await asyncio.shield(pending)
+        except TimeoutError:
+            abandon_persistence()
+            return False
+        return not persistence_abandoned.is_set()
+
+    async def persist_record(record: Any) -> None:
+        """Run a synchronous store write without blocking deadline cancellation."""
+        nonlocal in_flight_write
+        if memory is None or persistence_abandoned.is_set():
+            return
+        target_memory = memory
+        write_finished = spawn_persistence_write(
+            lambda: target_memory.service.upsert(record),
+            name="vss-vlm-persistence-write",
+        )
+        in_flight_write = write_finished
+        try:
+            outcome = await asyncio.shield(write_finished)
+        finally:
+            if in_flight_write is write_finished and write_finished.done():
+                in_flight_write = None
+        if isinstance(outcome, Exception):
             raise outcome
 
     async def close(
         status: Literal["failed", "partial", "timeout"],
         detail: str,
     ) -> Literal["absent", "closed", "stale"]:
+        nonlocal in_flight_write
         if memory is None or job_id is None or created_at is None or input_data is None:
             return "absent"
+        if persistence_abandoned.is_set() or not await await_in_flight_write():
+            return "stale"
+        if memory is None:
+            return "absent"
         target_memory = memory
-        write_finished: asyncio.Future[bool] = loop.create_future()
 
-        def write() -> None:
-            with persistence_lock:
-                # Type guards: these are guaranteed non-None by the outer close() check
-                assert job_id is not None
-                assert created_at is not None
-                closed = mark_terminal(
-                    target_memory,
-                    adapter,
-                    job_id=job_id,
-                    created_at=created_at,
-                    input_data=input_data,
-                    status=status,
-                    message=detail,
-                    attempts=1,
-                    backoff_seconds=0,
-                )
-
-            def report() -> None:
-                if not write_finished.done():
-                    write_finished.set_result(closed)
-
-            with contextlib.suppress(RuntimeError):
-                loop.call_soon_threadsafe(report)
+        def mark() -> bool:
+            # Type guards: these are guaranteed non-None by the outer close() check
+            assert job_id is not None
+            assert created_at is not None
+            return mark_terminal(
+                target_memory,
+                adapter,
+                job_id=job_id,
+                created_at=created_at,
+                input_data=input_data,
+                status=status,
+                message=detail,
+                attempts=1,
+                backoff_seconds=0,
+            )
 
         # A daemon thread prevents a store's normal request timeout from extending
         # the CLI's end-to-end deadline. The write may finish in the background,
         # but the caller waits only for the reserved part of the shared budget.
-        threading.Thread(target=write, name="vss-vlm-terminal-write", daemon=True).start()
+        # Never start this terminal write while an earlier persist is still running:
+        # the caller may close the store as soon as this runner returns.
+        write_finished = spawn_persistence_write(mark, name="vss-vlm-terminal-write")
+        in_flight_write = write_finished
         write_timeout = min(terminal_write_reserve, max(0.0, deadline - loop.time()))
         if write_timeout <= 0:
+            abandon_persistence()
             return "stale"
         try:
             async with asyncio.timeout(write_timeout):
                 closed = await asyncio.shield(write_finished)
         except TimeoutError:
+            abandon_persistence()
             return "stale"
-        return "closed" if closed else "stale"
+        finally:
+            if in_flight_write is write_finished and write_finished.done():
+                in_flight_write = None
+        return "closed" if closed is True else "stale"
 
     def timeout_result(*, record: Literal["absent", "closed", "stale"]) -> VLMJobResult:
         return VLMJobResult(
@@ -479,6 +521,7 @@ async def run_vlm_job(
             )
             raise VLMJobError(result, error) from error
     finally:
+        abandon_persistence()
         if owns_analyzer and analyzer is not None:
             close_analyzer = getattr(analyzer, "aclose", None)
             if close_analyzer is not None:

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 _CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _TERMINAL_WRITE_ATTEMPTS = 3
 _TERMINAL_WRITE_BACKOFF_SECONDS = 0.5
+_CLEANUP_TIMEOUT_SECONDS = 1.0
 
 
 def _ulid() -> str:
@@ -274,6 +275,13 @@ async def run_vlm_job(
     def close(status: Literal["failed", "partial", "timeout"], detail: str) -> Literal["absent", "closed", "stale"]:
         if memory is None or job_id is None or created_at is None or input_data is None:
             return "absent"
+        attempts = _TERMINAL_WRITE_ATTEMPTS
+        backoff_seconds = _TERMINAL_WRITE_BACKOFF_SECONDS
+        # Past the shared deadline, persistence is one best-effort write. The
+        # usual retry/sleep would return after the documented maximum.
+        if deadline - loop.time() <= 0:
+            attempts = 1
+            backoff_seconds = 0
         closed = mark_terminal(
             memory,
             adapter,
@@ -282,8 +290,8 @@ async def run_vlm_job(
             input_data=input_data,
             status=status,
             message=detail,
-            attempts=_TERMINAL_WRITE_ATTEMPTS,
-            backoff_seconds=_TERMINAL_WRITE_BACKOFF_SECONDS,
+            attempts=attempts,
+            backoff_seconds=backoff_seconds,
         )
         return "closed" if closed else "stale"
 
@@ -409,7 +417,11 @@ async def run_vlm_job(
         if owns_analyzer and analyzer is not None:
             close_analyzer = getattr(analyzer, "aclose", None)
             if close_analyzer is not None:
-                await close_analyzer()
+                try:
+                    async with asyncio.timeout(_CLEANUP_TIMEOUT_SECONDS):
+                        await close_analyzer()
+                except Exception:
+                    pass
 
 
 __all__ = [

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -251,49 +251,28 @@ async def run_vlm_job(
     resolver = resolve_sensor_fn or resolve_sensor
     segments_reader = recorded_segments_fn or recorded_segments
     vst_url = str(deployment.base_url).rstrip("/")
-    sensor = await resolver(vst_url, request.sensor, timeout_seconds=float(timeout_seconds))
-    segments = await segments_reader(vst_url, sensor.stream_id, timeout_seconds=float(timeout_seconds))
-    if not segments:
-        from vss_core.vios import VIOSInvalidInputError
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
 
-        raise VIOSInvalidInputError(f"nothing is recorded for sensor {sensor.name!r}")
-    start_time, end_time = resolve_window(segments, request.start_time, request.end_time, sensor.kind)
+    def remaining_seconds() -> float:
+        left = deadline - loop.time()
+        if left <= 0:
+            raise TimeoutError()
+        return left
 
     owns_analyzer = analyzer is None
-    if analyzer is None:
-        analyzer, model = _production_analyzer(deployment, timeout_seconds)
-    else:
-        model = analyzer_model or type(analyzer).__name__
-
-    job_id = mint_job_id()
-    created_at = utc_now_iso()
+    sensor = None
+    start_time: str | None = None
+    end_time: str | None = None
+    job_id: str | None = None
+    created_at: str | None = None
+    input_data: Any = None
+    model = analyzer_model or (type(analyzer).__name__ if analyzer is not None else "")
     adapter = VLMAdapter()
-    params = {
-        "model": model,
-        "time_format": "iso",
-        "timeout_seconds": timeout_seconds,
-    }
-    input_data = adapter.build_input(
-        prompt=request.prompt,
-        intent=request.intent,
-        sensor_name=sensor.name,
-        sensor_type=sensor.kind,
-        sensor_id=sensor.sensor_id,
-        stream_id=sensor.stream_id,
-        start_time=start_time,
-        end_time=end_time,
-        params=params,
-    )
     persistence_error: str | None = None
-    if memory is not None:
-        try:
-            memory.service.upsert(adapter.submitted_record(job_id=job_id, created_at=created_at, input_data=input_data))
-        except Exception as error:
-            persistence_error = str(error)
-            memory = None
 
     def close(status: Literal["failed", "partial", "timeout"], detail: str) -> Literal["absent", "closed", "stale"]:
-        if memory is None:
+        if memory is None or job_id is None or created_at is None or input_data is None:
             return "absent"
         closed = mark_terminal(
             memory,
@@ -308,9 +287,64 @@ async def run_vlm_job(
         )
         return "closed" if closed else "stale"
 
+    def timeout_result(*, record: Literal["absent", "closed", "stale"]) -> VLMJobResult:
+        return VLMJobResult(
+            job_id=job_id or mint_job_id(),
+            status="timeout",
+            answer=None,
+            sensor_name=sensor.name if sensor is not None else request.sensor,
+            start_time=start_time or request.start_time,
+            end_time=end_time or request.end_time,
+            model=model or "vlm",
+            persisted=record == "closed",
+            record=record,
+            error=f"VLM job timed out after {timeout_seconds}s",
+            persistence_error=persistence_error,
+        )
+
     try:
         try:
             async with asyncio.timeout(timeout_seconds):
+                sensor = await resolver(vst_url, request.sensor, timeout_seconds=remaining_seconds())
+                segments = await segments_reader(vst_url, sensor.stream_id, timeout_seconds=remaining_seconds())
+                if not segments:
+                    from vss_core.vios import VIOSInvalidInputError
+
+                    raise VIOSInvalidInputError(f"nothing is recorded for sensor {sensor.name!r}")
+                start_time, end_time = resolve_window(segments, request.start_time, request.end_time, sensor.kind)
+
+                if analyzer is None:
+                    analyzer, model = _production_analyzer(deployment, max(1, int(remaining_seconds())))
+                elif not model:
+                    model = type(analyzer).__name__
+
+                job_id = mint_job_id()
+                created_at = utc_now_iso()
+                params = {
+                    "model": model,
+                    "time_format": "iso",
+                    "timeout_seconds": timeout_seconds,
+                }
+                input_data = adapter.build_input(
+                    prompt=request.prompt,
+                    intent=request.intent,
+                    sensor_name=sensor.name,
+                    sensor_type=sensor.kind,
+                    sensor_id=sensor.sensor_id,
+                    stream_id=sensor.stream_id,
+                    start_time=start_time,
+                    end_time=end_time,
+                    params=params,
+                )
+                if memory is not None:
+                    try:
+                        memory.service.upsert(
+                            adapter.submitted_record(job_id=job_id, created_at=created_at, input_data=input_data)
+                        )
+                    except Exception as error:
+                        persistence_error = str(error)
+                        memory = None
+
                 answer = await analyzer.analyze(
                     sensor_id=sensor.sensor_id,
                     start_timestamp=start_time,
@@ -318,24 +352,44 @@ async def run_vlm_job(
                     prompt=request.prompt,
                     time_format="iso",
                 )
+
+                success_record: Literal["absent", "closed", "stale"] = "absent"
+                persisted = False
+                if memory is not None:
+                    try:
+                        memory.service.upsert(
+                            adapter.terminal_record(
+                                job_id=job_id,
+                                created_at=created_at,
+                                status="completed",
+                                input_data=input_data,
+                                output=adapter.build_output(answer=answer, model=model),
+                            )
+                        )
+                        success_record = "closed"
+                        persisted = True
+                    except Exception as error:
+                        persistence_error = str(error)
+                        success_record = close("partial", f"completion persistence failed: {error}")
+                final_status: Literal["completed", "partial"] = "partial" if persistence_error else "completed"
+                return VLMJobResult(
+                    job_id=job_id,
+                    status=final_status,
+                    answer=answer,
+                    sensor_name=sensor.name,
+                    start_time=start_time,
+                    end_time=end_time,
+                    model=model,
+                    persisted=persisted,
+                    record=success_record,
+                    persistence_error=persistence_error,
+                )
         except TimeoutError as error:
-            detail = f"VLM inference timed out after {timeout_seconds}s"
-            record = close("timeout", detail)
-            result = VLMJobResult(
-                job_id=job_id,
-                status="timeout",
-                answer=None,
-                sensor_name=sensor.name,
-                start_time=start_time,
-                end_time=end_time,
-                model=model,
-                persisted=record == "closed",
-                record=record,
-                error=detail,
-                persistence_error=persistence_error,
-            )
-            raise VLMJobError(result, error) from error
+            record = close("timeout", f"VLM job timed out after {timeout_seconds}s")
+            raise VLMJobError(timeout_result(record=record), error) from error
         except Exception as error:
+            if job_id is None or sensor is None or start_time is None or end_time is None:
+                raise
             record = close("failed", str(error))
             result = VLMJobResult(
                 job_id=job_id,
@@ -351,40 +405,8 @@ async def run_vlm_job(
                 persistence_error=persistence_error,
             )
             raise VLMJobError(result, error) from error
-
-        success_record: Literal["absent", "closed", "stale"] = "absent"
-        persisted = False
-        if memory is not None:
-            try:
-                memory.service.upsert(
-                    adapter.terminal_record(
-                        job_id=job_id,
-                        created_at=created_at,
-                        status="completed",
-                        input_data=input_data,
-                        output=adapter.build_output(answer=answer, model=model),
-                    )
-                )
-                success_record = "closed"
-                persisted = True
-            except Exception as error:
-                persistence_error = str(error)
-                success_record = close("partial", f"completion persistence failed: {error}")
-        final_status: Literal["completed", "partial"] = "partial" if persistence_error else "completed"
-        return VLMJobResult(
-            job_id=job_id,
-            status=final_status,
-            answer=answer,
-            sensor_name=sensor.name,
-            start_time=start_time,
-            end_time=end_time,
-            model=model,
-            persisted=persisted,
-            record=success_record,
-            persistence_error=persistence_error,
-        )
     finally:
-        if owns_analyzer:
+        if owns_analyzer and analyzer is not None:
             close_analyzer = getattr(analyzer, "aclose", None)
             if close_analyzer is not None:
                 await close_analyzer()

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
     from collections.abc import Callable
 
+    from vss_core.introspection.models import VLMEvidence
     from vss_core.vios import SensorRef
     from vss_core.vlm import VLMAnalyzer
 
@@ -110,6 +111,92 @@ class VLMJobError(Exception):
         super().__init__(str(cause))
         self.result = result
         self.cause = cause
+
+
+class IntrospectionVLMJobRunner:
+    """Adapt persisted VLM jobs to the core introspection runner protocol."""
+
+    def __init__(
+        self,
+        deployment: config_mod.Deployment,
+        *,
+        memory: Any | None,
+        timeout_seconds: int = 180,
+        analyzer: VLMAnalyzer | None = None,
+        analyzer_model: str | None = None,
+        resolve_sensor_fn: Callable[..., Awaitable[SensorRef]] | None = None,
+        recorded_segments_fn: Callable[..., Awaitable[list[tuple[str, str]]]] | None = None,
+    ) -> None:
+        self._deployment = deployment
+        self._memory = memory
+        self._timeout_seconds = timeout_seconds
+        self._analyzer = analyzer
+        self._analyzer_model = analyzer_model
+        self._resolve_sensor_fn = resolve_sensor_fn
+        self._recorded_segments_fn = recorded_segments_fn
+        self.persistence_errors: list[str] = []
+        self.backend_errors: list[str] = []
+        self.timed_out = False
+
+    async def run(
+        self,
+        *,
+        sensor: str,
+        start_time: str,
+        end_time: str,
+        prompt: str,
+        intent: str,
+    ) -> VLMEvidence:
+        from vss_core.introspection import VLMEvidence
+
+        if intent != "introspection":
+            raise ValueError("introspection VLM jobs require intent='introspection'")
+        request = VLMJobRequest(
+            sensor=sensor,
+            start_time=start_time,
+            end_time=end_time,
+            prompt=prompt,
+            intent="introspection",
+        )
+        try:
+            result = await run_vlm_job(
+                request,
+                self._deployment,
+                analyzer=self._analyzer,
+                analyzer_model=self._analyzer_model,
+                memory=self._memory,
+                timeout_seconds=self._timeout_seconds,
+                resolve_sensor_fn=self._resolve_sensor_fn,
+                recorded_segments_fn=self._recorded_segments_fn,
+            )
+        except VLMJobError as error:
+            self.timed_out = self.timed_out or error.result.status == "timeout"
+            if _is_backend_error(error.cause):
+                self.backend_errors.append(str(error.cause))
+            raise
+        except Exception as error:
+            if _is_backend_error(error):
+                self.backend_errors.append(str(error))
+            raise
+        if result.persistence_error is not None:
+            self.persistence_errors.append(result.persistence_error)
+        if result.answer is None:  # pragma: no cover - successful runner results always carry an answer
+            raise RuntimeError("VLM job completed without an answer")
+        return VLMEvidence(
+            job_id=result.job_id,
+            persisted=result.persisted,
+            sensor=result.sensor_name,
+            start_time=result.start_time,
+            end_time=result.end_time,
+            answer=result.answer,
+        )
+
+
+def _is_backend_error(error: BaseException) -> bool:
+    return any(
+        klass.__name__ in {"BackendUnreachableError", "ConnectError", "ConnectTimeout", "VSTError", "VIOSTimeoutError"}
+        for klass in type(error).__mro__
+    )
 
 
 def _production_analyzer(deployment: config_mod.Deployment, timeout_seconds: int) -> tuple[VLMAnalyzer, str]:
@@ -301,6 +388,7 @@ async def run_vlm_job(
 
 
 __all__ = [
+    "IntrospectionVLMJobRunner",
     "VLMJobError",
     "VLMJobRequest",
     "VLMJobResult",

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -5,10 +5,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
 import secrets
+import threading
 import time
 from typing import TYPE_CHECKING
 from typing import Any
@@ -35,8 +37,7 @@ if TYPE_CHECKING:
     from vss_core.vlm import VLMAnalyzer
 
 _CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
-_TERMINAL_WRITE_ATTEMPTS = 3
-_TERMINAL_WRITE_BACKOFF_SECONDS = 0.5
+_TERMINAL_WRITE_RESERVE_SECONDS = 1.0
 _CLEANUP_TIMEOUT_SECONDS = 1.0
 
 
@@ -147,6 +148,7 @@ class IntrospectionVLMJobRunner:
         end_time: str,
         prompt: str,
         intent: str,
+        timeout_seconds: float | None = None,
     ) -> VLMEvidence:
         from vss_core.introspection import VLMEvidence
 
@@ -159,6 +161,9 @@ class IntrospectionVLMJobRunner:
             prompt=prompt,
             intent="introspection",
         )
+        effective_timeout = float(self._timeout_seconds)
+        if timeout_seconds is not None:
+            effective_timeout = min(effective_timeout, timeout_seconds)
         try:
             result = await run_vlm_job(
                 request,
@@ -166,7 +171,7 @@ class IntrospectionVLMJobRunner:
                 analyzer=self._analyzer,
                 analyzer_model=self._analyzer_model,
                 memory=self._memory,
-                timeout_seconds=self._timeout_seconds,
+                timeout_seconds=effective_timeout,
                 resolve_sensor_fn=self._resolve_sensor_fn,
                 recorded_segments_fn=self._recorded_segments_fn,
             )
@@ -237,7 +242,7 @@ async def run_vlm_job(
     analyzer: VLMAnalyzer | None = None,
     analyzer_model: str | None = None,
     memory: Any | None = None,
-    timeout_seconds: int = 180,
+    timeout_seconds: float = 180,
     resolve_sensor_fn: Callable[..., Awaitable[SensorRef]] | None = None,
     recorded_segments_fn: Callable[..., Awaitable[list[tuple[str, str]]]] | None = None,
 ) -> VLMJobResult:
@@ -247,13 +252,15 @@ async def run_vlm_job(
     from vss_core.vios import resolve_sensor
     from vss_core.vios import resolve_window
 
-    if timeout_seconds < 1:
-        raise ValueError("timeout_seconds must be >= 1")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be > 0")
     resolver = resolve_sensor_fn or resolve_sensor
     segments_reader = recorded_segments_fn or recorded_segments
     vst_url = str(deployment.base_url).rstrip("/")
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout_seconds
+    terminal_write_reserve = min(_TERMINAL_WRITE_RESERVE_SECONDS, timeout_seconds / 4)
+    work_deadline = deadline - terminal_write_reserve
 
     def remaining_seconds() -> float:
         left = deadline - loop.time()
@@ -272,27 +279,46 @@ async def run_vlm_job(
     adapter = VLMAdapter()
     persistence_error: str | None = None
 
-    def close(status: Literal["failed", "partial", "timeout"], detail: str) -> Literal["absent", "closed", "stale"]:
+    async def close(
+        status: Literal["failed", "partial", "timeout"],
+        detail: str,
+    ) -> Literal["absent", "closed", "stale"]:
         if memory is None or job_id is None or created_at is None or input_data is None:
             return "absent"
-        attempts = _TERMINAL_WRITE_ATTEMPTS
-        backoff_seconds = _TERMINAL_WRITE_BACKOFF_SECONDS
-        # Past the shared deadline, persistence is one best-effort write. The
-        # usual retry/sleep would return after the documented maximum.
-        if deadline - loop.time() <= 0:
-            attempts = 1
-            backoff_seconds = 0
-        closed = mark_terminal(
-            memory,
-            adapter,
-            job_id=job_id,
-            created_at=created_at,
-            input_data=input_data,
-            status=status,
-            message=detail,
-            attempts=attempts,
-            backoff_seconds=backoff_seconds,
-        )
+        write_finished: asyncio.Future[bool] = loop.create_future()
+
+        def write() -> None:
+            closed = mark_terminal(
+                memory,
+                adapter,
+                job_id=job_id,
+                created_at=created_at,
+                input_data=input_data,
+                status=status,
+                message=detail,
+                attempts=1,
+                backoff_seconds=0,
+            )
+
+            def report() -> None:
+                if not write_finished.done():
+                    write_finished.set_result(closed)
+
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(report)
+
+        # A daemon thread prevents a store's normal request timeout from extending
+        # the CLI's end-to-end deadline. The write may finish in the background,
+        # but the caller waits only for the reserved part of the shared budget.
+        threading.Thread(target=write, name="vss-vlm-terminal-write", daemon=True).start()
+        write_timeout = min(terminal_write_reserve, max(0.0, deadline - loop.time()))
+        if write_timeout <= 0:
+            return "stale"
+        try:
+            async with asyncio.timeout(write_timeout):
+                closed = await asyncio.shield(write_finished)
+        except TimeoutError:
+            return "stale"
         return "closed" if closed else "stale"
 
     def timeout_result(*, record: Literal["absent", "closed", "stale"]) -> VLMJobResult:
@@ -306,13 +332,13 @@ async def run_vlm_job(
             model=model or "vlm",
             persisted=record == "closed",
             record=record,
-            error=f"VLM job timed out after {timeout_seconds}s",
+            error=f"VLM job timed out after {timeout_seconds:g}s",
             persistence_error=persistence_error,
         )
 
     try:
         try:
-            async with asyncio.timeout(timeout_seconds):
+            async with asyncio.timeout_at(work_deadline):
                 sensor = await resolver(vst_url, request.sensor, timeout_seconds=remaining_seconds())
                 segments = await segments_reader(vst_url, sensor.stream_id, timeout_seconds=remaining_seconds())
                 if not segments:
@@ -378,7 +404,7 @@ async def run_vlm_job(
                         persisted = True
                     except Exception as error:
                         persistence_error = str(error)
-                        success_record = close("partial", f"completion persistence failed: {error}")
+                        success_record = await close("partial", f"completion persistence failed: {error}")
                 final_status: Literal["completed", "partial"] = "partial" if persistence_error else "completed"
                 return VLMJobResult(
                     job_id=job_id,
@@ -393,12 +419,18 @@ async def run_vlm_job(
                     persistence_error=persistence_error,
                 )
         except TimeoutError as error:
-            record = close("timeout", f"VLM job timed out after {timeout_seconds}s")
+            record = await close("timeout", f"VLM job timed out after {timeout_seconds:g}s")
+            raise VLMJobError(timeout_result(record=record), error) from error
+        except asyncio.CancelledError as error:
+            # An enclosing introspection deadline can cancel this runner after
+            # the submitted record is written. Close it within this runner's
+            # remaining budget before propagating a terminal timeout result.
+            record = await close("timeout", f"VLM job timed out after {timeout_seconds:g}s")
             raise VLMJobError(timeout_result(record=record), error) from error
         except Exception as error:
             if job_id is None or sensor is None or start_time is None or end_time is None:
                 raise
-            record = close("failed", str(error))
+            record = await close("failed", str(error))
             result = VLMJobResult(
                 job_id=job_id,
                 status="failed",
@@ -417,11 +449,13 @@ async def run_vlm_job(
         if owns_analyzer and analyzer is not None:
             close_analyzer = getattr(analyzer, "aclose", None)
             if close_analyzer is not None:
-                try:
-                    async with asyncio.timeout(_CLEANUP_TIMEOUT_SECONDS):
-                        await close_analyzer()
-                except Exception:
-                    pass
+                cleanup_timeout = min(_CLEANUP_TIMEOUT_SECONDS, max(0.0, deadline - loop.time()))
+                if cleanup_timeout > 0:
+                    try:
+                        async with asyncio.timeout(cleanup_timeout):
+                            await close_analyzer()
+                    except Exception:
+                        pass
 
 
 __all__ = [

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -1,0 +1,309 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reusable, bounded VLM job runner shared by CLI and introspection."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+import secrets
+import time
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Literal
+from typing import Self
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import field_validator
+from pydantic import model_validator
+
+from vss_cli import config as config_mod
+from vss_cli.persistence import mark_terminal
+
+from .memory_adapter import VLMAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from collections.abc import Callable
+
+    from vss_core.vios import SensorRef
+    from vss_core.vlm import VLMAnalyzer
+
+_CROCKFORD32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_TERMINAL_WRITE_ATTEMPTS = 3
+_TERMINAL_WRITE_BACKOFF_SECONDS = 0.5
+
+
+def _ulid() -> str:
+    value = (int(time.time() * 1000) & ((1 << 48) - 1)) << 80 | secrets.randbits(80)
+    return "".join(_CROCKFORD32[(value >> shift) & 0x1F] for shift in range(125, -1, -5))
+
+
+def mint_job_id() -> str:
+    """Mint the public ``vlm-<ULID>`` job handle."""
+    return f"vlm-{_ulid()}"
+
+
+class VLMJobRequest(BaseModel):
+    """Strict shared request accepted by CLI and introspection callers."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    sensor: str = Field(min_length=1)
+    start_time: str = Field(min_length=1)
+    end_time: str = Field(min_length=1)
+    prompt: str = Field(min_length=1, max_length=512_000)
+    intent: Literal["video-qa", "introspection/internal"] = "video-qa"
+
+    @field_validator("sensor", "prompt")
+    @classmethod
+    def _nonempty(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must be non-empty")
+        return stripped
+
+    @field_validator("start_time", "end_time")
+    @classmethod
+    def _utc_iso(cls, value: str) -> str:
+        stripped = value.strip()
+        try:
+            parsed = datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+        except ValueError as error:
+            raise ValueError("must be an ISO-8601 UTC instant") from error
+        if parsed.tzinfo is None or parsed.utcoffset() != UTC.utcoffset(parsed):
+            raise ValueError("must include the UTC timezone (Z or +00:00)")
+        return parsed.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    @model_validator(mode="after")
+    def _ordered_window(self) -> Self:
+        start = datetime.fromisoformat(self.start_time.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(self.end_time.replace("Z", "+00:00"))
+        if start >= end:
+            raise ValueError("start_time must be before end_time")
+        return self
+
+
+@dataclass(frozen=True)
+class VLMJobResult:
+    job_id: str
+    status: Literal["completed", "failed", "partial", "timeout"]
+    answer: str | None
+    sensor_name: str
+    start_time: str
+    end_time: str
+    model: str
+    persisted: bool
+    record: Literal["absent", "closed", "stale"]
+    error: str | None = None
+    persistence_error: str | None = None
+
+
+class VLMJobError(Exception):
+    """A terminal inference failure that still carries its persisted handle."""
+
+    def __init__(self, result: VLMJobResult, cause: BaseException) -> None:
+        super().__init__(str(cause))
+        self.result = result
+        self.cause = cause
+
+
+def _production_analyzer(deployment: config_mod.Deployment, timeout_seconds: int) -> tuple[VLMAnalyzer, str]:
+    from vss_core.vios import VSTClient
+    from vss_core.vlm import OpenAIVLMAnalyzer
+
+    service = deployment.services.get("rt_vlm")
+    if service is None or not service.models:
+        raise config_mod.ConfigError("the configured RT-VLM service reports no model")
+    model = service.models[0]
+    vst = VSTClient(
+        internal_url=str(deployment.base_url),
+        external_url=str(deployment.base_url),
+        timeout_seconds=float(timeout_seconds),
+    )
+    return (
+        OpenAIVLMAnalyzer(
+            base_url=f"{service.url.rstrip('/')}/v1",
+            model=model,
+            vst=vst,
+            timeout_seconds=timeout_seconds,
+            media_mode="video_url",
+            video_url_scope="external",
+            cosmos_nim_runtime_options=False,
+        ),
+        model,
+    )
+
+
+async def run_vlm_job(
+    request: VLMJobRequest,
+    deployment: config_mod.Deployment,
+    *,
+    analyzer: VLMAnalyzer | None = None,
+    analyzer_model: str | None = None,
+    memory: Any | None = None,
+    timeout_seconds: int = 180,
+    resolve_sensor_fn: Callable[..., Awaitable[SensorRef]] | None = None,
+    recorded_segments_fn: Callable[..., Awaitable[list[tuple[str, str]]]] | None = None,
+) -> VLMJobResult:
+    """Validate one VIOS interval and perform exactly one bounded inference."""
+    from vss_core.memory.adapters import utc_now_iso
+    from vss_core.vios import recorded_segments
+    from vss_core.vios import resolve_sensor
+    from vss_core.vios import resolve_window
+
+    if timeout_seconds < 1:
+        raise ValueError("timeout_seconds must be >= 1")
+    resolver = resolve_sensor_fn or resolve_sensor
+    segments_reader = recorded_segments_fn or recorded_segments
+    vst_url = str(deployment.base_url).rstrip("/")
+    sensor = await resolver(vst_url, request.sensor, timeout_seconds=float(timeout_seconds))
+    segments = await segments_reader(vst_url, sensor.stream_id, timeout_seconds=float(timeout_seconds))
+    if not segments:
+        from vss_core.vios import VIOSInvalidInputError
+
+        raise VIOSInvalidInputError(f"nothing is recorded for sensor {sensor.name!r}")
+    start_time, end_time = resolve_window(segments, request.start_time, request.end_time, sensor.kind)
+
+    owns_analyzer = analyzer is None
+    if analyzer is None:
+        analyzer, model = _production_analyzer(deployment, timeout_seconds)
+    else:
+        model = analyzer_model or type(analyzer).__name__
+
+    job_id = mint_job_id()
+    created_at = utc_now_iso()
+    adapter = VLMAdapter()
+    params = {
+        "model": model,
+        "time_format": "iso",
+        "timeout_seconds": timeout_seconds,
+    }
+    input_data = adapter.build_input(
+        prompt=request.prompt,
+        intent=request.intent,
+        sensor_name=sensor.name,
+        sensor_type=sensor.kind,
+        sensor_id=sensor.sensor_id,
+        stream_id=sensor.stream_id,
+        start_time=start_time,
+        end_time=end_time,
+        params=params,
+    )
+    persistence_error: str | None = None
+    if memory is not None:
+        try:
+            memory.service.upsert(adapter.submitted_record(job_id=job_id, created_at=created_at, input_data=input_data))
+        except Exception as error:
+            persistence_error = str(error)
+            memory = None
+
+    def close(status: Literal["failed", "partial", "timeout"], detail: str) -> Literal["absent", "closed", "stale"]:
+        if memory is None:
+            return "absent"
+        closed = mark_terminal(
+            memory,
+            adapter,
+            job_id=job_id,
+            created_at=created_at,
+            input_data=input_data,
+            status=status,
+            message=detail,
+            attempts=_TERMINAL_WRITE_ATTEMPTS,
+            backoff_seconds=_TERMINAL_WRITE_BACKOFF_SECONDS,
+        )
+        return "closed" if closed else "stale"
+
+    try:
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                answer = await analyzer.analyze(
+                    sensor_id=sensor.sensor_id,
+                    start_timestamp=start_time,
+                    end_timestamp=end_time,
+                    prompt=request.prompt,
+                    time_format="iso",
+                )
+        except TimeoutError as error:
+            detail = f"VLM inference timed out after {timeout_seconds}s"
+            record = close("timeout", detail)
+            result = VLMJobResult(
+                job_id=job_id,
+                status="timeout",
+                answer=None,
+                sensor_name=sensor.name,
+                start_time=start_time,
+                end_time=end_time,
+                model=model,
+                persisted=record == "closed",
+                record=record,
+                error=detail,
+                persistence_error=persistence_error,
+            )
+            raise VLMJobError(result, error) from error
+        except Exception as error:
+            record = close("failed", str(error))
+            result = VLMJobResult(
+                job_id=job_id,
+                status="failed",
+                answer=None,
+                sensor_name=sensor.name,
+                start_time=start_time,
+                end_time=end_time,
+                model=model,
+                persisted=record == "closed",
+                record=record,
+                error=str(error),
+                persistence_error=persistence_error,
+            )
+            raise VLMJobError(result, error) from error
+
+        success_record: Literal["absent", "closed", "stale"] = "absent"
+        persisted = False
+        if memory is not None:
+            try:
+                memory.service.upsert(
+                    adapter.terminal_record(
+                        job_id=job_id,
+                        created_at=created_at,
+                        status="completed",
+                        input_data=input_data,
+                        output=adapter.build_output(answer=answer, model=model),
+                    )
+                )
+                success_record = "closed"
+                persisted = True
+            except Exception as error:
+                persistence_error = str(error)
+                success_record = close("partial", f"completion persistence failed: {error}")
+        final_status: Literal["completed", "partial"] = "partial" if persistence_error else "completed"
+        return VLMJobResult(
+            job_id=job_id,
+            status=final_status,
+            answer=answer,
+            sensor_name=sensor.name,
+            start_time=start_time,
+            end_time=end_time,
+            model=model,
+            persisted=persisted,
+            record=success_record,
+            persistence_error=persistence_error,
+        )
+    finally:
+        if owns_analyzer:
+            close_analyzer = getattr(analyzer, "aclose", None)
+            if close_analyzer is not None:
+                await close_analyzer()
+
+
+__all__ = [
+    "VLMJobError",
+    "VLMJobRequest",
+    "VLMJobResult",
+    "mint_job_id",
+    "run_vlm_job",
+]

--- a/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
+++ b/services/agent/packages/vss_cli/src/vss_cli/vlm/runner.py
@@ -318,6 +318,9 @@ async def run_vlm_job(
 
         def write() -> None:
             with persistence_lock:
+                # Type guards: these are guaranteed non-None by the outer close() check
+                assert job_id is not None
+                assert created_at is not None
                 closed = mark_terminal(
                     target_memory,
                     adapter,

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_configure_memory.py
@@ -86,6 +86,7 @@ def test_memory_show_prints_only_effective_memory_configuration(config_home: Pat
             "workspace": None,
             "write_by_default": False,
         },
+        "introspection": None,
     }
     assert "services" not in result.output
     assert "base_url" not in result.output
@@ -326,3 +327,219 @@ def test_memory_config_without_markdown_section_uses_disabled_defaults(
     memory_config = config_mod.load().memory
     assert memory_config is not None
     assert memory_config.markdown == config_mod.MarkdownMemoryConfig()
+
+
+def test_configure_introspection_judge_round_trip_and_show(config_home: Path) -> None:
+    criteria = "Require direct support from every cited record."
+    result = _invoke(
+        "introspection",
+        "--judge-endpoint",
+        "http://127.0.0.1:18789/v1",
+        "--judge-model",
+        "openclaw/default",
+        "--judge-backend-model",
+        "ollama/gemma3:12b",
+        "--judge-api-key-env",
+        "OPENCLAW_GATEWAY_TOKEN",
+        "--judge-criteria",
+        criteria,
+    )
+
+    assert result.exit_code == 0, result.output
+    memory_config = config_mod.load().memory
+    assert memory_config is not None
+    assert memory_config.introspection == config_mod.IntrospectionMemoryConfig(
+        judge=config_mod.IntrospectionJudgeConfig(
+            endpoint="http://127.0.0.1:18789/v1",
+            model="openclaw/default",
+            backend_model="ollama/gemma3:12b",
+            api_key_env="OPENCLAW_GATEWAY_TOKEN",
+            criteria_prompt=criteria,
+        )
+    )
+    shown = json.loads(_invoke("show").output)
+    assert shown["introspection"]["judge"] == memory_config.introspection.judge.to_json()
+
+
+def test_first_introspection_configuration_requires_only_endpoint(config_home: Path) -> None:
+    missing = _invoke("introspection")
+    assert missing.exit_code == int(Exit.INVALID_INPUT)
+    assert "--judge-endpoint is required" in missing.output
+
+    configured = _invoke("introspection", "--judge-endpoint", "http://127.0.0.1:18789/v1")
+    assert configured.exit_code == 0, configured.output
+    judge = config_mod.load().memory.introspection.judge  # type: ignore[union-attr]
+    assert judge.model == "openclaw/default"
+    assert judge.criteria_prompt == config_mod.DEFAULT_INTROSPECTION_CRITERIA_PROMPT
+    assert judge.backend_model is None
+    assert judge.api_key_env is None
+
+
+def test_introspection_criteria_file_stores_utf8_contents(config_home: Path) -> None:
+    criteria_file = config_home / "criteria.txt"
+    criteria_file.write_text("Require direct evidence.\nPreserve uncertainty.\n", encoding="utf-8")
+
+    result = _invoke(
+        "introspection",
+        "--judge-endpoint",
+        "https://llm.example.com/v1",
+        "--judge-criteria-file",
+        str(criteria_file),
+    )
+
+    assert result.exit_code == 0, result.output
+    judge = config_mod.load().memory.introspection.judge  # type: ignore[union-attr]
+    assert judge.criteria_prompt == "Require direct evidence.\nPreserve uncertainty.\n"
+
+
+def test_introspection_partial_updates_and_clear_flags(config_home: Path) -> None:
+    assert (
+        _invoke(
+            "introspection",
+            "--judge-endpoint",
+            "http://127.0.0.1:18789/v1",
+            "--judge-api-key-env",
+            "OPENCLAW_GATEWAY_TOKEN",
+            "--judge-backend-model",
+            "ollama/gemma3:12b",
+            "--judge-criteria",
+            "Original criteria",
+        ).exit_code
+        == 0
+    )
+    assert _invoke("introspection", "--judge-model", "openclaw/research").exit_code == 0
+    judge = config_mod.load().memory.introspection.judge  # type: ignore[union-attr]
+    assert judge.endpoint == "http://127.0.0.1:18789/v1"
+    assert judge.model == "openclaw/research"
+    assert judge.api_key_env == "OPENCLAW_GATEWAY_TOKEN"
+    assert judge.backend_model == "ollama/gemma3:12b"
+    assert judge.criteria_prompt == "Original criteria"
+
+    cleared = _invoke(
+        "introspection",
+        "--clear-judge-api-key-env",
+        "--clear-judge-backend-model",
+    )
+    assert cleared.exit_code == 0, cleared.output
+    judge = config_mod.load().memory.introspection.judge  # type: ignore[union-attr]
+    assert judge.api_key_env is None
+    assert judge.backend_model is None
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        (
+            "--judge-endpoint",
+            "https://llm.example/v1",
+            "--judge-criteria",
+            "inline",
+            "--judge-criteria-file",
+            __file__,
+        ),
+        (
+            "--judge-endpoint",
+            "https://llm.example/v1",
+            "--judge-backend-model",
+            "model",
+            "--clear-judge-backend-model",
+        ),
+        (
+            "--judge-endpoint",
+            "https://llm.example/v1",
+            "--judge-api-key-env",
+            "TOKEN",
+            "--clear-judge-api-key-env",
+        ),
+    ),
+)
+def test_introspection_rejects_conflicting_options(config_home: Path, args: tuple[str, ...]) -> None:
+    assert _invoke("introspection", *args).exit_code == int(Exit.INVALID_INPUT)
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    (
+        ({"endpoint": ""}, "endpoint must be non-empty"),
+        ({"model": ""}, "model must be non-empty"),
+        ({"criteria_prompt": " "}, "criteria must be non-empty"),
+        ({"api_key_env": "NOT-VALID"}, "environment variable"),
+        ({"backend_model": ""}, "backend model must be non-empty"),
+    ),
+)
+def test_introspection_judge_rejects_invalid_values(updates: dict[str, object], message: str) -> None:
+    values: dict[str, object] = {
+        "endpoint": "https://llm.example/v1",
+        "model": "custom-model",
+        "criteria_prompt": "Direct evidence only.",
+    }
+    values.update(updates)
+    with pytest.raises(config_mod.ConfigError, match=message):
+        config_mod.IntrospectionJudgeConfig(**values).validate()  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    (
+        ({"judge": {"endpoint": "https://llm.example/v1"}, "extra": True}, "memory.introspection"),
+        ({"judge": {"endpoint": "https://llm.example/v1", "extra": True}}, "memory.introspection.judge"),
+    ),
+)
+def test_introspection_config_rejects_unknown_fields(raw: dict[str, object], message: str) -> None:
+    with pytest.raises(config_mod.ConfigError, match=message):
+        config_mod.IntrospectionMemoryConfig.from_json(raw)
+
+
+def test_old_memory_configuration_without_introspection_still_loads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(config_mod.CONFIG_HOME_ENV, str(tmp_path))
+    tmp_path.joinpath("config.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "base_url": "http://example",
+                "services": {"elasticsearch": {"url": "http://example/elasticsearch"}},
+                "memory": {
+                    "enabled": True,
+                    "backend": "elasticsearch",
+                    "index": "vss-memory",
+                    "persist_by_default": True,
+                    "markdown": {
+                        "enabled": False,
+                        "harness": "openclaw",
+                        "workspace": None,
+                        "write_by_default": False,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    memory_config = config_mod.load().memory
+    assert memory_config is not None
+    assert memory_config.introspection is None
+
+
+def test_show_never_resolves_or_displays_judge_secret(
+    config_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CUSTOM_LLM_API_KEY", "super-secret-value")
+    assert (
+        _invoke(
+            "introspection",
+            "--judge-endpoint",
+            "https://llm.example/v1",
+            "--judge-api-key-env",
+            "CUSTOM_LLM_API_KEY",
+        ).exit_code
+        == 0
+    )
+
+    shown = _invoke("show")
+    assert shown.exit_code == 0
+    assert "CUSTOM_LLM_API_KEY" in shown.output
+    assert "super-secret-value" not in shown.output

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -189,7 +189,7 @@ def test_introspect_help_exposes_exact_options() -> None:
     (
         ("--sensor", "warehouse"),
         ("--job-id", "summary-01"),
-        ("--record-id", "event-1"),
+        ("--job-id", "summary-01", "--record-type", "event", "--record-id", "event-1"),
         ("--record-type", "event", "--sensor", "warehouse"),
         ("--group", "summary", "--sensor", "warehouse"),
         ("--start-time", "2026-08-19T20:00:00Z", "--end-time", "2026-08-19T21:00:00+00:00"),
@@ -211,6 +211,8 @@ def test_introspect_accepts_each_selector(selector: tuple[str, ...]) -> None:
         ("--query", "What happened?"),
         ("--query", "What happened?", "--group", "summary"),
         ("--query", "What happened?", "--record-type", "event"),
+        ("--query", "What happened?", "--record-id", "event-1"),
+        ("--query", "What happened?", "--job-id", "summary-01", "--record-id", "event-1"),
         ("--query", "What happened?", "--start-time", "2026-08-19T20:00:00Z"),
         ("--query", "What happened?", "--end-time", "2026-08-19T21:00:00Z"),
         (
@@ -288,8 +290,14 @@ def test_introspect_no_memory_emits_json_and_exit_five() -> None:
 
 
 @pytest.mark.parametrize(
-    ("persist_by_default", "persistence_errors", "expected_exit"),
-    ((True, [], Exit.SUCCESS), (False, [], Exit.SUCCESS), (True, ["memory offline"], Exit.PARTIAL)),
+    ("persist_by_default", "persistence_errors", "failure_kind", "timed_out", "backend_errors", "expected_exit"),
+    (
+        (True, [], None, False, [], Exit.SUCCESS),
+        (False, [], None, False, [], Exit.SUCCESS),
+        (True, ["memory offline"], None, False, [], Exit.PARTIAL),
+        (True, ["memory offline"], "timeout", True, [], Exit.TIMEOUT),
+        (True, ["memory offline"], "backend_unreachable", False, ["rt-vlm offline"], Exit.BACKEND_UNREACHABLE),
+    ),
 )
 def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
     monkeypatch: pytest.MonkeyPatch,
@@ -297,6 +305,9 @@ def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
     injected_memory: Memory,
     persist_by_default: bool,
     persistence_errors: list[str],
+    failure_kind: str | None,
+    timed_out: bool,
+    backend_errors: list[str],
     expected_exit: Exit,
 ) -> None:
     import vss_cli.vlm.runner as runner_mod
@@ -323,14 +334,14 @@ def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
     class FakeRunner:
         def __init__(self, _deployment: Any, **kwargs: Any) -> None:
             self.persistence_errors = persistence_errors
-            self.backend_errors: list[str] = []
-            self.timed_out = False
+            self.backend_errors = backend_errors
+            self.timed_out = timed_out
             observed["runner_memory"] = kwargs["memory"]
 
     async def fake_introspect(*_args: Any, **kwargs: Any) -> IntrospectionResult:
         observed["memory_service"] = kwargs["memory"]
         assert injected_memory.service.list_jobs() == []
-        return _introspection_result()
+        return _introspection_result().model_copy(update={"failure_kind": failure_kind})
 
     monkeypatch.setattr(config_mod, "load", lambda: deployment)
     monkeypatch.setattr(introspection_mod, "OpenAIIntrospectionClient", FakeClient)

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -24,6 +24,7 @@ from vss_core.memory.backends.in_memory import InMemoryStore
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from pathlib import Path
 
 _CREATED = "2026-08-19T20:00:00Z"
 
@@ -268,12 +269,31 @@ def test_introspect_emits_result_before_status_exit(
     assert "failure_kind" not in payload
 
 
+def test_introspect_no_memory_emits_json_and_exit_five() -> None:
+    async def fake(_request: Any) -> IntrospectionResult:
+        return _introspection_result("no_memory")
+
+    set_test_introspect(fake)
+    result = _invoke("introspect", "--query", "Was the worker wearing PPE?", "--sensor", "warehouse")
+
+    assert result.exit_code == 5 == int(Exit.NOT_FOUND)
+    assert json.loads(result.output) == {
+        "status": "no_memory",
+        "sufficient_from_memory": False,
+        "answer": None,
+        "memory_evidence": [],
+        "vlm_evidence": [],
+        "unresolved_gaps": [],
+    }
+
+
 @pytest.mark.parametrize(
     ("persist_by_default", "persistence_errors", "expected_exit"),
     ((True, [], Exit.SUCCESS), (False, [], Exit.SUCCESS), (True, ["memory offline"], Exit.PARTIAL)),
 )
 def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     injected_memory: Memory,
     persist_by_default: bool,
     persistence_errors: list[str],
@@ -291,6 +311,7 @@ def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
         memory=config_mod.MemoryConfig(enabled=True, persist_by_default=persist_by_default),
     )
     observed: dict[str, Any] = {}
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     class FakeClient:
         def __init__(self, **kwargs: Any) -> None:
@@ -325,3 +346,4 @@ def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
     assert observed["memory_service"] is injected_memory.service
     assert (observed["runner_memory"] is injected_memory) is persist_by_default
     assert injected_memory.service.list_jobs() == []
+    assert list(tmp_path.rglob("*.md")) == []

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -11,10 +11,13 @@ from typing import Any
 from click.testing import CliRunner
 import pytest
 
+from vss_cli import config as config_mod
 from vss_cli.exits import Exit
 from vss_cli.memory import Memory
 from vss_cli.memory_cmd import memory
+from vss_cli.memory_cmd import set_test_introspect
 from vss_cli.memory_cmd import set_test_memory
+from vss_core.introspection import IntrospectionResult
 from vss_core.memory import MemoryService
 from vss_core.memory import UnifiedMemoryRecord
 from vss_core.memory.backends.in_memory import InMemoryStore
@@ -68,6 +71,7 @@ def injected_memory() -> Generator[Memory]:
     facade = Memory(MemoryService(InMemoryStore()), index="vss-memory")
     set_test_memory(facade)
     yield facade
+    set_test_introspect(None)
     set_test_memory(None)
 
 
@@ -78,12 +82,12 @@ def _invoke(*args: str, input: str | None = None) -> Any:
 def test_memory_exposes_store_verbs_not_job_grammar() -> None:
     result = _invoke("--help")
     assert result.exit_code == 0
-    assert all(verb in result.output for verb in ("upsert", "get", "query", "events"))
+    assert all(verb in result.output for verb in ("upsert", "get", "query", "events", "introspect"))
     assert all(verb not in result.output for verb in ("run", "status", "list"))
 
 
 def test_memory_verbs_do_not_expose_static_index_selection() -> None:
-    for verb in ("upsert", "get", "query", "events"):
+    for verb in ("upsert", "get", "query", "events", "introspect"):
         result = _invoke(verb, "--help")
         assert result.exit_code == 0, result.output
         assert "--memory-index" not in result.output
@@ -151,3 +155,173 @@ def test_invalid_inputs_exit_two() -> None:
 def test_unknown_handles_exit_five() -> None:
     assert _invoke("get", "--job-id", "missing").exit_code == int(Exit.NOT_FOUND)
     assert _invoke("events", "--asset-id", "missing").exit_code == int(Exit.NOT_FOUND)
+
+
+def _introspection_result(status: str = "completed") -> IntrospectionResult:
+    return IntrospectionResult(
+        status=status,
+        sufficient_from_memory=status == "completed",
+        answer="A forklift crossed the aisle." if status != "no_memory" else None,
+    )
+
+
+def test_introspect_help_exposes_exact_options() -> None:
+    result = _invoke("introspect", "--help")
+    assert result.exit_code == 0
+    for option in (
+        "--query",
+        "--sensor",
+        "--start-time",
+        "--end-time",
+        "--job-id",
+        "--record-id",
+        "--record-type",
+        "--group",
+        "--pretty",
+    ):
+        assert option in result.output
+    assert "--no-persist" not in result.output
+
+
+@pytest.mark.parametrize(
+    "selector",
+    (
+        ("--sensor", "warehouse"),
+        ("--job-id", "summary-01"),
+        ("--record-id", "event-1"),
+        ("--record-type", "event", "--sensor", "warehouse"),
+        ("--group", "summary", "--sensor", "warehouse"),
+        ("--start-time", "2026-08-19T20:00:00Z", "--end-time", "2026-08-19T21:00:00+00:00"),
+    ),
+)
+def test_introspect_accepts_each_selector(selector: tuple[str, ...]) -> None:
+    async def fake(_request: Any) -> IntrospectionResult:
+        return _introspection_result()
+
+    set_test_introspect(fake)
+    result = _invoke("introspect", "--query", "What happened?", *selector)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["status"] == "completed"
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        ("--query", "What happened?"),
+        ("--query", "What happened?", "--group", "summary"),
+        ("--query", "What happened?", "--record-type", "event"),
+        ("--query", "What happened?", "--start-time", "2026-08-19T20:00:00Z"),
+        ("--query", "What happened?", "--end-time", "2026-08-19T21:00:00Z"),
+        (
+            "--query",
+            "What happened?",
+            "--sensor",
+            "warehouse",
+            "--start-time",
+            "not-iso",
+            "--end-time",
+            "2026-08-19T21:00:00Z",
+        ),
+        ("--query", " ", "--sensor", "warehouse"),
+    ),
+)
+def test_introspect_rejects_invalid_scope_and_values(args: tuple[str, ...]) -> None:
+    assert _invoke("introspect", *args).exit_code == int(Exit.INVALID_INPUT)
+
+
+def test_introspect_compact_and_pretty_json() -> None:
+    async def fake(_request: Any) -> IntrospectionResult:
+        return _introspection_result()
+
+    set_test_introspect(fake)
+    compact = _invoke("introspect", "--query", "What?", "--sensor", "warehouse")
+    pretty = _invoke("introspect", "--query", "What?", "--sensor", "warehouse", "--pretty")
+    assert "\n" not in compact.output.rstrip("\n")
+    assert ": " not in compact.output
+    assert '\n  "status"' in pretty.output
+    assert json.loads(compact.output) == json.loads(pretty.output)
+
+
+@pytest.mark.parametrize(
+    ("status", "failure_kind", "exit_code"),
+    (
+        ("completed", None, Exit.SUCCESS),
+        ("partial", None, Exit.SUCCESS),
+        ("no_memory", None, Exit.NOT_FOUND),
+        ("partial", "timeout", Exit.TIMEOUT),
+        ("partial", "backend_unreachable", Exit.BACKEND_UNREACHABLE),
+    ),
+)
+def test_introspect_emits_result_before_status_exit(
+    status: str,
+    failure_kind: str | None,
+    exit_code: Exit,
+) -> None:
+    async def fake(_request: Any) -> IntrospectionResult:
+        return _introspection_result(status).model_copy(update={"failure_kind": failure_kind})
+
+    set_test_introspect(fake)
+    result = _invoke("introspect", "--query", "What?", "--sensor", "warehouse")
+    assert result.exit_code == int(exit_code)
+    payload = json.loads(result.output)
+    assert payload["status"] == status
+    assert "failure_kind" not in payload
+
+
+@pytest.mark.parametrize(
+    ("persist_by_default", "persistence_errors", "expected_exit"),
+    ((True, [], Exit.SUCCESS), (False, [], Exit.SUCCESS), (True, ["memory offline"], Exit.PARTIAL)),
+)
+def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
+    monkeypatch: pytest.MonkeyPatch,
+    injected_memory: Memory,
+    persist_by_default: bool,
+    persistence_errors: list[str],
+    expected_exit: Exit,
+) -> None:
+    import vss_cli.vlm.runner as runner_mod
+    import vss_core.introspection as introspection_mod
+
+    deployment = config_mod.Deployment(
+        base_url="http://vss.test",
+        services={
+            "rt_vlm": config_mod.Service(url="http://vss.test/rtvi-vlm", models=["first-model"]),
+            "elasticsearch": config_mod.Service(url="http://vss.test/elasticsearch"),
+        },
+        memory=config_mod.MemoryConfig(enabled=True, persist_by_default=persist_by_default),
+    )
+    observed: dict[str, Any] = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            observed["client"] = kwargs
+
+        async def aclose(self) -> None:
+            observed["closed"] = True
+
+    class FakeRunner:
+        def __init__(self, _deployment: Any, **kwargs: Any) -> None:
+            self.persistence_errors = persistence_errors
+            self.backend_errors: list[str] = []
+            self.timed_out = False
+            observed["runner_memory"] = kwargs["memory"]
+
+    async def fake_introspect(*_args: Any, **kwargs: Any) -> IntrospectionResult:
+        observed["memory_service"] = kwargs["memory"]
+        assert injected_memory.service.list_jobs() == []
+        return _introspection_result()
+
+    monkeypatch.setattr(config_mod, "load", lambda: deployment)
+    monkeypatch.setattr(introspection_mod, "OpenAIIntrospectionClient", FakeClient)
+    monkeypatch.setattr(introspection_mod, "introspect", fake_introspect)
+    monkeypatch.setattr(runner_mod, "IntrospectionVLMJobRunner", FakeRunner)
+
+    result = _invoke("introspect", "--query", "What?", "--sensor", "warehouse")
+
+    assert result.exit_code == int(expected_exit), result.output
+    assert json.loads(result.output)["answer"] == "A forklift crossed the aisle."
+    assert observed["client"]["model"] == "first-model"
+    assert observed["closed"] is True
+    assert observed["memory_service"] is injected_memory.service
+    assert (observed["runner_memory"] is injected_memory) is persist_by_default
+    assert injected_memory.service.list_jobs() == []

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_memory_cmd.py
@@ -166,6 +166,27 @@ def _introspection_result(status: str = "completed") -> IntrospectionResult:
     )
 
 
+def _introspection_memory_config(
+    *,
+    model: str = "openclaw/default",
+    backend_model: str | None = "ollama/gemma3:12b",
+    api_key_env: str | None = "HARNESS_TOKEN",
+    persist_by_default: bool = True,
+) -> config_mod.MemoryConfig:
+    return config_mod.MemoryConfig(
+        persist_by_default=persist_by_default,
+        introspection=config_mod.IntrospectionMemoryConfig(
+            judge=config_mod.IntrospectionJudgeConfig(
+                endpoint="https://text-judge.example/v1",
+                model=model,
+                backend_model=backend_model,
+                api_key_env=api_key_env,
+                criteria_prompt="Require direct evidence.",
+            )
+        ),
+    )
+
+
 def test_introspect_help_exposes_exact_options() -> None:
     result = _invoke("introspect", "--help")
     assert result.exit_code == 0
@@ -316,13 +337,14 @@ def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
     deployment = config_mod.Deployment(
         base_url="http://vss.test",
         services={
-            "rt_vlm": config_mod.Service(url="http://vss.test/rtvi-vlm", models=["first-model"]),
+            "rt_vlm": config_mod.Service(url="http://vss.test/rtvi-vlm", models=["visual-only-model"]),
             "elasticsearch": config_mod.Service(url="http://vss.test/elasticsearch"),
         },
-        memory=config_mod.MemoryConfig(enabled=True, persist_by_default=persist_by_default),
+        memory=_introspection_memory_config(persist_by_default=persist_by_default),
     )
     observed: dict[str, Any] = {}
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HARNESS_TOKEN", "runtime-secret")
 
     class FakeClient:
         def __init__(self, **kwargs: Any) -> None:
@@ -352,9 +374,146 @@ def test_introspect_uses_normal_internal_vlm_policy_without_persisting_itself(
 
     assert result.exit_code == int(expected_exit), result.output
     assert json.loads(result.output)["answer"] == "A forklift crossed the aisle."
-    assert observed["client"]["model"] == "first-model"
+    assert observed["client"]["base_url"] == "https://text-judge.example/v1"
+    assert observed["client"]["model"] == "openclaw/default"
+    assert observed["client"]["backend_model"] == "ollama/gemma3:12b"
+    assert observed["client"]["api_key"] == "runtime-secret"
+    assert observed["client"]["criteria_prompt"] == "Require direct evidence."
     assert observed["closed"] is True
     assert observed["memory_service"] is injected_memory.service
     assert (observed["runner_memory"] is injected_memory) is persist_by_default
     assert injected_memory.service.list_jobs() == []
     assert list(tmp_path.rglob("*.md")) == []
+
+
+def test_introspect_requires_configured_text_judge(
+    monkeypatch: pytest.MonkeyPatch,
+    injected_memory: Memory,
+) -> None:
+    deployment = config_mod.Deployment(
+        base_url="http://vss.test",
+        services={"elasticsearch": config_mod.Service(url="http://vss.test/elasticsearch")},
+        memory=config_mod.MemoryConfig(),
+    )
+    monkeypatch.setattr(config_mod, "load", lambda: deployment)
+
+    result = _invoke("introspect", "--query", "What?", "--sensor", "warehouse")
+
+    assert result.exit_code == int(Exit.CONFIGURATION)
+    assert "vss configure memory introspection" in result.output
+    assert injected_memory.service.list_jobs() == []
+
+
+def test_introspect_requires_configured_credential_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployment = config_mod.Deployment(
+        base_url="http://vss.test",
+        services={"elasticsearch": config_mod.Service(url="http://vss.test/elasticsearch")},
+        memory=_introspection_memory_config(api_key_env="MISSING_HARNESS_TOKEN"),
+    )
+    monkeypatch.delenv("MISSING_HARNESS_TOKEN", raising=False)
+    monkeypatch.setattr(config_mod, "load", lambda: deployment)
+
+    result = _invoke("introspect", "--query", "What?", "--sensor", "warehouse")
+
+    assert result.exit_code == int(Exit.CONFIGURATION)
+    assert "MISSING_HARNESS_TOKEN" in result.output
+    assert "missing or empty" in result.output
+
+
+def test_introspect_uses_custom_text_model_without_rt_vlm_for_judging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vss_cli.vlm.runner as runner_mod
+    import vss_core.introspection as introspection_mod
+
+    deployment = config_mod.Deployment(
+        base_url="http://vss.test",
+        services={"elasticsearch": config_mod.Service(url="http://vss.test/elasticsearch")},
+        memory=_introspection_memory_config(
+            model="llama-3.3-70b-instruct",
+            backend_model=None,
+            api_key_env=None,
+        ),
+    )
+    observed: dict[str, Any] = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            observed["client"] = kwargs
+
+        async def aclose(self) -> None:
+            observed["closed"] = True
+
+    class FakeRunner:
+        def __init__(self, actual_deployment: Any, **_kwargs: Any) -> None:
+            self.persistence_errors: list[str] = []
+            self.backend_errors: list[str] = []
+            self.timed_out = False
+            observed["runner_deployment"] = actual_deployment
+
+    async def fake_introspect(*_args: Any, **_kwargs: Any) -> IntrospectionResult:
+        return _introspection_result()
+
+    monkeypatch.setattr(config_mod, "load", lambda: deployment)
+    monkeypatch.setattr(introspection_mod, "OpenAIIntrospectionClient", FakeClient)
+    monkeypatch.setattr(introspection_mod, "introspect", fake_introspect)
+    monkeypatch.setattr(runner_mod, "IntrospectionVLMJobRunner", FakeRunner)
+
+    result = _invoke("introspect", "--query", "What?", "--sensor", "warehouse")
+
+    assert result.exit_code == 0, result.output
+    assert observed["client"]["base_url"] == "https://text-judge.example/v1"
+    assert observed["client"]["model"] == "llama-3.3-70b-instruct"
+    assert observed["client"]["backend_model"] is None
+    assert observed["client"]["api_key"] is None
+    assert observed["runner_deployment"] is deployment
+    assert observed["closed"] is True
+
+
+def test_judge_endpoint_failure_does_not_fall_back_to_rt_vlm_and_closes_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    import vss_cli.vlm.runner as runner_mod
+    import vss_core.introspection as introspection_mod
+
+    deployment = config_mod.Deployment(
+        base_url="http://vss.test",
+        services={
+            "rt_vlm": config_mod.Service(url="http://visual-only.test/rtvi-vlm", models=["visual-model"]),
+            "elasticsearch": config_mod.Service(url="http://vss.test/elasticsearch"),
+        },
+        memory=_introspection_memory_config(api_key_env=None),
+    )
+    observed: dict[str, Any] = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            observed["client"] = kwargs
+
+        async def aclose(self) -> None:
+            observed["closed"] = True
+
+    class FakeRunner:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.persistence_errors: list[str] = []
+            self.backend_errors: list[str] = []
+            self.timed_out = False
+
+    async def failing_introspect(*_args: Any, **_kwargs: Any) -> IntrospectionResult:
+        raise httpx.ConnectError("text judge offline")
+
+    monkeypatch.setattr(config_mod, "load", lambda: deployment)
+    monkeypatch.setattr(introspection_mod, "OpenAIIntrospectionClient", FakeClient)
+    monkeypatch.setattr(introspection_mod, "introspect", failing_introspect)
+    monkeypatch.setattr(runner_mod, "IntrospectionVLMJobRunner", FakeRunner)
+
+    result = _invoke("introspect", "--query", "What?", "--sensor", "warehouse")
+
+    assert result.exit_code == int(Exit.BACKEND_UNREACHABLE)
+    assert observed["client"]["base_url"] == "https://text-judge.example/v1"
+    assert observed["client"]["model"] != "visual-model"
+    assert observed["closed"] is True

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_memory.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_memory.py
@@ -202,6 +202,10 @@ def test_persisted_search_parent_and_children(search_group: SearchGroup) -> None
     assert children[0].output is not None
     assert children[0].output.ext is not None
     assert "rank" in children[0].output.ext
+    assert children[0].input is not None
+    assert children[0].input.sensors is not None
+    assert children[0].input.sensors[0].id == "warehouse"
+    assert children[0].input.sensors[0].info == {"sensor_id": "warehouse-camera"}
     assert result.body["data"][0]["description"] == "hit 1"
 
 

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
@@ -119,15 +119,42 @@ test "${VSS_PUBLIC_URL}" = 'https://public.example'
     )
 
 
-def test_ask_video_accepts_only_pre_resolved_confirmed_search_handoff() -> None:
+def test_ask_video_routes_vss_questions_through_cli_memory_and_vlm() -> None:
     ask_video = (ASK_VIDEO_SKILL / "SKILL.md").read_text(encoding="utf-8")
     normalized = " ".join(ask_video.split())
+    evals = json.loads((ASK_VIDEO_SKILL / "evals/evals.json").read_text(encoding="utf-8"))
+    evals_by_id = {case["id"]: case for case in evals}
 
     assert 'version: "3.3.0"' in ask_video
     assert "user-confirmed vss-search-archive handoff with a pre-resolved bounded VIDEO_URL" in ask_video
     assert "Treat that URL as Path A; do not rerun search or resolve a different interval" in normalized
     assert "The caller owns verdict validation and any fallback" in normalized
     assert "do not rerun search, resolve a sensor, broaden the clip, or choose another interval" in normalized
+    assert "Hot conversation context -> answer directly" in normalized
+    assert "Explicit stored summary/result -> `vss memory get` or `vss memory query`" in normalized
+    assert "General video question where past memory may exist -> `vss memory introspect`" in normalized
+    assert "Exact sensor/time or explicit fresh visual verification -> `vss vlm run`" in normalized
+    assert "`introspect` returns `no_memory` -> conditional `vss vlm run`" in normalized
+    assert "Do not call an OpenAI-compatible `/chat/completions` endpoint directly" in normalized
+    assert "Never enter this fallback after `vss memory introspect`" in normalized
+    assert "curl " not in ask_video
+    assert {
+        "ask-video-hot-context",
+        "ask-video-memory-get",
+        "ask-video-memory-query",
+        "ask-video-introspect",
+        "ask-video-direct-vlm",
+        "ask-video-no-memory-with-window",
+        "ask-video-no-memory-without-window",
+    } <= evals_by_id.keys()
+    assert any(
+        "Does not invoke vss vlm run" in behavior
+        for behavior in evals_by_id["ask-video-no-memory-without-window"]["expected_behavior"]
+    )
+    assert any(
+        "Runs one vss vlm run" in behavior
+        for behavior in evals_by_id["ask-video-no-memory-with-window"]["expected_behavior"]
+    )
 
 
 def test_search_harbor_eval_exercises_cli_verification_contract() -> None:

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
@@ -123,6 +123,9 @@ def test_ask_video_routes_vss_questions_through_cli_memory_and_vlm() -> None:
     ask_video = (ASK_VIDEO_SKILL / "SKILL.md").read_text(encoding="utf-8")
     normalized = " ".join(ask_video.split())
     evals = json.loads((ASK_VIDEO_SKILL / "evals/evals.json").read_text(encoding="utf-8"))
+    direct_vlm_evals = json.loads(
+        (ASK_VIDEO_SKILL / "evals/direct_vlm_video_understanding.json").read_text(encoding="utf-8")
+    )
     evals_by_id = {case["id"]: case for case in evals}
 
     assert 'version: "3.3.0"' in ask_video
@@ -146,6 +149,11 @@ def test_ask_video_routes_vss_questions_through_cli_memory_and_vlm() -> None:
     )
     assert "Do not call an OpenAI-compatible `/chat/completions` endpoint directly" in normalized
     assert "Never enter this fallback after `vss memory introspect`" in normalized
+    assert "send the **native MP4 bytes as one video input**" in normalized
+    assert "data:video/mp4;base64,<base64 of the complete MP4 file>" in ask_video
+    assert "Do not run `ffmpeg`, OpenCV, or any frame extractor" in normalized
+    assert "image/jpeg" in json.dumps(direct_vlm_evals)
+    assert "data:video/mp4;base64," in json.dumps(direct_vlm_evals)
     assert "curl " not in ask_video
     assert {
         "ask-video-hot-context",

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
@@ -135,6 +135,13 @@ def test_ask_video_routes_vss_questions_through_cli_memory_and_vlm() -> None:
     assert "General video question where past memory may exist -> `vss memory introspect`" in normalized
     assert "Exact sensor/time or explicit fresh visual verification -> `vss vlm run`" in normalized
     assert "`introspect` returns `no_memory` -> conditional `vss vlm run`" in normalized
+    assert "`introspect` requires grounded, useful scope" in normalized
+    assert '`"no_memory"` and exit code 5' in normalized
+    assert "expected not-found result, not a general command or backend failure" in normalized
+    assert (
+        "Do not automatically run a VLM afterward unless an exact sensor and exact ISO-8601 UTC start/end window"
+        in normalized
+    )
     assert "Do not call an OpenAI-compatible `/chat/completions` endpoint directly" in normalized
     assert "Never enter this fallback after `vss memory introspect`" in normalized
     assert "curl " not in ask_video

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_search_verification_contract.py
@@ -131,7 +131,9 @@ def test_ask_video_routes_vss_questions_through_cli_memory_and_vlm() -> None:
     assert "The caller owns verdict validation and any fallback" in normalized
     assert "do not rerun search, resolve a sensor, broaden the clip, or choose another interval" in normalized
     assert "Hot conversation context -> answer directly" in normalized
-    assert "Explicit stored summary/result -> `vss memory get` or `vss memory query`" in normalized
+    assert (
+        "Explicit stored summary/result -> `vss memory get`, `vss summarize get`, or `vss memory query`" in normalized
+    )
     assert "General video question where past memory may exist -> `vss memory introspect`" in normalized
     assert "Exact sensor/time or explicit fresh visual verification -> `vss vlm run`" in normalized
     assert "`introspect` returns `no_memory` -> conditional `vss vlm run`" in normalized
@@ -161,6 +163,10 @@ def test_ask_video_routes_vss_questions_through_cli_memory_and_vlm() -> None:
     assert any(
         "Runs one vss vlm run" in behavior
         for behavior in evals_by_id["ask-video-no-memory-with-window"]["expected_behavior"]
+    )
+    assert any(
+        "vss memory get --job-id sum-01JXYZ or vss summarize get --job-id sum-01JXYZ" in behavior
+        for behavior in evals_by_id["ask-video-memory-get"]["expected_behavior"]
     )
 
 

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_summarize.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_summarize.py
@@ -628,6 +628,53 @@ def test_persist_writes_one_unified_memory_record(
     }
 
 
+def test_summary_memory_prefers_media_name_and_preserves_internal_ids(
+    configured: config_mod.Deployment, monkeypatch: pytest.MonkeyPatch, memory: memory_mod.Memory
+) -> None:
+    _capture_post(monkeypatch)
+    result = _run("--id", "stream-uuid", "--video-id", "video-uuid", "--media-name", "west-entrance")
+    assert result.exit_code == 0, result.output
+
+    sensor = _persisted(memory)["input"]["sensors"][0]
+    assert sensor["id"] == "west-entrance"
+    assert sensor["info"]["stream_id"] == "stream-uuid"
+    assert sensor["info"]["video_id"] == "video-uuid"
+
+
+def test_summary_memory_resolves_vios_name(
+    configured: config_mod.Deployment, monkeypatch: pytest.MonkeyPatch, memory: memory_mod.Memory
+) -> None:
+    from vss_core.vios import SensorRef
+
+    config_mod.save(
+        config_mod.Deployment(
+            base_url=configured.base_url,
+            services={**configured.services, "vst": config_mod.Service(url=f"{BASE_URL}/vst")},
+            memory=configured.memory,
+        )
+    )
+
+    async def resolve_sensor(*_args: Any, **_kwargs: Any) -> SensorRef:
+        return SensorRef(
+            name="west-entrance",
+            sensor_id="sensor-uuid",
+            stream_id="stream-uuid",
+            url="rtsp://camera",
+            kind="stream",
+        )
+
+    monkeypatch.setattr("vss_core.vios.resolve_sensor", resolve_sensor)
+    _capture_post(monkeypatch)
+    result = _run("--id", "stream-uuid")
+    assert result.exit_code == 0, result.output
+
+    sensor = _persisted(memory)["input"]["sensors"][0]
+    assert sensor["id"] == "west-entrance"
+    assert sensor["info"]["sensor_id"] == "sensor-uuid"
+    assert sensor["info"]["stream_id"] == "stream-uuid"
+    assert sensor["info"]["video_id"] == "stream-uuid"
+
+
 def test_explicit_note_opt_in_writes_openclaw_daily_note(
     configured: config_mod.Deployment,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Hermetic contract tests for the persisted ``vss vlm`` job."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from click.testing import CliRunner
+from pydantic import ValidationError
+import pytest
+
+from vss_cli import config as config_mod
+from vss_cli import memory as memory_mod
+from vss_cli.group import Context
+from vss_cli.vlm.group import VLM
+from vss_cli.vlm.runner import VLMJobError
+from vss_cli.vlm.runner import VLMJobRequest
+from vss_cli.vlm.runner import VLMJobResult
+from vss_cli.vlm.runner import run_vlm_job
+from vss_core._foundation.errors import BackendUnreachableError
+from vss_core.memory import InMemoryStore
+from vss_core.memory import MemoryQuery
+from vss_core.memory import MemoryService
+from vss_core.vios import SensorRef
+from vss_core.vios import VIOSInvalidInputError
+from vss_core.vios import VIOSNotFoundError
+
+START = "2026-08-13T20:00:00.000Z"
+END = "2026-08-13T20:00:10.000Z"
+SEGMENTS = [("2026-08-13T19:59:00.000Z", "2026-08-13T20:01:00.000Z")]
+
+
+def _deployment(*, persist: bool = True) -> config_mod.Deployment:
+    return config_mod.Deployment(
+        base_url="http://vss.test",
+        services={
+            "vst": config_mod.Service(url="http://vss.test/vst"),
+            "rt_vlm": config_mod.Service(url="http://vss.test/rtvi-vlm", models=["test-vlm"]),
+            "elasticsearch": config_mod.Service(url="http://vss.test/elasticsearch"),
+        },
+        memory=config_mod.MemoryConfig(enabled=persist, persist_by_default=persist),
+    )
+
+
+def _memory() -> memory_mod.Memory:
+    return memory_mod.Memory(MemoryService(InMemoryStore()), index="test-memory")
+
+
+async def _sensor(*_args: Any, **_kwargs: Any) -> SensorRef:
+    return SensorRef(
+        name="warehouse",
+        sensor_id="sensor-1",
+        stream_id="stream-1",
+        url="file:///warehouse.mp4",
+        kind="video",
+    )
+
+
+async def _segments(*_args: Any, **_kwargs: Any) -> list[tuple[str, str]]:
+    return SEGMENTS
+
+
+class _Analyzer:
+    def __init__(self, *, answer: str = "A forklift crosses the aisle.", error: Exception | None = None) -> None:
+        self.answer = answer
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    async def analyze(self, **kwargs: Any) -> str:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.answer
+
+
+def _run(
+    analyzer: _Analyzer,
+    *,
+    memory: memory_mod.Memory | None = None,
+    timeout_seconds: int = 180,
+    resolver: Any = _sensor,
+    segments: Any = _segments,
+) -> VLMJobResult:
+    return asyncio.run(
+        run_vlm_job(
+            VLMJobRequest(sensor="warehouse", start_time=START, end_time=END, prompt="What happened?"),
+            _deployment(),
+            analyzer=analyzer,
+            analyzer_model="test-vlm",
+            memory=memory,
+            timeout_seconds=timeout_seconds,
+            resolve_sensor_fn=resolver,
+            recorded_segments_fn=segments,
+        )
+    )
+
+
+def test_runner_performs_one_inference_and_persists_parent_only() -> None:
+    memory = _memory()
+    analyzer = _Analyzer()
+
+    result = _run(analyzer, memory=memory)
+
+    assert result.status == "completed"
+    assert result.job_id.startswith("vlm-") and len(result.job_id) == 30
+    assert len(analyzer.calls) == 1
+    records = memory.service.list_jobs()
+    assert len(records) == 1
+    record = records[0].model_dump_memory()
+    assert record["job"]["group"] == "vlm"
+    assert record["job"]["operation"] == "run"
+    assert record["input"]["query"] == "What happened?"
+    assert record["input"]["intent"] == "video-qa"
+    assert record["input"]["sensors"][0]["id"] == "warehouse"
+    assert record["input"]["window"]["start"]["timestamp"] == "2026-08-13T20:00:00Z"
+    assert record["output"]["answer"] == analyzer.answer
+    assert record["output"]["ext"]["model"] == "test-vlm"
+    assert memory.service.query(MemoryQuery(job_id=result.job_id, limit=10)) == records
+
+
+def test_runner_without_memory_never_persists() -> None:
+    result = _run(_Analyzer(), memory=None)
+    assert result.record == "absent"
+    assert result.persisted is False
+
+
+def test_timeout_is_terminal_and_closes_record() -> None:
+    class _SlowAnalyzer(_Analyzer):
+        async def analyze(self, **kwargs: Any) -> str:
+            self.calls.append(kwargs)
+            await asyncio.sleep(2)
+            return self.answer
+
+    memory = _memory()
+    with pytest.raises(VLMJobError) as caught:
+        _run(_SlowAnalyzer(), memory=memory, timeout_seconds=1)
+
+    assert caught.value.result.status == "timeout"
+    assert caught.value.result.record == "closed"
+    assert memory.service.list_jobs()[0].job.status == "timeout"
+
+
+def test_invalid_window_never_calls_analyzer() -> None:
+    analyzer = _Analyzer()
+
+    with pytest.raises(VIOSInvalidInputError, match="single recorded segment"):
+        asyncio.run(
+            run_vlm_job(
+                VLMJobRequest(
+                    sensor="warehouse",
+                    start_time="2026-08-13T20:00:00.000Z",
+                    end_time="2026-08-13T21:00:10.000Z",
+                    prompt="What happened?",
+                ),
+                _deployment(),
+                analyzer=analyzer,
+                resolve_sensor_fn=_sensor,
+                recorded_segments_fn=lambda *_args, **_kwargs: asyncio.sleep(
+                    0,
+                    result=[
+                        ("2026-08-13T19:59:00.000Z", "2026-08-13T20:01:00.000Z"),
+                        ("2026-08-13T21:00:00.000Z", "2026-08-13T21:01:00.000Z"),
+                    ],
+                ),
+            )
+        )
+    assert analyzer.calls == []
+
+
+def test_unrecorded_window_never_calls_analyzer() -> None:
+    analyzer = _Analyzer()
+
+    async def no_segments(*_args: Any, **_kwargs: Any) -> list[tuple[str, str]]:
+        return []
+
+    with pytest.raises(VIOSInvalidInputError, match="nothing is recorded"):
+        _run(analyzer, segments=no_segments)
+    assert analyzer.calls == []
+
+
+def test_missing_sensor_never_calls_analyzer() -> None:
+    analyzer = _Analyzer()
+
+    async def missing(*_args: Any, **_kwargs: Any) -> SensorRef:
+        raise VIOSNotFoundError("no VIOS sensor named 'missing'")
+
+    with pytest.raises(VIOSNotFoundError):
+        _run(analyzer, resolver=missing)
+    assert analyzer.calls == []
+
+
+def test_backend_failure_is_terminal_and_persisted() -> None:
+    memory = _memory()
+    analyzer = _Analyzer(error=BackendUnreachableError("vlm", "offline"))
+
+    with pytest.raises(VLMJobError) as caught:
+        _run(analyzer, memory=memory)
+
+    assert caught.value.result.status == "failed"
+    assert caught.value.result.record == "closed"
+    assert memory.service.list_jobs()[0].job.status == "failed"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("sensor", " "),
+        ("prompt", "\t"),
+        ("start_time", "2026-08-13T20:00:00"),
+        ("end_time", "2026-08-13T20:00:10-07:00"),
+    ],
+)
+def test_input_requires_nonempty_fields_and_utc(field: str, value: str) -> None:
+    payload = {"sensor": "warehouse", "start_time": START, "end_time": END, "prompt": "What happened?"}
+    payload[field] = value
+    with pytest.raises(ValidationError):
+        VLMJobRequest(**payload)
+
+
+def test_status_get_and_list_are_memory_reads() -> None:
+    memory = _memory()
+    result = _run(_Analyzer(), memory=memory)
+    context = Context(deployment=_deployment(), memory=memory)
+
+    assert VLM.status(result.job_id, context).body["job"]["status"] == "completed"
+    assert VLM.get(result.job_id, context).body["children"] == []
+    listed = VLM.list({"sensor_id": "warehouse"}, context).body
+    assert listed[0]["job"]["job_id"] == result.job_id
+
+
+def test_help_has_only_negative_persistence_override() -> None:
+    result = CliRunner().invoke(VLM.cli(), ["run", "--help"])
+    assert result.exit_code == 0
+    assert "--no-persist" in result.output
+    assert "--persist" not in result.output.replace("--no-persist", "")

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -15,6 +15,7 @@ from vss_cli import config as config_mod
 from vss_cli import memory as memory_mod
 from vss_cli.group import Context
 from vss_cli.vlm.group import VLM
+from vss_cli.vlm.runner import IntrospectionVLMJobRunner
 from vss_cli.vlm.runner import VLMJobError
 from vss_cli.vlm.runner import VLMJobRequest
 from vss_cli.vlm.runner import VLMJobResult
@@ -124,6 +125,96 @@ def test_runner_without_memory_never_persists() -> None:
     result = _run(_Analyzer(), memory=None)
     assert result.record == "absent"
     assert result.persisted is False
+
+
+def test_introspection_adapter_runs_direct_job_with_normal_persistence() -> None:
+    memory = _memory()
+    analyzer = _Analyzer()
+    runner = IntrospectionVLMJobRunner(
+        _deployment(),
+        memory=memory,
+        analyzer=analyzer,
+        analyzer_model="test-vlm",
+        resolve_sensor_fn=_sensor,
+        recorded_segments_fn=_segments,
+    )
+
+    evidence = asyncio.run(
+        runner.run(
+            sensor="warehouse",
+            start_time=START,
+            end_time=END,
+            prompt="What happened?",
+            intent="introspection",
+        )
+    )
+
+    assert evidence.persisted is True
+    assert evidence.answer == analyzer.answer
+    assert memory.service.list_jobs()[0].input.intent == "introspection"
+    assert runner.persistence_errors == []
+
+
+def test_introspection_adapter_preserves_answer_when_persistence_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memory = _memory()
+    analyzer = _Analyzer()
+    original_upsert = memory.service.upsert
+    writes = 0
+
+    def fail_completion(record: Any) -> Any:
+        nonlocal writes
+        writes += 1
+        if writes > 1:
+            raise BackendUnreachableError("memory", "offline")
+        return original_upsert(record)
+
+    monkeypatch.setattr(memory.service, "upsert", fail_completion)
+    runner = IntrospectionVLMJobRunner(
+        _deployment(),
+        memory=memory,
+        analyzer=analyzer,
+        analyzer_model="test-vlm",
+        resolve_sensor_fn=_sensor,
+        recorded_segments_fn=_segments,
+    )
+
+    evidence = asyncio.run(
+        runner.run(
+            sensor="warehouse",
+            start_time=START,
+            end_time=END,
+            prompt="What happened?",
+            intent="introspection",
+        )
+    )
+
+    assert evidence.answer == analyzer.answer
+    assert evidence.persisted is False
+    assert runner.persistence_errors
+
+
+def test_introspection_adapter_with_disabled_persistence_writes_nothing() -> None:
+    runner = IntrospectionVLMJobRunner(
+        _deployment(persist=False),
+        memory=None,
+        analyzer=_Analyzer(),
+        analyzer_model="test-vlm",
+        resolve_sensor_fn=_sensor,
+        recorded_segments_fn=_segments,
+    )
+    evidence = asyncio.run(
+        runner.run(
+            sensor="warehouse",
+            start_time=START,
+            end_time=END,
+            prompt="What happened?",
+            intent="introspection",
+        )
+    )
+    assert evidence.persisted is False
+    assert runner.persistence_errors == []
 
 
 def test_timeout_is_terminal_and_closes_record() -> None:

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -256,6 +256,50 @@ def test_timeout_is_shared_across_validation_and_inference() -> None:
     assert elapsed < 1.5
 
 
+def test_timeout_recovery_does_not_retry_persist_or_hang_on_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vss_cli.vlm.runner as runner_mod
+
+    class _HangingCleanupAnalyzer(_Analyzer):
+        async def analyze(self, **kwargs: Any) -> str:
+            self.calls.append(kwargs)
+            await asyncio.sleep(2)
+            return self.answer
+
+        async def aclose(self) -> None:
+            await asyncio.sleep(10)
+
+    class _FailingTerminalStore(InMemoryStore):
+        def upsert(self, record: Any) -> Any:
+            if record.job.status == "timeout":
+                time.sleep(0.2)
+                raise BackendUnreachableError("elasticsearch", "offline")
+            return super().upsert(record)
+
+    analyzer = _HangingCleanupAnalyzer()
+    monkeypatch.setattr(runner_mod, "_production_analyzer", lambda *_args, **_kwargs: (analyzer, "test-vlm"))
+    memory = memory_mod.Memory(MemoryService(_FailingTerminalStore()), index="test-memory")
+
+    started = time.monotonic()
+    with pytest.raises(VLMJobError) as caught:
+        asyncio.run(
+            run_vlm_job(
+                VLMJobRequest(sensor="warehouse", start_time=START, end_time=END, prompt="What happened?"),
+                _deployment(),
+                memory=memory,
+                timeout_seconds=1,
+                resolve_sensor_fn=_sensor,
+                recorded_segments_fn=_segments,
+            )
+        )
+    elapsed = time.monotonic() - started
+
+    assert caught.value.result.status == "timeout"
+    assert caught.value.result.record == "stale"
+    assert elapsed < 3
+
+
 def test_later_phases_receive_remaining_timeout_not_a_fresh_budget() -> None:
     seen: dict[str, float] = {}
 

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -324,6 +324,30 @@ def test_timeout_terminal_write_is_bounded_by_shared_deadline() -> None:
     assert time.monotonic() - started < 1.2
 
 
+def test_completion_write_is_bounded_by_shared_deadline() -> None:
+    class _NearDeadlineAnalyzer(_Analyzer):
+        async def analyze(self, **kwargs: Any) -> str:
+            self.calls.append(kwargs)
+            await asyncio.sleep(0.6)
+            return self.answer
+
+    class _SlowCompletionStore(InMemoryStore):
+        def upsert(self, record: Any) -> Any:
+            if record.job.status == "completed":
+                time.sleep(2)
+            return super().upsert(record)
+
+    memory = memory_mod.Memory(MemoryService(_SlowCompletionStore()), index="test-memory")
+    started = time.monotonic()
+
+    with pytest.raises(VLMJobError) as caught:
+        _run(_NearDeadlineAnalyzer(), memory=memory, timeout_seconds=1)
+
+    assert caught.value.result.status == "timeout"
+    assert caught.value.result.record == "stale"
+    assert time.monotonic() - started < 1.2
+
+
 def test_cancellation_after_submission_closes_terminal_record() -> None:
     started = asyncio.Event()
 

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from typing import Any
 
@@ -383,6 +384,45 @@ def test_cancellation_after_submission_closes_terminal_record() -> None:
     assert error.result.status == "timeout"
     assert error.result.record == "closed"
     assert memory.service.list_jobs()[0].job.status == "timeout"
+
+
+def test_timeout_does_not_start_terminal_write_while_persist_is_in_flight() -> None:
+    submitted = threading.Event()
+    statuses: list[str] = []
+
+    class _HangingSubmitStore(InMemoryStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.closed = False
+
+        def upsert(self, record: Any) -> Any:
+            statuses.append(record.job.status)
+            if record.job.status == "submitted":
+                submitted.set()
+                time.sleep(2)
+            if self.closed:
+                raise RuntimeError("upsert after store close")
+            return super().upsert(record)
+
+        def close(self) -> None:
+            self.closed = True
+
+    store = _HangingSubmitStore()
+    memory = memory_mod.Memory(MemoryService(store), index="test-memory")
+    started = time.monotonic()
+
+    with pytest.raises(VLMJobError) as caught:
+        _run(_Analyzer(), memory=memory, timeout_seconds=1)
+
+    store.close()
+    submitted.wait(timeout=2)
+
+    assert caught.value.result.status == "timeout"
+    assert caught.value.result.record == "stale"
+    assert time.monotonic() - started < 1.2
+    assert statuses.count("timeout") == 0
+    assert statuses.count("partial") == 0
+    assert statuses.count("failed") == 0
 
 
 def test_later_phases_receive_remaining_timeout_not_a_fresh_budget() -> None:

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -297,7 +297,68 @@ def test_timeout_recovery_does_not_retry_persist_or_hang_on_cleanup(
 
     assert caught.value.result.status == "timeout"
     assert caught.value.result.record == "stale"
-    assert elapsed < 3
+    assert elapsed < 1.2
+
+
+def test_timeout_terminal_write_is_bounded_by_shared_deadline() -> None:
+    class _SlowAnalyzer(_Analyzer):
+        async def analyze(self, **kwargs: Any) -> str:
+            self.calls.append(kwargs)
+            await asyncio.sleep(2)
+            return self.answer
+
+    class _HangingTerminalStore(InMemoryStore):
+        def upsert(self, record: Any) -> Any:
+            if record.job.status == "timeout":
+                time.sleep(2)
+            return super().upsert(record)
+
+    memory = memory_mod.Memory(MemoryService(_HangingTerminalStore()), index="test-memory")
+    started = time.monotonic()
+
+    with pytest.raises(VLMJobError) as caught:
+        _run(_SlowAnalyzer(), memory=memory, timeout_seconds=1)
+
+    assert caught.value.result.status == "timeout"
+    assert caught.value.result.record == "stale"
+    assert time.monotonic() - started < 1.2
+
+
+def test_cancellation_after_submission_closes_terminal_record() -> None:
+    started = asyncio.Event()
+
+    class _CancelledAnalyzer(_Analyzer):
+        async def analyze(self, **kwargs: Any) -> str:
+            self.calls.append(kwargs)
+            started.set()
+            await asyncio.Event().wait()
+            return self.answer
+
+    memory = _memory()
+
+    async def cancel_after_submission() -> VLMJobError:
+        task = asyncio.create_task(
+            run_vlm_job(
+                VLMJobRequest(sensor="warehouse", start_time=START, end_time=END, prompt="What happened?"),
+                _deployment(),
+                analyzer=_CancelledAnalyzer(),
+                analyzer_model="test-vlm",
+                memory=memory,
+                resolve_sensor_fn=_sensor,
+                recorded_segments_fn=_segments,
+            )
+        )
+        await started.wait()
+        task.cancel()
+        with pytest.raises(VLMJobError) as caught:
+            await task
+        return caught.value
+
+    error = asyncio.run(cancel_after_submission())
+
+    assert error.result.status == "timeout"
+    assert error.result.record == "closed"
+    assert memory.service.list_jobs()[0].job.status == "timeout"
 
 
 def test_later_phases_receive_remaining_timeout_not_a_fresh_budget() -> None:

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 from click.testing import CliRunner
@@ -231,6 +232,47 @@ def test_timeout_is_terminal_and_closes_record() -> None:
     assert caught.value.result.status == "timeout"
     assert caught.value.result.record == "closed"
     assert memory.service.list_jobs()[0].job.status == "timeout"
+
+
+def test_timeout_is_shared_across_validation_and_inference() -> None:
+    class _SlowAnalyzer(_Analyzer):
+        async def analyze(self, **kwargs: Any) -> str:
+            self.calls.append(kwargs)
+            await asyncio.sleep(0.8)
+            return self.answer
+
+    async def slow_sensor(*_args: Any, **_kwargs: Any) -> SensorRef:
+        await asyncio.sleep(0.8)
+        return await _sensor()
+
+    analyzer = _SlowAnalyzer()
+    started = time.monotonic()
+    with pytest.raises(VLMJobError) as caught:
+        _run(analyzer, resolver=slow_sensor, timeout_seconds=1)
+    elapsed = time.monotonic() - started
+
+    assert caught.value.result.status == "timeout"
+    assert caught.value.result.record == "absent"
+    assert elapsed < 1.5
+
+
+def test_later_phases_receive_remaining_timeout_not_a_fresh_budget() -> None:
+    seen: dict[str, float] = {}
+
+    async def tracking_sensor(*_args: Any, timeout_seconds: float, **_kwargs: Any) -> SensorRef:
+        seen["sensor"] = timeout_seconds
+        await asyncio.sleep(0.3)
+        return await _sensor()
+
+    async def tracking_segments(*_args: Any, timeout_seconds: float, **_kwargs: Any) -> list[tuple[str, str]]:
+        seen["segments"] = timeout_seconds
+        return SEGMENTS
+
+    _run(_Analyzer(), timeout_seconds=1, resolver=tracking_sensor, segments=tracking_segments)
+
+    assert seen["sensor"] <= 1
+    assert seen["segments"] < seen["sensor"]
+    assert seen["segments"] <= 0.8
 
 
 def test_invalid_window_never_calls_analyzer() -> None:

--- a/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
+++ b/services/agent/packages/vss_cli/tests/unit_test/cli/test_vlm.py
@@ -326,3 +326,27 @@ def test_help_has_only_negative_persistence_override() -> None:
     assert result.exit_code == 0
     assert "--no-persist" in result.output
     assert "--persist" not in result.output.replace("--no-persist", "")
+
+
+def test_production_analyzer_passes_in_cluster_clip_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeVST:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["vst"] = kwargs
+
+    class _FakeAnalyzer:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["analyzer"] = kwargs
+
+    monkeypatch.setattr("vss_core.vios.VSTClient", _FakeVST)
+    monkeypatch.setattr("vss_core.vlm.OpenAIVLMAnalyzer", _FakeAnalyzer)
+
+    from vss_cli.vlm.runner import _production_analyzer
+
+    analyzer, model = _production_analyzer(_deployment(), 30)
+
+    assert model == "test-vlm"
+    assert analyzer is not None
+    assert captured["analyzer"]["video_url_scope"] == "internal"
+    assert captured["analyzer"]["media_mode"] == "video_url"

--- a/services/agent/packages/vss_core/src/vss_core/introspection/__init__.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/__init__.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight public API for bounded memory introspection."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+from typing import Any
+
+__all__ = [
+    "AnswerSynthesizer",
+    "GroundedGap",
+    "IntrospectionRequest",
+    "IntrospectionResult",
+    "IntrospectionSettings",
+    "IntrospectionVLMRunner",
+    "InvalidJudgeResponseError",
+    "OpenAIIntrospectionClient",
+    "SufficiencyDecision",
+    "SufficiencyJudge",
+    "VLMEvidence",
+]
+
+_LAZY_EXPORTS = {
+    "GroundedGap": ".models",
+    "IntrospectionRequest": ".models",
+    "IntrospectionResult": ".models",
+    "IntrospectionSettings": ".models",
+    "SufficiencyDecision": ".models",
+    "VLMEvidence": ".models",
+    "AnswerSynthesizer": ".protocols",
+    "IntrospectionVLMRunner": ".protocols",
+    "SufficiencyJudge": ".protocols",
+    "InvalidJudgeResponseError": ".judge",
+    "OpenAIIntrospectionClient": ".judge",
+}
+
+if TYPE_CHECKING:
+    from .judge import InvalidJudgeResponseError
+    from .judge import OpenAIIntrospectionClient
+    from .models import GroundedGap
+    from .models import IntrospectionRequest
+    from .models import IntrospectionResult
+    from .models import IntrospectionSettings
+    from .models import SufficiencyDecision
+    from .models import VLMEvidence
+    from .protocols import AnswerSynthesizer
+    from .protocols import IntrospectionVLMRunner
+    from .protocols import SufficiencyJudge
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(module_name, __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value

--- a/services/agent/packages/vss_core/src/vss_core/introspection/__init__.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/__init__.py
@@ -16,10 +16,12 @@ __all__ = [
     "IntrospectionSettings",
     "IntrospectionVLMRunner",
     "InvalidJudgeResponseError",
+    "MemoryEvidence",
     "OpenAIIntrospectionClient",
     "SufficiencyDecision",
     "SufficiencyJudge",
     "VLMEvidence",
+    "introspect",
 ]
 
 _LAZY_EXPORTS = {
@@ -27,6 +29,7 @@ _LAZY_EXPORTS = {
     "IntrospectionRequest": ".models",
     "IntrospectionResult": ".models",
     "IntrospectionSettings": ".models",
+    "MemoryEvidence": ".models",
     "SufficiencyDecision": ".models",
     "VLMEvidence": ".models",
     "AnswerSynthesizer": ".protocols",
@@ -34,6 +37,7 @@ _LAZY_EXPORTS = {
     "SufficiencyJudge": ".protocols",
     "InvalidJudgeResponseError": ".judge",
     "OpenAIIntrospectionClient": ".judge",
+    "introspect": ".orchestrator",
 }
 
 if TYPE_CHECKING:
@@ -43,8 +47,10 @@ if TYPE_CHECKING:
     from .models import IntrospectionRequest
     from .models import IntrospectionResult
     from .models import IntrospectionSettings
+    from .models import MemoryEvidence
     from .models import SufficiencyDecision
     from .models import VLMEvidence
+    from .orchestrator import introspect
     from .protocols import AnswerSynthesizer
     from .protocols import IntrospectionVLMRunner
     from .protocols import SufficiencyJudge

--- a/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
@@ -12,7 +12,6 @@ import httpx
 from pydantic import ValidationError
 
 from vss_core._foundation.errors import ConfigurationError
-from vss_core.introspection.models import GroundedGap
 from vss_core.introspection.models import IntrospectionSettings
 from vss_core.introspection.models import SufficiencyDecision
 from vss_core.introspection.models import VLMEvidence
@@ -76,7 +75,7 @@ class OpenAIIntrospectionClient:
         query: str,
         memory_evidence: list[UnifiedMemoryRecord],
         vlm_evidence: list[VLMEvidence],
-        unresolved_gaps: list[GroundedGap],
+        unresolved_gaps: list[str],
     ) -> str:
         """Produce a final answer from supplied evidence without another judge pass."""
         prompt = _synthesis_prompt(query, memory_evidence, vlm_evidence, unresolved_gaps)
@@ -161,18 +160,17 @@ def _synthesis_prompt(
     query: str,
     memory_evidence: list[UnifiedMemoryRecord],
     vlm_evidence: list[VLMEvidence],
-    unresolved_gaps: list[GroundedGap],
+    unresolved_gaps: list[str],
 ) -> str:
     memory_payload = [record.model_dump_memory() for record in memory_evidence]
     vlm_payload = [item.model_dump(mode="json") for item in vlm_evidence]
-    gap_payload = [item.model_dump(mode="json") for item in unresolved_gaps]
     return (
         "Answer the query using only the supplied memory and VLM evidence. Clearly qualify uncertainty represented "
         "by unresolved gaps. Return plain text only.\n"
         f"QUERY:\n{query}\n"
         f"MEMORY_EVIDENCE:\n{json.dumps(memory_payload, separators=(',', ':'))}\n"
         f"VLM_EVIDENCE:\n{json.dumps(vlm_payload, separators=(',', ':'))}\n"
-        f"UNRESOLVED_GAPS:\n{json.dumps(gap_payload, separators=(',', ':'))}"
+        f"UNRESOLVED_GAPS:\n{json.dumps(unresolved_gaps, separators=(',', ':'))}"
     )
 
 

--- a/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
@@ -165,8 +165,10 @@ def _synthesis_prompt(
     memory_payload = [record.model_dump_memory() for record in memory_evidence]
     vlm_payload = [item.model_dump(mode="json") for item in vlm_evidence]
     return (
-        "Answer the query using only the supplied memory and VLM evidence. Clearly qualify uncertainty represented "
-        "by unresolved gaps. Return plain text only.\n"
+        "Answer the query using only facts explicitly stated in the supplied memory and VLM evidence. "
+        "An unresolved gap is unknown: never turn missing evidence into a positive or negative claim. "
+        "Clearly state what cannot be confirmed; if no evidence directly supports an answer, say it cannot be "
+        "determined. Return plain text only.\n"
         f"QUERY:\n{query}\n"
         f"MEMORY_EVIDENCE:\n{json.dumps(memory_payload, separators=(',', ':'))}\n"
         f"VLM_EVIDENCE:\n{json.dumps(vlm_payload, separators=(',', ':'))}\n"

--- a/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
@@ -55,7 +55,7 @@ class OpenAIIntrospectionClient:
             transport=transport,
         )
 
-    async def judge(self, query: str, records: list[UnifiedMemoryRecord]) -> SufficiencyDecision:
+    async def judge(self, *, query: str, records: list[UnifiedMemoryRecord]) -> SufficiencyDecision:
         """Judge memory sufficiency, retrying once only for invalid model output."""
         prompt = _judge_prompt(query, records, self._settings.sufficiency_threshold)
         last_error: InvalidJudgeResponseError | None = None
@@ -72,6 +72,7 @@ class OpenAIIntrospectionClient:
 
     async def synthesize(
         self,
+        *,
         query: str,
         memory_evidence: list[UnifiedMemoryRecord],
         vlm_evidence: list[VLMEvidence],
@@ -146,7 +147,8 @@ def _judge_prompt(query: str, records: list[UnifiedMemoryRecord], threshold: flo
         f"Use a sufficiency threshold of {threshold:.2f}. "
         "Return JSON only, with exactly the fields approved by the schema; do not add markdown or commentary. "
         "Every evidence_record_id must be an ID from the supplied records. Each gap must ask one targeted question "
-        "using a supplied sensor name and an ISO-8601 UTC window overlapping that sensor's supplied record window. "
+        "using a supplied sensor name plus start_time and end_time as ISO-8601 UTC instants that overlap that "
+        "sensor's supplied record window. "
         "Use canonical input.sensors[].id names or legacy input.sensors[].info.name names. "
         "If sufficient is true, gaps must be empty.\n"
         f"SCHEMA:\n{json.dumps(schema, separators=(',', ':'))}\n"

--- a/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
@@ -32,6 +32,8 @@ class OpenAIIntrospectionClient:
         *,
         base_url: str,
         model: str,
+        criteria_prompt: str,
+        backend_model: str | None = None,
         api_key: str | None = None,
         settings: IntrospectionSettings | None = None,
         client: httpx.AsyncClient | None = None,
@@ -41,11 +43,17 @@ class OpenAIIntrospectionClient:
             raise ConfigurationError("introspection base_url must be non-empty")
         if not model.strip():
             raise ConfigurationError("introspection model must be non-empty")
+        if not criteria_prompt.strip():
+            raise ConfigurationError("introspection criteria_prompt must be non-empty")
+        if backend_model is not None and not backend_model.strip():
+            raise ConfigurationError("introspection backend_model must be non-empty when configured")
         if client is not None and transport is not None:
             raise ConfigurationError("provide either an httpx client or transport, not both")
 
         self._base_url = _normalize_base_url(base_url)
         self._model = model.strip()
+        self._criteria_prompt = criteria_prompt
+        self._backend_model = backend_model.strip() if backend_model is not None else None
         self._api_key = api_key
         self._settings = settings or IntrospectionSettings()
         self._owns_client = client is None
@@ -56,10 +64,15 @@ class OpenAIIntrospectionClient:
 
     async def judge(self, *, query: str, records: list[UnifiedMemoryRecord]) -> SufficiencyDecision:
         """Judge memory sufficiency, retrying once only for invalid model output."""
-        prompt = _judge_prompt(query, records, self._settings.sufficiency_threshold)
+        prompt = _judge_prompt(
+            query,
+            records,
+            self._settings.sufficiency_threshold,
+            self._criteria_prompt,
+        )
         last_error: InvalidJudgeResponseError | None = None
         for _attempt in range(2):
-            content = await self._chat(prompt, json_only=True)
+            content = await self._chat(prompt)
             try:
                 decision = _parse_decision(content)
                 return decision.validate_grounding(records)
@@ -79,22 +92,22 @@ class OpenAIIntrospectionClient:
     ) -> str:
         """Produce a final answer from supplied evidence without another judge pass."""
         prompt = _synthesis_prompt(query, memory_evidence, vlm_evidence, unresolved_gaps)
-        answer = (await self._chat(prompt, json_only=False)).strip()
+        answer = (await self._chat(prompt)).strip()
         if not answer:
             raise ValueError("answer synthesizer returned empty content")
         return answer
 
-    async def _chat(self, prompt: str, *, json_only: bool) -> str:
+    async def _chat(self, prompt: str) -> str:
         payload: dict[str, Any] = {
             "model": self._model,
             "temperature": 0,
             "messages": [{"role": "user", "content": prompt}],
         }
-        if json_only:
-            payload["response_format"] = {"type": "json_object"}
         headers = {"Content-Type": "application/json"}
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
+        if self._backend_model is not None:
+            headers["x-openclaw-model"] = self._backend_model
 
         response = await self._client.post(self._chat_completions_url, headers=headers, json=payload)
         response.raise_for_status()
@@ -138,21 +151,28 @@ def _strip_code_fence(content: str) -> str:
     return "\n".join(lines[1:-1]).strip()
 
 
-def _judge_prompt(query: str, records: list[UnifiedMemoryRecord], threshold: float) -> str:
+def _judge_prompt(
+    query: str,
+    records: list[UnifiedMemoryRecord],
+    threshold: float,
+    criteria_prompt: str,
+) -> str:
     schema = SufficiencyDecision.model_json_schema()
     evidence = [record.model_dump_memory() for record in records]
     return (
-        "Decide whether the retrieved memory evidence is sufficient to answer the query. "
-        f"Use a sufficiency threshold of {threshold:.2f}. "
-        "Return JSON only, with exactly the fields approved by the schema; do not add markdown or commentary. "
-        "Every evidence_record_id must be an ID from the supplied records. Each gap must ask one targeted question "
-        "using a supplied sensor name plus start_time and end_time as ISO-8601 UTC instants that overlap that "
-        "sensor's supplied record window. "
+        "FIXED VSS GROUNDING AND SAFETY RULES:\n"
+        "Judge only the supplied memory records. Do not invent evidence. "
+        "Every evidence_record_id must come from the supplied records. "
+        "Each gap must ask one targeted question using a sensor from the supplied records, and its start_time and "
+        "end_time must be ISO-8601 UTC instants that overlap that sensor's supplied record window. "
         "Use canonical input.sensors[].id names or legacy input.sensors[].info.name names. "
-        "If sufficient is true, gaps must be empty.\n"
-        f"SCHEMA:\n{json.dumps(schema, separators=(',', ':'))}\n"
-        f"QUERY:\n{query}\n"
-        f"RECORDS:\n{json.dumps(evidence, separators=(',', ':'))}"
+        "When sufficient is true, gaps must be empty. "
+        "Return JSON only, with exactly the fields required by the schema; do not add markdown or commentary.\n"
+        f"CONFIGURED SUFFICIENCY CRITERIA:\n{criteria_prompt}\n"
+        f"SUFFICIENCY THRESHOLD:\n{threshold:.2f}\n"
+        f"REQUIRED RESPONSE SCHEMA:\n{json.dumps(schema, separators=(',', ':'))}\n"
+        f"USER QUERY:\n{query}\n"
+        f"RETRIEVED RECORDS:\n{json.dumps(evidence, separators=(',', ':'))}"
     )
 
 

--- a/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
@@ -74,7 +74,7 @@ class OpenAIIntrospectionClient:
         for _attempt in range(2):
             content = await self._chat(prompt)
             try:
-                decision = _parse_decision(content)
+                decision = _normalize_evidence_ids(_parse_decision(content), records)
                 return decision.validate_grounding(records)
             except (InvalidJudgeResponseError, ValidationError, ValueError) as error:
                 last_error = InvalidJudgeResponseError(f"invalid sufficiency judge response: {error}")
@@ -158,11 +158,12 @@ def _judge_prompt(
     criteria_prompt: str,
 ) -> str:
     schema = SufficiencyDecision.model_json_schema()
-    evidence = [record.model_dump_memory() for record in records]
+    evidence = [_judge_record(record) for record in records]
     return (
         "FIXED VSS GROUNDING AND SAFETY RULES:\n"
         "Judge only the supplied memory records. Do not invent evidence. "
-        "Every evidence_record_id must come from the supplied records. "
+        "For every evidence_record_id, copy exactly one top-level evidence_record_id value from the supplied records. "
+        "Never construct an ID or cite an Elasticsearch document ID, embedding reference, or compound #event# ID. "
         "Each gap must ask one targeted question using a sensor from the supplied records, and its start_time and "
         "end_time must be ISO-8601 UTC instants that overlap that sensor's supplied record window. "
         "Use canonical input.sensors[].id names or legacy input.sensors[].info.name names. "
@@ -174,6 +175,51 @@ def _judge_prompt(
         f"USER QUERY:\n{query}\n"
         f"RETRIEVED RECORDS:\n{json.dumps(evidence, separators=(',', ':'))}"
     )
+
+
+def _judge_record(record: UnifiedMemoryRecord) -> dict[str, Any]:
+    """Expose one unambiguous citeable ID and omit internal embedding identifiers."""
+    payload = record.model_dump_memory()
+    output = payload.get("output")
+    if isinstance(output, dict):
+        output.pop("embedding", None)
+    return {"evidence_record_id": _record_id(record), **payload}
+
+
+def _normalize_evidence_ids(
+    decision: SufficiencyDecision,
+    records: list[UnifiedMemoryRecord],
+) -> SufficiencyDecision:
+    """Map only known storage/embedding aliases back to public evidence IDs."""
+    aliases: dict[str, set[str]] = {}
+    for record in records:
+        public_id = _record_id(record)
+        candidates = {public_id, _storage_id(record)}
+        if record.output is not None:
+            for embedding in record.output.embedding or []:
+                if embedding.es_ref:
+                    candidates.add(embedding.es_ref)
+                    candidates.add(embedding.es_ref.rsplit("/", 1)[-1])
+        for candidate in candidates:
+            aliases.setdefault(candidate, set()).add(public_id)
+
+    normalized: list[str] = []
+    for evidence_id in decision.evidence_record_ids:
+        targets = aliases.get(evidence_id)
+        public_id = next(iter(targets)) if targets is not None and len(targets) == 1 else evidence_id
+        if public_id not in normalized:
+            normalized.append(public_id)
+    return decision.model_copy(update={"evidence_record_ids": normalized})
+
+
+def _record_id(record: UnifiedMemoryRecord) -> str:
+    return record.job.record_id or record.job.job_id
+
+
+def _storage_id(record: UnifiedMemoryRecord) -> str:
+    if record.job.record_id is None or record.job.record_type is None:
+        return record.job.job_id
+    return f"{record.job.job_id}#{record.job.record_type}#{record.job.record_id}"
 
 
 def _synthesis_prompt(

--- a/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/judge.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Text-only OpenAI-compatible sufficiency judge and answer synthesizer."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from typing import Any
+
+import httpx
+from pydantic import ValidationError
+
+from vss_core._foundation.errors import ConfigurationError
+from vss_core.introspection.models import GroundedGap
+from vss_core.introspection.models import IntrospectionSettings
+from vss_core.introspection.models import SufficiencyDecision
+from vss_core.introspection.models import VLMEvidence
+
+if TYPE_CHECKING:
+    from vss_core.memory.models import UnifiedMemoryRecord
+
+
+class InvalidJudgeResponseError(ValueError):
+    """The judge returned invalid JSON, an invalid schema, or ungrounded data."""
+
+
+class OpenAIIntrospectionClient:
+    """OpenAI-compatible text client implementing both introspection text roles."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        api_key: str | None = None,
+        settings: IntrospectionSettings | None = None,
+        client: httpx.AsyncClient | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        if not base_url.strip():
+            raise ConfigurationError("introspection base_url must be non-empty")
+        if not model.strip():
+            raise ConfigurationError("introspection model must be non-empty")
+        if client is not None and transport is not None:
+            raise ConfigurationError("provide either an httpx client or transport, not both")
+
+        self._base_url = _normalize_base_url(base_url)
+        self._model = model.strip()
+        self._api_key = api_key
+        self._settings = settings or IntrospectionSettings()
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            timeout=httpx.Timeout(float(self._settings.timeout_seconds)),
+            transport=transport,
+        )
+
+    async def judge(self, query: str, records: list[UnifiedMemoryRecord]) -> SufficiencyDecision:
+        """Judge memory sufficiency, retrying once only for invalid model output."""
+        prompt = _judge_prompt(query, records, self._settings.sufficiency_threshold)
+        last_error: InvalidJudgeResponseError | None = None
+        for _attempt in range(2):
+            content = await self._chat(prompt, json_only=True)
+            try:
+                decision = _parse_decision(content)
+                return decision.validate_grounding(records)
+            except (InvalidJudgeResponseError, ValidationError, ValueError) as error:
+                last_error = InvalidJudgeResponseError(f"invalid sufficiency judge response: {error}")
+        if last_error is None:  # pragma: no cover - the fixed two-attempt loop always sets this
+            raise AssertionError("judge retry loop produced no result")
+        raise last_error
+
+    async def synthesize(
+        self,
+        query: str,
+        memory_evidence: list[UnifiedMemoryRecord],
+        vlm_evidence: list[VLMEvidence],
+        unresolved_gaps: list[GroundedGap],
+    ) -> str:
+        """Produce a final answer from supplied evidence without another judge pass."""
+        prompt = _synthesis_prompt(query, memory_evidence, vlm_evidence, unresolved_gaps)
+        answer = (await self._chat(prompt, json_only=False)).strip()
+        if not answer:
+            raise ValueError("answer synthesizer returned empty content")
+        return answer
+
+    async def _chat(self, prompt: str, *, json_only: bool) -> str:
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "temperature": 0,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if json_only:
+            payload["response_format"] = {"type": "json_object"}
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        response = await self._client.post(self._chat_completions_url, headers=headers, json=payload)
+        response.raise_for_status()
+        try:
+            content = response.json()["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError, json.JSONDecodeError) as error:
+            raise ValueError("OpenAI-compatible response contained no message content") from error
+        if not isinstance(content, str):
+            raise ValueError("OpenAI-compatible message content must be text")
+        return content
+
+    @property
+    def _chat_completions_url(self) -> str:
+        if self._base_url.endswith("/chat/completions"):
+            return self._base_url
+        return f"{self._base_url}/chat/completions"
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+
+def _parse_decision(content: str) -> SufficiencyDecision:
+    stripped = _strip_code_fence(content)
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError as error:
+        raise InvalidJudgeResponseError("response is not valid JSON") from error
+    if not isinstance(payload, dict):
+        raise InvalidJudgeResponseError("response JSON must be an object")
+    return SufficiencyDecision.model_validate(payload)
+
+
+def _strip_code_fence(content: str) -> str:
+    stripped = content.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = stripped.splitlines()
+    if len(lines) < 3 or lines[-1].strip() != "```":
+        return stripped
+    return "\n".join(lines[1:-1]).strip()
+
+
+def _judge_prompt(query: str, records: list[UnifiedMemoryRecord], threshold: float) -> str:
+    schema = SufficiencyDecision.model_json_schema()
+    evidence = [record.model_dump_memory() for record in records]
+    return (
+        "Decide whether the retrieved memory evidence is sufficient to answer the query. "
+        f"Use a sufficiency threshold of {threshold:.2f}. "
+        "Return JSON only, with exactly the fields approved by the schema; do not add markdown or commentary. "
+        "Every evidence_record_id must be an ID from the supplied records. Each gap must ask one targeted question "
+        "using a supplied sensor name and an ISO-8601 UTC window overlapping that sensor's supplied record window. "
+        "Use canonical input.sensors[].id names or legacy input.sensors[].info.name names. "
+        "If sufficient is true, gaps must be empty.\n"
+        f"SCHEMA:\n{json.dumps(schema, separators=(',', ':'))}\n"
+        f"QUERY:\n{query}\n"
+        f"RECORDS:\n{json.dumps(evidence, separators=(',', ':'))}"
+    )
+
+
+def _synthesis_prompt(
+    query: str,
+    memory_evidence: list[UnifiedMemoryRecord],
+    vlm_evidence: list[VLMEvidence],
+    unresolved_gaps: list[GroundedGap],
+) -> str:
+    memory_payload = [record.model_dump_memory() for record in memory_evidence]
+    vlm_payload = [item.model_dump(mode="json") for item in vlm_evidence]
+    gap_payload = [item.model_dump(mode="json") for item in unresolved_gaps]
+    return (
+        "Answer the query using only the supplied memory and VLM evidence. Clearly qualify uncertainty represented "
+        "by unresolved gaps. Return plain text only.\n"
+        f"QUERY:\n{query}\n"
+        f"MEMORY_EVIDENCE:\n{json.dumps(memory_payload, separators=(',', ':'))}\n"
+        f"VLM_EVIDENCE:\n{json.dumps(vlm_payload, separators=(',', ':'))}\n"
+        f"UNRESOLVED_GAPS:\n{json.dumps(gap_payload, separators=(',', ':'))}"
+    )
+
+
+def _normalize_base_url(base_url: str) -> str:
+    normalized = base_url.strip().rstrip("/")
+    if normalized.endswith("/chat/completions") or normalized.endswith("/v1"):
+        return normalized
+    return f"{normalized}/v1"
+
+
+__all__ = ["InvalidJudgeResponseError", "OpenAIIntrospectionClient"]

--- a/services/agent/packages/vss_core/src/vss_core/introspection/models.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/models.py
@@ -217,6 +217,7 @@ class IntrospectionResult(_StrictModel):
     memory_evidence: list[MemoryEvidence] = Field(default_factory=list)
     vlm_evidence: list[VLMEvidence] = Field(default_factory=list)
     unresolved_gaps: list[str] = Field(default_factory=list)
+    failure_kind: Literal["backend_unreachable", "timeout"] | None = Field(default=None, exclude=True)
 
     @field_validator("answer", mode="after")
     @classmethod

--- a/services/agent/packages/vss_core/src/vss_core/introspection/models.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/models.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Strict data contracts and grounding validation for memory introspection."""
+
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from typing import Any
+from typing import Self
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import field_validator
+from pydantic import model_validator
+
+from vss_core.memory.models import UnifiedMemoryRecord  # noqa: TC001 - Pydantic resolves this model at runtime.
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+def _nonempty(value: str, field_name: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} must be non-empty")
+    return stripped
+
+
+def parse_utc_instant(value: str) -> datetime:
+    """Parse a strict ISO-8601 UTC instant without accepting naive/local time."""
+    stripped = value.strip()
+    try:
+        parsed = datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("must be an ISO-8601 UTC instant") from error
+    if parsed.tzinfo is None or parsed.utcoffset() != UTC.utcoffset(parsed):
+        raise ValueError("must include the UTC timezone (Z or +00:00)")
+    return parsed.astimezone(UTC)
+
+
+class GroundedGap(_StrictModel):
+    """One targeted VLM question grounded in retrieved sensor/time metadata."""
+
+    question: str
+    sensor: str
+    start: str
+    end: str
+
+    @field_validator("question", "sensor", mode="after")
+    @classmethod
+    def _require_nonempty(cls, value: str, info: Any) -> str:
+        return _nonempty(value, info.field_name)
+
+    @field_validator("start", "end", mode="after")
+    @classmethod
+    def _require_utc(cls, value: str) -> str:
+        parse_utc_instant(value)
+        return value.strip()
+
+    @model_validator(mode="after")
+    def _ordered_window(self) -> Self:
+        if parse_utc_instant(self.start) > parse_utc_instant(self.end):
+            raise ValueError("gap start must be before or equal to end")
+        return self
+
+
+class SufficiencyDecision(_StrictModel):
+    """Judge result constrained to approved evidence and grounded follow-ups."""
+
+    sufficient: bool
+    reason: str
+    evidence_record_ids: list[str]
+    gaps: list[GroundedGap]
+
+    @field_validator("reason", mode="after")
+    @classmethod
+    def _require_reason(cls, value: str) -> str:
+        return _nonempty(value, "reason")
+
+    @field_validator("evidence_record_ids", mode="after")
+    @classmethod
+    def _require_nonempty_unique_evidence_ids(cls, value: list[str]) -> list[str]:
+        normalized = [_nonempty(item, "evidence_record_ids item") for item in value]
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("evidence_record_ids must not contain duplicates")
+        return normalized
+
+    @model_validator(mode="after")
+    def _sufficient_has_no_gaps(self) -> Self:
+        if self.sufficient and self.gaps:
+            raise ValueError("a sufficient decision must not contain gaps")
+        return self
+
+    def validate_grounding(self, records: list[UnifiedMemoryRecord]) -> Self:
+        """Reject evidence IDs, sensors, and windows not grounded in ``records``."""
+        record_ids = {_record_id(record) for record in records}
+        unknown_ids = sorted(set(self.evidence_record_ids) - record_ids)
+        if unknown_ids:
+            raise ValueError(f"unknown evidence_record_ids: {unknown_ids}")
+
+        for gap in self.gaps:
+            start = parse_utc_instant(gap.start)
+            end = parse_utc_instant(gap.end)
+            matching_records = [record for record in records if gap.sensor in _sensor_names(record)]
+            if not matching_records:
+                raise ValueError(f"gap sensor {gap.sensor!r} is not present in retrieved records")
+            if not any(_record_window_overlaps(record, start, end) for record in matching_records):
+                raise ValueError(
+                    f"gap window {gap.start!r} to {gap.end!r} does not overlap a retrieved record "
+                    f"for sensor {gap.sensor!r}"
+                )
+        return self
+
+
+class VLMEvidence(_StrictModel):
+    """Text evidence returned by a grounded introspection VLM query."""
+
+    sensor: str
+    start: str
+    end: str
+    prompt: str
+    intent: str
+    content: str
+
+    @field_validator("sensor", "prompt", "intent", "content", mode="after")
+    @classmethod
+    def _require_text(cls, value: str, info: Any) -> str:
+        return _nonempty(value, info.field_name)
+
+    @field_validator("start", "end", mode="after")
+    @classmethod
+    def _require_utc(cls, value: str) -> str:
+        parse_utc_instant(value)
+        return value.strip()
+
+    @model_validator(mode="after")
+    def _ordered_window(self) -> Self:
+        if parse_utc_instant(self.start) > parse_utc_instant(self.end):
+            raise ValueError("VLM evidence start must be before or equal to end")
+        return self
+
+
+class IntrospectionSettings(_StrictModel):
+    """Resource bounds for one introspection workflow."""
+
+    max_memory_records: int = Field(default=10, ge=1)
+    max_vlm_queries: int = Field(default=3, ge=0)
+    max_clip_duration_seconds: int = Field(default=60, ge=1)
+    timeout_seconds: int = Field(default=180, ge=1)
+    sufficiency_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
+
+
+class IntrospectionRequest(_StrictModel):
+    """Input to a bounded memory introspection workflow."""
+
+    query: str
+    records: list[UnifiedMemoryRecord]
+
+    @field_validator("query", mode="after")
+    @classmethod
+    def _require_query(cls, value: str) -> str:
+        return _nonempty(value, "query")
+
+
+class IntrospectionResult(_StrictModel):
+    """Final text answer and the evidence used to produce it."""
+
+    answer: str
+    decision: SufficiencyDecision
+    memory_evidence: list[UnifiedMemoryRecord] = Field(default_factory=list)
+    vlm_evidence: list[VLMEvidence] = Field(default_factory=list)
+    unresolved_gaps: list[GroundedGap] = Field(default_factory=list)
+
+    @field_validator("answer", mode="after")
+    @classmethod
+    def _require_answer(cls, value: str) -> str:
+        return _nonempty(value, "answer")
+
+
+def _record_id(record: UnifiedMemoryRecord) -> str:
+    return record.job.record_id or record.job.job_id
+
+
+def _sensor_names(record: UnifiedMemoryRecord) -> set[str]:
+    names: set[str] = set()
+    if record.input is None or not record.input.sensors:
+        return names
+    for sensor in record.input.sensors:
+        names.add(sensor.id)
+        if sensor.info is not None:
+            legacy_name = sensor.info.get("name")
+            if isinstance(legacy_name, str) and legacy_name.strip():
+                names.add(legacy_name.strip())
+    return names
+
+
+def _record_window_overlaps(record: UnifiedMemoryRecord, start: datetime, end: datetime) -> bool:
+    if record.input is None or record.input.window is None:
+        return False
+    record_start = record.input.window.start.timestamp.astimezone(UTC)
+    record_end = (
+        record.input.window.end.timestamp.astimezone(UTC) if record.input.window.end is not None else record_start
+    )
+    return record_start <= end and record_end >= start
+
+
+__all__ = [
+    "GroundedGap",
+    "IntrospectionRequest",
+    "IntrospectionResult",
+    "IntrospectionSettings",
+    "SufficiencyDecision",
+    "VLMEvidence",
+    "parse_utc_instant",
+]

--- a/services/agent/packages/vss_core/src/vss_core/introspection/models.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/models.py
@@ -195,6 +195,12 @@ class IntrospectionRequest(_StrictModel):
             raise ValueError("start_time must be before or equal to end_time")
         return self
 
+    @model_validator(mode="after")
+    def _complete_child_identity(self) -> Self:
+        if self.record_id is not None and (self.job_id is None or self.record_type is None):
+            raise ValueError("child identity requires job_id, record_type, and record_id together")
+        return self
+
 
 class MemoryEvidence(_StrictModel):
     """Stable public identity for one memory record used in synthesis."""

--- a/services/agent/packages/vss_core/src/vss_core/introspection/models.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/models.py
@@ -46,15 +46,15 @@ class GroundedGap(_StrictModel):
 
     question: str
     sensor: str
-    start: str
-    end: str
+    start_time: str
+    end_time: str
 
     @field_validator("question", "sensor", mode="after")
     @classmethod
     def _require_nonempty(cls, value: str, info: Any) -> str:
         return _nonempty(value, info.field_name)
 
-    @field_validator("start", "end", mode="after")
+    @field_validator("start_time", "end_time", mode="after")
     @classmethod
     def _require_utc(cls, value: str) -> str:
         parse_utc_instant(value)
@@ -62,8 +62,8 @@ class GroundedGap(_StrictModel):
 
     @model_validator(mode="after")
     def _ordered_window(self) -> Self:
-        if parse_utc_instant(self.start) > parse_utc_instant(self.end):
-            raise ValueError("gap start must be before or equal to end")
+        if parse_utc_instant(self.start_time) > parse_utc_instant(self.end_time):
+            raise ValueError("gap start_time must be before or equal to end_time")
         return self
 
 
@@ -102,14 +102,14 @@ class SufficiencyDecision(_StrictModel):
             raise ValueError(f"unknown evidence_record_ids: {unknown_ids}")
 
         for gap in self.gaps:
-            start = parse_utc_instant(gap.start)
-            end = parse_utc_instant(gap.end)
+            start_time = parse_utc_instant(gap.start_time)
+            end_time = parse_utc_instant(gap.end_time)
             matching_records = [record for record in records if gap.sensor in _sensor_names(record)]
             if not matching_records:
                 raise ValueError(f"gap sensor {gap.sensor!r} is not present in retrieved records")
-            if not any(_record_window_overlaps(record, start, end) for record in matching_records):
+            if not any(_record_window_overlaps(record, start_time, end_time) for record in matching_records):
                 raise ValueError(
-                    f"gap window {gap.start!r} to {gap.end!r} does not overlap a retrieved record "
+                    f"gap window {gap.start_time!r} to {gap.end_time!r} does not overlap a retrieved record "
                     f"for sensor {gap.sensor!r}"
                 )
         return self
@@ -119,8 +119,8 @@ class VLMEvidence(_StrictModel):
     """Text evidence returned by a grounded introspection VLM query."""
 
     sensor: str
-    start: str
-    end: str
+    start_time: str
+    end_time: str
     prompt: str
     intent: str
     content: str
@@ -130,7 +130,7 @@ class VLMEvidence(_StrictModel):
     def _require_text(cls, value: str, info: Any) -> str:
         return _nonempty(value, info.field_name)
 
-    @field_validator("start", "end", mode="after")
+    @field_validator("start_time", "end_time", mode="after")
     @classmethod
     def _require_utc(cls, value: str) -> str:
         parse_utc_instant(value)
@@ -138,8 +138,8 @@ class VLMEvidence(_StrictModel):
 
     @model_validator(mode="after")
     def _ordered_window(self) -> Self:
-        if parse_utc_instant(self.start) > parse_utc_instant(self.end):
-            raise ValueError("VLM evidence start must be before or equal to end")
+        if parse_utc_instant(self.start_time) > parse_utc_instant(self.end_time):
+            raise ValueError("VLM evidence start_time must be before or equal to end_time")
         return self
 
 

--- a/services/agent/packages/vss_core/src/vss_core/introspection/models.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/models.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from datetime import UTC
 from datetime import datetime
 from typing import Any
+from typing import Literal
 from typing import Self
 
 from pydantic import BaseModel
@@ -15,6 +16,8 @@ from pydantic import Field
 from pydantic import field_validator
 from pydantic import model_validator
 
+from vss_core.memory.models import MemoryGroup  # noqa: TC001 - Pydantic resolves this model at runtime.
+from vss_core.memory.models import RecordType  # noqa: TC001 - Pydantic resolves this model at runtime.
 from vss_core.memory.models import UnifiedMemoryRecord  # noqa: TC001 - Pydantic resolves this model at runtime.
 
 
@@ -118,14 +121,14 @@ class SufficiencyDecision(_StrictModel):
 class VLMEvidence(_StrictModel):
     """Text evidence returned by a grounded introspection VLM query."""
 
+    job_id: str
+    persisted: bool
     sensor: str
     start_time: str
     end_time: str
-    prompt: str
-    intent: str
-    content: str
+    answer: str
 
-    @field_validator("sensor", "prompt", "intent", "content", mode="after")
+    @field_validator("job_id", "sensor", "answer", mode="after")
     @classmethod
     def _require_text(cls, value: str, info: Any) -> str:
         return _nonempty(value, info.field_name)
@@ -157,26 +160,69 @@ class IntrospectionRequest(_StrictModel):
     """Input to a bounded memory introspection workflow."""
 
     query: str
-    records: list[UnifiedMemoryRecord]
+    sensor: str | None = None
+    job_id: str | None = None
+    record_id: str | None = None
+    record_type: RecordType | None = None
+    group: MemoryGroup | None = None
+    start_time: str | None = None
+    end_time: str | None = None
 
-    @field_validator("query", mode="after")
+    @field_validator("query", "sensor", "job_id", "record_id", mode="after")
     @classmethod
-    def _require_query(cls, value: str) -> str:
-        return _nonempty(value, "query")
+    def _require_nonempty_selector(cls, value: str | None, info: Any) -> str | None:
+        if value is None:
+            return None
+        return _nonempty(value, info.field_name)
+
+    @field_validator("start_time", "end_time", mode="after")
+    @classmethod
+    def _require_utc_window(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        parse_utc_instant(value)
+        return value.strip()
+
+    @model_validator(mode="after")
+    def _paired_ordered_window(self) -> Self:
+        if (self.start_time is None) != (self.end_time is None):
+            raise ValueError("start_time and end_time must be provided together")
+        if (
+            self.start_time is not None
+            and self.end_time is not None
+            and parse_utc_instant(self.start_time) > parse_utc_instant(self.end_time)
+        ):
+            raise ValueError("start_time must be before or equal to end_time")
+        return self
+
+
+class MemoryEvidence(_StrictModel):
+    """Stable public identity for one memory record used in synthesis."""
+
+    record_id: str
+    job_id: str
+
+    @field_validator("record_id", "job_id", mode="after")
+    @classmethod
+    def _require_identity(cls, value: str, info: Any) -> str:
+        return _nonempty(value, info.field_name)
 
 
 class IntrospectionResult(_StrictModel):
-    """Final text answer and the evidence used to produce it."""
+    """Strict stdout-safe result of one bounded introspection workflow."""
 
-    answer: str
-    decision: SufficiencyDecision
-    memory_evidence: list[UnifiedMemoryRecord] = Field(default_factory=list)
+    status: Literal["completed", "partial", "no_memory"]
+    sufficient_from_memory: bool
+    answer: str | None
+    memory_evidence: list[MemoryEvidence] = Field(default_factory=list)
     vlm_evidence: list[VLMEvidence] = Field(default_factory=list)
-    unresolved_gaps: list[GroundedGap] = Field(default_factory=list)
+    unresolved_gaps: list[str] = Field(default_factory=list)
 
     @field_validator("answer", mode="after")
     @classmethod
-    def _require_answer(cls, value: str) -> str:
+    def _require_answer(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return _nonempty(value, "answer")
 
 
@@ -212,6 +258,7 @@ __all__ = [
     "IntrospectionRequest",
     "IntrospectionResult",
     "IntrospectionSettings",
+    "MemoryEvidence",
     "SufficiencyDecision",
     "VLMEvidence",
     "parse_utc_instant",

--- a/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded, memory-first introspection orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from dataclasses import field
+from typing import TYPE_CHECKING
+from typing import Literal
+
+from vss_core.introspection.models import GroundedGap
+from vss_core.introspection.models import IntrospectionRequest
+from vss_core.introspection.models import IntrospectionResult
+from vss_core.introspection.models import IntrospectionSettings
+from vss_core.introspection.models import MemoryEvidence
+from vss_core.introspection.models import SufficiencyDecision
+from vss_core.introspection.models import VLMEvidence
+from vss_core.introspection.models import parse_utc_instant
+from vss_core.memory.store import MemoryQuery
+
+if TYPE_CHECKING:
+    from vss_core.introspection.protocols import AnswerSynthesizer
+    from vss_core.introspection.protocols import IntrospectionVLMRunner
+    from vss_core.introspection.protocols import SufficiencyJudge
+    from vss_core.memory.models import UnifiedMemoryRecord
+    from vss_core.memory.service import MemoryService
+
+
+@dataclass
+class _WorkflowState:
+    records: list[UnifiedMemoryRecord] = field(default_factory=list)
+    memory_records: list[UnifiedMemoryRecord] = field(default_factory=list)
+    vlm_evidence: list[VLMEvidence] = field(default_factory=list)
+    unresolved: list[str] = field(default_factory=list)
+    pending: list[GroundedGap] = field(default_factory=list)
+    sufficient_from_memory: bool = False
+
+
+async def introspect(
+    request: IntrospectionRequest,
+    *,
+    memory: MemoryService,
+    judge: SufficiencyJudge,
+    synthesizer: AnswerSynthesizer,
+    vlm_runner: IntrospectionVLMRunner,
+    settings: IntrospectionSettings,
+) -> IntrospectionResult:
+    """Answer one request with one judge, bounded inspections, and one synthesis."""
+    state = _WorkflowState()
+    try:
+        async with asyncio.timeout(settings.timeout_seconds):
+            return await _run_workflow(
+                request,
+                memory=memory,
+                judge=judge,
+                synthesizer=synthesizer,
+                vlm_runner=vlm_runner,
+                settings=settings,
+                state=state,
+            )
+    except TimeoutError:
+        state.unresolved.extend(f"{_gap_label(gap)}: not inspected before workflow timeout" for gap in state.pending)
+        state.unresolved.append(f"introspection workflow timed out after {settings.timeout_seconds} seconds")
+        return _result(
+            status="partial",
+            sufficient_from_memory=state.sufficient_from_memory,
+            answer=None,
+            memory_records=state.memory_records,
+            vlm_evidence=state.vlm_evidence,
+            unresolved=state.unresolved,
+        )
+
+
+async def _run_workflow(
+    request: IntrospectionRequest,
+    *,
+    memory: MemoryService,
+    judge: SufficiencyJudge,
+    synthesizer: AnswerSynthesizer,
+    vlm_runner: IntrospectionVLMRunner,
+    settings: IntrospectionSettings,
+    state: _WorkflowState,
+) -> IntrospectionResult:
+    query = MemoryQuery(
+        text=request.query,
+        sensor_id=request.sensor,
+        job_id=request.job_id,
+        record_id=request.record_id,
+        record_type=request.record_type,
+        group=request.group,
+        since=request.start_time,
+        until=request.end_time,
+        time_field="window",
+        include_children=True,
+        parents_only=False,
+        limit=settings.max_memory_records,
+    )
+    try:
+        state.records = await _retrieve_records(memory, query, settings.max_memory_records)
+    except Exception as error:
+        return _result(
+            status="partial",
+            sufficient_from_memory=False,
+            answer=None,
+            unresolved=[f"memory retrieval failed: {error}"],
+        )
+    if not state.records:
+        return _result(status="no_memory", sufficient_from_memory=False, answer=None)
+
+    try:
+        decision = await judge.judge(query=request.query, records=state.records)
+    except Exception as error:
+        state.memory_records = _useful_records(state.records)
+        state.unresolved.append(f"sufficiency judge failed after validation retry: {error}")
+        answer = await _synthesize_best_effort(request, synthesizer, state)
+        return _result(
+            status="partial",
+            sufficient_from_memory=False,
+            answer=answer,
+            memory_records=state.memory_records,
+            unresolved=state.unresolved,
+        )
+
+    state.sufficient_from_memory = decision.sufficient
+    state.memory_records = _validated_memory_evidence(decision, state.records, state.unresolved)
+    if decision.sufficient:
+        answer = await _synthesize_best_effort(request, synthesizer, state)
+        return _result(
+            status="completed" if answer is not None and not state.unresolved else "partial",
+            sufficient_from_memory=True,
+            answer=answer,
+            memory_records=state.memory_records,
+            unresolved=state.unresolved,
+        )
+
+    valid_gaps = _validated_gaps(decision.gaps, state.records, settings, state.unresolved)
+    state.pending = list(valid_gaps)
+    for index, gap in enumerate(valid_gaps):
+        if index >= settings.max_vlm_queries:
+            state.unresolved.extend(
+                f"{_gap_label(remaining)}: not inspected because the VLM query cap is {settings.max_vlm_queries}"
+                for remaining in valid_gaps[index:]
+            )
+            break
+        try:
+            evidence = await vlm_runner.run(
+                sensor=gap.sensor,
+                start_time=gap.start_time,
+                end_time=gap.end_time,
+                prompt=gap.question,
+                intent="introspection",
+            )
+            state.vlm_evidence.append(evidence)
+        except Exception as error:
+            state.unresolved.append(f"{_gap_label(gap)}: VLM inspection failed: {error}")
+        state.pending.pop(0)
+
+    if not decision.gaps:
+        state.unresolved.append(f"memory was insufficient: {decision.reason}")
+
+    answer = await _synthesize_best_effort(request, synthesizer, state)
+    status: Literal["completed", "partial"] = "completed" if answer is not None and not state.unresolved else "partial"
+    return _result(
+        status=status,
+        sufficient_from_memory=False,
+        answer=answer,
+        memory_records=state.memory_records,
+        vlm_evidence=state.vlm_evidence,
+        unresolved=state.unresolved,
+    )
+
+
+async def _synthesize_best_effort(
+    request: IntrospectionRequest,
+    synthesizer: AnswerSynthesizer,
+    state: _WorkflowState,
+) -> str | None:
+    try:
+        return await synthesizer.synthesize(
+            query=request.query,
+            memory_evidence=state.memory_records,
+            vlm_evidence=state.vlm_evidence,
+            unresolved_gaps=state.unresolved,
+        )
+    except Exception as error:
+        state.unresolved.append(f"answer synthesis failed: {error}")
+        return None
+
+
+def _validated_memory_evidence(
+    decision: SufficiencyDecision,
+    records: list[UnifiedMemoryRecord],
+    unresolved: list[str],
+) -> list[UnifiedMemoryRecord]:
+    by_id = {_record_id(record): record for record in records}
+    selected: list[UnifiedMemoryRecord] = []
+    for record_id in decision.evidence_record_ids:
+        record = by_id.get(record_id)
+        if record is None:
+            unresolved.append(f"judge referenced unknown memory evidence record_id {record_id!r}")
+        else:
+            selected.append(record)
+    return selected
+
+
+def _validated_gaps(
+    gaps: list[GroundedGap],
+    records: list[UnifiedMemoryRecord],
+    settings: IntrospectionSettings,
+    unresolved: list[str],
+) -> list[GroundedGap]:
+    valid: list[GroundedGap] = []
+    for gap in gaps:
+        duration = (parse_utc_instant(gap.end_time) - parse_utc_instant(gap.start_time)).total_seconds()
+        if duration > settings.max_clip_duration_seconds:
+            unresolved.append(
+                f"{_gap_label(gap)}: rejected because {duration:g}s exceeds "
+                f"the {settings.max_clip_duration_seconds}s clip limit"
+            )
+            continue
+        try:
+            SufficiencyDecision(
+                sufficient=False,
+                reason="validate one gap",
+                evidence_record_ids=[],
+                gaps=[gap],
+            ).validate_grounding(records)
+        except ValueError as error:
+            unresolved.append(f"{_gap_label(gap)}: rejected as ungrounded: {error}")
+            continue
+        valid.append(gap)
+    return valid
+
+
+def _prioritize(records: list[UnifiedMemoryRecord]) -> list[UnifiedMemoryRecord]:
+    indexed = list(enumerate(records))
+    indexed.sort(
+        key=lambda item: (
+            0
+            if item[1].job.is_child and item[1].job.record_type in {"event", "search_hit", "incident"}
+            else 1
+            if item[1].job.is_parent and item[1].output is not None and bool(item[1].output.answer)
+            else 2,
+            item[0],
+        )
+    )
+    return [record for _, record in indexed]
+
+
+async def _retrieve_records(
+    memory: MemoryService,
+    query: MemoryQuery,
+    limit: int,
+) -> list[UnifiedMemoryRecord]:
+    records = await asyncio.to_thread(memory.query, query)
+    known_parents = {record.job.job_id for record in records if record.job.is_parent}
+    child_job_ids = list(dict.fromkeys(record.job.job_id for record in records if record.job.is_child))
+    for job_id in child_job_ids:
+        if job_id in known_parents:
+            continue
+        parents = await asyncio.to_thread(
+            memory.query,
+            MemoryQuery(
+                job_id=job_id,
+                include_children=False,
+                parents_only=True,
+                limit=1,
+            ),
+        )
+        if parents:
+            records.append(parents[0])
+            known_parents.add(job_id)
+
+    prioritized = _prioritize(list({_record_identity(record): record for record in records}.values()))
+    selected = prioritized[:limit]
+    useful_parents = [
+        record
+        for record in prioritized
+        if record.job.is_parent and record.output is not None and bool(record.output.answer)
+    ]
+    if useful_parents and selected and not any(record.job.is_parent for record in selected):
+        selected[-1] = useful_parents[0]
+    return selected
+
+
+def _useful_records(records: list[UnifiedMemoryRecord]) -> list[UnifiedMemoryRecord]:
+    useful = [record for record in records if record.output is not None and bool(record.output.answer)]
+    return useful or records
+
+
+def _record_id(record: UnifiedMemoryRecord) -> str:
+    return record.job.record_id or record.job.job_id
+
+
+def _record_identity(record: UnifiedMemoryRecord) -> tuple[str, str | None, str | None]:
+    return (record.job.job_id, record.job.record_type, record.job.record_id)
+
+
+def _gap_label(gap: GroundedGap) -> str:
+    return f"{gap.question!r} on {gap.sensor!r} from {gap.start_time} to {gap.end_time}"
+
+
+def _result(
+    *,
+    status: Literal["completed", "partial", "no_memory"],
+    sufficient_from_memory: bool,
+    answer: str | None,
+    memory_records: list[UnifiedMemoryRecord] | None = None,
+    vlm_evidence: list[VLMEvidence] | None = None,
+    unresolved: list[str] | None = None,
+) -> IntrospectionResult:
+    return IntrospectionResult(
+        status=status,
+        sufficient_from_memory=sufficient_from_memory,
+        answer=answer,
+        memory_evidence=[
+            MemoryEvidence(record_id=_record_id(record), job_id=record.job.job_id) for record in (memory_records or [])
+        ],
+        vlm_evidence=vlm_evidence or [],
+        unresolved_gaps=unresolved or [],
+    )
+
+
+__all__ = ["introspect"]

--- a/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
@@ -284,15 +284,12 @@ async def _retrieve_records(
                 job_id=job_id,
                 sensor_id=query.sensor_id,
                 group=query.group,
-                since=query.since,
-                until=query.until,
-                time_field=query.time_field,
                 include_children=False,
                 parents_only=True,
                 limit=1,
             ),
         )
-        if parents:
+        if parents and _parent_matches_time_scope(parents[0], query):
             records.append(parents[0])
             known_parents.add(job_id)
 
@@ -319,6 +316,16 @@ def _record_id(record: UnifiedMemoryRecord) -> str:
 
 def _record_identity(record: UnifiedMemoryRecord) -> tuple[str, str | None, str | None]:
     return (record.job.job_id, record.job.record_type, record.job.record_id)
+
+
+def _parent_matches_time_scope(parent: UnifiedMemoryRecord, query: MemoryQuery) -> bool:
+    """Keep scoped parents without windows, but reject known non-overlapping windows."""
+    window = parent.input.window if parent.input is not None else None
+    if window is None:
+        return True
+    if query.since is not None and window.end.timestamp < query.since:
+        return False
+    return query.until is None or window.start.timestamp <= query.until
 
 
 def _gap_label(gap: GroundedGap) -> str:

--- a/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
@@ -274,6 +274,11 @@ async def _retrieve_records(
             memory.query,
             MemoryQuery(
                 job_id=job_id,
+                sensor_id=query.sensor_id,
+                group=query.group,
+                since=query.since,
+                until=query.until,
+                time_field=query.time_field,
                 include_children=False,
                 parents_only=True,
                 limit=1,

--- a/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
@@ -85,8 +85,11 @@ async def _run_workflow(
     settings: IntrospectionSettings,
     state: _WorkflowState,
 ) -> IntrospectionResult:
+    identity_scoped = request.job_id is not None or request.record_id is not None
     query = MemoryQuery(
-        text=request.query,
+        # Identity selectors choose the evidence; the natural-language question
+        # remains the judge/synthesis prompt and must not filter that evidence.
+        text=None if identity_scoped else request.query,
         sensor_id=request.sensor,
         job_id=request.job_id,
         record_id=request.record_id,

--- a/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
@@ -50,8 +50,10 @@ async def introspect(
 ) -> IntrospectionResult:
     """Answer one request with one judge, bounded inspections, and one synthesis."""
     state = _WorkflowState()
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + settings.timeout_seconds
     try:
-        async with asyncio.timeout(settings.timeout_seconds):
+        async with asyncio.timeout_at(deadline):
             return await _run_workflow(
                 request,
                 memory=memory,
@@ -60,6 +62,7 @@ async def introspect(
                 vlm_runner=vlm_runner,
                 settings=settings,
                 state=state,
+                deadline=deadline,
             )
     except TimeoutError:
         state.unresolved.extend(f"{_gap_label(gap)}: not inspected before workflow timeout" for gap in state.pending)
@@ -84,8 +87,9 @@ async def _run_workflow(
     vlm_runner: IntrospectionVLMRunner,
     settings: IntrospectionSettings,
     state: _WorkflowState,
+    deadline: float,
 ) -> IntrospectionResult:
-    identity_scoped = request.job_id is not None or request.record_id is not None
+    identity_scoped = request.job_id is not None
     query = MemoryQuery(
         # Identity selectors choose the evidence; the natural-language question
         # remains the judge/synthesis prompt and must not filter that evidence.
@@ -161,6 +165,7 @@ async def _run_workflow(
                 end_time=gap.end_time,
                 prompt=gap.question,
                 intent="introspection",
+                timeout_seconds=max(0.0, deadline - asyncio.get_running_loop().time()),
             )
             state.vlm_evidence.append(evidence)
         except Exception as error:

--- a/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
@@ -323,7 +323,7 @@ def _parent_matches_time_scope(parent: UnifiedMemoryRecord, query: MemoryQuery) 
     window = parent.input.window if parent.input is not None else None
     if window is None:
         return True
-    if query.since is not None and window.end.timestamp < query.since:
+    if query.since is not None and window.end is not None and window.end.timestamp < query.since:
         return False
     return query.until is None or window.start.timestamp <= query.until
 

--- a/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/orchestrator.py
@@ -36,6 +36,7 @@ class _WorkflowState:
     unresolved: list[str] = field(default_factory=list)
     pending: list[GroundedGap] = field(default_factory=list)
     sufficient_from_memory: bool = False
+    failure_kind: Literal["backend_unreachable"] | None = None
 
 
 async def introspect(
@@ -70,6 +71,7 @@ async def introspect(
             memory_records=state.memory_records,
             vlm_evidence=state.vlm_evidence,
             unresolved=state.unresolved,
+            failure_kind="timeout",
         )
 
 
@@ -105,6 +107,7 @@ async def _run_workflow(
             sufficient_from_memory=False,
             answer=None,
             unresolved=[f"memory retrieval failed: {error}"],
+            failure_kind="backend_unreachable" if _is_backend_unreachable(error) else None,
         )
     if not state.records:
         return _result(status="no_memory", sufficient_from_memory=False, answer=None)
@@ -112,6 +115,8 @@ async def _run_workflow(
     try:
         decision = await judge.judge(query=request.query, records=state.records)
     except Exception as error:
+        if _is_backend_unreachable(error):
+            state.failure_kind = "backend_unreachable"
         state.memory_records = _useful_records(state.records)
         state.unresolved.append(f"sufficiency judge failed after validation retry: {error}")
         answer = await _synthesize_best_effort(request, synthesizer, state)
@@ -121,6 +126,7 @@ async def _run_workflow(
             answer=answer,
             memory_records=state.memory_records,
             unresolved=state.unresolved,
+            failure_kind=state.failure_kind,
         )
 
     state.sufficient_from_memory = decision.sufficient
@@ -133,6 +139,7 @@ async def _run_workflow(
             answer=answer,
             memory_records=state.memory_records,
             unresolved=state.unresolved,
+            failure_kind=state.failure_kind,
         )
 
     valid_gaps = _validated_gaps(decision.gaps, state.records, settings, state.unresolved)
@@ -169,6 +176,7 @@ async def _run_workflow(
         memory_records=state.memory_records,
         vlm_evidence=state.vlm_evidence,
         unresolved=state.unresolved,
+        failure_kind=state.failure_kind,
     )
 
 
@@ -185,6 +193,8 @@ async def _synthesize_best_effort(
             unresolved_gaps=state.unresolved,
         )
     except Exception as error:
+        if _is_backend_unreachable(error):
+            state.failure_kind = "backend_unreachable"
         state.unresolved.append(f"answer synthesis failed: {error}")
         return None
 
@@ -302,6 +312,22 @@ def _gap_label(gap: GroundedGap) -> str:
     return f"{gap.question!r} on {gap.sensor!r} from {gap.start_time} to {gap.end_time}"
 
 
+def _is_backend_unreachable(error: BaseException) -> bool:
+    return any(
+        klass.__name__
+        in {
+            "BackendUnreachableError",
+            "ConnectError",
+            "ConnectTimeout",
+            "HTTPStatusError",
+            "ReadTimeout",
+            "VSTError",
+            "VIOSTimeoutError",
+        }
+        for klass in type(error).__mro__
+    )
+
+
 def _result(
     *,
     status: Literal["completed", "partial", "no_memory"],
@@ -310,6 +336,7 @@ def _result(
     memory_records: list[UnifiedMemoryRecord] | None = None,
     vlm_evidence: list[VLMEvidence] | None = None,
     unresolved: list[str] | None = None,
+    failure_kind: Literal["backend_unreachable", "timeout"] | None = None,
 ) -> IntrospectionResult:
     return IntrospectionResult(
         status=status,
@@ -320,6 +347,7 @@ def _result(
         ],
         vlm_evidence=vlm_evidence or [],
         unresolved_gaps=unresolved or [],
+        failure_kind=failure_kind,
     )
 
 

--- a/services/agent/packages/vss_core/src/vss_core/introspection/protocols.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/protocols.py
@@ -41,6 +41,7 @@ class IntrospectionVLMRunner(Protocol):
         end_time: str,
         prompt: str,
         intent: str,
+        timeout_seconds: float | None = None,
     ) -> VLMEvidence: ...
 
 

--- a/services/agent/packages/vss_core/src/vss_core/introspection/protocols.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/protocols.py
@@ -17,13 +17,14 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class SufficiencyJudge(Protocol):
-    async def judge(self, query: str, records: list[UnifiedMemoryRecord]) -> SufficiencyDecision: ...
+    async def judge(self, *, query: str, records: list[UnifiedMemoryRecord]) -> SufficiencyDecision: ...
 
 
 @runtime_checkable
 class AnswerSynthesizer(Protocol):
     async def synthesize(
         self,
+        *,
         query: str,
         memory_evidence: list[UnifiedMemoryRecord],
         vlm_evidence: list[VLMEvidence],
@@ -35,6 +36,7 @@ class AnswerSynthesizer(Protocol):
 class IntrospectionVLMRunner(Protocol):
     async def run(
         self,
+        *,
         sensor: str,
         start_time: str,
         end_time: str,

--- a/services/agent/packages/vss_core/src/vss_core/introspection/protocols.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/protocols.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Dependency-injection protocols for bounded memory introspection."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Protocol
+from typing import runtime_checkable
+
+if TYPE_CHECKING:
+    from vss_core.introspection.models import GroundedGap
+    from vss_core.introspection.models import SufficiencyDecision
+    from vss_core.introspection.models import VLMEvidence
+    from vss_core.memory.models import UnifiedMemoryRecord
+
+
+@runtime_checkable
+class SufficiencyJudge(Protocol):
+    async def judge(self, query: str, records: list[UnifiedMemoryRecord]) -> SufficiencyDecision: ...
+
+
+@runtime_checkable
+class AnswerSynthesizer(Protocol):
+    async def synthesize(
+        self,
+        query: str,
+        memory_evidence: list[UnifiedMemoryRecord],
+        vlm_evidence: list[VLMEvidence],
+        unresolved_gaps: list[GroundedGap],
+    ) -> str: ...
+
+
+@runtime_checkable
+class IntrospectionVLMRunner(Protocol):
+    async def run(
+        self,
+        sensor: str,
+        start_time: str,
+        end_time: str,
+        prompt: str,
+        intent: str,
+    ) -> VLMEvidence: ...
+
+
+__all__ = ["AnswerSynthesizer", "IntrospectionVLMRunner", "SufficiencyJudge"]

--- a/services/agent/packages/vss_core/src/vss_core/introspection/protocols.py
+++ b/services/agent/packages/vss_core/src/vss_core/introspection/protocols.py
@@ -9,7 +9,6 @@ from typing import Protocol
 from typing import runtime_checkable
 
 if TYPE_CHECKING:
-    from vss_core.introspection.models import GroundedGap
     from vss_core.introspection.models import SufficiencyDecision
     from vss_core.introspection.models import VLMEvidence
     from vss_core.memory.models import UnifiedMemoryRecord
@@ -28,7 +27,7 @@ class AnswerSynthesizer(Protocol):
         query: str,
         memory_evidence: list[UnifiedMemoryRecord],
         vlm_evidence: list[VLMEvidence],
-        unresolved_gaps: list[GroundedGap],
+        unresolved_gaps: list[str],
     ) -> str: ...
 
 

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/elasticsearch.py
@@ -188,7 +188,17 @@ class ElasticsearchMemoryStore:
         if status:
             filters.append({"term": {"job.status.keyword": status}})
         if sensor_id:
-            filters.append({"term": {"input.sensors.id.keyword": sensor_id}})
+            filters.append(
+                {
+                    "bool": {
+                        "should": [
+                            {"term": {"input.sensors.id.keyword": sensor_id}},
+                            {"term": {"input.sensors.info.name.keyword": sensor_id}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
         if record_type:
             filters.append({"term": {"job.record_type.keyword": record_type}})
         if record_id:
@@ -270,9 +280,13 @@ class ElasticsearchMemoryStore:
             bool_query["filter"] = filters
         if must_not:
             bool_query["must_not"] = must_not
+        recency_sort = [
+            {"job.updated_at": {"order": "desc", "missing": "_last"}},
+            {"job.created_at": {"order": "desc"}},
+        ]
         return {
             "size": max(limit, 0),
-            "sort": [{"job.updated_at": {"order": "desc", "missing": "_last"}}, {"job.created_at": {"order": "desc"}}],
+            "sort": [{"_score": {"order": "desc"}}, *recency_sort] if text else recency_sort,
             "query": {"bool": bool_query},
         }
 

--- a/services/agent/packages/vss_core/src/vss_core/memory/backends/in_memory.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/backends/in_memory.py
@@ -17,7 +17,10 @@ def _sensor_match(record: UnifiedMemoryRecord, sensor_id: str | None) -> bool:
     if not sensor_id:
         return True
     sensors = (record.input.sensors if record.input is not None else None) or []
-    return any(sensor.id == sensor_id for sensor in sensors)
+    return any(
+        sensor.id == sensor_id or (sensor.info is not None and sensor.info.get("name") == sensor_id)
+        for sensor in sensors
+    )
 
 
 def _time_in_range(value: datetime, since: datetime | None, until: datetime | None) -> bool:
@@ -89,6 +92,12 @@ def _matches_query(record: UnifiedMemoryRecord, query: MemoryQuery) -> bool:
     return True
 
 
+def _text_score(record: UnifiedMemoryRecord, text: str) -> int:
+    """Simple relevance score for parity with Elasticsearch ``_score`` ordering."""
+    needle = text.casefold()
+    return sum(haystack.casefold().count(needle) for haystack in _text_haystacks(record))
+
+
 def _matches_filters(record: UnifiedMemoryRecord, filters: JobFilters) -> bool:
     if record.job.is_child:
         return False
@@ -134,7 +143,10 @@ class InMemoryStore:
 
     def query(self, query: MemoryQuery) -> list[UnifiedMemoryRecord]:
         matched = [record for record in self._records.values() if _matches_query(record, query)]
-        matched.sort(key=_sort_key, reverse=True)
+        if query.text:
+            matched.sort(key=lambda record: (_text_score(record, query.text or ""), _sort_key(record)), reverse=True)
+        else:
+            matched.sort(key=_sort_key, reverse=True)
         return matched[: max(query.limit, 0)]
 
     def list_jobs(self, filters: JobFilters) -> list[UnifiedMemoryRecord]:

--- a/services/agent/packages/vss_core/src/vss_core/memory/models.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/models.py
@@ -152,7 +152,11 @@ class JobInfo(BaseModel):
 
 
 class SensorInfo(BaseModel):
-    """Sensor / video source identity carried on a memory record."""
+    """Sensor / video source identity carried on a memory record.
+
+    ``id`` is the human-readable VIOS sensor name used for recall. Backend
+    sensor UUIDs, stream IDs, and video IDs belong in ``info``.
+    """
 
     model_config = ConfigDict(extra="forbid")
 

--- a/services/agent/packages/vss_core/src/vss_core/memory/store.py
+++ b/services/agent/packages/vss_core/src/vss_core/memory/store.py
@@ -113,6 +113,8 @@ def is_parent_storage_id(storage_id: str) -> bool:
 class MemoryQuery:
     """Free-form / filtered query over persisted unified-memory records.
 
+    ``sensor_id`` names a VIOS sensor. Backends also match legacy records that
+    stored that name in ``input.sensors[].info.name``.
     ``since`` / ``until`` filter on ``job.created_at`` when ``time_field`` is
     ``\"created_at\"`` (default), or on child event windows when
     ``time_field=\"window\"`` (``input.window.start`` / ``end`` overlap).

--- a/services/agent/packages/vss_core/src/vss_core/vlm/openai.py
+++ b/services/agent/packages/vss_core/src/vss_core/vlm/openai.py
@@ -16,18 +16,13 @@
 
 from __future__ import annotations
 
-import asyncio
 import base64
 from datetime import datetime
 import logging
-import math
-from pathlib import Path
-import tempfile
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 
-import cv2
 import httpx
 
 from vss_core._foundation.errors import BackendUnreachableError
@@ -40,6 +35,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# ``frame_base64`` remains accepted as a compatibility alias, but now sends the
+# native MP4 just like ``video_base64`` instead of extracting JPEG frames.
 MediaMode = Literal["video_url", "video_base64", "frame_base64"]
 VideoURLScope = Literal["internal", "external"]
 _VLM_RETRYABLE_ERRORS = (httpx.TimeoutException, httpx.TransportError)
@@ -47,15 +44,6 @@ _VLM_RETRYABLE_ERRORS = (httpx.TimeoutException, httpx.TransportError)
 
 class _RetryableVLMStatusError(Exception):
     """Raised for HTTP 5xx responses so tenacity retries the request."""
-
-
-class _FrameExtractionError(ValueError):
-    """Raised when decoding/selecting frames from a VST clip fails.
-
-    A ``ValueError`` subclass so it is distinguishable from response-parse
-    ValueErrors, letting ``analyze`` report clip/frame problems separately from
-    "invalid VLM response format".
-    """
 
 
 class OpenAIVLMAnalyzer:
@@ -139,7 +127,6 @@ class OpenAIVLMAnalyzer:
             content = await self._build_content(
                 prompt=prompt,
                 clip_url=clip_url,
-                duration_seconds=duration_seconds,
             )
             payload = {
                 "model": self._model,
@@ -168,9 +155,6 @@ class OpenAIVLMAnalyzer:
             # elsewhere already carry backend context — let them propagate as-is
             # rather than masking them as a VLM error.
             raise
-        except _FrameExtractionError as e:
-            logger.error("VLM frame extraction failed: %s", scrub_log(e))
-            raise BackendUnreachableError("vlm", f"Frame extraction from VST clip failed: {e}", e) from e
         except (httpx.HTTPError, _RetryableVLMStatusError) as e:
             logger.error("VLM request failed: %s", scrub_log(e))
             raise BackendUnreachableError("vlm", str(e), e) from e
@@ -209,7 +193,7 @@ class OpenAIVLMAnalyzer:
 
     def _add_model_runtime_options(self, payload: dict[str, Any], duration_seconds: float) -> None:
         model = self._model.lower()
-        if self._cosmos_nim_runtime_options and "cosmos" in model and self._media_mode != "frame_base64":
+        if self._cosmos_nim_runtime_options and "cosmos" in model:
             payload["media_io_kwargs"] = {
                 "video": {
                     "num_frames": _dynamic_num_frames(duration_seconds, self._max_frames, self._max_fps),
@@ -223,7 +207,6 @@ class OpenAIVLMAnalyzer:
         *,
         prompt: str,
         clip_url: str,
-        duration_seconds: float,
     ) -> list[dict[str, Any]]:
         if self._media_mode == "video_url":
             return [
@@ -244,34 +227,10 @@ class OpenAIVLMAnalyzer:
             raise BackendUnreachableError("vst", detail) from None
         video_bytes = response.content
 
-        if self._media_mode == "video_base64":
-            video_b64 = base64.b64encode(video_bytes).decode("ascii")
-            return [
-                {"type": "text", "text": prompt},
-                {"type": "video_url", "video_url": {"url": f"data:video/mp4;base64,{video_b64}"}},
-            ]
-
-        frame_b64s = await asyncio.to_thread(
-            _select_base64_frames,
-            video_bytes,
-            duration_seconds,
-            self._max_frames,
-            self._max_fps,
-        )
-        if not frame_b64s:
-            raise _FrameExtractionError("No frames selected from VST clip")
+        video_b64 = base64.b64encode(video_bytes).decode("ascii")
         return [
-            {
-                "type": "text",
-                "text": (
-                    "The following images are a sequence of frames from a video. "
-                    f"Answer the user's question based on the video: {prompt}"
-                ),
-            },
-            *[
-                {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{frame_b64}"}}
-                for frame_b64 in frame_b64s
-            ],
+            {"type": "text", "text": prompt},
+            {"type": "video_url", "video_url": {"url": f"data:video/mp4;base64,{video_b64}"}},
         ]
 
     async def aclose(self) -> None:
@@ -317,41 +276,3 @@ def _dynamic_num_frames(duration_seconds: float, max_frames: int, max_fps: int) 
 
 def _parse_iso(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
-
-
-def _select_base64_frames(video_bytes: bytes, duration_seconds: float, max_frames: int, max_fps: int) -> list[str]:
-    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=True) as tmp:
-        tmp.write(video_bytes)
-        tmp.flush()
-        step_size = max(duration_seconds / max_frames, 1.0 / max_fps)
-        return _frame_select(tmp.name, duration_seconds, step_size)
-
-
-def _frame_select(video_path: str, duration_seconds: float, step_size: float) -> list[str]:
-    cap = cv2.VideoCapture(str(Path(video_path)))
-    if not cap.isOpened():
-        raise _FrameExtractionError(f"Could not open video file: {video_path}")
-    try:
-        fps = cap.get(cv2.CAP_PROP_FPS)
-        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        if fps <= 0 or total_frames <= 0:
-            raise _FrameExtractionError("Video has no readable frames")
-        end_frame = min(total_frames - 1, math.ceil(duration_seconds * fps))
-        step_size_frame = max(1, math.floor(step_size * fps))
-        selected_frames = list(range(0, end_frame, step_size_frame))
-        if not selected_frames:
-            selected_frames = [0]
-
-        base64_frames: list[str] = []
-        for frame_idx in selected_frames:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
-            ok, frame = cap.read()
-            if not ok:
-                raise _FrameExtractionError(f"Could not read frame {frame_idx} from {video_path}")
-            ok, buffer = cv2.imencode(".jpg", frame)
-            if not ok:
-                raise _FrameExtractionError(f"Could not encode frame {frame_idx} from {video_path}")
-            base64_frames.append(base64.b64encode(buffer.tobytes()).decode("ascii"))
-        return base64_frames
-    finally:
-        cap.release()

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
@@ -312,6 +312,8 @@ async def test_synthesize_uses_supplied_evidence_only() -> None:
         prompt = body["messages"][0]["content"]
         assert "camera-east" in prompt
         assert "A person carried a small box." in prompt
+        assert "An unresolved gap is unknown" in prompt
+        assert "never turn missing evidence into a positive or negative claim" in prompt
         return httpx.Response(
             200,
             json={"choices": [{"message": {"content": " A person carried a small box. "}}]},

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
@@ -146,12 +146,12 @@ def test_decision_does_not_fill_missing_approved_fields() -> None:
 )
 def test_vlm_evidence_validation(updates: dict[str, object]) -> None:
     payload: dict[str, object] = {
+        "job_id": "vlm-1",
+        "persisted": True,
         "sensor": "camera-east",
         "start_time": "2026-08-26T12:00:10Z",
         "end_time": "2026-08-26T12:00:20Z",
-        "prompt": "Was the person carrying a package?",
-        "intent": "introspection",
-        "content": "A person carried a small box.",
+        "answer": "A person carried a small box.",
     }
     payload.update(updates)
     with pytest.raises(ValidationError):
@@ -325,12 +325,12 @@ async def test_synthesize_uses_supplied_evidence_only() -> None:
     )
     evidence = VLMEvidence.model_validate(
         {
+            "job_id": "vlm-1",
+            "persisted": True,
             "sensor": "camera-east",
             "start_time": "2026-08-26T12:00:10Z",
             "end_time": "2026-08-26T12:00:20Z",
-            "prompt": "Was the person carrying a package?",
-            "intent": "introspection",
-            "content": "A person carried a small box.",
+            "answer": "A person carried a small box.",
         }
     )
     try:
@@ -338,7 +338,7 @@ async def test_synthesize_uses_supplied_evidence_only() -> None:
             query="What happened?",
             memory_evidence=[_record()],
             vlm_evidence=[evidence],
-            unresolved_gaps=[GroundedGap.model_validate(_gap())],
+            unresolved_gaps=["package color remains unknown"],
         )
     finally:
         await client.aclose()

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
@@ -27,6 +27,8 @@ from vss_core.memory.models import TimestampPoint
 from vss_core.memory.models import TimeWindow
 from vss_core.memory.models import UnifiedMemoryRecord
 
+_CRITERIA = "Require direct evidence for all material claims."
+
 
 def _record(
     *,
@@ -211,7 +213,11 @@ def test_window_must_overlap_record_for_the_same_sensor() -> None:
 
 
 def test_client_satisfies_judge_and_synthesizer_protocols() -> None:
-    client = OpenAIIntrospectionClient(base_url="https://rt-vlm.example/v1", model="first-rt-vlm-model")
+    client = OpenAIIntrospectionClient(
+        base_url="https://text-judge.example/v1",
+        model="custom-text-model",
+        criteria_prompt=_CRITERIA,
+    )
 
     assert isinstance(client, SufficiencyJudge)
     assert isinstance(client, AnswerSynthesizer)
@@ -226,16 +232,32 @@ async def test_judge_retries_once_after_invalid_json_then_accepts_fenced_json() 
         calls += 1
         body = json.loads(request.content)
         assert body["temperature"] == 0
-        assert body["response_format"] == {"type": "json_object"}
+        assert body["model"] == "openclaw/default"
+        assert "response_format" not in body
+        assert request.headers["authorization"] == "Bearer gateway-secret"
+        assert request.headers["x-openclaw-model"] == "ollama/gemma3:12b"
         prompt = body["messages"][0]["content"]
-        assert "threshold of 0.70" in prompt
+        assert prompt.count(_CRITERIA) == 1
+        assert "FIXED VSS GROUNDING AND SAFETY RULES:" in prompt
+        assert "Judge only the supplied memory records" in prompt
+        assert "Do not invent evidence" in prompt
+        assert "REQUIRED RESPONSE SCHEMA:" in prompt
+        assert "SUFFICIENCY THRESHOLD:\n0.70" in prompt
         assert "start_time and end_time" in prompt
+        assert prompt.index("FIXED VSS GROUNDING") < prompt.index("CONFIGURED SUFFICIENCY CRITERIA")
+        assert prompt.index("CONFIGURED SUFFICIENCY CRITERIA") < prompt.index("SUFFICIENCY THRESHOLD")
+        assert prompt.index("SUFFICIENCY THRESHOLD") < prompt.index("REQUIRED RESPONSE SCHEMA")
+        assert prompt.index("REQUIRED RESPONSE SCHEMA") < prompt.index("USER QUERY")
+        assert prompt.index("USER QUERY") < prompt.index("RETRIEVED RECORDS")
         content = "not-json" if calls == 1 else f"```json\n{json.dumps(_decision())}\n```"
         return httpx.Response(200, json={"choices": [{"message": {"content": content}}]}, request=request)
 
     client = OpenAIIntrospectionClient(
-        base_url="https://rt-vlm.example",
-        model="first-rt-vlm-model",
+        base_url="https://text-judge.example",
+        model="openclaw/default",
+        backend_model="ollama/gemma3:12b",
+        api_key="gateway-secret",
+        criteria_prompt=_CRITERIA,
         transport=httpx.MockTransport(handler),
     )
     try:
@@ -263,8 +285,9 @@ async def test_judge_fails_after_second_invalid_response() -> None:
         )
 
     client = OpenAIIntrospectionClient(
-        base_url="https://rt-vlm.example/v1",
-        model="first-rt-vlm-model",
+        base_url="https://text-judge.example/v1",
+        model="custom-text-model",
+        criteria_prompt=_CRITERIA,
         transport=httpx.MockTransport(handler),
     )
     try:
@@ -291,8 +314,9 @@ async def test_ungrounded_gap_is_rejected_after_one_retry() -> None:
         )
 
     client = OpenAIIntrospectionClient(
-        base_url="https://rt-vlm.example/v1",
-        model="first-rt-vlm-model",
+        base_url="https://text-judge.example/v1",
+        model="custom-text-model",
+        criteria_prompt=_CRITERIA,
         transport=httpx.MockTransport(handler),
     )
     try:
@@ -309,6 +333,8 @@ async def test_synthesize_uses_supplied_evidence_only() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
         assert "response_format" not in body
+        assert "authorization" not in request.headers
+        assert "x-openclaw-model" not in request.headers
         prompt = body["messages"][0]["content"]
         assert "camera-east" in prompt
         assert "A person carried a small box." in prompt
@@ -321,8 +347,9 @@ async def test_synthesize_uses_supplied_evidence_only() -> None:
         )
 
     client = OpenAIIntrospectionClient(
-        base_url="https://rt-vlm.example/v1",
-        model="first-rt-vlm-model",
+        base_url="https://text-judge.example/v1",
+        model="custom-text-model",
+        criteria_prompt=_CRITERIA,
         transport=httpx.MockTransport(handler),
     )
     evidence = VLMEvidence.model_validate(
@@ -358,8 +385,9 @@ async def test_http_failure_is_not_retried() -> None:
         return httpx.Response(503, request=request)
 
     client = OpenAIIntrospectionClient(
-        base_url="https://rt-vlm.example/v1",
-        model="first-rt-vlm-model",
+        base_url="https://text-judge.example/v1",
+        model="custom-text-model",
+        criteria_prompt=_CRITERIA,
         transport=httpx.MockTransport(handler),
     )
     try:

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
@@ -20,8 +20,10 @@ from vss_core.introspection.models import SufficiencyDecision
 from vss_core.introspection.models import VLMEvidence
 from vss_core.introspection.protocols import AnswerSynthesizer
 from vss_core.introspection.protocols import SufficiencyJudge
+from vss_core.memory.models import EmbeddingRef
 from vss_core.memory.models import JobInfo
 from vss_core.memory.models import MemoryInput
+from vss_core.memory.models import MemoryOutput
 from vss_core.memory.models import SensorInfo
 from vss_core.memory.models import TimestampPoint
 from vss_core.memory.models import TimeWindow
@@ -269,6 +271,56 @@ async def test_judge_retries_once_after_invalid_json_then_accepts_fenced_json() 
     assert result.evidence_record_ids == ["event-1"]
     assert result.gaps[0].start_time == "2026-08-26T12:00:10Z"
     assert result.gaps[0].end_time == "2026-08-26T12:00:20Z"
+
+
+@pytest.mark.asyncio
+async def test_judge_uses_public_citation_ids_and_normalizes_known_storage_aliases() -> None:
+    calls = 0
+    record = _record().model_copy(
+        update={
+            "output": MemoryOutput(
+                embedding=[
+                    EmbeddingRef(
+                        es_ref="vss-memory-embeddings-v1/search-1#search_hit#event-1",
+                        doc_ids=["search-1#search_hit#event-1"],
+                        kind="text",
+                    )
+                ]
+            )
+        }
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        prompt = json.loads(request.content)["messages"][0]["content"]
+        supplied = json.loads(prompt.split("RETRIEVED RECORDS:\n", 1)[1])
+        assert supplied[0]["evidence_record_id"] == "event-1"
+        assert "embedding" not in supplied[0].get("output", {})
+        assert "search-1#search_hit#event-1" not in prompt
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {"message": {"content": json.dumps(_decision(evidence_record_ids=["search-1#search_hit#event-1"]))}}
+                ]
+            },
+            request=request,
+        )
+
+    client = OpenAIIntrospectionClient(
+        base_url="https://text-judge.example/v1",
+        model="custom-text-model",
+        criteria_prompt=_CRITERIA,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        result = await client.judge(query="What happened?", records=[record])
+    finally:
+        await client.aclose()
+
+    assert calls == 1
+    assert result.evidence_record_ids == ["event-1"]
 
 
 @pytest.mark.asyncio

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
@@ -14,8 +14,12 @@ import pytest
 
 from vss_core.introspection.judge import InvalidJudgeResponseError
 from vss_core.introspection.judge import OpenAIIntrospectionClient
+from vss_core.introspection.models import GroundedGap
 from vss_core.introspection.models import IntrospectionSettings
 from vss_core.introspection.models import SufficiencyDecision
+from vss_core.introspection.models import VLMEvidence
+from vss_core.introspection.protocols import AnswerSynthesizer
+from vss_core.introspection.protocols import SufficiencyJudge
 from vss_core.memory.models import JobInfo
 from vss_core.memory.models import MemoryInput
 from vss_core.memory.models import SensorInfo
@@ -29,8 +33,8 @@ def _record(
     record_id: str = "event-1",
     sensor: str = "camera-east",
     legacy_name: str = "legacy-east",
-    start: datetime = datetime(2026, 8, 26, 12, 0, tzinfo=UTC),
-    end: datetime = datetime(2026, 8, 26, 12, 1, tzinfo=UTC),
+    start_time: datetime = datetime(2026, 8, 26, 12, 0, tzinfo=UTC),
+    end_time: datetime = datetime(2026, 8, 26, 12, 1, tzinfo=UTC),
 ) -> UnifiedMemoryRecord:
     return UnifiedMemoryRecord(
         job=JobInfo(
@@ -39,13 +43,27 @@ def _record(
             record_type="search_hit",
             group="search",
             status="completed",
-            created_at=start,
+            created_at=start_time,
         ),
         input=MemoryInput(
             sensors=[SensorInfo(id=sensor, info={"name": legacy_name})],
-            window=TimeWindow(start=TimestampPoint(timestamp=start), end=TimestampPoint(timestamp=end)),
+            window=TimeWindow(
+                start=TimestampPoint(timestamp=start_time),
+                end=TimestampPoint(timestamp=end_time),
+            ),
         ),
     )
+
+
+def _gap(**updates: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "question": "Was the person carrying a package?",
+        "sensor": "camera-east",
+        "start_time": "2026-08-26T12:00:10Z",
+        "end_time": "2026-08-26T12:00:20Z",
+    }
+    payload.update(updates)
+    return payload
 
 
 def _decision(**updates: object) -> dict[str, object]:
@@ -53,14 +71,7 @@ def _decision(**updates: object) -> dict[str, object]:
         "sufficient": False,
         "reason": "The event needs a closer visual check.",
         "evidence_record_ids": ["event-1"],
-        "gaps": [
-            {
-                "question": "Was the person carrying a package?",
-                "sensor": "camera-east",
-                "start": "2026-08-26T12:00:10Z",
-                "end": "2026-08-26T12:00:20Z",
-            }
-        ],
+        "gaps": [_gap()],
     }
     payload.update(updates)
     return payload
@@ -84,41 +95,32 @@ def test_settings_defaults_and_strict_types() -> None:
         _decision(reason=" "),
         _decision(sufficient=True),
         _decision(evidence_record_ids=["event-1", "event-1"]),
-        _decision(
-            gaps=[
-                {
-                    "question": " ",
-                    "sensor": "camera-east",
-                    "start": "2026-08-26T12:00:10Z",
-                    "end": "2026-08-26T12:00:20Z",
-                }
-            ]
-        ),
-        _decision(
-            gaps=[
-                {
-                    "question": "Check",
-                    "sensor": "camera-east",
-                    "start": "2026-08-26 12:00:10",
-                    "end": "2026-08-26T12:00:20Z",
-                }
-            ]
-        ),
-        _decision(
-            gaps=[
-                {
-                    "question": "Check",
-                    "sensor": "camera-east",
-                    "start": "2026-08-26T12:00:20Z",
-                    "end": "2026-08-26T12:00:10Z",
-                }
-            ]
-        ),
+        _decision(evidence_record_ids=[" "]),
+        _decision(gaps=[_gap(question=" ")]),
+        _decision(gaps=[_gap(sensor=" ")]),
+        _decision(gaps=[_gap(start_time="2026-08-26 12:00:10")]),
+        _decision(gaps=[_gap(end_time="2026-08-26T12:00:20")]),
+        _decision(gaps=[_gap(start_time="2026-08-26T12:00:20Z", end_time="2026-08-26T12:00:10Z")]),
     ),
 )
 def test_decision_schema_validation(payload: dict[str, object]) -> None:
     with pytest.raises(ValidationError):
         SufficiencyDecision.model_validate(payload)
+
+
+def test_gap_requires_start_time_and_end_time_field_names() -> None:
+    with pytest.raises(ValidationError):
+        GroundedGap.model_validate(
+            {
+                "question": "Was the person carrying a package?",
+                "sensor": "camera-east",
+                "start": "2026-08-26T12:00:10Z",
+                "end": "2026-08-26T12:00:20Z",
+            }
+        )
+
+    gap = GroundedGap.model_validate(_gap())
+    assert gap.model_dump() == _gap()
 
 
 def test_decision_does_not_fill_missing_approved_fields() -> None:
@@ -132,18 +134,41 @@ def test_decision_does_not_fill_missing_approved_fields() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "updates",
+    (
+        {"start": "2026-08-26T12:00:10Z", "end": "2026-08-26T12:00:20Z"},
+        {"start_time": "2026-08-26T12:00:20Z", "end_time": "2026-08-26T12:00:10Z"},
+        {"start_time": "2026-08-26T12:00:10"},
+        {"content": " "},
+        {"intent": " "},
+    ),
+)
+def test_vlm_evidence_validation(updates: dict[str, object]) -> None:
+    payload: dict[str, object] = {
+        "sensor": "camera-east",
+        "start_time": "2026-08-26T12:00:10Z",
+        "end_time": "2026-08-26T12:00:20Z",
+        "prompt": "Was the person carrying a package?",
+        "intent": "introspection",
+        "content": "A person carried a small box.",
+    }
+    payload.update(updates)
+    with pytest.raises(ValidationError):
+        VLMEvidence.model_validate(payload)
+
+
 def test_grounding_accepts_canonical_and_legacy_sensor_names() -> None:
     records = [_record()]
     canonical = SufficiencyDecision.model_validate(_decision())
     legacy = SufficiencyDecision.model_validate(
         _decision(
             gaps=[
-                {
-                    "question": "Was the person carrying a package?",
-                    "sensor": "legacy-east",
-                    "start": "2026-08-26T12:00:10+00:00",
-                    "end": "2026-08-26T12:00:20+00:00",
-                }
+                _gap(
+                    sensor="legacy-east",
+                    start_time="2026-08-26T12:00:10+00:00",
+                    end_time="2026-08-26T12:00:20+00:00",
+                )
             ]
         )
     )
@@ -156,30 +181,9 @@ def test_grounding_accepts_canonical_and_legacy_sensor_names() -> None:
     ("payload", "message"),
     (
         (_decision(evidence_record_ids=["invented"]), "unknown evidence_record_ids"),
+        (_decision(gaps=[_gap(sensor="invented-camera")]), "not present"),
         (
-            _decision(
-                gaps=[
-                    {
-                        "question": "Check",
-                        "sensor": "invented-camera",
-                        "start": "2026-08-26T12:00:10Z",
-                        "end": "2026-08-26T12:00:20Z",
-                    }
-                ]
-            ),
-            "not present",
-        ),
-        (
-            _decision(
-                gaps=[
-                    {
-                        "question": "Check",
-                        "sensor": "camera-east",
-                        "start": "2026-08-26T13:00:10Z",
-                        "end": "2026-08-26T13:00:20Z",
-                    }
-                ]
-            ),
+            _decision(gaps=[_gap(start_time="2026-08-26T13:00:10Z", end_time="2026-08-26T13:00:20Z")]),
             "does not overlap",
         ),
     ),
@@ -197,21 +201,20 @@ def test_window_must_overlap_record_for_the_same_sensor() -> None:
         record_id="event-2",
         sensor="camera-west",
         legacy_name="legacy-west",
-        start=datetime(2026, 8, 26, 13, 0, tzinfo=UTC),
-        end=datetime(2026, 8, 26, 13, 1, tzinfo=UTC),
+        start_time=datetime(2026, 8, 26, 13, 0, tzinfo=UTC),
+        end_time=datetime(2026, 8, 26, 13, 1, tzinfo=UTC),
     )
-    payload = _decision(
-        gaps=[
-            {
-                "question": "Check east",
-                "sensor": "camera-east",
-                "start": "2026-08-26T13:00:10Z",
-                "end": "2026-08-26T13:00:20Z",
-            }
-        ]
-    )
+    payload = _decision(gaps=[_gap(start_time="2026-08-26T13:00:10Z", end_time="2026-08-26T13:00:20Z")])
+
     with pytest.raises(ValueError, match="does not overlap"):
         SufficiencyDecision.model_validate(payload).validate_grounding([_record(), other])
+
+
+def test_client_satisfies_judge_and_synthesizer_protocols() -> None:
+    client = OpenAIIntrospectionClient(base_url="https://rt-vlm.example/v1", model="first-rt-vlm-model")
+
+    assert isinstance(client, SufficiencyJudge)
+    assert isinstance(client, AnswerSynthesizer)
 
 
 @pytest.mark.asyncio
@@ -224,7 +227,9 @@ async def test_judge_retries_once_after_invalid_json_then_accepts_fenced_json() 
         body = json.loads(request.content)
         assert body["temperature"] == 0
         assert body["response_format"] == {"type": "json_object"}
-        assert "threshold of 0.70" in body["messages"][0]["content"]
+        prompt = body["messages"][0]["content"]
+        assert "threshold of 0.70" in prompt
+        assert "start_time and end_time" in prompt
         content = "not-json" if calls == 1 else f"```json\n{json.dumps(_decision())}\n```"
         return httpx.Response(200, json={"choices": [{"message": {"content": content}}]}, request=request)
 
@@ -234,12 +239,14 @@ async def test_judge_retries_once_after_invalid_json_then_accepts_fenced_json() 
         transport=httpx.MockTransport(handler),
     )
     try:
-        result = await client.judge("What happened?", [_record()])
+        result = await client.judge(query="What happened?", records=[_record()])
     finally:
         await client.aclose()
 
     assert calls == 2
     assert result.evidence_record_ids == ["event-1"]
+    assert result.gaps[0].start_time == "2026-08-26T12:00:10Z"
+    assert result.gaps[0].end_time == "2026-08-26T12:00:20Z"
 
 
 @pytest.mark.asyncio
@@ -262,11 +269,81 @@ async def test_judge_fails_after_second_invalid_response() -> None:
     )
     try:
         with pytest.raises(InvalidJudgeResponseError):
-            await client.judge("What happened?", [_record()])
+            await client.judge(query="What happened?", records=[_record()])
     finally:
         await client.aclose()
 
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_ungrounded_gap_is_rejected_after_one_retry() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        payload = _decision(gaps=[_gap(sensor="invented-camera")])
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": json.dumps(payload)}}]},
+            request=request,
+        )
+
+    client = OpenAIIntrospectionClient(
+        base_url="https://rt-vlm.example/v1",
+        model="first-rt-vlm-model",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(InvalidJudgeResponseError, match="not present"):
+            await client.judge(query="What happened?", records=[_record()])
+    finally:
+        await client.aclose()
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_synthesize_uses_supplied_evidence_only() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert "response_format" not in body
+        prompt = body["messages"][0]["content"]
+        assert "camera-east" in prompt
+        assert "A person carried a small box." in prompt
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": " A person carried a small box. "}}]},
+            request=request,
+        )
+
+    client = OpenAIIntrospectionClient(
+        base_url="https://rt-vlm.example/v1",
+        model="first-rt-vlm-model",
+        transport=httpx.MockTransport(handler),
+    )
+    evidence = VLMEvidence.model_validate(
+        {
+            "sensor": "camera-east",
+            "start_time": "2026-08-26T12:00:10Z",
+            "end_time": "2026-08-26T12:00:20Z",
+            "prompt": "Was the person carrying a package?",
+            "intent": "introspection",
+            "content": "A person carried a small box.",
+        }
+    )
+    try:
+        answer = await client.synthesize(
+            query="What happened?",
+            memory_evidence=[_record()],
+            vlm_evidence=[evidence],
+            unresolved_gaps=[GroundedGap.model_validate(_gap())],
+        )
+    finally:
+        await client.aclose()
+
+    assert answer == "A person carried a small box."
 
 
 @pytest.mark.asyncio
@@ -285,7 +362,7 @@ async def test_http_failure_is_not_retried() -> None:
     )
     try:
         with pytest.raises(httpx.HTTPStatusError):
-            await client.judge("What happened?", [_record()])
+            await client.judge(query="What happened?", records=[_record()])
     finally:
         await client.aclose()
 

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_introspection.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for strict introspection contracts and the text-only judge."""
+
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+import json
+
+import httpx
+from pydantic import ValidationError
+import pytest
+
+from vss_core.introspection.judge import InvalidJudgeResponseError
+from vss_core.introspection.judge import OpenAIIntrospectionClient
+from vss_core.introspection.models import IntrospectionSettings
+from vss_core.introspection.models import SufficiencyDecision
+from vss_core.memory.models import JobInfo
+from vss_core.memory.models import MemoryInput
+from vss_core.memory.models import SensorInfo
+from vss_core.memory.models import TimestampPoint
+from vss_core.memory.models import TimeWindow
+from vss_core.memory.models import UnifiedMemoryRecord
+
+
+def _record(
+    *,
+    record_id: str = "event-1",
+    sensor: str = "camera-east",
+    legacy_name: str = "legacy-east",
+    start: datetime = datetime(2026, 8, 26, 12, 0, tzinfo=UTC),
+    end: datetime = datetime(2026, 8, 26, 12, 1, tzinfo=UTC),
+) -> UnifiedMemoryRecord:
+    return UnifiedMemoryRecord(
+        job=JobInfo(
+            job_id="search-1",
+            record_id=record_id,
+            record_type="search_hit",
+            group="search",
+            status="completed",
+            created_at=start,
+        ),
+        input=MemoryInput(
+            sensors=[SensorInfo(id=sensor, info={"name": legacy_name})],
+            window=TimeWindow(start=TimestampPoint(timestamp=start), end=TimestampPoint(timestamp=end)),
+        ),
+    )
+
+
+def _decision(**updates: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sufficient": False,
+        "reason": "The event needs a closer visual check.",
+        "evidence_record_ids": ["event-1"],
+        "gaps": [
+            {
+                "question": "Was the person carrying a package?",
+                "sensor": "camera-east",
+                "start": "2026-08-26T12:00:10Z",
+                "end": "2026-08-26T12:00:20Z",
+            }
+        ],
+    }
+    payload.update(updates)
+    return payload
+
+
+def test_settings_defaults_and_strict_types() -> None:
+    assert IntrospectionSettings().model_dump() == {
+        "max_memory_records": 10,
+        "max_vlm_queries": 3,
+        "max_clip_duration_seconds": 60,
+        "timeout_seconds": 180,
+        "sufficiency_threshold": 0.7,
+    }
+    with pytest.raises(ValidationError):
+        IntrospectionSettings(max_memory_records="10")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        _decision(reason=" "),
+        _decision(sufficient=True),
+        _decision(evidence_record_ids=["event-1", "event-1"]),
+        _decision(
+            gaps=[
+                {
+                    "question": " ",
+                    "sensor": "camera-east",
+                    "start": "2026-08-26T12:00:10Z",
+                    "end": "2026-08-26T12:00:20Z",
+                }
+            ]
+        ),
+        _decision(
+            gaps=[
+                {
+                    "question": "Check",
+                    "sensor": "camera-east",
+                    "start": "2026-08-26 12:00:10",
+                    "end": "2026-08-26T12:00:20Z",
+                }
+            ]
+        ),
+        _decision(
+            gaps=[
+                {
+                    "question": "Check",
+                    "sensor": "camera-east",
+                    "start": "2026-08-26T12:00:20Z",
+                    "end": "2026-08-26T12:00:10Z",
+                }
+            ]
+        ),
+    ),
+)
+def test_decision_schema_validation(payload: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        SufficiencyDecision.model_validate(payload)
+
+
+def test_decision_does_not_fill_missing_approved_fields() -> None:
+    with pytest.raises(ValidationError):
+        SufficiencyDecision.model_validate(
+            {
+                "sufficient": True,
+                "reason": "Enough evidence",
+                "evidence_record_ids": ["event-1"],
+            }
+        )
+
+
+def test_grounding_accepts_canonical_and_legacy_sensor_names() -> None:
+    records = [_record()]
+    canonical = SufficiencyDecision.model_validate(_decision())
+    legacy = SufficiencyDecision.model_validate(
+        _decision(
+            gaps=[
+                {
+                    "question": "Was the person carrying a package?",
+                    "sensor": "legacy-east",
+                    "start": "2026-08-26T12:00:10+00:00",
+                    "end": "2026-08-26T12:00:20+00:00",
+                }
+            ]
+        )
+    )
+
+    assert canonical.validate_grounding(records) is canonical
+    assert legacy.validate_grounding(records) is legacy
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    (
+        (_decision(evidence_record_ids=["invented"]), "unknown evidence_record_ids"),
+        (
+            _decision(
+                gaps=[
+                    {
+                        "question": "Check",
+                        "sensor": "invented-camera",
+                        "start": "2026-08-26T12:00:10Z",
+                        "end": "2026-08-26T12:00:20Z",
+                    }
+                ]
+            ),
+            "not present",
+        ),
+        (
+            _decision(
+                gaps=[
+                    {
+                        "question": "Check",
+                        "sensor": "camera-east",
+                        "start": "2026-08-26T13:00:10Z",
+                        "end": "2026-08-26T13:00:20Z",
+                    }
+                ]
+            ),
+            "does not overlap",
+        ),
+    ),
+)
+def test_grounding_rejects_invented_ids_sensors_and_windows(
+    payload: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        SufficiencyDecision.model_validate(payload).validate_grounding([_record()])
+
+
+def test_window_must_overlap_record_for_the_same_sensor() -> None:
+    other = _record(
+        record_id="event-2",
+        sensor="camera-west",
+        legacy_name="legacy-west",
+        start=datetime(2026, 8, 26, 13, 0, tzinfo=UTC),
+        end=datetime(2026, 8, 26, 13, 1, tzinfo=UTC),
+    )
+    payload = _decision(
+        gaps=[
+            {
+                "question": "Check east",
+                "sensor": "camera-east",
+                "start": "2026-08-26T13:00:10Z",
+                "end": "2026-08-26T13:00:20Z",
+            }
+        ]
+    )
+    with pytest.raises(ValueError, match="does not overlap"):
+        SufficiencyDecision.model_validate(payload).validate_grounding([_record(), other])
+
+
+@pytest.mark.asyncio
+async def test_judge_retries_once_after_invalid_json_then_accepts_fenced_json() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        body = json.loads(request.content)
+        assert body["temperature"] == 0
+        assert body["response_format"] == {"type": "json_object"}
+        assert "threshold of 0.70" in body["messages"][0]["content"]
+        content = "not-json" if calls == 1 else f"```json\n{json.dumps(_decision())}\n```"
+        return httpx.Response(200, json={"choices": [{"message": {"content": content}}]}, request=request)
+
+    client = OpenAIIntrospectionClient(
+        base_url="https://rt-vlm.example",
+        model="first-rt-vlm-model",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        result = await client.judge("What happened?", [_record()])
+    finally:
+        await client.aclose()
+
+    assert calls == 2
+    assert result.evidence_record_ids == ["event-1"]
+
+
+@pytest.mark.asyncio
+async def test_judge_fails_after_second_invalid_response() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": '{"sufficient": false}'}}]},
+            request=request,
+        )
+
+    client = OpenAIIntrospectionClient(
+        base_url="https://rt-vlm.example/v1",
+        model="first-rt-vlm-model",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(InvalidJudgeResponseError):
+            await client.judge("What happened?", [_record()])
+    finally:
+        await client.aclose()
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_http_failure_is_not_retried() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(503, request=request)
+
+    client = OpenAIIntrospectionClient(
+        base_url="https://rt-vlm.example/v1",
+        model="first-rt-vlm-model",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.judge("What happened?", [_record()])
+    finally:
+        await client.aclose()
+
+    assert calls == 1

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -98,15 +98,22 @@ def _decision(*, sufficient: bool = False, gaps: list[GroundedGap] | None = None
 
 
 class _Judge:
-    def __init__(self, decision: SufficiencyDecision | None = None, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        decision: SufficiencyDecision | None = None,
+        error: Exception | None = None,
+        *,
+        expected_query: str = "forklift",
+    ) -> None:
         self.decision = decision or _decision()
         self.error = error
+        self.expected_query = expected_query
         self.calls = 0
         self.records: list[UnifiedMemoryRecord] = []
 
     async def judge(self, **kwargs: Any) -> SufficiencyDecision:
         self.calls += 1
-        assert kwargs["query"] == "forklift"
+        assert kwargs["query"] == self.expected_query
         self.records = kwargs["records"]
         if self.error is not None:
             raise self.error
@@ -233,7 +240,7 @@ async def test_builds_internal_parent_child_query_with_all_request_selectors() -
 
     assert result.status == "completed"
     query = memory.queries[0]
-    assert query.text == "forklift"
+    assert query.text is None
     assert query.sensor_id == "camera-east"
     assert query.job_id == "search-1"
     assert query.record_id == "event-1"
@@ -254,6 +261,33 @@ async def test_builds_internal_parent_child_query_with_all_request_selectors() -
     assert parent_query.text is None
     assert parent_query.record_id is None
     assert [record.job.is_child for record in judge.records] == [True, False]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("identity", ({"job_id": "search-1"}, {"record_id": "event-1"}))
+async def test_exact_identity_uses_paraphrased_question_only_as_judge_prompt(identity: dict[str, str]) -> None:
+    child = _record(
+        query="Describe the worker's clothing.",
+        answer="The worker wore a hard hat and yellow safety vest.",
+    )
+    memory, _ = _memory(child)
+    judge = _Judge(_decision(sufficient=True), expected_query="Was the worker wearing PPE?")
+
+    result = await introspect(
+        IntrospectionRequest(
+            query="Was the worker wearing PPE?",
+            **identity,
+        ),
+        memory=memory,
+        judge=judge,
+        synthesizer=_Synthesizer(),
+        vlm_runner=_Runner(),
+        settings=IntrospectionSettings(),
+    )
+
+    assert result.status == "completed"
+    assert judge.calls == 1
+    assert [record.job.record_id for record in judge.records] == ["event-1"]
 
 
 @pytest.mark.asyncio

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -380,6 +380,38 @@ async def test_parent_expansion_keeps_windowless_parent_of_time_scoped_child() -
 
 
 @pytest.mark.asyncio
+async def test_parent_expansion_keeps_open_ended_parent_of_time_scoped_child() -> None:
+    child = _record()
+    parent = _record(record_id=None, query="shift notes", answer="Open warehouse shift.")
+    assert parent.input is not None and parent.input.window is not None
+    parent = parent.model_copy(
+        update={
+            "input": parent.input.model_copy(update={"window": TimeWindow(start=parent.input.window.start, end=None)})
+        }
+    )
+    memory, _ = _memory(parent, child)
+    judge = _Judge(_decision(sufficient=True))
+
+    result = await introspect(
+        IntrospectionRequest(
+            query="forklift",
+            sensor="camera-east",
+            start_time=START,
+            end_time=END,
+        ),
+        memory=memory,
+        judge=judge,
+        synthesizer=_Synthesizer(),
+        vlm_runner=_Runner(),
+        settings=IntrospectionSettings(),
+    )
+
+    assert result.status == "completed"
+    assert [record.job.is_child for record in judge.records] == [True, False]
+    assert judge.records[1].output.answer == "Open warehouse shift."
+
+
+@pytest.mark.asyncio
 async def test_one_grounded_gap_runs_one_vlm_and_one_final_synthesis() -> None:
     result, judge, synthesizer, runner = await _run()
 

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -34,9 +34,16 @@ END = "2026-08-26T12:01:00Z"
 
 
 def _record(
-    *, record_id: str | None = "event-1", answer: str = "A forklift crossed the loading bay."
+    *,
+    record_id: str | None = "event-1",
+    query: str = "forklift",
+    answer: str = "A forklift crossed the loading bay.",
+    sensor: str = "camera-east",
+    start: datetime | None = None,
+    end: datetime | None = None,
 ) -> UnifiedMemoryRecord:
-    start = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+    start = start or datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+    end = end or datetime(2026, 8, 26, 12, 1, tzinfo=UTC)
     return UnifiedMemoryRecord(
         job=JobInfo(
             job_id="search-1",
@@ -47,11 +54,11 @@ def _record(
             created_at=start,
         ),
         input=MemoryInput(
-            query="forklift",
-            sensors=[SensorInfo(id="camera-east")],
+            query=query,
+            sensors=[SensorInfo(id=sensor)],
             window=TimeWindow(
                 start=TimestampPoint(timestamp=start),
-                end=TimestampPoint(timestamp=datetime(2026, 8, 26, 12, 1, tzinfo=UTC)),
+                end=TimestampPoint(timestamp=end),
             ),
         ),
         output=MemoryOutput(answer=answer),
@@ -235,9 +242,99 @@ async def test_builds_internal_parent_child_query_with_all_request_selectors() -
     assert query.time_field == "window"
     assert query.include_children is True
     assert query.limit == 7
-    assert memory.queries[1].parents_only is True
-    assert memory.queries[1].job_id == "search-1"
+    parent_query = memory.queries[1]
+    assert parent_query.parents_only is True
+    assert parent_query.include_children is False
+    assert parent_query.job_id == "search-1"
+    assert parent_query.sensor_id == "camera-east"
+    assert parent_query.group == "search"
+    assert parent_query.time_field == "window"
+    assert parent_query.since is not None
+    assert parent_query.until is not None
+    assert parent_query.text is None
+    assert parent_query.record_id is None
     assert [record.job.is_child for record in judge.records] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_parent_expansion_does_not_add_out_of_scope_parents() -> None:
+    scoped_child = _record()
+    other_sensor_parent = _record(record_id=None, sensor="camera-west")
+    memory, _ = _memory(other_sensor_parent, scoped_child)
+    judge = _Judge(_decision(sufficient=True))
+
+    result = await introspect(
+        IntrospectionRequest(
+            query="forklift",
+            sensor="camera-east",
+            start_time=START,
+            end_time=END,
+        ),
+        memory=memory,
+        judge=judge,
+        synthesizer=_Synthesizer(),
+        vlm_runner=_Runner(),
+        settings=IntrospectionSettings(),
+    )
+
+    assert result.status == "completed"
+    assert [record.job.record_id for record in judge.records] == ["event-1"]
+    assert all(record.input.sensors[0].id == "camera-east" for record in judge.records)
+
+
+@pytest.mark.asyncio
+async def test_parent_expansion_does_not_add_parents_outside_the_time_window() -> None:
+    scoped_child = _record()
+    earlier_parent = _record(
+        record_id=None,
+        start=datetime(2026, 8, 26, 10, 0, tzinfo=UTC),
+        end=datetime(2026, 8, 26, 10, 5, tzinfo=UTC),
+    )
+    memory, _ = _memory(earlier_parent, scoped_child)
+    judge = _Judge(_decision(sufficient=True))
+
+    result = await introspect(
+        IntrospectionRequest(
+            query="forklift",
+            sensor="camera-east",
+            start_time=START,
+            end_time=END,
+        ),
+        memory=memory,
+        judge=judge,
+        synthesizer=_Synthesizer(),
+        vlm_runner=_Runner(),
+        settings=IntrospectionSettings(),
+    )
+
+    assert result.status == "completed"
+    assert [record.job.record_id for record in judge.records] == ["event-1"]
+
+
+@pytest.mark.asyncio
+async def test_parent_expansion_keeps_in_scope_parent_without_text_match() -> None:
+    child = _record()
+    parent = _record(record_id=None, query="shift notes", answer="Warehouse shift summary.")
+    memory, _ = _memory(parent, child)
+    judge = _Judge(_decision(sufficient=True))
+
+    result = await introspect(
+        IntrospectionRequest(
+            query="forklift",
+            sensor="camera-east",
+            start_time=START,
+            end_time=END,
+        ),
+        memory=memory,
+        judge=judge,
+        synthesizer=_Synthesizer(),
+        vlm_runner=_Runner(),
+        settings=IntrospectionSettings(),
+    )
+
+    assert result.status == "completed"
+    assert [record.job.is_child for record in judge.records] == [True, False]
+    assert judge.records[1].output.answer == "Warehouse shift summary."
 
 
 @pytest.mark.asyncio

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -1,0 +1,406 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Hermetic tests for the bounded memory introspection workflow."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from vss_core.introspection.judge import InvalidJudgeResponseError
+from vss_core.introspection.models import GroundedGap
+from vss_core.introspection.models import IntrospectionRequest
+from vss_core.introspection.models import IntrospectionSettings
+from vss_core.introspection.models import SufficiencyDecision
+from vss_core.introspection.models import VLMEvidence
+from vss_core.introspection.orchestrator import introspect
+from vss_core.memory.backends.in_memory import InMemoryStore
+from vss_core.memory.models import JobInfo
+from vss_core.memory.models import MemoryInput
+from vss_core.memory.models import MemoryOutput
+from vss_core.memory.models import SensorInfo
+from vss_core.memory.models import TimestampPoint
+from vss_core.memory.models import TimeWindow
+from vss_core.memory.models import UnifiedMemoryRecord
+from vss_core.memory.service import MemoryService
+
+START = "2026-08-26T12:00:00Z"
+END = "2026-08-26T12:01:00Z"
+
+
+def _record(
+    *, record_id: str | None = "event-1", answer: str = "A forklift crossed the loading bay."
+) -> UnifiedMemoryRecord:
+    start = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+    return UnifiedMemoryRecord(
+        job=JobInfo(
+            job_id="search-1",
+            record_id=record_id,
+            record_type="search_hit" if record_id is not None else None,
+            group="search",
+            status="completed",
+            created_at=start,
+        ),
+        input=MemoryInput(
+            query="forklift",
+            sensors=[SensorInfo(id="camera-east")],
+            window=TimeWindow(
+                start=TimestampPoint(timestamp=start),
+                end=TimestampPoint(timestamp=datetime(2026, 8, 26, 12, 1, tzinfo=UTC)),
+            ),
+        ),
+        output=MemoryOutput(answer=answer),
+    )
+
+
+def _memory(*records: UnifiedMemoryRecord) -> tuple[MemoryService, InMemoryStore]:
+    store = InMemoryStore()
+    for record in records:
+        store.upsert(record)
+    store.upsert_ids.clear()
+    return MemoryService(store), store
+
+
+def _gap(
+    *,
+    question: str = "What was the forklift carrying?",
+    sensor: str = "camera-east",
+    start_time: str = "2026-08-26T12:00:10Z",
+    end_time: str = "2026-08-26T12:00:20Z",
+) -> GroundedGap:
+    return GroundedGap(
+        question=question,
+        sensor=sensor,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+def _decision(*, sufficient: bool = False, gaps: list[GroundedGap] | None = None) -> SufficiencyDecision:
+    return SufficiencyDecision(
+        sufficient=sufficient,
+        reason="Memory is enough." if sufficient else "A visual detail is missing.",
+        evidence_record_ids=["event-1"],
+        gaps=[] if sufficient else (gaps if gaps is not None else [_gap()]),
+    )
+
+
+class _Judge:
+    def __init__(self, decision: SufficiencyDecision | None = None, error: Exception | None = None) -> None:
+        self.decision = decision or _decision()
+        self.error = error
+        self.calls = 0
+        self.records: list[UnifiedMemoryRecord] = []
+
+    async def judge(self, **kwargs: Any) -> SufficiencyDecision:
+        self.calls += 1
+        assert kwargs["query"] == "forklift"
+        self.records = kwargs["records"]
+        if self.error is not None:
+            raise self.error
+        return self.decision
+
+
+class _Synthesizer:
+    def __init__(self, answer: str = "Supported answer.", *, delay: float = 0) -> None:
+        self.answer = answer
+        self.delay = delay
+        self.calls: list[dict[str, Any]] = []
+
+    async def synthesize(self, **kwargs: Any) -> str:
+        self.calls.append(kwargs)
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return self.answer
+
+
+class _Runner:
+    def __init__(
+        self,
+        *,
+        failures: set[int] | None = None,
+        delay: float = 0,
+        persisted: bool = True,
+    ) -> None:
+        self.failures = failures or set()
+        self.delay = delay
+        self.persisted = persisted
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(self, **kwargs: Any) -> VLMEvidence:
+        index = len(self.calls)
+        self.calls.append(kwargs)
+        assert kwargs["intent"] == "introspection"
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if index in self.failures:
+            raise RuntimeError(f"inference {index + 1} unavailable")
+        return VLMEvidence(
+            job_id=f"vlm-{index + 1}",
+            persisted=self.persisted,
+            sensor=kwargs["sensor"],
+            start_time=kwargs["start_time"],
+            end_time=kwargs["end_time"],
+            answer=f"visual answer {index + 1}",
+        )
+
+
+async def _run(
+    *,
+    memory: MemoryService | None = None,
+    judge: _Judge | None = None,
+    synthesizer: _Synthesizer | None = None,
+    runner: _Runner | None = None,
+    settings: IntrospectionSettings | None = None,
+) -> tuple[Any, _Judge, _Synthesizer, _Runner]:
+    if memory is None:
+        memory, _ = _memory(_record(record_id=None), _record())
+    actual_judge = judge or _Judge()
+    actual_synthesizer = synthesizer or _Synthesizer()
+    actual_runner = runner or _Runner()
+    result = await introspect(
+        IntrospectionRequest(query="forklift"),
+        memory=memory,
+        judge=actual_judge,
+        synthesizer=actual_synthesizer,
+        vlm_runner=actual_runner,
+        settings=settings or IntrospectionSettings(),
+    )
+    return result, actual_judge, actual_synthesizer, actual_runner
+
+
+@pytest.mark.asyncio
+async def test_sufficient_memory_uses_zero_vlm_and_one_synthesis() -> None:
+    result, judge, synthesizer, runner = await _run(judge=_Judge(_decision(sufficient=True)))
+
+    assert result.status == "completed"
+    assert result.sufficient_from_memory is True
+    assert result.answer == "Supported answer."
+    assert result.model_dump().keys() == {
+        "status",
+        "sufficient_from_memory",
+        "answer",
+        "memory_evidence",
+        "vlm_evidence",
+        "unresolved_gaps",
+    }
+    assert judge.calls == 1
+    assert len(synthesizer.calls) == 1
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_builds_internal_parent_child_query_with_all_request_selectors() -> None:
+    class _QueryMemory:
+        def __init__(self) -> None:
+            self.queries: list[Any] = []
+
+        def query(self, query: Any) -> list[UnifiedMemoryRecord]:
+            self.queries.append(query)
+            return [_record()] if query.record_type else [_record(record_id=None)]
+
+    memory = _QueryMemory()
+    judge = _Judge(_decision(sufficient=True))
+    result = await introspect(
+        IntrospectionRequest(
+            query="forklift",
+            sensor="camera-east",
+            job_id="search-1",
+            record_id="event-1",
+            record_type="search_hit",
+            group="search",
+            start_time=START,
+            end_time=END,
+        ),
+        memory=memory,  # type: ignore[arg-type]
+        judge=judge,
+        synthesizer=_Synthesizer(),
+        vlm_runner=_Runner(),
+        settings=IntrospectionSettings(max_memory_records=7),
+    )
+
+    assert result.status == "completed"
+    query = memory.queries[0]
+    assert query.text == "forklift"
+    assert query.sensor_id == "camera-east"
+    assert query.job_id == "search-1"
+    assert query.record_id == "event-1"
+    assert query.record_type == "search_hit"
+    assert query.group == "search"
+    assert query.time_field == "window"
+    assert query.include_children is True
+    assert query.limit == 7
+    assert memory.queries[1].parents_only is True
+    assert memory.queries[1].job_id == "search-1"
+    assert [record.job.is_child for record in judge.records] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_one_grounded_gap_runs_one_vlm_and_one_final_synthesis() -> None:
+    result, judge, synthesizer, runner = await _run()
+
+    assert result.status == "completed"
+    assert result.sufficient_from_memory is False
+    assert len(result.vlm_evidence) == 1
+    assert result.unresolved_gaps == []
+    assert judge.calls == len(synthesizer.calls) == len(runner.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_vlm_calls_are_capped_at_three_in_returned_order() -> None:
+    gaps = [_gap(question=f"question {index}") for index in range(4)]
+    result, _, _, runner = await _run(judge=_Judge(_decision(gaps=gaps)))
+
+    assert [call["prompt"] for call in runner.calls] == ["question 0", "question 1", "question 2"]
+    assert result.status == "partial"
+    assert "question 3" in result.unresolved_gaps[0]
+    assert "query cap is 3" in result.unresolved_gaps[0]
+
+
+@pytest.mark.asyncio
+async def test_gap_over_sixty_seconds_is_rejected_without_vlm_call() -> None:
+    gap = _gap(end_time="2026-08-26T12:01:11Z")
+    result, _, _, runner = await _run(judge=_Judge(_decision(gaps=[gap])))
+
+    assert runner.calls == []
+    assert result.status == "partial"
+    assert "exceeds the 60s clip limit" in result.unresolved_gaps[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "gap",
+    [
+        _gap(sensor="invented-camera"),
+        _gap(start_time="2026-08-26T13:00:00Z", end_time="2026-08-26T13:00:10Z"),
+    ],
+    ids=["invented-sensor", "ungrounded-window"],
+)
+async def test_ungrounded_sensor_or_window_is_rejected_without_vlm_call(gap: GroundedGap) -> None:
+    result, _, _, runner = await _run(judge=_Judge(_decision(gaps=[gap])))
+
+    assert runner.calls == []
+    assert result.status == "partial"
+    assert "rejected as ungrounded" in result.unresolved_gaps[0]
+
+
+@pytest.mark.asyncio
+async def test_no_memory_returns_structured_result_without_model_calls() -> None:
+    memory, _ = _memory()
+    result, judge, synthesizer, runner = await _run(memory=memory)
+
+    assert result.model_dump() == {
+        "status": "no_memory",
+        "sufficient_from_memory": False,
+        "answer": None,
+        "memory_evidence": [],
+        "vlm_evidence": [],
+        "unresolved_gaps": [],
+    }
+    assert judge.calls == 0
+    assert synthesizer.calls == []
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_judge_invalid_once_then_succeeds_inside_single_client_call() -> None:
+    class _RetryingJudge(_Judge):
+        def __init__(self) -> None:
+            super().__init__(_decision(sufficient=True))
+            self.attempts = 0
+
+        async def judge(self, **kwargs: Any) -> SufficiencyDecision:
+            self.calls += 1
+            for attempt in range(2):
+                self.attempts += 1
+                if attempt == 0:
+                    continue
+                return self.decision
+            raise AssertionError
+
+    judge = _RetryingJudge()
+    result, _, _, runner = await _run(judge=judge)
+
+    assert result.status == "completed"
+    assert judge.calls == 1
+    assert judge.attempts == 2
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_judge_invalid_twice_returns_partial_supported_answer_without_speculation() -> None:
+    judge = _Judge(error=InvalidJudgeResponseError("invalid after two attempts"))
+    result, _, synthesizer, runner = await _run(judge=judge)
+
+    assert result.status == "partial"
+    assert result.answer == "Supported answer."
+    assert result.memory_evidence
+    assert runner.calls == []
+    assert len(synthesizer.calls) == 1
+    assert "judge failed after validation retry" in result.unresolved_gaps[0]
+
+
+@pytest.mark.asyncio
+async def test_mixed_vlm_failure_keeps_successful_evidence_and_synthesizes_once() -> None:
+    gaps = [_gap(question=f"question {index}") for index in range(3)]
+    result, _, synthesizer, runner = await _run(
+        judge=_Judge(_decision(gaps=gaps)),
+        runner=_Runner(failures={1}),
+    )
+
+    assert len(runner.calls) == 3
+    assert [item.job_id for item in result.vlm_evidence] == ["vlm-1", "vlm-3"]
+    assert result.status == "partial"
+    assert "inference 2 unavailable" in result.unresolved_gaps[0]
+    assert len(synthesizer.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_all_vlm_calls_fail_but_memory_supports_one_final_synthesis() -> None:
+    gaps = [_gap(question=f"question {index}") for index in range(2)]
+    result, _, synthesizer, _ = await _run(
+        judge=_Judge(_decision(gaps=gaps)),
+        runner=_Runner(failures={0, 1}),
+    )
+
+    assert result.status == "partial"
+    assert result.answer == "Supported answer."
+    assert result.vlm_evidence == []
+    assert len(result.unresolved_gaps) == 2
+    assert len(synthesizer.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_total_workflow_timeout_is_partial_and_does_not_synthesize_after_deadline() -> None:
+    result, _, synthesizer, _ = await _run(
+        runner=_Runner(delay=2),
+        settings=IntrospectionSettings(timeout_seconds=1),
+    )
+
+    assert result.status == "partial"
+    assert result.answer is None
+    assert any("workflow timed out after 1 seconds" in gap for gap in result.unresolved_gaps)
+    assert synthesizer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_introspection_never_writes_memory() -> None:
+    memory, store = _memory(_record(record_id=None), _record())
+    result, _, _, _ = await _run(memory=memory)
+
+    assert result.status == "completed"
+    assert store.upsert_ids == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("persisted", [True, False], ids=["persistence-enabled", "persistence-disabled"])
+async def test_injected_vlm_adapter_reports_internal_job_persistence_policy(persisted: bool) -> None:
+    result, _, _, _ = await _run(runner=_Runner(persisted=persisted))
+
+    assert result.status == "completed"
+    assert result.vlm_evidence[0].persisted is persisted
+    assert result.vlm_evidence[0].job_id == "vlm-1"

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -255,9 +255,9 @@ async def test_builds_internal_parent_child_query_with_all_request_selectors() -
     assert parent_query.job_id == "search-1"
     assert parent_query.sensor_id == "camera-east"
     assert parent_query.group == "search"
-    assert parent_query.time_field == "window"
-    assert parent_query.since is not None
-    assert parent_query.until is not None
+    assert parent_query.time_field == "created_at"
+    assert parent_query.since is None
+    assert parent_query.until is None
     assert parent_query.text is None
     assert parent_query.record_id is None
     assert [record.job.is_child for record in judge.records] == [True, False]
@@ -352,9 +352,11 @@ async def test_parent_expansion_does_not_add_parents_outside_the_time_window() -
 
 
 @pytest.mark.asyncio
-async def test_parent_expansion_keeps_in_scope_parent_without_text_match() -> None:
+async def test_parent_expansion_keeps_windowless_parent_of_time_scoped_child() -> None:
     child = _record()
     parent = _record(record_id=None, query="shift notes", answer="Warehouse shift summary.")
+    assert parent.input is not None
+    parent = parent.model_copy(update={"input": parent.input.model_copy(update={"window": None})})
     memory, _ = _memory(parent, child)
     judge = _Judge(_decision(sufficient=True))
 

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 
+from vss_core._foundation.errors import BackendUnreachableError
 from vss_core.introspection.judge import InvalidJudgeResponseError
 from vss_core.introspection.models import GroundedGap
 from vss_core.introspection.models import IntrospectionRequest
@@ -345,6 +346,16 @@ async def test_judge_invalid_twice_returns_partial_supported_answer_without_spec
 
 
 @pytest.mark.asyncio
+async def test_judge_backend_failure_carries_nonserialized_exit_signal() -> None:
+    judge = _Judge(error=BackendUnreachableError("rt-vlm", "offline"))
+    result, _, _, _ = await _run(judge=judge)
+
+    assert result.status == "partial"
+    assert result.failure_kind == "backend_unreachable"
+    assert "failure_kind" not in result.model_dump(mode="json")
+
+
+@pytest.mark.asyncio
 async def test_mixed_vlm_failure_keeps_successful_evidence_and_synthesizes_once() -> None:
     gaps = [_gap(question=f"question {index}") for index in range(3)]
     result, _, synthesizer, runner = await _run(
@@ -383,6 +394,8 @@ async def test_total_workflow_timeout_is_partial_and_does_not_synthesize_after_d
 
     assert result.status == "partial"
     assert result.answer is None
+    assert result.failure_kind == "timeout"
+    assert "failure_kind" not in result.model_dump(mode="json")
     assert any("workflow timed out after 1 seconds" in gap for gap in result.unresolved_gaps)
     assert synthesizer.calls == []
 

--- a/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
+++ b/services/agent/packages/vss_core/tests/unit_test/introspection/test_orchestrator.py
@@ -264,7 +264,13 @@ async def test_builds_internal_parent_child_query_with_all_request_selectors() -
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("identity", ({"job_id": "search-1"}, {"record_id": "event-1"}))
+@pytest.mark.parametrize(
+    "identity",
+    (
+        {"job_id": "search-1"},
+        {"job_id": "search-1", "record_type": "search_hit", "record_id": "event-1"},
+    ),
+)
 async def test_exact_identity_uses_paraphrased_question_only_as_judge_prompt(identity: dict[str, str]) -> None:
     child = _record(
         query="Describe the worker's clothing.",
@@ -518,7 +524,7 @@ async def test_all_vlm_calls_fail_but_memory_supports_one_final_synthesis() -> N
 
 @pytest.mark.asyncio
 async def test_total_workflow_timeout_is_partial_and_does_not_synthesize_after_deadline() -> None:
-    result, _, synthesizer, _ = await _run(
+    result, _, synthesizer, runner = await _run(
         runner=_Runner(delay=2),
         settings=IntrospectionSettings(timeout_seconds=1),
     )
@@ -529,6 +535,7 @@ async def test_total_workflow_timeout_is_partial_and_does_not_synthesize_after_d
     assert "failure_kind" not in result.model_dump(mode="json")
     assert any("workflow timed out after 1 seconds" in gap for gap in result.unresolved_gaps)
     assert synthesizer.calls == []
+    assert 0 < runner.calls[0]["timeout_seconds"] <= 1
 
 
 @pytest.mark.asyncio

--- a/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_vlm_openai.py
+++ b/services/agent/packages/vss_core/tests/unit_test/lib/search_core/test_vlm_openai.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 
 import httpx
@@ -88,6 +89,45 @@ async def test_rt_vlm_uses_video_url_without_direct_cosmos_nim_options() -> None
         assert answer == '{"subject:forklift": true}'
     finally:
         await analyzer.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("media_mode", ("video_base64", "frame_base64"))
+async def test_base64_modes_send_one_native_mp4_video_part(media_mode: str) -> None:
+    video_bytes = b"\x00\x00\x00\x20ftypisom\x00\x00\x02\x00native-video"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, content=video_bytes, request=request)
+        payload = json.loads(request.content)
+        content = payload["messages"][0]["content"]
+        assert len(content) == 2
+        assert content[0] == {"type": "text", "text": "What happened?"}
+        assert content[1]["type"] == "video_url"
+        data_uri = content[1]["video_url"]["url"]
+        assert data_uri.startswith("data:video/mp4;base64,")
+        assert base64.b64decode(data_uri.partition(",")[2]) == video_bytes
+        assert all(part["type"] != "image_url" for part in content)
+        return httpx.Response(200, json={"choices": [{"message": {"content": "A worker moved."}}]}, request=request)
+
+    analyzer = OpenAIVLMAnalyzer(
+        base_url="https://vlm.example/v1",
+        model="model",
+        vst=_VST(),  # type: ignore[arg-type]
+        media_mode=media_mode,  # type: ignore[arg-type]
+    )
+    analyzer._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        answer = await analyzer.analyze(
+            sensor_id="sensor-1",
+            start_timestamp="2025-01-01T00:00:00Z",
+            end_timestamp="2025-01-01T00:00:05Z",
+            prompt="What happened?",
+        )
+    finally:
+        await analyzer.aclose()
+
+    assert answer == "A worker moved."
 
 
 def test_direct_cosmos_nim_keeps_runtime_options_by_default() -> None:

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_elasticsearch.py
@@ -231,7 +231,24 @@ def test_build_search_body_parent_filters() -> None:
     bool_query = body["query"]["bool"]
     assert {"exists": {"field": "job.record_id"}} in bool_query["must_not"]
     assert {"term": {"job.group.keyword": "search"}} in bool_query["filter"]
-    assert {"term": {"input.sensors.id.keyword": "cam-1"}} in bool_query["filter"]
+    assert {
+        "bool": {
+            "should": [
+                {"term": {"input.sensors.id.keyword": "cam-1"}},
+                {"term": {"input.sensors.info.name.keyword": "cam-1"}},
+            ],
+            "minimum_should_match": 1,
+        }
+    } in bool_query["filter"]
+    assert body["sort"][0] == {"_score": {"order": "desc"}}
+
+
+def test_build_search_body_without_text_sorts_only_by_recency() -> None:
+    body = ElasticsearchMemoryStore._build_search_body(sensor_id="cam-1")
+    assert body["sort"] == [
+        {"job.updated_at": {"order": "desc", "missing": "_last"}},
+        {"job.created_at": {"order": "desc"}},
+    ]
 
 
 def test_build_search_body_child_window_filters() -> None:

--- a/services/agent/packages/vss_core/tests/unit_test/memory/test_memory.py
+++ b/services/agent/packages/vss_core/tests/unit_test/memory/test_memory.py
@@ -575,6 +575,55 @@ def test_query_children_by_job_and_type() -> None:
     assert all(k.job.is_child for k in kids)
 
 
+@pytest.mark.parametrize(
+    "sensor",
+    [
+        {"id": "west-entrance"},
+        {"id": "sensor-uuid", "info": {"name": "west-entrance"}},
+    ],
+    ids=["canonical-name", "legacy-info-name"],
+)
+def test_memory_query_sensor_matches_canonical_and_legacy_names(sensor: dict[str, object]) -> None:
+    store = InMemoryStore()
+    store.upsert(_parent(input={"query": "q", "sensors": [sensor]}))
+
+    matches = store.query(MemoryQuery(sensor_id="west-entrance"))
+    assert [record.job.job_id for record in matches] == ["summarize-01TEST"]
+
+
+def test_text_query_sorts_relevance_before_recency() -> None:
+    store = InMemoryStore()
+    store.upsert(
+        _parent(
+            job={
+                "job_id": "older-relevant",
+                "group": "summary",
+                "operation": "run",
+                "status": "completed",
+                "created_at": "2026-07-20T12:00:00Z",
+            },
+            output={"answer": "forklift forklift forklift"},
+        )
+    )
+    store.upsert(
+        _parent(
+            job={
+                "job_id": "newer-less-relevant",
+                "group": "summary",
+                "operation": "run",
+                "status": "completed",
+                "created_at": "2026-07-22T12:00:00Z",
+            },
+            output={"answer": "forklift"},
+        )
+    )
+
+    matches = store.query(MemoryQuery(text="forklift"))
+    assert [record.job.job_id for record in matches] == ["older-relevant", "newer-less-relevant"]
+    recent = store.query(MemoryQuery())
+    assert [record.job.job_id for record in recent] == ["newer-less-relevant", "older-relevant"]
+
+
 def test_parent_lifecycle_preserves_created_at() -> None:
     store = InMemoryStore()
     adapter = SummaryAdapter()

--- a/skills/operations/vss-ask-video/SKILL.md
+++ b/skills/operations/vss-ask-video/SKILL.md
@@ -206,6 +206,25 @@ standalone local file/base64 video and no VSS deployment or VIOS sensor is in
 scope. It may use a caller-provided OpenAI-compatible VLM according to that
 service's documented media format. Label the result as non-VSS.
 
+For an MP4, send the **native MP4 bytes as one video input**. Read the file
+directly, base64-encode the complete byte sequence, and construct exactly:
+
+```text
+data:video/mp4;base64,<base64 of the complete MP4 file>
+```
+
+Pass that URI in one OpenAI-compatible `video_url` content part:
+
+```json
+{"type":"video_url","video_url":{"url":"data:video/mp4;base64,<complete MP4 base64>"}}
+```
+
+Do not run `ffmpeg`, OpenCV, or any frame extractor. Do not convert the video
+to JPEG/PNG images or send an `image_url` array: extracted frames are not the
+requested native video input and can discard motion, timing, and audio. If the
+caller-provided VLM does not support a native MP4 `video_url` data URI, report
+that incompatibility instead of silently changing the media format.
+
 Never enter this fallback after `vss memory introspect`, use it for a named VIOS
 sensor or stored VSS result, or combine local/base64 media with introspection.
 If the request could refer to VSS memory, ask the user to choose the standalone

--- a/skills/operations/vss-ask-video/SKILL.md
+++ b/skills/operations/vss-ask-video/SKILL.md
@@ -108,12 +108,15 @@ For bounded introspection, preserve the user's question verbatim:
 vss memory introspect --query '<user question>' --sensor '<sensor-name>'
 ```
 
-`introspect` requires useful scope: `--sensor`, `--job-id`, `--record-id`, or a
-complete UTC time range. Add only grounded selectors. A time range requires
+`introspect` requires grounded, useful scope: `--sensor`, `--job-id`,
+`--record-id`, or a complete UTC time range. Add only grounded selectors. A time range requires
 both `--start-time` and `--end-time`. `--record-type` and `--group` refine scope
 but do not establish it. The command may perform its own bounded VLM follow-ups;
-do not duplicate them manually. Treat `no_memory` as a structured not-found
-outcome, not a backend failure.
+do not duplicate them manually. `no_memory` returns JSON with status
+`"no_memory"` and exit code 5; this is an expected not-found result, not a
+general command or backend failure. Do not automatically run a VLM afterward
+unless an exact sensor and exact ISO-8601 UTC start/end window were already
+grounded before introspection returned.
 
 For one fresh inspection, use **`vss vlm run`** — never a hand-built VLM request.
 

--- a/skills/operations/vss-ask-video/SKILL.md
+++ b/skills/operations/vss-ask-video/SKILL.md
@@ -58,9 +58,10 @@ Apply these routes in order:
 1. **Hot conversation context -> answer directly.** If current messages or
    current-turn tool output already contain the answer, answer from that
    evidence. Do not query memory or run a model.
-2. **Explicit stored summary/result -> `vss memory get` or `vss memory query`.**
-   For a known `job_id`, use `get`. To find or list stored results by text,
-   sensor, type, status, or time, use `query`.
+2. **Explicit stored summary/result -> `vss memory get`, `vss summarize get`,
+   or `vss memory query`.** For a known `job_id`, read the stored parent with
+   `vss memory get` or, for a summarize job, `vss summarize get`. To find or
+   list stored results by text, sensor, type, status, or time, use `query`.
 3. **General video question where past memory may exist -> `vss memory
    introspect`.** Use this for a substantive question about prior video analysis
    when hot context does not answer it and the user did not request one exact
@@ -93,6 +94,8 @@ For an explicit stored parent:
 
 ```bash
 vss memory get --job-id '<job-id>'
+# summarize jobs may also use:
+vss summarize get --job-id '<job-id>'
 ```
 
 For a known child, add both `--record-type event|search_hit|incident` and
@@ -176,7 +179,8 @@ If `vss vlm run` exits non-zero, stop and report the error:
   aisle at 10:14 UTC." User: "When did the forklift cross?" -> answer `10:14
   UTC` directly; run no command.
 - **Explicit stored parent:** "Show me the summary from job `sum-01JXYZ`." ->
-  `vss memory get --job-id sum-01JXYZ`.
+  `vss memory get --job-id sum-01JXYZ` or `vss summarize get --job-id
+  sum-01JXYZ`.
 - **Stored-result discovery:** "Find stored search results about forklifts on
   `dock_cam`." -> `vss memory query --query 'forklifts' --sensor-id dock_cam`.
 - **General memory-aware question:** "Was anyone missing PPE on

--- a/skills/operations/vss-ask-video/SKILL.md
+++ b/skills/operations/vss-ask-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vss-ask-video
-description: Use this skill to ask a fresh visual question about a recorded video clip using the vss vlm run CLI, including a user-confirmed vss-search-archive handoff with a pre-resolved bounded VIDEO_URL. Not for retrieval or metadata-answerable questions.
+description: Routes VSS video questions through hot conversation context, stored memory, bounded introspection, or an exact-window vss vlm run CLI job, including a user-confirmed vss-search-archive handoff with a pre-resolved bounded VIDEO_URL. Not for retrieval or metadata-answerable questions.
 license: Apache-2.0
 metadata:
   version: "3.3.0"
@@ -8,318 +8,218 @@ metadata:
   tags: "nvidia blueprint operational"
 ---
 
-# Video QnA using `vss vlm run`
+# Ask a VSS video question
 
-Answer a fresh visual question about a video by running **`vss vlm run`** — the VSS CLI command
-that resolves the VLM endpoint from the recorded deployment config, sends the user's question with
-the video, persists the answer to memory, and returns the result. **This skill does not call**
-`POST /generate` on the VSS agent. It requires a **deployed VSS with `vss configure` already run**
-and a reachable `rt_vlm` service.
+Answer from the cheapest grounded source that can satisfy the question. For a
+running VSS deployment, use the project-local `vss` CLI. Do not call an
+OpenAI-compatible `/chat/completions` endpoint directly or fall back to raw REST
+when a CLI command fails.
 
-> **Hard rule — every answer comes from `vss vlm run`.** Every question, including
-> **temporal / timing ones** ("at what timestamp did X happen", "how long", "when does Y
-> start"), is answered by a single **`vss vlm run`** call. A timing question is not a
-> reason to reach for another tool: put it in `--prompt` and read the timing out of the
-> answer.
+This skill does not call `POST /generate` on the VSS agent. It requires a
+**deployed VSS with `vss configure` already run**.
+
+> **Hard rule — never substitute a hand-built HTTP call for the CLI.**
+> Specifically, do **not**:
+> - `POST` to `/v1/chat/completions` yourself. `vss vlm run` owns that call.
+> - Build VIOS clip URLs by hand (e.g. `/vst/api/v1/storage/file/<id>/url`).
+>   `--sensor` resolves the sensor, recorded window and clip URL internally.
+> - `POST` to `http://<host>:8000/generate` or `/v1/summarize`.
 >
-> Never substitute a hand-built HTTP call for the CLI. Specifically, do **not**:
-> - `POST` to `/v1/chat/completions` yourself. `vss vlm run` owns that call and sends the
->   frame-sampling parameter with it; a hand-rolled request omits it, the model sees only
->   the opening frame, and timing questions become unanswerable.
-> - Build VIOS clip URLs by hand (e.g. `/vst/api/v1/storage/file/<id>/url`). `--sensor`
->   resolves the sensor, the recorded window and the clip URL internally.
-> - `POST` to `http://<host>:8000/generate` (the agent's summarize pipeline) or
->   `/v1/summarize` under any circumstances.
->
-> If `vss vlm run` fails, report the exit code (see *Error Handling*). Do not retry the
-> question by hand-rolling the request.
-
----
-
-## Agent harness
-
-**Harness-agnostic** — whatever runs it (Claude Code, Codex, Cursor, or the NAT VSS Agent)
-calls `vss vlm run` via the CLI. A running `vss-agent` is optional; what is required is
-`vss configure` having been run once against the deployed VSS so the rt_vlm service URL is
-recorded.
-
----
-
-## When to Use
-
-- The user asks **what happens in the video**, what **objects / people / actions** appear,
-  **colors**, **timing**, **safety**, or other **visual facts** that require watching the clip.
-- The user asks for **details** that **cannot be answered** from existing messages, summaries,
-  Elasticsearch/MCP results, or filenames alone—you need **model inference on the video**.
-- Follow-up questions about **content details** after a coarse summary or after report generation.
-- `vss-search-archive` has already displayed only `unverified` results, the user
-  explicitly confirmed visual verification, and the caller supplies one exact
-  bounded clip as `VIDEO_URL`. Treat that URL as Path A; do not rerun search or
-  resolve a different interval.
-
----
-
-## Negative Triggers
-
-Do **not** use this skill when the request is one of the following:
-
-- A **database / MCP / prior tool output** already answers the question, unless
-  the user explicitly wants fresh visual verification. The confirmed bounded
-  `vss-search-archive` handoff above is the only search-result exception; use
-  `/vss-query-analytics` for analytics-result verification.
-- Archive/semantic similarity retrieval ("find forklifts", "search all videos for tailgating")
-  → use `/vss-search-archive`. This skill may inspect only the pre-resolved
-  bounded clip that search hands off after confirmation; it never performs the
-  retrieval itself.
-- A request for a **formatted/structured report** ("generate a report", "analysis report")
-  → use `/vss-generate-video-report`.
-- Summarizing a long recording → use `/vss-summarize-video`.
-- Deploy/teardown/profile changes → use `/vss-deploy-profile`.
-
----
+> If `vss vlm run` fails, report the exit code. Do not retry the question by
+> hand-rolling the request.
 
 ## Prerequisites
 
-A deployed VSS stack with **`rt_vlm` service reachable through the configured origin**. Run
-`vss configure` once per deployment — all subsequent `vss vlm run` calls read the recorded URL.
-
-### Setup
-
-Set up the CLI and run `vss configure` per [AGENTS.md](../../AGENTS.md).
-
-Verify `rt_vlm` was discovered:
+A deployed VSS stack with **`rt_vlm` reachable through the configured origin**.
+Run `vss configure` once per deployment. Bootstrap, exit codes, and common CLI
+rules live in [AGENTS.md](../../../AGENTS.md).
 
 ```bash
 vss configure check
 # Expected: rt_vlm   ok   http://<origin>/rtvi-vlm   HTTP 200
 ```
 
-Bootstrap detail, exit codes and the rules that go with them are in
-[AGENTS.md](../../AGENTS.md).
-
----
-
 ## Instructions
 
-1. **Run the numbered steps** — *Step 1* (obtain the video source — directly from the user, or
-   optionally resolve a clip URL from VST/VIOS) → *Step 2* (`vss vlm run` — one command) →
-   *Step 3* (return the answer).
-2. **Return only the final answer text** to the user.
-
-For a confirmed search-result handoff, use only the caller-supplied `VIDEO_URL`
-and visual question. Do not consume similarity scores, filenames, object IDs,
-or other retrieval metadata as visual evidence, and do not rerun search,
-resolve a sensor, broaden the clip, or choose another interval. The caller owns
-verdict validation and any fallback after this skill returns.
-
----
-
-## Sensor check (only when sourcing the clip from VST/VIOS)
-
-**This section applies only on Step 1, Path B — when you are sourcing the video from VST/VIOS.**
-If the user provided the video directly (a file path or URL), **skip this entirely** and use
-Step 1, Path A.
-
-When using VST/VIOS, **you MUST list VST sensors before resolving a clip URL.** This is required
-even when the user names the sensor explicitly, even when the user asserts the video is already
-uploaded, and even when a previous turn appeared to use the same video. Do not skip this step.
-
-> **Running the CLI.** Bootstrap, `vss configure`, exit codes and the sensor-resolution
-> rules live in [AGENTS.md](../../AGENTS.md) at the repo root — read it once rather than per skill.
-
-1. List sensors (capture first — a bare pipe into `jq` would hide a failed
-   `vss` behind `jq`'s exit code and read as "no sensors"):
-   ```bash
-   # Each block is its own shell; define what it uses.
-   VSS=(uv run --project "${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}/services/agent" --no-dev --extra cli vss)
-   set -o pipefail
-   SENSORS=$("${VSS[@]}" vios list --type video) || { echo "vss vios list failed" >&2; exit 1; }
-   printf '%s' "${SENSORS}" | jq -r '.sensors[].name'
-   ```
-
-2. Compare the returned `name` values against the user-supplied `<sensor-id>` (or **filename stem**,
-   e.g. `warehouse_safety_0001`).
-
-   A row may carry an `error` field — VIOS listed the sensor but could not describe it (no
-   streams, or no id). It is still listed on purpose: the name **exists**, so treating it as
-   absent and uploading would create a duplicate and a 409.
-
-3. **If a matching sensor is present** → proceed to Step 1. If its row carries an `error`,
-   report that rather than uploading over it.
-
-4. **If no matching sensor is present** — upload the video first, then re-list to confirm the new
-   sensor appears:
-   ```bash
-   # Each block is its own shell; define what it uses.
-   VSS=(uv run --project "${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}/services/agent" --no-dev --extra cli vss)
-   "${VSS[@]}" vios add /path/to/<filename>
-   ```
-   See `/vss-manage-video-io-storage` for the REST-level upload semantics (v1 vs v2, conflict
-   handling, delete flow). In interactive runs, confirm with the user before uploading. **Never**
-   upload without first running the sensor-list check above.
-
----
-
-## Step 1 — Identify the video source
-
-Determine whether the video comes from the user directly (Path A) or from a named VST/VIOS
-sensor (Path B). This decides which `vss vlm run` flag to use in Step 2.
-
-### Path A — provided directly by the user (default; no VST/VIOS)
-
-If the user hands you a file path or a URL, use Path A in Step 2:
-
-- **URL** → pass as `--media-url <url>`. RT-VLM fetches the video directly.
-- **Local file** → pass as `--file /path/to/clip.mp4`. The CLI reads the file and sends it
-  inline as a base64-encoded `data:video/mp4;base64,…` URI.
-
-A user-confirmed search-result handoff with a pre-resolved bounded `VIDEO_URL` uses this
-same path. Do not discard that URL and enter Path B merely because the caller also retains
-a sensor ID or timestamps for reporting.
-
-Then go straight to Step 2 — **skip the Sensor check**.
-
-### Path B — resolve from VST/VIOS (optional)
-
-> **Hard rule — a question that names a sensor is Path B and MUST use `--sensor`.**
-> When the question references a VIOS sensor (e.g. `warehouse_safety_0001`), pass
-> `--sensor <name>` to `vss vlm run`. The CLI resolves the sensor by name, reads the recorded
-> range, mints a normalised and warmed clip URL, and sends it to RT-VLM — all in one call.
-> Do **not** hand-build a `/storage/file/<streamId>/url` call or inline a local copy as base64.
->
-> **A follow-up that names no video stays on the sensor already in play.** Re-use the same
-> `--sensor <name>` (and optionally `--start-time` / `--end-time`) from the prior turn.
-
-When the clip lives on a named sensor: confirm the sensor exists (the *Sensor check* above
-— required on this path), then use `--sensor <name>` in Step 2.
-
-To restrict the clip to a known time window, add `--start-time` / `--end-time` (ISO 8601):
+### Bootstrap the CLI once
 
 ```bash
-# Optional window. Both or neither — not one alone.
-START_TIME='2025-01-01T00:00:00Z'
-END_TIME='2025-01-01T00:00:30Z'
+VSS_REPO_ROOT="${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}"
+vss() { uv run --project "${VSS_REPO_ROOT}/services/agent" --no-dev --extra cli vss "$@"; }
+vss --version
 ```
 
----
+Never construct an endpoint or replace a failed CLI call with raw HTTP.
 
-## Step 2 — Ask the VLM
+### Choose exactly one initial route
 
-One call, one attempt. `vss vlm run` reads the `rt_vlm` endpoint from the recorded config,
-sends the prompt with the video, and prints the result as JSON.
+Apply these routes in order:
 
-**Path A — URL or local file:**
+1. **Hot conversation context -> answer directly.** If current messages or
+   current-turn tool output already contain the answer, answer from that
+   evidence. Do not query memory or run a model.
+2. **Explicit stored summary/result -> `vss memory get` or `vss memory query`.**
+   For a known `job_id`, use `get`. To find or list stored results by text,
+   sensor, type, status, or time, use `query`.
+3. **General video question where past memory may exist -> `vss memory
+   introspect`.** Use this for a substantive question about prior video analysis
+   when hot context does not answer it and the user did not request one exact
+   stored record or fresh visual verification.
+4. **Exact sensor/time or explicit fresh visual verification -> `vss vlm
+   run`.** Bypass introspection when the user supplies a grounded VIOS sensor
+   plus exact ISO-8601 UTC start/end times, or explicitly asks to watch, inspect,
+   re-check, or freshly verify that exact window. A user-confirmed
+   vss-search-archive handoff with a pre-resolved bounded `VIDEO_URL` uses this
+   route as Path A; do not rerun search or resolve a different interval.
+5. **`introspect` returns `no_memory` -> conditional `vss vlm run`.** Run the
+   VLM only when a grounded sensor and exact ISO-8601 UTC start/end window are
+   already available from the request, hot context, or trusted tool output.
+   Otherwise explain that no matching memory was found and that an exact
+   recorded sensor/window is needed. Never invent or broaden a window.
+
+Do not call `memory query`, `memory introspect`, and `vlm run` speculatively or
+in parallel. The only escalation is the specified `no_memory` fallback.
+
+For a confirmed search-result handoff, use only the caller-supplied `VIDEO_URL`
+and visual question. Treat that URL as Path A; do not rerun search or
+resolve a different interval. Do not consume similarity scores, filenames,
+object IDs, or other retrieval metadata as visual evidence, and do not rerun
+search, resolve a sensor, broaden the clip, or choose another interval. The
+caller owns verdict validation and any fallback after this skill returns.
+
+### Run the selected command
+
+For an explicit stored parent:
 
 ```bash
-# Each block is its own shell; define what it uses.
+vss memory get --job-id '<job-id>'
+```
+
+For a known child, add both `--record-type event|search_hit|incident` and
+`--record-id '<record-id>'`. For discovery, apply only relevant filters:
+
+```bash
+vss memory query --query '<search text>' --sensor-id '<sensor-name>' --limit 20
+```
+
+For bounded introspection, preserve the user's question verbatim:
+
+```bash
+vss memory introspect --query '<user question>' --sensor '<sensor-name>'
+```
+
+`introspect` requires useful scope: `--sensor`, `--job-id`, `--record-id`, or a
+complete UTC time range. Add only grounded selectors. A time range requires
+both `--start-time` and `--end-time`. `--record-type` and `--group` refine scope
+but do not establish it. The command may perform its own bounded VLM follow-ups;
+do not duplicate them manually. Treat `no_memory` as a structured not-found
+outcome, not a backend failure.
+
+For one fresh inspection, use **`vss vlm run`** — never a hand-built VLM request.
+
+**Path A — URL or local file** (default when the user or search handoff provides
+media directly; skip the sensor check):
+
+```bash
 VSS=(uv run --project "${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}/services/agent" --no-dev --extra cli vss)
 # Exit 6 means the answer was produced but could not be written to memory.
-# The answer is still valid, so keep it; only persistence needs retrying.
 check_rc() { [ "$1" -eq 0 ] || [ "$1" -eq 6 ] || { echo "vss vlm run failed (exit $1)" >&2; exit "$1"; }; }
 
-# URL (RT-VLM fetches it):
 RC=0
-RESULT=$("${VSS[@]}" vlm run \
-  --prompt "${USER_QUESTION}" \
-  --media-url "${VIDEO_URL}") || RC=$?
+RESULT=$("${VSS[@]}" vlm run --prompt "${USER_QUESTION}" --media-url "${VIDEO_URL}") || RC=$?
 check_rc "${RC}"
 
 # Local file (inlined as base64):
-# RC=0
-# RESULT=$("${VSS[@]}" vlm run \
-#   --prompt "${USER_QUESTION}" \
-#   --file "${VIDEO_FILE}") || RC=$?
-# check_rc "${RC}"
+# RESULT=$("${VSS[@]}" vlm run --prompt "${USER_QUESTION}" --file "${VIDEO_FILE}") || RC=$?
 ```
 
-**Path B — named sensor (with optional time window):**
+**Path B — named VIOS sensor** (optional window). List sensors first even when
+the user names the sensor. Then:
 
 ```bash
-# Each block is its own shell; define what it uses.
-VSS=(uv run --project "${VSS_REPO_ROOT:-$HOME/video-search-and-summarization}/services/agent" --no-dev --extra cli vss)
-# Exit 6 means the answer was produced but could not be written to memory.
-# The answer is still valid, so keep it; only persistence needs retrying.
-check_rc() { [ "$1" -eq 0 ] || [ "$1" -eq 6 ] || { echo "vss vlm run failed (exit $1)" >&2; exit "$1"; }; }
-
-# Without a time window (full recorded clip):
 RC=0
 RESULT=$("${VSS[@]}" vlm run \
   --prompt "${USER_QUESTION}" \
-  --sensor "${SENSOR_NAME}") || RC=$?
+  --sensor "${SENSOR_NAME}" \
+  --start-time "${START_TIME}" \
+  --end-time "${END_TIME}") || RC=$?
 check_rc "${RC}"
-
-# With a time window:
-# RC=0
-# RESULT=$("${VSS[@]}" vlm run \
-#   --prompt "${USER_QUESTION}" \
-#   --sensor "${SENSOR_NAME}" \
-#   --start-time "${START_TIME}" \
-#   --end-time "${END_TIME}") || RC=$?
-# check_rc "${RC}"
 ```
 
-**Optional flags:**
+A question that names a sensor is Path B and MUST use `--sensor`. Do not
+hand-build a `/storage/file/<streamId>/url` call. The window must be fully
+recorded and start before end. Cite the returned `job_id`, sensor, and window.
+Do not substitute `vss vios clip`, direct VLM HTTP, or a local copy for a
+failed `vss vlm run`.
 
-| Flag | Default | When to use |
-|---|---|---|
-| `--intent <critic\|report\|qa\|introspection>` | `qa` | Set when the question has a known intent for memory tagging. |
-| `--no-persist` | persist | Pass when you do not want the answer written to the memory index. |
-| `--model <id>` | first model from rt_vlm | Override when the deployment serves multiple models. |
-| `--timeout <sec>` | 30 | Raise for long clips or slow inference. |
-| `--num-frames <N>` | 8 | Fixed-frame budget sent to RT-VLM as `num_frames_per_second_or_fixed_frames_chunk`. Raise for long clips where the default 8 frames misses key moments. |
+### Return a grounded answer
 
----
+State whether the answer came from hot context, stored memory, introspection, or
+a fresh VLM job when that distinction matters. Preserve uncertainty and cite
+available handles. Extract `.answer` from the CLI JSON. On CLI failure, report
+the diagnostic and a useful recovery step; do not fabricate an answer.
 
-## Step 3 — Return the answer
-
-Extract the answer from the JSON result and return it to the user:
-
-```bash
-# The CLI emits a body JSON line then a completion-marker JSON line.
-# Print the full output so the trajectory contains the status and answer.
-printf '%s\n' "${RESULT}"
-# Select the line that carries .answer so the marker line is silently skipped.
-ANSWER=$(printf '%s' "${RESULT}" | jq -rR 'try (fromjson | objects | select(has("answer")) | .answer)')
-```
-
-Return only `$ANSWER` to the user — plain text, light markdown is fine. Do not wrap it in a
-report template.
-
----
+If `vss vlm run` exits non-zero, stop and report the error:
+- `2` — invalid input. Fix the request; do not retry it unchanged.
+- `3` — backend unreachable. Retrying is reasonable.
+- `4` — required service missing from the recorded config. Re-run `vss configure`.
+- `5` — the sensor name is not in VIOS. List sensors and confirm the name.
+- `6` — the answer was produced but could not be written to memory. Keep the answer.
+- `7` — timeout (raise `--timeout`).
 
 ## Examples
 
-- "What's happening in this clip? `/home/me/forklift.mp4`" → Path A (`--file /home/me/forklift.mp4`).
-- "Is the worker wearing PPE? `https://example.com/clip.mp4`" → Path A (`--media-url https://example.com/clip.mp4`).
-- "Is the worker in `warehouse_safety_0001` wearing PPE?" → sensor check → Path B (`--sensor warehouse_safety_0001`).
-- "At what timestamp did the worker climb the ladder?" → same Path B; `vss vlm run` handles the clip.
-- "What color is the truck at 00:12 in `dock_cam`?" → Path B with `--start-time` / `--end-time`.
+- **Hot conversation:** The previous turn says, "A forklift crossed the loading
+  aisle at 10:14 UTC." User: "When did the forklift cross?" -> answer `10:14
+  UTC` directly; run no command.
+- **Explicit stored parent:** "Show me the summary from job `sum-01JXYZ`." ->
+  `vss memory get --job-id sum-01JXYZ`.
+- **Stored-result discovery:** "Find stored search results about forklifts on
+  `dock_cam`." -> `vss memory query --query 'forklifts' --sensor-id dock_cam`.
+- **General memory-aware question:** "Was anyone missing PPE on
+  `warehouse_safety_0001`?" -> `vss memory introspect --query ... --sensor
+  warehouse_safety_0001`.
+- **Exact fresh verification:** "Freshly verify whether the worker wore a hard
+  hat on `dock_cam` from `2026-08-13T20:00:00Z` to
+  `2026-08-13T20:00:30Z`." -> `vss vlm run` with that exact sensor/window.
+- **Search handoff:** confirmed unverified hit with bounded `VIDEO_URL` -> Path A
+  `--media-url`.
+- **No-memory with scope:** Introspection returns `no_memory`, while trusted
+  context provides `dock_cam` and `2026-08-13T20:00:00Z` through
+  `2026-08-13T20:00:30Z` -> run one `vss vlm run` for exactly that interval.
+- **No-memory without scope:** "Did a forklift enter the loading area last
+  week?" returns `no_memory`, with no exact sensor/window -> explain no matching
+  memory/window exists and ask for the sensor and exact UTC window; do not run
+  the VLM.
 
----
+## Explicit non-VSS local-file fallback
 
-## Error Handling
+This separate fallback applies only when the user explicitly asks about a
+standalone local file/base64 video and no VSS deployment or VIOS sensor is in
+scope. It may use a caller-provided OpenAI-compatible VLM according to that
+service's documented media format. Label the result as non-VSS.
 
-- If `vss vlm run` exits non-zero, stop and report the error. The code says what to do next:
-  - `2` — invalid input: conflicting or missing media source, a time window without `--sensor`, an unreadable `--file`, or a URL RT-VLM rejected (e.g. SSRF-blocked). Fix the request; do not retry it unchanged.
-  - `3` — backend unreachable: rt_vlm returned 5xx, refused the connection, or replied with an unusable or empty answer. Infrastructure rather than the request — retrying is reasonable.
-  - `4` — required service missing from the recorded config: `rt_vlm` for every request, or `vst` when using `--sensor`. Re-run `vss configure` against an origin that exposes every required service.
-  - `5` — the sensor name is not in VIOS. Do not retry as-is: list the sensors (see *Sensor check*) and confirm the intended name with the user.
-  - `6` — the answer was produced but could not be written to memory. The answer on stdout is valid; only the memory write failed.
-  - `7` — timeout (raise `--timeout`).
-- If **no video is available** (neither a URL/file nor a sensor), stop and ask the user for one.
-- If `rt_vlm` is not listed as `ok` in `vss configure check`, the deployment does not serve it.
-  Stop and report that; standing the service up is a deployment task (see *Cross-Reference*).
+Never enter this fallback after `vss memory introspect`, use it for a named VIOS
+sensor or stored VSS result, or combine local/base64 media with introspection.
+If the request could refer to VSS memory, ask the user to choose the standalone
+file or the VSS sensor. If a VSS deployment is configured, use Path A
+`vss vlm run --file` / `--media-url` instead.
 
----
+## Negative triggers
+
+- Archive/semantic similarity retrieval ("find videos of ...") -> `/vss-search-archive`.
+  This skill may inspect only the pre-resolved bounded clip that search hands
+  off after confirmation; it never performs the retrieval itself.
+- Long-form summarization -> `/vss-summarize-video`.
+- Structured reports -> `/vss-generate-video-report`.
+- Existing analytics incidents or metrics -> `/vss-query-analytics`.
+- Deployment/profile changes -> `/vss-deploy-profile`.
 
 ## Cross-Reference
 
-- **`/vss-manage-video-io-storage`** — *optional* (Step 1, Path B): REST-level upload semantics.
-- **`/vss-deploy-dense-captioning`** — *optional*: stand up a standalone RT-VLM if rt_vlm is
-  not deployed. **Do not re-run `vss configure` against the standalone RT-VLM URL** if you also
-  use Path B (`--sensor` / `vss vios`): doing so replaces the deployment config with one that
-  lacks VIOS routes, breaking the sensor path. Instead, expose RT-VLM through the same origin
-  as VIOS and re-run `vss configure` against that shared origin.
-- **`/vss-generate-video-report`** — timestamped **reports** via the same VLM path; this skill
-  returns an ad-hoc **answer**, not a report.
-- **`/vss-query-analytics`** — read already-computed incidents/metrics (no live VLM inference).
+- **`/vss-manage-video-io-storage`** — optional Path B upload semantics.
+- **`/vss-deploy-dense-captioning`** — optional standalone RT-VLM. Do not
+  re-run `vss configure` against a standalone RT-VLM URL if you also need VIOS.
+- **`/vss-generate-video-report`** — timestamped reports; this skill returns an
+  ad-hoc answer.
+- **`/vss-query-analytics`** — already-computed incidents/metrics.

--- a/skills/operations/vss-ask-video/evals/base_profile_video_understanding.json
+++ b/skills/operations/vss-ask-video/evals/base_profile_video_understanding.json
@@ -20,7 +20,7 @@
     {
       "query": "Read the stored VSS summary with job id sum-01JXYZ.",
       "checks": [
-        "The trajectory uses the project-local CLI bootstrap from root AGENTS.md and runs vss memory get --job-id sum-01JXYZ.",
+        "The trajectory uses the project-local CLI bootstrap from root AGENTS.md and runs vss memory get --job-id sum-01JXYZ or vss summarize get --job-id sum-01JXYZ.",
         "It does not run memory introspect, vss vlm run, or direct chat/completions."
       ]
     },

--- a/skills/operations/vss-ask-video/evals/base_profile_video_understanding.json
+++ b/skills/operations/vss-ask-video/evals/base_profile_video_understanding.json
@@ -1,7 +1,6 @@
 {
   "skills": [
-    "vss-ask-video",
-    "vss-deploy-profile"
+    "vss-ask-video"
   ],
   "resources": {
     "platforms": {
@@ -12,47 +11,45 @@
   },
   "expects": [
     {
-      "query": "Deploy the VSS **base** profile on `{{platform}}` via `/vss-deploy-profile -p base`. Run autonomously.\n\n**Environment & prerequisites:** VSS **base** profile on the target host: VST reachable at http://localhost:30888/vst/api/v1. After deploying, run `vss configure` (from the vss-ask-video SKILL.md setup block) to discover the rt_vlm endpoint — the skill uses `vss vlm run` to call it, it does NOT call POST /generate directly. Set Brev secure-link vars if checks validate media URLs. (See `skills/vss-ask-video/SKILL.md`).",
+      "query": "The current conversation already states that the forklift crossed at 10:14 UTC. When did it cross?",
       "checks": [
-        "`curl -sf --max-time 15 http://localhost:8000/docs` returns exit 0 (Agent REST API responsive)",
-        "`curl -sf --max-time 15 http://localhost:3000/` returns exit 0 (Agent UI responsive)",
-        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
-        "`docker ps --format '{{.Names}}' | grep -qx vss-agent-ui` returns exit 0",
-        "`docker ps --format '{{.Names}}' | grep -qx redis` returns exit 0"
+        "The final answer says 10:14 UTC from hot conversation context.",
+        "No vss memory command, vss vlm run, or direct chat/completions call is made."
       ]
     },
     {
-      "query": "Check if the warehouse_safety_0001 video is already uploaded on VST. If it doesn't exist, upload the warehouse_safety_0001 video to VIOS with timestamp 2025-01-01T00:00:00.000Z. If it exists, skip the uploading.",
+      "query": "Read the stored VSS summary with job id sum-01JXYZ.",
       "checks": [
-        "Trajectory or reasoning shows probing VST/VIOS for warehouse_safety_0001 **before** deciding to upload — for example `vss vios list --type video`, the agent tools, or equivalent REST such as curl /vst/api/v1/sensor/list — not an unconditional upload.",
-        "curl -sf http://localhost:30888/vst/api/v1/sensor/list returns a JSON array containing a sensor whose name matches the uploaded video's filename stem",
-        "curl -sf http://localhost:30888/vst/api/v1/sensor/<sensorId>/streams returns a non-empty streams array whose main stream's url is a local file path under /home/vst/... or similar (NOT rtsp://)"
+        "The trajectory uses the project-local CLI bootstrap from root AGENTS.md and runs vss memory get --job-id sum-01JXYZ.",
+        "It does not run memory introspect, vss vlm run, or direct chat/completions."
       ]
     },
     {
-      "query": "Verify the VSS stack is ready for the **vss-ask-video** skill. Confirm VST is reachable and lists at least one stream, and that a VLM endpoint resolves.",
+      "query": "Find stored VSS results about forklifts for sensor dock_cam.",
       "checks": [
-        "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost:30888/vst/api/v1/sensor/version returns 200",
-        "curl -sf --max-time 10 http://localhost:30888/vst/api/v1/sensor/streams returns HTTP 200 and a non-empty JSON body",
-        "Either VLM_BASE_URL + VLM_NAME (NIM Cosmos) or RTVI_VLM_BASE_URL + VLM_NAME (RT-VLM Cosmos) are resolvable from the vss-agent container environment (read via `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`; the image is distroless so `docker exec vss-agent env` will not work), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
+        "The trajectory runs vss memory query with forklift text and dock_cam sensor scope.",
+        "It does not run memory introspect or vss vlm run."
       ]
     },
     {
-      "query": "Is the worker in warehouse_safety_0001 wearing PPE?",
+      "query": "Use any past VSS analysis that may exist to answer: was anyone missing PPE on warehouse_safety_0001?",
       "checks": [
-        "The run used `vss vlm run --sensor warehouse_safety_0001` (Path B of vss-ask-video) to send the question and the VIOS-resolved clip to RT-VLM in one call. The CLI resolves the sensor by name, reads the recorded range, mints the clip URL, and sends it to the VLM endpoint internally — no separate clip-URL step is required. The command exited 0. A bare hand-built REST call to /vst/api/v1/storage/file/<streamId>/url does not satisfy this check.",
-        "The `vss vlm run` command output (the body JSON line) contains `\"status\": \"completed\"` and a non-empty `\"answer\"` field, confirming that the CLI successfully POSTed to the rt_vlm /v1/chat/completions endpoint and received a 2xx response with a valid answer.",
-        "The run did NOT POST to http://localhost:8000/generate.",
-        "The final assistant reply answers in plain text or light markdown whether the worker is wearing PPE according to the user question, derived from the VLM response (any <think>...</think> block stripped). There should be no errors included in the final response."
+        "The trajectory runs vss memory introspect with the verbatim question and warehouse_safety_0001 scope.",
+        "It does not call an OpenAI chat/completions endpoint directly."
       ]
     },
     {
-      "query": "At what timestamp did the worker climb up the ladder in warehouse_safety_0001? Answer from the clip recorded on that VIOS sensor — not from a local copy of the file and not from any pre-extracted frames left on this host.",
+      "query": "Freshly verify dock_cam from 2026-08-13T20:00:00Z to 2026-08-13T20:00:30Z: was the worker wearing a hard hat?",
       "checks": [
-        "The run used `vss vlm run --sensor warehouse_safety_0001` (Path B of vss-ask-video) to send the question and the VIOS-resolved clip to RT-VLM in one call. The CLI resolves the sensor by name, reads the recorded range, mints the clip URL, and sends it to the VLM endpoint internally. The command exited 0. A bare hand-built REST call to /vst/api/v1/storage/file/<streamId>/url does not satisfy this check.",
-        "The `vss vlm run` command output (the body JSON line) contains `\"status\": \"completed\"` and a non-empty `\"answer\"` field, confirming that the CLI successfully POSTed to the rt_vlm /v1/chat/completions endpoint and received a 2xx response with a valid answer.",
-        "The run did NOT POST to http://localhost:8000/generate.",
-        "The final assistant reply answers the question in plain text or light markdown and includes a timestamp, derived from the VLM response (any <think>...</think> block stripped). There should be no errors included in the final response."
+        "The trajectory runs exactly one vss vlm run with dock_cam, the exact supplied UTC bounds, and the question.",
+        "It does not run memory introspect or call chat/completions directly."
+      ]
+    },
+    {
+      "query": "The preceding vss memory introspect result is no_memory. No exact sensor or UTC window is available. Continue safely.",
+      "checks": [
+        "The response explains that no matching memory/window is available and requests an exact recorded sensor and UTC window.",
+        "It does not invoke vss vlm run and does not switch to local-file/base64 inference."
       ]
     }
   ]

--- a/skills/operations/vss-ask-video/evals/direct_vlm_video_understanding.json
+++ b/skills/operations/vss-ask-video/evals/direct_vlm_video_understanding.json
@@ -11,10 +11,10 @@
   },
   "expects": [
     {
-      "query": "There is no VSS deployment or VIOS sensor in scope. Explicitly use the standalone non-VSS fallback to answer 'Is the worker wearing PPE?' from local file warehouse_safety_0001.mp4 by inlining it as base64 to the caller-provided OpenAI-compatible VLM.",
+      "query": "There is no VSS deployment or VIOS sensor in scope. Explicitly use the standalone non-VSS fallback to answer 'Is the worker wearing PPE?' from local file warehouse_safety_0001.mp4. Send the complete MP4 bytes as one native data:video/mp4;base64 video_url input to the caller-provided OpenAI-compatible VLM; do not extract or send JPEG/PNG frames.",
       "checks": [
         "The response clearly labels this as the explicit non-VSS local-file fallback.",
-        "The local MP4 is sent as a base64 video input to the caller-provided VLM.",
+        "The complete local MP4 is base64-encoded and sent as one video_url content part whose URI starts with data:video/mp4;base64,. No ffmpeg, OpenCV, frame extraction, image/jpeg, image/png, or image_url inputs are used.",
         "The trajectory does not run vss memory introspect, vss memory query, vss memory get, vss vlm run, or access VIOS.",
         "The answer is derived from the standalone VLM response."
       ]

--- a/skills/operations/vss-ask-video/evals/direct_vlm_video_understanding.json
+++ b/skills/operations/vss-ask-video/evals/direct_vlm_video_understanding.json
@@ -1,7 +1,6 @@
 {
   "skills": [
-    "vss-ask-video",
-    "vss-deploy-profile"
+    "vss-ask-video"
   ],
   "resources": {
     "platforms": {
@@ -12,35 +11,19 @@
   },
   "expects": [
     {
-      "query": "Deploy the VSS **base** profile on `{{platform}}` via `/vss-deploy-profile -p base` so a local NIM Cosmos VLM is serving. Run autonomously.\n\n**Purpose of this eval:** it exercises the **vss-ask-video direct-VLM path with NO VST/VIOS** — later steps answer a question about a *local* video file by POSTing it straight to the VLM's `/v1/chat/completions` (inline base64 or a self-served URL). The skill does NOT call `POST /generate` and does NOT resolve a VST clip URL. For this step, only bring the base profile up so a VLM endpoint resolves. Read `VLM_BASE_URL` / `VLM_NAME` / `VLM_MODE` (and `RTVI_VLM_BASE_URL` for RT-VLM) off the `vss-agent` container env — the image is distroless, so use `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`, not `docker exec`. (See `skills/vss-ask-video/SKILL.md`.)",
+      "query": "There is no VSS deployment or VIOS sensor in scope. Explicitly use the standalone non-VSS fallback to answer 'Is the worker wearing PPE?' from local file warehouse_safety_0001.mp4 by inlining it as base64 to the caller-provided OpenAI-compatible VLM.",
       "checks": [
-        "`docker ps --format '{{.Names}}' | grep -qx vss-agent` returns exit 0",
-        "A VLM endpoint resolves from the vss-agent container environment (read via `docker inspect vss-agent --format '{{range .Config.Env}}{{println .}}{{end}}'`): either VLM_BASE_URL + VLM_NAME (NIM Cosmos, base default :30082) or RTVI_VLM_BASE_URL + VLM_NAME (RT-VLM), and a GET against the chosen endpoint's /v1/models returns 200 with the model id present in .data[].id"
+        "The response clearly labels this as the explicit non-VSS local-file fallback.",
+        "The local MP4 is sent as a base64 video input to the caller-provided VLM.",
+        "The trajectory does not run vss memory introspect, vss memory query, vss memory get, vss vlm run, or access VIOS.",
+        "The answer is derived from the standalone VLM response."
       ]
     },
     {
-      "query": "Obtain the VSS sample data **as a local file on disk** (do NOT upload it to VST/VIOS). Configure NGC access, then run `ngc registry resource download-version nvidia/vss-developer/dev-profile-sample-data:3.2.0` and extract it (e.g. `tar -xf dev-profile-sample-data_v3.2.0/dev-profile-sample-data.tar.gz -C ./sample-data`) so that a local copy of `warehouse_safety_0001.mp4` exists on disk. This route uses the local file directly — it must NOT be registered as a VST sensor or uploaded via VIOS.",
+      "query": "Answer this question about the local video file warehouse_safety_0001.mp4 using a configured VSS deployment and vss-ask-video Path A --file — do NOT use VST/VIOS and do NOT call the agent's summarize pipeline: Is the worker wearing PPE?",
       "checks": [
-        "A local, non-empty file named warehouse_safety_0001.mp4 exists on disk after this step (e.g. `find . -name warehouse_safety_0001.mp4` returns a path to a file with size > 0), sourced from the NGC `nvidia/vss-developer/dev-profile-sample-data` resource.",
-        "The trajectory shows the video was obtained as a local file (NGC resource download + extract) and was NOT uploaded to VIOS/VST for this step (no PUT to the VST sensor/stream registration endpoints such as /vst/api/v1/... for warehouse_safety_0001)."
-      ]
-    },
-    {
-      "query": "Answer this question about the **local** video file `warehouse_safety_0001.mp4` (the on-disk copy from the previous step) using the **vss-ask-video** skill with the local file as input (Path A `--file`) — do NOT use VST/VIOS and do NOT call the agent's summarize pipeline: **Is the worker wearing PPE?**",
-      "checks": [
-        "The run used `vss vlm run --file <path/to/warehouse_safety_0001.mp4>` (or the `${VSS[@]} vlm run --file` equivalent from the skill’s SKILL.md bootstrap) to send the local video to RT-VLM. The CLI inlines the file as base64 internally and POSTs it to the rt_vlm /v1/chat/completions endpoint. The command exited 0 and the output JSON contains `\"status\": \"completed\"` and a non-empty `\"answer\"` field.",
-        "The run did NOT perform any GET to a VST clip-URL endpoint (no request to a http://<host>:30888/vst/api/v1/storage/file/.../url style URL) — the video came from the local file, not VST.",
-        "The run did NOT POST to http://<host>:8000/generate.",
-        "The final assistant reply answers whether the worker is wearing PPE in plain text or light markdown, derived from the VLM response (any <think>...</think> block stripped), with no errors in the final response."
-      ]
-    },
-    {
-      "query": "Now answer a second question about the same local `warehouse_safety_0001.mp4` using the **vss-ask-video** skill with a self-served URL (Path A `--media-url`) instead of inline base64 — still WITHOUT VST/VIOS and WITHOUT `POST /generate`. Serve the local file over a simple HTTP URL the VLM can reach (e.g. `python3 -m http.server` bound to the host IP), then use `vss vlm run --media-url <url>` as the skill instructs: **At what timestamp does the worker climb the ladder?**",
-      "checks": [
-        "The run used `vss vlm run --media-url <self-served-url>` (or the `${VSS[@]} vlm run --media-url` equivalent from the skill’s SKILL.md) to send the self-served video URL to RT-VLM. The command exited 0 and the output JSON contains `\"status\": \"completed\"` and a non-empty `\"answer\"` field. Backend-conditional kwargs — RT-VLM (default for vss configure’s rt_vlm) must receive `num_frames_per_second_or_fixed_frames_chunk` with a non-zero value so it samples more than the opening frame; the CLI always includes this. Earlier failed or empty attempts do not count against this check.",
-        "The run did NOT perform any GET to a VST clip-URL endpoint (no http://<host>:30888/vst/api/v1/storage/file/.../url request).",
-        "The run did NOT POST to http://<host>:8000/generate.",
-        "The final assistant reply answers the question in plain text or light markdown and includes a timestamp, derived from the VLM response (any <think>...</think> block stripped), with no errors in the final response."
+        "The run used `vss vlm run --file` to send the local video to RT-VLM. The command exited 0 and the output JSON contains a non-empty answer.",
+        "The run did NOT POST to http://<host>:8000/generate."
       ]
     }
   ]

--- a/skills/operations/vss-ask-video/evals/evals.json
+++ b/skills/operations/vss-ask-video/evals/evals.json
@@ -3,9 +3,79 @@
     "id": "ask-video-routing",
     "question": "What skills can I use to ask a question about a video?",
     "expected_skill": "vss-ask-video",
-    "ground_truth": "vss-ask-video is the skill for asking a question about a video; in response to this request the agent should identify and load it.",
+    "ground_truth": "vss-ask-video selects hot context, stored memory, memory introspection, or an exact-window VLM job.",
     "expected_behavior": [
-      "Loads (activates) the vss-ask-video skill in response to the question."
+      "Loads vss-ask-video and describes its memory-first routing policy."
+    ]
+  },
+  {
+    "id": "ask-video-hot-context",
+    "question": "The prior answer said the forklift crossed at 10:14 UTC. When did it cross?",
+    "expected_skill": "vss-ask-video",
+    "ground_truth": "Answer 10:14 UTC directly from hot conversation context.",
+    "expected_behavior": [
+      "Answers directly from current conversation evidence.",
+      "Does not invoke vss memory or vss vlm."
+    ]
+  },
+  {
+    "id": "ask-video-memory-get",
+    "question": "Show me the stored summary from job sum-01JXYZ.",
+    "expected_skill": "vss-ask-video",
+    "ground_truth": "Read the exact stored parent with vss memory get.",
+    "expected_behavior": [
+      "Runs vss memory get --job-id sum-01JXYZ.",
+      "Does not invoke memory introspect, vss vlm run, or direct chat/completions."
+    ]
+  },
+  {
+    "id": "ask-video-memory-query",
+    "question": "Find stored forklift results for dock_cam.",
+    "expected_skill": "vss-ask-video",
+    "ground_truth": "Discover stored records with vss memory query.",
+    "expected_behavior": [
+      "Runs vss memory query with forklift text and dock_cam sensor scope.",
+      "Does not invoke memory introspect or vss vlm run."
+    ]
+  },
+  {
+    "id": "ask-video-introspect",
+    "question": "Was anyone missing PPE on warehouse_safety_0001? Use any past VSS analysis that may exist.",
+    "expected_skill": "vss-ask-video",
+    "ground_truth": "Ask bounded VSS memory introspection first.",
+    "expected_behavior": [
+      "Runs vss memory introspect with the question and warehouse_safety_0001 sensor.",
+      "Does not call chat/completions directly."
+    ]
+  },
+  {
+    "id": "ask-video-direct-vlm",
+    "question": "Freshly verify dock_cam from 2026-08-13T20:00:00Z to 2026-08-13T20:00:30Z: was the worker wearing a hard hat?",
+    "expected_skill": "vss-ask-video",
+    "ground_truth": "Use one vss vlm run for the exact sensor and UTC window.",
+    "expected_behavior": [
+      "Runs vss vlm run with dock_cam, both exact timestamps, and the user's question.",
+      "Does not run memory introspect or direct chat/completions."
+    ]
+  },
+  {
+    "id": "ask-video-no-memory-with-window",
+    "question": "Memory introspection returned no_memory. Trusted context gives dock_cam from 2026-08-13T20:00:00Z to 2026-08-13T20:00:30Z. Freshly answer the same question.",
+    "expected_skill": "vss-ask-video",
+    "ground_truth": "Escalate once to vss vlm run because exact grounded media scope exists.",
+    "expected_behavior": [
+      "Runs one vss vlm run for exactly the supplied sensor/window.",
+      "Does not broaden or invent a window."
+    ]
+  },
+  {
+    "id": "ask-video-no-memory-without-window",
+    "question": "Memory introspection returned no_memory for whether a forklift entered last week; no exact sensor or UTC window is known.",
+    "expected_skill": "vss-ask-video",
+    "ground_truth": "Explain that no matching memory/window exists and request grounded scope.",
+    "expected_behavior": [
+      "Explains that no matching memory was found and asks for an exact recorded sensor/window.",
+      "Does not invoke vss vlm run or a standalone local-file fallback."
     ]
   }
 ]

--- a/skills/operations/vss-ask-video/evals/evals.json
+++ b/skills/operations/vss-ask-video/evals/evals.json
@@ -22,9 +22,9 @@
     "id": "ask-video-memory-get",
     "question": "Show me the stored summary from job sum-01JXYZ.",
     "expected_skill": "vss-ask-video",
-    "ground_truth": "Read the exact stored parent with vss memory get.",
+    "ground_truth": "Read the exact stored parent with vss memory get or vss summarize get.",
     "expected_behavior": [
-      "Runs vss memory get --job-id sum-01JXYZ.",
+      "Runs vss memory get --job-id sum-01JXYZ or vss summarize get --job-id sum-01JXYZ.",
       "Does not invoke memory introspect, vss vlm run, or direct chat/completions."
     ]
   },

--- a/skills/operations/vss-ask-video/skill-card.md
+++ b/skills/operations/vss-ask-video/skill-card.md
@@ -1,5 +1,5 @@
 ## Description: <br>
-Use this skill to ask a fresh visual question about a recorded video clip by calling a VLM endpoint directly (OpenAI-compatible chat/completions). <br>
+Routes VSS video questions through hot conversation context, exact stored-memory reads, bounded memory introspection, or an exact-window `vss vlm run`. Direct VLM HTTP is reserved for an explicitly separate non-VSS local-file fallback. <br>
 
 This skill is ready for commercial/non-commercial use. <br>
 
@@ -9,25 +9,24 @@ NVIDIA <br>
 ### License/Terms of Use: <br>
 Apache-2.0 <br>
 ## Use Case: <br>
-Developers and engineers building video analytics applications who need to ask ad-hoc visual questions about recorded video clips by calling a vision language model endpoint directly. <br>
+Developers and operators answering ad-hoc questions about current or previously analyzed VSS video while preserving provenance and avoiding unnecessary fresh inference. <br>
 
 ### Deployment Geography for Use: <br>
 Global <br>
 
 ## Known Risks and Mitigations: <br>
-Risk: Review before execution as proposals could introduce incorrect or misleading guidance into skills. <br>
-Mitigation: Review and scan skill before deployment. <br>
+Risk: Answers can be misleading if an agent invents a media window or treats missing memory as visual evidence. <br>
+Mitigation: The skill requires grounded scope, routes `no_memory` explicitly, and uses the project-local VSS CLI. <br>
 
 ## Reference(s): <br>
 - [NVIDIA AI Blueprint: Video Search and Summarization](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization) <br>
 - [VSS Documentation](https://docs.nvidia.com/vss/latest/index.html) <br>
 
-
 ## Skill Output: <br>
-**Output Type(s):** [Analysis, API Calls] <br>
-**Output Format:** [Markdown with extracted VLM response text] <br>
+**Output Type(s):** [Analysis, CLI Calls] <br>
+**Output Format:** [Markdown grounded in conversation, memory, or VLM job output] <br>
 **Output Parameters:** [1D] <br>
-**Other Properties Related to Output:** [VLM reasoning (`<think>...</think>`) blocks are stripped before returning the final answer] <br>
+**Other Properties Related to Output:** [Includes available VSS job/record provenance. VLM reasoning (`<think>...</think>`) blocks are stripped before returning the final answer] <br>
 
 ## Evaluation Agents Used: <br>
 - Claude Code (`claude-code`) <br>


### PR DESCRIPTION
## Summary
- Added `vss memory introspect` to retrieve relevant memories, assess sufficiency, and run targeted VLM follow-ups when information is missing.
- Added `vss vlm run` as a reusable, persisted VLM job operating on VIOS sensor and time-window handles.
- Standardized `input.sensors[].id` on the human-readable VIOS sensor name while retaining internal identifiers in `info`.
- Added a bounded introspection workflow with one sufficiency check, up to three VLM calls, and one final answer synthesis.
- Introspection results are returned through stdout only, while internal VLM calls follow the configured persistence policy.
- Updated `vss-ask-video` to route requests between hot context, memory retrieval, memory introspection, and direct visual inspection.

Reference JIRA ticket: https://jirasw.nvidia.com/browse/VIA-2572

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
