### PR TITLE
fix(ci): cancel stale License Diff runs on PR mirror updates

### DIFF
--- a/.github/scripts/test_osrb_dispatch.py
+++ b/.github/scripts/test_osrb_dispatch.py
@@ -151,6 +151,27 @@ class DispatchTests(unittest.TestCase):
         self.assertIn("### What to do", license_workflow)
         self.assertIn("Developer instructions", license_workflow)
 
+    def test_license_diff_cancels_stale_pr_runs(self) -> None:
+        license_workflow = LICENSE_WORKFLOW.read_text()
+        self.assertIn("group: license-diff-${{ github.ref }}", license_workflow)
+        self.assertIn("cancel-in-progress: true", license_workflow)
+
+    def test_cancelled_license_diff_does_not_start_osrb(self) -> None:
+        """A superseded CSV must not launch the private reviewer.
+
+        License Diff is still allowed to *fail* (non-empty diffs fail on
+        develop) and OSRB Review must still run in that case.
+        """
+        workflow = WORKFLOW.read_text()
+        self.assertIn(
+            "github.event.workflow_run.conclusion != 'cancelled'",
+            workflow,
+        )
+        self.assertNotIn(
+            "github.event.workflow_run.conclusion == 'success'",
+            workflow,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/license-diff.yml
+++ b/.github/workflows/license-diff.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - "pull-request/[0-9]+"
 
+# Same shape as ci.yml: one License Diff per PR mirror. A newer revision
+# cancels the stale run so OSRB's workflow_run follower is not launched
+# from an obsolete CSV.
+concurrency:
+  group: license-diff-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/osrb-review.yml
+++ b/.github/workflows/osrb-review.yml
@@ -29,7 +29,12 @@ defaults:
 jobs:
   review:
     name: Trigger private OSRB review
-    if: startsWith(github.event.workflow_run.head_branch, 'pull-request/')
+    # License Diff is allowed to fail (non-empty diffs still fail on
+    # develop). Cancelled is different: a superseded PR revision must not
+    # start the private GitLab reviewer.
+    if: >-
+      startsWith(github.event.workflow_run.head_branch, 'pull-request/') &&
+      github.event.workflow_run.conclusion != 'cancelled'
     runs-on: [self-hosted, downstream-pipeline]
     timeout-minutes: 45
     env:


### PR DESCRIPTION
Keep one License Diff per pull-request/N so a rebase does not leave an obsolete CSV job running, and skip OSRB Review when that job is cancelled.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
