### PR TITLE
fix(ci): skip behavior-analytics integration when its sources are unc…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -865,6 +865,10 @@ jobs:
   behavior-analytics-integration-test:
     name: Integration (behavior analytics)
     needs: prepare-source
+    # Same path gate as Test (sdr-mw-l) / configurator jobs: skip the ~150 min
+    # compose suite when this PR did not touch BA sources or ci.yml (license-diff
+    # and similar). Diff-resolution failure still runs it via unit-test-workflow-changed.
+    if: needs.prepare-source.outputs.build-behavior-analytics == 'true' || needs.prepare-source.outputs.unit-test-workflow-changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 150
     env:


### PR DESCRIPTION
…hanged

The compose suite ran on every PR-mirror push, including license-diff-only changes. Gate it the same way as the sdr-mw-l and configurator unit jobs.

## Summary

## Plan

## Related Issue

## Changes

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md).
- [ ] I have installed and run [pre-commit hooks](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#1-enable-pre-commit-hooks) locally (`uv run pre-commit install` once, then hooks run on every `git commit`).
- [ ] Every commit on this PR is [DCO sign-off](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/blob/HEAD/CONTRIBUTING.md#developer-certificate-of-origin-dco)'d (`git commit -s` adds a `Signed-off-by` trailer that certifies you have the right to submit the change under Apache-2.0).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] No secrets, API keys, or credentials committed.
