### PR TITLE
fix(ci): cancel superseded PR mirror CI when the source PR moves

### DIFF
--- a/.github/scripts/cancel_stale_pr_ci.py
+++ b/.github/scripts/cancel_stale_pr_ci.py
@@ -6,10 +6,12 @@
 PR CI is gated on copy-pr-bot updating the mirror (``/ok to test``). Until
 that push, GitHub concurrency cannot see a new run and will not cancel the
 old one. This helper is the source-PR side of that: on synchronize or close,
-cancel mirror runs whose tree is no longer the source head.
+cancel mirror runs that are not testing the current source head.
 
-Tree, not commit SHA: the bot may copy a fork onto a new commit with the
-same tree. Cancelling by SHA would kill the run that just started.
+copy-pr-bot often pushes a merge of the approved SHA into the PR base, so
+the run's tree is the merge result, not the source-head tree. A current run
+is one whose commit, or one of its parents, is the source SHA or shares its
+tree (fork copies rewrite SHAs).
 """
 from __future__ import annotations
 
@@ -19,14 +21,24 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Any, Callable
+from typing import Any, Callable, NamedTuple
 
 GITHUB_API = "https://api.github.com"
-ACTIVE_STATUSES = frozenset({"in_progress", "queued", "waiting"})
+# GitHub's workflow-run status filter. requested/pending are runs that have
+# been created but have not reached a runner yet.
+ACTIVE_STATUSES = frozenset(
+    {"in_progress", "pending", "queued", "requested", "waiting"}
+)
 
 
 class CancelError(RuntimeError):
     """A GitHub API call failed."""
+
+
+class CommitInfo(NamedTuple):
+    sha: str
+    tree: str | None
+    parent_shas: tuple[str, ...]
 
 
 def require_env(name: str) -> str:
@@ -68,15 +80,38 @@ def github(
         raise CancelError(f"{method} {path} failed: {exc.reason}") from exc
 
 
-def commit_tree_sha(repo: str, sha: str, get: Callable[..., Any] = github) -> str | None:
+def parse_commit(payload: dict[str, Any], sha: str) -> CommitInfo:
+    tree = (payload.get("commit") or {}).get("tree") or {}
+    tree_sha = tree.get("sha")
+    parents = tuple(
+        str(parent["sha"])
+        for parent in payload.get("parents") or []
+        if parent.get("sha")
+    )
+    return CommitInfo(
+        sha=str(payload.get("sha") or sha),
+        tree=str(tree_sha) if tree_sha else None,
+        parent_shas=parents,
+    )
+
+
+def load_commit(
+    repo: str,
+    sha: str,
+    cache: dict[str, CommitInfo | None],
+    get: Callable[..., Any] = github,
+) -> CommitInfo | None:
+    if sha in cache:
+        return cache[sha]
     try:
         payload = get("GET", repo, f"/commits/{urllib.parse.quote(sha)}")
     except CancelError as exc:
-        print(f"Could not resolve tree for {sha}: {exc}", file=sys.stderr)
+        print(f"Could not resolve commit {sha}: {exc}", file=sys.stderr)
+        cache[sha] = None
         return None
-    tree = (payload.get("commit") or {}).get("tree") or {}
-    tree_sha = tree.get("sha")
-    return str(tree_sha) if tree_sha else None
+    info = parse_commit(payload, sha)
+    cache[sha] = info
+    return info
 
 
 def list_active_runs(
@@ -94,7 +129,12 @@ def list_active_runs(
                 f"/actions/runs?branch={quoted}&status={status}"
                 f"&per_page=100&page={page}"
             )
-            payload = get("GET", repo, path)
+            try:
+                payload = get("GET", repo, path)
+            except CancelError as exc:
+                if "HTTP 422" in str(exc):
+                    break
+                raise
             batch = payload.get("workflow_runs") or []
             for run in batch:
                 run_id = run.get("id")
@@ -109,11 +149,33 @@ def list_active_runs(
     return runs
 
 
+def mirrors_current_source(
+    *,
+    source_sha: str,
+    source_tree: str | None,
+    run_sha: str,
+    run_tree: str | None,
+    parent_shas: tuple[str, ...],
+    parent_trees: tuple[str | None, ...],
+) -> bool:
+    """True when the run is CI for the current source head.
+
+    Direct copy: same SHA or same tree. Merge-into-base mirror: the source
+    SHA (or a same-tree fork copy of it) is a parent of the merge commit.
+    """
+    if source_sha and source_sha in {run_sha, *parent_shas}:
+        return True
+    if not source_tree:
+        return False
+    trees = {run_tree, *parent_trees}
+    trees.discard(None)
+    return source_tree in trees
+
+
 def should_cancel_run(
     *,
     run: dict[str, Any],
-    source_tree: str | None,
-    run_tree: str | None,
+    matches_source: bool,
     closed: bool,
     this_run_id: int | None,
 ) -> bool:
@@ -124,9 +186,7 @@ def should_cancel_run(
         return False
     if closed:
         return True
-    if not source_tree or not run_tree:
-        return False
-    return run_tree != source_tree
+    return not matches_source
 
 
 def cancel_run(repo: str, run_id: int, post: Callable[..., Any] = github) -> None:
@@ -140,6 +200,33 @@ def cancel_run(repo: str, run_id: int, post: Callable[..., Any] = github) -> Non
         raise
 
 
+def run_matches_source(
+    repo: str,
+    source_sha: str,
+    source_tree: str | None,
+    head_sha: str,
+    cache: dict[str, CommitInfo | None],
+    get: Callable[..., Any] = github,
+) -> bool:
+    if not head_sha:
+        return False
+    run_commit = load_commit(repo, head_sha, cache, get)
+    if run_commit is None:
+        return True
+    parent_trees: list[str | None] = []
+    for parent_sha in run_commit.parent_shas:
+        parent = load_commit(repo, parent_sha, cache, get)
+        parent_trees.append(None if parent is None else parent.tree)
+    return mirrors_current_source(
+        source_sha=source_sha,
+        source_tree=source_tree,
+        run_sha=run_commit.sha,
+        run_tree=run_commit.tree,
+        parent_shas=run_commit.parent_shas,
+        parent_trees=tuple(parent_trees),
+    )
+
+
 def main() -> int:
     repo = require_env("GITHUB_REPOSITORY")
     pr_number = require_env("PR_NUMBER")
@@ -148,11 +235,13 @@ def main() -> int:
     this_run_raw = os.environ.get("GITHUB_RUN_ID", "").strip()
     this_run_id = int(this_run_raw) if this_run_raw.isdigit() else None
     branch = f"pull-request/{pr_number}"
+    cache: dict[str, CommitInfo | None] = {}
 
-    source_tree = commit_tree_sha(repo, source_sha) if source_sha else None
-    if not closed and source_tree is None:
+    source_commit = load_commit(repo, source_sha, cache) if source_sha else None
+    source_tree = None if source_commit is None else source_commit.tree
+    if not closed and source_commit is None:
         print(
-            "Source tree unavailable; not cancelling (avoid killing a live "
+            "Source commit unavailable; not cancelling (avoid killing a live "
             "mirror copy of a fork SHA)."
         )
         return 0
@@ -163,11 +252,12 @@ def main() -> int:
         if not isinstance(run_id, int):
             continue
         head_sha = str(run.get("head_sha") or "")
-        run_tree = commit_tree_sha(repo, head_sha) if head_sha else None
+        matches = run_matches_source(
+            repo, source_sha, source_tree, head_sha, cache
+        )
         if not should_cancel_run(
             run=run,
-            source_tree=source_tree,
-            run_tree=run_tree,
+            matches_source=matches,
             closed=closed,
             this_run_id=this_run_id,
         ):

--- a/.github/scripts/cancel_stale_pr_ci.py
+++ b/.github/scripts/cancel_stale_pr_ci.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Cancel in-flight CI on ``pull-request/<N>`` after the source PR moves.
+
+PR CI is gated on copy-pr-bot updating the mirror (``/ok to test``). Until
+that push, GitHub concurrency cannot see a new run and will not cancel the
+old one. This helper is the source-PR side of that: on synchronize or close,
+cancel mirror runs whose tree is no longer the source head.
+
+Tree, not commit SHA: the bot may copy a fork onto a new commit with the
+same tree. Cancelling by SHA would kill the run that just started.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable
+
+GITHUB_API = "https://api.github.com"
+ACTIVE_STATUSES = frozenset({"in_progress", "queued", "waiting"})
+
+
+class CancelError(RuntimeError):
+    """A GitHub API call failed."""
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise CancelError(f"{name} is not configured")
+    return value
+
+
+def github(
+    method: str,
+    repo: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(
+        f"{GITHUB_API}/repos/{repo}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {require_env('GITHUB_TOKEN')}",
+            "Content-Type": "application/json",
+            "User-Agent": "vss-cancel-stale-pr-ci/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=45) as response:
+            body = response.read()
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read(500).decode("utf-8", errors="replace")
+        raise CancelError(
+            f"{method} {path} returned HTTP {exc.code}: {detail}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise CancelError(f"{method} {path} failed: {exc.reason}") from exc
+
+
+def commit_tree_sha(repo: str, sha: str, get: Callable[..., Any] = github) -> str | None:
+    try:
+        payload = get("GET", repo, f"/commits/{urllib.parse.quote(sha)}")
+    except CancelError as exc:
+        print(f"Could not resolve tree for {sha}: {exc}", file=sys.stderr)
+        return None
+    tree = (payload.get("commit") or {}).get("tree") or {}
+    tree_sha = tree.get("sha")
+    return str(tree_sha) if tree_sha else None
+
+
+def list_active_runs(
+    repo: str,
+    branch: str,
+    get: Callable[..., Any] = github,
+) -> list[dict[str, Any]]:
+    seen: set[int] = set()
+    runs: list[dict[str, Any]] = []
+    quoted = urllib.parse.quote(branch, safe="")
+    for status in sorted(ACTIVE_STATUSES):
+        page = 1
+        while page <= 20:
+            path = (
+                f"/actions/runs?branch={quoted}&status={status}"
+                f"&per_page=100&page={page}"
+            )
+            payload = get("GET", repo, path)
+            batch = payload.get("workflow_runs") or []
+            for run in batch:
+                run_id = run.get("id")
+                if not isinstance(run_id, int) or run_id in seen:
+                    continue
+                if run.get("status") in ACTIVE_STATUSES:
+                    seen.add(run_id)
+                    runs.append(run)
+            if len(batch) < 100:
+                break
+            page += 1
+    return runs
+
+
+def should_cancel_run(
+    *,
+    run: dict[str, Any],
+    source_tree: str | None,
+    run_tree: str | None,
+    closed: bool,
+    this_run_id: int | None,
+) -> bool:
+    run_id = run.get("id")
+    if this_run_id is not None and run_id == this_run_id:
+        return False
+    if run.get("status") not in ACTIVE_STATUSES:
+        return False
+    if closed:
+        return True
+    if not source_tree or not run_tree:
+        return False
+    return run_tree != source_tree
+
+
+def cancel_run(repo: str, run_id: int, post: Callable[..., Any] = github) -> None:
+    try:
+        post("POST", repo, f"/actions/runs/{run_id}/cancel")
+    except CancelError as exc:
+        message = str(exc)
+        if "HTTP 409" in message:
+            print(f"Run {run_id} already completing; skip cancel")
+            return
+        raise
+
+
+def main() -> int:
+    repo = require_env("GITHUB_REPOSITORY")
+    pr_number = require_env("PR_NUMBER")
+    source_sha = os.environ.get("SOURCE_SHA", "").strip()
+    closed = os.environ.get("PR_CLOSED", "").strip().lower() in {"1", "true", "yes"}
+    this_run_raw = os.environ.get("GITHUB_RUN_ID", "").strip()
+    this_run_id = int(this_run_raw) if this_run_raw.isdigit() else None
+    branch = f"pull-request/{pr_number}"
+
+    source_tree = commit_tree_sha(repo, source_sha) if source_sha else None
+    if not closed and source_tree is None:
+        print(
+            "Source tree unavailable; not cancelling (avoid killing a live "
+            "mirror copy of a fork SHA)."
+        )
+        return 0
+
+    cancelled = 0
+    for run in list_active_runs(repo, branch):
+        run_id = run.get("id")
+        if not isinstance(run_id, int):
+            continue
+        head_sha = str(run.get("head_sha") or "")
+        run_tree = commit_tree_sha(repo, head_sha) if head_sha else None
+        if not should_cancel_run(
+            run=run,
+            source_tree=source_tree,
+            run_tree=run_tree,
+            closed=closed,
+            this_run_id=this_run_id,
+        ):
+            continue
+        print(f"Cancelling run {run_id} ({run.get('name')}) sha={head_sha[:12]}")
+        cancel_run(repo, run_id)
+        cancelled += 1
+    print(f"Cancelled {cancelled} stale run(s) on {branch}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except CancelError as exc:
+        print(exc, file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/.github/scripts/test_cancel_stale_pr_ci.py
+++ b/.github/scripts/test_cancel_stale_pr_ci.py
@@ -14,9 +14,82 @@ assert SPEC and SPEC.loader
 module = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(module)
 
+SOURCE = "s" * 40
+BASE = "b" * 40
+MERGE = "m" * 40
+SOURCE_TREE = "stree"
+MERGE_TREE = "mtree"
+BASE_TREE = "btree"
+OLD_SOURCE = "o" * 40
+OLD_TREE = "otree"
 
-def run(*, run_id: int = 1, status: str = "in_progress", head_sha: str = "a" * 40) -> dict:
+
+def run(*, run_id: int = 1, status: str = "in_progress", head_sha: str = MERGE) -> dict:
     return {"id": run_id, "status": status, "head_sha": head_sha, "name": "CI"}
+
+
+class MirrorsCurrentSourceTest(unittest.TestCase):
+    def test_exact_sha_copy(self):
+        self.assertTrue(
+            module.mirrors_current_source(
+                source_sha=SOURCE,
+                source_tree=SOURCE_TREE,
+                run_sha=SOURCE,
+                run_tree=SOURCE_TREE,
+                parent_shas=(BASE,),
+                parent_trees=(BASE_TREE,),
+            )
+        )
+
+    def test_fork_copy_same_tree_different_sha(self):
+        self.assertTrue(
+            module.mirrors_current_source(
+                source_sha=SOURCE,
+                source_tree=SOURCE_TREE,
+                run_sha="c" * 40,
+                run_tree=SOURCE_TREE,
+                parent_shas=(),
+                parent_trees=(),
+            )
+        )
+
+    def test_merge_into_base_keeps_current_run(self):
+        """CPR-bot merge result tree differs from the source head tree."""
+        self.assertTrue(
+            module.mirrors_current_source(
+                source_sha=SOURCE,
+                source_tree=SOURCE_TREE,
+                run_sha=MERGE,
+                run_tree=MERGE_TREE,
+                parent_shas=(BASE, SOURCE),
+                parent_trees=(BASE_TREE, SOURCE_TREE),
+            )
+        )
+
+    def test_merge_of_old_head_is_stale(self):
+        self.assertFalse(
+            module.mirrors_current_source(
+                source_sha=SOURCE,
+                source_tree=SOURCE_TREE,
+                run_sha=MERGE,
+                run_tree=MERGE_TREE,
+                parent_shas=(BASE, OLD_SOURCE),
+                parent_trees=(BASE_TREE, OLD_TREE),
+            )
+        )
+
+    def test_fork_merge_matches_parent_tree(self):
+        copied = "k" * 40
+        self.assertTrue(
+            module.mirrors_current_source(
+                source_sha=SOURCE,
+                source_tree=SOURCE_TREE,
+                run_sha=MERGE,
+                run_tree=MERGE_TREE,
+                parent_shas=(BASE, copied),
+                parent_trees=(BASE_TREE, SOURCE_TREE),
+            )
+        )
 
 
 class ShouldCancelTest(unittest.TestCase):
@@ -24,8 +97,7 @@ class ShouldCancelTest(unittest.TestCase):
         self.assertTrue(
             module.should_cancel_run(
                 run=run(),
-                source_tree="new",
-                run_tree="new",
+                matches_source=True,
                 closed=True,
                 this_run_id=99,
             )
@@ -35,57 +107,75 @@ class ShouldCancelTest(unittest.TestCase):
         self.assertFalse(
             module.should_cancel_run(
                 run=run(run_id=99),
-                source_tree="new",
-                run_tree="old",
+                matches_source=False,
                 closed=True,
                 this_run_id=99,
             )
         )
 
-    def test_same_tree_is_kept_even_when_sha_differs(self):
-        """copy-pr-bot may rewrite the commit; the tree is what CI is testing."""
+    def test_current_run_is_kept(self):
         self.assertFalse(
             module.should_cancel_run(
                 run=run(),
-                source_tree="same-tree",
-                run_tree="same-tree",
+                matches_source=True,
                 closed=False,
                 this_run_id=99,
             )
         )
 
-    def test_stale_tree_is_cancelled(self):
+    def test_stale_run_is_cancelled(self):
         self.assertTrue(
             module.should_cancel_run(
                 run=run(),
-                source_tree="after-rebase",
-                run_tree="before-rebase",
+                matches_source=False,
                 closed=False,
                 this_run_id=99,
             )
         )
 
-    def test_unknown_tree_is_not_cancelled(self):
-        self.assertFalse(
-            module.should_cancel_run(
-                run=run(),
-                source_tree=None,
-                run_tree="before-rebase",
-                closed=False,
-                this_run_id=99,
+    def test_requested_and_pending_are_active(self):
+        self.assertIn("requested", module.ACTIVE_STATUSES)
+        self.assertIn("pending", module.ACTIVE_STATUSES)
+        for status in ("requested", "pending"):
+            self.assertTrue(
+                module.should_cancel_run(
+                    run=run(status=status),
+                    matches_source=False,
+                    closed=False,
+                    this_run_id=99,
+                )
             )
-        )
 
     def test_completed_run_is_ignored(self):
         self.assertFalse(
             module.should_cancel_run(
                 run=run(status="completed"),
-                source_tree="new",
-                run_tree="old",
+                matches_source=False,
                 closed=False,
                 this_run_id=99,
             )
         )
+
+
+class ListActiveRunsTest(unittest.TestCase):
+    def test_skips_status_that_github_rejects(self):
+        calls: list[str] = []
+
+        def get(_method: str, _repo: str, path: str):
+            calls.append(path)
+            if "status=requested" in path:
+                raise module.CancelError("GET /actions/runs returned HTTP 422: invalid")
+            if "status=in_progress" in path:
+                return {
+                    "workflow_runs": [
+                        {"id": 7, "status": "in_progress", "head_sha": MERGE}
+                    ]
+                }
+            return {"workflow_runs": []}
+
+        runs = module.list_active_runs("owner/repo", "pull-request/1900", get)
+        self.assertEqual([run["id"] for run in runs], [7])
+        self.assertTrue(any("status=requested" in path for path in calls))
 
 
 class WorkflowTest(unittest.TestCase):

--- a/.github/scripts/test_cancel_stale_pr_ci.py
+++ b/.github/scripts/test_cancel_stale_pr_ci.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("cancel_stale_pr_ci.py")
+WORKFLOW = Path(__file__).resolve().parent.parent / "workflows" / "cancel-stale-pr-ci.yml"
+SPEC = importlib.util.spec_from_file_location("cancel_stale_pr_ci", SCRIPT)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+def run(*, run_id: int = 1, status: str = "in_progress", head_sha: str = "a" * 40) -> dict:
+    return {"id": run_id, "status": status, "head_sha": head_sha, "name": "CI"}
+
+
+class ShouldCancelTest(unittest.TestCase):
+    def test_closed_pr_cancels_active_runs(self):
+        self.assertTrue(
+            module.should_cancel_run(
+                run=run(),
+                source_tree="new",
+                run_tree="new",
+                closed=True,
+                this_run_id=99,
+            )
+        )
+
+    def test_does_not_cancel_self(self):
+        self.assertFalse(
+            module.should_cancel_run(
+                run=run(run_id=99),
+                source_tree="new",
+                run_tree="old",
+                closed=True,
+                this_run_id=99,
+            )
+        )
+
+    def test_same_tree_is_kept_even_when_sha_differs(self):
+        """copy-pr-bot may rewrite the commit; the tree is what CI is testing."""
+        self.assertFalse(
+            module.should_cancel_run(
+                run=run(),
+                source_tree="same-tree",
+                run_tree="same-tree",
+                closed=False,
+                this_run_id=99,
+            )
+        )
+
+    def test_stale_tree_is_cancelled(self):
+        self.assertTrue(
+            module.should_cancel_run(
+                run=run(),
+                source_tree="after-rebase",
+                run_tree="before-rebase",
+                closed=False,
+                this_run_id=99,
+            )
+        )
+
+    def test_unknown_tree_is_not_cancelled(self):
+        self.assertFalse(
+            module.should_cancel_run(
+                run=run(),
+                source_tree=None,
+                run_tree="before-rebase",
+                closed=False,
+                this_run_id=99,
+            )
+        )
+
+    def test_completed_run_is_ignored(self):
+        self.assertFalse(
+            module.should_cancel_run(
+                run=run(status="completed"),
+                source_tree="new",
+                run_tree="old",
+                closed=False,
+                this_run_id=99,
+            )
+        )
+
+
+class WorkflowTest(unittest.TestCase):
+    def test_pull_request_target_does_not_checkout_the_pr_head(self):
+        text = WORKFLOW.read_text()
+        self.assertIn("pull_request_target:", text)
+        self.assertIn("persist-credentials: false", text)
+        self.assertNotIn("ref: ${{ github.event.pull_request.head", text)
+        self.assertIn("actions: write", text)
+
+    def test_ci_runs_these_tests(self):
+        ci = (Path(__file__).resolve().parent.parent / "workflows" / "ci.yml").read_text()
+        self.assertIn("python3 .github/scripts/test_cancel_stale_pr_ci.py", ci)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cancel-stale-pr-ci.yml
+++ b/.github/workflows/cancel-stale-pr-ci.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# PR CI runs on copy-pr-bot `pull-request/<N>` pushes, not on the source PR
+# event. Concurrency in those workflows only fires when the *mirror* moves.
+# A rebase of the source PR otherwise leaves the previous mirror SHA running
+# until the next `/ok to test`.
+#
+# This workflow is cancel-only. It does not start CI and does not execute
+# PR code: `pull_request_target` with a base-ref checkout (the default SHA)
+# and no credentials.
+
+name: Cancel Stale PR CI
+
+on:
+  pull_request_target:
+    types: [synchronize, closed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cancel-stale-pr-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cancel:
+    name: Cancel superseded mirror runs
+    if: github.event.pull_request.head.ref != format('pull-request/{0}', github.event.pull_request.number)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Base/default SHA of this trusted workflow — never the PR head.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Cancel in-flight pull-request/N runs whose tree is stale
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_CLOSED: ${{ github.event.action == 'closed' }}
+        run: python3 .github/scripts/cancel_stale_pr_ci.py

--- a/.github/workflows/cancel-stale-pr-ci.yml
+++ b/.github/workflows/cancel-stale-pr-ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cancel in-flight pull-request/N runs whose tree is stale
+      - name: Cancel in-flight pull-request/N runs that are not the current source head
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1478,6 +1478,7 @@ jobs:
           python3 .github/scripts/test_trigger_downstream_pipeline.py
           python3 .github/scripts/test_advance_ghcr_alias.py
           python3 .github/scripts/test_cleanup_pr_tags.py
+          python3 .github/scripts/test_cancel_stale_pr_ci.py
 
       - name: Unit-test the GHCR immutability/provenance guard
         run: python3 .github/scripts/test_ghcr_image_guard.py


### PR DESCRIPTION
Mirror concurrency only sees copy-pr-bot pushes. Cancel in-flight pull-request/N runs from the source PR synchronize/close so a rebase does not keep the previous SHA on runners until the next /ok to test.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
